### PR TITLE
feat(web): add a reset-all button to keybindings settings

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -1,4 +1,9 @@
-import { KeybindingCommand, KeybindingRule, KeybindingsConfig } from "@t3tools/contracts";
+import {
+  KeybindingCommand,
+  KeybindingRule,
+  KeybindingsConfig,
+  MAX_KEYBINDINGS_COUNT,
+} from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import { assertFailure } from "@effect/vitest/utils";
@@ -496,6 +501,54 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
         persistedView,
         Keybindings.DEFAULT_KEYBINDINGS.map(({ key, command }) => ({ key, command })),
       );
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
+  it.effect("refuses to reset a keybindings config it cannot read", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      // A directory at the config path fails the read the same way a transient
+      // filesystem error would, without overwriting rules that are still there.
+      yield* fs.makeDirectory(keybindingsConfigPath, { recursive: true });
+
+      const result = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        return yield* keybindings.resetKeybindingRulesToDefaults;
+      }).pipe(toDetailResult);
+
+      assertFailure(result, "failed to read keybindings config");
+      assert.isTrue((yield* fs.stat(keybindingsConfigPath)).type === "Directory");
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
+  it.effect("keeps every default when preserved script bindings exceed the max count", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      const scriptBudget = MAX_KEYBINDINGS_COUNT - Keybindings.DEFAULT_KEYBINDINGS.length;
+      const scriptRules = Array.from(
+        { length: scriptBudget + 5 },
+        (_, index): KeybindingRule => ({
+          key: "mod+r",
+          command: `script.s${index}.run`,
+        }),
+      );
+      yield* writeKeybindingsConfig(keybindingsConfigPath, scriptRules);
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        return yield* keybindings.resetKeybindingRulesToDefaults;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedDefaults = persisted
+        .filter((rule) => !String(rule.command).startsWith("script."))
+        .map(({ key, command }) => ({ key, command }));
+      assert.deepEqual(
+        persistedDefaults,
+        Keybindings.DEFAULT_KEYBINDINGS.map(({ key, command }) => ({ key, command })),
+      );
+      assert.equal(persisted.length, MAX_KEYBINDINGS_COUNT);
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -549,6 +549,13 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
         Keybindings.DEFAULT_KEYBINDINGS.map(({ key, command }) => ({ key, command })),
       );
       assert.equal(persisted.length, MAX_KEYBINDINGS_COUNT);
