### PR TITLE
feat(server): expand project favicon resolution with PWA manifest and directory scan

### DIFF
--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -256,5 +256,76 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         expect(resolved).toContain("public/brand/logo.svg");
       }),
     );
+
+    it.effect("resolves icon from PWA manifest.json", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "manifest.json",
+          JSON.stringify({
+            icons: [{ src: "/icon-512.png", sizes: "512x512", type: "image/png" }],
+          }),
+        );
+        yield* writeTextFile(cwd, "public/icon-512.png", "png");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("public/icon-512.png");
+      }),
+    );
+
+    it.effect("prefers larger manifest icon by declared size", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "manifest.json",
+          JSON.stringify({
+            icons: [
+              { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
+              { src: "/icon-512.png", sizes: "512x512", type: "image/png" },
+            ],
+          }),
+        );
+        yield* writeTextFile(cwd, "public/icon-192.png", "png");
+        yield* writeTextFile(cwd, "public/icon-512.png", "png");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("public/icon-512.png");
+      }),
+    );
+
+    it.effect("falls back to directory scan for common asset folders", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "images/icon.png", "png");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("images/icon.png");
+      }),
+    );
+
+    it.effect("directory scan respects name and extension priority", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "images/icon.png", "png");
+        yield* writeTextFile(cwd, "images/favicon.ico", "ico");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("images/favicon.ico");
+      }),
+    );
   });
 });

--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -327,5 +327,88 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         expect(resolved).toContain("images/favicon.ico");
       }),
     );
