### PR TITLE
feat(opencode): expose skills and slash commands

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -63,6 +63,7 @@ const runtimeMock = {
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
     abortPromise: null as Promise<void> | null,
+    abortError: null as Error | null,
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
@@ -72,6 +73,8 @@ const runtimeMock = {
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as unknown[],
+    subscribedEventsGate: null as Promise<void> | null,
+    subscribedEventsConsumed: 0,
     sessionGetIds: [] as string[],
     missingSessionIds: new Set<string>(),
     transientErrorSessionIds: new Set<string>(),
@@ -86,6 +89,7 @@ const runtimeMock = {
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
     this.state.abortPromise = null;
+    this.state.abortError = null;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
@@ -95,6 +99,8 @@ const runtimeMock = {
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
+    this.state.subscribedEventsGate = null;
+    this.state.subscribedEventsConsumed = 0;
     this.state.sessionGetIds.length = 0;
     this.state.missingSessionIds.clear();
     this.state.transientErrorSessionIds.clear();
@@ -184,6 +190,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         abort: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.abortCalls.push(sessionID);
           await runtimeMock.state.abortPromise;
+          if (runtimeMock.state.abortError) {
+            throw runtimeMock.state.abortError;
+          }
         },
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
@@ -218,8 +227,10 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       event: {
         subscribe: async () => ({
           stream: (async function* () {
+            await runtimeMock.state.subscribedEventsGate;
             for (const event of runtimeMock.state.subscribedEvents) {
               yield event;
+              runtimeMock.state.subscribedEventsConsumed += 1;
             }
           })(),
         }),
@@ -563,6 +574,23 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       runtimeMock.state.abortPromise = new Promise<void>((resolve) => {
         resolveAbort = resolve;
       });
+      let releaseLateEvents!: () => void;
+      runtimeMock.state.subscribedEventsGate = new Promise<void>((resolve) => {
+        releaseLateEvents = resolve;
+      });
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "session.error",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            error: {
+              data: {
+                message: "late abort error",
+              },
+            },
+          },
+        },
+      ];
       const terminalEvents: Array<ProviderRuntimeEvent> = [];
       const eventsFiber = yield* adapter.streamEvents.pipe(
         Stream.filter(
@@ -594,8 +622,20 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const interruptFiber = yield* adapter
         .interruptTurn(threadId, turn.turnId)
         .pipe(Effect.forkChild);
+      for (
+        let attempt = 0;
+        attempt < 10 && runtimeMock.state.abortCalls.length === 0;
+        attempt += 1
+      ) {
+        yield* Effect.yieldNow;
+      }
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
+      const joinedInterruptFiber = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.forkChild);
       yield* Effect.yieldNow;
       NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
+      yield* Fiber.interrupt(interruptFiber);
 
       const steeredTurn = yield* adapter.sendTurn({
         threadId,
@@ -609,9 +649,16 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
 
       rejectCommand(new Error("late command failure"));
       resolveAbort();
-      yield* Fiber.join(interruptFiber);
-      yield* Effect.yieldNow;
-      yield* Effect.yieldNow;
+      yield* Fiber.join(joinedInterruptFiber);
+      releaseLateEvents();
+      for (
+        let attempt = 0;
+        attempt < 10 && runtimeMock.state.subscribedEventsConsumed === 0;
+        attempt += 1
+      ) {
+        yield* Effect.yieldNow;
+      }
+      NodeAssert.equal(runtimeMock.state.subscribedEventsConsumed, 1);
 
       NodeAssert.equal(terminalEvents.length, 1);
       const completed = terminalEvents[0];
@@ -625,6 +672,72 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.equal(sessions[0]?.status, "ready");
       NodeAssert.equal(sessions[0]?.activeTurnId, undefined);
       yield* Fiber.interrupt(eventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("reports a deferred command failure when abort also fails", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-command-and-abort-failure");
+      let rejectCommand!: (error: Error) => void;
+      runtimeMock.state.commandPromise = new Promise<void>((_resolve, reject) => {
+        rejectCommand = reject;
+      });
+      let resolveAbort!: () => void;
+      runtimeMock.state.abortPromise = new Promise<void>((resolve) => {
+        resolveAbort = resolve;
+      });
+      runtimeMock.state.abortError = new Error("abort failed");
+      const terminalEventFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.completed" || event.type === "turn.aborted"),
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "/review src/provider",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "anthropic/sonnet",
+        ),
+      });
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.forkChild);
+      for (
+        let attempt = 0;
+        attempt < 10 && runtimeMock.state.abortCalls.length === 0;
+        attempt += 1
+      ) {
+        yield* Effect.yieldNow;
+      }
+      rejectCommand(new Error("command failed during abort"));
+      resolveAbort();
+
+      const interruptExit = yield* Fiber.await(interruptFiber);
+      NodeAssert.equal(Exit.isFailure(interruptExit), true);
+      const events = Array.from(
+        yield* Fiber.join(terminalEventFiber).pipe(Effect.timeout("1 second")),
+      );
+      const completed = events[0];
+      if (completed?.type !== "turn.completed") {
+        throw new Error("Expected a failed turn.completed event");
+      }
+      NodeAssert.equal(completed.payload.state, "failed");
+      NodeAssert.equal(completed.payload.errorMessage, "command failed during abort");
+
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -19,6 +19,7 @@ import {
   OpenCodeSettings,
   ProviderDriverKind,
   ProviderInstanceId,
+  type ProviderRuntimeEvent,
   ThreadId,
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
@@ -543,6 +544,63 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.equal(completed.payload.state, "failed");
       NodeAssert.equal(completed.payload.errorMessage, "command failed");
 
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("keeps a late command rejection from overwriting an interruption", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-interrupted-command");
+      let rejectCommand!: (error: Error) => void;
+      runtimeMock.state.commandPromise = new Promise<void>((_resolve, reject) => {
+        rejectCommand = reject;
+      });
+      const terminalEvents: Array<ProviderRuntimeEvent> = [];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.completed" || event.type === "turn.aborted"),
+        ),
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            terminalEvents.push(event);
+          }),
+        ),
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "/review src/provider",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "anthropic/sonnet",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, turn.turnId);
+      rejectCommand(new Error("late command failure"));
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      NodeAssert.equal(terminalEvents.length, 1);
+      const completed = terminalEvents[0];
+      if (completed?.type !== "turn.completed") {
+        throw new Error("Expected an interrupted turn.completed event");
+      }
+      NodeAssert.equal(completed.payload.state, "interrupted");
+      NodeAssert.equal(completed.payload.stopReason, "Interrupted by user.");
+
+      const sessions = yield* adapter.listSessions();
+      NodeAssert.equal(sessions[0]?.status, "ready");
+      NodeAssert.equal(sessions[0]?.activeTurnId, undefined);
+      yield* Fiber.interrupt(eventsFiber);
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -495,6 +495,58 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("completes the lifecycle when a detached slash command fails", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-failed-command");
+      let rejectCommand!: (error: Error) => void;
+      runtimeMock.state.commandPromise = new Promise<void>((_resolve, reject) => {
+        rejectCommand = reject;
+      });
+      const terminalEventFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.completed" || event.type === "turn.aborted"),
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "/review src/provider",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "anthropic/sonnet",
+        ),
+      });
+      rejectCommand(new Error("command failed"));
+
+      const events = Array.from(
+        yield* Fiber.join(terminalEventFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        ["turn.completed"],
+      );
+      const completed = events[0];
+      if (completed?.type !== "turn.completed") {
+        throw new Error("Expected a failed turn.completed event");
+      }
+      NodeAssert.equal(completed.payload.state, "failed");
+      NodeAssert.equal(completed.payload.errorMessage, "command failed");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("falls back to a fresh session when the persisted session is gone", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -64,6 +64,7 @@ const runtimeMock = {
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
+    commandCalls: [] as Array<unknown>,
     promptAsyncError: null as Error | null,
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
@@ -84,6 +85,7 @@ const runtimeMock = {
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
+    this.state.commandCalls.length = 0;
     this.state.promptAsyncError = null;
     this.state.closeError = null;
     this.state.messages = [];
@@ -182,6 +184,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           if (runtimeMock.state.promptAsyncError) {
             throw runtimeMock.state.promptAsyncError;
           }
+        },
+        command: async (input: unknown) => {
+          runtimeMock.state.commandCalls.push(input);
         },
         messages: async () => ({ data: runtimeMock.state.messages }),
         revert: async ({ sessionID, messageID }: { sessionID: string; messageID?: string }) => {
@@ -384,6 +389,76 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         sessionId: "ses_persisted",
       });
 
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("dispatches leading slash commands through the OpenCode command endpoint", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-command");
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "/review src/provider",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "anthropic/sonnet",
+          [
+            { id: "agent", value: "build" },
+            { id: "variant", value: "high" },
+          ],
+        ),
+      });
+
+      NodeAssert.deepEqual(runtimeMock.state.commandCalls, [
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          command: "review",
+          arguments: "src/provider",
+          model: "anthropic/sonnet",
+          agent: "build",
+          variant: "high",
+        },
+      ]);
+      NodeAssert.deepEqual(runtimeMock.state.promptCalls, []);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("supplies empty arguments for slash commands without arguments", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-command-without-arguments");
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "/quota",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/big-pickle",
+        ),
+      });
+
+      NodeAssert.deepEqual(runtimeMock.state.commandCalls, [
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          command: "quota",
+          arguments: "",
+          model: "opencode/big-pickle",
+        },
+      ]);
+      NodeAssert.deepEqual(runtimeMock.state.promptCalls, []);
       yield* adapter.stopSession(threadId);
     }),
   );
