### PR TITLE
fix(web): gate PR actions on source-control provider auth readiness

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1,10 +1,12 @@
-import type { VcsStatusResult } from "@t3tools/contracts";
+import type { SourceControlProviderDiscoveryItem, VcsStatusResult } from "@t3tools/contracts";
+import * as Option from "effect/Option";
 import { assert, describe, it } from "vite-plus/test";
 import {
   buildGitActionProgressStages,
   buildMenuItems,
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
+  resolveChangeRequestProviderReadiness,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
   resolveQuickAction,
@@ -1121,6 +1123,174 @@ describe("resolveThreadBranchMetadataPatch", () => {
         expectedBranch: "feature/previous-ref",
       },
     );
+  });
+});
+
+function discoveredProvider(
+  overrides: Partial<SourceControlProviderDiscoveryItem> = {},
+): SourceControlProviderDiscoveryItem {
+  return {
+    kind: "github",
+    label: "GitHub",
+    executable: "gh",
+    status: "available",
+    version: Option.some("gh version 2.62.0"),
+    installHint: "Install the GitHub command-line tool (`gh`) via https://cli.github.com/.",
+    detail: Option.none(),
+    auth: {
+      status: "authenticated",
+      account: Option.some("octocat"),
+      host: Option.some("github.com"),
+      detail: Option.none(),
+    },
+    ...overrides,
+  };
+}
+
+const GITHUB_PROVIDER_INFO = {
+  kind: "github",
+  name: "GitHub",
+  baseUrl: "https://github.com",
+} as const;
+
+describe("resolveChangeRequestProviderReadiness", () => {
+  it("is ready while discovery has not loaded", () => {
+    const readiness = resolveChangeRequestProviderReadiness(GITHUB_PROVIDER_INFO, null);
+    assert.deepEqual(readiness, { ready: true, hint: null });
+  });
+
+  it("is ready when the repository provider is not known", () => {
+    const readiness = resolveChangeRequestProviderReadiness(undefined, [discoveredProvider()]);
+    assert.deepEqual(readiness, { ready: true, hint: null });
+  });
+
+  it("is ready when the provider CLI is authenticated", () => {
+    const readiness = resolveChangeRequestProviderReadiness(GITHUB_PROVIDER_INFO, [
+      discoveredProvider(),
+    ]);
+    assert.deepEqual(readiness, { ready: true, hint: null });
+  });
+
+  it("is not ready with the install hint when the provider CLI is missing", () => {
+    const readiness = resolveChangeRequestProviderReadiness(GITHUB_PROVIDER_INFO, [
+      discoveredProvider({ status: "missing" }),
+    ]);
+    assert.deepEqual(readiness, {
+      ready: false,
+      hint: "Install the GitHub command-line tool (`gh`) via https://cli.github.com/.",
+    });
+  });
+
+  it("is not ready with the auth detail when the provider CLI is unauthenticated", () => {
+    const readiness = resolveChangeRequestProviderReadiness(GITHUB_PROVIDER_INFO, [
+      discoveredProvider({
+        auth: {
+          status: "unauthenticated",
+          account: Option.none(),
+          host: Option.none(),
+          detail: Option.some("Run `gh auth login` to authenticate GitHub CLI."),
+        },
+      }),
+    ]);
+    assert.deepEqual(readiness, {
+      ready: false,
+      hint: "Run `gh auth login` to authenticate GitHub CLI.",
+    });
+  });
+
+  it("is ready when the provider auth state is unknown", () => {
+    const readiness = resolveChangeRequestProviderReadiness(GITHUB_PROVIDER_INFO, [
+      discoveredProvider({
+        auth: {
+          status: "unknown",
+          account: Option.none(),
+          host: Option.none(),
+          detail: Option.none(),
+        },
+      }),
+    ]);
+    assert.deepEqual(readiness, { ready: true, hint: null });
+  });
+});
+
+describe("when: the source control provider CLI is unauthenticated", () => {
+  const unauthenticated = {
+    ready: false,
+    hint: "Run `gh auth login` to authenticate GitHub CLI.",
+  } as const;
+
+  it("buildMenuItems disables create PR but keeps push enabled", () => {
+    const items = buildMenuItems(status({ aheadCount: 2, pr: null }), false, true, unauthenticated);
+    assert.deepInclude(items[1], { id: "push", disabled: false });
+    assert.deepInclude(items[2], { id: "pr", label: "Create PR", disabled: true });
+  });
+
+  it("resolveQuickAction degrades commit-push-PR to commit & push", () => {
+    const quick = resolveQuickAction(
+      status({ hasWorkingTreeChanges: true }),
+      false,
+      false,
+      true,
+      unauthenticated,
+    );
+    assert.deepInclude(quick, {
+      kind: "run_action",
+      action: "commit_push",
+      label: "Commit & push",
+      disabled: false,
+    });
+  });
+
+  it("resolveQuickAction degrades push-and-create-PR to plain push", () => {
+    const quick = resolveQuickAction(
+      status({ aheadCount: 2, pr: null }),
+      false,
+      false,
+      true,
+      unauthenticated,
+    );
+    assert.deepInclude(quick, {
+      kind: "run_action",
+      action: "push",
+      label: "Push",
+      disabled: false,
+    });
+  });
+
+  it("resolveQuickAction disables create PR with the auth hint when synced", () => {
+    const quick = resolveQuickAction(
+      status({ aheadCount: 0, behindCount: 0, aheadOfDefaultCount: 1, pr: null }),
+      false,
+      false,
+      true,
+      unauthenticated,
+    );
+    assert.deepEqual(quick, {
+      label: "Create PR",
+      disabled: true,
+      kind: "show_hint",
+      hint: "Run `gh auth login` to authenticate GitHub CLI.",
+    });
+  });
+
+  it("resolveQuickAction still opens an existing PR", () => {
+    const quick = resolveQuickAction(
+      status({
+        pr: {
+          number: 17,
+          title: "Existing PR",
+          url: "https://example.com/pr/17",
+          baseRef: "main",
+          headRef: "feature/test",
+          state: "open",
+        },
+      }),
+      false,
+      false,
+      true,
+      unauthenticated,
+    );
+    assert.deepInclude(quick, { kind: "open_pr", label: "View PR", disabled: false });
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -1,9 +1,12 @@
 import type {
   GitRunStackedActionResult,
   GitStackedAction,
+  SourceControlProviderDiscoveryItem,
+  SourceControlProviderInfo,
   VcsStatusResult,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
+import * as Option from "effect/Option";
 import {
   DEFAULT_CHANGE_REQUEST_TERMINOLOGY,
   getChangeRequestTerminology,
@@ -51,6 +54,46 @@ function resolveChangeRequestTerminology(
     : DEFAULT_CHANGE_REQUEST_TERMINOLOGY;
 }
 
+export interface ChangeRequestProviderReadiness {
+  readonly ready: boolean;
+  readonly hint: string | null;
+}
+
+export const READY_CHANGE_REQUEST_PROVIDER: ChangeRequestProviderReadiness = {
+  ready: true,
+  hint: null,
+};
+
+export function resolveChangeRequestProviderReadiness(
+  sourceControlProvider: SourceControlProviderInfo | undefined,
+  discoveredProviders: ReadonlyArray<SourceControlProviderDiscoveryItem> | null,
+): ChangeRequestProviderReadiness {
+  // Only gate when we positively know the provider CLI is unusable; while
+  // discovery is loading (or the provider is unrecognized) assume ready so the
+  // actions don't flash disabled.
+  if (!sourceControlProvider || discoveredProviders === null) {
+    return READY_CHANGE_REQUEST_PROVIDER;
+  }
+  const discovered = discoveredProviders.find(
+    (provider) => provider.kind === sourceControlProvider.kind,
+  );
+  if (!discovered) {
+    return READY_CHANGE_REQUEST_PROVIDER;
+  }
+  if (discovered.status !== "available") {
+    return { ready: false, hint: discovered.installHint };
+  }
+  if (discovered.auth.status === "unauthenticated") {
+    return {
+      ready: false,
+      hint:
+        Option.getOrNull(discovered.auth.detail) ??
+        `${discovered.label} is not authenticated. Open Settings -> Source Control for setup guidance.`,
+    };
+  }
+  return READY_CHANGE_REQUEST_PROVIDER;
+}
+
 export function buildGitActionProgressStages(input: {
   action: GitStackedAction;
   hasCustomCommitMessage: boolean;
@@ -95,6 +138,7 @@ export function buildMenuItems(
   gitStatus: VcsStatusResult | null,
   isBusy: boolean,
   hasPrimaryRemote = true,
+  providerReadiness: ChangeRequestProviderReadiness = READY_CHANGE_REQUEST_PROVIDER,
 ): GitActionMenuItem[] {
   if (!gitStatus) return [];
   const terminology = resolveChangeRequestTerminology(gitStatus);
@@ -119,6 +163,7 @@ export function buildMenuItems(
     !hasOpenPr &&
     hasDefaultBranchDelta &&
     !isBehind &&
+    providerReadiness.ready &&
     (gitStatus.hasUpstream || canPushWithoutUpstream);
   const canOpenPr = !isBusy && hasOpenPr;
 
@@ -169,6 +214,7 @@ export function resolveQuickAction(
   isBusy: boolean,
   isDefaultRef = false,
   hasPrimaryRemote = true,
+  providerReadiness: ChangeRequestProviderReadiness = READY_CHANGE_REQUEST_PROVIDER,
 ): GitQuickAction {
   if (isBusy) {
     return { label: "Commit", disabled: true, kind: "show_hint", hint: "Git action in progress." };
@@ -205,7 +251,7 @@ export function resolveQuickAction(
     if (!gitStatus.hasUpstream && !hasPrimaryRemote) {
       return { label: "Commit", disabled: false, kind: "run_action", action: "commit" };
     }
-    if (hasOpenPr || isDefaultRef) {
+    if (hasOpenPr || isDefaultRef || !providerReadiness.ready) {
       return { label: "Commit & push", disabled: false, kind: "run_action", action: "commit_push" };
     }
     return {
@@ -238,7 +284,7 @@ export function resolveQuickAction(
         hint: "No local commits to push.",
       };
     }
-    if (hasOpenPr || isDefaultRef) {
+    if (hasOpenPr || isDefaultRef || !providerReadiness.ready) {
       return {
         label: "Push",
         disabled: false,
@@ -272,7 +318,7 @@ export function resolveQuickAction(
   }
 
   if (isAhead) {
-    if (hasOpenPr || isDefaultRef) {
+    if (hasOpenPr || isDefaultRef || !providerReadiness.ready) {
       return {
         label: "Push",
         disabled: false,
@@ -293,6 +339,15 @@ export function resolveQuickAction(
   }
 
   if (hasDefaultBranchDelta && !isDefaultRef) {
+    if (!providerReadiness.ready) {
+      return {
+        label: `Create ${terminology.shortLabel}`,
+        disabled: true,
+        kind: "show_hint",
+        hint:
+          providerReadiness.hint ?? `Creating a ${terminology.singular} is currently unavailable.`,
+      };
+    }
     return {
       label: `Create ${terminology.shortLabel}`,
       disabled: false,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -38,11 +38,13 @@ import { cn } from "~/lib/utils";
 import {
   buildGitActionProgressStages,
   buildMenuItems,
+  type ChangeRequestProviderReadiness,
   type GitActionIconName,
   type GitActionMenuItem,
   type GitQuickAction,
   type DefaultBranchConfirmableAction,
   requiresDefaultBranchConfirmation,
+  resolveChangeRequestProviderReadiness,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
   resolveThreadBranchMetadataPatch,
@@ -262,11 +264,13 @@ function getMenuActionDisabledReason({
   gitStatus,
   isBusy,
   hasPrimaryRemote,
+  changeRequestProviderReadiness,
 }: {
   item: GitActionMenuItem;
   gitStatus: VcsStatusResult | null;
   isBusy: boolean;
   hasPrimaryRemote: boolean;
+  changeRequestProviderReadiness: ChangeRequestProviderReadiness;
 }): string | null {
   if (!item.disabled) return null;
   if (isBusy) return "Git action in progress.";
@@ -307,6 +311,12 @@ function getMenuActionDisabledReason({
 
   if (hasOpenPr) {
     return `View ${terminology.singular} is currently unavailable.`;
+  }
+  if (!changeRequestProviderReadiness.ready) {
+    return (
+      changeRequestProviderReadiness.hint ??
+      `Create ${terminology.singular} is currently unavailable.`
+    );
   }
   if (!hasBranch) {
     return `Detached HEAD: checkout a refName before creating a ${terminology.singular}.`;
@@ -1099,6 +1109,24 @@ export default function GitActionsControl({
   const hasPrimaryRemote = gitStatus?.hasPrimaryRemote ?? false;
   const gitStatusForActions = gitStatus;
 
+  const sourceControlDiscovery = useEnvironmentQuery(
+    activeEnvironmentId === null
+      ? null
+      : sourceControlEnvironment.discovery({
+          environmentId: activeEnvironmentId,
+          input: {},
+        }),
+  );
+  const refreshSourceControlDiscovery = sourceControlDiscovery.refresh;
+  const changeRequestProviderReadiness: ChangeRequestProviderReadiness = useMemo(
+    () =>
+      resolveChangeRequestProviderReadiness(
+        gitStatusForActions?.sourceControlProvider,
+        sourceControlDiscovery.data?.sourceControlProviders ?? null,
+      ),
+    [gitStatusForActions?.sourceControlProvider, sourceControlDiscovery.data],
+  );
+
   const allFiles = gitStatusForActions?.workingTree.files ?? [];
   const selectedFiles = allFiles.filter((f) => !excludedFiles.has(f.path));
   const allSelected = excludedFiles.size === 0;
@@ -1144,13 +1172,31 @@ export default function GitActionsControl({
   }, [gitStatusForActions?.isDefaultRef]);
 
   const gitActionMenuItems = useMemo(
-    () => buildMenuItems(gitStatusForActions, isGitActionRunning, hasPrimaryRemote),
-    [gitStatusForActions, hasPrimaryRemote, isGitActionRunning],
+    () =>
+      buildMenuItems(
+        gitStatusForActions,
+        isGitActionRunning,
+        hasPrimaryRemote,
+        changeRequestProviderReadiness,
+      ),
+    [changeRequestProviderReadiness, gitStatusForActions, hasPrimaryRemote, isGitActionRunning],
   );
   const quickAction = useMemo(
     () =>
-      resolveQuickAction(gitStatusForActions, isGitActionRunning, isDefaultRef, hasPrimaryRemote),
-    [gitStatusForActions, hasPrimaryRemote, isDefaultRef, isGitActionRunning],
+      resolveQuickAction(
+        gitStatusForActions,
+        isGitActionRunning,
+        isDefaultRef,
+        hasPrimaryRemote,
+        changeRequestProviderReadiness,
+      ),
+    [
+      changeRequestProviderReadiness,
+      gitStatusForActions,
+      hasPrimaryRemote,
+      isDefaultRef,
+      isGitActionRunning,
+    ],
   );
   const quickActionDisabledReason = quickAction.disabled
     ? (quickAction.hint ?? "This action is currently unavailable.")
@@ -1190,6 +1236,12 @@ export default function GitActionsControl({
       refreshTimeout = window.setTimeout(() => {
         refreshTimeout = null;
         requestVcsStatusRefresh(refreshVcsStatus, activeEnvironmentId, gitCwd);
+        // Re-probe provider auth when it is currently blocking PR actions so
+        // authenticating in a terminal (e.g. `gh auth login`) re-enables them
+        // on window focus.
+        if (!changeRequestProviderReadiness.ready) {
+          refreshSourceControlDiscovery();
+        }
       }, GIT_STATUS_WINDOW_REFRESH_DEBOUNCE_MS);
     };
     const handleVisibilityChange = () => {
@@ -1208,7 +1260,13 @@ export default function GitActionsControl({
       window.removeEventListener("focus", scheduleRefreshCurrentGitStatus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [activeEnvironmentId, gitCwd, refreshVcsStatus]);
+  }, [
+    activeEnvironmentId,
+    changeRequestProviderReadiness.ready,
+    gitCwd,
+    refreshSourceControlDiscovery,
+    refreshVcsStatus,
+  ]);
 
   const openExistingPr = useCallback(async () => {
     const api = readLocalApi();
@@ -1743,6 +1801,7 @@ export default function GitActionsControl({
                   gitStatus: gitStatusForActions,
                   isBusy: isGitActionRunning,
                   hasPrimaryRemote,
+                  changeRequestProviderReadiness,
                 });
                 if (item.disabled && disabledReason) {
                   return (

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -280,6 +280,7 @@ function getMenuActionDisabledReason({
   const hasChanges = gitStatus.hasWorkingTreeChanges;
   const hasOpenPr = gitStatus.pr?.state === "open";
   const isAhead = gitStatus.aheadCount > 0;
+  const hasDefaultBranchDelta = (gitStatus.aheadOfDefaultCount ?? gitStatus.aheadCount) > 0;
   const isBehind = gitStatus.behindCount > 0;
   const terminology = getSourceControlPresentation(gitStatus.sourceControlProvider).terminology;
 
@@ -312,12 +313,6 @@ function getMenuActionDisabledReason({
   if (hasOpenPr) {
     return `View ${terminology.singular} is currently unavailable.`;
   }
-  if (!changeRequestProviderReadiness.ready) {
-    return (
-      changeRequestProviderReadiness.hint ??
-      `Create ${terminology.singular} is currently unavailable.`
-    );
-  }
   if (!hasBranch) {
     return `Detached HEAD: checkout a refName before creating a ${terminology.singular}.`;
   }
@@ -327,11 +322,19 @@ function getMenuActionDisabledReason({
   if (!gitStatus.hasUpstream && !hasPrimaryRemote) {
     return `Add an "origin" remote before creating a ${terminology.singular}.`;
   }
-  if (!isAhead) {
+  if (!hasDefaultBranchDelta) {
     return `No local commits to include in a ${terminology.singular}.`;
   }
   if (isBehind) {
     return `Branch is behind upstream. Pull/rebase before creating a ${terminology.singular}.`;
+  }
+  // Auth readiness last: git-state blockers above are the user's immediate
+  // next step; the provider hint shows once the branch is otherwise PR-ready.
+  if (!changeRequestProviderReadiness.ready) {
+    return (
+      changeRequestProviderReadiness.hint ??
+      `Create ${terminology.singular} is currently unavailable.`
+    );
   }
   return `Create ${terminology.singular} is currently unavailable.`;
 }


### PR DESCRIPTION
## What changed

Fixes #1368.

The Create PR menu item and the git quick action offered PR creation even when the provider CLI (e.g. `gh`) was missing or unauthenticated. The action would only fail server-side after commit/push had already run, and the resulting disabled/enabled state never mentioned the actual blocker — nothing in `VcsStatusResult` carries provider auth state, so `buildMenuItems`/`resolveQuickAction` could not gate on it.

This surfaces the existing source-control discovery auth probe (`sourceControlEnvironment.discovery`, already used by the Publish-repository dialog's readiness check) into the main git action group:

- **Create PR** (menu + quick action) is disabled with the provider's own auth hint (e.g. ``Run `gh auth login` to authenticate GitHub CLI with an active account.``) when the CLI is missing or unauthenticated.
- Combo quick actions degrade instead of dead-ending: `commit_push_pr` → `commit_push`, `push & create PR` → `push`, so commit/push keep working while PR creation is unavailable.
- While the gate is engaged, window focus re-probes discovery, so running `gh auth login` in a terminal and switching back re-enables the actions (the second half of the issue).
- While discovery is loading or the provider is unrecognized, nothing is gated — no flash of disabled state, and non-CLI setups behave exactly as before.

## Why it should exist

Maintainer direction on the issue: "We should check that `gh` is installed and authed before showing PR actions." This does exactly that, reusing the probe/readiness pattern that already ships for the publish flow, web app only (the mobile app has an independent copy of this logic in `packages/client-runtime/src/state/gitActions.ts`; happy to follow up there if wanted).

## Scope

- `apps/web/src/components/GitActionsControl.logic.ts` — new pure `resolveChangeRequestProviderReadiness` + an optional readiness param on `buildMenuItems`/`resolveQuickAction` (defaults preserve existing behavior).
- `apps/web/src/components/GitActionsControl.tsx` — discovery query, readiness wiring, disabled-reason hint, focus re-probe.
- `apps/web/src/components/GitActionsControl.logic.test.ts` — 11 new unit tests covering the readiness resolution and the gating/degradation behavior.

## Verification

- `vp test` (web unit suite, 1529 tests), `tsgo --noEmit`, `vp lint`, and `vp fmt --check` all pass.
- Verified end-to-end against a real dev stack (`dev-runner dev`, scratch `--home-dir`): launched the server with `GH_CONFIG_DIR` pointed at an empty directory so `gh auth status` reports unauthenticated, added a local repo with a `github.com` origin and a feature branch one commit ahead of main. Observed:
  - quick action shows **Push** instead of **Push & create PR**;
  - menu shows **Create PR** disabled while **Push** stays enabled;
  - hovering the disabled item shows the probe's own hint: ``Run `gh auth login` to authenticate GitHub CLI with an active account.``

Can attach screenshots of the disabled state + tooltip if helpful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Web-only UI/logic gating with conservative defaults during loading; commit/push behavior preserved and covered by new unit tests.
> 
> **Overview**
> **Create PR** and PR-related quick actions in the git toolbar now depend on source-control provider discovery (same probe as publish), so users are not offered PR creation when the provider CLI is missing or unauthenticated.
> 
> Adds `resolveChangeRequestProviderReadiness` and threads optional readiness into `buildMenuItems` and `resolveQuickAction`: **Create PR** disables with the provider’s install/auth hint; combo actions degrade (`commit_push_pr` → commit & push, push-and-create-PR → push) while commit/push stay available. Viewing an existing open PR is unchanged.
> 
> `GitActionsControl` loads `sourceControlEnvironment.discovery`, passes readiness into menus and disabled-reason tooltips (auth checked after git-state blockers), and re-probes discovery on window focus when PR actions are blocked so terminal `gh auth login` can re-enable them without a full refresh. While discovery is loading or the provider is unknown, nothing is gated to avoid a flash of disabled UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b21c3c22f3a1a2a44c14f1c38b52e2e2802bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate PR actions in GitActionsControl on source-control provider CLI auth readiness
> - Adds `resolveChangeRequestProviderReadiness` in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/4639/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) to determine if PR actions should be available based on provider CLI install status and authentication state, returning a user-facing hint when blocked.
> - `buildMenuItems` and `resolveQuickAction` now accept a `providerReadiness` parameter; when not ready, the Create PR menu item is disabled and actions that would create a PR degrade to commit & push or plain push.
> - `getMenuActionDisabledReason` in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/4639/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) appends provider-specific install or auth guidance to the disabled tooltip when provider readiness blocks PR creation.
> - The `GitActionsControl` component fetches source control provider discovery data and re-checks it on window focus when PR actions are currently blocked, so authentication changes via CLI re-enable PR actions without a manual refresh.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10b21c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->