### PR TITLE
fix(server): reconcile stopped sessions after restart

### DIFF
--- a/apps/server/src/orchestration/decider.settled.test.ts
+++ b/apps/server/src/orchestration/decider.settled.test.ts
@@ -470,6 +470,28 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
     }),
   );
 
+  it.effect("rejects a conditional session write after the projected session changes", () =>
+    Effect.gen(function* () {
+      const currentSession = makeSession("running");
+      const error = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-stale-session-write"),
+          threadId: ThreadId.make("thread-1"),
+          expectedSessionUpdatedAt: "2025-12-31T23:59:00.000Z",
+          session: {
+            ...currentSession,
+            status: "stopped",
+          },
+          createdAt: NOW,
+        },
+        readModel: makeReadModel(null, null, currentSession),
+      }).pipe(Effect.flip);
+
+      expect(error._tag).toBe("OrchestrationCommandInvariantError");
+    }),
+  );
+
   it.effect("unsettles for approval and user-input activities but not others", () =>
     Effect.gen(function* () {
       const approvalResult = yield* decideOrchestrationCommand({

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -946,6 +946,15 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      if (
+        command.expectedSessionUpdatedAt !== undefined &&
+        thread.session?.updatedAt !== command.expectedSessionUpdatedAt
+      ) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' session changed after the command was prepared.`,
+        });
+      }
       const sessionSetEvent: Omit<OrchestrationEvent, "sequence"> = {
         ...(yield* withEventBase({
           aggregateKind: "thread",

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -17,6 +17,10 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
+import {
+  OrchestrationEngineService,
+  type OrchestrationEngineShape,
+} from "../../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
 import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntime.ts";
@@ -176,6 +180,9 @@ describe("ProviderSessionReaper", () => {
       rollbackConversation: () => unsupported(),
       streamEvents: Stream.empty,
     };
+    const dispatch = vi.fn<OrchestrationEngineShape["dispatch"]>(() =>
+      Effect.succeed({ sequence: 1 }),
+    );
 
     const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
       Layer.provide(SqlitePersistenceMemory),
@@ -190,6 +197,14 @@ describe("ProviderSessionReaper", () => {
       Layer.provideMerge(providerSessionDirectoryLayer),
       Layer.provideMerge(runtimeRepositoryLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, providerService)),
+      Layer.provideMerge(
+        Layer.succeed(OrchestrationEngineService, {
+          dispatch,
+          readEvents: () => Stream.empty,
+          streamDomainEvents: Stream.empty,
+          latestSequence: Effect.succeed(0),
+        }),
+      ),
       Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getCommandReadModel: () => Effect.die("unused"),
@@ -218,8 +233,121 @@ describe("ProviderSessionReaper", () => {
     );
 
     runtime = ManagedRuntime.make(layer);
-    return { stopSession, stoppedThreadIds };
+    return { dispatch, stopSession, stoppedThreadIds };
   }
+
+  it("projects durable stopped bindings that were left working during shutdown", async () => {
+    const threadId = ThreadId.make("thread-reaper-stopped-during-shutdown");
+    const projectedAt = "2026-04-14T00:00:00.000Z";
+    const stoppedAt = "2026-04-14T00:01:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          session: {
+            threadId,
+            status: "starting",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: projectedAt,
+          },
+        },
+      ]),
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        adapterKey: "codex",
+        runtimeMode: "full-access",
+        status: "stopped",
+        lastSeenAt: stoppedAt,
+        resumeCursor: null,
+        runtimePayload: {
+          activeTurnId: null,
+          lastRuntimeEvent: "provider.stopAll",
+          lastRuntimeEventAt: stoppedAt,
+        },
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await Effect.runPromise(Scope.make("sequential"));
+    await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
+
+    await waitFor(() => harness.dispatch.mock.calls.length === 1);
+
+    expect(harness.stopSession).not.toHaveBeenCalled();
+    expect(harness.dispatch.mock.calls[0]?.[0]).toMatchObject({
+      type: "thread.session.set",
+      threadId,
+      createdAt: stoppedAt,
+      session: {
+        threadId,
+        status: "stopped",
+        providerName: "codex",
+        providerInstanceId: "codex",
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: stoppedAt,
+      },
+    });
+  });
+
+  it("does not overwrite a projected session newer than the stopped binding", async () => {
+    const threadId = ThreadId.make("thread-reaper-stale-stopped-binding");
+    const stoppedAt = "2026-04-14T00:00:00.000Z";
+    const projectedAt = "2026-04-14T00:01:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          session: {
+            threadId,
+            status: "starting",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: projectedAt,
+          },
+        },
+      ]),
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        adapterKey: "codex",
+        runtimeMode: "full-access",
+        status: "stopped",
+        lastSeenAt: stoppedAt,
+        resumeCursor: null,
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await Effect.runPromise(Scope.make("sequential"));
+    await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
+    await Effect.runPromise(drainFibers);
+
+    expect(harness.dispatch).not.toHaveBeenCalled();
+    expect(harness.stopSession).not.toHaveBeenCalled();
+  });
 
   it("reaps stale persisted sessions without active turns", async () => {
     const threadId = ThreadId.make("thread-reaper-stale");

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -288,6 +288,7 @@ describe("ProviderSessionReaper", () => {
     expect(harness.dispatch.mock.calls[0]?.[0]).toMatchObject({
       type: "thread.session.set",
       threadId,
+      expectedSessionUpdatedAt: projectedAt,
       createdAt: stoppedAt,
       session: {
         threadId,
@@ -490,7 +491,7 @@ describe("ProviderSessionReaper", () => {
     const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
     scope = await Effect.runPromise(Scope.make("sequential"));
     await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
-    await Effect.runPromise(drainFibers);
+    await runtime!.runPromise(drainFibers);
 
     expect(harness.stopSession).not.toHaveBeenCalled();
     const remaining = await runtime!.runPromise(repository.getByThreadId({ threadId }));
@@ -537,8 +538,8 @@ describe("ProviderSessionReaper", () => {
     );
 
     const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
-    scope = await Effect.runPromise(Scope.make("sequential"));
-    await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
     await Effect.runPromise(drainFibers);
 
     expect(harness.stopSession).not.toHaveBeenCalled();
@@ -623,8 +624,8 @@ describe("ProviderSessionReaper", () => {
     );
 
     const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
-    scope = await Effect.runPromise(Scope.make("sequential"));
-    await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
 
     await waitFor(() => harness.stopSession.mock.calls.length === 2);
 

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -21,6 +21,7 @@ import {
   OrchestrationEngineService,
   type OrchestrationEngineShape,
 } from "../../orchestration/Services/OrchestrationEngine.ts";
+import { OrchestrationCommandInvariantError } from "../../orchestration/Errors.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
 import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntime.ts";
@@ -141,6 +142,8 @@ describe("ProviderSessionReaper", () => {
 
   async function createHarness(input: {
     readonly readModel: ReturnType<typeof makeReadModel>;
+    readonly dispatchImplementation?: OrchestrationEngineShape["dispatch"];
+    readonly sweepIntervalMs?: number;
     readonly stopSessionImplementation?: (input: {
       readonly threadId: ThreadId;
     }) => ReturnType<ProviderServiceShape["stopSession"]>;
@@ -180,8 +183,8 @@ describe("ProviderSessionReaper", () => {
       rollbackConversation: () => unsupported(),
       streamEvents: Stream.empty,
     };
-    const dispatch = vi.fn<OrchestrationEngineShape["dispatch"]>(() =>
-      Effect.succeed({ sequence: 1 }),
+    const dispatch = vi.fn<OrchestrationEngineShape["dispatch"]>(
+      input.dispatchImplementation ?? (() => Effect.succeed({ sequence: 1 })),
     );
 
     const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
@@ -192,7 +195,7 @@ describe("ProviderSessionReaper", () => {
     );
     const layer = makeProviderSessionReaperLive({
       inactivityThresholdMs: 1_000,
-      sweepIntervalMs: 60_000,
+      sweepIntervalMs: input.sweepIntervalMs ?? 60_000,
     }).pipe(
       Layer.provideMerge(providerSessionDirectoryLayer),
       Layer.provideMerge(runtimeRepositoryLayer),
@@ -344,10 +347,76 @@ describe("ProviderSessionReaper", () => {
     const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
     scope = await Effect.runPromise(Scope.make("sequential"));
     await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
-    await Effect.runPromise(drainFibers);
+    await runtime!.runPromise(drainFibers);
 
     expect(harness.dispatch).not.toHaveBeenCalled();
     expect(harness.stopSession).not.toHaveBeenCalled();
+  });
+
+  it("uses a fresh command ID when retrying a rejected reconciliation", async () => {
+    const threadId = ThreadId.make("thread-reaper-retry-reconciliation");
+    const projectedAt = "2026-04-14T00:00:00.000Z";
+    const stoppedAt = "2026-04-14T00:01:00.000Z";
+    let attempt = 0;
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          session: {
+            threadId,
+            status: "starting",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: projectedAt,
+          },
+        },
+      ]),
+      dispatchImplementation: (command) => {
+        attempt += 1;
+        return attempt === 1
+          ? Effect.fail(
+              new OrchestrationCommandInvariantError({
+                commandType: command.type,
+                detail: "simulated concurrent session update",
+              }),
+            )
+          : Effect.succeed({ sequence: 1 });
+      },
+      sweepIntervalMs: 1,
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        adapterKey: "codex",
+        runtimeMode: "full-access",
+        status: "stopped",
+        lastSeenAt: stoppedAt,
+        resumeCursor: null,
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
+
+    await waitFor(() => harness.dispatch.mock.calls.length >= 2);
+    await Effect.runPromise(Scope.close(scope, Exit.void));
+    scope = null;
+
+    const firstCommandId = harness.dispatch.mock.calls[0]?.[0].commandId;
+    const secondCommandId = harness.dispatch.mock.calls[1]?.[0].commandId;
+    expect(firstCommandId).toMatch(/^server:provider-session-reconcile:/);
+    expect(secondCommandId).toMatch(/^server:provider-session-reconcile:/);
+    expect(secondCommandId).not.toBe(firstCommandId);
   });
 
   it("reaps stale persisted sessions without active turns", async () => {
@@ -540,7 +609,7 @@ describe("ProviderSessionReaper", () => {
     const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
     scope = await runtime!.runPromise(Scope.make("sequential"));
     await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
-    await Effect.runPromise(drainFibers);
+    await runtime!.runPromise(drainFibers);
 
     expect(harness.stopSession).not.toHaveBeenCalled();
     const remaining = await runtime!.runPromise(repository.getByThreadId({ threadId }));
@@ -707,8 +776,8 @@ describe("ProviderSessionReaper", () => {
     );
 
     const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
-    scope = await Effect.runPromise(Scope.make("sequential"));
-    await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
 
     await waitFor(() => harness.stopSession.mock.calls.length === 2);
 

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -1,3 +1,4 @@
+import { CommandId } from "@t3tools/contracts";
 import * as Clock from "effect/Clock";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -5,8 +6,12 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 
+import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
-import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
+import {
+  ProviderSessionDirectory,
+  type ProviderRuntimeBindingWithMetadata,
+} from "../Services/ProviderSessionDirectory.ts";
 import {
   ProviderSessionReaper,
   type ProviderSessionReaperShape,
@@ -25,6 +30,7 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
   Effect.gen(function* () {
     const providerService = yield* ProviderService;
     const directory = yield* ProviderSessionDirectory;
+    const orchestrationEngine = yield* OrchestrationEngineService;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
 
     const inactivityThresholdMs = Math.max(
@@ -33,6 +39,82 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
     );
     const sweepIntervalMs = Math.max(1, options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS);
 
+    // Provider shutdown can persist "stopped" after runtime event consumers
+    // have closed, leaving the projection on its last transient status.
+    const reconcileStoppedBinding = Effect.fn("ProviderSessionReaper.reconcileStoppedBinding")(
+      function* (binding: ProviderRuntimeBindingWithMetadata) {
+        const thread = yield* projectionSnapshotQuery
+          .getThreadShellById(binding.threadId)
+          .pipe(Effect.map(Option.getOrUndefined));
+        const session = thread?.session;
+        if (!session || session.status === "stopped") {
+          return;
+        }
+
+        const stoppedAtMs = Date.parse(binding.lastSeenAt);
+        if (Number.isNaN(stoppedAtMs)) {
+          yield* Effect.logWarning("provider.session.reaper.invalid-last-seen", {
+            threadId: binding.threadId,
+            provider: binding.provider,
+            lastSeenAt: binding.lastSeenAt,
+          });
+          return;
+        }
+
+        const projectedAtMs = Date.parse(session.updatedAt);
+        if (!Number.isNaN(projectedAtMs) && stoppedAtMs < projectedAtMs) {
+          yield* Effect.logDebug("provider.session.reaper.skipped-stale-stopped-binding", {
+            threadId: binding.threadId,
+            provider: binding.provider,
+            bindingLastSeenAt: binding.lastSeenAt,
+            projectedSessionUpdatedAt: session.updatedAt,
+          });
+          return;
+        }
+
+        yield* orchestrationEngine
+          .dispatch({
+            type: "thread.session.set",
+            commandId: CommandId.make(
+              `server:provider-session-reconcile:${binding.threadId}:${binding.lastSeenAt}`,
+            ),
+            threadId: binding.threadId,
+            session: {
+              threadId: binding.threadId,
+              status: "stopped",
+              providerName: binding.provider,
+              ...(binding.providerInstanceId !== undefined
+                ? { providerInstanceId: binding.providerInstanceId }
+                : session.providerInstanceId !== undefined
+                  ? { providerInstanceId: session.providerInstanceId }
+                  : {}),
+              runtimeMode: binding.runtimeMode ?? session.runtimeMode,
+              activeTurnId: null,
+              lastError: session.lastError,
+              updatedAt: binding.lastSeenAt,
+            },
+            createdAt: binding.lastSeenAt,
+          })
+          .pipe(
+            Effect.tap(() =>
+              Effect.logInfo("provider.session.reaper.reconciled-stopped-binding", {
+                threadId: binding.threadId,
+                provider: binding.provider,
+                stoppedAt: binding.lastSeenAt,
+                projectedStatus: session.status,
+              }),
+            ),
+            Effect.catchCause((cause) =>
+              Effect.logWarning("provider.session.reaper.reconcile-stopped-binding-failed", {
+                threadId: binding.threadId,
+                provider: binding.provider,
+                cause,
+              }),
+            ),
+          );
+      },
+    );
+
     const sweep = Effect.gen(function* () {
       const bindings = yield* directory.listBindings();
       const now = yield* Clock.currentTimeMillis;
@@ -40,6 +122,7 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
 
       for (const binding of bindings) {
         if (binding.status === "stopped") {
+          yield* reconcileStoppedBinding(binding);
           continue;
         }
 

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -79,6 +79,7 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
               `server:provider-session-reconcile:${binding.threadId}:${binding.lastSeenAt}`,
             ),
             threadId: binding.threadId,
+            expectedSessionUpdatedAt: session.updatedAt,
             session: {
               threadId: binding.threadId,
               status: "stopped",
@@ -102,6 +103,13 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
                 provider: binding.provider,
                 stoppedAt: binding.lastSeenAt,
                 projectedStatus: session.status,
+              }),
+            ),
+            Effect.catchTag("OrchestrationCommandInvariantError", () =>
+              Effect.logDebug("provider.session.reaper.skipped-concurrent-session-update", {
+                threadId: binding.threadId,
+                provider: binding.provider,
+                projectedSessionUpdatedAt: session.updatedAt,
               }),
             ),
             Effect.catchCause((cause) =>

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -1,5 +1,6 @@
 import { CommandId } from "@t3tools/contracts";
 import * as Clock from "effect/Clock";
+import * as Crypto from "effect/Crypto";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -32,6 +33,9 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
     const directory = yield* ProviderSessionDirectory;
     const orchestrationEngine = yield* OrchestrationEngineService;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+    const crypto = yield* Crypto.Crypto;
+    const serverCommandId = (tag: string) =>
+      crypto.randomUUIDv4.pipe(Effect.map((uuid) => CommandId.make(`server:${tag}:${uuid}`)));
 
     const inactivityThresholdMs = Math.max(
       1,
@@ -75,9 +79,7 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
         yield* orchestrationEngine
           .dispatch({
             type: "thread.session.set",
-            commandId: CommandId.make(
-              `server:provider-session-reconcile:${binding.threadId}:${binding.lastSeenAt}`,
-            ),
+            commandId: yield* serverCommandId("provider-session-reconcile"),
             threadId: binding.threadId,
             expectedSessionUpdatedAt: session.updatedAt,
             session: {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -800,6 +800,7 @@ const ThreadSessionSetCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   session: OrchestrationSession,
+  expectedSessionUpdatedAt: Schema.optional(IsoDateTime),
   createdAt: IsoDateTime,
 });
 


### PR DESCRIPTION
## Summary

- reconcile durable stopped provider bindings with thread session projections during the initial reaper sweep
- clear abandoned pending turns through the existing stopped-session projection path so restarted threads can be settled
- reject reconciliation atomically if the projected session changes before dispatch, so a concurrent restart cannot be overwritten
- use a fresh command ID for each reconciliation attempt so a rejected receipt cannot poison a later retry
- cover shutdown divergence, stale-binding ordering, concurrent session updates, and rejected-command retries with regression tests

Fixes #4561

## Verification

- `pnpm exec vp test run apps/server/src/provider/Layers/ProviderSessionReaper.test.ts apps/server/src/orchestration/decider.settled.test.ts` — 21 tests passed
- `pnpm exec vp run --filter t3 typecheck`
- `pnpm exec vp run --filter @t3tools/contracts typecheck`
- targeted formatting checks for changed files
- targeted lint for changed files
- read-only production-state inspection confirmed the failure shape: projected `starting` with no active turn, durable runtime `stopped`, and an abandoned pending turn; the sidebar was initially stuck Working, then looked idle after a recovery message while settling remained blocked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread session projection paths after restart and adds server-initiated orchestration dispatches on every reaper sweep for stopped bindings; guarded by optional concurrency checks but still affects settling/working UI state.
> 
> **Overview**
> Fixes threads that stay stuck in a transient session state (e.g. **starting** / working) when shutdown persisted a durable **stopped** provider binding but never updated the thread projection.
> 
> **Provider session reaper** now treats `stopped` bindings as reconciliation targets on each sweep: it reads the projected session, skips when already stopped or when the binding’s `lastSeenAt` is older than `session.updatedAt`, and otherwise dispatches `thread.session.set` with a server-generated command id to project **stopped** (clearing `activeTurnId`). Invariant rejections are logged and retried on later sweeps with a new command id.
> 
> **Orchestration** adds optional `expectedSessionUpdatedAt` on `thread.session.set`; the decider rejects the command with `OrchestrationCommandInvariantError` when the projected session’s `updatedAt` no longer matches, so reconciliation cannot clobber a concurrent restart or newer session write.
> 
> Regression tests cover shutdown divergence, stale-binding ordering, concurrent session updates, and retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56da49d6260e6bcd401d889f73dc81f763b2c5b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile stopped provider sessions after server restart
> - Adds `reconcileStoppedBinding` to [`ProviderSessionReaper`](https://github.com/pingdotgg/t3code/pull/4562/files#diff-06512dd4ebe9bbf2d3c8222739f659850d9baa547215a0aae698850d1cc39196), which dispatches a `thread.session.set` command for bindings persisted as `stopped` so their projected session status is updated after a restart.
> - Skips dispatch when the binding's `lastSeenAt` is older than the projected session's `updatedAt`, preventing stale writes from overwriting newer state.
> - Adds an optional `expectedSessionUpdatedAt` field to the `thread.session.set` command schema in [`orchestration.ts`](https://github.com/pingdotgg/t3code/pull/4562/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af) for conditional write semantics.
> - The decider in [`decider.ts`](https://github.com/pingdotgg/t3code/pull/4562/files#diff-6f7345ef9257e77e02acccced5be5251aa0f108aa0620614c5c80cc072949dc6) now returns `OrchestrationCommandInvariantError` when `expectedSessionUpdatedAt` is provided but does not match the projected session's `updatedAt`.
> - Risk: The reaper now depends on `OrchestrationEngineService` and `Crypto`; misconfigured environments missing these services will fail at startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56da49d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

