### PR TITLE
fix(web): persist the Settled shelf's collapsed state

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1,4 +1,5 @@
 import { autoAnimate } from "@formkit/auto-animate";
+import * as Schema from "effect/Schema";
 import { useAtomValue } from "@effect/atom-react";
 import {
   canSnooze,
@@ -87,6 +88,7 @@ import { openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
@@ -158,6 +160,9 @@ import { useComposerDraftStore } from "../composerDraftStore";
 // stays behind an explicit Show more.
 const SETTLED_TAIL_INITIAL_COUNT = 10;
 const SETTLED_TAIL_PAGE_COUNT = 25;
+// Collapsing Settled is a lasting preference — someone who tucks history away
+// doesn't want it back on the next launch.
+const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:settled-expanded";
 const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> = {
   repository: "Group by repository",
   repository_path: "Group by repository path",
@@ -1473,8 +1478,15 @@ export default function SidebarV2() {
     () => setSettledVisibleCount((count) => count + SETTLED_TAIL_PAGE_COUNT),
     [],
   );
-  const [settledShelfExpanded, setSettledShelfExpanded] = useState(true);
-  const toggleSettledShelf = useCallback(() => setSettledShelfExpanded((value) => !value), []);
+  const [settledShelfExpanded, setSettledShelfExpanded] = useLocalStorage(
+    SETTLED_SHELF_EXPANDED_KEY,
+    true,
+    Schema.Boolean,
+  );
+  const toggleSettledShelf = useCallback(
+    () => setSettledShelfExpanded((value) => !value),
+    [setSettledShelfExpanded],
+  );
   const renderedSettledThreads = useMemo(() => {
     if (settledShelfExpanded) return visibleSettledThreads;
     if (routeThreadKey === null) return [];


### PR DESCRIPTION
## What changed

The Settled shelf in Sidebar V2 now remembers whether you collapsed it.

<img width="389" height="620" alt="image" src="https://github.com/user-attachments/assets/a0f7d4ad-b391-413b-ab9c-3cc3692129c1" />


## Why

Collapsing a section reads as a lasting preference, not a per-session one. Tucking history away and finding it back on every relaunch means re-collapsing it forever.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist the Settled shelf's collapsed state in local storage
> Replaces the in-memory `useState` for `settledShelfExpanded` in [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4573/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) with `useLocalStorage`, keyed at `t3code:sidebar-v2:settled-expanded`. The shelf now defaults to expanded on first visit and retains its state across page reloads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d84f3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI preference only—no server, auth, or data-path changes; worst case is a bad stored boolean falling back to the default expanded state.
> 
> **Overview**
> **Persists whether the Sidebar V2 Settled shelf is expanded** across reloads by storing that preference in `localStorage` instead of session-only React state.
> 
> `settledShelfExpanded` in `SidebarV2.tsx` now uses `useLocalStorage` with key `t3code:sidebar-v2:settled-expanded`, default **expanded** (`true`), and `Schema.Boolean` for read/write validation. Collapse/expand behavior is unchanged; only the toggle’s expanded/collapsed choice survives a new session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d84f3ff1a8d91a2cd4f4c91dc8647c3eb58d7c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->