### PR TITLE
feat(opencode): report context window usage

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -68,6 +68,12 @@ const runtimeMock = {
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as unknown[],
+    providerList: {
+      all: [],
+      default: {},
+      connected: [],
+    } as Record<string, unknown>,
+    providerListCalls: 0,
     sessionGetIds: [] as string[],
     missingSessionIds: new Set<string>(),
     transientErrorSessionIds: new Set<string>(),
@@ -88,6 +94,12 @@ const runtimeMock = {
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
+    this.state.providerList = {
+      all: [],
+      default: {},
+      connected: [],
+    };
+    this.state.providerListCalls = 0;
     this.state.sessionGetIds.length = 0;
     this.state.missingSessionIds.clear();
     this.state.transientErrorSessionIds.clear();
@@ -211,6 +223,12 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             }
           })(),
         }),
+      },
+      provider: {
+        list: async () => {
+          runtimeMock.state.providerListCalls += 1;
+          return { data: runtimeMock.state.providerList };
+        },
       },
     }) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
   loadOpenCodeInventory: () =>
@@ -1187,6 +1205,94 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.ok(metadataUpdated);
       if (metadataUpdated.type === "thread.metadata.updated") {
         NodeAssert.equal(metadataUpdated.payload.name, "Investigate OpenCode title sync");
+      }
+    }),
+  );
+
+  it.effect("emits context-window usage from completed assistant messages", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-token-usage");
+      runtimeMock.state.providerList = {
+        all: [
+          {
+            id: "anthropic",
+            models: {
+              "claude-sonnet-4": {
+                id: "claude-sonnet-4",
+                limit: {
+                  context: 200_000,
+                  output: 64_000,
+                },
+              },
+            },
+          },
+        ],
+        default: {},
+        connected: ["anthropic"],
+      };
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "message.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            info: {
+              id: "msg-token-usage",
+              sessionID: "http://127.0.0.1:9999/session",
+              role: "assistant",
+              time: { created: 1, completed: 2 },
+              parentID: "msg-user",
+              modelID: "claude-sonnet-4",
+              providerID: "anthropic",
+              mode: "build",
+              agent: "build",
+              path: { cwd: "/repo", root: "/repo" },
+              cost: 0,
+              tokens: {
+                input: 40_000,
+                output: 2_000,
+                reasoning: 1_000,
+                cache: {
+                  read: 5_000,
+                  write: 500,
+                },
+              },
+            },
+          },
+        },
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      const usageEvent = events.find((event) => event.type === "thread.token-usage.updated");
+      NodeAssert.equal(runtimeMock.state.providerListCalls, 1);
+      NodeAssert.equal(usageEvent?.type, "thread.token-usage.updated");
+      if (usageEvent?.type === "thread.token-usage.updated") {
+        NodeAssert.deepEqual(usageEvent.payload.usage, {
+          usedTokens: 48_500,
+          maxTokens: 200_000,
+          inputTokens: 45_500,
+          cachedInputTokens: 5_000,
+          outputTokens: 2_000,
+          reasoningOutputTokens: 1_000,
+          lastUsedTokens: 48_500,
+          lastInputTokens: 45_500,
+          lastCachedInputTokens: 5_000,
+          lastOutputTokens: 2_000,
+          lastReasoningOutputTokens: 1_000,
+        });
       }
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1215,6 +1215,14 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const threadId = asThreadId("thread-opencode-token-usage");
       runtimeMock.state.providerList = {
         all: [
+          null,
+          { id: "missing-models" },
+          {
+            id: "malformed-model",
+            models: {
+              broken: { id: "broken", limit: null },
+            },
+          },
           {
             id: "anthropic",
             models: {
@@ -1290,6 +1298,70 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           lastUsedTokens: 48_500,
           lastInputTokens: 45_500,
           lastCachedInputTokens: 5_000,
+          lastOutputTokens: 2_000,
+          lastReasoningOutputTokens: 1_000,
+        });
+      }
+    }),
+  );
+
+  it.effect("handles assistant usage without cache details", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-token-usage-no-cache");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "message.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            info: {
+              id: "msg-token-usage-no-cache",
+              sessionID: "http://127.0.0.1:9999/session",
+              role: "assistant",
+              time: { created: 1, completed: 2 },
+              parentID: "msg-user",
+              modelID: "claude-sonnet-4",
+              providerID: "anthropic",
+              mode: "build",
+              agent: "build",
+              path: { cwd: "/repo", root: "/repo" },
+              cost: 0,
+              tokens: {
+                input: 40_000,
+                output: 2_000,
+                reasoning: 1_000,
+              },
+            },
+          },
+        },
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      const usageEvent = events.find((event) => event.type === "thread.token-usage.updated");
+      NodeAssert.equal(usageEvent?.type, "thread.token-usage.updated");
+      if (usageEvent?.type === "thread.token-usage.updated") {
+        NodeAssert.deepEqual(usageEvent.payload.usage, {
+          usedTokens: 43_000,
+          inputTokens: 40_000,
+          cachedInputTokens: 0,
+          outputTokens: 2_000,
+          reasoningOutputTokens: 1_000,
+          lastUsedTokens: 43_000,
+          lastInputTokens: 40_000,
+          lastCachedInputTokens: 0,
           lastOutputTokens: 2_000,
           lastReasoningOutputTokens: 1_000,
         });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -7,6 +7,7 @@ import {
   type ProviderSession,
   RuntimeItemId,
   RuntimeRequestId,
+  type ThreadTokenUsageSnapshot,
   ThreadId,
   type ToolLifecycleItemType,
   TurnId,
@@ -23,7 +24,14 @@ import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
-import type { OpencodeClient, Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
+import type {
+  AssistantMessage,
+  OpencodeClient,
+  Part,
+  PermissionRequest,
+  ProviderListResponse,
+  QuestionRequest,
+} from "@opencode-ai/sdk/v2";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -204,6 +212,73 @@ function openCodeEventSessionTitle(event: OpenCodeSubscribedEvent): string | und
   return trimText(event.properties.info.title);
 }
 
+function finiteNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.round(value)
+    : undefined;
+}
+
+function finitePositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.round(value)
+    : undefined;
+}
+
+function openCodeModelSlug(providerID: string, modelID: string): string {
+  return `${providerID}/${modelID}`;
+}
+
+function collectOpenCodeModelContextWindows(
+  providerList: ProviderListResponse | undefined,
+): ReadonlyMap<string, number> {
+  const result = new Map<string, number>();
+  for (const provider of providerList?.all ?? []) {
+    for (const [modelID, model] of Object.entries(provider.models)) {
+      const contextWindow = finitePositiveInteger(model.limit.context);
+      if (contextWindow === undefined) {
+        continue;
+      }
+      result.set(openCodeModelSlug(provider.id, modelID), contextWindow);
+      result.set(openCodeModelSlug(provider.id, model.id), contextWindow);
+    }
+  }
+  return result;
+}
+
+function normalizeOpenCodeTokenUsage(
+  tokens: AssistantMessage["tokens"] | undefined,
+  contextWindow?: number,
+): ThreadTokenUsageSnapshot | undefined {
+  if (!tokens) {
+    return undefined;
+  }
+  const nonCachedInputTokens = finiteNonNegativeInteger(tokens.input) ?? 0;
+  const cachedInputTokens = finiteNonNegativeInteger(tokens.cache.read) ?? 0;
+  const cacheWriteInputTokens = finiteNonNegativeInteger(tokens.cache.write) ?? 0;
+  const inputTokens = nonCachedInputTokens + cachedInputTokens + cacheWriteInputTokens;
+  const outputTokens = finiteNonNegativeInteger(tokens.output) ?? 0;
+  const reasoningOutputTokens = finiteNonNegativeInteger(tokens.reasoning) ?? 0;
+  const usedTokens = inputTokens + outputTokens + reasoningOutputTokens;
+  if (usedTokens <= 0) {
+    return undefined;
+  }
+
+  const maxTokens = finitePositiveInteger(contextWindow);
+  return {
+    usedTokens,
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+    reasoningOutputTokens,
+    lastUsedTokens: usedTokens,
+    lastInputTokens: inputTokens,
+    lastCachedInputTokens: cachedInputTokens,
+    lastOutputTokens: outputTokens,
+    lastReasoningOutputTokens: reasoningOutputTokens,
+  };
+}
+
 interface OpenCodeSessionContext {
   session: ProviderSession;
   readonly client: OpencodeClient;
@@ -213,6 +288,7 @@ interface OpenCodeSessionContext {
   readonly pendingPermissions: Map<string, PermissionRequest>;
   readonly pendingQuestions: Map<string, QuestionRequest>;
   readonly messageRoleById: Map<string, "user" | "assistant">;
+  readonly modelContextWindowBySlug: ReadonlyMap<string, number>;
   readonly partById: Map<string, Part>;
   readonly emittedTextByPartId: Map<string, string>;
   readonly completedAssistantPartIds: Set<string>;
@@ -826,10 +902,28 @@ export function makeOpenCodeAdapter(
         }
 
         case "message.updated": {
-          context.messageRoleById.set(event.properties.info.id, event.properties.info.role);
-          if (event.properties.info.role === "assistant") {
+          const info = event.properties.info;
+          context.messageRoleById.set(info.id, info.role);
+          if (info.role === "assistant") {
+            const usage = normalizeOpenCodeTokenUsage(
+              info.tokens,
+              context.modelContextWindowBySlug.get(
+                openCodeModelSlug(info.providerID, info.modelID),
+              ),
+            );
+            if (usage) {
+              yield* emit({
+                ...(yield* buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  raw: event,
+                })),
+                type: "thread.token-usage.updated",
+                payload: { usage },
+              });
+            }
             for (const part of context.partById.values()) {
-              if (part.messageID !== event.properties.info.id) {
+              if (part.messageID !== info.id) {
                 continue;
               }
               yield* emitAssistantTextDelta(context, part, turnId, event);
@@ -1214,6 +1308,16 @@ export function makeOpenCodeAdapter(
                 directory,
                 ...(server.external && serverPassword ? { serverPassword } : {}),
               });
+              const modelContextWindowBySlug = yield* runOpenCodeSdk("provider.list", () =>
+                client.provider.list(),
+              ).pipe(
+                Effect.map((response) => collectOpenCodeModelContextWindows(response.data)),
+                Effect.catch((cause) =>
+                  Effect.logWarning(
+                    `Failed to load OpenCode model context windows: ${cause.detail}`,
+                  ).pipe(Effect.as(new Map<string, number>())),
+                ),
+              );
               const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
               if (mcpSession && !server.external) {
                 yield* runOpenCodeSdk("mcp.add", () =>
@@ -1320,6 +1424,7 @@ export function makeOpenCodeAdapter(
                 client,
                 openCodeSession: resolved.openCodeSession,
                 created: resolved.created,
+                modelContextWindowBySlug,
               };
             }).pipe(Effect.provideService(Scope.Scope, sessionScope)),
           );
@@ -1379,6 +1484,7 @@ export function makeOpenCodeAdapter(
           partById: new Map(),
           emittedTextByPartId: new Map(),
           messageRoleById: new Map(),
+          modelContextWindowBySlug: started.modelContextWindowBySlug,
           completedAssistantPartIds: new Set(),
           turns: [],
           activeTurnId: undefined,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -29,7 +29,6 @@ import type {
   OpencodeClient,
   Part,
   PermissionRequest,
-  ProviderListResponse,
   QuestionRequest,
 } from "@opencode-ai/sdk/v2";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
@@ -228,18 +227,47 @@ function openCodeModelSlug(providerID: string, modelID: string): string {
   return `${providerID}/${modelID}`;
 }
 
-function collectOpenCodeModelContextWindows(
-  providerList: ProviderListResponse | undefined,
-): ReadonlyMap<string, number> {
+function collectOpenCodeModelContextWindows(providerList: unknown): ReadonlyMap<string, number> {
   const result = new Map<string, number>();
-  for (const provider of providerList?.all ?? []) {
-    for (const [modelID, model] of Object.entries(provider.models)) {
-      const contextWindow = finitePositiveInteger(model.limit.context);
+  if (
+    !providerList ||
+    typeof providerList !== "object" ||
+    !Array.isArray((providerList as { readonly all?: unknown }).all)
+  ) {
+    return result;
+  }
+
+  for (const provider of (providerList as { readonly all: ReadonlyArray<unknown> }).all) {
+    if (
+      !provider ||
+      typeof provider !== "object" ||
+      typeof (provider as { readonly id?: unknown }).id !== "string" ||
+      !(provider as { readonly models?: unknown }).models ||
+      typeof (provider as { readonly models?: unknown }).models !== "object"
+    ) {
+      continue;
+    }
+    const providerID = (provider as { readonly id: string }).id;
+    const models = (provider as { readonly models: Record<string, unknown> }).models;
+    for (const [modelID, model] of Object.entries(models)) {
+      if (!model || typeof model !== "object") {
+        continue;
+      }
+      const modelRecord = model as { readonly id?: unknown; readonly limit?: unknown };
+      const limit = modelRecord.limit;
+      if (!limit || typeof limit !== "object") {
+        continue;
+      }
+      const contextWindow = finitePositiveInteger(
+        (limit as { readonly context?: unknown }).context,
+      );
       if (contextWindow === undefined) {
         continue;
       }
-      result.set(openCodeModelSlug(provider.id, modelID), contextWindow);
-      result.set(openCodeModelSlug(provider.id, model.id), contextWindow);
+      result.set(openCodeModelSlug(providerID, modelID), contextWindow);
+      if (typeof modelRecord.id === "string") {
+        result.set(openCodeModelSlug(providerID, modelRecord.id), contextWindow);
+      }
     }
   }
   return result;
@@ -253,8 +281,8 @@ function normalizeOpenCodeTokenUsage(
     return undefined;
   }
   const nonCachedInputTokens = finiteNonNegativeInteger(tokens.input) ?? 0;
-  const cachedInputTokens = finiteNonNegativeInteger(tokens.cache.read) ?? 0;
-  const cacheWriteInputTokens = finiteNonNegativeInteger(tokens.cache.write) ?? 0;
+  const cachedInputTokens = finiteNonNegativeInteger(tokens.cache?.read) ?? 0;
+  const cacheWriteInputTokens = finiteNonNegativeInteger(tokens.cache?.write) ?? 0;
   const inputTokens = nonCachedInputTokens + cachedInputTokens + cacheWriteInputTokens;
   const outputTokens = finiteNonNegativeInteger(tokens.output) ?? 0;
   const reasoningOutputTokens = finiteNonNegativeInteger(tokens.reasoning) ?? 0;


### PR DESCRIPTION
## What Changed

- Emit the provider-neutral `thread.token-usage.updated` event from OpenCode assistant message updates.
- Include input, cache read/write, output, and reasoning tokens in the active context snapshot.
- Load each OpenCode model's context limit from `provider.list()` when a session starts, while keeping that lookup best-effort.
- Add focused adapter coverage for model-limit lookup and normalized usage emission.

## Why

OpenCode sessions already expose per-message token usage and model context limits, but the adapter did not forward them into T3 Code's existing context-window pipeline. As a result, the existing context-window meter had no usage data for OpenCode threads. This keeps the change inside the provider adapter and reuses the current contracts, ingestion, and UI.

## UI Changes

No UI components or styling changed. The existing context-window meter now receives usage snapshots for OpenCode sessions; screenshots and interaction video are not applicable to this adapter-only change.

## Validation

- `pnpm exec vp test run apps/server/src/provider/Layers/OpenCodeAdapter.test.ts` (32 passed)
- Targeted formatting and lint passed for the changed files
- `git diff --check` passed
- `pnpm exec vp run --filter t3 typecheck` passed (with unrelated existing suggestions only)
- GitHub CI passed: Check, Test, Mobile Native Static Analysis, and Release Smoke

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable: no UI code changed)
- [x] I included a video for animation/interaction changes (not applicable: no animation or interaction changed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adapter-only event emission with defensive parsing and best-effort provider lookup; no auth, persistence, or UI logic changes.
> 
> **Overview**
> **OpenCode threads can now drive the existing context-window meter** by forwarding token usage into the same `thread.token-usage.updated` pipeline other providers already use.
> 
> On **session start**, the adapter calls `provider.list()` once and builds a per-model context-window map (failures log a warning and continue with no limits). On **`message.updated`** for assistant messages with token data, it emits a normalized `ThreadTokenUsageSnapshot`—input totals include cache read/write, plus output and reasoning, with optional `maxTokens` when a limit was found.
> 
> Tests extend the runtime mock with `provider.list` and add cases for full cache breakdown and usage without cache details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd209348fa2041ad44f7151e9c18514fbeadedde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report context window usage in thread token-usage events from OpenCode adapter
> - At session start, `makeOpenCodeAdapter` calls `provider.list` to build a slug-to-context-window map (`providerID/modelID` → max tokens); failures log a warning and use an empty map.
> - On each assistant `message.updated` event, token usage (input, cache read/write, output, reasoning) is aggregated and emitted as a `thread.token-usage.updated` event, with `maxTokens` populated from the context window map when available.
> - Adds `normalizeOpenCodeTokenUsage` and `collectOpenCodeModelContextWindows` helpers in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/4572/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) to handle aggregation and provider inventory parsing.
> - New tests in [OpenCodeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/4572/files#diff-2d1ef28752ab2f1ec0f021e6723508dc18e6a9294ebd20255ec3767afe34cf5f) cover both the normal case (with cache details) and the missing-cache-fields edge case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd20934.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

