### PR TITLE
feat(codex): enable input dialogs in default mode

### DIFF
--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -142,9 +142,11 @@ Your active mode changes only when new developer instructions with a different \
 
 ## request_user_input availability
 
-The \`request_user_input\` tool is unavailable in Default mode. If you call it while in Default mode, it will return an error.
+Use the \`request_user_input\` tool only when it is listed in the available tools for this turn.
 
-In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
+In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. When \`request_user_input\` is available, reserve it for genuine human-only blockers such as one-time verification codes, CAPTCHA handoffs, missing personal or application details, and high-impact decisions where a reasonable assumption would be risky. Do not use it for routine preferences or information that can be discovered from local context. For a free-form value such as a verification code, let the user supply a custom answer through the prompt.
+
+If human input is required but \`request_user_input\` is unavailable, ask one concise plain-text question. Never write a multiple choice question as a textual assistant message.
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
 </collaboration_mode>`;
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -6,6 +6,7 @@ import * as NodePath from "node:path";
 import {
   ApprovalRequestId,
   CodexSettings,
+  EnvironmentId,
   EventId,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -35,6 +36,7 @@ import * as Stream from "effect/Stream";
 import * as CodexErrors from "effect-codex-app-server/errors";
 
 import { ServerConfig } from "../../config.ts";
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderAdapterValidationError } from "../Errors.ts";
 import type { CodexAdapterShape } from "../Services/CodexAdapter.ts";
@@ -277,6 +279,7 @@ validationLayer("CodexAdapterLive validation", (it) => {
       });
 
       NodeAssert.deepStrictEqual(validationRuntimeFactory.factory.mock.calls[0]?.[0], {
+        appServerArgs: ["--enable", "default_mode_request_user_input"],
         binaryPath: "codex",
         cwd: process.cwd(),
         launchArgs: "",
@@ -288,6 +291,45 @@ validationLayer("CodexAdapterLive validation", (it) => {
       });
     }),
   );
+
+  it.effect("combines Default-mode user input with the T3 MCP configuration", () => {
+    const threadId = asThreadId("thread-mcp-user-input");
+    return Effect.gen(function* () {
+      validationRuntimeFactory.factory.mockClear();
+      McpProviderSession.setMcpProviderSession({
+        environmentId: EnvironmentId.make("environment-mcp-user-input"),
+        threadId,
+        providerSessionId: "provider-session-mcp-user-input",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        endpoint: "http://127.0.0.1:3773/mcp",
+        authorizationHeader: "Bearer test-mcp-token",
+      });
+
+      const adapter = yield* CodexAdapter;
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const runtimeOptions = validationRuntimeFactory.factory.mock.calls[0]?.[0];
+      NodeAssert.deepStrictEqual(runtimeOptions?.appServerArgs, [
+        "--enable",
+        "default_mode_request_user_input",
+        "-c",
+        "mcp_servers.t3-code.url=http://127.0.0.1:3773/mcp",
+        "-c",
+        'mcp_servers.t3-code.bearer_token_env_var="T3_MCP_BEARER_TOKEN"',
+      ]);
+      NodeAssert.equal(runtimeOptions?.environment?.T3_MCP_BEARER_TOKEN, "test-mcp-token");
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          McpProviderSession.clearMcpProviderSession(threadId);
+        }),
+      ),
+    );
+  });
 });
 
 const sessionRuntimeFactory = makeRuntimeFactory();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1395,6 +1395,18 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             ? getCodexServiceTierOptionValue(input.modelSelection)
             : undefined;
         const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+        const appServerArgs = [
+          "--enable",
+          "default_mode_request_user_input",
+          ...(mcpSession
+            ? [
+                "-c",
+                `mcp_servers.t3-code.url=${mcpSession.endpoint}`,
+                "-c",
+                'mcp_servers.t3-code.bearer_token_env_var="T3_MCP_BEARER_TOKEN"',
+              ]
+            : []),
+        ];
         const runtimeInput: CodexSessionRuntimeOptions = {
           threadId: input.threadId,
           providerInstanceId: boundInstanceId,
@@ -1411,18 +1423,13 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             ? { model: input.modelSelection.model }
             : {}),
           ...(serviceTier ? { serviceTier } : {}),
