### PR TITLE
fix(shared): stop reporting "not a worktree" when .git cannot be read

### DIFF
--- a/packages/shared/src/devHome.test.ts
+++ b/packages/shared/src/devHome.test.ts
@@ -8,15 +8,27 @@ import * as Effect from "effect/Effect";
 
 import { resolveGitWorktreePath, resolveWorktreeT3Home } from "./devHome.ts";
 
+/**
+ * Denying read on the `.git` file only proves anything for a user the mode
+ * applies to. Root ignores it, and Windows has no equivalent, so the
+ * unreadable case is skipped rather than silently passing there.
+ */
+const canDenyReads = typeof process.getuid === "function" && process.getuid() !== 0;
+
 const makeRepo = (
   kind:
     | "worktree"
     | "checkout"
-    | "bare"
+    | "no-repo"
     | "submodule"
+    | "unparseable-git-file"
     | "unreadable-git-file"
     | "bare-repo-worktree"
-    | "custom-common-dir-worktree",
+    | "custom-common-dir-worktree"
+    | "relative-worktree"
+    | "windows-worktree"
+    | "shallow-gitdir"
+    | "nested-checkout",
 ) =>
   Effect.acquireRelease(
     Effect.sync(() => {
@@ -29,18 +41,45 @@ const makeRepo = (
       } else if (kind === "custom-common-dir-worktree") {
         // $GIT_COMMON_DIR need not be named `.git` at all.
         NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: /srv/store/worktrees/x\n");
+      } else if (kind === "relative-worktree") {
+        // git >= 2.48 with `worktree.useRelativePaths` writes a relative pointer.
+        NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: ../.git/worktrees/x\n");
+      } else if (kind === "windows-worktree") {
+        NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: C:\\repo\\.git\\worktrees\\x\n");
+      } else if (kind === "shallow-gitdir") {
+        // Nothing precedes `worktrees`, so there is no common dir to speak of.
+        NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: worktrees/x\n");
       } else if (kind === "submodule") {
         NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: ../.git/modules/sub\n");
-      } else if (kind === "unreadable-git-file") {
+      } else if (kind === "unparseable-git-file") {
         NodeFS.writeFileSync(NodePath.join(root, ".git"), "not a gitdir pointer\n");
+      } else if (kind === "unreadable-git-file") {
+        const gitPath = NodePath.join(root, ".git");
+        NodeFS.writeFileSync(gitPath, "gitdir: /elsewhere/.git/worktrees/x\n");
+        NodeFS.chmodSync(gitPath, 0o000);
       } else if (kind === "checkout") {
         NodeFS.mkdirSync(NodePath.join(root, ".git"));
       }
       const nested = NodePath.join(root, "apps", "web", "src");
       NodeFS.mkdirSync(nested, { recursive: true });
+      if (kind === "nested-checkout") {
+        // A worktree that contains a second, unrelated repository. Walking up
+        // from inside the inner one must stop there, not adopt the outer root.
+        NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: /elsewhere/.git/worktrees/x\n");
+        NodeFS.mkdirSync(NodePath.join(root, "apps", "web", ".git"));
+      }
       return { root, nested };
     }),
-    ({ root }) => Effect.sync(() => NodeFS.rmSync(root, { recursive: true, force: true })),
+    ({ root }) =>
+      Effect.sync(() => {
+        // Restore read permission first: a 0o000 file is still removable, but
+        // only because the directory is writable — do not depend on that.
+        const gitPath = NodePath.join(root, ".git");
+        if (NodeFS.existsSync(gitPath) && NodeFS.statSync(gitPath).isFile()) {
+          NodeFS.chmodSync(gitPath, 0o600);
+        }
+        NodeFS.rmSync(root, { recursive: true, force: true });
+      }),
   );
 
 describe("resolveGitWorktreePath", () => {
@@ -60,7 +99,7 @@ describe("resolveGitWorktreePath", () => {
 
   it.effect("reports a directory outside a repository", () =>
     Effect.gen(function* () {
-      const { nested } = yield* makeRepo("bare");
+      const { nested } = yield* makeRepo("no-repo");
       assert.equal(yield* resolveGitWorktreePath(nested), undefined);
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
@@ -74,7 +113,7 @@ describe("resolveGitWorktreePath", () => {
 
   it.effect("reports a .git file without a usable gitdir pointer", () =>
     Effect.gen(function* () {
-      const { nested } = yield* makeRepo("unreadable-git-file");
+      const { nested } = yield* makeRepo("unparseable-git-file");
       assert.equal(yield* resolveGitWorktreePath(nested), undefined);
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
@@ -92,6 +131,47 @@ describe("resolveGitWorktreePath", () => {
       assert.equal(yield* resolveGitWorktreePath(nested), NodePath.resolve(root));
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
+
+  it.effect("finds a worktree from a relative gitdir pointer", () =>
+    Effect.gen(function* () {
+      const { root, nested } = yield* makeRepo("relative-worktree");
+      assert.equal(yield* resolveGitWorktreePath(nested), NodePath.resolve(root));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("finds a worktree from a Windows gitdir pointer", () =>
+    Effect.gen(function* () {
+      const { root, nested } = yield* makeRepo("windows-worktree");
+      assert.equal(yield* resolveGitWorktreePath(nested), NodePath.resolve(root));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("rejects a gitdir with nothing before `worktrees`", () =>
+    Effect.gen(function* () {
+      const { nested } = yield* makeRepo("shallow-gitdir");
+      assert.equal(yield* resolveGitWorktreePath(nested), undefined);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("stops at a repository nested inside a worktree", () =>
+    Effect.gen(function* () {
+      const { nested } = yield* makeRepo("nested-checkout");
+      assert.equal(yield* resolveGitWorktreePath(nested), undefined);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect.skipIf(!canDenyReads)(
+    "fails instead of reporting `not a worktree` when .git cannot be read",
+    () =>
+      Effect.gen(function* () {
+        const { nested } = yield* makeRepo("unreadable-git-file");
+        // The whole point: an unreadable pointer is not an answer. Reporting
+        // `undefined` would send the caller at the shared home and its live
+        // database, which is the outcome this module exists to prevent.
+        const error = yield* Effect.flip(resolveGitWorktreePath(nested));
+        assert.notEqual(error.reason._tag, "NotFound");
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
 });
 
 describe("resolveWorktreeT3Home", () => {
@@ -101,6 +181,21 @@ describe("resolveWorktreeT3Home", () => {
       const home = yield* resolveWorktreeT3Home(nested);
       assert.equal(home, NodePath.join(NodePath.resolve(root), ".t3"));
       assert.isFalse(NodeFS.existsSync(home ?? ""));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("answers with undefined outside a linked worktree", () =>
+    Effect.gen(function* () {
+      const { nested } = yield* makeRepo("checkout");
+      assert.equal(yield* resolveWorktreeT3Home(nested), undefined);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect.skipIf(!canDenyReads)("propagates an unreadable .git rather than falling back", () =>
+    Effect.gen(function* () {
+      const { nested } = yield* makeRepo("unreadable-git-file");
+      const error = yield* Effect.flip(resolveWorktreeT3Home(nested));
+      assert.notEqual(error.reason._tag, "NotFound");
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 });

--- a/packages/shared/src/devHome.ts
+++ b/packages/shared/src/devHome.ts
@@ -12,6 +12,18 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+
+/**
+ * A missing `.git` is the ordinary answer to "is this a worktree root?" — it
+ * means keep walking up. Any other failure is not evidence of absence: an
+ * unreadable file, a busy descriptor or a disconnected network mount all say
+ * "unknown", and answering "not a worktree" to unknown is precisely the
+ * outcome this module exists to prevent, because the caller then falls through
+ * to the shared home and its live database. Only absence is absence; the rest
+ * propagate.
+ */
+const isAbsent = (error: PlatformError.PlatformError): boolean => error.reason._tag === "NotFound";
 
 /**
  * A `.git` file points at the real git directory. A linked worktree's lives at
@@ -55,7 +67,11 @@ const pointsAtLinkedWorktree = (gitFileContents: string, path: Path.Path): boole
  */
 export const resolveGitWorktreePath = (
   cwd: string,
-): Effect.Effect<string | undefined, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<
+  string | undefined,
+  PlatformError.PlatformError,
+  FileSystem.FileSystem | Path.Path
+> =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -63,7 +79,10 @@ export const resolveGitWorktreePath = (
     let directory = path.resolve(cwd);
     for (;;) {
       const gitPath = path.join(directory, ".git");
-      const info = yield* fileSystem.stat(gitPath).pipe(Effect.option);
+      const info = yield* fileSystem.stat(gitPath).pipe(
+        Effect.map(Option.some),
+        Effect.catchIf(isAbsent, () => Effect.succeed(Option.none())),
+      );
       if (Option.isSome(info)) {
         // A directory means the main checkout. Stop either way: nesting one
         // repository inside another does not make the outer one this root.
@@ -71,10 +90,10 @@ export const resolveGitWorktreePath = (
           return undefined;
         }
         // A submodule also has a `.git` file, but it is not a worktree of this
-        // repository and gets no worktree-local home.
-        const contents = yield* fileSystem
-          .readFileString(gitPath)
-          .pipe(Effect.orElseSucceed(() => ""));
+        // repository and gets no worktree-local home. `stat` has already
+        // established the file is there, so a read failure here is a real
+        // fault rather than an answer — let it surface.
+        const contents = yield* fileSystem.readFileString(gitPath);
         return pointsAtLinkedWorktree(contents, path) ? directory : undefined;
       }
       const parent = path.dirname(directory);
@@ -92,7 +111,11 @@ export const resolveGitWorktreePath = (
  */
 export const resolveWorktreeT3Home = (
   cwd: string,
-): Effect.Effect<string | undefined, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<
+  string | undefined,
+  PlatformError.PlatformError,
+  FileSystem.FileSystem | Path.Path
+> =>
   Effect.gen(function* () {
     const worktreePath = yield* resolveGitWorktreePath(cwd);
     if (worktreePath === undefined) {


### PR DESCRIPTION
Follow-up to #4555. Found while reviewing that commit's behavior in a linked worktree.

## The problem

`resolveGitWorktreePath` swallows every filesystem failure:

```ts
const info = yield* fileSystem.stat(gitPath).pipe(Effect.option);
// ...
const contents = yield* fileSystem.readFileString(gitPath).pipe(Effect.orElseSucceed(() => ""));
```

`Effect.option` turns *any* `stat` error into `None`, so the walk continues upward. `orElseSucceed(() => "")` turns any read error into an empty string, which parses as "no gitdir pointer". Both paths answer `undefined` — *not a worktree*.

That answer isn't harmless in this module specifically. `resolveWorktreeT3Home`'s own docstring makes the argument:

> Deliberately does not require the directory to exist yet: falling back because it is missing **would send callers at the shared home**.

Right — and that's exactly what the error paths do. `dev-runner.ts` falls through to an ambient `T3CODE_HOME`, which `cli/config.ts` treats as an explicit base dir, which selects the `userdata` leaf. So an `EACCES` on a `.git` file, a transient `EBUSY`, or a stalled network mount quietly points a worktree dev server at `~/.t3/userdata` — the installed app's live database. The one outcome the module exists to prevent, reached through the one path that isn't guarded.

## The change

Distinguish absence from failure. Only a `NotFound` reason means "no `.git` here, keep walking":

```ts
const isAbsent = (error: PlatformError.PlatformError): boolean => error.reason._tag === "NotFound";
```

Everything else propagates, so the error channel becomes `PlatformError` instead of `never`. Once `stat` has established the file exists, a read failure is a fault rather than an answer, so `readFileString` propagates too.

`error.reason._tag === "NotFound"` matches existing precedent in the codebase — `DesktopSavedEnvironments.ts:250` and `relayClient.ts:150` do the same thing.

**The trade is deliberate and worth stating:** a dev server now refuses to start on an unreadable `.git` rather than starting against the wrong database. Failing loudly is recoverable; silently opening production state isn't. Happy to make it a warning-and-fall-back instead if you'd rather, but that reintroduces the hazard.

Only one production call site (`dev-runner.ts:514`), and the widened error channel typechecks through it without changes.

## Tests

The fixture named `"unreadable-git-file"` wrote a perfectly readable file containing `not a gitdir pointer` — that's the *unparseable* path. The genuinely unreadable case had no coverage at all. Renamed it, and added a real `chmod 000` case.

**Both new tests fail against the current implementation and pass against this one:**

```
 × resolveGitWorktreePath > fails instead of reporting `not a worktree` when .git cannot be read
 × resolveWorktreeT3Home > propagates an unreadable .git rather than falling back
   Tests  2 failed | 13 passed (15)
```

They're skipped where the mode proves nothing — running as root, and Windows, which has no equivalent — following the `it.live.skipIf` precedent in `orchestrationEngine.integration.test.ts`.

Also covered, all previously untested:

- **relative `gitdir:` pointers** — git ≥ 2.48 with `worktree.useRelativePaths`; the `path.normalize` call exists for this and nothing exercised it
- **Windows `gitdir:` pointers** — the sole reason `replaceAll("\\", "/")` exists
- **the `segments.length >= 3` boundary** — `gitdir: worktrees/x`
- **a repository nested inside a worktree** — the "nesting one repository inside another does not make the outer one this root" comment was documented but unguarded
- **`resolveWorktreeT3Home`'s negative case** — it had one test, and not the safety-relevant branch

Renamed the `"bare"` fixture to `"no-repo"`: it creates no `.git` at all, which read oddly next to `"bare-repo-worktree"`, which genuinely is the bare case.

## Verification

| Check | Result |
| --- | --- |
| `packages/shared` tests | 39 files, 302 tests, pass |
| `scripts` tests | 16 files, 152 tests, pass |
| `typecheck` (all 15 packages) | exit 0 |
| `lint` | exit 0, 0 errors |
| `fmt --check` | clean |

## Not addressed

`pointsAtLinkedWorktree` does `.replaceAll("\\", "/")` before `normalize`, which mangles a POSIX filename containing a literal backslash. Real but vanishingly unlikely, and fixing it properly means branching on platform — left alone rather than bundled into a correctness fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dev data-directory resolution so I/O errors block startup rather than silently using shared/live userdata; behavior change at the dev-runner call site but intentionally safer.
> 
> **Overview**
> **`resolveGitWorktreePath` / `resolveWorktreeT3Home` no longer turn `.git` I/O failures into “not a worktree”.** Only `NotFound` on `stat` continues the parent walk; permission errors, busy mounts, etc. fail the effect. After `stat` proves a `.git` file exists, `readFileString` errors propagate instead of being treated as an empty/unparseable pointer. Both exports now surface `PlatformError` on the error channel.
> 
> Tests split **unparseable** vs **unreadable** `.git` fixtures, add `chmod 000` coverage (skipped on root/Windows), and exercise relative/Windows `gitdir:` pointers, shallow `worktrees/x` paths, nested repos inside worktrees, plus `resolveWorktreeT3Home` fallbacks and error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb41383e37901601dac9182eb794bec1e826373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveGitWorktreePath` to propagate errors when `.git` exists but cannot be read
> - `resolveGitWorktreePath` previously swallowed read errors on `.git`, which could silently report a directory as "not a worktree". It now propagates any non-`NotFound` `PlatformError` instead of returning `undefined`.
> - `resolveWorktreeT3Home` inherits this behavior and will also fail with a `PlatformError` when `.git` is unreadable.
> - A new `isAbsent` helper in [devHome.ts](https://github.com/pingdotgg/t3code/pull/4603/files#diff-77ea98aaec3bbe7740817fc180fa324901af50b98efee5617284c8deaaf9a40b) distinguishes `NotFound` errors (treated as absence) from other failures (propagated).
> - Tests in [devHome.test.ts](https://github.com/pingdotgg/t3code/pull/4603/files#diff-62ba2dbb7ca5ee76582382442eafd51423683f10c3f3c30d13453cae844ee0fa) are extended to cover relative/Windows gitdir pointers, shallow gitdir rejection, nested repo boundaries, and unreadable `.git` propagation; unreadable-file tests are skipped when the platform cannot enforce file permissions.
> - Behavioral Change: callers of `resolveGitWorktreePath` and `resolveWorktreeT3Home` must now handle `PlatformError` failures where they previously never failed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bb4138.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->