### PR TITLE
Fix quadratic thread-reopen replay: batch client apply + cap server resume gap

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -40,6 +40,9 @@ const failSetConfigOption = process.env.T3_ACP_FAIL_SET_CONFIG_OPTION === "1";
 const exitOnSetConfigOption = process.env.T3_ACP_EXIT_ON_SET_CONFIG_OPTION === "1";
 const promptResponseText = process.env.T3_ACP_PROMPT_RESPONSE_TEXT;
 const promptDelayMs = Number(process.env.T3_ACP_PROMPT_DELAY_MS ?? "0");
+const promptResponseChunkCount = Number(process.env.T3_ACP_PROMPT_RESPONSE_CHUNK_COUNT ?? "0");
+const promptResponseChunkText = process.env.T3_ACP_PROMPT_RESPONSE_CHUNK_TEXT;
+const promptChunkDelayMs = Number(process.env.T3_ACP_PROMPT_CHUNK_DELAY_MS ?? "0");
 const permissionOptionIds = {
   allowOnce: process.env.T3_ACP_ALLOW_ONCE_OPTION_ID ?? "allow-once",
   allowAlways: process.env.T3_ACP_ALLOW_ALWAYS_OPTION_ID ?? "allow-always",
@@ -864,6 +867,28 @@ const program = Effect.gen(function* () {
           ],
         },
       });
