### PR TITLE
Separate client and environment settings

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -387,7 +387,9 @@ function AboutVersionSection() {
   );
 }
 
-export function useSettingsRestore(onRestored?: () => void) {
+export type SettingsOwnership = "client" | "environment";
+
+export function useSettingsRestore(ownership: SettingsOwnership, onRestored?: () => void) {
   const { theme, setTheme } = useTheme();
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
@@ -397,8 +399,8 @@ export function useSettingsRestore(onRestored?: () => void) {
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
 
-  const changedSettingLabels = useMemo(
-    () => [
+  const changedSettingLabels = useMemo(() => {
+    const clientSettingLabels = [
       ...(theme !== "system" ? ["Theme"] : []),
       ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? ["Glass opacity"] : []),
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
@@ -418,6 +420,14 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar
         ? ["Auto-open task panel"]
         : []),
+      ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
+        ? ["Archive confirmation"]
+        : []),
+      ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
+        ? ["Delete confirmation"]
+        : []),
+    ];
+    const environmentSettingLabels = [
       ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
         ? ["Assistant output"]
         : []),
@@ -439,34 +449,29 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
-      ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
-        ? ["Archive confirmation"]
-        : []),
-      ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
-        ? ["Delete confirmation"]
-        : []),
       ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
-    ],
-    [
-      isTextGenerationModelDirty,
-      settings.autoOpenPlanSidebar,
-      settings.confirmThreadArchive,
-      settings.confirmThreadDelete,
-      settings.addProjectBaseDirectory,
-      settings.defaultThreadEnvMode,
-      settings.newWorktreesStartFromOrigin,
-      settings.diffIgnoreWhitespace,
-      settings.glassOpacity,
-      settings.automaticGitFetchInterval,
-      settings.enableAssistantStreaming,
-      settings.enableProviderUpdateChecks,
-      settings.sidebarProjectGroupingMode,
-      settings.sidebarThreadPreviewCount,
-      settings.timestampFormat,
-      settings.wordWrap,
-      theme,
-    ],
-  );
+    ];
+    return ownership === "client" ? clientSettingLabels : environmentSettingLabels;
+  }, [
+    isTextGenerationModelDirty,
+    ownership,
+    settings.autoOpenPlanSidebar,
+    settings.confirmThreadArchive,
+    settings.confirmThreadDelete,
+    settings.addProjectBaseDirectory,
+    settings.defaultThreadEnvMode,
+    settings.newWorktreesStartFromOrigin,
+    settings.diffIgnoreWhitespace,
+    settings.glassOpacity,
+    settings.automaticGitFetchInterval,
+    settings.enableAssistantStreaming,
+    settings.enableProviderUpdateChecks,
+    settings.sidebarProjectGroupingMode,
+    settings.sidebarThreadPreviewCount,
+    settings.timestampFormat,
+    settings.wordWrap,
+    theme,
+  ]);
 
   const restoreDefaults = useCallback(async () => {
     if (changedSettingLabels.length === 0) return;
@@ -478,6 +483,7 @@ export function useSettingsRestore(onRestored?: () => void) {
     );
     if (!confirmed) return;
 
+    if (ownership === "client") {
     setTheme("system");
     updateSettings({
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
@@ -487,18 +493,22 @@ export function useSettingsRestore(onRestored?: () => void) {
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
+        confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
+        confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+      });
+    } else {
+      updateSettings({
       enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
       enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
-      confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
-      confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
       textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
     });
+    }
     onRestored?.();
-  }, [changedSettingLabels, onRestored, setTheme, updateSettings]);
+  }, [changedSettingLabels, onRestored, ownership, setTheme, updateSettings]);
 
   return {
     changedSettingLabels,
@@ -506,7 +516,7 @@ export function useSettingsRestore(onRestored?: () => void) {
   };
 }
 
