### PR TITLE
feat(web): make the right-panel resize handle keyboard operable

### DIFF
--- a/apps/web/src/components/preview/PreviewPanelShell.tsx
+++ b/apps/web/src/components/preview/PreviewPanelShell.tsx
@@ -53,7 +53,15 @@ export function PreviewPanelShell(props: {
       data-preview-panel-mode={props.mode}
       data-preview-panel-maximized={props.maximized ? "true" : "false"}
     >
-      {isInline && !props.maximized ? <RightPanelResizeHandle handlers={handlers} /> : null}
+      {isInline && !props.maximized ? (
+        <RightPanelResizeHandle
+          handlers={handlers}
+          label="Resize preview panel"
+          maxWidth={maxWidth}
+          minWidth={PREVIEW_PANEL_MIN_WIDTH}
+          width={width}
+        />
+      ) : null}
       {useDragRegion ? <div className="electron-drag-region h-0 w-full" aria-hidden /> : null}
       {props.children}
     </div>

--- a/apps/web/src/components/preview/RightPanelResizeHandle.tsx
+++ b/apps/web/src/components/preview/RightPanelResizeHandle.tsx
@@ -4,6 +4,16 @@ import { cn } from "~/lib/utils";
 interface Props {
   handlers: ResizableWidthHandlers;
   className?: string;
+  /**
+   * Current and allowed width in px. Optional so existing call sites keep
+   * compiling, but pass them: reachable by keyboard while announcing nothing
+   * is worse than not reachable at all.
+   */
+  width?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  /** Spoken name, so the handle is never announced as a bare separator. */
+  label?: string;
 }
 
 /**
@@ -13,21 +23,36 @@ interface Props {
  *   user can grab a few pixels off the edge without aiming.
  * - Visual indicator is a 1px line that lights up on hover/active to mirror
  *   VS Code / Cursor.
+ * - Focusable window splitter: arrow keys move it, Shift makes the step
+ *   coarse, Home/End park it at either extreme. The line lights up on keyboard
+ *   focus too — otherwise focus would sit on something invisible.
  */
-export function RightPanelResizeHandle({ handlers, className }: Props) {
+export function RightPanelResizeHandle({
+  handlers,
+  className,
+  width,
+  minWidth,
+  maxWidth,
+  label,
+}: Props) {
   return (
     <div
       role="separator"
       aria-orientation="vertical"
+      aria-label={label ?? "Resize panel"}
+      aria-valuenow={width}
+      aria-valuemin={minWidth}
+      aria-valuemax={maxWidth}
+      tabIndex={0}
       className={cn(
-        "group absolute inset-y-0 -left-1 z-20 w-2 cursor-col-resize select-none",
+        "group absolute inset-y-0 -left-1 z-20 w-2 cursor-col-resize select-none outline-hidden",
         className,
       )}
       {...handlers}
     >
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors duration-150 group-hover:bg-border group-active:bg-primary/60"
+        className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors duration-150 group-hover:bg-border group-focus-visible:bg-primary group-active:bg-primary/60"
       />
     </div>
   );

--- a/apps/web/src/hooks/useResizableWidth.test.ts
+++ b/apps/web/src/hooks/useResizableWidth.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { nextWidthForKey } from "./useResizableWidth";
+
+const BOUNDS = { minWidth: 220, maxWidth: 520 } as const;
+
+function press(
+  key: string,
+  edge: "left" | "right",
+  extra: { width?: number; shiftKey?: boolean } = {},
+) {
+  return nextWidthForKey({
+    key,
+    shiftKey: extra.shiftKey ?? false,
+    width: extra.width ?? 300,
+    edge,
+    ...BOUNDS,
+  });
+}
+
+describe("nextWidthForKey", () => {
+  it("moves the handle left on ArrowLeft — whichever edge it sits on", () => {
+    // Right-anchored panel: handle on its left edge, so left = wider.
+    expect(press("ArrowLeft", "left")).toBe(308);
+    // Left-anchored panel: handle on its right edge, so left = narrower.
+    expect(press("ArrowLeft", "right")).toBe(292);
+  });
+
+  it("moves the handle right on ArrowRight", () => {
+    expect(press("ArrowRight", "left")).toBe(292);
+    expect(press("ArrowRight", "right")).toBe(308);
+  });
+
+  it("takes a coarse step with Shift", () => {
+    expect(press("ArrowLeft", "left", { shiftKey: true })).toBe(348);
+  });
+
+  it("parks the handle at either extreme with Home and End", () => {
+    // Home = handle all the way left, which for a right-anchored panel is
+    // its widest — not its smallest number.
+    expect(press("Home", "left")).toBe(520);
+    expect(press("End", "left")).toBe(220);
+    expect(press("Home", "right")).toBe(220);
+    expect(press("End", "right")).toBe(520);
+  });
+
+  it("leaves keys it does not own alone", () => {
+    expect(press("ArrowUp", "left")).toBeNull();
+    expect(press("Enter", "left")).toBeNull();
+    expect(press("a", "left")).toBeNull();
+  });
+
+  it("may step past the bounds — the caller clamps", () => {
+    // Deliberate: this function answers "where does the key point", the hook
+    // owns the allowed range. Splitting it the other way would duplicate the
+    // clamp that already guards the stored and dragged width.
+    expect(press("ArrowLeft", "left", { width: 518 })).toBe(526);
+  });
+});

--- a/apps/web/src/hooks/useResizableWidth.ts
+++ b/apps/web/src/hooks/useResizableWidth.ts
@@ -1,9 +1,19 @@
 import * as Schema from "effect/Schema";
-import { type PointerEvent as ReactPointerEvent, useCallback, useRef, useState } from "react";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 
 import { getLocalStorageItem, setLocalStorageItem } from "./useLocalStorage";
 
 const WidthSchema = Schema.Finite;
+
+/** Arrow-key step, and the coarse step held Shift gives you. */
+const KEYBOARD_STEP = 8;
+const KEYBOARD_COARSE_STEP = 48;
 
 export interface UseResizableWidthOptions {
   /** localStorage key the persisted width is stored under. */
@@ -24,6 +34,47 @@ export interface ResizableWidthHandlers {
   readonly onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onPointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onPointerCancel: (event: ReactPointerEvent<HTMLElement>) => void;
+  /**
+   * Arrow keys nudge the handle, Shift makes the step coarse, Home/End park it
+   * at either extreme. Without this the handle is mouse-only — the panel width
+   * would be the one part of the layout a keyboard user cannot reach.
+   */
+  readonly onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
+}
+
+/**
+ * Width a key press asks for, or `null` if the key is not ours to handle.
+ *
+ * Keys are spatial: ArrowLeft always moves the handle left. Whether that
+ * widens or narrows the panel depends on which edge the handle sits on — so
+ * the same key does opposite things on a left- and a right-anchored panel,
+ * and that is correct.
+ *
+ * Pure and exported so the direction/step rules can be tested without a DOM.
+ */
+export function nextWidthForKey(input: {
+  readonly key: string;
+  readonly shiftKey: boolean;
+  readonly width: number;
+  readonly minWidth: number;
+  readonly maxWidth: number;
+  readonly edge: "left" | "right";
+}): number | null {
+  const { key, shiftKey, width, minWidth, maxWidth, edge } = input;
+  const widerToTheLeft = edge === "left";
+  const step = shiftKey ? KEYBOARD_COARSE_STEP : KEYBOARD_STEP;
+  switch (key) {
+    case "ArrowLeft":
+      return widerToTheLeft ? width + step : width - step;
+    case "ArrowRight":
+      return widerToTheLeft ? width - step : width + step;
+    case "Home":
+      return widerToTheLeft ? maxWidth : minWidth;
+    case "End":
+      return widerToTheLeft ? minWidth : maxWidth;
+    default:
+      return null;
+  }
 }
 
 /**
@@ -133,13 +184,10 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
     [clamp, edge],
   );
 
-  const onPointerUp = useCallback(
-    (event: ReactPointerEvent<HTMLElement>) => {
-      const state = dragStateRef.current;
-      if (!state || state.pointerId !== event.pointerId) return;
-      const finalWidth = clamp(state.pending);
-      releasePointer(event.pointerId);
-      // Commit once at drag-end to avoid 60Hz localStorage writes.
+  /** Persist and apply in one go — the end of a drag, or a single key press. */
+  const commit = useCallback(
+    (value: number) => {
+      const finalWidth = clamp(value);
       try {
         setLocalStorageItem(storageKey, finalWidth, WidthSchema);
       } catch (error) {
@@ -147,7 +195,19 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
       }
       setWidth(finalWidth);
     },
-    [clamp, releasePointer, storageKey],
+    [clamp, storageKey],
+  );
+
+  const onPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      const state = dragStateRef.current;
+      if (!state || state.pointerId !== event.pointerId) return;
+      const pending = state.pending;
+      releasePointer(event.pointerId);
+      // Commit once at drag-end to avoid 60Hz localStorage writes.
+      commit(pending);
+    },
+    [commit, releasePointer],
   );
 
   const onPointerCancel = useCallback(
@@ -161,8 +221,27 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
     [releasePointer],
   );
 
+  const onKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLElement>) => {
+      // Modified presses belong to the browser or the app, not to the handle.
+      if (event.altKey || event.ctrlKey || event.metaKey) return;
+      const next = nextWidthForKey({
+        key: event.key,
+        shiftKey: event.shiftKey,
+        width: clampedWidth,
+        minWidth,
+        maxWidth,
+        edge,
+      });
+      if (next === null) return;
+      event.preventDefault();
+      commit(next);
+    },
+    [clampedWidth, commit, edge, maxWidth, minWidth],
+  );
+
   return {
     width: clampedWidth,
-    handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
+    handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onKeyDown },
   };
 }