@@ -855,6 +930,64 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       });
     }).pipe(Effect.provide(adapterLayer));
   });
+
+  it.effect("uses the plan agent when interaction mode overrides the selected agent", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-plan-mode-agent");
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Draft a plan",
+        interactionMode: "plan",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "anthropic/claude-sonnet-4-5",
+          [{ id: "agent", value: "build" }],
+        ),
+      });
+
+      NodeAssert.equal(
+        (runtimeMock.state.promptCalls.at(-1) as { agent?: string } | undefined)?.agent,
+        "plan",
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("repairs a stale plan agent selection when returning to default mode", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-default-mode-agent");
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Implement the plan",
+        interactionMode: "default",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "anthropic/claude-sonnet-4-5",
+          [{ id: "agent", value: "plan" }],
+        ),
+      });
+
+      NodeAssert.equal(
+        (runtimeMock.state.promptCalls.at(-1) as { agent?: string } | undefined)?.agent,
+        "build",
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
 
   it.effect("uses the bound custom instance id for fallback sendTurn model selection", () => {
     const instanceId = ProviderInstanceId.make("opencode_zen");

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -65,6 +65,7 @@ const runtimeMock = {
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
     commandCalls: [] as Array<unknown>,
+    commandPromise: null as Promise<void> | null,
     promptAsyncError: null as Error | null,
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
@@ -86,6 +87,7 @@ const runtimeMock = {
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
     this.state.commandCalls.length = 0;
+    this.state.commandPromise = null;
     this.state.promptAsyncError = null;
     this.state.closeError = null;
     this.state.messages = [];
@@ -187,6 +189,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         command: async (input: unknown) => {
           runtimeMock.state.commandCalls.push(input);
+          await runtimeMock.state.commandPromise;
         },
         messages: async () => ({ data: runtimeMock.state.messages }),
         revert: async ({ sessionID, messageID }: { sessionID: string; messageID?: string }) => {
@@ -459,6 +462,35 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         },
       ]);
       NodeAssert.deepEqual(runtimeMock.state.promptCalls, []);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("returns without waiting for a long-running slash command", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-long-command");
+      let resolveCommand!: () => void;
+      runtimeMock.state.commandPromise = new Promise<void>((resolve) => {
+        resolveCommand = resolve;
+      });
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "/review src/provider",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "anthropic/sonnet",
+        ),
+      });
+
+      NodeAssert.equal(runtimeMock.state.commandCalls.length, 1);
+      resolveCommand();
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -62,6 +62,7 @@ const runtimeMock = {
     sessionCreateInputs: [] as Array<Record<string, unknown>>,
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
+    abortPromise: null as Promise<void> | null,
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
@@ -84,6 +85,7 @@ const runtimeMock = {
     this.state.sessionCreateInputs.length = 0;
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
+    this.state.abortPromise = null;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
@@ -181,6 +183,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         abort: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.abortCalls.push(sessionID);
+          await runtimeMock.state.abortPromise;
         },
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
@@ -556,6 +559,10 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       runtimeMock.state.commandPromise = new Promise<void>((_resolve, reject) => {
         rejectCommand = reject;
       });
+      let resolveAbort!: () => void;
+      runtimeMock.state.abortPromise = new Promise<void>((resolve) => {
+        resolveAbort = resolve;
+      });
       const terminalEvents: Array<ProviderRuntimeEvent> = [];
       const eventsFiber = yield* adapter.streamEvents.pipe(
         Stream.filter(
@@ -584,8 +591,25 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           "anthropic/sonnet",
         ),
       });
-      yield* adapter.interruptTurn(threadId, turn.turnId);
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
+
+      const steeredTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Include the tests",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "anthropic/sonnet",
+        ),
+      });
+      NodeAssert.equal(steeredTurn.turnId, turn.turnId);
+
       rejectCommand(new Error("late command failure"));
+      resolveAbort();
+      yield* Fiber.join(interruptFiber);
       yield* Effect.yieldNow;
       yield* Effect.yieldNow;
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -801,6 +801,9 @@ export function makeOpenCodeAdapter(
         return false;
       }
       attempt.terminalClaimed = true;
