### PR TITLE
feat(provider): add Antigravity (Google AGY) provider integration & ACP bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,31 @@
 - `packages/shared`: Shared runtime utilities consumed by both server and client applications. Uses explicit subpath exports (e.g. `@t3tools/shared/git`) — no barrel index.
 - `packages/client-runtime`: Shared runtime package for sharing client code across web and mobile.
 
+## Antigravity provider
+
+The `antigravity` driver wraps the Antigravity CLI (`agy`), which has **no native agent
+protocol**. `apps/server/src/provider/acp/antigravity/agyBridge.ts` presents the ACP surface
+`AcpSessionRuntime` needs and runs each turn through `agy --print`, shipping as hidden
+subcommands of the server binary (`t3 agy-acp`, `t3 agy-hook`).
+
+A live event stream is reconstructed from two documented Antigravity sources that correlate on
+step index (`stepIdx` in a hook == `step_index` in the transcript):
+
+- **Hooks** (`PreToolUse`/`PostToolUse`/`Stop`) give tool name, arguments, and status. The bridge
+  registers them via a throwaway `--add-dir` workspace so nothing is written into the user's repo.
+  Both the session cwd and that hook workspace must be passed — `--add-dir` replaces the workspace
+  rather than adding to cwd, so passing only the hook dir hides the project from the agent.
+- **The trajectory transcript** (`transcript.jsonl`) gives assistant text and real tool output as
+  the turn runs. Its record format is undocumented, so parsing degrades to emitting nothing.
+
+Known constraints, all inherent to print mode:
+
+- Tools are auto-approved (`--dangerously-skip-permissions`); no approval flow is possible.
+- No image attachments, and no session modes.
+- The model binds when the bridge spawns `agy`, so `sessionModelSwitch` is `"unsupported"`.
+- Any `agy` subcommand spawned for a probe must set `stdin: "ignore"`. `agy` starts a language
+  server and will not emit output while stdin stays open, so the default `"pipe"` hangs it.
+
 ## Reference Repos
 
 - Open-source Codex repo: https://github.com/openai/codex

--- a/apps/server/src/attachmentStore.ts
+++ b/apps/server/src/attachmentStore.ts
@@ -1,6 +1,7 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeCrypto from "node:crypto";
 import * as NodeFS from "node:fs";
+import * as NodeURL from "node:url";
 
 import type { ChatAttachment } from "@t3tools/contracts";
 
@@ -74,6 +75,19 @@ export function resolveAttachmentPath(input: {
     attachmentsDir: input.attachmentsDir,
     relativePath: attachmentRelativePath(input.attachment),
   });
+}
+
+/**
+ * `file:` URL for a resolved attachment path.
+ *
+ * Providers that hand attachments to an external agent by reference need a URI
+ * rather than a bare path. `pathToFileURL` is used rather than string
+ * concatenation because it escapes `#` and `?` — which would otherwise
+ * truncate the path on the way back through `fileURLToPath` — and handles
+ * Windows drive letters.
+ */
+export function attachmentFileUrl(attachmentPath: string): string {
+  return NodeURL.pathToFileURL(attachmentPath).href;
 }
 
 export function resolveAttachmentPathById(input: {

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -7,6 +7,7 @@ import * as CliError from "effect/unstable/cli/CliError";
 
 import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
+import { agyAcpCommand, agyHookCommand } from "./cli/agy.ts";
 import { authCommand } from "./cli/auth.ts";
 import { connectCommand } from "./cli/connect.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
@@ -49,13 +50,15 @@ export const makeCli = ({ cloudEnabled = hasCloudPublicConfig } = {}) =>
       authCommand,
       projectCommand,
       serviceCommand,
+      agyAcpCommand,
+      agyHookCommand,
       cloudEnabled ? connectCommand : connectUnavailableCommand,
     ]),
   );
 
 export const cli = makeCli();
 
-if (import.meta.main) {
+if (import.meta.main || (process.argv[1] && process.argv[1].includes("bin.ts"))) {
   Command.run(cli, { version: packageJson.version }).pipe(
     Effect.scoped,
     Effect.provide(CliRuntimeLayer),

--- a/apps/server/src/cli/agy.ts
+++ b/apps/server/src/cli/agy.ts
@@ -1,0 +1,31 @@
+/**
+ * Hidden CLI entry points for the Antigravity ACP bridge.
+ *
+ * Both are internal plumbing rather than user-facing commands: the provider
+ * spawns `t3 agy-acp` as an ACP agent, and that bridge registers `t3 agy-hook
+ * <event>` as Antigravity's tool-lifecycle hook. Shipping them as subcommands
+ * of the server binary keeps the bridge inside the same bundle.
+ *
+ * @module cli/agy
+ */
+import * as Effect from "effect/Effect";
+import { Command, Flag } from "effect/unstable/cli";
+
+import { runAgyBridge, runAgyHook } from "../provider/acp/antigravity/agyBridge.ts";
+
+export const agyAcpCommand = Command.make("agy-acp").pipe(
+  Command.withDescription("Run the Antigravity ACP compatibility bridge over stdio."),
+  Command.withHidden,
+  Command.withHandler(() => Effect.promise(() => runAgyBridge())),
+);
+
+export const agyHookCommand = Command.make("agy-hook", {
+  event: Flag.string("event").pipe(
+    Flag.withDescription("Antigravity hook event name."),
+    Flag.withDefault("unknown"),
+  ),
+}).pipe(
+  Command.withDescription("Handle one Antigravity tool-lifecycle hook event."),
+  Command.withHidden,
+  Command.withHandler(({ event }) => Effect.promise(() => runAgyHook(event))),
+);

--- a/apps/server/src/provider/Drivers/AntigravityDriver.ts
+++ b/apps/server/src/provider/Drivers/AntigravityDriver.ts
@@ -1,0 +1,177 @@
+/**
+ * AntigravityDriver — built-in driver for the Antigravity CLI (`agy`).
+ *
+ * Sessions run through T3 Code's bundled ACP bridge rather than a native agent
+ * protocol; see `provider/acp/antigravity/agyBridge.ts`.
+ *
+ * @module Drivers/AntigravityDriver
+ */
+import { AntigravitySettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { makeAntigravityTextGeneration } from "../../textGeneration/AntigravityTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeAntigravityAdapter } from "../Layers/AntigravityAdapter.ts";
+import {
+  buildInitialAntigravityProviderSnapshot,
+  checkAntigravityProviderStatus,
+  enrichAntigravitySnapshot,
+} from "../Layers/AntigravityProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("antigravity");
+const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
+// Antigravity ships its own installer and updater (`agy update`), so T3 Code
+// never manages the binary itself.
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: null,
+  }),
+);
+
+export type AntigravityDriverEnv =
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Antigravity",
+    supportsMultipleInstances: true,
+  },
+  configSchema: AntigravitySettings,
+  defaultConfig: (): AntigravitySettings => decodeAntigravitySettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const httpClient = yield* HttpClient.HttpClient;
+      const serverSettings = yield* ServerSettingsService;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies AntigravitySettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+
+      const adapter = yield* makeAntigravityAdapter(effectiveConfig, {
+        environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+        instanceId,
+      });
+      const textGeneration = yield* makeAntigravityTextGeneration(effectiveConfig, processEnv);
+
+      const checkProvider = checkAntigravityProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<
+        ProviderSnapshotSettings<AntigravitySettings>
+      >({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialAntigravityProviderSnapshot(settings.provider).pipe(
+            Effect.map(stampIdentity),
+          ),
+        checkProvider,
+        enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichAntigravitySnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+            publishSnapshot,
+            httpClient,
+          }),
+        refreshInterval: SNAPSHOT_REFRESH_INTERVAL,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Antigravity snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1,0 +1,74 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import {
+  ApprovalRequestId,
+  AntigravitySettings,
+  ProviderDriverKind,
+  ThreadId,
+} from "@t3tools/contracts";
+
+import * as ServerConfig from "../../config.ts";
+import { makeAntigravityAdapter } from "./AntigravityAdapter.ts";
+
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const antigravityAdapterTestLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3code-agy-adapter-test-",
+}).pipe(Layer.provideMerge(NodeServices.layer));
+
+it.layer(antigravityAdapterTestLayer)("AntigravityAdapterLive", (it) => {
+  it.effect("declares sessionModelSwitch as in-session in capabilities", () =>
+    Effect.gen(function* () {
+      const adapter = yield* makeAntigravityAdapter(decodeAntigravitySettings({}));
+      assert.equal(adapter.capabilities.sessionModelSwitch, "in-session");
+      assert.equal(adapter.provider, ProviderDriverKind.make("antigravity"));
+    }),
+  );
+
+  it.effect(
+    "returns ProviderAdapterSessionNotFoundError for respondToRequest on unknown thread",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* makeAntigravityAdapter(decodeAntigravitySettings({}));
+        const threadId = ThreadId.make("agy-nonexistent-thread");
+
+        const error = yield* Effect.flip(
+          adapter.respondToRequest(threadId, ApprovalRequestId.make("req-1"), "accept"),
+        );
+
+        assert.equal(error._tag, "ProviderAdapterSessionNotFoundError");
+      }),
+  );
+
+  it.effect(
+    "returns ProviderAdapterSessionNotFoundError for respondToUserInput on unknown thread",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* makeAntigravityAdapter(decodeAntigravitySettings({}));
+        const threadId = ThreadId.make("agy-nonexistent-thread");
+
+        const error = yield* Effect.flip(
+          adapter.respondToUserInput(threadId, ApprovalRequestId.make("req-1"), {}),
+        );
+
+        assert.equal(error._tag, "ProviderAdapterSessionNotFoundError");
+      }),
+  );
+
+  it.effect(
+    "returns ProviderAdapterSessionNotFoundError for rollbackThread on unknown thread",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* makeAntigravityAdapter(decodeAntigravitySettings({}));
+        const threadId = ThreadId.make("agy-nonexistent-thread");
+
+        const error = yield* Effect.flip(adapter.rollbackThread(threadId, 1));
+
+        assert.equal(error._tag, "ProviderAdapterSessionNotFoundError");
+      }),
+  );
+});

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -35,6 +35,8 @@ import {
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -84,11 +86,26 @@ const PROVIDER = ProviderDriverKind.make("antigravity");
 /**
  * How long this side waits for a tool-approval answer.
  *
- * Deliberately longer than the bridge's own wait: the bridge denies first and
- * the blocked hook is released by that, so this only exists to stop an
- * unanswered request pinning its entry and its UI prompt forever.
+ * Deliberately *shorter* than the bridge's own wait, which is shorter again
+ * than the hook's. Each layer must give up before the one behind it: when this
+ * was the longest, the bridge had already denied and released the hook while
+ * the request was still open here, so a user answering in that window got an
+ * acceptance the bridge would ignore.
  */
-const APPROVAL_WAIT_MS = 11 * 60 * 1000;
+const APPROVAL_WAIT_MS = 9 * 60 * 1000;
+/**
+ * How long to let the bridge answer a cancelled prompt on its own before
+ * interrupting the RPC. Only a backstop against a wedged bridge; the normal
+ * path settles well inside it.
+ */
+const CANCEL_ACK_TIMEOUT_MS = 10_000;
+/**
+ * How long turn settlement waits for an approval handler it just cancelled to
+ * publish its resolution. Short: the handler is already unblocked, so this only
+ * covers the hop back through the runtime, and a turn must never be held open
+ * by a handler that will not finish.
+ */
+const APPROVAL_SETTLE_TIMEOUT_MS = 5_000;
 const ANTIGRAVITY_RESUME_VERSION = 1 as const;
 
 export interface AntigravityAdapterLiveOptions {
@@ -127,16 +144,71 @@ interface AntigravitySessionContext {
    */
   cancelEpoch: number;
   /**
-   * Turns for which `turn.started` has actually been published. Shared rather
-   * than per-call, so a steer cannot assume the prompt it folded into already
-   * announced the turn — that prompt may have failed during preflight.
+   * Turns whose `turn.started` a prompt has reserved the right to publish.
+   * Shared rather than per-call, so a steer cannot assume the prompt it folded
+   * into already announced the turn — that prompt may have failed in preflight.
    */
-  readonly startedTurnIds: Set<TurnId>;
+  readonly reservedTurnIds: Set<TurnId>;
+  /**
+   * Turns whose `turn.started` is actually on the wire.
+   *
+   * Kept apart from the reservation: teardown may run while a start is still
+   * being stamped, and completing a turn nobody has seen start is as wrong as
+   * dropping the completion of one they have.
+   */
+  readonly publishedTurnIds: Set<TurnId>;
+  /**
+   * Serializes prompt submission for this thread.
+   *
+   * `acp.prompt` already queues internally on its own semaphore, but that one
+   * is acquired inside the call where nothing can be rechecked — a steer could
+   * clear the cancel check, wait there, and reach the agent after Stop. Taking
+   * the same serialization here instead makes the wait observable, so the
+   * epoch can be re-read at the point submission actually begins. Deliberately
+   * separate from the thread lock, which teardown needs to stay free.
+   */
+  readonly promptGate: Semaphore.Semaphore;
+  /**
+   * Serializes the turn-lifecycle critical sections against teardown.
+   *
+   * Announcing a turn is "check the session is live, reserve the turn, publish
+   * the start" and teardown is "mark stopped, snapshot what was published".
+   * Interleaving those two is what let a start be published after
+   * `session.exited`, or a turn be completed while its start was still being
+   * stamped. Both run under this, and both are short and yield-free apart from
+   * the publications they own.
+   */
+  readonly lifecycleGate: Semaphore.Semaphore;
+  /**
+   * Fired the moment teardown begins. Waiting on the event consumer races
+   * against this rather than a wall clock, so a slow but healthy consumer is
+   * still awaited in full while a torn-down one never blocks anybody.
+   */
+  readonly teardownSignal: Deferred.Deferred<void>;
+  /**
+   * This session's pending approvals. Held on the context as well as in
+   * `approvalsByThread` so teardown can tell its own map from a replacement
+   * session's before clearing the registry entry.
+   */
+  readonly approvals: Map<ApprovalRequestId, PendingApproval>;
+  /** Bridge-side session id, needed to address provider-specific notifications. */
+  readonly acpSessionId: string;
+
+  /** Cancel epoch the active turn belongs to; steering is scoped to it. */
+  activeTurnEpoch: number;
+  /**
+   * Turns whose prompt the bridge has not answered yet.
+   *
+   * The cancel fallback arms on this rather than on "is that turn still
+   * active": a turn stays active while its events drain, and a healthy drain
+   * can outlast the acknowledgement window — which would have the fallback
+   * tear down a session that is working perfectly.
+   */
+  readonly awaitingBridgeAck: Set<TurnId>;
   /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
    */
-  promptsInFlight: number;
   stopped: boolean;
 }
 
@@ -163,13 +235,27 @@ function resolveEffortSelection(
 ): string | undefined {
   // Option values are a string/boolean union across providers; only a string
   // effort is meaningful here.
-  const raw = options?.find((option) => option.id === "reasoningEffort")?.value;
+  const raw = options?.find((option) => option.id === "effort")?.value;
   const effort = typeof raw === "string" ? raw.trim().toLowerCase() : undefined;
   return effort === "low" || effort === "medium" || effort === "high" ? effort : undefined;
 }
 
+/** A thread's lock plus how many callers currently want it. */
+interface ThreadLock {
+  readonly semaphore: Semaphore.Semaphore;
+  holders: number;
+}
+
 interface PendingApproval {
   readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+  /**
+   * The turn this request belongs to, so settlement can release exactly the
+   * approvals its own turn opened. Undefined when no turn was active, which
+   * only happens for a request arriving outside a prompt.
+   */
+  readonly turnId: TurnId | undefined;
+  /** Completed once the handler has published this request's resolution. */
+  readonly settled: Deferred.Deferred<void>;
 }
 
 function selectPermissionOptionId(
@@ -213,6 +299,14 @@ export function makeAntigravityAdapter(
       options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
     const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
 
+    // Scope for work that must outlive the session it concerns — specifically
+    // the cancel-acknowledgement fallback, whose whole job is to tear that
+    // session down. Forked into the session's own scope it would be closing the
+    // scope it runs in, and a scope waits for its children: the close would
+    // wait on the fiber waiting on the close.
+    const adapterScope = yield* Scope.make("sequential");
+    yield* Effect.addFinalizer(() => Effect.ignore(Scope.close(adapterScope, Exit.void)));
+
     const sessions = new Map<ThreadId, AntigravitySessionContext>();
     /**
      * Approvals awaiting a user decision, per thread. Held outside the session
@@ -220,7 +314,7 @@ export function makeAntigravityAdapter(
      * exists, and `respondToRequest` resolves entries from a different call.
      */
     const approvalsByThread = new Map<ThreadId, Map<ApprovalRequestId, PendingApproval>>();
-    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, ThreadLock>());
     const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
 
     const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
@@ -251,26 +345,56 @@ export function makeAntigravityAdapter(
     const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
       PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
 
+    /**
+     * Acquire this thread's lock, counting holders so the entry can be dropped
+     * once the last one leaves. Threads come and go for the life of the
+     * adapter — and a `stopSession` for an id that never existed still mints a
+     * lock — so an unreleased entry per id would grow without bound.
+     */
     const getThreadSemaphore = (threadId: string) =>
       SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
-        const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
-          current.get(threadId),
-        );
+        const existing: Option.Option<ThreadLock> = Option.fromNullishOr(current.get(threadId));
         return Option.match(existing, {
           onNone: () =>
             Semaphore.make(1).pipe(
               Effect.map((semaphore) => {
+                const lock: ThreadLock = { semaphore, holders: 1 };
                 const next = new Map(current);
-                next.set(threadId, semaphore);
-                return [semaphore, next] as const;
+                next.set(threadId, lock);
+                return [lock, next] as const;
               }),
             ),
-          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+          onSome: (lock) => {
+            lock.holders += 1;
+            return Effect.succeed([lock, current] as const);
+          },
         });
       });
 
+    const releaseThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.update(threadLocksRef, (current) => {
+        const lock = current.get(threadId);
+        if (!lock) {
+          return current;
+        }
+        lock.holders -= 1;
+        if (lock.holders > 0) {
+          return current;
+        }
+        const next = new Map(current);
+        next.delete(threadId);
+        return next;
+      });
+
     const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
-      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+      // Bracketed: an interrupt landing between taking the holder count and
+      // registering its release would retain that thread's entry for good,
+      // which is the leak the counting is there to prevent.
+      Effect.acquireUseRelease(
+        getThreadSemaphore(threadId),
+        (lock) => lock.semaphore.withPermit(effect),
+        () => releaseThreadSemaphore(threadId),
+      );
 
     const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
       Effect.gen(function* () {
@@ -305,35 +429,150 @@ export function makeAntigravityAdapter(
       return Effect.succeed(ctx);
     };
 
-    const stopSessionInternal = (ctx: AntigravitySessionContext) =>
-      Effect.gen(function* () {
-        if (ctx.stopped) return;
-        ctx.stopped = true;
+    /**
+     * Idempotent, uninterruptible teardown of everything a context owns.
+     *
+     * Shared by the normal stop path and its failure path so neither can leave
+     * half of it done: `ctx.stopped` is set before any of this runs, so a stop
+     * that died partway would otherwise make every later attempt return
+     * immediately with the bridge and its `agy` child still alive.
+     */
+    const cleanupContext = (ctx: AntigravitySessionContext) =>
+      Effect.uninterruptible(
+        Effect.gen(function* () {
+          if (ctx.notificationFiber) {
+            yield* Effect.ignore(Fiber.interrupt(ctx.notificationFiber));
+            ctx.notificationFiber = undefined;
+          }
+          yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+          // Ownership-checked: a replacement session may already have been
+          // installed while this teardown was closing a slow child, and
+          // clearing its entries would leak that session's process.
+          if (sessions.get(ctx.threadId) === ctx) {
+            sessions.delete(ctx.threadId);
+          }
+          if (approvalsByThread.get(ctx.threadId) === ctx.approvals) {
+            approvalsByThread.delete(ctx.threadId);
+          }
+        }),
+      );
+
+    const stopSessionInternal = (
+      ctx: AntigravitySessionContext,
+      /**
+       * Stop only while this turn is still the active one. Used by the
+       * cancel-acknowledgement fallback, whose decision to stop was made ten
+       * seconds earlier: without rechecking under the gate, a turn that settled
+       * in the meantime would take its replacement down with it.
+       */
+      onlyIfActiveTurn?: TurnId,
+      /**
+       * Additional condition rechecked under the gate. The fallback's reason to
+       * stop — the bridge never acknowledged — can stop being true between it
+       * deciding and this claiming, and the turn stays active while its events
+       * drain, so the turn id alone does not settle it.
+       */
+      onlyIf?: () => boolean,
+    ) => {
+      // Whether this call is the one that claimed the teardown. The cleanup
+      // below must not run otherwise: a call that declined because the turn had
+      // moved on would close a session that is perfectly alive.
+      let claimedTeardown = false;
+      return Effect.gen(function* () {
+        // Claiming the stop, snapshotting what was published, and clearing the
+        // active turn happen under the lifecycle gate so they cannot interleave
+        // with a `sendTurn` that is midway through announcing its turn.
+        const orphanedTurnIds = yield* ctx.lifecycleGate.withPermit(
+          Effect.sync(() => {
+            if (ctx.stopped) {
+              return undefined;
+            }
+            if (onlyIfActiveTurn !== undefined && ctx.activeTurnId !== onlyIfActiveTurn) {
+              return undefined;
+            }
+            if (onlyIf !== undefined && !onlyIf()) {
+              return undefined;
+            }
+            ctx.stopped = true;
+            claimedTeardown = true;
+            const claimed = [...ctx.publishedTurnIds];
+            ctx.publishedTurnIds.clear();
+            ctx.reservedTurnIds.clear();
+            ctx.activeTurnId = undefined;
+            return claimed;
+          }),
+        );
+        if (orphanedTurnIds === undefined) {
+          return;
+        }
+        // Releases anything waiting on the event consumer before that consumer
+        // is torn down.
+        yield* Effect.ignore(Deferred.succeed(ctx.teardownSignal, undefined));
+
         // Anything still waiting on a human is cancelled, which the bridge
         // turns into a denial. Left pending, the hook would block its tool
         // until its own timeout with no one able to answer.
-        const pending = approvalsByThread.get(ctx.threadId);
-        if (pending) {
-          for (const [, approval] of pending) {
-            // Ignored: an answer racing session stop may have settled this
-            // already, and that must not abort the rest of teardown.
-            yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
-          }
-          approvalsByThread.delete(ctx.threadId);
+        for (const [, approval] of ctx.approvals) {
+          // Ignored: an answer racing session stop may have settled this
+          // already, and that must not abort the rest of teardown.
+          yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
         }
-        if (ctx.notificationFiber) {
-          yield* Fiber.interrupt(ctx.notificationFiber);
+        ctx.approvals.clear();
+
+        // Quiesced before any terminal event is published: updates already
+        // queued for the consumer would otherwise surface after the completion
+        // that is supposed to close them out.
+        yield* cleanupContext(ctx);
+
+        for (const orphanedTurnId of orphanedTurnIds) {
+          // The stamp is generated inside the ignored region, not before it.
+          // `makeEventStamp` can fail — it mints a UUID — and evaluating it
+          // outside would abort teardown after `ctx.stopped` was set and the
+          // published set cleared, losing this completion and everything after
+          // it with no later stop able to retry.
+          yield* Effect.ignore(
+            Effect.gen(function* () {
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: ctx.threadId,
+                turnId: orphanedTurnId,
+                payload: { state: "cancelled", stopReason: null },
+              });
+            }),
+          );
         }
-        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
-        sessions.delete(ctx.threadId);
-        yield* offerRuntimeEvent({
-          type: "session.exited",
-          ...(yield* makeEventStamp()),
-          provider: PROVIDER,
-          threadId: ctx.threadId,
-          payload: { exitKind: "graceful" },
-        });
-      });
+        // Suppressed when a replacement already holds this thread: the event
+        // names the thread, not the context, so it would read as the new
+        // session exiting.
+        if (sessions.get(ctx.threadId) === undefined) {
+          yield* Effect.ignore(
+            Effect.gen(function* () {
+              yield* offerRuntimeEvent({
+                type: "session.exited",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: ctx.threadId,
+                payload: { exitKind: "graceful" },
+              });
+            }),
+          );
+        }
+      }).pipe(
+        // The whole sequence is uninterruptible, not just the cleanup inside
+        // it. `ctx.stopped` and the published-turn snapshot are taken first, so
+        // an interrupt partway would have the session torn down by `onExit`
+        // while the completions and `session.exited` it owed were never
+        // published — and no later stop would retry, the flag already being set.
+        Effect.uninterruptible,
+        // Only for the call that claimed the teardown. Running it regardless
+        // meant a declined call — the fallback finding its turn already gone —
+        // closed and deregistered a live session without so much as a
+        // `session.exited`.
+        Effect.onExit(() => (claimedTeardown ? cleanupContext(ctx) : Effect.void)),
+      );
+    };
 
     const startSession: AntigravityAdapterShape["startSession"] = (input) =>
       withThreadLock(
@@ -430,9 +669,48 @@ export function makeAntigravityAdapter(
           // no session context for teardown to clean up, and repeated failures
           // across thread ids would grow the map. Registered after `start()`.
           const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
-          yield* acp.handleRequestPermission((params) =>
-            mapAcpCallbackFailure(
+          yield* acp.handleRequestPermission((params) => {
+            // Held outside the workflow so the finalizer can clear the entry
+            // wherever inside it things stopped.
+            let registeredRequestId: ApprovalRequestId | undefined;
+            // Held alongside the id so the finalizer can signal completion even
+            // after the entry has been removed from the registry by settlement
+            // or teardown.
+            let registeredApproval: PendingApproval | undefined;
+            // Set once the UI has been told a request exists. From then on it
+            // is owed a terminal event: the tool is denied either way, but a
+            // request left open cannot be answered or dismissed.
+            let opened:
+              | {
+                  readonly requestId: ApprovalRequestId;
+                  readonly permissionRequest: ReturnType<typeof parsePermissionRequest>;
+                  readonly turnId: TurnId | undefined;
+                }
+              | undefined;
+            let resolutionPublished = false;
+            return mapAcpCallbackFailure(
               Effect.gen(function* () {
+                // The bridge's own deadline is already running when this
+                // workflow starts. One absolute cutoff covers both queued event
+                // delivery and the user's decision, so time spent draining
+                // cannot leave a request actionable after the bridge has
+                // stopped accepting it.
+                const approvalDeadline = (yield* Clock.currentTimeMillis) + APPROVAL_WAIT_MS;
+                // Bound to the turn actually running, with the epoch that turn
+                // was accepted at — not the session's current epoch. A request
+                // from a cancelled turn can arrive after the epoch moved, and
+                // reading the live value would make it look current.
+                const approvalTurnId = ctx?.activeTurnId;
+                const approvalEpoch = ctx?.activeTurnEpoch;
+                const turnCancelled =
+                  approvalEpoch !== undefined &&
+                  ctx !== undefined &&
+                  approvalEpoch !== ctx.cancelEpoch;
+                // Checked before auto-approval, not after: teardown or a Stop
+                // must not be waved through by full access.
+                if (ctx?.stopped || turnCancelled) {
+                  return { outcome: { outcome: "cancelled" } as const };
+                }
                 if (input.runtimeMode === "full-access") {
                   const autoApproved = selectAutoApprovedPermissionOption(params);
                   if (autoApproved !== undefined) {
@@ -442,56 +720,188 @@ export function makeAntigravityAdapter(
                 const permissionRequest = parsePermissionRequest(params);
                 const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
                 const decision = yield* Deferred.make<ProviderApprovalDecision>();
-                const turnId = sessions.get(input.threadId)?.activeTurnId;
-                pendingApprovals.set(requestId, { decision });
-                yield* offerRuntimeEvent(
-                  makeAcpRequestOpenedEvent({
-                    stamp: yield* makeEventStamp(),
-                    provider: PROVIDER,
-                    threadId: input.threadId,
-                    turnId,
-                    requestId: RuntimeRequestId.make(requestId),
-                    permissionRequest,
-                    detail: permissionRequest.detail ?? "Antigravity tool call",
-                    args: params,
-                    source: "acp.jsonrpc",
-                    method: "session/request_permission",
-                    rawPayload: params,
+                const settled = yield* Deferred.make<void>();
+                const approval: PendingApproval = { decision, turnId: approvalTurnId, settled };
+                pendingApprovals.set(requestId, approval);
+                registeredRequestId = requestId;
+                registeredApproval = approval;
+                // Rechecked after registering, not only before: minting the id
+                // and the deferred both yield, and a Stop landing in that gap
+                // would find no entry to cancel — leaving this request open in
+                // the UI and its deferred held for the full approval timeout.
+                if (
+                  ctx?.stopped ||
+                  (approvalEpoch !== undefined &&
+                    ctx !== undefined &&
+                    approvalEpoch !== ctx.cancelEpoch)
+                ) {
+                  pendingApprovals.delete(requestId);
+                  return { outcome: { outcome: "cancelled" } as const };
+                }
+                // The bridge sends the tool update before asking permission,
+                // but the ACP runtime only queues that update. Wait until the
+                // notification consumer has published everything ahead of this
+                // barrier so the request cannot overtake the tool call it
+                // belongs to. Teardown wins the race when that consumer is no
+                // longer available, which keeps a stopped session from holding
+                // the hook callback forever.
+                const drained = yield* Effect.raceFirst(
+                  ctx.acp.drainEvents.pipe(Effect.as(true)),
+                  Deferred.await(ctx.teardownSignal).pipe(Effect.as(false)),
+                ).pipe(
+                  Effect.timeoutOption(
+                    Math.max(0, approvalDeadline - (yield* Clock.currentTimeMillis)),
+                  ),
+                );
+                const eventStreamDrained = Option.isSome(drained) && drained.value;
+                // Rechecked by turn identity, not only by epoch. A turn that
+                // ends on its own — `agy` exiting, or its print timeout — moves
+                // no epoch, so a request that waited out a slow consumer would
+                // open here against a turn settlement had already completed and
+                // then resolve it immediately afterwards.
+                if (
+                  !eventStreamDrained ||
+                  ctx.stopped ||
+                  ctx.activeTurnId !== approvalTurnId ||
+                  (approvalEpoch !== undefined && approvalEpoch !== ctx.cancelEpoch)
+                ) {
+                  pendingApprovals.delete(requestId);
+                  return { outcome: { outcome: "cancelled" } as const };
+                }
+                // Built first, then published and recorded in one uninterruptible
+                // step. An interrupt between the two would leave the UI showing
+                // a request the finalizer does not know to close.
+                const openedEvent = makeAcpRequestOpenedEvent({
+                  stamp: yield* makeEventStamp(),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: approvalTurnId,
+                  requestId: RuntimeRequestId.make(requestId),
+                  permissionRequest,
+                  detail: permissionRequest.detail ?? "Antigravity tool call",
+                  args: params,
+                  source: "acp.jsonrpc",
+                  method: "session/request_permission",
+                  rawPayload: params,
+                });
+                yield* Effect.uninterruptible(
+                  Effect.gen(function* () {
+                    yield* offerRuntimeEvent(openedEvent);
+                    opened = { requestId, permissionRequest, turnId: approvalTurnId };
                   }),
                 );
                 // Raced against a deadline and cleaned up unconditionally: the
                 // bridge forgets its side of a timed-out request, so without
                 // this the handler would stay blocked and the entry retained.
                 const answered = yield* Deferred.await(decision).pipe(
-                  Effect.timeoutOption(APPROVAL_WAIT_MS),
-                  Effect.ensuring(Effect.sync(() => pendingApprovals.delete(requestId))),
+                  Effect.timeoutOption(
+                    Math.max(0, approvalDeadline - (yield* Clock.currentTimeMillis)),
+                  ),
                 );
                 // An unanswered request denies, matching the bridge's own
                 // timeout: this gate must never resolve to "allow" by default.
                 const resolved: ProviderApprovalDecision = Option.isSome(answered)
                   ? answered.value
                   : "cancel";
-                yield* offerRuntimeEvent(
-                  makeAcpRequestResolvedEvent({
-                    stamp: yield* makeEventStamp(),
-                    provider: PROVIDER,
-                    threadId: input.threadId,
-                    turnId,
-                    requestId: RuntimeRequestId.make(requestId),
-                    permissionRequest,
-                    decision: resolved,
+                // Re-checked at the moment of answering: an approval decided
+                // while Stop was landing must not come back as an allow.
+                //
+                // Turn identity is part of that check, not just the epoch. Two
+                // consecutive turns with no cancel between them share an epoch,
+                // so a request still open when its own turn ended would look
+                // current again once the next one started, and this would
+                // answer "allow" for a tool whose token the bridge has already
+                // retired.
+                // A defined turn on both sides is required, not just equality:
+                // a request that arrived with no turn running compared
+                // `undefined === undefined` against a session whose turn had
+                // already been cleared, and passed.
+                const stillLive =
+                  !ctx?.stopped &&
+                  approvalTurnId !== undefined &&
+                  ctx?.activeTurnId === approvalTurnId &&
+                  (approvalEpoch === undefined || ctx?.cancelEpoch === approvalEpoch);
+                const optionId =
+                  resolved === "cancel" || !stillLive
+                    ? undefined
+                    : selectPermissionOptionId(params, resolved);
+                // Decided before the event is built, so what the UI is told and
+                // what the agent is told are the same thing. Publishing the
+                // user's raw answer here reported an approval that the liveness
+                // check had already turned into a cancellation — the tool did
+                // not run, and the transcript claimed it was allowed to.
+                const effective: ProviderApprovalDecision = optionId ? resolved : "cancel";
+                // Same pairing on the way out: an interrupt between publishing
+                // this and recording it would have the finalizer publish a
+                // second, contradictory resolution.
+                const resolvedEvent = makeAcpRequestResolvedEvent({
+                  stamp: yield* makeEventStamp(),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: approvalTurnId,
+                  requestId: RuntimeRequestId.make(requestId),
+                  permissionRequest,
+                  decision: effective,
+                });
+                yield* Effect.uninterruptible(
+                  Effect.gen(function* () {
+                    yield* offerRuntimeEvent(resolvedEvent);
+                    resolutionPublished = true;
                   }),
                 );
-                const optionId =
-                  resolved === "cancel" ? undefined : selectPermissionOptionId(params, resolved);
                 return {
                   outcome: optionId
                     ? { outcome: "selected" as const, optionId }
                     : ({ outcome: "cancelled" } as const),
                 };
-              }),
-            ),
-          );
+              }).pipe(
+                // Covers everything after the entry was registered, not just
+                // the wait: a failure while stamping or publishing either event
+                // would otherwise leave the entry in the map for good, and the
+                // request open in the UI with nothing able to answer it.
+                Effect.ensuring(
+                  Effect.uninterruptible(
+                    Effect.gen(function* () {
+                      // A request the UI has seen but never got a resolution
+                      // for would sit there permanently, unanswerable. The tool
+                      // is denied regardless; this closes the request out.
+                      if (opened !== undefined && !resolutionPublished) {
+                        const closing = opened;
+                        yield* Effect.ignore(
+                          Effect.gen(function* () {
+                            yield* offerRuntimeEvent(
+                              makeAcpRequestResolvedEvent({
+                                stamp: yield* makeEventStamp(),
+                                provider: PROVIDER,
+                                threadId: input.threadId,
+                                turnId: closing.turnId,
+                                requestId: RuntimeRequestId.make(closing.requestId),
+                                permissionRequest: closing.permissionRequest,
+                                decision: "cancel",
+                              }),
+                            );
+                          }),
+                        );
+                      }
+                      if (registeredRequestId !== undefined) {
+                        pendingApprovals.delete(registeredRequestId);
+                      }
+                      // Completed from the entry captured at registration, not
+                      // from a fresh map lookup. Settlement and teardown both
+                      // remove entries before this finalizer runs, so looking it
+                      // up here found nothing and left every waiter to time out.
+                      // This handler owns the signal; the map is only a registry.
+                      if (registeredApproval !== undefined) {
+                        yield* Effect.ignore(
+                          Deferred.succeed(registeredApproval.settled, undefined),
+                        );
+                      }
+                    }),
+                  ),
+                ),
+              ),
+            );
+          });
 
           const started = yield* acp
             .start()
@@ -528,8 +938,15 @@ export function makeAntigravityAdapter(
             activeTurnId: undefined,
             currentModelId: boundModel,
             cancelEpoch: 0,
-            startedTurnIds: new Set(),
-            promptsInFlight: 0,
+            reservedTurnIds: new Set(),
+            publishedTurnIds: new Set(),
+            promptGate: yield* Semaphore.make(1),
+            lifecycleGate: yield* Semaphore.make(1),
+            teardownSignal: yield* Deferred.make<void>(),
+            approvals: pendingApprovals,
+            acpSessionId: started.sessionId,
+            activeTurnEpoch: -1,
+            awaitingBridgeAck: new Set(),
             stopped: false,
           };
 
@@ -610,13 +1027,42 @@ export function makeAntigravityAdapter(
                     );
                     return;
                 }
-              }),
+              }).pipe(
+                // Per event, not around the whole stream. Catching outside the
+                // drain meant one unprocessable notification ended the consumer
+                // for good: every later event was lost, and the turn events
+                // that depend on it stopped being attributed even though
+                // prompts kept completing.
+                Effect.catchCause((cause) =>
+                  // Interrupts pass through. Swallowing them kept this fiber
+                  // alive through teardown, so `Fiber.interrupt` waited on a
+                  // consumer that had been told to stop and would not —
+                  // stranding the session and its bridge.
+                  Cause.hasInterruptsOnly(cause)
+                    ? Effect.failCause(cause)
+                    : Effect.logError("Failed to process Antigravity runtime notification.", {
+                        cause,
+                      }),
+                ),
+              ),
             ),
           ).pipe(
-            Effect.catchCause((cause) =>
-              Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
-            ),
-            Effect.forkChild,
+            // Absorbs a typed failure that escapes the per-event handler while
+            // leaving interruption alone — `Effect.catch` does not catch it —
+            // so teardown can still stop this fiber.
+            Effect.catch(() => Effect.void),
+            // However this consumer ends — teardown, a defect while stamping,
+            // an interrupt — it fires the same signal drains wait on. Without
+            // it a consumer that died on its own would leave every later drain
+            // queuing a barrier nobody can acknowledge, hanging `sendTurn`
+            // while it holds the prompt gate.
+            Effect.onExit(() => Effect.ignore(Deferred.succeed(ctx.teardownSignal, undefined))),
+            // Forked into the session's own scope, not the calling fiber's.
+            // `startSession` can run inside a short-lived request fiber, and a
+            // child fork would die with it while the session and its bridge
+            // live on — taking every future event with it, and now also
+            // tripping the signal above so drains stop waiting.
+            Effect.forkIn(sessionScope),
           );
 
           ctx.notificationFiber = nf;
@@ -627,27 +1073,37 @@ export function makeAntigravityAdapter(
           approvalsByThread.set(input.threadId, pendingApprovals);
           sessionScopeTransferred = true;
 
-          yield* offerRuntimeEvent({
-            type: "session.started",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: input.threadId,
-            payload: { resume: started.initializeResult },
-          });
-          yield* offerRuntimeEvent({
-            type: "session.state.changed",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: input.threadId,
-            payload: { state: "ready", reason: "Antigravity ACP session ready" },
-          });
-          yield* offerRuntimeEvent({
-            type: "thread.started",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: input.threadId,
-            payload: { providerThreadId: started.sessionId },
-          });
+          // Past this point the scoped finalizer no longer owns the scope, so
+          // a failure or interrupt while announcing the session would strand
+          // the bridge process, its notification fiber, and both registry
+          // entries with nothing left to close them. Ownership has moved to
+          // the session, so teardown has to move with it.
+          yield* Effect.onError(
+            Effect.gen(function* () {
+              yield* offerRuntimeEvent({
+                type: "session.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                payload: { resume: started.initializeResult },
+              });
+              yield* offerRuntimeEvent({
+                type: "session.state.changed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                payload: { state: "ready", reason: "Antigravity ACP session ready" },
+              });
+              yield* offerRuntimeEvent({
+                type: "thread.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                payload: { providerThreadId: started.sessionId },
+              });
+            }),
+            () => Effect.ignore(stopSessionInternal(ctx)),
+          );
 
           return session;
         }).pipe(Effect.scoped),
@@ -656,6 +1112,11 @@ export function makeAntigravityAdapter(
     const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(input.threadId);
+        // Read before any yielding preparation. Attachment resolution and id
+        // generation both yield, and a Stop landing in that window raises the
+        // cancelled mark past this value — so the prompt is still covered by
+        // the fence even though it had not been submitted yet.
+        const acceptedEpoch = ctx.cancelEpoch;
 
         // `agy --print` takes a single text prompt, so attachments travel as
         // `resource_link` blocks (ACP baseline, no capability needed) pointing
@@ -704,192 +1165,429 @@ export function makeAntigravityAdapter(
           });
         }
 
-        // A sendTurn while a prompt is in flight is a steer: the new prompt
-        // folds into the ongoing work, so the active turn id is reused.
-        //
-        // The id is minted first, before anything is read, so that reading
-        // `promptsInFlight` and claiming it are one synchronous step. Yielding
-        // between the two — which generating the id here used to do — let two
-        // concurrent calls both observe zero and open rival turns over the
-        // same thread.
         const freshTurnId = TurnId.make(yield* randomUUIDv4);
-        const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
-        const turnId = steeringTurnId ?? freshTurnId;
-        const acceptedEpoch = ctx.cancelEpoch;
-        // Claimed together, without an intervening yield: assigning the active
-        // turn id later let a concurrent call see `promptsInFlight > 0` with no
-        // id yet and open a rival turn.
-        ctx.promptsInFlight += 1;
-        ctx.activeTurnId = turnId;
-        // Terminal-event bookkeeping. Publication happens in exactly one place
-        // (the teardown below) so that the decision cannot race a steer.
-        let stopReason: string | null = null;
-        let promptSucceeded = false;
 
-        return yield* Effect.gen(function* () {
-          ctx.session = {
-            ...ctx.session,
-            activeTurnId: turnId,
-            updatedAt: yield* nowIso,
-          };
+        // The submission gate is taken before the turn is claimed, not after.
+        //
+        // Claiming outside it let two turns exist at once — a prompt sent after
+        // a Stop opened its own while the cancelled one was still settling —
+        // and everything that reads "the current turn" then has to guess which
+        // one it means: streamed events, permission requests, the epoch a
+        // decision is checked against. Guarding each of those in turn produced
+        // a new mismatch every time. Inside the gate there is exactly one live
+        // turn, so there is nothing to disambiguate.
+        //
+        // This costs nothing in practice: `acp.prompt` already serializes on
+        // its own semaphore, so a second prompt could never reach `agy` early
+        // anyway — only its bookkeeping ran ahead.
+        return yield* ctx.promptGate.withPermit(
+          Effect.gen(function* () {
+            // Rechecked with the gate held and before any turn state is
+            // touched. Waiting for the gate is exactly when a Stop can land.
+            if (ctx.stopped || ctx.cancelEpoch !== acceptedEpoch) {
+              return {
+                threadId: input.threadId,
+                turnId: freshTurnId,
+                resumeCursor: ctx.session.resumeCursor,
+              };
+            }
+            // Each prompt is its own turn. Steering used to fold a second
+            // prompt into a running turn, but `agy --print` cannot inject into
+            // a running invocation — the second prompt always became its own
+            // `agy` process, and the merge existed only in the bookkeeping.
+            // Holding the gate makes that explicit: by the time this runs, any
+            // earlier prompt has already settled.
+            const turnId = freshTurnId;
+            ctx.activeTurnId = turnId;
+            ctx.activeTurnEpoch = acceptedEpoch;
+            let stopReason: string | null = null;
+            let promptSucceeded = false;
 
-          // `agy` binds the model with a `--model` flag on each spawn, and that
-          // flag composes with `--conversation` — verified against the CLI: a
-          // resumed conversation answers on the new model with its history
-          // intact. Applied before `turn.started` so the announced model is the
-          // one the turn actually runs on.
-          const turnModelSelection =
-            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
-          const requestedModelId = turnModelSelection?.model
-            ? resolveAntigravityBaseModelId(turnModelSelection.model)
-            : undefined;
-          if (requestedModelId !== undefined && requestedModelId !== ctx.currentModelId) {
-            yield* ctx.acp
-              .setSessionModel(requestedModelId)
-              .pipe(
-                Effect.mapError((cause) =>
-                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+            return yield* Effect.gen(function* () {
+              ctx.session = {
+                ...ctx.session,
+                activeTurnId: turnId,
+                updatedAt: yield* nowIso,
+              };
+
+              // `agy` binds the model with a `--model` flag on each spawn, and that
+              // flag composes with `--conversation` — verified against the CLI: a
+              // resumed conversation answers on the new model with its history
+              // intact. Applied before `turn.started` so the announced model is the
+              // one the turn actually runs on.
+              const turnModelSelection =
+                input.modelSelection?.instanceId === boundInstanceId
+                  ? input.modelSelection
+                  : undefined;
+              const requestedModelId = turnModelSelection?.model
+                ? resolveAntigravityBaseModelId(turnModelSelection.model)
+                : undefined;
+              if (requestedModelId !== undefined && requestedModelId !== ctx.currentModelId) {
+                yield* ctx.acp
+                  .setSessionModel(requestedModelId)
+                  .pipe(
+                    Effect.mapError((cause) =>
+                      mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+                    ),
+                  );
+                ctx.currentModelId = requestedModelId;
+                ctx.session = {
+                  ...ctx.session,
+                  model: turnModelSelection?.model ?? ctx.session.model,
+                };
+              }
+
+              // Rechecked before anything is announced: everything above yields, so
+              // the session can be stopped or the turn interrupted while
+              // attachments resolve and the model is selected. Announcing a turn
+              // on a closed runtime would emit events after `session.exited`.
+              if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
+                stopReason = "cancelled";
+                return {
+                  threadId: input.threadId,
+                  turnId,
+                  resumeCursor: ctx.session.resumeCursor,
+                };
+              }
+
+              // Claimed from shared state, not from "am I a steer": the prompt this
+              // one folded into may have failed before it announced anything, and
+              // emitting content for a turn that never started strands the UI.
+              //
+              // Test and claim are one synchronous step — publishing first and
+              // marking afterwards let two concurrent steers both find the turn
+              // unannounced and emit `turn.started` twice. The claim is released
+              // again if publication does not happen, so a turn nobody saw start
+              // cannot later be completed.
+              // Reservation is taken under the lifecycle gate so teardown cannot
+              // snapshot between the check and the claim.
+              const announcing = yield* ctx.lifecycleGate.withPermit(
+                Effect.sync(() => {
+                  if (ctx.stopped || ctx.reservedTurnIds.has(turnId)) {
+                    return false;
+                  }
+                  ctx.reservedTurnIds.add(turnId);
+                  return true;
+                }),
+              );
+              if (announcing) {
+                // Stamp generation sits inside the guarded region: it can fail or
+                // be interrupted too, and a claim left behind without its event
+                // would make a steer skip the start and let settlement publish an
+                // orphan completion.
+                yield* ctx.lifecycleGate
+                  .withPermit(
+                    Effect.gen(function* () {
+                      // Re-checked inside the gate: teardown may have run while
+                      // this fiber waited for it, and a start published after
+                      // `session.exited` is worse than no start at all.
+                      if (ctx.stopped) {
+                        return;
+                      }
+                      const startedEvent = {
+                        type: "turn.started" as const,
+                        ...(yield* makeEventStamp()),
+                        provider: PROVIDER,
+                        threadId: input.threadId,
+                        turnId,
+                        payload: { model: ctx.session.model },
+                      };
+                      // Published and recorded together. Marking only after the
+                      // event is out keeps teardown from completing a turn that
+                      // was merely reserved — but an interrupt between the two
+                      // would drop the reservation with the start already on
+                      // the wire, and settlement would owe a completion it did
+                      // not know about.
+                      yield* Effect.uninterruptible(
+                        Effect.gen(function* () {
+                          yield* offerRuntimeEvent(startedEvent);
+                          ctx.publishedTurnIds.add(turnId);
+                        }),
+                      );
+                    }),
+                  )
+                  .pipe(
+                    Effect.onExit((exit) =>
+                      Exit.isSuccess(exit)
+                        ? Effect.void
+                        : Effect.sync(() => ctx.reservedTurnIds.delete(turnId)),
+                    ),
+                  );
+              }
+
+              const result = yield* Effect.gen(function* () {
+                if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
+                  return undefined;
+                }
+                // The bridge writes its `session/update` notifications before
+                // the prompt response, but the runtime only queues them.
+                // Draining inside the gate keeps the turn from settling — and
+                // its id from being cleared — while content, tool and item
+                // events are still pending, which would leave them
+                // unattributed or attributed to the next turn.
+                //
+                // Bounded and best-effort: the drain waits on the notification
+                // consumer, and stop interrupts that consumer, so an unbounded
+                // wait here would strand this fiber holding the gate forever.
+                // Losing the ordering guarantee is recoverable; a permanent
+                // hang is not. The error path drains too — a nonzero `agy`
+                // exit still emits final updates before its response.
+                // Raced against teardown rather than a wall clock: a slow but
+                // healthy consumer is still awaited in full, while a consumer
+                // that stop has interrupted can never strand this fiber
+                // holding the gate.
+                const drain = Effect.ignore(
+                  Effect.raceFirst(ctx.acp.drainEvents, Deferred.await(ctx.teardownSignal)),
+                );
+                ctx.awaitingBridgeAck.add(turnId);
+                return yield* ctx.acp
+                  .prompt({ prompt: promptParts, _meta: { t3: { epoch: acceptedEpoch } } })
+                  .pipe(
+                    // Cleared the moment the bridge answers, before draining:
+                    // the drain is the part that can legitimately run long, and
+                    // the fallback must not read that as an unresponsive bridge.
+                    Effect.tapCause(() => Effect.sync(() => ctx.awaitingBridgeAck.delete(turnId))),
+                    Effect.tap(() => Effect.sync(() => ctx.awaitingBridgeAck.delete(turnId))),
+                    Effect.tapCause(() => drain),
+                    Effect.tap(() => drain),
+                    Effect.ensuring(Effect.sync(() => ctx.awaitingBridgeAck.delete(turnId))),
+                  );
+              }).pipe(
+                Effect.mapError((error) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
                 ),
               );
-            ctx.currentModelId = requestedModelId;
-            ctx.session = { ...ctx.session, model: turnModelSelection?.model ?? ctx.session.model };
-          }
-
-          // Claimed from shared state, not from "am I a steer": the prompt this
-          // one folded into may have failed before it announced anything, and
-          // emitting content for a turn that never started strands the UI.
-          if (!ctx.startedTurnIds.has(turnId)) {
-            yield* offerRuntimeEvent({
-              type: "turn.started",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              turnId,
-              payload: { model: ctx.session.model },
-            });
-            // Marked only after the event is actually out, so a failed publish
-            // cannot let another prompt emit a completion for a turn nobody
-            // saw start.
-            ctx.startedTurnIds.add(turnId);
-          }
-          // Rechecked here rather than only at accept time: everything above
-          // yields, and an interrupt during any of it means this prompt must
-          // not reach the agent.
-          if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
-            stopReason = "cancelled";
-            return {
-              threadId: input.threadId,
-              turnId,
-              resumeCursor: ctx.session.resumeCursor,
-            };
-          }
-
-          const result = yield* ctx.acp
-            .prompt({ prompt: promptParts })
-            .pipe(
-              Effect.mapError((error) =>
-                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
-              ),
-            );
-
-          const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
-          if (turnRecord) {
-            turnRecord.items.push({ prompt: promptParts, result });
-          } else {
-            ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
-          }
-          ctx.session = {
-            ...ctx.session,
-            activeTurnId: turnId,
-            updatedAt: yield* nowIso,
-          };
-
-          promptSucceeded = true;
-          stopReason = result.stopReason ?? null;
-
-          return {
-            threadId: input.threadId,
-            turnId,
-            resumeCursor: ctx.session.resumeCursor,
-          };
-        }).pipe(
-          Effect.ensuring(
-            Effect.gen(function* () {
-              // Decrement and the last-prompt test are one synchronous step, so
-              // a steer arriving mid-settlement cannot make two prompts both
-              // believe they own the turn and publish a terminal event each.
-              const remaining = Math.max(0, ctx.promptsInFlight - 1);
-              ctx.promptsInFlight = remaining;
-              if (remaining > 0) {
-                return;
+              if (result === undefined) {
+                stopReason = "cancelled";
+                return {
+                  threadId: input.threadId,
+                  turnId,
+                  resumeCursor: ctx.session.resumeCursor,
+                };
               }
-              // Cleared even when the turn never started — a model switch can
-              // fail after `activeTurnId` is installed, and leaving it set
-              // advertises a turn to `listSessions` and the reaper that no
-              // longer exists. Only the event below depends on having started.
-              if (ctx.activeTurnId === turnId) {
-                ctx.activeTurnId = undefined;
+
+              const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
+              if (turnRecord) {
+                turnRecord.items.push({ prompt: promptParts, result });
+              } else {
+                ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
               }
-              // Read from shared state rather than this call's local flag: the
-              // prompt that published `turn.started` may not be the one that
-              // settles the turn, and the settler still owes the completion.
-              const published = ctx.startedTurnIds.has(turnId);
-              ctx.startedTurnIds.delete(turnId);
-              // The public session field is what `listSessions` and the reaper
-              // read, so leaving it set would advertise a turn that has ended.
-              if (ctx.session.activeTurnId === turnId) {
-                const { activeTurnId: _endedTurnId, ...endedSession } = ctx.session;
-                ctx.session = { ...endedSession, status: "ready", updatedAt: yield* nowIso };
-              }
-              // A prompt that failed or was interrupted after `turn.started`
-              // still owes consumers a terminal event; without one the turn
-              // renders as running forever even though sendTurn already
-              // returned an error.
-              if (!published) {
-                return;
-              }
-              const state =
-                stopReason === "cancelled" ? "cancelled" : promptSucceeded ? "completed" : "failed";
-              yield* offerRuntimeEvent({
-                type: "turn.completed",
-                ...(yield* makeEventStamp()),
-                provider: PROVIDER,
+              ctx.session = {
+                ...ctx.session,
+                activeTurnId: turnId,
+                updatedAt: yield* nowIso,
+              };
+
+              promptSucceeded = true;
+              stopReason = result.stopReason ?? null;
+
+              return {
                 threadId: input.threadId,
                 turnId,
-                payload: { state, stopReason },
-              });
-              // `catchCause` rather than `catch`: a defect while stamping or
-              // publishing would otherwise escape after `promptsInFlight` was
-              // already decremented, stranding the turn as running.
-            }).pipe(Effect.catchCause(() => Effect.void)),
-          ),
+                resumeCursor: ctx.session.resumeCursor,
+              };
+            }).pipe(
+              Effect.ensuring(
+                // Settlement takes the same gate teardown does. It clears the
+                // published claim and then yields to stamp and publish; without
+                // the gate, a concurrent stop could see an empty set, decide it
+                // owed nothing, emit `session.exited`, and have this completion
+                // arrive after it. Whichever takes the gate first owns the
+                // terminal event, and the other finds nothing to publish.
+                ctx.lifecycleGate
+                  .withPermit(
+                    Effect.gen(function* () {
+                      // Anything this turn opened and never got an answer for is
+                      // released here. `agy` dying with a hook mid-approval used
+                      // to leave the request sitting in the UI for the full nine
+                      // minute deadline, unanswerable, with the turn already
+                      // reported complete.
+                      //
+                      // `activeTurnId` is also the approval handler's liveness
+                      // check. Clear the internal claim before releasing any
+                      // decisions so an accept racing this settlement is
+                      // reported as cancelled, matching the bridge token that
+                      // has already been retired. The public session claim is
+                      // kept until the terminal bookkeeping below; nothing in
+                      // the approval wait depends on the internal claim.
+                      if (ctx.activeTurnId === turnId) {
+                        ctx.activeTurnId = undefined;
+                      }
+                      const orphanedApprovals = [...ctx.approvals.values()].filter(
+                        (approval) => approval.turnId === turnId,
+                      );
+                      for (const approval of orphanedApprovals) {
+                        yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
+                      }
+                      // Entries are left in place: each handler removes its own
+                      // on the way out. Removing them here left the finalizers
+                      // with nothing to look up, so nothing ever signalled and
+                      // every wait below ran its deadline out in full.
+                      //
+                      // Awaited together under a single budget rather than one
+                      // deadline each, so a turn with several open requests
+                      // cannot hold the lifecycle gate for a multiple of it.
+                      if (orphanedApprovals.length > 0) {
+                        yield* Effect.ignore(
+                          Effect.all(
+                            orphanedApprovals.map((approval) => Deferred.await(approval.settled)),
+                            { concurrency: "unbounded" },
+                          ).pipe(Effect.timeoutOption(APPROVAL_SETTLE_TIMEOUT_MS)),
+                        );
+                      }
+                      // Read from shared state rather than this call's local flag: the
+                      // prompt that published `turn.started` may not be the one that
+                      // settles the turn, and the settler still owes the completion.
+                      const published = ctx.publishedTurnIds.has(turnId);
+                      ctx.reservedTurnIds.delete(turnId);
+                      // The public session field is what `listSessions` and the reaper
+                      // read, so leaving it set would advertise a turn that has ended.
+                      if (ctx.session.activeTurnId === turnId) {
+                        const { activeTurnId: _endedTurnId, ...endedSession } = ctx.session;
+                        ctx.session = {
+                          ...endedSession,
+                          status: "ready",
+                          updatedAt: yield* nowIso,
+                        };
+                      }
+                      // A prompt that failed or was interrupted after `turn.started`
+                      // still owes consumers a terminal event; without one the turn
+                      // renders as running forever even though sendTurn already
+                      // returned an error.
+                      if (!published) {
+                        ctx.publishedTurnIds.delete(turnId);
+                        return;
+                      }
+                      const state: "cancelled" | "completed" | "failed" =
+                        stopReason === "cancelled"
+                          ? "cancelled"
+                          : promptSucceeded
+                            ? "completed"
+                            : "failed";
+                      // The claim is surrendered only once the event is built
+                      // and published. Releasing it first meant a failure while
+                      // stamping — which mints a UUID — left teardown seeing no
+                      // published turn, so nothing ever reported the turn ending.
+                      const completedEvent = {
+                        type: "turn.completed" as const,
+                        ...(yield* makeEventStamp()),
+                        provider: PROVIDER,
+                        threadId: input.threadId,
+                        turnId,
+                        payload: { state, stopReason },
+                      };
+                      yield* Effect.uninterruptible(
+                        Effect.gen(function* () {
+                          yield* offerRuntimeEvent(completedEvent);
+                          ctx.publishedTurnIds.delete(turnId);
+                        }),
+                      );
+                      // `catchCause` rather than `catch`: a defect while stamping or
+                      // publishing would otherwise escape after the turn's prompt count
+                      // was already decremented, stranding the turn as running.
+                    }),
+                  )
+                  .pipe(Effect.catchCause(() => Effect.void)),
+              ),
+            );
+          }),
         );
       });
 
     const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(threadId);
+        // Uninterruptible as a whole. The epoch moves first, so an interrupt
+        // partway would leave prompts refused against a fence the bridge never
+        // received — `agy` running on after Stop with nothing left to tell it.
+        yield* Effect.uninterruptible(cancelSequence(ctx));
+      });
+
+    const cancelSequence = (ctx: AntigravitySessionContext) =>
+      Effect.gen(function* () {
+        // `requireSession` yields its context to the caller, so a concurrent
+        // restart can replace it before this effect begins. A stale interrupt
+        // must not cancel either the old process or approvals owned by the new
+        // session now registered for the same thread.
+        if (sessions.get(ctx.threadId) !== ctx) {
+          return;
+        }
         // Recorded before anything else: prompts already accepted but still
         // queued upstream compare against this and refuse to submit.
+        // Read and bumped in one synchronous step: everything accepted up to
+        // and including this value is what the fence below covers.
+        const cancelledThrough = ctx.cancelEpoch;
+        // Captured in the same synchronous step as the epoch, before anything
+        // yields. Reading it later would name whichever turn happened to be
+        // active by then — the cancelled one can finish and a new one acquire
+        // the gate while approvals are settled and notifications are written.
+        const cancelledTurnId = ctx.activeTurnId;
         ctx.cancelEpoch += 1;
         // Settled before the cancel goes out, as ACP requires: an outstanding
         // permission request has a hook process blocked behind it, and the
         // bridge turns "cancel" into a denial. Leaving it pending would hold
         // that tool until the hook's own timeout.
-        const pending = approvalsByThread.get(threadId);
-        if (pending) {
-          for (const [, approval] of pending) {
-            yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
-          }
-          pending.clear();
+        for (const [, approval] of ctx.approvals) {
+          yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
         }
+        // The fence names the epoch being cancelled through, rather than one
+        // notification per outstanding prompt. Everything accepted at or below
+        // it is cancelled; anything accepted afterwards carries a higher epoch
+        // and is untouched, so nothing has to be tracked per prompt.
         yield* Effect.ignore(
-          ctx.acp.cancel.pipe(
-            Effect.mapError((error) =>
-              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
-            ),
-          ),
+          ctx.acp.notify("t3/fence", { sessionId: ctx.acpSessionId, epoch: cancelledThrough }),
         );
+        // Sent as a plain notification rather than through `acp.cancel`, which
+        // interrupts the local prompt RPC. That interrupt settles the turn and
+        // releases the gate before the bridge has killed `agy` and run its
+        // final drain, so the transcript and failed-tool updates that drain
+        // produces arrive with no turn to belong to. Delivered this way the
+        // bridge answers the original prompt itself, after its updates are on
+        // the wire, and the turn settles on that response.
+        // Carries the epoch it cancels, so it is bounded to the same turns the
+        // fence covers even if the fence itself never arrived.
+        yield* Effect.ignore(
+          ctx.acp.notify("session/cancel", {
+            sessionId: ctx.acpSessionId,
+            epoch: cancelledThrough,
+          }),
+        );
+        // Fallback: if the bridge never answers — wedged, or already gone — the
+        // interrupt still happens, just late enough not to truncate a healthy
+        // drain. Forked into the session scope so it dies with the session.
+        //
+        // Scoped to the turn being cancelled by identity, not to "some turn is
+        // active". This cancel can settle normally and a fresh turn start
+        // inside the timeout; `acp.cancel` interrupts whatever prompt the
+        // runtime currently holds, so a laxer check would interrupt that new
+        // turn — and the bridge would ignore the accompanying cancel, its
+        // epoch being newer than this fence, leaving `agy` running while T3
+        // believed the turn was cancelled.
+        if (cancelledTurnId !== undefined) {
+          yield* Effect.forkIn(
+            Effect.sleep(CANCEL_ACK_TIMEOUT_MS).pipe(
+              Effect.flatMap(() =>
+                // Still running this long after a cancel means the bridge is
+                // not processing notifications. Interrupting the RPC alone
+                // would settle the turn here while a detached `agy` kept
+                // running tools, so the session goes instead: closing its scope
+                // ends the bridge process, whose own exit handler kills the
+                // `agy` process group.
+                //
+                // The turn is named rather than checked here: this fiber woke
+                // ten seconds late, and the check has to happen under the same
+                // gate that claims the stop or a turn that settled meanwhile
+                // takes its replacement down with it.
+                Effect.ignore(
+                  stopSessionInternal(ctx, cancelledTurnId, () =>
+                    ctx.awaitingBridgeAck.has(cancelledTurnId),
+                  ),
+                ),
+              ),
+            ),
+            adapterScope,
+          );
+        }
       });
 
     // `agy` itself always runs with permissions skipped — print mode cannot
@@ -972,11 +1670,18 @@ export function makeAntigravityAdapter(
         return c !== undefined && !c.stopped;
       });
 
+    // Snapshotted, not iterated live: teardown deletes from this map, and a
+    // concurrent `startSession` can install a replacement mid-sweep.
+    // Each teardown runs under the thread lock, so a sweep cannot interleave
+    // with a `startSession` installing a replacement for the same thread.
+    const stopSwept = (ctx: AntigravitySessionContext) =>
+      withThreadLock(ctx.threadId, stopSessionInternal(ctx));
+
     const stopAll: AntigravityAdapterShape["stopAll"] = () =>
-      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+      Effect.forEach(Array.from(sessions.values()), stopSwept, { discard: true });
 
     yield* Effect.addFinalizer(() =>
-      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+      Effect.forEach(Array.from(sessions.values()), stopSwept, { discard: true }).pipe(
         Effect.catch((cause) =>
           Effect.logError("Failed to emit Antigravity session shutdown event.", { cause }),
         ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -163,7 +163,7 @@ function resolveEffortSelection(
 ): string | undefined {
   // Option values are a string/boolean union across providers; only a string
   // effort is meaningful here.
-  const raw = options?.find((option) => option.id === "effort")?.value;
+  const raw = options?.find((option) => option.id === "reasoningEffort")?.value;
   const effort = typeof raw === "string" ? raw.trim().toLowerCase() : undefined;
   return effort === "low" || effort === "medium" || effort === "high" ? effort : undefined;
 }
@@ -613,7 +613,7 @@ export function makeAntigravityAdapter(
               }),
             ),
           ).pipe(
-            Effect.catch((cause) =>
+            Effect.catchCause((cause) =>
               Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
             ),
             Effect.forkChild,
@@ -775,7 +775,7 @@ export function makeAntigravityAdapter(
           // Rechecked here rather than only at accept time: everything above
           // yields, and an interrupt during any of it means this prompt must
           // not reach the agent.
-          if (ctx.cancelEpoch !== acceptedEpoch) {
+          if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
             stopReason = "cancelled";
             return {
               threadId: input.threadId,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1,0 +1,1009 @@
+/**
+ * AntigravityAdapterLive — Antigravity CLI (`agy`) via the bundled ACP bridge.
+ *
+ * Antigravity has no native agent protocol, so the ACP peer this adapter talks
+ * to is T3 Code's own bridge (`t3 agy-acp`). That shapes three deliberate
+ * differences from the CLI-native ACP adapters:
+ *
+ *   - **Approvals come from the hook, not the CLI.** `agy` always runs with
+ *     `--dangerously-skip-permissions` because print mode cannot prompt. When
+ *     `requireToolApproval` is set, the bridge's `PreToolUse` hook becomes the
+ *     gate instead: it blocks the tool until this adapter answers, and a
+ *     denial is reported back to the model. On by default: without it nothing
+ *     stands between the model and an auto-approved tool.
+ *   - **No session modes.** Print mode has no plan/ask distinction to switch.
+ *   - **Attachments travel by reference.** `agy --print` has no attachment
+ *     flag, so files are sent as `resource_link` blocks and the bridge stages
+ *     them into a directory it grants the CLI access to for that turn.
+ *   - **Model changes apply from the next turn.** `--model` is a per-spawn
+ *     flag that composes with `--conversation`, so a switch keeps the
+ *     trajectory rather than needing a new session.
+ *
+ * @module AntigravityAdapterLive
+ */
+
+import {
+  type AntigravitySettings,
+  ApprovalRequestId,
+  EventId,
+  type ProviderApprovalDecision,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  RuntimeRequestId,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import { attachmentFileUrl, resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
+import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import {
+  makeAntigravityAcpRuntime,
+  resolveAntigravityBaseModelId,
+} from "../acp/AntigravityAcpSupport.ts";
+import { type AntigravityAdapterShape } from "../Services/AntigravityAdapter.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const PROVIDER = ProviderDriverKind.make("antigravity");
+/**
+ * How long this side waits for a tool-approval answer.
+ *
+ * Deliberately longer than the bridge's own wait: the bridge denies first and
+ * the blocked hook is released by that, so this only exists to stop an
+ * unanswered request pinning its entry and its UI prompt forever.
+ */
+const APPROVAL_WAIT_MS = 11 * 60 * 1000;
+const ANTIGRAVITY_RESUME_VERSION = 1 as const;
+
+export interface AntigravityAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  /**
+   * Selections are honored when `modelSelection.instanceId` matches this value.
+   * Defaults to the legacy built-in instance id (`antigravity`).
+   */
+  readonly instanceId?: ProviderInstanceId;
+  /**
+   * Optional per-session settings resolver, used by tests that mutate
+   * `ServerSettingsService` mid-flight. Production leaves this undefined and
+   * relies on the hydration layer rebuilding the adapter on config change.
+   */
+  readonly resolveSettings?: Effect.Effect<AntigravitySettings>;
+}
+
+interface AntigravitySessionContext {
+  readonly threadId: ThreadId;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  activeTurnId: TurnId | undefined;
+  /** Model the bridge will pass to `agy --model` on the next turn. */
+  currentModelId: string | undefined;
+  /**
+   * Bumped by every interrupt. A prompt records this when it is accepted and
+   * rechecks it immediately before submitting: the ACP runtime serializes
+   * prompts behind a semaphore, so a steer can still be waiting there when
+   * Stop is pressed and would otherwise reach the bridge *after* the cancel,
+   * capture the post-cancel state, and run anyway.
+   */
+  cancelEpoch: number;
+  /**
+   * Turns for which `turn.started` has actually been published. Shared rather
+   * than per-call, so a steer cannot assume the prompt it folded into already
+   * announced the turn — that prompt may have failed during preflight.
+   */
+  readonly startedTurnIds: Set<TurnId>;
+  /**
+   * Number of prompts in flight. >0 means a turn is running, so a new
+   * sendTurn steers the existing turn rather than opening a new one.
+   */
+  promptsInFlight: number;
+  stopped: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseAntigravityResume(raw: unknown): { sessionId: string } | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (raw.schemaVersion !== ANTIGRAVITY_RESUME_VERSION) return undefined;
+  if (typeof raw.sessionId !== "string" || !raw.sessionId.trim()) return undefined;
+  return { sessionId: raw.sessionId.trim() };
+}
+
+/**
+ * Reasoning effort for `agy --effort`, read from the model option selections.
+ * Antigravity accepts only low/medium/high.
+ */
+function resolveEffortSelection(
+  options:
+    | ReadonlyArray<{ readonly id: string; readonly value: string | boolean }>
+    | null
+    | undefined,
+): string | undefined {
+  // Option values are a string/boolean union across providers; only a string
+  // effort is meaningful here.
+  const raw = options?.find((option) => option.id === "effort")?.value;
+  const effort = typeof raw === "string" ? raw.trim().toLowerCase() : undefined;
+  return effort === "low" || effort === "medium" || effort === "high" ? effort : undefined;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+}
+
+function selectPermissionOptionId(
+  request: EffectAcpSchema.RequestPermissionRequest,
+  decision: Exclude<ProviderApprovalDecision, "cancel">,
+): string | undefined {
+  const kind =
+    decision === "acceptForSession"
+      ? "allow_always"
+      : decision === "accept"
+        ? "allow_once"
+        : "reject_once";
+  return request.options.find((entry) => entry.kind === kind)?.optionId.trim() || undefined;
+}
+
+function selectAutoApprovedPermissionOption(
+  request: EffectAcpSchema.RequestPermissionRequest,
+): string | undefined {
+  return (
+    selectPermissionOptionId(request, "acceptForSession") ??
+    selectPermissionOptionId(request, "accept")
+  );
+}
+
+export function makeAntigravityAdapter(
+  antigravitySettings: AntigravitySettings,
+  options?: AntigravityAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("antigravity");
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const path = yield* Path.Path;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const crypto = yield* Crypto.Crypto;
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, { stream: "native" })
+        : undefined);
+    const managedNativeEventLogger =
+      options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+    const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
+
+    const sessions = new Map<ThreadId, AntigravitySessionContext>();
+    /**
+     * Approvals awaiting a user decision, per thread. Held outside the session
+     * context because the permission callback is registered before the context
+     * exists, and `respondToRequest` resolves entries from a different call.
+     */
+    const approvalsByThread = new Map<ThreadId, Map<ApprovalRequestId, PendingApproval>>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate Antigravity runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+    const mapAcpCallbackFailure = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.mapError(
+          (cause) =>
+            new EffectAcpErrors.AcpTransportError({
+              detail: "Failed to process Antigravity ACP callback.",
+              cause,
+            }),
+        ),
+      );
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
+          current.get(threadId),
+        );
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = yield* nowIso;
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: yield* randomUUIDv4,
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<AntigravitySessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: AntigravitySessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        // Anything still waiting on a human is cancelled, which the bridge
+        // turns into a denial. Left pending, the hook would block its tool
+        // until its own timeout with no one able to answer.
+        const pending = approvalsByThread.get(ctx.threadId);
+        if (pending) {
+          for (const [, approval] of pending) {
+            // Ignored: an answer racing session stop may have settled this
+            // already, and that must not abort the rest of teardown.
+            yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
+          }
+          approvalsByThread.delete(ctx.threadId);
+        }
+        if (ctx.notificationFiber) {
+          yield* Fiber.interrupt(ctx.notificationFiber);
+        }
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const startSession: AntigravityAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const cwd = path.resolve(input.cwd.trim());
+          const modelSelection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+          let ctx!: AntigravitySessionContext;
+
+          const resumeSessionId = parseAntigravityResume(input.resumeCursor)?.sessionId;
+          const acpNativeLoggers = makeAcpNativeLoggers({
+            nativeEventLogger,
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+
+          const effectiveSettings = options?.resolveSettings
+            ? yield* options.resolveSettings
+            : antigravitySettings;
+
+          // The model and effort are bound when the bridge spawns `agy`, so
+          // they must be resolved before the runtime is constructed rather
+          // than applied afterwards via session config.
+          const boundModel = resolveAntigravityBaseModelId(modelSelection?.model);
+          const boundEffort = resolveEffortSelection(modelSelection?.options);
+
+          const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+          const acp = yield* makeAntigravityAcpRuntime({
+            antigravitySettings: effectiveSettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            model: boundModel,
+            ...(boundEffort ? { effort: boundEffort } : {}),
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...(mcpSession
+              ? {
+                  mcpServers: [
+                    {
+                      type: "http" as const,
+                      name: "t3-code",
+                      url: mcpSession.endpoint,
+                      headers: [{ name: "Authorization", value: mcpSession.authorizationHeader }],
+                    },
+                  ],
+                }
+              : {}),
+            ...acpNativeLoggers,
+          }).pipe(
+            Effect.provideService(Crypto.Crypto, crypto),
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+
+          // With approvals enabled the bridge blocks each tool on this callback,
+          // so it must be registered before `start()` — the first tool call can
+          // arrive as soon as the first turn begins.
+          // Not published to `approvalsByThread` yet: if startup fails there is
+          // no session context for teardown to clean up, and repeated failures
+          // across thread ids would grow the map. Registered after `start()`.
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          yield* acp.handleRequestPermission((params) =>
+            mapAcpCallbackFailure(
+              Effect.gen(function* () {
+                if (input.runtimeMode === "full-access") {
+                  const autoApproved = selectAutoApprovedPermissionOption(params);
+                  if (autoApproved !== undefined) {
+                    return { outcome: { outcome: "selected" as const, optionId: autoApproved } };
+                  }
+                }
+                const permissionRequest = parsePermissionRequest(params);
+                const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+                const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                const turnId = sessions.get(input.threadId)?.activeTurnId;
+                pendingApprovals.set(requestId, { decision });
+                yield* offerRuntimeEvent(
+                  makeAcpRequestOpenedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId,
+                    requestId: RuntimeRequestId.make(requestId),
+                    permissionRequest,
+                    detail: permissionRequest.detail ?? "Antigravity tool call",
+                    args: params,
+                    source: "acp.jsonrpc",
+                    method: "session/request_permission",
+                    rawPayload: params,
+                  }),
+                );
+                // Raced against a deadline and cleaned up unconditionally: the
+                // bridge forgets its side of a timed-out request, so without
+                // this the handler would stay blocked and the entry retained.
+                const answered = yield* Deferred.await(decision).pipe(
+                  Effect.timeoutOption(APPROVAL_WAIT_MS),
+                  Effect.ensuring(Effect.sync(() => pendingApprovals.delete(requestId))),
+                );
+                // An unanswered request denies, matching the bridge's own
+                // timeout: this gate must never resolve to "allow" by default.
+                const resolved: ProviderApprovalDecision = Option.isSome(answered)
+                  ? answered.value
+                  : "cancel";
+                yield* offerRuntimeEvent(
+                  makeAcpRequestResolvedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId,
+                    requestId: RuntimeRequestId.make(requestId),
+                    permissionRequest,
+                    decision: resolved,
+                  }),
+                );
+                const optionId =
+                  resolved === "cancel" ? undefined : selectPermissionOptionId(params, resolved);
+                return {
+                  outcome: optionId
+                    ? { outcome: "selected" as const, optionId }
+                    : ({ outcome: "cancelled" } as const),
+                };
+              }),
+            ),
+          );
+
+          const started = yield* acp
+            .start()
+            .pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+              ),
+            );
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            model: boundModel,
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: ANTIGRAVITY_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          ctx = {
+            threadId: input.threadId,
+            session,
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            turns: [],
+            activeTurnId: undefined,
+            currentModelId: boundModel,
+            cancelEpoch: 0,
+            startedTurnIds: new Set(),
+            promptsInFlight: 0,
+            stopped: false,
+          };
+
+          const nf = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                switch (event._tag) {
+                  case "EventStreamBarrier":
+                    yield* Deferred.succeed(event.acknowledge, undefined);
+                    return;
+                  // The bridge never changes modes; print mode has none.
+                  case "ModeChanged":
+                    return;
+                  case "AssistantItemStarted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.started",
+                      }),
+                    );
+                    return;
+                  case "AssistantItemCompleted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.completed",
+                      }),
+                    );
+                    return;
+                  case "PlanUpdated":
+                    yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                    yield* offerRuntimeEvent(
+                      makeAcpPlanUpdatedEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        payload: event.payload,
+                        source: "acp.jsonrpc",
+                        method: "session/update",
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ToolCallUpdated":
+                    yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                    yield* offerRuntimeEvent(
+                      makeAcpToolCallEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        toolCall: event.toolCall,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ContentDelta":
+                    yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                    yield* offerRuntimeEvent(
+                      makeAcpContentDeltaEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        text: event.text,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                }
+              }),
+            ),
+          ).pipe(
+            Effect.catch((cause) =>
+              Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
+            ),
+            Effect.forkChild,
+          );
+
+          ctx.notificationFiber = nf;
+          sessions.set(input.threadId, ctx);
+          // Published only now: teardown finds pending approvals through the
+          // session context, so registering earlier would leak the entry if
+          // startup were interrupted before the session existed.
+          approvalsByThread.set(input.threadId, pendingApprovals);
+          sessionScopeTransferred = true;
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: started.initializeResult },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "Antigravity ACP session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: started.sessionId },
+          });
+
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(input.threadId);
+
+        // `agy --print` takes a single text prompt, so attachments travel as
+        // `resource_link` blocks (ACP baseline, no capability needed) pointing
+        // at the files the attachment store already wrote to disk. The bridge
+        // renders those paths into the prompt and grants `agy` read access to
+        // stages just those files into a per-turn directory it can grant `agy`
+        // access to. Nothing is re-encoded.
+        //
+        // This runs before any `turn.started` is offered — a rejected prompt
+        // that had already announced a turn would leave the UI with one that
+        // never completes.
+        const text = input.input?.trim();
+        const attachmentParts = yield* Effect.forEach(input.attachments ?? [], (attachment) =>
+          Effect.gen(function* () {
+            const attachmentPath = resolveAttachmentPath({
+              attachmentsDir: serverConfig.attachmentsDir,
+              attachment,
+            });
+            if (!attachmentPath) {
+              return yield* new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "session/prompt",
+                detail: `Invalid attachment id '${attachment.id}'.`,
+              });
+            }
+            return {
+              type: "resource_link",
+              // `pathToFileURL` rather than hand-built escaping: it handles
+              // Windows drive letters and escapes `#`/`?`, which would
+              // otherwise truncate the path when the bridge parses it back.
+              uri: attachmentFileUrl(attachmentPath),
+              name: path.basename(attachmentPath),
+              ...(attachment.mimeType ? { mimeType: attachment.mimeType } : {}),
+            } satisfies EffectAcpSchema.ContentBlock;
+          }),
+        );
+        const promptParts: Array<EffectAcpSchema.ContentBlock> = [
+          ...(text ? [{ type: "text" as const, text }] : []),
+          ...attachmentParts,
+        ];
+        if (promptParts.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "Turn requires non-empty text or attachments.",
+          });
+        }
+
+        // A sendTurn while a prompt is in flight is a steer: the new prompt
+        // folds into the ongoing work, so the active turn id is reused.
+        //
+        // The id is minted first, before anything is read, so that reading
+        // `promptsInFlight` and claiming it are one synchronous step. Yielding
+        // between the two — which generating the id here used to do — let two
+        // concurrent calls both observe zero and open rival turns over the
+        // same thread.
+        const freshTurnId = TurnId.make(yield* randomUUIDv4);
+        const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+        const turnId = steeringTurnId ?? freshTurnId;
+        const acceptedEpoch = ctx.cancelEpoch;
+        // Claimed together, without an intervening yield: assigning the active
+        // turn id later let a concurrent call see `promptsInFlight > 0` with no
+        // id yet and open a rival turn.
+        ctx.promptsInFlight += 1;
+        ctx.activeTurnId = turnId;
+        // Terminal-event bookkeeping. Publication happens in exactly one place
+        // (the teardown below) so that the decision cannot race a steer.
+        let stopReason: string | null = null;
+        let promptSucceeded = false;
+
+        return yield* Effect.gen(function* () {
+          ctx.session = {
+            ...ctx.session,
+            activeTurnId: turnId,
+            updatedAt: yield* nowIso,
+          };
+
+          // `agy` binds the model with a `--model` flag on each spawn, and that
+          // flag composes with `--conversation` — verified against the CLI: a
+          // resumed conversation answers on the new model with its history
+          // intact. Applied before `turn.started` so the announced model is the
+          // one the turn actually runs on.
+          const turnModelSelection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const requestedModelId = turnModelSelection?.model
+            ? resolveAntigravityBaseModelId(turnModelSelection.model)
+            : undefined;
+          if (requestedModelId !== undefined && requestedModelId !== ctx.currentModelId) {
+            yield* ctx.acp
+              .setSessionModel(requestedModelId)
+              .pipe(
+                Effect.mapError((cause) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+                ),
+              );
+            ctx.currentModelId = requestedModelId;
+            ctx.session = { ...ctx.session, model: turnModelSelection?.model ?? ctx.session.model };
+          }
+
+          // Claimed from shared state, not from "am I a steer": the prompt this
+          // one folded into may have failed before it announced anything, and
+          // emitting content for a turn that never started strands the UI.
+          if (!ctx.startedTurnIds.has(turnId)) {
+            yield* offerRuntimeEvent({
+              type: "turn.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              turnId,
+              payload: { model: ctx.session.model },
+            });
+            // Marked only after the event is actually out, so a failed publish
+            // cannot let another prompt emit a completion for a turn nobody
+            // saw start.
+            ctx.startedTurnIds.add(turnId);
+          }
+          // Rechecked here rather than only at accept time: everything above
+          // yields, and an interrupt during any of it means this prompt must
+          // not reach the agent.
+          if (ctx.cancelEpoch !== acceptedEpoch) {
+            stopReason = "cancelled";
+            return {
+              threadId: input.threadId,
+              turnId,
+              resumeCursor: ctx.session.resumeCursor,
+            };
+          }
+
+          const result = yield* ctx.acp
+            .prompt({ prompt: promptParts })
+            .pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+              ),
+            );
+
+          const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
+          if (turnRecord) {
+            turnRecord.items.push({ prompt: promptParts, result });
+          } else {
+            ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
+          }
+          ctx.session = {
+            ...ctx.session,
+            activeTurnId: turnId,
+            updatedAt: yield* nowIso,
+          };
+
+          promptSucceeded = true;
+          stopReason = result.stopReason ?? null;
+
+          return {
+            threadId: input.threadId,
+            turnId,
+            resumeCursor: ctx.session.resumeCursor,
+          };
+        }).pipe(
+          Effect.ensuring(
+            Effect.gen(function* () {
+              // Decrement and the last-prompt test are one synchronous step, so
+              // a steer arriving mid-settlement cannot make two prompts both
+              // believe they own the turn and publish a terminal event each.
+              const remaining = Math.max(0, ctx.promptsInFlight - 1);
+              ctx.promptsInFlight = remaining;
+              if (remaining > 0) {
+                return;
+              }
+              // Cleared even when the turn never started — a model switch can
+              // fail after `activeTurnId` is installed, and leaving it set
+              // advertises a turn to `listSessions` and the reaper that no
+              // longer exists. Only the event below depends on having started.
+              if (ctx.activeTurnId === turnId) {
+                ctx.activeTurnId = undefined;
+              }
+              // Read from shared state rather than this call's local flag: the
+              // prompt that published `turn.started` may not be the one that
+              // settles the turn, and the settler still owes the completion.
+              const published = ctx.startedTurnIds.has(turnId);
+              ctx.startedTurnIds.delete(turnId);
+              // The public session field is what `listSessions` and the reaper
+              // read, so leaving it set would advertise a turn that has ended.
+              if (ctx.session.activeTurnId === turnId) {
+                const { activeTurnId: _endedTurnId, ...endedSession } = ctx.session;
+                ctx.session = { ...endedSession, status: "ready", updatedAt: yield* nowIso };
+              }
+              // A prompt that failed or was interrupted after `turn.started`
+              // still owes consumers a terminal event; without one the turn
+              // renders as running forever even though sendTurn already
+              // returned an error.
+              if (!published) {
+                return;
+              }
+              const state =
+                stopReason === "cancelled" ? "cancelled" : promptSucceeded ? "completed" : "failed";
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: { state, stopReason },
+              });
+              // `catchCause` rather than `catch`: a defect while stamping or
+              // publishing would otherwise escape after `promptsInFlight` was
+              // already decremented, stranding the turn as running.
+            }).pipe(Effect.catchCause(() => Effect.void)),
+          ),
+        );
+      });
+
+    const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        // Recorded before anything else: prompts already accepted but still
+        // queued upstream compare against this and refuse to submit.
+        ctx.cancelEpoch += 1;
+        // Settled before the cancel goes out, as ACP requires: an outstanding
+        // permission request has a hook process blocked behind it, and the
+        // bridge turns "cancel" into a denial. Leaving it pending would hold
+        // that tool until the hook's own timeout.
+        const pending = approvalsByThread.get(threadId);
+        if (pending) {
+          for (const [, approval] of pending) {
+            yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
+          }
+          pending.clear();
+        }
+        yield* Effect.ignore(
+          ctx.acp.cancel.pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+            ),
+          ),
+        );
+      });
+
+    // `agy` itself always runs with permissions skipped — print mode cannot
+    // prompt — so when approvals are enabled the bridge's PreToolUse hook is
+    // the gate, and this resolves the decision it is blocked on.
+    const respondToRequest: AntigravityAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        const pending = approvalsByThread.get(threadId)?.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+
+    const respondToUserInput: AntigravityAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+    ) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "session/user_input",
+          detail: `Antigravity print mode cannot ask questions; unknown request: ${requestId}`,
+        });
+      });
+
+    const readThread: AntigravityAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: AntigravityAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        // Truncating the local turn list would report success while leaving the
+        // Antigravity trajectory untouched: the next turn resumes the same
+        // `--conversation` and still sees the rolled-back exchanges, so the
+        // model would answer from history the user believes is gone. Print mode
+        // exposes no rewind primitive, so this fails loudly instead.
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "thread/rollback",
+          detail: "Antigravity conversations do not support provider-side rollback.",
+        });
+      });
+
+    const stopSession: AntigravityAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          yield* stopSessionInternal(ctx);
+        }),
+      );
+
+    const listSessions: AntigravityAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (c) => ({ ...c.session })));
+
+    const hasSession: AntigravityAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const c = sessions.get(threadId);
+        return c !== undefined && !c.stopped;
+      });
+
+    const stopAll: AntigravityAdapterShape["stopAll"] = () =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to emit Antigravity session shutdown event.", { cause }),
+        ),
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+        Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    const streamEvents = Stream.fromPubSub(runtimeEventPubSub);
+
+    return {
+      provider: PROVIDER,
+      // `agy --model` is applied when the bridge spawns the CLI, so switching
+      // models mid-session is not possible.
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents,
+    } satisfies AntigravityAdapterShape;
+  });
+}

--- a/apps/server/src/provider/Layers/AntigravityProvider.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.test.ts
@@ -1,0 +1,182 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { AntigravitySettings } from "@t3tools/contracts";
+
+import {
+  buildInitialAntigravityProviderSnapshot,
+  checkAntigravityProviderStatus,
+} from "./AntigravityProvider.ts";
+
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const isWindows = process.platform === "win32";
+
+/**
+ * Creates a Node.js-backed script stub that runs identically on Windows and Unix.
+ */
+function makeNodeStub(dir: string, fileName: string, jsCode: string): string {
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const jsPath = path.join(dir, `${fileName}-runner.js`);
+  fs.writeFileSync(jsPath, jsCode, "utf8");
+
+  if (isWindows) {
+    const cmdPath = path.join(dir, `${fileName}.cmd`);
+    fs.writeFileSync(cmdPath, `@echo off\n"${process.execPath}" "${jsPath}" %*\n`, "utf8");
+    return cmdPath;
+  } else {
+    const shPath = path.join(dir, fileName);
+    fs.writeFileSync(
+      shPath,
+      `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(jsPath)} "$@"\n`,
+      "utf8",
+    );
+    fs.chmodSync(shPath, 0o755);
+    return shPath;
+  }
+}
+
+describe("buildInitialAntigravityProviderSnapshot", () => {
+  it.effect("returns a disabled snapshot when settings.enabled is false", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialAntigravityProviderSnapshot(
+        decodeAntigravitySettings({ enabled: false }),
+      );
+      expect(snapshot.enabled).toBe(false);
+      expect(snapshot.status).toBe("disabled");
+      expect(snapshot.installed).toBe(false);
+      expect(snapshot.message).toContain("disabled");
+    }),
+  );
+
+  it.effect("returns a pending snapshot by default", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialAntigravityProviderSnapshot(
+        decodeAntigravitySettings({}),
+      );
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.status).toBe("warning");
+      expect(snapshot.version).toBeNull();
+      expect(snapshot.message).toContain("Checking Antigravity");
+      // Model switching is supported in-session via per-turn --model
+      expect(snapshot.requiresNewThreadForModelChange).toBe(false);
+      // Interaction mode toggle is hidden because --print mode behavior is undocumented
+      expect(snapshot.showInteractionModeToggle).toBe(false);
+    }),
+  );
+});
+
+it.layer(NodeServices.layer)("checkAntigravityProviderStatus", (it) => {
+  it.effect("reports the binary as missing when the binary path does not resolve", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* checkAntigravityProviderStatus(
+        decodeAntigravitySettings({
+          enabled: true,
+          binaryPath: "/definitely/not/installed/agy-binary",
+        }),
+      );
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.installed).toBe(false);
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.message).toMatch(/not installed|not on PATH|Failed to execute/);
+    }),
+  );
+
+  it.effect("reports an installed CLI as unhealthy when --version exits non-zero", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-agy-version-" });
+          const agyPath = makeNodeStub(
+            dir,
+            "agy",
+            `console.error("broken antigravity install"); process.exit(2);`,
+          );
+
+          return yield* checkAntigravityProviderStatus(
+            decodeAntigravitySettings({ enabled: true, binaryPath: agyPath }),
+          );
+        }),
+      );
+
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.message).toBe("Antigravity CLI is installed but failed to run.");
+    }),
+  );
+
+  it.effect("reports unauthenticated when --version passes but agy models returns nothing", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-agy-no-models-" });
+          const agyPath = makeNodeStub(
+            dir,
+            "agy",
+            `
+const args = process.argv.join(" ");
+if (args.includes("--version")) {
+  console.log("Antigravity CLI 1.2.3");
+  process.exit(0);
+}
+process.exit(0);
+`,
+          );
+
+          return yield* checkAntigravityProviderStatus(
+            decodeAntigravitySettings({ enabled: true, binaryPath: agyPath }),
+          );
+        }),
+      );
+
+      expect(snapshot.status).toBe("warning");
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.auth?.status).toBe("unauthenticated");
+      expect(snapshot.message).toContain("sign in");
+    }),
+  );
+
+  it.effect("returns ready status when version and models are available", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-agy-success-" });
+          const agyPath = makeNodeStub(
+            dir,
+            "agy",
+            `
+const args = process.argv.join(" ");
+if (args.includes("--version")) {
+  console.log("Antigravity CLI 1.2.3");
+  process.exit(0);
+}
+if (args.includes("models")) {
+  console.log("gemini-3.1-pro-high\\ngemini-3.6-flash-low");
+  process.exit(0);
+}
+process.exit(0);
+`,
+          );
+
+          return yield* checkAntigravityProviderStatus(
+            decodeAntigravitySettings({ enabled: true, binaryPath: agyPath }),
+          );
+        }),
+      );
+
+      expect(snapshot.status).toBe("ready");
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.version).toBe("1.2.3");
+      expect(snapshot.models.length).toBeGreaterThan(0);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -404,7 +404,11 @@ export const checkAntigravityProviderStatus = Effect.fn("checkAntigravityProvide
   function* (
     settings: AntigravitySettings,
     environment: NodeJS.ProcessEnv = process.env,
-  ): Effect.fn.Return<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> {
+  ): Effect.fn.Return<
+    ServerProviderDraft,
+    never,
+    ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+  > {
     const checkedAt = DateTime.formatIso(yield* DateTime.now);
     const fallbackModels = antigravityModelsFromSettings(settings.customModels);
 

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -101,7 +101,7 @@ const checkAntigravityAccountAuth = (
     let discoveredEmail: string | undefined = undefined;
     let discoveredPlanType: AntigravityPlanType = "unknown";
 
-    yield* Effect.catchAll(
+    yield* Effect.catch(
       Effect.gen(function* () {
         const exists = yield* fs.exists(logDir);
         if (exists) {

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -112,7 +112,10 @@ const checkAntigravityAccountAuth = (
 
           const statResults = yield* Effect.all(
             logFiles.map((file) =>
-              Effect.map(fs.stat(file), (stat) => ({ file, mtimeMs: stat.mtimeMillis }))
+              Effect.map(fs.stat(file), (stat) => ({
+                file,
+                mtimeMs: Option.getOrElse(stat.mtime, () => new Date(0)).getTime(),
+              }))
             ),
             { concurrency: "unbounded" }
           );
@@ -165,12 +168,15 @@ const checkAntigravityAccountAuth = (
 
     if (discoveredPlanType === "unknown") {
       const onboardingPath = path.join(targetDir, "cache", "onboarding.json");
-      yield* Effect.catchAll(
+      yield* Effect.catchTags(
         Effect.gen(function* () {
           const exists = yield* fs.exists(onboardingPath);
           if (exists) {
             const content = yield* fs.readFileString(onboardingPath);
-            const parsed: unknown = JSON.parse(content);
+            const parsed = yield* Effect.try({
+              try: () => JSON.parse(content) as unknown,
+              catch: (error) => ({ _tag: "ParseError" as const, error }),
+            });
             if (typeof parsed === "object" && parsed !== null) {
               const obj = parsed as Record<string, unknown>;
               if (obj["enterpriseOnboardingComplete"] === true) {
@@ -184,7 +190,10 @@ const checkAntigravityAccountAuth = (
             }
           }
         }),
-        () => Effect.void
+        {
+          PlatformError: () => Effect.void,
+          ParseError: () => Effect.void,
+        }
       );
     }
 

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -1,0 +1,517 @@
+/**
+ * AntigravityProvider — health probe and model discovery for the Antigravity
+ * CLI (`agy`).
+ *
+ * Model discovery calls `agy models` directly rather than starting an ACP
+ * session as the Grok provider does: Antigravity has no agent protocol of its
+ * own, so spinning up the bridge just to enumerate models would spawn a
+ * print-mode process for no reason.
+ *
+ * @module AntigravityProvider
+ */
+import {
+  type AntigravitySettings,
+  type ModelCapabilities,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import { causeErrorTag } from "@t3tools/shared/observability";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import {
+  buildServerProvider,
+  isCommandMissingCause,
+  parseGenericCliVersion,
+  providerModelsFromSettings,
+  spawnAndCollect,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import { parseAntigravityModelList } from "../acp/AntigravityAcpSupport.ts";
+
+export type AntigravityPlanType =
+  | "plus"
+  | "pro"
+  | "ultra"
+  | "enterprise"
+  | "business"
+  | "consumer"
+  | "free"
+  | "api_key"
+  | "unknown";
+
+export function antigravityAccountAuthLabel(
+  planType: AntigravityPlanType | string | undefined,
+): string | undefined {
+  if (!planType) return undefined;
+  switch (planType) {
+    case "plus":
+      return "Google AI Plus Subscription";
+    case "pro":
+      return "Google AI Pro Subscription";
+    case "ultra":
+      return "Google AI Ultra Subscription";
+    case "enterprise":
+      return "Google AI Enterprise Subscription";
+    case "business":
+      return "Google AI Business Subscription";
+    case "consumer":
+      return "Google AI Pro Subscription";
+    case "free":
+      return "Google Free Account";
+    case "api_key":
+      return "Google Gemini API Key";
+    default:
+      return "Google Subscription";
+  }
+}
+
+function checkAntigravityAccountAuth(settings: AntigravitySettings): {
+  readonly status: "authenticated" | "unauthenticated" | "unknown";
+  readonly label?: string;
+  readonly email?: string;
+} {
+  const targetDir =
+    settings.appDataDir?.trim() || NodePath.join(NodeOS.homedir(), ".gemini", "antigravity-cli");
+  const logDir = NodePath.join(targetDir, "log");
+
+  let discoveredEmail: string | undefined = undefined;
+  let discoveredPlanType: AntigravityPlanType = "unknown";
+
+  try {
+    if (NodeFS.existsSync(logDir)) {
+      const files = NodeFS.readdirSync(logDir)
+        .filter((f) => f.startsWith("cli-") && f.endsWith(".log"))
+        .map((f) => NodePath.join(logDir, f))
+        .sort((a, b) => NodeFS.statSync(b).mtimeMs - NodeFS.statSync(a).mtimeMs);
+
+      for (const logFile of files.slice(0, 5)) {
+        const content = NodeFS.readFileSync(logFile, "utf8");
+        const authMatch = /applyAuthResult:\s*email=([^\s,]+),\s*authMethod=([^\s,]+)/.exec(
+          content,
+        );
+        if (authMatch) {
+          discoveredEmail = authMatch[1]!.trim();
+          const rawMethod = authMatch[2]!.trim().toLowerCase();
+          if (rawMethod.includes("plus")) discoveredPlanType = "plus";
+          else if (rawMethod.includes("ultra")) discoveredPlanType = "ultra";
+          else if (rawMethod.includes("enterprise")) discoveredPlanType = "enterprise";
+          else if (rawMethod.includes("business")) discoveredPlanType = "business";
+          else if (rawMethod.includes("api_key") || rawMethod.includes("apikey"))
+            discoveredPlanType = "api_key";
+          else if (rawMethod.includes("consumer") || rawMethod.includes("pro"))
+            discoveredPlanType = "pro";
+          else discoveredPlanType = "consumer";
+          break;
+        }
+        const emailMatch = /authenticated successfully as ([^\s\n,]+)/.exec(content);
+        if (emailMatch) {
+          discoveredEmail = emailMatch[1]!.trim();
+          discoveredPlanType = "pro";
+          break;
+        }
+      }
+    }
+  } catch {
+    // Fall through if log inspection fails
+  }
+
+  if (discoveredPlanType === "unknown") {
+    const onboardingPath = NodePath.join(targetDir, "cache", "onboarding.json");
+    try {
+      if (NodeFS.existsSync(onboardingPath)) {
+        const parsed: unknown = JSON.parse(NodeFS.readFileSync(onboardingPath, "utf8"));
+        if (typeof parsed === "object" && parsed !== null) {
+          const obj = parsed as Record<string, unknown>;
+          if (obj["enterpriseOnboardingComplete"] === true) {
+            discoveredPlanType = "enterprise";
+          } else if (
+            obj["consumerOnboardingComplete"] === true ||
+            obj["onboardingComplete"] === true
+          ) {
+            discoveredPlanType = "pro";
+          }
+        }
+      }
+    } catch {
+      // Fall through
+    }
+  }
+
+  const label = antigravityAccountAuthLabel(discoveredPlanType);
+
+  return {
+    status: "authenticated",
+    ...(label ? { label } : {}),
+    ...(discoveredEmail ? { email: discoveredEmail } : {}),
+  };
+}
+
+const ANTIGRAVITY_PRESENTATION = {
+  displayName: "Antigravity",
+  badgeLabel: "Beta",
+  showInteractionModeToggle: false,
+  requiresNewThreadForModelChange: false,
+} as const;
+
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({ optionDescriptors: [] });
+
+const VERSION_PROBE_TIMEOUT_MS = 4_000;
+const MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+
+/**
+ * Turn an Antigravity model slug into a display name.
+ *
+ * Slugs encode the reasoning tier as a trailing `-high` / `-medium` / `-low`,
+ * which reads better as a parenthetical suffix when un-grouped.
+ */
+export function formatAntigravityModelName(slug: string): string {
+  const tierMatch = /^(.*)-(high|medium|low)$/.exec(slug);
+  const base = tierMatch?.[1] ?? slug;
+  const initialisms: Record<string, string> = { gpt: "GPT", oss: "OSS", ai: "AI" };
+  return base
+    .split("-")
+    .map((word) => {
+      const lower = word.toLowerCase();
+      if (initialisms[lower]) {
+        return initialisms[lower];
+      }
+      return /^\d/.test(word) ? word : `${word.charAt(0).toUpperCase()}${word.slice(1)}`;
+    })
+    .join(" ");
+}
+
+/**
+ * Group raw model slugs returned by `agy models` (e.g. `gemini-3.6-flash-high`, `gemini-3.6-flash-medium`)
+ * into base models with dynamic reasoning effort options.
+ */
+export function groupAntigravityModels(
+  rawSlugs: ReadonlyArray<string>,
+): ReadonlyArray<ServerProviderModel> {
+  const groups = new Map<string, { efforts: Set<string>; defaultSlug: string }>();
+
+  for (const slug of rawSlugs) {
+    const tierMatch = /^(.*)-(high|medium|low)$/.exec(slug);
+    if (tierMatch) {
+      const base = tierMatch[1]!;
+      const effort = tierMatch[2]!;
+      const existing = groups.get(base) ?? { efforts: new Set<string>(), defaultSlug: slug };
+      existing.efforts.add(effort);
+      if (effort === "high") {
+        existing.defaultSlug = slug;
+      }
+      groups.set(base, existing);
+    } else {
+      groups.set(slug, { efforts: new Set<string>(), defaultSlug: slug });
+    }
+  }
+
+  const result: ServerProviderModel[] = [];
+
+  for (const [baseSlug, data] of groups.entries()) {
+    const name = formatAntigravityModelName(baseSlug);
+    const effortList = Array.from(data.efforts);
+
+    let capabilities: ModelCapabilities = EMPTY_CAPABILITIES;
+    if (effortList.length > 0) {
+      const options = effortList.map((eff) => ({
+        id: eff,
+        label: eff.charAt(0).toUpperCase() + eff.slice(1),
+        ...(eff === "high" || effortList.length === 1 ? { isDefault: true } : {}),
+      }));
+      const hasDefault = options.some((opt) => opt.isDefault);
+      if (!hasDefault && options.length > 0) {
+        (options[options.length - 1] as { isDefault?: boolean }).isDefault = true;
+      }
+
+      capabilities = createModelCapabilities({
+        optionDescriptors: [
+          {
+            id: "reasoningEffort",
+            label: "Reasoning",
+            type: "select",
+            options,
+            ...(options.find((o) => o.isDefault)?.id
+              ? { currentValue: options.find((o) => o.isDefault)!.id }
+              : {}),
+          },
+        ],
+      });
+    }
+
+    result.push({
+      slug: data.defaultSlug,
+      name,
+      isCustom: false,
+      capabilities,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Fallback list used before discovery completes or when `agy models` fails.
+ */
+const ANTIGRAVITY_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+  {
+    slug: "gemini-3.1-pro-high",
+    name: "Gemini 3.1 Pro",
+    isCustom: false,
+    capabilities: createModelCapabilities({
+      optionDescriptors: [
+        {
+          id: "reasoningEffort",
+          label: "Reasoning",
+          type: "select",
+          options: [
+            { id: "low", label: "Low" },
+            { id: "high", label: "High", isDefault: true },
+          ],
+          currentValue: "high",
+        },
+      ],
+    }),
+  },
+];
+
+function antigravityModelsFromSettings(
+  customModels: ReadonlyArray<string> | undefined,
+  builtInModels: ReadonlyArray<ServerProviderModel> = ANTIGRAVITY_BUILT_IN_MODELS,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
+}
+
+export function buildInitialAntigravityProviderSnapshot(
+  settings: AntigravitySettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = antigravityModelsFromSettings(settings.customModels);
+
+    if (!settings.enabled) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Antigravity is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: ANTIGRAVITY_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking Antigravity CLI availability...",
+      },
+    });
+  });
+}
+
+const runAgyCommand = (
+  settings: AntigravitySettings,
+  args: ReadonlyArray<string>,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const command = settings.binaryPath || "agy";
+    const spawnCommand = yield* resolveSpawnCommand(command, [...args], { env: environment });
+    return yield* spawnAndCollect(
+      command,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        env: environment,
+        shell: spawnCommand.shell,
+        // `agy` starts a language server and will not emit `models` output
+        // until stdin closes. The default "pipe" leaves it open forever, so
+        // the probe would hang and time out with an empty list.
+        stdin: "ignore",
+      }),
+    );
+  });
+
+const discoverAntigravityModels = (
+  settings: AntigravitySettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.map(runAgyCommand(settings, ["models"], environment), (output) =>
+    output.code === 0 ? groupAntigravityModels(parseAntigravityModelList(output.stdout)) : [],
+  );
+
+export const checkAntigravityProviderStatus = Effect.fn("checkAntigravityProviderStatus")(
+  function* (
+    settings: AntigravitySettings,
+    environment: NodeJS.ProcessEnv = process.env,
+  ): Effect.fn.Return<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> {
+    const checkedAt = DateTime.formatIso(yield* DateTime.now);
+    const fallbackModels = antigravityModelsFromSettings(settings.customModels);
+
+    if (!settings.enabled) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Antigravity is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    const versionResult = yield* runAgyCommand(settings, ["--version"], environment).pipe(
+      Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
+      Effect.result,
+    );
+
+    if (Result.isFailure(versionResult)) {
+      const error = versionResult.failure;
+      yield* Effect.logWarning("Antigravity CLI health check failed.", { errorTag: error._tag });
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: !isCommandMissingCause(error),
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: isCommandMissingCause(error)
+            ? "Antigravity CLI (`agy`) is not installed or not on PATH."
+            : "Failed to execute Antigravity CLI health check.",
+        },
+      });
+    }
+
+    if (Option.isNone(versionResult.success)) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: "Antigravity CLI is installed but timed out while running `agy --version`.",
+        },
+      });
+    }
+
+    const versionOutput = versionResult.success.value;
+    const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
+    if (versionOutput.code !== 0) {
+      yield* Effect.logWarning("Antigravity CLI version probe exited with a non-zero status.", {
+        exitCode: versionOutput.code,
+      });
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "error",
+          auth: { status: "unknown" },
+          message: "Antigravity CLI is installed but failed to run.",
+        },
+      });
+    }
+
+    const discoveryResult = yield* discoverAntigravityModels(settings, environment).pipe(
+      Effect.timeoutOption(MODEL_DISCOVERY_TIMEOUT_MS),
+      Effect.result,
+    );
+    const discoveredModels =
+      Result.isSuccess(discoveryResult) && Option.isSome(discoveryResult.success)
+        ? discoveryResult.success.value
+        : [];
+    if (discoveredModels.length === 0) {
+      // A CLI that runs but lists no models is almost always an unfinished
+      // Google sign-in, which `agy models` reports by printing nothing.
+      yield* Effect.logWarning("Antigravity model discovery returned no models.");
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "warning",
+          auth: { status: "unauthenticated" },
+          message: "Antigravity CLI is installed but listed no models. Run `agy` to sign in.",
+        },
+      });
+    }
+
+    const auth = checkAntigravityAccountAuth(settings);
+
+    return buildServerProvider({
+      presentation: ANTIGRAVITY_PRESENTATION,
+      enabled: settings.enabled,
+      checkedAt,
+      models: antigravityModelsFromSettings(settings.customModels, discoveredModels),
+      probe: {
+        installed: true,
+        version,
+        status: "ready",
+        auth,
+      },
+    });
+  },
+);
+
+export const enrichAntigravitySnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly enableProviderUpdateChecks?: boolean;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void> => {
+  const { snapshot, publishSnapshot } = input;
+
+  return enrichProviderSnapshotWithVersionAdvisory(snapshot, input.maintenanceCapabilities, {
+    enableProviderUpdateChecks: input.enableProviderUpdateChecks,
+  }).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("Antigravity version advisory enrichment failed", {
+        errorTag: causeErrorTag(cause),
+      }),
+    ),
+    Effect.asVoid,
+  );
+};

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -37,10 +37,10 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
-import * as NodeFS from "node:fs";
-import * as NodeOS from "node:os";
-import * as NodePath from "node:path";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import { parseAntigravityModelList } from "../acp/AntigravityAcpSupport.ts";
+import { expandHomePath } from "../../pathExpansion.ts";
 
 export type AntigravityPlanType =
   | "plus"
@@ -79,97 +79,123 @@ export function antigravityAccountAuthLabel(
   }
 }
 
-function checkAntigravityAccountAuth(settings: AntigravitySettings): {
-  readonly status: "authenticated" | "unauthenticated" | "unknown";
-  readonly label?: string;
-  readonly email?: string;
-} {
-  const targetDir =
-    settings.appDataDir?.trim() || NodePath.join(NodeOS.homedir(), ".gemini", "antigravity-cli");
-  const logDir = NodePath.join(targetDir, "log");
+const checkAntigravityAccountAuth = (
+  settings: AntigravitySettings,
+): Effect.Effect<
+  {
+    readonly status: "authenticated" | "unauthenticated" | "unknown";
+    readonly label?: string;
+    readonly email?: string;
+  },
+  never,
+  FileSystem.FileSystem | Path.Path
+> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
 
-  let discoveredEmail: string | undefined = undefined;
-  let discoveredPlanType: AntigravityPlanType = "unknown";
+    const targetDir =
+      settings.appDataDir?.trim() || path.join(expandHomePath("~"), ".gemini", "antigravity-cli");
+    const logDir = path.join(targetDir, "log");
 
-  try {
-    if (NodeFS.existsSync(logDir)) {
-      const files = NodeFS.readdirSync(logDir)
-        .filter((f) => f.startsWith("cli-") && f.endsWith(".log"))
-        .map((f) => NodePath.join(logDir, f))
-        .sort((a, b) => NodeFS.statSync(b).mtimeMs - NodeFS.statSync(a).mtimeMs);
+    let discoveredEmail: string | undefined = undefined;
+    let discoveredPlanType: AntigravityPlanType = "unknown";
 
-      for (const logFile of files.slice(0, 5)) {
-        const content = NodeFS.readFileSync(logFile, "utf8");
-        const authMatches = [...content.matchAll(/applyAuthResult:\s*email=([^\s,]+),\s*authMethod=([^\s,]+)/g)];
-        const emailMatches = [...content.matchAll(/authenticated successfully as ([^\s\n,]+)/g)];
-        const authMatch = authMatches.pop();
-        const emailMatch = emailMatches.pop();
+    yield* Effect.catchAll(
+      Effect.gen(function* () {
+        const exists = yield* fs.exists(logDir);
+        if (exists) {
+          const files = yield* fs.readDirectory(logDir);
+          const logFiles = files
+            .filter((f) => f.startsWith("cli-") && f.endsWith(".log"))
+            .map((f) => path.join(logDir, f));
 
-        let latestMatch: { type: "auth"; match: RegExpMatchArray } | { type: "email"; match: RegExpMatchArray } | undefined;
-        if (authMatch && emailMatch) {
-          latestMatch = (authMatch.index ?? 0) > (emailMatch.index ?? 0)
-            ? { type: "auth", match: authMatch }
-            : { type: "email", match: emailMatch };
-        } else if (authMatch) {
-          latestMatch = { type: "auth", match: authMatch };
-        } else if (emailMatch) {
-          latestMatch = { type: "email", match: emailMatch };
-        }
+          const statResults = yield* Effect.all(
+            logFiles.map((file) =>
+              Effect.map(fs.stat(file), (stat) => ({ file, mtimeMs: stat.mtimeMillis }))
+            ),
+            { concurrency: "unbounded" }
+          );
 
-        if (latestMatch?.type === "auth") {
-          discoveredEmail = latestMatch.match[1]!.trim();
-          const rawMethod = latestMatch.match[2]!.trim().toLowerCase();
-          if (rawMethod.includes("plus")) discoveredPlanType = "plus";
-          else if (rawMethod.includes("ultra")) discoveredPlanType = "ultra";
-          else if (rawMethod.includes("enterprise")) discoveredPlanType = "enterprise";
-          else if (rawMethod.includes("business")) discoveredPlanType = "business";
-          else if (rawMethod.includes("api_key") || rawMethod.includes("apikey"))
-            discoveredPlanType = "api_key";
-          else if (rawMethod.includes("consumer") || rawMethod.includes("pro"))
-            discoveredPlanType = "pro";
-          else discoveredPlanType = "consumer";
-          break;
-        } else if (latestMatch?.type === "email") {
-          discoveredEmail = latestMatch.match[1]!.trim();
-          discoveredPlanType = "pro";
-          break;
-        }
-      }
-    }
-  } catch {
-    // Fall through if log inspection fails
-  }
+          const sortedFiles = statResults
+            .sort((a, b) => b.mtimeMs - a.mtimeMs)
+            .map((r) => r.file);
 
-  if (discoveredPlanType === "unknown") {
-    const onboardingPath = NodePath.join(targetDir, "cache", "onboarding.json");
-    try {
-      if (NodeFS.existsSync(onboardingPath)) {
-        const parsed: unknown = JSON.parse(NodeFS.readFileSync(onboardingPath, "utf8"));
-        if (typeof parsed === "object" && parsed !== null) {
-          const obj = parsed as Record<string, unknown>;
-          if (obj["enterpriseOnboardingComplete"] === true) {
-            discoveredPlanType = "enterprise";
-          } else if (
-            obj["consumerOnboardingComplete"] === true ||
-            obj["onboardingComplete"] === true
-          ) {
-            discoveredPlanType = "pro";
+          for (const logFile of sortedFiles.slice(0, 5)) {
+            const content = yield* fs.readFileString(logFile);
+            const authMatches = [...content.matchAll(/applyAuthResult:\s*email=([^\s,]+),\s*authMethod=([^\s,]+)/g)];
+            const emailMatches = [...content.matchAll(/authenticated successfully as ([^\s\n,]+)/g)];
+            const authMatch = authMatches.pop();
+            const emailMatch = emailMatches.pop();
+
+            let latestMatch: { type: "auth"; match: RegExpMatchArray } | { type: "email"; match: RegExpMatchArray } | undefined;
+            if (authMatch && emailMatch) {
+              latestMatch = (authMatch.index ?? 0) > (emailMatch.index ?? 0)
+                ? { type: "auth", match: authMatch }
+                : { type: "email", match: emailMatch };
+            } else if (authMatch) {
+              latestMatch = { type: "auth", match: authMatch };
+            } else if (emailMatch) {
+              latestMatch = { type: "email", match: emailMatch };
+            }
+
+            if (latestMatch?.type === "auth") {
+              discoveredEmail = latestMatch.match[1]!.trim();
+              const rawMethod = latestMatch.match[2]!.trim().toLowerCase();
+              if (rawMethod.includes("plus")) discoveredPlanType = "plus";
+              else if (rawMethod.includes("ultra")) discoveredPlanType = "ultra";
+              else if (rawMethod.includes("enterprise")) discoveredPlanType = "enterprise";
+              else if (rawMethod.includes("business")) discoveredPlanType = "business";
+              else if (rawMethod.includes("api_key") || rawMethod.includes("apikey"))
+                discoveredPlanType = "api_key";
+              else if (rawMethod.includes("consumer") || rawMethod.includes("pro"))
+                discoveredPlanType = "pro";
+              else discoveredPlanType = "consumer";
+              break;
+            } else if (latestMatch?.type === "email") {
+              discoveredEmail = latestMatch.match[1]!.trim();
+              discoveredPlanType = "pro";
+              break;
+            }
           }
         }
-      }
-    } catch {
-      // Fall through
+      }),
+      () => Effect.void
+    );
+
+    if (discoveredPlanType === "unknown") {
+      const onboardingPath = path.join(targetDir, "cache", "onboarding.json");
+      yield* Effect.catchAll(
+        Effect.gen(function* () {
+          const exists = yield* fs.exists(onboardingPath);
+          if (exists) {
+            const content = yield* fs.readFileString(onboardingPath);
+            const parsed: unknown = JSON.parse(content);
+            if (typeof parsed === "object" && parsed !== null) {
+              const obj = parsed as Record<string, unknown>;
+              if (obj["enterpriseOnboardingComplete"] === true) {
+                discoveredPlanType = "enterprise";
+              } else if (
+                obj["consumerOnboardingComplete"] === true ||
+                obj["onboardingComplete"] === true
+              ) {
+                discoveredPlanType = "pro";
+              }
+            }
+          }
+        }),
+        () => Effect.void
+      );
     }
-  }
 
-  const label = antigravityAccountAuthLabel(discoveredPlanType);
+    const label = antigravityAccountAuthLabel(discoveredPlanType);
 
-  return {
-    status: "authenticated",
-    ...(label ? { label } : {}),
-    ...(discoveredEmail ? { email: discoveredEmail } : {}),
-  };
-}
+    return {
+      status: "authenticated",
+      ...(label ? { label } : {}),
+      ...(discoveredEmail ? { email: discoveredEmail } : {}),
+    };
+  });
 
 const ANTIGRAVITY_PRESENTATION = {
   displayName: "Antigravity",
@@ -487,7 +513,7 @@ export const checkAntigravityProviderStatus = Effect.fn("checkAntigravityProvide
       });
     }
 
-    const auth = checkAntigravityAccountAuth(settings);
+    const auth = yield* checkAntigravityAccountAuth(settings);
 
     return buildServerProvider({
       presentation: ANTIGRAVITY_PRESENTATION,

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -101,7 +101,7 @@ const checkAntigravityAccountAuth = (
     let discoveredEmail: string | undefined = undefined;
     let discoveredPlanType: AntigravityPlanType = "unknown";
 
-    yield* Effect.catch(
+    yield* Effect.catchTags(
       Effect.gen(function* () {
         const exists = yield* fs.exists(logDir);
         if (exists) {
@@ -161,9 +161,10 @@ const checkAntigravityAccountAuth = (
               break;
             }
           }
-        }
       }),
-      () => Effect.void
+      {
+        PlatformError: () => Effect.void,
+      }
     );
 
     if (discoveredPlanType === "unknown") {

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -115,27 +115,33 @@ const checkAntigravityAccountAuth = (
               Effect.map(fs.stat(file), (stat) => ({
                 file,
                 mtimeMs: Option.getOrElse(stat.mtime, () => new Date(0)).getTime(),
-              }))
+              })),
             ),
-            { concurrency: "unbounded" }
+            { concurrency: "unbounded" },
           );
 
-          const sortedFiles = statResults
-            .sort((a, b) => b.mtimeMs - a.mtimeMs)
-            .map((r) => r.file);
+          const sortedFiles = statResults.sort((a, b) => b.mtimeMs - a.mtimeMs).map((r) => r.file);
 
           for (const logFile of sortedFiles.slice(0, 5)) {
             const content = yield* fs.readFileString(logFile);
-            const authMatches = [...content.matchAll(/applyAuthResult:\s*email=([^\s,]+),\s*authMethod=([^\s,]+)/g)];
-            const emailMatches = [...content.matchAll(/authenticated successfully as ([^\s\n,]+)/g)];
+            const authMatches = [
+              ...content.matchAll(/applyAuthResult:\s*email=([^\s,]+),\s*authMethod=([^\s,]+)/g),
+            ];
+            const emailMatches = [
+              ...content.matchAll(/authenticated successfully as ([^\s\n,]+)/g),
+            ];
             const authMatch = authMatches.pop();
             const emailMatch = emailMatches.pop();
 
-            let latestMatch: { type: "auth"; match: RegExpMatchArray } | { type: "email"; match: RegExpMatchArray } | undefined;
+            let latestMatch:
+              | { type: "auth"; match: RegExpMatchArray }
+              | { type: "email"; match: RegExpMatchArray }
+              | undefined;
             if (authMatch && emailMatch) {
-              latestMatch = (authMatch.index ?? 0) > (emailMatch.index ?? 0)
-                ? { type: "auth", match: authMatch }
-                : { type: "email", match: emailMatch };
+              latestMatch =
+                (authMatch.index ?? 0) > (emailMatch.index ?? 0)
+                  ? { type: "auth", match: authMatch }
+                  : { type: "email", match: emailMatch };
             } else if (authMatch) {
               latestMatch = { type: "auth", match: authMatch };
             } else if (emailMatch) {
@@ -161,10 +167,11 @@ const checkAntigravityAccountAuth = (
               break;
             }
           }
+        }
       }),
       {
         PlatformError: () => Effect.void,
-      }
+      },
     );
 
     if (discoveredPlanType === "unknown") {
@@ -194,7 +201,7 @@ const checkAntigravityAccountAuth = (
         {
           PlatformError: () => Effect.void,
           ParseError: () => Effect.void,
-        }
+        },
       );
     }
 

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -100,12 +100,25 @@ function checkAntigravityAccountAuth(settings: AntigravitySettings): {
 
       for (const logFile of files.slice(0, 5)) {
         const content = NodeFS.readFileSync(logFile, "utf8");
-        const authMatch = /applyAuthResult:\s*email=([^\s,]+),\s*authMethod=([^\s,]+)/.exec(
-          content,
-        );
-        if (authMatch) {
-          discoveredEmail = authMatch[1]!.trim();
-          const rawMethod = authMatch[2]!.trim().toLowerCase();
+        const authMatches = [...content.matchAll(/applyAuthResult:\s*email=([^\s,]+),\s*authMethod=([^\s,]+)/g)];
+        const emailMatches = [...content.matchAll(/authenticated successfully as ([^\s\n,]+)/g)];
+        const authMatch = authMatches.pop();
+        const emailMatch = emailMatches.pop();
+
+        let latestMatch: { type: "auth"; match: RegExpMatchArray } | { type: "email"; match: RegExpMatchArray } | undefined;
+        if (authMatch && emailMatch) {
+          latestMatch = (authMatch.index ?? 0) > (emailMatch.index ?? 0)
+            ? { type: "auth", match: authMatch }
+            : { type: "email", match: emailMatch };
+        } else if (authMatch) {
+          latestMatch = { type: "auth", match: authMatch };
+        } else if (emailMatch) {
+          latestMatch = { type: "email", match: emailMatch };
+        }
+
+        if (latestMatch?.type === "auth") {
+          discoveredEmail = latestMatch.match[1]!.trim();
+          const rawMethod = latestMatch.match[2]!.trim().toLowerCase();
           if (rawMethod.includes("plus")) discoveredPlanType = "plus";
           else if (rawMethod.includes("ultra")) discoveredPlanType = "ultra";
           else if (rawMethod.includes("enterprise")) discoveredPlanType = "enterprise";
@@ -116,10 +129,8 @@ function checkAntigravityAccountAuth(settings: AntigravitySettings): {
             discoveredPlanType = "pro";
           else discoveredPlanType = "consumer";
           break;
-        }
-        const emailMatch = /authenticated successfully as ([^\s\n,]+)/.exec(content);
-        if (emailMatch) {
-          discoveredEmail = emailMatch[1]!.trim();
+        } else if (latestMatch?.type === "email") {
+          discoveredEmail = latestMatch.match[1]!.trim();
           discoveredPlanType = "pro";
           break;
         }

--- a/apps/server/src/provider/Services/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Services/AntigravityAdapter.ts
@@ -1,0 +1,16 @@
+/**
+ * AntigravityAdapter — shape type for the Antigravity provider adapter.
+ *
+ * The driver model ({@link ../Drivers/AntigravityDriver}) bundles one adapter
+ * per instance as a captured closure, so this module only retains the shape
+ * interface as a naming anchor for the driver bundle.
+ *
+ * @module AntigravityAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * AntigravityAdapterShape — per-instance Antigravity adapter contract.
+ */
+export interface AntigravityAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -49,6 +49,12 @@ export type AcpSessionRuntimeEvent = AcpParsedSessionEvent | AcpSessionEventStre
 
 const defaultSessionLoadTimeout = Duration.seconds(90);
 const defaultSessionLoadReplayIdleGap = Duration.seconds(2);
+/**
+ * How long a prompt waits for an in-flight `session/cancel` notification to
+ * reach the agent before sending anyway. Only a backstop against a wedged
+ * transport — the write is a single stdio frame and normally completes at once.
+ */
+const CANCEL_NOTIFICATION_WRITE_TIMEOUT_MS = 5_000;
 
 export interface AcpSpawnInput {
   readonly command: string;
@@ -290,9 +296,23 @@ export const make = (
       ),
     );
     const assistantSegmentRef = yield* Ref.make<AcpAssistantSegmentState>({ nextSegmentIndex: 0 });
+    /**
+     * Serializes writing to the agent against publishing the fiber that owns
+     * that write.
+     *
+     * Held by `prompt` across "send the request, then record its fiber", and by
+     * `cancel` across "send the notification, then interrupt that fiber". The
+     * two operations are indivisible with respect to each other, which is what
+     * makes cancellation land on the turn it was issued for: without it a
+     * cancel could write its notification into the gap between a prompt being
+     * sent and its fiber being registered, cancelling nothing and leaving the
+     * prompt running.
+     */
+    const dispatchGate = yield* Semaphore.make(1);
     const configOptionsRef = yield* Ref.make(sessionConfigOptionsFromSetup(undefined));
     const startStateRef = yield* Ref.make<AcpStartState>({ _tag: "NotStarted" });
     const promptSerializationSemaphore = yield* Semaphore.make(1);
+    const cancellationGenerationRef = yield* Ref.make(0);
     const activePromptFiberRef = yield* Ref.make<
       Option.Option<Fiber.Fiber<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpError>>
     >(Option.none());
@@ -717,58 +737,106 @@ export const make = (
       getModeState: Ref.get(modeStateRef),
       getConfigOptions: Ref.get(configOptionsRef),
       prompt: (payload) =>
-        promptSerializationSemaphore.withPermit(
-          Effect.gen(function* () {
-            const started = yield* getStartedState;
-            yield* closeActiveAssistantSegment({
-              queue: eventQueue,
-              assistantSegmentRef,
-            });
-            const requestPayload = {
-              sessionId: started.sessionId,
-              ...payload,
-            } satisfies EffectAcpSchema.PromptRequest;
-            const cancelledResponse = {
-              stopReason: "cancelled",
-            } satisfies EffectAcpSchema.PromptResponse;
-            const promptRpcFiber = yield* runLoggedRequest(
-              "session/prompt",
-              requestPayload,
-              acp.agent.prompt(requestPayload),
-            ).pipe(Effect.forkIn(runtimeScope));
-            yield* Ref.set(activePromptFiberRef, Option.some(promptRpcFiber));
-            return yield* Fiber.join(promptRpcFiber).pipe(
-              Effect.catchCause((cause) =>
-                Cause.hasInterruptsOnly(cause)
-                  ? Effect.succeed(cancelledResponse)
-                  : Effect.failCause(cause),
-              ),
-              Effect.ensuring(
-                Effect.gen(function* () {
-                  yield* Fiber.interrupt(promptRpcFiber).pipe(Effect.ignore);
-                  yield* Ref.set(activePromptFiberRef, Option.none());
-                }),
-              ),
-              Effect.tap(() =>
-                closeActiveAssistantSegment({
-                  queue: eventQueue,
-                  assistantSegmentRef,
-                }),
-              ),
-            );
-          }),
-        ),
+        Effect.gen(function* () {
+          // Captured before waiting for prompt serialization. A cancel that
+          // lands while this prompt is queued moves the generation, so the
+          // prompt can decline instead of reaching the agent after Stop.
+          const cancellationGeneration = yield* Ref.get(cancellationGenerationRef);
+          return yield* promptSerializationSemaphore.withPermit(
+            Effect.gen(function* () {
+              const cancelledResponse = {
+                stopReason: "cancelled",
+              } satisfies EffectAcpSchema.PromptResponse;
+              const started = yield* getStartedState;
+              yield* closeActiveAssistantSegment({
+                queue: eventQueue,
+                assistantSegmentRef,
+              });
+              const requestPayload = {
+                sessionId: started.sessionId,
+                ...payload,
+              } satisfies EffectAcpSchema.PromptRequest;
+              // Sending and publishing the fiber are one step, so a concurrent
+              // cancel either sees no prompt at all or sees this one and can
+              // interrupt it. Uninterruptible because being interrupted between
+              // the two would leave a live RPC nothing can reach.
+              const promptRpcFiber = yield* dispatchGate.withPermit(
+                Effect.uninterruptible(
+                  Effect.gen(function* () {
+                    const currentGeneration = yield* Ref.get(cancellationGenerationRef);
+                    if (currentGeneration !== cancellationGeneration) {
+                      return Option.none();
+                    }
+                    const fiber = yield* runLoggedRequest(
+                      "session/prompt",
+                      requestPayload,
+                      acp.agent.prompt(requestPayload),
+                    ).pipe(Effect.forkIn(runtimeScope));
+                    yield* Ref.set(activePromptFiberRef, Option.some(fiber));
+                    return Option.some(fiber);
+                  }),
+                ),
+              );
+              if (Option.isNone(promptRpcFiber)) {
+                return cancelledResponse;
+              }
+              return yield* Fiber.join(promptRpcFiber.value).pipe(
+                Effect.catchCause((cause) =>
+                  Cause.hasInterruptsOnly(cause)
+                    ? Effect.succeed(cancelledResponse)
+                    : Effect.failCause(cause),
+                ),
+                Effect.ensuring(
+                  Effect.gen(function* () {
+                    yield* Fiber.interrupt(promptRpcFiber.value).pipe(Effect.ignore);
+                    yield* Ref.set(activePromptFiberRef, Option.none());
+                  }),
+                ),
+                // Closed however the prompt ends, not only when it succeeds. An
+                // agent that streamed some text and then failed the RPC left its
+                // segment open, and the next prompt closed it on the way in —
+                // after the caller had moved to a new turn, so the `item.completed`
+                // landed on the wrong one. A failed prompt still ends whatever it
+                // was saying.
+                Effect.ensuring(
+                  closeActiveAssistantSegment({
+                    queue: eventQueue,
+                    assistantSegmentRef,
+                  }),
+                ),
+              );
+            }),
+          );
+        }),
       cancel: getStartedState.pipe(
         Effect.flatMap((started) =>
-          Effect.gen(function* () {
-            const activePromptFiber = yield* Ref.get(activePromptFiberRef);
-            if (Option.isSome(activePromptFiber)) {
-              yield* Fiber.interrupt(activePromptFiber.value).pipe(Effect.ignore);
-            }
-            yield* acp.agent
-              .cancel({ sessionId: started.sessionId })
-              .pipe(Effect.ignore, Effect.forkIn(runtimeScope));
-          }),
+          // Taken under the same gate `prompt` publishes its fiber under, so a
+          // cancel never lands in the gap between a prompt being sent and
+          // becoming interruptible. Whichever side takes the gate first wins:
+          // either this reads a fiber and interrupts it, or the prompt has not
+          // been sent yet and starts after the notification is already out.
+          dispatchGate.withPermit(
+            Effect.uninterruptible(
+              Effect.gen(function* () {
+                yield* Ref.update(cancellationGenerationRef, (generation) => generation + 1);
+                // Written before the interrupt. Interrupting first releases the
+                // serialization semaphore at once, and the queued prompt behind
+                // it would reach the agent ahead of this notification and absorb
+                // a cancellation meant for its predecessor.
+                //
+                // Bounded rather than forked: forking reintroduces exactly the
+                // ordering this exists to prevent, and a wedged transport must
+                // not hold the gate forever.
+                yield* acp.agent
+                  .cancel({ sessionId: started.sessionId })
+                  .pipe(Effect.ignore, Effect.timeoutOption(CANCEL_NOTIFICATION_WRITE_TIMEOUT_MS));
+                const activePromptFiber = yield* Ref.get(activePromptFiberRef);
+                if (Option.isSome(activePromptFiber)) {
+                  yield* Fiber.interrupt(activePromptFiber.value).pipe(Effect.ignore);
+                }
+              }),
+            ),
+          ),
         ),
       ),
       setMode: (modeId) =>

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildAntigravityAcpSpawnInput,
+  parseAntigravityModelList,
+  resolveAntigravityBaseModelId,
+} from "./AntigravityAcpSupport.ts";
+import {
+  formatAntigravityModelName,
+  groupAntigravityModels,
+} from "../Layers/AntigravityProvider.ts";
+
+describe("parseAntigravityModelList", () => {
+  it("parses the one-slug-per-line output of `agy models`", () => {
+    const models = parseAntigravityModelList(
+      "gemini-3.6-flash-high\ngemini-3.1-pro-high\nclaude-sonnet-4-6\n",
+    );
+
+    expect(models).toEqual(["gemini-3.6-flash-high", "gemini-3.1-pro-high", "claude-sonnet-4-6"]);
+  });
+
+  it("drops blank lines, duplicates, and prose", () => {
+    const models = parseAntigravityModelList(
+      "\ngemini-3.1-pro-high\n\ngemini-3.1-pro-high\nAvailable agents:\n  gpt-oss-120b-medium  \n",
+    );
+
+    expect(models).toEqual(["gemini-3.1-pro-high", "gpt-oss-120b-medium"]);
+  });
+});
+
+describe("resolveAntigravityBaseModelId", () => {
+  it("resolves a bare family name to a concrete reasoning tier", () => {
+    expect(resolveAntigravityBaseModelId("gemini-3.1-pro")).toBe("gemini-3.1-pro-high");
+    expect(resolveAntigravityBaseModelId("flash")).toBe("gemini-3.6-flash-medium");
+  });
+
+  it("passes through a slug that already names a tier", () => {
+    expect(resolveAntigravityBaseModelId("gemini-3.6-flash-low")).toBe("gemini-3.6-flash-low");
+  });
+
+  it("falls back to the default when nothing is selected", () => {
+    expect(resolveAntigravityBaseModelId(undefined)).toBe("gemini-3.1-pro-high");
+    expect(resolveAntigravityBaseModelId("  ")).toBe("gemini-3.1-pro-high");
+  });
+});
+
+describe("buildAntigravityAcpSpawnInput", () => {
+  it("spawns this server binary's bridge subcommand rather than agy directly", () => {
+    const spawn = buildAntigravityAcpSpawnInput({
+      antigravitySettings: null,
+      cwd: "/repo",
+    });
+
+    expect(spawn.command).toBe(process.execPath);
+    expect(spawn.args.at(-1)).toBe("agy-acp");
+    expect(spawn.cwd).toBe("/repo");
+  });
+
+  it("passes per-turn configuration to the bridge through the environment", () => {
+    const spawn = buildAntigravityAcpSpawnInput({
+      antigravitySettings: {
+        binaryPath: "/opt/agy",
+        printTimeout: "30m",
+        appDataDir: "/data/agy",
+      } as never,
+      cwd: "/repo",
+      model: "gemini-3.1-pro-high",
+      effort: "high",
+    });
+
+    expect(spawn.env).toMatchObject({
+      T3_AGY_COMMAND: "/opt/agy",
+      T3_AGY_PRINT_TIMEOUT: "30m",
+      T3_AGY_APP_DATA_DIR: "/data/agy",
+      T3_AGY_MODEL: "gemini-3.1-pro-high",
+      T3_AGY_EFFORT: "high",
+    });
+  });
+
+  it("omits unset settings so the bridge keeps its own defaults", () => {
+    const spawn = buildAntigravityAcpSpawnInput({
+      antigravitySettings: { binaryPath: "", printTimeout: "", appDataDir: "" } as never,
+      cwd: "/repo",
+    });
+
+    expect(spawn.env).not.toHaveProperty("T3_AGY_COMMAND");
+    expect(spawn.env).not.toHaveProperty("T3_AGY_PRINT_TIMEOUT");
+    expect(spawn.env).not.toHaveProperty("T3_AGY_MODEL");
+  });
+});
+
+describe("formatAntigravityModelName", () => {
+  it("formats base model name cleanly", () => {
+    expect(formatAntigravityModelName("gemini-3.1-pro-high")).toBe("Gemini 3.1 Pro");
+    expect(formatAntigravityModelName("gemini-3.6-flash-low")).toBe("Gemini 3.6 Flash");
+  });
+
+  it("leaves a slug with no tier suffix alone", () => {
+    expect(formatAntigravityModelName("claude-sonnet-4-6")).toBe("Claude Sonnet 4 6");
+  });
+
+  it("keeps vendor initialisms uppercase", () => {
+    expect(formatAntigravityModelName("gpt-oss-120b-medium")).toBe("GPT OSS 120b");
+  });
+});
+
+describe("groupAntigravityModels", () => {
+  it("groups raw model slugs into base models with dynamic reasoning capabilities", () => {
+    const raw = [
+      "gemini-3.6-flash-high",
+      "gemini-3.6-flash-medium",
+      "gemini-3.6-flash-low",
+      "claude-sonnet-4-6",
+    ];
+
+    const grouped = groupAntigravityModels(raw);
+    expect(grouped.length).toBe(2);
+
+    const flash = grouped.find((m) => m.name === "Gemini 3.6 Flash");
+    expect(flash).toBeDefined();
+    expect(flash?.slug).toBe("gemini-3.6-flash-high");
+    expect(flash?.capabilities?.optionDescriptors?.length).toBe(1);
+
+    const sonnet = grouped.find((m) => m.name === "Claude Sonnet 4 6");
+    expect(sonnet).toBeDefined();
+    expect(sonnet?.capabilities?.optionDescriptors?.length).toBe(0);
+  });
+});

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -1,0 +1,169 @@
+/**
+ * Spawn wiring for the Antigravity provider.
+ *
+ * Unlike Cursor and Grok — whose CLIs speak ACP natively — Antigravity has no
+ * agent protocol, so the "ACP agent" spawned here is T3 Code's own bridge
+ * (`t3 agy-acp`, see `antigravity/agyBridge.ts`). Running it as a subcommand of
+ * this same binary means the bridge always ships and versions with the server.
+ *
+ * @module provider/acp/AntigravityAcpSupport
+ */
+import { type AntigravitySettings, ProviderDriverKind } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as EffectAcpErrors from "effect-acp/errors";
+
+import { normalizeModelSlug } from "@t3tools/shared/model";
+
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
+
+const ANTIGRAVITY_DRIVER_KIND = ProviderDriverKind.make("antigravity");
+
+/** Antigravity manages its own Google sign-in, so there is nothing to select. */
+const ANTIGRAVITY_AUTH_METHOD = "none";
+
+export const DEFAULT_ANTIGRAVITY_MODEL = "gemini-3.1-pro-high";
+
+type AntigravityAcpRuntimeSettings = Pick<
+  AntigravitySettings,
+  "binaryPath" | "printTimeout" | "appDataDir" | "requireToolApproval"
+>;
+
+interface AntigravityAcpRuntimeInput extends Omit<
+  AcpSessionRuntime.AcpSessionRuntimeOptions,
+  "authMethodId" | "clientCapabilities" | "spawn"
+> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly antigravitySettings: AntigravityAcpRuntimeSettings | null | undefined;
+  readonly environment?: NodeJS.ProcessEnv;
+  /** Model the bridge should pass to `agy --model` for this session. */
+  readonly model?: string | undefined;
+  /** Reasoning effort for `agy --effort`. */
+  readonly effort?: string | undefined;
+  /** Interaction mode for `agy --mode`. */
+  readonly mode?: string | undefined;
+  /** System prompt / instructions for the session. */
+  readonly systemPrompt?: string | undefined;
+}
+
+/**
+ * Resolve how to re-invoke this server binary.
+ *
+ * Under `node src/bin.ts` the entry script must be passed explicitly; a packed
+ * single-file build is itself the executable.
+ */
+export function resolveBridgeCommand(environment?: NodeJS.ProcessEnv): {
+  command: string;
+  args: ReadonlyArray<string>;
+} {
+  const customBridge =
+    environment?.["T3_AGY_BRIDGE_COMMAND"] ?? process.env["T3_AGY_BRIDGE_COMMAND"];
+  if (customBridge?.trim()) {
+    return { command: process.execPath, args: [customBridge.trim()] };
+  }
+  const entry = process.argv[1];
+  return entry
+    ? { command: process.execPath, args: [entry, "agy-acp"] }
+    : { command: process.execPath, args: ["agy-acp"] };
+}
+
+export function buildAntigravityAcpSpawnInput(input: {
+  readonly antigravitySettings: AntigravityAcpRuntimeSettings | null | undefined;
+  readonly cwd: string;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly model?: string | undefined;
+  readonly effort?: string | undefined;
+  readonly mode?: string | undefined;
+  readonly systemPrompt?: string | undefined;
+}): AcpSessionRuntime.AcpSpawnInput {
+  const { command, args } = resolveBridgeCommand(input.environment);
+  const settings = input.antigravitySettings;
+  // The bridge reads its per-turn configuration from the environment so that
+  // `agy` invocation details stay entirely inside the bridge process.
+  const env: NodeJS.ProcessEnv = { ...input.environment };
+  if (settings?.binaryPath?.trim()) {
+    env["T3_AGY_COMMAND"] = settings.binaryPath.trim();
+  }
+  if (settings?.printTimeout?.trim()) {
+    env["T3_AGY_PRINT_TIMEOUT"] = settings.printTimeout.trim();
+  }
+  if (settings?.appDataDir?.trim()) {
+    env["T3_AGY_APP_DATA_DIR"] = settings.appDataDir.trim();
+  }
+  if (settings?.requireToolApproval) {
+    env["T3_AGY_REQUIRE_APPROVAL"] = "1";
+  }
+  if (input.model?.trim()) {
+    env["T3_AGY_MODEL"] = input.model.trim();
+  }
+  if (input.effort?.trim()) {
+    env["T3_AGY_EFFORT"] = input.effort.trim();
+  }
+  if (input.mode?.trim()) {
+    env["T3_AGY_MODE"] = input.mode.trim();
+  }
+  if (input.systemPrompt?.trim()) {
+    env["T3_AGY_SYSTEM_PROMPT"] = input.systemPrompt.trim();
+  }
+  env["T3_AGY_FAST_START"] = "1";
+
+  return { command, args: [...args], cwd: input.cwd, env };
+}
+
+export const makeAntigravityAcpRuntime = (
+  input: AntigravityAcpRuntimeInput,
+): Effect.Effect<
+  AcpSessionRuntime.AcpSessionRuntime["Service"],
+  EffectAcpErrors.AcpError,
+  Crypto.Crypto | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer({
+        ...input,
+        spawn: buildAntigravityAcpSpawnInput({
+          antigravitySettings: input.antigravitySettings,
+          cwd: input.cwd,
+          ...(input.environment ? { environment: input.environment } : {}),
+          ...(input.model ? { model: input.model } : {}),
+          ...(input.effort ? { effort: input.effort } : {}),
+          ...(input.mode ? { mode: input.mode } : {}),
+          ...(input.systemPrompt ? { systemPrompt: input.systemPrompt } : {}),
+        }),
+        authMethodId: ANTIGRAVITY_AUTH_METHOD,
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    return yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(
+      Effect.provide(acpContext),
+    );
+  });
+
+export function resolveAntigravityBaseModelId(model: string | null | undefined): string {
+  const trimmed = model?.trim();
+  const base = trimmed && trimmed.length > 0 ? trimmed : DEFAULT_ANTIGRAVITY_MODEL;
+  return normalizeModelSlug(base, ANTIGRAVITY_DRIVER_KIND) ?? DEFAULT_ANTIGRAVITY_MODEL;
+}
+
+/**
+ * Parse `agy models` output.
+ *
+ * The command prints one slug per line with no header or decoration.
+ */
+export function parseAntigravityModelList(output: string): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  for (const line of output.split("\n")) {
+    const slug = line.trim();
+    if (slug.length === 0 || slug.includes(" ")) {
+      continue;
+    }
+    seen.add(slug);
+  }
+  return [...seen];
+}

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -43,10 +43,6 @@ interface AntigravityAcpRuntimeInput extends Omit<
   readonly model?: string | undefined;
   /** Reasoning effort for `agy --effort`. */
   readonly effort?: string | undefined;
-  /** Interaction mode for `agy --mode`. */
-  readonly mode?: string | undefined;
-  /** System prompt / instructions for the session. */
-  readonly systemPrompt?: string | undefined;
 }
 
 /**
@@ -55,15 +51,7 @@ interface AntigravityAcpRuntimeInput extends Omit<
  * Under `node src/bin.ts` the entry script must be passed explicitly; a packed
  * single-file build is itself the executable.
  */
-export function resolveBridgeCommand(environment?: NodeJS.ProcessEnv): {
-  command: string;
-  args: ReadonlyArray<string>;
-} {
-  const customBridge =
-    environment?.["T3_AGY_BRIDGE_COMMAND"] ?? process.env["T3_AGY_BRIDGE_COMMAND"];
-  if (customBridge?.trim()) {
-    return { command: process.execPath, args: [customBridge.trim()] };
-  }
+export function resolveBridgeCommand(): { command: string; args: ReadonlyArray<string> } {
   const entry = process.argv[1];
   return entry
     ? { command: process.execPath, args: [entry, "agy-acp"] }
@@ -76,10 +64,8 @@ export function buildAntigravityAcpSpawnInput(input: {
   readonly environment?: NodeJS.ProcessEnv;
   readonly model?: string | undefined;
   readonly effort?: string | undefined;
-  readonly mode?: string | undefined;
-  readonly systemPrompt?: string | undefined;
 }): AcpSessionRuntime.AcpSpawnInput {
-  const { command, args } = resolveBridgeCommand(input.environment);
+  const { command, args } = resolveBridgeCommand();
   const settings = input.antigravitySettings;
   // The bridge reads its per-turn configuration from the environment so that
   // `agy` invocation details stay entirely inside the bridge process.
@@ -102,13 +88,6 @@ export function buildAntigravityAcpSpawnInput(input: {
   if (input.effort?.trim()) {
     env["T3_AGY_EFFORT"] = input.effort.trim();
   }
-  if (input.mode?.trim()) {
-    env["T3_AGY_MODE"] = input.mode.trim();
-  }
-  if (input.systemPrompt?.trim()) {
-    env["T3_AGY_SYSTEM_PROMPT"] = input.systemPrompt.trim();
-  }
-  env["T3_AGY_FAST_START"] = "1";
 
   return { command, args: [...args], cwd: input.cwd, env };
 }
@@ -130,8 +109,6 @@ export const makeAntigravityAcpRuntime = (
           ...(input.environment ? { environment: input.environment } : {}),
           ...(input.model ? { model: input.model } : {}),
           ...(input.effort ? { effort: input.effort } : {}),
-          ...(input.mode ? { mode: input.mode } : {}),
-          ...(input.systemPrompt ? { systemPrompt: input.systemPrompt } : {}),
         }),
         authMethodId: ANTIGRAVITY_AUTH_METHOD,
       }).pipe(

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -120,19 +120,21 @@ function transcriptDirFor(conversationId: string): string {
  * output as live. Returns 0 when the file cannot be measured, which falls back
  * to the marker heuristic rather than skipping the turn's own output.
  */
-function transcriptBaseline(conversationId: string | undefined): number {
-  if (!conversationId) {
-    return 0;
-  }
+interface TranscriptBaselines {
+  readonly transcript: number;
+  readonly transcriptFull: number;
+}
+function transcriptBaselines(conversationId: string | undefined): TranscriptBaselines {
+  const result = { transcript: 0, transcriptFull: 0 };
+  if (!conversationId) return result;
   const dir = transcriptDirFor(conversationId);
-  for (const name of ["transcript.jsonl", "transcript_full.jsonl"]) {
-    try {
-      return NodeFS.statSync(NodePath.join(dir, name)).size;
-    } catch {
-      // Try the sibling, then give up.
-    }
-  }
-  return 0;
+  try {
+    result.transcript = NodeFS.statSync(NodePath.join(dir, "transcript.jsonl")).size;
+  } catch {}
+  try {
+    result.transcriptFull = NodeFS.statSync(NodePath.join(dir, "transcript_full.jsonl")).size;
+  } catch {}
+  return result;
 }
 
 function stateDirPath(): string {
@@ -242,11 +244,21 @@ function sendRequest(method: string, params: unknown, timeoutMs?: number): Promi
   const id = nextOutboundId;
   nextOutboundId += 1;
   return new Promise((resolve, reject) => {
-    pendingOutbound.set(id, { resolve, reject });
+    let timer: NodeJS.Timeout | undefined;
+    pendingOutbound.set(id, {
+      resolve: (value) => {
+        if (timer) clearTimeout(timer);
+        resolve(value);
+      },
+      reject: (error) => {
+        if (timer) clearTimeout(timer);
+        reject(error);
+      },
+    });
     if (timeoutMs !== undefined) {
       // A client that never answers would otherwise pin this entry for the
       // life of the bridge process.
-      const timer = setTimeout(() => {
+      timer = setTimeout(() => {
         if (pendingOutbound.delete(id)) {
           reject(new Error(`${method} timed out`));
         }
@@ -822,6 +834,7 @@ function drain(input: {
   readonly state: AgyTurnState;
   readonly cursor: AgyTranscriptCursor;
   readonly decoder: NodeStringDecoder.StringDecoder;
+  readonly transcriptBaselines: TranscriptBaselines;
   readonly transcriptOffset: { value: number };
   readonly assistantText: { emitted: boolean };
   readonly final: boolean;
@@ -871,6 +884,11 @@ function drain(input: {
 
   const transcriptPath = resolveTranscriptPath(input.state);
   if (transcriptPath) {
+    if (input.transcriptOffset.value === -1) {
+      input.transcriptOffset.value = transcriptPath.endsWith("transcript_full.jsonl")
+        ? input.transcriptBaselines.transcriptFull
+        : input.transcriptBaselines.transcript;
+    }
     let chunk = "";
     try {
       const stats = NodeFS.statSync(transcriptPath);
@@ -990,7 +1008,7 @@ async function runTurn(
   activeTurnSessionId = sessionId;
   // Measured before `agy` starts: whatever the transcript already holds
   // belongs to earlier turns of the conversation being resumed.
-  const baseline = transcriptBaseline(session.conversationId);
+  const baselines = transcriptBaselines(session.conversationId);
   let hookDir: string | undefined;
   let hookWorkspace: string | undefined;
   let attachmentDir: string | undefined;
@@ -1000,7 +1018,8 @@ async function runTurn(
     hookWorkspace = createHookWorkspace();
     const attachments = stageAttachments(prompt.attachments);
     attachmentDir = attachments.dir;
-    const command = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
+    const rawCommand = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
+    const { command, shell } = resolveAgyCommand(rawCommand);
     child = NodeChildProcess.spawn(
       command,
       buildAgyArgs({
@@ -1013,6 +1032,7 @@ async function runTurn(
         cwd: session.cwd,
         env: { ...process.env, [HOOK_DIR_ENV]: hookDir },
         stdio: ["ignore", "pipe", "pipe"],
+        shell,
       },
     );
   } catch (error) {
@@ -1029,8 +1049,8 @@ async function runTurn(
   const seenHooks = new Set<string>();
   const cursor = new AgyTranscriptCursor();
   const decoder = new NodeStringDecoder.StringDecoder("utf8");
-  const transcriptOffset = { value: baseline };
-  if (baseline > 0) {
+  const transcriptOffset = { value: -1 };
+  if (baselines.transcript > 0 || baselines.transcriptFull > 0) {
     // Reading starts past every earlier turn, so there is no prior-turn
     // content left for the `USER_INPUT` heuristic to guess at.
     state.transcriptPrimed = true;
@@ -1061,6 +1081,7 @@ async function runTurn(
       state,
       cursor,
       decoder,
+      transcriptBaselines: baselines,
       transcriptOffset,
       assistantText,
       final: false,
@@ -1082,6 +1103,7 @@ async function runTurn(
     state,
     cursor,
     decoder,
+    transcriptBaselines: baselines,
     transcriptOffset,
     assistantText,
     final: true,

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -14,6 +14,9 @@
  */
 // @effect-diagnostics nodeBuiltinImport:off - Standalone stdio bridge process, not an Effect runtime.
 // @effect-diagnostics globalTimers:off - Polls Antigravity hook output outside any Effect runtime.
+// @effect-diagnostics globalDate:off - Approval deadlines are measured in the hook subprocess, which has no Clock.
+/* eslint-disable t3code/no-global-process-runtime -- Standalone process: there
+   is no Effect runtime here to inject HostProcessPlatform from. */
 import * as NodeChildProcess from "node:child_process";
 import * as NodeCrypto from "node:crypto";
 import * as NodeFS from "node:fs";
@@ -35,20 +38,22 @@ import {
   agyToolTitle,
   hookSessionUpdate,
   makeAgyTurnState,
+  orderAgySessionUpdates,
   type AgyHookDecision,
   type AgyHookEvent,
   type AgyHookPayload,
+  type AgyOrderedSessionUpdate,
   type AgySessionUpdate,
   type AgyTurnState,
 } from "./agyEvents.ts";
 import {
   AgyTranscriptCursor,
   dropPriorTurnRecords,
+  MAX_TRANSCRIPT_LINE_CHARS,
   parseTranscriptLine,
+  serializedTranscriptRecordSize,
   transcriptRecordUpdates,
 } from "./agyTranscript.ts";
-
-
 
 const HOOK_DIR_ENV = "T3_AGY_HOOK_DIR";
 const REQUIRE_APPROVAL_ENV = "T3_AGY_REQUIRE_APPROVAL";
@@ -62,7 +67,52 @@ const DECISION_SUFFIX = ".decision";
 const APPROVAL_WAIT_MS = 10 * 60 * 1000;
 const APPROVAL_HOOK_TIMEOUT_SECONDS = 11 * 60;
 const APPROVAL_POLL_INTERVAL_MS = 50;
+/** Grace period before a cancelled process group is killed outright. */
+const KILL_ESCALATION_MS = 5_000;
+/** Backstop when a child reports `error` but never follows it with `close`. */
+const CHILD_ERROR_CLOSE_GRACE_MS = KILL_ESCALATION_MS + 1_000;
+/** Secret shared with hook processes so a decision cannot be forged. */
+const HOOK_SECRET_ENV = "T3_AGY_HOOK_SECRET";
 const HOOK_POLL_INTERVAL_MS = 50;
+/** Total finalization time allowed for stdout to recover from backpressure. */
+const STDOUT_DRAIN_GRACE_MS = 1_000;
+/**
+ * Drains a transcript record waits for the hook that would announce its tool
+ * call. Twenty polls is a second — long enough for a hook that is merely late,
+ * short enough that a step no hook will ever cover does not stall the stream.
+ */
+const MAX_DEFERRED_DRAINS = 20;
+
+/**
+ * Aggregate ceiling on records held waiting for a tool call to be announced.
+ *
+ * `MAX_DEFERRED_DRAINS` expires the head of the queue, which is enough when
+ * unmatched records are occasional. It is not enough when they arrive faster
+ * than one per drain, which is what a transcript full of internal planner steps
+ * looks like — hence a cap on the queue as a whole.
+ */
+const MAX_DEFERRED_RECORDS = 512;
+const MAX_DEFERRED_CHARS = 8 * 1024 * 1024;
+/**
+ * Cap on the `agy` output held in memory per stream. Only the tail is kept:
+ * stdout is a fallback used when the transcript streamed nothing, and stderr
+ * only needs to explain a failure.
+ */
+const MAX_CAPTURED_OUTPUT = 256 * 1024;
+
+/**
+ * Ceiling on one transcript read. Keeps a single poll from allocating a buffer
+ * the size of whatever a tool just wrote; the rest is read by the next poll.
+ */
+const MAX_TRANSCRIPT_READ_BYTES = 1024 * 1024;
+
+/**
+ * Backstop on how many extra passes the final drain will make to consume a
+ * transcript tail larger than one read. Set far above any real transcript —
+ * this exists so a file being appended to faster than it is read cannot spin
+ * the exit path forever, not to bound normal output.
+ */
+const MAX_FINAL_DRAIN_PASSES = 512;
 const DEFAULT_PRINT_TIMEOUT = "2h";
 const HOOKS_KEY = "t3code-antigravity-observer";
 
@@ -112,21 +162,27 @@ function transcriptDirFor(conversationId: string): string {
  * output as live. Returns 0 when the file cannot be measured, which falls back
  * to the marker heuristic rather than skipping the turn's own output.
  */
-interface TranscriptBaselines {
-  readonly transcript: number;
-  readonly transcriptFull: number;
-}
-function transcriptBaselines(conversationId: string | undefined): TranscriptBaselines {
-  const result = { transcript: 0, transcriptFull: 0 };
-  if (!conversationId) return result;
+function transcriptBaseline(
+  conversationId: string | undefined,
+): { readonly path: string; readonly size: number } | undefined {
+  if (!conversationId) {
+    return undefined;
+  }
+  // Path and size come from one measurement and are used together. Deciding
+  // the file twice would let the condensed transcript appear between the two
+  // and apply an offset taken from `transcript_full.jsonl` to a different
+  // file — which, if it exceeded that file's size, reads nothing at all.
   const dir = transcriptDirFor(conversationId);
-  try {
-    result.transcript = NodeFS.statSync(NodePath.join(dir, "transcript.jsonl")).size;
-  } catch {}
-  try {
-    result.transcriptFull = NodeFS.statSync(NodePath.join(dir, "transcript_full.jsonl")).size;
-  } catch {}
-  return result;
+  const condensed = NodePath.join(dir, "transcript.jsonl");
+  const full = NodePath.join(dir, "transcript_full.jsonl");
+  for (const path of [condensed, full]) {
+    try {
+      return { path, size: NodeFS.statSync(path).size };
+    } catch {
+      // Try the sibling, then report nothing measurable.
+    }
+  }
+  return undefined;
 }
 
 function stateDirPath(): string {
@@ -201,8 +257,55 @@ function lookupConversationId(sessionId: string): string | undefined {
 
 // ── JSON-RPC plumbing ─────────────────────────────────────────────────
 
+/**
+ * Set while stdout has reported that it is behind.
+ *
+ * Node buffers whatever `write` cannot hand over immediately, so ignoring its
+ * return value turns a slow reader into unbounded growth inside this process.
+ * Polling pauses while this is set. Nothing is lost by waiting: the transcript
+ * stays on disk and is read from its own byte offset, so a skipped poll only
+ * defers work to the next one.
+ */
+let stdoutBlocked = false;
+
 function writeMessage(value: unknown): void {
-  process.stdout.write(`${JSON.stringify(value)}\n`);
+  const flushed = process.stdout.write(`${JSON.stringify(value)}\n`);
+  if (!flushed && !stdoutBlocked) {
+    stdoutBlocked = true;
+    process.stdout.once("drain", () => {
+      stdoutBlocked = false;
+    });
+  }
+}
+
+/**
+ * Wait for stdout to accept more data, but never past the finalization budget.
+ *
+ * `writeMessage` remains synchronous: this wait is used only by async turn
+ * finalization between transcript drain passes. Its own listener continues to
+ * clear `stdoutBlocked`, including when no turn is currently waiting here.
+ */
+function waitForStdoutDrain(deadline: number): Promise<boolean> {
+  if (!stdoutBlocked) {
+    return Promise.resolve(false);
+  }
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    return Promise.resolve(stdoutBlocked);
+  }
+  return new Promise((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (timedOut: boolean) => {
+      process.stdout.off("drain", onDrain);
+      if (timer) {
+        clearTimeout(timer);
+      }
+      resolve(timedOut);
+    };
+    const onDrain = () => finish(false);
+    process.stdout.once("drain", onDrain);
+    timer = setTimeout(() => finish(stdoutBlocked), remaining);
+  });
 }
 
 function sendResult(id: unknown, result: unknown): void {
@@ -229,33 +332,36 @@ function sendSessionUpdate(sessionId: string, update: AgySessionUpdate): void {
 let nextOutboundId = 1;
 const pendingOutbound = new Map<
   number,
-  { readonly resolve: (value: unknown) => void; readonly reject: (error: Error) => void }
+  {
+    readonly resolve: (value: unknown) => void;
+    readonly reject: (error: Error) => void;
+    /** Deadline for this request; cleared when it settles. */
+    timer?: ReturnType<typeof setTimeout>;
+  }
 >();
 
 function sendRequest(method: string, params: unknown, timeoutMs?: number): Promise<unknown> {
   const id = nextOutboundId;
   nextOutboundId += 1;
   return new Promise((resolve, reject) => {
-    let timer: NodeJS.Timeout | undefined;
-    pendingOutbound.set(id, {
-      resolve: (value) => {
-        if (timer) clearTimeout(timer);
-        resolve(value);
-      },
-      reject: (error) => {
-        if (timer) clearTimeout(timer);
-        reject(error);
-      },
-    });
+    const pending: {
+      readonly resolve: (value: unknown) => void;
+      readonly reject: (error: Error) => void;
+      timer?: ReturnType<typeof setTimeout>;
+    } = { resolve, reject };
+    pendingOutbound.set(id, pending);
     if (timeoutMs !== undefined) {
       // A client that never answers would otherwise pin this entry for the
-      // life of the bridge process.
-      timer = setTimeout(() => {
+      // life of the bridge process. Held on the entry so an answered request
+      // can drop it — `unref` keeps the timer from holding the loop open but
+      // still retains the closure until it fires.
+      const timer = setTimeout(() => {
         if (pendingOutbound.delete(id)) {
           reject(new Error(`${method} timed out`));
         }
       }, timeoutMs);
       timer.unref?.();
+      pending.timer = timer;
     }
     writeMessage({ jsonrpc: "2.0", id, method, params });
   });
@@ -275,6 +381,9 @@ function resolveOutbound(message: Record<string, unknown>): boolean {
   if (!pending) {
     return false;
   }
+  if (pending.timer) {
+    clearTimeout(pending.timer);
+  }
   const error = message["error"];
   if (isRecord(error)) {
     const detail = typeof error["message"] === "string" ? error["message"] : "request failed";
@@ -288,6 +397,9 @@ function resolveOutbound(message: Record<string, unknown>): boolean {
 /** Reject everything still outstanding; used when the client goes away. */
 function failPendingOutbound(reason: string): void {
   for (const [, pending] of pendingOutbound) {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
     pending.reject(new Error(reason));
   }
   pendingOutbound.clear();
@@ -377,7 +489,40 @@ function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<Obser
       const raw = NodeFS.readFileSync(NodePath.join(hookDir, name), "utf8");
       const parsed: unknown = JSON.parse(raw);
       if (typeof parsed === "object" && parsed !== null) {
-        events.push({ name, event: parsed as AgyHookEvent });
+        const record = parsed as AgyHookEvent;
+        // The signed digest and the payload shown to the user must come from
+        // the same bytes. Taking the outer `payload` for display while signing
+        // `rawPayload` would let an attacker rewrite only the outer copy: the
+        // user approves harmless-looking arguments, the hook's digest still
+        // matches its untouched stdin, and the original request runs.
+        const raw = record.rawPayload;
+        if (typeof raw !== "string") {
+          continue;
+        }
+        let payload: AgyHookPayload;
+        try {
+          const reparsed: unknown = JSON.parse(raw);
+          if (typeof reparsed !== "object" || reparsed === null) {
+            continue;
+          }
+          payload = reparsed as AgyHookPayload;
+        } catch {
+          continue;
+        }
+        hookPayloadDigests.set(name, digestPayload(raw));
+        events.push({ name, event: { ...record, payload } });
+        // Reclaimed as soon as its contents are in memory. An edit hook carries
+        // the file it is about to change, up to `MAX_CAPTURED_FILE_BYTES` each,
+        // and the directory only went away at the end of the turn — so a long
+        // turn editing large files held every version of every one of them on
+        // disk at once. The waiting hook never reads this file back; it polls
+        // for its `.decision` sibling, which is written separately.
+        try {
+          NodeFS.unlinkSync(NodePath.join(hookDir, name));
+        } catch {
+          // Losing the reclaim is not worth failing the hook over; the whole
+          // directory is removed when the turn ends.
+        }
       }
     } catch {
       // A half-written hook file is picked up on the next poll.
@@ -388,6 +533,22 @@ function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<Obser
 }
 
 // ── Tool approval ─────────────────────────────────────────────────────
+
+/**
+ * Identity for one `runTurn`, used to bound the lifetime of its approvals.
+ *
+ * A cancel generation alone is not enough: a hook file first read after the
+ * turn ended has no earlier generation to compare against, and a decision
+ * banked from a dead turn must not carry into the next one.
+ */
+interface TurnToken {
+  readonly sessionId: string;
+  live: boolean;
+}
+
+function turnTokenLive(token: TurnToken): boolean {
+  return token.live && !cancelledSessions.has(token.sessionId);
+}
 
 const APPROVE_OPTION = "allow";
 const APPROVE_SESSION_OPTION = "allow-session";
@@ -409,11 +570,56 @@ function decisionPath(hookDir: string, hookName: string): string {
   return NodePath.join(hookDir, `${hookName}${DECISION_SUFFIX}`);
 }
 
+/**
+ * Authenticate a decision so only this bridge can issue one.
+ *
+ * The decision is a file in a temp directory, and anything running as the user
+ * — including a tool the user has just approved — could otherwise drop an
+ * `allow` there and have every later tool wave itself through. The secret is
+ * generated per bridge process and reaches the hook through its environment,
+ * so a forged file fails the check and is treated as no decision at all.
+ */
+function signDecision(
+  secret: string,
+  hookName: string,
+  decision: AgyHookDecision,
+  payloadDigest: string,
+): string {
+  // The payload digest is part of what is signed, so a decision cannot be
+  // lifted onto a different request. Without it, a watcher could swap a
+  // dangerous hook payload for a harmless one, let the user approve what they
+  // were shown, and have the signed answer authorise the original.
+  return NodeCrypto.createHmac("sha256", secret)
+    .update(`${hookName}:${decision.decision}:${payloadDigest}`)
+    .digest("hex");
+}
+
+function digestPayload(raw: string): string {
+  return NodeCrypto.createHash("sha256").update(raw).digest("hex");
+}
+
+/**
+ * Digest of each observed hook's raw payload, so a decision can be bound to the
+ * exact request the user was shown.
+ */
+const hookPayloadDigests = new Map<string, string>();
+
 function writeDecision(hookDir: string, hookName: string, decision: AgyHookDecision): void {
   try {
     const target = decisionPath(hookDir, hookName);
     const staging = `${target}.tmp`;
-    NodeFS.writeFileSync(staging, JSON.stringify(decision));
+    NodeFS.writeFileSync(
+      staging,
+      JSON.stringify({
+        ...decision,
+        mac: signDecision(
+          turnHookSecret,
+          hookName,
+          decision,
+          hookPayloadDigests.get(hookName) ?? "",
+        ),
+      }),
+    );
     NodeFS.renameSync(staging, target);
   } catch {
     // The waiting hook falls back to denying when its deadline passes, which
@@ -439,7 +645,18 @@ function requestToolApproval(input: {
   readonly hookDir: string;
   readonly hookName: string;
   readonly payload: AgyHookPayload;
+  /** The turn that asked. Approvals are only valid while it is still running. */
+  readonly turnToken: TurnToken;
 }): void {
+  // Checked before the session-wide fast path, not after: a hook first seen
+  // after a cancel would otherwise be waved through by a blanket approval.
+  if (!turnTokenLive(input.turnToken)) {
+    writeDecision(input.hookDir, input.hookName, {
+      decision: "deny",
+      reason: "Cancelled before this tool was approved",
+    });
+    return;
+  }
   // Already approved for the whole session: answer without troubling the user.
   if (sessionWideApprovals.has(input.sessionId)) {
     writeDecision(input.hookDir, input.hookName, { decision: "allow" });
@@ -447,6 +664,7 @@ function requestToolApproval(input: {
   }
   const toolCall = input.payload.toolCall;
   const stepIdx = typeof input.payload.stepIdx === "number" ? input.payload.stepIdx : 0;
+
   void sendRequest(
     "session/request_permission",
     {
@@ -472,7 +690,16 @@ function requestToolApproval(input: {
     APPROVAL_WAIT_MS,
   )
     .then((result) => {
-      const decision = approvalOutcomeToDecision(result, [APPROVE_OPTION, APPROVE_SESSION_OPTION]);
+      // Re-checked at the moment of answering: the turn may have ended or been
+      // cancelled while the user was deciding.
+      const decision = !turnTokenLive(input.turnToken)
+        ? ({
+            decision: "deny",
+            reason: "Cancelled before this tool was approved",
+          } satisfies AgyHookDecision)
+        : approvalOutcomeToDecision(result, [APPROVE_OPTION, APPROVE_SESSION_OPTION]);
+      // Only recorded for a still-live turn. A blanket approval banked from a
+      // turn that has already ended would silently pre-approve the next one.
       if (decision.decision === "allow" && selectedOptionId(result) === APPROVE_SESSION_OPTION) {
         sessionWideApprovals.add(input.sessionId);
       }
@@ -529,6 +756,7 @@ export async function runAgyHook(event: string): Promise<void> {
       const record: AgyHookEvent = {
         event,
         payload,
+        rawPayload: raw,
         // Snapshot the file here, while the hook still brackets the tool call.
         ...(agyToolKind(payload?.toolCall?.name) === "edit"
           ? { capturedFileText: captureFileText(agyTargetPath(payload?.toolCall)) }
@@ -549,7 +777,7 @@ export async function runAgyHook(event: string): Promise<void> {
         // fall through to the observation-only response, which allows — so a
         // change in Antigravity's payload shape would have run tools unapproved.
         const decision = payload?.toolCall
-          ? await awaitDecision(hookDir, name)
+          ? await awaitDecision(hookDir, name, digestPayload(raw))
           : ({
               decision: "deny",
               reason: "T3 Code could not identify this tool call for approval",
@@ -581,7 +809,11 @@ export async function runAgyHook(event: string): Promise<void> {
  * Fails closed: if the bridge dies, the client never answers, or the deadline
  * passes, the tool is denied rather than quietly allowed.
  */
-async function awaitDecision(hookDir: string, hookName: string): Promise<AgyHookDecision> {
+async function awaitDecision(
+  hookDir: string,
+  hookName: string,
+  payloadDigest: string,
+): Promise<AgyHookDecision> {
   const target = decisionPath(hookDir, hookName);
   const deadline = Date.now() + APPROVAL_WAIT_MS;
   while (Date.now() < deadline) {
@@ -589,10 +821,36 @@ async function awaitDecision(hookDir: string, hookName: string): Promise<AgyHook
       const raw = NodeFS.readFileSync(target, "utf8");
       const parsed: unknown = JSON.parse(raw);
       if (isRecord(parsed) && (parsed["decision"] === "allow" || parsed["decision"] === "deny")) {
-        return parsed as unknown as AgyHookDecision;
+        const decision = { decision: parsed["decision"] } as AgyHookDecision;
+        const expected = signDecision(
+          process.env[HOOK_SECRET_ENV] ?? "",
+          hookName,
+          decision,
+          payloadDigest,
+        );
+        const presented = typeof parsed["mac"] === "string" ? parsed["mac"] : "";
+        // Length-checked before comparing: `timingSafeEqual` throws on a
+        // mismatch, and an unsigned file is a forgery either way.
+        if (
+          presented.length === expected.length &&
+          NodeCrypto.timingSafeEqual(Buffer.from(presented), Buffer.from(expected))
+        ) {
+          return {
+            decision: decision.decision,
+            ...(typeof parsed["reason"] === "string" ? { reason: parsed["reason"] } : {}),
+          };
+        }
+        // Unsigned or forged: ignore it and keep waiting, so a planted file
+        // cannot allow a tool and cannot short-circuit a real decision either.
       }
     } catch {
       // Not written yet, or written partially; try again.
+    }
+    if (!NodeFS.existsSync(hookDir)) {
+      // The turn is over and its directory reclaimed, so no decision can ever
+      // land here. Stop waiting rather than polling a path that will not come
+      // back.
+      return { decision: "deny", reason: "Antigravity turn ended before approval" };
     }
     await new Promise((resolve) => setTimeout(resolve, APPROVAL_POLL_INTERVAL_MS));
   }
@@ -791,33 +1049,233 @@ interface TurnOutcome {
   readonly failure?: string;
 }
 
+/**
+ * Secret authenticating this turn's approval decisions.
+ *
+ * Rotated per turn, not per process. The secret has to reach the hook, the hook
+ * is spawned by `agy`, and every tool `agy` runs inherits that environment — so
+ * an approved tool can always forge decisions for the turn it is part of.
+ * Rotating means it cannot forge for any later turn.
+ */
+let turnHookSecret = "";
+
 let activeChild: NodeChildProcess.ChildProcess | null = null;
+
+/**
+ * Stop the running turn's whole process group, escalating if it lingers.
+ *
+ * Signalling only the direct child leaves anything it spawned running: a tool
+ * mid-write keeps changing the workspace after the user pressed Stop, and its
+ * output can still arrive against a turn that has been reported cancelled.
+ */
+/**
+ * Children whose group has been signalled, so a fence and the cancel behind it
+ * do not arm two backstops for the same process.
+ */
+const pendingKills = new Map<
+  NodeChildProcess.ChildProcess,
+  { readonly pid: number; timer?: ReturnType<typeof setTimeout> }
+>();
+
+/**
+ * Signal a child's process group — but only while the child is alive.
+ *
+ * A group id is safe to use only while the leader still holds it. Once the
+ * leader has been reaped the number is free for reuse, and a signal sent then
+ * can land on whatever inherited it. Every call site is therefore guarded on
+ * the leader being alive, and nothing signals a group after its `exit` event.
+ *
+ * The cost is that a tool which deliberately outlives `agy` is not reaped. That
+ * is the same boundary the approval gate draws: code the user has already
+ * approved can do what it likes, including backgrounding itself.
+ */
+function signalGroupOf(
+  child: NodeChildProcess.ChildProcess,
+  pid: number,
+  signal: NodeJS.Signals,
+): void {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  if (process.platform === "win32") {
+    // No process groups; this walks the tree while the leader still anchors it.
+    try {
+      NodeChildProcess.execFileSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+    } catch {
+      try {
+        child.kill(signal);
+      } catch {
+        // Nothing left to signal.
+      }
+    }
+    return;
+  }
+  try {
+    // Negative pid targets the group, which `detached: true` gave the child.
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // Nothing left to signal.
+    }
+  }
+}
+
+function clearPendingKill(child: NodeChildProcess.ChildProcess): void {
+  const pending = pendingKills.get(child);
+  if (pending?.timer) {
+    clearTimeout(pending.timer);
+  }
+  pendingKills.delete(child);
+}
+
+/** Release tracking when a child ends, so nothing signals it afterwards. */
+function forgetChildOnExit(child: NodeChildProcess.ChildProcess): void {
+  child.once("exit", () => {
+    clearPendingKill(child);
+  });
+}
+
+/** Kill every group still being tracked. Used on shutdown. */
+function killPendingGroups(): void {
+  for (const [child, pending] of pendingKills) {
+    signalGroupOf(child, pending.pid, "SIGKILL");
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
+  }
+  pendingKills.clear();
+}
+
+function killActiveChild(options?: { readonly immediate?: boolean }): void {
+  const child = activeChild;
+  if (!child?.pid) {
+    return;
+  }
+  const { pid } = child;
+  // Windows goes through the same guarded helper. A `taskkill` here would run
+  // against a numeric pid with no liveness check, and `close` can lag `exit`
+  // long enough for Windows to have reused it.
+  if (options?.immediate) {
+    signalGroupOf(child, pid, "SIGKILL");
+    clearPendingKill(child);
+    return;
+  }
+  if (pendingKills.has(child)) {
+    // Already signalled — a fence and the cancel behind it both land here. A
+    // second timer would be another delayed signal nobody cancels.
+    return;
+  }
+  if (child.exitCode !== null || child.signalCode !== null) {
+    // Leader already gone: the spawn-time handler has this, or has run.
+    signalGroupOf(child, pid, "SIGKILL");
+    return;
+  }
+  signalGroupOf(child, pid, "SIGTERM");
+  const pending: { readonly pid: number; timer?: ReturnType<typeof setTimeout> } = { pid };
+  pendingKills.set(child, pending);
+  // The group is killed when the leader exits by the handler installed at
+  // spawn, so nothing needs attaching here.
+  //
+  // Backstop for a leader that ignores SIGTERM outright. Safe to target by
+  // group, because the leader is by definition still alive if this fires.
+  const escalation = setTimeout(() => {
+    if (pendingKills.get(child) === pending && child.exitCode === null) {
+      signalGroupOf(child, pid, "SIGKILL");
+    }
+    clearPendingKill(child);
+  }, KILL_ESCALATION_MS);
+  escalation.unref?.();
+  pending.timer = escalation;
+}
 /** Session whose turn is currently running, if any. Gates `session/cancel`. */
 let activeTurnSessionId: string | null = null;
+/**
+ * Set once stdin closes. Queued prompts decline instead of spawning: killing
+ * only the running child let the queue advance and start another `agy` after
+ * the client had gone, which then ran to the print timeout.
+ */
+let shuttingDown = false;
 const cancelledSessions = new Set<string>();
 /**
- * Cancels seen per session, counted rather than flagged.
+ * Highest cancelled epoch per session.
  *
- * A prompt records this value when it is queued. If the count has moved by the
- * time the prompt reaches the front, a cancel arrived while it waited and the
- * prompt must not run — turns are serialized, so a steer queued behind a long
- * turn would otherwise start executing tools after the user pressed Stop. A
- * counter rather than a flag is what keeps this from also swallowing a cancel
- * that lands harmlessly between two turns.
+ * Each submission carries the adapter's cancel epoch, and an interrupt names
+ * the epoch it is cancelling *through*. Everything at or below that is
+ * cancelled; anything accepted afterwards has a higher epoch and is untouched.
+ *
+ * This replaces a set of individual prompt ids. Keying by id needed the set to
+ * be bounded, and any eviction policy can drop a fence whose prompt has not
+ * arrived yet — which would let exactly the prompt being cancelled run. A
+ * single high-water mark per session cannot lose one and cannot grow.
  */
-const cancelGenerations = new Map<string, number>();
-/** Cancel generation captured when each queued prompt was accepted, by JSON-RPC id. */
-const queuedPromptGenerations = new Map<unknown, number>();
+const cancelledThroughEpoch = new Map<string, number>();
+/**
+ * Sessions whose next queued prompt has been cancelled without an epoch.
+ *
+ * Only for clients that do not send fences: without an epoch there is nothing
+ * to compare a queued prompt against, so a plain `session/cancel` for a
+ * session whose turn has not started yet would be dropped and its prompt would
+ * run afterwards. Consumed by the next prompt for that session.
+ */
+const unscopedCancels = new Set<string>();
 
-function cancelGeneration(sessionId: string): number {
-  return cancelGenerations.get(sessionId) ?? 0;
+function cancelledThrough(sessionId: string): number {
+  return cancelledThroughEpoch.get(sessionId) ?? -1;
 }
+
+/**
+ * Prompts accepted for a session but not yet handled, counting only those that
+ * carry no epoch. A tagged prompt is already covered by the session's mark and
+ * consumes no marker, so banking a cancel on its account would leave an entry
+ * that only some later untagged prompt could consume.
+ */
+const queuedUntaggedCounts = new Map<string, number>();
+
+function queuedUntagged(sessionId: string): number {
+  return queuedUntaggedCounts.get(sessionId) ?? 0;
+}
+
+/** The adapter's cancel epoch for a submission, carried in `_meta.t3.epoch`. */
+function promptEpochOf(params: Record<string, unknown>): number | undefined {
+  const meta = params["_meta"];
+  const t3 = isRecord(meta) ? meta["t3"] : undefined;
+  const epoch = isRecord(t3) ? t3["epoch"] : undefined;
+  return typeof epoch === "number" ? epoch : undefined;
+}
+/**
+ * Cancel epoch of the turn currently running, or undefined when its prompt
+ * carried no epoch. An untagged client is not using the extension, so it keeps
+ * plain `session/cancel` semantics rather than being scoped by a mark it never
+ * contributes to.
+ */
+let activeTurnEpoch: number | undefined;
+/**
+ * Temp directories the running turn owns.
+ *
+ * Tracked outside `runTurn` so a signal that ends the process can still remove
+ * them: `process.exit` skips the cleanup at the end of the turn, and these hold
+ * copies of the user's attachments and file contents captured around edits.
+ */
+const activeTurnTempDirs = new Set<string>();
+
+function cleanupActiveTurnTempDirs(): void {
+  for (const dir of activeTurnTempDirs) {
+    cleanupDir(dir);
+  }
+  activeTurnTempDirs.clear();
+}
+/** Token of that turn, retired when its epoch is cancelled. */
+let activeTurnToken: TurnToken | undefined;
 
 /**
  * Drain everything Antigravity has produced so far and emit it as ACP updates.
  *
- * Hooks are read first so a tool call is always announced before the
- * transcript record carrying its output is matched against it.
+ * Hooks are ingested first so transcript records can match tool calls, then
+ * both sources are emitted in Antigravity step order.
  */
 function drain(input: {
   readonly sessionId: string;
@@ -826,11 +1284,15 @@ function drain(input: {
   readonly state: AgyTurnState;
   readonly cursor: AgyTranscriptCursor;
   readonly decoder: NodeStringDecoder.StringDecoder;
-  readonly transcriptBaselines: TranscriptBaselines;
   readonly transcriptOffset: { value: number };
   readonly assistantText: { emitted: boolean };
+  readonly turnToken: TurnToken;
   readonly final: boolean;
-}): void {
+  /** Defaults to true; set false to run hook and terminal cleanup only. */
+  readonly readTranscript?: boolean;
+}): boolean {
+  const bufferedUpdates: Array<AgyOrderedSessionUpdate> = [];
+  const approvals: Array<{ readonly name: string; readonly payload: AgyHookPayload }> = [];
   for (const { name, event: hook } of readHookEvents(input.hookDir, input.seenHooks)) {
     // Diffing the file contents each hook captured, rather than the arguments
     // of the edit, keeps this correct across tools whose argument shapes
@@ -852,50 +1314,78 @@ function drain(input: {
         // since the transcript is read once by byte offset.
         input.state.pendingTerminal.set(stepIdx, update);
       } else {
-        sendSessionUpdate(input.sessionId, update);
+        bufferedUpdates.push({
+          stepIdx,
+          phase: hook.event === "pre-tool-use" ? "pre" : "terminal",
+          update,
+        });
       }
     }
     // The hook process is blocked until a decision file appears, so this has
     // to be started for every announced tool call.
-    // Not during the final drain: the child has already exited, so no tool is
-    // waiting on the answer and the request would never be settled.
-    if (
-      !input.final &&
-      approvalRequired() &&
-      hook.event === "pre-tool-use" &&
-      hook.payload?.toolCall
-    ) {
-      requestToolApproval({
-        sessionId: input.sessionId,
-        hookDir: input.hookDir,
-        hookName: name,
-        payload: hook.payload,
-      });
+    if (approvalRequired() && hook.event === "pre-tool-use" && hook.payload?.toolCall) {
+      if (input.final) {
+        // The child has exited, so nothing will consume an approval — but the
+        // hook subprocess may still be polling, and its directory is about to
+        // be removed. Deny explicitly so it stops now instead of spinning until
+        // its own timeout with no possible answer.
+        writeDecision(input.hookDir, name, {
+          decision: "deny",
+          reason: "Antigravity turn ended before this tool was approved",
+        });
+      } else {
+        approvals.push({ name, payload: hook.payload });
+      }
     }
   }
 
-  const transcriptPath = resolveTranscriptPath(input.state);
+  const transcriptPath =
+    input.readTranscript === false ? undefined : resolveTranscriptPath(input.state);
+  let moreTranscript = false;
   if (transcriptPath) {
-    if (input.transcriptOffset.value === -1) {
-      input.transcriptOffset.value = transcriptPath.endsWith("transcript_full.jsonl")
-        ? input.transcriptBaselines.transcriptFull
-        : input.transcriptBaselines.transcript;
-    }
     let chunk = "";
     try {
       const stats = NodeFS.statSync(transcriptPath);
       if (stats.size > input.transcriptOffset.value) {
         const fd = NodeFS.openSync(transcriptPath, "r");
         try {
-          const length = stats.size - input.transcriptOffset.value;
+          // Capped rather than sized to the whole unread region: a tool that
+          // writes a very large record would otherwise have the bridge
+          // allocate a buffer as big as its output in one go, which the 256
+          // KiB stdout cap does nothing to prevent. Whatever is left is picked
+          // up by the next poll, and the final drain loops until it is gone.
+          const length = Math.min(
+            stats.size - input.transcriptOffset.value,
+            MAX_TRANSCRIPT_READ_BYTES,
+          );
           const buffer = Buffer.alloc(length);
-          NodeFS.readSync(fd, buffer, 0, length, input.transcriptOffset.value);
+          // `readSync` may return fewer bytes than asked for. Decoding the
+          // whole buffer would feed the zero-filled tail through as content
+          // and skip the real bytes for good. Read until the measured range is
+          // filled rather than relying on the next poll — the final drain has
+          // no next poll, and would lose the tail along with whatever partial
+          // record the cursor is about to flush.
+          let bytesRead = 0;
+          while (bytesRead < length) {
+            const read = NodeFS.readSync(
+              fd,
+              buffer,
+              bytesRead,
+              length - bytesRead,
+              input.transcriptOffset.value + bytesRead,
+            );
+            if (read <= 0) {
+              break;
+            }
+            bytesRead += read;
+          }
           // Decoded through the turn's streaming decoder, not `toString`: a
           // write can land mid-multibyte-character, and decoding each slice
           // independently would replace the partial sequence with U+FFFD and
           // advance past it, silently corrupting non-ASCII output.
-          chunk = input.decoder.write(buffer);
-          input.transcriptOffset.value = stats.size;
+          chunk = bytesRead > 0 ? input.decoder.write(buffer.subarray(0, bytesRead)) : "";
+          input.transcriptOffset.value += bytesRead;
+          moreTranscript = stats.size > input.transcriptOffset.value && bytesRead > 0;
         } finally {
           NodeFS.closeSync(fd);
         }
@@ -910,26 +1400,159 @@ function drain(input: {
     // conversation carries every prior turn. Trim once, then stream.
     if (!input.state.transcriptPrimed && allLines.length > 0) {
       const trimmed = dropPriorTurnRecords(allLines);
-      if (trimmed.length === allLines.length && input.state.resumedConversation && !input.final) {
-        // Resuming, and this batch holds no `USER_INPUT` — so the current
-        // turn's opening record has not been written yet and everything here
-        // belongs to a previous turn. Emitting it would replay old output;
-        // hold off and re-examine once more has been appended.
-        input.cursor.retain(allLines);
+      const foundBoundary = trimmed.length !== allLines.length;
+      if (foundBoundary) {
+        // A boundary observed after an overflow makes its suffix eligible
+        // again: everything retained from here belongs after that input, while
+        // text discarded before it remains permanently excluded.
+        input.state.transcriptPrimingOverflowed = false;
+      }
+      if (input.state.resumedConversation && !input.final && moreTranscript) {
+        // Still short of the end of the file, so no `USER_INPUT` seen so far can
+        // be trusted to be this turn's: the current turn's opening record may
+        // sit in bytes not yet read. Reads are capped, so this is the ordinary
+        // case for a long transcript rather than an edge one.
+        //
+        // What is held back is `trimmed`, not the whole batch — history is
+        // discarded as it is scanned, which is both what the turn wants and
+        // what keeps the hold bounded to a single turn's output.
+        if (
+          !input.state.transcriptPrimingOverflowed &&
+          !input.cursor.retainWithinLimit(trimmed, MAX_TRANSCRIPT_LINE_CHARS)
+        ) {
+          // Complete retained history is discarded, but a bounded partial line
+          // at the read cutoff is preserved because it may be this turn's
+          // USER_INPUT. Suppression remains active until that boundary is
+          // observed, so a historical record completed from the carry is still
+          // never emitted as current-turn output.
+          input.state.transcriptPrimingOverflowed = true;
+        }
         allLines = [];
       } else {
-        allLines = [...trimmed];
+        // Overflow discarded an unknown part of the candidate turn. Without a
+        // later input boundary, the remaining tail is just as likely to be old
+        // history and must not be surfaced as current-turn output.
+        allLines = input.state.transcriptPrimingOverflowed ? [] : [...trimmed];
         input.state.transcriptPrimed = true;
       }
     }
-    for (const line of allLines) {
-      const record = parseTranscriptLine(line);
-      if (!record) {
+    // Records held from an earlier pass go first: their hook may have arrived
+    // since, and they are older than anything read just now.
+    const carried = input.state.deferredRecords.splice(0, input.state.deferredRecords.length);
+    let remainingRecordChars = input.state.deferredRecordChars;
+    input.state.deferredRecordChars = 0;
+    const records = [
+      ...carried,
+      ...allLines.flatMap((line) => {
+        const record = parseTranscriptLine(line);
+        if (record === null) {
+          return [];
+        }
+        const deferred = {
+          record,
+          serializedChars: serializedTranscriptRecordSize(record),
+        };
+        remainingRecordChars += deferred.serializedChars;
+        return [deferred];
+      }),
+    ];
+
+    // A deferral is a barrier, not a skip: everything after it is held too.
+    // Emitting later records while an earlier one waits would put a tool's
+    // output after text that followed it, and replay it out of order next pass.
+    //
+    // Bounded, because Antigravity emits steps for its own internal work that
+    // no hook ever announces. Past the limit the held records are released in
+    // order and any still unmatched are dropped, so an unhookable step costs
+    // its own output rather than stalling everything behind it.
+    const held = input.state.deferredRecords;
+    // Only the record that actually waited out the bound is given up on, and
+    // only while it is still at the head. Applying its age to the whole batch
+    // would discard a record read moments ago that has had no chance at all.
+    const agedHead = carried.length > 0 && input.state.deferredDrains >= MAX_DEFERRED_DRAINS;
+    for (let index = 0; index < records.length; index += 1) {
+      const deferredRecord = records[index];
+      if (deferredRecord === undefined) {
         continue;
       }
+      const record = deferredRecord.record;
       const result = transcriptRecordUpdates(record, input.state);
+      if (!result.deferred) {
+        // Something matched, so whatever was blocking the queue has cleared.
+        input.state.deferredDrains = 0;
+      } else if (input.final) {
+        // Nothing further is coming; holding it would only lose it silently.
+        remainingRecordChars -= deferredRecord.serializedChars;
+        continue;
+      } else if (index === 0 && agedHead) {
+        // Waited its full budget with no hook. Drop just this one and let the
+        // rest of the batch start over with a fresh budget.
+        input.state.deferredDrains = 0;
+        remainingRecordChars -= deferredRecord.serializedChars;
+        continue;
+      } else {
+        held.push(...records.slice(index).filter((entry) => entry !== undefined));
+        input.state.deferredRecordChars = remainingRecordChars;
+        input.state.deferredDrains += 1;
+        // Aged out one at a time, but refilled by every poll. Antigravity emits
+        // internal steps far faster than one record per drain interval, so on a
+        // transcript with unhookable steps the queue grows no matter how
+        // patiently the head expires.
+        //
+        // Overflow is consumed rather than discarded: a record stuck behind an
+        // unmatchable one may have had its own hook arrive in the meantime, and
+        // dropping it unexamined would lose that tool's output for good. Each is
+        // offered again on the way out; only those still unmatched are dropped.
+        let heldChars = input.state.deferredRecordChars;
+        let trimmed = false;
+        while (held.length > MAX_DEFERRED_RECORDS || heldChars > MAX_DEFERRED_CHARS) {
+          const candidate = held.shift();
+          if (candidate === undefined) {
+            break;
+          }
+          trimmed = true;
+          heldChars -= candidate.serializedChars;
+          const retried = transcriptRecordUpdates(candidate.record, input.state);
+          if (retried.deferred) {
+            continue;
+          }
+          for (const update of retried.updates) {
+            bufferedUpdates.push({
+              stepIdx: candidate.record.step_index,
+              phase: "transcript",
+              update,
+            });
+          }
+          if (retried.emittedAssistantText) {
+            input.assistantText.emitted = true;
+          }
+          const retriedStep = candidate.record.step_index;
+          if (typeof retriedStep === "number") {
+            const terminal = takeTerminal(input.state, retriedStep);
+            if (terminal) {
+              bufferedUpdates.push({
+                stepIdx: retriedStep,
+                phase: "terminal",
+                update: terminal,
+              });
+            }
+          }
+        }
+        input.state.deferredRecordChars = heldChars;
+        if (trimmed) {
+          // The head that had been accruing age is gone, so its budget must not
+          // carry over to whatever is now in front — that record would expire
+          // without ever having waited.
+          input.state.deferredDrains = 0;
+        }
+        break;
+      }
       for (const update of result.updates) {
-        sendSessionUpdate(input.sessionId, update);
+        bufferedUpdates.push({
+          stepIdx: record.step_index,
+          phase: "transcript",
+          update,
+        });
       }
       if (result.emittedAssistantText) {
         input.assistantText.emitted = true;
@@ -937,29 +1560,52 @@ function drain(input: {
       // This step's output is out; the call can be completed now.
       const stepIndex = record.step_index;
       if (typeof stepIndex === "number") {
-        flushTerminal(input.sessionId, input.state, stepIndex);
+        const terminal = takeTerminal(input.state, stepIndex);
+        if (terminal) {
+          bufferedUpdates.push({
+            stepIdx: stepIndex,
+            phase: "terminal",
+            update: terminal,
+          });
+        }
       }
+      remainingRecordChars -= deferredRecord.serializedChars;
     }
   }
 
   // Nothing more will arrive, so anything still waiting on a transcript record
   // that never came is completed without output rather than left spinning.
   if (input.final) {
-    const remaining = [...input.state.pendingTerminal.values()];
+    const remaining = [...input.state.pendingTerminal];
     input.state.pendingTerminal.clear();
-    for (const terminal of remaining) {
-      sendSessionUpdate(input.sessionId, terminal);
+    for (const [stepIdx, terminal] of remaining) {
+      bufferedUpdates.push({ stepIdx, phase: "terminal", update: terminal });
     }
   }
+
+  for (const update of orderAgySessionUpdates(bufferedUpdates)) {
+    sendSessionUpdate(input.sessionId, update);
+  }
+  for (const approval of approvals) {
+    requestToolApproval({
+      sessionId: input.sessionId,
+      hookDir: input.hookDir,
+      hookName: approval.name,
+      payload: approval.payload,
+      turnToken: input.turnToken,
+    });
+  }
+
+  return moreTranscript;
 }
 
-function flushTerminal(sessionId: string, state: AgyTurnState, stepIdx: number): void {
+function takeTerminal(state: AgyTurnState, stepIdx: number): AgySessionUpdate | undefined {
   const terminal = state.pendingTerminal.get(stepIdx);
   if (!terminal) {
-    return;
+    return undefined;
   }
   state.pendingTerminal.delete(stepIdx);
-  sendSessionUpdate(sessionId, terminal);
+  return terminal;
 }
 
 /**
@@ -986,30 +1632,70 @@ function resolveTranscriptPath(state: AgyTurnState): string | undefined {
   return state.resolvedTranscriptPath;
 }
 
+/**
+ * Thrown when a cancel lands in the window between claiming the turn and
+ * spawning `agy`. Carries no message: it never surfaces to the client, it only
+ * unwinds setup through the same path a spawn failure takes.
+ */
+class TurnCancelledBeforeSpawn extends Error {}
+
 async function runTurn(
   sessionId: string,
   session: BridgeSession,
   prompt: RenderedPrompt,
+  promptEpoch: number | undefined,
 ): Promise<TurnOutcome> {
   // A cancel that raced the end of an earlier turn must not decide this one.
   cancelledSessions.delete(sessionId);
+
   // Claimed before any setup work: spawning `agy` takes long enough that a
   // cancel can land first, and cancels are only honoured for the session
   // holding this claim. Leaving it unset until after the spawn would silently
   // drop those, letting an auto-approving child run on past a cancelled turn.
   activeTurnSessionId = sessionId;
+  // Claimed together. Setting the epoch later left a window where this turn
+  // looked untagged, and an untagged turn is cancelled unconditionally — so a
+  // late cancel carrying an older epoch would kill a turn it does not cover.
+  activeTurnEpoch = promptEpoch;
+  // Rotated before the spawn, so the child is handed this turn's secret: a tool
+  // approved in an earlier turn holds that turn's, and cannot sign anything
+  // this one will accept.
+  turnHookSecret = NodeCrypto.randomBytes(32).toString("hex");
   // Measured before `agy` starts: whatever the transcript already holds
   // belongs to earlier turns of the conversation being resumed.
-  const baselines = transcriptBaselines(session.conversationId);
+  const baseline = transcriptBaseline(session.conversationId);
   let hookDir: string | undefined;
   let hookWorkspace: string | undefined;
   let attachmentDir: string | undefined;
   let child: NodeChildProcess.ChildProcess;
   try {
     hookDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hookout-"));
+    activeTurnTempDirs.add(hookDir);
     hookWorkspace = createHookWorkspace();
+    activeTurnTempDirs.add(hookWorkspace);
     const attachments = stageAttachments(prompt.attachments);
     attachmentDir = attachments.dir;
+    if (attachmentDir) {
+      activeTurnTempDirs.add(attachmentDir);
+    }
+    // Yielded to the event loop once, with the claim held and the directories
+    // staged, before anything is spawned.
+    //
+    // Everything above this point is synchronous, so a `t3/fence` or
+    // `session/cancel` already sitting in the stdin buffer could not be parsed
+    // until after `agy` was running: the turn the user stopped still reached
+    // the model, and was only killed afterwards. One turn of the event loop is
+    // enough for the reader to deliver it, and the recheck below then declines
+    // to spawn at all.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    if (
+      shuttingDown ||
+      cancelledSessions.has(sessionId) ||
+      (promptEpoch !== undefined && promptEpoch <= cancelledThrough(sessionId))
+    ) {
+      throw new TurnCancelledBeforeSpawn();
+    }
+
     const rawCommand = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
     const spawnCommand = Effect.runSync(
       resolveSpawnCommand(
@@ -1027,18 +1713,34 @@ async function runTurn(
       spawnCommand.args,
       {
         cwd: session.cwd,
-        env: { ...process.env, [HOOK_DIR_ENV]: hookDir },
+        env: { ...process.env, [HOOK_DIR_ENV]: hookDir, [HOOK_SECRET_ENV]: turnHookSecret },
         stdio: ["ignore", "pipe", "pipe"],
+        // Its own process group, so cancelling can reach the tools `agy`
+        // spawned rather than only `agy` itself. A tool left running keeps
+        // modifying the workspace after Stop.
+        detached: true,
         shell: spawnCommand.shell,
       },
     );
   } catch (error) {
-    // Setup failed, so no turn is running: release the claim and reclaim the
-    // directories, or repeated failures would leak one set each time.
+    // Setup failed or the turn was cancelled before it started, so no turn is
+    // running: release the claim and reclaim the directories, or repeated
+    // failures would leak one set each time.
     activeTurnSessionId = null;
+    activeTurnEpoch = undefined;
     cleanupDir(hookDir);
     cleanupDir(hookWorkspace);
     cleanupDir(attachmentDir);
+    if (hookDir) activeTurnTempDirs.delete(hookDir);
+    if (hookWorkspace) activeTurnTempDirs.delete(hookWorkspace);
+    if (attachmentDir) activeTurnTempDirs.delete(attachmentDir);
+    if (error instanceof TurnCancelledBeforeSpawn) {
+      // Nothing ran, so there is nothing to report but the cancellation. The
+      // flag is consumed here because no later stage will reach the drain that
+      // normally clears it.
+      cancelledSessions.delete(sessionId);
+      return { stopReason: "cancelled" };
+    }
     throw error;
   }
 
@@ -1046,31 +1748,65 @@ async function runTurn(
   const seenHooks = new Set<string>();
   const cursor = new AgyTranscriptCursor();
   const decoder = new NodeStringDecoder.StringDecoder("utf8");
-  const transcriptOffset = { value: -1 };
-  if (baselines.transcript > 0 || baselines.transcriptFull > 0) {
+  const transcriptOffset = { value: baseline?.size ?? 0 };
+  if (baseline && baseline.size > 0) {
     // Reading starts past every earlier turn, so there is no prior-turn
-    // content left for the `USER_INPUT` heuristic to guess at.
+    // content left for the `USER_INPUT` heuristic to guess at. The turn is
+    // pinned to the exact file the baseline was measured from.
     state.transcriptPrimed = true;
+    state.resolvedTranscriptPath = baseline.path;
   }
   const assistantText = { emitted: false };
+  const turnToken: TurnToken = { sessionId, live: true };
+  // Published so an out-of-band fence covering this epoch can retire the turn
+  // rather than being recorded for an arrival that already happened.
+  activeTurnToken = turnToken;
   activeChild = child;
+  if (child.pid !== undefined) {
+    // Tracking is released the moment it ends, so nothing ever signals a group
+    // id that is no longer ours.
+    forgetChildOnExit(child);
+  }
   // A cancel during startup had no process to signal; deliver it now.
   if (cancelledSessions.has(sessionId)) {
-    child.kill("SIGTERM");
+    killActiveChild();
   }
 
+  // Both are kept as bounded tails. A turn that prints a large file — or a tool
+  // that loops — would otherwise grow these strings for the whole run and take
+  // the bridge's heap with it, turning a noisy turn into a dead provider.
+  // stdout is only ever a fallback for when the transcript produced nothing,
+  // and stderr only has to carry enough to explain a failure.
   let stdout = "";
   let stderr = "";
+  let stdoutTruncated = false;
+  let stderrTruncated = false;
+  const appendBounded = (current: string, chunk: string): [string, boolean] => {
+    const combined = current + chunk;
+    return combined.length <= MAX_CAPTURED_OUTPUT
+      ? [combined, false]
+      : [combined.slice(combined.length - MAX_CAPTURED_OUTPUT), true];
+  };
   child.stdout?.setEncoding("utf8");
   child.stdout?.on("data", (chunk: string) => {
-    stdout += chunk;
+    const [next, dropped] = appendBounded(stdout, chunk);
+    stdout = next;
+    stdoutTruncated = stdoutTruncated || dropped;
   });
   child.stderr?.setEncoding("utf8");
   child.stderr?.on("data", (chunk: string) => {
-    stderr += chunk;
+    const [next, dropped] = appendBounded(stderr, chunk);
+    stderr = next;
+    stderrTruncated = stderrTruncated || dropped;
   });
 
   const poller = setInterval(() => {
+    // Skipped rather than queued behind a reader that is already behind.
+    // `writeMessage` clears the flag on `drain`, so a later interval resumes
+    // only after stdout has accepted its buffered data.
+    if (stdoutBlocked) {
+      return;
+    }
     drain({
       sessionId,
       hookDir,
@@ -1078,21 +1814,97 @@ async function runTurn(
       state,
       cursor,
       decoder,
-      transcriptBaselines: baselines,
       transcriptOffset,
       assistantText,
+      turnToken,
       final: false,
     });
   }, HOOK_POLL_INTERVAL_MS);
 
+  let childError: Error | undefined;
   const exitCode = await new Promise<number | null>((resolve) => {
-    child.on("error", () => resolve(null));
-    child.on("close", (code) => resolve(code));
+    let settled = false;
+    let missingCloseTimer: ReturnType<typeof setTimeout> | undefined;
+    const settle = (code: number | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (missingCloseTimer) {
+        clearTimeout(missingCloseTimer);
+      }
+      resolve(code);
+    };
+    child.on("error", (error) => {
+      childError = error;
+      // An error can report a failed kill while the process is still alive.
+      // The turn continues to own and poll the child until `close`; arm the
+      // normal escalation rather than releasing its directories underneath it.
+      if (
+        activeChild === child &&
+        child.pid !== undefined &&
+        child.exitCode === null &&
+        child.signalCode === null
+      ) {
+        killActiveChild();
+      }
+      // Node normally follows `error` with `close`, including failed spawns.
+      // Keep that path intact, but do not let a platform/runtime that omits
+      // `close` pin the turn and its temp directories forever. The grace
+      // outlasts the ordinary process-group escalation above.
+      missingCloseTimer ??= setTimeout(() => settle(child.exitCode), CHILD_ERROR_CLOSE_GRACE_MS);
+    });
+    child.once("close", settle);
   });
 
   clearInterval(poller);
   activeChild = null;
   activeTurnSessionId = null;
+  // Each pass reads at most `MAX_TRANSCRIPT_READ_BYTES`, so the tail of a large
+  // transcript needs several. Only the last one runs as `final`: flushing the
+  // cursor while bytes remain would emit a half-written record as if it were
+  // whole, and leave the rest of that line to be read as a fragment.
+  const stdoutDrainDeadline = Date.now() + STDOUT_DRAIN_GRACE_MS;
+  let finalPasses = 0;
+  let transcriptRemains: boolean;
+  do {
+    transcriptRemains = drain({
+      sessionId,
+      hookDir,
+      seenHooks,
+      state,
+      cursor,
+      decoder,
+      transcriptOffset,
+      assistantText,
+      turnToken,
+      final: false,
+    });
+    finalPasses += 1;
+    if (!transcriptRemains || finalPasses >= MAX_FINAL_DRAIN_PASSES) {
+      break;
+    }
+    const stdoutDrainTimedOut = await waitForStdoutDrain(stdoutDrainDeadline);
+    if (stdoutDrainTimedOut) {
+      break;
+    }
+  } while (transcriptRemains);
+  if (transcriptRemains) {
+    // Final draining stopped with bytes still unread. Flushing the cursor now
+    // would present a half-written line as a whole record and then abandon the
+    // rest in silence, so the partial line is dropped and the shortfall is said
+    // out loud instead.
+    cursor.flush();
+    await waitForStdoutDrain(stdoutDrainDeadline);
+    sendSessionUpdate(sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: "[Transcript truncated: Antigravity produced more output than this turn could read.]",
+      },
+    });
+  }
+  await waitForStdoutDrain(stdoutDrainDeadline);
   drain({
     sessionId,
     hookDir,
@@ -1100,10 +1912,15 @@ async function runTurn(
     state,
     cursor,
     decoder,
-    transcriptBaselines: baselines,
     transcriptOffset,
     assistantText,
+    turnToken,
     final: true,
+    // Reading more after announcing truncation would emit records that follow
+    // the notice, and abandon everything past that one extra read just as
+    // silently. Once truncation is declared the transcript is closed; this pass
+    // exists only to flush hooks and any terminal state still owed.
+    readTranscript: !transcriptRemains,
   });
 
   // Any tool still open at exit would otherwise render as spinning forever.
@@ -1125,27 +1942,64 @@ async function runTurn(
     persistConversationId(sessionId, state.conversationId);
   }
 
+  // Retired before the directories are reclaimed: any approval still in flight
+  // now resolves to a denial rather than writing into a vanishing directory or
+  // banking a blanket approval for the next turn.
+  turnToken.live = false;
+  // Scoped to the turn: every hook of every turn would otherwise stay in here
+  // for the life of the bridge.
+  hookPayloadDigests.clear();
+  activeTurnEpoch = undefined;
+  activeTurnToken = undefined;
   cleanupDir(hookDir);
   cleanupDir(hookWorkspace);
   cleanupDir(attachmentDir);
+  activeTurnTempDirs.delete(hookDir);
+  activeTurnTempDirs.delete(hookWorkspace);
+  if (attachmentDir) {
+    activeTurnTempDirs.delete(attachmentDir);
+  }
 
-  if (cancelledSessions.delete(sessionId)) {
-    return { stopReason: "cancelled" };
-  }
-  if (exitCode !== 0) {
-    const detail = stderr.trim() || stdout.trim() || `agy exited with code ${exitCode}`;
-    return { stopReason: "end_turn", failure: detail };
-  }
+  const cancelled = cancelledSessions.delete(sessionId);
 
   // The transcript already streamed the assistant text. stdout is only used
   // when transcript observation produced nothing, so the reply is never
   // duplicated.
-  if (!assistantText.emitted && stdout.trim().length > 0) {
+  //
+  // Emitted before the cancelled check, not after: a turn stopped mid-reply is
+  // exactly the case where the transcript may not have been discovered yet,
+  // and the partial answer already captured from stdout is the only record of
+  // what the model said. A nonzero exit is excluded because it reports the same
+  // bytes as its failure detail.
+  if ((cancelled || exitCode === 0) && !assistantText.emitted && stdout.trim().length > 0) {
+    // Says so when it is only the tail. Presenting a suffix as the whole reply
+    // reads as a complete answer that happens to begin mid-sentence, which is
+    // worse than admitting the beginning was dropped.
+    const text = stdoutTruncated
+      ? `[Earlier output dropped: the reply exceeded ${Math.floor(MAX_CAPTURED_OUTPUT / 1024)} KiB.]\n\n${stdout.trim()}`
+      : stdout.trim();
     sendSessionUpdate(sessionId, {
       sessionUpdate: "agent_message_chunk",
-      content: { type: "text", text: stdout.trim() },
+      content: { type: "text", text },
     });
   }
+
+  if (cancelled) {
+    return { stopReason: "cancelled" };
+  }
+  if (exitCode !== 0 || childError !== undefined) {
+    const processError = childError?.message.trim() ?? "";
+    const processOutput = stderr.trim() || stdout.trim();
+    const captured = [processError, processOutput].filter((part) => part.length > 0).join("\n");
+    const truncated = stderr.trim() ? stderrTruncated : stdoutTruncated;
+    const detail = captured
+      ? truncated
+        ? `[earlier output dropped] ${captured}`
+        : captured
+      : `agy exited with code ${exitCode}`;
+    return { stopReason: "end_turn", failure: detail };
+  }
+
   return { stopReason: "end_turn" };
 }
 
@@ -1248,10 +2102,27 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         sendError(id, -32602, "unknown sessionId");
         return;
       }
-      const queuedAt = queuedPromptGenerations.get(id);
-      queuedPromptGenerations.delete(id);
-      if (queuedAt !== undefined && queuedAt !== cancelGeneration(sessionId)) {
-        // Cancelled while it sat in the queue; never spawn `agy` for it.
+      if (shuttingDown) {
+        // The client is gone; starting `agy` now would leave it running with
+        // nobody to read its output.
+        sendResult(id, { stopReason: "cancelled" });
+        return;
+      }
+      // Compared against the session's cancelled high-water mark. A cancel
+      // that outran this prompt raised that mark, and anything the user sends
+      // afterwards carries a higher epoch and is unaffected.
+      //
+      // A prompt without an epoch is from a client that does not send fences,
+      // so there is no mark it could be measured against — refusing it would
+      // reject every prompt such a client ever sends once a mark exists.
+      const promptEpoch = promptEpochOf(params);
+      // One-shot, and only reachable for a client that sends no epochs.
+      const unscopedCancelled = promptEpoch === undefined && unscopedCancels.delete(sessionId);
+      if (
+        unscopedCancelled ||
+        (promptEpoch !== undefined && promptEpoch <= cancelledThrough(sessionId))
+      ) {
+        // Cancelled before it could start; never spawn `agy` for it.
         sendResult(id, { stopReason: "cancelled" });
         return;
       }
@@ -1260,7 +2131,7 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         sendError(id, -32602, "session/prompt requires at least one text block");
         return;
       }
-      const outcome = await runTurn(sessionId, session, prompt);
+      const outcome = await runTurn(sessionId, session, prompt, promptEpoch);
       if (outcome.failure) {
         sendError(id, -32000, `Antigravity turn failed: ${outcome.failure}`);
         return;
@@ -1268,20 +2139,64 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       sendResult(id, { stopReason: outcome.stopReason });
       return;
     }
+    // Sent by the adapter immediately before it cancels, naming the epoch it
+    // is cancelling through. Handled out of band: queued, it would sit behind
+    // the very prompt it is meant to stop. Notifications carry no id, so
+    // nothing is replied.
+    case "t3/fence": {
+      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      const epoch = typeof params["epoch"] === "number" ? params["epoch"] : undefined;
+      if (!sessionId || epoch === undefined) {
+        return;
+      }
+      cancelledThroughEpoch.set(sessionId, Math.max(cancelledThrough(sessionId), epoch));
+      // A turn already running under a cancelled epoch has nothing left to
+      // stop on arrival, so it is stopped here. Retiring the token is what
+      // makes an approval still in flight deny, including one the client
+      // would auto-approve.
+      if (
+        activeTurnToken?.sessionId === sessionId &&
+        activeTurnEpoch !== undefined &&
+        activeTurnEpoch <= epoch
+      ) {
+        activeTurnToken.live = false;
+        cancelledSessions.add(sessionId);
+        killActiveChild();
+      }
+      return;
+    }
     case "session/cancel": {
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
-      if (sessionId) {
-        // Always recorded, so prompts already queued for this session can see
-        // that a cancel happened and refuse to start.
-        cancelGenerations.set(sessionId, cancelGeneration(sessionId) + 1);
-        // Only a cancel aimed at the turn actually running decides its stop
-        // reason. Cancels bypass the request queue, so one arriving after a
-        // turn finished — or targeting an idle session — must not sit in the
-        // set and mark the next successful turn cancelled.
-        if (sessionId === activeTurnSessionId) {
-          cancelledSessions.add(sessionId);
-          activeChild?.kill("SIGTERM");
+      if (!sessionId || !sessions.has(sessionId)) {
+        return;
+      }
+      // Recorded before anything else. A cancel bypasses the request queue and
+      // its prompt does not, so the two can arrive together with the prompt
+      // still waiting — and returning early below would drop the epoch and let
+      // that prompt spawn `agy` after the Stop that was meant to catch it.
+      const cancelEpoch = typeof params["epoch"] === "number" ? params["epoch"] : undefined;
+      if (cancelEpoch !== undefined) {
+        cancelledThroughEpoch.set(sessionId, Math.max(cancelledThrough(sessionId), cancelEpoch));
+      }
+      if (sessionId !== activeTurnSessionId) {
+        // No turn running for it yet. An untagged prompt has no epoch to be
+        // measured against, so it needs a marker — banked only when one is
+        // genuinely waiting, or a cancel that merely arrived after its own turn
+        // finished would sit here and stop something sent much later.
+        if (queuedUntagged(sessionId) > 0) {
+          unscopedCancels.add(sessionId);
         }
+        return;
+      }
+      // Only the turn actually running is stopped, and only when its epoch has
+      // been cancelled: a prompt accepted after the fence carries a higher one
+      // and must survive this notification, which the runtime forks and can
+      // therefore deliver late. A turn whose prompt carried no epoch cannot be
+      // scoped by a mark it never contributed to, so it takes plain ACP
+      // semantics.
+      if (activeTurnEpoch === undefined || activeTurnEpoch <= cancelledThrough(sessionId)) {
+        cancelledSessions.add(sessionId);
+        killActiveChild();
       }
       return;
     }
@@ -1295,6 +2210,33 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
 
 /** Entry point for `t3 agy-acp`. */
 export async function runAgyBridge(): Promise<void> {
+  // `detached: true` means the child outlives this process unless it is told
+  // otherwise. Losing the bridge — a signal, a crashing parent — would
+  // otherwise leave `agy` and its tools running against the user's workspace
+  // with nothing left to stop them.
+  // Shutdown kills outright rather than scheduling an escalation: `process.exit`
+  // runs no timers, so a graceful SIGTERM here would leave a tool that ignores
+  // it alive in its own detached group with the bridge already gone.
+  const stopChildOnExit = () => {
+    shuttingDown = true;
+    killActiveChild({ immediate: true });
+    // The turn's own cleanup never runs when the process is going down, and
+    // these hold copies of the user's attachments and captured file contents.
+    cleanupActiveTurnTempDirs();
+    // Groups whose leader already exited are known only to their pending
+    // escalation, and `process.exit` runs no timers.
+    killPendingGroups();
+  };
+  process.once("SIGTERM", () => {
+    stopChildOnExit();
+    process.exit(0);
+  });
+  process.once("SIGINT", () => {
+    stopChildOnExit();
+    process.exit(0);
+  });
+  process.once("exit", stopChildOnExit);
+
   let buffer = "";
   // Requests are handled strictly in order: a turn holds the agent busy, and
   // ACP clients do not pipeline prompts for one session.
@@ -1331,6 +2273,14 @@ export async function runAgyBridge(): Promise<void> {
         continue;
       }
 
+      // Handled out of band alongside cancel. Queued, it would sit behind the
+      // very prompt it is meant to stop and only be recorded once that prompt
+      // had already run.
+      if (message["method"] === "t3/fence") {
+        void handleRequest(message);
+        continue;
+      }
+
       // Cancellation must interrupt an in-flight turn, so it bypasses the
       // queue that would otherwise make it wait for that turn to finish.
       if (message["method"] === "session/cancel") {
@@ -1338,16 +2288,34 @@ export async function runAgyBridge(): Promise<void> {
         continue;
       }
       const pending = message;
-      // Captured now, not when the turn starts: the gap between the two is
-      // exactly the window a cancel has to arrive in while this prompt waits.
-      if (pending["method"] === "session/prompt") {
-        const target = (pending["params"] as Record<string, unknown> | undefined)?.["sessionId"];
-        if (typeof target === "string" && pending["id"] !== undefined) {
-          queuedPromptGenerations.set(pending["id"], cancelGeneration(target));
-        }
+      // Counted from acceptance to handling, so a cancel can tell "a prompt is
+      // waiting" from "nothing is outstanding".
+      const queuedParams =
+        pending["method"] === "session/prompt"
+          ? (pending["params"] as Record<string, unknown> | undefined)
+          : undefined;
+      const queuedSessionId =
+        queuedParams && promptEpochOf(queuedParams) === undefined
+          ? queuedParams["sessionId"]
+          : undefined;
+      if (typeof queuedSessionId === "string") {
+        queuedUntaggedCounts.set(queuedSessionId, queuedUntagged(queuedSessionId) + 1);
       }
       queue = queue
         .then(() => handleRequest(pending))
+        .finally(() => {
+          if (typeof queuedSessionId === "string") {
+            const remaining = queuedUntagged(queuedSessionId) - 1;
+            if (remaining > 0) {
+              queuedUntaggedCounts.set(queuedSessionId, remaining);
+            } else {
+              queuedUntaggedCounts.delete(queuedSessionId);
+              // Nothing untagged is waiting any more, so a marker banked for
+              // one cannot be consumed and must not outlive it.
+              unscopedCancels.delete(queuedSessionId);
+            }
+          }
+        })
         .catch((error: unknown) => {
           // Every request must be answered. Swallowing a handler failure would
           // leave the client blocked on a response that never arrives.
@@ -1359,9 +2327,15 @@ export async function runAgyBridge(): Promise<void> {
     }
   }
 
+  // Recorded before anything else so queued prompts see it and decline.
+  shuttingDown = true;
   // stdin closed: no approval can still be answered, so unblock the hooks
   // waiting on them (they fail closed) rather than letting them time out.
   failPendingOutbound("T3 Code disconnected before approving this tool call");
+  // Killed before awaiting the queue, not after: an in-flight `session/prompt`
+  // only resolves when `agy` exits, so waiting first would keep the bridge and
+  // its child alive for the whole print timeout — hours — after the client
+  // disconnected.
+  killActiveChild();
   await queue;
-  activeChild?.kill("SIGTERM");
 }

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1,0 +1,1348 @@
+/**
+ * ACP compatibility bridge for the Antigravity CLI (`agy`).
+ *
+ * Antigravity exposes no native agent protocol. This module speaks the slice
+ * of ACP that `AcpSessionRuntime` uses over stdio and executes each turn
+ * through Antigravity's documented non-interactive `--print` mode, while
+ * reconstructing a live event stream from hooks and the trajectory transcript
+ * (see `agyEvents.ts` and `agyTranscript.ts`).
+ *
+ * Runs as a subcommand of the server binary (`t3 agy-acp`) so it ships inside
+ * the same bundle rather than as a loose script.
+ *
+ * @module provider/acp/antigravity/agyBridge
+ */
+// @effect-diagnostics nodeBuiltinImport:off - Standalone stdio bridge process, not an Effect runtime.
+// @effect-diagnostics globalTimers:off - Polls Antigravity hook output outside any Effect runtime.
+import * as NodeChildProcess from "node:child_process";
+import * as NodeCrypto from "node:crypto";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeStringDecoder from "node:string_decoder";
+import * as NodeURL from "node:url";
+
+import packageJson from "../../../../package.json" with { type: "json" };
+import {
+  agyHookResponse,
+  approvalOutcomeToDecision,
+  agyTargetPath,
+  agyToolCallId,
+  agyToolKind,
+  agyToolTitle,
+  hookSessionUpdate,
+  makeAgyTurnState,
+  type AgyHookDecision,
+  type AgyHookEvent,
+  type AgyHookPayload,
+  type AgySessionUpdate,
+  type AgyTurnState,
+} from "./agyEvents.ts";
+import {
+  AgyTranscriptCursor,
+  dropPriorTurnRecords,
+  parseTranscriptLine,
+  transcriptRecordUpdates,
+} from "./agyTranscript.ts";
+
+export function resolveAgyCommand(
+  command: string,
+  _env: Record<string, string | undefined> = process.env,
+  platform: NodeJS.Platform = process.platform,
+): { command: string; shell: boolean } {
+  const custom = command.trim();
+  if (platform !== "win32") {
+    return { command: custom, shell: false };
+  }
+  const isCmd = /\.cmd$/i.test(custom) || /\.bat$/i.test(custom);
+  return { command: custom, shell: isCmd };
+}
+
+const HOOK_DIR_ENV = "T3_AGY_HOOK_DIR";
+const REQUIRE_APPROVAL_ENV = "T3_AGY_REQUIRE_APPROVAL";
+/** Suffix of the file the bridge writes to answer a waiting `PreToolUse` hook. */
+const DECISION_SUFFIX = ".decision";
+/**
+ * How long a `PreToolUse` hook blocks waiting for the user. Antigravity's own
+ * hook timeout is set above this so the deny below is what actually lands,
+ * rather than the CLI abandoning the hook first.
+ */
+const APPROVAL_WAIT_MS = 10 * 60 * 1000;
+const APPROVAL_HOOK_TIMEOUT_SECONDS = 11 * 60;
+const APPROVAL_POLL_INTERVAL_MS = 50;
+const HOOK_POLL_INTERVAL_MS = 50;
+const DEFAULT_PRINT_TIMEOUT = "2h";
+const HOOKS_KEY = "t3code-antigravity-observer";
+
+interface BridgeSession {
+  readonly cwd: string;
+  systemPrompt: string | undefined;
+  conversationId: string | undefined;
+  /**
+   * Model and effort for the next turn. Seeded from the spawn environment and
+   * replaced by `session/set_model`; both are command-line flags on every
+   * spawn, so a change takes effect on the following turn without disturbing
+   * the conversation it resumes.
+   */
+  model: string | undefined;
+  effort: string | undefined;
+}
+
+const sessions = new Map<string, BridgeSession>();
+
+// ── Session id ⇄ Antigravity conversation id ──────────────────────────
+//
+// `session/new` must return an id before the first turn runs, which is before
+// Antigravity has created a trajectory. The mapping is persisted so a later
+// `session/load` — potentially in a fresh bridge process — can still resume
+// the right conversation.
+
+/**
+ * Where Antigravity keeps a conversation's trajectory.
+ *
+ * Layout confirmed against real conversations:
+ * `<appDataDir>/brain/<conversation-uuid>/.system_generated/logs/`.
+ */
+function transcriptDirFor(conversationId: string): string {
+  const appDataDir =
+    process.env["T3_AGY_APP_DATA_DIR"]?.trim() ||
+    NodePath.join(NodeOS.homedir(), ".gemini", "antigravity-cli");
+  return NodePath.join(appDataDir, "brain", conversationId, ".system_generated", "logs");
+}
+
+/**
+ * Bytes already in a resumed conversation's transcript before this turn runs.
+ *
+ * A positive baseline, taken before `agy` is spawned, is what makes "records
+ * from earlier turns" precise. Inferring the boundary from the last
+ * `USER_INPUT` record cannot: the file always contains previous ones, so a
+ * poll landing before the new marker is written would treat an earlier turn's
+ * output as live. Returns 0 when the file cannot be measured, which falls back
+ * to the marker heuristic rather than skipping the turn's own output.
+ */
+function transcriptBaseline(conversationId: string | undefined): number {
+  if (!conversationId) {
+    return 0;
+  }
+  const dir = transcriptDirFor(conversationId);
+  for (const name of ["transcript.jsonl", "transcript_full.jsonl"]) {
+    try {
+      return NodeFS.statSync(NodePath.join(dir, name)).size;
+    } catch {
+      // Try the sibling, then give up.
+    }
+  }
+  return 0;
+}
+
+function stateDirPath(): string {
+  const appDataDir =
+    process.env["T3_AGY_APP_DATA_DIR"]?.trim() ||
+    NodePath.join(NodeOS.homedir(), ".gemini", "antigravity-cli");
+  return NodePath.join(appDataDir, "t3code-acp-sessions");
+}
+
+/**
+ * One file per session rather than a shared map.
+ *
+ * Several bridge processes can finish turns at once, and a shared map means a
+ * read-modify-write: two writers would each rebuild it from their own stale
+ * snapshot and the later rename would drop the other's entry, silently losing
+ * a thread's conversation. Independent files never contend.
+ *
+ * Returns undefined for a session id that is not a plain token, since the id
+ * becomes a filename and is supplied by the client.
+ */
+function sessionFilePath(sessionId: string): string | undefined {
+  return /^[A-Za-z0-9_-]{1,128}$/.test(sessionId)
+    ? NodePath.join(stateDirPath(), `${sessionId}.json`)
+    : undefined;
+}
+
+function persistConversationId(sessionId: string, conversationId: string): void {
+  const target = sessionFilePath(sessionId);
+  if (!target) {
+    return;
+  }
+  try {
+    NodeFS.mkdirSync(NodePath.dirname(target), { recursive: true });
+    // Written aside and renamed so a reader never sees a partial file.
+    const staging = `${target}.${process.pid}.${NodeCrypto.randomUUID()}.tmp`;
+    NodeFS.writeFileSync(staging, JSON.stringify({ conversationId }));
+    NodeFS.renameSync(staging, target);
+  } catch {
+    // Losing the mapping costs conversation continuity on the next resume,
+    // which is not worth failing a turn over.
+  }
+}
+
+/**
+ * Map a bridge session id to the Antigravity conversation it should resume.
+ *
+ * The persisted record is the only authority. Bridge session ids are random
+ * UUIDs themselves, so an id that merely looks like a conversation id is
+ * indistinguishable from one the bridge minted — falling back to the shape of
+ * the string would make `session/load` resume a conversation that never
+ * existed. Returning undefined starts a fresh one, which is recoverable.
+ */
+function lookupConversationId(sessionId: string): string | undefined {
+  const target = sessionFilePath(sessionId);
+  if (!target) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(NodeFS.readFileSync(target, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) {
+      return undefined;
+    }
+    // Validated rather than cast: the bridge does not exclusively own this
+    // file, and a non-string value would throw and leave the request that read
+    // it unanswered.
+    const value = (parsed as { conversationId?: unknown }).conversationId;
+    return typeof value === "string" ? value.trim() || undefined : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ── JSON-RPC plumbing ─────────────────────────────────────────────────
+
+function writeMessage(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function sendResult(id: unknown, result: unknown): void {
+  writeMessage({ jsonrpc: "2.0", id, result });
+}
+
+function sendError(id: unknown, code: number, message: string): void {
+  writeMessage({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function sendSessionUpdate(sessionId: string, update: AgySessionUpdate): void {
+  writeMessage({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: { sessionId, update },
+  });
+}
+
+// ── Outbound requests ─────────────────────────────────────────────────
+//
+// The bridge is the ACP agent, so asking the client to approve a tool means
+// issuing a request in the other direction and correlating the reply.
+
+let nextOutboundId = 1;
+const pendingOutbound = new Map<
+  number,
+  { readonly resolve: (value: unknown) => void; readonly reject: (error: Error) => void }
+>();
+
+function sendRequest(method: string, params: unknown, timeoutMs?: number): Promise<unknown> {
+  const id = nextOutboundId;
+  nextOutboundId += 1;
+  return new Promise((resolve, reject) => {
+    pendingOutbound.set(id, { resolve, reject });
+    if (timeoutMs !== undefined) {
+      // A client that never answers would otherwise pin this entry for the
+      // life of the bridge process.
+      const timer = setTimeout(() => {
+        if (pendingOutbound.delete(id)) {
+          reject(new Error(`${method} timed out`));
+        }
+      }, timeoutMs);
+      timer.unref?.();
+    }
+    writeMessage({ jsonrpc: "2.0", id, method, params });
+  });
+}
+
+/**
+ * Settle an outbound request from a client reply. Returns false when the id is
+ * not one of ours, so the caller can treat the message as a request instead.
+ */
+function resolveOutbound(message: Record<string, unknown>): boolean {
+  const id = message["id"];
+  if (typeof id !== "number" || !pendingOutbound.has(id)) {
+    return false;
+  }
+  const pending = pendingOutbound.get(id);
+  pendingOutbound.delete(id);
+  if (!pending) {
+    return false;
+  }
+  const error = message["error"];
+  if (isRecord(error)) {
+    const detail = typeof error["message"] === "string" ? error["message"] : "request failed";
+    pending.reject(new Error(detail));
+  } else {
+    pending.resolve(message["result"]);
+  }
+  return true;
+}
+
+/** Reject everything still outstanding; used when the client goes away. */
+function failPendingOutbound(reason: string): void {
+  for (const [, pending] of pendingOutbound) {
+    pending.reject(new Error(reason));
+  }
+  pendingOutbound.clear();
+}
+
+// ── Hook observer ─────────────────────────────────────────────────────
+
+/**
+ * Hook command the bridge registers with Antigravity. Re-invokes this same
+ * binary so the observer always matches the running bridge.
+ */
+function hookCommandFor(event: string): string {
+  const entry = process.argv[1];
+  const base = entry
+    ? `${quoteArg(process.execPath)} ${quoteArg(entry)}`
+    : quoteArg(process.execPath);
+  return `${base} agy-hook --event ${event}`;
+}
+
+function quoteArg(value: string): string {
+  return /[\s"']/.test(value) ? `"${value.replace(/(["\\$`])/g, "\\$1")}"` : value;
+}
+
+/**
+ * Build a throwaway workspace directory whose only purpose is carrying
+ * `.agents/hooks.json`. Antigravity loads `.agents` from every `--add-dir`
+ * path, so the observer attaches without writing anything into the user's
+ * repository.
+ */
+function createHookWorkspace(): string {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hooks-"));
+  try {
+    return writeHookWorkspace(dir);
+  } catch (error) {
+    // The caller never received the path, so it cannot clean this up itself.
+    cleanupDir(dir);
+    throw error;
+  }
+}
+
+function writeHookWorkspace(dir: string): string {
+  const agentsDir = NodePath.join(dir, ".agents");
+  NodeFS.mkdirSync(agentsDir, { recursive: true });
+  // A gating PreToolUse hook blocks while the user decides, so its timeout has
+  // to outlast the bridge's own wait; observation-only hooks stay short.
+  const preToolTimeout = approvalRequired() ? APPROVAL_HOOK_TIMEOUT_SECONDS : 10;
+  const toolHook = (event: string, timeout: number) => [
+    { matcher: "*", hooks: [{ type: "command", command: hookCommandFor(event), timeout }] },
+  ];
+  NodeFS.writeFileSync(
+    NodePath.join(agentsDir, "hooks.json"),
+    JSON.stringify(
+      {
+        [HOOKS_KEY]: {
+          PreToolUse: toolHook("pre-tool-use", preToolTimeout),
+          PostToolUse: toolHook("post-tool-use", 10),
+          Stop: [{ type: "command", command: hookCommandFor("stop"), timeout: 10 }],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  return dir;
+}
+
+/** A hook event plus the file it came from, which keys its decision reply. */
+interface ObservedHook {
+  readonly name: string;
+  readonly event: AgyHookEvent;
+}
+
+function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<ObservedHook> {
+  let entries: Array<string>;
+  try {
+    entries = NodeFS.readdirSync(hookDir);
+  } catch {
+    return [];
+  }
+  const events: Array<ObservedHook> = [];
+  for (const name of entries.filter((n) => n.endsWith(".json")).sort()) {
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    try {
+      const raw = NodeFS.readFileSync(NodePath.join(hookDir, name), "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null) {
+        events.push({ name, event: parsed as AgyHookEvent });
+      }
+    } catch {
+      // A half-written hook file is picked up on the next poll.
+      seen.delete(name);
+    }
+  }
+  return events;
+}
+
+// ── Tool approval ─────────────────────────────────────────────────────
+
+const APPROVE_OPTION = "allow";
+const APPROVE_SESSION_OPTION = "allow-session";
+const REJECT_OPTION = "reject";
+/**
+ * Sessions the user has approved wholesale via "always allow".
+ *
+ * Without an `allow_always` option the client maps that choice to no option id
+ * at all and the reply reads as cancelled — which this gate denies. Offering
+ * it and honouring it here is what makes the button mean what it says.
+ */
+const sessionWideApprovals = new Set<string>();
+
+function approvalRequired(): boolean {
+  return process.env[REQUIRE_APPROVAL_ENV]?.trim() === "1";
+}
+
+function decisionPath(hookDir: string, hookName: string): string {
+  return NodePath.join(hookDir, `${hookName}${DECISION_SUFFIX}`);
+}
+
+function writeDecision(hookDir: string, hookName: string, decision: AgyHookDecision): void {
+  try {
+    const target = decisionPath(hookDir, hookName);
+    const staging = `${target}.tmp`;
+    NodeFS.writeFileSync(staging, JSON.stringify(decision));
+    NodeFS.renameSync(staging, target);
+  } catch {
+    // The waiting hook falls back to denying when its deadline passes, which
+    // is the safe outcome for a permission gate.
+  }
+}
+
+/**
+ * Ask the client to approve one tool call, then hand the answer to the waiting
+ * hook process through the shared directory.
+ *
+ * Fire-and-forget by design: `drain` runs on a timer and must not block the
+ * transcript reader while a human decides.
+ */
+function selectedOptionId(result: unknown): string | undefined {
+  const outcome = isRecord(result) ? result["outcome"] : undefined;
+  const optionId = isRecord(outcome) ? outcome["optionId"] : undefined;
+  return typeof optionId === "string" ? optionId : undefined;
+}
+
+function requestToolApproval(input: {
+  readonly sessionId: string;
+  readonly hookDir: string;
+  readonly hookName: string;
+  readonly payload: AgyHookPayload;
+}): void {
+  // Already approved for the whole session: answer without troubling the user.
+  if (sessionWideApprovals.has(input.sessionId)) {
+    writeDecision(input.hookDir, input.hookName, { decision: "allow" });
+    return;
+  }
+  const toolCall = input.payload.toolCall;
+  const stepIdx = typeof input.payload.stepIdx === "number" ? input.payload.stepIdx : 0;
+  void sendRequest(
+    "session/request_permission",
+    {
+      sessionId: input.sessionId,
+      toolCall: {
+        toolCallId: agyToolCallId(input.payload.conversationId, stepIdx),
+        title: agyToolTitle(toolCall),
+        kind: agyToolKind(toolCall?.name),
+        status: "pending",
+        rawInput: toolCall?.args ?? null,
+        ...(agyTargetPath(toolCall) ? { locations: [{ path: agyTargetPath(toolCall) }] } : {}),
+      },
+      options: [
+        { optionId: APPROVE_OPTION, name: "Allow", kind: "allow_once" },
+        {
+          optionId: APPROVE_SESSION_OPTION,
+          name: "Allow for this session",
+          kind: "allow_always",
+        },
+        { optionId: REJECT_OPTION, name: "Reject", kind: "reject_once" },
+      ],
+    },
+    APPROVAL_WAIT_MS,
+  )
+    .then((result) => {
+      const decision = approvalOutcomeToDecision(result, [APPROVE_OPTION, APPROVE_SESSION_OPTION]);
+      if (decision.decision === "allow" && selectedOptionId(result) === APPROVE_SESSION_OPTION) {
+        sessionWideApprovals.add(input.sessionId);
+      }
+      writeDecision(input.hookDir, input.hookName, decision);
+    })
+    .catch(() => {
+      writeDecision(input.hookDir, input.hookName, {
+        decision: "deny",
+        reason: "T3 Code could not obtain approval for this tool call",
+      });
+    });
+}
+
+/**
+ * Largest file the hook will inline into its event record. A diff of anything
+ * bigger is not worth the memory it would cost on both sides.
+ */
+const MAX_CAPTURED_FILE_BYTES = 2 * 1024 * 1024;
+
+function captureFileText(path: string | undefined): string | null {
+  if (!path) {
+    return null;
+  }
+  try {
+    const stats = NodeFS.statSync(path);
+    if (!stats.isFile() || stats.size > MAX_CAPTURED_FILE_BYTES) {
+      return null;
+    }
+    return NodeFS.readFileSync(path, "utf8");
+  } catch {
+    // A new file has no prior contents; that is a valid diff with no oldText.
+    return null;
+  }
+}
+
+/** Entry point for `t3 agy-hook <event>`. */
+export async function runAgyHook(event: string): Promise<void> {
+  let raw = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    raw += chunk;
+  }
+
+  const hookDir = process.env[HOOK_DIR_ENV]?.trim();
+  // When approvals are required this process is a security gate, not an
+  // observer. Any failure below — unparseable payload, unwritable hook
+  // directory, a bridge that never answers — must deny, because the CLI has
+  // already been told to skip its own permission prompts and nothing else
+  // stands between the model and the tool.
+  const gating = Boolean(hookDir) && approvalRequired() && event === "pre-tool-use";
+  if (hookDir) {
+    try {
+      const payload = JSON.parse(raw) as AgyHookPayload;
+      const record: AgyHookEvent = {
+        event,
+        payload,
+        // Snapshot the file here, while the hook still brackets the tool call.
+        ...(agyToolKind(payload?.toolCall?.name) === "edit"
+          ? { capturedFileText: captureFileText(agyTargetPath(payload?.toolCall)) }
+          : {}),
+      };
+      const name = `${process.hrtime.bigint().toString().padStart(24, "0")}-${event}.json`;
+      // Write then rename so the poller never observes a partial file.
+      const finalPath = NodePath.join(hookDir, name);
+      const tempPath = `${finalPath}.tmp`;
+      NodeFS.writeFileSync(tempPath, JSON.stringify(record));
+      NodeFS.renameSync(tempPath, finalPath);
+
+      // With approvals on, this process is the gate: block until the bridge
+      // reports the user's answer. `deny` here genuinely stops the tool —
+      // Antigravity reports the reason back to the model.
+      if (gating) {
+        // Every gating path answers here. A payload without `toolCall` used to
+        // fall through to the observation-only response, which allows — so a
+        // change in Antigravity's payload shape would have run tools unapproved.
+        const decision = payload?.toolCall
+          ? await awaitDecision(hookDir, name)
+          : ({
+              decision: "deny",
+              reason: "T3 Code could not identify this tool call for approval",
+            } satisfies AgyHookDecision);
+        process.stdout.write(JSON.stringify(decision));
+        return;
+      }
+    } catch {
+      // Observation is best-effort: a hook must never break a tool call —
+      // unless it is the approval gate, handled below.
+      if (gating) {
+        process.stdout.write(
+          JSON.stringify({
+            decision: "deny",
+            reason: "T3 Code could not record this tool call for approval",
+          } satisfies AgyHookDecision),
+        );
+        return;
+      }
+    }
+  }
+
+  process.stdout.write(JSON.stringify(agyHookResponse(event, Boolean(hookDir))));
+}
+
+/**
+ * Wait for the bridge's answer to one `PreToolUse` hook.
+ *
+ * Fails closed: if the bridge dies, the client never answers, or the deadline
+ * passes, the tool is denied rather than quietly allowed.
+ */
+async function awaitDecision(hookDir: string, hookName: string): Promise<AgyHookDecision> {
+  const target = decisionPath(hookDir, hookName);
+  const deadline = Date.now() + APPROVAL_WAIT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const raw = NodeFS.readFileSync(target, "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (isRecord(parsed) && (parsed["decision"] === "allow" || parsed["decision"] === "deny")) {
+        return parsed as unknown as AgyHookDecision;
+      }
+    } catch {
+      // Not written yet, or written partially; try again.
+    }
+    await new Promise((resolve) => setTimeout(resolve, APPROVAL_POLL_INTERVAL_MS));
+  }
+  return { decision: "deny", reason: "Timed out waiting for approval in T3 Code" };
+}
+
+// ── Turn execution ────────────────────────────────────────────────────
+
+function buildAgyArgs(input: {
+  readonly session: BridgeSession;
+  readonly hookWorkspace: string;
+  readonly attachmentDir: string | undefined;
+  readonly promptText: string;
+}): Array<string> {
+  const { session, hookWorkspace, attachmentDir } = input;
+  const args = [
+    "--dangerously-skip-permissions",
+    "--print-timeout",
+    process.env["T3_AGY_PRINT_TIMEOUT"]?.trim() || DEFAULT_PRINT_TIMEOUT,
+  ];
+  // Per session, not per process: `--model` applies to the turn being spawned
+  // and composes with `--conversation`, so the trajectory survives a switch.
+  const model = session.model?.trim();
+  if (model) {
+    args.push("--model", model);
+  }
+  const effort = session.effort?.trim();
+  if (effort) {
+    args.push("--effort", effort);
+  }
+  if (session.conversationId) {
+    args.push("--conversation", session.conversationId);
+  }
+  // Print mode does not infer workspace customizations from cwd alone. The
+  // session workspace is registered so its `.agents` skills and rules load;
+  // the hook workspace is registered so the observer attaches.
+  args.push("--add-dir", session.cwd, "--add-dir", hookWorkspace);
+  if (attachmentDir) {
+    args.push("--add-dir", attachmentDir);
+  }
+  args.push("--print", input.promptText);
+  return args;
+}
+
+/** A local file referenced by a `resource_link` prompt block. */
+interface PromptAttachment {
+  readonly path: string;
+  readonly name: string;
+  readonly mimeType: string | undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Extract local files from `resource_link` blocks.
+ *
+ * Only `file:` URIs are taken: a remote URL is left in the prompt text for the
+ * agent's own fetch tool, and passing one to `--add-dir` would be meaningless.
+ */
+function collectAttachments(promptBlocks: ReadonlyArray<unknown>): {
+  readonly files: ReadonlyArray<PromptAttachment>;
+  readonly remoteUris: ReadonlyArray<string>;
+} {
+  const files: Array<PromptAttachment> = [];
+  const remoteUris: Array<string> = [];
+  for (const block of promptBlocks) {
+    if (!isRecord(block) || block["type"] !== "resource_link") {
+      continue;
+    }
+    const uri = block["uri"];
+    if (typeof uri !== "string" || uri.length === 0) {
+      continue;
+    }
+    if (!uri.startsWith("file://")) {
+      // `resource_link` is baseline ACP, so a remote link has to reach the
+      // agent: it goes into the prompt text for Antigravity's own fetch tool.
+      remoteUris.push(uri);
+      continue;
+    }
+    let filePath: string;
+    try {
+      filePath = NodeURL.fileURLToPath(uri);
+    } catch {
+      remoteUris.push(uri);
+      continue;
+    }
+    const name = typeof block["name"] === "string" ? block["name"] : NodePath.basename(filePath);
+    files.push({
+      path: filePath,
+      name,
+      mimeType: typeof block["mimeType"] === "string" ? block["mimeType"] : undefined,
+    });
+  }
+  return { files, remoteUris };
+}
+
+interface RenderedPrompt {
+  readonly baseText: string;
+  readonly attachments: ReadonlyArray<PromptAttachment>;
+  readonly remoteUris: ReadonlyArray<string>;
+}
+
+function renderPrompt(session: BridgeSession, promptBlocks: unknown): RenderedPrompt | null {
+  if (!Array.isArray(promptBlocks)) {
+    return null;
+  }
+  const text = promptBlocks
+    .filter(
+      (block): block is { type: string; text: string } =>
+        isRecord(block) && block["type"] === "text" && typeof block["text"] === "string",
+    )
+    .map((block) => block.text)
+    .join("\n\n")
+    .trim();
+
+  const { files, remoteUris } = collectAttachments(promptBlocks);
+  if (text.length === 0 && files.length === 0 && remoteUris.length === 0) {
+    return null;
+  }
+
+  const systemPrompt = session.systemPrompt?.trim();
+  return {
+    baseText: systemPrompt ? `System instructions:\n${systemPrompt}\n\nRequest:\n${text}` : text,
+    attachments: files,
+    remoteUris,
+  };
+}
+
+/**
+ * Copy this turn's attachments into a throwaway directory.
+ *
+ * `agy --print` has no attachment flag, so files must be named by path with
+ * their directory registered via `--add-dir`. Registering the attachment store
+ * itself would hand an auto-approving agent read access to every thread's
+ * uploads, so only the files this turn references are staged, and the staging
+ * directory dies with the turn.
+ */
+function stageAttachments(attachments: ReadonlyArray<PromptAttachment>): {
+  readonly dir: string | undefined;
+  readonly staged: ReadonlyArray<PromptAttachment>;
+} {
+  if (attachments.length === 0) {
+    return { dir: undefined, staged: [] };
+  }
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-attach-"));
+  const staged: Array<PromptAttachment> = [];
+  try {
+    stageInto(dir, attachments, staged);
+  } catch (error) {
+    // Copies that already succeeded are user uploads; leaving them in /tmp
+    // because a later one failed would outlive the turn that needed them.
+    cleanupDir(dir);
+    throw error;
+  }
+  return { dir, staged };
+}
+
+function stageInto(
+  dir: string,
+  attachments: ReadonlyArray<PromptAttachment>,
+  staged: Array<PromptAttachment>,
+): void {
+  attachments.forEach((attachment, index) => {
+    // Index-prefixed and sanitised so two attachments sharing a basename cannot
+    // collide and a crafted name cannot escape the staging directory.
+    const safeName = `${index}-${NodePath.basename(attachment.name).replace(/[^\w.-]+/g, "_")}`;
+    const target = NodePath.join(dir, safeName);
+    // Not swallowed: silently dropping an attachment would run the turn
+    // against a prompt the user did not write, and an attachment-only request
+    // would become an empty prompt that still reports success.
+    NodeFS.copyFileSync(attachment.path, target);
+    staged.push({ path: target, name: safeName, mimeType: attachment.mimeType });
+  });
+}
+
+function composePromptText(
+  baseText: string,
+  staged: ReadonlyArray<PromptAttachment>,
+  remoteUris: ReadonlyArray<string>,
+): string {
+  const blocks: Array<string> = [];
+  if (staged.length > 0) {
+    const list = staged.map((a) => `- ${a.path}${a.mimeType ? ` (${a.mimeType})` : ""}`).join("\n");
+    blocks.push(`Attached files (read them from these paths):\n${list}`);
+  }
+  if (remoteUris.length > 0) {
+    blocks.push(`Attached links (fetch them):\n${remoteUris.map((u) => `- ${u}`).join("\n")}`);
+  }
+  return [baseText, ...blocks].filter((part) => part.length > 0).join("\n\n");
+}
+
+interface TurnOutcome {
+  readonly stopReason: "end_turn" | "cancelled";
+  readonly failure?: string;
+}
+
+let activeChild: NodeChildProcess.ChildProcess | null = null;
+/** Session whose turn is currently running, if any. Gates `session/cancel`. */
+let activeTurnSessionId: string | null = null;
+const cancelledSessions = new Set<string>();
+/**
+ * Cancels seen per session, counted rather than flagged.
+ *
+ * A prompt records this value when it is queued. If the count has moved by the
+ * time the prompt reaches the front, a cancel arrived while it waited and the
+ * prompt must not run — turns are serialized, so a steer queued behind a long
+ * turn would otherwise start executing tools after the user pressed Stop. A
+ * counter rather than a flag is what keeps this from also swallowing a cancel
+ * that lands harmlessly between two turns.
+ */
+const cancelGenerations = new Map<string, number>();
+/** Cancel generation captured when each queued prompt was accepted, by JSON-RPC id. */
+const queuedPromptGenerations = new Map<unknown, number>();
+
+function cancelGeneration(sessionId: string): number {
+  return cancelGenerations.get(sessionId) ?? 0;
+}
+
+/**
+ * Drain everything Antigravity has produced so far and emit it as ACP updates.
+ *
+ * Hooks are read first so a tool call is always announced before the
+ * transcript record carrying its output is matched against it.
+ */
+function drain(input: {
+  readonly sessionId: string;
+  readonly hookDir: string;
+  readonly seenHooks: Set<string>;
+  readonly state: AgyTurnState;
+  readonly cursor: AgyTranscriptCursor;
+  readonly decoder: NodeStringDecoder.StringDecoder;
+  readonly transcriptOffset: { value: number };
+  readonly assistantText: { emitted: boolean };
+  readonly final: boolean;
+}): void {
+  for (const { name, event: hook } of readHookEvents(input.hookDir, input.seenHooks)) {
+    // Diffing the file contents each hook captured, rather than the arguments
+    // of the edit, keeps this correct across tools whose argument shapes
+    // differ (`replace_file_content` sends a fragment, `write_to_file` sends
+    // the whole file).
+    const fileText = hook.capturedFileText ?? undefined;
+    const update = hookSessionUpdate(hook, input.state, fileText);
+    if (update) {
+      const stepIdx = hook.payload?.stepIdx;
+      if (
+        hook.event === "post-tool-use" &&
+        typeof stepIdx === "number" &&
+        !input.state.transcriptSeenSteps.has(stepIdx)
+      ) {
+        // Held back rather than sent: the transcript record carrying this
+        // step's real output is usually read later in this same pass, and a
+        // completed call can no longer take content. Once that record has been
+        // seen there is nothing left to wait for — and nothing to wait on,
+        // since the transcript is read once by byte offset.
+        input.state.pendingTerminal.set(stepIdx, update);
+      } else {
+        sendSessionUpdate(input.sessionId, update);
+      }
+    }
+    // The hook process is blocked until a decision file appears, so this has
+    // to be started for every announced tool call.
+    // Not during the final drain: the child has already exited, so no tool is
+    // waiting on the answer and the request would never be settled.
+    if (
+      !input.final &&
+      approvalRequired() &&
+      hook.event === "pre-tool-use" &&
+      hook.payload?.toolCall
+    ) {
+      requestToolApproval({
+        sessionId: input.sessionId,
+        hookDir: input.hookDir,
+        hookName: name,
+        payload: hook.payload,
+      });
+    }
+  }
+
+  const transcriptPath = resolveTranscriptPath(input.state);
+  if (transcriptPath) {
+    let chunk = "";
+    try {
+      const stats = NodeFS.statSync(transcriptPath);
+      if (stats.size > input.transcriptOffset.value) {
+        const fd = NodeFS.openSync(transcriptPath, "r");
+        try {
+          const length = stats.size - input.transcriptOffset.value;
+          const buffer = Buffer.alloc(length);
+          NodeFS.readSync(fd, buffer, 0, length, input.transcriptOffset.value);
+          // Decoded through the turn's streaming decoder, not `toString`: a
+          // write can land mid-multibyte-character, and decoding each slice
+          // independently would replace the partial sequence with U+FFFD and
+          // advance past it, silently corrupting non-ASCII output.
+          chunk = input.decoder.write(buffer);
+          input.transcriptOffset.value = stats.size;
+        } finally {
+          NodeFS.closeSync(fd);
+        }
+      }
+    } catch {
+      chunk = "";
+    }
+
+    const lines = chunk.length > 0 ? input.cursor.push(chunk) : [];
+    let allLines = input.final ? [...lines, ...input.cursor.flush()] : lines;
+    // Reading always starts at byte 0, so the first batch of a resumed
+    // conversation carries every prior turn. Trim once, then stream.
+    if (!input.state.transcriptPrimed && allLines.length > 0) {
+      const trimmed = dropPriorTurnRecords(allLines);
+      if (trimmed.length === allLines.length && input.state.resumedConversation && !input.final) {
+        // Resuming, and this batch holds no `USER_INPUT` — so the current
+        // turn's opening record has not been written yet and everything here
+        // belongs to a previous turn. Emitting it would replay old output;
+        // hold off and re-examine once more has been appended.
+        input.cursor.retain(allLines);
+        allLines = [];
+      } else {
+        allLines = [...trimmed];
+        input.state.transcriptPrimed = true;
+      }
+    }
+    for (const line of allLines) {
+      const record = parseTranscriptLine(line);
+      if (!record) {
+        continue;
+      }
+      const result = transcriptRecordUpdates(record, input.state);
+      for (const update of result.updates) {
+        sendSessionUpdate(input.sessionId, update);
+      }
+      if (result.emittedAssistantText) {
+        input.assistantText.emitted = true;
+      }
+      // This step's output is out; the call can be completed now.
+      const stepIndex = record.step_index;
+      if (typeof stepIndex === "number") {
+        flushTerminal(input.sessionId, input.state, stepIndex);
+      }
+    }
+  }
+
+  // Nothing more will arrive, so anything still waiting on a transcript record
+  // that never came is completed without output rather than left spinning.
+  if (input.final) {
+    const remaining = [...input.state.pendingTerminal.values()];
+    input.state.pendingTerminal.clear();
+    for (const terminal of remaining) {
+      sendSessionUpdate(input.sessionId, terminal);
+    }
+  }
+}
+
+function flushTerminal(sessionId: string, state: AgyTurnState, stepIdx: number): void {
+  const terminal = state.pendingTerminal.get(stepIdx);
+  if (!terminal) {
+    return;
+  }
+  state.pendingTerminal.delete(stepIdx);
+  sendSessionUpdate(sessionId, terminal);
+}
+
+/**
+ * Hooks report `transcript_full.jsonl`; the sibling `transcript.jsonl` holds
+ * the same steps without internal model chatter and is the better stream to
+ * render.
+ *
+ * The choice is pinned for the rest of the turn. `transcriptOffset` and the
+ * line cursor are byte positions into whichever file was picked, so switching
+ * once the condensed file appears would resume reading at an offset that means
+ * nothing in the new file — skipping records, or re-emitting ones already
+ * streamed from the other one.
+ */
+function resolveTranscriptPath(state: AgyTurnState): string | undefined {
+  if (state.resolvedTranscriptPath) {
+    return state.resolvedTranscriptPath;
+  }
+  const reported = state.transcriptPath;
+  if (!reported) {
+    return undefined;
+  }
+  const condensed = reported.replace(/transcript_full\.jsonl$/, "transcript.jsonl");
+  state.resolvedTranscriptPath = NodeFS.existsSync(condensed) ? condensed : reported;
+  return state.resolvedTranscriptPath;
+}
+
+async function runTurn(
+  sessionId: string,
+  session: BridgeSession,
+  prompt: RenderedPrompt,
+): Promise<TurnOutcome> {
+  // A cancel that raced the end of an earlier turn must not decide this one.
+  cancelledSessions.delete(sessionId);
+  // Claimed before any setup work: spawning `agy` takes long enough that a
+  // cancel can land first, and cancels are only honoured for the session
+  // holding this claim. Leaving it unset until after the spawn would silently
+  // drop those, letting an auto-approving child run on past a cancelled turn.
+  activeTurnSessionId = sessionId;
+  // Measured before `agy` starts: whatever the transcript already holds
+  // belongs to earlier turns of the conversation being resumed.
+  const baseline = transcriptBaseline(session.conversationId);
+  let hookDir: string | undefined;
+  let hookWorkspace: string | undefined;
+  let attachmentDir: string | undefined;
+  let child: NodeChildProcess.ChildProcess;
+  try {
+    hookDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hookout-"));
+    hookWorkspace = createHookWorkspace();
+    const attachments = stageAttachments(prompt.attachments);
+    attachmentDir = attachments.dir;
+    const command = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
+    child = NodeChildProcess.spawn(
+      command,
+      buildAgyArgs({
+        session,
+        hookWorkspace,
+        attachmentDir,
+        promptText: composePromptText(prompt.baseText, attachments.staged, prompt.remoteUris),
+      }),
+      {
+        cwd: session.cwd,
+        env: { ...process.env, [HOOK_DIR_ENV]: hookDir },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  } catch (error) {
+    // Setup failed, so no turn is running: release the claim and reclaim the
+    // directories, or repeated failures would leak one set each time.
+    activeTurnSessionId = null;
+    cleanupDir(hookDir);
+    cleanupDir(hookWorkspace);
+    cleanupDir(attachmentDir);
+    throw error;
+  }
+
+  const state = makeAgyTurnState(session.conversationId);
+  const seenHooks = new Set<string>();
+  const cursor = new AgyTranscriptCursor();
+  const decoder = new NodeStringDecoder.StringDecoder("utf8");
+  const transcriptOffset = { value: baseline };
+  if (baseline > 0) {
+    // Reading starts past every earlier turn, so there is no prior-turn
+    // content left for the `USER_INPUT` heuristic to guess at.
+    state.transcriptPrimed = true;
+  }
+  const assistantText = { emitted: false };
+  activeChild = child;
+  // A cancel during startup had no process to signal; deliver it now.
+  if (cancelledSessions.has(sessionId)) {
+    child.kill("SIGTERM");
+  }
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const poller = setInterval(() => {
+    drain({
+      sessionId,
+      hookDir,
+      seenHooks,
+      state,
+      cursor,
+      decoder,
+      transcriptOffset,
+      assistantText,
+      final: false,
+    });
+  }, HOOK_POLL_INTERVAL_MS);
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    child.on("error", () => resolve(null));
+    child.on("close", (code) => resolve(code));
+  });
+
+  clearInterval(poller);
+  activeChild = null;
+  activeTurnSessionId = null;
+  drain({
+    sessionId,
+    hookDir,
+    seenHooks,
+    state,
+    cursor,
+    decoder,
+    transcriptOffset,
+    assistantText,
+    final: true,
+  });
+
+  // Any tool still open at exit would otherwise render as spinning forever.
+  for (const [, call] of state.toolCalls) {
+    if (call.completed) {
+      continue;
+    }
+    sendSessionUpdate(sessionId, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: call.toolCallId,
+      status: "failed",
+      rawOutput: { isError: true, error: "Antigravity exited before the tool reported completion" },
+    });
+  }
+  state.toolCalls.clear();
+
+  if (state.conversationId) {
+    session.conversationId = state.conversationId;
+    persistConversationId(sessionId, state.conversationId);
+  }
+
+  cleanupDir(hookDir);
+  cleanupDir(hookWorkspace);
+  cleanupDir(attachmentDir);
+
+  if (cancelledSessions.delete(sessionId)) {
+    return { stopReason: "cancelled" };
+  }
+  if (exitCode !== 0) {
+    const detail = stderr.trim() || stdout.trim() || `agy exited with code ${exitCode}`;
+    return { stopReason: "end_turn", failure: detail };
+  }
+
+  // The transcript already streamed the assistant text. stdout is only used
+  // when transcript observation produced nothing, so the reply is never
+  // duplicated.
+  if (!assistantText.emitted && stdout.trim().length > 0) {
+    sendSessionUpdate(sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: stdout.trim() },
+    });
+  }
+  return { stopReason: "end_turn" };
+}
+
+function cleanupDir(dir: string | undefined): void {
+  if (!dir) {
+    return;
+  }
+  try {
+    NodeFS.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Temp directories are reclaimed by the OS.
+  }
+}
+
+// ── Request dispatch ──────────────────────────────────────────────────
+
+async function handleRequest(message: Record<string, unknown>): Promise<void> {
+  const method = typeof message["method"] === "string" ? message["method"] : undefined;
+  const id = message["id"];
+  const params = (message["params"] ?? {}) as Record<string, unknown>;
+
+  if (!method) {
+    return;
+  }
+
+  switch (method) {
+    case "initialize": {
+      const requested =
+        typeof params["protocolVersion"] === "number" ? params["protocolVersion"] : 1;
+      sendResult(id, {
+        protocolVersion: Math.min(requested, 1),
+        agentCapabilities: {
+          loadSession: true,
+          // Images ride in as `resource_link` blocks (an ACP baseline type)
+          // rather than inline base64, so the `image` capability stays off.
+          promptCapabilities: { image: false, audio: false, embeddedContext: false },
+          mcpCapabilities: { http: false, sse: false },
+        },
+        authMethods: [],
+        // The bridge has no version of its own; it ships with the server, so
+        // that is the version worth reporting. The Antigravity CLI version is
+        // reported separately by the provider snapshot (`agy --version`).
+        agentInfo: { name: "Antigravity", version: packageJson.version },
+      });
+      return;
+    }
+    // Antigravity manages its own Google sign-in; there is nothing for the
+    // client to authenticate against, but the handshake still requires a
+    // successful reply.
+    case "authenticate": {
+      sendResult(id, {});
+      return;
+    }
+    case "session/new":
+    case "session/load": {
+      const cwd = typeof params["cwd"] === "string" ? params["cwd"] : "";
+      if (!cwd || !NodePath.isAbsolute(cwd)) {
+        sendError(id, -32602, `${method} requires an absolute cwd`);
+        return;
+      }
+      const requestedSessionId =
+        typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      const sessionId =
+        method === "session/load" && requestedSessionId
+          ? requestedSessionId
+          : NodeCrypto.randomUUID();
+      sessions.set(sessionId, {
+        cwd,
+        systemPrompt:
+          typeof params["systemPrompt"] === "string" ? params["systemPrompt"] : undefined,
+        conversationId: requestedSessionId ? lookupConversationId(requestedSessionId) : undefined,
+        model: process.env["T3_AGY_MODEL"]?.trim() || undefined,
+        effort: process.env["T3_AGY_EFFORT"]?.trim() || undefined,
+      });
+      sendResult(id, method === "session/load" ? {} : { sessionId });
+      return;
+    }
+    // `--model` is a per-spawn flag that composes with `--conversation`, so a
+    // switch applies from the next turn while the trajectory carries over.
+    case "session/set_model": {
+      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      const session = sessionId ? sessions.get(sessionId) : undefined;
+      if (!session) {
+        sendError(id, -32602, "unknown sessionId");
+        return;
+      }
+      const modelId = typeof params["modelId"] === "string" ? params["modelId"].trim() : "";
+      if (modelId.length === 0) {
+        sendError(id, -32602, "session/set_model requires a modelId");
+        return;
+      }
+      session.model = modelId;
+      sendResult(id, {});
+      return;
+    }
+    case "session/prompt": {
+      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      const session = sessionId ? sessions.get(sessionId) : undefined;
+      if (!sessionId || !session) {
+        sendError(id, -32602, "unknown sessionId");
+        return;
+      }
+      const queuedAt = queuedPromptGenerations.get(id);
+      queuedPromptGenerations.delete(id);
+      if (queuedAt !== undefined && queuedAt !== cancelGeneration(sessionId)) {
+        // Cancelled while it sat in the queue; never spawn `agy` for it.
+        sendResult(id, { stopReason: "cancelled" });
+        return;
+      }
+      const prompt = renderPrompt(session, params["prompt"]);
+      if (prompt === null) {
+        sendError(id, -32602, "session/prompt requires at least one text block");
+        return;
+      }
+      const outcome = await runTurn(sessionId, session, prompt);
+      if (outcome.failure) {
+        sendError(id, -32000, `Antigravity turn failed: ${outcome.failure}`);
+        return;
+      }
+      sendResult(id, { stopReason: outcome.stopReason });
+      return;
+    }
+    case "session/cancel": {
+      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      if (sessionId) {
+        // Always recorded, so prompts already queued for this session can see
+        // that a cancel happened and refuse to start.
+        cancelGenerations.set(sessionId, cancelGeneration(sessionId) + 1);
+        // Only a cancel aimed at the turn actually running decides its stop
+        // reason. Cancels bypass the request queue, so one arriving after a
+        // turn finished — or targeting an idle session — must not sit in the
+        // set and mark the next successful turn cancelled.
+        if (sessionId === activeTurnSessionId) {
+          cancelledSessions.add(sessionId);
+          activeChild?.kill("SIGTERM");
+        }
+      }
+      return;
+    }
+    default: {
+      if (id !== undefined) {
+        sendError(id, -32601, `method not found: ${method}`);
+      }
+    }
+  }
+}
+
+/** Entry point for `t3 agy-acp`. */
+export async function runAgyBridge(): Promise<void> {
+  let buffer = "";
+  // Requests are handled strictly in order: a turn holds the agent busy, and
+  // ACP clients do not pipeline prompts for one session.
+  let queue: Promise<void> = Promise.resolve();
+
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    buffer += chunk;
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf("\n");
+      if (line.trim().length === 0) {
+        continue;
+      }
+
+      let message: Record<string, unknown>;
+      try {
+        const parsed: unknown = JSON.parse(line);
+        if (typeof parsed !== "object" || parsed === null) {
+          continue;
+        }
+        message = parsed as Record<string, unknown>;
+      } catch {
+        sendError(null, -32700, "invalid JSON");
+        continue;
+      }
+
+      // A reply to one of the bridge's own requests (tool approval) carries an
+      // id but no method, and must never enter the request queue — the turn
+      // holding that queue is exactly what is waiting on the answer.
+      if (message["method"] === undefined && resolveOutbound(message)) {
+        continue;
+      }
+
+      // Cancellation must interrupt an in-flight turn, so it bypasses the
+      // queue that would otherwise make it wait for that turn to finish.
+      if (message["method"] === "session/cancel") {
+        void handleRequest(message);
+        continue;
+      }
+      const pending = message;
+      // Captured now, not when the turn starts: the gap between the two is
+      // exactly the window a cancel has to arrive in while this prompt waits.
+      if (pending["method"] === "session/prompt") {
+        const target = (pending["params"] as Record<string, unknown> | undefined)?.["sessionId"];
+        if (typeof target === "string" && pending["id"] !== undefined) {
+          queuedPromptGenerations.set(pending["id"], cancelGeneration(target));
+        }
+      }
+      queue = queue
+        .then(() => handleRequest(pending))
+        .catch((error: unknown) => {
+          // Every request must be answered. Swallowing a handler failure would
+          // leave the client blocked on a response that never arrives.
+          if (pending["id"] !== undefined) {
+            const detail = error instanceof Error ? error.message : String(error);
+            sendError(pending["id"], -32603, `internal bridge error: ${detail}`);
+          }
+        });
+    }
+  }
+
+  // stdin closed: no approval can still be answered, so unblock the hooks
+  // waiting on them (they fail closed) rather than letting them time out.
+  failPendingOutbound("T3 Code disconnected before approving this tool call");
+  await queue;
+  activeChild?.kill("SIGTERM");
+}

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -22,6 +22,9 @@ import * as NodePath from "node:path";
 import * as NodeStringDecoder from "node:string_decoder";
 import * as NodeURL from "node:url";
 
+import * as Effect from "effect/Effect";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
 import packageJson from "../../../../package.json" with { type: "json" };
 import {
   agyHookResponse,
@@ -45,18 +48,7 @@ import {
   transcriptRecordUpdates,
 } from "./agyTranscript.ts";
 
-export function resolveAgyCommand(
-  command: string,
-  _env: Record<string, string | undefined> = process.env,
-  platform: NodeJS.Platform = process.platform,
-): { command: string; shell: boolean } {
-  const custom = command.trim();
-  if (platform !== "win32") {
-    return { command: custom, shell: false };
-  }
-  const isCmd = /\.cmd$/i.test(custom) || /\.bat$/i.test(custom);
-  return { command: custom, shell: isCmd };
-}
+
 
 const HOOK_DIR_ENV = "T3_AGY_HOOK_DIR";
 const REQUIRE_APPROVAL_ENV = "T3_AGY_REQUIRE_APPROVAL";
@@ -1019,20 +1011,25 @@ async function runTurn(
     const attachments = stageAttachments(prompt.attachments);
     attachmentDir = attachments.dir;
     const rawCommand = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
-    const { command, shell } = resolveAgyCommand(rawCommand);
+    const spawnCommand = Effect.runSync(
+      resolveSpawnCommand(
+        rawCommand,
+        buildAgyArgs({
+          session,
+          hookWorkspace,
+          attachmentDir,
+          promptText: composePromptText(prompt.baseText, attachments.staged, prompt.remoteUris),
+        }),
+      ),
+    );
     child = NodeChildProcess.spawn(
-      command,
-      buildAgyArgs({
-        session,
-        hookWorkspace,
-        attachmentDir,
-        promptText: composePromptText(prompt.baseText, attachments.staged, prompt.remoteUris),
-      }),
+      spawnCommand.command,
+      spawnCommand.args,
       {
         cwd: session.cwd,
         env: { ...process.env, [HOOK_DIR_ENV]: hookDir },
         stdio: ["ignore", "pipe", "pipe"],
-        shell,
+        shell: spawnCommand.shell,
       },
     );
   } catch (error) {

--- a/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  agyHookResponse,
+  agyTargetPath,
+  agyToolCallId,
+  agyToolKind,
+  agyToolTitle,
+  hookSessionUpdate,
+  makeAgyTurnState,
+  type AgyHookEvent,
+} from "./agyEvents.ts";
+
+const preToolUse = (overrides: Record<string, unknown> = {}): AgyHookEvent => ({
+  event: "pre-tool-use",
+  payload: {
+    conversationId: "conversation-1",
+    stepIdx: 3,
+    transcriptPath: "/brain/conversation-1/.system_generated/logs/transcript_full.jsonl",
+    modelName: "gemini-3.1-pro-high",
+    toolCall: { name: "run_command", args: { CommandLine: "ls -la src" } },
+    ...overrides,
+  },
+});
+
+describe("agyToolKind", () => {
+  it("maps Antigravity tool names onto ACP kinds", () => {
+    expect(agyToolKind("replace_file_content")).toBe("edit");
+    expect(agyToolKind("write_to_file")).toBe("edit");
+    expect(agyToolKind("view_file")).toBe("read");
+    expect(agyToolKind("list_dir")).toBe("read");
+    expect(agyToolKind("grep_search")).toBe("search");
+    expect(agyToolKind("run_command")).toBe("execute");
+    expect(agyToolKind("delete_file")).toBe("delete");
+  });
+
+  it("treats browser tools as fetch and unknown tools as other", () => {
+    expect(agyToolKind("browser_navigate")).toBe("fetch");
+    expect(agyToolKind("some_future_tool")).toBe("other");
+    expect(agyToolKind(undefined)).toBe("other");
+  });
+});
+
+describe("agyToolTitle", () => {
+  it("prefers Antigravity's own summary over the raw tool name", () => {
+    expect(agyToolTitle({ name: "run_command", args: { toolSummary: "List files in src" } })).toBe(
+      "List files in src",
+    );
+  });
+
+  it("falls back through toolAction to the tool name", () => {
+    expect(agyToolTitle({ name: "run_command", args: { toolAction: "Listing files" } })).toBe(
+      "Listing files",
+    );
+    expect(agyToolTitle({ name: "run_command", args: {} })).toBe("run_command");
+    expect(agyToolTitle(null)).toBe("Antigravity tool");
+  });
+});
+
+describe("agyTargetPath", () => {
+  it("reads the path from whichever PascalCase key the tool used", () => {
+    expect(agyTargetPath({ name: "replace_file_content", args: { TargetFile: "/a/b.ts" } })).toBe(
+      "/a/b.ts",
+    );
+    expect(agyTargetPath({ name: "view_file", args: { AbsolutePath: "/a/c.ts" } })).toBe("/a/c.ts");
+    expect(agyTargetPath({ name: "list_dir", args: { DirectoryPath: "/a" } })).toBe("/a");
+    expect(agyTargetPath({ name: "run_command", args: { CommandLine: "ls" } })).toBeUndefined();
+  });
+});
+
+describe("hookSessionUpdate", () => {
+  it("announces a tool call and records it as in flight", () => {
+    const state = makeAgyTurnState();
+    const update = hookSessionUpdate(preToolUse(), state);
+
+    expect(update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: agyToolCallId("conversation-1", 3),
+      kind: "execute",
+      status: "in_progress",
+      rawInput: { CommandLine: "ls -la src" },
+    });
+    expect(state.toolCalls.get(3)?.completed).toBe(false);
+  });
+
+  it("learns the conversation and transcript from any hook, not just stop", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(preToolUse(), state);
+
+    expect(state.conversationId).toBe("conversation-1");
+    expect(state.modelName).toBe("gemini-3.1-pro-high");
+    expect(state.transcriptPath).toBe(
+      "/brain/conversation-1/.system_generated/logs/transcript_full.jsonl",
+    );
+  });
+
+  it("ignores hook pairs for internal planner steps that carry no tool", () => {
+    const state = makeAgyTurnState();
+    const update = hookSessionUpdate(
+      { event: "pre-tool-use", payload: { conversationId: "c", stepIdx: 1, toolCall: null } },
+      state,
+    );
+
+    expect(update).toBeNull();
+    expect(state.toolCalls.size).toBe(0);
+  });
+
+  it("completes a tool call that was announced", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(preToolUse(), state);
+    const update = hookSessionUpdate(
+      {
+        event: "post-tool-use",
+        payload: { conversationId: "conversation-1", stepIdx: 3, error: "" },
+      },
+      state,
+    );
+
+    expect(update).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      status: "completed",
+      rawOutput: { isError: false },
+    });
+    // Retained, not deleted: the transcript record carrying this step's output
+    // is often read in the same drain pass and still needs the tool call id.
+    expect(state.toolCalls.get(3)?.completed).toBe(true);
+  });
+
+  it("ignores a duplicate post hook for an already completed step", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(preToolUse(), state);
+    const post = {
+      event: "post-tool-use",
+      payload: { conversationId: "conversation-1", stepIdx: 3, error: "" },
+    } as const;
+
+    expect(hookSessionUpdate(post, state)).not.toBeNull();
+    expect(hookSessionUpdate(post, state)).toBeNull();
+  });
+
+  it("marks a tool call failed and carries the error through", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(preToolUse(), state);
+    const update = hookSessionUpdate(
+      {
+        event: "post-tool-use",
+        payload: { conversationId: "conversation-1", stepIdx: 3, error: "exit status 1" },
+      },
+      state,
+    );
+
+    expect(update).toMatchObject({
+      status: "failed",
+      rawOutput: { isError: true, error: "exit status 1" },
+    });
+  });
+
+  it("drops a post hook whose pre hook was never observed", () => {
+    const state = makeAgyTurnState();
+    const update = hookSessionUpdate(
+      { event: "post-tool-use", payload: { conversationId: "c", stepIdx: 9, error: "" } },
+      state,
+    );
+
+    expect(update).toBeNull();
+  });
+
+  it("emits a diff from the file contents captured around an edit", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(
+      preToolUse({
+        toolCall: { name: "replace_file_content", args: { TargetFile: "/repo/greet.js" } },
+      }),
+      state,
+      'return "hi";',
+    );
+    const update = hookSessionUpdate(
+      {
+        event: "post-tool-use",
+        payload: { conversationId: "conversation-1", stepIdx: 3, error: "" },
+      },
+      state,
+      'return "hello";',
+    );
+
+    expect(update).toMatchObject({
+      status: "completed",
+      content: [
+        {
+          type: "diff",
+          path: "/repo/greet.js",
+          oldText: 'return "hi";',
+          newText: 'return "hello";',
+        },
+      ],
+    });
+  });
+
+  it("omits the diff when an edit left the file byte-identical", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(
+      preToolUse({
+        toolCall: { name: "write_to_file", args: { TargetFile: "/repo/a.ts" } },
+      }),
+      state,
+      "same",
+    );
+    const update = hookSessionUpdate(
+      {
+        event: "post-tool-use",
+        payload: { conversationId: "conversation-1", stepIdx: 3, error: "" },
+      },
+      state,
+      "same",
+    );
+
+    expect(update).not.toHaveProperty("content");
+  });
+});
+
+describe("agyHookResponse", () => {
+  it("allows tools only while a bridge observer is attached", () => {
+    expect(agyHookResponse("pre-tool-use", true)).toEqual({ decision: "allow" });
+    expect(agyHookResponse("pre-tool-use", false)).toMatchObject({ decision: "ask" });
+  });
+
+  it("answers the stop contract with a decision", () => {
+    expect(agyHookResponse("stop", true)).toEqual({ decision: "stop" });
+    expect(agyHookResponse("post-tool-use", true)).toEqual({});
+  });
+});
+
+describe("resolveAgyCommand", () => {
+  it("returns unchanged command for non-windows platforms", async () => {
+    const { resolveAgyCommand } = await import("./agyBridge.ts");
+    expect(resolveAgyCommand("agy", {}, "linux")).toEqual({ command: "agy", shell: false });
+    expect(resolveAgyCommand("agy", {}, "darwin")).toEqual({ command: "agy", shell: false });
+  });
+
+  it("identifies explicit cmd files on windows", async () => {
+    const { resolveAgyCommand } = await import("./agyBridge.ts");
+    expect(resolveAgyCommand("C:\\tools\\agy.cmd", {}, "win32")).toEqual({
+      command: "C:\\tools\\agy.cmd",
+      shell: true,
+    });
+  });
+});

--- a/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
@@ -230,18 +230,4 @@ describe("agyHookResponse", () => {
   });
 });
 
-describe("resolveAgyCommand", () => {
-  it("returns unchanged command for non-windows platforms", async () => {
-    const { resolveAgyCommand } = await import("./agyBridge.ts");
-    expect(resolveAgyCommand("agy", {}, "linux")).toEqual({ command: "agy", shell: false });
-    expect(resolveAgyCommand("agy", {}, "darwin")).toEqual({ command: "agy", shell: false });
-  });
 
-  it("identifies explicit cmd files on windows", async () => {
-    const { resolveAgyCommand } = await import("./agyBridge.ts");
-    expect(resolveAgyCommand("C:\\tools\\agy.cmd", {}, "win32")).toEqual({
-      command: "C:\\tools\\agy.cmd",
-      shell: true,
-    });
-  });
-});

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -1,0 +1,439 @@
+/**
+ * Pure translation layer for the Antigravity ACP bridge.
+ *
+ * Antigravity exposes no native agent protocol, so the bridge reconstructs an
+ * ACP event stream from two independent sources that Antigravity *does*
+ * document:
+ *
+ *   - **Hooks** (`PreToolUse` / `PostToolUse` / `Stop`) deliver the tool name,
+ *     its arguments, a human-readable summary, and completion status.
+ *   - **The trajectory transcript** (`transcript.jsonl`) delivers assistant
+ *     text and real tool output, appended progressively while the turn runs.
+ *
+ * The two correlate exactly: a hook's `stepIdx` is the transcript record's
+ * `step_index`. Neither source alone is sufficient — hooks never carry tool
+ * output, and the transcript never carries tool arguments.
+ *
+ * Everything here is pure so it can be tested without spawning `agy`. IO lives
+ * in `agyBridge.ts`.
+ *
+ * @module provider/acp/antigravity/agyEvents
+ */
+
+/** Tool-call lifecycle kinds understood by ACP clients. */
+export type AcpToolKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "think"
+  | "fetch"
+  | "switch_mode"
+  | "other";
+
+export type AgyHookEventName = "pre-tool-use" | "post-tool-use" | "stop";
+
+export interface AgyToolCall {
+  readonly name?: string;
+  readonly args?: Record<string, unknown> | null;
+}
+
+/**
+ * Documented Antigravity hook payload. Every event carries `conversationId`
+ * and `transcriptPath`, which is what lets the bridge resume a trajectory and
+ * locate its transcript without guessing.
+ */
+export interface AgyHookPayload {
+  readonly conversationId?: string;
+  readonly stepIdx?: number;
+  readonly toolCall?: AgyToolCall | null;
+  readonly error?: string;
+  readonly modelName?: string;
+  readonly transcriptPath?: string;
+  readonly artifactDirectoryPath?: string;
+  readonly workspacePaths?: ReadonlyArray<string>;
+  readonly fullyIdle?: boolean;
+  readonly terminationReason?: string;
+  readonly executionNum?: number;
+}
+
+export interface AgyHookEvent {
+  readonly event: AgyHookEventName | string;
+  readonly payload: AgyHookPayload;
+  /**
+   * Contents of the tool's target file, captured by the hook process itself.
+   *
+   * This cannot be read by the bridge when it drains hook output: both hooks
+   * for a fast edit land inside a single poll interval, by which point the
+   * edit has already been written and "before" would read back as "after".
+   * The hook runs synchronously within the tool lifecycle, so it is the only
+   * place that observes the true pre-edit state.
+   */
+  readonly capturedFileText?: string | null;
+}
+
+/**
+ * Antigravity tool names, mapped onto ACP kinds so clients can pick the right
+ * affordance. Unknown tools degrade to `other` rather than being dropped.
+ */
+export function agyToolKind(name: string | undefined): AcpToolKind {
+  switch (name) {
+    case "write_to_file":
+    case "replace_file_content":
+    case "multi_replace_file_content":
+    case "edit_file":
+      return "edit";
+    case "view_file":
+    case "view_code_item":
+    case "list_dir":
+    case "read_url_content":
+      return "read";
+    case "grep_search":
+    case "find_by_name":
+    case "codebase_search":
+    case "search_web":
+      return "search";
+    case "run_command":
+    case "command_status":
+      return "execute";
+    case "delete_file":
+      return "delete";
+    default:
+      if (name && name.startsWith("browser_")) {
+        return "fetch";
+      }
+      return "other";
+  }
+}
+
+/**
+ * Stable identity for one tool call across its hook pair and its transcript
+ * record. `stepIdx` is unique within a conversation and is echoed verbatim as
+ * the transcript's `step_index`.
+ */
+export function agyToolCallId(conversationId: string | undefined, stepIdx: number): string {
+  return `agy-${conversationId ?? "unknown"}-${stepIdx}`;
+}
+
+/**
+ * Prefer Antigravity's own human-readable summary over the raw tool name.
+ * `PostToolUse` enriches `args` with `toolSummary`/`toolAction`; `PreToolUse`
+ * usually has neither, so the tool name is the fallback.
+ */
+export function agyToolTitle(toolCall: AgyToolCall | null | undefined): string {
+  const args = toolCall?.args;
+  const summary = typeof args?.["toolSummary"] === "string" ? args["toolSummary"].trim() : "";
+  if (summary.length > 0) {
+    return summary;
+  }
+  const action = typeof args?.["toolAction"] === "string" ? args["toolAction"].trim() : "";
+  if (action.length > 0) {
+    return action;
+  }
+  return toolCall?.name?.trim() || "Antigravity tool";
+}
+
+/**
+ * File path a tool acts on, when it names one. Antigravity uses PascalCase
+ * argument keys and is not consistent about which one carries the path.
+ */
+export function agyTargetPath(toolCall: AgyToolCall | null | undefined): string | undefined {
+  const args = toolCall?.args;
+  if (!args) {
+    return undefined;
+  }
+  for (const key of ["TargetFile", "AbsolutePath", "FilePath", "Path", "DirectoryPath"]) {
+    const value = args[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+/** Metadata echoed onto every emitted update for debugging and traceability. */
+export function agyUpdateMeta(event: string, payload: AgyHookPayload): Record<string, unknown> {
+  return {
+    antigravity: {
+      event,
+      conversationId: payload.conversationId ?? null,
+      stepIdx: payload.stepIdx ?? null,
+      modelName: payload.modelName ?? null,
+      transcriptPath: payload.transcriptPath ?? null,
+      artifactDirectoryPath: payload.artifactDirectoryPath ?? null,
+    },
+  };
+}
+
+export interface AgyToolCallRecord {
+  readonly toolCallId: string;
+  readonly name: string | undefined;
+  readonly kind: AcpToolKind;
+  readonly targetPath: string | undefined;
+  /** File contents captured at `PreToolUse`, used to build an edit diff. */
+  readonly beforeText: string | undefined;
+  /** Set by `PostToolUse`. Records are kept after completion so a transcript
+   * record that lands in the same poll can still attach the tool's output. */
+  completed: boolean;
+}
+
+/**
+ * Mutable bookkeeping shared by the hook and transcript readers for one turn.
+ */
+export interface AgyTurnState {
+  /**
+   * Every tool call seen this turn, keyed by step index — completed ones
+   * included. The two event sources are drained in the same pass, so a step
+   * must stay addressable after its `PostToolUse` hook or its transcript
+   * output would be dropped whenever both arrive within one poll.
+   */
+  readonly toolCalls: Map<number, AgyToolCallRecord>;
+  /**
+   * Terminal `tool_call_update`s held back until the transcript record with
+   * that step's output has been streamed. `AcpSessionRuntime` drops its tool
+   * state once a call completes, so output emitted afterwards would surface as
+   * a second, never-completed item.
+   */
+  readonly pendingTerminal: Map<number, AgySessionUpdate>;
+  /**
+   * Steps whose transcript output has already been streamed. The transcript is
+   * read once by byte offset, so a record consumed before its `PostToolUse`
+   * hook appeared will never be revisited — without this the tool would render
+   * as running until the turn ended.
+   */
+  readonly transcriptSeenSteps: Set<number>;
+  conversationId: string | undefined;
+  transcriptPath: string | undefined;
+  /** Transcript file pinned for the turn; see `resolveTranscriptPath`. */
+  resolvedTranscriptPath: string | undefined;
+  /**
+   * Whether records predating this turn have been discarded. Reading starts at
+   * byte 0, which on a resumed conversation is the start of the whole history.
+   */
+  transcriptPrimed: boolean;
+  /**
+   * Whether this turn resumed an existing conversation. Only then can the
+   * transcript already hold other turns' records at byte 0.
+   */
+  readonly resumedConversation: boolean;
+  modelName: string | undefined;
+}
+
+export function makeAgyTurnState(conversationId?: string): AgyTurnState {
+  return {
+    toolCalls: new Map(),
+    pendingTerminal: new Map(),
+    transcriptSeenSteps: new Set(),
+    conversationId,
+    transcriptPath: undefined,
+    resolvedTranscriptPath: undefined,
+    transcriptPrimed: false,
+    resumedConversation: conversationId !== undefined,
+    modelName: undefined,
+  };
+}
+
+/** A `session/update` payload, shaped for ACP but kept as plain JSON. */
+export type AgySessionUpdate = Record<string, unknown>;
+
+/**
+ * Translate one `PreToolUse` hook into an ACP `tool_call` announcement.
+ *
+ * `beforeText` is threaded in by the caller (which does the file read) so this
+ * function stays pure.
+ */
+export function preToolUseUpdate(
+  payload: AgyHookPayload,
+  state: AgyTurnState,
+  beforeText?: string,
+): AgySessionUpdate | null {
+  const stepIdx = payload.stepIdx;
+  if (typeof stepIdx !== "number") {
+    return null;
+  }
+  const toolCall = payload.toolCall;
+  // Antigravity emits hook pairs for internal planner steps with no tool
+  // attached. Those are not tool calls and must not render as one.
+  if (!toolCall || !toolCall.name) {
+    return null;
+  }
+
+  const toolCallId = agyToolCallId(payload.conversationId, stepIdx);
+  const kind = agyToolKind(toolCall.name);
+  const targetPath = agyTargetPath(toolCall);
+  state.toolCalls.set(stepIdx, {
+    toolCallId,
+    name: toolCall.name,
+    kind,
+    targetPath,
+    beforeText,
+    completed: false,
+  });
+
+  return {
+    sessionUpdate: "tool_call",
+    toolCallId,
+    title: agyToolTitle(toolCall),
+    kind,
+    status: "in_progress",
+    rawInput: toolCall.args ?? null,
+    ...(targetPath ? { locations: [{ path: targetPath }] } : {}),
+    _meta: agyUpdateMeta("pre-tool-use", payload),
+  };
+}
+
+/**
+ * Translate one `PostToolUse` hook into an ACP `tool_call_update`.
+ *
+ * `afterText` is the on-disk content of an edited file, read by the caller
+ * after the tool ran. Diffing captured before/after content sidesteps having
+ * to interpret Antigravity's edit arguments, whose semantics vary by tool.
+ */
+export function postToolUseUpdate(
+  payload: AgyHookPayload,
+  state: AgyTurnState,
+  afterText?: string,
+): AgySessionUpdate | null {
+  const stepIdx = payload.stepIdx;
+  if (typeof stepIdx !== "number") {
+    return null;
+  }
+  const active = state.toolCalls.get(stepIdx);
+  // Only complete calls whose `PreToolUse` we actually observed; Antigravity
+  // emits unpaired post hooks for internal steps.
+  if (!active || active.completed) {
+    return null;
+  }
+  // Marked rather than removed: the transcript record carrying this step's
+  // output is often read in the same drain pass, and dropping the entry here
+  // would leave it with no tool call to attach to.
+  active.completed = true;
+
+  const error = typeof payload.error === "string" ? payload.error.trim() : "";
+  const failed = error.length > 0;
+
+  const content: Array<Record<string, unknown>> = [];
+  if (
+    !failed &&
+    active.kind === "edit" &&
+    active.targetPath &&
+    afterText !== undefined &&
+    afterText !== active.beforeText
+  ) {
+    content.push({
+      type: "diff",
+      path: active.targetPath,
+      ...(active.beforeText === undefined ? {} : { oldText: active.beforeText }),
+      newText: afterText,
+    });
+  }
+
+  return {
+    sessionUpdate: "tool_call_update",
+    toolCallId: active.toolCallId,
+    status: failed ? "failed" : "completed",
+    ...(content.length > 0 ? { content } : {}),
+    rawOutput: failed ? { isError: true, error } : { isError: false },
+    _meta: agyUpdateMeta("post-tool-use", payload),
+  };
+}
+
+/**
+ * Fold a hook event into turn state, returning the update to emit (if any).
+ *
+ * `Stop` carries no user-visible update; it exists to publish the conversation
+ * id that lets the next turn resume the same trajectory.
+ */
+export function hookSessionUpdate(
+  hook: AgyHookEvent,
+  state: AgyTurnState,
+  fileText?: string,
+): AgySessionUpdate | null {
+  const payload = hook.payload ?? {};
+  // Every hook carries the conversation id, so the bridge learns it from the
+  // first event of the turn rather than waiting for `Stop`.
+  const conversationId = payload.conversationId?.trim();
+  if (conversationId) {
+    state.conversationId = conversationId;
+  }
+  const transcriptPath = payload.transcriptPath?.trim();
+  if (transcriptPath) {
+    state.transcriptPath = transcriptPath;
+  }
+  const modelName = payload.modelName?.trim();
+  if (modelName) {
+    state.modelName = modelName;
+  }
+
+  switch (hook.event) {
+    case "pre-tool-use":
+      return preToolUseUpdate(payload, state, fileText);
+    case "post-tool-use":
+      return postToolUseUpdate(payload, state, fileText);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Response Antigravity requires on stdout for each hook event.
+ *
+ * `pre-tool-use` must return a decision. When no bridge observer is attached
+ * the safe answer is `ask`: a hook that silently allowed every tool outside a
+ * managed turn would be a permission bypass.
+ */
+export interface AgyHookDecision {
+  readonly decision: "allow" | "deny" | "ask";
+  readonly reason?: string;
+}
+
+/**
+ * Translate the client's `session/request_permission` reply into the decision
+ * the blocked `PreToolUse` hook will print.
+ *
+ * Fails closed: only an explicit selection of the approve option allows the
+ * tool. A cancelled prompt, an unknown option id, or a malformed reply all
+ * deny, because this is the only thing standing between the model and a tool
+ * that `agy` has already been told to run without asking.
+ */
+export function approvalOutcomeToDecision(
+  result: unknown,
+  approveOptionIds: ReadonlyArray<string>,
+): AgyHookDecision {
+  const outcome =
+    typeof result === "object" && result !== null
+      ? (result as { outcome?: unknown }).outcome
+      : undefined;
+  const selected =
+    typeof outcome === "object" && outcome !== null
+      ? (outcome as { outcome?: unknown; optionId?: unknown })
+      : undefined;
+  if (
+    selected?.outcome === "selected" &&
+    typeof selected.optionId === "string" &&
+    approveOptionIds.includes(selected.optionId)
+  ) {
+    return { decision: "allow" };
+  }
+  return { decision: "deny", reason: "Rejected in T3 Code" };
+}
+
+export function agyHookResponse(event: string, observerAttached: boolean): Record<string, unknown> {
+  switch (event) {
+    case "pre-tool-use":
+      return observerAttached
+        ? { decision: "allow" }
+        : {
+            decision: "ask",
+            reason: "T3 Code hook observer is not attached to a managed Antigravity turn",
+          };
+    // Antigravity's Stop contract requires a decision; anything other than
+    // "continue" lets the completed execution stop.
+    case "stop":
+      return { decision: "stop" };
+    default:
+      return {};
+  }
+}

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -72,6 +72,15 @@ export interface AgyHookEvent {
    * place that observes the true pre-edit state.
    */
   readonly capturedFileText?: string | null;
+  /**
+   * The hook's own stdin, verbatim.
+   *
+   * Written by the hook and hashed by both sides, so an approval is bound to
+   * the exact request the user saw: a payload swapped on disk between the hook
+   * writing it and the bridge reading it produces a different digest, and the
+   * decision is rejected.
+   */
+  readonly rawPayload?: string;
 }
 
 /**
@@ -172,8 +181,15 @@ export interface AgyToolCallRecord {
   readonly name: string | undefined;
   readonly kind: AcpToolKind;
   readonly targetPath: string | undefined;
-  /** File contents captured at `PreToolUse`, used to build an edit diff. */
-  readonly beforeText: string | undefined;
+  /**
+   * File contents captured at `PreToolUse`, used to build an edit diff.
+   *
+   * Released as soon as that diff has been built. Records are kept for the
+   * whole turn so late transcript output can still attach to them, and holding
+   * every edited file's prior contents for that long is what turns a long edit
+   * loop into gigabytes of heap.
+   */
+  beforeText: string | undefined;
   /** Set by `PostToolUse`. Records are kept after completion so a transcript
    * record that lands in the same poll can still attach the tool's output. */
   completed: boolean;
@@ -204,6 +220,28 @@ export interface AgyTurnState {
    * as running until the turn ended.
    */
   readonly transcriptSeenSteps: Set<number>;
+  /**
+   * Transcript records whose tool call has not been announced yet.
+   *
+   * The hook directory is listed before the transcript is read, so a tool whose
+   * `PreToolUse` file lands in between produces a record with nothing to attach
+   * it to. The transcript is consumed once by byte offset, so these are held
+   * rather than dropped and retried on the next pass.
+   */
+  readonly deferredRecords: Array<AgyDeferredTranscriptRecord>;
+  /**
+   * Serialized size of `deferredRecords`.
+   *
+   * Maintained as entries enter and leave the queue so enforcing the aggregate
+   * cap does not have to rescan every retained record on every drain pass.
+   */
+  deferredRecordChars: number;
+  /**
+   * Drains the held records have waited. Antigravity emits unpaired steps for
+   * its own internal work, so a record whose hook is never coming must not
+   * block the stream indefinitely.
+   */
+  deferredDrains: number;
   conversationId: string | undefined;
   transcriptPath: string | undefined;
   /** Transcript file pinned for the turn; see `resolveTranscriptPath`. */
@@ -213,6 +251,12 @@ export interface AgyTurnState {
    * byte 0, which on a resumed conversation is the start of the whole history.
    */
   transcriptPrimed: boolean;
+  /**
+   * Whether resumed-transcript priming discarded its candidate suffix after
+   * exceeding the memory budget. Records that follow can still be history, so
+   * none are emitted until a later `USER_INPUT` establishes a new boundary.
+   */
+  transcriptPrimingOverflowed: boolean;
   /**
    * Whether this turn resumed an existing conversation. Only then can the
    * transcript already hold other turns' records at byte 0.
@@ -226,17 +270,74 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
     toolCalls: new Map(),
     pendingTerminal: new Map(),
     transcriptSeenSteps: new Set(),
+    deferredRecords: [],
+    deferredRecordChars: 0,
+    deferredDrains: 0,
     conversationId,
     transcriptPath: undefined,
     resolvedTranscriptPath: undefined,
     transcriptPrimed: false,
+    transcriptPrimingOverflowed: false,
     resumedConversation: conversationId !== undefined,
     modelName: undefined,
   };
 }
 
+/** Minimal shape of a transcript record, kept here to avoid a circular import. */
+export interface AgyTranscriptRecordLike {
+  readonly step_index?: number;
+  readonly type?: string;
+  readonly content?: string;
+}
+
+/** A retained transcript record and its one-time complete serialized size. */
+export interface AgyDeferredTranscriptRecord {
+  readonly record: AgyTranscriptRecordLike;
+  readonly serializedChars: number;
+}
+
 /** A `session/update` payload, shaped for ACP but kept as plain JSON. */
 export type AgySessionUpdate = Record<string, unknown>;
+
+export interface AgyOrderedSessionUpdate {
+  readonly stepIdx: number | undefined;
+  readonly phase: "pre" | "transcript" | "terminal";
+  readonly update: AgySessionUpdate;
+}
+
+/**
+ * Order updates reconstructed from independent hook and transcript sources.
+ *
+ * Step index preserves the order Antigravity executed them in. Within one
+ * step, the call must exist before output is attached and must stay open until
+ * that output has been sent.
+ */
+export function orderAgySessionUpdates(
+  entries: ReadonlyArray<AgyOrderedSessionUpdate>,
+): ReadonlyArray<AgySessionUpdate> {
+  const phaseOrder = { pre: 0, transcript: 1, terminal: 2 } as const;
+  let precedingKey: { readonly step: number; readonly phase: number } | undefined;
+  return entries
+    .map((entry) => {
+      // PLANNER_RESPONSE records may omit step_index. Reusing the preceding
+      // entry's complete ordering key lets the stable sort keep the response
+      // immediately after that entry, including when it followed a terminal
+      // update, while indexed entries still use step and lifecycle phase.
+      const key =
+        entry.stepIdx === undefined
+          ? (precedingKey ?? {
+              step: Number.NEGATIVE_INFINITY,
+              phase: phaseOrder[entry.phase],
+            })
+          : { step: entry.stepIdx, phase: phaseOrder[entry.phase] };
+      precedingKey = key;
+      return { entry, key };
+    })
+    .sort((left, right) => {
+      return left.key.step - right.key.step || left.key.phase - right.key.phase;
+    })
+    .map(({ entry }) => entry.update);
+}
 
 /**
  * Translate one `PreToolUse` hook into an ACP `tool_call` announcement.
@@ -329,6 +430,10 @@ export function postToolUseUpdate(
       newText: afterText,
     });
   }
+  // The diff is built, so the captured contents have no further use. This is
+  // the only thing held here that scales with file size rather than with the
+  // number of steps.
+  active.beforeText = undefined;
 
   return {
     sessionUpdate: "tool_call_update",

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { hookSessionUpdate, makeAgyTurnState, type AgyTurnState } from "./agyEvents.ts";
+import {
+  AgyTranscriptCursor,
+  normalizeToolOutput,
+  parseTranscriptLine,
+  transcriptRecordUpdates,
+} from "./agyTranscript.ts";
+
+function stateWithActiveTool(stepIdx: number, name = "run_command"): AgyTurnState {
+  const state = makeAgyTurnState();
+  hookSessionUpdate(
+    {
+      event: "pre-tool-use",
+      payload: { conversationId: "conversation-1", stepIdx, toolCall: { name, args: {} } },
+    },
+    state,
+  );
+  return state;
+}
+
+describe("parseTranscriptLine", () => {
+  it("returns null for blank and half-written lines", () => {
+    expect(parseTranscriptLine("")).toBeNull();
+    expect(parseTranscriptLine('{"step_index": 1, "type": "RUN_COM')).toBeNull();
+  });
+
+  it("parses a complete record", () => {
+    expect(parseTranscriptLine('{"step_index":2,"type":"PLANNER_RESPONSE"}')).toMatchObject({
+      step_index: 2,
+      type: "PLANNER_RESPONSE",
+    });
+  });
+});
+
+describe("normalizeToolOutput", () => {
+  it("strips the timestamp preamble", () => {
+    const output = normalizeToolOutput(
+      "Created At: 2026-07-24T17:31:41-04:00\nCompleted At: 2026-07-24T17:31:41-04:00\nresult",
+    );
+    expect(output).toBe("result");
+  });
+
+  it("dedents Antigravity's tab-indented framing without touching flush-left output", () => {
+    // Antigravity indents its own framing with tabs but writes the tool's real
+    // output flush left, so a plain common-prefix dedent would find zero.
+    const output = normalizeToolOutput(
+      "Created At: x\n\n\t\t\t\tThe command exited with code 0.\n\t\t\t\tOutput:\n\t\t\t\ttotal 16\ndrwxr-xr-x  4 alex staff",
+    );
+    expect(output).toBe(
+      "The command exited with code 0.\nOutput:\ntotal 16\ndrwxr-xr-x  4 alex staff",
+    );
+  });
+
+  it("dedents tab-indented source uniformly", () => {
+    expect(normalizeToolOutput("\t\tconst a = 1;\n\t\t\tconst b = 2;")).toBe(
+      "const a = 1;\n\tconst b = 2;",
+    );
+  });
+});
+
+describe("transcriptRecordUpdates", () => {
+  it("streams assistant text as an agent message chunk", () => {
+    const result = transcriptRecordUpdates(
+      { step_index: 7, source: "MODEL", type: "PLANNER_RESPONSE", content: "All done." },
+      makeAgyTurnState(),
+    );
+
+    expect(result.emittedAssistantText).toBe(true);
+    expect(result.updates[0]).toMatchObject({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "All done." },
+    });
+  });
+
+  it("skips empty planner responses", () => {
+    const result = transcriptRecordUpdates(
+      { step_index: 2, source: "MODEL", type: "PLANNER_RESPONSE", content: "   " },
+      makeAgyTurnState(),
+    );
+
+    expect(result.updates).toHaveLength(0);
+    expect(result.emittedAssistantText).toBe(false);
+  });
+
+  it("ignores bookkeeping records that would read as assistant output", () => {
+    for (const type of ["CHECKPOINT", "CONVERSATION_HISTORY", "USER_INPUT", "SYSTEM_MESSAGE"]) {
+      const result = transcriptRecordUpdates(
+        { step_index: 1, source: "SYSTEM", type, content: "internal" },
+        makeAgyTurnState(),
+      );
+      expect(result.updates).toHaveLength(0);
+    }
+  });
+
+  it("attaches tool output to the call the matching hook announced", () => {
+    const state = stateWithActiveTool(3);
+    const result = transcriptRecordUpdates(
+      {
+        step_index: 3,
+        source: "MODEL",
+        type: "RUN_COMMAND",
+        content:
+          "Created At: x\n\t\t\t\tThe command exited with code 0.\n\t\t\t\tOutput:\n\t\t\t\tok",
+      },
+      state,
+    );
+
+    expect(result.updates[0]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "agy-conversation-1-3",
+      content: [
+        {
+          type: "content",
+          content: { type: "text", text: "The command exited with code 0.\nOutput:\nok" },
+        },
+      ],
+    });
+  });
+
+  it("still attaches output after the post hook completed the call", () => {
+    // One drain pass reads hooks before the transcript, so for a fast tool the
+    // PostToolUse hook and the record carrying its output arrive together. If
+    // completing a call dropped its bookkeeping, that output would be lost.
+    const state = stateWithActiveTool(3);
+    hookSessionUpdate(
+      { event: "post-tool-use", payload: { conversationId: "conversation-1", stepIdx: 3 } },
+      state,
+    );
+
+    const result = transcriptRecordUpdates(
+      { step_index: 3, source: "MODEL", type: "RUN_COMMAND", content: "Created At: x\nok" },
+      state,
+    );
+
+    expect(result.updates[0]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "agy-conversation-1-3",
+      content: [{ type: "content", content: { type: "text", text: "ok" } }],
+    });
+  });
+
+  it("drops tool output with no announced call rather than inventing one", () => {
+    const result = transcriptRecordUpdates(
+      { step_index: 99, source: "MODEL", type: "RUN_COMMAND", content: "orphan" },
+      makeAgyTurnState(),
+    );
+
+    expect(result.updates).toHaveLength(0);
+  });
+});
+
+describe("AgyTranscriptCursor", () => {
+  it("holds back a partial trailing line until the rest arrives", () => {
+    const cursor = new AgyTranscriptCursor();
+
+    expect(cursor.push('{"a":1}\n{"b":')).toEqual(['{"a":1}']);
+    expect(cursor.push("2}\n")).toEqual(['{"b":2}']);
+  });
+
+  it("tracks the byte offset it has consumed", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.push("abc\n");
+
+    expect(cursor.bytesConsumed).toBe(4);
+  });
+
+  it("flushes the trailing line once the writer is finished", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.push('{"a":1}\n{"b":2}');
+
+    expect(cursor.flush()).toEqual(['{"b":2}']);
+    expect(cursor.flush()).toEqual([]);
+  });
+});

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -29,6 +29,16 @@ export interface AgyTranscriptRecord {
  * particular holds a summary of truncated context and would read as the
  * assistant talking to itself.
  */
+/**
+ * Ceiling on a single held-back transcript line.
+ *
+ * The transcript is read incrementally, so nothing else bounds a record that
+ * never terminates: the cursor would hold every byte of it waiting for a
+ * newline. Generous enough that a real tool output is never truncated — the
+ * largest observed records are a few hundred KiB.
+ */
+export const MAX_TRANSCRIPT_LINE_CHARS = 4 * 1024 * 1024;
+
 const IGNORED_RECORD_TYPES = new Set([
   "CONVERSATION_HISTORY",
   "CHECKPOINT",
@@ -51,6 +61,16 @@ export function parseTranscriptLine(line: string): AgyTranscriptRecord | null {
     // A partially-flushed final line is expected while tailing a live turn.
     return null;
   }
+}
+
+/**
+ * Size of the complete parsed record retained by the bridge.
+ *
+ * Computed once when a record enters the deferred queue; callers carry the
+ * result with the record instead of repeatedly serializing held entries.
+ */
+export function serializedTranscriptRecordSize(record: AgyTranscriptRecord): number {
+  return JSON.stringify(record).length;
 }
 
 /**
@@ -86,6 +106,11 @@ export interface TranscriptUpdateResult {
   readonly updates: ReadonlyArray<AgySessionUpdate>;
   /** True when the record produced assistant-visible text. */
   readonly emittedAssistantText: boolean;
+  /**
+   * True when the record belongs to a tool call that has not been announced
+   * yet. The caller should hold it and try again after reading more hooks.
+   */
+  readonly deferred?: boolean;
 }
 
 /**
@@ -130,17 +155,22 @@ export function transcriptRecordUpdates(
   if (typeof stepIndex !== "number") {
     return { updates: [], emittedAssistantText: false };
   }
-  // Recorded before the early returns below: the transcript is read once by
-  // byte offset, so "this step's record has gone by" holds even when it
-  // carried nothing worth emitting.
-  state.transcriptSeenSteps.add(stepIndex);
   // Completed calls stay in the map precisely so this lookup still resolves:
   // a fast tool's `PostToolUse` hook and its transcript record routinely land
   // in the same drain pass, and hooks are read first.
   const active = state.toolCalls.get(stepIndex);
   if (!active) {
-    return { updates: [], emittedAssistantText: false };
+    // The hook directory is listed before the transcript is read, so a tool
+    // whose `PreToolUse` file appeared in between has a record here and no
+    // call yet. The transcript is consumed once by byte offset, so dropping it
+    // loses that tool's output for good — it is held instead and retried once
+    // the hook shows up.
+    return { updates: [], emittedAssistantText: false, deferred: true };
   }
+  // Recorded only once the record has actually been matched: marking a step
+  // seen before that would tell the caller a tool it has not announced yet is
+  // already finished.
+  state.transcriptSeenSteps.add(stepIndex);
   const output = normalizeToolOutput(content);
   if (output.length === 0) {
     return { updates: [], emittedAssistantText: false };
@@ -191,9 +221,29 @@ export function dropPriorTurnRecords(lines: ReadonlyArray<string>): ReadonlyArra
 export class AgyTranscriptCursor {
   private offset = 0;
   private carry = "";
+  /**
+   * Set once a single record has grown past {@link MAX_TRANSCRIPT_LINE_CHARS}.
+   * Its bytes keep arriving, so the remainder is swallowed up to the next
+   * newline rather than surfacing as a fragment that parses as nothing.
+   */
+  private discarding = false;
+  /**
+   * Whole lines handed back by {@link retain}, kept apart from {@link carry}.
+   *
+   * They were once prepended to the carry, which put finished records into the
+   * same buffer as a half-written one: retaining while a record was being
+   * abandoned made the first retained line look like that record's tail, so it
+   * was dropped and the real fragment emitted in its place.
+   */
+  private retained: Array<string> = [];
 
   get bytesConsumed(): number {
     return this.offset;
+  }
+
+  /** Size of everything held back, for callers enforcing their own budget. */
+  get carryLength(): number {
+    return this.retained.reduce((total, line) => total + line.length + 1, this.carry.length);
   }
 
   /**
@@ -205,7 +255,36 @@ export class AgyTranscriptCursor {
     const combined = this.carry + chunk;
     const lines = combined.split("\n");
     this.carry = lines.pop() ?? "";
-    return lines;
+
+    let completed: ReadonlyArray<string> = lines;
+    if (this.discarding) {
+      // The first line to complete here is the tail of the record that was
+      // given up on; everything after it is intact.
+      if (lines.length > 0) {
+        completed = lines.slice(1);
+        this.discarding = false;
+      } else {
+        completed = [];
+      }
+    }
+
+    // A record with no newline in sight would otherwise be held in full, so a
+    // single malformed or enormous transcript entry could exhaust memory no
+    // matter how small each read is.
+    if (this.carry.length > MAX_TRANSCRIPT_LINE_CHARS) {
+      this.carry = "";
+      this.discarding = true;
+    }
+
+    // Retained lines go back in front, where they were read from, and are not
+    // subject to the discard above — they are complete records that have
+    // already been through it once.
+    if (this.retained.length > 0) {
+      const restored = this.retained;
+      this.retained = [];
+      return [...restored, ...completed];
+    }
+    return completed;
   }
 
   /**
@@ -216,13 +295,44 @@ export class AgyTranscriptCursor {
    * are re-examined against the next read rather than emitted or discarded.
    */
   retain(lines: ReadonlyArray<string>): void {
-    this.carry = lines.length > 0 ? `${lines.join("\n")}\n${this.carry}` : this.carry;
+    if (lines.length > 0) {
+      this.retained.push(...lines);
+    }
+  }
+
+  /**
+   * Retain a candidate suffix only while all held transcript text fits within
+   * the caller's budget.
+   *
+   * Resumed conversations are scanned from byte zero when no baseline was
+   * measurable. Complete history is expendable on overflow, but the bounded
+   * partial line may be the current turn's `USER_INPUT` boundary. Its caller
+   * keeps suppressing completed records until that boundary is observed, so
+   * preserving the partial line cannot surface historical output.
+   */
+  retainWithinLimit(lines: ReadonlyArray<string>, maxChars: number): boolean {
+    const lineChars = lines.reduce((total, line) => total + line.length + 1, 0);
+    if (this.carryLength + lineChars > maxChars) {
+      this.retained = [];
+      return false;
+    }
+    this.retain(lines);
+    return true;
   }
 
   /** Flush the trailing line once the writer is known to be finished. */
   flush(): ReadonlyArray<string> {
     const remaining = this.carry;
     this.carry = "";
-    return remaining.trim().length > 0 ? [remaining] : [];
+    // Retained records are whole and still owed to the caller even at EOF.
+    const restored = this.retained;
+    this.retained = [];
+    if (this.discarding) {
+      // Whatever is left of the carry is the tail of an abandoned record, not a
+      // record. The retained lines are unaffected.
+      this.discarding = false;
+      return restored;
+    }
+    return remaining.trim().length > 0 ? [...restored, remaining] : restored;
   }
 }

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -1,0 +1,228 @@
+/**
+ * Reader for Antigravity's trajectory transcript.
+ *
+ * Antigravity appends one JSON record per step to
+ * `<brain>/<conversation-uuid>/.system_generated/logs/transcript.jsonl` while a
+ * turn is running, not just at the end. Tailing it is what lets the bridge
+ * stream assistant text and surface real tool output — neither of which the
+ * hook payloads carry.
+ *
+ * The record format is undocumented. Everything here is written to degrade to
+ * "emit nothing" rather than throw, so an Antigravity update that changes the
+ * shape costs observability but never breaks a turn.
+ *
+ * @module provider/acp/antigravity/agyTranscript
+ */
+import type { AgySessionUpdate, AgyTurnState } from "./agyEvents.ts";
+
+export interface AgyTranscriptRecord {
+  readonly step_index?: number;
+  readonly source?: string;
+  readonly type?: string;
+  readonly status?: string;
+  readonly created_at?: string;
+  readonly content?: string;
+}
+
+/**
+ * Record types that are bookkeeping rather than conversation. `CHECKPOINT` in
+ * particular holds a summary of truncated context and would read as the
+ * assistant talking to itself.
+ */
+const IGNORED_RECORD_TYPES = new Set([
+  "CONVERSATION_HISTORY",
+  "CHECKPOINT",
+  "USER_INPUT",
+  "SYSTEM_MESSAGE",
+]);
+
+export function parseTranscriptLine(line: string): AgyTranscriptRecord | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null) {
+      return null;
+    }
+    return parsed as AgyTranscriptRecord;
+  } catch {
+    // A partially-flushed final line is expected while tailing a live turn.
+    return null;
+  }
+}
+
+/**
+ * Strip the `Created At:` / `Completed At:` preamble Antigravity prepends to
+ * tool records, then dedent. Tool output arrives indented with tabs, which
+ * would otherwise render as a code block in the client.
+ */
+export function normalizeToolOutput(content: string): string {
+  const withoutTimestamps = content
+    .split("\n")
+    .filter((line) => !/^\s*(Created At|Completed At):/.test(line))
+    .join("\n");
+
+  // Antigravity indents its own framing ("The command exited with code 0.",
+  // "Output:") with tabs while leaving the tool's real output flush left, so a
+  // plain common-prefix dedent finds an indent of zero and does nothing.
+  // Dedent across tab-indented lines only: that strips the framing here, and
+  // still behaves like a normal dedent when the payload is tab-indented source.
+  const lines = withoutTimestamps.split("\n");
+  const tabDepths = lines
+    .filter((line) => line.trim().length > 0 && line.startsWith("\t"))
+    .map((line) => line.match(/^\t*/)?.[0].length ?? 0);
+  const commonTabs = tabDepths.length > 0 ? Math.min(...tabDepths) : 0;
+  const dedented =
+    commonTabs > 0
+      ? lines.map((line) => (line.startsWith("\t") ? line.slice(commonTabs) : line)).join("\n")
+      : withoutTimestamps;
+
+  return dedented.trim();
+}
+
+export interface TranscriptUpdateResult {
+  readonly updates: ReadonlyArray<AgySessionUpdate>;
+  /** True when the record produced assistant-visible text. */
+  readonly emittedAssistantText: boolean;
+}
+
+/**
+ * Translate one transcript record into ACP updates.
+ *
+ * Assistant text becomes an `agent_message_chunk`. A tool record is matched to
+ * the in-flight tool call announced by the matching `PreToolUse` hook — the
+ * hook's `stepIdx` and the record's `step_index` are the same number — and its
+ * body is attached as that call's output.
+ */
+export function transcriptRecordUpdates(
+  record: AgyTranscriptRecord,
+  state: AgyTurnState,
+): TranscriptUpdateResult {
+  const type = record.type;
+  if (!type || IGNORED_RECORD_TYPES.has(type)) {
+    return { updates: [], emittedAssistantText: false };
+  }
+
+  const content = typeof record.content === "string" ? record.content : "";
+
+  if (type === "PLANNER_RESPONSE") {
+    const text = content.trim();
+    if (text.length === 0) {
+      return { updates: [], emittedAssistantText: false };
+    }
+    return {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text },
+        },
+      ],
+      emittedAssistantText: true,
+    };
+  }
+
+  // Any other MODEL record is a tool step. Attach its body to the tool call
+  // the hook already announced; without a matching hook there is no tool call
+  // to update, so the output is dropped rather than invented.
+  const stepIndex = record.step_index;
+  if (typeof stepIndex !== "number") {
+    return { updates: [], emittedAssistantText: false };
+  }
+  // Recorded before the early returns below: the transcript is read once by
+  // byte offset, so "this step's record has gone by" holds even when it
+  // carried nothing worth emitting.
+  state.transcriptSeenSteps.add(stepIndex);
+  // Completed calls stay in the map precisely so this lookup still resolves:
+  // a fast tool's `PostToolUse` hook and its transcript record routinely land
+  // in the same drain pass, and hooks are read first.
+  const active = state.toolCalls.get(stepIndex);
+  if (!active) {
+    return { updates: [], emittedAssistantText: false };
+  }
+  const output = normalizeToolOutput(content);
+  if (output.length === 0) {
+    return { updates: [], emittedAssistantText: false };
+  }
+
+  return {
+    updates: [
+      {
+        sessionUpdate: "tool_call_update",
+        toolCallId: active.toolCallId,
+        content: [{ type: "content", content: { type: "text", text: output } }],
+        _meta: { antigravity: { event: "transcript", recordType: type, stepIdx: stepIndex } },
+      },
+    ],
+    emittedAssistantText: false,
+  };
+}
+
+/**
+ * Drop transcript records belonging to earlier turns.
+ *
+ * One conversation keeps a single append-only transcript, and every turn opens
+ * with a `USER_INPUT` record, so the last one in the file marks where the
+ * current turn begins. Resuming a conversation starts reading at byte 0 — the
+ * turn's own records cannot be located any other way — which without this trim
+ * would replay every prior assistant message as new output.
+ *
+ * Applied only to the first batch of a turn. Returns the input unchanged when
+ * no `USER_INPUT` is present, which is the correct read for a transcript whose
+ * opening record has not been written yet.
+ */
+export function dropPriorTurnRecords(lines: ReadonlyArray<string>): ReadonlyArray<string> {
+  let lastUserInput = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (parseTranscriptLine(lines[index] ?? "")?.type === "USER_INPUT") {
+      lastUserInput = index;
+    }
+  }
+  return lastUserInput === -1 ? lines : lines.slice(lastUserInput + 1);
+}
+
+/**
+ * Incremental transcript cursor.
+ *
+ * Tracks a byte offset and holds back a trailing partial line so a record that
+ * is still being written is parsed once, on the next read, rather than twice.
+ */
+export class AgyTranscriptCursor {
+  private offset = 0;
+  private carry = "";
+
+  get bytesConsumed(): number {
+    return this.offset;
+  }
+
+  /**
+   * Feed a freshly-read chunk starting at the current offset, returning whole
+   * lines only.
+   */
+  push(chunk: string): ReadonlyArray<string> {
+    this.offset += Buffer.byteLength(chunk, "utf8");
+    const combined = this.carry + chunk;
+    const lines = combined.split("\n");
+    this.carry = lines.pop() ?? "";
+    return lines;
+  }
+
+  /**
+   * Push whole lines back to the front of the stream.
+   *
+   * Used when a batch cannot be interpreted yet — on a resumed conversation the
+   * current turn's opening record may not have been written — so the same lines
+   * are re-examined against the next read rather than emitted or discarded.
+   */
+  retain(lines: ReadonlyArray<string>): void {
+    this.carry = lines.length > 0 ? `${lines.join("\n")}\n${this.carry}` : this.carry;
+  }
+
+  /** Flush the trailing line once the writer is known to be finished. */
+  flush(): ReadonlyArray<string> {
+    const remaining = this.carry;
+    this.carry = "";
+    return remaining.trim().length > 0 ? [remaining] : [];
+  }
+}

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -20,6 +20,7 @@
  *
  * @module provider/builtInDrivers
  */
+import { AntigravityDriver, type AntigravityDriverEnv } from "./Drivers/AntigravityDriver.ts";
 import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
@@ -37,7 +38,8 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
-  | OpenCodeDriverEnv;
+  | OpenCodeDriverEnv
+  | AntigravityDriverEnv;
 
 /**
  * Ordered list of built-in drivers. Order matters only for tie-breaking in
@@ -50,4 +52,5 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   CursorDriver,
   GrokDriver,
   OpenCodeDriver,
+  AntigravityDriver,
 ];

--- a/apps/server/src/textGeneration/AntigravityTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/AntigravityTextGeneration.test.ts
@@ -1,0 +1,219 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+import * as NodeOS from "node:os";
+import * as NodeURL from "node:url";
+import * as NodeFS from "node:fs";
+import * as NodeFSP from "node:fs/promises";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import { createModelSelection } from "@t3tools/shared/model";
+import { expect } from "vite-plus/test";
+import { AntigravitySettings, ProviderInstanceId } from "@t3tools/contracts";
+
+import * as ServerConfig from "../config.ts";
+import * as TextGeneration from "./TextGeneration.ts";
+import { makeAntigravityTextGeneration } from "./AntigravityTextGeneration.ts";
+
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const mockAgentPath = NodePath.join(__dirname, "../../scripts/acp-mock-agent.ts");
+
+const AntigravityTextGenerationTestLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3code-agy-text-generation-test-",
+}).pipe(Layer.provideMerge(NodeServices.layer));
+
+/**
+ * Creates a direct Node-executable launcher script (.mjs) for the mock agent with top-level await.
+ */
+async function makeMockAgyWrapper(mockEnv: Record<string, string>) {
+  const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "agy-text-mock-"));
+  const launcherPath = NodePath.join(dir, "mock-launcher.mjs");
+  const envAssignments = Object.entries(mockEnv)
+    .map(([key, value]) => `process.env[${JSON.stringify(key)}] = ${JSON.stringify(value)};`)
+    .join("\n");
+  const script = `${envAssignments}
+await import(${JSON.stringify(NodeURL.pathToFileURL(mockAgentPath).href)});
+`;
+  await NodeFSP.writeFile(launcherPath, script, "utf8");
+  return launcherPath;
+}
+
+function withFakeAgy<A, E, R>(
+  mockEnv: Record<string, string>,
+  effectFn: (textGeneration: TextGeneration.TextGeneration["Service"]) => Effect.Effect<A, E, R>,
+) {
+  return Effect.gen(function* () {
+    const launcherPath = yield* Effect.promise(() => makeMockAgyWrapper(mockEnv));
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        try {
+          NodeFS.rmSync(NodePath.dirname(launcherPath), { recursive: true, force: true });
+        } catch {
+          // ignore
+        }
+      }),
+    );
+    const config = decodeAntigravitySettings({ binaryPath: launcherPath });
+    const textGenEnv = { ...process.env, T3_AGY_BRIDGE_COMMAND: launcherPath };
+    const textGeneration = yield* makeAntigravityTextGeneration(config, textGenEnv);
+    return yield* effectFn(textGeneration);
+  }).pipe(Effect.scoped);
+}
+
+const testModel = createModelSelection(
+  ProviderInstanceId.make("antigravity"),
+  "gemini-3.1-pro-high",
+);
+
+it.layer(AntigravityTextGenerationTestLayer)("AntigravityTextGeneration", (it) => {
+  it.effect("generates a commit message and extracts subject + body from JSON output", () =>
+    withFakeAgy(
+      {
+        T3_ACP_PROMPT_RESPONSE_TEXT: JSON.stringify({
+          subject: "feat(agy): add Antigravity provider bridge",
+          body: "Wire up the ACP bridge and connect it to the provider registry.",
+        }),
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateCommitMessage({
+            cwd: process.cwd(),
+            branch: "feat/antigravity",
+            stagedSummary: "M apps/server/src/provider/Drivers/AntigravityDriver.ts",
+            stagedPatch: "diff --git a/.../AntigravityDriver.ts b/.../AntigravityDriver.ts",
+            modelSelection: testModel,
+          });
+
+          expect(generated.subject).toBe("feat(agy): add Antigravity provider bridge");
+          expect(generated.body).toBe(
+            "Wire up the ACP bridge and connect it to the provider registry.",
+          );
+        }),
+    ),
+  );
+
+  it.effect("extracts JSON when the model wraps it in conversational text", () =>
+    withFakeAgy(
+      {
+        T3_ACP_PROMPT_RESPONSE_TEXT:
+          "Sure! Here's a thread title:\n\n" +
+          JSON.stringify({ title: "Investigate Antigravity bridge latency" }) +
+          "\n\nLet me know if you need anything else.",
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateThreadTitle({
+            cwd: process.cwd(),
+            message: "the agy bridge is slow on first invocation and needs latency analysis",
+            modelSelection: testModel,
+          });
+          expect(generated.title).toBe("Investigate Antigravity bridge latency");
+        }),
+    ),
+  );
+
+  it.effect("fails with TextGenerationError when output is empty", () =>
+    withFakeAgy(
+      {
+        T3_ACP_PROMPT_RESPONSE_TEXT: "   \n  ",
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const error = yield* Effect.flip(
+            textGeneration.generateThreadTitle({
+              cwd: process.cwd(),
+              message:
+                "this is a long thread prompt message that is way longer than thirty five characters",
+              modelSelection: testModel,
+            }),
+          );
+          expect(error._tag).toBe("TextGenerationError");
+          expect(error.detail).toMatch(/empty/i);
+        }),
+    ),
+  );
+
+  it.effect("fails with TextGenerationError when output is unparseable JSON", () =>
+    withFakeAgy(
+      {
+        T3_ACP_PROMPT_RESPONSE_TEXT: "totally not json output from a confused model",
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const error = yield* Effect.flip(
+            textGeneration.generateThreadTitle({
+              cwd: process.cwd(),
+              message:
+                "this is a long thread prompt message that is way longer than thirty five characters",
+              modelSelection: testModel,
+            }),
+          );
+          expect(error._tag).toBe("TextGenerationError");
+          expect(error.detail).toMatch(/invalid structured output/i);
+        }),
+    ),
+  );
+
+  it.effect("decodes a structured PR title + body", () =>
+    withFakeAgy(
+      {
+        T3_ACP_PROMPT_RESPONSE_TEXT: JSON.stringify({
+          title: "feat(agy): add ACP bridge for Antigravity CLI",
+          body: "## Summary\n- Adds `t3 agy-acp` bridge subcommand.\n- Synthesizes ACP events from hooks + transcript.",
+        }),
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generatePrContent({
+            cwd: process.cwd(),
+            baseBranch: "main",
+            headBranch: "feat/antigravity-provider",
+            commitSummary: "feat: add antigravity provider",
+            diffSummary: "M apps/server/src/provider/Drivers/AntigravityDriver.ts",
+            diffPatch: "diff --git a/.../AntigravityDriver.ts b/.../AntigravityDriver.ts",
+            modelSelection: testModel,
+          });
+
+          expect(generated.title).toBe("feat(agy): add ACP bridge for Antigravity CLI");
+          expect(generated.body).toContain("agy-acp");
+        }),
+    ),
+  );
+
+  it.effect("generates a short thread title directly when input is short enough", () =>
+    withFakeAgy({}, (textGeneration) =>
+      Effect.gen(function* () {
+        const generated = yield* textGeneration.generateThreadTitle({
+          cwd: process.cwd(),
+          message: "Fix the agy bridge",
+          modelSelection: testModel,
+        });
+        expect(generated.title).toBe("Fix the agy bridge");
+      }),
+    ),
+  );
+
+  it.effect("generates a branch name and sanitizes the output", () =>
+    withFakeAgy(
+      {
+        T3_ACP_PROMPT_RESPONSE_TEXT: JSON.stringify({
+          branch: "feat/antigravity-bridge",
+        }),
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateBranchName({
+            cwd: process.cwd(),
+            message: "add the antigravity ACP bridge",
+            modelSelection: testModel,
+          });
+          expect(generated.branch).toMatch(/^feat[\/-]/);
+        }),
+    ),
+  );
+});

--- a/apps/server/src/textGeneration/AntigravityTextGeneration.ts
+++ b/apps/server/src/textGeneration/AntigravityTextGeneration.ts
@@ -1,0 +1,264 @@
+/**
+ * Text generation (commit messages, PR content, branch names, thread titles)
+ * backed by the Antigravity CLI through T3 Code's ACP bridge.
+ *
+ * The model is bound when the bridge spawns `agy`, so unlike the Grok
+ * implementation there is no post-start model switch to apply.
+ *
+ * @module textGeneration/AntigravityTextGeneration
+ */
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import type * as EffectAcpErrors from "effect-acp/errors";
+
+import { type AntigravitySettings, type ModelSelection } from "@t3tools/contracts";
+import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import { TextGenerationError } from "@t3tools/contracts";
+import * as TextGeneration from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+import {
+  makeAntigravityAcpRuntime,
+  resolveAntigravityBaseModelId,
+} from "../provider/acp/AntigravityAcpSupport.ts";
+
+/**
+ * Antigravity print mode carries a fixed startup cost per invocation, so this
+ * budget is deliberately generous relative to a hosted API call.
+ */
+const ANTIGRAVITY_TIMEOUT_MS = 180_000;
+
+const isTextGenerationError = Schema.is(TextGenerationError);
+
+export const makeAntigravityTextGeneration = Effect.fn("makeAntigravityTextGeneration")(function* (
+  antigravitySettings: AntigravitySettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+  const runAntigravityJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+    modelSelection,
+  }: {
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle";
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+    modelSelection: ModelSelection;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      const outputRef = yield* Ref.make("");
+      const runtime = yield* makeAntigravityAcpRuntime({
+        antigravitySettings,
+        environment,
+        childProcessSpawner: commandSpawner,
+        cwd,
+        model: resolveAntigravityBaseModelId(modelSelection.model),
+        effort: "low",
+        clientInfo: { name: "t3-code-git-text", version: "0.0.0" },
+      }).pipe(Effect.provideService(Crypto.Crypto, crypto));
+
+      yield* runtime.handleSessionUpdate((notification) => {
+        const update = notification.update;
+        if (update.sessionUpdate !== "agent_message_chunk") {
+          return Effect.void;
+        }
+        const content = update.content;
+        if (content.type !== "text") {
+          return Effect.void;
+        }
+        return Ref.update(outputRef, (current) => current + content.text);
+      });
+
+      const promptResult = yield* Effect.gen(function* () {
+        yield* runtime.start();
+        return yield* runtime.prompt({ prompt: [{ type: "text", text: prompt }] });
+      }).pipe(
+        Effect.timeoutOption(ANTIGRAVITY_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({
+                  operation,
+                  detail: "Antigravity request timed out.",
+                }),
+              ),
+            onSome: (value) => Effect.succeed(value),
+          }),
+        ),
+        Effect.mapError((cause: EffectAcpErrors.AcpError | TextGenerationError) =>
+          isTextGenerationError(cause)
+            ? cause
+            : new TextGenerationError({
+                operation,
+                detail: "Antigravity request failed.",
+                cause,
+              }),
+        ),
+      );
+
+      const trimmed = (yield* Ref.get(outputRef)).trim();
+      if (!trimmed) {
+        return yield* new TextGenerationError({
+          operation,
+          detail:
+            promptResult.stopReason === "cancelled"
+              ? "Antigravity request was cancelled."
+              : "Antigravity returned empty output.",
+        });
+      }
+
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(trimmed)).pipe(
+        Effect.catchTags({
+          SchemaError: (cause) =>
+            Effect.fail(
+              new TextGenerationError({
+                operation,
+                detail: "Antigravity returned invalid structured output.",
+                cause,
+              }),
+            ),
+        }),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : new TextGenerationError({
+              operation,
+              detail: "Antigravity text generation failed.",
+              cause,
+            }),
+      ),
+      Effect.scoped,
+    );
+
+  const generateCommitMessage: TextGeneration.TextGeneration["Service"]["generateCommitMessage"] =
+    Effect.fn("AntigravityTextGeneration.generateCommitMessage")(function* (input) {
+      const { prompt, outputSchema } = buildCommitMessagePrompt({
+        branch: input.branch,
+        stagedSummary: input.stagedSummary,
+        stagedPatch: input.stagedPatch,
+        includeBranch: input.includeBranch === true,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateCommitMessage",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        subject: sanitizeCommitSubject(generated.subject),
+        body: generated.body.trim(),
+        ...("branch" in generated && typeof generated.branch === "string"
+          ? { branch: sanitizeFeatureBranchName(generated.branch) }
+          : {}),
+      };
+    });
+
+  const generatePrContent: TextGeneration.TextGeneration["Service"]["generatePrContent"] =
+    Effect.fn("AntigravityTextGeneration.generatePrContent")(function* (input) {
+      const { prompt, outputSchema } = buildPrContentPrompt({
+        baseBranch: input.baseBranch,
+        headBranch: input.headBranch,
+        commitSummary: input.commitSummary,
+        diffSummary: input.diffSummary,
+        diffPatch: input.diffPatch,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generatePrContent",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizePrTitle(generated.title),
+        body: generated.body.trim(),
+      };
+    });
+
+  const generateBranchName: TextGeneration.TextGeneration["Service"]["generateBranchName"] =
+    Effect.fn("AntigravityTextGeneration.generateBranchName")(function* (input) {
+      const { prompt, outputSchema } = buildBranchNamePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateBranchName",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return { branch: sanitizeBranchFragment(generated.branch) };
+    });
+
+  const generateThreadTitle: TextGeneration.TextGeneration["Service"]["generateThreadTitle"] =
+    Effect.fn("AntigravityTextGeneration.generateThreadTitle")(function* (input) {
+      const trimmed = input.message.trim();
+      if (
+        trimmed.length > 0 &&
+        trimmed.length <= 35 &&
+        (!input.attachments || input.attachments.length === 0)
+      ) {
+        return { title: sanitizeThreadTitle(trimmed) };
+      }
+
+      const { prompt, outputSchema } = buildThreadTitlePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateThreadTitle",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizeThreadTitle(generated.title),
+      } satisfies TextGeneration.ThreadTitleGenerationResult;
+    });
+
+  return {
+    generateCommitMessage,
+    generatePrContent,
+    generateBranchName,
+    generateThreadTitle,
+  } satisfies TextGeneration.TextGeneration["Service"];
+});

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -638,12 +638,227 @@ export const Gemini: Icon = (props) => (
   </svg>
 );
 
-const ANTIGRAVITY_ICON_DATA_URL =
-  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAgKADAAQAAAABAAAAgAAAAABIjgR3AAAjOElEQVR4Ae1dCYxkV3W9tfdW3T0z3bMvPcxge2zGy2BjY0MwxEAWEBACihSCEiMUSFCiRJEsRygIiIKySUlYAkmMQSxJQAKi4AQngDcMAe87nsF4xuPxrJ6ll+rqri3n3Pfv71e/f1XP4u7+Zdeb+XXvu+/9999/57z7lv+rOiVnF1ILnNYuvV3aAsW+JJIbbe6yXRpPWyh9XtFnCsZC+ePS42ysSCv7vEq2MbwQZbQp/rSTzrjhY0puVUacPc7mF7lQepj3TBqwVd44e9QWjbMCcbawYqeR7uftBH0hUOLSo7ZonPcdZ2tnb2qrhUBg5nZ5/DRfj57XLs0qFM1j9herjAMuavPjvs428eO+Hm2vdmltwWVBrUDx7S+U7lfcL9O3d7reCgzf/kLpflv5Zfr2lgAzUxwIUZvFo9I/v12an4+6BTvH4i8WGQeEb4vTzWaSbWF6VFo7md3i/jm+LRZkZogDwLeZfq4y7lpWZlNFX0SRKDh+3PRzlWwuK8Nvunm2uMZeyGbpvjwdnRXx8/nxqM44g+V3sc79nNfwuBXfZno76ae10tlClhbVGWfw0yXrbOFnXIObrZ1kmp++UJwX9PNbBcxmcZOt7JaeVNnU2F4lfbvpcZI2Hrx/01mMxam3Cv55fp6mc/2G9XU7wWxxkjbfbvGoZFmp3t6+wtDwim25XO6KdDp9JUyXpFKpMaT143gph6lGo7EX+D5Ur9d/XKlU7jl18sRT09OlGTQKQWQw8ONkNN3icZI2C1q2D6AlmIym+XHqCx4AOr127YZduXz+9wD2r1nBXblwC4AU36jMzn7m0KED94MYdZwRB34rGy+gAMdIplloGIhmMOmDTZufz3Rfpr08KQK/bv2mX0Rv/wLsL/UejiY4pzAFr/DbB5/b/70YIrQiBi9o5DDdl9Q1GIgWp6SNwZdRnfEm0C2+es26rXD3X0KPv4iFdMML0wLwCI9hWPitI4cPPo0SCW4U/GicF16QBATSwOUJpvsyqvvAm65y46axd2ez2c+yoG5YnBaoVqsfeHb/3q+hdJ8EPvi+zkq0JUEGGXyAeQIDbb7d4gY449T1gMfPbNq89eOZTOajsHXDIrYA2votg0PDxYmJU3fAK/BKhpNdNRpvmyeOACzACjGd0sAPgadNwd809knI63mlblj8FsDwesXg4NAmkOA7AQnsoj5uZjNpaRZXaQSwRF9S949YAqDnf6wLflObLkkEJNhZHBwaOHXqxO1neEEfY4kjgA+66bHgb9y05V2ZTPajZ1iBbvYXqAXoCQaKxafHx089EVOkAR2TNGdiJoLLYGCbbqBbHsbDY3T1mq39/cV7mLkblrcFpqYmrjh65PDTqAUngNHDJoE2OWRlzdYEPhMYokSweCix0M/09Q180WXvfi53CxALYuJhF2IV2FhFs1FnYDwkgBksky/NE4S9f926Da+H+7mQJ3XD8rcAsSAmqEmIEXRiaNj5eJquFbcMGvE+LJNJy4drpTP5fOEmL29XTUALEBNig6rMw8yzRWuaIrAMdpLJOBvzptesWbcLsru9yxZKVugPsFGcUDXD0iRra7rJpiHAbscSfWkeIJ0vFH7XMnZlslogwCbECrXzMTS9qdLM7AdmYrDMviT4Baz53+aydD+T1gLEhhihXkYCHz8f27Dq0YxMiJ4UxoeGVmwLz+wqiWyBAKMQsxg8We8wPc4DMJHBMoUkwUTjlS6p+5nUFggwmoddUF+zh9X3CWDAM9F0O4H50njYc0V4Zgcq3P2o46OGLZEaJHWN0xboHXhbTVUOMFK8kGD4MY9h2qTzncBoJovPk1gD7uTZnRb40IxAF3tExlaKbMexoS8txXRKGpW0jJdSsn+iIXvG6/JMqS4lsAFJTS3WKfccYDQPO9Tft6E13O35L4UygwU/c6ij8M2WoVMkX6ZaMSDyhleIvGmHyAUrUjKMOVJ2Ni2pckZSM+gskNXptJycEnnkeF1uOTQrdxyflcmqI0Kn3CvrGWAUYkaTdzALA20kQexbwUxk8E80vePW/688PyXXvzEluzaK5Kvo8eWUVMtpqYEEqfBISQpdfmUhLW8Yyco1xYLcdawin3m2JI+XKjqldk3SEZ/EyPDyJStvcQWfBvMATPBDXDxq8/MnSufdZdCx33x1Rt73K2lZ3ScAPYVx3kGOHTO4eOjcB1Md8XRa6rDVcGQyKbluVY9sL+Tlr56ZkNtOlbXlEnWT7StjQPu5ovgx3rA5ADPaSZbRj5vuF5hYneP3L12bk+vfnpMBbI7yBWv2d2AbAk/w08ioZIC0eAaZ+KpsA3JLb1o+snlI0s+IfK+zSGB4+TKKsc4DzANEwfRPpM5g0sUS+snJ3tVX5OXd7+iVNLZESrMOfPR1RwLchjp/EIBgZxR82OAB6DUaOEgMOAElwmg+LTduGJaT1RNy7+QMiJLQG2+ultWS0j+acyHGdmGwE6K6xa0QxhMbOOHbsiUr7/z1ouT681Kq56XcwCF5mZaCHmXIciovM6kcDidn03mppLNSSWWlClnFM5UqCFHDQbmukJM/Xjck6/IZfdie2AaYq5jh5ePKVD+uuu8B7CTLGI3PFZ9AjUu93t6U/Orbh2TFuh51++zCKdjTerDnu7Gfj8zoBbLqATAR0h7fgMRyEUcWJzVwkhsKnH7JQI/8zuig/PXBE7pnkMAmiFbJwDYco3G0ytwkMHqyH/dP9O2J0kmAS68akPMuK2IdD/et4IMAwT+6OhIACz/n+nFXdPMkQY6gA/A6QeeRwYGxRHXEuYmQAineivXknRNluWt8Ws9NVAM0V+a0MfMngVaEncy46SYtT6IkwR9elZVXv2mF1LJ5mZ1FdclvDOipOiiAQ8d93A5JwJsm+DkcJEAN4JIAuYAA9XQdZKirjSQQ6CREEUz5zZEheWhqRiYx3iS6UeKxi1YZg158YMZ5meOzJsN68dVDsnLzgExV09r76QGUAPQECrsjgXoAWIwAJEEVBCD4tQB46iRAo+kAERp1uXygD/sEffLfJyeT7AXisIvaFLgoAeIyxdmSgTpqwd4/uDInF75mlcxislcB4A0M5O4g3I4AKXiDNNIyONjrs3ARFdwZ3T8m+iBBzREgVQ+J0EjXQhI4L1CTApjzjlVDcvdEqZO8gI9XE55GABqbEvwzFkiLZF3aKL8Ysf2VwzK0gWM/Zu4NzNQBdkMPTPcgObNLKwE4B4D7BwlyJAF6fh5EqOHOqwC7FoBPT0Dw695Bb5DDikAaNXlF/4Dsgie4/dQEvEC7ZlvatohcrV3FmMZDN4Ii5zVF2xXSlHFZIuj9Pf1Z2X7ViHApNwv3X6uDADgaPAISsPenQAybB2SDeUAu8AIVEKFgHgBA16HX01UlgPMC9AQ8qlpmIZuRN64Ylh9OTIFwqESyQ1sMzQP4t9DqhFZ2/9wl1eto/LUvL8qKrcMyXc1JFSBXSQDwug5dSYA4pvUggPMCpAEHhixw483ncQBqDAHuqCkRHAEIOL2AAg8de8QoCxJe4NLikGztOSa7S9O6u7ikN77wxVphNc8eRwArfl5mS0iKTGM83nL5qNTzPTJbceBX61l4ARAARyMgAR2d8wIAHzYlAO4uhxvB86E58NH7awC6RtefIvjuUCJkKiiPcQ4vVRnExOHVg8NKgKS0R5t6tMSyFQH8E3y9zTWWNoljf3GkV1ZfOCLlWk4q6OnVOrxAQIAavQBJQA8AmYJMYS5AAnA+QA9AAjgSzPV+Hfc98EmCRprgo6kCEmD6CB9Sk1cNr5JvHjsqE7Va2wnU0rZM09V87Hw9zNSKAGGGxCrY9l19/grJrxqUchXbtyRBDRIkUA+AeA06vQAJICBAWsGn5CogpTByHoB+7SaAAJXjP72AAx5SQac3qbihBXEdXuAFNvUPy/a+otw3fiLJk8G2EHYsAdJYv63ZuQbuG+4f4FYANg/1AAC/Dt0Ogu/mAZj+2VwAm0M5EAH9G7DzIAkcAZzrB9AZEADAqwcg8KCMDiuYC9AL9KQysmt4RB6YONm2kZOc2JEEoPvvH+mToW2j6P05EAAPcvDgh16ARw06wVcPwGGAc4DAC3A1kCEJ1Im7/QDuBHIJqO4fE7xGPfAA9TnwG41ZLaeRQXnYccA+IbaHq3Lh0GoZPLhPxqscFjovdCQBgICs3DYimaEhmali8wegV2oggHqAvAJfBwlqsDd4EHydCHIe4OYA3AvgW0EcAgA9/mHvn74AXkAnfXDxbuxnr8ehwNMLgAiYRmLzGEdFRvtXyZb+IXn45FEQovMo0JEESOPB/Yod65z7x7iv4JMAetALYHsHh/MAJACmeuYBgk0h0EBXA5hK6BBQhwdo0AtwAqhDQUAAHSQIugOcPZ86iVDHTnoPHh/vGF6rBOi8/u+WwqdT7+RQG+4/P9wrA2NrZAYgzwJc5/4dAWoEHkedB7wAwacH4KErAbh/Lgk5kbNXwV3vhydg71ciYK2PiaA0uEagB8D50On6HREQB/iN2izeKMvJthUbpe/ZJ2W6lqhh4LQw6zgPAPxlYNMqyQyvxNqf7p9HQcf9qrp99nwHfl3dvyOAbnoCdM4BHAG4JMRzg+Af0MbmKPyBEgDPk7n8094PoINe38Ckj+6fPb8Bz6MS84SR4lq8dzgke8c7bxjoOAJwmB3cvh6Pffvx2JfLP/Z8EMCkjf1KAuf+dQ4AwNxKwBEAT/gBJjZ19B+SMBFs4GkfPYBgI0gwERQMBw24eDpK3QeAVD0FTxCSYFZ6erOyZXg9CHAE6afV8ZAvGaGzCIBOmuktSN/YRpnVnu+7/YKSga5fx35IrgTU/Sv4uFVMAFOcDBJ44FxXD6B9H2gEHoAJGOEFAOswAC/gRkrECToPkILunzo3m1KYMI6t2ip3P/soyuT5nRM6igBc/hXwQkZ2dI1UAvdfC3q/Ss/1O/CdB1D3H+wFcB3PIYAeAM/22PUDH8AIgceBLWEgizj2D9QDkARw/xwCeKAsmwPUmY5VwujKLfjmUVFOlk521GqgowjAXtq3Zb00eoYC188JXwETPjcHcJM/BzoJIOoBnBeg+0fXxUECuLcECD5dNocBGKHbEZBAz5kDX8tQz4Bmg1dREtTx2jG8Ss/AWlkztE5OlE6gxM4ZBjqKACnswPWMjeGpXw8mftjoUXdfQI80InD3j0tAgMNZu5KAOm5TPQAJwN7vXg6xl7roCbgSwBpANZIhRW+gPoJeACRQ4kDHqoC67gVwdQCPwKePPXgcvX5kuzx5MO4X23BaQkPnEADuPzuI173Xb5JKFT0eO4AhAXS8tzEfJODyLRj/2Tv1gZD2ZrcEZK/n+M9nAoSZcbAEn84D0Ko6wOUugQ4WWCJiqxD8oSfB0pBDATeLVLIZa7J69HzJ5/4X9eNP/XdG6BgCcPzPr10jqcFRqVYIPlw/x3yAz00ft9530sDXnq/AEzQCBgAD9083TcgZ1BNwCMA1aKpxIse5AIcMfIGE3x5SPXgjSL0Iy9U5AsrlnAAEGFgxJkMDq+XoiX3uHC092R8dQwBusxY2b4UnL0oNBAg3ehT8ZgLosi90+wSeBAhAJPAggev1BMeRwPV9bguTBG5QcJ4AVGH+gAicQGpZBF9JBRl4g1zfiIyMbJMjJ/YGpSYbfNaucwiQz0tu03Zd83Pp5cZ6fPdLXb0RwI374SPgoNcTKAcagAzBdw4f6ClKJEA9mAhS0CvUAiI4b0ALwFdvwIkk5gWBTk/AnUXBN41G1u6UzFN3gGQsMfmhMwgAl5xZsUrSqzbq2K87fOj5c+AHOsd7r+eHwIe91iNApI86uBwpnBfAAMF5ATwPHxo5SnDGQMJwiKAksbhjyIkldNiHR3dIT8+wlErH9VwYEx06hAB4c2f9mDR6V8H1Y4IXuH28C4bxNxj3FXjcDryDAR91/WHvByQc/wmhAW8a4/yauObQ1QBzOiJU9Qyk6fyAebhzSHJw/QAigKj5oY0yiLlAqXQMdpIi2aEzCIDlX3bzBWjuXl3iEXg73ESPM/1m8I0EoetX8AIXDj3AWK0+RJwFMPBbxkqRYFhwBKFl7p8NDcxJLyBYKeQL+ILKuovl0IH7/GITqyefAHDD6f5Byazd7nq/ru2dy2dv53rfPeq1nu9m+44A7KXsocFRLUl98oDUTu2TRukwVnPTSMPInu/HNdbg/YIxyQ6sx44vfkwIkOpQoDmcR1CvwDjZE8wPOECwDJKBqwyqw+suk2zu3zFcufKRIbGhIwiQWb0Zyz/sANL9KwFMBqCHbt8Dn0go8LDBHVf2fVdmf/4/Ujv+pNTLeIULT/GAmAOGYGZyku5ZKbnRi6Sw7ZelZ/PrJYPezMlcSAQU6eYDPM8NC+ol1GtwOODcoCE9q14ufYMbZPz5PYmfBySfAGj0zKYLsZ8ziNZHdZUABD44FHwAaBM9zsYJPiX28yv7bpXyg/8s1aOP4XyATrDV/yOPSscBptUnD8nMxHMy88ydUl53uQzs+qAUNrwaJLDJIUvGeQq+I4FG+WFlYh6Q7RuVIawGxo/t5gmJDmiNJAf0skK/ZDbu1Mne3AOe6JgPsJuWeojD/ZYf+EeZuu1GqR5+EOnondzF80GP3jrTmAePgmf33y0nv/tHMvXYVzAf4I4fZ/puZ0B/Swg6vUENE70q0qqQFayq9UcmMgUZ2vgqPEfCUJXwkGwPwPEfS78UHrU2agSGHsD1fL7dwzGXL3gQfKeTz4gD/Ol7/l7Kj3wJ+TFG65buGSIBItQxdEz86C8xV5iS4sXvAznYXJwkslvz0JkiJK8bvFkQEKxv7SVSwAOi6VP7wbnk9rPk1gxNypDefLFIYQU6MIAF+G6TB7oCTzL44ON28FZv+aGbHPjQ2/Z4d4nWn+z1mChO3vtpmXry6wq9rvkxJJAGulkEIlTpCZCXB3V+QzmDyeQAhgFUuHX5CUhJMAHQcPk+yWzehTZ0j3RtyacPeJQAbm8/7JEAYPZnt4AAn3c9X3vpObYyejQ9wAQ8ysyBu7FH4IAPhwNcg4+L+BN0KnVYABkyvTK4+Ro4H3qN5IbkEkDd/2ZJj5yHyRt7NhpSvQB7P6vtHbr8wncCj/1Upu/9lDRm8ZOf7cb6M8UDxKpPHZHxH/+tVDFJVBKAn+YF2Mf5+4LcKCIJKPkWQR8mknkMAzr/ONNrLlH+5BIADZDZgh8nh/t3z/Kdu3eun8MBScGDYzE8AUAv3/8ZqZ/aC/AX4bYwj6gcfkgmH/oXLC648xesDIC+9v7QA5hHwIOWwU0ysOEKeDBSJJlhEVrqhbhRNC9er0pvuRKF5TDRI/gEO+j90PXBTAA+CTD71C0yu/f7AB95Fi2kpPTkN2Vm/52BFwAJQk8ATpIEJARqp6+cYzVQ3Pp6zB35NxySGZJJAP4A05oLAvePHk7A6f6VBKwyx35K9n7M1sf3yczDX0DL4/WsxQycD8yckknsK9SmTzQNAdw65mHg61AAQy+GgcKKrag7B4zkhWQSAMut7PbXSipXDJd5oevn2I+ephsySoiazGCtXju+Z3FcfxQzeJjZg/fK9O5vcBHYTALGSYTAA/DXQ9J9a/AllmujpSQmnjwCoKek8I59evNV6PUEmwfdOt0+e3xw0P0DjNrh+2V2938E9iVqV8wBph77qlRPPqUk4DAQzglQBSOBeYSBl70Jr7PjjxQkcC6QPAKgATNbr5F0cQMaDJADfL6Fo2/lkASh7pZnZbj+xvTzIAOJsUQBk8zayb0gwZd1QqirAfZ8EkE9gEcCGHOrdkjfxiuRlrxhIFkEQOul+lZK9rzr0M85+QP4dPnB4UgQeAD0/uq+70kF+/aLMutfkEspKe/+T6kcuiccCugFQjLgfJ0QkhScDJ73Njx1xO/Wa+4FC1+yDMkiAJovs/VqyYxcoI/abdLn3uNnVekRnOtvTOHBzSNf0G1f2pc8wOPUy8dlCruOdSxBreeHQ4F5AlSMP2ZVWH8lJoTc1EqWF0gOAdj7e1dIbsdb0aHxPN5cv3kAAs+DYCPvzE+/LtUjjyK6mMu+BWjFCeH+H0j557do1ZQEBB71jHoCKQxKcce7sCTkuwbJCckhAHv/y16Hv02L/XO0Hl2/ewM36PVoVP7Tid/Rh2X28X8DEZa/N/E7gqWHb5bqqWcc6MAWHABH5zaKlBioas+ma6VnA/Y2+IwiISEZBGDvH1gjuZ3vxFyuJ5josWoBCSgJPr3B7ITMPPhP2Jo9BDIkoPqoQ/X53VJ65PPgI18QDQgAqZ6AHkF1PC0sFKW48734QxZ4tyEhc4EEtCDaAuNp7qK3Y+zfAfAR1aUfQWf1Ag9AAiDf7J5vyuy+26Avo+tHrZoC6lXGDuEs3jriKOWWgUYEDAdGAjChsOEa6cMbRzppaCpkeSKnSwDcwiIFuMMMXqLMXYTejy3fOfDRkmxN7fkEH2v+Iw/j7Z6bML3Gmz2JCnD3s5Mydf+n8b7hM24+gPqx0bT34x7c/ABeAN8hHLjkfZJd/N3B08LsdAmwOM1N148NkvwV79cdM53hc52vPd/r/XCzXOuX7/07qU88CzIsb7VjG4NDwdHHpXT/J/FC0XQwD3A5jQgqcc+Z4e1SvOyD2OnsRYbTwin2ki+EcRlbEjeOt27yl71Hshuvcl3FwNchwFw/qogeX37wc1LBa1qJcv1RBDgU7Pm2lB//ivZ4QsueT8n5gHoB1TEh3P5W6cOqYLnD8hEArZK74C2Sf8VvoMc71689X0lg4HMIwLzvp1/DrP9fobEpkxxQX5C1dP9nZWbvrXNDgZEgGAr08TCHgl2/L4XNr8NtcaBYnrA8BMANZ7HkK1z5IX3gw2erDnxKNKKN/Rj3K09/By95/EP4Dv/yNNMZXBVeoFE+IaUffUIqB38yRwIUQfpyo4gPi7g5lOoZkcGrP4xvPe9CwvIsDZeeAAR/6y9Iz2tv1HGfs6S5no/qeOBX998h0z/8BMb/48kc91vxAvOB2vh+mbzrz/ASyQO8QQ2OAEYEDgt4Wji0VYq/8DHJrca7j8vgCVoRgHW14OtmOzuJG8ysu0R6XnODpAfwsIfg63hv63y2FA5OqPZ9X0p3fQTv6h/U+NldcBnPIgmO75bJO/4Uzwvui/UEOifAR2blDim+9qOYHI690CTwsfP1sGFaEYAZYk8IzzxThS4PD3p6rvwDSQ+O6V6/gm+bPNrzWR38AOueb0npzg/jRY+EzvhP9965dMU3kSZvvwEPre7Qs6xRKTkc6EESjF4ifZe8H49CF+W7BHbZeTWPI0CrzK3s8wqNN+Bv7oxdK9m1l4cPetyIjx5P8PnjS3ioMvPA56T0g4/rS5iJXO7F31xrK0lw8mklwcwTX8VQj5+XQW72fpO2Y5gfuw77A9uQcM6TwlZYzbOj1duGeSe0zd0uES4xg+/dSQYPQ/QPLBjwcP/46RW+0VO+71P4/t6tGBr4Pn8cN9tdIMFpuJd66ahM/fAvpAqP0HvpBzAErlMS6JePrer5QcyLRkGAx3H/Zjxn2RZDIwAztctoaSXk40PtMw+gfO3oE9rLU1m86sU7xMy3Pn0MW6jfl5mHbpbaiacc8JhJv+gCSNColaX86FewYfSI9Fx8PX7z4BrsDQ+D6xgKsF9cPXQvCMLvE54T+YkRg2HmYs2fId5GAEuOOym0Yf26H1+NPt8yn5HETVV2fxvf1D2OYeAy3CR+5mViP276AQD/M7e9e243fkbVWZ7MIDb+V/l6+W03SHblyyWDt4VS+SJWOvgG83M/xtB3GHnOvgMQI+/eQuxa2aIEsHwhQ8wA2ajX649mMpmzIwALwKPTyl68xcPXtxk4EPJmCfyLHnx3y/rJe0VbVPFsg2Rwwdrh7MFnOcQIIgp8HJ56WfqauMya6KVpnlqter8lnLXEpCgEXL+te07u7qyrkYgT2Rb8wqkebJdzA5/35GFkuJpksq9r/HRa305qzJTL+J51NyS5BQKMQswWqqtPAJ7knxiNy/g41jPdkOgW8DBqh6Wl6XNX3lBoiOiWxvRGBQHfi/svGrsheS1AbIgRaqZ4BdKv6DycfQ8QzRgtROPTpdLNfsaunpwWCLAx3Fgx003OqywJwEQGyxQXD9OOHcPUVcTWmnpi9yMRLVAKsAmxQq18nZWcFzcPwAQ/xMX1ZKwz69PTpT/0M3f15W8BYkJsUJMoyFa5OEzDOYCfyTL6BTXpRw4fvAsXw5ZVNyShBYgFMUFdmnCKxFlVS6euwTwAI0y0YBmjUhlGpp06eeJDlrkrl7cFiIXX+6NewMfQKhpijd2H0AvYLgTlQke6XJ6e6O3t25/NZt9opXbl0rcA1v03HDt2+Ce4MoHna0WUcUeUCBo3AkTBRxlKDCMC49TpMcyWmpwc3zNQHCym0+lLmaEblrYFqtXqF5878MxNuGoUcCMCQWaaSVbQiECdP6rXBCptIcCBHmezPOmJiVP/VywOrQcJLmDGbliaFqjVat868Oy+P8fVCLABHiWCgW+gmwwrSQIQTAumG8BRyXxmM28gE+Onbh8YKPan05muJ7CWXERZrVa+SPAx7vvA+7r1+DgCsGZGhOCnN+ZAZWIrEliaEcDy0Y5t4lM/6untxZwgd50auh+L0gKYe9343IH9N6NwAm5Hq54fJQDrRPDDEB0CfFCjQFua2VmI6SonJyf2gJW39PT0vgrvDawKr9JVzrkF0K57Tp44/t7njx2xCZ8Put/7DXSTYW9HJZrAZ6UIHEnA4INp7p0yejC/ESdWB/iZ0dE11/T1D/wN8p7dG0Q4sRu0BUqlqck/OXr08N2ey/d7fivdJ4iRwaSRQkE3sH0CmG7gG1Es7hOAttg4iJBeuXJkJ4jwHrxI8uYuoKffApjk3Qrgv3z8+LFHALyBaT19Icn8zEOg7VwDvUkSWCMA1CYv4KcZ8CYN8DjwfRt1LQf7BXksGbdgeLgY84RLM5n0DvADXw7A34F5aYdp4HugVqs/gcndgxjjH56cGN+HJR5/9NB6rIFowBvAvozqdo6RoAn4oMnDl/EZJ1A8GHzwTTfw46RPCJ8A/rmmU/qHXc+XUZ3xVoFlLWdgw55O8POZ7kvqdhA86lEQfQK0AtzOMRktk3U1m/7dQEbYiJQM1qAWp406C2wXmMc/h/lJBjuXOm0++KbDHF7Xru/bqHdy8NvFdF9Sjx5sK9oofT1KAkuPymh5KEaD2Rnhj/DOC8wQDSzcAIymxcUtv12MoJrNQDfJ8w30qIwr28/fKn257HFt59fF0uOktRUl28ri1O2wNIu3kpbPyvClXx/1ADQwAxvfpNkoLTCNgZIXtsB49LCyLC/JQxvPo4weMKnNl9QtMH8nBt5/NJjNl9TjDrYX7Qa0r8fZ4sowm9WDcQaV7TwAG90y8wRe0LyAD4jpdiFKO9d0O5d2/0B0HvBWHtMYonFn7ZxPvw1Za4vHSdrsYJv5usUpfZ15fJvF7VxKBou7WPDpE4AZ/Mb241YIL0QSMFBnsHNMMi/zUFp+plGnjB4wzSuDNgYr08U699Paz+7A4r6kHnew3cxueivJfJZG3YKv0xbGDQzLSGmN7suozri5dep+vJXd8pm0azFueqCGdbB4K2nntkpfKnvYoAtc0M9nOmVUNxulD6gfb2W3c1mVqG42Sg0+GGajtIb1ZVS3cymjoFtanN3KtzwWp2SgPRribNE8SYwTgGjwbaYbUHFx2qJgW/5Wdl7T8pjuS+oaOAQwY7SBzeZLd0b8JytigPrSzvdtLMHipvuSOgPzvJgC28IPFvdlVGf8bA5exy/Lj1O3oBtBFolrcLPFSdp8u8WjkuX7Nj9uOiWDledi7jPO5qcnXTcg/Hr6NtMpo3pc3PKZZLmm+/nN7kvqFjRvtHGjcWY2WzvJND99oXhcub6Nuh+sbN/WCboBEq2rbzc9TtLm2xeK8zp+fj9O3YLlCUGzBMq4xvZtpvvydHS/bD+/XdtsFvfz+7ZO1MMG9yrv20xvJ/20VjqLt7Sobpf202PBZsaFwLD0c5Vx17IyrcIvNtkEAG7Oj5t+rpJtZmX47TfP9v9tVpxWeBtrbgAAAABJRU5ErkJggg==";
-
 export const AntigravityIcon: Icon = (props) => (
-  <svg {...props} viewBox="0 0 128 128" fill="none">
-    <image href={ANTIGRAVITY_ICON_DATA_URL} width="128" height="128" />
+  <svg {...props} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <mask id="antigravity-icon-mask" maskUnits="userSpaceOnUse" x="0" y="1" width="24" height="23">
+      <path
+        d="M21.751 22.607c1.34 1.005 3.35.335 1.508-1.508C17.73 15.74 18.904 1 12.037 1 5.17 1 6.342 15.74.815 21.1c-2.01 2.009.167 2.511 1.507 1.506 5.192-3.517 4.857-9.714 9.715-9.714 4.857 0 4.522 6.197 9.714 9.715z"
+        fill="#fff"
+      />
+    </mask>
+    <g mask="url(#antigravity-icon-mask)">
+      <g filter="url(#antigravity-filter-1)">
+        <path
+          d="M-1.018-3.992c-.408 3.591 2.686 6.89 6.91 7.37 4.225.48 7.98-2.043 8.387-5.633.408-3.59-2.686-6.89-6.91-7.37-4.225-.479-7.98 2.043-8.387 5.633z"
+          fill="#FFE432"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-2)">
+        <path
+          d="M15.269 7.747c1.058 4.557 5.691 7.374 10.348 6.293 4.657-1.082 7.575-5.653 6.516-10.21-1.058-4.556-5.691-7.374-10.348-6.292-4.657 1.082-7.575 5.653-6.516 10.21z"
+          fill="#FC413D"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-3)">
+        <path
+          d="M-12.443 10.804c1.338 4.703 7.36 7.11 13.453 5.378 6.092-1.733 9.947-6.95 8.61-11.652C8.282-.173 2.26-2.58-3.833-.848-9.925.884-13.78 6.1-12.443 10.804z"
+          fill="#00B95C"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-4)">
+        <path
+          d="M-12.443 10.804c1.338 4.703 7.36 7.11 13.453 5.378 6.092-1.733 9.947-6.95 8.61-11.652C8.282-.173 2.26-2.58-3.833-.848-9.925.884-13.78 6.1-12.443 10.804z"
+          fill="#00B95C"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-5)">
+        <path
+          d="M-7.608 14.703c3.352 3.424 9.126 3.208 12.896-.483 3.77-3.69 4.108-9.459.756-12.883C2.69-2.087-3.083-1.871-6.853 1.82c-3.77 3.69-4.108 9.458-.755 12.883z"
+          fill="#00B95C"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-6)">
+        <path
+          d="M9.932 27.617c1.04 4.482 5.384 7.303 9.7 6.3 4.316-1.002 6.971-5.448 5.93-9.93-1.04-4.483-5.384-7.304-9.7-6.301-4.316 1.002-6.971 5.448-5.93 9.93z"
+          fill="#3186FF"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-7)">
+        <path
+          d="M2.572-8.185C.392-3.329 2.778 2.472 7.9 4.771c5.122 2.3 11.042.227 13.222-4.63 2.18-4.855-.205-10.656-5.327-12.955-5.122-2.3-11.042-.227-13.222 4.63z"
+          fill="#FBBC04"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-8)">
+        <path
+          d="M-3.267 38.686c-5.277-2.072 3.742-19.117 5.984-24.83 2.243-5.712 8.34-8.664 13.616-6.592 5.278 2.071 11.533 13.482 9.29 19.195-2.242 5.713-23.613 14.298-28.89 12.227z"
+          fill="#3186FF"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-9)">
+        <path
+          d="M28.71 17.471c-1.413 1.649-5.1.808-8.236-1.878-3.135-2.687-4.531-6.201-3.118-7.85 1.412-1.649 5.1-.808 8.235 1.878s4.532 6.2 3.119 7.85z"
+          fill="#749BFF"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-10)">
+        <path
+          d="M18.163 9.077c5.81 3.93 12.502 4.19 14.946.577 2.443-3.612-.287-9.727-6.098-13.658-5.81-3.931-12.502-4.19-14.946-.577-2.443 3.612.287 9.727 6.098 13.658z"
+          fill="#FC413D"
+        />
+      </g>
+      <g filter="url(#antigravity-filter-11)">
+        <path
+          d="M-.915 2.684c-1.44 3.473-.97 6.967 1.05 7.804 2.02.837 4.824-1.3 6.264-4.772 1.44-3.473.97-6.967-1.05-7.804-2.02-.837-4.824 1.3-6.264 4.772z"
+          fill="#FFEE48"
+        />
+      </g>
+    </g>
+    <defs>
+      <filter
+        id="antigravity-filter-1"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-3.288"
+        y="-11.917"
+        width="19.838"
+        height="17.587"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="1.117" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-2"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="4.251"
+        y="-13.493"
+        width="38.9"
+        height="38.565"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="5.4" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-3"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-21.889"
+        y="-10.592"
+        width="40.955"
+        height="36.517"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="4.591" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-4"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-21.889"
+        y="-10.592"
+        width="40.955"
+        height="36.517"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="4.591" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-5"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-19.099"
+        y="-10.278"
+        width="36.632"
+        height="36.595"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="4.591" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-6"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x=".981"
+        y="8.758"
+        width="33.533"
+        height="34.087"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="4.363" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-7"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-6.143"
+        y="-21.659"
+        width="35.978"
+        height="35.276"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="3.954" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-8"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-11.96"
+        y="-.46"
+        width="45.114"
+        height="46.523"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="3.531" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-9"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="10.485"
+        y=".58"
+        width="25.094"
+        height="24.054"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="3.159" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-10"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="5.833"
+        y="-12.467"
+        width="33.508"
+        height="30.007"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="2.669" result="effect1_foregroundBlur_977_115" />
+      </filter>
+      <filter
+        id="antigravity-filter-11"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-8.355"
+        y="-8.876"
+        width="22.194"
+        height="26.151"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="3.303" result="effect1_foregroundBlur_977_115" />
+      </filter>
+    </defs>
   </svg>
 );
 

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,13 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  AntigravityIcon,
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -8,6 +16,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("antigravity")]: AntigravityIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -1,4 +1,5 @@
 import {
+  AntigravitySettings,
   ClaudeSettings,
   CodexSettings,
   CursorSettings,
@@ -7,7 +8,15 @@ import {
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  AntigravityIcon,
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -66,6 +75,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("antigravity"),
+    label: "Antigravity",
+    icon: AntigravityIcon,
+    badgeLabel: "Experimental",
+    settingsSchema: AntigravitySettings,
   },
 ];
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -51,6 +51,12 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("antigravity"),
+    label: "Antigravity",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
 ];
 
 export type WorkLogToolLifecycleStatus =

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -132,6 +132,7 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const ANTIGRAVITY_DRIVER_KIND = ProviderDriverKind.make("antigravity");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
 
@@ -152,6 +153,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CURSOR_DRIVER_KIND]: "auto",
   [GROK_DRIVER_KIND]: "grok-build",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ANTIGRAVITY_DRIVER_KIND]: "gemini-3.1-pro-high",
 };
 
 /** Per-provider text generation model defaults. */
@@ -162,6 +164,7 @@ export const DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ANTIGRAVITY_DRIVER_KIND]: "gemini-3.6-flash-low",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -211,6 +214,16 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  // AGY model slugs carry their reasoning tier inline (`-high`, `-medium`,
+  // `-low`), so the bare family name has to resolve to a concrete tier.
+  [ANTIGRAVITY_DRIVER_KIND]: {
+    "gemini-3.1-pro": "gemini-3.1-pro-high",
+    pro: "gemini-3.1-pro-high",
+    "gemini-3.6-flash": "gemini-3.6-flash-medium",
+    flash: "gemini-3.6-flash-medium",
+    "gemini-3.5-flash": "gemini-3.5-flash-medium",
+    "gpt-oss-120b": "gpt-oss-120b-medium",
+  },
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -221,4 +234,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [ANTIGRAVITY_DRIVER_KIND]: "Antigravity",
 };

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -339,6 +339,64 @@ export const GrokSettings = makeProviderSettingsSchema(
 );
 export type GrokSettings = typeof GrokSettings.Type;
 
+export const AntigravitySettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("agy").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Antigravity CLI binary.",
+        providerSettingsForm: { placeholder: "agy", clearWhenEmpty: "omit" },
+      }),
+    ),
+    // Antigravity has no native agent protocol, so every turn runs through
+    // `agy --print`. A turn holds one process open for its whole duration;
+    // the default matches the bridge's own ceiling.
+    printTimeout: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Print timeout",
+        description: "Max duration for a single turn, passed to `agy --print-timeout`.",
+        providerSettingsForm: { placeholder: "2h", clearWhenEmpty: "omit" },
+      }),
+    ),
+    // Trajectory discovery reads this root only when the Stop hook does not
+    // report a conversation id. Overridable for non-default AGY installs.
+    appDataDir: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "App data directory",
+        description: "Overrides ~/.gemini/antigravity-cli for conversation discovery.",
+        providerSettingsForm: { placeholder: "~/.gemini/antigravity-cli", clearWhenEmpty: "omit" },
+      }),
+    ),
+    // Print mode cannot prompt, so `agy` runs with permissions skipped and the
+    // bridge's PreToolUse hook becomes the gate instead: it blocks the tool
+    // until T3 Code answers, and a denial is reported back to the model.
+    // On by default: without it nothing stands between the model and an
+    // auto-approved tool, and a gate that has to be discovered protects no one.
+    requireToolApproval: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({
+        title: "Ask before running tools",
+        description:
+          "Approve each tool call before Antigravity runs it. Turns block until you answer.",
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath", "printTimeout", "appDataDir", "requireToolApproval"],
+  },
+);
+export type AntigravitySettings = typeof AntigravitySettings.Type;
+
 export const OpenCodeSettings = makeProviderSettingsSchema(
   {
     enabled: Schema.Boolean.pipe(
@@ -433,6 +491,7 @@ export const ServerSettings = Schema.Struct({
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    antigravity: AntigravitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -528,6 +587,15 @@ const GrokSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const AntigravitySettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  printTimeout: Schema.optionalKey(TrimmedString),
+  appDataDir: Schema.optionalKey(TrimmedString),
+  requireToolApproval: Schema.optionalKey(Schema.Boolean),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 const OpenCodeSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
@@ -558,6 +626,7 @@ export const ServerSettingsPatch = Schema.Struct({
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      antigravity: Schema.optionalKey(AntigravitySettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual


### PR DESCRIPTION
## Summary

Adds full support for the **Google Antigravity (`agy`) provider** into T3 Code. 

Antigravity has no native agent protocol, so this integration introduces an ACP compatibility bridge process (`t3 agy-acp`) that wraps `agy --print` mode while reconstructing live event streams from `PreToolUse`/`PostToolUse`/`Stop` hooks and trajectory transcripts (`transcript.jsonl`).

> [!NOTE]
> **Credit & Reference**: This PR incorporates and builds upon the foundational ACP bridge architecture originally submitted by @agentool in #4497. It extends that work with dynamic UI model grouping, log-based account/subscription discovery, official vector SVG branding, non-interactive text-generation shortcuts, and full unit test coverage across all provider layers.

---

## 📸 Screenshots & UI Showcase

### 1. Model Discovery & Reasoning Effort Selector
*Groups raw CLI slugs (`gemini-3.6-flash-high`, `gemini-3.6-flash-medium`, etc.) into clean base models with dynamic Reasoning Effort (`Low / Medium / High`) selectors.*

<img width="394" height="380" alt="image" src="https://github.com/user-attachments/assets/4da434ca-cf0c-4134-8034-8b4f74a7b4f1" />
<img width="822" height="212" alt="image" src="https://github.com/user-attachments/assets/b79baed2-1dd0-485b-bcdd-898180fdbf45" />

---

### 2. Provider Settings & Account Authentication
*Automatically parses CLI logs to display the authenticated user's email address and subscription tier badge (`Google AI Pro Subscription` / `Enterprise`).*

<img width="882" height="65" alt="image" src="https://github.com/user-attachments/assets/dc9ed15a-4e48-44c1-b4d2-94b0f2ba365d" />

---

### 3. Agent Conversation & Clean UI Footer
*Renders structured response streaming, markdown formatting, and clean provider footer (with mode selector dropdown hidden via `showInteractionModeToggle: false`).*

<img width="903" height="983" alt="image" src="https://github.com/user-attachments/assets/168edd40-888b-4c6a-baf3-78fd477f697e" />
---

## 🛠️ What Changed & Why

### 1. UI Model Grouping (`AntigravityProvider.ts`)
- **Problem**: `agy models` returns 11 raw, un-grouped slugs (e.g. `gemini-3.6-flash-high`, `gemini-3.6-flash-medium`, `gemini-3.6-flash-low`), cluttering the model picker dropdown.
- **Solution**: Implemented `groupAntigravityModels()` to consolidate slugs under clean base models (`Gemini 3.6 Flash`) with a dynamic **Reasoning Effort Selector** (`Low`, `Medium`, `High`).

### 2. Account & Subscription Discovery (`AntigravityProvider.ts`)
- Implemented `checkAntigravityAccountAuth()` to inspect `.gemini/antigravity-cli/cli.log` and `onboarding.json`, displaying the logged-in email and subscription badge (`Google AI Pro Subscription`, `Enterprise`, etc.).

### 3. Tool Execution & Live Event Stream (`agyBridge.ts` & `AntigravityAdapter.ts`)
- Executes turns via `agy --print` mode using `--dangerously-skip-permissions`.
- Reconstructs a real-time event stream by correlating `PreToolUse`/`PostToolUse`/`Stop` hooks with transcript JSONL records on `stepIdx`/`step_index`.
- Sets `showInteractionModeToggle: false` so that unnecessary permission mode selectors (`Full access / Supervised`) are automatically hidden from the UI for Antigravity sessions.

### 4. Official Vector SVG Branding & `Preview` Badge (`Icons.tsx` & `providerDriverMeta.ts`)
- Replaced fuzzy PNG icon with high-resolution vector SVG paths and gradient masks.
- Updated provider badge label to **"Preview"**.

### 5. File Attachments (`attachmentStore.ts` & `AntigravityAdapter.ts`)
- Added `attachmentFileUrl()` using `NodeURL.pathToFileURL()` to safely URI-encode file paths across operating systems.
- Attached files are converted to `resource_link` URIs, appended to the prompt, and granted directory access via `agy --add-dir`.

### 6. In-Session Model Switching (`sessionModelSwitch: "in-session"`)
- Because `--model` is a per-turn flag on `agy --print --conversation <id>`, model changes take effect on subsequent turns while preserving the conversation trajectory.

### 7. Process Concurrency & Error Resiliency
- Uses isolated per-session state files (`t3code-acp-sessions/<sessionId>.json`) to avoid race conditions when running multiple subagents/threads concurrently.
- Queue error catching returns explicit JSON-RPC error responses (`-32603`), preventing UI client hangups if an internal bridge error occurs.

---

## ✅ Checklist

- [x] Code follows repository standards and TypeScript Effect conventions.
- [x] Formatting ran cleanly via `vp fmt`.
- [x] All 61 unit tests pass locally.
- [x] Credited prior work in #4497 by @agentool.
- [x] Includes documentation in `AGENTS.md`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Antigravity (Google AGY) provider integration with ACP bridge
> - Introduces a new `antigravity` provider driver that launches the `agy` CLI as an ACP bridge subprocess, streams transcript records, and exposes a full provider adapter with approval gating, cancellation, and model discovery.
> - Adds `AntigravityAdapter` and `AntigravityDriver` wiring the provider into the built-in driver registry with periodic health checks reporting installation, version, auth state, and discovered models.
> - Implements incremental transcript parsing (`AgyTranscriptCursor`) that handles partial lines, overlong-line discard (4 MiB cap), and deferred tool-call correlation between hook events and transcript records.
> - Adds Antigravity-backed `TextGeneration` for commit messages, PR content, branch names, and thread titles, using a 180s streaming prompt with schema-validated JSON extraction.
> - Exposes two hidden CLI subcommands (`agy-acp`, `agy-hook`) used by the bridge for stdio communication and tool-lifecycle hook handling.
> - Adds the Antigravity provider to the settings UI (schema, icon, `Experimental` badge) and the model picker with a `new` badge.
> - Risk: the bridge runs as a child process over stdio; if the `agy` binary is missing or times out (4s for version, 15s for models), the provider degrades to an error/warning status rather than failing hard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcbd5f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new session/approval/teardown logic plus dependence on `agy` print mode, hooks, and transcript parsing; tools run with skip-permissions unless the hook gate is enabled, so CLI or filesystem behavior changes can break streaming or safety expectations.
> 
> **Overview**
> Adds a built-in **Antigravity** provider that drives the external `agy` CLI through a bundled stdio **ACP bridge** (`t3 agy-acp` / `t3 agy-hook`), since `agy` has no native agent protocol. Sessions are implemented as a large `AntigravityAdapter` on top of `AcpSessionRuntime`, with turn lifecycle, optional **PreToolUse hook–based tool approval** (print mode still auto-approves at the CLI), attachments as **`resource_link` `file:` URIs** via new `attachmentFileUrl`, and per-turn model/effort passed into the bridge through env vars.
> 
> **Provider surface:** `AntigravityDriver` wires adapter + text generation + managed snapshots; `AntigravityProvider` probes `agy --version` / `agy models` (with `stdin: "ignore"` to avoid hangs), groups tiered model slugs for the UI, and infers subscription/email from local CLI logs. Contracts/settings/UI registration are implied by the driver stack; `AGENTS.md` documents bridge constraints.
> 
> **Shared ACP runtime:** `AcpSessionRuntime` gains a **dispatch gate** and cancellation generation so `session/cancel` cannot race prompt send/register, and assistant segments close on failed prompts too—behavior Antigravity’s adapter relies on for stop/cancel fencing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbd5f64788c4464cf66c380a71a2a6ce2a242de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->