### PR TITLE
Error instead of silently failing when browsing an unreachable environment

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -6,6 +6,7 @@ import {
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
   resolveBrowseAvailability,
+  resolveProjectPathActionAvailability,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -103,6 +104,30 @@ describe("resolveBrowseAvailability", () => {
   it("blocks browsing when no environment is selected", () => {
     expect(
       resolveBrowseAvailability({
+        environmentLabel: null,
+        connectionPhase: null,
+        connectionError: null,
+      }),
+    ).toEqual({ _tag: "Unavailable", message: "Select an environment first." });
+  });
+});
+
+describe("resolveProjectPathActionAvailability", () => {
+  it("allows opening an existing project while its environment is unreachable", () => {
+    expect(
+      resolveProjectPathActionAvailability({
+        projectAlreadyExists: true,
+        environmentLabel: "remote-box",
+        connectionPhase: "offline",
+        connectionError: null,
+      }),
+    ).toEqual({ _tag: "Available" });
+  });
+
+  it("fails closed when adding a new project for a missing environment", () => {
+    expect(
+      resolveProjectPathActionAvailability({
+        projectAlreadyExists: false,
         environmentLabel: null,
         connectionPhase: null,
         connectionError: null,

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -16,7 +16,20 @@ describe("resolveBrowseAvailability", () => {
         environmentLabel: "workstation",
         connectionPhase: "connected",
         connectionError: null,
-        browseError: null,
+      }),
+    ).toEqual({ _tag: "Available" });
+  });
+
+  it("stays available on a connected environment even when browse fails", () => {
+    // A browse failure on a reachable host is not an availability problem. The
+    // server returns read_directory_failed for a missing parent, which is the
+    // "type a new folder name and press Enter to create it" case -- gating on
+    // it would make Create & Add unable to ever create anything.
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: "workstation",
+        connectionPhase: "connected",
+        connectionError: "read_directory_failed",
       }),
     ).toEqual({ _tag: "Available" });
   });
@@ -27,12 +40,8 @@ describe("resolveBrowseAvailability", () => {
         environmentLabel: "workstation",
         connectionPhase: "available",
         connectionError: null,
-        browseError: null,
       }),
-    ).toEqual({
-      _tag: "Unavailable",
-      message: "workstation isn't connected, so its files can't be browsed.",
-    });
+    ).toEqual({ _tag: "Unavailable", message: "workstation isn't connected." });
   });
 
   it("blocks browsing an offline environment", () => {
@@ -41,12 +50,8 @@ describe("resolveBrowseAvailability", () => {
         environmentLabel: "workstation",
         connectionPhase: "offline",
         connectionError: null,
-        browseError: null,
       }),
-    ).toEqual({
-      _tag: "Unavailable",
-      message: "workstation is offline, so its files can't be browsed.",
-    });
+    ).toEqual({ _tag: "Unavailable", message: "workstation is offline." });
   });
 
   it("surfaces the connection failure reason when the environment is unreachable", () => {
@@ -55,7 +60,6 @@ describe("resolveBrowseAvailability", () => {
         environmentLabel: "remote-box",
         connectionPhase: "error",
         connectionError: "ssh: connect: host unreachable",
-        browseError: null,
       }),
     ).toEqual({
       _tag: "Unavailable",
@@ -69,7 +73,6 @@ describe("resolveBrowseAvailability", () => {
         environmentLabel: "remote-box",
         connectionPhase: "error",
         connectionError: null,
-        browseError: null,
       }),
     ).toEqual({ _tag: "Unavailable", message: "Can't reach remote-box." });
   });
@@ -80,25 +83,10 @@ describe("resolveBrowseAvailability", () => {
         environmentLabel: "remote-box",
         connectionPhase: "reconnecting",
         connectionError: "socket closed",
-        browseError: null,
       }),
     ).toEqual({
       _tag: "Unavailable",
       message: "Reconnecting to remote-box. Reason: socket closed",
-    });
-  });
-
-  it("surfaces a browse failure on an otherwise connected environment", () => {
-    expect(
-      resolveBrowseAvailability({
-        environmentLabel: "remote-box",
-        connectionPhase: "connected",
-        connectionError: null,
-        browseError: "EACCES: permission denied",
-      }),
-    ).toEqual({
-      _tag: "Unavailable",
-      message: "Can't browse remote-box. Reason: EACCES: permission denied",
     });
   });
 
