### PR TITLE
fix(web): render markdown images from workspace files

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -1,0 +1,104 @@
+import { EnvironmentId, ThreadId, type ScopedThreadRef } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { AssetUrlState } from "../assets/assetUrls";
+
+const assetUrlState = vi.hoisted(() => ({
+  current: { _tag: "Success", url: "https://environment.example/assets/shot.png" } as AssetUrlState,
+  requests: [] as Array<unknown>,
+}));
+
+vi.mock("../assets/assetUrls", () => ({
+  useAssetUrlState: (environmentId: unknown, resource: unknown) => {
+    assetUrlState.requests.push({ environmentId, resource });
+    return assetUrlState.current;
+  },
+}));
+
+vi.mock("@effect/atom-react", () => ({ useAtomValue: () => undefined }));
+vi.mock("../state/assets", () => ({ assetEnvironment: { createUrl: () => ({}) } }));
+vi.mock("../state/server", () => ({ serverEnvironment: { configValueAtom: () => ({}) } }));
+vi.mock("../state/preview", () => ({ previewEnvironment: { open: {} } }));
+vi.mock("../state/entities", () => ({ useActiveEnvironmentId: () => "environment-1" }));
+vi.mock("../state/session", () => ({ usePreparedConnection: () => ({ _tag: "None" }) }));
+vi.mock("../state/use-atom-command", () => ({ useAtomCommand: () => () => Promise.resolve() }));
+vi.mock("../state/use-atom-query-runner", () => ({
+  useAtomQueryRunner: () => () => Promise.resolve(),
+}));
+vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
+vi.mock("../editorPreferences", () => ({
+  useOpenInPreferredEditor: () => () => Promise.resolve(),
+}));
+
+const ChatMarkdown = (await import("./ChatMarkdown")).default;
+
+const CWD = "/home/dev/project";
+const threadRef: ScopedThreadRef = {
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: ThreadId.make("thread-1"),
+};
+
+function render(text: string): string {
+  return renderToStaticMarkup(<ChatMarkdown text={text} cwd={CWD} threadRef={threadRef} />);
+}
+
+describe("ChatMarkdown images", () => {
+  beforeEach(() => {
+    assetUrlState.current = {
+      _tag: "Success",
+      url: "https://environment.example/assets/shot.png",
+    };
+    assetUrlState.requests = [];
+  });
+
+  it("serves a workspace image path through a signed asset url", () => {
+    const markup = render("![portrait pip](docs/shots/portrait.png)");
+
+    expect(assetUrlState.requests).toEqual([
+      {
+        environmentId: threadRef.environmentId,
+        resource: {
+          _tag: "workspace-file",
+          threadId: threadRef.threadId,
+          path: `${CWD}/docs/shots/portrait.png`,
+        },
+      },
+    ]);
+    expect(markup).toContain('src="https://environment.example/assets/shot.png"');
+    expect(markup).toContain('alt="portrait pip"');
+    expect(markup).not.toContain('src="docs/shots/portrait.png"');
+  });
+
+  it("resolves absolute workspace paths the agent writes out in full", () => {
+    render(`![landscape pip](${CWD}/docs/shots/landscape.png)`);
+
+    expect(assetUrlState.requests).toEqual([
+      {
+        environmentId: threadRef.environmentId,
+        resource: {
+          _tag: "workspace-file",
+          threadId: threadRef.threadId,
+          path: `${CWD}/docs/shots/landscape.png`,
+        },
+      },
+    ]);
+  });
+
+  it("falls back to a file chip when the environment refuses the asset", () => {
+    assetUrlState.current = { _tag: "Failure" };
+
+    const markup = render("![docked](docs/shots/docked.png)");
+
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain("docked.png");
+    expect(markup).toContain("chat-markdown-file-link");
+  });
+
+  it("leaves remote image sources untouched", () => {
+    const markup = render("![logo](https://example.com/logo.png)");
+
+    expect(assetUrlState.requests).toEqual([]);
+    expect(markup).toContain('src="https://example.com/logo.png"');
+  });
+});

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -10,6 +10,7 @@ import {
   WrapTextIcon,
 } from "lucide-react";
 import type { ScopedThreadRef, ServerProviderSkill } from "@t3tools/contracts";
