### PR TITLE
fix(orchestrator): surface provider turn interrupt failures in the thread

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -231,7 +231,7 @@ describe("ProviderCommandReactor", () => {
         turnId: asTurnId("turn-1"),
       }),
     );
-    const interruptTurn = vi.fn((_: unknown) => Effect.void);
+    const interruptTurn = vi.fn<ProviderServiceShape["interruptTurn"]>(() => Effect.void);
     const respondToRequest = vi.fn<ProviderServiceShape["respondToRequest"]>(() => Effect.void);
     const respondToUserInput = vi.fn<ProviderServiceShape["respondToUserInput"]>(() => Effect.void);
     const stopSession = vi.fn((input: unknown) =>
@@ -1757,6 +1757,74 @@ describe("ProviderCommandReactor", () => {
       threadId: "thread-1",
     });
   });
+
+  effectIt.effect(
+    "appends an interrupt failure activity when the provider rejects the interrupt",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() => createHarness());
+        const now = "2026-01-01T00:00:00.000Z";
+        harness.interruptTurn.mockImplementation(() =>
+          Effect.fail(
+            new ProviderAdapterRequestError({
+              provider: "codex",
+              method: "turn/interrupt",
+              detail: "expected active turn id turn-2 but found turn-1",
+            }),
+          ),
+        );
+
+        yield* harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-session-set-interrupt-failure"),
+          threadId: ThreadId.make("thread-1"),
+          session: {
+            threadId: ThreadId.make("thread-1"),
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "approval-required",
+            activeTurnId: asTurnId("turn-1"),
+            lastError: null,
+            updatedAt: now,
+          },
+          createdAt: now,
+        });
+
+        yield* harness.engine.dispatch({
+          type: "thread.turn.interrupt",
+          commandId: CommandId.make("cmd-turn-interrupt-failure"),
+          threadId: ThreadId.make("thread-1"),
+          turnId: asTurnId("turn-1"),
+          createdAt: now,
+        });
+
+        yield* Effect.promise(() =>
+          waitFor(async () => {
+            const readModel = await harness.readModel();
+            const thread = readModel.threads.find(
+              (entry) => entry.id === ThreadId.make("thread-1"),
+            );
+            return (
+              thread?.activities.some(
+                (activity) => activity.kind === "provider.turn.interrupt.failed",
+              ) ?? false
+            );
+          }),
+        );
+
+        const readModel = yield* Effect.promise(() => harness.readModel());
+        const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+        expect(
+          thread?.activities.find((activity) => activity.kind === "provider.turn.interrupt.failed"),
+        ).toMatchObject({
+          tone: "error",
+          turnId: "turn-1",
+          payload: {
+            detail: "expected active turn id turn-2 but found turn-1",
+          },
+        });
+      }),
+  );
 
   it("starts a fresh session when only projected session state exists", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -904,7 +904,22 @@ const make = Effect.gen(function* () {
     }
 
     // Orchestration turn ids are not provider turn ids, so interrupt by session.
-    yield* providerService.interruptTurn({ threadId: event.payload.threadId });
+    yield* providerService.interruptTurn({ threadId: event.payload.threadId }).pipe(
+      Effect.catchCause((cause) =>
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.void
+          : // Without this the rejection only reaches a log line, so Stop
+            // generation looks like it worked while the turn keeps running.
+            appendProviderFailureActivity({
+              threadId: event.payload.threadId,
+              kind: "provider.turn.interrupt.failed",
+              summary: "Provider turn interrupt failed",
+              detail: formatFailureDetail(cause),
+              turnId: event.payload.turnId ?? null,
+              createdAt: event.payload.createdAt,
+            }).pipe(Effect.asVoid),
+      ),
+    );
   });
 
   const processApprovalResponseRequested = Effect.fn("processApprovalResponseRequested")(function* (


### PR DESCRIPTION
Fixes #4524

## Problem

When the provider rejects `turn/interrupt`, the failure goes nowhere the user can see. `processTurnInterruptRequested` issues the call bare:

```ts
yield* providerService.interruptTurn({ threadId: event.payload.threadId });
```

so the cause propagates up to `processDomainEventSafely`, which terminates it in a `logWarning`. The orchestration command is still receipted `accepted`, `thread.turn-interrupt-requested` is persisted normally, and no activity is appended. **Stop generation looks like it worked while the turn keeps running**, and the only trace is a line in `server-child.log`. The reporter clicked it 16 times in 17 seconds — 16 accepted receipts, 0 receipt errors, 0 activities.

## Change

The mechanism already exists and is already used one branch up in the same function: the "no active provider session" case appends a `provider.turn.interrupt.failed` activity. The sibling `processApprovalResponseRequested` likewise wraps its provider call in `Effect.catchCause` → `appendProviderFailureActivity`. The interrupt call was simply not wired to it.

This catches the cause and appends the same activity kind, so a rejected interrupt now shows up in the thread exactly like the missing-session case:

- `formatFailureDetail` is reused, so a `ProviderAdapterRequestError` surfaces its `detail` (`expected active turn id X but found Y`) instead of a pretty-printed cause. That is the same helper the turn-start failure path uses.
- Interrupt-only causes stay silent, matching `handleTurnStartFailure`.

No client change is needed: the thread already renders `tone: "error"` activities, which is the behavior the issue asks for.

## Tests

`ProviderCommandReactor.test.ts` — new case makes `interruptTurn` fail with a `ProviderAdapterRequestError` and asserts a `provider.turn.interrupt.failed` activity lands on the thread carrying the provider's own detail and the requested turn id.

I confirmed it is not vacuous: with the source change stashed the new test fails, and it passes with the change. `vp test run src/orchestration/Layers/ProviderCommandReactor.test.ts` — 35 passed.

The `interruptTurn` mock is now declared as `vi.fn<ProviderServiceShape["interruptTurn"]>` so a failing effect is assignable, matching how `respondToRequest` is already declared in that harness. The test is written with `effectIt.effect` rather than `Effect.runPromise`, so it adds no new entries against the `no-manual-effect-runtime-in-tests` baseline.

Typecheck, lint, and format clean for `apps/server`.

## Out of scope

The issue also notes that its own trigger came from a downstream `turn/steer` implementation adopting the steer response'"'"'s turn id as the active one, and flags that #231 could land in the same state. That is a separate concern; this PR only makes any such rejection visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized orchestration error-handling around interrupt; no auth or data-model changes, and behavior aligns with existing approval-response failure surfacing.
> 
> **Overview**
> When **Stop generation** triggers `turn/interrupt`, a provider rejection used to disappear into server logs while the command still looked accepted. This change wires `processTurnInterruptRequested` so `interruptTurn` failures are caught and surfaced as a **`provider.turn.interrupt.failed`** thread activity (same path as the no-session case and approval responses), using **`formatFailureDetail`** so adapter errors show their `detail` text.
> 
> Interrupt-only causes are still swallowed, matching turn-start failure handling. A reactor test mocks a failing `interruptTurn` and asserts the error activity appears with the expected tone, turn id, and payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be0c97eb539fc88ad5f9911df31472a820a9a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface provider turn interrupt failures as activities in the thread
> - In `ProviderCommandReactor.processTurnInterrupt`, wraps `providerService.interruptTurn` with `Effect.catchCause` to handle failures gracefully.
> - On failure, appends a `provider.turn.interrupt.failed` activity with formatted detail via `appendProviderFailureActivity`; interrupt-only causes are silently ignored.
> - Adds a test verifying that a `ProviderAdapterRequestError` from `interruptTurn` produces the expected failure activity with correct tone, turnId, and payload detail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4be0c97.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->