### PR TITLE
fix(web): glitchy diff view scrolling

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -863,10 +863,13 @@ export default function DiffPanel({
                   if (filePath) openDiffFile(filePath);
                 }}
               >
+                {/* The diffs virtualizer scrolls by repositioning its own sticky window through
+                    inline top/bottom insets. Do not override those insets from here: pinning the
+                    window freezes the rendered rows while the scrollbar keeps moving. */}
                 <AnnotatableCodeView
                   viewerRef={codeViewRef}
                   key={collapseScopeKey ?? reviewSectionId}
-                  className="diff-render-surface h-full min-h-0 overflow-auto [&>div>div:last-child]:top-0! [&>div>div:last-child]:bottom-auto!"
+                  className="diff-render-surface h-full min-h-0 overflow-auto"
                   files={codeViewFiles}
                   sectionId={reviewSectionId}
                   sectionTitle={reviewSectionTitle}

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -81,6 +81,13 @@ interface CollapsedDiffFilesState {
 
 const EMPTY_COLLAPSED_DIFF_FILE_KEYS: ReadonlySet<string> = new Set();
 
+/**
+ * Height of the file header rendered by `DIFF_PANEL_UNSAFE_CSS` below, in pixels. The diffs
+ * virtualizer reserves scroll space per file from `itemMetrics.diffHeaderHeight`, so the two have to
+ * agree: over-reserving leaves phantom scroll space that shows up as a gap above the first file.
+ */
+const DIFF_FILE_HEADER_HEIGHT = 33;
+
 const DIFF_PANEL_UNSAFE_CSS = `
 [data-diffs-header],
 [data-diff],
@@ -133,7 +140,9 @@ const DIFF_PANEL_UNSAFE_CSS = `
   font-family: var(--font-sans) !important;
   font-size: 12px !important;
   line-height: 1 !important;
-  min-height: 32px !important;
+  box-sizing: border-box !important;
+  height: ${DIFF_FILE_HEADER_HEIGHT}px !important;
+  min-height: ${DIFF_FILE_HEADER_HEIGHT}px !important;
   padding-block: 6px !important;
 }
 
@@ -915,7 +924,8 @@ export default function DiffPanel({
                     themeType: resolvedTheme as DiffThemeType,
                     unsafeCSS: DIFF_PANEL_UNSAFE_CSS,
                     stickyHeaders: true,
-                    layout: { paddingTop: 8, paddingBottom: 8, gap: 8 },
+                    itemMetrics: { diffHeaderHeight: DIFF_FILE_HEADER_HEIGHT },
+                    layout: { paddingTop: 0, paddingBottom: 8, gap: 8 },
                   }}
                 />
               </div>


### PR DESCRIPTION
## What Changed

Two fixes in the diff panel, both in `DiffPanel.tsx`:

1. Removed the `[&>div>div:last-child]:top-0! [&>div>div:last-child]:bottom-auto!` overrides added in #4475, which froze scrolling.
2. Told the virtualizer the real file-header height, and dropped `layout.paddingTop` to `0`, which removes the gap above the first file.

## Why — frozen scrolling


