### PR TITLE
fix(server): keep the last completed turn when a session settles

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1429,6 +1429,17 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       assert.deepEqual(settledRows, [
         { state: "completed", completedAt: "2026-01-01T00:01:00.000Z" },
       ]);
+
+      // The settling session reports `activeTurnId: null`. The thread
+      // shell must still point at the finished turn — otherwise every reader
+      // of the last completion (unseen-completion pill, snooze raised hand,
+      // cross-project awareness) goes blind the moment a run ends.
+      const shellRows = yield* sql<{ readonly latestTurnId: string | null }>`
+        SELECT latest_turn_id AS "latestTurnId"
+        FROM projection_threads
+        WHERE thread_id = ${threadId}
+      `;
+      assert.deepEqual(shellRows, [{ latestTurnId: turnId }]);
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -809,7 +809,14 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           }
           yield* projectionThreadRepository.upsert({
             ...existingRow.value,
-            latestTurnId: event.payload.session.activeTurnId,
+            // `latestTurnId` means the LATEST turn, not the ACTIVE one.
+            // A settling session reports `activeTurnId: null`, and writing that
+            // through made the shell forget every finished run the instant it
+            // ended. Everything keyed on the last completion went quiet with
+            // it: the sidebar's "Completed" pill, the raised-hand check on a
+            // snoozed thread, and the cross-project awareness feed. Keep the
+            // last known turn; only a newer one replaces it.
+            latestTurnId: event.payload.session.activeTurnId ?? existingRow.value.latestTurnId,
             updatedAt: event.occurredAt,
           });
           yield* refreshThreadShellSummary(event.payload.threadId);


### PR DESCRIPTION
## What changed

`ProjectionPipeline` handles `thread.session-set` by writing `event.payload.session.activeTurnId` straight into the projection row's `latestTurnId`.

A settling session reports `activeTurnId: null`. Since `latestTurnId` means the *latest* turn and not the *active* one, that null wiped the just-finished turn from the thread shell at the exact moment the run completed.

One line, plus a regression assertion:

```ts
latestTurnId: event.payload.session.activeTurnId ?? existingRow.value.latestTurnId,
```

## Why it should exist

Everything downstream that keys on the last completion went quiet with it:

- the sidebar's unseen-completion pill (`hasUnseenCompletion` reads `latestTurn`),
- `threadRaisedHandWhileSnoozed` — a snoozed thread stopped raising its hand when a run completed,
- the cross-project agent awareness feed in `packages/shared/src/agentAwareness.ts`.

The symptom is easy to miss because it is a disappearance, not an error: a thread finishes, and the shell forgets that it ever ran.

## Test

`ProjectionPipeline.test.ts` — the existing settle case now also asserts that `projection_threads.latest_turn_id` still points at the finished turn after the session settles. It fails without the fix.

`vp test run apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts` → 22 passed.

## Notes

No UI change, so no before/after images — the visible effect is elsewhere in the app and depends on which reader you look at.

Found while building a cross-project awareness surface on top of the orchestration projections; the thread shells kept losing their last completed turn, which turned out to be this rather than anything in my own code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted projection fix with a regression test; behavior change only when session settles with null active turn.
> 
> **Overview**
> When a run ends, `thread.session-set` can report `activeTurnId: null` while the session settles. **`ProjectionPipeline`** was copying that into `projection_threads.latest_turn_id`, even though that field tracks the **latest** turn, not the currently active one—so the thread shell dropped the just-finished turn at completion.
> 
> The handler now keeps the previous value when `activeTurnId` is null: `activeTurnId ?? existingRow.value.latestTurnId`. A new turn still replaces it when the session reports a non-null active id (e.g. steer).
> 
> **Regression test:** the existing turn-lifecycle settle case also asserts `latest_turn_id` still points at the completed turn after session settle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5825a815c59f19d4c30763594a54dc83611db1e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve last completed turn ID when a session settles in `ProjectionPipeline`
> When a `thread.session-set` event arrives with `activeTurnId: null` (i.e. the session is settling), the projector was overwriting `latestTurnId` with `null`. Now it uses the nullish coalescing operator to fall back to the existing `latestTurnId`, keeping the last completed turn's ID intact.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5825a81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->