### PR TITLE
fix(web): reconcile client state when a settle does not land

### DIFF
--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -19,6 +19,7 @@ import {
   type PlatformConnectionRegistration,
   PrimaryConnectionRegistration,
   PrimaryConnectionTarget,
+  ResyncRequests,
   Wakeups,
 } from "@t3tools/client-runtime/connection";
 import { bootstrapRemoteBearerSession } from "@t3tools/client-runtime/authorization";
@@ -110,7 +111,7 @@ const wakeupsLayer = Wakeups.layer({
     managedRelayAccountChanges(appAtomRegistry).pipe(
       Stream.map(() => "credentials-changed" as const),
     ),
-  ),
+  ).pipe(Stream.merge(ResyncRequests.resyncRequestStream)),
 });
 
 function clientMetadata() {

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -13,6 +13,8 @@ import { useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef } from "react";
 
 import { getFallbackThreadIdAfterDelete } from "../components/Sidebar.logic";
+import { requestResync } from "../lib/resyncRequests";
+import { confirmSettleConverged as confirmSettleConvergedWith } from "../lib/settleConvergence";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
@@ -412,6 +414,17 @@ export function useThreadActions() {
     ],
   );
 
+  const confirmSettleConverged = useCallback(async (target: ScopedThreadRef) => {
+    await confirmSettleConvergedWith({
+      readSettled: () => {
+        const shell = readThreadShell(target);
+        return shell === null ? null : shell.settledOverride === "settled";
+      },
+      requestResync: () => requestResync(),
+      delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    });
+  }, []);
+
   const settleThread = useCallback(
     async (target: ScopedThreadRef) => {
       // Version skew: never send the command to a server that predates it —
@@ -430,7 +443,13 @@ export function useThreadActions() {
       // Settle may only target what effectiveSettled could classify as
       // settled: not starting/running sessions, not threads waiting on
       // approvals or user input. Anything else would hide live work.
+      //
+      // This reads the LOCAL view, so a stale one refuses a settle the server
+      // would have accepted. Ask for a reconcile on the way out: if the block
+      // was real the resync changes nothing, and if the view was stale the
+      // next attempt sees the truth instead of failing forever.
       if (resolved && !canSettle(resolved.thread, { now: new Date().toISOString() })) {
+        requestResync();
         return AsyncResult.failure(
           Cause.fail(
             new ThreadSettleBlockedError({
@@ -442,12 +461,22 @@ export function useThreadActions() {
       }
       // Settle is a high-frequency lifecycle action and stays silent — no
       // toast.
-      return settleThreadMutation({
+      const result = await settleThreadMutation({
         environmentId: target.environmentId,
         input: { threadId: target.threadId },
       });
+      // A settle the server accepts always publishes an authoritative
+      // thread-upserted, so the local view should show it settled shortly
+      // after. When it does not, the client is working from a view the server
+      // no longer agrees with: every further click succeeds as an idempotent
+      // no-op and silently changes nothing, which reads as a dead control.
+      // Reconcile instead of stranding the user until they restart.
+      if (result._tag === "Success") {
+        void confirmSettleConverged(target);
+      }
+      return result;
     },
-    [resolveThreadTarget, settleThreadMutation],
+    [confirmSettleConverged, resolveThreadTarget, settleThreadMutation],
   );
 
   const unsettleThread = useCallback(

--- a/apps/web/src/lib/resyncRequests.test.ts
+++ b/apps/web/src/lib/resyncRequests.test.ts
@@ -111,6 +111,34 @@ describe("requestResync", () => {
     expect(fired).toBe(2);
   });
 
+  it("does not fire a trailing reconcile that an immediate one already covered", () => {
+    // A backward clock jump fires immediately while a trailing reconcile is
+    // still scheduled. That pending timer is now obsolete: letting it run
+    // would produce two reconciles for one logical request.
+    const fired = withHarness((h) => {
+      h.requestAt(1_000_000);
+      h.requestAt(1_000_100);
+      h.requestAt(0);
+      expect(h.fired()).toBe(2);
+      h.runDueTimers();
+    });
+    expect(fired).toBe(2);
+  });
+
+  it("still reconciles for a request that arrives after an immediate fire", () => {
+    // The obsolete-timer check must not swallow a request raised *after* the
+    // reconcile that superseded it.
+    const fired = withHarness((h) => {
+      h.requestAt(0);
+      h.requestAt(100);
+      h.requestAt(RESYNC_MIN_INTERVAL_MS);
+      expect(h.fired()).toBe(2);
+      h.requestAt(RESYNC_MIN_INTERVAL_MS + 100);
+      h.runDueTimers();
+    });
+    expect(fired).toBe(3);
+  });
+
   it("recovers from a backward clock jump instead of wedging shut", () => {
     // An NTP correction or manual clock change must not suppress every
     // reconcile until wall time catches back up to the old timestamp.

--- a/apps/web/src/lib/resyncRequests.test.ts
+++ b/apps/web/src/lib/resyncRequests.test.ts
@@ -1,0 +1,49 @@
+import { ResyncRequests } from "@t3tools/client-runtime/connection";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  RESYNC_MIN_INTERVAL_MS,
+  requestResync,
+  resetResyncThrottleForTesting,
+} from "./resyncRequests";
+
+function countRequests(run: (notify: (nowMs: number) => void) => void): number {
+  resetResyncThrottleForTesting();
+  let seen = 0;
+  const unsubscribe = ResyncRequests.onResyncRequested(() => {
+    seen += 1;
+  });
+  try {
+    run(requestResync);
+  } finally {
+    unsubscribe();
+    resetResyncThrottleForTesting();
+  }
+  return seen;
+}
+
+describe("requestResync", () => {
+  it("passes a request through to subscribers", () => {
+    expect(countRequests((notify) => notify(0))).toBe(1);
+  });
+
+  it("coalesces a burst into one reconcile", () => {
+    // Settling many threads at once must not ask for the same snapshot fetch
+    // and resubscribe once per thread.
+    const seen = countRequests((notify) => {
+      for (let i = 0; i < 20; i += 1) {
+        notify(i);
+      }
+    });
+    expect(seen).toBe(1);
+  });
+
+  it("allows another reconcile once the window has passed", () => {
+    const seen = countRequests((notify) => {
+      notify(0);
+      notify(RESYNC_MIN_INTERVAL_MS - 1);
+      notify(RESYNC_MIN_INTERVAL_MS);
+    });
+    expect(seen).toBe(2);
+  });
+});

--- a/apps/web/src/lib/resyncRequests.test.ts
+++ b/apps/web/src/lib/resyncRequests.test.ts
@@ -3,47 +3,121 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   RESYNC_MIN_INTERVAL_MS,
+  type ResyncScheduler,
   requestResync,
   resetResyncThrottleForTesting,
 } from "./resyncRequests";
 
-function countRequests(run: (notify: (nowMs: number) => void) => void): number {
+interface Harness {
+  readonly scheduler: ResyncScheduler;
+  /** Request a reconcile as if the clock read `nowMs`. */
+  readonly requestAt: (nowMs: number) => void;
+  /** Run every timer whose deadline has passed, advancing the clock to it. */
+  readonly runDueTimers: () => void;
+  readonly fired: () => number;
+}
+
+function harness(): { harness: Harness; dispose: () => void } {
   resetResyncThrottleForTesting();
-  let seen = 0;
+  let fired = 0;
   const unsubscribe = ResyncRequests.onResyncRequested(() => {
-    seen += 1;
+    fired += 1;
   });
+  let clock = 0;
+  const timers: Array<{ at: number; run: () => void }> = [];
+  const scheduler: ResyncScheduler = {
+    now: () => clock,
+    setTimer: (run, delayMs) => {
+      timers.push({ at: clock + delayMs, run });
+    },
+  };
+  return {
+    harness: {
+      scheduler,
+      requestAt: (nowMs) => {
+        clock = nowMs;
+        requestResync(scheduler);
+      },
+      runDueTimers: () => {
+        const due = timers.splice(0, timers.length);
+        for (const timer of due) {
+          clock = timer.at;
+          timer.run();
+        }
+      },
+      fired: () => fired,
+    },
+    dispose: () => {
+      unsubscribe();
+      resetResyncThrottleForTesting();
+    },
+  };
+}
+
+function withHarness(run: (h: Harness) => void): number {
+  const { harness: h, dispose } = harness();
   try {
-    run(requestResync);
+    run(h);
+    return h.fired();
   } finally {
-    unsubscribe();
-    resetResyncThrottleForTesting();
+    dispose();
   }
-  return seen;
 }
 
 describe("requestResync", () => {
-  it("passes a request through to subscribers", () => {
-    expect(countRequests((notify) => notify(0))).toBe(1);
+  it("passes the first request straight through", () => {
+    expect(withHarness((h) => h.requestAt(0))).toBe(1);
   });
 
-  it("coalesces a burst into one reconcile", () => {
+  it("coalesces a burst into one immediate reconcile", () => {
     // Settling many threads at once must not ask for the same snapshot fetch
     // and resubscribe once per thread.
-    const seen = countRequests((notify) => {
+    const fired = withHarness((h) => {
       for (let i = 0; i < 20; i += 1) {
-        notify(i);
+        h.requestAt(i);
       }
     });
-    expect(seen).toBe(1);
+    expect(fired).toBe(1);
   });
 
-  it("allows another reconcile once the window has passed", () => {
-    const seen = countRequests((notify) => {
-      notify(0);
-      notify(RESYNC_MIN_INTERVAL_MS - 1);
-      notify(RESYNC_MIN_INTERVAL_MS);
+  it("still reconciles for a request suppressed inside the window", () => {
+    // The whole point of a request is that someone observed the client
+    // disagreeing with the server. Dropping it would leave that standing.
+    const fired = withHarness((h) => {
+      h.requestAt(0);
+      h.requestAt(100);
+      expect(h.fired()).toBe(1);
+      h.runDueTimers();
     });
-    expect(seen).toBe(2);
+    expect(fired).toBe(2);
+  });
+
+  it("collapses many suppressed requests into a single trailing reconcile", () => {
+    const fired = withHarness((h) => {
+      h.requestAt(0);
+      for (let i = 1; i < 20; i += 1) {
+        h.requestAt(i * 10);
+      }
+      h.runDueTimers();
+    });
+    expect(fired).toBe(2);
+  });
+
+  it("fires immediately once the window has passed", () => {
+    const fired = withHarness((h) => {
+      h.requestAt(0);
+      h.requestAt(RESYNC_MIN_INTERVAL_MS);
+    });
+    expect(fired).toBe(2);
+  });
+
+  it("recovers from a backward clock jump instead of wedging shut", () => {
+    // An NTP correction or manual clock change must not suppress every
+    // reconcile until wall time catches back up to the old timestamp.
+    const fired = withHarness((h) => {
+      h.requestAt(1_000_000);
+      h.requestAt(0);
+    });
+    expect(fired).toBe(2);
   });
 });

--- a/apps/web/src/lib/resyncRequests.ts
+++ b/apps/web/src/lib/resyncRequests.ts
@@ -1,0 +1,29 @@
+import { ResyncRequests } from "@t3tools/client-runtime/connection";
+
+/**
+ * Coalescing wrapper around the shared resync signal.
+ *
+ * A reconcile costs a snapshot fetch and a resubscribe, and the callers that
+ * need one arrive in bursts — settling twenty threads at once would otherwise
+ * ask twenty times for work that a single reconcile already covers for the
+ * whole environment.
+ */
+
+/** Minimum spacing between reconciles. */
+export const RESYNC_MIN_INTERVAL_MS = 5_000;
+
+let lastRequestAtMs: number | null = null;
+
+/** Request a reconcile, dropping anything inside the coalescing window. */
+export function requestResync(nowMs: number = Date.now()): void {
+  if (lastRequestAtMs !== null && nowMs - lastRequestAtMs < RESYNC_MIN_INTERVAL_MS) {
+    return;
+  }
+  lastRequestAtMs = nowMs;
+  ResyncRequests.requestResync();
+}
+
+/** Test seam: forget the coalescing window. */
+export function resetResyncThrottleForTesting(): void {
+  lastRequestAtMs = null;
+}

--- a/apps/web/src/lib/resyncRequests.ts
+++ b/apps/web/src/lib/resyncRequests.ts
@@ -7,23 +7,65 @@ import { ResyncRequests } from "@t3tools/client-runtime/connection";
  * need one arrive in bursts — settling twenty threads at once would otherwise
  * ask twenty times for work that a single reconcile already covers for the
  * whole environment.
+ *
+ * Coalescing here is trailing-edge, not leading-edge-only. A request exists
+ * because something observed the client disagreeing with the server, so
+ * dropping it outright would defeat the recovery this exists to perform: a
+ * request suppressed behind an earlier one would leave that disagreement
+ * standing until the user happened to act again. Suppressed requests instead
+ * collapse into one reconcile at the end of the window.
  */
 
 /** Minimum spacing between reconciles. */
 export const RESYNC_MIN_INTERVAL_MS = 5_000;
 
-let lastRequestAtMs: number | null = null;
+export interface ResyncScheduler {
+  readonly now: () => number;
+  readonly setTimer: (run: () => void, delayMs: number) => void;
+}
 
-/** Request a reconcile, dropping anything inside the coalescing window. */
-export function requestResync(nowMs: number = Date.now()): void {
-  if (lastRequestAtMs !== null && nowMs - lastRequestAtMs < RESYNC_MIN_INTERVAL_MS) {
-    return;
-  }
-  lastRequestAtMs = nowMs;
+const defaultScheduler: ResyncScheduler = {
+  now: () => Date.now(),
+  setTimer: (run, delayMs) => {
+    setTimeout(run, delayMs);
+  },
+};
+
+let lastFiredAtMs: number | null = null;
+let trailingScheduled = false;
+
+function fire(atMs: number): void {
+  lastFiredAtMs = atMs;
   ResyncRequests.requestResync();
 }
 
-/** Test seam: forget the coalescing window. */
+/**
+ * Request a reconcile. Fires immediately when the window is open, otherwise
+ * defers to the end of the current window — never drops the request.
+ */
+export function requestResync(scheduler: ResyncScheduler = defaultScheduler): void {
+  const nowMs = scheduler.now();
+  const elapsedMs = lastFiredAtMs === null ? null : nowMs - lastFiredAtMs;
+  // A clock that jumped backward (NTP correction, manual change) must not
+  // wedge the throttle shut until wall time catches back up: a negative
+  // elapsed means the recorded timestamp is meaningless, so start a fresh
+  // window rather than suppressing every reconcile in the meantime.
+  if (elapsedMs === null || elapsedMs < 0 || elapsedMs >= RESYNC_MIN_INTERVAL_MS) {
+    fire(nowMs);
+    return;
+  }
+  if (trailingScheduled) {
+    return;
+  }
+  trailingScheduled = true;
+  scheduler.setTimer(() => {
+    trailingScheduled = false;
+    fire(scheduler.now());
+  }, RESYNC_MIN_INTERVAL_MS - elapsedMs);
+}
+
+/** Test seam: forget the coalescing window and any pending trailing fire. */
 export function resetResyncThrottleForTesting(): void {
-  lastRequestAtMs = null;
+  lastFiredAtMs = null;
+  trailingScheduled = false;
 }

--- a/apps/web/src/lib/resyncRequests.ts
+++ b/apps/web/src/lib/resyncRequests.ts
@@ -33,9 +33,12 @@ const defaultScheduler: ResyncScheduler = {
 
 let lastFiredAtMs: number | null = null;
 let trailingScheduled = false;
+/** Whether a request has arrived that no reconcile has covered yet. */
+let requestOutstanding = false;
 
 function fire(atMs: number): void {
   lastFiredAtMs = atMs;
+  requestOutstanding = false;
   ResyncRequests.requestResync();
 }
 
@@ -54,12 +57,22 @@ export function requestResync(scheduler: ResyncScheduler = defaultScheduler): vo
     fire(nowMs);
     return;
   }
+  requestOutstanding = true;
   if (trailingScheduled) {
     return;
   }
   trailingScheduled = true;
   scheduler.setTimer(() => {
     trailingScheduled = false;
+    // An immediate reconcile may have landed since this was scheduled — an
+    // open window, or a backward clock jump. It already covered whatever was
+    // outstanding, so firing again would be the double reconcile the
+    // coalescing exists to prevent. Tracking outstanding work rather than
+    // cancelling the timer keeps a request that arrived *after* that
+    // reconcile from being dropped along with the obsolete one.
+    if (!requestOutstanding) {
+      return;
+    }
     fire(scheduler.now());
   }, RESYNC_MIN_INTERVAL_MS - elapsedMs);
 }
@@ -68,4 +81,5 @@ export function requestResync(scheduler: ResyncScheduler = defaultScheduler): vo
 export function resetResyncThrottleForTesting(): void {
   lastFiredAtMs = null;
   trailingScheduled = false;
+  requestOutstanding = false;
 }

--- a/apps/web/src/lib/settleConvergence.test.ts
+++ b/apps/web/src/lib/settleConvergence.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { confirmSettleConverged } from "./settleConvergence";
+
+function harness(readings: ReadonlyArray<boolean | null>) {
+  const waits: number[] = [];
+  let resyncs = 0;
+  let index = 0;
+  return {
+    waits,
+    resyncCount: () => resyncs,
+    options: {
+      readSettled: () => readings[Math.min(index++, readings.length - 1)] as boolean | null,
+      requestResync: () => {
+        resyncs += 1;
+      },
+      delay: async (ms: number) => {
+        waits.push(ms);
+      },
+      delaysMs: [10, 20, 30] as const,
+    },
+  };
+}
+
+describe("confirmSettleConverged", () => {
+  it("stops at the first check when the view already agrees", async () => {
+    const h = harness([true]);
+    await expect(confirmSettleConverged(h.options)).resolves.toBe("converged");
+    expect(h.waits).toEqual([10]);
+    expect(h.resyncCount()).toBe(0);
+  });
+
+  it("keeps checking while the view lags, then converges without a resync", async () => {
+    const h = harness([false, false, true]);
+    await expect(confirmSettleConverged(h.options)).resolves.toBe("converged");
+    expect(h.waits).toEqual([10, 20, 30]);
+    expect(h.resyncCount()).toBe(0);
+  });
+
+  it("requests a resync when the view never reflects the accepted settle", async () => {
+    const h = harness([false, false, false]);
+    await expect(confirmSettleConverged(h.options)).resolves.toBe("resync-requested");
+    expect(h.waits).toEqual([10, 20, 30]);
+    expect(h.resyncCount()).toBe(1);
+  });
+
+  it("leaves a thread that vanished from the shell alone", async () => {
+    const h = harness([null]);
+    await expect(confirmSettleConverged(h.options)).resolves.toBe("thread-absent");
+    expect(h.resyncCount()).toBe(0);
+  });
+});

--- a/apps/web/src/lib/settleConvergence.ts
+++ b/apps/web/src/lib/settleConvergence.ts
@@ -1,0 +1,55 @@
+/**
+ * Watchdog for a settle that the server accepted but the local view never
+ * reflects.
+ *
+ * An accepted `thread.settle` always publishes an authoritative
+ * `thread-upserted`, so the thread should read as settled locally within a
+ * moment. When it does not, the client is working from a view the server no
+ * longer agrees with — and because settling an already-settled thread is a
+ * deliberate idempotent no-op, every further click succeeds while changing
+ * nothing. The control looks dead and the thread cannot be moved to settled at
+ * all until the client is restarted.
+ *
+ * Polling rather than subscribing keeps this out of the atom graph: it runs
+ * only after an explicit user action, and only until the view agrees.
+ */
+
+/** How long to wait before each re-read. Spaced out rather than uniform: the
+ *  common case resolves on the first check, and a slow environment gets a
+ *  couple of longer chances before we escalate to a resync. */
+export const SETTLE_CONVERGENCE_DELAYS_MS: readonly number[] = [150, 500, 1200];
+
+export type SettleConvergenceOutcome =
+  /** The local view caught up on its own; nothing to do. */
+  | "converged"
+  /** The view never caught up, so a reconcile was requested. */
+  | "resync-requested"
+  /** The thread left the shell entirely (deleted, archived); not our problem. */
+  | "thread-absent";
+
+export interface SettleConvergenceOptions {
+  /** `true` when the local view shows the thread settled, `false` when it does
+   *  not, and `null` when the thread is no longer in the local shell. */
+  readonly readSettled: () => boolean | null;
+  readonly requestResync: () => void;
+  readonly delay: (ms: number) => Promise<void>;
+  readonly delaysMs?: readonly number[];
+}
+
+export async function confirmSettleConverged(
+  options: SettleConvergenceOptions,
+): Promise<SettleConvergenceOutcome> {
+  const delays = options.delaysMs ?? SETTLE_CONVERGENCE_DELAYS_MS;
+  for (const waitMs of delays) {
+    await options.delay(waitMs);
+    const settled = options.readSettled();
+    if (settled === null) {
+      return "thread-absent";
+    }
+    if (settled) {
+      return "converged";
+    }
+  }
+  options.requestResync();
+  return "resync-requested";
+}

--- a/packages/client-runtime/src/connection/index.ts
+++ b/packages/client-runtime/src/connection/index.ts
@@ -29,5 +29,6 @@ export {
   PlatformEnvironmentRemovalError,
 } from "./registry.ts";
 export { ConnectionResolver } from "./resolver.ts";
+export * as ResyncRequests from "./resyncRequests.ts";
 export { EnvironmentSupervisor, type EnvironmentSupervisorOptions } from "./supervisor.ts";
 export * as Wakeups from "./wakeups.ts";

--- a/packages/client-runtime/src/connection/resyncRequests.ts
+++ b/packages/client-runtime/src/connection/resyncRequests.ts
@@ -1,0 +1,50 @@
+import * as Effect from "effect/Effect";
+import * as Queue from "effect/Queue";
+import * as Stream from "effect/Stream";
+
+/**
+ * A manual "the client's view looks wrong, reconcile it" signal.
+ *
+ * Snapshot-backed subscriptions (shell, threads) already reconcile on a
+ * foreground wake: they reload the HTTP snapshot and resume the stream from
+ * its sequence. That is the same work a client restart does, and until now a
+ * restart was the only way to ask for it. Callers that *observe* a
+ * disagreement — a lifecycle command whose effect never lands in the local
+ * view — can request it here instead of stranding the user.
+ *
+ * Deliberately not Effect-scoped: the callers are UI event handlers, and a
+ * request is fire-and-forget. Requests raised before the wakeups layer is
+ * built are dropped rather than buffered; there is nothing to reconcile
+ * before the first subscription exists.
+ */
+export type ResyncListener = () => void;
+
+const listeners = new Set<ResyncListener>();
+
+/** Ask every snapshot-backed subscription to reconcile against the server.
+ *
+ *  One reconcile covers every thread in the environment, so callers that can
+ *  fire in bursts (bulk lifecycle actions) should coalesce before calling
+ *  this rather than asking once per item. */
+export function requestResync(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Subscribe to resync requests. Returns an unsubscribe function. */
+export function onResyncRequested(listener: ResyncListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Resync requests as a `ConnectionWakeup` stream, for the wakeups layer. */
+export const resyncRequestStream: Stream.Stream<"resync-requested"> =
+  Stream.callback<"resync-requested">((queue) =>
+    Effect.acquireRelease(
+      Effect.sync(() => onResyncRequested(() => Queue.offerUnsafe(queue, "resync-requested"))),
+      (unsubscribe) => Effect.sync(unsubscribe),
+    ).pipe(Effect.asVoid),
+  );

--- a/packages/client-runtime/src/connection/wakeups.ts
+++ b/packages/client-runtime/src/connection/wakeups.ts
@@ -2,7 +2,20 @@ import * as Context from "effect/Context";
 import * as Layer from "effect/Layer";
 import type * as Stream from "effect/Stream";
 
-export type ConnectionWakeup = "application-active" | "credentials-changed";
+/** Why a live subscription should re-establish itself.
+ *
+ *  `resync-requested` is the explicit form: something observed the client's
+ *  view disagreeing with the server and asked for the same reconciliation a
+ *  foreground wake performs (reload the HTTP snapshot, resume the stream from
+ *  its sequence). It exists so a stale view is recoverable in place instead of
+ *  only by restarting the client. */
+export type ConnectionWakeup = "application-active" | "credentials-changed" | "resync-requested";
+
+/** Wakeups that should re-establish snapshot-backed subscriptions. Credential
+ *  changes are excluded: they are handled by the connection supervisor. */
+export function wakeupResubscribes(reason: ConnectionWakeup): boolean {
+  return reason === "application-active" || reason === "resync-requested";
+}
 
 export class ConnectionWakeups extends Context.Service<
   ConnectionWakeups,

--- a/packages/client-runtime/src/state/shell.ts
+++ b/packages/client-runtime/src/state/shell.ts
@@ -171,8 +171,7 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
 
   const foregroundResubscriptions = Option.match(wakeups, {
     onNone: () => Stream.never,
-    onSome: (service) =>
-      service.changes.pipe(Stream.filter((reason) => reason === "application-active")),
+    onSome: (service) => service.changes.pipe(Stream.filter(ConnectionWakeups.wakeupResubscribes)),
   });
 
   yield* setSynchronizing;

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -235,8 +235,7 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
 
   const foregroundResubscriptions = Option.match(wakeups, {
     onNone: () => Stream.never,
-    onSome: (service) =>
-      service.changes.pipe(Stream.filter((reason) => reason === "application-active")),
+    onSome: (service) => service.changes.pipe(Stream.filter(ConnectionWakeups.wakeupResubscribes)),
   });
 
   yield* setSynchronizing;


### PR DESCRIPTION
## What Changed

Settle can now recover a client whose view has drifted from the server, instead of requiring a client restart.

- New `resync-requested` `ConnectionWakeup`. Snapshot-backed subscriptions (`shell`, `threads`) already reconcile on a foreground wake — reload the HTTP snapshot, resume the stream from its sequence — but nothing could ask for that on demand. They now resubscribe on this reason too, via a shared `wakeupResubscribes` predicate.
- New `ResyncRequests` emitter in `client-runtime`, merged into the web app's wakeups layer.
- `settleThread` requests a reconcile when it observes a disagreement:
  - when the local `canSettle` guard blocks the send, and
  - when a settle the server accepted never lands in the local view (checked at 150/500/1200 ms, then escalated).
- Requests are coalesced behind a 5 s window, so bulk settle asks once rather than once per thread.

## Why

Settling acts on the client's local view, and when that view is stale the action becomes unrecoverable in both directions:

- `canSettle` (`threadSettled.ts`) refuses to send while the client's copy of `session.status` is `starting | running`, even if the server has since moved the session to `ready`.
- A settle the server *accepts* against an already-settled thread is a deliberate idempotent no-op — it re-emits `thread.settled` with the original `settledAt` and the existing `updatedAt` (`decider.ts`) so bulk-settle and double-click stay quiet. If the local view never applies the resulting `thread-upserted`, every subsequent click succeeds while changing nothing visible.

Either way the control reads as dead and the thread cannot be moved to settled at all. The only known fix was restarting the client — which works precisely because it reloads the snapshot and resubscribes. This makes that same reconciliation reachable in place.

The server side already publishes what a client needs to converge: `threadUpsertOrRemove` re-reads the current projected row and emits `thread-upserted` after any thread event, including the idempotent re-emit. The gap is that nothing on the client notices when its view has stopped tracking that.

Reported in #4589.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — no visual change; this only affects when a reconcile is requested
- [ ] I included a video for animation/interaction changes — n/a

---

Validation (scoped per `AGENTS.md`, which reserves repo-wide `vp check` / `vp run typecheck` for CI):

```
vitest run apps/web/src/lib/ packages/client-runtime/src/state/    # 429 passed
tsgo --noEmit                                                      # apps/web, packages/client-runtime — clean
vp lint --report-unused-disable-directives                         # no findings in changed files
```

Note on verification honesty: the underlying desync has no deterministic repro yet, so the new escalation path is covered by unit tests rather than an end-to-end reproduction. The happy path is unchanged — the convergence check reads once and exits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live subscription reconciliation and thread lifecycle UX; behavior is guarded by throttling and unit tests but the underlying desync has no deterministic E2E repro.
> 
> **Overview**
> Fixes **settle** appearing broken when the local thread view is stale: the server may accept the command (or the client may block on `canSettle`) while the UI never updates until a restart.
> 
> Adds an on-demand **`resync-requested`** connection wakeup (via `ResyncRequests` in client-runtime, merged into the web wakeups layer). **Shell** and **thread** snapshot subscriptions now resubscribe on that reason as well as foreground activation, using shared `wakeupResubscribes`.
> 
> **`settleThread`** requests a coalesced reconcile (5s trailing-edge throttle in `resyncRequests.ts`) when the local `canSettle` guard blocks, and after a successful settle runs **`confirmSettleConverged`** polling; if settled state still does not appear, it escalates to another resync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc3aefd627cc5417544dc99c0ead5399ac6115a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile client state when a thread settle does not land locally
> - Adds a `resync-requested` wakeup type to `ConnectionWakeup` and wires it into the wakeups layer via a new `ResyncRequests.resyncRequestStream` in [`platform.ts`](https://github.com/pingdotgg/t3code/pull/4593/files#diff-11f2bf026d367970576edae81c8c89f388524df2325db0c3dfb4b953437fbc4c).
> - Adds [`settleConvergence.ts`](https://github.com/pingdotgg/t3code/pull/4593/files#diff-cc8eedc8c3fa2d816b5ee96c9a7fd7c482eed994c7a82ff3ffa10fb078d27338), which polls the local thread shell after a successful settle and calls `requestResync` if the settled state never converges.
> - Adds [`resyncRequests.ts`](https://github.com/pingdotgg/t3code/pull/4593/files#diff-7ab91e356a08cb3a63a7ac401de1dc07d5078c8131d02fa1b0008c63dba24fd4), a trailing-edge coalescing wrapper that fires at most one immediate and one trailing resync per 5-second window.
> - Updates `settleThread` in [`useThreadActions.ts`](https://github.com/pingdotgg/t3code/pull/4593/files#diff-7d3463056176ee1e173c0ae885b4305a70a7cc854fee7040d9b9a5a28dfbda50) to request a resync when a local `canSettle` check fails, and to run convergence polling after a successful mutation.
> - `foregroundResubscriptions` in [`shell.ts`](https://github.com/pingdotgg/t3code/pull/4593/files#diff-538b14bdf595ee51e55aaaa249aab3e8505b533401c51b92360b4d9c37251c83) and [`threads.ts`](https://github.com/pingdotgg/t3code/pull/4593/files#diff-3389d9e86e5f65222bc1be800d0aa21f5356629eaf916680112dcbd606822815) now resubscribe on `resync-requested` in addition to `application-active`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fc3aef.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->