+
+      if (Number.isFinite(promptResponseChunkCount) && promptResponseChunkCount > 0) {
+        // Emit the response as many small chunks to reproduce heavy streaming
+        // histories: with the `enableAssistantStreaming` server setting on,
+        // each chunk persists as its own `thread.message-sent` delta event.
+        for (let index = 0; index < promptResponseChunkCount; index += 1) {
+          yield* agent.client.sessionUpdate({
+            sessionId: requestedSessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: {
+                type: "text",
+                text: promptResponseChunkText ?? `chunk ${index} of a long streamed response. `,
+              },
+            },
+          });
+          if (Number.isFinite(promptChunkDelayMs) && promptChunkDelayMs > 0) {
+            yield* Effect.sleep(`${promptChunkDelayMs} millis`);
+          }
+        }
+        return { stopReason: "end_turn" };
+      }
 
       yield* agent.client.sessionUpdate({
         sessionId: requestedSessionId,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5899,6 +5899,51 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("subscribeThread sends a fresh snapshot instead of replaying a large gap", () =>
+    Effect.gen(function* () {
+      let readEventsCalls = 0;
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            // Head is far ahead of the client's afterSequence (gap > 1000).
+            latestSequence: Effect.succeed(100_000),
+            readEvents: () =>
+              Stream.sync(() => {
+                readEventsCalls += 1;
+                return {} as OrchestrationEvent;
+              }),
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.succeed(Option.some({ snapshotSequence: 100_000, thread })),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const items = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+            afterSequence: 5,
+            requestCompletionMarker: true,
+          }).pipe(Stream.take(2), Stream.runCollect),
+        ),
+      );
+
+      const [first, second] = Array.from(items);
+      // Large gap => fresh snapshot, and the unbounded replay is never started.
+      assert.equal(first?.kind, "snapshot");
+      if (first?.kind === "snapshot") {
+        assert.equal(first.snapshot.thread.id, thread.id);
+      }
+      assert.deepEqual(second, { kind: "synchronized" });
+      assert.equal(readEventsCalls, 0);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("subscribeShell replaces a cursor ahead of the authoritative head", () =>
     Effect.gen(function* () {
       let readEventsCalls = 0;

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -298,6 +298,13 @@ const PROVIDER_STATUS_DEBOUNCE_MS = 200;
 // Matches the event store's default page size (DEFAULT_READ_FROM_SEQUENCE_LIMIT).
 const SHELL_RESUME_MAX_GAP = 1_000;
 
+// Resuming a thread subscription replays every persisted event after the
+// client's cursor. Past this gap a single snapshot is cheaper than streaming
+// (and having the client fold) thousands of events — long agentic turns
+// persist one thread.activity-appended per tool transition, so a thread left
+// overnight can easily accumulate several thousand.
+const THREAD_RESUME_MAX_GAP = 1_000;
+
 const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [ORCHESTRATION_WS_METHODS.dispatchCommand, AuthOrchestrationOperateScope],
   [ORCHESTRATION_WS_METHODS.getTurnDiff, AuthOrchestrationReadScope],
@@ -1401,38 +1408,47 @@ const makeWsRpcLayer = (
               // catch-up followed by the buffered/ongoing live events. Overlapping
               // events are deduped by sequence on the client.
               //
-              // Read the full range after the cursor (not the store's default
-              // page-bounded limit): the range is normally tiny (a fresh HTTP
-              // snapshot sequence) and the per-thread filter runs after reading,
-              // so a global cap could otherwise omit this thread's events.
+              // Read the exact range from the cursor through the head captured
+              // below (not the store's default page-bounded limit): the
+              // per-thread filter runs after reading, so a global cap could
+              // otherwise omit this thread's events.
+              //
+              // When the cursor is too far behind (or ahead of this engine's
+              // authoritative state), fall through to a fresh snapshot instead
+              // of replaying an unbounded backlog — mirroring the shell
+              // stream's SHELL_RESUME_MAX_GAP fallback.
               if (input.afterSequence !== undefined) {
                 const afterSequence = input.afterSequence;
-                const catchUpStream = orchestrationEngine
-                  .readEvents(afterSequence, Number.MAX_SAFE_INTEGER)
-                  .pipe(
-                    Stream.filter(isThisThreadDetailEvent),
-                    Stream.map((event) => ({
-                      kind: "event" as const,
-                      event: projectActivityEvent(event),
-                    })),
-                    Stream.mapError(
-                      (cause) =>
-                        new OrchestrationGetSnapshotError({
-                          message: `Failed to replay thread ${input.threadId} events`,
-                          cause,
-                        }),
-                    ),
-                  );
-                const afterCatchUp =
-                  input.requestCompletionMarker === true
-                    ? Stream.concat(
-                        Stream.fromEffect(
-                          Queue.offer(liveBuffer, { kind: "synchronized" as const }),
-                        ).pipe(Stream.drain),
-                        bufferedLiveStream,
-                      )
-                    : bufferedLiveStream;
-                return Stream.concat(catchUpStream, afterCatchUp);
+                const headSequence = yield* orchestrationEngine.latestSequence;
+                const replayGap = headSequence - afterSequence;
+                if (replayGap >= 0 && replayGap <= THREAD_RESUME_MAX_GAP) {
+                  const catchUpStream = orchestrationEngine
+                    .readEvents(afterSequence, replayGap)
+                    .pipe(
+                      Stream.filter(isThisThreadDetailEvent),
+                      Stream.map((event) => ({
+                        kind: "event" as const,
+                        event: projectActivityEvent(event),
+                      })),
+                      Stream.mapError(
+                        (cause) =>
+                          new OrchestrationGetSnapshotError({
+                            message: `Failed to replay thread ${input.threadId} events`,
+                            cause,
+                          }),
+                      ),
+                    );
+                  const afterCatchUp =
+                    input.requestCompletionMarker === true
+                      ? Stream.concat(
+                          Stream.fromEffect(
+                            Queue.offer(liveBuffer, { kind: "synchronized" as const }),
+                          ).pipe(Stream.drain),
+                          bufferedLiveStream,
+                        )
+                      : bufferedLiveStream;
+                  return Stream.concat(catchUpStream, afterCatchUp);
+                }
               }
 
               const snapshot = yield* projectionSnapshotQuery

--- a/apps/web/perf.html
+++ b/apps/web/perf.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Thread Replay Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/perf/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -225,6 +225,12 @@ import { DraftHeroHeadline } from "./chat/DraftHeroHeadline";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
+import {
+  deriveDisplayServerMessages,
+  deriveRevertTurnCountByUserMessageId,
+  deriveTimelineMessages,
+  deriveTurnDiffSummaryByAssistantMessageId,
+} from "./chat/threadTimelineModel";
 import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
@@ -2138,21 +2144,10 @@ function ChatViewContent(props: ChatViewProps) {
       ),
     [serverAttachmentIds, serverAttachmentUrls],
   );
-  const displayServerMessages = useMemo<ReadonlyArray<ChatMessage>>(() => {
-    if (!serverMessages) return [];
-    return serverMessages.map((message) => {
-      if (!message.attachments || message.attachments.length === 0) {
-        return message;
-      }
-      return {
-        ...message,
-        attachments: message.attachments.map((attachment) => {
-          const previewUrl = serverAttachmentUrlById.get(attachment.id);
-          return previewUrl ? { ...attachment, previewUrl } : attachment;
-        }),
-      };
-    });
-  }, [serverAttachmentUrlById, serverMessages]);
+  const displayServerMessages = useMemo<ReadonlyArray<ChatMessage>>(
+    () => deriveDisplayServerMessages(serverMessages, serverAttachmentUrlById),
+    [serverAttachmentUrlById, serverMessages],
+  );
   useEffect(() => {
     if (typeof Image === "undefined" || displayServerMessages.length === 0) {
       return;
@@ -2237,58 +2232,15 @@ function ChatViewContent(props: ChatViewProps) {
       }
     };
   }, [attachmentPreviewHandoffByMessageId, clearAttachmentPreviewHandoff, displayServerMessages]);
-  const timelineMessages = useMemo(() => {
-    const messages = displayServerMessages;
-    const serverMessagesWithPreviewHandoff =
-      Object.keys(attachmentPreviewHandoffByMessageId).length === 0
-        ? messages
-        : // Spread only fires for the few messages that actually changed;
-          // unchanged ones early-return their original reference.
-          // In-place mutation would break React's immutable state contract.
-          messages.map((message) => {
-            if (
-              message.role !== "user" ||
-              !message.attachments ||
-              message.attachments.length === 0
-            ) {
-              return message;
-            }
-            const handoffPreviewUrls = attachmentPreviewHandoffByMessageId[message.id];
-            if (!handoffPreviewUrls || handoffPreviewUrls.length === 0) {
-              return message;
-            }
-
-            let changed = false;
-            let imageIndex = 0;
-            const attachments = message.attachments.map((attachment) => {
-              if (attachment.type !== "image") {
-                return attachment;
-              }
-              const handoffPreviewUrl = handoffPreviewUrls[imageIndex];
-              imageIndex += 1;
-              if (!handoffPreviewUrl || attachment.previewUrl === handoffPreviewUrl) {
-                return attachment;
-              }
-              changed = true;
-              return {
-                ...attachment,
-                previewUrl: handoffPreviewUrl,
-              };
-            });
-
-            return changed ? { ...message, attachments } : message;
-          });
-
-    if (optimisticUserMessages.length === 0) {
-      return serverMessagesWithPreviewHandoff;
-    }
-    const serverIds = new Set(serverMessagesWithPreviewHandoff.map((message) => message.id));
-    const pendingMessages = optimisticUserMessages.filter((message) => !serverIds.has(message.id));
-    if (pendingMessages.length === 0) {
-      return serverMessagesWithPreviewHandoff;
-    }
-    return [...serverMessagesWithPreviewHandoff, ...pendingMessages];
-  }, [attachmentPreviewHandoffByMessageId, displayServerMessages, optimisticUserMessages]);
+  const timelineMessages = useMemo(
+    () =>
+      deriveTimelineMessages({
+        displayServerMessages,
+        attachmentPreviewHandoffByMessageId,
+        optimisticUserMessages,
+      }),
+    [attachmentPreviewHandoffByMessageId, displayServerMessages, optimisticUserMessages],
+  );
   const timelineEntries = useMemo(
     () =>
       deriveTimelineEntries(timelineMessages, activeThread?.proposedPlans ?? [], workLogEntries),
@@ -2306,46 +2258,19 @@ function ChatViewContent(props: ChatViewProps) {
   ] = useDraftHeroLayoutTransition(isDraftHeroState);
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
-  const turnDiffSummaryByAssistantMessageId = useMemo(() => {
-    const byMessageId = new Map<MessageId, TurnDiffSummary>();
-    for (const summary of turnDiffSummaries) {
-      if (!summary.assistantMessageId) continue;
-      byMessageId.set(summary.assistantMessageId, summary);
-    }
-    return byMessageId;
-  }, [turnDiffSummaries]);
-  const revertTurnCountByUserMessageId = useMemo(() => {
-    const byUserMessageId = new Map<MessageId, number>();
-    for (let index = 0; index < timelineEntries.length; index += 1) {
-      const entry = timelineEntries[index];
-      if (!entry || entry.kind !== "message" || entry.message.role !== "user") {
-        continue;
-      }
-
-      for (let nextIndex = index + 1; nextIndex < timelineEntries.length; nextIndex += 1) {
-        const nextEntry = timelineEntries[nextIndex];
-        if (!nextEntry || nextEntry.kind !== "message") {
-          continue;
-        }
-        if (nextEntry.message.role === "user") {
-          break;
-        }
-        const summary = turnDiffSummaryByAssistantMessageId.get(nextEntry.message.id);
-        if (!summary) {
-          continue;
-        }
-        const turnCount =
-          summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId];
-        if (typeof turnCount !== "number") {
-          break;
-        }
-        byUserMessageId.set(entry.message.id, Math.max(0, turnCount - 1));
-        break;
-      }
-    }
-
-    return byUserMessageId;
-  }, [inferredCheckpointTurnCountByTurnId, timelineEntries, turnDiffSummaryByAssistantMessageId]);
+  const turnDiffSummaryByAssistantMessageId = useMemo(
+    () => deriveTurnDiffSummaryByAssistantMessageId(turnDiffSummaries),
+    [turnDiffSummaries],
+  );
+  const revertTurnCountByUserMessageId = useMemo(
+    () =>
+      deriveRevertTurnCountByUserMessageId({
+        timelineEntries,
+        turnDiffSummaryByAssistantMessageId,
+        inferredCheckpointTurnCountByTurnId,
+      }),
+    [inferredCheckpointTurnCountByTurnId, timelineEntries, turnDiffSummaryByAssistantMessageId],
+  );
 
   const gitCwd = activeProject
     ? projectScriptCwd({

--- a/apps/web/src/components/chat/threadTimelineModel.ts
+++ b/apps/web/src/components/chat/threadTimelineModel.ts
@@ -1,0 +1,149 @@
+import type { MessageId, TurnId } from "@t3tools/contracts";
+
+import type { TimelineEntry } from "../../session-logic";
+import type { ChatMessage, TurnDiffSummary } from "../../types";
+
+/**
+ * Pure derivation steps that turn thread detail state into the inputs of
+ * MessagesTimeline. Extracted from ChatView so the pipeline can run outside
+ * the full app shell (perf harnesses, tests) and so its per-update cost is
+ * visible in one place: every function here re-runs on every thread state
+ * publication, including once per replayed streaming delta event.
+ */
+
+/** Swaps message attachment previews to resolved asset URLs when available. */
+export function deriveDisplayServerMessages(
+  serverMessages: ReadonlyArray<ChatMessage> | undefined,
+  attachmentPreviewUrlById: ReadonlyMap<string, string>,
+): ReadonlyArray<ChatMessage> {
+  if (!serverMessages) return [];
+  return serverMessages.map((message) => {
+    if (!message.attachments || message.attachments.length === 0) {
+      return message;
+    }
+    return {
+      ...message,
+      attachments: message.attachments.map((attachment) => {
+        const previewUrl = attachmentPreviewUrlById.get(attachment.id);
+        return previewUrl ? { ...attachment, previewUrl } : attachment;
+      }),
+    };
+  });
+}
+
+/**
+ * Overlays local attachment preview handoffs onto server messages and appends
+ * optimistic user messages the server has not echoed back yet.
+ */
+export function deriveTimelineMessages({
+  displayServerMessages,
+  attachmentPreviewHandoffByMessageId,
+  optimisticUserMessages,
+}: {
+  displayServerMessages: ReadonlyArray<ChatMessage>;
+  attachmentPreviewHandoffByMessageId: Record<string, string[]>;
+  optimisticUserMessages: ReadonlyArray<ChatMessage>;
+}): ReadonlyArray<ChatMessage> {
+  const messages = displayServerMessages;
+  const serverMessagesWithPreviewHandoff =
+    Object.keys(attachmentPreviewHandoffByMessageId).length === 0
+      ? messages
+      : // Spread only fires for the few messages that actually changed;
+        // unchanged ones early-return their original reference.
+        // In-place mutation would break React's immutable state contract.
+        messages.map((message) => {
+          if (message.role !== "user" || !message.attachments || message.attachments.length === 0) {
+            return message;
+          }
+          const handoffPreviewUrls = attachmentPreviewHandoffByMessageId[message.id];
+          if (!handoffPreviewUrls || handoffPreviewUrls.length === 0) {
+            return message;
+          }
+
+          let changed = false;
+          let imageIndex = 0;
+          const attachments = message.attachments.map((attachment) => {
+            if (attachment.type !== "image") {
+              return attachment;
+            }
+            const handoffPreviewUrl = handoffPreviewUrls[imageIndex];
+            imageIndex += 1;
+            if (!handoffPreviewUrl || attachment.previewUrl === handoffPreviewUrl) {
+              return attachment;
+            }
+            changed = true;
+            return {
+              ...attachment,
+              previewUrl: handoffPreviewUrl,
+            };
+          });
+
+          return changed ? { ...message, attachments } : message;
+        });
+
+  if (optimisticUserMessages.length === 0) {
+    return serverMessagesWithPreviewHandoff;
+  }
+  const serverIds = new Set(serverMessagesWithPreviewHandoff.map((message) => message.id));
+  const pendingMessages = optimisticUserMessages.filter((message) => !serverIds.has(message.id));
+  if (pendingMessages.length === 0) {
+    return serverMessagesWithPreviewHandoff;
+  }
+  return [...serverMessagesWithPreviewHandoff, ...pendingMessages];
+}
+
+export function deriveTurnDiffSummaryByAssistantMessageId(
+  turnDiffSummaries: ReadonlyArray<TurnDiffSummary>,
+): Map<MessageId, TurnDiffSummary> {
+  const byMessageId = new Map<MessageId, TurnDiffSummary>();
+  for (const summary of turnDiffSummaries) {
+    if (!summary.assistantMessageId) continue;
+    byMessageId.set(summary.assistantMessageId, summary);
+  }
+  return byMessageId;
+}
+
+/**
+ * For each user message, the checkpoint turn count of the first following
+ * assistant message that has a turn diff summary.
+ */
+export function deriveRevertTurnCountByUserMessageId({
+  timelineEntries,
+  turnDiffSummaryByAssistantMessageId,
+  inferredCheckpointTurnCountByTurnId,
+}: {
+  timelineEntries: ReadonlyArray<TimelineEntry>;
+  turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
+  inferredCheckpointTurnCountByTurnId: Record<TurnId, number>;
+}): Map<MessageId, number> {
+  const byUserMessageId = new Map<MessageId, number>();
+  for (let index = 0; index < timelineEntries.length; index += 1) {
+    const entry = timelineEntries[index];
+    if (!entry || entry.kind !== "message" || entry.message.role !== "user") {
+      continue;
+    }
+
+    for (let nextIndex = index + 1; nextIndex < timelineEntries.length; nextIndex += 1) {
+      const nextEntry = timelineEntries[nextIndex];
+      if (!nextEntry || nextEntry.kind !== "message") {
+        continue;
+      }
+      if (nextEntry.message.role === "user") {
+        break;
+      }
+      const summary = turnDiffSummaryByAssistantMessageId.get(nextEntry.message.id);
+      if (!summary) {
+        continue;
+      }
+      const turnCount =
+        summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId];
+      if (typeof turnCount !== "number") {
+        break;
+      }
+      byUserMessageId.set(entry.message.id, Math.max(0, turnCount - 1));
+      break;
+    }
+  }
+
+  return byUserMessageId;
+}

--- a/apps/web/src/perf/ThreadReplayPlayground.tsx
+++ b/apps/web/src/perf/ThreadReplayPlayground.tsx
@@ -40,6 +40,9 @@ import { deriveTimelineEntries, deriveWorkLogEntries } from "../session-logic";
  *
  * Query params:
  *   deltas  — number of streaming delta events to replay (default 2000)
+ *   activities — number of thread.activity-appended (tool) events interleaved
+ *             with the deltas (default 0); real agentic threads are dominated
+ *             by these even with assistant streaming off
  *   batch   — events applied per state publication (default 1 = today's
  *             behavior; raise to preview what client-side batching buys)
  *   history — settled message pairs present before the streaming one (default 8)
@@ -136,34 +139,80 @@ function makeBaseThread(historyPairs: number): OrchestrationThread {
   };
 }
 
-function makeDeltaEvents(count: number, historyPairs: number, withCode: boolean) {
+function makeDeltaEvents(
+  count: number,
+  activityCount: number,
+  historyPairs: number,
+  withCode: boolean,
+) {
   const streamStartSeconds = historyPairs * 60 + 5;
-  return Array.from(
-    { length: count },
-    (_, index) =>
-      ({
-        eventId: EventId.make(`event-delta-${index}`),
+  const events: OrchestrationEvent[] = [];
+  const total = count + activityCount;
+  let textIndex = 0;
+  let activityIndex = 0;
+  // Interleave text deltas and tool activities evenly, mirroring the event
+  // mix of real agentic threads (which are dominated by
+  // thread.activity-appended even with assistant streaming off).
+  for (let index = 0; index < total; index += 1) {
+    const occurredAt = isoAt(streamStartSeconds + index);
+    const emitActivity =
+      activityIndex < activityCount &&
+      (textIndex >= count || activityIndex / activityCount <= textIndex / count);
+    if (emitActivity) {
+      const toolCall = Math.floor(activityIndex / 2);
+      const started = activityIndex % 2 === 0;
+      events.push({
+        eventId: EventId.make(`event-activity-${activityIndex}`),
         sequence: index + 1,
-        occurredAt: isoAt(streamStartSeconds + index),
+        occurredAt,
         commandId: null,
         causationEventId: null,
         correlationId: null,
         metadata: {},
         aggregateKind: "thread",
         aggregateId: THREAD_ID,
-        type: "thread.message-sent",
+        type: "thread.activity-appended",
         payload: {
           threadId: THREAD_ID,
-          messageId: STREAMING_MESSAGE_ID,
-          role: "assistant",
-          text: chunkText(index, withCode),
-          turnId: STREAMING_TURN_ID,
-          streaming: true,
-          createdAt: isoAt(streamStartSeconds),
-          updatedAt: isoAt(streamStartSeconds + index),
+          activity: {
+            id: EventId.make(`activity-${activityIndex}`),
+            tone: "tool",
+            kind: started ? "tool.started" : "tool.completed",
+            summary: started ? `Tool call ${toolCall} started` : `Tool call ${toolCall} completed`,
+            payload: { itemType: "dynamic_tool_call", detail: `Tool ${toolCall}` },
+            turnId: STREAMING_TURN_ID,
+            createdAt: occurredAt,
+          },
         },
-      }) as OrchestrationEvent,
-  );
+      } as OrchestrationEvent);
+      activityIndex += 1;
+      continue;
+    }
+    events.push({
+      eventId: EventId.make(`event-delta-${textIndex}`),
+      sequence: index + 1,
+      occurredAt,
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      aggregateKind: "thread",
+      aggregateId: THREAD_ID,
+      type: "thread.message-sent",
+      payload: {
+        threadId: THREAD_ID,
+        messageId: STREAMING_MESSAGE_ID,
+        role: "assistant",
+        text: chunkText(textIndex, withCode),
+        turnId: STREAMING_TURN_ID,
+        streaming: true,
+        createdAt: isoAt(streamStartSeconds),
+        updatedAt: occurredAt,
+      },
+    } as OrchestrationEvent);
+    textIndex += 1;
+  }
+  return events;
 }
 
 const macrotask = () =>
@@ -210,6 +259,7 @@ function readParams() {
   };
   return {
     deltas: num("deltas", 2000),
+    activities: num("activities", 0),
     batch: num("batch", 1),
     history: num("history", 8),
     code: search.get("code") !== "0",
@@ -252,7 +302,10 @@ export function ThreadReplayPlayground() {
   const baseThread = useMemo(() => makeBaseThread(params.history), [params.history]);
   const [thread, setThread] = useState<OrchestrationThread>(baseThread);
   const listRef = useRef<LegendListRef | null>(null);
-  const statsRef = useRef<ReplayStats>({ ...INITIAL_STATS, totalDeltas: params.deltas });
+  const statsRef = useRef<ReplayStats>({
+    ...INITIAL_STATS,
+    totalDeltas: params.deltas + params.activities,
+  });
   const runningRef = useRef(false);
 
   useEffect(() => {
@@ -279,12 +332,12 @@ export function ThreadReplayPlayground() {
     Object.assign(stats, {
       ...INITIAL_STATS,
       running: true,
-      totalDeltas: params.deltas,
+      totalDeltas: params.deltas + params.activities,
     });
     setThread(baseThread);
     await macrotask();
 
-    const events = makeDeltaEvents(params.deltas, params.history, params.code);
+    const events = makeDeltaEvents(params.deltas, params.activities, params.history, params.code);
     const startedAt = performance.now();
     let current = baseThread;
     let previousTick = startedAt;
@@ -372,6 +425,14 @@ export function ThreadReplayPlayground() {
               className="w-20 rounded border border-border bg-transparent px-1 py-0.5"
               name="deltas"
               defaultValue={params.deltas}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            activities
+            <input
+              className="w-20 rounded border border-border bg-transparent px-1 py-0.5"
+              name="activities"
+              defaultValue={params.activities}
             />
           </label>
           <label className="flex flex-col gap-1">

--- a/apps/web/src/perf/ThreadReplayPlayground.tsx
+++ b/apps/web/src/perf/ThreadReplayPlayground.tsx
@@ -253,15 +253,15 @@ const INITIAL_STATS: ReplayStats = {
 
 function readParams() {
   const search = new URLSearchParams(window.location.search);
-  const num = (key: string, fallback: number) => {
+  const num = (key: string, fallback: number, minimum = 1) => {
     const raw = Number(search.get(key));
-    return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : fallback;
+    return Number.isFinite(raw) && raw >= minimum ? Math.floor(raw) : fallback;
   };
   return {
-    deltas: num("deltas", 2000),
-    activities: num("activities", 0),
+    deltas: num("deltas", 2000, 0),
+    activities: num("activities", 0, 0),
     batch: num("batch", 1),
-    history: num("history", 8),
+    history: num("history", 8, 0),
     code: search.get("code") !== "0",
     auto: search.get("auto") === "1",
   };

--- a/apps/web/src/perf/ThreadReplayPlayground.tsx
+++ b/apps/web/src/perf/ThreadReplayPlayground.tsx
@@ -1,0 +1,450 @@
+import { Profiler, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { LegendListRef } from "@legendapp/list/react";
+
+import {
+  EnvironmentId,
+  EventId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+  type OrchestrationEvent,
+  type OrchestrationMessage,
+  type OrchestrationThread,
+} from "@t3tools/contracts";
+import { applyThreadDetailEvent } from "@t3tools/client-runtime/state/thread-reducer";
+
+import { MessagesTimeline } from "../components/chat/MessagesTimeline";
+import {
+  deriveDisplayServerMessages,
+  deriveRevertTurnCountByUserMessageId,
+  deriveTimelineMessages,
+  deriveTurnDiffSummaryByAssistantMessageId,
+} from "../components/chat/threadTimelineModel";
+import { deriveTimelineEntries, deriveWorkLogEntries } from "../session-logic";
+
+/**
+ * Thread replay perf playground.
+ *
+ * Reproduces the "big chugging render" when a thread with a large backlog of
+ * persisted streaming deltas is reopened: the client applies the replayed
+ * `thread.message-sent` events one at a time, and every application publishes
+ * a new thread state that re-runs the timeline derivation and re-renders the
+ * streaming message's markdown.
+ *
+ * This page drives the real reducer (`applyThreadDetailEvent`), the real
+ * derivation pipeline (`threadTimelineModel` + `deriveTimelineEntries`), and
+ * the real `MessagesTimeline` component with synthetic events — no server,
+ * no provider, no auth. Served by the web dev server at /perf.html.
+ *
+ * Query params:
+ *   deltas  — number of streaming delta events to replay (default 2000)
+ *   batch   — events applied per state publication (default 1 = today's
+ *             behavior; raise to preview what client-side batching buys)
+ *   history — settled message pairs present before the streaming one (default 8)
+ *   code    — 1 to include code fences in the streamed markdown (default 1)
+ *   auto    — 1 to start the replay on load
+ */
+
+const THREAD_ID = ThreadId.make("thread-perf");
+const STREAMING_MESSAGE_ID = MessageId.make("msg-streaming");
+const STREAMING_TURN_ID = TurnId.make("turn-perf");
+const ENVIRONMENT_ID = EnvironmentId.make("environment-perf");
+const BASE_TIME_MS = Date.parse("2026-04-01T00:00:00.000Z");
+
+const isoAt = (offsetSeconds: number) =>
+  new Date(BASE_TIME_MS + offsetSeconds * 1000).toISOString();
+
+function chunkText(index: number, withCode: boolean): string {
+  if (withCode && index % 40 === 12) {
+    return "\n\n```ts\nconst step" + index + " = replay(" + index + ");\n```\n\n";
+  }
+  if (index % 23 === 0) {
+    return "\n\nParagraph " + index + " of the streamed reply covers another detail. ";
+  }
+  return "token" + index + " lorem ipsum dolor sit amet ";
+}
+
+function historyMessage(pairIndex: number, role: "user" | "assistant"): OrchestrationMessage {
+  const offset = pairIndex * 60 + (role === "user" ? 0 : 30);
+  return {
+    id: MessageId.make(`msg-history-${pairIndex}-${role}`),
+    role,
+    text:
+      role === "user"
+        ? `History question ${pairIndex}: how does step ${pairIndex} work?`
+        : `History answer ${pairIndex} with some **markdown**, a list:\n\n- item one\n- item two\n\nand a fence:\n\n\`\`\`ts\nexport const answer${pairIndex} = ${pairIndex};\n\`\`\`\n`,
+    turnId: role === "assistant" ? TurnId.make(`turn-history-${pairIndex}`) : null,
+    streaming: false,
+    createdAt: isoAt(offset),
+    updatedAt: isoAt(offset),
+  };
+}
+
+function makeBaseThread(historyPairs: number): OrchestrationThread {
+  const messages: OrchestrationMessage[] = [];
+  for (let index = 0; index < historyPairs; index += 1) {
+    messages.push(historyMessage(index, "user"), historyMessage(index, "assistant"));
+  }
+  const startedAt = isoAt(historyPairs * 60);
+  messages.push({
+    id: MessageId.make("msg-final-user"),
+    role: "user",
+    text: "Please stream a very long answer.",
+    turnId: null,
+    streaming: false,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+  });
+  return {
+    id: THREAD_ID,
+    projectId: ProjectId.make("project-perf"),
+    title: "Replay perf thread",
+    modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: {
+      turnId: STREAMING_TURN_ID,
+      state: "running",
+      requestedAt: startedAt,
+      startedAt,
+      completedAt: null,
+      assistantMessageId: STREAMING_MESSAGE_ID,
+    },
+    createdAt: isoAt(0),
+    updatedAt: startedAt,
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    deletedAt: null,
+    messages,
+    proposedPlans: [],
+    activities: [],
+    checkpoints: [],
+    session: {
+      threadId: THREAD_ID,
+      status: "running",
+      providerName: "codex",
+      runtimeMode: "full-access",
+      activeTurnId: STREAMING_TURN_ID,
+      lastError: null,
+      updatedAt: startedAt,
+    },
+  };
+}
+
+function makeDeltaEvents(count: number, historyPairs: number, withCode: boolean) {
+  const streamStartSeconds = historyPairs * 60 + 5;
+  return Array.from(
+    { length: count },
+    (_, index) =>
+      ({
+        eventId: EventId.make(`event-delta-${index}`),
+        sequence: index + 1,
+        occurredAt: isoAt(streamStartSeconds + index),
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        type: "thread.message-sent",
+        payload: {
+          threadId: THREAD_ID,
+          messageId: STREAMING_MESSAGE_ID,
+          role: "assistant",
+          text: chunkText(index, withCode),
+          turnId: STREAMING_TURN_ID,
+          streaming: true,
+          createdAt: isoAt(streamStartSeconds),
+          updatedAt: isoAt(streamStartSeconds + index),
+        },
+      }) as OrchestrationEvent,
+  );
+}
+
+const macrotask = () =>
+  new Promise<void>((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      channel.port1.close();
+      resolve();
+    };
+    channel.port2.postMessage(null);
+  });
+
+interface ReplayStats {
+  running: boolean;
+  done: boolean;
+  applied: number;
+  totalDeltas: number;
+  wallMs: number;
+  commits: number;
+  commitMs: number;
+  longTasks: number;
+  longTaskMs: number;
+  maxStallMs: number;
+}
+
+const INITIAL_STATS: ReplayStats = {
+  running: false,
+  done: false,
+  applied: 0,
+  totalDeltas: 0,
+  wallMs: 0,
+  commits: 0,
+  commitMs: 0,
+  longTasks: 0,
+  longTaskMs: 0,
+  maxStallMs: 0,
+};
+
+function readParams() {
+  const search = new URLSearchParams(window.location.search);
+  const num = (key: string, fallback: number) => {
+    const raw = Number(search.get(key));
+    return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : fallback;
+  };
+  return {
+    deltas: num("deltas", 2000),
+    batch: num("batch", 1),
+    history: num("history", 8),
+    code: search.get("code") !== "0",
+    auto: search.get("auto") === "1",
+  };
+}
+
+function StatsPanel({ statsRef }: { statsRef: React.RefObject<ReplayStats> }) {
+  const [snapshot, setSnapshot] = useState<ReplayStats>(INITIAL_STATS);
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setSnapshot({ ...statsRef.current });
+    }, 250);
+    return () => window.clearInterval(interval);
+  }, [statsRef]);
+
+  const s = snapshot;
+  const status = s.running ? "replaying…" : s.done ? "done" : "idle";
+  return (
+    <div className="flex flex-wrap gap-x-6 gap-y-1 font-mono text-xs text-muted-foreground">
+      <span>status: {status}</span>
+      <span>
+        applied: {s.applied}/{s.totalDeltas}
+      </span>
+      <span>wall: {s.wallMs.toFixed(0)}ms</span>
+      <span>react commits: {s.commits}</span>
+      <span>commit time: {s.commitMs.toFixed(0)}ms</span>
+      <span>
+        long tasks: {s.longTasks} ({s.longTaskMs.toFixed(0)}ms)
+      </span>
+      <span>worst stall: {s.maxStallMs.toFixed(0)}ms</span>
+    </div>
+  );
+}
+
+const noop = () => {};
+
+export function ThreadReplayPlayground() {
+  const params = useMemo(readParams, []);
+  const baseThread = useMemo(() => makeBaseThread(params.history), [params.history]);
+  const [thread, setThread] = useState<OrchestrationThread>(baseThread);
+  const listRef = useRef<LegendListRef | null>(null);
+  const statsRef = useRef<ReplayStats>({ ...INITIAL_STATS, totalDeltas: params.deltas });
+  const runningRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof PerformanceObserver === "undefined") return;
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          statsRef.current.longTasks += 1;
+          statsRef.current.longTaskMs += entry.duration;
+        }
+      });
+      observer.observe({ entryTypes: ["longtask"] });
+      return () => observer.disconnect();
+    } catch {
+      // Long task timing is unsupported in this browser (e.g. Firefox).
+      return;
+    }
+  }, []);
+
+  const runReplay = useCallback(async () => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    const stats = statsRef.current;
+    Object.assign(stats, {
+      ...INITIAL_STATS,
+      running: true,
+      totalDeltas: params.deltas,
+    });
+    setThread(baseThread);
+    await macrotask();
+
+    const events = makeDeltaEvents(params.deltas, params.history, params.code);
+    const startedAt = performance.now();
+    let current = baseThread;
+    let previousTick = startedAt;
+    for (let index = 0; index < events.length; index += params.batch) {
+      for (let offset = 0; offset < params.batch && index + offset < events.length; offset += 1) {
+        const result = applyThreadDetailEvent(
+          current,
+          events[index + offset] as OrchestrationEvent,
+        );
+        if (result.kind === "updated") {
+          current = result.thread;
+        }
+      }
+      stats.applied = Math.min(index + params.batch, events.length);
+      setThread(current);
+      // One macrotask per publication mirrors the one-event-at-a-time stream
+      // apply in threads.ts and lets React commit between applications.
+      await macrotask();
+      const now = performance.now();
+      stats.maxStallMs = Math.max(stats.maxStallMs, now - previousTick);
+      previousTick = now;
+      stats.wallMs = now - startedAt;
+    }
+    stats.wallMs = performance.now() - startedAt;
+    stats.running = false;
+    stats.done = true;
+    runningRef.current = false;
+  }, [baseThread, params]);
+
+  useEffect(() => {
+    if (params.auto) {
+      void runReplay();
+    }
+  }, [params.auto, runReplay]);
+
+  const onProfilerRender = useCallback((_id: string, _phase: string, actualDuration: number) => {
+    statsRef.current.commits += 1;
+    statsRef.current.commitMs += actualDuration;
+  }, []);
+
+  const environmentThread = useMemo(() => ({ ...thread, environmentId: ENVIRONMENT_ID }), [thread]);
+  const displayServerMessages = useMemo(
+    () => deriveDisplayServerMessages(environmentThread.messages, EMPTY_URL_MAP),
+    [environmentThread.messages],
+  );
+  const timelineMessages = useMemo(
+    () =>
+      deriveTimelineMessages({
+        displayServerMessages,
+        attachmentPreviewHandoffByMessageId: EMPTY_HANDOFFS,
+        optimisticUserMessages: EMPTY_MESSAGES,
+      }),
+    [displayServerMessages],
+  );
+  const workLogEntries = useMemo(
+    () => deriveWorkLogEntries(environmentThread.activities),
+    [environmentThread.activities],
+  );
+  const timelineEntries = useMemo(
+    () => deriveTimelineEntries(timelineMessages, environmentThread.proposedPlans, workLogEntries),
+    [environmentThread.proposedPlans, timelineMessages, workLogEntries],
+  );
+  const turnDiffSummaryByAssistantMessageId = useMemo(
+    () => deriveTurnDiffSummaryByAssistantMessageId(environmentThread.checkpoints),
+    [environmentThread.checkpoints],
+  );
+  const revertTurnCountByUserMessageId = useMemo(
+    () =>
+      deriveRevertTurnCountByUserMessageId({
+        timelineEntries,
+        turnDiffSummaryByAssistantMessageId,
+        inferredCheckpointTurnCountByTurnId: EMPTY_TURN_COUNTS,
+      }),
+    [timelineEntries, turnDiffSummaryByAssistantMessageId],
+  );
+
+  return (
+    <div className="flex h-screen flex-col gap-3 bg-background p-4 text-foreground">
+      <div className="flex flex-wrap items-end gap-3">
+        <h1 className="text-sm font-semibold">Thread replay playground</h1>
+        <form method="get" className="flex flex-wrap items-end gap-2 text-xs">
+          <label className="flex flex-col gap-1">
+            deltas
+            <input
+              className="w-20 rounded border border-border bg-transparent px-1 py-0.5"
+              name="deltas"
+              defaultValue={params.deltas}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            batch
+            <input
+              className="w-14 rounded border border-border bg-transparent px-1 py-0.5"
+              name="batch"
+              defaultValue={params.batch}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            history
+            <input
+              className="w-14 rounded border border-border bg-transparent px-1 py-0.5"
+              name="history"
+              defaultValue={params.history}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            code
+            <input
+              className="w-10 rounded border border-border bg-transparent px-1 py-0.5"
+              name="code"
+              defaultValue={params.code ? "1" : "0"}
+            />
+          </label>
+          <input type="hidden" name="auto" value="1" />
+          <button className="rounded border border-border px-2 py-1 hover:bg-accent" type="submit">
+            Run
+          </button>
+        </form>
+      </div>
+      <StatsPanel statsRef={statsRef} />
+      <div className="relative min-h-0 flex-1 overflow-hidden rounded-lg border border-border">
+        <Profiler id="messages-timeline" onRender={onProfilerRender}>
+          <MessagesTimeline
+            isWorking={true}
+            activeTurnInProgress={true}
+            activeTurnStartedAt={environmentThread.latestTurn?.startedAt ?? null}
+            listRef={listRef}
+            timelineEntries={timelineEntries}
+            latestTurn={environmentThread.latestTurn}
+            runningTurnId={
+              environmentThread.session?.status === "running"
+                ? environmentThread.session.activeTurnId
+                : null
+            }
+            turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
+            routeThreadKey="perf-thread"
+            onOpenTurnDiff={noop}
+            revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
+            onRevertUserMessage={noop}
+            isRevertingCheckpoint={false}
+            onImageExpand={noop}
+            activeThreadEnvironmentId={ENVIRONMENT_ID}
+            markdownCwd={undefined}
+            resolvedTheme={document.documentElement.classList.contains("dark") ? "dark" : "light"}
+            timestampFormat="locale"
+            workspaceRoot={undefined}
+            anchorMessageId={null}
+            onAnchorReady={noop}
+            onAnchorSizeChanged={noop}
+            contentInsetEndAdjustment={0}
+            onIsAtEndChange={noop}
+            onManualNavigation={noop}
+          />
+        </Profiler>
+      </div>
+    </div>
+  );
+}
+
+const EMPTY_URL_MAP: ReadonlyMap<string, string> = new Map();
+const EMPTY_HANDOFFS: Record<string, string[]> = {};
+const EMPTY_MESSAGES: ReadonlyArray<never> = [];
+const EMPTY_TURN_COUNTS: Record<TurnId, number> = {};

--- a/apps/web/src/perf/main.tsx
+++ b/apps/web/src/perf/main.tsx
@@ -1,0 +1,14 @@
+import ReactDOM from "react-dom/client";
+
+import "@fontsource-variable/dm-sans/index.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
+import "../index.css";
+
+import { ThreadReplayPlayground } from "./ThreadReplayPlayground";
+
+// No StrictMode: its intentional double-rendering would skew every
+// measurement this page exists to take.
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <ThreadReplayPlayground />,
+);

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -123,6 +123,10 @@
       "types": "./src/state/threads.ts",
       "default": "./src/state/threads.ts"
     },
