### PR TITLE
fix(web): constrain branch toolbar context

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -321,7 +321,7 @@ export const BranchToolbar = memo(function BranchToolbar({
           onUsePreviousWorktree={onUsePreviousWorktree}
         />
       ) : (
-        <div className="flex min-w-0 shrink-0 items-center gap-1">
+        <div className="flex min-w-0 flex-1 items-center gap-1">
           {showEnvironmentIndicator && availableEnvironments && (
             <>
               <BranchToolbarEnvironmentSelector

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -50,7 +50,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
 
   if (envLocked) {
     return (
-      <span className="inline-flex items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
+      <span className="inline-flex shrink-0 items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
         {activeWorktreePath ? (
           <>
             <FolderGitIcon className="size-3" />
@@ -79,7 +79,12 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
       }}
       items={envModeItems}
     >
-      <SelectTrigger variant="ghost" size="xs" className="font-medium" aria-label="Workspace">
+      <SelectTrigger
+        variant="ghost"
+        size="xs"
+        className="shrink-0 font-medium"
+        aria-label="Workspace"
+      >
         {effectiveEnvMode === "worktree" ? (
           <FolderGit2Icon className="size-3" />
         ) : activeWorktreePath ? (

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -43,13 +43,13 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
 
   if (envLocked || onEnvironmentChange === undefined) {
     return (
-      <span className="inline-flex items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
+      <span className="inline-flex min-w-0 max-w-full items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
         {activeEnvironment?.isPrimary ? (
-          <MonitorIcon className="size-3" />
+          <MonitorIcon className="size-3 shrink-0" />
         ) : (
-          <CloudIcon className="size-3" />
+          <CloudIcon className="size-3 shrink-0" />
         )}
-        {activeEnvironment?.label ?? "Run on"}
+        <span className="truncate">{activeEnvironment?.label ?? "Run on"}</span>
       </span>
     );
   }
@@ -61,11 +61,16 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
       onValueChange={(value) => onEnvironmentChange(value as EnvironmentId)}
       items={environmentItems}
     >
-      <SelectTrigger variant="ghost" size="xs" className="font-medium" aria-label="Run on">
+      <SelectTrigger
+        variant="ghost"
+        size="xs"
+        className="min-w-0 max-w-full font-medium"
+        aria-label="Run on"
+      >
         {activeEnvironment?.isPrimary ? (
-          <MonitorIcon className="size-3" />
+          <MonitorIcon className="size-3 shrink-0" />
         ) : (
-          <CloudIcon className="size-3" />
+          <CloudIcon className="size-3 shrink-0" />
         )}
         <SelectValue />
       </SelectTrigger>


### PR DESCRIPTION
## What Changed

Keeps checkout and branch controls visible by truncating long machine and workspace names within the composer context bar.

## Why

Long remote machine names could push neighboring controls off-screen.

<img width="470" height="424" alt="image" src="https://github.com/user-attachments/assets/a3f4b41b-db26-4bb6-a154-4567c1ee5fb5" />


## UI Changes

**Before**

![Before](https://github.com/user-attachments/assets/0c830974-adee-47c6-bfa8-a126edb03aa1)

**After**

![After](https://github.com/user-attachments/assets/530b5cba-a189-45f6-9103-5f81b183d562)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] A video is not needed because this change does not alter motion or timing behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout changes in the composer context bar with no auth, data, or API impact.
> 
> **Overview**
> Fixes the desktop composer **context bar** so long **Run on** (machine/environment) labels no longer shove checkout and branch controls off-screen.
> 
> The left context group in `BranchToolbar` now uses **`flex-1`** instead of **`shrink-0`**, so it shares horizontal space with the branch selector. **`BranchToolbarEnvironmentSelector`** truncates the environment name (`min-w-0`, `max-w-full`, `truncate` on the label) while icons stay fixed with **`shrink-0`**. **`BranchToolbarEnvModeSelector`** keeps workspace controls from collapsing by marking the locked label and workspace **`SelectTrigger`** as **`shrink-0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf0c0e93d3aad0ad4b972611c97d02e8e301cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->