@@ -108,12 +96,8 @@ describe("resolveBrowseAvailability", () => {
         environmentLabel: null,
         connectionPhase: "offline",
         connectionError: null,
-        browseError: null,
       }),
-    ).toEqual({
-      _tag: "Unavailable",
-      message: "this environment is offline, so its files can't be browsed.",
-    });
+    ).toEqual({ _tag: "Unavailable", message: "this environment is offline." });
   });
 
   it("blocks browsing when no environment is selected", () => {
@@ -122,9 +106,8 @@ describe("resolveBrowseAvailability", () => {
         environmentLabel: null,
         connectionPhase: null,
         connectionError: null,
-        browseError: null,
       }),
-    ).toEqual({ _tag: "Unavailable", message: "Select an environment to browse." });
+    ).toEqual({ _tag: "Unavailable", message: "Select an environment first." });
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -5,8 +5,128 @@ import {
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
+  resolveBrowseAvailability,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
+
+describe("resolveBrowseAvailability", () => {
+  it("allows browsing a connected environment", () => {
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: "workstation",
+        connectionPhase: "connected",
+        connectionError: null,
+        browseError: null,
+      }),
+    ).toEqual({ _tag: "Available" });
+  });
+
+  it("blocks browsing an environment that is not connected", () => {
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: "workstation",
+        connectionPhase: "available",
+        connectionError: null,
+        browseError: null,
+      }),
+    ).toEqual({
+      _tag: "Unavailable",
+      message: "workstation isn't connected, so its files can't be browsed.",
+    });
+  });
+
+  it("blocks browsing an offline environment", () => {
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: "workstation",
+        connectionPhase: "offline",
+        connectionError: null,
+        browseError: null,
+      }),
+    ).toEqual({
+      _tag: "Unavailable",
+      message: "workstation is offline, so its files can't be browsed.",
+    });
+  });
+
+  it("surfaces the connection failure reason when the environment is unreachable", () => {
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: "remote-box",
+        connectionPhase: "error",
+        connectionError: "ssh: connect: host unreachable",
+        browseError: null,
+      }),
+    ).toEqual({
+      _tag: "Unavailable",
+      message: "Can't reach remote-box. Reason: ssh: connect: host unreachable",
+    });
+  });
+
+  it("reports a bare unreachable message when no reason is available", () => {
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: "remote-box",
+        connectionPhase: "error",
+        connectionError: null,
+        browseError: null,
+      }),
+    ).toEqual({ _tag: "Unavailable", message: "Can't reach remote-box." });
+  });
+
+  it("reports transient reconnects without claiming the host is gone", () => {
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: "remote-box",
+        connectionPhase: "reconnecting",
+        connectionError: "socket closed",
+        browseError: null,
+      }),
+    ).toEqual({
+      _tag: "Unavailable",
+      message: "Reconnecting to remote-box. Reason: socket closed",
+    });
+  });
+
+  it("surfaces a browse failure on an otherwise connected environment", () => {
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: "remote-box",
+        connectionPhase: "connected",
+        connectionError: null,
+        browseError: "EACCES: permission denied",
+      }),
+    ).toEqual({
+      _tag: "Unavailable",
+      message: "Can't browse remote-box. Reason: EACCES: permission denied",
+    });
+  });
+
+  it("falls back to a generic label when the environment has no label", () => {
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: null,
+        connectionPhase: "offline",
+        connectionError: null,
+        browseError: null,
+      }),
+    ).toEqual({
+      _tag: "Unavailable",
+      message: "this environment is offline, so its files can't be browsed.",
+    });
+  });
+
+  it("blocks browsing when no environment is selected", () => {
+    expect(
+      resolveBrowseAvailability({
+        environmentLabel: null,
+        connectionPhase: null,
+        connectionError: null,
+        browseError: null,
+      }),
+    ).toEqual({ _tag: "Unavailable", message: "Select an environment to browse." });
+  });
+});
 
 describe("enumerateCommandPaletteItems", () => {
   it("assigns positional jump shortcuts to the first nine displayed items", () => {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import {
   type KeybindingCommand,
   type FilesystemBrowseEntry,
@@ -294,6 +295,67 @@ export function filterCommandPaletteGroups(input: {
 
     return [{ value: group.value, label: group.label, items }];
   });
+}
+
+/**
+ * Whether the filesystem behind the add-project browser can actually be
+ * reached right now. Browsing resolves paths on the *selected environment*, so
+ * an unreachable environment must fail loudly: without this the browse query
+ * just returns nothing, the directory list renders empty, and the palette
+ * cheerfully offers to "Create & Add" a folder on a host we never contacted.
+ */
+export type BrowseAvailability =
+  | { readonly _tag: "Available" }
+  | { readonly _tag: "Unavailable"; readonly message: string };
+
+const AVAILABLE_BROWSE: BrowseAvailability = { _tag: "Available" };
+
+function unavailable(message: string): BrowseAvailability {
+  return { _tag: "Unavailable", message };
+}
+
+export function resolveBrowseAvailability(input: {
+  readonly environmentLabel: string | null;
+  readonly connectionPhase: EnvironmentConnectionPhase | null;
+  readonly connectionError: string | null;
+  readonly browseError: string | null;
+}): BrowseAvailability {
+  const label = input.environmentLabel ?? "this environment";
+
+  if (input.connectionPhase === null) {
+    return unavailable("Select an environment to browse.");
+  }
+
+  switch (input.connectionPhase) {
+    case "connecting":
+      return unavailable(`Connecting to ${label}...`);
+    case "reconnecting":
+      return unavailable(
+        input.connectionError
+          ? `Reconnecting to ${label}. Reason: ${input.connectionError}`
+          : `Reconnecting to ${label}...`,
+      );
+    case "offline":
+      return unavailable(`${label} is offline, so its files can't be browsed.`);
+    case "available":
+      return unavailable(`${label} isn't connected, so its files can't be browsed.`);
+    case "error":
+      return unavailable(
+        input.connectionError
+          ? `Can't reach ${label}. Reason: ${input.connectionError}`
+          : `Can't reach ${label}.`,
+      );
+    case "connected":
+      break;
+  }
+
+  // Connected, but the browse RPC itself failed (permission denied, path
+  // resolution error, environment wedged mid-request).
+  if (input.browseError !== null) {
+    return unavailable(`Can't browse ${label}. Reason: ${input.browseError}`);
+  }
+
+  return AVAILABLE_BROWSE;
 }
 
 export function buildBrowseGroups(input: {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -348,6 +348,23 @@ export function resolveBrowseAvailability(input: {
   }
 }
 
+/**
+ * Opening a project already present in local state does not need a filesystem
+ * round trip. Adding a new path does, so it must use the same fail-closed
+ * reachability verdict as browsing.
+ */
+export function resolveProjectPathActionAvailability(input: {
+  readonly projectAlreadyExists: boolean;
+  readonly environmentLabel: string | null;
+  readonly connectionPhase: EnvironmentConnectionPhase | null;
+  readonly connectionError: string | null;
+}): BrowseAvailability {
+  if (input.projectAlreadyExists) {
+    return AVAILABLE_BROWSE;
+  }
+  return resolveBrowseAvailability(input);
+}
+
 export function buildBrowseGroups(input: {
   browseEntries: ReadonlyArray<FilesystemBrowseEntry>;
   browseQuery: string;

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -298,11 +298,16 @@ export function filterCommandPaletteGroups(input: {
 }
 
 /**
- * Whether the filesystem behind the add-project browser can actually be
- * reached right now. Browsing resolves paths on the *selected environment*, so
- * an unreachable environment must fail loudly: without this the browse query
- * just returns nothing, the directory list renders empty, and the palette
- * cheerfully offers to "Create & Add" a folder on a host we never contacted.
+ * Whether the *selected environment* can be reached right now. Browsing
+ * resolves paths on that environment's filesystem, so an unreachable one must
+ * fail loudly: otherwise the browse query returns nothing and the empty
+ * directory list is indistinguishable from a real empty directory.
+ *
+ * Deliberately keyed on reachability ONLY, never on a browse failure. Browse
+ * legitimately fails on a reachable host when the path does not exist yet --
+ * the server surfaces `read_directory_failed` for a missing parent, which is
+ * exactly the "type a new folder name and press Enter to create it" case. If
+ * that blocked submission, Create & Add could never create anything.
  */
 export type BrowseAvailability =
   | { readonly _tag: "Available" }
@@ -318,44 +323,29 @@ export function resolveBrowseAvailability(input: {
   readonly environmentLabel: string | null;
   readonly connectionPhase: EnvironmentConnectionPhase | null;
   readonly connectionError: string | null;
-  readonly browseError: string | null;
 }): BrowseAvailability {
   const label = input.environmentLabel ?? "this environment";
+  const withReason = (text: string) =>
+    input.connectionError ? `${text} Reason: ${input.connectionError}` : text;
 
   if (input.connectionPhase === null) {
-    return unavailable("Select an environment to browse.");
+    return unavailable("Select an environment first.");
   }
 
   switch (input.connectionPhase) {
+    case "connected":
+      return AVAILABLE_BROWSE;
     case "connecting":
       return unavailable(`Connecting to ${label}...`);
     case "reconnecting":
-      return unavailable(
-        input.connectionError
-          ? `Reconnecting to ${label}. Reason: ${input.connectionError}`
-          : `Reconnecting to ${label}...`,
-      );
+      return unavailable(withReason(`Reconnecting to ${label}.`));
     case "offline":
-      return unavailable(`${label} is offline, so its files can't be browsed.`);
+      return unavailable(`${label} is offline.`);
     case "available":
-      return unavailable(`${label} isn't connected, so its files can't be browsed.`);
+      return unavailable(`${label} isn't connected.`);
     case "error":
-      return unavailable(
-        input.connectionError
-          ? `Can't reach ${label}. Reason: ${input.connectionError}`
-          : `Can't reach ${label}.`,
-      );
-    case "connected":
-      break;
+      return unavailable(withReason(`Can't reach ${label}.`));
   }
-
-  // Connected, but the browse RPC itself failed (permission denied, path
-  // resolution error, environment wedged mid-request).
-  if (input.browseError !== null) {
-    return unavailable(`Can't browse ${label}. Reason: ${input.browseError}`);
-  }
-
-  return AVAILABLE_BROWSE;
 }
 
 export function buildBrowseGroups(input: {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -44,8 +44,6 @@ import {
 } from "react";
 import { useAtomValue } from "@effect/atom-react";
 
-import { connectionStatusText } from "@t3tools/client-runtime/connection";
-
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
@@ -744,7 +742,6 @@ function OpenCommandPaletteDialog(props: {
     environmentLabel: browseEnvironment?.label ?? null,
     connectionPhase: browseEnvironmentConnection?.phase ?? null,
     connectionError: browseEnvironmentConnection?.error ?? null,
-    browseError: browseQuery.error,
   });
   const browseUnavailableMessage =
     isBrowsing && browseAvailability._tag === "Unavailable" ? browseAvailability.message : null;
@@ -1290,16 +1287,25 @@ function OpenCommandPaletteDialog(props: {
 
       // The path is resolved on the target environment, so refuse outright when
       // that environment is unreachable rather than dispatching an add that can
-      // only fail — or silently create a directory we never verified.
+      // only fail. Reuse the browse verdict so the toast states the reason
+      // ("<env> isn't connected.") rather than a bare status word.
       const targetEnvironment =
         environments.find((environment) => environment.environmentId === input.environmentId) ??
         null;
-      if (targetEnvironment !== null && targetEnvironment.connection.phase !== "connected") {
+      const targetAvailability =
+        targetEnvironment === null
+          ? null
+          : resolveBrowseAvailability({
+              environmentLabel: targetEnvironment.label,
+              connectionPhase: targetEnvironment.connection.phase,
+              connectionError: targetEnvironment.connection.error,
+            });
+      if (targetAvailability?._tag === "Unavailable") {
         toastManager.add(
           stackedThreadToast({
             type: "error",
             title: "Failed to add project",
-            description: connectionStatusText(targetEnvironment.connection),
+            description: targetAvailability.message,
           }),
         );
         return;

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -44,6 +44,8 @@ import {
 } from "react";
 import { useAtomValue } from "@effect/atom-react";
 
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
+
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
@@ -102,6 +104,7 @@ import {
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
+  resolveBrowseAvailability,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -715,10 +718,16 @@ function OpenCommandPaletteDialog(props: {
   const browseDirectoryPath = isBrowsing ? getBrowseDirectoryPath(query) : "";
   const browseFilterQuery =
     isBrowsing && !hasTrailingPathSeparator(query) ? getBrowseLeafPathSegment(query) : "";
+  // Browsing resolves paths on the selected environment's filesystem. Don't
+  // issue the request at all unless that environment is actually connected —
+  // otherwise the failure is indistinguishable from an empty directory.
+  const browseEnvironmentConnection = browseEnvironment?.connection ?? null;
+  const isBrowseEnvironmentConnected = browseEnvironmentConnection?.phase === "connected";
   const browseQuery = useEnvironmentQuery(
     isBrowsing &&
       browseDirectoryPath.length > 0 &&
       browseEnvironmentId !== null &&
+      isBrowseEnvironmentConnected &&
       !relativePathNeedsActiveProject
       ? filesystemEnvironment.browse({
           environmentId: browseEnvironmentId,
@@ -731,6 +740,14 @@ function OpenCommandPaletteDialog(props: {
   );
   const browseResult = browseQuery.data;
   const isBrowsePending = browseQuery.isPending;
+  const browseAvailability = resolveBrowseAvailability({
+    environmentLabel: browseEnvironment?.label ?? null,
+    connectionPhase: browseEnvironmentConnection?.phase ?? null,
+    connectionError: browseEnvironmentConnection?.error ?? null,
+    browseError: browseQuery.error,
+  });
+  const browseUnavailableMessage =
+    isBrowsing && browseAvailability._tag === "Unavailable" ? browseAvailability.message : null;
   const browseEntries = browseResult?.entries ?? EMPTY_BROWSE_ENTRIES;
   const { filteredEntries: filteredBrowseEntries, exactEntry: exactBrowseEntry } = useMemo(
     () => filterBrowseEntries({ browseEntries, browseFilterQuery, highlightedItemValue }),
@@ -1271,6 +1288,23 @@ function OpenCommandPaletteDialog(props: {
     }) => {
       const rawCwd = input.rawCwd;
 
+      // The path is resolved on the target environment, so refuse outright when
+      // that environment is unreachable rather than dispatching an add that can
+      // only fail — or silently create a directory we never verified.
+      const targetEnvironment =
+        environments.find((environment) => environment.environmentId === input.environmentId) ??
+        null;
+      if (targetEnvironment !== null && targetEnvironment.connection.phase !== "connected") {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to add project",
+            description: connectionStatusText(targetEnvironment.connection),
+          }),
+        );
+        return;
+      }
+
       if (isUnsupportedWindowsProjectPath(rawCwd.trim(), input.platform)) {
         toastManager.add(
           stackedThreadToast({
@@ -1603,9 +1637,13 @@ function OpenCommandPaletteDialog(props: {
   if (addProjectCloneFlow?.step === "repository") {
     displayedGroups = [];
   } else if (addProjectCloneFlow?.step === "confirm") {
-    displayedGroups = relativePathNeedsActiveProject ? [] : cloneDestinationBrowseGroups;
+    displayedGroups =
+      relativePathNeedsActiveProject || browseUnavailableMessage !== null
+        ? []
+        : cloneDestinationBrowseGroups;
   } else if (isBrowsing) {
-    displayedGroups = relativePathNeedsActiveProject ? [] : browseGroups;
+    displayedGroups =
+      relativePathNeedsActiveProject || browseUnavailableMessage !== null ? [] : browseGroups;
   }
 
   const inputPlaceholder =
@@ -1613,7 +1651,10 @@ function OpenCommandPaletteDialog(props: {
     getCommandPaletteInputPlaceholder(paletteMode);
   const isSubmenu = paletteMode === "submenu" || paletteMode === "submenu-browse";
   const hasHighlightedBrowseItem = highlightedItemValue?.startsWith("browse:") ?? false;
-  const canSubmitBrowsePath = isBrowsing && !relativePathNeedsActiveProject;
+  // An unreachable environment can't confirm whether the path exists, so never
+  // offer to add — or worse, create — a directory we were unable to inspect.
+  const canSubmitBrowsePath =
+    isBrowsing && !relativePathNeedsActiveProject && browseUnavailableMessage === null;
   const willCreateProjectPath =
     canSubmitBrowsePath &&
     !isBrowsePending &&
@@ -1966,13 +2007,14 @@ function OpenCommandPaletteDialog(props: {
                     aria-label={`${submitActionLabel} (${addShortcutLabel})`}
                     disabled={
                       relativePathNeedsActiveProject ||
+                      browseUnavailableMessage !== null ||
                       (isCloneDestinationStep && isRemoteProjectPending)
                     }
                     onMouseDown={(event) => {
                       event.preventDefault();
                     }}
                     onClick={() => {
-                      if (relativePathNeedsActiveProject) {
+                      if (relativePathNeedsActiveProject || browseUnavailableMessage !== null) {
                         return;
                       }
                       if (isCloneDestinationStep) {
@@ -2029,16 +2071,18 @@ function OpenCommandPaletteDialog(props: {
                       ? "Enter a Git clone URL and press Enter to continue."
                       : "Enter a repository path and press Enter to look it up.",
                 }
-              : addProjectCloneFlow?.step === "confirm"
-                ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
-                : relativePathNeedsActiveProject
-                  ? { emptyStateMessage: "Relative paths require an active project." }
-                  : willCreateProjectPath
-                    ? {
-                        emptyStateMessage:
-                          "Press Enter to create this folder and add it as a project.",
-                      }
-                    : {})}
+              : browseUnavailableMessage !== null
+                ? { emptyStateMessage: browseUnavailableMessage }
+                : addProjectCloneFlow?.step === "confirm"
+                  ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
+                  : relativePathNeedsActiveProject
+                    ? { emptyStateMessage: "Relative paths require an active project." }
+                    : willCreateProjectPath
+                      ? {
+                          emptyStateMessage:
+                            "Press Enter to create this folder and add it as a project.",
+                        }
+                      : {})}
           />
         </CommandPanel>
         <CommandFooter className="gap-3 max-sm:flex-col max-sm:items-start">

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -103,6 +103,7 @@ import {
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
   resolveBrowseAvailability,
+  resolveProjectPathActionAvailability,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -1285,32 +1286,6 @@ function OpenCommandPaletteDialog(props: {
     }) => {
       const rawCwd = input.rawCwd;
 
-      // The path is resolved on the target environment, so refuse outright when
-      // that environment is unreachable rather than dispatching an add that can
-      // only fail. Reuse the browse verdict so the toast states the reason
-      // ("<env> isn't connected.") rather than a bare status word.
-      const targetEnvironment =
-        environments.find((environment) => environment.environmentId === input.environmentId) ??
-        null;
-      const targetAvailability =
-        targetEnvironment === null
-          ? null
-          : resolveBrowseAvailability({
-              environmentLabel: targetEnvironment.label,
-              connectionPhase: targetEnvironment.connection.phase,
-              connectionError: targetEnvironment.connection.error,
-            });
-      if (targetAvailability?._tag === "Unavailable") {
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Failed to add project",
-            description: targetAvailability.message,
-          }),
-        );
-        return;
-      }
-
       if (isUnsupportedWindowsProjectPath(rawCwd.trim(), input.platform)) {
         toastManager.add(
           stackedThreadToast({
@@ -1340,6 +1315,26 @@ function OpenCommandPaletteDialog(props: {
         projects.filter((project) => project.environmentId === input.environmentId),
         cwd,
       );
+      const targetEnvironment =
+        environments.find((environment) => environment.environmentId === input.environmentId) ??
+        null;
+      const targetAvailability = resolveProjectPathActionAvailability({
+        projectAlreadyExists: existing !== undefined,
+        environmentLabel: targetEnvironment?.label ?? null,
+        connectionPhase: targetEnvironment?.connection.phase ?? null,
+        connectionError: targetEnvironment?.connection.error ?? null,
+      });
+      if (targetAvailability._tag === "Unavailable") {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to add project",
+            description: targetAvailability.message,
+          }),
+        );
+        return;
+      }
+
       if (existing) {
         const latestThread = getLatestThreadForProject(
           threads.filter((thread) => thread.environmentId === existing.environmentId),
@@ -1375,8 +1370,7 @@ function OpenCommandPaletteDialog(props: {
 
       const projectId = newProjectId();
       const targetEnvironmentProviders =
-        environments.find((environment) => environment.environmentId === input.environmentId)
-          ?.serverConfig?.providers ??
+        targetEnvironment?.serverConfig?.providers ??
         (input.environmentId === primaryEnvironmentId ? providers : []);
       const createResult = await createProject({
         environmentId: input.environmentId,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1189,10 +1189,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (composerTriggerKind === "skill") {
       return "No skills found. Try / to browse provider commands.";
     }
-    return composerTriggerKind === "path"
-      ? "No matching files or folders."
-      : "No matching command.";
-  }, [composerTriggerKind]);
+    if (composerTriggerKind === "path") {
+      // Path search runs against the thread's environment. A failed lookup is
+      // not the same as "this workspace has no such file" -- say so instead of
+      // rendering an empty menu that reads like a definitive answer.
+      return workspaceEntries.error ?? "No matching files or folders.";
+    }
+    return "No matching command.";
+  }, [composerTriggerKind, workspaceEntries.error]);
 
   // ------------------------------------------------------------------
   // Provider traits UI


### PR DESCRIPTION
## What Changed

The add-project browser (`⌘K → Add project → Local folder`) resolves paths on the **selected environment's** filesystem via `filesystemEnvironment.browse`, but never read that query's error. This adds an explicit availability check and fails closed instead of failing silently.

- New pure `resolveBrowseAvailability` in `CommandPalette.logic.ts` maps the environment's connection phase (`available` / `offline` / `connecting` / `reconnecting` / `error` / `connected`) onto an `Available` | `Unavailable { message }` verdict, carrying the underlying reason when there is one. It is keyed on **reachability only** — a browse failure on a reachable host means the path does not exist yet (the server returns `read_directory_failed` for a missing parent), which is exactly the Create & Add case, so it must not gate submission.
- The browse RPC is no longer issued at all unless the environment is `connected`.
- `canSubmitBrowsePath` is false when unavailable, which disables the Enter path, the submit button, and the clone-destination step (they share it). This also withholds the "create this folder and add it as a project" affordance, so the UI can never offer to create a directory on a host it failed to inspect.
- The reason renders in the results empty state instead of a blank list.
- `handleAddProjectForEnvironment` refuses with an explicit toast when the target environment is not connected, reusing the same verdict so the toast states the reason rather than a bare status word. This is the layer that covers the desktop folder-picker entry point, which bypasses the browse UI entirely.
- `ChatComposer`'s `@`-path mention search dropped its error the same way, so an unreachable environment rendered "No matching files or folders." That reads as a definitive answer to a question we never got to ask; it now surfaces the actual failure.

## Why

Browsing resolves paths on a machine that may not be reachable, so "no entries" and "could not ask" are very different answers that looked identical.

Reproduced against a paired remote environment that was then killed: the palette rendered an empty **Directories** group indistinguishable from an empty directory, showed no reason anywhere, and left the **Add** button enabled. Pressing Enter did nothing at all — no toast, no error, no state change. The failure was entirely invisible.

`FileBrowserPanel` and `FilePreviewPanel` already render `.error` for project file reads, so the add-project browser and the composer path search were the outliers rather than the convention.

## UI Changes

Both captures are the same flow — `Add project` → the remote environment → `Local folder` → `~/` — against a paired remote whose backend was killed.

| Before | After |
| --- | --- |
| ![Add-project browser against an unreachable environment: an empty "Directories" group, no error text, and an enabled Add button](https://raw.githubusercontent.com/colonelpanic8/t3code/4a2a5c5a51fd1fbfa60c353003e2c8dd53e9e2e5/unreachable-environment-browse/before.png) | ![Same flow showing "Reconnecting to railbird-sf. Reason: Failed to fetch remote environment endpoint ..." with the Add button disabled](https://raw.githubusercontent.com/colonelpanic8/t3code/4a2a5c5a51fd1fbfa60c353003e2c8dd53e9e2e5/unreachable-environment-browse/after.png) |

Before: empty list, no reason, **Add** enabled, Enter silently does nothing.
After: `Reconnecting to railbird-sf. Reason: Failed to fetch remote environment endpoint http://127.0.0.1:47319/.well-known/t3/environment (HttpClientError: Transport error ...)`, **Add** disabled.

Verified live in the web app against two `t3 serve` instances: the second was paired as a remote environment, confirmed `Connected`, then killed to produce the unreachable state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] No animation/interaction change, so no video

Validation:

- [x] `vp test run apps/web/src/components/CommandPalette.logic.test.ts` (14 tests, 9 new)
- [x] `vp run --filter @t3tools/web typecheck` (no errors in changed files)
- [x] `vp lint` on all four changed files (no new findings)
- [x] `vp fmt --check` on all four changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused UI and guard logic with unit tests; behavior is intentionally fail-closed for unreachable hosts but keeps existing-project open and connected-host folder creation paths.
> 
> **Overview**
> **Unreachable environments no longer look like empty directories** in add-project browse, clone destination pickers, and the chat `@` path menu.
> 
> The palette adds pure helpers **`resolveBrowseAvailability`** and **`resolveProjectPathActionAvailability`**: availability follows **connection phase only** (not browse/RPC errors), so **Create & Add** still works when a connected host returns `read_directory_failed` for a path that does not exist yet. Browse RPCs are skipped unless the environment is **`connected`**; submit/Enter, directory lists, and create-folder affordances are disabled when unavailable, with the reason in the empty state. **`handleAddProjectForEnvironment`** toasts the same message when adding a new path (including desktop folder picker); opening an **existing** project path stays allowed offline.
> 
> **`ChatComposer`** path mentions now show **`workspaceEntries.error`** instead of a generic “No matching files or folders.” when lookup fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc43772035682f822d004d2de4f028ad7d695cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show errors instead of silently failing when browsing an unreachable environment
> - Adds `resolveBrowseAvailability` in [CommandPalette.logic.ts](https://github.com/pingdotgg/t3code/pull/4590/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e) to compute structured availability and user-facing messages based on the environment's connection phase and error.
> - The command palette now suppresses browse queries, hides browse groups, and disables submit actions when the selected environment is not connected.
> - The 'Add Project' flow shows an error toast and aborts when the target environment is unreachable, while opening an existing project path is still allowed unconditionally.
> - The chat composer's path menu now surfaces the workspace error text instead of the generic 'No matching files or folders.' message when loading fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0dc4377.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


---

### Review follow-up (429e392a6)

Bugbot caught two issues on the first commit; both are fixed.

**Browse errors blocked folder creation (high).** Real regression, and my fault for unit-testing that branch instead of exercising it. `WorkspaceEntries.browse` only swallows `EACCES`/`EPERM` to an empty listing — `ENOENT` propagates as `read_directory_failed`. Treating that as `Unavailable` made `canSubmitBrowsePath` false, so Create & Add could never create a folder that did not already exist. Availability is now keyed on connection phase alone. Verified end to end: on a connected environment `~/brand-new-folder-xyz/` shows an enabled **Create & Add**, and Enter creates the directory and adds the project. Regression test added pinning `connected` + browse error to `Available`.

**Toast used status, not reason (medium).** `connectionStatusText` renders the bare phase word, so the refusal really did read "Failed to add project — Available". The guard now reuses the availability verdict and reads "<environment> isn't connected."