+    "./state/thread-reducer": {
+      "types": "./src/state/threadReducer.ts",
+      "default": "./src/state/threadReducer.ts"
+    },
     "./state/thread-sort": {
       "types": "./src/state/threadSort.ts",
       "default": "./src/state/threadSort.ts"

--- a/packages/client-runtime/src/state/threadReplayPerf.test.ts
+++ b/packages/client-runtime/src/state/threadReplayPerf.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Reproduction / benchmark for the thread-resume replay chug.
+ *
+ * When a thread accumulates many persisted streaming `thread.message-sent`
+ * delta events (assistant streaming enabled) and a client resumes its
+ * subscription with `afterSequence`, the server replays every event
+ * individually and the client applies them one at a time. Each apply copies
+ * the whole message array, re-concatenates the whole accumulated text, and
+ * publishes a new state to every subscriber (i.e. a React render of the full
+ * timeline + markdown reparse per delta). Total work is quadratic in the
+ * backlog.
+ *
+ * These tests quantify that on the real code paths so a fix can be verified:
+ *  - "reducer replay cost" times the pure `applyThreadDetailEvent` fold,
+ *    including a per-event full read of the accumulated text to model the
+ *    renderer consuming each intermediate state (V8 cons strings make the
+ *    concat itself cheap until the string is read).
+ *  - "resume replay emissions" drives the real threads state machine through
+ *    a resumed subscription and counts how many state values subscribers
+ *    observe. Today this is one per delta event — the deterministic signature
+ *    of the bug. A batching/coalescing fix should collapse it to a small
+ *    number regardless of backlog size, and cut the wall time accordingly.
+ *
+ * Run with:
+ *   pnpm --filter @t3tools/client-runtime test src/state/threadReplayPerf.test.ts
+ *
+ * For an end-to-end repro in the real app, see the chunked-response mode of
+ * apps/server/scripts/acp-mock-agent.ts (T3_ACP_PROMPT_RESPONSE_CHUNK_COUNT)
+ * with the `enableAssistantStreaming` server setting turned on.
+ */
+import {
+  EventId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+  type OrchestrationEvent,
+  type OrchestrationThread,
+  type OrchestrationThreadStreamItem,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Queue from "effect/Queue";
+
+import { applyThreadDetailEvent } from "./threadReducer.ts";
+import { CACHED_SNAPSHOT_SEQUENCE, makeThreadSyncHarness } from "./threadsSyncHarness.test-util.ts";
+
+const THREAD_ID = ThreadId.make("thread-1");
+const STREAMING_MESSAGE_ID = MessageId.make("msg-streaming");
+const TURN_ID = TurnId.make("turn-1");
+const CHUNK_TEXT = "another twenty-four chars. ";
+
+const baseThread: OrchestrationThread = {
+  id: THREAD_ID,
+  projectId: ProjectId.make("project-1"),
+  title: "Replay perf thread",
+  modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+  runtimeMode: "full-access",
+  interactionMode: "default",
+  branch: null,
+  worktreePath: null,
+  latestTurn: null,
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-01T00:00:00.000Z",
+  archivedAt: null,
+  settledOverride: null,
+  settledAt: null,
+  deletedAt: null,
+  messages: [],
+  proposedPlans: [],
+  activities: [],
+  checkpoints: [],
+  session: null,
+};
+
+const streamingDeltaEvent = (index: number, sequence: number): OrchestrationEvent =>
+  ({
+    eventId: EventId.make(`event-delta-${index}`),
+    sequence,
+    occurredAt: "2026-04-01T01:00:00.000Z",
+    commandId: null,
+    causationEventId: null,
+    correlationId: null,
+    metadata: {},
+    aggregateKind: "thread",
+    aggregateId: THREAD_ID,
+    type: "thread.message-sent",
+    payload: {
+      threadId: THREAD_ID,
+      messageId: STREAMING_MESSAGE_ID,
+      role: "assistant",
+      text: CHUNK_TEXT,
+      turnId: TURN_ID,
+      streaming: true,
+      createdAt: "2026-04-01T01:00:00.000Z",
+      updatedAt: "2026-04-01T01:00:00.000Z",
+    },
+  }) as OrchestrationEvent;
+
+/**
+ * Force the accumulated text to be read the way a renderer would. Without
+ * this, V8 cons strings defer the O(length) concat cost to the first read,
+ * which in the app happens on every emission (markdown parse of the full
+ * message text).
+ */
+const readFullText = (text: string): number => {
+  let total = 0;
+  for (let index = 0; index < text.length; index += 256) {
+    total += text.charCodeAt(index);
+  }
+  return total;
+};
+
+describe("thread replay performance", () => {
+  it.effect("reducer replay cost grows superlinearly with delta backlog", () =>
+    Effect.gen(function* () {
+      const timings: Array<{ deltas: number; ms: number }> = [];
+
+      for (const deltas of [1000, 2000, 4000, 8000]) {
+        let thread = baseThread;
+        const events = Array.from({ length: deltas }, (_, index) =>
+          streamingDeltaEvent(index, index + 1),
+        );
+
+        const startedAt = performance.now();
+        for (const event of events) {
+          const result = applyThreadDetailEvent(thread, event);
+          if (result.kind === "updated") {
+            thread = result.thread;
+          }
+          // Model the renderer consuming each intermediate state.
+          readFullText(thread.messages[0]?.text ?? "");
+        }
+        const ms = performance.now() - startedAt;
+
+        expect(thread.messages).toHaveLength(1);
+        expect(thread.messages[0]?.text).toHaveLength(deltas * CHUNK_TEXT.length);
+        timings.push({ deltas, ms });
+      }
+
+      // Report the curve; doubling the backlog roughly quadruples total cost
+      // when the behavior is quadratic.
+      yield* Effect.log(
+        `[threadReplayPerf] reducer fold: ${timings
+          .map(({ deltas, ms }) => `${deltas} deltas -> ${ms.toFixed(1)}ms`)
+          .join(", ")}`,
+      );
+    }),
+  );
+
+  it.effect("resume replay publishes one state per delta event", () =>
+    Effect.gen(function* () {
+      const deltas = 2000;
+      const harness = yield* makeThreadSyncHarness({
+        cached: baseThread,
+        completionMarker: true,
+      });
+
+      // Wait for the cached thread to be published before starting the clock.
+      yield* Queue.take(harness.observed).pipe(
+        Effect.repeat({
+          until: (state) => Option.isSome(state.data),
+        }),
+      );
+
+      const startedAt = performance.now();
+      const items: Array<OrchestrationThreadStreamItem> = Array.from(
+        { length: deltas },
+        (_, index) => ({
+          kind: "event",
+          event: streamingDeltaEvent(index, CACHED_SNAPSHOT_SEQUENCE + 1 + index),
+        }),
+      );
+      yield* Queue.offerAll(harness.inputs, items);
+      yield* Queue.offer(harness.inputs, { kind: "synchronized" });
+
+      // Drain observed states until the replay has fully applied, counting
+      // how many state publications subscribers had to process.
+      let emissions = 0;
+      let caughtUp = false;
+      while (!caughtUp) {
+        const state = yield* Queue.take(harness.observed);
+        emissions += 1;
+        // Model the renderer consuming each published state.
+        if (Option.isSome(state.data)) {
+          readFullText(state.data.value.messages[0]?.text ?? "");
+        }
+        caughtUp =
+          state.status === "live" &&
+          Option.isSome(state.data) &&
+          (state.data.value.messages[0]?.text.length ?? 0) === deltas * CHUNK_TEXT.length;
+      }
+      const ms = performance.now() - startedAt;
+
+      yield* Effect.log(
+        `[threadReplayPerf] resume replay: ${deltas} deltas -> ${emissions} state emissions in ${ms.toFixed(1)}ms`,
+      );
+
+      // Today every delta event becomes its own state publication (plus the
+      // synchronized transition). This assertion documents the current
+      // behavior; a batching fix should slash `emissions` far below `deltas`
+      // and this expectation should be updated to enforce the improvement,
+      // e.g. `expect(emissions).toBeLessThan(deltas / 10)`.
+      expect(emissions).toBeGreaterThanOrEqual(2);
+      expect(emissions).toBeLessThanOrEqual(deltas + 2);
+    }),
+  );
+});

--- a/packages/client-runtime/src/state/threadReplayPerf.test.ts
+++ b/packages/client-runtime/src/state/threadReplayPerf.test.ts
@@ -198,13 +198,11 @@ describe("thread replay performance", () => {
         `[threadReplayPerf] resume replay: ${deltas} deltas -> ${emissions} state emissions in ${ms.toFixed(1)}ms`,
       );
 
-      // Today every delta event becomes its own state publication (plus the
-      // synchronized transition). This assertion documents the current
-      // behavior; a batching fix should slash `emissions` far below `deltas`
-      // and this expectation should be updated to enforce the improvement,
-      // e.g. `expect(emissions).toBeLessThan(deltas / 10)`.
+      // Drain-based batching in threads.ts must fold a replay backlog into
+      // far fewer state publications than events; one publication per event
+      // is the quadratic-reopen regression this test guards against.
       expect(emissions).toBeGreaterThanOrEqual(2);
-      expect(emissions).toBeLessThanOrEqual(deltas + 2);
+      expect(emissions).toBeLessThan(deltas / 10);
     }),
   );
 });

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -11,6 +11,7 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import { Atom } from "effect/unstable/reactivity";
@@ -242,8 +243,12 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
   });
 
   const applyItem = (item: OrchestrationThreadStreamItem) => applyItems([item]);
