### PR TITLE
fix: close actions dropdown when editing

### DIFF
--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -138,6 +138,7 @@ export default function ProjectScriptsControl({
 }: ProjectScriptsControlProps) {
   const addScriptFormId = React.useId();
   const [editingScriptId, setEditingScriptId] = useState<string | null>(null);
+  const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [name, setName] = useState("");
   const [command, setCommand] = useState("");
@@ -255,6 +256,7 @@ export default function ProjectScriptsControl({
   };
 
   const openEditDialog = (script: ProjectScript) => {
+    setActionsMenuOpen(false);
     setEditingScriptId(script.id);
     setName(script.name);
     setCommand(script.command);
@@ -349,7 +351,11 @@ export default function ProjectScriptsControl({
             <TooltipPopup side="top">Run {primaryScript.name}</TooltipPopup>
           </Tooltip>
           <GroupSeparator className="hidden @3xl/header-actions:block" />
-          <Menu highlightItemOnHover={false}>
+          <Menu
+            highlightItemOnHover={false}
+            open={actionsMenuOpen}
+            onOpenChange={setActionsMenuOpen}
+          >
             <MenuTrigger
               render={<Button size="icon-xs" variant="outline" aria-label="Script actions" />}
             >
@@ -408,7 +414,7 @@ export default function ProjectScriptsControl({
           </Menu>
         </Group>
       ) : importableScripts.length > 0 ? (
-        <Menu highlightItemOnHover={false}>
+        <Menu highlightItemOnHover={false} open={actionsMenuOpen} onOpenChange={setActionsMenuOpen}>
           <MenuTrigger render={<Button size="xs" variant="outline" aria-label="Project actions" />}>
             <PlusIcon className="size-3.5" />
             <span className="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5">

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -138,7 +138,10 @@ export default function ProjectScriptsControl({
 }: ProjectScriptsControlProps) {
   const addScriptFormId = React.useId();
   const [editingScriptId, setEditingScriptId] = useState<string | null>(null);
-  const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
+  const [actionsMenuOpen, setActionsMenuOpen] = useState({
+    scripts: false,
+    imports: false,
+  });
   const [dialogOpen, setDialogOpen] = useState(false);
   const [name, setName] = useState("");
   const [command, setCommand] = useState("");
@@ -256,7 +259,7 @@ export default function ProjectScriptsControl({
   };
 
   const openEditDialog = (script: ProjectScript) => {
-    setActionsMenuOpen(false);
+    setActionsMenuOpen({ scripts: false, imports: false });
     setEditingScriptId(script.id);
     setName(script.name);
     setCommand(script.command);
@@ -353,8 +356,8 @@ export default function ProjectScriptsControl({
           <GroupSeparator className="hidden @3xl/header-actions:block" />
           <Menu
             highlightItemOnHover={false}
-            open={actionsMenuOpen}
-            onOpenChange={setActionsMenuOpen}
+            open={actionsMenuOpen.scripts}
+            onOpenChange={(open) => setActionsMenuOpen({ scripts: open, imports: false })}
           >
             <MenuTrigger
               render={<Button size="icon-xs" variant="outline" aria-label="Script actions" />}
@@ -414,7 +417,11 @@ export default function ProjectScriptsControl({
           </Menu>
         </Group>
       ) : importableScripts.length > 0 ? (
-        <Menu highlightItemOnHover={false} open={actionsMenuOpen} onOpenChange={setActionsMenuOpen}>
+        <Menu
+          highlightItemOnHover={false}
+          open={actionsMenuOpen.imports}
+          onOpenChange={(open) => setActionsMenuOpen({ scripts: false, imports: open })}
+        >
           <MenuTrigger render={<Button size="xs" variant="outline" aria-label="Project actions" />}>
             <PlusIcon className="size-3.5" />
             <span className="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5">


### PR DESCRIPTION
## What Changed

- Made the project actions dropdown controlled.
- Close the dropdown when an action’s edit button is selected.
- Preserve the existing behavior that prevents editing from running the action.

## Why

The actions dropdown remained open behind the Edit Action dialog because the edit button stops the menu item’s click event to avoid running the action. Explicitly closing the menu before opening the dialog matches the existing Add Action behavior while keeping action execution suppressed.

## UI Changes

### Before

Opening the Edit Action dialog left the actions dropdown visible behind it.

<img width="1073" height="965" alt="before" src="https://github.com/user-attachments/assets/3114d82e-63da-4edb-8c41-294b485eb8d4" />

### After

Selecting edit closes the actions dropdown before opening the Edit Action dialog.

https://github.com/user-attachments/assets/16ca6c59-bbc4-4aef-abbd-f9e900f2f16a

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI state change in the header actions menu with no auth, data, or backend impact.
> 
> **Overview**
> Fixes the **Edit Action** flow in `ProjectScriptsControl` so the actions dropdown no longer stays open behind the dialog.
> 
> The script and import **Menu** components are now **controlled** via `actionsMenuOpen` (`scripts` / `imports`). **`openEditDialog`** sets both flags to `false` before opening the dialog—needed because the edit control stops propagation on the menu item, which prevented the menu from closing on its own. Opening one menu still clears the other through `onOpenChange`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31e5c657ac9a0f0dc8d5408207bac5697b189094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close actions dropdowns in `ProjectScriptsControl` when opening the edit dialog
> Converts both `Menu` components in [ProjectScriptsControl.tsx](https://github.com/pingdotgg/t3code/pull/4660/files#diff-e891caffa18ba1b7506cceb8fe52ad48887e3161ef59bee56d37cd57b61c511b) to controlled components using a shared `actionsMenuOpen` state. Opening the edit dialog now closes any open dropdown, and the two menus are mutually exclusive — opening one closes the other.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31e5c65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->