### PR TITLE
fix(mobile): use Android monospace font family

### DIFF
--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -4,6 +4,10 @@
 /* ─── Theme tokens ──────────────────────────────────────────────────── */
 @layer theme {
   :root {
+    @variant android {
+      --font-mono: "monospace";
+    }
+
     @variant light {
       /* Page backgrounds */
       --color-screen: #f2f2f7;


### PR DESCRIPTION
## Summary

- Override the mobile `--font-mono` token with Android's system `monospace` family.
- Keep the existing font fallback stack unchanged on other platforms.

## Why

React Native Android treats `fontFamily` as one exact family name. The web-style fallback list generated by `font-mono` is therefore not resolved and Android falls back to the proportional default font.

## Testing

- `vp fmt apps/mobile/global.css --check`
- Built the Preview release APK with a fresh Metro/Hermes bundle.
- Verified monospace rendering on a Pixel 9 Pro XL.

Closes #4582


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix monospace font family on Android in mobile app
> Sets `--font-mono` to the generic `monospace` font family inside an `@variant android` block in [global.css](https://github.com/pingdotgg/t3code/pull/4609/files#diff-7866ed7dabc2533089bba8b32fc861187ccbafd1ab2ef9bb833bc842a07bdf96), so monospace text renders correctly on Android devices.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce70ba4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS token override for Android typography with no auth, data, or business-logic impact.
> 
> **Overview**
> Adds an **Android-only** override for the `--font-mono` theme token in `global.css`, setting it to the generic `"monospace"` family inside `@variant android`.
> 
> On Android, React Native matches `fontFamily` to a single family name, so the usual web-style fallback stack for `font-mono` does not apply and monospace UI (diffs, code, branch labels) was rendering in the default proportional font. **iOS and other platforms keep their existing mono stack** unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce70ba43390cb156a66cad94256082e62d3ce752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->