+      if (context.interruptAttempt === attempt) {
+        context.interruptAttempt = undefined;
+      }
       context.recentlyInterruptedTurnId = attempt.turnId;
       if (context.activeTurnId === attempt.turnId) {
         context.activeTurnId = undefined;
@@ -1508,9 +1511,6 @@ export function makeOpenCodeAdapter(
       // the active turn id is reused instead of opening a new turn.
       const steeringTurnId = context.activeTurnId;
       const turnId = steeringTurnId ?? TurnId.make(`opencode-turn-${yield* randomUUIDv4}`);
-      if (steeringTurnId === undefined) {
-        context.recentlyInterruptedTurnId = undefined;
-      }
       const modelSelection =
         input.modelSelection ??
         (context.session.model
@@ -1552,6 +1552,9 @@ export function makeOpenCodeAdapter(
       const agent = getModelSelectionStringOptionValue(modelSelection, "agent");
       const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
 
+      if (steeringTurnId === undefined) {
+        context.recentlyInterruptedTurnId = undefined;
+      }
       context.activeTurnId = turnId;
       // Build and plan are OpenCode's built-in interaction modes, not model
       // traits. Plan mode always wins; default mode also repairs stale model
@@ -1707,10 +1710,6 @@ export function makeOpenCodeAdapter(
               yield* completeInterruptedTurn(context, ownedAttempt);
             }
 
-            if (context.interruptAttempt === ownedAttempt) {
-              context.interruptAttempt = undefined;
-            }
-
             if (Exit.isFailure(abortExit) && !ownedAttempt.terminalClaimed) {
               if (ownedAttempt.pendingCommandError) {
                 yield* failDetachedCommand(
@@ -1719,10 +1718,16 @@ export function makeOpenCodeAdapter(
                   ownedAttempt.pendingCommandError,
                 );
               }
+              if (context.interruptAttempt === ownedAttempt) {
+                context.interruptAttempt = undefined;
+              }
               yield* Deferred.failCause(ownedAttempt.completion, abortExit.cause);
               return;
             }
 
+            if (context.interruptAttempt === ownedAttempt) {
+              context.interruptAttempt = undefined;
+            }
             yield* Deferred.succeed(ownedAttempt.completion, undefined);
           });
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1458,7 +1458,11 @@ export function makeOpenCodeAdapter(
       const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
 
       context.activeTurnId = turnId;
-      context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
+      // Build and plan are OpenCode's built-in interaction modes, not model
+      // traits. Plan mode always wins; default mode also repairs stale model
+      // selections created when `plan` was exposed in the agent picker.
+      context.activeAgent =
+        input.interactionMode === "plan" ? "plan" : agent === "plan" ? "build" : agent;
       context.activeVariant = variant;
       yield* updateProviderSession(
         context,
@@ -1481,15 +1485,31 @@ export function makeOpenCodeAdapter(
         });
       }
 
-      yield* runOpenCodeSdk("session.promptAsync", () =>
-        context.client.session.promptAsync({
-          sessionID: context.openCodeSessionId,
-          model: parsedModel,
-          ...(context.activeAgent ? { agent: context.activeAgent } : {}),
-          ...(context.activeVariant ? { variant: context.activeVariant } : {}),
-          parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
-        }),
-      ).pipe(
+      const slashCommand = text?.match(/^\/([^\s/]+)(?:\s+([\s\S]*))?$/);
+      const command = slashCommand?.[1];
+      const request: Effect.Effect<unknown, OpenCodeRuntimeError> = command
+        ? runOpenCodeSdk("session.command", () =>
+            context.client.session.command({
+              sessionID: context.openCodeSessionId,
+              command,
+              arguments: slashCommand?.[2] ?? "",
+              ...(modelSelection?.model ? { model: modelSelection.model } : {}),
+              ...(context.activeAgent ? { agent: context.activeAgent } : {}),
+              ...(context.activeVariant ? { variant: context.activeVariant } : {}),
+              ...(fileParts.length > 0 ? { parts: fileParts } : {}),
+            }),
+          )
+        : runOpenCodeSdk("session.promptAsync", () =>
+            context.client.session.promptAsync({
+              sessionID: context.openCodeSessionId,
+              model: parsedModel,
+              ...(context.activeAgent ? { agent: context.activeAgent } : {}),
+              ...(context.activeVariant ? { variant: context.activeVariant } : {}),
+              parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
+            }),
+          );
+
+      yield* request.pipe(
         Effect.mapError(toRequestError),
         // On failure of a fresh turn: clear active-turn state, flip the
         // session back to ready with lastError set, emit turn.aborted, then

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1584,18 +1584,40 @@ export function makeOpenCodeAdapter(
     const interruptTurn: OpenCodeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
+        const interruptedTurnId = turnId ?? context.activeTurnId;
+        const ownsInterruptedTurn =
+          interruptedTurnId !== undefined && context.activeTurnId === interruptedTurnId;
+        if (ownsInterruptedTurn) {
+          // Relinquish ownership before awaiting the abort request. A detached
+          // command may reject while abort is in flight; its failure handler
+          // must not overwrite the interruption with a hard failure.
+          context.activeTurnId = undefined;
+        }
         yield* runOpenCodeSdk("session.abort", () =>
           context.client.session.abort({ sessionID: context.openCodeSessionId }),
-        ).pipe(Effect.mapError(toRequestError));
-        if (turnId ?? context.activeTurnId) {
+        ).pipe(
+          Effect.mapError(toRequestError),
+          Effect.tapError(() =>
+            ownsInterruptedTurn && context.activeTurnId === undefined
+              ? Effect.sync(() => {
+                  context.activeTurnId = interruptedTurnId;
+                })
+              : Effect.void,
+          ),
+        );
+        if (interruptedTurnId) {
+          if (ownsInterruptedTurn && context.activeTurnId === undefined) {
+            yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
+          }
           yield* emit({
             ...(yield* buildEventBase({
               threadId,
-              turnId: turnId ?? context.activeTurnId,
+              turnId: interruptedTurnId,
             })),
-            type: "turn.aborted",
+            type: "turn.completed",
             payload: {
-              reason: "Interrupted by user.",
+              state: "interrupted",
+              stopReason: "Interrupted by user.",
             },
           });
         }

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -216,6 +216,7 @@ interface OpenCodeSessionContext {
   readonly partById: Map<string, Part>;
   readonly emittedTextByPartId: Map<string, string>;
   readonly completedAssistantPartIds: Set<string>;
+  readonly interruptingTurnIds: Set<TurnId>;
   readonly turns: Array<OpenCodeTurnSnapshot>;
   activeTurnId: TurnId | undefined;
   activeAgent: string | undefined;
@@ -1057,6 +1058,7 @@ export function makeOpenCodeAdapter(
           }
 
           if (event.properties.status.type === "idle" && turnId) {
+            const wasInterrupted = context.interruptingTurnIds.delete(turnId);
             context.activeTurnId = undefined;
             yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
             yield* emit({
@@ -1067,7 +1069,8 @@ export function makeOpenCodeAdapter(
               })),
               type: "turn.completed",
               payload: {
-                state: "completed",
+                state: wasInterrupted ? "interrupted" : "completed",
+                ...(wasInterrupted ? { stopReason: "Interrupted by user." } : {}),
               },
             });
           }
@@ -1077,14 +1080,19 @@ export function makeOpenCodeAdapter(
         case "session.error": {
           const message = sessionErrorMessage(event.properties.error);
           const activeTurnId = context.activeTurnId;
+          const wasInterrupted =
+            activeTurnId !== undefined && context.interruptingTurnIds.delete(activeTurnId);
           context.activeTurnId = undefined;
           yield* updateProviderSession(
             context,
             {
-              status: "error",
-              lastError: message,
+              status: wasInterrupted ? "ready" : "error",
+              ...(wasInterrupted ? {} : { lastError: message }),
             },
-            { clearActiveTurnId: true },
+            {
+              clearActiveTurnId: true,
+              ...(wasInterrupted ? { clearLastError: true } : {}),
+            },
           );
           if (activeTurnId) {
             yield* emit({
@@ -1095,23 +1103,27 @@ export function makeOpenCodeAdapter(
               })),
               type: "turn.completed",
               payload: {
-                state: "failed",
-                errorMessage: message,
+                state: wasInterrupted ? "interrupted" : "failed",
+                ...(wasInterrupted
+                  ? { stopReason: "Interrupted by user." }
+                  : { errorMessage: message }),
               },
             });
           }
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              raw: event,
-            })),
-            type: "runtime.error",
-            payload: {
-              message,
-              class: "provider_error",
-              detail: event.properties.error,
-            },
-          });
+          if (!wasInterrupted) {
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                raw: event,
+              })),
+              type: "runtime.error",
+              payload: {
+                message,
+                class: "provider_error",
+                detail: event.properties.error,
+              },
+            });
+          }
           break;
         }
 
