### PR TITLE
fix(windows): discover Cursor Agent CLI install dir

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -336,6 +336,7 @@ describe("resolveKnownWindowsCliDirs", () => {
       "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
       "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
       "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+      "C:\\Users\\testuser\\AppData\\Local\\cursor-agent",
       "C:\\Users\\testuser\\.bun\\bin",
       "C:\\Users\\testuser\\scoop\\shims",
     ]);
@@ -476,6 +477,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+          "C:\\Users\\testuser\\AppData\\Local\\cursor-agent",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
           "C:\\Shell\\Bin",
@@ -524,6 +526,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+          "C:\\Users\\testuser\\AppData\\Local\\cursor-agent",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
           "C:\\Shell\\Bin",

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -616,7 +616,7 @@ export function resolveKnownWindowsCliDirs(env: NodeJS.ProcessEnv): ReadonlyArra
   return [
     ...(appData ? [`${appData}\\npm`] : []),
     ...(localAppData ? [`${localAppData}\\Programs\\nodejs`, `${localAppData}\\Volta\\bin`] : []),
-    ...(localAppData ? [`${localAppData}\\pnpm`] : []),
+    ...(localAppData ? [`${localAppData}\\pnpm`, `${localAppData}\\cursor-agent`] : []),
     ...(userProfile ? [`${userProfile}\\.bun\\bin`, `${userProfile}\\scoop\\shims`] : []),
   ];
 }


### PR DESCRIPTION
## Summary
- Add `%LOCALAPPDATA%\cursor-agent` to `resolveKnownWindowsCliDirs` so Windows desktop can find the official Cursor Agent CLI even when the Electron process has a stale User PATH.
- Update shell unit tests that assert the known-dir PATH composition.

## Why
On Windows, the Cursor Agent installer places `agent.cmd` / `cursor-agent.cmd` under `%LOCALAPPDATA%\cursor-agent` and updates User PATH. T3's Electron process can still miss that PATH entry (common after install without a full relaunch from a parent with a fresh environment). Provider health checks then report `Cursor CLI command agent was not found` even though the binary exists and `agent --version` works in a refreshed shell.

T3 already prepends known Windows CLI dirs (npm, node, Volta, pnpm, bun, scoop) via `resolveWindowsEnvironment`. Including the Cursor Agent install dir follows that pattern and removes the need for users to hardcode an absolute `binaryPath`.

Reproduced locally: installed CLI present + on User PATH, T3 still failed until `providers.cursor.binaryPath` was set to the absolute `agent.cmd` path. After this fallback, discovery should succeed without that workaround.

Official install docs: https://cursor.com/docs/cli/installation

## Test plan
- [x] `vp test run packages/shared/src/shell.test.ts` (29/29 pass)
- [x] On Windows desktop: install Cursor CLI, leave default/binary name `agent` or `cursor-agent`, ensure User PATH includes `%LOCALAPPDATA%\cursor-agent` but launch T3 from a process that may have a stale PATH; Cursor provider should become `installed` / `ready` without setting an absolute binary path
- [x] Confirm absolute `binaryPath` override still works

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive PATH fallback in shared shell utilities; no auth, security, or data-path changes.
> 
> **Overview**
> Adds **`%LOCALAPPDATA%\cursor-agent`** to the known Windows CLI install directories in `resolveKnownWindowsCliDirs`, so `resolveWindowsEnvironment` prepends that folder to PATH the same way it already does for npm, Node, Volta, pnpm, bun, and scoop.
> 
> This is meant to fix Cursor provider health checks when the Electron process has a **stale User PATH** after installing the official Cursor Agent CLI, so `agent` / `cursor-agent` can be resolved without setting an absolute `binaryPath`.
> 
> Unit tests for `resolveKnownWindowsCliDirs` and `resolveWindowsEnvironment` PATH composition were updated to include the new directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf80362b3eba0a6991b646715a07e429fa169b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cursor Agent CLI install dir to Windows PATH discovery
> Extends `resolveKnownWindowsCliDirs` in [shell.ts](https://github.com/pingdotgg/t3code/pull/4569/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) to include the `cursor-agent` directory under `LOCALAPPDATA` when that environment variable is defined. This brings Cursor Agent in line with other `LOCALAPPDATA`-based tools already discovered on Windows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbf8036.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->