### PR TITLE
perf(mobile): cut thread-reopen replay churn in the feed pipeline

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownBlock.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownBlock.ios.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Image, ScrollView, Text, useColorScheme, View } from "react-native";
 import type { MarkdownNode } from "react-native-nitro-markdown/headless";
 
@@ -21,6 +21,11 @@ type HighlightedCode = ReadonlyArray<ReadonlyArray<MarkdownHighlightedToken>>;
 const highlightedCodeCache = new Map<string, HighlightedCode>();
 const highlightedCodePromiseCache = new Map<string, Promise<HighlightedCode>>();
 const HIGHLIGHTED_CODE_CACHE_LIMIT = 64;
+// A code change on a mounted block means the text is still streaming (or a
+// backlog replay is appending to it). Highlighting every intermediate state
+// runs Shiki once per delta and evicts settled entries from the cache, so wait
+// for the text to hold still before spending a highlight pass.
+const HIGHLIGHT_STREAMING_DEBOUNCE_MS = 200;
 
 function nodeKey(node: MarkdownNode, index: number): string {
   return `${node.type}:${node.beg ?? index}:${node.end ?? index}`;
@@ -127,8 +132,11 @@ function useHighlightedCode(
     tokens: highlightedCodeCache.get(key) ?? null,
   }));
 
+  const hasRunRef = useRef(false);
   useEffect(() => {
     let active = true;
+    const isFirstRun = !hasRunRef.current;
+    hasRunRef.current = true;
     const cached = highlightedCodeCache.get(key);
     if (cached) {
       cacheHighlightedCode(key, cached);
@@ -138,19 +146,31 @@ function useHighlightedCode(
       };
     }
 
-    void loadHighlightedCode(code, language, theme, highlightCode)
-      .then((tokens) => {
-        if (active) {
-          setHighlighted({ key, tokens });
-        }
-      })
-      .catch(() => {
-        if (active) {
-          setHighlighted({ key, tokens: null });
-        }
-      });
+    const load = () => {
+      void loadHighlightedCode(code, language, theme, highlightCode)
+        .then((tokens) => {
+          if (active) {
+            setHighlighted({ key, tokens });
+          }
+        })
+        .catch(() => {
+          if (active) {
+            setHighlighted({ key, tokens: null });
+          }
+        });
+    };
+
+    if (isFirstRun) {
+      load();
+      return () => {
+        active = false;
+      };
+    }
+
+    const timer = setTimeout(load, HIGHLIGHT_STREAMING_DEBOUNCE_MS);
     return () => {
       active = false;
+      clearTimeout(timer);
     };
   }, [code, highlightCode, key, language, theme]);
 

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -39,7 +39,7 @@ import {
   COMPOSER_EXPANDED_CHROME,
   ThreadComposer,
 } from "./ThreadComposer";