@@ -1380,6 +1392,7 @@ export function makeOpenCodeAdapter(
           emittedTextByPartId: new Map(),
           messageRoleById: new Map(),
           completedAssistantPartIds: new Set(),
+          interruptingTurnIds: new Set(),
           turns: [],
           activeTurnId: undefined,
           activeAgent: undefined,
@@ -1519,7 +1532,9 @@ export function makeOpenCodeAdapter(
         // start-failure recovery. A failed steer leaves the still-running
         // original turn untouched.
         Effect.tapError((requestError) =>
-          steeringTurnId !== undefined || context.activeTurnId !== turnId
+          steeringTurnId !== undefined ||
+          context.activeTurnId !== turnId ||
+          context.interruptingTurnIds.has(turnId)
             ? Effect.void
             : Effect.gen(function* () {
                 context.activeTurnId = undefined;
@@ -1588,25 +1603,28 @@ export function makeOpenCodeAdapter(
         const ownsInterruptedTurn =
           interruptedTurnId !== undefined && context.activeTurnId === interruptedTurnId;
         if (ownsInterruptedTurn) {
-          // Relinquish ownership before awaiting the abort request. A detached
-          // command may reject while abort is in flight; its failure handler
-          // must not overwrite the interruption with a hard failure.
-          context.activeTurnId = undefined;
+          // Keep active-turn ownership while abort is in flight so a
+          // concurrent send remains steering for this turn. The marker keeps
+          // a detached command rejection from overwriting the interruption.
+          context.interruptingTurnIds.add(interruptedTurnId);
         }
         yield* runOpenCodeSdk("session.abort", () =>
           context.client.session.abort({ sessionID: context.openCodeSessionId }),
         ).pipe(
           Effect.mapError(toRequestError),
           Effect.tapError(() =>
-            ownsInterruptedTurn && context.activeTurnId === undefined
+            ownsInterruptedTurn
               ? Effect.sync(() => {
-                  context.activeTurnId = interruptedTurnId;
+                  context.interruptingTurnIds.delete(interruptedTurnId);
                 })
               : Effect.void,
           ),
         );
-        if (interruptedTurnId) {
-          if (ownsInterruptedTurn && context.activeTurnId === undefined) {
+        // The idle event may win this race and emit the interrupted completion
+        // first. Deleting the marker is the one-shot claim for terminal state.
+        if (interruptedTurnId && context.interruptingTurnIds.delete(interruptedTurnId)) {
+          if (context.activeTurnId === interruptedTurnId) {
+            context.activeTurnId = undefined;
             yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
           }
           yield* emit({

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1509,7 +1509,7 @@ export function makeOpenCodeAdapter(
             }),
           );
 
-      yield* request.pipe(
+      const dispatchedRequest = request.pipe(
         Effect.mapError(toRequestError),
         // On failure of a fresh turn: clear active-turn state, flip the
         // session back to ready with lastError set, emit turn.aborted, then
@@ -1517,7 +1517,7 @@ export function makeOpenCodeAdapter(
         // here — `toRequestError` already produced the right shape. A failed
         // steer leaves the still-running original turn untouched.
         Effect.tapError((requestError) =>
-          steeringTurnId !== undefined
+          steeringTurnId !== undefined || context.activeTurnId !== turnId
             ? Effect.void
             : Effect.gen(function* () {
                 context.activeTurnId = undefined;
@@ -1545,6 +1545,16 @@ export function makeOpenCodeAdapter(
               }),
         ),
       );
+      if (command) {
+        // Unlike `promptAsync`, OpenCode's command endpoint does not return
+        // until the full assistant turn finishes. Keep the request attached to
+        // the session scope while returning the dispatch result immediately;
+        // the event stream remains authoritative for turn completion.
+        yield* dispatchedRequest.pipe(Effect.ignore, Effect.forkIn(context.sessionScope));
+        yield* Effect.yieldNow;
+      } else {
+        yield* dispatchedRequest;
+      }
 
       return {
         threadId: input.threadId,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -15,6 +15,7 @@ import {
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
@@ -216,11 +217,12 @@ interface OpenCodeSessionContext {
   readonly partById: Map<string, Part>;
   readonly emittedTextByPartId: Map<string, string>;
   readonly completedAssistantPartIds: Set<string>;
-  readonly interruptingTurnIds: Set<TurnId>;
   readonly turns: Array<OpenCodeTurnSnapshot>;
   activeTurnId: TurnId | undefined;
   activeAgent: string | undefined;
   activeVariant: string | undefined;
+  interruptAttempt: OpenCodeInterruptAttempt | undefined;
+  recentlyInterruptedTurnId: TurnId | undefined;
   /**
    * One-shot guard flipped by `stopOpenCodeContext` / `emitUnexpectedExit`.
    * The session lifecycle is owned by `sessionScope`; this Ref exists only
@@ -236,6 +238,13 @@ interface OpenCodeSessionContext {
    *   - tears down the OpenCode server process for scope-owned servers.
    */
   readonly sessionScope: Scope.Closeable;
+}
+
+interface OpenCodeInterruptAttempt {
+  readonly turnId: TurnId;
+  readonly completion: Deferred.Deferred<void, ProviderAdapterRequestError>;
+  terminalClaimed: boolean;
+  pendingCommandError: ProviderAdapterRequestError | undefined;
 }
 
 export interface OpenCodeAdapterLiveOptions {
@@ -783,6 +792,67 @@ export function makeOpenCodeAdapter(
       }
     });
 
+    const completeInterruptedTurn = Effect.fn("completeInterruptedTurn")(function* (
+      context: OpenCodeSessionContext,
+      attempt: OpenCodeInterruptAttempt,
+      raw?: unknown,
+    ) {
+      if (attempt.terminalClaimed) {
+        return false;
+      }
+      attempt.terminalClaimed = true;
+      context.recentlyInterruptedTurnId = attempt.turnId;
+      if (context.activeTurnId === attempt.turnId) {
+        context.activeTurnId = undefined;
+        yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
+      }
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId: attempt.turnId,
+          ...(raw !== undefined ? { raw } : {}),
+        })),
+        type: "turn.completed",
+        payload: {
+          state: "interrupted",
+          stopReason: "Interrupted by user.",
+        },
+      });
+      return true;
+    });
+
+    const failDetachedCommand = Effect.fn("failDetachedCommand")(function* (
+      context: OpenCodeSessionContext,
+      turnId: TurnId,
+      requestError: ProviderAdapterRequestError,
+    ) {
+      if (context.activeTurnId !== turnId) {
+        return;
+      }
+      context.activeTurnId = undefined;
+      context.activeAgent = undefined;
+      context.activeVariant = undefined;
+      yield* updateProviderSession(
+        context,
+        {
+          status: "error",
+          lastError: requestError.detail,
+        },
+        { clearActiveTurnId: true },
+      );
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId,
+        })),
+        type: "turn.completed",
+        payload: {
+          state: "failed",
+          errorMessage: requestError.detail,
+        },
+      });
+    });
+
     const handleSubscribedEvent = Effect.fn("handleSubscribedEvent")(function* (
       context: OpenCodeSessionContext,
       event: OpenCodeSubscribedEvent,
@@ -1058,21 +1128,28 @@ export function makeOpenCodeAdapter(
           }
 
           if (event.properties.status.type === "idle" && turnId) {
-            const wasInterrupted = context.interruptingTurnIds.delete(turnId);
-            context.activeTurnId = undefined;
-            yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
-            yield* emit({
-              ...(yield* buildEventBase({
-                threadId: context.session.threadId,
-                turnId,
-                raw: event,
-              })),
-              type: "turn.completed",
-              payload: {
-                state: wasInterrupted ? "interrupted" : "completed",
-                ...(wasInterrupted ? { stopReason: "Interrupted by user." } : {}),
-              },
-            });
+            const interruptAttempt = context.interruptAttempt;
+            if (interruptAttempt?.turnId === turnId) {
+              yield* completeInterruptedTurn(context, interruptAttempt, event);
+            } else {
+              context.activeTurnId = undefined;
+              yield* updateProviderSession(
+                context,
+                { status: "ready" },
+                { clearActiveTurnId: true },
+              );
+              yield* emit({
+                ...(yield* buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  raw: event,
+                })),
+                type: "turn.completed",
+                payload: {
+                  state: "completed",
+                },
+              });
+            }
           }
           break;
         }
@@ -1080,18 +1157,23 @@ export function makeOpenCodeAdapter(
         case "session.error": {
           const message = sessionErrorMessage(event.properties.error);
           const activeTurnId = context.activeTurnId;
-          const wasInterrupted =
-            activeTurnId !== undefined && context.interruptingTurnIds.delete(activeTurnId);
+          const interruptAttempt = context.interruptAttempt;
+          if (activeTurnId && interruptAttempt?.turnId === activeTurnId) {
+            yield* completeInterruptedTurn(context, interruptAttempt, event);
+            break;
+          }
+          if (activeTurnId === undefined && context.recentlyInterruptedTurnId !== undefined) {
+            break;
+          }
           context.activeTurnId = undefined;
           yield* updateProviderSession(
             context,
             {
-              status: wasInterrupted ? "ready" : "error",
-              ...(wasInterrupted ? {} : { lastError: message }),
+              status: "error",
+              lastError: message,
             },
             {
               clearActiveTurnId: true,
-              ...(wasInterrupted ? { clearLastError: true } : {}),
             },
           );
           if (activeTurnId) {
@@ -1103,27 +1185,23 @@ export function makeOpenCodeAdapter(
               })),
               type: "turn.completed",
               payload: {
-                state: wasInterrupted ? "interrupted" : "failed",
-                ...(wasInterrupted
-                  ? { stopReason: "Interrupted by user." }
-                  : { errorMessage: message }),
+                state: "failed",
+                errorMessage: message,
               },
             });
           }
-          if (!wasInterrupted) {
-            yield* emit({
-              ...(yield* buildEventBase({
-                threadId: context.session.threadId,
-                raw: event,
-              })),
-              type: "runtime.error",
-              payload: {
-                message,
-                class: "provider_error",
-                detail: event.properties.error,
-              },
-            });
-          }
+          yield* emit({
+            ...(yield* buildEventBase({
+              threadId: context.session.threadId,
+              raw: event,
+            })),
+            type: "runtime.error",
+            payload: {
+              message,
+              class: "provider_error",
+              detail: event.properties.error,
+            },
+          });
           break;
         }
 
@@ -1392,11 +1470,12 @@ export function makeOpenCodeAdapter(
           emittedTextByPartId: new Map(),
           messageRoleById: new Map(),
           completedAssistantPartIds: new Set(),
-          interruptingTurnIds: new Set(),
           turns: [],
           activeTurnId: undefined,
           activeAgent: undefined,
           activeVariant: undefined,
+          interruptAttempt: undefined,
+          recentlyInterruptedTurnId: undefined,
           stopped: yield* Ref.make(false),
           sessionScope: started.sessionScope,
         };
