### PR TITLE
fix(dev): skip browser-blocked ports

### DIFF
--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -26,6 +26,12 @@ Shared browser dev is single-origin: Vite proxies the backend paths, so never se
 
 The dev runner disables browser auto-open by default. Do not pass `--browser` during automated testing: an automatically opened page can consume the one-time bootstrap token before the controlled browser uses it.
 
+### Verify a shared environment before human handoff
+
+When another person will use the printed pairing URL, first open the shared origin without the pairing path or fragment in the controlled browser and confirm the T3 Code app loads. This browser navigation is required even when curl succeeds because browsers block some otherwise reachable ports before making a network request.
+
+Do not open the other person's complete pairing URL during this reachability check; doing so consumes its one-time token. If the agent also needs an authenticated browser, create and consume a separate pairing token, then leave a fresh token for the other person.
+
 ## Preserve the environment while iterating
 
 Treat the overall testing or implementation loop—not an assistant turn or one verification pass—as the environment lifecycle boundary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 - Start the web stack with `vp run dev`. Add `--share` when someone needs to open it from another device on the tailnet.
 - Browser dev is single-origin: Vite proxies `/api`, `/ws`, `/oauth`, and `/.well-known` to the backend. Do not set `VITE_HTTP_URL` or `VITE_WS_URL` for `dev`/`dev:web`.
 - Worktree paths supply stable preferred port offsets. Read the actual server and web ports from the `[dev-runner]` line because occupied ports can still shift them.
+- Before handing off a `--share` URL, open its origin in a controlled browser and confirm the app loads. A successful curl is insufficient because browsers reject some otherwise reachable ports.
 
 ## Package Roles
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -43,7 +43,7 @@
 
 `dev` and `dev:web` leave `VITE_HTTP_URL` and `VITE_WS_URL` unset so the browser resolves the backend from `window.location.origin`. Vite proxies `/api`, `/ws`, `/oauth`, and `/.well-known` to the server, allowing the same bundle to work from localhost or a tailnet hostname.
 
-Worktrees derive a preferred port offset from their path. The runner shifts both ports together when either is occupied, so treat the `[dev-runner]` output as authoritative.
+Worktrees derive a preferred port offset from their path. The runner shifts both ports together when either is occupied or the web port is blocked by browsers, so treat the `[dev-runner]` output as authoritative.
 
 ## Running multiple dev instances
 

--- a/scripts/dev-runner.test.ts
+++ b/scripts/dev-runner.test.ts
@@ -25,6 +25,7 @@ import {
   devPortProbeHosts,
   findFirstAvailableOffset,
   getDevRunnerModeArgs,
+  isBrowserAllowedPort,
   resolveModePortOffsets,
   resolveOffset,
   runDevRunnerWithInput,
@@ -547,6 +548,41 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
       }),
     );
 