-export function GeneralSettingsPanel() {
+function OwnershipSettingsPanel({ ownership }: { ownership: SettingsOwnership }) {
   const { theme, setTheme } = useTheme();
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
@@ -554,7 +564,9 @@ export function GeneralSettingsPanel() {
 
   return (
     <SettingsPageContainer>
-      <SettingsSection title="General">
+      <SettingsSection title={ownership === "client" ? "Client" : "Environment"}>
+        {ownership === "client" ? (
+          <>
         <SettingsRow
           title="Theme"
           description="Choose how T3 Code looks across the app."
@@ -644,7 +656,8 @@ export function GeneralSettingsPanel() {
                 label="project grouping"
                 onClick={() =>
                   updateSettings({
-                    sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
+                        sidebarProjectGroupingMode:
+                          DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
                   })
                 }
               />
@@ -761,7 +774,11 @@ export function GeneralSettingsPanel() {
             />
           }
         />
+          </>
+        ) : null}
 
+        {ownership === "environment" ? (
+          <>
         <SettingsRow
           title="Assistant output"
           description="Show token-by-token output while a response is in progress."
@@ -799,7 +816,8 @@ export function GeneralSettingsPanel() {
                 label="provider update checks"
                 onClick={() =>
                   updateSettings({
-                    enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+                        enableProviderUpdateChecks:
+                          DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
                   })
                 }
               />
@@ -815,7 +833,10 @@ export function GeneralSettingsPanel() {
             />
           }
         />
+          </>
+        ) : null}
 
+        {ownership === "client" ? (
         <SettingsRow
           title="Auto-open task panel"
           description="Open the right-side plan and task panel automatically when steps appear."
@@ -841,7 +862,10 @@ export function GeneralSettingsPanel() {
             />
           }
         />
+        ) : null}
 
+        {ownership === "environment" ? (
+          <>
         <SettingsRow
           title="New threads"
           description="Pick the default workspace mode for newly created draft threads."
@@ -945,7 +969,11 @@ export function GeneralSettingsPanel() {
             />
           }
         />
+          </>
+        ) : null}
 
+        {ownership === "client" ? (
+          <>
         <SettingsRow
           title="Archive confirmation"
           description="Require a second click on the inline archive action before a thread is archived."
@@ -997,7 +1025,10 @@ export function GeneralSettingsPanel() {
             />
           }
         />
+          </>
+        ) : null}
 
+        {ownership === "environment" ? (
         <SettingsRow
           title="Text generation model"
           description="Default model for generated text like thread titles and source control content. Source control settings can override it with a dedicated source control writer model."
@@ -1071,8 +1102,10 @@ export function GeneralSettingsPanel() {
             </div>
           }
         />
+        ) : null}
       </SettingsSection>
 
+      {ownership === "client" ? (
       <SettingsSection title="About">
         {isElectron || HOSTED_APP_CHANNEL ? (
           <AboutVersionSection />
@@ -1082,6 +1115,9 @@ export function GeneralSettingsPanel() {
             description="Current version of the application."
           />
         )}
+        </SettingsSection>
+      ) : (
+        <SettingsSection title="Diagnostics">
         <SettingsRow
           title="Diagnostics"
           description={diagnosticsDescription}
@@ -1092,8 +1128,17 @@ export function GeneralSettingsPanel() {
           }
         />
       </SettingsSection>
+      )}
     </SettingsPageContainer>
   );
+}
+
+export function GeneralSettingsPanel() {
+  return <OwnershipSettingsPanel ownership="client" />;
+}
+
+export function EnvironmentSettingsPanel() {
+  return <OwnershipSettingsPanel ownership="environment" />;
 }
 
 export function ProviderSettingsPanel() {

--- a/apps/web/src/components/settings/SettingsSidebarNav.test.ts
+++ b/apps/web/src/components/settings/SettingsSidebarNav.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { SETTINGS_NAV_GROUPS } from "./SettingsSidebarNav";
+
+describe("settings navigation ownership", () => {
+  it("separates client-owned pages from environment-owned pages", () => {
+    expect(
+      SETTINGS_NAV_GROUPS.map((group) => ({
+        label: group.label,
+        routes: group.items.map((item) => item.to),
+      })),
+    ).toEqual([
+      {
+        label: "Client",
+        routes: [
+          "/settings/general",
+          "/settings/connections",
+          "/settings/beta",
+          "/settings/archived",
+        ],
+      },
+      {
+        label: "Environment",
+        routes: [
+          "/settings/environment",
+          "/settings/keybindings",
+          "/settings/providers",
+          "/settings/source-control",
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -15,6 +15,7 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -24,6 +25,7 @@ import { T3ConnectSidebarAvatar, T3ConnectSidebarSignIn } from "../clerk/T3Conne
 
 export type SettingsSectionPath =
   | "/settings/general"
+  | "/settings/environment"
   | "/settings/keybindings"
   | "/settings/providers"
   | "/settings/source-control"
@@ -31,18 +33,34 @@ export type SettingsSectionPath =
   | "/settings/beta"
   | "/settings/archived";
 
-export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
+export type SettingsNavItem = {
   label: string;
   to: SettingsSectionPath;
   icon: ComponentType<{ className?: string }>;
+};
+
+export const SETTINGS_NAV_GROUPS: ReadonlyArray<{
+  label: "Client" | "Environment";
+  items: ReadonlyArray<SettingsNavItem>;
 }> = [
-  { label: "General", to: "/settings/general", icon: Settings2Icon },
-  { label: "Keybindings", to: "/settings/keybindings", icon: KeyboardIcon },
-  { label: "Providers", to: "/settings/providers", icon: BotIcon },
-  { label: "Source Control", to: "/settings/source-control", icon: GitBranchIcon },
-  { label: "Connections", to: "/settings/connections", icon: Link2Icon },
-  { label: "Beta", to: "/settings/beta", icon: FlaskConicalIcon },
-  { label: "Archive", to: "/settings/archived", icon: ArchiveIcon },
+  {
+    label: "Client",
+    items: [
+      { label: "General", to: "/settings/general", icon: Settings2Icon },
+      { label: "Connections", to: "/settings/connections", icon: Link2Icon },
+      { label: "Beta", to: "/settings/beta", icon: FlaskConicalIcon },
+      { label: "Archive", to: "/settings/archived", icon: ArchiveIcon },
+    ],
+  },
+  {
+    label: "Environment",
+    items: [
+      { label: "General", to: "/settings/environment", icon: Settings2Icon },
+      { label: "Keybindings", to: "/settings/keybindings", icon: KeyboardIcon },
+      { label: "Providers", to: "/settings/providers", icon: BotIcon },
+      { label: "Source Control", to: "/settings/source-control", icon: GitBranchIcon },
+    ],
+  },
 ];
 
 export function SettingsSidebarNav({ pathname }: { pathname: string }) {
@@ -72,37 +90,42 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   return (
     <>
       <SidebarContent className="overflow-x-hidden">
-        <SidebarGroup className="px-2 py-3">
-          <SidebarMenu>
-            {SETTINGS_NAV_ITEMS.map((item) => {
-              const Icon = item.icon;
-              const isActive = pathname === item.to;
-              return (
-                <SidebarMenuItem key={item.to}>
-                  <SidebarMenuButton
-                    size="sm"
-                    isActive={isActive}
-                    className={
-                      isActive
-                        ? "h-8 items-center gap-2 rounded-md bg-sidebar-row-active px-2 py-1.5 text-left text-sm font-medium text-sidebar-foreground"
-                        : "h-8 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium text-sidebar-muted-foreground/80 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
-                    }
-                    onClick={() => handleSectionClick(item.to)}
-                  >
-                    <Icon
+        {SETTINGS_NAV_GROUPS.map((group) => (
+          <SidebarGroup className="px-2 py-2 first:pt-3" key={group.label}>
+            <SidebarGroupLabel className="h-6 px-2 text-[10px] font-semibold tracking-[0.08em] text-sidebar-muted-foreground/55 uppercase">
+              {group.label}
+            </SidebarGroupLabel>
+            <SidebarMenu>
+              {group.items.map((item) => {
+                const Icon = item.icon;
+                const isActive = pathname === item.to;
+                return (
+                  <SidebarMenuItem key={item.to}>
+                    <SidebarMenuButton
+                      size="sm"
+                      isActive={isActive}
                       className={
                         isActive
-                          ? "size-4 shrink-0 text-sidebar-foreground"
-                          : "size-4 shrink-0 text-sidebar-muted-foreground/60"
+                          ? "h-8 items-center gap-2 rounded-md bg-sidebar-row-active px-2 py-1.5 text-left text-sm font-medium text-sidebar-foreground"
+                          : "h-8 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium text-sidebar-muted-foreground/80 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
                       }
-                    />
-                    <span className="truncate">{item.label}</span>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              );
-            })}
-          </SidebarMenu>
-        </SidebarGroup>
+                      onClick={() => handleSectionClick(item.to)}
+                    >
+                      <Icon
+                        className={
+                          isActive
+                            ? "size-4 shrink-0 text-sidebar-foreground"
+                            : "size-4 shrink-0 text-sidebar-muted-foreground/60"
+                        }
+                      />
+                      <span className="truncate">{item.label}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </SidebarGroup>
+        ))}
       </SidebarContent>
       <SidebarFooter className="p-2">
         <T3ConnectSidebarSignIn />

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as SettingsSourceControlRouteImport } from './routes/settings.sou
 import { Route as SettingsProvidersRouteImport } from './routes/settings.providers'
 import { Route as SettingsKeybindingsRouteImport } from './routes/settings.keybindings'
 import { Route as SettingsGeneralRouteImport } from './routes/settings.general'
+import { Route as SettingsEnvironmentRouteImport } from './routes/settings.environment'
 import { Route as SettingsDiagnosticsRouteImport } from './routes/settings.diagnostics'
 import { Route as SettingsConnectionsRouteImport } from './routes/settings.connections'
 import { Route as SettingsBetaRouteImport } from './routes/settings.beta'
@@ -70,6 +71,11 @@ const SettingsGeneralRoute = SettingsGeneralRouteImport.update({
   path: '/general',
   getParentRoute: () => SettingsRoute,
 } as any)
+const SettingsEnvironmentRoute = SettingsEnvironmentRouteImport.update({
+  id: '/environment',
+  path: '/environment',
+  getParentRoute: () => SettingsRoute,
+} as any)
 const SettingsDiagnosticsRoute = SettingsDiagnosticsRouteImport.update({
   id: '/diagnostics',
   path: '/diagnostics',
@@ -117,6 +123,7 @@ export interface FileRoutesByFullPath {
   '/settings/beta': typeof SettingsBetaRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/diagnostics': typeof SettingsDiagnosticsRoute
+  '/settings/environment': typeof SettingsEnvironmentRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/providers': typeof SettingsProvidersRoute
@@ -133,6 +140,7 @@ export interface FileRoutesByTo {
   '/settings/beta': typeof SettingsBetaRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/diagnostics': typeof SettingsDiagnosticsRoute
+  '/settings/environment': typeof SettingsEnvironmentRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/providers': typeof SettingsProvidersRoute
@@ -152,6 +160,7 @@ export interface FileRoutesById {
   '/settings/beta': typeof SettingsBetaRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/diagnostics': typeof SettingsDiagnosticsRoute
+  '/settings/environment': typeof SettingsEnvironmentRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/providers': typeof SettingsProvidersRoute
@@ -172,6 +181,7 @@ export interface FileRouteTypes {
     | '/settings/beta'
     | '/settings/connections'
     | '/settings/diagnostics'
+    | '/settings/environment'
     | '/settings/general'
     | '/settings/keybindings'
     | '/settings/providers'
@@ -188,6 +198,7 @@ export interface FileRouteTypes {
     | '/settings/beta'
     | '/settings/connections'
     | '/settings/diagnostics'
+    | '/settings/environment'
     | '/settings/general'
     | '/settings/keybindings'
     | '/settings/providers'
@@ -206,6 +217,7 @@ export interface FileRouteTypes {
     | '/settings/beta'
     | '/settings/connections'
     | '/settings/diagnostics'
+    | '/settings/environment'
     | '/settings/general'
     | '/settings/keybindings'
     | '/settings/providers'
@@ -288,6 +300,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsGeneralRouteImport
       parentRoute: typeof SettingsRoute
     }
+    '/settings/environment': {
+      id: '/settings/environment'
+      path: '/environment'
+      fullPath: '/settings/environment'
+      preLoaderRoute: typeof SettingsEnvironmentRouteImport
+      parentRoute: typeof SettingsRoute
+    }
     '/settings/diagnostics': {
       id: '/settings/diagnostics'
       path: '/diagnostics'
@@ -359,6 +378,7 @@ interface SettingsRouteChildren {
   SettingsBetaRoute: typeof SettingsBetaRoute
   SettingsConnectionsRoute: typeof SettingsConnectionsRoute
   SettingsDiagnosticsRoute: typeof SettingsDiagnosticsRoute
+  SettingsEnvironmentRoute: typeof SettingsEnvironmentRoute
   SettingsGeneralRoute: typeof SettingsGeneralRoute
   SettingsKeybindingsRoute: typeof SettingsKeybindingsRoute
   SettingsProvidersRoute: typeof SettingsProvidersRoute
@@ -370,6 +390,7 @@ const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsBetaRoute: SettingsBetaRoute,
   SettingsConnectionsRoute: SettingsConnectionsRoute,
   SettingsDiagnosticsRoute: SettingsDiagnosticsRoute,
+  SettingsEnvironmentRoute: SettingsEnvironmentRoute,
   SettingsGeneralRoute: SettingsGeneralRoute,
   SettingsKeybindingsRoute: SettingsKeybindingsRoute,
   SettingsProvidersRoute: SettingsProvidersRoute,

--- a/apps/web/src/routes/settings.environment.tsx
+++ b/apps/web/src/routes/settings.environment.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { EnvironmentSettingsPanel } from "../components/settings/SettingsPanels";
+
+function SettingsEnvironmentRoute() {
+  return <EnvironmentSettingsPanel />;
+}
+
+export const Route = createFileRoute("/settings/environment")({
+  component: SettingsEnvironmentRoute,
+});

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -9,15 +9,21 @@ import {
 } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
 
-import { useSettingsRestore } from "../components/settings/SettingsPanels";
+import { type SettingsOwnership, useSettingsRestore } from "../components/settings/SettingsPanels";
 import { Button } from "../components/ui/button";
 import { SidebarInset } from "../components/ui/sidebar";
 import { isElectron } from "../env";
 import { cn } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 
-function RestoreDefaultsButton({ onRestored }: { onRestored: () => void }) {
-  const { changedSettingLabels, restoreDefaults } = useSettingsRestore(onRestored);
+function RestoreDefaultsButton({
+  ownership,
+  onRestored,
+}: {
+  ownership: SettingsOwnership;
+  onRestored: () => void;
+}) {
+  const { changedSettingLabels, restoreDefaults } = useSettingsRestore(ownership, onRestored);
 
   return (
     <Button
@@ -37,7 +43,12 @@ function SettingsContentLayout() {
   const navigate = useNavigate();
   const canGoBack = useCanGoBack();
   const [restoreSignal, setRestoreSignal] = useState(0);
-  const showRestoreDefaults = location.pathname === "/settings/general";
+  const restoreOwnership: SettingsOwnership | null =
+    location.pathname === "/settings/general"
+      ? "client"
+      : location.pathname === "/settings/environment"
+        ? "environment"
+        : null;
   const handleRestored = () => setRestoreSignal((value) => value + 1);
   const navigateBackWithinApp = useCallback(() => {
     if (canGoBack) {
@@ -80,9 +91,9 @@ function SettingsContentLayout() {
           >
             <div className="flex min-h-7 items-center gap-2 sm:min-h-6">
               <span className="text-sm font-medium text-foreground">Settings</span>
-              {showRestoreDefaults ? (
+              {restoreOwnership ? (
                 <div className="ms-auto flex items-center gap-2">
-                  <RestoreDefaultsButton onRestored={handleRestored} />
+                  <RestoreDefaultsButton ownership={restoreOwnership} onRestored={handleRestored} />
                 </div>
               ) : null}
             </div>
@@ -99,9 +110,9 @@ function SettingsContentLayout() {
             <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings
             </span>
-            {showRestoreDefaults ? (
+            {restoreOwnership ? (
               <div className="ms-auto flex items-center gap-2">
-                <RestoreDefaultsButton onRestored={handleRestored} />
+                <RestoreDefaultsButton ownership={restoreOwnership} onRestored={handleRestored} />
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## What Changed

- Group the settings navigation by Client and Environment ownership.
- Split the mixed General page into client settings at `/settings/general` and environment settings at `/settings/environment`.
- Scope Restore defaults to the settings owned by the current page.

## Why

Settings that follow the graphical client and settings that configure the connected execution environment currently appear together, obscuring where changes apply. Making ownership explicit supports first-class remote environments and complements #4559 and #4564.

## UI Changes

Before: one flat settings navigation and a General page mixing client preferences with environment configuration.

After: labeled Client and Environment navigation groups with separate General pages. The affected flows were verified in an authenticated web client; the preview screenshot/recording endpoint failed during capture, so no reliable artifact is attached.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (capture tooling failed; DOM-level integrated verification passed)
- [x] A video is not applicable; this change adds no animation or interaction behavior

## Verification

- `vp test run src/components/settings/SettingsSidebarNav.test.ts --project unit`
- Targeted `vp lint` on the six affected files
- `vp build` in `apps/web`
- Authenticated integrated web verification of both settings pages and their visible controls
- Web typecheck was attempted and remains blocked by existing errors in unrelated files on `origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI routing and conditional rendering; no auth or persistence model changes beyond which keys restore-defaults touches per page.
> 
> **Overview**
> Settings navigation is now grouped under **Client** and **Environment**, and the old mixed General page is split into two routes.
> 
> **Client** (`/settings/general`) keeps UI and app preferences (theme, glass opacity, sidebar, confirmations, etc.) plus **About**. **Environment** (`/settings/environment`) holds execution-related options (streaming, provider checks, new-thread defaults, text generation model) and moves **Diagnostics** off the client General page.
> 
> `useSettingsRestore` takes an `ownership` argument so **Restore defaults** only lists and resets settings for the active panel, on both General pages. A unit test locks in the nav group → route mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433b42a3eef5c64fa1059ee7cd6ad5cb003f2c49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate client and environment settings into distinct panels in the settings sidebar
> - Adds a new `/settings/environment` route that renders an `EnvironmentSettingsPanel`, splitting settings that belong to the environment (streaming, provider checks, git, model selection) away from client settings (theme, UI, confirmations).
> - Replaces the flat `SETTINGS_NAV_ITEMS` with `SETTINGS_NAV_GROUPS` in [`SettingsSidebarNav.tsx`](https://github.com/pingdotgg/t3code/pull/4567/files#diff-0c64e545aee60962b27c61f412d1b564c5896199b9538212702b7da60246d134), grouping nav items under labeled "Client" and "Environment" sections.
> - Updates `useSettingsRestore` to accept an `ownership` argument so the "Restore Defaults" button resets only the settings belonging to the current panel's scope.
> - Behavioral Change: the "Restore Defaults" button now only appears on the Client and Environment settings pages, and its effect is scoped to that panel's owned settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 433b42a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->