### PR TITLE
fix(server): survive client resets on WebSocket upgrade sockets

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -13,6 +13,7 @@ import {
   browserApiCorsLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
+import { guardUpgradeSockets } from "./upgradeSocketGuard.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
@@ -137,7 +138,7 @@ const HttpServerLive = Layer.unwrap(
         Effect.promise(() => import("@effect/platform-node/NodeHttpServer")),
         Effect.promise(() => import("node:http")),
       ]);
-      return NodeHttpServer.layer(NodeHttp.createServer, {
+      return NodeHttpServer.layer(() => guardUpgradeSockets(NodeHttp.createServer()), {
         host: config.host ?? "127.0.0.1",
         port: config.port,
         gracefulShutdownTimeout: HTTP_PREEMPTIVE_SHUTDOWN_GRACE_MS,

--- a/apps/server/src/upgradeSocketGuard.test.ts
+++ b/apps/server/src/upgradeSocketGuard.test.ts
@@ -1,0 +1,96 @@
+import * as NodeHttp from "node:http";
+import * as NodeNet from "node:net";
+
+import { expect, it } from "@effect/vitest";
+
+import { guardUpgradeSockets } from "./upgradeSocketGuard.ts";
+
+const UPGRADE_REQUEST =
+  "GET /ws HTTP/1.1\r\n" +
+  "Host: 127.0.0.1\r\n" +
+  "Upgrade: websocket\r\n" +
+  "Connection: Upgrade\r\n" +
+  "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+  "Sec-WebSocket-Version: 13\r\n" +
+  "\r\n";
+
+const listen = (server: NodeHttp.Server): Promise<number> =>
+  new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as NodeNet.AddressInfo).port));
+  });
+
+const close = (server: NodeHttp.Server): Promise<void> =>
+  new Promise((resolve) => server.close(() => resolve()));
+
+const resetUpgradeConnection = (port: number): Promise<void> =>
+  new Promise((resolve) => {
+    const socket = NodeNet.connect(port, "127.0.0.1");
+    socket.on("error", () => resolve());
+    socket.on("connect", () => {
+      socket.write(UPGRADE_REQUEST);
+      setTimeout(() => {
+        socket.resetAndDestroy();
+        resolve();
+      }, 50);
+    });
+  });
+
+const makeUpgradeServer = () => {
+  const server = NodeHttp.createServer((_request, response) => {
+    response.writeHead(200);
+    response.end("ok");
+  });
+  server.on("upgrade", (_request, socket) => {
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+    );
+  });
+  return server;
+};
+
+const httpGet = (port: number): Promise<number> =>
+  new Promise((resolve, reject) => {
+    NodeHttp.get({ host: "127.0.0.1", port, path: "/" }, (response) => {
+      response.resume();
+      resolve(response.statusCode ?? 0);
+    }).on("error", reject);
+  });
+
+it("attaches an error listener to every upgrade socket", async () => {
+  const server = guardUpgradeSockets(makeUpgradeServer());
+  // Registered after the guard, so it runs second and observes the guard's listener.
+  const observed = new Promise<number>((resolve) => {
+    server.on("upgrade", (_request, socket) => resolve(socket.listenerCount("error")));
+  });
+  const port = await listen(server);
+  try {
+    const client = NodeNet.connect(port, "127.0.0.1");
+    client.on("error", () => {});
+    client.on("connect", () => client.write(UPGRADE_REQUEST));
+    expect(await observed).toBe(1);
+    client.destroy();
+  } finally {
+    await close(server);
+  }
+});
+
+it("keeps the server alive when a client RSTs a /ws upgrade connection", async () => {
+  const uncaught: Array<unknown> = [];
+  const onUncaught = (error: unknown) => uncaught.push(error);
+  process.on("uncaughtException", onUncaught);
+
+  const server = guardUpgradeSockets(makeUpgradeServer());
+  const port = await listen(server);
+  try {
+    for (let i = 0; i < 10; i++) {
+      await resetUpgradeConnection(port);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(uncaught).toEqual([]);
+    expect(await httpGet(port)).toBe(200);
+  } finally {
+    process.off("uncaughtException", onUncaught);
+    await close(server);
+  }
+});

--- a/apps/server/src/upgradeSocketGuard.ts
+++ b/apps/server/src/upgradeSocketGuard.ts
@@ -1,0 +1,15 @@
+import type * as NodeHttp from "node:http";
+import type * as NodeNet from "node:net";
+
+// Node throws an uncaught exception — taking the whole process down — when a
+// socket emits 'error' with no listener attached. @effect/platform-node's
+// upgrade handler wires a 'close' listener on the raw upgrade socket but not an
+// 'error' one, so a client that RSTs a /ws connection during or right after the
+// handshake kills the server. Attaching a no-op 'error' listener on every
+// upgrade socket turns the reset into a normal disconnect.
+export const guardUpgradeSockets = (server: NodeHttp.Server): NodeHttp.Server => {
+  server.on("upgrade", (_request, socket: NodeNet.Socket) => {
+    socket.on("error", () => {});
+  });
+  return server;
+};


### PR DESCRIPTION
## What Changed

Attach a no-op `'error'` listener to every WebSocket upgrade socket, so a client reset degrades to an ordinary disconnect instead of killing the server process.

Only the Node factory in `server.ts` is touched. The Bun path goes through `Bun.serve` and never hands out raw upgrade sockets, so it needs no guard.

## Why

A client that sends an upgrade request to `/ws` and then resets the connection takes the whole server down. Node throws an uncaught exception when a socket emits `'error'` with no listener, and `@effect/platform-node@4.0.0-beta.78` wires a `'close'` listener on the raw upgrade socket in `makeUpgradeHandler` but never an `'error'` one:

```js
socket.on("close", () => {
  if (!socket.writableEnded) {
    fiber.interruptUnsafe(parent.id, ClientAbort.annotation)
  }
})
```

Authentication is not a barrier. The `'upgrade'` event fires before the route runs, so a client whose credentials are rejected has already passed through the unguarded socket — a rejected connection that resets kills the server exactly like an accepted one.

```
node:events:497
      throw er; // Unhandled 'error' event
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
  errno: -104, code: 'ECONNRESET', syscall: 'read'

systemd: t3code.service: Main process exited, code=exited, status=1/FAILURE
```

Every in-flight session dies with the process, not just the one whose socket reset.

**Trigger conditions.** Two have to hold together. Probed against an unpatched `0.0.29-nightly.20260725.899`:

| client behaviour after upgrade | outcome |
|---|---|
| reads the response, closes with FIN | survives |
| reads the response, resets | survives |
| leaves the response unread, closes with FIN | survives |
| **leaves the response unread, resets** | **dies** |

Unread bytes in the receive buffer make the kernel emit RST instead of FIN, and that RST lands on the unlistened socket. The same probe against a bare connection, partial headers, a completed `GET /`, a `POST /mcp` and an SSE `GET /mcp` leaves the server up — only the upgrade path is affected.

**Impact.** Unlikely from ordinary traffic: browsers read their response and close cleanly, and a three-week journal on my deployment shows zero occurrences from normal client churn. The crashes I observed were self-inflicted by a scripted client that ignored the response. But it takes about ten lines and no credentials to trigger deliberately and repeatedly, so on any deployment listening beyond loopback it is an availability problem rather than a rare glitch.

**Upstream.** The gap is in `@effect/platform-node` and arguably belongs there too. A guard here is still worth having: three lines, holds regardless of what upstream does, and keeps server liveness independent of a transitive dependency's socket handling.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — n/a, no UI change
- [x] I included a video for animation/interaction changes — n/a

---

### Tests

`apps/server/src/upgradeSocketGuard.test.ts` covers that the listener is attached to every upgrade socket, and that ten consecutive resets leave the server answering requests with no `uncaughtException`.

- new tests pass; full `apps/server` suite green (1622 passed, 7 skipped)
- `vp check` reports 0 errors (remaining 11 warnings are pre-existing in `apps/web`)
- `vpr typecheck` failures are limited to `scripts/lib/resolve-catalog.ts` and reproduce on a clean checkout
- built with `vp pack` and re-ran the probe against `dist/bin.mjs`: 20 consecutive resets on the previously fatal case, server alive, nothing fatal logged

Negative control: with the guard removed, the same sequence produces `UNCAUGHT: ECONNRESET` and exit code 42.