Bug recording:
[drive.google.com/file/d/1NTx4NwwMEoniZdPxjBqd4pEkBZcSkUMy/view?usp=sharing](https://drive.google.com/file/d/1NTx4NwwMEoniZdPxjBqd4pEkBZcSkUMy/view?usp=sharing)


The scrollbar thumb moved smoothly while the rendered rows stayed put, then jumped.

`@pierre/diffs` does not scroll natively. `CodeView` renders a window of files into a `position: sticky` container and sets its insets inline on every layout pass:

```js
const stickyJitter = -Math.max(stickyContainerHeight + randomOffset, 0) + height;
this.stickyContainer.style.top = `${stickyJitter}px`;
this.stickyContainer.style.bottom = `${stickyJitter + itemMetrics.diffHeaderHeight}px`;
```

Those negative insets are what let the rendered window travel with the scroll (window height − viewport height) before the virtualizer re-anchors it. The Tailwind selector `& > div > div:last-child` resolves to exactly that sticky window (`root > container > stickyContainer`), not the file header it was meant to align, and `!important` beat the inline styles. Pinned at `top: 0` the window has zero travel: it clamps to the top of the viewport, so `scrollTop` and the scrollbar keep moving while the visible rows do not, until the next virtualizer re-render swaps in a new window.

Sticky file headers are pinned separately inside each file's shadow DOM via `DIFF_PANEL_UNSAFE_CSS` (`[data-diffs-header] { position: sticky !important; top: 0 }`), so header alignment is unaffected by this revert.

## Why — gap above the first file

`DIFF_PANEL_UNSAFE_CSS` shrinks the file header to the app's type scale (33px rendered), but the virtualizer kept reserving its default `itemMetrics.diffHeaderHeight` of 44px per file. The extra 11px per file is phantom scroll space. With everything collapsed the content is shorter than the viewport, so the sticky window's *positive* top inset pushes it down by exactly that slack — a gap that grows with the file count:

```
before  collapsed item: virtualHeight 44, domHeight 33  -> slack 11px per file
after   collapsed item: virtualHeight 33, domHeight 33  -> slack 0
```

The header height is now a single `DIFF_FILE_HEADER_HEIGHT` constant used both by the CSS and by `itemMetrics.diffHeaderHeight` so the two cannot drift. `min-height` is pinned alongside `height` because the library's own `min-height: 36px` otherwise wins over `height`.

That left an 8px gap from `layout.paddingTop: 8` above the first header at rest, which vanished as soon as the header pinned during scrolling. `paddingTop` is now `0`, so the top of the list looks the same at rest and scrolled.

## Verification

Measured in Chromium over CDP against the dev app, scrolling with real wheel events and sampling after every tick. `rel` is the sticky window's top relative to the panel:

**Frozen scrolling, before** — window pinned, 540px of scroll with no content movement:

```
scrollTop=  60  rel= 0  line=0,0
scrollTop= 180  rel= 0  line=0,0
scrollTop= 360  rel= 0  line=0,0
scrollTop= 540  rel= 0  line=0,0
scrollTop= 600  rel= 0  line=2,2   <- first movement, as a jump
```

**After** — window tracks the scroll continuously:

```
scrollTop=  60  rel= -60  line=0,0
scrollTop= 120  rel=-120  line=3,3
scrollTop= 180  rel=-180  line=6,6
scrollTop= 240  rel=-240  line=9,9
```

Over a 45-tick continuous scroll the visible content was frozen in 8/44 samples before and 1/24 after (the remaining one is the first sample).

**Gaps, after:**

```
expanded @ top:  gapAboveFirstFile 0   (was 8)
collapsed:       slack 0, gapAboveFirstFile 0   (was 11px per file + 8)
collapsed items: virtualHeight 33 == domHeight 33
```

Line metrics were checked too and already match (`lineHeight: 20` vs 20px rendered), so no other item metric needed adjusting.

`tsgo --noEmit` on `apps/web`, `vp lint`, and `vp fmt --check` on the touched file are clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after evidence for the UI change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in the diff panel with no auth, data, or API impact; risk is limited to diff rendering and scroll behavior.
> 
> **Overview**
> Fixes **frozen diff scrolling** and **gaps above the first file** in the diff panel by aligning `@pierre/diffs` virtualization with the styled file headers.
> 
> **Scrolling:** Removes Tailwind overrides on the virtualizer’s sticky window (`top-0!` / `bottom-auto!`) that pinned the window and let the scrollbar move while rows stayed still. Adds a comment warning not to override those inline insets.
> 
> **Layout metrics:** Introduces `DIFF_FILE_HEADER_HEIGHT` (33px) shared by `[data-diffs-header]` CSS (`height` / `min-height`, `box-sizing`) and `options.itemMetrics.diffHeaderHeight`, so reserved scroll height matches the rendered header (was ~44px default vs 33px DOM). Sets `layout.paddingTop` from `8` to `0` to remove the top gap at rest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 522b594cf2a476d2893865e394011d28724ca695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix glitchy scrolling in diff view by aligning header height with virtualizer
> Fixes a scroll mismatch in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/4591/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) caused by the diff file header rendering at 32px while the virtualizer reserved 33px. 
> - Sets a shared `DIFF_FILE_HEADER_HEIGHT = 33` constant used by both the CSS and the virtualizer's `itemMetrics.diffHeaderHeight`.
> - Adds `box-sizing: border-box` and a fixed `height` to the `[data-diffs-header]` CSS rule so the header renders at exactly 33px.
> - Removes manual `top`/`bottom` Tailwind overrides from `AnnotatableCodeView`, deferring sticky positioning entirely to the virtualizer.
> - Sets `paddingTop` to 0 (was 8) to avoid extra space above the first diff item.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 522b594.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->