+import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -69,8 +70,10 @@ import {
   normalizeMarkdownLinkDestination,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
+  type MarkdownFileLinkMeta,
 } from "../markdown-links";
 import { readLocalApi } from "../localApi";
+import { useAssetUrlState } from "../assets/assetUrls";
 import { cn } from "../lib/utils";
 import { useRightPanelStore } from "../rightPanelStore";
 import { useActiveEnvironmentId } from "../state/entities";
@@ -816,6 +819,20 @@ function buildFileLinkParentSuffixByPath(filePaths: ReadonlyArray<string>): Map<
   return suffixByPath;
 }
 
+function markdownFileLinkLabel(
+  meta: MarkdownFileLinkMeta,
+  parentSuffix: string | undefined,
+): string {
+  const labelParts = [meta.basename];
+  if (typeof parentSuffix === "string" && parentSuffix.length > 0) {
+    labelParts.push(parentSuffix);
+  }
+  if (meta.line) {
+    labelParts.push(`L${meta.line}${meta.column ? `:C${meta.column}` : ""}`);
+  }
+  return labelParts.join(" · ");
+}
+
 function extractMarkdownLinkHrefs(text: string): string[] {
   const hrefs: string[] = [];
   for (const match of text.matchAll(MARKDOWN_LINK_HREF_PATTERN)) {
@@ -1001,6 +1018,70 @@ function MarkdownExternalLinkContent({
       </span>
       {childNodes.slice(1)}
     </>
+  );
+}
+
+const MARKDOWN_IMAGE_CLASS_NAME = "chat-markdown-image";
+
+/**
+ * Workspace images can't be loaded straight from their filesystem path — the web
+ * origin only serves the client bundle, so `<img src="/home/me/shot.png">` resolves
+ * to the SPA fallback and renders as a broken image. Mint a signed asset URL for the
+ * file instead, and degrade to the usual file chip when the environment refuses it.
+ */
+function MarkdownWorkspaceImage({
+  threadRef,
+  filePath,
+  alt,
+  title,
+  fallback,
+  onOpen,
+}: {
+  threadRef: ScopedThreadRef;
+  filePath: string;
+  alt: string;
+  title: string;
+  fallback: ReactNode;
+  onOpen: (() => void) | undefined;
+}) {
+  const assetUrl = useAssetUrlState(threadRef.environmentId, {
+    _tag: "workspace-file",
+    threadId: threadRef.threadId,
+    path: filePath,
+  });
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+
+  if (assetUrl._tag === "Loading") {
+    return <span className="chat-markdown-image-placeholder" role="presentation" />;
+  }
+  if (assetUrl._tag === "Failure" || failedUrl === assetUrl.url) {
+    return <>{fallback}</>;
+  }
+
+  const image = (
+    <img
+      src={assetUrl.url}
+      alt={alt}
+      title={title}
+      loading="lazy"
+      draggable={false}
+      className={MARKDOWN_IMAGE_CLASS_NAME}
+      onError={() => setFailedUrl(assetUrl.url)}
+    />
+  );
+  if (!onOpen) {
+    return image;
+  }
+
+  return (
+    <button
+      type="button"
+      className="cursor-zoom-in"
+      aria-label={`Preview ${title}`}
+      onClick={onOpen}
+    >
+      {image}
+    </button>
   );
 }
 
@@ -1456,15 +1537,6 @@ function ChatMarkdown({
         }
 
         const parentSuffix = fileLinkParentSuffixByPath.get(fileLinkMeta.filePath);
-        const labelParts = [fileLinkMeta.basename];
-        if (typeof parentSuffix === "string" && parentSuffix.length > 0) {
-          labelParts.push(parentSuffix);
-        }
-        if (fileLinkMeta.line) {
-          labelParts.push(
-            `L${fileLinkMeta.line}${fileLinkMeta.column ? `:C${fileLinkMeta.column}` : ""}`,
-          );
-        }
 
         return (
           <MarkdownFileLink
@@ -1474,7 +1546,7 @@ function ChatMarkdown({
             displayPath={fileLinkMeta.displayPath}
             workspaceRelativePath={fileLinkMeta.workspaceRelativePath}
             line={fileLinkMeta.line}
-            label={labelParts.join(" · ")}
+            label={markdownFileLinkLabel(fileLinkMeta, parentSuffix)}
             copyMarkdown={`[${fileLinkMeta.basename}](${normalizedHref})`}
             theme={resolvedTheme}
             threadRef={threadRef}
@@ -1487,6 +1559,62 @@ function ChatMarkdown({
                 : undefined
             }
             className={props.className}
+          />
+        );
+      },
+      img({ node: _node, src, alt, ...props }) {
+        const altText = alt ?? "";
+        const normalizedSrc = typeof src === "string" ? normalizeMarkdownLinkHrefKey(src) : "";
+        const plainImage = (
+          <img
+            {...props}
+            src={src}
+            alt={altText}
+            loading="lazy"
+            className={cn(MARKDOWN_IMAGE_CLASS_NAME, props.className)}
+          />
+        );
+        if (!threadRef || normalizedSrc.length === 0) {
+          return plainImage;
+        }
+
+        const fileLinkMeta =
+          markdownFileLinkMetaByHref.get(normalizedSrc) ??
+          resolveMarkdownFileLinkMeta(normalizedSrc, cwd);
+        // Remote sources load fine on their own; only local paths need an asset URL,
+        // and the environment only signs URLs for previewable image types.
+        if (!fileLinkMeta || !isWorkspaceImagePreviewPath(fileLinkMeta.filePath)) {
+          return plainImage;
+        }
+
+        const parentSuffix = fileLinkParentSuffixByPath.get(fileLinkMeta.filePath);
+        const label = markdownFileLinkLabel(fileLinkMeta, parentSuffix);
+        const workspaceRelativePath = fileLinkMeta.workspaceRelativePath;
+        return (
+          <MarkdownWorkspaceImage
+            threadRef={threadRef}
+            filePath={fileLinkMeta.filePath}
+            alt={altText}
+            title={fileLinkMeta.displayPath}
+            onOpen={
+              workspaceRelativePath
+                ? () => useRightPanelStore.getState().openFile(threadRef, workspaceRelativePath)
+                : undefined
+            }
+            fallback={
+              <MarkdownFileLink
+                href={fileLinkMeta.targetPath}
+                targetPath={fileLinkMeta.targetPath}
+                iconPath={fileLinkMeta.filePath}
+                displayPath={fileLinkMeta.displayPath}
+                workspaceRelativePath={workspaceRelativePath}
+                label={label}
+                copyMarkdown={`![${altText}](${normalizedSrc})`}
+                theme={resolvedTheme}
+                threadRef={threadRef}
+                onOpen={openInPreferredEditor}
+              />
+            }
           />
         );
       },
@@ -1526,6 +1654,7 @@ function ChatMarkdown({
       },
     }),
     [
+      cwd,
       diffThemeName,
       fileLinkParentSuffixByPath,
       isStreaming,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1581,15 +1581,35 @@ function ChatMarkdown({
         const fileLinkMeta =
           markdownFileLinkMetaByHref.get(normalizedSrc) ??
           resolveMarkdownFileLinkMeta(normalizedSrc, cwd);
-        // Remote sources load fine on their own; only local paths need an asset URL,
-        // and the environment only signs URLs for previewable image types.
-        if (!fileLinkMeta || !isWorkspaceImagePreviewPath(fileLinkMeta.filePath)) {
+        // Remote sources load fine on their own; only local paths need an asset URL.
+        if (!fileLinkMeta) {
           return plainImage;
         }
 
         const parentSuffix = fileLinkParentSuffixByPath.get(fileLinkMeta.filePath);
         const label = markdownFileLinkLabel(fileLinkMeta, parentSuffix);
         const workspaceRelativePath = fileLinkMeta.workspaceRelativePath;
+        const fallback = (
+          <MarkdownFileLink
+            href={fileLinkMeta.targetPath}
+            targetPath={fileLinkMeta.targetPath}
+            iconPath={fileLinkMeta.filePath}
+            displayPath={fileLinkMeta.displayPath}
+            workspaceRelativePath={workspaceRelativePath}
+            label={label}
+            copyMarkdown={`![${altText}](${normalizedSrc})`}
+            theme={resolvedTheme}
+            threadRef={threadRef}
+            onOpen={openInPreferredEditor}
+          />
+        );
+        // The environment signs only previewable image types. Keep other local
+        // image destinations useful as file chips instead of emitting a raw
+        // filesystem URL that the browser cannot load.
+        if (!isWorkspaceImagePreviewPath(fileLinkMeta.filePath)) {
+          return fallback;
+        }
+
         return (
           <MarkdownWorkspaceImage
             threadRef={threadRef}
@@ -1601,20 +1621,7 @@ function ChatMarkdown({
                 ? () => useRightPanelStore.getState().openFile(threadRef, workspaceRelativePath)
                 : undefined
             }
-            fallback={
-              <MarkdownFileLink
-                href={fileLinkMeta.targetPath}
-                targetPath={fileLinkMeta.targetPath}
-                iconPath={fileLinkMeta.filePath}
-                displayPath={fileLinkMeta.displayPath}
-                workspaceRelativePath={workspaceRelativePath}
-                label={label}
-                copyMarkdown={`![${altText}](${normalizedSrc})`}
-                theme={resolvedTheme}
-                threadRef={threadRef}
-                onOpen={openInPreferredEditor}
-              />
-            }
+            fallback={fallback}
           />
         );
       },

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1049,9 +1049,13 @@ function MarkdownWorkspaceImage({
     threadId: threadRef.threadId,
     path: filePath,
   });
+  const preparedConnection = usePreparedConnection(threadRef.environmentId);
   const [failedUrl, setFailedUrl] = useState<string | null>(null);
 
   if (assetUrl._tag === "Loading") {
+    if (preparedConnection._tag === "None") {
+      return <>{fallback}</>;
+    }
     return <span className="chat-markdown-image-placeholder" role="presentation" />;
   }
   if (assetUrl._tag === "Failure" || failedUrl === assetUrl.url) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1211,6 +1211,27 @@ label:has(> select#reasoning-effort) select {
   white-space: nowrap;
 }
 
+.chat-markdown .chat-markdown-image {
+  display: block;
+  max-width: 100%;
+  max-height: 32rem;
+  height: auto;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background-color: var(--muted);
+  object-fit: contain;
+}
+
+.chat-markdown .chat-markdown-image-placeholder {
+  display: block;
+  width: 100%;
+  max-width: 24rem;
+  aspect-ratio: 16 / 9;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background-color: var(--muted);
+}
+
 .chat-markdown blockquote {
   border-left: 2px solid var(--border);
   padding-left: 0.8rem;

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -69,6 +69,10 @@ describe("resolveMarkdownFileLinkTarget", () => {
     expect(resolveMarkdownFileLinkTarget("https://example.com/docs")).toBeNull();
   });
 
+  it("does not treat protocol-relative urls as workspace files", () => {
+    expect(resolveMarkdownFileLinkMeta("//cdn.example.com/logo.png", "/repo/project")).toBeNull();
+  });
+
   it("does not double-decode file URLs", () => {
     expect(resolveMarkdownFileLinkTarget("file:///Users/julius/project/file%2520name.md")).toBe(
       "/Users/julius/project/file%20name.md",

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -192,6 +192,7 @@ export function resolveMarkdownFileLinkMeta(
   href: string | undefined,
   cwd?: string,
 ): MarkdownFileLinkMeta | null {
+  if (href?.startsWith("//")) return null;
   const targetPath = resolveMarkdownFileLinkTarget(href, cwd);
   if (!targetPath) return null;
 


### PR DESCRIPTION
## What Changed

`ChatMarkdown` had no `img` renderer, so a markdown image whose source is a local path fell through to a bare `<img src="docs/shots/portrait.png">`. Local sources now resolve through the same signed workspace-asset URL that the file preview panel already uses.

- `apps/web/src/components/ChatMarkdown.tsx` — new `img` component. A source that resolves to a workspace file (relative to the thread `cwd`, absolute, or `file://`) is rendered from `assets.createUrl({_tag: "workspace-file", …})`. Remote `http(s)` sources pass through untouched.
- Sources the environment will not sign — outside the workspace root, deleted, not a previewable image type — degrade to the existing file chip rather than a broken image.
- Loaded images are click-to-open in the file preview, wrapped in a `<button aria-label="Preview …">` following the pattern already used for annotation crops in `MessagesTimeline`.
- `apps/web/src/index.css` — `.chat-markdown-image` sizing (max 100% wide, 32rem tall, contained, bordered) and a loading placeholder. There was no image styling at all before.

Also lifted the duplicated file-chip label construction out of the `a` renderer into `markdownFileLinkLabel` so the image fallback builds the same label.

## Why

The web origin only serves the client bundle. An unknown path falls through to the SPA handler in `apps/server/src/http.ts`, which answers with `index.html` — so every local-path image decoded as HTML and rendered as the broken-image icon. Only `http(s)` sources could ever have worked.

This matters because agents write these. Ask one to summarize UI work and it produces `![portrait pip](docs/shots/portrait.png)` pointing at screenshots it just captured in the workspace; every one of them rendered broken.

The asset endpoint is the right lever rather than a new file-serving route: it already signs short-lived, claim-scoped URLs, already restricts to files inside the thread's workspace root, and already gates on previewable image types. The fix reuses that boundary instead of widening it, which is why an out-of-workspace path degrades to a chip instead of loading.

## UI Changes

Before — a message with four workspace screenshots, all broken:

![markdown images before](https://raw.githubusercontent.com/colonelpanic8/t3code/98a93009bb3c9e2efb47b865e341a1d27cd2ad97/screenshots/markdown-images-before.png)

After — same message, same files:

![markdown images after](https://raw.githubusercontent.com/colonelpanic8/t3code/98a93009bb3c9e2efb47b865e341a1d27cd2ad97/screenshots/markdown-images-after.png)

## Verification

New `apps/web/src/components/ChatMarkdown.test.tsx` covers the four cases: relative path, absolute path, refused asset (falls back to the chip), and remote URL (untouched). Confirmed the tests fail against the unmodified component — the baseline output is literally `<img src="docs/shots/docked.png">`.

```
cd apps/web && tsgo --noEmit
vp test run --project unit src/components/ChatMarkdown.test.tsx \
  src/components/chat/MessagesTimeline.test.tsx src/markdown-list-indentation.test.tsx
vp lint apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.test.tsx
vp fmt --check apps/web/src/components/ChatMarkdown.tsx apps/web/src/index.css
```

Integrated web pass through `test-t3-app`: isolated dev environment, real project, the message above sent and rendered in the controlled browser. All four images load from `/api/assets/…`; a missing file renders the chip; a remote URL is passed through unchanged.

Not addressed here, to keep this focused: mobile's `NativeMarkdownImage` passes the raw href to `<Image source={{uri}}>` and has the same defect, but it needs async resolution on a different render path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes — n/a, no motion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chat markdown rendering and reuses existing signed-asset boundaries; adds tests and a small link-parser guard.
> 
> **Overview**
> Chat markdown **workspace image paths** no longer render as broken `<img>` tags pointing at filesystem paths. A new **`img` renderer** resolves relative, absolute, and `file://` sources through **`useAssetUrlState`** (signed `workspace-file` URLs), leaves **`http(s)`** URLs unchanged, and shows a **file chip** when signing fails or the path is not a previewable image type.
> 
> **`MarkdownWorkspaceImage`** handles loading placeholders, `onError` fallback, and optional click-to-open in the file preview panel. File-chip labels are shared via **`markdownFileLinkLabel`**. **`resolveMarkdownFileLinkMeta`** now ignores **protocol-relative** (`//…`) URLs so they are not treated as workspace files. **CSS** adds `.chat-markdown-image` and a loading placeholder. **`ChatMarkdown.test.tsx`** covers the four main cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 929653023ea083b947da7d2817bbad7b7df3f3fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render workspace image files inline in chat markdown
> - Adds a `MarkdownWorkspaceImage` component in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/4631/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) that resolves local workspace image paths to signed asset URLs and renders them as `<img>` elements with lazy loading.
> - Non-previewable local image paths fall back to a file chip (`MarkdownFileLink`); remote `http(s)` and protocol-relative URLs are left unchanged.
> - Adds a guard in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/4631/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) to prevent protocol-relative URLs (`//...`) from being treated as workspace file paths.
> - Adds CSS in [index.css](https://github.com/pingdotgg/t3code/pull/4631/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) for `.chat-markdown-image` and `.chat-markdown-image-placeholder` to constrain size and apply consistent visual styling.
> - Adds `cwd` to the `markdownComponents` `useMemo` dependency array so image/link resolution updates when the working directory changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9296530.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->