### PR TITLE
perf(mobile): defer work-log detail serialization

### DIFF
--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -108,7 +108,8 @@ export function ThreadWorkLog(props: {
       <View className="gap-px">
         {rows.map((row) => {
           const expanded = props.expandedRows[row.id] ?? false;
-          const canExpand = row.fullDetail !== null;
+          const canExpand = row.canExpand;
+          const fullDetail = expanded ? row.getFullDetail() : null;
           const displayText = row.detail ? `${row.summary} ${row.detail}` : row.summary;
           const iconIsDestructive = row.icon === "alert" || row.icon === "warning";
 
@@ -133,7 +134,7 @@ export function ThreadWorkLog(props: {
                     props.onToggleRow(row.id);
                   }
                 }}
-                onLongPress={() => props.onCopyRow(row.id, row.copyText)}
+                onLongPress={() => props.onCopyRow(row.id, row.getCopyText())}
                 style={({ pressed }) => ({
                   backgroundColor: pressed ? pressedBackground : "transparent",
                 })}
@@ -204,7 +205,7 @@ export function ThreadWorkLog(props: {
                 </View>
               </Pressable>
 
-              {expanded && row.fullDetail ? (
+              {fullDetail ? (
                 <View className="ml-7 border-l border-neutral-300/60 pb-1 pl-3 pt-0.5 dark:border-white/[0.12]">
                   <ScrollView
                     nestedScrollEnabled
@@ -217,7 +218,7 @@ export function ThreadWorkLog(props: {
                       selectable
                       className="font-mono text-2xs leading-normal text-foreground-muted"
                     >
-                      {row.fullDetail}
+                      {fullDetail}
                     </Text>
                   </ScrollView>
                 </View>

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -161,20 +161,22 @@ describe("buildThreadFeed", () => {
       return;
     }
 
-    expect(group.activities).toEqual([
-      {
-        id: "tool-completed",
-        createdAt: "2026-04-01T00:00:02.000Z",
-        turnId: "turn-1",
-        summary: "Run tests",
-        detail: "bun run test",
-        fullDetail: "/bin/zsh -lc 'bun run test'",
-        copyText: "Run tests\nbun run test\n/bin/zsh -lc 'bun run test'",
-        icon: "command",
-        toolLike: true,
-        status: "success",
-      },
-    ]);
+    expect(group.activities).toHaveLength(1);
+    expect(group.activities[0]).toMatchObject({
+      id: "tool-completed",
+      createdAt: "2026-04-01T00:00:02.000Z",
+      turnId: "turn-1",
+      summary: "Run tests",
+      detail: "bun run test",
+      canExpand: true,
+      icon: "command",
+      toolLike: true,
+      status: "success",
+    });
+    expect(group.activities[0]?.getFullDetail()).toBe("/bin/zsh -lc 'bun run test'");
+    expect(group.activities[0]?.getCopyText()).toBe(
+      "Run tests\nbun run test\n/bin/zsh -lc 'bun run test'",
+    );
   });
 
   it("keeps MCP inputs available to expanded mobile work rows", () => {
@@ -223,8 +225,55 @@ describe("buildThreadFeed", () => {
     }
 
     expect(group.activities[0]?.icon).toBe("wrench");
-    expect(group.activities[0]?.fullDetail).toContain('"query": "work log"');
-    expect(group.activities[0]?.fullDetail).toContain("repository.search");
+    expect(group.activities[0]?.getFullDetail()).toContain('"query": "work log"');
+    expect(group.activities[0]?.getFullDetail()).toContain("repository.search");
+  });
+
+  it("defers large tool output expansion until a work row is opened or copied", () => {
+    let serializedToolOutputs = 0;
+    const activities = Array.from({ length: 5_000 }, (_, index) =>
+      makeActivity({
+        id: EventId.make(`large-tool-${index}`),
+        kind: "tool.completed",
+        tone: "tool",
+        summary: `Tool ${index}`,
+        createdAt: new Date(Date.UTC(2026, 3, 1, 0, 0, index)).toISOString(),
+        payload: {
+          title: `Tool ${index}`,
+          itemType: "mcp_tool_call",
+          status: "completed",
+          data: {
+            item: {
+              toJSON: () => {
+                serializedToolOutputs += 1;
+                return { output: "x".repeat(32_768) };
+              },
+            },
+          },
+        },
+      }),
+    );
+    const thread = makeThread({
+      id: ThreadId.make("thread-large-tools"),
+      projectId: ProjectId.make("project-1"),
+      title: "Large tools",
+      activities,
+    });
+
+    const feed = buildThreadFeed(thread);
+    expect(serializedToolOutputs).toBe(0);
+
+    const group = feed[0];
+    expect(group).toMatchObject({ type: "activity-group" });
+    if (!group || group.type !== "activity-group") {
+      return;
+    }
+
+    expect(group.activities).toHaveLength(5_000);
+    expect(group.activities[0]?.getFullDetail()).toContain('"output"');
+    expect(serializedToolOutputs).toBe(1);
+    expect(group.activities[0]?.getCopyText()).toContain('"output"');
+    expect(serializedToolOutputs).toBe(1);
   });
 
   it("folds settled turn work while leaving the terminal answer visible", () => {
@@ -439,8 +488,9 @@ describe("buildThreadFeed", () => {
       turnId: null,
       summary: `Tool ${id}`,
       detail: null,
-      fullDetail: null,
-      copyText: id,
+      canExpand: false,
+      getFullDetail: () => null,
+      getCopyText: () => id,
       icon: "command",
       toolLike: true,
       status,

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -36,8 +36,9 @@ export interface ThreadFeedActivity {
   readonly turnId: TurnId | null;
   readonly summary: string;
   readonly detail: string | null;
-  readonly fullDetail: string | null;
-  readonly copyText: string;
+  readonly canExpand: boolean;
+  readonly getFullDetail: () => string | null;
+  readonly getCopyText: () => string;
   readonly icon:
     | "agent"
     | "alert"
@@ -552,6 +553,27 @@ function buildWorkEntryExpandedBody(entry: WorkLogEntry): string | null {
   }
 
   return blocks.length > 0 ? blocks.join("\n\n") : null;
+}
+
+function workEntryHasExpandedBody(entry: WorkLogEntry): boolean {
+  return (
+    (entry.itemType === "mcp_tool_call" && entry.toolData !== undefined) ||
+    Boolean((entry.rawCommand ?? entry.command)?.trim()) ||
+    Boolean(entry.detail?.trim()) ||
+    (entry.changedFiles?.some((path) => path.trim().length > 0) ?? false)
+  );
+}
+
+function memoizeValue<T>(build: () => T): () => T {
+  let value: T;
+  let initialized = false;
+  return () => {
+    if (!initialized) {
+      value = build();
+      initialized = true;
+    }
+    return value;
+  };
 }
 
 function workEntryPreview(
@@ -1353,7 +1375,14 @@ export function buildThreadFeed(
         .map<RawThreadFeedEntry>((entry) => {
           const summary = workEntryHeading(entry);
           const detail = workEntryPreview(entry);
-          const fullDetail = buildWorkEntryExpandedBody(entry);
+          const getFullDetail = memoizeValue(() => buildWorkEntryExpandedBody(entry));
+          const getCopyText = memoizeValue(() =>
+            [summary, detail, getFullDetail()]
+              .filter((value, index, values): value is string => {
+                return Boolean(value) && values.indexOf(value) === index;
+              })
+              .join("\n"),
+          );
           return {
             type: "activity",
             id: entry.id,
@@ -1365,13 +1394,10 @@ export function buildThreadFeed(
               turnId: entry.turnId,
               summary,
               detail,
-              fullDetail,
+              canExpand: workEntryHasExpandedBody(entry),
+              getFullDetail,
+              getCopyText,
               icon: workEntryIcon(entry),
-              copyText: [summary, detail, fullDetail]
-                .filter((value, index, values): value is string => {
-                  return Boolean(value) && values.indexOf(value) === index;
-                })
-                .join("\n"),
               toolLike: workLogEntryIsToolLike(entry),
               status: workEntryStatus(entry),
             },


### PR DESCRIPTION
## What Changed

- Defer full mobile work-log detail serialization until a row is expanded or copied.
- Memoize the expanded detail and copy text so repeat interactions reuse the first serialization.
- Keep the existing collapsed text, expanded payload, and copied output unchanged.
- Add a regression test covering 5,000 large MCP tool activities.

## Why

Mobile feed construction eagerly built and serialized the full detail text for every work-log activity, including large MCP/tool payloads that remained collapsed. This made opening a thread pay the cost for content the user might never inspect.

The feed now builds only the compact row model up front. In the regression test, constructing a feed with 5,000 large tool results performs zero full-output serializations; the first expansion performs one, and copying reuses that memoized value.

This is intentionally mobile-only. It does not change sync payload size, activity-history paging, server memory use, or any protocol/schema.

## UI Changes

No visual change. Existing work-log rows still expand to the complete detail and long-press still copies the complete text.

Verified on an iOS Simulator against an isolated local T3 environment with a 4 KB MCP result:

- the work log rendered;
- the row expanded to the full payload;
- long-press copied the complete 4,296-byte row text.

## Validation

- `pnpm exec vp test run apps/mobile/src/lib/threadActivity.test.ts` — 9 tests passed
- `cd apps/mobile && pnpm exec vp run typecheck` — passed
- `pnpm exec vp lint --report-unused-disable-directives apps/mobile/src/lib/threadActivity.ts apps/mobile/src/lib/threadActivity.test.ts apps/mobile/src/features/threads/thread-work-log.tsx` — passed
- `pnpm exec vp fmt --write apps/mobile/src/lib/threadActivity.ts apps/mobile/src/lib/threadActivity.test.ts apps/mobile/src/features/threads/thread-work-log.tsx` — passed
- iOS Simulator verification against a disposable backend — passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable because there is no visual change
- [x] A video is not applicable because the existing interaction is unchanged


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer work-log detail serialization in thread feed to lazy getters
> - Replaces eagerly computed `fullDetail` and `copyText` fields on `ThreadFeedActivity` with `canExpand`, `getFullDetail()`, and `getCopyText()` getter functions in [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/4607/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5).
> - Introduces a `memoizeValue` helper so full detail and copy text are computed at most once per activity, on first access.
> - Adds `workEntryHasExpandedBody` to determine expandability from content presence rather than from a prebuilt string.
> - Updates [ThreadWorkLog](https://github.com/pingdotgg/t3code/pull/4607/files#diff-06f278f3ca8d6524ea378cdd0d5fea4e0a691986d150c0b93b43724ed8d40909) to gate expansion on `row.canExpand` and call getters only when the row is expanded or copied.
> - Behavioral Change: callers previously reading `row.fullDetail` or `row.copyText` directly must now call `row.getFullDetail()` and `row.getCopyText()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fb3cb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile presentation-layer refactor with tests; no sync, protocol, or auth changes, and user-visible expand/copy behavior is preserved.
> 
> **Overview**
> **Mobile thread work-log rows no longer build full detail or copy text when the feed is constructed.** `ThreadFeedActivity` drops eager `fullDetail` / `copyText` strings in favor of `canExpand` plus memoized `getFullDetail()` and `getCopyText()` that run only on expand or long-press.
> 
> Feed mapping in `threadActivity.ts` uses `workEntryHasExpandedBody` for expandability and a `memoizeValue` helper so large MCP/tool JSON is serialized at most once per row. `ThreadWorkLog` reads those getters only when needed, so opening a thread with thousands of collapsed tool rows avoids upfront serialization (covered by a new 5,000-activity regression test).
> 
> **No intended UI or copy behavior change** for collapsed summaries, expanded bodies, or long-press copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb3cb4e539d41353a997831f0915845d64a64f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved thread work-log rows to expand only when additional details are available.
  * Enhanced long-press copying to provide the most relevant complete activity text.
  * Deferred detail and copy-text generation until needed for smoother performance.

* **Bug Fixes**
  * Improved handling of expanded work-entry details and copied content, including duplicate text prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->