+          appServerArgs,
           ...(mcpSession
             ? {
                 environment: {
                   ...(options?.environment ?? process.env),
                   T3_MCP_BEARER_TOKEN: mcpSession.authorizationHeader.replace(/^Bearer\s+/, ""),
                 },
-                appServerArgs: [
-                  "-c",
-                  `mcp_servers.t3-code.url=${mcpSession.endpoint}`,
-                  "-c",
-                  'mcp_servers.t3-code.bearer_token_env_var="T3_MCP_BEARER_TOKEN"',
-                ],
               }
             : {}),
         };

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -259,6 +259,21 @@ describe("buildCodexDeveloperInstructions", () => {
     NodeAssert.match(instructions, /as gpt-5\.3-codex with high reasoning effort/);
   });
 
+  it("reserves Default-mode user input prompts for genuine human blockers", () => {
+    const instructions = buildCodexDeveloperInstructions("default", {
+      model: "gpt-5.3-codex",
+      reasoningEffort: "high",
+    });
+
+    NodeAssert.doesNotMatch(instructions, /unavailable in Default mode/);
+    NodeAssert.match(instructions, /only when it is listed in the available tools/);
+    NodeAssert.match(instructions, /one-time verification codes/);
+    NodeAssert.match(instructions, /CAPTCHA handoffs/);
+    NodeAssert.match(instructions, /missing personal or application details/);
+    NodeAssert.match(instructions, /Do not use it for routine preferences/);
+    NodeAssert.match(instructions, /ask one concise plain-text question/);
+  });
+
   it("includes runtime info alongside plan mode instructions", () => {
     const instructions = buildCodexDeveloperInstructions("plan", {
       model: "gpt-5.3-codex",


### PR DESCRIPTION
## What Changed

- Enable Codex app-server default_mode_request_user_input for every new session.
- Preserve the feature flag when T3 MCP arguments are also configured.
- Update Default-mode developer instructions so request_user_input is used only when advertised and only for genuine human blockers.
- Add focused adapter and developer-instruction coverage.

## Why

Codex gates interactive user-input requests in Default mode behind this app-server feature. Without it, Default-mode sessions cannot surface the existing T3 input dialog for verification codes, CAPTCHA handoffs, missing personal details, or other true human blockers.

## UI Changes

No UI components changed. The existing request-user-input dialog is now reachable from Default-mode Codex sessions. In an isolated browser run, Codex requested a one-time verification code, the dialog rendered its options and custom-answer field, and submitting a custom code resumed the turn successfully.

## Verification

- vp test run apps/server/src/provider/Layers/CodexAdapter.test.ts apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
- vp fmt --check on the four changed files
- vp lint --report-unused-disable-directives on the four changed files
- vp run --filter t3 typecheck
- Isolated authenticated browser verification with a live Default-mode Codex session

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Existing UI behavior was manually verified; no UI component or visual styling changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Codex session launch args and agent prompting for interactive input; behavior is scoped to the Codex adapter but affects when turns pause for user input.
> 
> **Overview**
> **Default-mode Codex sessions** can now surface the existing T3 user-input dialog by always passing `--enable default_mode_request_user_input` when starting the app server. When a thread has T3 MCP configured, that flag is **prepended** to the existing `mcp_servers.t3-code` args instead of only attaching MCP flags.
> 
> **Default-mode developer instructions** no longer treat `request_user_input` as unavailable. The model is told to call it only when the tool is advertised for the turn, to reserve it for genuine human blockers (verification codes, CAPTCHA, missing personal details, risky decisions), and to fall back to a single plain-text question if the tool is not available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a81bdf41d2deb4ff22dd8965318fe5b1ff5bee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable `request_user_input` dialog in Codex default mode
> - `makeCodexAdapter.startSession` now always passes `--enable default_mode_request_user_input` in `appServerArgs`, activating input dialogs in default mode.
> - Developer instructions in [CodexDeveloperInstructions.ts](https://github.com/pingdotgg/t3code/pull/4618/files#diff-bfed4010ccd0734199963a19269942f8abbe9e3b025dd0e8e0253dfe8af72c04) are updated to restrict `request_user_input` to genuine human-only blockers (verification codes, CAPTCHAs, missing personal details, high-impact decisions) and discourage use for routine preferences.
> - When `request_user_input` is unavailable but human input is needed, the model is instructed to ask a single concise plain-text question instead of sending multiple-choice messages.
> - Behavioral Change: all new Codex sessions will receive the `--enable default_mode_request_user_input` flag by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11a81bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->