@@ -1429,6 +1508,9 @@ export function makeOpenCodeAdapter(
       // the active turn id is reused instead of opening a new turn.
       const steeringTurnId = context.activeTurnId;
       const turnId = steeringTurnId ?? TurnId.make(`opencode-turn-${yield* randomUUIDv4}`);
+      if (steeringTurnId === undefined) {
+        context.recentlyInterruptedTurnId = undefined;
+      }
       const modelSelection =
         input.modelSelection ??
         (context.session.model
@@ -1531,48 +1613,47 @@ export function makeOpenCodeAdapter(
         // prompt dispatch failures still propagate to the caller, which owns
         // start-failure recovery. A failed steer leaves the still-running
         // original turn untouched.
-        Effect.tapError((requestError) =>
-          steeringTurnId !== undefined ||
-          context.activeTurnId !== turnId ||
-          context.interruptingTurnIds.has(turnId)
-            ? Effect.void
-            : Effect.gen(function* () {
-                context.activeTurnId = undefined;
-                context.activeAgent = undefined;
-                context.activeVariant = undefined;
-                yield* updateProviderSession(
-                  context,
-                  {
-                    status: command ? "error" : "ready",
-                    model: modelSelection?.model ?? context.session.model,
-                    lastError: requestError.detail,
-                  },
-                  { clearActiveTurnId: true },
-                );
-                const eventBase = yield* buildEventBase({
-                  threadId: input.threadId,
-                  turnId,
-                });
-                if (command) {
-                  yield* emit({
-                    ...eventBase,
-                    type: "turn.completed",
-                    payload: {
-                      state: "failed",
-                      errorMessage: requestError.detail,
-                    },
-                  });
-                } else {
-                  yield* emit({
-                    ...eventBase,
-                    type: "turn.aborted",
-                    payload: {
-                      reason: requestError.detail,
-                    },
-                  });
-                }
-              }),
-        ),
+        Effect.tapError((requestError) => {
+          if (steeringTurnId !== undefined || context.activeTurnId !== turnId) {
+            return Effect.void;
+          }
+          const interruptAttempt = context.interruptAttempt;
+          if (command && interruptAttempt?.turnId === turnId) {
+            return Effect.sync(() => {
+              interruptAttempt.pendingCommandError = requestError;
+            });
+          }
+          if (command && context.recentlyInterruptedTurnId === turnId) {
+            return Effect.void;
+          }
+          if (command) {
+            return failDetachedCommand(context, turnId, requestError);
+          }
+          return Effect.gen(function* () {
+            context.activeTurnId = undefined;
+            context.activeAgent = undefined;
+            context.activeVariant = undefined;
+            yield* updateProviderSession(
+              context,
+              {
+                status: "ready",
+                model: modelSelection?.model ?? context.session.model,
+                lastError: requestError.detail,
+              },
+              { clearActiveTurnId: true },
+            );
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: input.threadId,
+                turnId,
+              })),
+              type: "turn.aborted",
+              payload: {
+                reason: requestError.detail,
+              },
+            });
+          });
+        }),
       );
       if (command) {
         // Unlike `promptAsync`, OpenCode's command endpoint does not return
@@ -1600,45 +1681,70 @@ export function makeOpenCodeAdapter(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
         const interruptedTurnId = turnId ?? context.activeTurnId;
-        const ownsInterruptedTurn =
-          interruptedTurnId !== undefined && context.activeTurnId === interruptedTurnId;
-        if (ownsInterruptedTurn) {
-          // Keep active-turn ownership while abort is in flight so a
-          // concurrent send remains steering for this turn. The marker keeps
-          // a detached command rejection from overwriting the interruption.
-          context.interruptingTurnIds.add(interruptedTurnId);
+        if (!interruptedTurnId) {
+          return yield* runOpenCodeSdk("session.abort", () =>
+            context.client.session.abort({ sessionID: context.openCodeSessionId }),
+          ).pipe(Effect.mapError(toRequestError));
         }
-        yield* runOpenCodeSdk("session.abort", () =>
-          context.client.session.abort({ sessionID: context.openCodeSessionId }),
-        ).pipe(
-          Effect.mapError(toRequestError),
-          Effect.tapError(() =>
-            ownsInterruptedTurn
-              ? Effect.sync(() => {
-                  context.interruptingTurnIds.delete(interruptedTurnId);
-                })
-              : Effect.void,
-          ),
-        );
-        // The idle event may win this race and emit the interrupted completion
-        // first. Deleting the marker is the one-shot claim for terminal state.
-        if (interruptedTurnId && context.interruptingTurnIds.delete(interruptedTurnId)) {
-          if (context.activeTurnId === interruptedTurnId) {
-            context.activeTurnId = undefined;
-            yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
-          }
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId,
-              turnId: interruptedTurnId,
-            })),
-            type: "turn.completed",
-            payload: {
-              state: "interrupted",
-              stopReason: "Interrupted by user.",
-            },
+
+        let attempt = context.interruptAttempt;
+        if (!attempt) {
+          attempt = {
+            turnId: interruptedTurnId,
+            completion: yield* Deferred.make<void, ProviderAdapterRequestError>(),
+            terminalClaimed: false,
+            pendingCommandError: undefined,
+          };
+          context.interruptAttempt = attempt;
+          const ownedAttempt = attempt;
+
+          const runInterrupt = Effect.gen(function* () {
+            const abortExit = yield* runOpenCodeSdk("session.abort", () =>
+              context.client.session.abort({ sessionID: context.openCodeSessionId }),
+            ).pipe(Effect.mapError(toRequestError), Effect.exit);
+
+            if (Exit.isSuccess(abortExit)) {
+              yield* completeInterruptedTurn(context, ownedAttempt);
+            }
+
+            if (context.interruptAttempt === ownedAttempt) {
+              context.interruptAttempt = undefined;
+            }
+
+            if (Exit.isFailure(abortExit) && !ownedAttempt.terminalClaimed) {
+              if (ownedAttempt.pendingCommandError) {
+                yield* failDetachedCommand(
+                  context,
+                  ownedAttempt.turnId,
+                  ownedAttempt.pendingCommandError,
+                );
+              }
+              yield* Deferred.failCause(ownedAttempt.completion, abortExit.cause);
+              return;
+            }
+
+            yield* Deferred.succeed(ownedAttempt.completion, undefined);
+          });
+
+          yield* runInterrupt.pipe(
+            Effect.catchCause((cause) =>
+              Effect.gen(function* () {
+                if (context.interruptAttempt === ownedAttempt) {
+                  context.interruptAttempt = undefined;
+                }
+                yield* Deferred.failCause(ownedAttempt.completion, cause);
+              }),
+            ),
+            Effect.forkIn(context.sessionScope),
+          );
+        } else if (attempt.turnId !== interruptedTurnId) {
+          yield* Effect.logDebug("OpenCode interrupt joined the active interrupt attempt", {
+            requestedTurnId: interruptedTurnId,
+            activeInterruptTurnId: attempt.turnId,
           });
         }
+
+        return yield* Deferred.await(attempt.completion);
       },
     );
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1511,11 +1511,13 @@ export function makeOpenCodeAdapter(
 
       const dispatchedRequest = request.pipe(
         Effect.mapError(toRequestError),
-        // On failure of a fresh turn: clear active-turn state, flip the
-        // session back to ready with lastError set, emit turn.aborted, then
-        // let the typed error propagate. We don't need to rebuild the error
-        // here — `toRequestError` already produced the right shape. A failed
-        // steer leaves the still-running original turn untouched.
+        // On failure of a fresh turn: clear active-turn state and publish a
+        // terminal runtime event. Commands are detached below because their
+        // endpoint waits for the full assistant turn, so their failure must
+        // close the orchestration lifecycle through turn.completed. Regular
+        // prompt dispatch failures still propagate to the caller, which owns
+        // start-failure recovery. A failed steer leaves the still-running
+        // original turn untouched.
         Effect.tapError((requestError) =>
           steeringTurnId !== undefined || context.activeTurnId !== turnId
             ? Effect.void
@@ -1526,22 +1528,34 @@ export function makeOpenCodeAdapter(
                 yield* updateProviderSession(
                   context,
                   {
-                    status: "ready",
+                    status: command ? "error" : "ready",
                     model: modelSelection?.model ?? context.session.model,
                     lastError: requestError.detail,
                   },
                   { clearActiveTurnId: true },
                 );
-                yield* emit({
-                  ...(yield* buildEventBase({
-                    threadId: input.threadId,
-                    turnId,
-                  })),
-                  type: "turn.aborted",
-                  payload: {
-                    reason: requestError.detail,
-                  },
+                const eventBase = yield* buildEventBase({
+                  threadId: input.threadId,
+                  turnId,
                 });
+                if (command) {
+                  yield* emit({
+                    ...eventBase,
+                    type: "turn.completed",
+                    payload: {
+                      state: "failed",
+                      errorMessage: requestError.detail,
+                    },
+                  });
+                } else {
+                  yield* emit({
+                    ...eventBase,
+                    type: "turn.aborted",
+                    payload: {
+                      reason: requestError.detail,
+                    },
+                  });
+                }
               }),
         ),
       );

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -267,10 +267,10 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
 
       NodeAssert.ok(agentDescriptor && agentDescriptor.type === "select");
       NodeAssert.deepEqual(agentDescriptor.options, [
-        { id: "build", label: "Default", isDefault: true },
+        { id: "build", label: "Default" },
         { id: "reviewer", label: "Reviewer" },
       ]);
-      NodeAssert.equal(agentDescriptor.currentValue, undefined);
+      NodeAssert.equal(agentDescriptor.currentValue, "build");
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -38,6 +38,8 @@ const runtimeMock = {
     inventory: {
       providerList: { connected: [] as string[], all: [] as unknown[], default: {} },
       agents: [] as unknown[],
+      commands: [] as unknown[],
+      skills: [] as unknown[],
     } as unknown,
   },
   reset() {
@@ -48,6 +50,8 @@ const runtimeMock = {
     this.state.inventory = {
       providerList: { connected: [], all: [] as unknown[], default: {} },
       agents: [] as unknown[],
+      commands: [] as unknown[],
+      skills: [] as unknown[],
     };
   },
 };
@@ -182,11 +186,14 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
           { name: "build", hidden: false, mode: "primary" },
           { name: "plan", hidden: false, mode: "primary" },
         ],
+        commands: [],
+        skills: [],
       };
 
       const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
       const model = snapshot.models.find((entry) => entry.slug === "openai/gpt-5.4");
 
