### PR TITLE
Fix Relay Worker RuntimeContext wiring

### DIFF
--- a/infra/relay/src/agentActivity/ApnsDeliveryQueue.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveryQueue.test.ts
@@ -1,5 +1,6 @@
 import * as NodeCryptoLayer from "@effect/platform-node/NodeCrypto";
 import { describe, expect, it } from "@effect/vitest";
+import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -28,6 +29,41 @@ const config: RelayConfiguration.RelayConfiguration["Service"] = {
 };
 
 describe("ApnsDeliveryQueue", () => {
+  it.effect("does not require the deployment RuntimeContext when building the Worker layer", () => {
+    const sent: unknown[] = [];
+    const sender: Cloudflare.Queues.WriteQueueClient = {
+      raw: Effect.die("raw queue binding is not used"),
+      send: (body) =>
+        Effect.sync(() => {
+          sent.push(body);
+        }),
+      sendBatch: () => Effect.die("batch queue binding is not used"),
+    };
+    const runtimeContext = {} as Alchemy.BaseRuntimeContext;
+    const layer = ApnsDeliveryQueue.layerCloudflareQueues(sender, runtimeContext).pipe(
+      Layer.provide(NodeCryptoLayer.layer),
+      Layer.provide(RelayConfiguration.layer(config)),
+    );
+
+    return Effect.gen(function* () {
+      const queue = yield* ApnsDeliveryQueue.ApnsDeliveryQueue;
+      yield* queue.enqueuePushNotification({
+        userId: "user-1",
+        deviceId: "device-1",
+        token: "push-token",
+        notification: {
+          title: "Thread",
+          body: "Input: Project",
+          environmentId: "env-1",
+          threadId: "thread-1",
+          deepLink: "/threads/env-1/thread-1",
+        },
+      });
+
+      expect(sent).toHaveLength(1);
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("preserves job identity and the queue sender cause", () => {
     const cause = new Error("queue unavailable");
     const senderCause = new Cloudflare.Queues.SendError({

--- a/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
@@ -208,21 +208,20 @@ export const make = Effect.gen(function* () {
 
 export const layer = Layer.effect(ApnsDeliveryQueue, make);
 
-export const layerCloudflareQueues = (sender: Cloudflare.Queues.WriteQueueClient) =>
+export const layerCloudflareQueues = (
+  sender: Cloudflare.Queues.WriteQueueClient,
+  alchemyRuntimeContext: Alchemy.BaseRuntimeContext,
+) =>
   layer.pipe(
     Layer.provide(
-      Layer.effect(
+      Layer.succeed(
         ApnsDeliveryQueueSender,
-        Alchemy.RuntimeContext.pipe(
-          Effect.map((alchemyRuntimeContext) =>
-            ApnsDeliveryQueueSender.of({
-              send: (body) =>
-                sender
-                  .send(body)
-                  .pipe(Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext)),
-            }),
-          ),
-        ),
+        ApnsDeliveryQueueSender.of({
+          send: (body) =>
+            sender
+              .send(body)
+              .pipe(Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext)),
+        }),
       ),
     ),
   );

--- a/infra/relay/src/environments/ManagedEndpointProvider.test.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.test.ts
@@ -2,6 +2,8 @@ import * as NodeCrypto from "node:crypto";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 
 import { describe, expect, it } from "@effect/vitest";
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
@@ -280,6 +282,47 @@ function expectedManagedTunnelName(environmentId: string, userId = "user_ABC"): 
 }
 
 describe("ManagedEndpointProvider", () => {
+  it.effect("does not require the deployment RuntimeContext when building the Worker layer", () => {
+    const tunnelClient = {
+      list: () => Effect.succeed({ result: [] }),
+      create: (request: { readonly name: string }) =>
+        Effect.succeed({ id: "tunnel-id", name: request.name }),
+      putConfiguration: () => Effect.void,
+      getToken: () => Effect.succeed("connector-token"),
+      delete: () => Effect.void,
+    } as unknown as Cloudflare.Tunnel.ReadWriteTunnelClient;
+    const dnsClient = {
+      listDnsRecords: () => Effect.succeed({ result: [] }),
+      createDnsRecord: () => Effect.succeed({ id: "dns-record-id" }),
+      updateDnsRecord: () => Effect.void,
+      deleteDnsRecord: () => Effect.void,
+    } as unknown as Cloudflare.DNS.ReadWriteDnsClient;
+    const runtimeContext = {} as Alchemy.BaseRuntimeContext;
+    const layer = ManagedEndpointProvider.layerCloudflareBindings(
+      tunnelClient,
+      dnsClient,
+      runtimeContext,
+    ).pipe(
+      Layer.provideMerge(NodeServices.layer),
+      Layer.provide(RelayConfiguration.layer(config)),
+      Layer.provide(
+        Layer.succeed(ManagedEndpointAllocations.ManagedEndpointAllocations, makeAllocations()),
+      ),
+      Layer.provide(Layer.succeed(ManagedTunnelLimits.ManagedTunnelLimits, makeTunnelLimits())),
+    );
+
+    return Effect.gen(function* () {
+      const provider = yield* ManagedEndpointProvider.ManagedEndpointProvider;
+      const result = yield* provider.provision({
+        userId: "user_ABC",
+        environmentId: "env_ABC",
+        origin: { localHttpHost: "127.0.0.1", localHttpPort: 3773 },
+      });
+
+      expect(result.runtime.connectorToken).toBe("connector-token");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("provisions a Cloudflare tunnel endpoint and connector token", () => {
     const tunnelCalls: TunnelCall[] = [];
     const dnsCalls: DnsCall[] = [];

--- a/infra/relay/src/environments/ManagedEndpointProvider.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.ts
@@ -811,137 +811,132 @@ export const layer = Layer.effect(ManagedEndpointProvider, make);
 export const layerCloudflareBindings = (
   tunnelClient: Cloudflare.Tunnel.ReadWriteTunnelClient,
   dnsClient: Cloudflare.DNS.ReadWriteDnsClient,
+  alchemyRuntimeContext: Alchemy.BaseRuntimeContext,
 ) =>
   layer.pipe(
     Layer.provide(
-      Layer.unwrap(
-        Alchemy.RuntimeContext.pipe(
-          Effect.map((alchemyRuntimeContext) =>
-            Layer.mergeAll(
-              layerTunnelClient({
-                list: (request) =>
-                  tunnelClient.list(request).pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new ManagedEndpointTunnelClientError({
-                          operation: "list",
-                          tunnelName: request.name,
-                          cause,
-                        }),
-                    ),
-                    Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-                  ),
-                create: (request) =>
-                  tunnelClient.create(request).pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new ManagedEndpointTunnelClientError({
-                          operation: "create",
-                          tunnelName: request.name,
-                          cause,
-                        }),
-                    ),
-                    Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-                  ),
-                putConfiguration: (tunnelId, config) =>
-                  tunnelClient.putConfiguration(tunnelId, config).pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new ManagedEndpointTunnelClientError({
-                          operation: "put-configuration",
-                          tunnelId,
-                          cause,
-                        }),
-                    ),
-                    Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-                  ),
-                getToken: (tunnelId) =>
-                  tunnelClient.getToken(tunnelId).pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new ManagedEndpointTunnelClientError({
-                          operation: "get-token",
-                          tunnelId,
-                          cause,
-                        }),
-                    ),
-                    Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-                  ),
-                delete: (tunnelId) =>
-                  tunnelClient.delete(tunnelId).pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new ManagedEndpointTunnelClientError({
-                          operation: "delete",
-                          tunnelId,
-                          cause,
-                        }),
-                    ),
-                    Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-                  ),
-              }),
-              layerDnsClient({
-                listRecords: (hostname) =>
-                  dnsClient.listDnsRecords({ search: hostname }).pipe(
-                    Effect.map((response) =>
-                      response.result.filter(
-                        (record): record is typeof record & { readonly id: string } =>
-                          typeof record.id === "string" &&
-                          normalizeHostname(record.name) === normalizeHostname(hostname),
-                      ),
-                    ),
-                    Effect.mapError(
-                      (cause) =>
-                        new ManagedEndpointDnsClientError({
-                          operation: "list-records",
-                          hostname,
-                          cause,
-                        }),
-                    ),
-                    Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-                  ),
-                createRecord: (request) =>
-                  dnsClient.createDnsRecord(request).pipe(
-                    Effect.map((response) => ({ id: response.id })),
-                    Effect.mapError(
-                      (cause) =>
-                        new ManagedEndpointDnsClientError({
-                          operation: "create-record",
-                          hostname: request.name,
-                          cause,
-                        }),
-                    ),
-                    Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-                  ),
-                updateRecord: (dnsRecordId, request) =>
-                  dnsClient.updateDnsRecord(dnsRecordId, request).pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new ManagedEndpointDnsClientError({
-                          operation: "update-record",
-                          hostname: request.name,
-                          dnsRecordId,
-                          cause,
-                        }),
-                    ),
-                    Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-                  ),
-                deleteRecord: (dnsRecordId) =>
-                  dnsClient.deleteDnsRecord(dnsRecordId).pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new ManagedEndpointDnsClientError({
-                          operation: "delete-record",
-                          dnsRecordId,
-                          cause,
-                        }),
-                    ),
-                    Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-                  ),
-              }),
+      Layer.mergeAll(
+        layerTunnelClient({
+          list: (request) =>
+            tunnelClient.list(request).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "list",
+                    tunnelName: request.name,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
             ),
-          ),
-        ),
+          create: (request) =>
+            tunnelClient.create(request).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "create",
+                    tunnelName: request.name,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          putConfiguration: (tunnelId, config) =>
+            tunnelClient.putConfiguration(tunnelId, config).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "put-configuration",
+                    tunnelId,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          getToken: (tunnelId) =>
+            tunnelClient.getToken(tunnelId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "get-token",
+                    tunnelId,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          delete: (tunnelId) =>
+            tunnelClient.delete(tunnelId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "delete",
+                    tunnelId,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+        }),
+        layerDnsClient({
+          listRecords: (hostname) =>
+            dnsClient.listDnsRecords({ search: hostname }).pipe(
+              Effect.map((response) =>
+                response.result.filter(
+                  (record): record is typeof record & { readonly id: string } =>
+                    typeof record.id === "string" &&
+                    normalizeHostname(record.name) === normalizeHostname(hostname),
+                ),
+              ),
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointDnsClientError({
+                    operation: "list-records",
+                    hostname,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          createRecord: (request) =>
+            dnsClient.createDnsRecord(request).pipe(
+              Effect.map((response) => ({ id: response.id })),
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointDnsClientError({
+                    operation: "create-record",
+                    hostname: request.name,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          updateRecord: (dnsRecordId, request) =>
+            dnsClient.updateDnsRecord(dnsRecordId, request).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointDnsClientError({
+                    operation: "update-record",
+                    hostname: request.name,
+                    dnsRecordId,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          deleteRecord: (dnsRecordId) =>
+            dnsClient.deleteDnsRecord(dnsRecordId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointDnsClientError({
+                    operation: "delete-record",
+                    dnsRecordId,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+        }),
       ),
     ),
   );

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -154,6 +154,8 @@ export const ApiLive = Api.make(
     //
     // 3. Runtime layers and app construction
     //
+    const alchemyRuntimeContext: Alchemy.BaseRuntimeContext = yield* Cloudflare.Worker;
+
     const loadSettings = Effect.gen(function* () {
       return RelayConfiguration.RelayConfiguration.of({
         relayIssuer: relayPublicOrigin,
@@ -193,12 +195,15 @@ export const ApiLive = Api.make(
         ManagedEndpointProvider.layerCloudflareBindings(
           managedEndpointTunnelBinding,
           managedEndpointDnsBinding,
+          alchemyRuntimeContext,
         ),
       ),
       Layer.provideMerge(DpopProofs.layer),
       Layer.provideMerge(ApnsDeliveries.layer),
       Layer.provideMerge(ApnsClient.layer.pipe(Layer.provideMerge(ApnsProviderTokens.layer))),
-      Layer.provideMerge(ApnsDeliveryQueue.layerCloudflareQueues(apnsDeliveryQueueSender)),
+      Layer.provideMerge(
+        ApnsDeliveryQueue.layerCloudflareQueues(apnsDeliveryQueueSender, alchemyRuntimeContext),
+      ),
       Layer.provideMerge(AgentActivityRows.layer),
       Layer.provideMerge(Devices.layer),
       Layer.provideMerge(EnvironmentCredentials.layer),


### PR DESCRIPTION
## Summary

- capture the Cloudflare Worker runtime context during Worker initialization
- pass that context explicitly to Queue and managed Tunnel/DNS adapters
- prevent request-time layer construction from requiring Alchemy deployment-only RuntimeContext service
- add regressions covering both affected runtime layers

## Incident verification

- rolled production back to the last pre-upgrade CI Worker version
- production /health: HTTP 200
- production DPoP CORS preflight: HTTP 204
- deployed this fix to dev_julius with only Api update; all database resources were noop
- dev_julius /health: HTTP 200
- dev_julius DPoP CORS preflight: HTTP 204
- post-deploy personal-stage plan: 16 noop

## Checks

- vp test run src/agentActivity/ApnsDeliveryQueue.test.ts src/environments/ManagedEndpointProvider.test.ts (27 passed)
- vp run typecheck
- targeted vp lint
- targeted vp fmt --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Worker wiring for push delivery and managed endpoint provisioning; behavior should be equivalent but mis-wiring could break those paths in production.
> 
> **Overview**
> Fixes Relay Worker failures where **APNs queue** and **managed tunnel/DNS** adapters tried to resolve Alchemy’s deployment-only `RuntimeContext` while assembling request-time Effect layers.
> 
> **Worker init** now reads `alchemyRuntimeContext` from `Cloudflare.Worker` and passes it into `ApnsDeliveryQueue.layerCloudflareQueues` and `ManagedEndpointProvider.layerCloudflareBindings`. Those helpers take the context as an explicit argument and wire it with `Layer.succeed` / static `Layer.mergeAll` instead of `Layer.effect` / `Layer.unwrap` over `Alchemy.RuntimeContext`, so layer construction no longer depends on a service that only exists at deploy time. Cloudflare client calls still get `Effect.provideService(Alchemy.RuntimeContext, …)` on each operation.
> 
> Regression tests assert both Worker layers can be built and exercised (enqueue push, provision managed endpoint) **without** providing deployment `RuntimeContext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6039ed2cac35d025bb6217171eadcab349c13e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Relay Worker RuntimeContext wiring by passing `BaseRuntimeContext` explicitly to layer builders
> - `ManagedEndpointProvider.layerCloudflareBindings` and `ApnsDeliveryQueue.layerCloudflareQueues` previously read `Alchemy.RuntimeContext` from the Effect environment; they now accept it as an explicit parameter.
> - In [worker.ts](https://github.com/pingdotgg/t3code/pull/4653/files#diff-ee3e83e585bf3596528c9f3dc2cca170c0e3a928eaaf504627f1a6bb1ae54f0f), `alchemyRuntimeContext` is obtained by yielding `Cloudflare.Worker` and passed directly into both layer builders.
> - New tests in [ApnsDeliveryQueue.test.ts](https://github.com/pingdotgg/t3code/pull/4653/files#diff-914820b42cc87555104b6554a5b4b140d885a9d4f20768b0aa342ed61ad307e1) and [ManagedEndpointProvider.test.ts](https://github.com/pingdotgg/t3code/pull/4653/files#diff-1e3156ad015026aac78e4fbfa2dc61a5623de85c9baf536959069656dcae24ce) verify that building each Worker layer no longer requires `Alchemy.RuntimeContext` in the environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6039ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->