### PR TITLE
Target server settings by environment

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -1,6 +1,8 @@
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 
@@ -11,6 +13,7 @@ import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
 import { installDesktopIpcHandlers } from "../ipc/DesktopIpcHandlers.ts";
 import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
+import * as DesktopBackendMode from "./DesktopBackendMode.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
 import * as DesktopApplicationMenu from "../window/DesktopApplicationMenu.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
@@ -54,6 +57,17 @@ export class DesktopDevelopmentBackendPortRequiredError extends Schema.TaggedErr
 ) {
   override get message(): string {
     return "T3CODE_PORT is required in desktop development.";
+  }
+}
+
+export class DesktopRendererAssetsUnavailableError extends Schema.TaggedErrorClass<DesktopRendererAssetsUnavailableError>()(
+  "DesktopRendererAssetsUnavailableError",
+  {
+    candidates: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    return `The packaged desktop renderer was not found. Checked: ${this.candidates.join(", ")}.`;
   }
 }
 
@@ -136,21 +150,68 @@ const handleFatalStartupError = Effect.fn("desktop.startup.handleFatalStartupErr
 const fatalStartupCause = <E>(stage: string, cause: Cause.Cause<E>) =>
   handleFatalStartupError(stage, Cause.pretty(cause)).pipe(Effect.andThen(Effect.failCause(cause)));
 
+const resolvePackagedClientRoot = Effect.fn("desktop.bootstrap.resolvePackagedClientRoot")(
+  function* (candidates: readonly string[]) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    for (const candidate of candidates) {
+      if (
+        yield* fileSystem
+          .exists(path.join(candidate, "index.html"))
+          .pipe(Effect.orElseSucceed(() => false))
+      ) {
+        return candidate;
+      }
+    }
+    return yield* new DesktopRendererAssetsUnavailableError({ candidates: [...candidates] });
+  },
+);
+
 const bootstrap = Effect.gen(function* () {
-  const pool = yield* DesktopBackendPool.DesktopBackendPool;
-  const primaryBackend = yield* pool.primary;
+  const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
   const state = yield* DesktopState.DesktopState;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
-  const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
-  const wslBackend = yield* DesktopWslBackend.DesktopWslBackend;
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
+  const backendMode = (yield* launchMode.get).effectiveMode;
   yield* logBootstrapInfo("bootstrap start");
+
+  if (backendMode === "client-only") {
+    if (environment.isDevelopment) {
+      yield* electronProtocol.registerDesktopProtocol({
+        scheme: ElectronProtocol.getDesktopScheme(true),
+        source: "proxy",
+        targetOrigin: Option.getOrThrow(environment.devServerUrl),
+        clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,
+      });
+    } else {
+      const staticRoot = yield* resolvePackagedClientRoot(environment.packagedClientRootCandidates);
+      yield* electronProtocol.registerDesktopProtocol({
+        scheme: ElectronProtocol.getDesktopScheme(false),
+        source: "static",
+        staticRoot,
+        clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,
+      });
+      yield* logBootstrapInfo("bootstrap resolved packaged renderer", { staticRoot });
+    }
+
+    yield* installDesktopIpcHandlers();
+    yield* logBootstrapInfo("bootstrap ipc handlers registered");
+    if (!(yield* Ref.get(state.quitting))) {
+      yield* desktopWindow.handleRendererReady;
+    }
+    return;
+  }
 
   if (environment.isDevelopment && Option.isNone(environment.configuredBackendPort)) {
     return yield* new DesktopDevelopmentBackendPortRequiredError();
   }
 
+  const pool = yield* DesktopBackendPool.DesktopBackendPool;
+  const primaryBackend = yield* pool.primary;
+  const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+  const wslBackend = yield* DesktopWslBackend.DesktopWslBackend;
   const backendPortSelection = yield* resolveDesktopBackendPort(environment.configuredBackendPort);
   const backendPort = backendPortSelection.port;
   yield* logBootstrapInfo(
@@ -171,14 +232,13 @@ const bootstrap = Effect.gen(function* () {
   }
   const serverExposureState = yield* serverExposure.configureFromSettings({ port: backendPort });
   const backendConfig = yield* serverExposure.backendConfig;
-  const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
   const rendererTarget = environment.isDevelopment
     ? Option.getOrThrow(environment.devServerUrl)
     : backendConfig.httpBaseUrl;
   yield* electronProtocol.registerDesktopProtocol({
     scheme: ElectronProtocol.getDesktopScheme(environment.isDevelopment),
+    source: "proxy",
     targetOrigin: rendererTarget,
-    backendOrigin: backendConfig.httpBaseUrl,
     clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,
   });
   yield* logBootstrapInfo("bootstrap resolved backend endpoint", {
@@ -223,6 +283,7 @@ const startup = Effect.gen(function* () {
   const clerk = yield* DesktopClerk.DesktopClerk;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
+  const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
@@ -230,7 +291,13 @@ const startup = Effect.gen(function* () {
   const userDataPath = yield* appIdentity.resolveUserDataPath;
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
-  yield* desktopSettings.load;
+  const settings = yield* desktopSettings.load;
+  const launchMode = yield* backendMode.latch(settings.backendMode);
+  yield* logStartupInfo("desktop backend mode selected", {
+    effectiveMode: launchMode.effectiveMode,
+    configuredMode: launchMode.configuredMode,
+    ...(launchMode.cliOverride === null ? {} : { cliOverride: launchMode.cliOverride }),
+  });
 
   if (environment.platform === "linux") {
     yield* electronApp.appendCommandLineSwitch("class", environment.linuxWmClass);
@@ -261,6 +328,10 @@ const scopedProgram = Effect.scoped(
 
     yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {
+        const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
+        if ((yield* backendMode.get).effectiveMode === "client-only") {
+          return;
+        }
         const pool = yield* DesktopBackendPool.DesktopBackendPool;
         // Stop every backend in the pool, not just the primary. The
         // electronApp.quit() path can race ahead of the layer-scope

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -199,7 +199,13 @@ const bootstrap = Effect.gen(function* () {
     yield* installDesktopIpcHandlers();
     yield* logBootstrapInfo("bootstrap ipc handlers registered");
     if (!(yield* Ref.get(state.quitting))) {
-      yield* desktopWindow.handleRendererReady;
+      yield* desktopWindow.handleRendererReady.pipe(
+        Effect.catch((error) =>
+          logBootstrapWarning("failed to open main window after renderer readiness", {
+            error: error.message,
+          }),
+        ),
+      );
     }
     return;
   }

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -6,6 +6,7 @@ import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 
+import type { DesktopBackendMode as DesktopBackendModeValue } from "@t3tools/contracts";
 import * as NetService from "@t3tools/shared/Net";
 import * as Crypto from "effect/Crypto";
 import * as ElectronApp from "../electron/ElectronApp.ts";
@@ -150,6 +151,26 @@ const handleFatalStartupError = Effect.fn("desktop.startup.handleFatalStartupErr
 const fatalStartupCause = <E>(stage: string, cause: Cause.Cause<E>) =>
   handleFatalStartupError(stage, Cause.pretty(cause)).pipe(Effect.andThen(Effect.failCause(cause)));
 
+export const latchDesktopBackendModeForStartup = Effect.fn(
+  "desktop.startup.latchDesktopBackendMode",
+)(function* (configuredMode: DesktopBackendModeValue) {
+  const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
+  return yield* backendMode
+    .latch(configuredMode)
+    .pipe(Effect.catchCause((cause) => fatalStartupCause("backendMode", cause)));
+});
+
+export const handleClientOnlyRendererReady = <E extends { readonly message: string }>(
+  rendererReady: Effect.Effect<void, E>,
+): Effect.Effect<void, E> =>
+  rendererReady.pipe(
+    Effect.tapError((error) =>
+      logBootstrapWarning("failed to open main window after renderer readiness", {
+        error: error.message,
+      }),
+    ),
+  );
+
 const resolvePackagedClientRoot = Effect.fn("desktop.bootstrap.resolvePackagedClientRoot")(
   function* (candidates: readonly string[]) {
     const fileSystem = yield* FileSystem.FileSystem;
@@ -199,13 +220,7 @@ const bootstrap = Effect.gen(function* () {
     yield* installDesktopIpcHandlers();
     yield* logBootstrapInfo("bootstrap ipc handlers registered");
     if (!(yield* Ref.get(state.quitting))) {
-      yield* desktopWindow.handleRendererReady.pipe(
-        Effect.catch((error) =>
-          logBootstrapWarning("failed to open main window after renderer readiness", {
-            error: error.message,
-          }),
-        ),
-      );
+      yield* handleClientOnlyRendererReady(desktopWindow.handleRendererReady);
     }
     return;
   }
@@ -289,7 +304,6 @@ const startup = Effect.gen(function* () {
   const clerk = yield* DesktopClerk.DesktopClerk;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
-  const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
@@ -298,7 +312,7 @@ const startup = Effect.gen(function* () {
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
   const settings = yield* desktopSettings.load;
-  const launchMode = yield* backendMode.latch(settings.backendMode);
+  const launchMode = yield* latchDesktopBackendModeForStartup(settings.backendMode);
   yield* logStartupInfo("desktop backend mode selected", {
     effectiveMode: launchMode.effectiveMode,
     configuredMode: launchMode.configuredMode,

--- a/apps/desktop/src/app/DesktopAppErrors.test.ts
+++ b/apps/desktop/src/app/DesktopAppErrors.test.ts
@@ -1,9 +1,22 @@
 import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import {
   DesktopBackendPortUnavailableError,
   DesktopDevelopmentBackendPortRequiredError,
+  handleClientOnlyRendererReady,
+  latchDesktopBackendModeForStartup,
 } from "./DesktopApp.ts";
+import * as DesktopBackendMode from "./DesktopBackendMode.ts";
+import * as DesktopShutdown from "./DesktopShutdown.ts";
+import * as DesktopState from "./DesktopState.ts";
 
 describe("DesktopApp errors", () => {
   it("preserves unavailable backend port context", () => {
@@ -27,4 +40,59 @@ describe("DesktopApp errors", () => {
 
     assert.equal(error.message, "T3CODE_PORT is required in desktop development.");
   });
+
+  it.effect("propagates client-only window creation failures", () =>
+    Effect.gen(function* () {
+      const error = new Error("window creation failed");
+
+      const exit = yield* Effect.exit(handleClientOnlyRendererReady(Effect.fail(error)));
+      assert(Exit.isFailure(exit));
+      const failure = Cause.findErrorOption(exit.cause);
+      assert(Option.isSome(failure));
+      assert.strictEqual(failure.value, error);
+    }),
+  );
+
+  it.effect("reports invalid backend-mode launch arguments as fatal startup errors", () =>
+    Effect.gen(function* () {
+      const quitCount = yield* Ref.make(0);
+      const shownErrors = yield* Ref.make<readonly { title: string; content: string }[]>([]);
+
+      const layer = Layer.mergeAll(
+        DesktopBackendMode.layerTest(["electron", "--backend-mode=invalid"]),
+        DesktopShutdown.layer,
+        DesktopState.layer,
+        Layer.mock(ElectronApp.ElectronApp)({
+          quit: Ref.update(quitCount, (count) => count + 1),
+        }),
+        Layer.mock(ElectronDialog.ElectronDialog)({
+          showErrorBox: (title, content) =>
+            Ref.update(shownErrors, (errors) => [...errors, { title, content }]),
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const exit = yield* Effect.exit(latchDesktopBackendModeForStartup("managed"));
+        assert(Exit.isFailure(exit));
+        const failure = Cause.findErrorOption(exit.cause);
+        assert(Option.isSome(failure));
+        assert(
+          DesktopBackendMode.isDesktopBackendModeArgumentError(failure.value),
+          "expected the original backend mode argument error",
+        );
+
+        const errors = yield* Ref.get(shownErrors);
+        assert.equal(errors.length, 1);
+        assert.equal(errors[0]?.title, "T3 Code failed to start");
+        assert.include(errors[0]?.content ?? "", "Stage: backendMode");
+        assert.include(errors[0]?.content ?? "", 'Invalid --backend-mode value "invalid"');
+        assert.equal(yield* Ref.get(quitCount), 1);
+
+        const state = yield* DesktopState.DesktopState;
+        assert.isTrue(yield* Ref.get(state.quitting));
+        const shutdown = yield* DesktopShutdown.DesktopShutdown;
+        yield* shutdown.awaitRequest;
+      }).pipe(Effect.provide(layer));
+    }),
+  );
 });

--- a/apps/desktop/src/app/DesktopBackendMode.test.ts
+++ b/apps/desktop/src/app/DesktopBackendMode.test.ts
@@ -1,0 +1,70 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import * as DesktopBackendMode from "./DesktopBackendMode.ts";
+
+describe("DesktopBackendMode", () => {
+  const captureThrown = (run: () => unknown): unknown => {
+    try {
+      run();
+    } catch (error) {
+      return error;
+    }
+    throw new Error("Expected the operation to throw.");
+  };
+
+  it("uses the persisted mode when no CLI override is present", () => {
+    assert.deepEqual(DesktopBackendMode.resolveDesktopBackendModeState([], "client-only"), {
+      effectiveMode: "client-only",
+      configuredMode: "client-only",
+      cliOverride: null,
+    });
+  });
+
+  it("gives the CLI override precedence without changing the configured mode", () => {
+    assert.deepEqual(
+      DesktopBackendMode.resolveDesktopBackendModeState(
+        ["electron", "main.cjs", "--backend-mode=client-only"],
+        "managed",
+      ),
+      {
+        effectiveMode: "client-only",
+        configuredMode: "managed",
+        cliOverride: "client-only",
+      },
+    );
+  });
+
+  it("accepts a separate flag value", () => {
+    assert.equal(
+      DesktopBackendMode.parseDesktopBackendModeOverride(["electron", "--backend-mode", "managed"]),
+      "managed",
+    );
+  });
+
+  it.each([
+    ["--backend-mode=other", "invalid-value"],
+    ["--backend-mode=", "missing-value"],
+    ["--backend-mode", "missing-value"],
+  ])("rejects invalid launch argument %s", (argument, reason) => {
+    const error = captureThrown(() =>
+      DesktopBackendMode.parseDesktopBackendModeOverride(["electron", argument]),
+    );
+    assert.isTrue(DesktopBackendMode.isDesktopBackendModeArgumentError(error));
+    if (DesktopBackendMode.isDesktopBackendModeArgumentError(error)) {
+      assert.equal(error.reason, reason);
+    }
+  });
+
+  it("rejects repeated overrides", () => {
+    const error = captureThrown(() =>
+      DesktopBackendMode.parseDesktopBackendModeOverride([
+        "--backend-mode=managed",
+        "--backend-mode=client-only",
+      ]),
+    );
+    assert.isTrue(DesktopBackendMode.isDesktopBackendModeArgumentError(error));
+    if (DesktopBackendMode.isDesktopBackendModeArgumentError(error)) {
+      assert.equal(error.reason, "repeated");
+    }
+  });
+});

--- a/apps/desktop/src/app/DesktopBackendMode.ts
+++ b/apps/desktop/src/app/DesktopBackendMode.ts
@@ -1,0 +1,128 @@
+import {
+  type DesktopBackendMode as DesktopBackendModeValue,
+  type DesktopBackendModeState,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+
+const BACKEND_MODE_FLAG = "--backend-mode";
+
+export class DesktopBackendModeArgumentError extends Schema.TaggedErrorClass<DesktopBackendModeArgumentError>()(
+  "DesktopBackendModeArgumentError",
+  {
+    value: Schema.NullOr(Schema.String),
+    reason: Schema.Literals(["missing-value", "invalid-value", "repeated"]),
+  },
+) {
+  override get message(): string {
+    if (this.reason === "missing-value") {
+      return `${BACKEND_MODE_FLAG} requires either "managed" or "client-only".`;
+    }
+    if (this.reason === "repeated") {
+      return `${BACKEND_MODE_FLAG} may only be specified once.`;
+    }
+    return `Invalid ${BACKEND_MODE_FLAG} value ${JSON.stringify(this.value)}. Expected "managed" or "client-only".`;
+  }
+}
+
+export const isDesktopBackendModeArgumentError = Schema.is(DesktopBackendModeArgumentError);
+
+function parseBackendMode(value: string | undefined): DesktopBackendModeValue {
+  if (value === undefined || value.length === 0) {
+    throw new DesktopBackendModeArgumentError({
+      value: value ?? null,
+      reason: "missing-value",
+    });
+  }
+  if (value === "managed" || value === "client-only") {
+    return value;
+  }
+  throw new DesktopBackendModeArgumentError({
+    value,
+    reason: "invalid-value",
+  });
+}
+
+export function parseDesktopBackendModeOverride(
+  argv: readonly string[],
+): DesktopBackendModeValue | null {
+  let override: DesktopBackendModeValue | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === undefined) continue;
+
+    let value: string | undefined;
+    if (argument === BACKEND_MODE_FLAG) {
+      value = argv[index + 1];
+      index += 1;
+    } else if (argument.startsWith(`${BACKEND_MODE_FLAG}=`)) {
+      value = argument.slice(BACKEND_MODE_FLAG.length + 1);
+    } else {
+      continue;
+    }
+
+    if (override !== null) {
+      throw new DesktopBackendModeArgumentError({
+        value: value ?? null,
+        reason: "repeated",
+      });
+    }
+    override = parseBackendMode(value);
+  }
+
+  return override;
+}
+
+export function resolveDesktopBackendModeState(
+  argv: readonly string[],
+  configuredMode: DesktopBackendModeValue,
+): DesktopBackendModeState {
+  const cliOverride = parseDesktopBackendModeOverride(argv);
+  return {
+    effectiveMode: cliOverride ?? configuredMode,
+    configuredMode,
+    cliOverride,
+  };
+}
+
+export class DesktopBackendMode extends Context.Service<
+  DesktopBackendMode,
+  {
+    readonly latch: (
+      configuredMode: DesktopBackendModeValue,
+    ) => Effect.Effect<DesktopBackendModeState, DesktopBackendModeArgumentError>;
+    readonly get: Effect.Effect<DesktopBackendModeState>;
+  }
+>()("@t3tools/desktop/app/DesktopBackendMode") {}
+
+export const make = Effect.fn("desktop.backendMode.make")(function* (argv: readonly string[]) {
+  const stateRef = yield* Ref.make<DesktopBackendModeState>({
+    effectiveMode: "managed",
+    configuredMode: "managed",
+    cliOverride: null,
+  });
+
+  return DesktopBackendMode.of({
+    latch: (configuredMode) =>
+      Effect.try({
+        try: () => resolveDesktopBackendModeState(argv, configuredMode),
+        catch: (cause) =>
+          isDesktopBackendModeArgumentError(cause)
+            ? cause
+            : new DesktopBackendModeArgumentError({
+                value: null,
+                reason: "invalid-value",
+              }),
+      }).pipe(Effect.tap((state) => Ref.set(stateRef, state))),
+    get: Ref.get(stateRef),
+  });
+});
+
+export const layer = Layer.effect(DesktopBackendMode, make(process.argv));
+
+export const layerTest = (argv: readonly string[] = []) =>
+  Layer.effect(DesktopBackendMode, make(argv));

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -67,6 +67,10 @@ describe("DesktopEnvironment", () => {
       assert.equal(environment.appRoot, "/repo");
       assert.equal(environment.backendEntryPath, "/repo/apps/server/dist/bin.mjs");
       assert.equal(environment.backendCwd, "/repo");
+      assert.deepEqual(environment.packagedClientRootCandidates, [
+        "/Applications/T3 Code.app/Contents/Resources/app.asar/apps/server/dist/client",
+        "/Applications/T3 Code.app/Contents/Resources/app.asar.unpacked/apps/server/dist/client",
+      ]);
       assert.equal(environment.appUserModelId, "com.t3tools.t3code.dev");
       assert.equal(environment.linuxWmClass, "t3code-dev");
       assert.deepEqual(

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -53,6 +53,7 @@ export class DesktopEnvironment extends Context.Service<
     readonly appRoot: string;
     readonly backendEntryPath: string;
     readonly backendCwd: string;
+    readonly packagedClientRootCandidates: readonly string[];
     readonly preloadPath: string;
     readonly appUpdateYmlPath: string;
     readonly devServerUrl: Option.Option<URL>;
@@ -188,6 +189,10 @@ const make = Effect.fn("desktop.environment.make")(function* (
     appRoot,
     backendEntryPath: path.join(appRoot, "apps/server/dist/bin.mjs"),
     backendCwd: input.isPackaged ? homeDirectory : appRoot,
+    packagedClientRootCandidates: [
+      path.join(input.appPath, "apps/server/dist/client"),
+      path.join(resourcesPath, "app.asar.unpacked/apps/server/dist/client"),
+    ],
     preloadPath: path.join(input.dirname, "preload.cjs"),
     appUpdateYmlPath: input.isPackaged
       ? path.join(resourcesPath, "app-update.yml")

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -1,0 +1,98 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+import * as DesktopLifecycle from "./DesktopLifecycle.ts";
+import * as DesktopShutdown from "./DesktopShutdown.ts";
+import * as DesktopState from "./DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronTheme from "../electron/ElectronTheme.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+
+function makeRuntimeLayer(input: {
+  readonly events: string[];
+  readonly shutdownFailure?: Error;
+  readonly exitFailure?: Error;
+}) {
+  return Layer.mergeAll(
+    DesktopState.layer,
+    Layer.succeed(
+      DesktopEnvironment.DesktopEnvironment,
+      DesktopEnvironment.DesktopEnvironment.of({
+        isDevelopment: false,
+      } as unknown as DesktopEnvironment.DesktopEnvironment["Service"]),
+    ),
+    Layer.succeed(
+      DesktopShutdown.DesktopShutdown,
+      DesktopShutdown.DesktopShutdown.of({
+        request: Effect.sync(() => {
+          input.events.push("shutdown-requested");
+        }),
+        awaitComplete: input.shutdownFailure
+          ? Effect.die(input.shutdownFailure)
+          : Effect.sync(() => {
+              input.events.push("shutdown-complete");
+            }),
+      } as unknown as DesktopShutdown.DesktopShutdown["Service"]),
+    ),
+    Layer.succeed(
+      DesktopWindow.DesktopWindow,
+      DesktopWindow.DesktopWindow.of({
+        flushMainWindowBounds: Effect.void,
+      } as unknown as DesktopWindow.DesktopWindow["Service"]),
+    ),
+    Layer.succeed(
+      ElectronApp.ElectronApp,
+      ElectronApp.ElectronApp.of({
+        relaunch: () =>
+          Effect.sync(() => {
+            input.events.push("relaunch-scheduled");
+          }),
+        exit: () =>
+          input.exitFailure
+            ? Effect.die(input.exitFailure)
+            : Effect.sync(() => {
+                input.events.push("exit");
+              }),
+      } as unknown as ElectronApp.ElectronApp["Service"]),
+    ),
+    Layer.succeed(
+      ElectronTheme.ElectronTheme,
+      ElectronTheme.ElectronTheme.of({} as ElectronTheme.ElectronTheme["Service"]),
+    ),
+  );
+}
+
+describe("DesktopLifecycle.relaunch", () => {
+  it.effect("surfaces shutdown failures after scheduling the replacement process", () => {
+    const shutdownFailure = new Error("shutdown failed");
+    const events: string[] = [];
+
+    return Effect.gen(function* () {
+      const error = yield* DesktopLifecycle.make
+        .relaunch("backendMode=client-only")
+        .pipe(Effect.flip);
+
+      assert.instanceOf(error, DesktopLifecycle.DesktopLifecycleRelaunchError);
+      assert.strictEqual(Cause.squash(error.cause as Cause.Cause<unknown>), shutdownFailure);
+      assert.deepEqual(events, ["relaunch-scheduled", "shutdown-requested"]);
+    }).pipe(Effect.provide(makeRuntimeLayer({ events, shutdownFailure })));
+  });
+
+  it.effect("surfaces exit failures instead of completing the relaunch early", () => {
+    const exitFailure = new Error("exit failed");
+    const events: string[] = [];
+
+    return Effect.gen(function* () {
+      const error = yield* DesktopLifecycle.make
+        .relaunch("backendMode=client-only")
+        .pipe(Effect.flip);
+
+      assert.instanceOf(error, DesktopLifecycle.DesktopLifecycleRelaunchError);
+      assert.strictEqual(Cause.squash(error.cause as Cause.Cause<unknown>), exitFailure);
+      assert.deepEqual(events, ["relaunch-scheduled", "shutdown-requested", "shutdown-complete"]);
+    }).pipe(Effect.provide(makeRuntimeLayer({ events, exitFailure })));
+  });
+});

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -170,10 +170,9 @@ export const make = DesktopLifecycle.of({
     }).pipe(
       Effect.catchCause((cause) => {
         const error = new DesktopLifecycleRelaunchError({ reason, cause });
-        return logLifecycleError(error.message, { error });
+        return Effect.fail(error);
       }),
-      Effect.forkDetach,
-      Effect.asVoid,
+      Effect.tapError((error) => logLifecycleError(error.message, { error })),
     );
   }),
   register: Effect.gen(function* () {

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -43,7 +43,7 @@ export class DesktopLifecycle extends Context.Service<
   {
     readonly relaunch: (
       reason: string,
-    ) => Effect.Effect<void, never, DesktopLifecycleRuntimeServices>;
+    ) => Effect.Effect<void, DesktopLifecycleRelaunchError, DesktopLifecycleRuntimeServices>;
     readonly register: Effect.Effect<void, never, Scope.Scope | DesktopLifecycleRuntimeServices>;
   }
 >()("@t3tools/desktop/app/DesktopLifecycle") {}
@@ -146,6 +146,18 @@ export const make = DesktopLifecycle.of({
     const environment = yield* DesktopEnvironment.DesktopEnvironment;
     const state = yield* DesktopState.DesktopState;
     yield* logLifecycleInfo("desktop relaunch requested", { reason });
+    if (!environment.isDevelopment) {
+      yield* electronApp
+        .relaunch({
+          execPath: process.execPath,
+          args: process.argv.slice(1),
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.fail(new DesktopLifecycleRelaunchError({ reason, cause })),
+          ),
+        );
+    }
     yield* Effect.gen(function* () {
       yield* Effect.yieldNow;
       yield* Ref.set(state.quitting, true);
@@ -154,10 +166,6 @@ export const make = DesktopLifecycle.of({
         yield* electronApp.exit(75);
         return;
       }
-      yield* electronApp.relaunch({
-        execPath: process.execPath,
-        args: process.argv.slice(1),
-      });
       yield* electronApp.exit(0);
     }).pipe(
       Effect.catchCause((cause) => {

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -403,6 +403,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
   const state = yield* Ref.make(initialState);
+  const startRequestedRef = yield* Ref.make(false);
   const mutex = yield* Semaphore.make(1);
 
   const { logWarning: logInstanceWarning, logError: logInstanceError } =
@@ -442,6 +443,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
   const start: Effect.Effect<void> = Effect.suspend(() =>
     mutex.withPermits(1)(
       Effect.gen(function* () {
+        yield* Ref.set(startRequestedRef, true);
         const current = yield* Ref.get(state);
         if (Option.isSome(current.active)) {
           return;
@@ -805,7 +807,11 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
       Effect.map(Option.getOrElse(() => false)),
     );
 
-  yield* Effect.addFinalizer(() => stop());
+  yield* Effect.addFinalizer(() =>
+    Ref.get(startRequestedRef).pipe(
+      Effect.flatMap((startRequested) => (startRequested ? stop() : Effect.void)),
+    ),
+  );
 
   return {
     id: spec.id,

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -74,6 +74,7 @@ function makePoolLayer(
           activate: Effect.die("unexpected window activate"),
           createMainIfBackendReady: Effect.die("unexpected window create"),
           showConnectingSplash: Effect.void,
+          handleRendererReady: Effect.void,
           handleBackendReady: () => Effect.void,
           handleBackendNotReady: Effect.void,
           flushMainWindowBounds: Effect.void,

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -251,6 +251,7 @@ describe("DesktopServerExposure", () => {
       get: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
       load: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
       setMainWindowBounds: () => Effect.die("unexpected main window bounds update"),
+      setBackendMode: () => Effect.die("unexpected backend mode update"),
       setServerExposureMode: () => Effect.fail(settingsFailure),
       setTailscaleServe: () => Effect.fail(settingsFailure),
       setUpdateChannel: () => Effect.die("unexpected update channel change"),

--- a/apps/desktop/src/electron/ElectronProtocol.test.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.test.ts
@@ -36,8 +36,8 @@ describe("ElectronProtocol", () => {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
             scheme: "t3code-dev",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
-            backendOrigin: new URL("http://127.0.0.1:3774/"),
             clerkFrontendApiHostname: "clerk.t3.codes",
           });
           assert.isDefined(handler);
@@ -100,8 +100,8 @@ describe("ElectronProtocol", () => {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
             scheme: "t3code",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
-            backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           });
           return yield* Effect.promise(() => handler!(new Request("t3code://other/")));
@@ -128,8 +128,8 @@ describe("ElectronProtocol", () => {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
             scheme: "t3code-dev",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:5733/"),
-            backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           });
           return yield* Effect.promise(() => handler!(new Request("t3code-dev://app/")));
@@ -152,8 +152,8 @@ describe("ElectronProtocol", () => {
       const error = yield* Effect.scoped(
         protocol.registerDesktopProtocol({
           scheme: "t3code-dev",
+          source: "proxy",
           targetOrigin: new URL("http://127.0.0.1:3773/"),
-          backendOrigin: new URL("http://127.0.0.1:3774/"),
           clerkFrontendApiHostname: undefined,
         }),
       ).pipe(Effect.flip);
@@ -177,8 +177,8 @@ describe("ElectronProtocol", () => {
         Effect.scoped(
           protocol.registerDesktopProtocol({
             scheme: "t3code",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
-            backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           }),
         ),
@@ -198,8 +198,8 @@ describe("ElectronProtocol", () => {
   it("keeps executable sources host-restricted while allowing runtime network resources", () => {
     const policy = ElectronProtocol.makeDesktopContentSecurityPolicy({
       scheme: "t3code",
+      source: "proxy",
       targetOrigin: new URL("http://127.0.0.1:3773/"),
-      backendOrigin: new URL("http://127.0.0.1:3773/"),
       clerkFrontendApiHostname: "clerk.t3.codes",
     });
     const directives = Object.fromEntries(
@@ -226,4 +226,117 @@ describe("ElectronProtocol", () => {
     ]);
     assert.deepEqual(directives["font-src"], ["'self'", "t3code:", "data:"]);
   });
+
+  it.effect("serves packaged assets, SPA routes, HEAD requests, and CSP", () =>
+    Effect.gen(function* () {
+      let handler: ((request: Request) => Promise<Response>) | undefined;
+      handleMock.mockImplementation((_scheme, nextHandler) => {
+        handler = nextHandler;
+      });
+      netFetchMock.mockImplementation(async (url: string) => {
+        if (url.endsWith("/index.html")) {
+          return new Response("<main>T3 Code</main>", { status: 200 });
+        }
+        if (url.endsWith("/assets/app-123.js")) {
+          return new Response("export {};", { status: 200 });
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const protocol = yield* ElectronProtocol.ElectronProtocol;
+          yield* protocol.registerDesktopProtocol({
+            scheme: "t3code",
+            source: "static",
+            staticRoot: "/opt/t3/apps/server/dist/client",
+            clerkFrontendApiHostname: undefined,
+          });
+          assert.isDefined(handler);
+
+          const root = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/", {
+                headers: { accept: "text/html" },
+              }),
+            ),
+          );
+          assert.equal(root.status, 200);
+          assert.equal(root.headers.get("content-type"), "text/html; charset=utf-8");
+          assert.include(root.headers.get("content-security-policy") ?? "", "default-src 'self'");
+          assert.equal(yield* Effect.promise(() => root.text()), "<main>T3 Code</main>");
+
+          const asset = yield* Effect.promise(() =>
+            handler!(new Request("t3code://app/assets/app-123.js")),
+          );
+          assert.equal(asset.headers.get("content-type"), "text/javascript; charset=utf-8");
+          assert.equal(yield* Effect.promise(() => asset.text()), "export {};");
+
+          const route = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/settings/connections", {
+                headers: { accept: "text/html" },
+              }),
+            ),
+          );
+          assert.equal(route.status, 200);
+          assert.equal(yield* Effect.promise(() => route.text()), "<main>T3 Code</main>");
+
+          const head = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/assets/app-123.js", {
+                method: "HEAD",
+              }),
+            ),
+          );
+          assert.equal(head.status, 200);
+          assert.equal(yield* Effect.promise(() => head.text()), "");
+        }),
+      );
+    }).pipe(Effect.provide(ElectronProtocol.layer)),
+  );
+
+  it.effect("does not fall back missing assets and rejects unsafe static requests", () =>
+    Effect.gen(function* () {
+      let handler: ((request: Request) => Promise<Response>) | undefined;
+      handleMock.mockImplementation((_scheme, nextHandler) => {
+        handler = nextHandler;
+      });
+      netFetchMock.mockResolvedValue(new Response(null, { status: 404 }));
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const protocol = yield* ElectronProtocol.ElectronProtocol;
+          yield* protocol.registerDesktopProtocol({
+            scheme: "t3code",
+            source: "static",
+            staticRoot: "/opt/t3/apps/server/dist/client",
+            clerkFrontendApiHostname: undefined,
+          });
+          assert.isDefined(handler);
+
+          const missingAsset = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/assets/missing.js", {
+                headers: { accept: "text/html" },
+              }),
+            ),
+          );
+          assert.equal(missingAsset.status, 404);
+          assert.equal(netFetchMock.mock.calls.length, 1);
+
+          const traversal = yield* Effect.promise(() =>
+            handler!(new Request("t3code://app/%2e%2e%2fsecret.txt")),
+          );
+          assert.equal(traversal.status, 403);
+
+          const unsupported = yield* Effect.promise(() =>
+            handler!(new Request("t3code://app/", { method: "POST" })),
+          );
+          assert.equal(unsupported.status, 405);
+          assert.equal(unsupported.headers.get("allow"), "GET, HEAD");
+        }),
+      );
+    }).pipe(Effect.provide(ElectronProtocol.layer)),
+  );
 });

--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -1,3 +1,4 @@
+// @effect-diagnostics nodeBuiltinImport:off - Electron static protocol handlers require synchronous platform path validation.
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -5,6 +6,8 @@ import * as NodeTimersPromises from "node:timers/promises";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
 
 import * as Electron from "electron";
 
@@ -48,12 +51,22 @@ export class ElectronProtocolUnregistrationError extends Schema.TaggedErrorClass
   }
 }
 
-export interface DesktopProtocolRegistrationInput {
+interface DesktopProtocolRegistrationBase {
   readonly scheme: string;
-  readonly targetOrigin: URL;
-  readonly backendOrigin: URL;
   readonly clerkFrontendApiHostname: string | undefined;
 }
+
+export type DesktopProtocolRegistrationInput = DesktopProtocolRegistrationBase &
+  (
+    | {
+        readonly source: "proxy";
+        readonly targetOrigin: URL;
+      }
+    | {
+        readonly source: "static";
+        readonly staticRoot: string;
+      }
+  );
 
 export class ElectronProtocol extends Context.Service<
   ElectronProtocol,
@@ -102,6 +115,143 @@ function withContentSecurityPolicy(response: Response, policy: string): Response
     statusText: response.statusText,
     headers,
   });
+}
+
+const STATIC_CONTENT_TYPES: Readonly<Record<string, string>> = {
+  ".css": "text/css; charset=utf-8",
+  ".gif": "image/gif",
+  ".html": "text/html; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+type StaticPathResolution =
+  | { readonly _tag: "Invalid"; readonly status: 400 | 403 }
+  | { readonly _tag: "Resolved"; readonly path: string; readonly relativePath: string };
+
+export function resolveDesktopStaticPath(
+  staticRoot: string,
+  encodedPathname: string,
+): StaticPathResolution {
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(encodedPathname);
+  } catch {
+    return { _tag: "Invalid", status: 400 };
+  }
+
+  if (
+    decodedPathname.includes("\0") ||
+    decodedPathname.includes("\\") ||
+    /^[a-zA-Z]:/u.test(decodedPathname.replace(/^\/+/u, ""))
+  ) {
+    return { _tag: "Invalid", status: 403 };
+  }
+
+  const segments = decodedPathname.split("/").filter((segment) => segment.length > 0);
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    return { _tag: "Invalid", status: 403 };
+  }
+
+  const relativePath = segments.length === 0 ? "index.html" : segments.join("/");
+  const normalizedRoot = NodePath.resolve(staticRoot);
+  const resolvedPath = NodePath.resolve(normalizedRoot, relativePath);
+  const relativeToRoot = NodePath.relative(normalizedRoot, resolvedPath);
+  if (
+    relativeToRoot === ".." ||
+    relativeToRoot.startsWith(`..${NodePath.sep}`) ||
+    NodePath.isAbsolute(relativeToRoot)
+  ) {
+    return { _tag: "Invalid", status: 403 };
+  }
+
+  return {
+    _tag: "Resolved",
+    path: resolvedPath,
+    relativePath,
+  };
+}
+
+function shouldUseSpaFallback(request: Request, relativePath: string): boolean {
+  if (NodePath.extname(relativePath) !== "") {
+    return false;
+  }
+  const accept = request.headers.get("accept") ?? "";
+  const mode = request.headers.get("sec-fetch-mode") ?? "";
+  return mode === "navigate" || accept.includes("text/html");
+}
+
+async function fetchStaticFile(path: string): Promise<Response> {
+  try {
+    return await Electron.net.fetch(NodeURL.pathToFileURL(path).href, { method: "GET" });
+  } catch {
+    return new Response(null, { status: 404 });
+  }
+}
+
+function withStaticResponseHeaders(response: Response, path: string, headOnly: boolean): Response {
+  const headers = new Headers(response.headers);
+  const contentType = STATIC_CONTENT_TYPES[NodePath.extname(path).toLowerCase()];
+  if (contentType !== undefined) {
+    headers.set("Content-Type", contentType);
+  }
+  return new Response(headOnly ? null : response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export async function serveDesktopStaticRequest(
+  request: Request,
+  staticRoot: string,
+  contentSecurityPolicy: string,
+): Promise<Response> {
+  const requestUrl = new URL(request.url);
+  if (requestUrl.host !== DESKTOP_HOST) {
+    return withContentSecurityPolicy(new Response(null, { status: 404 }), contentSecurityPolicy);
+  }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return withContentSecurityPolicy(
+      new Response(null, {
+        status: 405,
+        headers: { Allow: "GET, HEAD" },
+      }),
+      contentSecurityPolicy,
+    );
+  }
+
+  const resolution = resolveDesktopStaticPath(staticRoot, requestUrl.pathname);
+  if (resolution._tag === "Invalid") {
+    return withContentSecurityPolicy(
+      new Response(null, { status: resolution.status }),
+      contentSecurityPolicy,
+    );
+  }
+
+  let response = await fetchStaticFile(resolution.path);
+  let responsePath = resolution.path;
+  if (response.status === 404 && shouldUseSpaFallback(request, resolution.relativePath)) {
+    // Resolve the shell through the same normalization as asset paths so a
+    // relative or non-normalized staticRoot still falls back correctly.
+    responsePath = NodePath.resolve(staticRoot, "index.html");
+    response = await fetchStaticFile(responsePath);
+  }
+
+  return withContentSecurityPolicy(
+    withStaticResponseHeaders(response, responsePath, request.method === "HEAD"),
+    contentSecurityPolicy,
+  );
 }
 
 async function proxyRequest(
@@ -181,9 +331,12 @@ export const make = Effect.gen(function* () {
       yield* Effect.acquireRelease(
         Effect.try({
           try: () => {
-            Electron.protocol.handle(input.scheme, (request) =>
-              proxyRequest(request, input.targetOrigin, contentSecurityPolicy),
-            );
+            Electron.protocol.handle(input.scheme, (request) => {
+              if (input.source === "static") {
+                return serveDesktopStaticRequest(request, input.staticRoot, contentSecurityPolicy);
+              }
+              return proxyRequest(request, input.targetOrigin, contentSecurityPolicy);
+            });
           },
           catch: (cause) => new ElectronProtocolRegistrationError({ scheme: input.scheme, cause }),
         }).pipe(Effect.andThen(Ref.set(registered, true))),

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 
 import * as DesktopIpc from "./DesktopIpc.ts";
 import { getClientSettings, setClientSettings } from "./methods/clientSettings.ts";
+import { getBackendModeState, setBackendMode } from "./methods/backendMode.ts";
 import {
   clearConnectionCatalog,
   getConnectionCatalog,
@@ -49,9 +50,11 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* PreviewIpc.installPreviewEventForwarding();
 
   yield* ipc.handleSync(getAppBranding);
+  yield* ipc.handleSync(getBackendModeState);
   yield* ipc.handleSync(getWindowFullscreenState);
   yield* ipc.handleSync(getLocalEnvironmentBootstraps);
   yield* ipc.handle(getLocalEnvironmentBearerToken);
+  yield* ipc.handle(setBackendMode);
 
   yield* ipc.handle(getClientSettings);
   yield* ipc.handle(setClientSettings);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -13,6 +13,8 @@ export const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 export const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 export const UPDATE_CHECK_CHANNEL = "desktop:update-check";
 export const GET_APP_BRANDING_CHANNEL = "desktop:get-app-branding";
+export const GET_BACKEND_MODE_STATE_CHANNEL = "desktop:get-backend-mode-state";
+export const SET_BACKEND_MODE_CHANNEL = "desktop:set-backend-mode";
 export const GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL = "desktop:get-local-environment-bootstraps";
 export const GET_LOCAL_ENVIRONMENT_BEARER_TOKEN_CHANNEL =
   "desktop:get-local-environment-bearer-token";

--- a/apps/desktop/src/ipc/methods/backendMode.test.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.test.ts
@@ -1,0 +1,47 @@
+import { DesktopBackendModeStateSchema } from "@t3tools/contracts";
+import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
+import * as DesktopLifecycle from "../../app/DesktopLifecycle.ts";
+import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
+import { setBackendMode } from "./backendMode.ts";
+
+const decodeBackendModeState = Schema.decodeUnknownEffect(DesktopBackendModeStateSchema);
+
+const unusedLifecycleRuntimeLayer =
+  Layer.empty as Layer.Layer<DesktopLifecycle.DesktopLifecycleRuntimeServices>;
+
+describe("backend mode IPC", () => {
+  it.effect("rejects the update when a packaged relaunch cannot be scheduled", () => {
+    const relaunchError = new DesktopLifecycle.DesktopLifecycleRelaunchError({
+      reason: "backendMode=client-only",
+      cause: Cause.die(new Error("relaunch failed")),
+    });
+    const layer = Layer.mergeAll(
+      DesktopBackendMode.layerTest(),
+      DesktopAppSettings.layerTest(),
+      Layer.succeed(
+        DesktopLifecycle.DesktopLifecycle,
+        DesktopLifecycle.DesktopLifecycle.of({
+          relaunch: () => Effect.fail(relaunchError),
+          register: Effect.void,
+        }),
+      ),
+      unusedLifecycleRuntimeLayer,
+    );
+
+    return Effect.gen(function* () {
+      const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+      yield* launchMode.latch("managed");
+      const error = yield* setBackendMode
+        .handler("client-only")
+        .pipe(Effect.flatMap(decodeBackendModeState), Effect.flip);
+
+      assert.strictEqual(error, relaunchError);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/desktop/src/ipc/methods/backendMode.test.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.test.ts
@@ -16,7 +16,7 @@ const unusedLifecycleRuntimeLayer =
   Layer.empty as Layer.Layer<DesktopLifecycle.DesktopLifecycleRuntimeServices>;
 
 describe("backend mode IPC", () => {
-  it.effect("rejects the update when a packaged relaunch cannot be scheduled", () => {
+  it.effect("restores the configured mode when a packaged relaunch cannot be scheduled", () => {
     const relaunchError = new DesktopLifecycle.DesktopLifecycleRelaunchError({
       reason: "backendMode=client-only",
       cause: Cause.die(new Error("relaunch failed")),
@@ -36,12 +36,14 @@ describe("backend mode IPC", () => {
 
     return Effect.gen(function* () {
       const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+      const settings = yield* DesktopAppSettings.DesktopAppSettings;
       yield* launchMode.latch("managed");
       const error = yield* setBackendMode
         .handler("client-only")
         .pipe(Effect.flatMap(decodeBackendModeState), Effect.flip);
 
       assert.strictEqual(error, relaunchError);
+      assert.equal((yield* settings.get).backendMode, "managed");
     }).pipe(Effect.provide(layer));
   });
 });

--- a/apps/desktop/src/ipc/methods/backendMode.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.ts
@@ -1,0 +1,60 @@
+import {
+  DesktopBackendModeSchema,
+  DesktopBackendModeStateSchema,
+  type DesktopBackendModeState,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
+import * as DesktopLifecycle from "../../app/DesktopLifecycle.ts";
+import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
+import * as IpcChannels from "../channels.ts";
+
+const readBackendModeState: Effect.Effect<
+  DesktopBackendModeState,
+  never,
+  DesktopBackendMode.DesktopBackendMode | DesktopAppSettings.DesktopAppSettings
+> = Effect.gen(function* () {
+  const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+  const settings = yield* DesktopAppSettings.DesktopAppSettings;
+  const launchState = yield* launchMode.get;
+  const configuredMode = (yield* settings.get).backendMode;
+  return {
+    ...launchState,
+    configuredMode,
+  };
+});
+
+export const getBackendModeState = DesktopIpc.makeSyncIpcMethod({
+  channel: IpcChannels.GET_BACKEND_MODE_STATE_CHANNEL,
+  result: DesktopBackendModeStateSchema,
+  handler: Effect.fn("desktop.ipc.backendMode.get")(function* () {
+    return yield* readBackendModeState;
+  }),
+});
+
+export const setBackendMode = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.SET_BACKEND_MODE_CHANNEL,
+  payload: DesktopBackendModeSchema,
+  result: DesktopBackendModeStateSchema,
+  handler: Effect.fn("desktop.ipc.backendMode.set")(function* (mode) {
+    const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+    const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
+    const settings = yield* DesktopAppSettings.DesktopAppSettings;
+    const change = yield* settings.setBackendMode(mode);
+    const launchState = yield* launchMode.get;
+    const state = {
+      ...launchState,
+      configuredMode: change.settings.backendMode,
+    };
+    if (
+      change.changed &&
+      launchState.cliOverride === null &&
+      launchState.effectiveMode !== change.settings.backendMode
+    ) {
+      yield* lifecycle.relaunch(`backendMode=${mode}`);
+    }
+    return state;
+  }),
+});

--- a/apps/desktop/src/ipc/methods/backendMode.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.ts
@@ -56,7 +56,17 @@ export const setBackendMode = DesktopIpc.makeIpcMethod({
     ) {
       yield* lifecycle
         .relaunch(`backendMode=${mode}`)
-        .pipe(Effect.tapError(() => settings.setBackendMode(previousMode)));
+        .pipe(
+          Effect.tapError(() =>
+            settings.get.pipe(
+              Effect.flatMap((currentSettings) =>
+                currentSettings.backendMode === mode
+                  ? settings.setBackendMode(previousMode)
+                  : Effect.void,
+              ),
+            ),
+          ),
+        );
     }
     return state;
   }),

--- a/apps/desktop/src/ipc/methods/backendMode.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.ts
@@ -42,6 +42,7 @@ export const setBackendMode = DesktopIpc.makeIpcMethod({
     const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
     const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
     const settings = yield* DesktopAppSettings.DesktopAppSettings;
+    const previousMode = (yield* settings.get).backendMode;
     const change = yield* settings.setBackendMode(mode);
     const launchState = yield* launchMode.get;
     const state = {
@@ -53,7 +54,9 @@ export const setBackendMode = DesktopIpc.makeIpcMethod({
       launchState.cliOverride === null &&
       launchState.effectiveMode !== change.settings.backendMode
     ) {
-      yield* lifecycle.relaunch(`backendMode=${mode}`);
+      yield* lifecycle
+        .relaunch(`backendMode=${mode}`)
+        .pipe(Effect.tapError(() => settings.setBackendMode(previousMode)));
     }
     return state;
   }),

--- a/apps/desktop/src/ipc/methods/window.test.ts
+++ b/apps/desktop/src/ipc/methods/window.test.ts
@@ -7,6 +7,7 @@ import type * as Electron from "electron";
 
 import * as DesktopBackendManager from "../../backend/DesktopBackendManager.ts";
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
 import { getLocalEnvironmentBootstraps, getWindowFullscreenState } from "./window.ts";
 
@@ -64,7 +65,14 @@ describe("getLocalEnvironmentBootstraps", () => {
           bootstrapToken: "bootstrap-token",
         },
       ]);
-    }).pipe(Effect.provide(DesktopBackendPool.layerTest([defaultWslInstance]))),
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([defaultWslInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    ),
   );
 
   it.effect("publishes a pending bootstrap only while a transient retry is scheduled", () => {
@@ -99,7 +107,14 @@ describe("getLocalEnvironmentBootstraps", () => {
           wsBaseUrl: null,
         },
       ]);
-    }).pipe(Effect.provide(DesktopBackendPool.layerTest([retryingInstance])));
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([retryingInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    );
   });
 
   it.effect("omits a bounded transient bootstrap after retries stop", () => {
@@ -127,8 +142,30 @@ describe("getLocalEnvironmentBootstraps", () => {
     return Effect.gen(function* () {
       const result = yield* getLocalEnvironmentBootstraps.handler();
       assert.deepEqual(result, []);
-    }).pipe(Effect.provide(DesktopBackendPool.layerTest([stoppedInstance])));
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([stoppedInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    );
   });
+
+  it.effect("returns no local bootstraps in client-only mode", () =>
+    Effect.gen(function* () {
+      const mode = yield* DesktopBackendMode.DesktopBackendMode;
+      yield* mode.latch("client-only");
+      assert.deepEqual(yield* getLocalEnvironmentBootstraps.handler(), []);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([defaultWslInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    ),
+  );
 });
 
 describe("getWindowFullscreenState", () => {

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -12,6 +12,7 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
 import * as DesktopLocalEnvironmentAuth from "../../backend/DesktopLocalEnvironmentAuth.ts";
 import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
@@ -69,6 +70,10 @@ export const getLocalEnvironmentBootstraps = DesktopIpc.makeSyncIpcMethod({
   channel: IpcChannels.GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL,
   result: Schema.Array(DesktopEnvironmentBootstrapSchema),
   handler: Effect.fn("desktop.ipc.window.getLocalEnvironmentBootstraps")(function* () {
+    const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+    if ((yield* launchMode.get).effectiveMode === "client-only") {
+      return [];
+    }
     const pool = yield* DesktopBackendPool.DesktopBackendPool;
     const instances = yield* pool.list;
     const bootstraps: DesktopEnvironmentBootstrap[] = [];

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -31,6 +31,7 @@ import * as ElectronTheme from "./electron/ElectronTheme.ts";
 import * as ElectronUpdater from "./electron/ElectronUpdater.ts";
 import * as ElectronWindow from "./electron/ElectronWindow.ts";
 import * as DesktopApp from "./app/DesktopApp.ts";
+import * as DesktopBackendMode from "./app/DesktopBackendMode.ts";
 import * as DesktopAppIdentity from "./app/DesktopAppIdentity.ts";
 import * as DesktopConnectionCatalogStore from "./app/DesktopConnectionCatalogStore.ts";
 import * as DesktopClerk from "./app/DesktopClerk.ts";
@@ -125,6 +126,7 @@ const electronLayer = Layer.mergeAll(
 const desktopFoundationLayer = Layer.mergeAll(
   DesktopState.layer,
   DesktopShutdown.layer,
+  DesktopBackendMode.layer,
   DesktopAppSettings.layer,
   DesktopClientSettings.layer,
   DesktopConnectionCatalogStore.layer.pipe(Layer.provideMerge(DesktopSavedEnvironments.layer)),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -38,9 +38,12 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   getBackendModeState: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_BACKEND_MODE_STATE_CHANNEL);
     if (typeof result !== "object" || result === null) {
+      // An unavailable mode handler means the renderer cannot safely assume
+      // that this process owns a backend. Fail closed into the connection-only
+      // routing path instead of trying to resolve t3code:// as an HTTP backend.
       return {
-        effectiveMode: "managed",
-        configuredMode: "managed",
+        effectiveMode: "client-only",
+        configuredMode: "client-only",
         cliOverride: null,
       };
     }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -35,6 +35,18 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     }
     return result as ReturnType<DesktopBridge["getAppBranding"]>;
   },
+  getBackendModeState: () => {
+    const result = ipcRenderer.sendSync(IpcChannels.GET_BACKEND_MODE_STATE_CHANNEL);
+    if (typeof result !== "object" || result === null) {
+      return {
+        effectiveMode: "managed",
+        configuredMode: "managed",
+        cliOverride: null,
+      };
+    }
+    return result as ReturnType<DesktopBridge["getBackendModeState"]>;
+  },
+  setBackendMode: (mode) => ipcRenderer.invoke(IpcChannels.SET_BACKEND_MODE_CHANNEL, mode),
   getLocalEnvironmentBootstraps: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL);
     if (!Array.isArray(result)) {

--- a/apps/desktop/src/settings/DesktopAppSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.test.ts
@@ -11,6 +11,7 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "./DesktopAppSettings.ts";
 
 const DesktopSettingsPatch = Schema.Struct({
+  backendMode: Schema.optionalKey(Schema.Literals(["managed", "client-only"])),
   mainWindowBounds: Schema.optionalKey(
     Schema.NullOr(
       Schema.Struct({
@@ -102,6 +103,7 @@ describe("DesktopSettings", () => {
     assert.deepEqual(
       DesktopAppSettings.resolveDefaultDesktopSettings("0.0.17-nightly.20260415.1"),
       {
+        backendMode: "managed",
         mainWindowBounds: null,
         mainWindowMaximized: false,
         serverExposureMode: "local-only",
@@ -121,6 +123,7 @@ describe("DesktopSettings", () => {
       Effect.gen(function* () {
         const settings = yield* DesktopAppSettings.DesktopAppSettings;
         yield* writeSettingsPatch({
+          backendMode: "client-only",
           serverExposureMode: "network-accessible",
           tailscaleServeEnabled: true,
           tailscaleServePort: 8443,
@@ -129,6 +132,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "client-only",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "network-accessible",
@@ -156,6 +160,10 @@ describe("DesktopSettings", () => {
         assert.isTrue(updateChannel.changed);
         assert.equal(updateChannel.settings.updateChannel, "nightly");
         assert.equal(updateChannel.settings.updateChannelConfiguredByUser, true);
+
+        const backendMode = yield* settings.setBackendMode("managed");
+        assert.isTrue(backendMode.changed);
+        assert.equal(backendMode.settings.backendMode, "managed");
       }),
     ),
   );
@@ -235,6 +243,7 @@ describe("DesktopSettings", () => {
         );
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           mainWindowBounds: { x: 120, y: 80, width: 1280, height: 900 },
           mainWindowMaximized: false,
           serverExposureMode: "network-accessible",
@@ -277,11 +286,13 @@ describe("DesktopSettings", () => {
 
         yield* settings.setMainWindowBounds({ x: -1200, y: 40, width: 1440, height: 960 }, true);
         yield* settings.setServerExposureMode("network-accessible");
+        yield* settings.setBackendMode("client-only");
 
         const persisted = yield* decodeDesktopSettingsPatch(
           yield* fileSystem.readFileString(environment.desktopSettingsPath),
         );
         assert.deepEqual(persisted, {
+          backendMode: "client-only",
           mainWindowBounds: { x: -1200, y: 40, width: 1440, height: 960 },
           mainWindowMaximized: true,
           serverExposureMode: "network-accessible",
@@ -300,6 +311,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",
@@ -327,6 +339,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",
@@ -353,6 +366,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",

--- a/apps/desktop/src/settings/DesktopAppSettings.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.ts
@@ -1,6 +1,8 @@
 import {
   DesktopServerExposureModeSchema,
+  DesktopBackendModeSchema,
   DesktopUpdateChannelSchema,
+  type DesktopBackendMode,
   type DesktopServerExposureMode,
   type DesktopUpdateChannel,
 } from "@t3tools/contracts";
@@ -20,6 +22,7 @@ import { resolveDefaultDesktopUpdateChannel } from "../updates/updateChannels.ts
 import { isValidDistroName } from "../wsl/wslPathParsing.ts";
 
 export interface DesktopSettings {
+  readonly backendMode: DesktopBackendMode;
   readonly mainWindowBounds: DesktopWindowBounds | null;
   readonly mainWindowMaximized: boolean;
   readonly serverExposureMode: DesktopServerExposureMode;
@@ -67,6 +70,7 @@ export const DEFAULT_MAIN_WINDOW_SIZE = {
 } as const;
 
 export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
+  backendMode: "managed",
   mainWindowBounds: null,
   mainWindowMaximized: false,
   serverExposureMode: "local-only",
@@ -87,6 +91,7 @@ const DesktopWindowBoundsDocument = Schema.Struct({
 });
 
 const DesktopSettingsDocument = Schema.Struct({
+  backendMode: Schema.optionalKey(DesktopBackendModeSchema),
   mainWindowBounds: Schema.optionalKey(Schema.NullOr(DesktopWindowBoundsDocument)),
   mainWindowMaximized: Schema.optionalKey(Schema.Boolean),
   serverExposureMode: Schema.optionalKey(DesktopServerExposureModeSchema),
@@ -147,6 +152,9 @@ export class DesktopAppSettings extends Context.Service<
     readonly setMainWindowBounds: (
       bounds: DesktopWindowBounds,
       isMaximized: boolean,
+    ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
+    readonly setBackendMode: (
+      mode: DesktopBackendMode,
     ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
     readonly setServerExposureMode: (
       mode: DesktopServerExposureMode,
@@ -216,6 +224,7 @@ function normalizeDesktopSettingsDocument(
     (parsed.wslBackendEnabled === undefined && parsed.wslMode === "wsl");
 
   return {
+    backendMode: parsed.backendMode === "client-only" ? "client-only" : "managed",
     mainWindowBounds,
     mainWindowMaximized: mainWindowBounds !== null && parsed.mainWindowMaximized === true,
     serverExposureMode:
@@ -238,6 +247,9 @@ function toDesktopSettingsDocument(
 ): DesktopSettingsDocument {
   const document: Mutable<DesktopSettingsDocument> = {};
 
+  if (settings.backendMode !== defaults.backendMode) {
+    document.backendMode = settings.backendMode;
+  }
   if (settings.mainWindowBounds !== null) {
     document.mainWindowBounds = settings.mainWindowBounds;
   }
@@ -281,6 +293,18 @@ function setServerExposureMode(
     : {
         ...settings,
         serverExposureMode: requestedMode,
+      };
+}
+
+function setBackendMode(
+  settings: DesktopSettings,
+  requestedMode: DesktopBackendMode,
+): DesktopSettings {
+  return settings.backendMode === requestedMode
+    ? settings
+    : {
+        ...settings,
+        backendMode: requestedMode,
       };
 }
 
@@ -506,6 +530,10 @@ export const make = Effect.gen(function* () {
           },
         }),
       ),
+    setBackendMode: (mode) =>
+      persist((settings) => setBackendMode(settings, mode)).pipe(
+        Effect.withSpan("desktop.settings.setBackendMode", { attributes: { mode } }),
+      ),
     setServerExposureMode: (mode) =>
       persist((settings) => setServerExposureMode(settings, mode)).pipe(
         Effect.withSpan("desktop.settings.setServerExposureMode", { attributes: { mode } }),
@@ -565,6 +593,7 @@ export const layerTest = (initialSettings: DesktopSettings = DEFAULT_DESKTOP_SET
         load: SynchronizedRef.get(settingsRef),
         setMainWindowBounds: (bounds, isMaximized) =>
           update((settings) => setMainWindowBounds(settings, bounds, isMaximized)),
+        setBackendMode: (mode) => update((settings) => setBackendMode(settings, mode)),
         setServerExposureMode: (mode) =>
           update((settings) => setServerExposureMode(settings, mode)),
         setTailscaleServe: (input) => update((settings) => setTailscaleServe(settings, input)),

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -159,6 +159,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
         get: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
         load: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
         setMainWindowBounds: () => Effect.die("unexpected main window bounds update"),
+        setBackendMode: () => Effect.die("unexpected backend mode update"),
         setServerExposureMode: () => Effect.die("unexpected server exposure update"),
         setTailscaleServe: () => Effect.die("unexpected Tailscale Serve update"),
         setUpdateChannel: () => Effect.fail(setUpdateChannelError),

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -74,6 +74,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     activate: Effect.void,
     createMainIfBackendReady: Effect.void,
     showConnectingSplash: Effect.void,
+    handleRendererReady: Effect.void,
     handleBackendReady: () => Effect.void,
     handleBackendNotReady: Effect.void,
     flushMainWindowBounds: Effect.void,

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -211,6 +211,7 @@ function makeTestLayer(input: {
         }
         return { settings: desktopSettings, changed };
       }),
+    setBackendMode: () => Effect.die("unexpected backend mode update"),
     setServerExposureMode: () => Effect.die("unexpected server exposure update"),
     setTailscaleServe: () => Effect.die("unexpected Tailscale Serve update"),
     setUpdateChannel: () => Effect.die("unexpected update channel change"),
@@ -434,6 +435,26 @@ describe("DesktopWindow", () => {
         assert.deepEqual(fakeWindow.setAutoHideCursor.mock.calls, [[false]]);
         assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["t3code-dev://app/"]);
         assert.equal(fakeWindow.openDevTools.mock.calls.length, 1);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("opens once the renderer is ready without a backend callback", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleRendererReady;
+        assert.equal(yield* Ref.get(createCount), 1);
+        assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["t3code-dev://app/"]);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -66,6 +66,9 @@ export class DesktopWindow extends Context.Service<
     // mode), before the WSL backend that serves the renderer is ready. It is
     // dismissed automatically once the real main window reveals.
     readonly showConnectingSplash: Effect.Effect<void>;
+    // Marks the packaged/Vite renderer as loadable independently of whether
+    // this desktop process owns a backend.
+    readonly handleRendererReady: Effect.Effect<void, DesktopWindowError>;
     // Marks the primary backend as ready so `createMainIfBackendReady` and the
     // macOS "activate without windows" path may open the real main window. The
     // renderer now always loads the local client URL (getDesktopUrl) and connects
@@ -728,6 +731,11 @@ export const make = Effect.gen(function* () {
     Effect.withSpan("desktop.window.showConnectingSplash"),
   );
 
+  const handleRendererReady = Ref.set(backendReadyRef, true).pipe(
+    Effect.andThen(createMainIfBackendReady),
+    Effect.withSpan("desktop.window.handleRendererReady"),
+  );
+
   return DesktopWindow.of({
     createMain,
     ensureMain,
@@ -755,10 +763,10 @@ export const make = Effect.gen(function* () {
     }).pipe(Effect.withSpan("desktop.window.activate")),
     createMainIfBackendReady,
     showConnectingSplash,
+    handleRendererReady,
     handleBackendReady: Effect.fn("desktop.window.handleBackendReady")(function* (httpBaseUrl) {
-      yield* Ref.set(backendReadyRef, true);
       yield* logWindowInfo("backend ready", { source: "http", url: httpBaseUrl.href });
-      yield* createMainIfBackendReady;
+      yield* handleRendererReady;
     }),
     handleBackendNotReady: Ref.set(backendReadyRef, false).pipe(
       Effect.withSpan("desktop.window.handleBackendNotReady"),

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,4 +1,3 @@
-import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
   useEffect,
@@ -13,7 +12,8 @@ import { isElectron } from "../env";
 import { getLocalStorageItem } from "../hooks/useLocalStorage";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { cn, isMacPlatform } from "../lib/utils";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import { useClientSettings } from "../hooks/useSettings";
 import ThreadSidebar from "./Sidebar";
 import ThreadSidebarV2 from "./SidebarV2";
@@ -59,7 +59,7 @@ function readInitialThreadSidebarWidth(): number {
 }
 
 function SidebarControl() {
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const keybindings = useDefaultServerConfig()?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const { toggleSidebar } = useSidebar();
   const isSidebarVisible = useSidebarVisibility();
   const stageBackdropVariant = useSidebarStageBackdropVariant();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -42,7 +42,6 @@ import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/proje
 import { truncate } from "@t3tools/shared/String";
 import { nextTerminalId, resolveTerminalSessionLabel } from "@t3tools/shared/terminalLabels";
 import { Debouncer } from "@tanstack/react-pacer";
-import { useAtomValue } from "@effect/atom-react";
 import {
   lazy,
   memo,
@@ -201,12 +200,8 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
-import {
-  primaryServerAvailableEditorsAtom,
-  primaryServerKeybindingsAtom,
-  primaryServerSettingsAtom,
-  serverEnvironment,
-} from "../state/server";
+import { serverEnvironment } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
@@ -1194,10 +1189,6 @@ function ChatViewContent(props: ChatViewProps) {
     (store) => store.threadLastVisitedAtById[routeThreadKey],
   );
   const settings = useEnvironmentSettings(environmentId);
-  // New-thread defaults live in the primary environment's settings.json (the
-  // settings UI never writes to remote environments), so read them from the
-  // primary server rather than the thread's environment.
-  const primaryServerSettings = useAtomValue(primaryServerSettingsAtom);
   const setStickyComposerModelSelection = useComposerDraftStore(
     (store) => store.setStickyModelSelection,
   );
@@ -1836,11 +1827,9 @@ function ChatViewContent(props: ChatViewProps) {
     selectedProvider: selectedProviderByThreadId,
     threadProvider,
   });
-  // Once a thread selects an environment, never substitute the primary
-  // environment's config while the selected environment is still loading.
-  const serverConfig = activeThread
-    ? (activeEnvironment?.serverConfig ?? null)
-    : (primaryEnvironment?.serverConfig ?? null);
+  // Once a thread or draft selects an environment, never substitute another
+  // environment's config while the selected one is still loading.
+  const serverConfig = environmentById.get(environmentId)?.serverConfig ?? null;
   const versionMismatch = resolveServerConfigVersionMismatch(serverConfig);
   const versionMismatchDismissKey =
     versionMismatch && activeThread
@@ -2362,8 +2351,8 @@ function ChatViewContent(props: ChatViewProps) {
           input: { cwd: gitStatusCwd },
         }),
   );
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
+  const keybindings = serverConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
+  const availableEditors = serverConfig?.availableEditors ?? [];
   // Prefer an instance-id match so a custom Codex instance (e.g.
   // `codex_personal`) surfaces its own status/message in the banner rather
   // than the default Codex's. Falls back to first-match-by-kind when no
@@ -3848,7 +3837,7 @@ function ChatViewContent(props: ChatViewProps) {
     ? (draftThread?.startFromOrigin ?? false)
     : canOverrideServerThreadEnvMode
       ? (pendingServerThreadStartFromOriginByThreadId[activeThread?.id ?? ""] ??
-        primaryServerSettings.newWorktreesStartFromOrigin)
+        settings.newWorktreesStartFromOrigin)
       : false;
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
@@ -5472,7 +5461,7 @@ function ChatViewContent(props: ChatViewProps) {
           envMode: mode,
           startFromOrigin: resolveNewDraftStartFromOrigin({
             envMode: mode,
-            newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+            newWorktreesStartFromOrigin: settings.newWorktreesStartFromOrigin,
           }),
           ...(mode === "worktree" && draftThread?.worktreePath ? { worktreePath: null } : {}),
         });
@@ -5484,7 +5473,7 @@ function ChatViewContent(props: ChatViewProps) {
       composerDraftTarget,
       draftThread?.worktreePath,
       isLocalDraftThread,
-      primaryServerSettings.newWorktreesStartFromOrigin,
+      settings.newWorktreesStartFromOrigin,
       setPendingServerThreadEnvMode,
       scheduleComposerFocus,
       setDraftThreadContext,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -42,7 +42,6 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
-import { useAtomValue } from "@effect/atom-react";
 
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
@@ -113,7 +112,8 @@ import { CommandPaletteResults } from "./CommandPaletteResults";
 import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "./Icons";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
-import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import { resolveDefaultProviderModelSelection } from "../providerInstances";
 import { resolveShortcutCommand, threadJumpIndexFromCommand } from "../keybindings";
 import {
@@ -390,7 +390,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
   const openAddProject = useCallback(() => dispatch({ _tag: "OpenAddProject" }), []);
   const openNewThreadIn = useCallback(() => dispatch({ _tag: "OpenNewThreadIn" }), []);
   const clearOpenIntent = useCallback(() => dispatch({ _tag: "ClearOpenIntent" }), []);
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const keybindings = useDefaultServerConfig()?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const composerHandleRef = useRef<ChatComposerHandle | null>(null);
   const routeTarget = useParams({
     strict: false,
@@ -502,8 +502,9 @@ function OpenCommandPaletteDialog(props: {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const providers = useAtomValue(primaryServerProvidersAtom);
+  const defaultServerConfig = useDefaultServerConfig();
+  const keybindings = defaultServerConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
+  const providers = defaultServerConfig?.providers ?? [];
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
   const currentView = viewStack.at(-1) ?? null;
   const [browseGeneration, setBrowseGeneration] = useState(0);

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -56,7 +56,11 @@ import { useEnvironmentQuery } from "../state/query";
 import { sourceControlEnvironment } from "../state/sourceControl";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
-import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import {
+  useAppOwnsLocalEnvironment,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
@@ -492,6 +496,7 @@ function OpenCommandPaletteDialog(props: {
   const { environments } = useEnvironments();
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
   const projects = useProjects();
@@ -540,12 +545,14 @@ function OpenCommandPaletteDialog(props: {
         projects: clientSettings.sidebarProjectSortOrder === "manual" ? orderedProjects : projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
+        ownsLocalEnvironment,
         resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
       }),
     [
       clientSettings.sidebarProjectSortOrder,
       environmentLabelById,
       orderedProjects,
+      ownsLocalEnvironment,
       primaryEnvironmentId,
       projectGroupingSettings,
       projects,

--- a/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
+++ b/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
@@ -1,11 +1,14 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useAtomValue } from "@effect/atom-react";
 import { DownloadIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { type ProviderDriverKind, type ProviderInstanceId } from "@t3tools/contracts";
+import {
+  type ProviderDriverKind,
+  type ProviderInstanceId,
+  type ServerProvider,
+} from "@t3tools/contracts";
 
-import { primaryServerProvidersAtom, serverEnvironment } from "../state/server";
-import { usePrimaryEnvironment } from "../state/environments";
+import { serverEnvironment } from "../state/server";
+import { useDefaultEnvironmentId, useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import { useDismissedProviderUpdateNotificationKeys } from "../providerUpdateDismissal";
 import { PROVIDER_ICON_BY_PROVIDER } from "./chat/providerIconUtils";
 import {
@@ -24,6 +27,7 @@ import { stackedThreadToast, toastManager } from "./ui/toast";
 import { useAtomCommand } from "../state/use-atom-command";
 
 const seenProviderUpdateNotificationKeys = new Set<string>();
+const EMPTY_SERVER_PROVIDERS: ReadonlyArray<ServerProvider> = [];
 type ProviderUpdateToastId = ReturnType<typeof toastManager.add>;
 
 type ActiveProviderUpdateToast =
@@ -112,8 +116,8 @@ function isTerminalProviderUpdateToastView(view: ProviderUpdateToastView) {
  */
 export function ProviderUpdatePrimaryNotification() {
   const navigate = useNavigate();
-  const providers = useAtomValue(primaryServerProvidersAtom);
-  const primaryEnvironment = usePrimaryEnvironment();
+  const defaultEnvironmentId = useDefaultEnvironmentId();
+  const providers = useDefaultServerConfig()?.providers ?? EMPTY_SERVER_PROVIDERS;
   const updateProvider = useAtomCommand(serverEnvironment.updateProvider, {
     reportFailure: false,
   });
@@ -212,7 +216,7 @@ export function ProviderUpdatePrimaryNotification() {
     };
 
     const runUpdates = () => {
-      if (updateStarted || oneClickProviders.length === 0 || !primaryEnvironment) {
+      if (updateStarted || oneClickProviders.length === 0 || defaultEnvironmentId === null) {
         return;
       }
       updateStarted = true;
@@ -238,7 +242,7 @@ export function ProviderUpdatePrimaryNotification() {
         for (const provider of oneClickProviders) {
           results.push(
             await updateProvider({
-              environmentId: primaryEnvironment.environmentId,
+              environmentId: defaultEnvironmentId,
               input: {
                 provider: provider.driver,
                 instanceId: provider.instanceId,
@@ -327,7 +331,7 @@ export function ProviderUpdatePrimaryNotification() {
     notificationKey,
     oneClickProviders,
     openProviderSettings,
-    primaryEnvironment,
+    defaultEnvironmentId,
     updateProviders,
   ]);
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -22,7 +22,6 @@ import {
   ThreadWorktreeIndicator,
 } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
-import { useAtomValue } from "@effect/atom-react";
 import { autoAnimate } from "@formkit/auto-animate";
 import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -198,7 +197,8 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import {
   derivePhysicalProjectKey,
   deriveProjectGroupingOverrideKey,
@@ -3024,7 +3024,7 @@ export default function Sidebar() {
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
       : false,
   );
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const keybindings = useDefaultServerConfig()?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const openAddProjectCommandPalette = useCallback(
     () => openCommandPalette({ open: "add-project" }),
     [],

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -71,6 +71,7 @@ import {
   type SidebarThreadSortOrder,
 } from "@t3tools/contracts/settings";
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
+import { isRemoteEnvironmentId } from "../environmentPresence";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
@@ -114,7 +115,13 @@ import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import { threadEnvironment, useEnvironmentThread } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
-import { useEnvironment, useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import {
+  useAppOwnsLocalEnvironment,
+  useEnvironment,
+  useEnvironmentPresenceScope,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "../state/environments";
 import {
   buildThreadRouteParams,
   resolveActiveThreadRouteRef,
@@ -382,9 +389,8 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     reportFailure: false,
   });
   const environment = useEnvironment(thread.environmentId);
-  const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const isRemoteThread =
-    primaryEnvironmentId !== null && thread.environmentId !== primaryEnvironmentId;
+  const presenceScope = useEnvironmentPresenceScope();
+  const isRemoteThread = isRemoteEnvironmentId(thread.environmentId, presenceScope);
   const remoteEnvLabel = environment?.label ?? null;
   // A desktop-local secondary backend (e.g. the WSL backend) shows up as a
   // bearer environment whose connection id is prefixed "local:". It runs on the
@@ -3037,6 +3043,7 @@ export default function Sidebar() {
   const shortcutModifiers = useShortcutModifierState();
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const environmentLabelById = useMemo(
     () =>
       new Map(
@@ -3091,6 +3098,7 @@ export default function Sidebar() {
       projects: orderedProjects,
       settings: projectGroupingSettings,
       primaryEnvironmentId,
+      ownsLocalEnvironment,
       resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
       isDesktopLocalEnvironment: (environmentId) => desktopLocalEnvironmentIds.has(environmentId),
     });
@@ -3098,6 +3106,7 @@ export default function Sidebar() {
     environmentLabelById,
     desktopLocalEnvironmentIds,
     orderedProjects,
+    ownsLocalEnvironment,
     projectGroupingSettings,
     primaryEnvironmentId,
   ]);

--- a/apps/web/src/components/SidebarStageBackdrop.tsx
+++ b/apps/web/src/components/SidebarStageBackdrop.tsx
@@ -1,9 +1,8 @@
-import { useAtomValue } from "@effect/atom-react";
 import { useId } from "react";
 
 import { APP_STAGE_LABEL } from "../branding";
 import { resolveServerBackedAppStageLabel } from "../branding.logic";
-import { primaryServerConfigAtom } from "../state/server";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 
 export type SidebarStageBackdropVariant = "nightly" | "dev";
 
@@ -21,8 +20,7 @@ export function resolveSidebarStageBackdropVariant(
 }
 
 export function useSidebarStageBackdropVariant(): SidebarStageBackdropVariant | null {
-  const primaryServerVersion =
-    useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
+  const primaryServerVersion = useDefaultServerConfig()?.environment.serverVersion ?? null;
 
   return resolveSidebarStageBackdropVariant(
     resolveServerBackedAppStageLabel({

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -88,7 +88,8 @@ import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
-import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import { useEnvironmentPresenceScope, useEnvironments } from "../state/environments";
+import { isRemoteEnvironmentId, type EnvironmentPresenceScope } from "../environmentPresence";
 import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
@@ -371,7 +372,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   wokeAt: string | null;
   isActive: boolean;
   jumpLabel: string | null;
-  currentEnvironmentId: string | null;
+  presenceScope: EnvironmentPresenceScope;
   environmentLabel: string | null;
   projectCwd: string | null;
   projectTitle: string | null;
@@ -523,8 +524,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     ? getTriggerDisplayModelLabel(selectedModel)
     : thread.modelSelection.model;
 
-  const isRemote =
-    props.currentEnvironmentId !== null && thread.environmentId !== props.currentEnvironmentId;
+  const isRemote = isRemoteEnvironmentId(thread.environmentId, props.presenceScope);
 
   const detailsTooltip = (
     <SidebarV2ThreadTooltip
@@ -1046,7 +1046,8 @@ export default function SidebarV2() {
     [],
   );
   const { environments } = useEnvironments();
-  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const presenceScope = useEnvironmentPresenceScope();
+  const { ownsLocalEnvironment, primaryEnvironmentId } = presenceScope;
   const clearSelection = useThreadSelectionStore((s) => s.clearSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
   const toggleThreadSelection = useThreadSelectionStore((s) => s.toggleThread);
@@ -1098,11 +1099,13 @@ export default function SidebarV2() {
         projects: sidebarProjectSortOrder === "manual" ? orderedProjects : projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
+        ownsLocalEnvironment,
         resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
       }),
     [
       environmentLabelById,
       orderedProjects,
+      ownsLocalEnvironment,
       primaryEnvironmentId,
       projectGroupingSettings,
       projects,
@@ -2427,7 +2430,7 @@ export default function SidebarV2() {
                       wokeAt={threadWokeAt(thread, { now: snoozeNow })}
                       isActive={routeThreadKey === threadKey}
                       jumpLabel={showJumpHints ? (jumpLabelByKey.get(threadKey) ?? null) : null}
-                      currentEnvironmentId={primaryEnvironmentId}
+                      presenceScope={presenceScope}
                       environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
                       projectCwd={
                         projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -91,7 +91,7 @@ import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironmentPresenceScope, useEnvironments } from "../state/environments";
 import { isRemoteEnvironmentId, type EnvironmentPresenceScope } from "../environmentPresence";
 import { useProjects, useThreadShells } from "../state/entities";
-import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
+import { environmentServerConfigsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
 import { projectEnvironment } from "../state/projects";
@@ -136,7 +136,8 @@ import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
 import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
-import { primaryServerProvidersAtom } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { CommandDialogTrigger } from "./ui/command";
 import { Button } from "./ui/button";
@@ -1001,7 +1002,8 @@ export default function SidebarV2() {
   const threads = useThreadShells();
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const defaultServerConfig = useDefaultServerConfig();
+  const keybindings = defaultServerConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
@@ -1116,7 +1118,7 @@ export default function SidebarV2() {
     () => sortLogicalProjectsForSidebar(unsortedProjectGroups, threads, sidebarProjectSortOrder),
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const serverProviders = defaultServerConfig?.providers ?? [];
   const providerEntryByInstanceId = useMemo(
     () =>
       new Map(

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -6,7 +6,8 @@ import {
 import type { VcsStatusResult } from "@t3tools/contracts";
 import { CloudIcon, FolderGit2Icon, GitPullRequestIcon, TerminalIcon } from "lucide-react";
 import { useMemo } from "react";
-import { useEnvironment, usePrimaryEnvironmentId } from "../state/environments";
+import { isRemoteEnvironmentId } from "../environmentPresence";
+import { useEnvironment, useEnvironmentPresenceScope } from "../state/environments";
 import { useProject } from "../state/entities";
 import { useEnvironmentQuery } from "../state/query";
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
@@ -301,9 +302,8 @@ export function ThreadRowTrailingStatus({ thread }: { thread: SidebarThreadSumma
     threadId: thread.id,
   });
   const environment = useEnvironment(thread.environmentId);
-  const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const isRemoteThread =
-    primaryEnvironmentId !== null && thread.environmentId !== primaryEnvironmentId;
+  const presenceScope = useEnvironmentPresenceScope();
+  const isRemoteThread = isRemoteEnvironmentId(thread.environmentId, presenceScope);
   const remoteEnvLabel = environment?.label ?? null;
   const threadEnvironmentLabel = isRemoteThread ? (remoteEnvLabel ?? "Remote") : null;
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -12,7 +12,11 @@ import {
   buildSidebarProjectSnapshots,
 } from "~/sidebarProjectGrouping";
 import { useProjects, useThreadShells } from "~/state/entities";
-import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
+import {
+  useAppOwnsLocalEnvironment,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "~/state/environments";
 import { sortLogicalProjectsForSidebar } from "../Sidebar.logic";
 import {
   Menu,
@@ -37,6 +41,7 @@ export function DraftHeroHeadline({
   const threads = useThreadShells();
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projectSortOrder = useClientSettings((settings) => settings.sidebarProjectSortOrder);
   const handleNewThread = useNewThreadHandler();
@@ -56,6 +61,7 @@ export function DraftHeroHeadline({
           projects,
           settings: projectGroupingSettings,
           primaryEnvironmentId,
+          ownsLocalEnvironment,
           resolveEnvironmentLabel: (environmentId) =>
             environmentLabelById.get(environmentId) ?? null,
         }),
@@ -64,6 +70,7 @@ export function DraftHeroHeadline({
       ),
     [
       environmentLabelById,
+      ownsLocalEnvironment,
       primaryEnvironmentId,
       projectGroupingSettings,
       projectSortOrder,

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -4,12 +4,13 @@ import { Radio as RadioPrimitive } from "@base-ui/react/radio";
 import { CheckIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
+  type EnvironmentId,
   ProviderInstanceId,
   ProviderDriverKind,
   type ProviderInstanceConfig,
 } from "@t3tools/contracts";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Button } from "../ui/button";
@@ -115,13 +116,20 @@ function validateInstanceId(id: string, existing: ReadonlySet<string>): string |
 }
 
 interface AddProviderInstanceDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  readonly open: boolean;
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+  readonly onOpenChange: (open: boolean) => void;
 }
 
-export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderInstanceDialogProps) {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+export function AddProviderInstanceDialog({
+  open,
+  environmentId,
+  environmentLabel,
+  onOpenChange,
+}: AddProviderInstanceDialogProps) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
 
   const [wizardStep, setWizardStep] = useState(0);
   const [driver, setDriver] = useState<ProviderDriverKind>(DEFAULT_DRIVER_KIND);
@@ -208,7 +216,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
       toastManager.add({
         type: "success",
         title: "Provider instance added",
-        description: `${driverOption.label} instance '${instanceId}' was added.`,
+        description: `${driverOption.label} instance '${instanceId}' was added to ${environmentLabel}.`,
       });
       onOpenChange(false);
     } catch (error) {
@@ -227,8 +235,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
           <DialogHeader>
             <DialogTitle>Add provider instance</DialogTitle>
             <DialogDescription>
-              Configure an additional provider instance — for example, a second Codex install
-              pointed at a different workspace.
+              Configure an additional provider instance on {environmentLabel}.
             </DialogDescription>
             <AddProviderInstanceWizardSteps
               currentStep={wizardStep}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -24,6 +24,8 @@ import {
   type AuthPairingLink,
   type AdvertisedEndpoint,
   type DesktopDiscoveredSshHost,
+  type DesktopBackendMode,
+  type DesktopBackendModeState,
   type DesktopSshEnvironmentTarget,
   type DesktopServerExposureState,
   type DesktopWslState,
@@ -1711,6 +1713,10 @@ function CloudRemoteEnvironmentRows({
 
 export function ConnectionsSettings() {
   const desktopBridge = window.desktopBridge;
+  const [desktopBackendModeState, setDesktopBackendModeState] =
+    useState<DesktopBackendModeState | null>(() => desktopBridge?.getBackendModeState?.() ?? null);
+  const [desktopBackendModeError, setDesktopBackendModeError] = useState<string | null>(null);
+  const [isUpdatingDesktopBackendMode, setIsUpdatingDesktopBackendMode] = useState(false);
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
   const connectPairing = useAtomCommand(connectPairingAtom, { reportFailure: false });
@@ -1734,6 +1740,10 @@ export function ConnectionsSettings() {
         .toSorted((left, right) => left.label.localeCompare(right.label)),
     [environments],
   );
+  const hasUsableClientOnlyEnvironment = savedEnvironments.some(
+    (environment) => !isDesktopLocalConnectionTarget(environment.entry.target),
+  );
+  const isClientOnlyDesktop = desktopBackendModeState?.effectiveMode === "client-only";
   const savedDesktopSshEnvironmentsByAlias = useMemo(
     () =>
       savedEnvironments.reduce<Record<string, EnvironmentPresentation>>(
@@ -1841,7 +1851,8 @@ export function ConnectionsSettings() {
   const setDefaultAdvertisedEndpointKey = useUiStateStore(
     (state) => state.setDefaultAdvertisedEndpointKey,
   );
-  const canManageLocalBackend = currentSessionScopes?.includes(AuthAccessWriteScope) ?? false;
+  const canManageLocalBackend =
+    !isClientOnlyDesktop && (currentSessionScopes?.includes(AuthAccessWriteScope) ?? false);
   const canManageRelay = currentSessionScopes?.includes(AuthRelayWriteScope) ?? false;
   const authAccessChanges = useEnvironmentQuery(
     canManageLocalBackend && primaryEnvironmentId !== null
@@ -2975,9 +2986,88 @@ export function ConnectionsSettings() {
     />
   );
 
+  const handleDesktopBackendModeChange = async (mode: DesktopBackendMode) => {
+    if (!desktopBridge || !desktopBackendModeState) return;
+    if (mode === desktopBackendModeState.configuredMode) return;
+    if (mode === "client-only" && !hasUsableClientOnlyEnvironment) {
+      setDesktopBackendModeError(
+        "Pair and save an environment before switching to client-only mode.",
+      );
+      setAddBackendDialogOpen(true);
+      return;
+    }
+
+    setIsUpdatingDesktopBackendMode(true);
+    setDesktopBackendModeError(null);
+    try {
+      const next = await desktopBridge.setBackendMode(mode);
+      setDesktopBackendModeState(next);
+      setIsUpdatingDesktopBackendMode(false);
+    } catch (error) {
+      setDesktopBackendModeError(
+        error instanceof Error ? error.message : "Could not update the desktop backend mode.",
+      );
+      setIsUpdatingDesktopBackendMode(false);
+    }
+  };
+
   return (
     <SettingsPageContainer>
-      {canManageLocalBackend ? (
+      {desktopBridge && desktopBackendModeState ? (
+        <SettingsSection title="Desktop application">
+          <SettingsRow
+            title="Backend mode"
+            description={
+              isClientOnlyDesktop
+                ? "Connect only to saved environments. This desktop process does not start or control a local backend."
+                : "Start and manage a local backend while retaining access to saved environments."
+            }
+            status={
+              desktopBackendModeError ? (
+                <span className="block text-destructive">{desktopBackendModeError}</span>
+              ) : desktopBackendModeState.cliOverride !== null ? (
+                <span className="block text-muted-foreground">
+                  This launch is overridden by --backend-mode=
+                  {desktopBackendModeState.cliOverride}. The saved preference applies when launched
+                  without that flag.
+                </span>
+              ) : null
+            }
+            control={
+              <Select
+                value={desktopBackendModeState.configuredMode}
+                onValueChange={(value) => {
+                  if (value === "managed" || value === "client-only") {
+                    void handleDesktopBackendModeChange(value);
+                  }
+                }}
+              >
+                <SelectTrigger
+                  className="w-full sm:w-48"
+                  aria-label="Desktop backend mode"
+                  disabled={isUpdatingDesktopBackendMode}
+                >
+                  <SelectValue>
+                    {desktopBackendModeState.configuredMode === "managed"
+                      ? "Managed backend"
+                      : "Client only"}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectItem hideIndicator value="managed">
+                    Managed backend
+                  </SelectItem>
+                  <SelectItem hideIndicator value="client-only">
+                    Client only
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+            }
+          />
+        </SettingsSection>
+      ) : null}
+
+      {isClientOnlyDesktop ? null : canManageLocalBackend ? (
         <>
           <SettingsSection title="This environment">
             {primaryVersionMismatch ? (

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
@@ -1,0 +1,81 @@
+import { assert, describe, it } from "@effect/vitest";
+import { EnvironmentId } from "@t3tools/contracts";
+
+import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
+
+const PRIMARY = EnvironmentId.make("primary");
+const ACTIVE = EnvironmentId.make("active");
+const SELECTED = EnvironmentId.make("selected");
+
+describe("resolveDiagnosticsEnvironmentId", () => {
+  it("preserves an explicit available selection", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: SELECTED,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [PRIMARY, ACTIVE, SELECTED],
+      }),
+      SELECTED,
+    );
+  });
+
+  it("defaults to the primary environment when one is available", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [ACTIVE, PRIMARY],
+      }),
+      PRIMARY,
+    );
+  });
+
+  it("uses the active environment when there is no primary environment", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [SELECTED, ACTIVE],
+      }),
+      ACTIVE,
+    );
+  });
+
+  it("falls back to the first available environment", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: null,
+        availableEnvironmentIds: [SELECTED, ACTIVE],
+      }),
+      SELECTED,
+    );
+  });
+
+  it("recovers when the explicit selection is no longer available", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: SELECTED,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [PRIMARY, ACTIVE],
+      }),
+      PRIMARY,
+    );
+  });
+
+  it("returns null when no environments are available", () => {
+    assert.isNull(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: SELECTED,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [],
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
@@ -3,6 +3,7 @@ import { EnvironmentId } from "@t3tools/contracts";
 
 import {
   addPendingProcessSignal,
+  connectedDiagnosticsData,
   diagnosticsConnectionNotice,
   pendingProcessSignalPids,
   removePendingProcessSignal,
@@ -131,6 +132,15 @@ describe("diagnosticsConnectionNotice", () => {
       diagnosticsConnectionNotice({ phase: "connecting", label: "Laptop", error: null }),
       "Connecting to Laptop...",
     );
+  });
+});
+
+describe("connectedDiagnosticsData", () => {
+  it("hides cached results after the selected environment disconnects", () => {
+    const cached = { processCount: 3 };
+
+    assert.strictEqual(connectedDiagnosticsData(true, cached), cached);
+    assert.isNull(connectedDiagnosticsData(false, cached));
   });
 });
 

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
@@ -1,7 +1,14 @@
 import { assert, describe, it } from "@effect/vitest";
 import { EnvironmentId } from "@t3tools/contracts";
 
-import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
+import {
+  addPendingProcessSignal,
+  diagnosticsConnectionNotice,
+  pendingProcessSignalPids,
+  removePendingProcessSignal,
+  resolveDiagnosticsEnvironmentId,
+  type PendingProcessSignal,
+} from "./DiagnosticsSettings.logic";
 
 const PRIMARY = EnvironmentId.make("primary");
 const ACTIVE = EnvironmentId.make("active");
@@ -76,6 +83,107 @@ describe("resolveDiagnosticsEnvironmentId", () => {
         activeEnvironmentId: ACTIVE,
         availableEnvironmentIds: [],
       }),
+    );
+  });
+});
+
+describe("diagnosticsConnectionNotice", () => {
+  it("returns null while the environment is connected", () => {
+    assert.isNull(
+      diagnosticsConnectionNotice({ phase: "connected", label: "Laptop", error: null }),
+    );
+  });
+
+  it("explains that an offline environment cannot report diagnostics", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "offline", label: "Laptop", error: null }),
+      "Laptop is offline. Diagnostics load once it reconnects.",
+    );
+  });
+
+  it("explains that a never-connected environment cannot report diagnostics", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "available", label: "Laptop", error: null }),
+      "Laptop is not connected. Diagnostics load once it connects.",
+    );
+  });
+
+  it("includes the failure reason while reconnecting", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({
+        phase: "reconnecting",
+        label: "Laptop",
+        error: "socket hang up",
+      }),
+      "Reconnecting to Laptop... Reason: socket hang up",
+    );
+  });
+
+  it("reports a blocked connection", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "error", label: "Laptop", error: "unauthorized" }),
+      "Could not connect to Laptop. Reason: unauthorized",
+    );
+  });
+
+  it("reports an initial connection attempt", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "connecting", label: "Laptop", error: null }),
+      "Connecting to Laptop...",
+    );
+  });
+});
+
+describe("pending process signals", () => {
+  it("tracks pending signals per environment and pid", () => {
+    const pending = addPendingProcessSignal(
+      addPendingProcessSignal([], { environmentId: PRIMARY, pid: 100 }),
+      { environmentId: ACTIVE, pid: 200 },
+    );
+
+    assert.deepEqual([...pendingProcessSignalPids(pending, PRIMARY)], [100]);
+    assert.deepEqual([...pendingProcessSignalPids(pending, ACTIVE)], [200]);
+    assert.deepEqual([...pendingProcessSignalPids(pending, SELECTED)], []);
+    assert.deepEqual([...pendingProcessSignalPids(pending, null)], []);
+  });
+
+  it("does not duplicate a signal that is already pending", () => {
+    const pending = addPendingProcessSignal([{ environmentId: PRIMARY, pid: 100 }], {
+      environmentId: PRIMARY,
+      pid: 100,
+    });
+
+    assert.equal(pending.length, 1);
+  });
+
+  it("keeps the same pid pending in another environment", () => {
+    const pending = addPendingProcessSignal(
+      addPendingProcessSignal([], { environmentId: PRIMARY, pid: 100 }),
+      { environmentId: ACTIVE, pid: 100 },
+    );
+
+    assert.deepEqual([...pendingProcessSignalPids(pending, PRIMARY)], [100]);
+    assert.deepEqual([...pendingProcessSignalPids(pending, ACTIVE)], [100]);
+  });
+
+  it("only clears the completed request, leaving other environments pending", () => {
+    const pending = addPendingProcessSignal(
+      addPendingProcessSignal([], { environmentId: PRIMARY, pid: 100 }),
+      { environmentId: ACTIVE, pid: 200 },
+    );
+
+    const remaining = removePendingProcessSignal(pending, { environmentId: PRIMARY, pid: 100 });
+
+    assert.deepEqual([...pendingProcessSignalPids(remaining, PRIMARY)], []);
+    assert.deepEqual([...pendingProcessSignalPids(remaining, ACTIVE)], [200]);
+  });
+
+  it("ignores completions for signals that are no longer pending", () => {
+    const pending: ReadonlyArray<PendingProcessSignal> = [{ environmentId: PRIMARY, pid: 100 }];
+
+    assert.strictEqual(
+      removePendingProcessSignal(pending, { environmentId: ACTIVE, pid: 100 }),
+      pending,
     );
   });
 });

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
@@ -1,0 +1,30 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+export function resolveDiagnosticsEnvironmentId(input: {
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly activeEnvironmentId: EnvironmentId | null;
+  readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;
+}): EnvironmentId | null {
+  const availableEnvironmentIds = new Set(input.availableEnvironmentIds);
+
+  if (
+    input.selectedEnvironmentId !== null &&
+    availableEnvironmentIds.has(input.selectedEnvironmentId)
+  ) {
+    return input.selectedEnvironmentId;
+  }
+  if (
+    input.primaryEnvironmentId !== null &&
+    availableEnvironmentIds.has(input.primaryEnvironmentId)
+  ) {
+    return input.primaryEnvironmentId;
+  }
+  if (
+    input.activeEnvironmentId !== null &&
+    availableEnvironmentIds.has(input.activeEnvironmentId)
+  ) {
+    return input.activeEnvironmentId;
+  }
+  return input.availableEnvironmentIds[0] ?? null;
+}

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
@@ -1,6 +1,10 @@
 import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import type { EnvironmentId } from "@t3tools/contracts";
 
+export function connectedDiagnosticsData<A>(isConnected: boolean, data: A | null): A | null {
+  return isConnected ? data : null;
+}
+
 export function resolveDiagnosticsEnvironmentId(input: {
   readonly selectedEnvironmentId: EnvironmentId | null;
   readonly primaryEnvironmentId: EnvironmentId | null;

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import type { EnvironmentId } from "@t3tools/contracts";
 
 export function resolveDiagnosticsEnvironmentId(input: {
@@ -27,4 +28,77 @@ export function resolveDiagnosticsEnvironmentId(input: {
     return input.activeEnvironmentId;
   }
   return input.availableEnvironmentIds[0] ?? null;
+}
+
+/**
+ * Diagnostics queries only run while the selected environment has a connected
+ * supervisor generation; otherwise they stay pending forever. Returns the
+ * message to show instead of a loading state, or `null` when diagnostics can
+ * actually be collected.
+ */
+export function diagnosticsConnectionNotice(input: {
+  readonly phase: EnvironmentConnectionPhase;
+  readonly label: string;
+  readonly error: string | null;
+}): string | null {
+  switch (input.phase) {
+    case "connected":
+      return null;
+    case "connecting":
+      return `Connecting to ${input.label}...`;
+    case "reconnecting":
+      return input.error
+        ? `Reconnecting to ${input.label}... Reason: ${input.error}`
+        : `Reconnecting to ${input.label}...`;
+    case "offline":
+      return `${input.label} is offline. Diagnostics load once it reconnects.`;
+    case "available":
+      return `${input.label} is not connected. Diagnostics load once it connects.`;
+    case "error":
+      return input.error
+        ? `Could not connect to ${input.label}. Reason: ${input.error}`
+        : `Could not connect to ${input.label}.`;
+  }
+}
+
+/**
+ * An in-flight process signal. Signals are identified by environment as well as
+ * pid so that a completion in one environment cannot clear pending state that
+ * belongs to another one.
+ */
+export interface PendingProcessSignal {
+  readonly environmentId: EnvironmentId;
+  readonly pid: number;
+}
+
+function isSamePendingProcessSignal(left: PendingProcessSignal, right: PendingProcessSignal) {
+  return left.environmentId === right.environmentId && left.pid === right.pid;
+}
+
+export function addPendingProcessSignal(
+  pending: ReadonlyArray<PendingProcessSignal>,
+  signal: PendingProcessSignal,
+): ReadonlyArray<PendingProcessSignal> {
+  return pending.some((entry) => isSamePendingProcessSignal(entry, signal))
+    ? pending
+    : [...pending, signal];
+}
+
+export function removePendingProcessSignal(
+  pending: ReadonlyArray<PendingProcessSignal>,
+  signal: PendingProcessSignal,
+): ReadonlyArray<PendingProcessSignal> {
+  const next = pending.filter((entry) => !isSamePendingProcessSignal(entry, signal));
+  return next.length === pending.length ? pending : next;
+}
+
+export function pendingProcessSignalPids(
+  pending: ReadonlyArray<PendingProcessSignal>,
+  environmentId: EnvironmentId | null,
+): ReadonlySet<number> {
+  return new Set(
+    pending
+      .filter((entry) => environmentId !== null && entry.environmentId === environmentId)
+      .map((entry) => entry.pid),
+  );
 }

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -2,11 +2,9 @@ import {
   AlertTriangleIcon,
   ChevronDownIcon,
   ChevronRightIcon,
-  CloudIcon,
   CopyIcon,
   FolderOpenIcon,
   InfoIcon,
-  MonitorIcon,
   RefreshCwIcon,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
@@ -31,20 +29,10 @@ import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFo
 import { useEnvironmentQuery } from "../../state/query";
 import { serverEnvironment } from "../../state/server";
 import { shellEnvironment } from "../../state/shell";
-import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
-import { useActiveEnvironmentId } from "../../state/entities";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
-import {
-  Select,
-  SelectGroup,
-  SelectGroupLabel,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "../ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
 import {
@@ -58,9 +46,9 @@ import {
   diagnosticsConnectionNotice,
   pendingProcessSignalPids,
   removePendingProcessSignal,
-  resolveDiagnosticsEnvironmentId,
   type PendingProcessSignal,
 } from "./DiagnosticsSettings.logic";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 const NUMBER_FORMAT = new Intl.NumberFormat();
@@ -839,28 +827,15 @@ interface LogsDirectoryState {
 }
 
 export function DiagnosticsSettingsPanel() {
-  const { environments } = useEnvironments();
-  const primaryEnvironment = usePrimaryEnvironment();
-  const activeEnvironmentId = useActiveEnvironmentId();
-  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
-  const environmentId = resolveDiagnosticsEnvironmentId({
-    selectedEnvironmentId,
-    primaryEnvironmentId: primaryEnvironment?.environmentId ?? null,
-    activeEnvironmentId,
-    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
-  });
-  const diagnosticsEnvironment =
-    environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  const {
+    environmentId,
+    environment: diagnosticsEnvironment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment,
+  } = useSettingsEnvironment();
   const observability = diagnosticsEnvironment?.serverConfig?.observability ?? null;
   const availableEditors = diagnosticsEnvironment?.serverConfig?.availableEditors ?? [];
-  const environmentItems = useMemo(
-    () =>
-      environments.map((environment) => ({
-        value: environment.environmentId,
-        label: environment.label,
-      })),
-    [environments],
-  );
   const signalServerProcess = useAtomCommand(serverEnvironment.signalProcess, {
     reportFailure: false,
   });
@@ -1082,37 +1057,12 @@ export function DiagnosticsSettingsPanel() {
           }
           control={
             diagnosticsEnvironment ? (
-              <Select
-                value={diagnosticsEnvironment.environmentId}
-                onValueChange={(value) => setSelectedEnvironmentId(value as EnvironmentId)}
-                items={environmentItems}
-              >
-                <SelectTrigger className="w-full sm:w-64" aria-label="Diagnostics environment">
-                  {diagnosticsEnvironment.entry.target._tag === "PrimaryConnectionTarget" ? (
-                    <MonitorIcon className="size-4" />
-                  ) : (
-                    <CloudIcon className="size-4" />
-                  )}
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectPopup align="end" alignItemWithTrigger={false}>
-                  <SelectGroup>
-                    <SelectGroupLabel>Machine</SelectGroupLabel>
-                    {environments.map((environment) => (
-                      <SelectItem key={environment.environmentId} value={environment.environmentId}>
-                        <span className="inline-flex items-center gap-1.5">
-                          {environment.entry.target._tag === "PrimaryConnectionTarget" ? (
-                            <MonitorIcon className="size-3" />
-                          ) : (
-                            <CloudIcon className="size-3" />
-                          )}
-                          {environment.label}
-                        </span>
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectPopup>
-              </Select>
+              <SettingsEnvironmentSelector
+                environmentId={diagnosticsEnvironment.environmentId}
+                environments={environments}
+                primaryEnvironmentId={primaryEnvironmentId}
+                onEnvironmentChange={selectEnvironment}
+              />
             ) : (
               <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
                 Manage connections

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -43,6 +43,7 @@ import {
 } from "./settingsLayout";
 import {
   addPendingProcessSignal,
+  connectedDiagnosticsData,
   diagnosticsConnectionNotice,
   pendingProcessSignalPids,
   removePendingProcessSignal,
@@ -846,14 +847,19 @@ export function DiagnosticsSettingsPanel() {
   const selectedResourceWindow =
     RESOURCE_HISTORY_WINDOWS.find((option) => option.windowMs === resourceWindowMs) ??
     RESOURCE_HISTORY_WINDOWS[1];
-  const { data, error, isPending, refresh } = useEnvironmentQuery(
+  const {
+    data: cachedTraceData,
+    error: cachedTraceError,
+    isPending,
+    refresh,
+  } = useEnvironmentQuery(
     environmentId === null
       ? null
       : serverEnvironment.traceDiagnostics({ environmentId, input: {} }),
   );
   const {
-    data: processData,
-    error: processError,
+    data: cachedProcessData,
+    error: cachedProcessError,
     isPending: isProcessPending,
     refresh: refreshProcesses,
   } = useEnvironmentQuery(
@@ -862,8 +868,8 @@ export function DiagnosticsSettingsPanel() {
       : serverEnvironment.processDiagnostics({ environmentId, input: {} }),
   );
   const {
-    data: resourceData,
-    error: resourceError,
+    data: cachedResourceData,
+    error: cachedResourceError,
     isPending: isResourcePending,
     refresh: refreshResources,
   } = useEnvironmentQuery(
@@ -942,17 +948,15 @@ export function DiagnosticsSettingsPanel() {
     })();
   }, [availableEditors, environmentId, observability?.logsDirectoryPath, openInEditor]);
 
-  const isInitialLoading = isPending && data === null;
-  const isProcessInitialLoading = isProcessPending && processData === null;
   const signalProcess = useCallback(
     (pid: number, signal: ServerProcessSignal) => {
+      if (environmentId === null || diagnosticsEnvironment?.connection.phase !== "connected") {
+        return;
+      }
       if (
         signal === "SIGKILL" &&
         !window.confirm(`Send SIGKILL to process ${pid}? This cannot be handled by the process.`)
       ) {
-        return;
-      }
-      if (environmentId === null) {
         return;
       }
 
@@ -998,7 +1002,12 @@ export function DiagnosticsSettingsPanel() {
         refreshProcesses();
       })();
     },
-    [environmentId, refreshProcesses, signalServerProcess],
+    [
+      diagnosticsEnvironment?.connection.phase,
+      environmentId,
+      refreshProcesses,
+      signalServerProcess,
+    ],
   );
 
   // Diagnostics RPCs only run while the environment's supervisor is connected,
@@ -1010,6 +1019,14 @@ export function DiagnosticsSettingsPanel() {
   });
   const isConnected = connectionNotice === null;
   const statPlaceholder = isConnected ? "..." : "—";
+  const data = connectedDiagnosticsData(isConnected, cachedTraceData);
+  const processData = connectedDiagnosticsData(isConnected, cachedProcessData);
+  const resourceData = connectedDiagnosticsData(isConnected, cachedResourceData);
+  const error = isConnected ? cachedTraceError : null;
+  const processError = isConnected ? cachedProcessError : null;
+  const resourceError = isConnected ? cachedResourceError : null;
+  const isInitialLoading = isPending && data === null;
+  const isProcessInitialLoading = isProcessPending && processData === null;
 
   const processDiagnosticsError = processData ? Option.getOrNull(processData.error) : null;
   const processResourceError = resourceData ? Option.getOrNull(resourceData.error) : null;

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -2,18 +2,22 @@ import {
   AlertTriangleIcon,
   ChevronDownIcon,
   ChevronRightIcon,
+  CloudIcon,
   CopyIcon,
   FolderOpenIcon,
   InfoIcon,
+  MonitorIcon,
   RefreshCwIcon,
 } from "lucide-react";
-import { useAtomValue } from "@effect/atom-react";
+import { Link } from "@tanstack/react-router";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import type {
+  EnvironmentId,
   ServerProcessDiagnosticsEntry,
   ServerProcessResourceHistorySummary,
   ServerProcessSignal,
@@ -25,19 +29,31 @@ import { cn } from "../../lib/utils";
 import { resolveAndPersistPreferredEditor } from "../../editorPreferences";
 import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFormat";
 import { useEnvironmentQuery } from "../../state/query";
-import {
-  primaryServerAvailableEditorsAtom,
-  primaryServerObservabilityAtom,
-  serverEnvironment,
-} from "../../state/server";
+import { serverEnvironment } from "../../state/server";
 import { shellEnvironment } from "../../state/shell";
-import { usePrimaryEnvironment } from "../../state/environments";
+import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
+import { useActiveEnvironmentId } from "../../state/entities";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
+import {
+  Select,
+  SelectGroup,
+  SelectGroupLabel,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
-import { SettingsPageContainer, SettingsSection, useRelativeTimeTick } from "./settingsLayout";
+import {
+  SettingsPageContainer,
+  SettingsRow,
+  SettingsSection,
+  useRelativeTimeTick,
+} from "./settingsLayout";
+import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 const NUMBER_FORMAT = new Intl.NumberFormat();
@@ -808,10 +824,28 @@ function DiagnosticsRefreshButton({
 }
 
 export function DiagnosticsSettingsPanel() {
-  const observability = useAtomValue(primaryServerObservabilityAtom);
-  const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
+  const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
-  const environmentId = primaryEnvironment?.environmentId ?? null;
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
+  const environmentId = resolveDiagnosticsEnvironmentId({
+    selectedEnvironmentId,
+    primaryEnvironmentId: primaryEnvironment?.environmentId ?? null,
+    activeEnvironmentId,
+    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+  });
+  const diagnosticsEnvironment =
+    environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  const observability = diagnosticsEnvironment?.serverConfig?.observability ?? null;
+  const availableEditors = diagnosticsEnvironment?.serverConfig?.availableEditors ?? [];
+  const environmentItems = useMemo(
+    () =>
+      environments.map((environment) => ({
+        value: environment.environmentId,
+        label: environment.label,
+      })),
+    [environments],
+  );
   const signalServerProcess = useAtomCommand(serverEnvironment.signalProcess, {
     reportFailure: false,
   });
@@ -956,8 +990,85 @@ export function DiagnosticsSettingsPanel() {
     ? Option.getOrElse(data.partialFailure, () => false)
     : false;
 
+  if (environmentId === null) {
+    return (
+      <SettingsPageContainer>
+        <SettingsSection title="Environment">
+          <SettingsRow
+            title="Diagnostics source"
+            description="Process, resource, and trace diagnostics are collected by a specific backend."
+            status="Connect an environment to view diagnostics."
+            control={
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Manage connections
+              </Button>
+            }
+          />
+        </SettingsSection>
+      </SettingsPageContainer>
+    );
+  }
+
   return (
     <SettingsPageContainer>
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Diagnostics source"
+          description="Process, resource, and trace diagnostics are collected by a specific backend. Choose the machine you want to inspect."
+          status={
+            diagnosticsEnvironment ? (
+              <>
+                {connectionStatusText(diagnosticsEnvironment.connection)}
+                {diagnosticsEnvironment.displayUrl
+                  ? ` · ${diagnosticsEnvironment.displayUrl}`
+                  : null}
+              </>
+            ) : (
+              "Connect an environment to view diagnostics."
+            )
+          }
+          control={
+            diagnosticsEnvironment ? (
+              <Select
+                value={diagnosticsEnvironment.environmentId}
+                onValueChange={(value) => setSelectedEnvironmentId(value as EnvironmentId)}
+                items={environmentItems}
+              >
+                <SelectTrigger className="w-full sm:w-64" aria-label="Diagnostics environment">
+                  {diagnosticsEnvironment.entry.target._tag === "PrimaryConnectionTarget" ? (
+                    <MonitorIcon className="size-4" />
+                  ) : (
+                    <CloudIcon className="size-4" />
+                  )}
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectGroup>
+                    <SelectGroupLabel>Machine</SelectGroupLabel>
+                    {environments.map((environment) => (
+                      <SelectItem key={environment.environmentId} value={environment.environmentId}>
+                        <span className="inline-flex items-center gap-1.5">
+                          {environment.entry.target._tag === "PrimaryConnectionTarget" ? (
+                            <MonitorIcon className="size-3" />
+                          ) : (
+                            <CloudIcon className="size-3" />
+                          )}
+                          {environment.label}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectPopup>
+              </Select>
+            ) : (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Manage connections
+              </Button>
+            )
+          }
+        />
+      </SettingsSection>
+
       <SettingsSection
         title="Live Processes"
         headerAction={

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -53,7 +53,14 @@ import {
   SettingsSection,
   useRelativeTimeTick,
 } from "./settingsLayout";
-import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
+import {
+  addPendingProcessSignal,
+  diagnosticsConnectionNotice,
+  pendingProcessSignalPids,
+  removePendingProcessSignal,
+  resolveDiagnosticsEnvironmentId,
+  type PendingProcessSignal,
+} from "./DiagnosticsSettings.logic";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 const NUMBER_FORMAT = new Intl.NumberFormat();
@@ -410,12 +417,12 @@ function ProcessSignalActions({
 
 function ProcessDiagnosticsTable({
   processes,
-  signalingPid,
+  signalingPids,
   onSignal,
   emptyLabel,
 }: {
   processes: ReadonlyArray<ServerProcessDiagnosticsEntry>;
-  signalingPid: number | null;
+  signalingPids: ReadonlySet<number>;
   onSignal: (pid: number, signal: ServerProcessSignal) => void;
   emptyLabel?: string;
 }) {
@@ -524,7 +531,7 @@ function ProcessDiagnosticsTable({
               <td className="p-2 align-middle sm:pr-4">
                 <ProcessSignalActions
                   process={process}
-                  isSignaling={signalingPid === process.pid}
+                  isSignaling={signalingPids.has(process.pid)}
                   onSignal={onSignal}
                 />
               </td>
@@ -823,6 +830,12 @@ function DiagnosticsRefreshButton({
   );
 }
 
+interface LogsDirectoryState {
+  readonly environmentId: EnvironmentId | null;
+  readonly isOpening: boolean;
+  readonly error: string | null;
+}
+
 export function DiagnosticsSettingsPanel() {
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
@@ -887,9 +900,20 @@ export function DiagnosticsSettingsPanel() {
           },
         }),
   );
-  const [isOpeningLogsDirectory, setIsOpeningLogsDirectory] = useState(false);
-  const [openLogsDirectoryError, setOpenLogsDirectoryError] = useState<string | null>(null);
-  const [signalingPid, setSignalingPid] = useState<number | null>(null);
+  // Panel-local state is keyed by environment so that a result produced for one
+  // environment is never shown for (or applied to) another one.
+  const [logsDirectoryState, setLogsDirectoryState] = useState<LogsDirectoryState | null>(null);
+  const [pendingSignals, setPendingSignals] = useState<ReadonlyArray<PendingProcessSignal>>([]);
+  const logsDirectory =
+    logsDirectoryState !== null && logsDirectoryState.environmentId === environmentId
+      ? logsDirectoryState
+      : null;
+  const isOpeningLogsDirectory = logsDirectory?.isOpening ?? false;
+  const openLogsDirectoryError = logsDirectory?.error ?? null;
+  const signalingPids = useMemo(
+    () => pendingProcessSignalPids(pendingSignals, environmentId),
+    [environmentId, pendingSignals],
+  );
 
   const openLogsDirectory = useCallback(() => {
     const logsDirectoryPath = observability?.logsDirectoryPath ?? null;
@@ -897,16 +921,23 @@ export function DiagnosticsSettingsPanel() {
 
     const editor = resolveAndPersistPreferredEditor(availableEditors ?? []);
     if (!editor) {
-      setOpenLogsDirectoryError("No available editors found.");
+      setLogsDirectoryState({
+        environmentId,
+        isOpening: false,
+        error: "No available editors found.",
+      });
       return;
     }
     if (environmentId === null) {
-      setOpenLogsDirectoryError("No environment is selected.");
+      setLogsDirectoryState({
+        environmentId,
+        isOpening: false,
+        error: "No environment is selected.",
+      });
       return;
     }
 
-    setIsOpeningLogsDirectory(true);
-    setOpenLogsDirectoryError(null);
+    setLogsDirectoryState({ environmentId, isOpening: true, error: null });
     void (async () => {
       const result = await openInEditor({
         environmentId,
@@ -915,13 +946,22 @@ export function DiagnosticsSettingsPanel() {
           editor,
         },
       });
-      setIsOpeningLogsDirectory(false);
-      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-        const error = squashAtomCommandFailure(result);
-        setOpenLogsDirectoryError(
-          error instanceof Error ? error.message : "Unable to open logs folder.",
-        );
-      }
+      const failure =
+        result._tag === "Failure" && !isAtomCommandInterrupted(result)
+          ? squashAtomCommandFailure(result)
+          : null;
+      const error =
+        failure === null
+          ? null
+          : failure instanceof Error
+            ? failure.message
+            : "Unable to open logs folder.";
+      // Only the request that owns the current pending state may clear it.
+      setLogsDirectoryState((current) =>
+        current !== null && current.environmentId === environmentId
+          ? { environmentId, isOpening: false, error }
+          : current,
+      );
     })();
   }, [availableEditors, environmentId, observability?.logsDirectoryPath, openInEditor]);
 
@@ -939,13 +979,14 @@ export function DiagnosticsSettingsPanel() {
         return;
       }
 
-      setSignalingPid(pid);
+      const pendingSignal: PendingProcessSignal = { environmentId, pid };
+      setPendingSignals((current) => addPendingProcessSignal(current, pendingSignal));
       void (async () => {
         const result = await signalServerProcess({
           environmentId,
           input: { pid, signal },
         });
-        setSignalingPid(null);
+        setPendingSignals((current) => removePendingProcessSignal(current, pendingSignal));
         if (result._tag === "Failure") {
           if (!isAtomCommandInterrupted(result)) {
             const error = squashAtomCommandFailure(result);
@@ -982,6 +1023,16 @@ export function DiagnosticsSettingsPanel() {
     },
     [environmentId, refreshProcesses, signalServerProcess],
   );
+
+  // Diagnostics RPCs only run while the environment's supervisor is connected,
+  // so anything else has to surface as a state instead of an endless spinner.
+  const connectionNotice = diagnosticsConnectionNotice({
+    phase: diagnosticsEnvironment?.connection.phase ?? "available",
+    label: diagnosticsEnvironment?.label ?? "This environment",
+    error: diagnosticsEnvironment?.connection.error ?? null,
+  });
+  const isConnected = connectionNotice === null;
+  const statPlaceholder = isConnected ? "..." : "—";
 
   const processDiagnosticsError = processData ? Option.getOrNull(processData.error) : null;
   const processResourceError = resourceData ? Option.getOrNull(resourceData.error) : null;
@@ -1075,7 +1126,7 @@ export function DiagnosticsSettingsPanel() {
           <div className="flex items-center gap-1.5">
             <DiagnosticsLastChecked checkedAt={processData?.readAt ?? null} />
             <DiagnosticsRefreshButton
-              isPending={isProcessPending}
+              isPending={isProcessPending && isConnected}
               label="Refresh process diagnostics"
               onClick={refreshProcesses}
             />
@@ -1085,21 +1136,21 @@ export function DiagnosticsSettingsPanel() {
         <StatsGrid>
           <StatBlock
             label="Child Processes"
-            value={processData ? formatCount(processData.processCount) : "..."}
+            value={processData ? formatCount(processData.processCount) : statPlaceholder}
           />
           <StatBlock
             label="CPU"
-            value={processData ? `${processData.totalCpuPercent.toFixed(1)}%` : "..."}
+            value={processData ? `${processData.totalCpuPercent.toFixed(1)}%` : statPlaceholder}
             tooltip="Total CPU across live child processes of the current server process. The desktop shell and other parent processes are not included."
           />
           <StatBlock
             label="Memory"
-            value={processData ? formatBytes(processData.totalRssBytes) : "..."}
+            value={processData ? formatBytes(processData.totalRssBytes) : statPlaceholder}
             tooltip="Total resident memory across live child processes of the current server process. The desktop shell and other parent processes are not included."
           />
           <StatBlock
             label="Server PID"
-            value={processData ? String(processData.serverPid) : "..."}
+            value={processData ? String(processData.serverPid) : statPlaceholder}
           />
         </StatsGrid>
         {processDiagnosticsError || processError ? (
@@ -1120,12 +1171,13 @@ export function DiagnosticsSettingsPanel() {
         ) : null}
         <ProcessDiagnosticsTable
           processes={processData?.processes ?? []}
-          signalingPid={signalingPid}
+          signalingPids={signalingPids}
           onSignal={signalProcess}
           emptyLabel={
-            isProcessInitialLoading
+            connectionNotice ??
+            (isProcessInitialLoading
               ? "Loading live processes..."
-              : "No live descendant processes found."
+              : "No live descendant processes found.")
           }
         />
       </SettingsSection>
@@ -1140,7 +1192,7 @@ export function DiagnosticsSettingsPanel() {
             />
             <DiagnosticsLastChecked checkedAt={resourceData?.readAt ?? null} />
             <DiagnosticsRefreshButton
-              isPending={isResourcePending}
+              isPending={isResourcePending && isConnected}
               label="Refresh resource history"
               onClick={refreshResources}
             />
@@ -1150,21 +1202,23 @@ export function DiagnosticsSettingsPanel() {
         <StatsGrid>
           <StatBlock
             label="CPU Time"
-            value={resourceData ? formatCpuTime(resourceData.totalCpuSecondsApprox) : "..."}
+            value={
+              resourceData ? formatCpuTime(resourceData.totalCpuSecondsApprox) : statPlaceholder
+            }
             tooltip="Approximate active CPU time for the T3 server root process and its descendants during the selected window. It grows only while sampled processes use CPU and older samples leave as the window moves."
           />
           <StatBlock
             label="Samples"
-            value={resourceData ? formatCount(resourceData.retainedSampleCount) : "..."}
+            value={resourceData ? formatCount(resourceData.retainedSampleCount) : statPlaceholder}
             tooltip="In-memory process samples retained by the server. This resets when the server restarts."
           />
           <StatBlock
             label="Interval"
-            value={resourceData ? formatDuration(resourceData.sampleIntervalMs) : "..."}
+            value={resourceData ? formatDuration(resourceData.sampleIntervalMs) : statPlaceholder}
           />
           <StatBlock
             label="Processes"
-            value={resourceData ? formatCount(resourceData.topProcesses.length) : "..."}
+            value={resourceData ? formatCount(resourceData.topProcesses.length) : statPlaceholder}
           />
         </StatsGrid>
         {processResourceError || resourceError ? (
@@ -1187,9 +1241,10 @@ export function DiagnosticsSettingsPanel() {
         <ProcessResourceHistoryTable
           processes={resourceData?.topProcesses ?? []}
           emptyLabel={
-            isResourcePending && resourceData === null
+            connectionNotice ??
+            (isResourcePending && resourceData === null
               ? "Collecting process resource samples..."
-              : "No process resource samples found for this window."
+              : "No process resource samples found for this window.")
           }
         />
       </SettingsSection>
@@ -1206,7 +1261,9 @@ export function DiagnosticsSettingsPanel() {
                     size="icon-xs"
                     variant="ghost"
                     className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                    disabled={!observability?.logsDirectoryPath || isOpeningLogsDirectory}
+                    disabled={
+                      !isConnected || !observability?.logsDirectoryPath || isOpeningLogsDirectory
+                    }
                     onClick={openLogsDirectory}
                     aria-label="Open logs folder"
                   >
@@ -1217,7 +1274,7 @@ export function DiagnosticsSettingsPanel() {
               <TooltipPopup side="top">Open logs folder</TooltipPopup>
             </Tooltip>
             <DiagnosticsRefreshButton
-              isPending={isPending}
+              isPending={isPending && isConnected}
               label="Refresh trace diagnostics"
               onClick={refresh}
             />
@@ -1225,15 +1282,15 @@ export function DiagnosticsSettingsPanel() {
         }
       >
         <StatsGrid>
-          <StatBlock label="Spans" value={data ? formatCount(data.recordCount) : "..."} />
+          <StatBlock label="Spans" value={data ? formatCount(data.recordCount) : statPlaceholder} />
           <StatBlock
             label="Failures"
-            value={data ? formatCount(data.failureCount) : "..."}
+            value={data ? formatCount(data.failureCount) : statPlaceholder}
             tone={data && data.failureCount > 0 ? "danger" : "default"}
           />
           <StatBlock
             label="Slow Spans"
-            value={data ? formatCount(data.slowSpanCount) : "..."}
+            value={data ? formatCount(data.slowSpanCount) : statPlaceholder}
             tooltip={
               data
                 ? `Spans with a duration of ${formatDuration(data.slowSpanThresholdMs)} or longer.`
@@ -1243,7 +1300,7 @@ export function DiagnosticsSettingsPanel() {
           />
           <StatBlock
             label="Parse Errors"
-            value={data ? formatCount(data.parseErrorCount) : "..."}
+            value={data ? formatCount(data.parseErrorCount) : statPlaceholder}
             tone={data && data.parseErrorCount > 0 ? "warning" : "default"}
           />
         </StatsGrid>
@@ -1303,7 +1360,12 @@ export function DiagnosticsSettingsPanel() {
             ))}
           </DiagnosticsTable>
         ) : (
-          <EmptyRows label={isInitialLoading ? "Loading failures..." : "No failed spans found."} />
+          <EmptyRows
+            label={
+              connectionNotice ??
+              (isInitialLoading ? "Loading failures..." : "No failed spans found.")
+            }
+          />
         )}
       </SettingsSection>
 
@@ -1332,7 +1394,10 @@ export function DiagnosticsSettingsPanel() {
           </DiagnosticsTable>
         ) : (
           <EmptyRows
-            label={isInitialLoading ? "Loading failure groups..." : "No repeated failures found."}
+            label={
+              connectionNotice ??
+              (isInitialLoading ? "Loading failure groups..." : "No repeated failures found.")
+            }
           />
         )}
       </SettingsSection>
@@ -1362,7 +1427,11 @@ export function DiagnosticsSettingsPanel() {
             ))}
           </DiagnosticsTable>
         ) : (
-          <EmptyRows label={isInitialLoading ? "Loading slow spans..." : "No spans found."} />
+          <EmptyRows
+            label={
+              connectionNotice ?? (isInitialLoading ? "Loading slow spans..." : "No spans found.")
+            }
+          />
         )}
       </SettingsSection>
 
@@ -1425,7 +1494,10 @@ export function DiagnosticsSettingsPanel() {
           </ScrollArea>
         ) : (
           <EmptyRows
-            label={isInitialLoading ? "Loading recent logs..." : "No warnings or errors found."}
+            label={
+              connectionNotice ??
+              (isInitialLoading ? "Loading recent logs..." : "No warnings or errors found.")
+            }
           />
         )}
       </SettingsSection>
@@ -1458,7 +1530,11 @@ export function DiagnosticsSettingsPanel() {
             ))}
           </DiagnosticsTable>
         ) : (
-          <EmptyRows label={isInitialLoading ? "Loading span names..." : "No spans found."} />
+          <EmptyRows
+            label={
+              connectionNotice ?? (isInitialLoading ? "Loading span names..." : "No spans found.")
+            }
+          />
         )}
       </SettingsSection>
     </SettingsPageContainer>

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -802,10 +802,12 @@ function DiagnosticsLastChecked({ checkedAt }: { checkedAt: DateTime.Utc | null 
 
 function DiagnosticsRefreshButton({
   isPending,
+  isDisabled = false,
   label,
   onClick,
 }: {
   isPending: boolean;
+  isDisabled?: boolean;
   label: string;
   onClick: () => void;
 }) {
@@ -817,7 +819,7 @@ function DiagnosticsRefreshButton({
             size="icon-xs"
             variant="ghost"
             className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-            disabled={isPending}
+            disabled={isPending || isDisabled}
             onClick={onClick}
             aria-label={label}
           >
@@ -937,7 +939,8 @@ export function DiagnosticsSettingsPanel() {
       return;
     }
 
-    setLogsDirectoryState({ environmentId, isOpening: true, error: null });
+    const request: LogsDirectoryState = { environmentId, isOpening: true, error: null };
+    setLogsDirectoryState(request);
     void (async () => {
       const result = await openInEditor({
         environmentId,
@@ -950,17 +953,16 @@ export function DiagnosticsSettingsPanel() {
         result._tag === "Failure" && !isAtomCommandInterrupted(result)
           ? squashAtomCommandFailure(result)
           : null;
-      const error =
+      const failureMessage =
         failure === null
           ? null
           : failure instanceof Error
             ? failure.message
             : "Unable to open logs folder.";
-      // Only the request that owns the current pending state may clear it.
+      // Identity check: only the request that still owns the slot may clear it,
+      // so a later request (in this or another environment) is never disturbed.
       setLogsDirectoryState((current) =>
-        current !== null && current.environmentId === environmentId
-          ? { environmentId, isOpening: false, error }
-          : current,
+        current === request ? { environmentId, isOpening: false, error: failureMessage } : current,
       );
     })();
   }, [availableEditors, environmentId, observability?.logsDirectoryPath, openInEditor]);
@@ -1127,6 +1129,7 @@ export function DiagnosticsSettingsPanel() {
             <DiagnosticsLastChecked checkedAt={processData?.readAt ?? null} />
             <DiagnosticsRefreshButton
               isPending={isProcessPending && isConnected}
+              isDisabled={!isConnected}
               label="Refresh process diagnostics"
               onClick={refreshProcesses}
             />
@@ -1193,6 +1196,7 @@ export function DiagnosticsSettingsPanel() {
             <DiagnosticsLastChecked checkedAt={resourceData?.readAt ?? null} />
             <DiagnosticsRefreshButton
               isPending={isResourcePending && isConnected}
+              isDisabled={!isConnected}
               label="Refresh resource history"
               onClick={refreshResources}
             />
@@ -1275,6 +1279,7 @@ export function DiagnosticsSettingsPanel() {
             </Tooltip>
             <DiagnosticsRefreshButton
               isPending={isPending && isConnected}
+              isDisabled={!isConnected}
               label="Refresh trace diagnostics"
               onClick={refresh}
             />

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import { EnvironmentId, type ResolvedKeybindingsConfig } from "@t3tools/contracts";
 
 import {
   buildKeybindingRows,
@@ -8,6 +8,7 @@ import {
   commandLabel,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
+  keybindingsSettingsEditorKey,
   parseWhenExpressionDraft,
   shortcutToKeybindingInput,
   unknownWhenVariables,
@@ -15,6 +16,14 @@ import {
 } from "./KeybindingsSettings.logic";
 
 describe("KeybindingsSettings.logic", () => {
+  it("keys editor state by environment so drafts are discarded on target changes", () => {
+    const first = EnvironmentId.make("first");
+    const second = EnvironmentId.make("second");
+
+    expect(keybindingsSettingsEditorKey(first)).not.toBe(keybindingsSettingsEditorKey(second));
+    expect(keybindingsSettingsEditorKey(null)).toBe("no-environment");
+  });
+
   it("builds searchable rows with readable key and when values", () => {
     const rows = buildKeybindingRows(
       [

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -1,4 +1,5 @@
 import {
+  type EnvironmentId,
   type KeybindingCommand,
   type KeybindingShortcut,
   type KeybindingWhenNode,
@@ -28,6 +29,10 @@ export interface KeybindingRow {
 
 export type WhenVariableOption = string;
 export type KeybindingCommandOption = KeybindingCommand;
+
+export function keybindingsSettingsEditorKey(environmentId: EnvironmentId | null): string {
+  return environmentId ?? "no-environment";
+}
 
 const CORE_WHEN_VARIABLES = ["terminalFocus", "terminalOpen", "true", "false"] as const;
 

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -42,7 +42,10 @@ import { useOpenInPreferredEditor } from "../../editorPreferences";
 import { formatShortcutLabel } from "../../keybindings";
 import { cn } from "../../lib/utils";
 import { serverEnvironment } from "../../state/server";
-import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
+import {
+  useSettingsEnvironment,
+  type SettingsEnvironmentTarget,
+} from "../../hooks/useSettingsEnvironment";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
@@ -61,6 +64,7 @@ import {
   isKnownWhenVariable,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
+  keybindingsSettingsEditorKey,
   parseWhenExpressionDraft,
   type KeybindingCommandOption,
   type KeybindingRow,
@@ -1083,7 +1087,11 @@ function NewKeybindingTableRow({
   );
 }
 
-export function KeybindingsSettingsPanel() {
+function KeybindingsSettingsPanelContent({
+  settingsEnvironment,
+}: {
+  settingsEnvironment: SettingsEnvironmentTarget;
+}) {
   const {
     environmentId,
     environment,
@@ -1091,7 +1099,7 @@ export function KeybindingsSettingsPanel() {
     primaryEnvironmentId,
     selectEnvironment,
     isReady: environmentsReady,
-  } = useSettingsEnvironment();
+  } = settingsEnvironment;
   const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
   const keybindings = serverConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const keybindingsConfigPath = serverConfig?.keybindingsConfigPath ?? null;
@@ -1373,5 +1381,15 @@ export function KeybindingsSettingsPanel() {
         </SettingsSection>
       ) : null}
     </SettingsPageContainer>
+  );
+}
+
+export function KeybindingsSettingsPanel() {
+  const settingsEnvironment = useSettingsEnvironment();
+  return (
+    <KeybindingsSettingsPanelContent
+      key={keybindingsSettingsEditorKey(settingsEnvironment.environmentId)}
+      settingsEnvironment={settingsEnvironment}
+    />
   );
 }

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -24,10 +24,14 @@ import {
 import {
   type KeybindingCommand,
   type KeybindingWhenNode,
+  type ServerConfig,
   type ServerRemoveKeybindingInput,
   type ServerUpsertKeybindingInput,
 } from "@t3tools/contracts";
 import { useAtomValue } from "@effect/atom-react";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { Link } from "@tanstack/react-router";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -37,13 +41,8 @@ import { isElectron } from "../../env";
 import { useOpenInPreferredEditor } from "../../editorPreferences";
 import { formatShortcutLabel } from "../../keybindings";
 import { cn } from "../../lib/utils";
-import {
-  primaryServerAvailableEditorsAtom,
-  primaryServerKeybindingsAtom,
-  primaryServerKeybindingsConfigPathAtom,
-  serverEnvironment,
-} from "../../state/server";
-import { usePrimaryEnvironment } from "../../state/environments";
+import { serverEnvironment } from "../../state/server";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
@@ -69,9 +68,12 @@ import {
   unknownWhenVariables,
   whenAstToExpression,
 } from "./KeybindingsSettings.logic";
-import { SettingsPageContainer, SettingsSection } from "./settingsLayout";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
+import { SettingsPageContainer, SettingsRow, SettingsSection } from "./settingsLayout";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { useAtomCommand } from "../../state/use-atom-command";
+
+const EMPTY_AVAILABLE_EDITORS: ServerConfig["availableEditors"] = [];
 
 function KeybindingPill({ value }: { value: string }) {
   const parts = value.split("+");
@@ -1082,20 +1084,26 @@ function NewKeybindingTableRow({
 }
 
 export function KeybindingsSettingsPanel() {
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const keybindingsConfigPath = useAtomValue(primaryServerKeybindingsConfigPathAtom);
-  const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
-  const primaryEnvironment = usePrimaryEnvironment();
+  const {
+    environmentId,
+    environment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment,
+    isReady: environmentsReady,
+  } = useSettingsEnvironment();
+  const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
+  const keybindings = serverConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
+  const keybindingsConfigPath = serverConfig?.keybindingsConfigPath ?? null;
+  const availableEditors = serverConfig?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
+  const isConnected = environment?.connection.phase === "connected";
   const upsertKeybinding = useAtomCommand(serverEnvironment.upsertKeybinding, {
     reportFailure: false,
   });
   const removeKeybindingMutation = useAtomCommand(serverEnvironment.removeKeybinding, {
     reportFailure: false,
   });
-  const openInPreferredEditor = useOpenInPreferredEditor(
-    primaryEnvironment?.environmentId ?? null,
-    availableEditors,
-  );
+  const openInPreferredEditor = useOpenInPreferredEditor(environmentId, availableEditors);
   const [query, setQuery] = useState("");
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -1149,7 +1157,7 @@ export function KeybindingsSettingsPanel() {
 
   const saveKeybinding = useCallback(
     (input: ServerUpsertKeybindingInput) => {
-      if (!primaryEnvironment) return;
+      if (environmentId === null || !isConnected) return;
       setSavingCommand(input.command);
       const payload: ServerUpsertKeybindingInput = {
         command: input.command,
@@ -1159,7 +1167,7 @@ export function KeybindingsSettingsPanel() {
       };
       void (async () => {
         const result = await upsertKeybinding({
-          environmentId: primaryEnvironment.environmentId,
+          environmentId,
           input: payload,
         });
         setSavingCommand(null);
@@ -1177,16 +1185,16 @@ export function KeybindingsSettingsPanel() {
         }
       })();
     },
-    [primaryEnvironment, upsertKeybinding],
+    [environmentId, isConnected, upsertKeybinding],
   );
 
   const removeKeybinding = useCallback(
     (row: KeybindingRow) => {
-      if (!primaryEnvironment) return;
+      if (environmentId === null || !isConnected) return;
       setSavingCommand(row.command);
       void (async () => {
         const result = await removeKeybindingMutation({
-          environmentId: primaryEnvironment.environmentId,
+          environmentId,
           input: rowKeybindingTarget(row),
         });
         setSavingCommand(null);
@@ -1200,7 +1208,7 @@ export function KeybindingsSettingsPanel() {
         }
       })();
     },
-    [primaryEnvironment, removeKeybindingMutation],
+    [environmentId, isConnected, removeKeybindingMutation],
   );
 
   const resetKeybinding = useCallback(
@@ -1229,109 +1237,141 @@ export function KeybindingsSettingsPanel() {
 
   return (
     <SettingsPageContainer className="max-w-5xl">
-      <SettingsSection
-        title="Keybindings"
-        headerAction={
-          <div className="flex items-center gap-1.5">
-            <ExpandableHeaderSearch
-              query={query}
-              onChange={setQuery}
-              isOpen={isSearchOpen}
-              onOpenChange={setIsSearchOpen}
-              inputRef={searchInputRef}
-              collapsedAccessory={bindingsCount}
-            />
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    type="button"
-                    size="icon-xs"
-                    variant="ghost"
-                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                    onClick={() => setIsAddingBinding(true)}
-                    aria-label="Add keybinding"
-                  >
-                    <PlusIcon className="size-3" />
-                  </Button>
-                }
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Keybindings environment"
+          description="Keybindings are stored by a specific server and can differ between environments."
+          status={
+            environment
+              ? [connectionStatusText(environment.connection), environment.displayUrl]
+                  .filter(Boolean)
+                  .join(" · ")
+              : environmentsReady
+                ? "Connect an environment to configure its keybindings."
+                : "Loading environments."
+          }
+          control={
+            environmentId !== null && environment !== null ? (
+              <SettingsEnvironmentSelector
+                environmentId={environmentId}
+                environments={environments}
+                primaryEnvironmentId={primaryEnvironmentId}
+                onEnvironmentChange={selectEnvironment}
               />
-              <TooltipPopup side="top">Add keybinding</TooltipPopup>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    type="button"
-                    size="icon-xs"
-                    variant="ghost"
-                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                    disabled={!keybindingsConfigPath}
-                    onClick={openKeybindingsFile}
-                    aria-label="Open keybindings.json"
-                  >
-                    <FileJsonIcon className="size-3" />
-                  </Button>
-                }
-              />
-              <TooltipPopup side="top">Open keybindings.json</TooltipPopup>
-            </Tooltip>
-          </div>
-        }
-      >
-        {!isElectron ? (
-          <div className="flex items-start gap-2 border-b border-warning/20 bg-warning/5 px-3 py-2.5 text-[12px] leading-relaxed text-muted-foreground sm:px-4">
-            <InfoIcon className="mt-0.5 size-3.5 shrink-0 text-warning" />
-            <p>
-              Some shortcuts may be claimed by the browser before T3 Code sees them. Use the desktop
-              app for better keybinding support.
-            </p>
-          </div>
-        ) : null}
-
-        <ScrollArea
-          chainVerticalScroll
-          scrollFade
-          hideScrollbars
-          className="w-full max-w-full rounded-none"
-        >
-          <div className="grid min-w-[680px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
-            <div>Command</div>
-            <div>Keybinding</div>
-            <div>When</div>
-            <div>Status</div>
-          </div>
-          <div className="min-w-[680px] divide-y divide-border/60">
-            {isAddingBinding ? (
-              <NewKeybindingTableRow
-                commandOptions={commandOptions}
-                allRows={rows}
-                variables={whenVariables}
-                isSaving={savingCommand !== null}
-                onSave={saveKeybinding}
-                onCancel={() => setIsAddingBinding(false)}
-              />
-            ) : null}
-            {rows.map((row) => (
-              <KeybindingTableRow
-                key={row.id}
-                row={row}
-                allRows={rows}
-                variables={whenVariables}
-                isSaving={savingCommand === row.command}
-                onSave={saveKeybinding}
-                onReset={resetKeybinding}
-                onRemove={removeKeybinding}
-              />
-            ))}
-            {rows.length === 0 && !isAddingBinding ? (
-              <div className="px-4 py-12 text-center text-sm text-muted-foreground">
-                No keybindings match your search.
-              </div>
-            ) : null}
-          </div>
-        </ScrollArea>
+            ) : environmentsReady ? (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Open connections
+              </Button>
+            ) : null
+          }
+        />
       </SettingsSection>
+
+      {isConnected ? (
+        <SettingsSection
+          title="Keybindings"
+          headerAction={
+            <div className="flex items-center gap-1.5">
+              <ExpandableHeaderSearch
+                query={query}
+                onChange={setQuery}
+                isOpen={isSearchOpen}
+                onOpenChange={setIsSearchOpen}
+                inputRef={searchInputRef}
+                collapsedAccessory={bindingsCount}
+              />
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="button"
+                      size="icon-xs"
+                      variant="ghost"
+                      className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                      onClick={() => setIsAddingBinding(true)}
+                      aria-label="Add keybinding"
+                    >
+                      <PlusIcon className="size-3" />
+                    </Button>
+                  }
+                />
+                <TooltipPopup side="top">Add keybinding</TooltipPopup>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="button"
+                      size="icon-xs"
+                      variant="ghost"
+                      className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                      disabled={!keybindingsConfigPath}
+                      onClick={openKeybindingsFile}
+                      aria-label="Open keybindings.json"
+                    >
+                      <FileJsonIcon className="size-3" />
+                    </Button>
+                  }
+                />
+                <TooltipPopup side="top">Open keybindings.json</TooltipPopup>
+              </Tooltip>
+            </div>
+          }
+        >
+          {!isElectron ? (
+            <div className="flex items-start gap-2 border-b border-warning/20 bg-warning/5 px-3 py-2.5 text-[12px] leading-relaxed text-muted-foreground sm:px-4">
+              <InfoIcon className="mt-0.5 size-3.5 shrink-0 text-warning" />
+              <p>
+                Some shortcuts may be claimed by the browser before T3 Code sees them. Use the
+                desktop app for better keybinding support.
+              </p>
+            </div>
+          ) : null}
+
+          <ScrollArea
+            chainVerticalScroll
+            scrollFade
+            hideScrollbars
+            className="w-full max-w-full rounded-none"
+          >
+            <div className="grid min-w-[680px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+              <div>Command</div>
+              <div>Keybinding</div>
+              <div>When</div>
+              <div>Status</div>
+            </div>
+            <div className="min-w-[680px] divide-y divide-border/60">
+              {isAddingBinding ? (
+                <NewKeybindingTableRow
+                  commandOptions={commandOptions}
+                  allRows={rows}
+                  variables={whenVariables}
+                  isSaving={savingCommand !== null}
+                  onSave={saveKeybinding}
+                  onCancel={() => setIsAddingBinding(false)}
+                />
+              ) : null}
+              {rows.map((row) => (
+                <KeybindingTableRow
+                  key={row.id}
+                  row={row}
+                  allRows={rows}
+                  variables={whenVariables}
+                  isSaving={savingCommand === row.command}
+                  onSave={saveKeybinding}
+                  onReset={resetKeybinding}
+                  onRemove={removeKeybinding}
+                />
+              ))}
+              {rows.length === 0 && !isAddingBinding ? (
+                <div className="px-4 py-12 text-center text-sm text-muted-foreground">
+                  No keybindings match your search.
+                </div>
+              ) : null}
+            </div>
+          </ScrollArea>
+        </SettingsSection>
+      ) : null}
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/components/settings/ProviderEnvironmentSelector.tsx
+++ b/apps/web/src/components/settings/ProviderEnvironmentSelector.tsx
@@ -1,0 +1,77 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { CloudIcon, MonitorIcon } from "lucide-react";
+import { useMemo } from "react";
+
+import type { EnvironmentPresentation } from "../../state/environments";
+import {
+  Select,
+  SelectGroup,
+  SelectGroupLabel,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+
+interface ProviderEnvironmentSelectorProps {
+  readonly environmentId: EnvironmentId;
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly onEnvironmentChange: (environmentId: EnvironmentId) => void;
+}
+
+export function ProviderEnvironmentSelector({
+  environmentId,
+  environments,
+  primaryEnvironmentId,
+  onEnvironmentChange,
+}: ProviderEnvironmentSelectorProps) {
+  const selectedEnvironment =
+    environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  const items = useMemo(
+    () =>
+      environments.map((environment) => ({
+        value: environment.environmentId,
+        label: environment.label,
+      })),
+    [environments],
+  );
+
+  return (
+    <Select
+      value={environmentId}
+      items={items}
+      onValueChange={(value) => onEnvironmentChange(value as EnvironmentId)}
+    >
+      <SelectTrigger
+        size="sm"
+        className="w-36 sm:w-52"
+        aria-label="Configure providers on environment"
+      >
+        {environmentId === primaryEnvironmentId ? (
+          <MonitorIcon className="size-3.5" />
+        ) : (
+          <CloudIcon className="size-3.5" />
+        )}
+        <SelectValue>{selectedEnvironment?.label ?? "Select environment"}</SelectValue>
+      </SelectTrigger>
+      <SelectPopup align="end" alignItemWithTrigger={false}>
+        <SelectGroup>
+          <SelectGroupLabel>Configure providers on</SelectGroupLabel>
+          {environments.map((environment) => (
+            <SelectItem key={environment.environmentId} value={environment.environmentId}>
+              <span className="inline-flex items-center gap-1.5">
+                {environment.environmentId === primaryEnvironmentId ? (
+                  <MonitorIcon className="size-3.5" />
+                ) : (
+                  <CloudIcon className="size-3.5" />
+                )}
+                {environment.label}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectPopup>
+    </Select>
+  );
+}

--- a/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
+++ b/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
@@ -13,19 +13,19 @@ import {
   SelectValue,
 } from "../ui/select";
 
-interface ProviderEnvironmentSelectorProps {
+interface SettingsEnvironmentSelectorProps {
   readonly environmentId: EnvironmentId;
   readonly environments: ReadonlyArray<EnvironmentPresentation>;
   readonly primaryEnvironmentId: EnvironmentId | null;
   readonly onEnvironmentChange: (environmentId: EnvironmentId) => void;
 }
 
-export function ProviderEnvironmentSelector({
+export function SettingsEnvironmentSelector({
   environmentId,
   environments,
   primaryEnvironmentId,
   onEnvironmentChange,
-}: ProviderEnvironmentSelectorProps) {
+}: SettingsEnvironmentSelectorProps) {
   const selectedEnvironment =
     environments.find((environment) => environment.environmentId === environmentId) ?? null;
   const items = useMemo(
@@ -43,11 +43,7 @@ export function ProviderEnvironmentSelector({
       items={items}
       onValueChange={(value) => onEnvironmentChange(value as EnvironmentId)}
     >
-      <SelectTrigger
-        size="sm"
-        className="w-36 sm:w-52"
-        aria-label="Configure providers on environment"
-      >
+      <SelectTrigger size="sm" className="w-36 sm:w-52" aria-label="Settings environment">
         {environmentId === primaryEnvironmentId ? (
           <MonitorIcon className="size-3.5" />
         ) : (
@@ -57,7 +53,7 @@ export function ProviderEnvironmentSelector({
       </SelectTrigger>
       <SelectPopup align="end" alignItemWithTrigger={false}>
         <SelectGroup>
-          <SelectGroupLabel>Configure providers on</SelectGroupLabel>
+          <SelectGroupLabel>Configure environment</SelectGroupLabel>
           {environments.map((environment) => (
             <SelectItem key={environment.environmentId} value={environment.environmentId}>
               <span className="inline-flex items-center gap-1.5">

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SERVER_SETTINGS,
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceId,
   type ProviderInstanceConfig,
@@ -10,7 +11,68 @@ import {
   formatDiagnosticsDescription,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
+  resolveProviderSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
+
+const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000001");
+const REMOTE_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000002");
+
+describe("provider settings environment selection", () => {
+  it("preserves an explicit selected environment", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID, REMOTE_ENVIRONMENT_ID],
+        selectedEnvironmentId: REMOTE_ENVIRONMENT_ID,
+        primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
+        activeEnvironmentId: LOCAL_ENVIRONMENT_ID,
+      }),
+    ).toBe(REMOTE_ENVIRONMENT_ID);
+  });
+
+  it("defaults to the primary environment in managed mode", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [REMOTE_ENVIRONMENT_ID, LOCAL_ENVIRONMENT_ID],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
+        activeEnvironmentId: REMOTE_ENVIRONMENT_ID,
+      }),
+    ).toBe(LOCAL_ENVIRONMENT_ID);
+  });
+
+  it("defaults to the active remote environment in client-only mode", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID, REMOTE_ENVIRONMENT_ID],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: REMOTE_ENVIRONMENT_ID,
+      }),
+    ).toBe(REMOTE_ENVIRONMENT_ID);
+  });
+
+  it("falls back when the selected environment is no longer available", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID],
+        selectedEnvironmentId: REMOTE_ENVIRONMENT_ID,
+        primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
+        activeEnvironmentId: REMOTE_ENVIRONMENT_ID,
+      }),
+    ).toBe(LOCAL_ENVIRONMENT_ID);
+  });
+
+  it("returns null when no environments are available", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: null,
+      }),
+    ).toBeNull();
+  });
+});
 
 describe("project grouping toggle", () => {
   it("enables repository grouping and disables into separate projects", () => {

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -11,16 +11,16 @@ import {
   formatDiagnosticsDescription,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
-  resolveProviderSettingsEnvironmentId,
+  resolveSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
 
 const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000001");
 const REMOTE_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000002");
 
-describe("provider settings environment selection", () => {
+describe("settings environment selection", () => {
   it("preserves an explicit selected environment", () => {
     expect(
-      resolveProviderSettingsEnvironmentId({
+      resolveSettingsEnvironmentId({
         availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID, REMOTE_ENVIRONMENT_ID],
         selectedEnvironmentId: REMOTE_ENVIRONMENT_ID,
         primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
@@ -31,7 +31,7 @@ describe("provider settings environment selection", () => {
 
   it("defaults to the primary environment in managed mode", () => {
     expect(
-      resolveProviderSettingsEnvironmentId({
+      resolveSettingsEnvironmentId({
         availableEnvironmentIds: [REMOTE_ENVIRONMENT_ID, LOCAL_ENVIRONMENT_ID],
         selectedEnvironmentId: null,
         primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
@@ -42,7 +42,7 @@ describe("provider settings environment selection", () => {
 
   it("defaults to the active remote environment in client-only mode", () => {
     expect(
-      resolveProviderSettingsEnvironmentId({
+      resolveSettingsEnvironmentId({
         availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID, REMOTE_ENVIRONMENT_ID],
         selectedEnvironmentId: null,
         primaryEnvironmentId: null,
@@ -53,7 +53,7 @@ describe("provider settings environment selection", () => {
 
   it("falls back when the selected environment is no longer available", () => {
     expect(
-      resolveProviderSettingsEnvironmentId({
+      resolveSettingsEnvironmentId({
         availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID],
         selectedEnvironmentId: REMOTE_ENVIRONMENT_ID,
         primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
@@ -62,9 +62,20 @@ describe("provider settings environment selection", () => {
     ).toBe(LOCAL_ENVIRONMENT_ID);
   });
 
+  it("uses the first saved environment when client-only mode has no active environment yet", () => {
+    expect(
+      resolveSettingsEnvironmentId({
+        availableEnvironmentIds: [REMOTE_ENVIRONMENT_ID, LOCAL_ENVIRONMENT_ID],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: null,
+      }),
+    ).toBe(REMOTE_ENVIRONMENT_ID);
+  });
+
   it("returns null when no environments are available", () => {
     expect(
-      resolveProviderSettingsEnvironmentId({
+      resolveSettingsEnvironmentId({
         availableEnvironmentIds: [],
         selectedEnvironmentId: null,
         primaryEnvironmentId: null,

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -7,12 +7,15 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 import {
+  buildGeneralSettingsRestorePatch,
   buildProviderInstanceUpdatePatch,
   formatDiagnosticsDescription,
+  hasChangedGeneralServerSettings,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
   resolveSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
+import * as Duration from "effect/Duration";
 
 const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000001");
 const REMOTE_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000002");
@@ -82,6 +85,33 @@ describe("settings environment selection", () => {
         activeEnvironmentId: null,
       }),
     ).toBeNull();
+  });
+});
+
+describe("general settings restore", () => {
+  it("detects whether server-backed general settings differ from their defaults", () => {
+    expect(hasChangedGeneralServerSettings(DEFAULT_SERVER_SETTINGS)).toBe(false);
+    expect(
+      hasChangedGeneralServerSettings({
+        ...DEFAULT_SERVER_SETTINGS,
+        automaticGitFetchInterval: Duration.seconds(5),
+      }),
+    ).toBe(true);
+  });
+
+  it("omits server-backed defaults when only client settings need restoring", () => {
+    const clientOnlyPatch = buildGeneralSettingsRestorePatch({
+      includeServerSettings: false,
+    });
+    const serverAndClientPatch = buildGeneralSettingsRestorePatch({
+      includeServerSettings: true,
+    });
+
+    expect(clientOnlyPatch).toHaveProperty("wordWrap");
+    expect(clientOnlyPatch).not.toHaveProperty("enableAssistantStreaming");
+    expect(clientOnlyPatch).not.toHaveProperty("textGenerationModelSelection");
+    expect(serverAndClientPatch).toHaveProperty("enableAssistantStreaming");
+    expect(serverAndClientPatch).toHaveProperty("textGenerationModelSelection");
   });
 });
 

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,4 +1,5 @@
 import type {
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceConfig,
   ProviderInstanceId,
@@ -7,6 +8,29 @@ import type {
   UnifiedSettings,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+
+export function resolveProviderSettingsEnvironmentId(input: {
+  readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly activeEnvironmentId: EnvironmentId | null;
+}): EnvironmentId | null {
+  const availableIds = new Set(input.availableEnvironmentIds);
+  const candidates = [
+    input.selectedEnvironmentId,
+    input.primaryEnvironmentId,
+    input.activeEnvironmentId,
+    input.availableEnvironmentIds[0] ?? null,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate !== null && availableIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
 
 export function isProjectGroupingEnabled(mode: SidebarProjectGroupingMode): boolean {
   return mode !== "separate";

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -9,7 +9,7 @@ import type {
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 
-export function resolveProviderSettingsEnvironmentId(input: {
+export function resolveSettingsEnvironmentId(input: {
   readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;
   readonly selectedEnvironmentId: EnvironmentId | null;
   readonly primaryEnvironmentId: EnvironmentId | null;

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -8,6 +8,51 @@ import type {
   UnifiedSettings,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import * as Duration from "effect/Duration";
+import * as Equal from "effect/Equal";
+
+export function hasChangedGeneralServerSettings(settings: ServerSettings): boolean {
+  return (
+    settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming ||
+    settings.enableProviderUpdateChecks !== DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks ||
+    Duration.toMillis(settings.automaticGitFetchInterval) !==
+      Duration.toMillis(DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval) ||
+    settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||
+    settings.newWorktreesStartFromOrigin !== DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ||
+    settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory ||
+    !Equal.equals(
+      settings.textGenerationModelSelection,
+      DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+    )
+  );
+}
+
+export function buildGeneralSettingsRestorePatch(input: {
+  readonly includeServerSettings: boolean;
+}): Partial<UnifiedSettings> {
+  return {
+    timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
+    wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
+    diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+    glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
+    sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+    sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
+    autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
+    confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
+    confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+    ...(input.includeServerSettings
+      ? {
+          enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
+          enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+          automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
+          defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+          newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+          addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+          textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+        }
+      : {}),
+  };
+}
 
 export function resolveSettingsEnvironmentId(input: {
   readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -400,8 +400,8 @@ export function useSettingsRestore(onRestored?: () => void) {
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
   const hasChangedServerSettings = hasChangedGeneralServerSettings(settings);
-  const canRestoreDefaults =
-    !hasChangedServerSettings || environment?.connection.phase === "connected";
+  const includeServerSettings =
+    hasChangedServerSettings && environment?.connection.phase === "connected";
 
   const changedSettingLabels = useMemo(
     () => [
@@ -424,25 +424,31 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar
         ? ["Auto-open task panel"]
         : []),
-      ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
+      ...(includeServerSettings &&
+      settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
         ? ["Assistant output"]
         : []),
-      ...(settings.enableProviderUpdateChecks !==
+      ...(includeServerSettings &&
+      settings.enableProviderUpdateChecks !==
       DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks
         ? ["Provider update checks"]
         : []),
-      ...(Duration.toMillis(settings.automaticGitFetchInterval) !==
+      ...(includeServerSettings &&
+      Duration.toMillis(settings.automaticGitFetchInterval) !==
       Duration.toMillis(DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval)
         ? ["Automatic Git fetch interval"]
         : []),
-      ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
+      ...(includeServerSettings &&
+      settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
         ? ["New thread mode"]
         : []),
-      ...(settings.newWorktreesStartFromOrigin !==
+      ...(includeServerSettings &&
+      settings.newWorktreesStartFromOrigin !==
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
-      ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
+      ...(includeServerSettings &&
+      settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
       ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
@@ -451,9 +457,10 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
-      ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
+      ...(includeServerSettings && isTextGenerationModelDirty ? ["Text generation model"] : []),
     ],
     [
+      includeServerSettings,
       isTextGenerationModelDirty,
       settings.autoOpenPlanSidebar,
       settings.confirmThreadArchive,
@@ -473,6 +480,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       theme,
     ],
   );
+  const canRestoreDefaults = changedSettingLabels.length > 0;
 
   const restoreDefaults = useCallback(async () => {
     if (changedSettingLabels.length === 0 || !canRestoreDefaults) return;
@@ -487,14 +495,14 @@ export function useSettingsRestore(onRestored?: () => void) {
     setTheme("system");
     updateSettings(
       buildGeneralSettingsRestorePatch({
-        includeServerSettings: hasChangedServerSettings,
+        includeServerSettings,
       }),
     );
     onRestored?.();
   }, [
     canRestoreDefaults,
     changedSettingLabels,
-    hasChangedServerSettings,
+    includeServerSettings,
     onRestored,
     setTheme,
     updateSettings,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -6,6 +6,7 @@ import { useAtomValue } from "@effect/atom-react";
 import {
   defaultInstanceIdForDriver,
   type DesktopUpdateChannel,
+  type EnvironmentId,
   PROVIDER_DISPLAY_NAMES,
   ProviderDriverKind,
   type ProviderInstanceConfig,
@@ -43,7 +44,12 @@ import { TraitsPicker } from "../chat/TraitsPicker";
 import { isElectron } from "../../env";
 import { buildHostedChannelSelectionUrl, type HostedAppChannel } from "../../hostedPairing";
 import { useTheme } from "../../hooks/useTheme";
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import {
+  useEnvironmentSettings,
+  usePrimarySettings,
+  useUpdateEnvironmentSettings,
+  useUpdatePrimarySettings,
+} from "../../hooks/useSettings";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -61,8 +67,12 @@ import {
   primaryServerProvidersAtom,
   serverEnvironment,
 } from "../../state/server";
-import { usePrimaryEnvironment } from "../../state/environments";
-import { useProjects } from "../../state/entities";
+import {
+  type EnvironmentPresentation,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "../../state/environments";
+import { useActiveEnvironmentId, useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFormat";
 import { Button } from "../ui/button";
@@ -80,6 +90,7 @@ import {
   type ProviderUpdateCandidate,
 } from "../ProviderUpdateLaunchNotification.logic";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
+import { ProviderEnvironmentSelector } from "./ProviderEnvironmentSelector";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import {
   buildProviderInstanceUpdatePatch,
@@ -88,6 +99,7 @@ import {
   projectGroupingModeFromToggle,
   readLastEnabledProjectGroupingMode,
   rememberEnabledProjectGroupingMode,
+  resolveProviderSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
 import {
   SettingResetButton,
@@ -1097,10 +1109,74 @@ export function GeneralSettingsPanel() {
 }
 
 export function ProviderSettingsPanel() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
-  const primaryEnvironment = usePrimaryEnvironment();
+  const { isReady, environments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
+  const environmentId = resolveProviderSettingsEnvironmentId({
+    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+    selectedEnvironmentId,
+    primaryEnvironmentId,
+    activeEnvironmentId,
+  });
+  const environment =
+    environmentId === null
+      ? null
+      : (environments.find((candidate) => candidate.environmentId === environmentId) ?? null);
+
+  if (environmentId === null || environment === null) {
+    return (
+      <SettingsPageContainer>
+        <SettingsSection title="Providers">
+          <SettingsRow
+            title={isReady ? "No connected environments" : "Loading environments"}
+            description={
+              isReady
+                ? "Connect an environment before configuring its provider accounts."
+                : "Waiting for available environments."
+            }
+            control={
+              isReady ? (
+                <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                  Open connections
+                </Button>
+              ) : null
+            }
+          />
+        </SettingsSection>
+      </SettingsPageContainer>
+    );
+  }
+
+  return (
+    <ProviderSettingsEnvironmentPanel
+      key={environmentId}
+      environmentId={environmentId}
+      environmentLabel={environment.label}
+      environments={environments}
+      primaryEnvironmentId={primaryEnvironmentId}
+      onEnvironmentChange={setSelectedEnvironmentId}
+    />
+  );
+}
+
+function ProviderSettingsEnvironmentPanel({
+  environmentId,
+  environmentLabel,
+  environments,
+  primaryEnvironmentId,
+  onEnvironmentChange,
+}: {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly onEnvironmentChange: (environmentId: EnvironmentId) => void;
+}) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const serverSettings = useAtomValue(serverEnvironment.settingsValueAtom(environmentId));
+  const serverProviders = useAtomValue(serverEnvironment.providersValueAtom(environmentId)) ?? [];
   const refreshServerProviders = useAtomCommand(serverEnvironment.refreshProviders, {
     reportFailure: false,
   });
@@ -1114,6 +1190,15 @@ export function ProviderSettingsPanel() {
   >(() => new Set());
   const [openInstanceDetails, setOpenInstanceDetails] = useState<Record<string, boolean>>({});
   const refreshingRef = useRef(false);
+
+  const environmentSelector = (
+    <ProviderEnvironmentSelector
+      environmentId={environmentId}
+      environments={environments}
+      primaryEnvironmentId={primaryEnvironmentId}
+      onEnvironmentChange={onEnvironmentChange}
+    />
+  );
 
   const providerUpdateCandidates = useMemo(
     () => collectProviderUpdateCandidates(serverProviders),
@@ -1145,14 +1230,9 @@ export function ProviderSettingsPanel() {
     if (refreshingRef.current) return;
     refreshingRef.current = true;
     setIsRefreshingProviders(true);
-    if (!primaryEnvironment) {
-      refreshingRef.current = false;
-      setIsRefreshingProviders(false);
-      return;
-    }
     void (async () => {
       const result = await refreshServerProviders({
-        environmentId: primaryEnvironment.environmentId,
+        environmentId,
         input: {},
       });
       refreshingRef.current = false;
@@ -1160,16 +1240,15 @@ export function ProviderSettingsPanel() {
       if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
         console.warn("Failed to refresh providers", {
           operation: "refresh-providers",
-          environmentId: primaryEnvironment.environmentId,
+          environmentId,
           ...safeErrorLogAttributes(squashAtomCommandFailure(result)),
         });
       }
     })();
-  }, [primaryEnvironment, refreshServerProviders]);
+  }, [environmentId, refreshServerProviders]);
 
   const runProviderUpdate = useCallback(
     async (candidate: ProviderUpdateCandidate) => {
-      if (!primaryEnvironment) return;
       let started = false;
       setUpdatingProviderDrivers((previous) => {
         if (previous.has(candidate.driver)) {
@@ -1185,7 +1264,7 @@ export function ProviderSettingsPanel() {
       }
 
       const result = await updateProvider({
-        environmentId: primaryEnvironment.environmentId,
+        environmentId,
         input: {
           provider: candidate.driver,
           instanceId: candidate.instanceId,
@@ -1213,8 +1292,21 @@ export function ProviderSettingsPanel() {
         return next;
       });
     },
-    [primaryEnvironment, updateProvider],
+    [environmentId, updateProvider],
   );
+
+  if (serverSettings === null) {
+    return (
+      <SettingsPageContainer>
+        <SettingsSection title="Providers" headerAction={environmentSelector}>
+          <SettingsRow
+            title={`Connecting to ${environmentLabel}`}
+            description="Provider settings will be available when this environment connects."
+          />
+        </SettingsSection>
+      </SettingsPageContainer>
+    );
+  }
 
   interface InstanceRow {
     readonly instanceId: ProviderInstanceId;
@@ -1393,6 +1485,7 @@ export function ProviderSettingsPanel() {
         title="Providers"
         headerAction={
           <div className="flex items-center gap-1.5">
+            {environmentSelector}
             <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
             <Tooltip>
               <TooltipTrigger
@@ -1535,7 +1628,12 @@ export function ProviderSettingsPanel() {
       </SettingsSection>
 
       {isAddInstanceDialogOpen ? (
-        <AddProviderInstanceDialog open onOpenChange={setIsAddInstanceDialogOpen} />
+        <AddProviderInstanceDialog
+          open
+          environmentId={environmentId}
+          environmentLabel={environmentLabel}
+          onOpenChange={setIsAddInstanceDialogOpen}
+        />
       ) : null}
     </SettingsPageContainer>
   );

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -15,6 +15,7 @@ import {
   type SidebarProjectGroupingMode,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import {
   isAtomCommandInterrupted,
@@ -44,12 +45,8 @@ import { TraitsPicker } from "../chat/TraitsPicker";
 import { isElectron } from "../../env";
 import { buildHostedChannelSelectionUrl, type HostedAppChannel } from "../../hostedPairing";
 import { useTheme } from "../../hooks/useTheme";
-import {
-  useEnvironmentSettings,
-  usePrimarySettings,
-  useUpdateEnvironmentSettings,
-  useUpdatePrimarySettings,
-} from "../../hooks/useSettings";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -62,17 +59,9 @@ import {
   sortProviderInstanceEntries,
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
-import {
-  primaryServerObservabilityAtom,
-  primaryServerProvidersAtom,
-  serverEnvironment,
-} from "../../state/server";
-import {
-  type EnvironmentPresentation,
-  useEnvironments,
-  usePrimaryEnvironmentId,
-} from "../../state/environments";
-import { useActiveEnvironmentId, useProjects } from "../../state/entities";
+import { serverEnvironment } from "../../state/server";
+import { type EnvironmentPresentation } from "../../state/environments";
+import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFormat";
 import { Button } from "../ui/button";
@@ -90,7 +79,7 @@ import {
   type ProviderUpdateCandidate,
 } from "../ProviderUpdateLaunchNotification.logic";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
-import { ProviderEnvironmentSelector } from "./ProviderEnvironmentSelector";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import {
   buildProviderInstanceUpdatePatch,
@@ -99,7 +88,6 @@ import {
   projectGroupingModeFromToggle,
   readLastEnabledProjectGroupingMode,
   rememberEnabledProjectGroupingMode,
-  resolveProviderSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
 import {
   SettingResetButton,
@@ -401,8 +389,9 @@ function AboutVersionSection() {
 
 export function useSettingsRestore(onRestored?: () => void) {
   const { theme, setTheme } = useTheme();
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const { environmentId } = useSettingsEnvironment();
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
 
   const isTextGenerationModelDirty = !Equal.equals(
     settings.textGenerationModelSelection ?? null,
@@ -520,13 +509,23 @@ export function useSettingsRestore(onRestored?: () => void) {
 
 export function GeneralSettingsPanel() {
   const { theme, setTheme } = useTheme();
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const {
+    environmentId,
+    environment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment,
+    isReady: environmentsReady,
+  } = useSettingsEnvironment();
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
   const lastEnabledProjectGroupingMode = useRef<SidebarProjectGroupingMode>(
     readLastEnabledProjectGroupingMode(),
   );
-  const observability = useAtomValue(primaryServerObservabilityAtom);
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
+  const observability = serverConfig?.observability ?? null;
+  const serverProviders = serverConfig?.providers ?? [];
+  const canConfigureServer = environment?.connection.phase === "connected";
   const glassOpacityRatio =
     (settings.glassOpacity - MIN_GLASS_OPACITY) / (MAX_GLASS_OPACITY - MIN_GLASS_OPACITY);
   const glassOpacitySliderStyle = {
@@ -566,6 +565,36 @@ export function GeneralSettingsPanel() {
 
   return (
     <SettingsPageContainer>
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Server settings"
+          description="Assistant behavior, workspace defaults, provider maintenance, and text generation are configured per environment."
+          status={
+            environment
+              ? [connectionStatusText(environment.connection), environment.displayUrl]
+                  .filter(Boolean)
+                  .join(" · ")
+              : environmentsReady
+                ? "Connect an environment to configure its server settings."
+                : "Loading environments."
+          }
+          control={
+            environmentId !== null && environment !== null ? (
+              <SettingsEnvironmentSelector
+                environmentId={environmentId}
+                environments={environments}
+                primaryEnvironmentId={primaryEnvironmentId}
+                onEnvironmentChange={selectEnvironment}
+              />
+            ) : environmentsReady ? (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Open connections
+              </Button>
+            ) : null
+          }
+        />
+      </SettingsSection>
+
       <SettingsSection title="General">
         <SettingsRow
           title="Theme"
@@ -793,6 +822,7 @@ export function GeneralSettingsPanel() {
           control={
             <Switch
               checked={settings.enableAssistantStreaming}
+              disabled={!canConfigureServer}
               onCheckedChange={(checked) =>
                 updateSettings({ enableAssistantStreaming: Boolean(checked) })
               }
@@ -820,6 +850,7 @@ export function GeneralSettingsPanel() {
           control={
             <Switch
               checked={settings.enableProviderUpdateChecks}
+              disabled={!canConfigureServer}
               onCheckedChange={(checked) =>
                 updateSettings({ enableProviderUpdateChecks: Boolean(checked) })
               }
@@ -882,7 +913,11 @@ export function GeneralSettingsPanel() {
                 }
               }}
             >
-              <SelectTrigger className="w-full sm:w-44" aria-label="Default thread mode">
+              <SelectTrigger
+                className="w-full sm:w-44"
+                aria-label="Default thread mode"
+                disabled={!canConfigureServer}
+              >
                 <SelectValue>
                   {settings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Local"}
                 </SelectValue>
@@ -921,6 +956,7 @@ export function GeneralSettingsPanel() {
             control={
               <Switch
                 checked={settings.newWorktreesStartFromOrigin}
+                disabled={!canConfigureServer}
                 onCheckedChange={(checked) =>
                   updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
                 }
@@ -949,6 +985,7 @@ export function GeneralSettingsPanel() {
           control={
             <DraftInput
               className="w-full sm:w-72"
+              disabled={!canConfigureServer}
               value={settings.addProjectBaseDirectory}
               onCommit={(next) => updateSettings({ addProjectBaseDirectory: next })}
               placeholder="~/"
@@ -1027,9 +1064,13 @@ export function GeneralSettingsPanel() {
             ) : null
           }
           control={
-            <div className="flex flex-wrap items-center justify-end gap-1.5">
+            <fieldset
+              className="flex flex-wrap items-center justify-end gap-1.5"
+              disabled={!canConfigureServer}
+            >
               <ProviderModelPicker
                 activeInstanceId={textGenInstanceId}
+                disabled={!canConfigureServer}
                 model={textGenModel}
                 lockedProvider={null}
                 instanceEntries={textGenerationModelInstanceEntries}
@@ -1080,7 +1121,7 @@ export function GeneralSettingsPanel() {
                   });
                 }}
               />
-            </div>
+            </fieldset>
           }
         />
       </SettingsSection>
@@ -1109,20 +1150,14 @@ export function GeneralSettingsPanel() {
 }
 
 export function ProviderSettingsPanel() {
-  const { isReady, environments } = useEnvironments();
-  const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const activeEnvironmentId = useActiveEnvironmentId();
-  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
-  const environmentId = resolveProviderSettingsEnvironmentId({
-    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
-    selectedEnvironmentId,
+  const {
+    isReady,
+    environments,
     primaryEnvironmentId,
-    activeEnvironmentId,
-  });
-  const environment =
-    environmentId === null
-      ? null
-      : (environments.find((candidate) => candidate.environmentId === environmentId) ?? null);
+    environmentId,
+    environment,
+    selectEnvironment,
+  } = useSettingsEnvironment();
 
   if (environmentId === null || environment === null) {
     return (
@@ -1153,9 +1188,11 @@ export function ProviderSettingsPanel() {
       key={environmentId}
       environmentId={environmentId}
       environmentLabel={environment.label}
+      environmentStatus={connectionStatusText(environment.connection)}
+      isConnected={environment.connection.phase === "connected"}
       environments={environments}
       primaryEnvironmentId={primaryEnvironmentId}
-      onEnvironmentChange={setSelectedEnvironmentId}
+      onEnvironmentChange={selectEnvironment}
     />
   );
 }
@@ -1163,12 +1200,16 @@ export function ProviderSettingsPanel() {
 function ProviderSettingsEnvironmentPanel({
   environmentId,
   environmentLabel,
+  environmentStatus,
+  isConnected,
   environments,
   primaryEnvironmentId,
   onEnvironmentChange,
 }: {
   readonly environmentId: EnvironmentId;
   readonly environmentLabel: string;
+  readonly environmentStatus: string;
+  readonly isConnected: boolean;
   readonly environments: ReadonlyArray<EnvironmentPresentation>;
   readonly primaryEnvironmentId: EnvironmentId | null;
   readonly onEnvironmentChange: (environmentId: EnvironmentId) => void;
@@ -1192,7 +1233,7 @@ function ProviderSettingsEnvironmentPanel({
   const refreshingRef = useRef(false);
 
   const environmentSelector = (
-    <ProviderEnvironmentSelector
+    <SettingsEnvironmentSelector
       environmentId={environmentId}
       environments={environments}
       primaryEnvironmentId={primaryEnvironmentId}
@@ -1295,13 +1336,13 @@ function ProviderSettingsEnvironmentPanel({
     [environmentId, updateProvider],
   );
 
-  if (serverSettings === null) {
+  if (serverSettings === null || !isConnected) {
     return (
       <SettingsPageContainer>
         <SettingsSection title="Providers" headerAction={environmentSelector}>
           <SettingsRow
-            title={`Connecting to ${environmentLabel}`}
-            description="Provider settings will be available when this environment connects."
+            title={`${environmentStatus}: ${environmentLabel}`}
+            description="Provider settings are available while this environment is connected."
           />
         </SettingsSection>
       </SettingsPageContainer>

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -82,8 +82,10 @@ import { ProviderInstanceCard } from "./ProviderInstanceCard";
 import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import {
+  buildGeneralSettingsRestorePatch,
   buildProviderInstanceUpdatePatch,
   formatDiagnosticsDescription,
+  hasChangedGeneralServerSettings,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
   readLastEnabledProjectGroupingMode,
@@ -389,7 +391,7 @@ function AboutVersionSection() {
 
 export function useSettingsRestore(onRestored?: () => void) {
   const { theme, setTheme } = useTheme();
-  const { environmentId } = useSettingsEnvironment();
+  const { environmentId, environment } = useSettingsEnvironment();
   const settings = useEnvironmentSettings(environmentId);
   const updateSettings = useUpdateEnvironmentSettings(environmentId);
 
@@ -397,6 +399,9 @@ export function useSettingsRestore(onRestored?: () => void) {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
+  const hasChangedServerSettings = hasChangedGeneralServerSettings(settings);
+  const canRestoreDefaults =
+    !hasChangedServerSettings || environment?.connection.phase === "connected";
 
   const changedSettingLabels = useMemo(
     () => [
@@ -470,7 +475,7 @@ export function useSettingsRestore(onRestored?: () => void) {
   );
 
   const restoreDefaults = useCallback(async () => {
-    if (changedSettingLabels.length === 0) return;
+    if (changedSettingLabels.length === 0 || !canRestoreDefaults) return;
     const api = readLocalApi();
     const confirmed = await (api ?? ensureLocalApi()).dialogs.confirm(
       ["Restore default settings?", `This will reset: ${changedSettingLabels.join(", ")}.`].join(
@@ -480,28 +485,23 @@ export function useSettingsRestore(onRestored?: () => void) {
     if (!confirmed) return;
 
     setTheme("system");
-    updateSettings({
-      timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
-      wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
-      diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
-      glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
-      sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
-      sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
-      autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
-      enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
-      enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
-      automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
-      defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
-      newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
-      addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
-      confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
-      confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
-      textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
-    });
+    updateSettings(
+      buildGeneralSettingsRestorePatch({
+        includeServerSettings: hasChangedServerSettings,
+      }),
+    );
     onRestored?.();
-  }, [changedSettingLabels, onRestored, setTheme, updateSettings]);
+  }, [
+    canRestoreDefaults,
+    changedSettingLabels,
+    hasChangedServerSettings,
+    onRestored,
+    setTheme,
+    updateSettings,
+  ]);
 
   return {
+    canRestoreDefaults,
     changedSettingLabels,
     restoreDefaults,
   };
@@ -811,6 +811,7 @@ export function GeneralSettingsPanel() {
             DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming ? (
               <SettingResetButton
                 label="assistant output"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
@@ -839,6 +840,7 @@ export function GeneralSettingsPanel() {
             DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks ? (
               <SettingResetButton
                 label="provider update checks"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
@@ -894,6 +896,7 @@ export function GeneralSettingsPanel() {
               DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
               <SettingResetButton
                 label="new threads"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
@@ -944,6 +947,7 @@ export function GeneralSettingsPanel() {
               DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
                 <SettingResetButton
                   label="new worktrees start from origin"
+                  disabled={!canConfigureServer}
                   onClick={() =>
                     updateSettings({
                       newWorktreesStartFromOrigin:
@@ -974,6 +978,7 @@ export function GeneralSettingsPanel() {
             DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory ? (
               <SettingResetButton
                 label="add project base directory"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
@@ -1054,6 +1059,7 @@ export function GeneralSettingsPanel() {
             isTextGenerationModelDirty ? (
               <SettingResetButton
                 label="text generation model"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     textGenerationModelSelection:

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -2,7 +2,10 @@ import { ChevronDownIcon, GitPullRequestIcon, RefreshCwIcon } from "lucide-react
 import * as Duration from "effect/Duration";
 import * as Option from "effect/Option";
 import { useState, type ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import type {
+  EnvironmentId,
   SourceControlProviderKind,
   SourceControlDiscoveryResult,
   SourceControlProviderAuth,
@@ -12,9 +15,9 @@ import type {
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { cn } from "../../lib/utils";
-import { usePrimaryEnvironment } from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
 import { sourceControlEnvironment } from "../../state/sourceControl";
 import { Badge } from "../ui/badge";
@@ -48,8 +51,14 @@ import {
   type Icon,
 } from "../Icons";
 import { RedactedSensitiveText } from "./RedactedSensitiveText";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import { SourceControlWritingSettingsSection } from "./SourceControlWritingSettings";
-import { SettingResetButton, SettingsPageContainer, SettingsSection } from "./settingsLayout";
+import {
+  SettingResetButton,
+  SettingsPageContainer,
+  SettingsRow,
+  SettingsSection,
+} from "./settingsLayout";
 
 const EMPTY_DISCOVERY_RESULT: SourceControlDiscoveryResult = {
   versionControlSystems: [],
@@ -291,11 +300,18 @@ function DiscoveryItemRow({
   );
 }
 
-function GitFetchIntervalSettings() {
-  const automaticGitFetchInterval = usePrimarySettings(
+function GitFetchIntervalSettings({
+  environmentId,
+  isConnected,
+}: {
+  environmentId: EnvironmentId;
+  isConnected: boolean;
+}) {
+  const automaticGitFetchInterval = useEnvironmentSettings(
+    environmentId,
     (settings) => settings.automaticGitFetchInterval,
   );
-  const updateSettings = useUpdatePrimarySettings();
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
   const automaticGitFetchIntervalSeconds = durationToSeconds(automaticGitFetchInterval);
   const defaultAutomaticGitFetchIntervalSeconds = durationToSeconds(
     DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
@@ -319,6 +335,7 @@ function GitFetchIntervalSettings() {
               {canResetFetchInterval ? (
                 <SettingResetButton
                   label="fetch interval"
+                  disabled={!isConnected}
                   onClick={() =>
                     updateSettings({
                       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
@@ -335,6 +352,7 @@ function GitFetchIntervalSettings() {
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <NumberField
+            disabled={!isConnected}
             value={automaticGitFetchIntervalSeconds}
             min={0}
             step={GIT_FETCH_INTERVAL_STEP_SECONDS}
@@ -441,9 +459,17 @@ function EmptySourceControlDiscovery({
 }
 
 export function SourceControlSettingsPanel() {
-  const environmentId = usePrimaryEnvironment()?.environmentId ?? null;
+  const {
+    environmentId,
+    environment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment,
+    isReady: environmentsReady,
+  } = useSettingsEnvironment();
+  const isConnected = environment?.connection.phase === "connected";
   const discovery = useEnvironmentQuery(
-    environmentId === null
+    environmentId === null || !isConnected
       ? null
       : sourceControlEnvironment.discovery({
           environmentId,
@@ -466,7 +492,7 @@ export function SourceControlSettingsPanel() {
             variant="ghost"
             className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
             onClick={handleScan}
-            disabled={discovery.isPending}
+            disabled={!isConnected || discovery.isPending}
             aria-label="Rescan server environment"
           >
             <RefreshCwIcon className={cn("size-3", discovery.isPending && "animate-spin")} />
@@ -479,7 +505,37 @@ export function SourceControlSettingsPanel() {
 
   return (
     <SettingsPageContainer>
-      {isInitialScanPending ? (
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Source control environment"
+          description="Git tooling, credentials, hosting integrations, and fetch behavior belong to a specific server."
+          status={
+            environment
+              ? [connectionStatusText(environment.connection), environment.displayUrl]
+                  .filter(Boolean)
+                  .join(" · ")
+              : environmentsReady
+                ? "Connect an environment to inspect its source-control configuration."
+                : "Loading environments."
+          }
+          control={
+            environmentId !== null && environment !== null ? (
+              <SettingsEnvironmentSelector
+                environmentId={environmentId}
+                environments={environments}
+                primaryEnvironmentId={primaryEnvironmentId}
+                onEnvironmentChange={selectEnvironment}
+              />
+            ) : environmentsReady ? (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Open connections
+              </Button>
+            ) : null
+          }
+        />
+      </SettingsSection>
+
+      {!isConnected || environmentId === null ? null : isInitialScanPending ? (
         <>
           <SourceControlSectionSkeleton title="Version Control" headerAction={scanButton} />
           <SourceControlSectionSkeleton title="Source Control Providers" />
@@ -490,7 +546,12 @@ export function SourceControlSettingsPanel() {
             <SettingsSection title="Version Control" headerAction={scanButton}>
               {result.versionControlSystems.map((item) => (
                 <DiscoveryItemRow key={`vcs:${item.kind}`} item={item}>
-                  {item.kind === "git" ? <GitFetchIntervalSettings /> : undefined}
+                  {item.kind === "git" ? (
+                    <GitFetchIntervalSettings
+                      environmentId={environmentId}
+                      isConnected={isConnected}
+                    />
+                  ) : undefined}
                 </DiscoveryItemRow>
               ))}
             </SettingsSection>
@@ -515,7 +576,12 @@ export function SourceControlSettingsPanel() {
         />
       )}
 
-      {environmentId !== null ? <SourceControlWritingSettingsSection /> : null}
+      {environmentId !== null ? (
+        <SourceControlWritingSettingsSection
+          environmentId={environmentId}
+          isConnected={isConnected}
+        />
+      ) : null}
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -1,11 +1,11 @@
 import { useAtomValue } from "@effect/atom-react";
 import { useRef } from "react";
-import type { SourceControlWritingStyleMode } from "@t3tools/contracts";
+import type { EnvironmentId, SourceControlWritingStyleMode } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import { createModelSelection } from "@t3tools/shared/model";
 import { resolveSourceControlWriterModelSelection } from "@t3tools/shared/serverSettings";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -15,7 +15,7 @@ import {
   getCustomModelOptionsByInstance,
   resolveAppModelSelectionState,
 } from "../../modelSelection";
-import { primaryServerProvidersAtom } from "../../state/server";
+import { serverEnvironment } from "../../state/server";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
@@ -40,10 +40,17 @@ const MODE_OPTIONS: Record<SourceControlWritingStyleMode, { label: string; descr
     },
   };
 
-export function SourceControlWritingSettingsSection() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+export function SourceControlWritingSettingsSection({
+  environmentId,
+  isConnected,
+}: {
+  environmentId: EnvironmentId;
+  isConnected: boolean;
+}) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const serverProviders =
+    useAtomValue(serverEnvironment.configValueAtom(environmentId))?.providers ?? [];
   const customInstructionsRef = useRef<HTMLTextAreaElement>(null);
   const style = settings.sourceControlWritingStyle;
   const defaults = DEFAULT_UNIFIED_SETTINGS.sourceControlWritingStyle;
@@ -79,6 +86,7 @@ export function SourceControlWritingSettingsSection() {
           isSourceControlWritingStyleDirty ? (
             <SettingResetButton
               label="source control writing style"
+              disabled={!isConnected}
               onClick={() =>
                 updateSettings({
                   sourceControlWritingStyle: {
@@ -92,6 +100,7 @@ export function SourceControlWritingSettingsSection() {
         }
         control={
           <Select
+            disabled={!isConnected}
             value={style.mode}
             onValueChange={(value) => {
               const customInstructions = customInstructionsRef.current?.value.trim();
@@ -119,6 +128,7 @@ export function SourceControlWritingSettingsSection() {
         {style.mode === "custom" ? (
           <div className="mt-3 max-w-2xl pb-3.5">
             <Textarea
+              disabled={!isConnected}
               key={style.customInstructions}
               ref={customInstructionsRef}
               defaultValue={style.customInstructions}
@@ -143,6 +153,7 @@ export function SourceControlWritingSettingsSection() {
           style.followChangeRequestTemplates !== defaults.followChangeRequestTemplates ? (
             <SettingResetButton
               label="change request templates"
+              disabled={!isConnected}
               onClick={() =>
                 updateSettings({
                   sourceControlWritingStyle: {
@@ -156,6 +167,7 @@ export function SourceControlWritingSettingsSection() {
         control={
           <Switch
             checked={style.followChangeRequestTemplates}
+            disabled={!isConnected}
             onCheckedChange={(checked) =>
               updateSettings({
                 sourceControlWritingStyle: {
@@ -176,6 +188,7 @@ export function SourceControlWritingSettingsSection() {
             {usesDedicatedModel ? (
               <ProviderModelPicker
                 activeInstanceId={activeSelection.instanceId}
+                disabled={!isConnected}
                 model={activeSelection.model}
                 lockedProvider={null}
                 instanceEntries={instanceEntries}
@@ -192,6 +205,7 @@ export function SourceControlWritingSettingsSection() {
             ) : null}
             <Switch
               checked={usesDedicatedModel}
+              disabled={!isConnected}
               onCheckedChange={(checked) =>
                 updateSettings({
                   sourceControlWriterModelSelection: checked

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -88,7 +88,15 @@ export function SettingsRow({
   );
 }
 
-export function SettingResetButton({ label, onClick }: { label: string; onClick: () => void }) {
+export function SettingResetButton({
+  label,
+  disabled = false,
+  onClick,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
   return (
     <Tooltip>
       <TooltipTrigger
@@ -98,6 +106,7 @@ export function SettingResetButton({ label, onClick }: { label: string; onClick:
             variant="ghost"
             aria-label={`Reset ${label} to default`}
             className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+            disabled={disabled}
             onClick={(event) => {
               event.stopPropagation();
               onClick();

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -1,11 +1,10 @@
-import { useAtomValue } from "@effect/atom-react";
 import { SettingsIcon } from "lucide-react";
 import { memo, useCallback } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 
 import { APP_STAGE_LABEL } from "../../branding";
 import { cn } from "../../lib/utils";
-import { primaryServerConfigAtom } from "../../state/server";
+import { useDefaultServerConfig } from "../../hooks/useDefaultServerConfig";
 import { resolveSidebarStageBadgeLabel } from "../Sidebar.logic";
 import { SidebarStageBackdrop, resolveSidebarStageBackdropVariant } from "../SidebarStageBackdrop";
 import {
@@ -72,8 +71,7 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
 }
 
 function useSidebarStageLabel() {
-  const primaryServerVersion =
-    useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
+  const primaryServerVersion = useDefaultServerConfig()?.environment.serverVersion ?? null;
 
   return resolveSidebarStageBadgeLabel({
     primaryServerVersion,

--- a/apps/web/src/components/sidebar/SidebarProviderUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarProviderUpdatePill.tsx
@@ -1,10 +1,9 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useAtomValue } from "@effect/atom-react";
 import type { ServerProvider } from "@t3tools/contracts";
 import { CircleCheckIcon, DownloadIcon, LoaderIcon, TriangleAlertIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useState, type CSSProperties } from "react";
 
-import { primaryServerProvidersAtom } from "../../state/server";
+import { useDefaultServerConfig } from "../../hooks/useDefaultServerConfig";
 import {
   getProviderUpdateSidebarPillView,
   type ProviderUpdateSidebarPillView,
@@ -40,7 +39,7 @@ function latestProviderCheckedAt(
 
 export function SidebarProviderUpdatePill() {
   const navigate = useNavigate();
-  const providers = useAtomValue(primaryServerProvidersAtom);
+  const providers = useDefaultServerConfig()?.providers ?? [];
   const [dismissedKeys, setDismissedKeys] = useState<ReadonlySet<string>>(() => new Set());
   const [renderedView, setRenderedView] = useState<ProviderUpdateSidebarPillView | null>(null);
   const [pendingView, setPendingView] = useState<ProviderUpdateSidebarPillView | null>(null);

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -45,7 +45,8 @@ import { FetchHttpClient } from "effect/unstable/http";
 import { readDesktopPrimaryBearerToken } from "../environments/primary/desktopAuth";
 import { primaryEnvironmentHttpLayer } from "../environments/primary/httpLayer";
 import {
-  readPrimaryEnvironmentTarget,
+  readOptionalPrimaryEnvironmentTarget,
+  isDesktopClientOnlyMode,
   type PrimaryEnvironmentTarget,
 } from "../environments/primary/target";
 import { clearComposerDraftsEnvironment } from "../composerDraftStore";
@@ -399,7 +400,7 @@ export type PrimaryEnvironmentTargetRead =
     };
 
 export function readPrimaryEnvironmentTargetResult(
-  readTarget: () => PrimaryEnvironmentTarget | null = readPrimaryEnvironmentTarget,
+  readTarget: () => PrimaryEnvironmentTarget | null = readOptionalPrimaryEnvironmentTarget,
 ): PrimaryEnvironmentTargetRead {
   try {
     return { _tag: "Success", target: readTarget() };
@@ -456,7 +457,7 @@ export function secondaryRegistrationsToRetainAfterTopologyRead(
 const platformConnectionSourceLayer = Layer.effect(
   PlatformConnectionSource,
   Effect.gen(function* () {
-    if (isHostedStaticApp()) {
+    if (isHostedStaticApp() || isDesktopClientOnlyMode()) {
       return PlatformConnectionSource.of({
         registrations: Stream.empty,
       });

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -81,6 +81,33 @@ describe("environment grouping", () => {
     expect(projectGroupCount).toBe(1);
   });
 
+  it("marks every project remote for an app with no local backend of its own", () => {
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+    });
+
+    const [clientOnly] = buildSidebarProjectSnapshots({
+      projects: [remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId: null,
+      ownsLocalEnvironment: false,
+      resolveEnvironmentLabel: () => "remote",
+    });
+
+    expect(clientOnly?.environmentPresence).toBe("remote-only");
+    expect(clientOnly?.remoteEnvironmentLabels).toEqual(["remote"]);
+
+    const [managed] = buildSidebarProjectSnapshots({
+      projects: [remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId: null,
+      resolveEnvironmentLabel: () => "remote",
+    });
+
+    expect(managed?.environmentPresence).toBe("local-only");
+  });
+
   it("keeps projects without repository identity physically scoped", () => {
     const primary = makeProject();
     const remote = makeProject({

--- a/apps/web/src/environmentPresence.test.ts
+++ b/apps/web/src/environmentPresence.test.ts
@@ -1,0 +1,29 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { isRemoteEnvironmentId } from "./environmentPresence";
+
+const primaryEnvironmentId = EnvironmentId.make("env-primary");
+const remoteEnvironmentId = EnvironmentId.make("env-remote");
+
+describe("isRemoteEnvironmentId", () => {
+  it("treats the primary environment as local and everything else as remote", () => {
+    const scope = { primaryEnvironmentId, ownsLocalEnvironment: true };
+
+    expect(isRemoteEnvironmentId(primaryEnvironmentId, scope)).toBe(false);
+    expect(isRemoteEnvironmentId(remoteEnvironmentId, scope)).toBe(true);
+  });
+
+  it("treats every environment as remote when the app owns no local backend", () => {
+    const scope = { primaryEnvironmentId: null, ownsLocalEnvironment: false };
+
+    expect(isRemoteEnvironmentId(remoteEnvironmentId, scope)).toBe(true);
+    expect(isRemoteEnvironmentId(primaryEnvironmentId, scope)).toBe(true);
+  });
+
+  it("treats nothing as remote while a managed app's primary is still registering", () => {
+    const scope = { primaryEnvironmentId: null, ownsLocalEnvironment: true };
+
+    expect(isRemoteEnvironmentId(remoteEnvironmentId, scope)).toBe(false);
+  });
+});

--- a/apps/web/src/environmentPresence.ts
+++ b/apps/web/src/environmentPresence.ts
@@ -1,0 +1,28 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+/**
+ * The comparison the UI uses to decide whether an environment is "remote" —
+ * i.e. somewhere other than the machine this app runs its own backend on.
+ */
+export interface EnvironmentPresenceScope {
+  /** The environment served by the app's own backend, when it has one. */
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  /**
+   * False when this app can never own a local backend: a client-only desktop
+   * and the hosted static web app only ever talk to backends they paired with,
+   * so every environment they reach is remote. This is deliberately separate
+   * from a null `primaryEnvironmentId`, which a managed app also reports while
+   * its local backend is still registering — there, nothing is remote yet.
+   */
+  readonly ownsLocalEnvironment: boolean;
+}
+
+export function isRemoteEnvironmentId(
+  environmentId: EnvironmentId,
+  scope: EnvironmentPresenceScope,
+): boolean {
+  if (!scope.ownsLocalEnvironment) {
+    return true;
+  }
+  return scope.primaryEnvironmentId !== null && environmentId !== scope.primaryEnvironmentId;
+}

--- a/apps/web/src/environments/primary/bootstrap.test.ts
+++ b/apps/web/src/environments/primary/bootstrap.test.ts
@@ -8,6 +8,7 @@ import {
   isPrimaryEnvironmentProtocolUnsupportedError,
   isPrimaryEnvironmentUrlInvalidError,
   readPrimaryEnvironmentTarget,
+  readOptionalPrimaryEnvironmentTarget,
   resolvePrimaryEnvironmentHttpUrl,
   resolveInitialPrimaryEnvironmentDescriptor,
   resetPrimaryEnvironmentDescriptorForTests,
@@ -256,5 +257,22 @@ describe("environmentBootstrap", () => {
       protocol: "file:",
       message: "The window-origin primary environment target uses unsupported protocol file:.",
     });
+  });
+
+  it("returns no primary target for a client-only desktop without using the custom origin", () => {
+    vi.stubGlobal("window", {
+      location: new URL("t3code://app/"),
+      history: { replaceState: vi.fn() },
+      desktopBridge: {
+        getBackendModeState: () => ({
+          effectiveMode: "client-only",
+          configuredMode: "client-only",
+          cliOverride: null,
+        }),
+        getLocalEnvironmentBootstraps: () => [],
+      },
+    });
+
+    expect(readOptionalPrimaryEnvironmentTarget()).toBeNull();
   });
 });

--- a/apps/web/src/environments/primary/index.ts
+++ b/apps/web/src/environments/primary/index.ts
@@ -48,6 +48,8 @@ export {
   PrimaryEnvironmentProtocolUnsupportedError,
   PrimaryEnvironmentUrlInvalidError,
   readPrimaryEnvironmentTarget,
+  readOptionalPrimaryEnvironmentTarget,
+  isDesktopClientOnlyMode,
   resolvePrimaryEnvironmentHttpUrl,
   isLoopbackHostname,
   type PrimaryEnvironmentTarget,

--- a/apps/web/src/environments/primary/target.ts
+++ b/apps/web/src/environments/primary/target.ts
@@ -73,6 +73,11 @@ export interface PrimaryEnvironmentTarget {
   };
 }
 
+export function isDesktopClientOnlyMode(): boolean {
+  const bridge = window.desktopBridge;
+  return bridge?.getBackendModeState?.().effectiveMode === "client-only";
+}
+
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 
 function getDesktopLocalEnvironmentBootstrap(): DesktopEnvironmentBootstrap | null {
@@ -291,4 +296,8 @@ export function readPrimaryEnvironmentTarget(): PrimaryEnvironmentTarget {
     resolveConfiguredPrimaryTarget() ??
     resolveWindowOriginPrimaryTarget()
   );
+}
+
+export function readOptionalPrimaryEnvironmentTarget(): PrimaryEnvironmentTarget | null {
+  return isDesktopClientOnlyMode() ? null : readPrimaryEnvironmentTarget();
 }

--- a/apps/web/src/hooks/useDefaultServerConfig.ts
+++ b/apps/web/src/hooks/useDefaultServerConfig.ts
@@ -20,5 +20,13 @@ export function useDefaultEnvironmentId() {
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const activeEnvironmentId = useActiveEnvironmentId();
   const { environments } = useEnvironments();
-  return primaryEnvironmentId ?? activeEnvironmentId ?? environments[0]?.environmentId ?? null;
+  const activeEnvironmentExists =
+    activeEnvironmentId !== null &&
+    environments.some((environment) => environment.environmentId === activeEnvironmentId);
+  return (
+    primaryEnvironmentId ??
+    (activeEnvironmentExists ? activeEnvironmentId : null) ??
+    environments[0]?.environmentId ??
+    null
+  );
 }

--- a/apps/web/src/hooks/useDefaultServerConfig.ts
+++ b/apps/web/src/hooks/useDefaultServerConfig.ts
@@ -1,0 +1,24 @@
+import { useAtomValue } from "@effect/atom-react";
+import type { ServerConfig } from "@t3tools/contracts";
+
+import { useActiveEnvironmentId } from "../state/entities";
+import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import { serverEnvironment } from "../state/server";
+
+/**
+ * Server configuration for global client surfaces.
+ *
+ * A managed client keeps using its primary backend. A client without a
+ * managed backend follows the active saved environment instead.
+ */
+export function useDefaultServerConfig(): ServerConfig | null {
+  const environmentId = useDefaultEnvironmentId();
+  return useAtomValue(serverEnvironment.configValueAtom(environmentId));
+}
+
+export function useDefaultEnvironmentId() {
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const { environments } = useEnvironments();
+  return primaryEnvironmentId ?? activeEnvironmentId ?? environments[0]?.environmentId ?? null;
+}

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -5,7 +5,6 @@ import {
 } from "@t3tools/client-runtime/environment";
 import {
   DEFAULT_RUNTIME_MODE,
-  DEFAULT_SERVER_SETTINGS,
   type ScopedProjectRef,
 } from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
@@ -23,7 +22,13 @@ import {
   getProjectOrderKey,
   selectProjectGroupingSettings,
 } from "../logicalProject";
-import { readThreadShell, useProjects, useServerConfigs, useThread } from "../state/entities";
+import {
+  readThreadShell,
+  useProjects,
+  useServerConfigs,
+  useThread,
+  waitForServerConfig,
+} from "../state/entities";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
 import { resolveThreadRouteTarget } from "../threadRoutes";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
@@ -40,7 +45,7 @@ export function useNewThreadHandler() {
   }, [router]);
 
   return useCallback(
-    (
+    async (
       projectRef: ScopedProjectRef,
       options?: {
         branch?: string | null;
@@ -102,8 +107,10 @@ export function useNewThreadHandler() {
           candidate.id === projectRef.projectId &&
           candidate.environmentId === projectRef.environmentId,
       );
-      const targetServerSettings =
-        serverConfigs.get(projectRef.environmentId)?.settings ?? DEFAULT_SERVER_SETTINGS;
+      const targetServerSettings = (
+        serverConfigs.get(projectRef.environmentId) ??
+        (await waitForServerConfig(projectRef.environmentId))
+      ).settings;
       const logicalProjectKey = project
         ? deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings)
         : scopedProjectKey(projectRef);

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -1,10 +1,13 @@
-import { useAtomValue } from "@effect/atom-react";
 import {
   scopedProjectKey,
   scopeProjectRef,
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
-import { DEFAULT_RUNTIME_MODE, type ScopedProjectRef } from "@t3tools/contracts";
+import {
+  DEFAULT_RUNTIME_MODE,
+  DEFAULT_SERVER_SETTINGS,
+  type ScopedProjectRef,
+} from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import {
@@ -20,21 +23,15 @@ import {
   getProjectOrderKey,
   selectProjectGroupingSettings,
 } from "../logicalProject";
-import { readThreadShell, useProjects, useThread } from "../state/entities";
+import { readThreadShell, useProjects, useServerConfigs, useThread } from "../state/entities";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
-import { primaryServerSettingsAtom } from "../state/server";
 import { resolveThreadRouteTarget } from "../threadRoutes";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { useClientSettings } from "./useSettings";
 
 export function useNewThreadHandler() {
   const projects = useProjects();
-  // New-thread defaults are a user preference, and the settings UI only ever
-  // edits the primary environment's settings.json. Reading the target
-  // environment's own settings here would silently reset remote projects to
-  // the decoded defaults ("local" mode, current branch), since nothing can
-  // set those values on a remote server.
-  const primaryServerSettings = useAtomValue(primaryServerSettingsAtom);
+  const serverConfigs = useServerConfigs();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const router = useRouter();
   const getCurrentRouteTarget = useCallback(() => {
@@ -105,6 +102,8 @@ export function useNewThreadHandler() {
           candidate.id === projectRef.projectId &&
           candidate.environmentId === projectRef.environmentId,
       );
+      const targetServerSettings =
+        serverConfigs.get(projectRef.environmentId)?.settings ?? DEFAULT_SERVER_SETTINGS;
       const logicalProjectKey = project
         ? deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings)
         : scopedProjectKey(projectRef);
@@ -146,7 +145,7 @@ export function useNewThreadHandler() {
           // preserved. When the draft is already open and no options were
           // passed, leave it alone entirely — the user may have just picked a
           // branch in the composer.
-          const defaultEnvMode = primaryServerSettings.defaultThreadEnvMode;
+          const defaultEnvMode = targetServerSettings.defaultThreadEnvMode;
           const workspaceContext = hasExplicitWorkspaceOption
             ? {
                 ...(hasBranchOption ? { branch: options?.branch ?? null } : {}),
@@ -162,7 +161,7 @@ export function useNewThreadHandler() {
                   envMode: defaultEnvMode,
                   startFromOrigin: resolveNewDraftStartFromOrigin({
                     envMode: defaultEnvMode,
-                    newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+                    newWorktreesStartFromOrigin: targetServerSettings.newWorktreesStartFromOrigin,
                   }),
                 };
           if (workspaceContext) {
@@ -245,7 +244,7 @@ export function useNewThreadHandler() {
       const draftId = newDraftId();
       const threadId = newThreadId();
       const createdAt = new Date().toISOString();
-      const initialEnvMode = options?.envMode ?? primaryServerSettings.defaultThreadEnvMode;
+      const initialEnvMode = options?.envMode ?? targetServerSettings.defaultThreadEnvMode;
       return (async () => {
         setLogicalProjectDraftThreadId(logicalProjectKey, projectRef, draftId, {
           threadId,
@@ -257,7 +256,7 @@ export function useNewThreadHandler() {
             options?.startFromOrigin ??
             resolveNewDraftStartFromOrigin({
               envMode: initialEnvMode,
-              newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+              newWorktreesStartFromOrigin: targetServerSettings.newWorktreesStartFromOrigin,
             }),
           runtimeMode: carryRuntimeMode ?? DEFAULT_RUNTIME_MODE,
           ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
@@ -279,7 +278,7 @@ export function useNewThreadHandler() {
         });
       })();
     },
-    [getCurrentRouteTarget, primaryServerSettings, projectGroupingSettings, projects, router],
+    [getCurrentRouteTarget, projectGroupingSettings, projects, router, serverConfigs],
   );
 }
 

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -15,8 +15,9 @@ import {
   type DraftThreadState,
   useComposerDraftStore,
 } from "../composerDraftStore";
-import { newDraftId, newThreadId } from "../lib/utils";
 import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
+import { stackedThreadToast, toastManager } from "../components/ui/toast";
+import { newDraftId, newThreadId } from "../lib/utils";
 import {
   deriveLogicalProjectKeyFromSettings,
   getProjectOrderKey,
@@ -107,10 +108,23 @@ export function useNewThreadHandler() {
           candidate.id === projectRef.projectId &&
           candidate.environmentId === projectRef.environmentId,
       );
-      const targetServerSettings = (
-        serverConfigs.get(projectRef.environmentId) ??
-        (await waitForServerConfig(projectRef.environmentId))
-      ).settings;
+      let targetServerConfig = serverConfigs.get(projectRef.environmentId);
+      if (targetServerConfig === undefined) {
+        try {
+          targetServerConfig = await waitForServerConfig(projectRef.environmentId);
+        } catch (error) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Unable to create thread",
+              description:
+                error instanceof Error ? error.message : "Server settings are unavailable.",
+            }),
+          );
+          return;
+        }
+      }
+      const targetServerSettings = targetServerConfig.settings;
       const logicalProjectKey = project
         ? deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings)
         : scopedProjectKey(projectRef);

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -5,9 +5,9 @@
  * `settings.json` on the server, fetched via `server.getConfig`) and
  * client-only settings (persisted in localStorage).
  *
- * Live server settings always require an environment id. Primary-environment
- * access is intentionally named as such so environment-sensitive consumers
- * cannot silently read the wrong server's settings.
+ * Live server settings require an environment id. Callers without a selected
+ * environment receive schema defaults for server fields while client fields
+ * remain fully functional.
  */
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { useAtomValue } from "@effect/atom-react";
@@ -222,10 +222,10 @@ export function useClientSettings<T = ClientSettings>(
 
 /** Read current settings for one environment, merged with client-local preferences. */
 export function useEnvironmentSettings<T = UnifiedSettings>(
-  environmentId: EnvironmentId,
+  environmentId: EnvironmentId | null,
   selector?: (settings: UnifiedSettings) => T,
 ): T {
-  const serverSettings = useAtomValue(serverEnvironment.settingsValueAtom(environmentId));
+  const serverSettings = useAtomValue(serverEnvironment.configValueAtom(environmentId))?.settings;
   return useMergedSettings(serverSettings ?? DEFAULT_SERVER_SETTINGS, selector);
 }
 
@@ -273,7 +273,7 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
   return updateSettings;
 }
 
-export function useUpdateEnvironmentSettings(environmentId: EnvironmentId) {
+export function useUpdateEnvironmentSettings(environmentId: EnvironmentId | null) {
   return useUpdateSettingsTarget(environmentId);
 }
 

--- a/apps/web/src/hooks/useSettingsEnvironment.ts
+++ b/apps/web/src/hooks/useSettingsEnvironment.ts
@@ -1,0 +1,56 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useAtomValue } from "@effect/atom-react";
+
+import { resolveSettingsEnvironmentId } from "../components/settings/SettingsPanels.logic";
+import { useActiveEnvironmentId } from "../state/entities";
+import {
+  useEnvironments,
+  usePrimaryEnvironmentId,
+  type EnvironmentPresentation,
+} from "../state/environments";
+import {
+  selectedSettingsEnvironmentIdAtom,
+  setSelectedSettingsEnvironmentId,
+} from "../state/settingsEnvironment";
+
+export interface SettingsEnvironmentTarget {
+  readonly isReady: boolean;
+  readonly environmentId: EnvironmentId | null;
+  readonly environment: EnvironmentPresentation | null;
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly selectEnvironment: (environmentId: EnvironmentId) => void;
+}
+
+/**
+ * Resolve the server environment configured by a settings surface.
+ *
+ * Managed clients retain their historical primary-server behavior. Clients
+ * without a managed backend start with the currently active saved
+ * environment, then fall back to the first available environment.
+ */
+export function useSettingsEnvironment(): SettingsEnvironmentTarget {
+  const { isReady, environments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const selectedEnvironmentId = useAtomValue(selectedSettingsEnvironmentIdAtom);
+  const environmentId = resolveSettingsEnvironmentId({
+    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+    selectedEnvironmentId,
+    primaryEnvironmentId,
+    activeEnvironmentId,
+  });
+  const environment =
+    environmentId === null
+      ? null
+      : (environments.find((candidate) => candidate.environmentId === environmentId) ?? null);
+
+  return {
+    isReady,
+    environmentId,
+    environment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment: setSelectedSettingsEnvironmentId,
+  };
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -36,7 +36,10 @@ import {
 import { useUiStateStore } from "../uiStateStore";
 import { syncBrowserChromeTheme } from "../hooks/useTheme";
 import { configureClientTracing } from "../observability/clientTracing";
-import { resolveInitialServerAuthGateState } from "../environments/primary";
+import {
+  isDesktopClientOnlyMode,
+  resolveInitialServerAuthGateState,
+} from "../environments/primary";
 import { hasHostedPairingRequest, isHostedStaticApp } from "../hostedPairing";
 import { shellEnvironment } from "../state/shell";
 import { useAtomValue } from "@effect/atom-react";
@@ -63,7 +66,7 @@ export const Route = createRootRoute({
       };
     }
 
-    if (isHostedStaticApp(new URL(window.location.href))) {
+    if (isHostedStaticApp(new URL(window.location.href)) || isDesktopClientOnlyMode()) {
       return {
         authGateState: {
           status: "hosted-static",

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -173,10 +173,13 @@ function DocumentTitleSync() {
 }
 
 function HostedStaticEnvironmentBootstrap() {
-  const { environments } = useEnvironments();
+  const { environments, isReady } = useEnvironments();
   const activeEnvironmentId = useActiveEnvironmentId();
 
   useEffect(() => {
+    if (!isReady) {
+      return;
+    }
     if (
       environments.some(
         (environment) => environment.entry.target._tag === "PrimaryConnectionTarget",
@@ -185,17 +188,15 @@ function HostedStaticEnvironmentBootstrap() {
       return;
     }
 
-    if (activeEnvironmentId) {
+    if (
+      activeEnvironmentId !== null &&
+      environments.some((environment) => environment.environmentId === activeEnvironmentId)
+    ) {
       return;
     }
 
-    const firstSavedEnvironment = environments[0];
-    if (!firstSavedEnvironment) {
-      return;
-    }
-
-    setActiveEnvironmentId(firstSavedEnvironment.environmentId);
-  }, [activeEnvironmentId, environments]);
+    setActiveEnvironmentId(environments[0]?.environmentId ?? null);
+  }, [activeEnvironmentId, environments, isReady]);
 
   return null;
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -28,6 +28,7 @@ import {
 } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { useClientSettings } from "../hooks/useSettings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKeyFromPath,
@@ -138,7 +139,7 @@ function RootRouteView() {
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
-        {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}
+        <ProviderUpdateLaunchNotification />
         {appShell}
       </AnchoredToastProvider>
     </ToastProvider>
@@ -156,8 +157,7 @@ function GlassAppearanceSync() {
 }
 
 function DocumentTitleSync() {
-  const primaryServerVersion =
-    useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
+  const primaryServerVersion = useDefaultServerConfig()?.environment.serverVersion ?? null;
   const title = resolveServerBackedAppDisplayName({
     baseName: APP_BASE_NAME,
     fallbackDisplayName: APP_DISPLAY_NAME,

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,5 +1,4 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
-import { useAtomValue } from "@effect/atom-react";
 import { useEffect, useMemo } from "react";
 
 import { isCommandPaletteOpen } from "../commandPaletteBus";
@@ -20,14 +19,15 @@ import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { stackedThreadToast, toastManager } from "~/components/ui/toast";
-import { primaryServerKeybindingsAtom } from "~/state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "~/hooks/useDefaultServerConfig";
 
 function ChatRouteGlobalShortcuts() {
   const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
     useHandleNewThread();
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const keybindings = useDefaultServerConfig()?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const sidebarV2Enabled = useClientSettings((settings) => settings.sidebarV2Enabled);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -6,7 +6,7 @@ import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
 import { useProjects } from "../state/entities";
-import { usePrimaryEnvironmentId } from "../state/environments";
+import { useAppOwnsLocalEnvironment, usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
@@ -32,15 +32,17 @@ function ChatRouteGlobalShortcuts() {
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const projectGroupCount = useMemo(
     () =>
       buildSidebarProjectSnapshots({
         projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
+        ownsLocalEnvironment,
         resolveEnvironmentLabel: () => null,
       }).length,
-    [primaryEnvironmentId, projectGroupingSettings, projects],
+    [ownsLocalEnvironment, primaryEnvironmentId, projectGroupingSettings, projects],
   );
   const terminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -17,13 +17,14 @@ import { cn } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 
 function RestoreDefaultsButton({ onRestored }: { onRestored: () => void }) {
-  const { changedSettingLabels, restoreDefaults } = useSettingsRestore(onRestored);
+  const { canRestoreDefaults, changedSettingLabels, restoreDefaults } =
+    useSettingsRestore(onRestored);
 
   return (
     <Button
       size="xs"
       variant="ghost"
-      disabled={changedSettingLabels.length === 0}
+      disabled={changedSettingLabels.length === 0 || !canRestoreDefaults}
       onClick={() => void restoreDefaults()}
     >
       <RotateCcwIcon className="mx-1 size-3.5" />

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -1,5 +1,6 @@
 import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentId, ScopedProjectRef } from "@t3tools/contracts";
+import { isRemoteEnvironmentId, type EnvironmentPresenceScope } from "./environmentPresence";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKey,
@@ -116,6 +117,10 @@ export function buildSidebarProjectSnapshots(input: {
   projects: ReadonlyArray<Project>;
   settings: ProjectGroupingSettings;
   primaryEnvironmentId: EnvironmentId | null;
+  // False when the app has no backend of its own (a client-only desktop or the
+  // hosted static web app), which makes every member of a group remote.
+  // Defaults to true so callers that always own a local backend are unchanged.
+  ownsLocalEnvironment?: boolean;
   resolveEnvironmentLabel: (environmentId: EnvironmentId) => string | null;
   // Returns true when an env id maps to a desktopLocal saved-env
   // record (today: the WSL backend). Defaults to "false for every
@@ -159,6 +164,10 @@ export function buildSidebarProjectSnapshots(input: {
     }
   }
 
+  const presenceScope: EnvironmentPresenceScope = {
+    primaryEnvironmentId: input.primaryEnvironmentId,
+    ownsLocalEnvironment: input.ownsLocalEnvironment ?? true,
+  };
   const result: SidebarProjectSnapshot[] = [];
   const seen = new Set<string>();
   for (const project of input.projects) {
@@ -177,17 +186,11 @@ export function buildSidebarProjectSnapshots(input: {
       continue;
     }
 
-    const hasLocal =
-      input.primaryEnvironmentId !== null &&
-      members.some((member) => member.environmentId === input.primaryEnvironmentId);
-    const hasRemote =
-      input.primaryEnvironmentId !== null
-        ? members.some((member) => member.environmentId !== input.primaryEnvironmentId)
-        : false;
-    const remoteMembers = members.filter(
-      (member) =>
-        input.primaryEnvironmentId !== null && member.environmentId !== input.primaryEnvironmentId,
+    const remoteMembers = members.filter((member) =>
+      isRemoteEnvironmentId(member.environmentId, presenceScope),
     );
+    const hasRemote = remoteMembers.length > 0;
+    const hasLocal = remoteMembers.length < members.length;
     const remoteEnvironmentLabels = remoteMembers
       .flatMap((member) => (member.environmentLabel ? [member.environmentLabel] : []))
       .filter((label, index, labels) => labels.indexOf(label) === index);

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -116,6 +116,29 @@ export function useServerConfigs(): ReadonlyMap<EnvironmentId, ServerConfig> {
   return useAtomValue(environmentServerConfigsAtom);
 }
 
+export async function waitForServerConfig(environmentId: EnvironmentId): Promise<ServerConfig> {
+  const readConfig = () => appAtomRegistry.get(environmentServerConfigsAtom).get(environmentId);
+  const current = readConfig();
+  if (current !== undefined) {
+    return current;
+  }
+
+  return await new Promise<ServerConfig>((resolve) => {
+    const unsubscribe = appAtomRegistry.subscribe(environmentServerConfigsAtom, (configs) => {
+      const config = configs.get(environmentId);
+      if (config === undefined) return;
+      unsubscribe();
+      resolve(config);
+    });
+
+    const config = readConfig();
+    if (config !== undefined) {
+      unsubscribe();
+      resolve(config);
+    }
+  });
+}
+
 export function useThreadShells(): ReadonlyArray<EnvironmentThreadShell> {
   return useAtomValue(environmentThreadShells.threadShellsAtom);
 }

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -31,6 +31,7 @@ const EMPTY_THREAD_REFS: ReadonlyArray<ScopedThreadRef> = Object.freeze([]);
 const EMPTY_MESSAGES: ReadonlyArray<OrchestrationMessage> = Object.freeze([]);
 const EMPTY_ACTIVITIES: ReadonlyArray<OrchestrationThreadActivity> = Object.freeze([]);
 const EMPTY_PROPOSED_PLANS: ReadonlyArray<OrchestrationProposedPlan> = Object.freeze([]);
+const SERVER_CONFIG_WAIT_TIMEOUT_MS = 10_000;
 
 const EMPTY_PROJECT_ATOM = Atom.make<EnvironmentProject | null>(null).pipe(
   Atom.withLabel("web-project:empty"),
@@ -123,18 +124,39 @@ export async function waitForServerConfig(environmentId: EnvironmentId): Promise
     return current;
   }
 
-  return await new Promise<ServerConfig>((resolve) => {
-    const unsubscribe = appAtomRegistry.subscribe(environmentServerConfigsAtom, (configs) => {
+  return await new Promise<ServerConfig>((resolve, reject) => {
+    let settled = false;
+    let unsubscribe: (() => void) | null = null;
+    const finish = (result: { config: ServerConfig } | { error: Error }) => {
+      if (settled) return;
+      settled = true;
+      globalThis.clearTimeout(timeoutId);
+      unsubscribe?.();
+      if ("config" in result) {
+        resolve(result.config);
+      } else {
+        reject(result.error);
+      }
+    };
+    const timeoutId = globalThis.setTimeout(() => {
+      finish({
+        error: new Error(`Timed out waiting for server settings for environment ${environmentId}.`),
+      });
+    }, SERVER_CONFIG_WAIT_TIMEOUT_MS);
+
+    unsubscribe = appAtomRegistry.subscribe(environmentServerConfigsAtom, (configs) => {
       const config = configs.get(environmentId);
       if (config === undefined) return;
-      unsubscribe();
-      resolve(config);
+      finish({ config });
     });
+    if (settled) {
+      unsubscribe();
+      return;
+    }
 
     const config = readConfig();
     if (config !== undefined) {
-      unsubscribe();
-      resolve(config);
+      finish({ config });
     }
   });
 }

--- a/apps/web/src/state/environments.ts
+++ b/apps/web/src/state/environments.ts
@@ -9,6 +9,9 @@ import * as Option from "effect/Option";
 import { useMemo } from "react";
 
 import { environmentCatalog } from "../connection/catalog";
+import type { EnvironmentPresenceScope } from "../environmentPresence";
+import { isDesktopClientOnlyMode } from "../environments/primary";
+import { isHostedStaticApp } from "../hostedPairing";
 import { environmentPresentations, useEnvironmentPresentation } from "./presentation";
 import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
 import { useEnvironmentQuery } from "./query";
@@ -58,6 +61,30 @@ export function useEnvironments() {
 
 export function usePrimaryEnvironmentId(): EnvironmentId | null {
   return useAtomValue(primaryEnvironmentIdAtom);
+}
+
+/**
+ * Whether this app can ever serve an environment from its own backend. A
+ * client-only desktop and the hosted static web app cannot, so they have no
+ * local environment for threads and projects to belong to.
+ */
+export function appOwnsLocalEnvironment(): boolean {
+  return !isHostedStaticApp() && !isDesktopClientOnlyMode();
+}
+
+export function useAppOwnsLocalEnvironment(): boolean {
+  // The answer is fixed for the app's lifetime: the hosted-static check is
+  // origin/build derived, and changing the desktop backend mode relaunches.
+  return useMemo(appOwnsLocalEnvironment, []);
+}
+
+export function useEnvironmentPresenceScope(): EnvironmentPresenceScope {
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
+  return useMemo(
+    () => ({ primaryEnvironmentId, ownsLocalEnvironment }),
+    [primaryEnvironmentId, ownsLocalEnvironment],
+  );
 }
 
 export function useEnvironment(

--- a/apps/web/src/state/settingsEnvironment.ts
+++ b/apps/web/src/state/settingsEnvironment.ts
@@ -1,0 +1,13 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { Atom } from "effect/unstable/reactivity";
+
+import { appAtomRegistry } from "../rpc/atomRegistry";
+
+export const selectedSettingsEnvironmentIdAtom = Atom.make<EnvironmentId | null>(null).pipe(
+  Atom.keepAlive,
+  Atom.withLabel("web-selected-settings-environment-id"),
+);
+
+export function setSelectedSettingsEnvironmentId(environmentId: EnvironmentId): void {
+  appAtomRegistry.set(selectedSettingsEnvironmentIdAtom, environmentId);
+}

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -163,6 +163,7 @@ export type DesktopRuntimeArch = "arm64" | "x64" | "other";
 export type DesktopTheme = "light" | "dark" | "system";
 export type DesktopUpdateChannel = "latest" | "nightly";
 export type DesktopAppStageLabel = "Alpha" | "Dev" | "Nightly";
+export type DesktopBackendMode = "managed" | "client-only";
 
 export const DesktopUpdateStatusSchema = Schema.Literals([
   "disabled",
@@ -178,6 +179,19 @@ export const DesktopRuntimeArchSchema = Schema.Literals(["arm64", "x64", "other"
 export const DesktopThemeSchema = Schema.Literals(["light", "dark", "system"]);
 export const DesktopUpdateChannelSchema = Schema.Literals(["latest", "nightly"]);
 export const DesktopAppStageLabelSchema = Schema.Literals(["Alpha", "Dev", "Nightly"]);
+export const DesktopBackendModeSchema = Schema.Literals(["managed", "client-only"]);
+
+export interface DesktopBackendModeState {
+  effectiveMode: DesktopBackendMode;
+  configuredMode: DesktopBackendMode;
+  cliOverride: DesktopBackendMode | null;
+}
+
+export const DesktopBackendModeStateSchema = Schema.Struct({
+  effectiveMode: DesktopBackendModeSchema,
+  configuredMode: DesktopBackendModeSchema,
+  cliOverride: Schema.NullOr(DesktopBackendModeSchema),
+});
 
 export interface DesktopAppBranding {
   baseName: string;
@@ -977,6 +991,8 @@ export const DesktopPreviewAutomationWaitForInputSchema = Schema.Struct({
 
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
+  getBackendModeState: () => DesktopBackendModeState;
+  setBackendMode: (mode: DesktopBackendMode) => Promise<DesktopBackendModeState>;
   // One bootstrap per pool instance currently registered with bootstrap
   // info (omits instances whose backend hasn't produced a config yet).
   // The primary backend is identified by id === PRIMARY_LOCAL_ENVIRONMENT_ID.


### PR DESCRIPTION
## What Changed

- Add one shared environment selector across General, Providers, Keybindings, Source Control, and Diagnostics settings.
- Route server-backed settings to the selected environment while keeping client-only preferences in local client storage.
- Use the active saved environment for global keybindings, provider updates, and server presentation when no primary environment exists.
- Resolve new-thread defaults, worktree behavior, editors, and keybindings from the project or thread environment.
- Incorporate per-environment provider configuration and environment-scoped diagnostics behavior.
- Disable server-backed controls while the selected environment is disconnected.

## Why

Client-only desktop mode deliberately has no `PrimaryConnectionTarget`, but several settings surfaces still read and wrote exclusively through primary-server atoms and hooks. Those controls therefore displayed defaults and silently failed to persist.

Settings now resolve an explicit selection first, then the managed primary environment, the active saved environment, and finally the first available environment. This preserves existing managed-client behavior while making client-only and multi-environment operation explicit.

## UI Changes

- General Settings now starts with a Server Settings environment row showing connection state and the selected environment.
- Providers, Keybindings, Source Control, and Diagnostics use the same shared selection.
- Client-local settings remain available when an environment is disconnected; server-backed controls are disabled until it reconnects.
- Provider accounts and authorization state are shown only for the selected environment.

This PR is stacked on `desktop-client-only-discovery`, the branch behind pingdotgg/t3code#4444. It also carries the environment-scoped provider and diagnostics work needed by the complete settings flow.

## Checklist

- [x] `vp test run apps/web/src/components/settings/SettingsPanels.logic.test.ts apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts apps/web/src/hooks/useSettings.test.ts` — 31 tests passed
- [x] Targeted `vp lint --report-unused-disable-directives` for all changed files
- [x] `vp run --filter @t3tools/web build`
- [x] Integrated authenticated browser verification across General, Providers, Keybindings, Source Control, and Diagnostics
- [x] Confirmed assistant output, provider update checks, and the add-project base path persist through reload
- [ ] `vp run --filter @t3tools/web typecheck` remains blocked by pre-existing unrelated errors in `BranchToolbarBranchSelector`, `ModelPickerContent`, `PreviewAutomationHosts`, and the atom command/query helpers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches desktop startup/shutdown, custom protocol static serving, and relaunch; web surfaces now depend on per-environment connection state instead of always-available primary server atoms.
> 
> **Overview**
> Introduces a **managed vs client-only** desktop backend mode (`--backend-mode`, persisted `backendMode`, IPC + Connections UI). In **client-only**, startup skips the backend pool, registers the custom protocol as **static** (packaged renderer) or **dev proxy**, opens the window via `handleRendererReady`, and omits local bootstraps; shutdown skips pool teardown. **Managed** mode keeps proxying to the backend but drops the separate `backendOrigin` on protocol registration.
> 
> **Electron protocol** gains `source: "proxy" | "static"` with path-normalized static serving (SPA fallback, HEAD, traversal guards). **Relaunch** schedules the replacement process earlier, surfaces **`DesktopLifecycleRelaunchError`**, and **`setBackendMode`** rolls back settings if relaunch fails.
> 
> On the web side, **server-backed settings** (General, Providers, Keybindings, Source Control, Diagnostics) use a shared **environment selector** and **`useSettingsEnvironment`** / per-environment settings hooks instead of primary-only reads. **Diagnostics** is scoped to the selected environment with connection notices, disabled refresh when offline, and per-environment pending process signals. **Chat, sidebar, and command palette** stop using `primaryServer*` atoms for keybindings, providers, and config—**`useDefaultServerConfig`** and thread/project environment config drive defaults; **remote thread** labeling uses **`EnvironmentPresenceScope`** / **`ownsLocalEnvironment`** rather than comparing only to the primary id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a79c675fd9869aa4553b0712c57ab14eec4281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope settings panels and server config reads to target environment with desktop client-only mode support
> - Settings panels (General, Providers, Source Control, Keybindings, Diagnostics) now include an environment selector and scope server-side reads and writes to the chosen environment; controls are disabled when the selected environment is not connected.
> - Adds a `client-only` desktop backend mode that skips local backend startup, serves the renderer from either a dev proxy or packaged static assets, and hides local backend management UI.
> - New `useDefaultServerConfig` and `useDefaultEnvironmentId` hooks replace direct reads from `primaryServer*` atoms across sidebar, command palette, and chat components.
> - `buildSidebarProjectSnapshots` and remote-thread indicators now use `isRemoteEnvironmentId` with an `EnvironmentPresenceScope` instead of direct primary environment ID comparisons.
> - `DesktopLifecycle.relaunch` now propagates typed `DesktopLifecycleRelaunchError` failures to callers; `setBackendMode` rolls back settings when a triggered relaunch fails.
> - Risk: Components that previously read from global primary-server atoms now depend on per-environment config availability; surfaces will show defaults or be disabled when no environment is connected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13a79c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->