### PR DESCRIPTION
## What changed

`RightPanelResizeHandle` was pointer-only: `role="separator"` with pointer handlers, no `tabIndex`, no name, no value. Panel width was the one part of the layout a keyboard user could not reach.

- **Arrow keys** nudge the handle by 8px, **Shift** makes the step 48px, **Home/End** park it at either extreme.
- The handle is focusable and announces itself as a window splitter — `aria-label`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax` — instead of an unnamed separator.
- The 1px line lights up on keyboard focus too (`group-focus-visible:bg-primary`), so focus never sits on something invisible.

Keys are spatial: `ArrowLeft` always moves the handle left, which widens or narrows depending on which edge the panel is anchored to. That rule lives in a pure function, `nextWidthForKey`, so the direction and step logic is testable without a DOM.

The new props on `RightPanelResizeHandle` are optional, so existing call sites keep compiling; `PreviewPanelShell` passes them.

## Why it should exist

`useResizableWidth` already owns clamping and persistence — the keyboard path is ~40 lines on top of machinery that exists. Without it the panel has a visible, draggable affordance that simply does not exist for anyone not using a pointer.

## Before / after

The change is only visible while the handle has focus, because before this patch the handle could not receive focus at all.

| before (handle blurred — and unreachable) | after (handle focused via Tab) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/andyon2/t3code/pr-assets/handle-blur.png" width="171"> | <img src="https://raw.githubusercontent.com/andyon2/t3code/pr-assets/handle-focus.png" width="171"> |

Interaction, walked through in a real browser on this branch: Tab reaches the handle right after the composer's send button; it reports `Resize preview panel`, `valuenow 540`, `min 360`, `max 714`. `Shift+ArrowLeft` ×3 widens the panel 540 → 684, `End` parks it at 360, `ArrowLeft` ×8 brings it to 424. Focus ring and line colour verified in the dark theme.

## Test

`apps/web/src/hooks/useResizableWidth.test.ts` covers `nextWidthForKey`: both edges, both step sizes, Home/End, and the keys it must ignore.

`vp test run --project unit apps/web/src/hooks/useResizableWidth.test.ts` → 6 passed.

## Notes

Read CONTRIBUTING first — happy for this to be closed or deferred. It is small, self-contained, and does not change any existing behaviour for pointer users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI/a11y change to panel resizing; pointer behavior unchanged and width still clamped and persisted through existing hook logic.
> 
> **Overview**
> Makes the preview panel resize handle **keyboard-accessible** and properly announced to assistive tech, without changing pointer drag behavior.
> 
> `useResizableWidth` now exposes `onKeyDown` and a shared `commit` path so arrow keys (8px), Shift+arrows (48px), and Home/End resize the panel with the same clamping and `localStorage` persistence as drag-end. Direction is edge-aware via exported pure helper `nextWidthForKey`, covered by new unit tests.
> 
> `RightPanelResizeHandle` becomes focusable (`tabIndex={0}`) with `aria-label` / value min-max, and shows focus on the 1px indicator. `PreviewPanelShell` passes width bounds and the label `"Resize preview panel"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ed91748c48ef81a0155b162db9029412ec80813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the right-panel resize handle keyboard operable
> - The `RightPanelResizeHandle` component gains `tabIndex=0`, ARIA attributes (`aria-label`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`), and a focus-visible highlight on the indicator line.
> - `useResizableWidth` gains an `onKeyDown` handler: Arrow keys move the panel width by a small step, Shift+Arrow moves by a coarse step, and Home/End jump to the min/max bounds. The new width is clamped and immediately persisted to localStorage.
> - A pure helper `nextWidthForKey` is exported from [useResizableWidth.ts](https://github.com/pingdotgg/t3code/pull/4581/files#diff-96534394ed1a9752ea07421d71c603ca870fc3df1e986db149612b91fdf3db66) to compute the next width from key input, aware of which edge the handle sits on.
> - `PreviewPanelShell` now passes `label`, `minWidth`, `maxWidth`, and current `width` to the handle to populate the ARIA value semantics correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7ed9174. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->