-
-  const pendingItems = yield* Queue.unbounded<OrchestrationThreadStreamItem>();
+  const applyLock = yield* Semaphore.make(1);
+  const subscriptionGeneration = yield* Ref.make(0);
+  const pendingItems = yield* Queue.unbounded<{
+    readonly generation: number;
+    readonly item: OrchestrationThreadStreamItem;
+  }>();
 
   yield* SubscriptionRef.changes(supervisor.state).pipe(
     Stream.runForEach((connectionState) => {
@@ -270,58 +275,74 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
     subscribeDynamic(
       ORCHESTRATION_WS_METHODS.subscribeThread,
       Effect.fn("EnvironmentThreadState.makeSubscribeInput")(function* (session) {
-        const supportsCompletionMarker = yield* session.initialConfig.pipe(
-          Effect.map((config) => config.threadResumeCompletionMarker === true),
-          Effect.orElseSucceed(() => false),
+        return yield* applyLock.withPermits(1)(
+          Effect.gen(function* () {
+            // A switched-out stream may already have queued items. Give every
+            // subscription attempt a generation and clear its predecessor's
+            // backlog before loading a replacement snapshot.
+            yield* Ref.update(subscriptionGeneration, (generation) => generation + 1);
+            yield* Queue.clear(pendingItems);
+
+            const supportsCompletionMarker = yield* session.initialConfig.pipe(
+              Effect.map((config) => config.threadResumeCompletionMarker === true),
+              Effect.orElseSucceed(() => false),
+            );
+            yield* Ref.set(awaitingCompletion, supportsCompletionMarker);
+            yield* setSynchronizing;
+
+            let current = yield* SubscriptionRef.get(state);
+            if (Option.isNone(current.data) && current.status !== "deleted") {
+              const prepared = yield* SubscriptionRef.get(supervisor.prepared).pipe(
+                Effect.flatMap(
+                  Option.match({
+                    onSome: Effect.succeed,
+                    onNone: () =>
+                      SubscriptionRef.changes(supervisor.prepared).pipe(
+                        Stream.filter(Option.isSome),
+                        Stream.map((value) => value.value),
+                        Stream.runHead,
+                        Effect.map(Option.getOrThrow),
+                      ),
+                  }),
+                ),
+              );
+              const httpSnapshot = yield* snapshotLoader.load(prepared, threadId);
+              if (Option.isSome(httpSnapshot)) {
+                yield* applyItem({ kind: "snapshot", snapshot: httpSnapshot.value });
+                current = yield* SubscriptionRef.get(state);
+              }
+            }
+
+            const sequence = yield* SubscriptionRef.get(lastSequence);
+            const canResume = Option.isSome(current.data);
+            if (!supportsCompletionMarker && canResume) {
+              yield* SubscriptionRef.update(state, (value) => ({
+                ...value,
+                status: value.status === "deleted" ? value.status : ("live" as const),
+                error: Option.none(),
+              }));
+            }
+
+            return {
+              threadId,
+              ...(canResume ? { afterSequence: sequence } : {}),
+              ...(supportsCompletionMarker ? { requestCompletionMarker: true as const } : {}),
+            };
+          }),
         );
-        yield* Ref.set(awaitingCompletion, supportsCompletionMarker);
-        yield* setSynchronizing;
-
-        let current = yield* SubscriptionRef.get(state);
-        if (Option.isNone(current.data) && current.status !== "deleted") {
-          const prepared = yield* SubscriptionRef.get(supervisor.prepared).pipe(
-            Effect.flatMap(
-              Option.match({
-                onSome: Effect.succeed,
-                onNone: () =>
-                  SubscriptionRef.changes(supervisor.prepared).pipe(
-                    Stream.filter(Option.isSome),
-                    Stream.map((value) => value.value),
-                    Stream.runHead,
-                    Effect.map(Option.getOrThrow),
-                  ),
-              }),
-            ),
-          );
-          const httpSnapshot = yield* snapshotLoader.load(prepared, threadId);
-          if (Option.isSome(httpSnapshot)) {
-            yield* applyItem({ kind: "snapshot", snapshot: httpSnapshot.value });
-            current = yield* SubscriptionRef.get(state);
-          }
-        }
-
-        const sequence = yield* SubscriptionRef.get(lastSequence);
-        const canResume = Option.isSome(current.data);
-        if (!supportsCompletionMarker && canResume) {
-          yield* SubscriptionRef.update(state, (value) => ({
-            ...value,
-            status: value.status === "deleted" ? value.status : ("live" as const),
-            error: Option.none(),
-          }));
-        }
-
-        return {
-          threadId,
-          ...(canResume ? { afterSequence: sequence } : {}),
-          ...(supportsCompletionMarker ? { requestCompletionMarker: true as const } : {}),
-        };
       }),
       {
         onExpectedFailure: setStreamError,
         retryExpectedFailureAfter: "250 millis",
         resubscribe: foregroundResubscriptions,
       },
-    ).pipe(Stream.runForEach((item) => Queue.offer(pendingItems, item))),
+    ).pipe(
+      Stream.runForEach((item) =>
+        Ref.get(subscriptionGeneration).pipe(
+          Effect.flatMap((generation) => Queue.offer(pendingItems, { generation, item })),
+        ),
+      ),
+    ),
   );
 
   // Drain-based batching: apply one item plus everything that accumulated
@@ -334,14 +355,24 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
   yield* Effect.forkScoped(
     Effect.forever(
       Effect.gen(function* () {
-        const batch: Array<OrchestrationThreadStreamItem> = [yield* Queue.take(pendingItems)];
+        const batch = [yield* Queue.take(pendingItems)];
         for (let round = 0; round < 32; round += 1) {
           yield* Effect.yieldNow;
           const more = yield* Queue.clear(pendingItems);
           if (more.length === 0) break;
           batch.push(...more);
         }
-        yield* applyItems(batch);
+        yield* applyLock.withPermits(1)(
+          Effect.gen(function* () {
+            const generation = yield* Ref.get(subscriptionGeneration);
+            const currentItems = batch
+              .filter((pending) => pending.generation === generation)
+              .map((pending) => pending.item);
+            if (currentItems.length > 0) {
+              yield* applyItems(currentItems);
+            }
+          }),
+        );
       }),
     ),
   );

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -179,45 +179,71 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
     );
   });
 
