### PR TITLE
Fix live sidebar resize limits and defer Alchemy runtime context

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,6 +1,12 @@
 import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
-import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import {
+  useEffect,
+  useState,
+  useSyncExternalStore,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 
 import { isElectron } from "../env";
@@ -30,6 +36,15 @@ import {
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 const MACOS_TRAFFIC_LIGHTS_LEFT_INSET = "90px";
+
+function subscribeToViewportWidth(onChange: () => void): () => void {
+  window.addEventListener("resize", onChange);
+  return () => window.removeEventListener("resize", onChange);
+}
+
+function readViewportWidth(): number {
+  return window.innerWidth;
+}
 
 function readInitialThreadSidebarWidth(): number {
   try {
@@ -109,7 +124,11 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const useSidebarV2Theme = useSidebarV2 || isOnSettings;
   const isMacosDesktop = isElectron && isMacPlatform(navigator.platform);
   const [sidebarWidth, setSidebarWidth] = useState(readInitialThreadSidebarWidth);
-  const sidebarMaximumWidth = resolveThreadSidebarMaximumWidth(window.innerWidth);
+  // Subscribed rather than read once: the clamp must track live window size,
+  // and a clamped drag ends with an unchanged width, which skips the re-render
+  // that would otherwise refresh a render-time snapshot.
+  const viewportWidth = useSyncExternalStore(subscribeToViewportWidth, readViewportWidth);
+  const sidebarMaximumWidth = resolveThreadSidebarMaximumWidth(viewportWidth);
   const [isWindowFullscreen, setIsWindowFullscreen] = useState(() => {
     const getWindowFullscreenState = window.desktopBridge?.getWindowFullscreenState;
     return isMacosDesktop && typeof getWindowFullscreenState === "function"


### PR DESCRIPTION
## Summary

- Track viewport width changes so sidebar resize limits update live.
- Resolve Alchemy runtime context through Effect layers when Cloudflare bindings are used.
- Simplify worker layer wiring and remove obsolete runtime-context construction tests.

## Testing

- Not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/layout change in sidebar sizing with no auth, data, or API impact.
> 
> **Overview**
> **Thread sidebar resize limits now follow live window width** instead of a one-time `window.innerWidth` read on render.
> 
> `AppSidebarLayout` subscribes to viewport width via `useSyncExternalStore` and a `resize` listener, then passes that value into `resolveThreadSidebarMaximumWidth` for the sidebar `resizable.maxWidth`. That fixes cases where the max clamp stayed stale after resize—or when a drag ended clamped without changing width, so no re-render refreshed the old snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efe630197bcb8799031afc84198e7489aee0479c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix live sidebar resize limits by subscribing to viewport width changes in `AppSidebarLayout`
> Previously, `sidebarMaximumWidth` was computed once at mount using `window.innerWidth`, so resizing the browser window had no effect. This replaces the one-time read with `useSyncExternalStore`, subscribing to `window` resize events so `sidebarMaximumWidth` stays current as the viewport changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efe6301.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->