### PR TITLE
feat(web): scope the sidebar to a single environment

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -12,7 +12,11 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef, SidebarProjectGroupingMode } from "@t3tools/contracts";
+import type {
+  EnvironmentId,
+  ScopedThreadRef,
+  SidebarProjectGroupingMode,
+} from "@t3tools/contracts";
 import {
   AlarmClockIcon,
   AlarmClockOffIcon,
@@ -115,7 +119,10 @@ import {
   sortSettledThreadsForSidebarV2,
   sortThreadsForSidebarV2,
 } from "./Sidebar.logic";
-import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
+import {
+  resolveEnvironmentOptionLabel,
+  resolveLocalCheckoutBranchMismatch,
+} from "./BranchToolbar.logic";
 import {
   prStatusIndicator,
   resolveThreadPr,
@@ -1170,15 +1177,62 @@ export default function SidebarV2() {
     [],
   );
 
+  const environmentScopeOptions = useMemo(
+    () =>
+      environments
+        .map((environment) => {
+          const isPrimary = environment.environmentId === primaryEnvironmentId;
+          return {
+            environmentId: environment.environmentId,
+            label: resolveEnvironmentOptionLabel({
+              isPrimary,
+              environmentId: environment.environmentId,
+              runtimeLabel: environment.label,
+            }),
+            description: isPrimary ? "This device" : environment.environmentId,
+            isPrimary,
+          };
+        })
+        .toSorted((left, right) => {
+          if (left.isPrimary !== right.isPrimary) {
+            return left.isPrimary ? -1 : 1;
+          }
+          return left.label.localeCompare(right.label);
+        }),
+    [environments, primaryEnvironmentId],
+  );
+  const [environmentScopeId, setEnvironmentScopeId] = useState<EnvironmentId | null>(null);
+  const scopedEnvironment = useMemo(
+    () =>
+      environmentScopeOptions.find((option) => option.environmentId === environmentScopeId) ?? null,
+    [environmentScopeId, environmentScopeOptions],
+  );
+  useEffect(() => {
+    if (environmentScopeId !== null && scopedEnvironment === null) {
+      setEnvironmentScopeId(null);
+    }
+  }, [environmentScopeId, scopedEnvironment]);
+
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
   const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
+  const visibleProjectGroups = useMemo(
+    () =>
+      environmentScopeId === null
+        ? projectGroups
+        : projectGroups.filter((project) =>
+            project.memberProjectRefs.some(
+              (projectRef) => projectRef.environmentId === environmentScopeId,
+            ),
+          ),
+    [environmentScopeId, projectGroups],
+  );
   const scopedProjectGroup = useMemo(
     () =>
       projectScopeKey === null
         ? null
-        : (projectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
-    [projectGroups, projectScopeKey],
+        : (visibleProjectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
+    [projectScopeKey, visibleProjectGroups],
   );
   const scopedProjectKeys = useMemo(
     () =>
@@ -1200,7 +1254,7 @@ export default function SidebarV2() {
   // hidden now, and bulk actions must never count or touch invisible rows.
   useEffect(() => {
     clearSelection();
-  }, [clearSelection, projectScopeKey]);
+  }, [clearSelection, environmentScopeId, projectScopeKey]);
 
   const handleRemoveProjectMembers = useCallback(
     async (projectGroup: SidebarProjectSnapshot, members: readonly SidebarProjectGroupMember[]) => {
@@ -1370,6 +1424,7 @@ export default function SidebarV2() {
     const visible = threads.filter(
       (thread) =>
         thread.archivedAt === null &&
+        (environmentScopeId === null || thread.environmentId === environmentScopeId) &&
         (scopedProjectKeys === null ||
           scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
     );
@@ -1415,6 +1470,7 @@ export default function SidebarV2() {
   }, [
     autoSettleAfterDays,
     changeRequestStateByKey,
+    environmentScopeId,
     nowMinute,
     scopedProjectKeys,
     serverConfigs,
@@ -1445,7 +1501,7 @@ export default function SidebarV2() {
   // filter context changes so a scope/search flip never inherits a deep
   // page state.
   const [settledVisibleCount, setSettledVisibleCount] = useState(SETTLED_TAIL_INITIAL_COUNT);
-  const settledResetKey = projectScopeKey ?? "all";
+  const settledResetKey = `${environmentScopeId ?? "all"}:${projectScopeKey ?? "all"}`;
   const lastSettledResetKeyRef = useRef(settledResetKey);
   if (lastSettledResetKeyRef.current !== settledResetKey) {
     lastSettledResetKeyRef.current = settledResetKey;
@@ -2265,6 +2321,55 @@ export default function SidebarV2() {
             </div>
           </div>
         </SidebarGroup>
+        {environmentScopeOptions.length > 1 ? (
+          <SidebarGroup className="px-2 pb-2 pt-0">
+            <Menu>
+              <MenuTrigger
+                aria-label="Filter threads by environment"
+                className="flex h-8 w-full min-w-0 cursor-pointer items-center gap-2 rounded-md px-2 text-left text-sm font-medium text-sidebar-muted-foreground outline-none hover:bg-sidebar-row-hover hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+              >
+                <ServerIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
+                <span className="min-w-0 flex-1 truncate">
+                  {scopedEnvironment?.label ?? "All environments"}
+                </span>
+                <ChevronDownIcon className="size-4 shrink-0 text-sidebar-muted-foreground/70" />
+              </MenuTrigger>
+              <MenuPopup align="start" className="w-(--anchor-width)">
+                <MenuRadioGroup
+                  value={environmentScopeId ?? "all"}
+                  onValueChange={(value) =>
+                    setEnvironmentScopeId(value === "all" ? null : (value as EnvironmentId))
+                  }
+                >
+                  <MenuRadioItem
+                    value="all"
+                    closeOnClick
+                    className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                  >
+                    <ServerIcon className="size-4 shrink-0" />
+                    <span className="min-w-0 truncate text-sm">All environments</span>
+                  </MenuRadioItem>
+                  {environmentScopeOptions.map((option) => (
+                    <MenuRadioItem
+                      key={option.environmentId}
+                      value={option.environmentId}
+                      closeOnClick
+                      className="px-1 py-1 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                    >
+                      <ServerIcon className="size-4 shrink-0" />
+                      <span className="flex min-w-0 flex-col">
+                        <span className="truncate text-sm">{option.label}</span>
+                        <span className="truncate text-xs font-normal text-sidebar-muted-foreground">
+                          {option.description}
+                        </span>
+                      </span>
+                    </MenuRadioItem>
+                  ))}
+                </MenuRadioGroup>
+              </MenuPopup>
+            </Menu>
+          </SidebarGroup>
+        ) : null}
         {projectGroups.length > 0 ? (
           <SidebarGroup className="px-2 pb-2 pt-0">
             <div className="flex items-center gap-1">
@@ -2302,7 +2407,7 @@ export default function SidebarV2() {
                       <FolderIcon className="size-4 shrink-0" />
                       <span className="min-w-0 truncate text-sm">All projects</span>
                     </MenuRadioItem>
-                    {projectGroups.map((project) => {
+                    {visibleProjectGroups.map((project) => {
                       const scopeKey = project.projectKey;
                       return (
                         <MenuRadioItem


### PR DESCRIPTION
Sidebar v2 can filter threads by project, but not by the machine they run on. With a remote environment paired alongside this device, both sets of threads land in one list with no way to look at just one of them.

This adds an environment menu above the project menu. It only takes up a row when more than one environment is connected, so single-machine setups are unchanged.

- **All environments** keeps today's behaviour.
- Each environment is presented the way the new-project picker presents it: the environment label, with `This device` or the environment id underneath, primary first.
- Picking one filters the thread list and narrows the project menu to the projects that live there, so a project scope never resolves to an empty list.

Both scopes are ordinary component state, matching the existing project scope: nothing new is persisted, and an environment that disappears resets the scope on its own.

## Verification

- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/web test` — 171 files, 1518 tests
- `vp lint`, `vp fmt --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope sidebar threads and projects to a single environment in `SidebarV2`
> - Adds an environment scope selector to the sidebar menu, visible when multiple environments exist, with an
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1045479.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
https://github.com/user-attachments/assets/3a3500db-9fab-4531-a4f6-3b69c2d5db26