+      // Later rules win, so the surviving scripts must be the trailing ones.
+      assert.deepEqual(
+        persisted
+          .filter((rule) => String(rule.command).startsWith("script."))
+          .map((rule) => rule.command),
+        scriptRules.slice(5).map((rule) => rule.command),
+      );
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -454,6 +454,51 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("resets customized keybindings to defaults while keeping script bindings", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+j", command: "terminal.toggle" },
+        { key: "mod+r", command: "script.run-tests.run" },
+      ]);
+
+      const resolved = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        return yield* keybindings.resetKeybindingRulesToDefaults;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedView = persisted.map(({ key, command }) => ({ key, command }));
+      assert.deepEqual(persistedView, [
+        ...Keybindings.DEFAULT_KEYBINDINGS.map(({ key, command }) => ({ key, command })),
+        { key: "mod+r", command: "script.run-tests.run" },
+      ]);
+      assert.isTrue(resolved.some((entry) => entry.command === "script.run-tests.run"));
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
+  it.effect("resets a malformed keybindings config to defaults", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* fs.makeDirectory(path.dirname(keybindingsConfigPath), { recursive: true });
+      yield* fs.writeFileString(keybindingsConfigPath, "{ not an array");
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        return yield* keybindings.resetKeybindingRulesToDefaults;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedView = persisted.map(({ key, command }) => ({ key, command }));
+      assert.deepEqual(
+        persistedView,
+        Keybindings.DEFAULT_KEYBINDINGS.map(({ key, command }) => ({ key, command })),
+      );
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("refuses to overwrite malformed keybindings config", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -725,14 +725,17 @@ const make = Effect.gen(function* () {
         const { keybindings: customConfig } = yield* loadRuntimeCustomKeybindingsConfig();
         const preservedScripts = customConfig.filter((entry) => isScriptKeybindingRule(entry));
         // Truncate the preserved scripts, never the defaults — a reset that
-        // dropped default rules to stay under the cap would defeat itself.
+        // dropped default rules to stay under the cap would defeat itself. Drop
+        // from the front, because later rules have higher precedence, so the
+        // trailing scripts are the ones actually in effect.
         const scriptBudget = Math.max(0, MAX_KEYBINDINGS_COUNT - DEFAULT_KEYBINDINGS.length);
-        const cappedConfig = [...DEFAULT_KEYBINDINGS, ...preservedScripts.slice(0, scriptBudget)];
-        if (preservedScripts.length > scriptBudget) {
+        const droppedScripts = Math.max(0, preservedScripts.length - scriptBudget);
+        const cappedConfig = [...DEFAULT_KEYBINDINGS, ...preservedScripts.slice(droppedScripts)];
+        if (droppedScripts > 0) {
           yield* Effect.logWarning("dropping script keybindings to stay under max entries", {
             path: keybindingsConfigPath,
             maxEntries: MAX_KEYBINDINGS_COUNT,
-            dropped: preservedScripts.length - scriptBudget,
+            dropped: droppedScripts,
           });
         }
         yield* writeConfigAtomically(cappedConfig);

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -295,7 +295,8 @@ export class Keybindings extends Context.Service<
      * Project script bindings are kept — they have no default to restore, so
      * dropping them would delete shortcuts the reset cannot give back. A config
      * that fails to parse is replaced outright, since that is the state the
-     * reset exists to escape.
+     * reset exists to escape; a config that cannot be read at all fails
+     * instead, rather than overwriting rules that are still on disk.
      */
     readonly resetKeybindingRulesToDefaults: Effect.Effect<
       ResolvedKeybindingsConfig,
@@ -717,14 +718,23 @@ const make = Effect.gen(function* () {
       ),
     resetKeybindingRulesToDefaults: upsertSemaphore.withPermits(1)(
       Effect.gen(function* () {
-        const loaded = yield* Effect.result(loadWritableCustomKeybindingsConfig());
-        const customConfig = loaded._tag === "Success" ? loaded.success : [];
+        // The runtime loader, not the writable one: a config that cannot be
+        // parsed must resolve to "no rules to preserve" so the reset can still
+        // replace it, while a filesystem failure still aborts rather than
+        // overwriting a file we could not read.
+        const { keybindings: customConfig } = yield* loadRuntimeCustomKeybindingsConfig();
         const preservedScripts = customConfig.filter((entry) => isScriptKeybindingRule(entry));
-        const nextConfig = [...DEFAULT_KEYBINDINGS, ...preservedScripts];
-        const cappedConfig =
-          nextConfig.length > MAX_KEYBINDINGS_COUNT
-            ? nextConfig.slice(-MAX_KEYBINDINGS_COUNT)
-            : nextConfig;
+        // Truncate the preserved scripts, never the defaults — a reset that
+        // dropped default rules to stay under the cap would defeat itself.
+        const scriptBudget = Math.max(0, MAX_KEYBINDINGS_COUNT - DEFAULT_KEYBINDINGS.length);
+        const cappedConfig = [...DEFAULT_KEYBINDINGS, ...preservedScripts.slice(0, scriptBudget)];
+        if (preservedScripts.length > scriptBudget) {
+          yield* Effect.logWarning("dropping script keybindings to stay under max entries", {
+            path: keybindingsConfigPath,
+            maxEntries: MAX_KEYBINDINGS_COUNT,
+            dropped: preservedScripts.length - scriptBudget,
+          });
+        }
         yield* writeConfigAtomically(cappedConfig);
         const nextResolved = mergeWithDefaultKeybindings(
           compileResolvedKeybindingsConfig(cappedConfig),

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -109,6 +109,10 @@ function isSameKeybindingRule(left: KeybindingRule, right: KeybindingRule): bool
   );
 }
 
+function isScriptKeybindingRule(rule: KeybindingRule): boolean {
+  return String(rule.command).startsWith("script.");
+}
+
 function keybindingShortcutContext(rule: KeybindingRule): string | null {
   const parsed = parseKeybindingShortcut(rule.key);
   if (!parsed) return null;
@@ -284,6 +288,19 @@ export class Keybindings extends Context.Service<
     readonly removeKeybindingRule: (
       input: ServerRemoveKeybindingInput,
     ) => Effect.Effect<ResolvedKeybindingsConfig, KeybindingsConfigError>;
+
+    /**
+     * Restore every default keybinding, discarding customizations.
+     *
+     * Project script bindings are kept — they have no default to restore, so
+     * dropping them would delete shortcuts the reset cannot give back. A config
+     * that fails to parse is replaced outright, since that is the state the
+     * reset exists to escape.
+     */
+    readonly resetKeybindingRulesToDefaults: Effect.Effect<
+      ResolvedKeybindingsConfig,
+      KeybindingsConfigError
+    >;
   }
 >()("t3/keybindings") {}
 
@@ -698,6 +715,31 @@ const make = Effect.gen(function* () {
           return nextResolved;
         }),
       ),
+    resetKeybindingRulesToDefaults: upsertSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        const loaded = yield* Effect.result(loadWritableCustomKeybindingsConfig());
+        const customConfig = loaded._tag === "Success" ? loaded.success : [];
+        const preservedScripts = customConfig.filter((entry) => isScriptKeybindingRule(entry));
+        const nextConfig = [...DEFAULT_KEYBINDINGS, ...preservedScripts];
+        const cappedConfig =
+          nextConfig.length > MAX_KEYBINDINGS_COUNT
+            ? nextConfig.slice(-MAX_KEYBINDINGS_COUNT)
+            : nextConfig;
+        yield* writeConfigAtomically(cappedConfig);
+        const nextResolved = mergeWithDefaultKeybindings(
+          compileResolvedKeybindingsConfig(cappedConfig),
+        );
+        yield* Cache.set(resolvedConfigCache, resolvedConfigCacheKey, {
+          keybindings: nextResolved,
+          issues: [],
+        });
+        yield* emitChange({
+          keybindings: nextResolved,
+          issues: [],
+        });
+        return nextResolved;
+      }),
+    ),
   } satisfies Keybindings["Service"];
 });
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -300,6 +300,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.serverUpdateServer, AuthOrchestrationOperateScope],
   [WS_METHODS.serverUpsertKeybinding, AuthOrchestrationOperateScope],
   [WS_METHODS.serverRemoveKeybinding, AuthOrchestrationOperateScope],