-  const applyItem = Effect.fn("EnvironmentThreadState.applyItem")(function* (
-    item: OrchestrationThreadStreamItem,
+  const applyItems = Effect.fn("EnvironmentThreadState.applyItems")(function* (
+    batch: Iterable<OrchestrationThreadStreamItem>,
   ) {
-    if (item.kind === "synchronized") {
+    // Fold the whole batch into at most one thread publication. A resume
+    // replay can deliver thousands of persisted events; publishing state per
+    // event makes reopening a thread quadratic in the backlog, because every
+    // publication re-derives and re-renders the full timeline.
+    let sequence = yield* SubscriptionRef.get(lastSequence);
+    let data = (yield* SubscriptionRef.get(state)).data;
+    let dirty = false;
+    let deleted = false;
+    let synchronized = false;
+
+    for (const item of batch) {
+      if (item.kind === "synchronized") {
+        synchronized = true;
+        continue;
+      }
+      if (item.kind === "snapshot") {
+        sequence = item.snapshot.snapshotSequence;
+        data = Option.some(item.snapshot.thread);
+        dirty = true;
+        deleted = false;
+        continue;
+      }
+      if (item.event.sequence <= sequence) {
+        continue;
+      }
+      sequence = item.event.sequence;
+      if (Option.isNone(data)) {
+        if (item.event.type === "thread.deleted") {
+          deleted = true;
+        }
+        continue;
+      }
+      const result = applyThreadDetailEvent(data.value, item.event);
+      if (result.kind === "updated") {
+        data = Option.some(result.thread);
+        dirty = true;
+      } else if (result.kind === "deleted") {
+        data = Option.none();
+        dirty = false;
+        deleted = true;
+      }
+    }
+
+    yield* SubscriptionRef.set(lastSequence, sequence);
+    if (deleted && Option.isNone(data)) {
+      yield* setDeleted();
+    } else if (dirty && Option.isSome(data)) {
+      yield* setThread(data.value);
+    }
+    if (synchronized) {
       yield* Ref.set(awaitingCompletion, false);
       yield* SubscriptionRef.update(state, (current) =>
         Option.isSome(current.data) && current.status !== "deleted"
           ? { ...current, status: "live" as const, error: Option.none() }
           : current,
       );
-      return;
-    }
-
-    if (item.kind === "snapshot") {
-      yield* SubscriptionRef.set(lastSequence, item.snapshot.snapshotSequence);
-      yield* setThread(item.snapshot.thread);
-      return;
-    }
-
-    const sequence = yield* SubscriptionRef.get(lastSequence);
-    if (item.event.sequence <= sequence) {
-      return;
-    }
-    yield* SubscriptionRef.set(lastSequence, item.event.sequence);
-
-    const current = yield* SubscriptionRef.get(state);
-    if (Option.isNone(current.data)) {
-      if (item.event.type === "thread.deleted") {
-        yield* setDeleted();
-      }
-      return;
-    }
-    const result = applyThreadDetailEvent(current.data.value, item.event);
-    if (result.kind === "updated") {
-      yield* setThread(result.thread);
-    } else if (result.kind === "deleted") {
-      yield* setDeleted();
     }
   });
+
+  const applyItem = (item: OrchestrationThreadStreamItem) => applyItems([item]);
+
+  const pendingItems = yield* Queue.unbounded<OrchestrationThreadStreamItem>();
 
   yield* SubscriptionRef.changes(supervisor.state).pipe(
     Stream.runForEach((connectionState) => {
@@ -295,7 +321,29 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
         retryExpectedFailureAfter: "250 millis",
         resubscribe: foregroundResubscriptions,
       },
-    ).pipe(Stream.runForEach(applyItem)),
+    ).pipe(Stream.runForEach((item) => Queue.offer(pendingItems, item))),
+  );
+
+  // Drain-based batching: apply one item plus everything that accumulated
+  // while the previous batch was being applied, giving the producer a few
+  // scheduler turns to flush a burst it is actively delivering (a resume
+  // replay arrives as one rapid burst). Live updates arriving one at a time
+  // publish immediately; a replay backlog folds into large batches with a
+  // single publication each, keeping thread reopen cost linear instead of
+  // quadratic. No timers, so batching never delays a quiet stream.
+  yield* Effect.forkScoped(
+    Effect.forever(
+      Effect.gen(function* () {
+        const batch: Array<OrchestrationThreadStreamItem> = [yield* Queue.take(pendingItems)];
+        for (let round = 0; round < 32; round += 1) {
+          yield* Effect.yieldNow;
+          const more = yield* Queue.clear(pendingItems);
+          if (more.length === 0) break;
+          batch.push(...more);
+        }
+        yield* applyItems(batch);
+      }),
+    ),
   );
 
   yield* Effect.addFinalizer(() =>

--- a/packages/client-runtime/src/state/threadsSyncHarness.test-util.ts
+++ b/packages/client-runtime/src/state/threadsSyncHarness.test-util.ts
@@ -1,0 +1,208 @@
+/**
+ * Test harness for driving the environment thread state machine with a fake
+ * socket, cache, and snapshot loader. Adapted from the inline harness in
+ * threads-sync.test.ts so perf/repro tests can reuse it; the filename avoids
+ * the `.test.ts` suffix so it is not collected as a suite itself.
+ */
+import {
+  EnvironmentId,
+  ORCHESTRATION_WS_METHODS,
+  ThreadId,
+  type OrchestrationThread,
+  type OrchestrationThreadDetailSnapshot,
+  type OrchestrationThreadStreamItem,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
+
+import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
+import {
+  AVAILABLE_CONNECTION_STATE,
+  PrimaryConnectionTarget,
+  type PreparedConnection,
+  type SupervisorConnectionState,
+} from "../connection/model.ts";
+import * as ConnectionWakeups from "../connection/wakeups.ts";
+import * as EnvironmentSupervisor from "../connection/supervisor.ts";
+import * as Persistence from "../platform/persistence.ts";
+import * as RpcSession from "../rpc/session.ts";
+import {
+  EMPTY_ENVIRONMENT_THREAD_STATE,
+  makeEnvironmentThreadState,
+  ThreadSnapshotLoader,
+  type EnvironmentThreadState,
+} from "./threads.ts";
+
+const TARGET = new PrimaryConnectionTarget({
+  environmentId: EnvironmentId.make("environment-1"),
+  label: "Test environment",
+  httpBaseUrl: "https://environment.example.test",
+  wsBaseUrl: "wss://environment.example.test",
+});
+export const HARNESS_THREAD_ID = ThreadId.make("thread-1");
+export const CACHED_SNAPSHOT_SEQUENCE = 7;
+const PREPARED: PreparedConnection = {
+  environmentId: TARGET.environmentId,
+  label: TARGET.label,
+  httpBaseUrl: TARGET.httpBaseUrl,
+  socketUrl: TARGET.wsBaseUrl,
+  httpAuthorization: null,
+  target: TARGET,
+};
+
+export type TestThreadInput = OrchestrationThreadStreamItem | Error;
+
+function testSession(
+  client: WsRpcProtocolClient,
+  options?: { readonly completionMarker?: boolean },
+): RpcSession.RpcSession {
+  return {
+    client,
+    initialConfig: Effect.succeed(
+      options?.completionMarker === true
+        ? ({ threadResumeCompletionMarker: true } as never)
+        : ({} as never),
+    ),
+    ready: Effect.void,
+    probe: Effect.void,
+    closed: Effect.never,
+  };
+}
+
+export const makeThreadSyncHarness = Effect.fn("TestEnvironmentThreads.makeHarness")(
+  function* (options?: {
+    readonly cached?: OrchestrationThread;
+    readonly httpSnapshot?: Option.Option<OrchestrationThreadDetailSnapshot>;
+    readonly completionMarker?: boolean;
+  }) {
+    const inputs = yield* Queue.unbounded<TestThreadInput>();
+    const observed = yield* Queue.unbounded<EnvironmentThreadState>();
+    const latest = yield* Ref.make<EnvironmentThreadState>(EMPTY_ENVIRONMENT_THREAD_STATE);
+    const retryCount = yield* Ref.make(0);
+    const subscriptionCount = yield* Ref.make(0);
+    const loaderCalls = yield* Ref.make(0);
+    const lastSubscribeAfterSequence = yield* Ref.make<number | undefined>(undefined);
+    const lastRequestCompletionMarker = yield* Ref.make<boolean | undefined>(undefined);
+    const savedThreads = yield* Ref.make<ReadonlyArray<OrchestrationThreadDetailSnapshot>>([]);
+    const removedThreads = yield* Ref.make<ReadonlyArray<ThreadId>>([]);
+    const wakeups = yield* Queue.unbounded<ConnectionWakeups.ConnectionWakeup>();
+    const supervisorState = yield* SubscriptionRef.make<SupervisorConnectionState>(
+      AVAILABLE_CONNECTION_STATE,
+    );
+    const streamFrom = (queue: Queue.Queue<TestThreadInput>) =>
+      Stream.fromQueue(queue).pipe(
+        Stream.mapEffect((input) =>
+          input instanceof Error ? Effect.fail(input) : Effect.succeed(input),
+        ),
+      );
+    const client = {
+      [ORCHESTRATION_WS_METHODS.subscribeThread]: (input: {
+        readonly afterSequence?: number;
+        readonly requestCompletionMarker?: boolean;
+      }) =>
+        Stream.unwrap(
+          Ref.updateAndGet(subscriptionCount, (count) => count + 1).pipe(
+            Effect.andThen(Ref.set(lastSubscribeAfterSequence, input.afterSequence)),
+            Effect.andThen(Ref.set(lastRequestCompletionMarker, input.requestCompletionMarker)),
+            Effect.as(streamFrom(inputs)),
+          ),
+        ),
+    } as unknown as WsRpcProtocolClient;
+    const supervisorSession = yield* SubscriptionRef.make<Option.Option<RpcSession.RpcSession>>(
+      Option.some(
+        testSession(
+          client,
+          options?.completionMarker === true ? { completionMarker: true } : undefined,
+        ),
+      ),
+    );
+    const prepared = yield* SubscriptionRef.make<Option.Option<PreparedConnection>>(
+      Option.some(PREPARED),
+    );
+    const snapshotLoader = ThreadSnapshotLoader.of({
+      load: (_prepared, threadId) =>
+        Ref.update(loaderCalls, (count) => count + 1).pipe(
+          Effect.as(
+            threadId === HARNESS_THREAD_ID
+              ? (options?.httpSnapshot ?? Option.none<OrchestrationThreadDetailSnapshot>())
+              : Option.none<OrchestrationThreadDetailSnapshot>(),
+          ),
+        ),
+    });
+    const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
+      target: TARGET,
+      state: supervisorState,
+      session: supervisorSession,
+      prepared,
+      connect: Effect.void,
+      disconnect: Effect.void,
+      retryNow: Ref.update(retryCount, (count) => count + 1),
+    } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+    const cache = Persistence.EnvironmentCacheStore.of({
+      loadShell: () => Effect.succeed(Option.none()),
+      saveShell: () => Effect.void,
+      loadThread: (_environmentId, threadId) =>
+        Effect.succeed(
+          threadId === HARNESS_THREAD_ID && options?.cached !== undefined
+            ? Option.some({
+                snapshotSequence: CACHED_SNAPSHOT_SEQUENCE,
+                thread: options.cached,
+              })
+            : Option.none(),
+        ),
+      saveThread: (_environmentId, thread) =>
+        Ref.update(savedThreads, (current) => [...current, thread]),
+      removeThread: (_environmentId, threadId) =>
+        Ref.update(removedThreads, (current) => [...current, threadId]),
+      loadServerConfig: () => Effect.succeed(Option.none()),
+      saveServerConfig: () => Effect.void,
+      loadVcsRefs: () => Effect.succeed(Option.none()),
+      saveVcsRefs: () => Effect.void,
+      clear: () => Effect.void,
+    });
+    const threadState = yield* makeEnvironmentThreadState(HARNESS_THREAD_ID).pipe(
+      Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+      Effect.provideService(Persistence.EnvironmentCacheStore, cache),
+      Effect.provideService(ThreadSnapshotLoader, snapshotLoader),
+      Effect.provideService(
+        ConnectionWakeups.ConnectionWakeups,
+        ConnectionWakeups.ConnectionWakeups.of({ changes: Stream.fromQueue(wakeups) }),
+      ),
+    );
+    yield* SubscriptionRef.changes(threadState).pipe(
+      Stream.runForEach((state) =>
+        Ref.set(latest, state).pipe(Effect.andThen(Queue.offer(observed, state))),
+      ),
+      Effect.forkScoped,
+    );
+
+    return {
+      inputs,
+      observed,
+      latest,
+      retryCount,
+      subscriptionCount,
+      loaderCalls,
+      lastSubscribeAfterSequence,
+      lastRequestCompletionMarker,
+      supervisorState,
+      supervisorSession,
+      savedThreads,
+      removedThreads,
+      wakeups,
+      replaceSession: SubscriptionRef.set(
+        supervisorSession,
+        Option.some(
+          testSession(
+            client,
+            options?.completionMarker === true ? { completionMarker: true } : undefined,
+          ),
+        ),
+      ),
+    };
+  },
+);


### PR DESCRIPTION
Fixes #4596.

Reopening a thread with a large persisted-event backlog visibly re-replayed the whole backlog: the server streamed every event since the client's cursor individually, and the client published a new state (full timeline re-derive + re-render) per event. Real threads carry thousands of events — a sampled database had a thread with 4,830 (4,170 of them `thread.activity-appended`, with assistant streaming off) — making reopen cost quadratic and freezing the UI for tens of seconds to minutes.

## The fix (two independent halves)

- **Client** (`packages/client-runtime/src/state/threads.ts`): subscription items now flow through a queue; the apply loop drains one item plus everything that accumulated (giving an in-flight burst a few scheduler turns to land) and folds the whole batch through the reducer with a **single state publication**. Live one-at-a-time updates publish immediately; no timers, so a quiet stream gains no latency.
- **Server** (`apps/server/src/ws.ts`): `subscribeThread` resume now mirrors the shell stream's gap cap — beyond `THREAD_RESUME_MAX_GAP` (1000) events (or a cursor ahead of the head), it sends a fresh snapshot plus the live tail instead of an unbounded replay. In-range replays are bounded to the captured head instead of `Number.MAX_SAFE_INTEGER`.

## Evidence

- The `threadReplayPerf` gauge (added here) drives the real resume path: 2000 replayed deltas previously produced **2,002 state publications**; the test now enforces **< 200**.
- The `/perf.html` playground (added here) mounts the real `MessagesTimeline` and showed one-publication-per-event costs ~37s for a real-thread mix (350 message + 4,200 activity events) and ~212s for 2000 streaming deltas; batched application measured ~5.4s / ~8.1s respectively (7–26×).
- New server test: `subscribeThread sends a fresh snapshot instead of replaying a large gap`.

## Also in this PR (repro tooling, first four commits)

- `threadTimelineModel.ts`: pure extraction of ChatView's timeline derivation (behavior-identical) so the pipeline runs outside the app shell.
- `/perf.html` dev playground replaying synthetic delta/activity backlogs through the real reducer + timeline with commit/stall metrics.
- `threadReplayPerf.test.ts` unit gauge and a chunked-streaming mode for `acp-mock-agent.ts` (`T3_ACP_PROMPT_RESPONSE_CHUNK_COUNT`) for end-to-end reproduction.

Tests: client-runtime 473/473, server `server.test.ts` 113/113, web timeline suites 101/101; typechecks clean across touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core thread WebSocket resume and client state publication semantics; mitigated by mirroring the existing shell gap cap, new server/client tests, and perf guards that limit emissions during large replays.
> 
> **Overview**
> Fixes **quadratic cost when reopening threads** with large persisted-event backlogs (streaming deltas and tool activities).
> 
> **Server:** `subscribeThread` resume now uses `THREAD_RESUME_MAX_GAP` (1000), matching the shell stream. Gaps larger than that (or an invalid cursor) skip per-event replay and send a **fresh thread snapshot** plus the live tail; in-range catch-up reads only through the captured head instead of an unbounded range.
> 
> **Client:** Thread subscription items go through a **queue and drain-based batching** loop that folds bursts into `applyItems` and **one state publication per batch** (live single events still publish promptly). Resubscribe clears stale queued items via a generation counter and an apply lock.
> 
> **Supporting changes:** Timeline derivation is moved to `threadTimelineModel.ts` (same behavior in `ChatView`). Adds `/perf.html` replay playground, `threadReplayPerf` benchmarks, shared sync test harness, and optional chunked mock-agent responses for reproducing heavy streaming histories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eaec3ebefd170d8f7b4e6b5187b2fbb54187127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix quadratic thread-reopen replay by batching client state updates and capping server replay gap
> - [`threads.ts`](https://github.com/pingdotgg/t3code/pull/4605/files#diff-3389d9e86e5f65222bc1be800d0aa21f5356629eaf916680112dcbd606822815): replaces per-event state publication with drain-based batching that folds up to 32 items into a single state emit, eliminating O(n) React renders during replay
> - [`ws.ts`](https://github.com/pingdotgg/t3code/pull/4605/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125): caps server-side replay at `THREAD_RESUME_MAX_GAP = 1_000` events; gaps exceeding this send a fresh snapshot instead of replaying all missed events
> - Extracts timeline derivation helpers into [`threadTimelineModel.ts`](https://github.com/pingdotgg/t3code/pull/4605/files#diff-669534ad43f3c6fefdf005048dffb8cd71969cad08fff0f1751128bf6a114173) and uses them in `ChatView`, enabling accurate profiling via the new [`ThreadReplayPlayground`](https://github.com/pingdotgg/t3code/pull/4605/files#diff-ffa27c7760aa914795d5599651acf8039c42491881577c676f5b3368dd1305c6)
> - Behavioral Change: live single events still publish promptly; resume replay now emits far fewer intermediate states, which may affect any code observing intermediate thread states during reconnect
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5eaec3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->