+      NodeAssert.equal(snapshot.showInteractionModeToggle, true);
       NodeAssert.ok(model);
       const variantDescriptor = model.capabilities?.optionDescriptors?.find(
         (descriptor) => descriptor.id === "variant" && descriptor.type === "select",
@@ -199,19 +206,137 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
       const agentDescriptor = model.capabilities?.optionDescriptors?.find(
         (descriptor) => descriptor.id === "agent" && descriptor.type === "select",
       );
-      NodeAssert.ok(agentDescriptor && agentDescriptor.type === "select");
-      NodeAssert.equal(
-        agentDescriptor.options.find((option) => option.isDefault === true)?.id,
-        "build",
-      );
+      NodeAssert.equal(agentDescriptor, undefined);
     }),
   );
 
-  it.effect("does not spawn a local server for health check (uses CLI instead)", () =>
+  it.effect("keeps custom agents selectable without duplicating build and plan modes", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.inventory = {
+        providerList: {
+          connected: ["openai"],
+          all: [
+            {
+              id: "openai",
+              name: "OpenAI",
+              source: "env",
+              env: [],
+              models: {
+                "gpt-5.4": {
+                  id: "gpt-5.4",
+                  providerID: "openai",
+                  name: "GPT-5.4",
+                  family: "gpt",
+                  api: { id: "gpt-5.4", url: "", npm: "" },
+                  capabilities: {
+                    temperature: true,
+                    reasoning: true,
+                    attachment: true,
+                    toolcall: true,
+                    input: { text: true, audio: false, image: true, video: false, pdf: true },
+                    output: { text: true, audio: false, image: false, video: false, pdf: false },
+                    interleaved: false,
+                  },
+                  cost: { input: 0, output: 0 },
+                  limit: { context: 128_000, output: 16_384 },
+                  status: "active",
+                  options: {},
+                  headers: {},
+                  release_date: "2026-01-01",
+                  variants: {},
+                },
+              },
+            },
+          ],
+          default: {},
+        },
+        agents: [
+          { name: "build", hidden: false, mode: "primary" },
+          { name: "plan", hidden: false, mode: "primary" },
+          { name: "reviewer", hidden: false, mode: "primary" },
+        ],
+        commands: [],
+        skills: [],
+      };
+
+      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const model = snapshot.models.find((entry) => entry.slug === "openai/gpt-5.4");
+      const agentDescriptor = model?.capabilities?.optionDescriptors?.find(
+        (descriptor) => descriptor.id === "agent" && descriptor.type === "select",
+      );
+
+      NodeAssert.ok(agentDescriptor && agentDescriptor.type === "select");
+      NodeAssert.deepEqual(agentDescriptor.options, [{ id: "reviewer", label: "Reviewer" }]);
+      NodeAssert.equal(agentDescriptor.currentValue, undefined);
+    }),
+  );
+
+  it.effect("closes the scoped local server after the authoritative inventory probe", () =>
     Effect.gen(function* () {
       yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
 
-      NodeAssert.equal(runtimeMock.state.closeCalls, 0);
+      NodeAssert.equal(runtimeMock.state.closeCalls, 1);
+    }),
+  );
+
+  it.effect("normalizes OpenCode slash commands and skill scopes", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.inventory = {
+        providerList: { connected: ["openai"], all: [], default: {} },
+        agents: [],
+        commands: [
+          {
+            name: "Review",
+            description: "Review changes",
+            template: "",
+            hints: ["[path]", "  [focus]  "],
+          },
+          {
+            name: "review",
+            description: "Duplicate",
+            template: "",
+            hints: [],
+          },
+        ],
+        skills: [
+          {
+            name: "customize-opencode",
+            description: "Customize OpenCode",
+            location: "<built-in>",
+            content: "",
+          },
+          {
+            name: "project-skill",
+            description: "Project guidance",
+            location: `${process.cwd()}/.agents/skills/project-skill/SKILL.md`,
+            content: "",
+          },
+          {
+            name: "personal-skill",
+            description: "Personal guidance",
+            location: "/home/test/.agents/skills/personal-skill/SKILL.md",
+            content: "",
+          },
+        ],
+      };
+
+      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+
+      NodeAssert.deepEqual(snapshot.slashCommands, [
+        {
+          name: "Review",
+          description: "Review changes",
+          input: { hint: "[path] [focus]" },
+        },
+      ]);
+      NodeAssert.deepEqual(
+        snapshot.skills.map(({ name, scope, enabled }) => ({ name, scope, enabled })),
+        [
+          { name: "customize-opencode", scope: "system", enabled: true },
+          { name: "personal-skill", scope: "user", enabled: true },
+          { name: "project-skill", scope: "project", enabled: true },
+        ],
+      );
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -266,7 +266,10 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
       );
 
       NodeAssert.ok(agentDescriptor && agentDescriptor.type === "select");
