### PR TITLE
Clear pending requests whose provider session is gone

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2174,6 +2174,144 @@ describe("ProviderCommandReactor", () => {
     expect(resolvedActivity).toBeUndefined();
   });
 
+  effectIt.effect(
+    "marks user-input responses stale when no provider session is bound to the thread",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() => createHarness());
+        const now = "2026-01-01T00:00:00.000Z";
+
+        yield* harness.engine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.make("cmd-user-input-requested-no-session"),
+          threadId: ThreadId.make("thread-1"),
+          activity: {
+            id: EventId.make("activity-user-input-requested-no-session"),
+            tone: "info",
+            kind: "user-input.requested",
+            summary: "User input requested",
+            payload: {
+              requestId: "user-input-request-1",
+              questions: [
+                {
+                  id: "fix_scope",
+                  header: "Fix scope",
+                  question: "How should I handle this?",
+                  options: [{ label: "Delete now", description: "Remove the garbage" }],
+                },
+              ],
+            },
+            turnId: null,
+            createdAt: now,
+          },
+          createdAt: now,
+        });
+
+        yield* harness.engine.dispatch({
+          type: "thread.user-input.respond",
+          commandId: CommandId.make("cmd-user-input-respond-no-session"),
+          threadId: ThreadId.make("thread-1"),
+          requestId: asApprovalRequestId("user-input-request-1"),
+          answers: {
+            fix_scope: "Delete now",
+          },
+          createdAt: now,
+        });
+
+        yield* Effect.promise(() =>
+          waitFor(async () => {
+            const readModel = await harness.readModel();
+            const thread = readModel.threads.find(
+              (entry) => entry.id === ThreadId.make("thread-1"),
+            );
+            return (
+              thread?.activities.some(
+                (activity) => activity.kind === "provider.user-input.respond.failed",
+              ) === true
+            );
+          }),
+        );
+
+        expect(harness.respondToUserInput).not.toHaveBeenCalled();
+
+        const readModel = yield* Effect.promise(() => harness.readModel());
+        const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+        const failureActivity = thread?.activities.find(
+          (activity) => activity.kind === "provider.user-input.respond.failed",
+        );
+        const detail = (failureActivity?.payload as Record<string, unknown> | undefined)?.detail;
+        expect(failureActivity?.payload).toMatchObject({ requestId: "user-input-request-1" });
+        expect(detail).toContain("No active provider session is bound to this thread.");
+        // The stale marker is what every pending-request accounting keys off, so a
+        // dead session clears the prompt instead of leaving it answerable forever.
+        // Clearing itself is covered by session-logic / threadActivity tests.
+        expect(detail).toContain("Stale pending user-input request: user-input-request-1");
+      }),
+  );
+
+  effectIt.effect(
+    "marks approval responses stale when no provider session is bound to the thread",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() => createHarness());
+        const now = "2026-01-01T00:00:00.000Z";
+
+        yield* harness.engine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.make("cmd-approval-requested-no-session"),
+          threadId: ThreadId.make("thread-1"),
+          activity: {
+            id: EventId.make("activity-approval-requested-no-session"),
+            tone: "approval",
+            kind: "approval.requested",
+            summary: "Command approval requested",
+            payload: {
+              requestId: "approval-request-1",
+              requestKind: "command",
+            },
+            turnId: null,
+            createdAt: now,
+          },
+          createdAt: now,
+        });
+
+        yield* harness.engine.dispatch({
+          type: "thread.approval.respond",
+          commandId: CommandId.make("cmd-approval-respond-no-session"),
+          threadId: ThreadId.make("thread-1"),
+          requestId: asApprovalRequestId("approval-request-1"),
+          decision: "acceptForSession",
+          createdAt: now,
+        });
+
+        yield* Effect.promise(() =>
+          waitFor(async () => {
+            const readModel = await harness.readModel();
+            const thread = readModel.threads.find(
+              (entry) => entry.id === ThreadId.make("thread-1"),
+            );
+            return (
+              thread?.activities.some(
+                (activity) => activity.kind === "provider.approval.respond.failed",
+              ) === true
+            );
+          }),
+        );
+
+        expect(harness.respondToRequest).not.toHaveBeenCalled();
+
+        const readModel = yield* Effect.promise(() => harness.readModel());
+        const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+        const failureActivity = thread?.activities.find(
+          (activity) => activity.kind === "provider.approval.respond.failed",
+        );
+        const detail = (failureActivity?.payload as Record<string, unknown> | undefined)?.detail;
+        expect(failureActivity?.payload).toMatchObject({ requestId: "approval-request-1" });
+        expect(detail).toContain("No active provider session is bound to this thread.");
+        expect(detail).toContain("Stale pending approval request: approval-request-1");
+      }),
+  );
+
   it("reacts to thread.session.stop by stopping provider session and clearing thread session state", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -166,6 +166,19 @@ function stalePendingRequestDetail(
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
 }
 
+// A response can only reach the provider through the live session holding the
+// pending callback, so once that session is gone the request is permanently
+// unanswerable — exactly the stale-request case. Reuse the stale detail so the
+// pending accounting that keys off it (web/mobile derivePending*, the decider's
+// settle guard, ProjectionPipeline) clears the request instead of leaving an
+// answerable card that appends an identical failure on every submit.
+function noActiveSessionRequestDetail(
+  requestKind: "approval" | "user-input",
+  requestId: string,
+): string {
+  return `No active provider session is bound to this thread. ${stalePendingRequestDetail(requestKind, requestId)}`;
+}
+
 function buildGeneratedWorktreeBranchName(raw: string): string {
   const normalized = raw
     .trim()
@@ -929,7 +942,7 @@ const make = Effect.gen(function* () {
         threadId: event.payload.threadId,
         kind: "provider.approval.respond.failed",
         summary: "Provider approval response failed",
-        detail: "No active provider session is bound to this thread.",
+        detail: noActiveSessionRequestDetail("approval", event.payload.requestId),
         turnId: null,
         createdAt: event.payload.createdAt,
         requestId: event.payload.requestId,
@@ -973,7 +986,7 @@ const make = Effect.gen(function* () {
           threadId: event.payload.threadId,
           kind: "provider.user-input.respond.failed",
           summary: "Provider user input response failed",
-          detail: "No active provider session is bound to this thread.",
+          detail: noActiveSessionRequestDetail("user-input", event.payload.requestId),
           turnId: null,
           createdAt: event.payload.createdAt,
           requestId: event.payload.requestId,

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -307,6 +307,51 @@ describe("derivePendingUserInputs", () => {
 
     expect(derivePendingUserInputs(activities)).toEqual([]);
   });
+
+  it("clears pending user-input prompts once no provider session is bound to the thread", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-open-no-session",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-no-session-1",
+          questions: [
+            {
+              id: "fix_scope",
+              header: "Fix scope",
+              question: "How should I handle this?",
+              options: [
+                {
+                  label: "Delete now",
+                  description: "Remove the garbage",
+                },
+              ],
+              multiSelect: false,
+            },
+          ],
+        },
+      }),
+      makeActivity({
+        id: "user-input-failed-no-session",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "provider.user-input.respond.failed",
+        summary: "Provider user input response failed",
+        tone: "error",
+        payload: {
+          requestId: "req-user-input-no-session-1",
+          detail:
+            "No active provider session is bound to this thread. Stale pending user-input request: req-user-input-no-session-1. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.",
+        },
+      }),
+    ];
+
+    // The prompt's callback died with the session, so leaving the card
+    // answerable only lets every submit append another identical failure.
+    expect(derivePendingUserInputs(activities)).toEqual([]);
+  });
 });
 
 describe("deriveActivePlanState", () => {


### PR DESCRIPTION
## What Changed

`ProviderCommandReactor` now records a *terminal* failure detail when an approval or
user-input response arrives for a thread whose provider session is gone, instead of a
bespoke string no pending-request accounting recognizes.

```
No active provider session is bound to this thread. Stale pending user-input request:
<id>. Provider callback state does not survive app restarts or recovered sessions.
Restart the turn to continue.
```

This reuses the existing `stalePendingRequestDetail(...)` text rather than adding a new
marker, so every consumer that already clears stale requests clears this one too — no
matcher changes, and already-shipped clients get the fix without rebuilding.

Applied to both `processUserInputResponseRequested` and `processApprovalResponseRequested`;
approvals had the identical bug. The turn-interrupt path keeps its plain message — it
gates no prompt.

## Why

A pending `AskUserQuestion` (or approval) request can only be answered through the live
provider session holding its callback — a `Deferred` in the adapter's in-memory
`pendingUserInputs` map. Once that session is gone the request is permanently
unanswerable; starting a new session cannot re-bind the dead tool call.

The reactor already refused to send those responses. But whether an open request is
*still answerable* is decided independently by four consumers, each scanning activities
and clearing on a `*.respond.failed` whose detail carries a known terminal marker:

- `derivePendingApprovals` / `derivePendingUserInputs` — `apps/web/src/session-logic.ts`
- the same pair in `apps/mobile/src/lib/threadActivity.ts`
- `hasOpenBlockingRequest` — the decider's settle/snooze guard
- `derivePendingUserInputCountFromActivities` and the pending-approval projector in
  `ProjectionPipeline`

`"No active provider session is bound to this thread."` matched none of them, so the
request stayed open forever. In practice: the question card kept rendering as answerable,
each Submit appended another identical `Provider user input response failed` row — I hit
seven of them stacked in one thread before diagnosing this — and the thread could no
longer be settled or snoozed.

The decider's own comment already states the constraint this change satisfies: *"The
clearing rules MUST match ProjectionPipeline's pending accounting … or settle would be
rejected on threads whose shell flags read as clear."*

Scope note: this covers the case where the session is **already gone** — an app restart,
where nothing had a chance to emit `user-input.resolved`. #4096 covers the complementary
case, cancelling pending prompts during a graceful `stopSession`. Neither subsumes the
other, and this change touches no file that #4096 modifies outside a test.

## UI Changes

No frontend source change — the only web file touched is a test. The user-visible effect
is that the question card now disappears after one failed submit instead of persisting;
that behavior lives entirely in `derivePendingUserInputs`, which is unchanged and
already covered by unit tests.

## Validation

```
vp test run src/orchestration                                    # apps/server, 192 passed (2 new)
vp test run --project unit src/session-logic.test.ts             # apps/web,   60 passed (1 new)
tsgo --noEmit                                                    # apps/server + apps/web, clean
vp lint --report-unused-disable-directives <changed files>       # clean
vp fmt --check <changed files>                                   # clean
```

Both new reactor tests were confirmed to **fail** against the pre-fix detail string and
pass after, so they pin the behavior rather than restating it. The new `session-logic`
test locks the emitted detail to actual clearing, so a future reword of the server-side
string breaks loudly instead of silently reopening this bug.

Per `AGENTS.md` I kept verification focused rather than running repo-wide `vp check` /
`vp run typecheck`, and did not run an integrated browser pass — the diff contains no
frontend source changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — n/a, no frontend source change
- [x] I included a video for animation/interaction changes — n/a, no motion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized failure-detail formatting in the orchestration reactor with regression tests; no auth or data-model changes, and existing clients benefit without matcher updates.
> 
> **Overview**
> When approval or user-input responses arrive on a thread with **no active provider session**, `ProviderCommandReactor` still refused to call the provider but recorded a failure detail that pending-request accounting did not treat as terminal—so question/approval cards stayed answerable and each submit stacked another identical failure.
> 
> **Server:** Adds `noActiveSessionRequestDetail`, which prefixes the existing no-session message with the same **stale pending request** text from `stalePendingRequestDetail`. That string is used for both `provider.approval.respond.failed` and `provider.user-input.respond.failed` when `hasSession` is false (turn interrupt keeps its plain message).
> 
> **Tests:** Two reactor tests assert the provider is not called and the failure payload includes both markers; one `session-logic` test locks that `derivePendingUserInputs` clears the prompt when it sees the combined detail—no web UI source changes required because matchers already key off the stale substring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495be4153ec9f9402140224e4ca2f9289a9d974a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear pending requests when no active provider session is bound to a thread
> - When a `thread.user-input.respond` or `thread.approval.respond` event arrives but no provider session is active, the resulting failure activity now includes both a no-active-session message and a stale pending request marker in its `payload.detail`.
> - A new `noActiveSessionRequestDetail` helper in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/4598/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) formats this combined detail string.
> - `derivePendingUserInputs` in [session-logic.test.ts](https://github.com/pingdotgg/t3code/pull/4598/files#diff-57adf4675e36941eb9badc7010414e9dae54f29534134a68c9e8808cda5c4e47) is verified to return an empty list when it sees the stale pending marker, so the UI clears the pending request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 495be41.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->