+
+    it.effect("directory scan prefers earlier directory over later better name", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "brand.svg", "svg");
+        yield* writeTextFile(cwd, "images/favicon.svg", "svg");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("brand.svg");
+        expect(resolved).not.toContain("images/favicon.svg");
+      }),
+    );
+
+    it.effect("directory scan continues after an unreadable directory", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "images/icon.png", "png");
+        const publicDir = path.join(cwd, "public");
+        const cause = PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method: "readDirectory",
+          pathOrDescriptor: publicDir,
+        });
+        const resolver = yield* makeResolverWithFileSystem(
+          FileSystem.FileSystem.of({
+            ...fileSystem,
+            readDirectory: (dirPath, options) =>
+              dirPath === publicDir
+                ? Effect.fail(cause)
+                : fileSystem.readDirectory(dirPath, options),
+          }),
+        );
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("images/icon.png");
+      }),
+    );
+
+    it.effect("manifest with JSON null falls back to directory scan", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "manifest.json", "null");
+        yield* writeTextFile(cwd, "images/icon.png", "png");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("images/icon.png");
+      }),
+    );
+
+    it.effect("manifest multi-size string picks largest dimension", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "manifest.json",
+          JSON.stringify({
+            icons: [
+              { src: "/icon-192.png", sizes: "192x192 512x512", type: "image/png" },
+              { src: "/icon-256.png", sizes: "256x256", type: "image/png" },
+            ],
+          }),
+        );
+        yield* writeTextFile(cwd, "public/icon-192.png", "png");
+        yield* writeTextFile(cwd, "public/icon-256.png", "png");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("icon-192.png");
+      }),
+    );
   });
 });

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -148,8 +148,14 @@ function extractIconHref(source: string): string | null {
 
 function parseIconSize(sizes: string | undefined): number {
   if (!sizes) return 0;
-  const match = sizes.match(/\b(\d+)x\d+\b/);
-  return match ? Number(match[1]) : 0;
+  let maxSize = 0;
+  for (const part of sizes.split(/\s+/)) {
+    const match = part.match(/^(\d+)x\d+$/);
+    if (match) {
+      maxSize = Math.max(maxSize, Number(match[1]));
+    }
+  }
+  return maxSize;
 }
 
 const optionOnNotFound = <A, R>(
@@ -247,18 +253,7 @@ export const make = Effect.gen(function* () {
         return null;
       }
 
-      const entries = yield* optionOnNotFound(fileSystem.readDirectory(absoluteDir)).pipe(
-        Effect.mapError(
-          (cause) =>
-            new ProjectFaviconResolutionError({
-              operation: "scan-directory",
-              workspaceRoot: projectCwd,
-              relativePath: dir,
-              absolutePath: absoluteDir,
-              cause,
-            }),
-        ),
-      );
+      const entries = yield* Effect.option(fileSystem.readDirectory(absoluteDir));
       if (Option.isNone(entries)) return null;
 
       let best: {
@@ -272,23 +267,13 @@ export const make = Effect.gen(function* () {
       } | null = null;
 
       for (const entry of entries.value) {
-        const priority = candidatePriority.get(entry);
+        const key = dir ? `${dir}/${entry}` : entry;
+        const priority = candidatePriority.get(key);
         if (!priority) continue;
 
         const absolutePath = path.join(absoluteDir, entry);
         const relativePath = dir ? path.join(dir, entry) : entry;
-        const stats = yield* optionOnNotFound(fileSystem.stat(absolutePath)).pipe(
-          Effect.mapError(
-            (cause) =>
-              new ProjectFaviconResolutionError({
-                operation: "stat-candidate",
-                workspaceRoot: projectCwd,
-                relativePath,
-                absolutePath,
-                cause,
-              }),
-          ),
-        );
+        const stats = yield* Effect.option(fileSystem.stat(absolutePath));
         if (Option.isNone(stats) || stats.value.type !== "File") continue;
 
         if (
@@ -316,7 +301,8 @@ export const make = Effect.gen(function* () {
       IMAGE_DIR_CANDIDATES.forEach((candidateDir, dirIdx) => {
         IMAGE_NAME_CANDIDATES.forEach((name, nameIdx) => {
           IMAGE_EXTENSIONS.forEach((ext, extIdx) => {
-            candidatePriority.set(`${name}${ext}`, { dirIdx, nameIdx, extIdx });
+            const key = candidateDir ? `${candidateDir}/${name}${ext}` : `${name}${ext}`;
+            candidatePriority.set(key, { dirIdx, nameIdx, extIdx });
           });
         });
       });
@@ -385,12 +371,14 @@ export const make = Effect.gen(function* () {
     );
     if (Option.isNone(source)) return null;
 
-    let manifest: { icons?: ReadonlyArray<{ src?: string; sizes?: string }> };
+    let parsed: unknown;
     try {
-      manifest = JSON.parse(source.value) as typeof manifest;
+      parsed = JSON.parse(source.value);
     } catch {
       return null;
     }
+    if (!parsed || typeof parsed !== "object") return null;
+    const manifest = parsed as { icons?: ReadonlyArray<{ src?: string; sizes?: string }> };
     if (!Array.isArray(manifest.icons)) return null;
 
     let bestIcon: string | null = null;

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -54,6 +54,47 @@ const ICON_SOURCE_FILES = [
   "src/index.html",
 ] as const;
 
+// Manifest files that may declare PWA icons.
+const MANIFEST_SOURCE_FILES = [
+  "manifest.json",
+  "public/manifest.json",
+  "site.webmanifest",
+  "public/site.webmanifest",
+] as const;
+
+// Directories scanned as a fallback for common icon filenames.
+const IMAGE_DIR_CANDIDATES = [
+  "",
+  "public",
+  "app",
+  "src",
+  "src/app",
+  "assets",
+  "src/assets",
+  "assets/icons",
+  "assets/icon",
+  "static",
+  "resources",
+  "images",
+  "img",
+  "media",
+  "app-icon",
+  ".idea",
+] as const;
+
+const IMAGE_NAME_CANDIDATES = [
+  "favicon",
+  "icon",
+  "logo",
+  "apple-touch-icon",
+  "app-icon",
+  "icon-rounded",
+  "brand",
+  "app",
+] as const;
+
+const IMAGE_EXTENSIONS = [".svg", ".png", ".jpg", ".jpeg", ".webp", ".ico"] as const;
+
 // Matches <link ...> tags or object-like icon metadata where rel/href can appear in any order.
 const LINK_ICON_HTML_RE =
   /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i;
@@ -68,6 +109,8 @@ export class ProjectFaviconResolutionError extends Schema.TaggedErrorClass<Proje
       "resolve-path",
       "stat-candidate",
       "read-source",
+      "read-manifest",
+      "scan-directory",
     ]),
     workspaceRoot: Schema.String,
     relativePath: Schema.optional(Schema.String),
@@ -103,6 +146,12 @@ function extractIconHref(source: string): string | null {
   return null;
 }
 
+function parseIconSize(sizes: string | undefined): number {
+  if (!sizes) return 0;
+  const match = sizes.match(/\b(\d+)x\d+\b/);
+  return match ? Number(match[1]) : 0;
+}
+
 const optionOnNotFound = <A, R>(
   effect: Effect.Effect<A, PlatformError.PlatformError, R>,
 ): Effect.Effect<Option.Option<A>, PlatformError.PlatformError, R> =>
@@ -124,6 +173,8 @@ export const make = Effect.gen(function* () {
     const clean = href.replace(/^\//, "");
     return [path.join("public", clean), clean];
   };
+
+  const toPosixRelativePath = (input: string): string => input.replaceAll("\\", "/");
 
   const findExistingFile = Effect.fn("ProjectFaviconResolver.findExistingFile")(function* (
     projectCwd: string,
@@ -164,6 +215,197 @@ export const make = Effect.gen(function* () {
       }
     }
     return null;
+  });
+
+  const findBestIconInDirectory = Effect.fn("ProjectFaviconResolver.findBestIconInDirectory")(
+    function* (
+      projectCwd: string,
+      dir: string,
+      candidatePriority: ReadonlyMap<
+        string,
+        { readonly dirIdx: number; readonly nameIdx: number; readonly extIdx: number }
+      >,
+    ): Effect.fn.Return<
+      {
+        readonly absolutePath: string;
+        readonly relativePath: string;
+        readonly priority: {
+          readonly dirIdx: number;
+          readonly nameIdx: number;
+          readonly extIdx: number;
+        };
+      } | null,
+      ProjectFaviconResolutionError
+    > {
+      const absoluteDir = path.resolve(projectCwd, dir);
+      const relativeToRoot = toPosixRelativePath(path.relative(projectCwd, absoluteDir));
+      if (
+        relativeToRoot.startsWith("../") ||
+        relativeToRoot === ".." ||
+        path.isAbsolute(relativeToRoot)
+      ) {
+        return null;
+      }
+
+      const entries = yield* optionOnNotFound(fileSystem.readDirectory(absoluteDir)).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProjectFaviconResolutionError({
+              operation: "scan-directory",
+              workspaceRoot: projectCwd,
+              relativePath: dir,
+              absolutePath: absoluteDir,
+              cause,
+            }),
+        ),
+      );
+      if (Option.isNone(entries)) return null;
+
+      let best: {
+        readonly absolutePath: string;
+        readonly relativePath: string;
+        readonly priority: {
+          readonly dirIdx: number;
+          readonly nameIdx: number;
+          readonly extIdx: number;
+        };
+      } | null = null;
+
+      for (const entry of entries.value) {
+        const priority = candidatePriority.get(entry);
+        if (!priority) continue;
+
+        const absolutePath = path.join(absoluteDir, entry);
+        const relativePath = dir ? path.join(dir, entry) : entry;
+        const stats = yield* optionOnNotFound(fileSystem.stat(absolutePath)).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ProjectFaviconResolutionError({
+                operation: "stat-candidate",
+                workspaceRoot: projectCwd,
+                relativePath,
+                absolutePath,
+                cause,
+              }),
+          ),
+        );
+        if (Option.isNone(stats) || stats.value.type !== "File") continue;
+
+        if (
+          !best ||
+          priority.dirIdx < best.priority.dirIdx ||
+          (priority.dirIdx === best.priority.dirIdx && priority.nameIdx < best.priority.nameIdx) ||
+          (priority.dirIdx === best.priority.dirIdx &&
+            priority.nameIdx === best.priority.nameIdx &&
+            priority.extIdx < best.priority.extIdx)
+        ) {
+          best = { absolutePath, relativePath, priority };
+        }
+      }
+
+      return best;
+    },
+  );
+
+  const findIconByDirectoryScan = Effect.fn("ProjectFaviconResolver.findIconByDirectoryScan")(
+    function* (projectCwd: string): Effect.fn.Return<string | null, ProjectFaviconResolutionError> {
+      const candidatePriority = new Map<
+        string,
+        { readonly dirIdx: number; readonly nameIdx: number; readonly extIdx: number }
+      >();
+      IMAGE_DIR_CANDIDATES.forEach((candidateDir, dirIdx) => {
+        IMAGE_NAME_CANDIDATES.forEach((name, nameIdx) => {
+          IMAGE_EXTENSIONS.forEach((ext, extIdx) => {
+            candidatePriority.set(`${name}${ext}`, { dirIdx, nameIdx, extIdx });
+          });
+        });
+      });
+
+      let best: {
+        readonly absolutePath: string;
+        readonly relativePath: string;
+        readonly priority: {
+          readonly dirIdx: number;
+          readonly nameIdx: number;
+          readonly extIdx: number;
+        };
+      } | null = null;
+
+      for (const candidateDir of IMAGE_DIR_CANDIDATES) {
+        const match = yield* findBestIconInDirectory(projectCwd, candidateDir, candidatePriority);
+        if (!match) continue;
+        if (
+          !best ||
+          match.priority.dirIdx < best.priority.dirIdx ||
+          (match.priority.dirIdx === best.priority.dirIdx &&
+            match.priority.nameIdx < best.priority.nameIdx) ||
+          (match.priority.dirIdx === best.priority.dirIdx &&
+            match.priority.nameIdx === best.priority.nameIdx &&
+            match.priority.extIdx < best.priority.extIdx)
+        ) {
+          best = match;
+        }
+      }
+
+      return best ? best.absolutePath : null;
+    },
+  );
+
+  const resolveManifestIcon = Effect.fn("ProjectFaviconResolver.resolveManifestIcon")(function* (
+    projectCwd: string,
+    relativePath: string,
+  ): Effect.fn.Return<string | null, ProjectFaviconResolutionError> {
+    const sourcePath = yield* workspacePaths
+      .resolveRelativePathWithinRoot({
+        workspaceRoot: projectCwd,
+        relativePath,
+      })
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProjectFaviconResolutionError({
+              operation: "resolve-path",
+              workspaceRoot: projectCwd,
+              relativePath,
+              cause,
+            }),
+        ),
+      );
+    const source = yield* optionOnNotFound(fileSystem.readFileString(sourcePath.absolutePath)).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProjectFaviconResolutionError({
+            operation: "read-manifest",
+            workspaceRoot: projectCwd,
+            relativePath,
+            absolutePath: sourcePath.absolutePath,
+            cause,
+          }),
+      ),
+    );
+    if (Option.isNone(source)) return null;
+
+    let manifest: { icons?: ReadonlyArray<{ src?: string; sizes?: string }> };
+    try {
+      manifest = JSON.parse(source.value) as typeof manifest;
+    } catch {
+      return null;
+    }
+    if (!Array.isArray(manifest.icons)) return null;
+
+    let bestIcon: string | null = null;
+    let bestSize = -1;
+    for (const icon of manifest.icons) {
+      if (typeof icon.src !== "string") continue;
+      const existing = yield* findExistingFile(projectCwd, resolveIconHref(icon.src));
+      if (!existing) continue;
+      const size = parseIconSize(icon.sizes);
+      if (size > bestSize) {
+        bestIcon = existing;
+        bestSize = size;
+      }
+    }
+    return bestIcon;
   });
 
   const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = Effect.fn(
@@ -237,6 +479,18 @@ export const make = Effect.gen(function* () {
       if (existing) {
         return existing;
       }
+    }
+
+    for (const manifestFile of MANIFEST_SOURCE_FILES) {
+      const existing = yield* resolveManifestIcon(projectCwd, manifestFile);
+      if (existing) {
+        return existing;
+      }
+    }
+
+    const scanned = yield* findIconByDirectoryScan(projectCwd);
+    if (scanned) {
+      return scanned;
     }
 
     return null;


### PR DESCRIPTION
Closes #4636

## What Changed

Two new resolution stages in `ProjectFaviconResolver`, both framework-agnostic and both tried only *after* every existing check fails:

1. **PWA manifests** — parses `manifest.json`, `public/manifest.json`, `site.webmanifest` and `public/site.webmanifest`, resolving each `icons[].src` on disk and preferring the largest declared `sizes`.
2. **Directory scan fallback** — walks common asset folders (`public`, `app`, `src`, `src/app`, `assets`, `src/assets`, `assets/icons`, `assets/icon`, `static`, `resources`, `images`, `img`, `media`, `app-icon`, `.idea`) for well-known basenames (`favicon`, `icon`, `logo`, `apple-touch-icon`, `app-icon`, `brand`, `app`), picking by directory → name → extension priority.

`ProjectFaviconResolutionError` gains `read-manifest` and `scan-directory` operations. Paths stay guarded inside the workspace root.

## Why

The resolver is good at React-shaped repos and falls back to the generic folder glyph for almost everything else. That's the complaint in #4304 ("works well for React projects and poorly for others"), #1020 and #4935, and it's what the reporter on #2561 pushed back with after it was closed: *"auto detect doesn't work for most projects, for example BE, cli databases or some specific monorepos."*

The two stages here are deliberately not per-framework. A Flutter app is the motivating case: no `package.json`, no `index.html`, icon at `assets/icons/icon.png` referenced only from `flutter_launcher_icons.yaml`. Nothing in the current resolver — or in any of the open favicon PRs — finds it, but a prioritized scan of asset directories does, and the same scan covers Android, Go, Rust, CLI and backend repos without teaching the resolver about any of them.

## How this differs from the other open favicon PRs

These are complementary, not competing — each works a different axis:

- **#4448 (Svelte paths)** and the closed #1613 add framework-specific candidates. This PR is the general form of that approach: the directory scan subsumes per-framework path lists, so ecosystems nobody has filed a PR for still resolve.
- **#4424 (monorepo workspaces)** searches *other roots* — `apps/*`, `packages/*`, `services/*`. This PR searches the selected root more thoroughly. Orthogonal; both can land, and this one does **not** close #1020.
- **#3854 (stack-specific defaults)** substitutes a stock framework logo when nothing is found. This PR finds the project's own icon, so it reduces how often that fallback is reached. A repo that has an icon should show it rather than a Next.js logo.
- **#4337 (refresh on click)** is cache invalidation for an already-resolved URL. No overlap.

## Note on custom icons

`t3.json` already supports `iconPath` and it is checked before everything here, so a project that wants an explicit icon has an escape hatch today. This PR only changes what happens when nothing is declared.

## Verification

- `npx vitest run src/project/ProjectFaviconResolver.test.ts` — 20/20 pass, covering manifest selection, multi-size strings, scan priority ordering, unreadable directories, permission failures, and manifest→scan fallback.
- `npx tsc --noEmit` clean.
- Built and installed the desktop app; verified against real repos including a Flutter project that previously showed the folder glyph.

Additive behind the same `resolvePath` API, and the added filesystem reads only happen on the path that currently returns `null`. Cursor Bugbot reviewed 709dbde as Low Risk.
