### PR TITLE
feat(web): open context menus with a long press on touch

### DIFF
--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -23,6 +23,7 @@ import {
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { readLocalApi } from "../localApi";
+import { longPressContextMenuProps } from "../longPressContextMenu";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { usePaginatedBranches } from "../state/queries";
 import { useProject, useThread } from "../state/entities";
@@ -672,6 +673,7 @@ export function BranchToolbarBranchSelector({
         className="pe-1.5"
         onClick={() => selectBranch(refName)}
         onContextMenu={(event) => handleBranchContextMenu(event, itemValue)}
+        {...longPressContextMenuProps}
       >
         <div className="flex w-full min-w-0 items-center justify-between gap-2">
           <span className="min-w-0 flex-1 truncate">{itemValue}</span>
@@ -728,6 +730,7 @@ export function BranchToolbarBranchSelector({
         <span
           className="flex min-w-0"
           onContextMenu={(event) => handleBranchContextMenu(event, resolvedActiveBranch)}
+          {...longPressContextMenuProps}
         >
           <ComboboxTrigger
             render={<Button variant="ghost" size="xs" />}

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -15,6 +15,7 @@ import { isElectron } from "~/env";
 import type { RightPanelSurface } from "~/rightPanelStore";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
+import { longPressContextMenuProps } from "~/longPressContextMenu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { ScrollArea } from "~/components/ui/scroll-area";
@@ -383,6 +384,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
                   onMouseDown={handleTabMouseDown}
                   onAuxClick={(event) => handleTabAuxClick(event, surface)}
                   onContextMenu={(event) => void handleTabContextMenu(event, surface)}
+                  {...longPressContextMenuProps}
                   className={cn(
                     "group flex h-7 min-w-25 max-w-44 shrink-0 items-center gap-1.5 rounded-md px-2 text-sm",
                     active

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -105,6 +105,7 @@ import {
 import { isModelPickerOpen } from "../modelPickerVisibility";
 import { useShortcutModifierState } from "../shortcutModifierState";
 import { readLocalApi } from "../localApi";
+import { longPressContextMenuProps } from "../longPressContextMenu";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { useDesktopUpdateState } from "../state/desktopUpdate";
@@ -677,6 +678,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         onDoubleClick={handleRowDoubleClick}
         onKeyDown={handleRowKeyDown}
         onContextMenu={handleRowContextMenu}
+        {...longPressContextMenuProps}
       >
         <div className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
           {prStatus && (
@@ -2223,6 +2225,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           className={`h-8 gap-2 rounded-md px-2 py-1.5 pr-8 text-left hover:bg-sidebar-row-hover group-hover/project-header:bg-sidebar-row-hover group-hover/project-header:text-sidebar-foreground max-sm:pr-14 ${
             isManualProjectSorting ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"
           }`}
+          {...longPressContextMenuProps}
           {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.attributes : {})}
           {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.listeners : {})}
           onPointerDownCapture={handleProjectButtonPointerDownCapture}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -69,6 +69,7 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { isMacPlatform } from "~/lib/utils";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { readLocalApi } from "../localApi";
+import { longPressContextMenuProps } from "../longPressContextMenu";
 import {
   deriveProjectGroupingOverrideKey,
   getProjectOrderKey,
@@ -748,6 +749,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 onDoubleClick={handleDoubleClick}
                 onKeyDown={handleKeyDown}
                 onContextMenu={handleContextMenu}
+                {...longPressContextMenuProps}
               />
             }
           >
@@ -857,6 +859,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               onDoubleClick={handleDoubleClick}
               onKeyDown={handleKeyDown}
               onContextMenu={handleContextMenu}
+              {...longPressContextMenuProps}
             />
           }
         >

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -56,6 +56,7 @@ import {
   sortProviderInstanceEntries,
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
+import { longPressContextMenuProps } from "../../longPressContextMenu";
 import {
   primaryServerObservabilityAtom,
   primaryServerProvidersAtom,
@@ -1714,6 +1715,7 @@ export function ArchivedThreadsPanel() {
                     }
                   })();
                 }}
+                {...longPressContextMenuProps}
                 title={thread.title}
                 description={
                   <>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1025,6 +1025,19 @@ code {
   -webkit-app-region: no-drag;
 }
 
+@media (pointer: coarse) {
+  [data-long-press-context-menu] {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  [data-long-press-context-menu] :is(input, textarea, [contenteditable]) {
+    -webkit-user-select: auto;
+    user-select: auto;
+  }
+}
+
 /* Scrollbar styling */
 ::-webkit-scrollbar {
   width: var(--app-scrollbar-width);

--- a/apps/web/src/longPressContextMenu.test.ts
+++ b/apps/web/src/longPressContextMenu.test.ts
@@ -1,0 +1,157 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { longPressContextMenuProps } from "./longPressContextMenu";
+
+class FakeMouseEvent {
+  constructor(
+    readonly type: string,
+    readonly init: Record<string, unknown> = {},
+  ) {}
+
+  preventDefault() {}
+  stopPropagation() {}
+}
+
+class FakeElement {
+  readonly dispatched: FakeMouseEvent[] = [];
+
+  constructor(private readonly matchedSelector: string | null = null) {}
+
+  closest(selector: string) {
+    if (this.matchedSelector === null) return null;
+    return selector.includes(this.matchedSelector) ? this : null;
+  }
+
+  dispatchEvent(event: FakeMouseEvent) {
+    this.dispatched.push(event);
+    return true;
+  }
+}
+
+type DocumentListener = () => void;
+
+let timers: Map<number, () => void>;
+let nextTimerId: number;
+let documentListeners: Map<string, DocumentListener[]>;
+
+function runPendingTimers() {
+  const callbacks = [...timers.values()];
+  timers.clear();
+  for (const callback of callbacks) callback();
+}
+
+function dispatchOnDocument(type: string) {
+  for (const listener of documentListeners.get(type) ?? []) listener();
+}
+
+function pointerEvent(target: FakeElement, overrides: Record<string, unknown> = {}) {
+  return {
+    clientX: 10,
+    clientY: 20,
+    currentTarget: target,
+    pointerType: "touch",
+    target: null,
+    ...overrides,
+  } as unknown as ReactPointerEvent;
+}
+
+beforeEach(() => {
+  timers = new Map();
+  nextTimerId = 1;
+  documentListeners = new Map();
+
+  vi.stubGlobal("window", {
+    clearTimeout: (id: number) => timers.delete(id),
+    setTimeout: (callback: () => void) => {
+      const id = nextTimerId++;
+      timers.set(id, callback);
+      return id;
+    },
+  });
+  vi.stubGlobal("document", {
+    addEventListener: (type: string, listener: DocumentListener) => {
+      documentListeners.set(type, [...(documentListeners.get(type) ?? []), listener]);
+    },
+    removeEventListener: (type: string, listener: DocumentListener) => {
+      documentListeners.set(
+        type,
+        (documentListeners.get(type) ?? []).filter((entry) => entry !== listener),
+      );
+    },
+  });
+  vi.stubGlobal("Element", FakeElement);
+  vi.stubGlobal("MouseEvent", FakeMouseEvent);
+});
+
+afterEach(() => {
+  longPressContextMenuProps.onPointerCancel();
+  vi.unstubAllGlobals();
+});
+
+describe("longPressContextMenuProps", () => {
+  it("opens a context menu at the press position after a long touch", () => {
+    const target = new FakeElement();
+
+    longPressContextMenuProps.onPointerDown(pointerEvent(target));
+    runPendingTimers();
+
+    expect(target.dispatched).toHaveLength(1);
+    expect(target.dispatched[0]?.type).toBe("contextmenu");
+    expect(target.dispatched[0]?.init).toMatchObject({
+      bubbles: true,
+      clientX: 10,
+      clientY: 20,
+    });
+  });
+
+  it.each(["mouse", "pen"])("leaves %s input to the native context menu", (pointerType) => {
+    const target = new FakeElement();
+
+    longPressContextMenuProps.onPointerDown(pointerEvent(target, { pointerType }));
+    runPendingTimers();
+
+    expect(target.dispatched).toHaveLength(0);
+  });
+
+  it("leaves long presses inside a text field alone", () => {
+    const target = new FakeElement();
+
+    longPressContextMenuProps.onPointerDown(
+      pointerEvent(target, { target: new FakeElement("input") }),
+    );
+    runPendingTimers();
+
+    expect(target.dispatched).toHaveLength(0);
+  });
+
+  it("survives small finger movement", () => {
+    const target = new FakeElement();
+
+    longPressContextMenuProps.onPointerDown(pointerEvent(target));
+    longPressContextMenuProps.onPointerMove(pointerEvent(target, { clientX: 14, clientY: 24 }));
+    runPendingTimers();
+
+    expect(target.dispatched).toHaveLength(1);
+  });
+
+  it("cancels once the finger moves past the tolerance", () => {
+    const target = new FakeElement();
+
+    longPressContextMenuProps.onPointerDown(pointerEvent(target));
+    longPressContextMenuProps.onPointerMove(pointerEvent(target, { clientX: 40 }));
+    runPendingTimers();
+
+    expect(target.dispatched).toHaveLength(0);
+  });
+
+  it("cancels when the browser fires its own context menu", () => {
+    const target = new FakeElement();
+
+    longPressContextMenuProps.onPointerDown(pointerEvent(target));
+    dispatchOnDocument("contextmenu");
+    runPendingTimers();
+
+    expect(target.dispatched).toHaveLength(0);
+  });
+});

--- a/apps/web/src/longPressContextMenu.ts
+++ b/apps/web/src/longPressContextMenu.ts
@@ -1,0 +1,68 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+
+const LONG_PRESS_DELAY_MS = 500;
+const LONG_PRESS_MOVE_TOLERANCE_PX = 5;
+
+let pendingPress: { origin: { x: number; y: number }; timeoutId: number } | null = null;
+
+function cancelPendingPress() {
+  if (!pendingPress) return;
+  window.clearTimeout(pendingPress.timeoutId);
+  document.removeEventListener("contextmenu", cancelPendingPress, true);
+  pendingPress = null;
+}
+
+function suppressRestOfGesture() {
+  const suppress = (event: Event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+  const stopSuppressing = () => {
+    document.removeEventListener("click", suppress, true);
+    document.removeEventListener("contextmenu", suppress, true);
+  };
+  document.addEventListener("click", suppress, true);
+  document.addEventListener("contextmenu", suppress, true);
+  document.addEventListener("pointerdown", stopSuppressing, { capture: true, once: true });
+}
+
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest("input, textarea, [contenteditable]") !== null;
+}
+
+export const longPressContextMenuProps = {
+  "data-long-press-context-menu": "",
+  onPointerCancel: cancelPendingPress,
+  onPointerDown: (event: ReactPointerEvent) => {
+    cancelPendingPress();
+    if (event.pointerType !== "touch" || isTextEntryTarget(event.target)) return;
+
+    const target = event.currentTarget;
+    const origin = { x: event.clientX, y: event.clientY };
+    pendingPress = {
+      origin,
+      timeoutId: window.setTimeout(() => {
+        cancelPendingPress();
+        target.dispatchEvent(
+          new MouseEvent("contextmenu", {
+            bubbles: true,
+            cancelable: true,
+            clientX: origin.x,
+            clientY: origin.y,
+          }),
+        );
+        suppressRestOfGesture();
+      }, LONG_PRESS_DELAY_MS),
+    };
+    document.addEventListener("contextmenu", cancelPendingPress, true);
+  },
+  onPointerMove: (event: ReactPointerEvent) => {
+    if (!pendingPress) return;
+    const movedX = Math.abs(event.clientX - pendingPress.origin.x);
+    const movedY = Math.abs(event.clientY - pendingPress.origin.y);
+    if (movedX > LONG_PRESS_MOVE_TOLERANCE_PX || movedY > LONG_PRESS_MOVE_TOLERANCE_PX) {
+      cancelPendingPress();
+    }
+  },
+  onPointerUp: cancelPendingPress,
+};


### PR DESCRIPTION
## Why

Touch input has no right-click, and iOS Safari never fires `contextmenu` on long press. Every context menu in the web app is therefore unreachable on a phone — sidebar thread rows, project headers, right-panel tabs, the branch selector and archived threads in settings all expose actions a touch user has no way to open.

Android Chrome does fire `contextmenu` on long press, so those menus already work there. This closes the gap without changing Android behaviour.

## What

`apps/web/src/longPressContextMenu.ts` exports one spreadable set of pointer handlers:

```tsx
<div onContextMenu={handleContextMenu} {...longPressContextMenuProps} />
```

- 500 ms timer on `pointerdown`, `pointerType === "touch"` only — mouse and pen keep the native path untouched.
- Cancels on movement past 5 px, on pointer up/cancel, and when the press starts inside an `input`, `textarea` or `contenteditable`, so scrolling, dragging and text entry are unaffected.
- Cancels when the browser fires its own `contextmenu`, so Android never opens the menu twice.
- After firing, suppresses the leftover `click` and `contextmenu` from the same gesture, so the row underneath does not also activate and the item under the finger is not picked when it lifts.

The handlers dispatch the `contextmenu` event every call site already handles, so no menu logic changed — each wired element gained a single line.

One rule in `index.css`, scoped to `pointer: coarse`, suppresses the iOS selection magnifier and callout on the wired elements while keeping text entry selectable.

## Wired surfaces

- `SidebarV2` thread rows, card and slim
- `Sidebar` thread rows and project headers
- `RightPanelTabs` tabs
- `BranchToolbarBranchSelector` items and trigger
- `ArchivedThreadsPanel` rows

## Deliberately not included

- **Chat markdown links** — iOS already shows its own callout there, and taking over long press would break text selection inside messages.
- **The file browser tree** (`@pierre/trees`) — rows render in shadow DOM and would need gesture support upstream.
- **Project headers while manual project sorting is on** — that row is a dnd-kit drag handle and keeps its own `onPointerDown`, so reordering is unchanged.

## Video

<!-- upload -->

## Verification

`apps/web` unit suite (1525 tests), `tsgo --noEmit`, `vp lint` and `vp fmt --check` all pass, including 7 new tests for the gesture.

Checked by hand on an iPhone against a local build: menus open on long press, rows do not activate on release, scrolling and renaming are unaffected, no selection magnifier, and Android Chrome still opens exactly one menu.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add long-press gesture to open context menus on touch devices
> - Introduces [`longPressContextMenuProps`](https://github.com/pingdotgg/t3code/pull/4594/files#diff-cf8a4866cbe467fe16a446838dcba40c6f3d5a5b1704d9dda9abc6d959e2524c), a shared props object that dispatches a synthetic `contextmenu` event after a 500ms touch hold, with 5px movement tolerance and suppression of duplicate click/contextmenu events.
> - Applies these props to branch selector items, sidebar rows, right panel tabs, and archived thread entries.
> - Adds CSS in [`index.css`](https://github.com/pingdotgg/t3code/pull/4594/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to suppress native touch callout and text selection on long-press targets (coarse pointer devices), while preserving selection in inputs and editables.
> - Behavioral Change: native long-press behavior (text selection, callout) is disabled on marked elements for touch users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32833ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

https://github.com/user-attachments/assets/8a56dc84-2af1-402a-aaaf-97f641f0d48f