### PR TITLE
fix(client-runtime): recover subscriptions that lose their transport

### DIFF
--- a/packages/client-runtime/src/rpc/client.test.ts
+++ b/packages/client-runtime/src/rpc/client.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -25,7 +26,13 @@ import {
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import * as RpcSession from "../rpc/session.ts";
 import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
-import { EnvironmentRpcRequestObserver, request, runStream, subscribe } from "./client.ts";
+import {
+  EnvironmentRpcRequestObserver,
+  request,
+  runStream,
+  subscribe,
+  subscribeDynamic,
+} from "./client.ts";
 
 const TARGET = new PrimaryConnectionTarget({
   environmentId: EnvironmentId.make("environment-1"),
@@ -53,7 +60,9 @@ function session(client: WsRpcProtocolClient): RpcSession.RpcSession {
   };
 }
 
-const makeHarness = Effect.fn("TestEnvironmentRpc.makeHarness")(function* () {
+const makeHarness = Effect.fn("TestEnvironmentRpc.makeHarness")(function* (options?: {
+  readonly retryNow?: Effect.Effect<void>;
+}) {
   const state = yield* SubscriptionRef.make<SupervisorConnectionState>(AVAILABLE_CONNECTION_STATE);
   const activeSession = yield* SubscriptionRef.make<Option.Option<RpcSession.RpcSession>>(
     Option.none(),
@@ -67,7 +76,7 @@ const makeHarness = Effect.fn("TestEnvironmentRpc.makeHarness")(function* () {
     prepared,
     connect: Effect.void,
     disconnect: Effect.void,
-    retryNow: Ref.update(retryCount, (count) => count + 1),
+    retryNow: options?.retryNow ?? Ref.update(retryCount, (count) => count + 1),
   } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
   return {
     activeSession,
@@ -304,6 +313,96 @@ describe("environment RPC", () => {
       yield* Fiber.interrupt(relayFiber);
 
       expect(yield* Ref.get(retryCount)).toBe(1);
+    }),
+  );
+
+  it.effect("ignores a transport failure from a session that has already been replaced", () =>
+    Effect.gen(function* () {
+      const failingClient = {
+        [WS_METHODS.subscribeTerminalEvents]: () =>
+          Stream.fail(
+            new RpcClientError.RpcClientError({
+              reason: new RpcClientError.RpcClientDefect({
+                message: "stale socket closed",
+                cause: new Error("stale socket closed"),
+              }),
+            }),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const replacementClient = {
+        [WS_METHODS.subscribeTerminalEvents]: () => Stream.never,
+      } as unknown as WsRpcProtocolClient;
+      const staleSession = session(failingClient);
+      const replacementSession = session(replacementClient);
+      const { activeSession, retryCount, supervisor } = yield* makeHarness();
+
+      const subscriptionFiber = yield* subscribeDynamic(
+        WS_METHODS.subscribeTerminalEvents,
+        (current) =>
+          current === staleSession
+            ? SubscriptionRef.set(activeSession, Option.some(replacementSession)).pipe(
+                Effect.as({}),
+              )
+            : Effect.succeed({}),
+      ).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+      yield* SubscriptionRef.set(activeSession, Option.some(staleSession));
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      yield* Fiber.interrupt(subscriptionFiber);
+
+      expect(yield* Ref.get(retryCount)).toBe(0);
+    }),
+  );
+
+  it.effect("allows recovery to retry when a same-session resubscribe interrupts the signal", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const blockRecovery = yield* Deferred.make<void>();
+      const resubscribe = yield* Queue.unbounded<void>();
+      const failingClient = {
+        [WS_METHODS.subscribeTerminalEvents]: () =>
+          Stream.fail(
+            new RpcClientError.RpcClientError({
+              reason: new RpcClientError.RpcClientDefect({
+                message: "socket closed",
+                cause: new Error("socket closed"),
+              }),
+            }),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const { activeSession, supervisor } = yield* makeHarness({
+        retryNow: Ref.update(attempts, (count) => count + 1).pipe(
+          Effect.andThen(Deferred.await(blockRecovery)),
+        ),
+      });
+
+      const subscriptionFiber = yield* subscribe(
+        WS_METHODS.subscribeTerminalEvents,
+        {},
+        {
+          resubscribe: Stream.fromQueue(resubscribe),
+        },
+      ).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+      yield* SubscriptionRef.set(activeSession, Option.some(session(failingClient)));
+      for (let attempt = 0; attempt < 100 && (yield* Ref.get(attempts)) < 1; attempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      yield* Queue.offer(resubscribe, undefined);
+      for (let attempt = 0; attempt < 100 && (yield* Ref.get(attempts)) < 2; attempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      yield* Fiber.interrupt(subscriptionFiber);
+
+      expect(yield* Ref.get(attempts)).toBe(2);
     }),
   );
 

--- a/packages/client-runtime/src/rpc/client.test.ts
+++ b/packages/client-runtime/src/rpc/client.test.ts
@@ -227,7 +227,83 @@ describe("environment RPC", () => {
       yield* Fiber.interrupt(subscriptionFiber);
 
       expect(subscriptions).toEqual(["first", "second"]);
-      expect(yield* Ref.get(retryCount)).toBe(0);
+      // The transport failure asks the supervisor for a new session. Nothing
+      // else guarantees one arrives: the supervisor replaces a session only
+      // when the socket reports closed or an `application-active` probe fails,
+      // so a stream that dies while the session stays usable would otherwise
+      // never resubscribe.
+      expect(yield* Ref.get(retryCount)).toBe(1);
+    }),
+  );
+
+  it.effect("asks the supervisor to reconnect when a subscription loses its transport", () =>
+    Effect.gen(function* () {
+      const client = {
+        [WS_METHODS.subscribeTerminalEvents]: () =>
+          Stream.fail(
+            new RpcClientError.RpcClientError({
+              reason: new RpcClientError.RpcClientDefect({
+                message: "socket closed",
+                cause: new Error("socket closed"),
+              }),
+            }),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const { activeSession, retryCount, supervisor } = yield* makeHarness();
+
+      const subscriptionFiber = yield* subscribe(WS_METHODS.subscribeTerminalEvents, {}).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+      yield* SubscriptionRef.set(activeSession, Option.some(session(client)));
+      for (let attempt = 0; attempt < 100 && (yield* Ref.get(retryCount)) < 1; attempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      yield* Fiber.interrupt(subscriptionFiber);
+
+      expect(yield* Ref.get(retryCount)).toBe(1);
+    }),
+  );
+
+  it.effect("asks once when several subscriptions lose the same session", () =>
+    Effect.gen(function* () {
+      // A dead transport takes every subscription for the environment at once.
+      // Each `retryNow` aborts an in-flight establishment attempt, so asking
+      // once per subscription would stall the reconnect it is trying to cause.
+      const failing = () =>
+        Stream.fail(
+          new RpcClientError.RpcClientError({
+            reason: new RpcClientError.RpcClientDefect({
+              message: "socket closed",
+              cause: new Error("socket closed"),
+            }),
+          }),
+        );
+      const client = {
+        [WS_METHODS.subscribeTerminalEvents]: failing,
+        [WS_METHODS.subscribeServerLifecycle]: failing,
+      } as unknown as WsRpcProtocolClient;
+      const { activeSession, retryCount, supervisor } = yield* makeHarness();
+
+      const terminalFiber = yield* subscribe(WS_METHODS.subscribeTerminalEvents, {}).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+      const relayFiber = yield* subscribe(WS_METHODS.subscribeServerLifecycle, {}).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+      yield* SubscriptionRef.set(activeSession, Option.some(session(client)));
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      yield* Fiber.interrupt(terminalFiber);
+      yield* Fiber.interrupt(relayFiber);
+
+      expect(yield* Ref.get(retryCount)).toBe(1);
     }),
   );
 

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -161,19 +161,36 @@ export function runStream<TTag extends EnvironmentStreamCommandRpcTag>(
  * describes, and so a later session can be reported in its own right.
  */
 const sessionsReportedBroken = new WeakSet<RpcSession>();
+const sessionsRequestingRecovery = new WeakSet<RpcSession>();
 
-function requestSessionRecovery(
+const requestSessionRecovery = Effect.fn("EnvironmentRpc.requestSessionRecovery")(function* (
   supervisor: EnvironmentSupervisor["Service"],
   session: RpcSession,
-): Effect.Effect<void> {
-  return Effect.suspend(() => {
-    if (sessionsReportedBroken.has(session)) {
+) {
+  const current = yield* SubscriptionRef.get(supervisor.session);
+  if (!Option.isSome(current) || current.value !== session) {
+    return;
+  }
+
+  return yield* Effect.suspend(() => {
+    if (sessionsReportedBroken.has(session) || sessionsRequestingRecovery.has(session)) {
       return Effect.void;
     }
-    sessionsReportedBroken.add(session);
-    return supervisor.retryNow;
+    sessionsRequestingRecovery.add(session);
+    return supervisor.retryNow.pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          sessionsReportedBroken.add(session);
+        }),
+      ),
+      Effect.ensuring(
+        Effect.sync(() => {
+          sessionsRequestingRecovery.delete(session);
+        }),
+      ),
+    );
   });
-}
+});
 
 interface SubscriptionOptions<TTag extends EnvironmentSubscriptionRpcTag> {
   readonly onExpectedFailure?: (

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -148,6 +148,33 @@ export function runStream<TTag extends EnvironmentStreamCommandRpcTag>(
   );
 }
 
+/**
+ * Sessions already reported as broken, so a burst of subscription failures
+ * asks the supervisor to reconnect once rather than once per subscription.
+ *
+ * An environment carries many durable subscriptions (the shell, the thread
+ * list, every open thread), and a dead transport tends to take all of them at
+ * the same moment. Each `retryNow` is a signal the supervisor acts on, and a
+ * signal delivered mid-establishment aborts that attempt -- so N unfiltered
+ * requests would abort N reconnects and stall recovery exactly when it is
+ * needed. Keyed on the session object so the entry dies with the session it
+ * describes, and so a later session can be reported in its own right.
+ */
+const sessionsReportedBroken = new WeakSet<RpcSession>();
+
+function requestSessionRecovery(
+  supervisor: EnvironmentSupervisor["Service"],
+  session: RpcSession,
+): Effect.Effect<void> {
+  return Effect.suspend(() => {
+    if (sessionsReportedBroken.has(session)) {
+      return Effect.void;
+    }
+    sessionsReportedBroken.add(session);
+    return supervisor.retryNow;
+  });
+}
+
 interface SubscriptionOptions<TTag extends EnvironmentSubscriptionRpcTag> {
   readonly onExpectedFailure?: (
     cause: Cause.Cause<EnvironmentRpcStreamFailure<TTag>>,
@@ -209,14 +236,29 @@ export function subscribeDynamic<TTag extends EnvironmentSubscriptionRpcTag>(
                                     reason._tag === "Fail" && isRpcClientError(reason.error),
                                 );
                               if (isTransportFailure) {
+                                // Draining here defers to the next session, but
+                                // nothing else guarantees one arrives: the
+                                // supervisor only replaces a session when the
+                                // socket reports closed or an
+                                // `application-active` probe fails. A stream
+                                // that dies while the session stays usable --
+                                // a half-open socket, or a failure confined to
+                                // this stream -- would otherwise leave the
+                                // subscription dead for the lifetime of the
+                                // session, silently, while unary calls on that
+                                // same session keep working. Ask the supervisor
+                                // to re-establish so the drain is a handoff
+                                // rather than a dead end.
                                 return Stream.fromEffect(
                                   Effect.logWarning(
-                                    "Durable RPC subscription lost its transport; waiting for the next session.",
+                                    "Durable RPC subscription lost its transport; requesting a new session.",
                                     {
                                       cause: Cause.pretty(cause),
                                       method: tag,
                                       environmentId: supervisor.target.environmentId,
                                     },
+                                  ).pipe(
+                                    Effect.andThen(requestSessionRecovery(supervisor, session)),
                                   ),
                                 ).pipe(Stream.drain);
                               }


### PR DESCRIPTION
## What Changed

A durable subscription that fails with a transport-level `RpcClientError` now asks the supervisor to re-establish the session, instead of draining and waiting for a session that may never come.

Requests are coalesced per session via a `WeakSet` keyed on the session object, so a burst of subscription failures produces exactly one reconnect request.

## Why

`subscribeDynamic` handles a transport failure by logging and draining, deferring to "the next session". Nothing guarantees one arrives. `supervisor.session` is written only when a connection lease is established (`connection/supervisor.ts:532`) or cleared on teardown (`:243`), and the only liveness probe runs on an `application-active` wakeup — a desktop window that stays visible never health-checks its connection.

So a stream that dies while the session stays usable — a half-open socket (NAT idle timeout, sleep/resume, VPN flap, where no close is ever delivered), or a failure confined to that one stream — leaves the subscription dead for the lifetime of the session.

Nothing surfaces it. Unary RPCs on that same session keep working, so the app looks connected and commands still round-trip while the environment's state silently stops updating.

This was diagnosed from a case where client and server were on different machines, so both sides could be inspected independently (#4589). On one connection at one moment:

- ten `thread.settle` commands were accepted server-side, with receipts
- the pre-existing shell subscription was dead — a new thread created during the incident never appeared in the sidebar, though the server had it running
- a thread-detail subscription created *after* the failure worked fine

That asymmetry is the signature: the drain is per subscription stream, so `subscribeToSession()` runs fresh for anything started afterward while already-drained streams stay dead. A connection-level failure could not produce it — it would take out the new subscription too. Other clients against the same server were unaffected throughout.

The user-visible result is an environment frozen in place: threads stuck showing Working long after they finished, new threads missing from the sidebar, and lifecycle actions succeeding as no-ops against a stale view. Only restarting the client recovers it, because a restart is the one thing that makes a new session.

Note that the branch immediately below this one already retries within the same session when `retryExpectedFailureAfter` is set (`state/shell.ts` passes `"250 millis"`). Only the transport branch had no path back.

## Why coalesce

An environment carries many durable subscriptions — the shell, the thread list, every open thread — and a dead transport tends to take all of them at the same moment. Each `retryNow` is a signal the supervisor acts on, and a signal delivered mid-establishment aborts that attempt (`supervisor.ts:362-384`). N unfiltered requests would abort N reconnects and stall recovery exactly when it is needed. The regression test for this fails with `expected 2 to be 1` if the guard is removed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — no UI change
- [ ] I included a video for animation/interaction changes — n/a

---

One existing test changed its expectation. `"keeps durable subscriptions alive across a transport failure and new session"` asserted `retryCount === 0`, and passed only because the test manually supplies the replacement session that production has no way to produce. It now expects one request.

Validation (scoped per `AGENTS.md`, which reserves repo-wide `vp check` / `vp run typecheck` for CI):

```
vitest run packages/client-runtime/src/    # 473 passed
tsgo --noEmit                              # packages/client-runtime — clean
vp lint --report-unused-disable-directives # no findings in changed files
```

Not addressed here, both worth their own change: unary `request` (`rpc/client.ts:107`) has no timeout, so a call into a hung session never settles — which can latch an in-flight guard in the UI; and there is no periodic liveness probe, only the `application-active` one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection recovery for all durable environment subscriptions; incorrect coalescing or stale-session handling could over- or under-reconnect, but scope is limited to transport failures and is heavily tested.
> 
> **Overview**
> Durable RPC subscriptions that fail with a transport-level `RpcClientError` no longer only log and drain while hoping the supervisor swaps sessions. **`subscribeDynamic`** now calls **`requestSessionRecovery`**, which triggers **`supervisor.retryNow`** when the failing session is still the active one, so reconnect can happen even when the socket looks fine to unary calls.
> 
> Recovery is **coalesced per session** with `WeakSet` guards so many subscriptions dying together produce **one** reconnect signal; stale sessions and in-flight duplicates are ignored. Domain failures still do not reconnect.
> 
> Tests cover single and multi-subscription reconnect, stale-session filtering, resubscribe interrupting recovery, and the updated expectation that transport failure implies one `retryNow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5836f14b7815f0277d04ebfa8142162647d9195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `subscribeDynamic` to recover subscriptions that lose their transport
> - When an `RpcClient` subscription fails with a transport error, `subscribeDynamic` now calls `supervisor.retryNow` before draining to await the next session.
> - A new `requestSessionRecovery` effect coalesces recovery signals per session: only one `retryNow` is issued per broken session, and signals from already-replaced sessions are ignored.
> - New tests in [client.test.ts](https://github.com/pingdotgg/t3code/pull/4602/files#diff-cef86a2ddd8a877a388fe59d61004f3479209d6e8ea5e9b00a8fd025f43ac9ed) cover deduplication, stale-session filtering, and in-flight resubscription interleaving.
> - Behavioral Change: subscriptions that previously silently drained on transport loss now actively trigger supervisor reconnection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5836f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->