### PR TITLE
test: account for lazy thread feed details

### DIFF
--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildThreadFeed } from "../../mobile/src/lib/threadActivity.ts";
+import { buildThreadFeed, type ThreadFeedActivity } from "../../mobile/src/lib/threadActivity.ts";
 import { deriveWorkLogEntries } from "../../web/src/session-logic.ts";
 import {
   projectActivityEvent,
@@ -134,18 +134,22 @@ const fixtures = [
 ] satisfies ReadonlyArray<OrchestrationThreadActivity>;
 
 describe("projectActivityPayload", () => {
+  function comparableActivity(activity: ThreadFeedActivity) {
+    return {
+      ...activity,
+      fullDetail: activity.getFullDetail(),
+      copyText: activity.getCopyText(),
+      getFullDetail: undefined,
+      getCopyText: undefined,
+    };
+  }
+
   function comparableThreadFeed(activities: ReadonlyArray<OrchestrationThreadActivity>) {
     return buildThreadFeed(makeThread(activities)).map((entry) =>
-      entry.type === "activity"
+      entry.type === "activity-group"
         ? {
             ...entry,
-            activity: {
-              ...entry.activity,
-              fullDetail: entry.activity.getFullDetail(),
-              copyText: entry.activity.getCopyText(),
-              getFullDetail: undefined,
-              getCopyText: undefined,
-            },
+            activities: entry.activities.map(comparableActivity),
           }
         : entry,
     );

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -134,6 +134,23 @@ const fixtures = [
 ] satisfies ReadonlyArray<OrchestrationThreadActivity>;
 
 describe("projectActivityPayload", () => {
+  function comparableThreadFeed(activities: ReadonlyArray<OrchestrationThreadActivity>) {
+    return buildThreadFeed(makeThread(activities)).map((entry) =>
+      entry.type === "activity"
+        ? {
+            ...entry,
+            activity: {
+              ...entry.activity,
+              fullDetail: entry.activity.getFullDetail(),
+              copyText: entry.activity.getCopyText(),
+              getFullDetail: undefined,
+              getCopyText: undefined,
+            },
+          }
+        : entry,
+    );
+  }
+
   it("drops unread bulk while retaining command, file, tool, and summary inputs", () => {
     const projected = projectActivityPayload(fixtures[0]!);
     expect(projected.payload).toEqual({
@@ -170,9 +187,7 @@ describe("projectActivityPayload", () => {
     for (const activity of fixtures) {
       const projected = projectActivityPayload(activity);
       expect(deriveWorkLogEntries([projected])).toEqual(deriveWorkLogEntries([activity]));
-      expect(buildThreadFeed(makeThread([projected]))).toEqual(
-        buildThreadFeed(makeThread([activity])),
-      );
+      expect(comparableThreadFeed([projected])).toEqual(comparableThreadFeed([activity]));
     }
   });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change with no production behavior impact; it only fixes equality assertions for lazy thread feed detail getters.
> 
> **Overview**
> Updates **ActivityPayloadProjection** tests so projected vs raw activities still produce equivalent mobile thread feeds after `buildThreadFeed` started exposing **lazy** `getFullDetail` and `getCopyText` on each activity.
> 
> Adds `comparableActivity` / `comparableThreadFeed` helpers that call those getters, store the results as `fullDetail` and `copyText`, and drop the function properties before `toEqual`. The “web and mobile derived output identical” loop now uses this helper instead of comparing `buildThreadFeed` output directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91ad3c4f83975af77dd3951effc0a3d78b98e0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread feed equality assertions to account for lazy `fullDetail` and `copyText` properties
> The test comparing web and mobile thread feed outputs was failing because `ThreadFeedActivity` exposes `fullDetail` and `copyText` as lazy getter methods rather than plain values. Introduces `comparableActivity` and `comparableThreadFeed` helpers in [ActivityPayloadProjection.test.ts](https://github.com/pingdotgg/t3code/pull/4628/files#diff-2eb9e9c454345137be3527a1e4e4d9a0e8f3ebfec49b222a298b7ba8a247b6b5) that materialize these values and remove the methods before comparison.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b91ad3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->