### PR TITLE
fix(web): clear stale provider update toast action

### DIFF
--- a/apps/web/src/components/ProviderUpdatePrimaryNotification.test.tsx
+++ b/apps/web/src/components/ProviderUpdatePrimaryNotification.test.tsx
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const toastMocks = vi.hoisted(() => ({
+  update: vi.fn(),
+}));
+
+vi.mock("./ui/toast", () => ({
+  stackedThreadToast: vi.fn((options) => options),
+  toastManager: {
+    add: vi.fn(),
+    close: vi.fn(),
+    update: toastMocks.update,
+  },
+}));
+
+import { updateProviderUpdateToast } from "./ProviderUpdatePrimaryNotification";
+
+describe("updateProviderUpdateToast", () => {
+  beforeEach(() => {
+    toastMocks.update.mockClear();
+  });
+
+  it.each([
+    {
+      view: {
+        phase: "running" as const,
+        type: "loading" as const,
+        title: "Updating provider",
+        description: "Running provider update command.",
+      },
+    },
+    {
+      view: {
+        phase: "succeeded" as const,
+        type: "success" as const,
+        title: "Provider updated",
+        description: "New sessions will use the updated provider.",
+        dismissAfterVisibleMs: 3_000,
+      },
+    },
+  ])("clears the prompt action in the $view.phase state", ({ view }) => {
+    updateProviderUpdateToast({
+      toastId: "provider-update-toast",
+      view,
+      openSettings: vi.fn(),
+    });
+
+    expect(toastMocks.update).toHaveBeenCalledWith(
+      "provider-update-toast",
+      expect.objectContaining({
+        type: view.type,
+        actionProps: undefined,
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/ProviderUpdatePrimaryNotification.test.tsx
+++ b/apps/web/src/components/ProviderUpdatePrimaryNotification.test.tsx
@@ -28,6 +28,7 @@ describe("updateProviderUpdateToast", () => {
         title: "Updating provider",
         description: "Running provider update command.",
       },
+      retainsSettingsAction: false,
     },
     {
       view: {
@@ -37,19 +38,45 @@ describe("updateProviderUpdateToast", () => {
         description: "New sessions will use the updated provider.",
         dismissAfterVisibleMs: 3_000,
       },
+      retainsSettingsAction: false,
     },
-  ])("clears the prompt action in the $view.phase state", ({ view }) => {
+    {
+      view: {
+        phase: "failed" as const,
+        type: "error" as const,
+        title: "Provider update failed",
+        description: "Update command failed.",
+      },
+      retainsSettingsAction: true,
+    },
+    {
+      view: {
+        phase: "unchanged" as const,
+        type: "warning" as const,
+        title: "Provider still needs an update",
+        description: "Provider still appears outdated.",
+      },
+      retainsSettingsAction: true,
+    },
+  ])("applies the expected action in the $view.phase state", ({ view, retainsSettingsAction }) => {
+    const openSettings = vi.fn();
+
     updateProviderUpdateToast({
       toastId: "provider-update-toast",
       view,
-      openSettings: vi.fn(),
+      openSettings,
     });
 
     expect(toastMocks.update).toHaveBeenCalledWith(
       "provider-update-toast",
       expect.objectContaining({
         type: view.type,
-        actionProps: undefined,
+        actionProps: retainsSettingsAction
+          ? {
+              children: "Settings",
+              onClick: openSettings,
+            }
+          : undefined,
       }),
     );
   });

--- a/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
+++ b/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
@@ -57,7 +57,7 @@ function ProviderUpdateToastIcon({ provider }: { provider: ProviderDriverKind })
   );
 }
 
-function updateProviderUpdateToast(input: {
+export function updateProviderUpdateToast(input: {
   readonly toastId: ProviderUpdateToastId;
   readonly view: ProviderUpdateToastView;
   readonly openSettings: () => void;
@@ -68,6 +68,9 @@ function updateProviderUpdateToast(input: {
       title: input.view.title,
       description: input.view.description,
       timeout: 0,
+      // Base UI shallow-merges toast updates, so omitting actionProps would
+      // retain the prompt's now-stale Update button in loading/success states.
+      actionProps: undefined,
       data: {
         hideCopyButton: true,
         ...(input.view.dismissAfterVisibleMs !== undefined


### PR DESCRIPTION
## What changed

- Clear the provider (Codex, OpenCode, etc) update toast's original `Update` action when it enters loading or success.
- Add focused coverage for both states in testing.

## Why

UI shallow-merges toast updates. The initial prompt supplies `actionProps`, but the loading and success updates previously omitted that field, so the stale `Update` button remained visible while the command ran and after completion.

Explicitly setting `actionProps: undefined` removes the stale control. Failed and unchanged states still provide their intended Settings action.

## Related work

This overlaps #3563 and #2655, which contain the same core one-line fix. This version is based on current `main` after the notification split into `ProviderUpdatePrimaryNotification.tsx` and adds regression coverage for both affected states.

## Validation

- `vp test run apps/web/src/components/ProviderUpdatePrimaryNotification.test.tsx apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts apps/web/src/components/ProviderUpdateEnvironmentRows.test.tsx` — 49 tests passed
- Targeted `vp lint`
- Targeted `vp fmt --check`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`

OpenCode was downgraded from `1.18.7` to `1.18.6` locally to leave a natural update-available state for manual verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated “Update” actions from persisting in provider update notifications after they transition to loading or success states.

* **Tests**
  * Added coverage to verify notification updates correctly clear obsolete action controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI toast behavior fix with regression tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes provider update toasts that still showed the initial **Update** button while loading or after success.
> 
> `updateProviderUpdateToast` now passes **`actionProps: undefined`** on loading and success updates because Base UI shallow-merges toast state—omitting the field left the prompt’s action in place. Failed and unchanged states still set a **Settings** action.
> 
> The helper is **exported** and covered by a new unit test that checks `actionProps` for running, succeeded, failed, and unchanged views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2728487444e9f5f7dd44c652d21e303c3998cb27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear stale action from provider update toast in loading and success states
> When a provider update toast transitions to a loading or success state, any previously set action (e.g. a Settings button) was being retained due to shallow-merge behavior in `toastManager.update`. [ProviderUpdatePrimaryNotification.tsx](https://github.com/pingdotgg/t3code/pull/4651/files#diff-d406ca641d650a2341fd7b4aa3ac1f6d980b270a7046f0f791dd54e39da147c9) now explicitly sets `actionProps` to `undefined` in those branches to clear the stale action. A comment explaining the shallow-merge behavior is also added.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2728487.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->