-      NodeAssert.deepEqual(agentDescriptor.options, [{ id: "reviewer", label: "Reviewer" }]);
+      NodeAssert.deepEqual(agentDescriptor.options, [
+        { id: "build", label: "Default", isDefault: true },
+        { id: "reviewer", label: "Reviewer" },
+      ]);
       NodeAssert.equal(agentDescriptor.currentValue, undefined);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -184,10 +184,15 @@ function openCodeCapabilitiesForModel(input: {
   // OpenCode's built-in `build` and `plan` agents are represented by the
   // provider interaction mode. Listing them as model traits creates two
   // independent controls for the same state. Keep only user-defined primary
-  // agents here; an absent selection lets OpenCode use its normal build agent.
-  const agentOptions = primaryAgents
+  // agents, with a synthetic Default choice that returns to the normal build
+  // agent after a custom agent has been selected.
+  const customAgentOptions = primaryAgents
     .filter((agent) => agent.name !== "build" && agent.name !== "plan")
     .map((agent) => ({ id: agent.name, label: titleCaseSlug(agent.name) }));
+  const agentOptions =
+    customAgentOptions.length > 0
+      ? [{ id: "build", label: "Default", isDefault: true as const }, ...customAgentOptions]
+      : [];
   return createModelCapabilities({
     optionDescriptors: [
       ...(variantOptions.length > 0

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -190,9 +190,7 @@ function openCodeCapabilitiesForModel(input: {
     .filter((agent) => agent.name !== "build" && agent.name !== "plan")
     .map((agent) => ({ id: agent.name, label: titleCaseSlug(agent.name) }));
   const agentOptions =
-    customAgentOptions.length > 0
-      ? [{ id: "build", label: "Default", isDefault: true as const }, ...customAgentOptions]
-      : [];
+    customAgentOptions.length > 0 ? [{ id: "build", label: "Default" }, ...customAgentOptions] : [];
   return createModelCapabilities({
     optionDescriptors: [
       ...(variantOptions.length > 0
@@ -213,6 +211,7 @@ function openCodeCapabilitiesForModel(input: {
               label: "Agent",
               type: "select" as const,
               options: agentOptions,
+              currentValue: "build",
             },
           ]
         : []),

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -2,6 +2,8 @@ import {
   type ModelCapabilities,
   type OpenCodeSettings,
   type ServerProviderModel,
+  type ServerProviderSkill,
+  type ServerProviderSlashCommand,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
@@ -26,7 +28,7 @@ import type { Agent, ProviderListResponse } from "@opencode-ai/sdk/v2";
 
 const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
-  showInteractionModeToggle: false,
+  showInteractionModeToggle: true,
 } as const;
 const MINIMUM_OPENCODE_VERSION = "1.14.19";
 
@@ -160,10 +162,6 @@ function inferDefaultVariant(
   return undefined;
 }
 
-function inferDefaultAgent(agents: ReadonlyArray<Agent>): string | undefined {
-  return agents.find((agent) => agent.name === "build")?.name ?? agents[0]?.name ?? undefined;
-}
-
 const DEFAULT_OPENCODE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
@@ -183,12 +181,13 @@ function openCodeCapabilitiesForModel(input: {
   const primaryAgents = input.agents.filter(
     (agent) => !agent.hidden && (agent.mode === "primary" || agent.mode === "all"),
   );
-  const defaultAgent = inferDefaultAgent(primaryAgents);
-  const agentOptions = primaryAgents.map((agent) =>
-    defaultAgent === agent.name
-      ? { id: agent.name, label: titleCaseSlug(agent.name), isDefault: true as const }
-      : { id: agent.name, label: titleCaseSlug(agent.name) },
-  );
+  // OpenCode's built-in `build` and `plan` agents are represented by the
+  // provider interaction mode. Listing them as model traits creates two
+  // independent controls for the same state. Keep only user-defined primary
+  // agents here; an absent selection lets OpenCode use its normal build agent.
+  const agentOptions = primaryAgents
+    .filter((agent) => agent.name !== "build" && agent.name !== "plan")
+    .map((agent) => ({ id: agent.name, label: titleCaseSlug(agent.name) }));
   return createModelCapabilities({
     optionDescriptors: [
       ...(variantOptions.length > 0
@@ -209,7 +208,6 @@ function openCodeCapabilitiesForModel(input: {
               label: "Agent",
               type: "select" as const,
               options: agentOptions,
-              ...(defaultAgent ? { currentValue: defaultAgent } : {}),
             },
           ]
         : []),
@@ -248,6 +246,72 @@ function flattenOpenCodeModels(input: OpenCodeInventory): ReadonlyArray<ServerPr
   }
 
   return models.toSorted((left, right) => left.name.localeCompare(right.name));
+}
+
+function openCodeSlashCommands(
+  inventory: OpenCodeInventory,
+): ReadonlyArray<ServerProviderSlashCommand> {
+  const commandsByName = new Map<string, ServerProviderSlashCommand>();
+
+  for (const command of inventory.commands) {
+    const name = nonEmptyTrimmed(command.name);
+    if (!name) {
+      continue;
+    }
+    const description = nonEmptyTrimmed(command.description);
+    const hint = command.hints
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+      .join(" ");
+    const key = name.toLowerCase();
+    const existing = commandsByName.get(key);
+    commandsByName.set(key, {
+      name: existing?.name ?? name,
+      ...(existing?.description
+        ? { description: existing.description }
+        : description
+          ? { description }
+          : {}),
+      ...(existing?.input ? { input: existing.input } : hint ? { input: { hint } } : {}),
+    });
+  }
+
+  return [...commandsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function openCodeSkills(
+  inventory: OpenCodeInventory,
+  cwd: string,
+): ReadonlyArray<ServerProviderSkill> {
+  const normalizedCwd = cwd.replaceAll("\\", "/").replace(/\/+$/, "");
+  const skillsByName = new Map<string, ServerProviderSkill>();
+
+  for (const skill of inventory.skills) {
+    const name = nonEmptyTrimmed(skill.name);
+    const location = nonEmptyTrimmed(skill.location);
+    if (!name || !location) {
+      continue;
+    }
+    const normalizedLocation = location.replaceAll("\\", "/");
+    const scope =
+      location === "<built-in>"
+        ? "system"
+        : normalizedCwd &&
+            (normalizedLocation === normalizedCwd ||
+              normalizedLocation.startsWith(`${normalizedCwd}/`))
+          ? "project"
+          : "user";
+    const description = nonEmptyTrimmed(skill.description);
+    skillsByName.set(name, {
+      name,
+      path: location,
+      scope,
+      enabled: true,
+      ...(description ? { description } : {}),
+    });
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
 }
 
 export const makePendingOpenCodeProvider = (
@@ -391,29 +455,23 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   }
 
   const inventoryExit = yield* Effect.exit(
-    (isExternalServer
-      ? Effect.scoped(
-          Effect.gen(function* () {
-            const server = yield* openCodeRuntime.connectToOpenCodeServer({
-              binaryPath: openCodeSettings.binaryPath,
-              serverUrl: openCodeSettings.serverUrl,
-              environment: resolvedEnvironment,
-            });
-            return yield* openCodeRuntime.loadOpenCodeInventory(
-              openCodeRuntime.createOpenCodeSdkClient({
-                baseUrl: server.url,
-                directory: cwd,
-                ...(openCodeSettings.serverPassword
-                  ? { serverPassword: openCodeSettings.serverPassword }
-                  : {}),
-              }),
-            );
-          }),
-        )
-      : openCodeRuntime.loadInventoryFromCli({
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* openCodeRuntime.connectToOpenCodeServer({
           binaryPath: openCodeSettings.binaryPath,
+          ...(isExternalServer ? { serverUrl: openCodeSettings.serverUrl } : {}),
           environment: resolvedEnvironment,
-        })
+        });
+        return yield* openCodeRuntime.loadOpenCodeInventory(
+          openCodeRuntime.createOpenCodeSdkClient({
+            baseUrl: server.url,
+            directory: cwd,
+            ...(openCodeSettings.serverPassword
+              ? { serverPassword: openCodeSettings.serverPassword }
+              : {}),
+          }),
+        );
+      }),
     ).pipe(
       Effect.mapError(
         (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
@@ -429,12 +487,16 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     customModels,
     DEFAULT_OPENCODE_MODEL_CAPABILITIES,
   );
+  const slashCommands = openCodeSlashCommands(inventoryExit.value);
+  const skills = openCodeSkills(inventoryExit.value, cwd);
   const connectedCount = inventoryExit.value.providerList.connected.length;
   return buildServerProvider({
     presentation: OPENCODE_PRESENTATION,
     enabled: true,
     checkedAt,
     models,
+    slashCommands,
+    skills,
     probe: {
       installed: true,
       version,

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -1,0 +1,41 @@
+import * as NodeAssert from "node:assert/strict";
+
+import { it } from "@effect/vitest";
+import type { OpencodeClient, ProviderListResponse } from "@opencode-ai/sdk/v2";
+import * as Effect from "effect/Effect";
+
+import { loadOpenCodeInventoryFromClient } from "./opencodeRuntime.ts";
+
+const providerList: ProviderListResponse = {
+  all: [],
+  connected: [],
+  default: {},
+};
+
+it.effect("keeps core inventory when optional command and skill discovery fail", () =>
+  Effect.gen(function* () {
+    const client = {
+      provider: {
+        list: async () => ({ data: providerList }),
+      },
+      app: {
+        agents: async () => ({ data: [] }),
+        skills: async () => {
+          throw new Error("skills unavailable");
+        },
+      },
+      command: {
+        list: async () => {
+          throw new Error("commands unavailable");
+        },
+      },
+    } as unknown as OpencodeClient;
+
+    const inventory = yield* loadOpenCodeInventoryFromClient(client);
+
+    NodeAssert.deepEqual(inventory.providerList, providerList);
+    NodeAssert.deepEqual(inventory.agents, []);
+    NodeAssert.deepEqual(inventory.commands, []);
+    NodeAssert.deepEqual(inventory.skills, []);
+  }),
+);

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -4,6 +4,8 @@ import type { ChatAttachment, ProviderApprovalDecision, RuntimeMode } from "@t3t
 import {
   createOpencodeClient,
   type Agent,
+  type AppSkillsResponse,
+  type Command,
   type FilePartInput,
   type Model,
   type OpencodeClient,
@@ -101,6 +103,8 @@ export interface OpenCodeCommandResult {
 export interface OpenCodeInventory {
   readonly providerList: ProviderListResponse;
   readonly agents: ReadonlyArray<Agent>;
+  readonly commands: ReadonlyArray<Command>;
+  readonly skills: AppSkillsResponse;
 }
 
 export interface ParsedOpenCodeModelSlug {
@@ -649,9 +653,29 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       Effect.map((result) => result.data ?? []),
     );
 
+  const loadCommands = (client: OpencodeClient) =>
+    runOpenCodeSdk("command.list", () => client.command.list()).pipe(
+      Effect.map((result) => result.data ?? []),
+    );
+
+  const loadSkills = (client: OpencodeClient) =>
+    runOpenCodeSdk("app.skills", () => client.app.skills()).pipe(
+      Effect.map((result) => result.data ?? []),
+    );
+
   const loadOpenCodeInventory: OpenCodeRuntimeShape["loadOpenCodeInventory"] = (client) =>
-    Effect.all([loadProviders(client), loadAgents(client)], { concurrency: "unbounded" }).pipe(
-      Effect.map(([providerList, agents]) => ({ providerList, agents })),
+    Effect.all(
+      [loadProviders(client), loadAgents(client), loadCommands(client), loadSkills(client)],
+      {
+        concurrency: "unbounded",
+      },
+    ).pipe(
+      Effect.map(([providerList, agents, commands, skills]) => ({
+        providerList,
+        agents,
+        commands,
+        skills,
+      })),
     );
 
   const loadInventoryFromCli: OpenCodeRuntimeShape["loadInventoryFromCli"] = (input) =>
@@ -728,6 +752,8 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       return {
         providerList: { all: allProviders, default: {}, connected },
         agents,
+        commands: [],
+        skills: [],
       };
     });
 

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -158,6 +158,57 @@ export interface OpenCodeRuntimeShape {
   }) => Effect.Effect<OpenCodeInventory, OpenCodeRuntimeError>;
 }
 
+export const loadOpenCodeInventoryFromClient = (
+  client: OpencodeClient,
+): Effect.Effect<OpenCodeInventory, OpenCodeRuntimeError> => {
+  const loadProviders = runOpenCodeSdk("provider.list", () => client.provider.list()).pipe(
+    Effect.filterMapOrFail(
+      (list) =>
+        list.data
+          ? Result.succeed(list.data)
+          : Result.fail(
+              new OpenCodeRuntimeError({
+                operation: "provider.list",
+                detail: "OpenCode provider list was empty.",
+              }),
+            ),
+      (result) => result,
+    ),
+  );
+  const loadAgents = runOpenCodeSdk("app.agents", () => client.app.agents()).pipe(
+    Effect.map((result) => result.data ?? []),
+  );
+  const loadCommands = runOpenCodeSdk("command.list", () => client.command.list()).pipe(
+    Effect.map((result) => result.data ?? []),
+    Effect.tapError((cause) =>
+      Effect.logWarning("OpenCode command discovery failed; continuing without commands.", {
+        detail: cause.detail,
+      }),
+    ),
+    Effect.orElseSucceed(() => [] as ReadonlyArray<Command>),
+  );
+  const loadSkills = runOpenCodeSdk("app.skills", () => client.app.skills()).pipe(
+    Effect.map((result) => result.data ?? []),
+    Effect.tapError((cause) =>
+      Effect.logWarning("OpenCode skill discovery failed; continuing without skills.", {
+        detail: cause.detail,
+      }),
+    ),
+    Effect.orElseSucceed(() => [] as AppSkillsResponse),
+  );
+
+  return Effect.all([loadProviders, loadAgents, loadCommands, loadSkills], {
+    concurrency: "unbounded",
+  }).pipe(
+    Effect.map(([providerList, agents, commands, skills]) => ({
+      providerList,
+      agents,
+      commands,
+      skills,
+    })),
+  );
+};
+
 function parseServerUrlFromOutput(output: string): string | null {
   for (const line of output.split("\n")) {
     if (!line.startsWith(OPENCODE_SERVER_READY_PREFIX)) {
@@ -632,51 +683,8 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       throwOnError: true,
     });
 
-  const loadProviders = (client: OpencodeClient) =>
-    runOpenCodeSdk("provider.list", () => client.provider.list()).pipe(
-      Effect.filterMapOrFail(
-        (list) =>
-          list.data
-            ? Result.succeed(list.data)
-            : Result.fail(
-                new OpenCodeRuntimeError({
-                  operation: "provider.list",
-                  detail: "OpenCode provider list was empty.",
-                }),
-              ),
-        (result) => result,
-      ),
-    );
-
-  const loadAgents = (client: OpencodeClient) =>
-    runOpenCodeSdk("app.agents", () => client.app.agents()).pipe(
-      Effect.map((result) => result.data ?? []),
-    );
-
-  const loadCommands = (client: OpencodeClient) =>
-    runOpenCodeSdk("command.list", () => client.command.list()).pipe(
-      Effect.map((result) => result.data ?? []),
-    );
-
-  const loadSkills = (client: OpencodeClient) =>
-    runOpenCodeSdk("app.skills", () => client.app.skills()).pipe(
-      Effect.map((result) => result.data ?? []),
-    );
-
   const loadOpenCodeInventory: OpenCodeRuntimeShape["loadOpenCodeInventory"] = (client) =>
-    Effect.all(
-      [loadProviders(client), loadAgents(client), loadCommands(client), loadSkills(client)],
-      {
-        concurrency: "unbounded",
-      },
-    ).pipe(
-      Effect.map(([providerList, agents, commands, skills]) => ({
-        providerList,
-        agents,
-        commands,
-        skills,
-      })),
-    );
+    loadOpenCodeInventoryFromClient(client);
 
   const loadInventoryFromCli: OpenCodeRuntimeShape["loadInventoryFromCli"] = (input) =>
     Effect.gen(function* () {


### PR DESCRIPTION
## What Changed

- Load OpenCode skills and slash commands from the authoritative SDK inventory and expose them through the existing composer surfaces.
- Dispatch leading OpenCode slash commands through `session.command`, preserving arguments, model, variant, agent, and attachments.
- Wire the existing `/plan` and `/default` interaction modes to OpenCode's built-in `plan` and `build` agents.
- Keep custom primary agents selectable while filtering the built-in `build` and `plan` agents out of the agent trait picker.
- Add focused provider and adapter coverage for discovery, normalization, dispatch, mode precedence, and stale selection recovery.

## Why

OpenCode exposed models and agents in T3 Code, but its skills and slash commands were unavailable. The built-in `/plan` and `/default` commands also had no effective OpenCode mode integration. Using OpenCode's SDK inventory and command endpoint matches the provider's native behavior, while representing `build`/`plan` through T3 Code's existing interaction-mode control avoids two conflicting controls for the same state.
<img width="804" height="319" alt="image" src="https://github.com/user-attachments/assets/02176545-526b-4c1a-ac33-6fc9f6784afe" />


## UI Changes

No React or other web UI files changed. The existing generic composer UI is populated differently by OpenCode provider metadata:

- Before: OpenCode showed `Build` and `Plan` in the agent trait picker, skills/provider slash commands were absent, and the standard Build/Plan interaction control was unavailable.
- After: the standard Build/Plan control is authoritative; only custom primary agents appear in the agent picker; OpenCode skills and slash commands appear in the existing `$` and `/` menus.

Integrated browser verification covered OpenCode provider selection, the absence of the duplicate built-in agent picker, and both `/plan` and `/default` transitions. No animation or motion behavior changed.

## Verification

- `pnpm --dir apps/server exec vp test run src/provider/Layers/OpenCodeAdapter.test.ts src/provider/Layers/OpenCodeProvider.test.ts` (43 tests)
- `pnpm --dir apps/server run typecheck`
- targeted `vp fmt` and `vp lint` for the five changed files
- fresh isolated web environment with OpenCode selected

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (behavior-only provider metadata change; before/after and integrated verification are documented above)
- [x] I included a video for animation/interaction changes (not applicable: no animation or motion changes)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn dispatch, interrupt semantics, and provider probing for OpenCode threads; mistakes could mis-route commands or mishandle cancellation, but behavior is heavily covered by new adapter/provider tests.
> 
> **Overview**
> Exposes **OpenCode skills and slash commands** in provider status by extending SDK inventory (commands/skills with graceful discovery failures) and normalizing them for the composer (`$` / `/` menus). Status checks now use a **scoped server connection** for authoritative inventory on both local and configured servers.
> 
> **Slash-command turns** in `OpenCodeAdapter` route leading `/name …` input to `session.command` (arguments, model, agent, variant, attachments) instead of `promptAsync`, fork the long-running request so `sendTurn` returns immediately, and close the turn via the event stream (`turn.completed` on success/failure). **Interrupt** is reworked with a deferred interrupt attempt so user cancellation wins over late command errors and idle/session.error events.
> 
> **Interaction mode** is enabled for OpenCode (`showInteractionModeToggle`); built-in `build`/`plan` agents are removed from model traits—plan/default modes force `plan`/`build`, and stale `plan` in the agent picker is repaired to `build`. Custom primary agents remain selectable via a synthetic **Default** option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e875ca28cbcbea71903b56a84daf65d8c92fae95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose skills and slash commands from OpenCode inventory in provider status
> - Adds `openCodeSlashCommands` and `openCodeSkills` normalizers in [OpenCodeProvider.ts](https://github.com/pingdotgg/t3code/pull/4588/files#diff-4477b51690b8bf5db4f32c13ac9bb4ed2be7798d366111f84b38be236cc034bd) and includes them in the provider health check result.
> - Extends `OpenCodeInventory` in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/4588/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) with `commands` and `skills` fields, loaded concurrently with graceful degradation on failure.
> - Slash command inputs (leading `/`) in `sendTurn` are now dispatched via `session.command` and return immediately rather than awaiting completion.
> - Adds interrupt coordination via `interruptAttempt` and `recentlyInterruptedTurnId` in session context to prevent late command errors from overwriting interrupted turn state.
> - Sets `showInteractionModeToggle` to `true` and changes agent options to expose only custom agents plus a synthetic `Default` option, removing built-in `build`/`plan` from the agent selector.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e875ca2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->