-import { ThreadFeed } from "./ThreadFeed";
+import { isLiveThreadEventTimestamp, ThreadFeed } from "./ThreadFeed";
 import type { ThreadContentPresentation } from "./threadContentPresentation";
 
 export interface ThreadDetailScreenProps {
@@ -49,6 +49,8 @@ export interface ThreadDetailScreenProps {
   readonly connectionError: string | null;
   readonly environmentLabel: string | null;
   readonly selectedThreadFeed: ReadonlyArray<ThreadFeedEntry>;
+  /** occurredAt of the latest applied detail event; stale ⇒ backlog replay. */
+  readonly lastDetailEventAt?: string | null;
   readonly activeWorkStartedAt: string | null;
   readonly activePendingApproval: PendingApproval | null;
   readonly respondingApprovalId: ApprovalRequestId | null;
@@ -119,7 +121,11 @@ function latestStreamingAssistantMessage(
   return null;
 }
 
-function useStreamingHaptics(threadId: ThreadId, feed: ReadonlyArray<ThreadFeedEntry>) {
+function useStreamingHaptics(
+  threadId: ThreadId,
+  feed: ReadonlyArray<ThreadFeedEntry>,
+  lastEventAt: string | null | undefined,
+) {
   const lastStreamingAssistantRef = useRef<{
     readonly id: string;
     readonly textLength: number;
@@ -159,6 +165,12 @@ function useStreamingHaptics(threadId: ThreadId, feed: ReadonlyArray<ThreadFeedE
       return;
     }
 
+    // Replayed backlog growth is not live typing — buzzing through a
+    // catch-up burst would fire haptics for output the user already missed.
+    if (!isLiveThreadEventTimestamp(lastEventAt)) {
+      return;
+    }
+
     const now = Date.now();
     if (!isNewStream && now - lastStreamHapticAtRef.current < 320) {
       return;
@@ -166,7 +178,7 @@ function useStreamingHaptics(threadId: ThreadId, feed: ReadonlyArray<ThreadFeedE
 
     lastStreamHapticAtRef.current = now;
     void Haptics.selectionAsync();
-  }, [threadId, feed]);
+  }, [threadId, feed, lastEventAt]);
 }
 
 export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: ThreadDetailScreenProps) {
@@ -224,7 +236,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const isSplitLayout = layoutVariant === "split";
   const contentMaxWidth = isSplitLayout ? CHAT_CONTENT_MAX_WIDTH : undefined;
   const selectedInstanceId = props.selectedThread.modelSelection.instanceId;
-  useStreamingHaptics(props.selectedThread.id, props.selectedThreadFeed);
+  useStreamingHaptics(props.selectedThread.id, props.selectedThreadFeed, props.lastDetailEventAt);
   const selectedProviderSkills = useMemo(
     () =>
       props.serverConfig?.providers.find((provider) => provider.instanceId === selectedInstanceId)
@@ -360,6 +372,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
             agentLabel={agentLabel}
             latestTurn={props.selectedThread.latestTurn}
             activeWorkStartedAt={props.activeWorkStartedAt}
+            lastEventAt={props.lastDetailEventAt}
             listRef={listRef}
             freeze={freeze}
             anchorMessageId={anchorMessageId}

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -121,6 +121,15 @@ function isFreshTimestamp(input: string): boolean {
   return Number.isFinite(timestamp) && Date.now() - timestamp < FRESH_ENTRY_WINDOW_MS;
 }
 
+// The reducer stamps the detail thread's updatedAt with each event's original
+// occurredAt, so a stale value while the feed is changing means the client is
+// replaying a backlog (thread reopen, resume after backgrounding) rather than
+// receiving live output. Replay bursts should not pay for per-commit layout
+// animations, animated end scrolls, or haptics.
+export function isLiveThreadEventTimestamp(input: string | null | undefined): boolean {
+  return input == null || isFreshTimestamp(input);
+}
+
 export interface ThreadFeedProps {
   readonly environmentId: EnvironmentId;
   readonly threadId: ThreadId;
@@ -130,6 +139,8 @@ export interface ThreadFeedProps {
   readonly agentLabel: string;
   readonly latestTurn: ThreadFeedLatestTurn | null;
   readonly activeWorkStartedAt: string | null;
+  /** occurredAt of the latest applied detail event; stale ⇒ backlog replay. */
+  readonly lastEventAt?: string | null;
   readonly listRef: RefObject<LegendListRef | null>;
   readonly freeze: SharedValue<boolean>;
   readonly anchorMessageId: MessageId | null;
@@ -1440,6 +1451,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     }
     return ids;
   }, [expandedWorkGroups]);
+  const replayCatchUp = !isLiveThreadEventTimestamp(props.lastEventAt);
   const presentedFeed = useMemo(
     () =>
       deriveThreadFeedPresentation(
@@ -1725,7 +1737,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
                 }
               : { scrollIndicatorInsets: { top: topContentInset, bottom: 0 } })}
             {...(anchoredEndSpace ? { anchoredEndSpace } : {})}
-            itemLayoutAnimation={FEED_ITEM_LAYOUT_TRANSITION}
+            itemLayoutAnimation={replayCatchUp ? undefined : FEED_ITEM_LAYOUT_TRANSITION}
             // Patched LegendList prop (patches/@legendapp__list@3.2.0.patch):
             // lets its scroll math clamp programmatic scrolls to -headerInset
             // instead of 0, so initialScrollAtEnd/maintainScrollAtEnd on short
@@ -1753,7 +1765,10 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
               disclosureToggleSettling
                 ? false
                 : {
-                    animated: true,
+                    // Instant (not animated) during backlog replay — an
+                    // animated scrollToEnd per catch-up publication churns the
+                    // scroll view for content the user never watched stream.
+                    animated: !replayCatchUp,
                     on: {
                       dataChange: true,
                       itemLayout: true,

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -755,6 +755,7 @@ function ThreadRouteContent(
           connectionError={routeConnectionError}
           environmentLabel={selectedEnvironmentConnection?.environmentLabel ?? null}
           selectedThreadFeed={composer.selectedThreadFeed}
+          lastDetailEventAt={selectedThreadDetail?.updatedAt ?? null}
           activeWorkStartedAt={composer.activeWorkStartedAt}
           activePendingApproval={requests.activePendingApproval}
           respondingApprovalId={requests.respondingApprovalId}

--- a/apps/mobile/src/features/threads/markdownCodeHighlightState.ts
+++ b/apps/mobile/src/features/threads/markdownCodeHighlightState.ts
@@ -2,7 +2,7 @@ import { useAtomValue } from "@effect/atom-react";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
   highlightCodeSnippet,
@@ -11,6 +11,23 @@ import {
 } from "../review/shikiReviewHighlighter";
 
 const MARKDOWN_CODE_HIGHLIGHT_IDLE_TTL_MS = 5 * 60_000;
+// A code change on a mounted block means the text is still streaming (or a
+// backlog replay is appending to it). Feeding every intermediate state into
+// the atom family would run Shiki per delta and retain one atom per delta for
+// the idle TTL, so wait for the text to hold still before highlighting.
+const MARKDOWN_CODE_HIGHLIGHT_STREAMING_DEBOUNCE_MS = 200;
+
+function useSettledValue<T>(value: T, delayMs: number): T {
+  const [settled, setSettled] = useState(value);
+  useEffect(() => {
+    if (settled === value) {
+      return;
+    }
+    const timer = setTimeout(() => setSettled(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [delayMs, settled, value]);
+  return settled;
+}
 
 export type MarkdownHighlightedCode = ReadonlyArray<ReadonlyArray<ReviewHighlightedToken>>;
 
@@ -72,16 +89,22 @@ export function useMarkdownCodeHighlight(input: {
   const normalizedLanguage = input.language?.trim() || "text";
   const enabled = input.enabled && Boolean(input.language?.trim());
   const atomLanguage = enabled ? normalizedLanguage : "text";
+  const settledCode = useSettledValue(input.code, MARKDOWN_CODE_HIGHLIGHT_STREAMING_DEBOUNCE_MS);
   const highlightAtom = useMemo(
     () =>
       markdownCodeHighlightAtom({
-        code: enabled ? input.code : "",
+        code: enabled ? settledCode : "",
         enabled,
         language: atomLanguage,
         theme: input.theme,
       }),
-    [atomLanguage, enabled, input.code, input.theme],
+    [atomLanguage, enabled, settledCode, input.theme],
   );
   const result = useAtomValue(highlightAtom);
-  return AsyncResult.isSuccess(result) ? result.value : null;
+  if (!AsyncResult.isSuccess(result)) {
+    return null;
+  }
+  // Highlighted tokens carry their own text; never render tokens for code
+  // that no longer matches what is on screen.
+  return settledCode === input.code ? result.value : null;
 }

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -13,6 +13,8 @@ import {
 
 import {
   buildThreadFeed,
+  derivePendingApprovals,
+  derivePendingUserInputs,
   deriveThreadFeedPresentation,
   type ThreadFeedActivity,
   type ThreadFeedEntry,
@@ -480,5 +482,140 @@ describe("buildThreadFeed", () => {
       type: "work-toggle",
       expanded: true,
     });
+  });
+});
+
+describe("thread derivation caching", () => {
+  const makeCachedThread = () =>
+    makeThread({
+      id: ThreadId.make("thread-cache"),
+      projectId: ProjectId.make("project-1"),
+      title: "Cache checks",
+      messages: [
+        {
+          id: MessageId.make("assistant-1"),
+          role: "assistant",
+          text: "Working on it.",
+          turnId: TurnId.make("turn-1"),
+          streaming: true,
+          createdAt: "2026-04-01T00:00:01.000Z",
+          updatedAt: "2026-04-01T00:00:01.000Z",
+        },
+      ],
+      activities: [
+        makeActivity({
+          id: EventId.make("tool-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Run tests",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Run tests",
+            itemType: "command_execution",
+            detail: "bun run test",
+            status: "completed",
+          },
+        }),
+        makeActivity({
+          id: EventId.make("approval-open"),
+          kind: "approval.requested",
+          tone: "approval",
+          summary: "Approve command",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            requestId: "approval-1",
+            requestKind: "command",
+            detail: "rm -rf dist",
+          },
+        }),
+      ],
+    });
+
+  it("returns the identical feed for unchanged messages and activities arrays", () => {
+    const thread = makeCachedThread();
+    const first = buildThreadFeed(thread);
+    // A publication that changes unrelated thread fields keeps both arrays.
+    const republished = { ...thread, updatedAt: "2026-04-01T00:00:09.000Z" };
+    expect(buildThreadFeed(republished)).toBe(first);
+  });
+
+  it("reuses derived activity rows when only messages change", () => {
+    const thread = makeCachedThread();
+    const first = buildThreadFeed(thread);
+    const streamed = {
+      ...thread,
+      messages: thread.messages.map((message) => ({
+        ...message,
+        text: `${message.text} More text.`,
+      })),
+    };
+    const second = buildThreadFeed(streamed);
+
+    expect(second).not.toBe(first);
+    const firstGroup = first.find((entry) => entry.type === "activity-group");
+    const secondGroup = second.find((entry) => entry.type === "activity-group");
+    expect(firstGroup?.type).toBe("activity-group");
+    if (firstGroup?.type !== "activity-group" || secondGroup?.type !== "activity-group") {
+      return;
+    }
+    expect(secondGroup.activities[0]).toBe(firstGroup.activities[0]);
+  });
+
+  it("recomputes when the activities array changes", () => {
+    const thread = makeCachedThread();
+    const first = buildThreadFeed(thread);
+    const appended = {
+      ...thread,
+      activities: [
+        ...thread.activities,
+        makeActivity({
+          id: EventId.make("tool-completed-2"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Read files",
+          createdAt: "2026-04-01T00:00:04.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Read files",
+            itemType: "file_read",
+            status: "completed",
+          },
+        }),
+      ],
+    };
+    const second = buildThreadFeed(appended);
+    expect(second).not.toBe(first);
+    const secondGroup = second.find((entry) => entry.type === "activity-group");
+    expect(secondGroup?.type).toBe("activity-group");
+    if (secondGroup?.type !== "activity-group") {
+      return;
+    }
+    expect(secondGroup.activities.map((activity) => activity.id)).toContain("tool-completed-2");
+  });
+
+  it("keeps pending approval and user-input results identity-stable per activities array", () => {
+    const thread = makeCachedThread();
+    const approvals = derivePendingApprovals(thread.activities);
+    expect(approvals).toMatchObject([{ requestId: "approval-1", requestKind: "command" }]);
+    expect(derivePendingApprovals(thread.activities)).toBe(approvals);
+
+    const userInputs = derivePendingUserInputs(thread.activities);
+    expect(derivePendingUserInputs(thread.activities)).toBe(userInputs);
+
+    const resolved = [
+      ...thread.activities,
+      makeActivity({
+        id: EventId.make("approval-resolved"),
+        kind: "approval.resolved",
+        tone: "approval",
+        summary: "Approved",
+        createdAt: "2026-04-01T00:00:05.000Z",
+        turnId: TurnId.make("turn-1"),
+        payload: { requestId: "approval-1" },
+      }),
+    ];
+    expect(derivePendingApprovals(resolved)).toEqual([]);
   });
 });

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -57,6 +57,62 @@ export interface ThreadFeedActivity {
 
 const MAX_VISIBLE_WORK_LOG_ENTRIES = 1;
 
+// The thread reducer reuses untouched message/activity objects and arrays
+// across state publications, so identity-keyed caches survive streaming
+// updates and backlog replay — only objects that actually changed re-derive.
+const sortedActivitiesCache = new WeakMap<
+  ReadonlyArray<OrchestrationThreadActivity>,
+  ReadonlyArray<OrchestrationThreadActivity>
+>();
+const workLogEntriesCache = new WeakMap<
+  ReadonlyArray<OrchestrationThreadActivity>,
+  DerivedWorkLogEntry[]
+>();
+const derivedWorkLogEntryCache = new WeakMap<OrchestrationThreadActivity, DerivedWorkLogEntry>();
+const mergedWorkLogEntryCache = new WeakMap<
+  DerivedWorkLogEntry,
+  WeakMap<DerivedWorkLogEntry, DerivedWorkLogEntry>
+>();
+const pendingApprovalsCache = new WeakMap<
+  ReadonlyArray<OrchestrationThreadActivity>,
+  PendingApproval[]
+>();
+const pendingUserInputsCache = new WeakMap<
+  ReadonlyArray<OrchestrationThreadActivity>,
+  PendingUserInput[]
+>();
+const messageFeedEntryCache = new WeakMap<
+  OrchestrationThread["messages"][number],
+  RawThreadFeedEntry
+>();
+const activityFeedEntryCache = new WeakMap<DerivedWorkLogEntry, RawThreadFeedEntry>();
+const createdAtMsCache = new WeakMap<RawThreadFeedEntry, number>();
+const threadFeedCache = new WeakMap<
+  OrchestrationThread["messages"],
+  WeakMap<ReadonlyArray<OrchestrationThreadActivity>, ThreadFeedEntry[]>
+>();
+
+function sortActivities(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ReadonlyArray<OrchestrationThreadActivity> {
+  const cached = sortedActivitiesCache.get(activities);
+  if (cached) {
+    return cached;
+  }
+  // The reducer maintains activities in this exact order, so the common case
+  // is a linear verification pass with no sort.
+  let alreadySorted = true;
+  for (let index = 1; index < activities.length; index += 1) {
+    if (activityOrder(activities[index - 1]!, activities[index]!) > 0) {
+      alreadySorted = false;
+      break;
+    }
+  }
+  const sorted = alreadySorted ? activities : Arr.sort(activities, activityOrder);
+  sortedActivitiesCache.set(activities, sorted);
+  return sorted;
+}
+
 type WorkLogToolLifecycleStatus = "inProgress" | "completed" | "failed" | "declined" | "stopped";
 
 interface WorkLogEntry {
@@ -237,7 +293,11 @@ function resolvePendingUserInputAnswer(
 function deriveWorkLogEntries(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): DerivedWorkLogEntry[] {
-  const ordered = Arr.sort(activities, activityOrder);
+  const cached = workLogEntriesCache.get(activities);
+  if (cached) {
+    return cached;
+  }
+  const ordered = sortActivities(activities);
   const entries: DerivedWorkLogEntry[] = [];
   for (const activity of ordered) {
     if (activity.kind === "tool.started") continue;
@@ -247,7 +307,9 @@ function deriveWorkLogEntries(
     if (isPlanBoundaryToolActivity(activity)) continue;
     entries.push(toDerivedWorkLogEntry(activity));
   }
-  return collapseDerivedWorkLogEntries(entries);
+  const collapsed = collapseDerivedWorkLogEntries(entries);
+  workLogEntriesCache.set(activities, collapsed);
+  return collapsed;
 }
 
 function isPlanBoundaryToolActivity(activity: OrchestrationThreadActivity): boolean {
@@ -263,6 +325,16 @@ function isPlanBoundaryToolActivity(activity: OrchestrationThreadActivity): bool
 }
 
 function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWorkLogEntry {
+  const cached = derivedWorkLogEntryCache.get(activity);
+  if (cached) {
+    return cached;
+  }
+  const entry = buildDerivedWorkLogEntry(activity);
+  derivedWorkLogEntryCache.set(activity, entry);
+  return entry;
+}
+
+function buildDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWorkLogEntry {
   const payload =
     activity.payload && typeof activity.payload === "object"
       ? (activity.payload as Record<string, unknown>)
@@ -379,6 +451,24 @@ function shouldCollapseToolLifecycleEntries(
 }
 
 function mergeDerivedWorkLogEntries(
+  previous: DerivedWorkLogEntry,
+  next: DerivedWorkLogEntry,
+): DerivedWorkLogEntry {
+  let byNext = mergedWorkLogEntryCache.get(previous);
+  if (!byNext) {
+    byNext = new WeakMap();
+    mergedWorkLogEntryCache.set(previous, byNext);
+  }
+  const cached = byNext.get(next);
+  if (cached) {
+    return cached;
+  }
+  const merged = buildMergedWorkLogEntry(previous, next);
+  byNext.set(next, merged);
+  return merged;
+}
+
+function buildMergedWorkLogEntry(
   previous: DerivedWorkLogEntry,
   next: DerivedWorkLogEntry,
 ): DerivedWorkLogEntry {
@@ -949,10 +1039,9 @@ function groupAdjacentActivities(entries: ReadonlyArray<RawThreadFeedEntry>): Th
 
     const previous = grouped.at(-1);
     if (previous?.type === "activity-group" && previous.turnId === entry.turnId) {
-      grouped[grouped.length - 1] = {
-        ...previous,
-        activities: [...previous.activities, entry.activity],
-      };
+      // The group entry is created below within this pass, so appending in
+      // place is safe and avoids re-copying the array per activity.
+      (previous.activities as ThreadFeedActivity[]).push(entry.activity);
       continue;
     }
 
@@ -1206,8 +1295,12 @@ function appendPresentedFeedEntry(
 export function derivePendingApprovals(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingApproval[] {
+  const cached = pendingApprovalsCache.get(activities);
+  if (cached) {
+    return cached;
+  }
   const openByRequestId = new Map<ApprovalRequestId, PendingApproval>();
-  const ordered = Arr.sort(activities, activityOrder);
+  const ordered = sortActivities(activities);
 
   for (const activity of ordered) {
     const payload =
@@ -1247,14 +1340,24 @@ export function derivePendingApprovals(
     }
   }
 
-  return Arr.sortWith([...openByRequestId.values()], (s) => new Date(s.createdAt), Order.Date);
+  const pending = Arr.sortWith(
+    [...openByRequestId.values()],
+    (s) => new Date(s.createdAt),
+    Order.Date,
+  );
+  pendingApprovalsCache.set(activities, pending);
+  return pending;
 }
 
 export function derivePendingUserInputs(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingUserInput[] {
+  const cached = pendingUserInputsCache.get(activities);
+  if (cached) {
+    return cached;
+  }
   const openByRequestId = new Map<ApprovalRequestId, PendingUserInput>();
-  const ordered = Arr.sort(activities, activityOrder);
+  const ordered = sortActivities(activities);
 
   for (const activity of ordered) {
     const payload =
@@ -1291,7 +1394,9 @@ export function derivePendingUserInputs(
     }
   }
 
-  return Arr.sortWith(openByRequestId.values(), (s) => new Date(s.createdAt), Order.Date);
+  const pending = Arr.sortWith(openByRequestId.values(), (s) => new Date(s.createdAt), Order.Date);
+  pendingUserInputsCache.set(activities, pending);
+  return pending;
 }
 
 export function setPendingUserInputCustomAnswer(
@@ -1323,64 +1428,105 @@ export function buildPendingUserInputAnswers(
   return answers;
 }
 
+function toMessageFeedEntry(message: OrchestrationThread["messages"][number]): RawThreadFeedEntry {
+  const cached = messageFeedEntryCache.get(message);
+  if (cached) {
+    return cached;
+  }
+  const entry: RawThreadFeedEntry = {
+    type: "message",
+    id: message.id,
+    createdAt: message.createdAt,
+    message,
+  };
+  messageFeedEntryCache.set(message, entry);
+  return entry;
+}
+
+function toActivityFeedEntry(entry: DerivedWorkLogEntry): RawThreadFeedEntry {
+  const cached = activityFeedEntryCache.get(entry);
+  if (cached) {
+    return cached;
+  }
+  const summary = workEntryHeading(entry);
+  const detail = workEntryPreview(entry);
+  const fullDetail = buildWorkEntryExpandedBody(entry);
+  const feedEntry: RawThreadFeedEntry = {
+    type: "activity",
+    id: entry.id,
+    createdAt: entry.createdAt,
+    turnId: entry.turnId,
+    activity: {
+      id: entry.id,
+      createdAt: entry.createdAt,
+      turnId: entry.turnId,
+      summary,
+      detail,
+      fullDetail,
+      icon: workEntryIcon(entry),
+      copyText: [summary, detail, fullDetail]
+        .filter((value, index, values): value is string => {
+          return Boolean(value) && values.indexOf(value) === index;
+        })
+        .join("\n"),
+      toolLike: workLogEntryIsToolLike(entry),
+      status: workEntryStatus(entry),
+    },
+  };
+  activityFeedEntryCache.set(entry, feedEntry);
+  return feedEntry;
+}
+
+function feedEntryCreatedAtMs(entry: RawThreadFeedEntry): number {
+  const cached = createdAtMsCache.get(entry);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const ms = Date.parse(entry.createdAt);
+  createdAtMsCache.set(entry, ms);
+  return ms;
+}
+
 export function buildThreadFeed(
   thread: OrchestrationThread,
   options?: {
     readonly loadedMessages?: ReadonlyArray<OrchestrationThread["messages"][number]>;
   },
 ): ThreadFeedEntry[] {
+  const cacheable = options === undefined;
+  if (cacheable) {
+    const cachedFeed = threadFeedCache.get(thread.messages)?.get(thread.activities);
+    if (cachedFeed) {
+      return cachedFeed;
+    }
+  }
   const loadedMessages = options?.loadedMessages ?? thread.messages;
   const oldestLoadedMessageCreatedAt =
     options?.loadedMessages !== undefined ? (loadedMessages[0]?.createdAt ?? null) : null;
   const workLogEntries = deriveWorkLogEntries(thread.activities);
-  const entries = Arr.sortWith(
-    [
-      ...loadedMessages.map<RawThreadFeedEntry>((message) => ({
-        type: "message",
-        id: message.id,
-        createdAt: message.createdAt,
-        message,
-      })),
-      ...workLogEntries
-        .filter((entry) => {
-          if (options?.loadedMessages === undefined) {
-            return true;
-          }
-          return (
-            oldestLoadedMessageCreatedAt === null || entry.createdAt >= oldestLoadedMessageCreatedAt
-          );
-        })
-        .map<RawThreadFeedEntry>((entry) => {
-          const summary = workEntryHeading(entry);
-          const detail = workEntryPreview(entry);
-          const fullDetail = buildWorkEntryExpandedBody(entry);
-          return {
-            type: "activity",
-            id: entry.id,
-            createdAt: entry.createdAt,
-            turnId: entry.turnId,
-            activity: {
-              id: entry.id,
-              createdAt: entry.createdAt,
-              turnId: entry.turnId,
-              summary,
-              detail,
-              fullDetail,
-              icon: workEntryIcon(entry),
-              copyText: [summary, detail, fullDetail]
-                .filter((value, index, values): value is string => {
-                  return Boolean(value) && values.indexOf(value) === index;
-                })
-                .join("\n"),
-              toolLike: workLogEntryIsToolLike(entry),
-              status: workEntryStatus(entry),
-            },
-          };
-        }),
-    ],
-    (s) => new Date(s.createdAt),
-    Order.Date,
-  );
+  const entries = [
+    ...loadedMessages.map(toMessageFeedEntry),
+    ...workLogEntries
+      .filter((entry) => {
+        if (options?.loadedMessages === undefined) {
+          return true;
+        }
+        return (
+          oldestLoadedMessageCreatedAt === null || entry.createdAt >= oldestLoadedMessageCreatedAt
+        );
+      })
+      .map(toActivityFeedEntry),
+  ];
+  entries.sort((a, b) => feedEntryCreatedAtMs(a) - feedEntryCreatedAtMs(b));
 
-  return groupAdjacentActivities(entries);
+  const feed = groupAdjacentActivities(entries);
+  if (cacheable) {
+    let byActivities = threadFeedCache.get(thread.messages);
+    if (!byActivities) {
+      byActivities = new WeakMap();
+      threadFeedCache.set(thread.messages, byActivities);
+    }
+    byActivities.set(thread.activities, feed);
+  }
+  return feed;
 }


### PR DESCRIPTION
## Summary

Mobile consumes thread state through the same shared subscription path whose quadratic replay is being fixed in #4605 (server gap cap + client batch apply). This PR fixes the mobile-only layers that remain after that lands: the render pipeline re-derived and re-animated the entire thread on every state publication, and several mobile-specific amplifiers (per-delta Shiki passes on the Hermes thread, layout animations and animated end-scrolls per commit, streaming haptics) made backlog replay worse on phones than on web — especially since mobile re-resumes with `afterSequence` on every app foreground.

### 1. Incremental thread-feed derivation (`threadActivity.ts`)

The reducer reuses untouched message/activity objects and arrays across publications, so the derivation chain now caches by object identity (WeakMaps):

- Unchanged activities skip the per-activity payload walks, `JSON.stringify`, and string rebuilding in `toDerivedWorkLogEntry`/`toActivityFeedEntry`; collapse merges are memoized pairwise.
- Message-only publications (streaming deltas) reuse the entire derived work log, and `derivePendingApprovals`/`derivePendingUserInputs` short-circuit on unchanged `activities` array identity.
- Publications touching neither array return the **identical feed array**, so `ThreadFeed`'s `memo` and the `presentedFeed` memo finally hold across the ~10 hooks/screens subscribed to the same publication.
- The double `Date`-allocating sort collapses to one numeric-timestamp sort with a linear already-sorted fast path (the reducer maintains exactly this order), and `groupAdjacentActivities` accumulates in place instead of re-spreading the group array per activity (quadratic within long tool runs).

### 2. Streaming code-highlight thrash

Both highlight caches key on the full code text, so every streaming/replayed delta was a guaranteed miss: one Shiki pass per delta on the shared JS thread, LRU eviction of settled entries (iOS), and one idle-TTL-retained atom per delta (JS path). Both paths now debounce highlighting until the code has held still for 200ms — first mount stays immediate, cache hits stay synchronous, and intermediate delta states never launch highlight work. Plain monospace text renders in the interim, matching existing behavior for not-yet-highlighted blocks.

### 3. Replay bursts no longer animate or buzz

The reducer stamps the detail thread's `updatedAt` with each event's original `occurredAt`, so a stale value while the feed is changing identifies backlog replay (thread reopen, resume after backgrounding) vs. live streaming. During replay, `ThreadFeed` drops the per-commit `LinearTransition` layout animation and switches `maintainScrollAtEnd` to instant, and `ThreadDetailScreen` suppresses streaming haptics so a large catch-up doesn't fire a vibration burst.

## Testing

- `vp test run` in `apps/mobile`: 92 files / 546 tests pass, including new identity-caching regression tests in `threadActivity.test.ts` (same-array feed identity, per-activity row reuse across message-only updates, recompute on activity append, pending-request result stability).
- `vp lint` clean; `vp format --check` clean.
- `tsc --noEmit` on this machine fails identically before/after in touched files (pre-existing broken React type resolution in the local pnpm store); verified no new errors by diffing per-file error sets against `main`.

Related: #4596, #4605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut thread-reopen replay churn by disabling animations and debouncing highlights during backlog catch-up
> - Adds `isLiveThreadEventTimestamp` in [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/4624/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245) to detect backlog replay; disables per-item layout animations and uses non-animated scroll-to-end during catch-up.
> - Suppresses haptic feedback in `useStreamingHaptics` when the latest event timestamp is stale (replay), wired through `ThreadDetailScreen` and `ThreadRouteScreen`.
> - Debounces markdown code highlighting by ~200ms during streaming via a new `useSettledValue` hook in [markdownCodeHighlightState.ts](https://github.com/pingdotgg/t3code/pull/4624/files#diff-e578dc59400598ef369a4b020da9a85e067c8bd097056e30b648359a583f90a2), preventing token/text mismatches mid-stream.
> - Adds WeakMap-based memoization throughout [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/4624/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5) (`buildThreadFeed`, `deriveWorkLogEntries`, `derivePendingApprovals`, etc.) to return stable array instances when inputs are unchanged.
> - Behavioral Change: layout animations and animated scroll are suppressed for all events during a replay catch-up window, not just the first.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ba0fbae. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->