+  [WS_METHODS.serverResetKeybindings, AuthOrchestrationOperateScope],
   [WS_METHODS.serverGetSettings, AuthOrchestrationReadScope],
   [WS_METHODS.serverUpdateSettings, AuthOrchestrationOperateScope],
   [WS_METHODS.serverDiscoverSourceControl, AuthOrchestrationReadScope],
@@ -1497,6 +1498,15 @@ const makeWsRpcLayer = (
             WS_METHODS.serverRemoveKeybinding,
             Effect.gen(function* () {
               const keybindingsConfig = yield* keybindings.removeKeybindingRule(rule);
+              return { keybindings: keybindingsConfig, issues: [] };
+            }),
+            { "rpc.aggregate": "server" },
+          ),
+        [WS_METHODS.serverResetKeybindings]: (_input) =>
+          observeRpcEffect(
+            WS_METHODS.serverResetKeybindings,
+            Effect.gen(function* () {
+              const keybindingsConfig = yield* keybindings.resetKeybindingRulesToDefaults;
               return { keybindings: keybindingsConfig, issues: [] };
             }),
             { "rpc.aggregate": "server" },

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -1243,7 +1243,14 @@ export function KeybindingsSettingsPanel() {
       if (!confirmed) return;
       // The primary environment can change while the dialog is open, and this
       // discards every customization — target only what the user was shown.
-      if (primaryEnvironmentRef.current?.environmentId !== environmentId) return;
+      if (primaryEnvironmentRef.current?.environmentId !== environmentId) {
+        toastManager.add({
+          title: "Keybindings were not reset",
+          description: "The active environment changed while the confirmation was open.",
+          type: "error",
+        });
+        return;
+      }
       setIsResetting(true);
       const result = await resetKeybindingsMutation({
         environmentId,

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -6,6 +6,7 @@ import {
   InfoIcon,
   MinusIcon,
   PlusIcon,
+  RotateCcwIcon,
   SearchIcon,
   TriangleAlertIcon,
   XIcon,
@@ -35,6 +36,7 @@ import {
 
 import { isElectron } from "../../env";
 import { useOpenInPreferredEditor } from "../../editorPreferences";
+import { readLocalApi } from "../../localApi";
 import { formatShortcutLabel } from "../../keybindings";
 import { cn } from "../../lib/utils";
 import {
@@ -1092,6 +1094,9 @@ export function KeybindingsSettingsPanel() {
   const removeKeybindingMutation = useAtomCommand(serverEnvironment.removeKeybinding, {
     reportFailure: false,
   });
+  const resetKeybindingsMutation = useAtomCommand(serverEnvironment.resetKeybindings, {
+    reportFailure: false,
+  });
   const openInPreferredEditor = useOpenInPreferredEditor(
     primaryEnvironment?.environmentId ?? null,
     availableEditors,
@@ -1220,6 +1225,33 @@ export function KeybindingsSettingsPanel() {
     [saveKeybinding],
   );
 
+  const [isResetting, setIsResetting] = useState(false);
+  const resetAllKeybindings = useCallback(() => {
+    if (!primaryEnvironment) return;
+    void (async () => {
+      const confirmed = await readLocalApi()?.dialogs.confirm(
+        [
+          "Reset all keybindings to their defaults?",
+          "Every customization is discarded. Project script bindings are kept.",
+        ].join("\n"),
+      );
+      if (!confirmed) return;
+      setIsResetting(true);
+      const result = await resetKeybindingsMutation({
+        environmentId: primaryEnvironment.environmentId,
+        input: {},
+      });
+      setIsResetting(false);
+      if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
+      const error = squashAtomCommandFailure(result);
+      toastManager.add({
+        title: "Unable to reset keybindings",
+        description: error instanceof Error ? error.message : "The keybindings were not reset.",
+        type: "error",
+      });
+    })();
+  }, [primaryEnvironment, resetKeybindingsMutation]);
+
   const bindingsCount = (
     <span className="text-[11px] text-muted-foreground">
       {rows.length + (isAddingBinding ? 1 : 0)}{" "}
@@ -1257,6 +1289,24 @@ export function KeybindingsSettingsPanel() {
                 }
               />
               <TooltipPopup side="top">Add keybinding</TooltipPopup>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                    disabled={!primaryEnvironment || isResetting}
+                    onClick={resetAllKeybindings}
+                    aria-label="Reset all keybindings to defaults"
+                  >
+                    <RotateCcwIcon className="size-3" />
+                  </Button>
+                }
+              />
+              <TooltipPopup side="top">Reset all to defaults</TooltipPopup>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -1226,8 +1226,13 @@ export function KeybindingsSettingsPanel() {
   );
 
   const [isResetting, setIsResetting] = useState(false);
+  const primaryEnvironmentRef = useRef(primaryEnvironment);
+  useEffect(() => {
+    primaryEnvironmentRef.current = primaryEnvironment;
+  }, [primaryEnvironment]);
   const resetAllKeybindings = useCallback(() => {
-    if (!primaryEnvironment) return;
+    const environmentId = primaryEnvironment?.environmentId;
+    if (!environmentId) return;
     void (async () => {
       const confirmed = await readLocalApi()?.dialogs.confirm(
         [
@@ -1236,9 +1241,12 @@ export function KeybindingsSettingsPanel() {
         ].join("\n"),
       );
       if (!confirmed) return;
+      // The primary environment can change while the dialog is open, and this
+      // discards every customization — target only what the user was shown.
+      if (primaryEnvironmentRef.current?.environmentId !== environmentId) return;
       setIsResetting(true);
       const result = await resetKeybindingsMutation({
-        environmentId: primaryEnvironment.environmentId,
+        environmentId,
         input: {},
       });
       setIsResetting(false);
@@ -1250,7 +1258,7 @@ export function KeybindingsSettingsPanel() {
         type: "error",
       });
     })();
-  }, [primaryEnvironment, resetKeybindingsMutation]);
+  }, [primaryEnvironment?.environmentId, resetKeybindingsMutation]);
 
   const bindingsCount = (
     <span className="text-[11px] text-muted-foreground">

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -339,6 +339,12 @@ export function createServerEnvironmentAtoms<R, E>(
       scheduler: configScheduler,
       concurrency: configConcurrency,
     }),
+    resetKeybindings: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:server:reset-keybindings",
+      tag: WS_METHODS.serverResetKeybindings,
+      scheduler: configScheduler,
+      concurrency: configConcurrency,
+    }),
     updateSettings: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:server:update-settings",
       tag: WS_METHODS.serverUpdateSettings,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -121,6 +121,7 @@ import {
   ServerLifecycleStreamEvent,
   ServerRemoveKeybindingInput,
   ServerRemoveKeybindingResult,
+  ServerResetKeybindingsResult,
   ServerProviderUpdatedPayload,
   ServerSelfUpdateError,
   ServerSelfUpdateInput,
@@ -211,6 +212,7 @@ export const WS_METHODS = {
   serverUpdateServer: "server.updateServer",
   serverUpsertKeybinding: "server.upsertKeybinding",
   serverRemoveKeybinding: "server.removeKeybinding",
+  serverResetKeybindings: "server.resetKeybindings",
   serverGetSettings: "server.getSettings",
   serverUpdateSettings: "server.updateSettings",
   serverDiscoverSourceControl: "server.discoverSourceControl",
@@ -248,6 +250,12 @@ export const WsServerUpsertKeybindingRpc = Rpc.make(WS_METHODS.serverUpsertKeybi
 export const WsServerRemoveKeybindingRpc = Rpc.make(WS_METHODS.serverRemoveKeybinding, {
   payload: ServerRemoveKeybindingInput,
   success: ServerRemoveKeybindingResult,
+  error: Schema.Union([KeybindingsConfigError, EnvironmentAuthorizationError]),
+});
+
+export const WsServerResetKeybindingsRpc = Rpc.make(WS_METHODS.serverResetKeybindings, {
+  payload: Schema.Struct({}),
+  success: ServerResetKeybindingsResult,
   error: Schema.Union([KeybindingsConfigError, EnvironmentAuthorizationError]),
 });
 
@@ -706,6 +714,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerUpdateServerRpc,
   WsServerUpsertKeybindingRpc,
   WsServerRemoveKeybindingRpc,
+  WsServerResetKeybindingsRpc,
   WsServerGetSettingsRpc,
   WsServerUpdateSettingsRpc,
   WsServerDiscoverSourceControlRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -451,6 +451,9 @@ export type ServerUpsertKeybindingResult = typeof ServerUpsertKeybindingResult.T
 export const ServerRemoveKeybindingResult = ServerUpsertKeybindingResult;
 export type ServerRemoveKeybindingResult = typeof ServerRemoveKeybindingResult.Type;
 
+export const ServerResetKeybindingsResult = ServerUpsertKeybindingResult;
+export type ServerResetKeybindingsResult = typeof ServerResetKeybindingsResult.Type;
+
 export const ServerConfigUpdatedPayload = Schema.Struct({
   issues: ServerConfigIssues,
   providers: ServerProviders,


### PR DESCRIPTION
Closes #4576

## Problem

Keybindings settings can reset a single row to its default, but there is no way to get the whole set back. A user carrying customizations from an older version can end up with conflicting bindings and no recourse short of hand-editing `keybindings.json` — which is exactly what someone in that state does not want to do, and which the issue calls out directly.

## Change

- **`server.resetKeybindings`** RPC → `Keybindings.resetKeybindingRulesToDefaults`, which rewrites the config with `DEFAULT_KEYBINDINGS`, refreshes the cache, and emits the change event like the existing upsert/remove paths.
- **Reset button** in the Keybindings settings header, beside Add keybinding and Open keybindings.json. It confirms first, since it discards every customization at once.

Two deliberate behaviors, both covered by tests:

- **Project script bindings (`script.*`) are kept.** They have no default to restore, so dropping them would delete shortcuts the reset cannot give back. The confirm dialog says so.
- **A config that fails to parse is replaced outright** instead of erroring. A malformed `keybindings.json` is the state this button exists to escape, so refusing to overwrite it would defeat the feature. `upsertKeybindingRule` keeps its existing refuse-to-overwrite behavior.

## Tests

`apps/server/src/keybindings.test.ts`:

- reset restores the defaults, drops customizations, and keeps the `script.*` rule;
- reset replaces a malformed config with the defaults.

`vp test run src/keybindings.test.ts` — 23 passed. (`fails when config directory is not writable` fails on this Windows host both with and without this change: `fs.chmod` does not restrict the directory there. Verified against a clean tree.)

Typecheck clean for `packages/contracts`, `packages/client-runtime`, `apps/server`, `apps/web`; lint and format checked on the changed files.

## Verified in the app

Ran the web stack against an isolated `--home-dir`, planted a customized `keybindings.json` (remapped `sidebar.toggle` and `terminal.toggle`, plus a `script.run-tests.run` binding), and clicked the button:

- confirm text: "Reset all keybindings to their defaults? / Every customization is discarded. Project script bindings are kept."
- on disk afterwards: the non-script rules are byte-identical to `DEFAULT_KEYBINDINGS`, the remapped shortcuts are gone, and `script.run-tests.run` survives;
- the table updates live, 42 bindings (41 defaults + the script rule).

## Not included

The issue also floats migrations for defaults that change upstream. That is a separate mechanism and is not part of this change; the startup sync still backfills newly added defaults as it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk-writes user keybinding config and overwrites malformed files on reset; behavior is intentional but can surprise users who relied on a broken on-disk file.
> 
> **Overview**
> Adds **reset all keybindings to defaults** end-to-end: a new `server.resetKeybindings` RPC (orchestration operate scope) wired through contracts, client-runtime, and the Keybindings settings header.
> 
> Server-side **`resetKeybindingRulesToDefaults`** rewrites `keybindings.json` with `DEFAULT_KEYBINDINGS`, keeps `script.*` rules, updates cache, and broadcasts changes like upsert/remove. **Malformed configs are replaced** on reset (unlike upsert, which still refuses to overwrite). **Unreadable configs fail** without writing. If script rules exceed the cap after reset, **defaults are never dropped**—oldest script entries are trimmed and a warning is logged.
> 
> The settings UI adds a **Reset all to defaults** control with confirmation (notes that script bindings stay), guards against environment changes while the dialog is open, and surfaces errors via toasts.
> 
> **Tests** cover happy path, malformed replacement, read failure, and max-count script truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e832d8a8a4eeea3c4f6ab127f8c02eac13063e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a reset-all button to keybindings settings
> - Adds a "Reset All" toolbar button in [KeybindingsSettings.tsx](https://github.com/pingdotgg/t3code/pull/4616/files#diff-12068495a79a13f54503fa3061aafb91f05537621626906b290ed059e660d4d4) that prompts for confirmation before resetting keybindings to defaults.
> - Implements `resetKeybindingRulesToDefaults` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/4616/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e): writes defaults plus any existing script bindings, updates the in-memory cache, and broadcasts a change event.
> - Exposes a new `server.resetKeybindings` WebSocket RPC in [ws.ts](https://github.com/pingdotgg/t3code/pull/4616/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125), gated by orchestration operate scope.
> - Script bindings are preserved up to `MAX_KEYBINDINGS_COUNT`; excess script rules are dropped (trailing rules survive) with a warning logged.
> - Risk: malformed keybinding configs are silently overwritten on reset; configs that cannot be read (e.g. a directory at the path) return a failure instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e832d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->