+    it.effect("skips browser-blocked web ports before probing availability", () =>
+      Effect.gen(function* () {
+        const probed: Array<{ port: number; role: string | undefined }> = [];
+        const offset = yield* findFirstAvailableOffset({
+          // 5733 + 833 = 6566, which browsers block as sane-port.
+          startOffset: 833,
+          requireServerPort: true,
+          requireWebPort: true,
+          checkPortAvailability: (port, role) => {
+            probed.push({ port, role });
+            return Effect.succeed(true);
+          },
+        });
+
+        assert.equal(offset, 834);
+        assert.deepStrictEqual(probed, [
+          { port: 14_607, role: "server" },
+          { port: 6567, role: "web" },
+        ]);
+      }),
+    );
+
+    it.effect("does not reject a server-only offset because its unused web port is blocked", () =>
+      Effect.gen(function* () {
+        const offset = yield* findFirstAvailableOffset({
+          startOffset: 833,
+          requireServerPort: true,
+          requireWebPort: false,
+          checkPortAvailability: () => Effect.succeed(true),
+        });
+
+        assert.equal(offset, 833);
+      }),
+    );
+
     it.effect("allows offsets where the non-required server port exceeds max", () =>
       Effect.gen(function* () {
         const offset = yield* findFirstAvailableOffset({
@@ -581,6 +617,19 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
         assert.ok(!("cause" in error));
       }),
     );
+  });
+
+  describe("isBrowserAllowedPort", () => {
+    it.each([6000, 6566, 6665, 6666, 6667, 6668, 6669, 6679, 6697])(
+      "rejects Fetch-blocked web port %s from the worktree offset range",
+      (port) => {
+        assert.equal(isBrowserAllowedPort(port), false);
+      },
+    );
+
+    it.each([5733, 5900, 6567, 6670, 8733])("allows browser-safe web port %s", (port) => {
+      assert.equal(isBrowserAllowedPort(port), true);
+    });
   });
 
   describe("checkPortAvailabilityOnHosts", () => {

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -29,6 +29,17 @@ const BASE_WEB_PORT = 5733;
 const MAX_HASH_OFFSET = 3000;
 const MAX_PORT = 65535;
 const DESKTOP_DEV_LOOPBACK_HOST = "127.0.0.1";
+// HTTP(S) requests to these ports are blocked by the Fetch standard before a
+// browser reaches the network. Keep the complete list here so explicit or
+// future wider offsets cannot produce a URL that curl accepts but browsers
+// reject. https://fetch.spec.whatwg.org/#port-blocking
+const FETCH_BAD_PORTS = new Set([
+  0, 1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102,
+  103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465,
+  512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993,
+  995, 1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668,
+  6669, 6679, 6697, 10080,
+]);
 // Dev servers bind loopback, so loopback is the only interface whose
 // availability decides whether we can use a port. Probing wildcards too made
 // the runner walk away from a perfectly free port whenever something else held
@@ -89,6 +100,10 @@ const DEV_RUNNER_MODES = Object.keys(MODE_ARGS) as Array<DevMode>;
 
 export function getDevRunnerModeArgs(mode: DevMode): ReadonlyArray<string> {
   return MODE_ARGS[mode];
+}
+
+export function isBrowserAllowedPort(port: number): boolean {
+  return !FETCH_BAD_PORTS.has(port);
 }
 
 export class DevRunnerConfigurationError extends Schema.TaggedErrorClass<DevRunnerConfigurationError>()(
@@ -496,6 +511,10 @@ export function findFirstAvailableOffset<R = NetService.NetService>({
         (!requireServerPort && !requireWebPort && (serverPortOutOfRange || webPortOutOfRange))
       ) {
         break;
+      }
+
+      if (requireWebPort && !isBrowserAllowedPort(webPort)) {
+        continue;
       }
 
       const checks: Array<Effect.Effect<boolean, never, R>> = [];


### PR DESCRIPTION
## What changed

- skip WHATWG Fetch bad ports when selecting browser-facing dev ports
- preserve backend-only port selection, since those ports are not navigated directly
- cover the original `6566` regression and every blocked port in the worktree offset range
- require a real browser reachability check before handing a shared environment to another person

## Why

The stable worktree hash for `t3code/prompt-save-queue` selected web port `6566`. The port was free, Tailscale Serve published it, and curl returned 200, but browsers block `6566` before making a network request. The runner therefore emitted a valid-looking pairing URL that no browser could open.

The allocator now treats browser-blocked web ports like unavailable ports and advances the shared offset, while leaving server-only modes unchanged.

## Verification

- `vp test run scripts/dev-runner.test.ts` — 68 tests passed
- `vp run --filter @t3tools/scripts typecheck`
- `vp lint scripts/dev-runner.ts scripts/dev-runner.test.ts --report-unused-disable-directives`
- `T3CODE_PORT_OFFSET=833 vp run dev --dry-run` — selected offset 834, web 6567, server 14607
- `T3CODE_PORT_OFFSET=833 vp run dev --share` — opened the tailnet origin in the controlled browser and confirmed the T3 pairing UI loaded without consuming the pairing token

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to local dev port allocation and agent documentation; behavior is covered by focused dev-runner tests with no production runtime impact.
> 
> **Overview**
> Fixes dev setups where **curl/Tailscale could reach a web port browsers refuse** (e.g. worktree offset landing on **6566**), which produced pairing URLs that looked valid but never loaded.
> 
> **Dev runner** adds the full Fetch “bad port” list and **`isBrowserAllowedPort`**, and **`findFirstAvailableOffset`** treats a blocked web port like an unavailable one—advancing the shared offset without probing—while **server-only** modes (`requireWebPort: false`) are unchanged. Tests cover the **6566 → 6567** regression and blocked ports in the worktree range.
> 
> **Agent/docs** now say port shifts can happen when the **web** port is browser-blocked, and that before handing off **`--share`** you must open the **origin** in a controlled browser (not curl), without consuming someone else’s one-time pairing URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0df5831b27083dc053dfa6d74bca08f198e5cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip browser-blocked ports when selecting dev server web ports
> - Introduces `FETCH_BAD_PORTS` (a set of ports rejected by browsers per the Fetch standard) and `isBrowserAllowedPort` in [dev-runner.ts](https://github.com/pingdotgg/t3code/pull/4608/files#diff-8ba446fc13205cee91be4164b3936316a911d90cfc2fb690c99c49ea439542bf)
> - `findFirstAvailableOffset` now skips candidate offsets whose derived web port is browser-blocked; server-only mode is unaffected
> - Updates docs and agent guidelines to note that `curl` can succeed on ports that browsers reject, and that `[dev-runner]` output is authoritative for the assigned port
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0df583.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->