### PR TITLE
fix(client-runtime): revalidate filesystem browse on remount

### DIFF
--- a/packages/client-runtime/src/state/filesystem.test.ts
+++ b/packages/client-runtime/src/state/filesystem.test.ts
@@ -1,0 +1,28 @@
+import { WS_METHODS } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { createEnvironmentRpcQueryAtomFamily } = vi.hoisted(() => ({
+  createEnvironmentRpcQueryAtomFamily: vi.fn(() => Symbol("filesystem-browse-query")),
+}));
+
+vi.mock("./runtime.ts", () => ({ createEnvironmentRpcQueryAtomFamily }));
+
+import { createFilesystemEnvironmentAtoms } from "./filesystem.ts";
+
+describe("filesystem browse query policy", () => {
+  beforeEach(() => {
+    createEnvironmentRpcQueryAtomFamily.mockClear();
+  });
+
+  it("marks directory listings stale immediately so browser remounts revalidate", () => {
+    const runtime = {} as never;
+
+    createFilesystemEnvironmentAtoms(runtime);
+
+    expect(createEnvironmentRpcQueryAtomFamily).toHaveBeenCalledWith(runtime, {
+      label: "environment-data:filesystem:browse",
+      tag: WS_METHODS.filesystemBrowse,
+      staleTimeMs: 0,
+    });
+  });
+});

--- a/packages/client-runtime/src/state/filesystem.ts
+++ b/packages/client-runtime/src/state/filesystem.ts
@@ -11,6 +11,8 @@ export function createFilesystemEnvironmentAtoms<R, E>(
     browse: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:filesystem:browse",
       tag: WS_METHODS.filesystemBrowse,
+      // Directory contents can change outside the app, so each browser mount must revalidate.
+      staleTimeMs: 0,
     }),
   };
 }


### PR DESCRIPTION
## What Changed

Set `filesystem.browse` query `staleTimeMs` to `0` in client-runtime, so remounting the Add Project browser revalidates directory listings against the live server response.

Also adds a focused unit test that asserts the browse query is wired with `staleTimeMs: 0`.

## Why

`#4600`: after creating a directory outside the app and reopening Add Project on the same path, newly created folders stayed missing until the default 30s SWR stale window expired.

Server `filesystem.browse` already does a fresh `readdir`. The bug was client-side query cache reuse on remount, not server indexing.

## UI Changes

No visual design change. Behavior only: Add Project directory list refreshes when the dialog remounts.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Fixes #4600

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow client-side cache tuning for directory browse only; no auth, data migration, or server behavior changes.
> 
> **Overview**
> Sets **`staleTimeMs: 0`** on the `filesystem.browse` environment RPC query so directory listings are always treated as stale. Remounting the Add Project browser (or any consumer of that query) refetches from the server instead of reusing the default ~30s SWR cache, which fixes folders created outside the app staying hidden until the stale window expired.
> 
> Adds a unit test that **`createFilesystemEnvironmentAtoms`** wires `browse` through `createEnvironmentRpcQueryAtomFamily` with that policy and the existing `filesystemBrowse` tag/label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae78c52e68a04b1c789bee267592f9789c88d43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `staleTimeMs: 0` on filesystem browse atom to revalidate on remount
> Directory listing queries were not revalidated when a component remounted, causing stale filesystem data to persist. Setting `staleTimeMs: 0` in [filesystem.ts](https://github.com/pingdotgg/t3code/pull/4620/files#diff-4fff3627afb7a162a811be90f9fb829954498dd2f1520cd682ed41a8599f813a) marks browse results as immediately stale so they are re-fetched on every mount.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ae78c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->