### PR TITLE
fix(preview): stabilize PiP viewport identity

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -22,9 +22,17 @@ import * as BrowserSession from "./BrowserSession.ts";
 import * as PreviewManager from "./Manager.ts";
 
 describe("fitPictureInPictureContentSize", () => {
-  it("fits landscape and portrait viewports without letterboxing the window", () => {
-    expect(PreviewManager.fitPictureInPictureContentSize([480, 320], 16 / 9)).toEqual([480, 270]);
-    expect(PreviewManager.fitPictureInPictureContentSize([480, 320], 9 / 16)).toEqual([240, 427]);
+  it("preserves the PiP content area across aspect-ratio changes", () => {
+    expect(PreviewManager.fitPictureInPictureContentSize([480, 320], 16 / 9)).toEqual([523, 294]);
+    expect(PreviewManager.fitPictureInPictureContentSize([480, 320], 9 / 16)).toEqual([294, 523]);
+  });
+
+  it("does not collapse toward the minimum size when orientation changes repeatedly", () => {
+    const portrait = PreviewManager.fitPictureInPictureContentSize([523, 294], 9 / 16);
+    const landscape = PreviewManager.fitPictureInPictureContentSize(portrait, 16 / 9);
+
+    expect(portrait).toEqual([294, 523]);
+    expect(landscape).toEqual([523, 294]);
   });
 });
 
@@ -1065,7 +1073,7 @@ describe("PreviewManager", () => {
           skipTransformProcessType: true,
         });
         expect(pictureInPictureWindow.setAspectRatio.mock.calls).toEqual([[0], [1280 / 720]]);
-        expect(pictureInPictureWindow.setContentSize).toHaveBeenCalledWith(480, 270, false);
+        expect(pictureInPictureWindow.setContentSize).toHaveBeenCalledWith(523, 294, false);
         expect(pictureInPictureWindow.setAspectRatio.mock.invocationCallOrder[0]).toBeLessThan(
           pictureInPictureWindow.setContentSize.mock.invocationCallOrder[0] ?? 0,
         );

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -104,6 +104,7 @@ const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
 const PICTURE_IN_PICTURE_INITIAL_HEIGHT = 320;
 const PICTURE_IN_PICTURE_MIN_WIDTH = 240;
 const PICTURE_IN_PICTURE_MIN_HEIGHT = 160;
+const PICTURE_IN_PICTURE_ASPECT_RATIO_EPSILON = 0.002;
 const DIAGNOSTIC_BUFFER_LIMIT = 200;
 const MAX_ARTIFACT_SITE_SLUG_LENGTH = 80;
 const AGENT_CURSOR_MOVE_MS = 160;
@@ -164,8 +165,8 @@ export const fitPictureInPictureContentSize = (
 ): readonly [width: number, height: number] => {
   const currentWidth = Math.max(1, current[0] ?? PICTURE_IN_PICTURE_INITIAL_WIDTH);
   const currentHeight = Math.max(1, current[1] ?? PICTURE_IN_PICTURE_INITIAL_HEIGHT);
-  let width =
-    currentWidth / currentHeight > aspectRatio ? currentHeight * aspectRatio : currentWidth;
+  const currentArea = currentWidth * currentHeight;
+  let width = Math.sqrt(currentArea * aspectRatio);
   let height = width / aspectRatio;
   const minimumScale = Math.max(
     1,
@@ -2074,7 +2075,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               tabId,
             );
             const aspectRatio = frame.width / frame.height;
-            if (previousAspectRatio !== aspectRatio) {
+            if (
+              previousAspectRatio === undefined ||
+              Math.abs(previousAspectRatio - aspectRatio) > PICTURE_IN_PICTURE_ASPECT_RATIO_EPSILON
+            ) {
               yield* attempt(
                 {
                   operation: "pictureInPicture.setAspectRatio",

--- a/apps/web/src/browser/ElectronBrowserHost.tsx
+++ b/apps/web/src/browser/ElectronBrowserHost.tsx
@@ -11,6 +11,7 @@ import { useActivePreviewSessions } from "~/previewStateStore";
 import { readPreviewAnnotationTheme } from "./annotationTheme";
 import { useBrowserPointerStore } from "./browserPointerStore";
 import { HostedBrowserWebview } from "./HostedBrowserWebview";
+import { previewRuntimeTabId } from "./previewRuntimeTabId";
 
 export function ElectronBrowserHost() {
   const { resolvedTheme } = useTheme();
@@ -23,6 +24,11 @@ export function ElectronBrowserHost() {
           ? Object.values(previewState.sessions).map((snapshot) => ({
               threadRef,
               snapshot,
+              runtimeTabId: previewRuntimeTabId(
+                threadRef,
+                previewState.serverEpoch,
+                snapshot.tabId,
+              ),
               zoomFactor: previewState.desktopByTabId[snapshot.tabId]?.zoomFactor ?? 1,
             }))
           : [];
@@ -74,13 +80,14 @@ export function ElectronBrowserHost() {
   if (!isElectron) return null;
   return (
     <div className="contents" data-electron-browser-host>
-      {sessions.map(({ threadRef, snapshot, zoomFactor }) => {
+      {sessions.map(({ threadRef, snapshot, runtimeTabId, zoomFactor }) => {
         const url = snapshot.navStatus._tag === "Idle" ? null : snapshot.navStatus.url;
         return (
           <HostedBrowserWebview
-            key={snapshot.tabId}
+            key={runtimeTabId}
             threadRef={threadRef}
             tabId={snapshot.tabId}
+            runtimeTabId={runtimeTabId}
             initialUrl={url}
             viewport={snapshot.viewport ?? FILL_PREVIEW_VIEWPORT}
             zoomFactor={zoomFactor}

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -9,7 +9,11 @@ import { usePreviewBridge } from "~/components/preview/usePreviewBridge";
 import { cn } from "~/lib/utils";
 
 import { resolveBrowserSurfacePanelRect, useBrowserSurfaceStore } from "./browserSurfaceStore";
-import { browserViewportSettingKey, resolveBrowserViewportLayout } from "./browserViewportLayout";
+import {
+  browserViewportSettingKey,
+  resolveBrowserViewportLayout,
+  resolveFittedBrowserViewport,
+} from "./browserViewportLayout";
 import { BrowserDeviceToolbar } from "./BrowserDeviceToolbar";
 import { BrowserViewportResizeHandles } from "./BrowserViewportResizeHandles";
 import { acquireDesktopTab, type AcquiredDesktopTab } from "./desktopTabLifetime";
@@ -40,11 +44,12 @@ declare global {
 export function HostedBrowserWebview(props: {
   readonly threadRef: ScopedThreadRef;
   readonly tabId: string;
+  readonly runtimeTabId: string;
   readonly initialUrl: string | null;
   readonly viewport: PreviewViewportSetting;
   readonly zoomFactor: number;
 }) {
-  const { threadRef, tabId, initialUrl, viewport, zoomFactor } = props;
+  const { threadRef, tabId, runtimeTabId, initialUrl, viewport, zoomFactor } = props;
   const config = usePreviewWebviewConfig(threadRef.environmentId);
   const [initialSrc] = useState(() => initialUrl ?? "about:blank");
   const tabLeaseRef = useRef<AcquiredDesktopTab | null>(null);
@@ -54,27 +59,28 @@ export function HostedBrowserWebview(props: {
   const [aspectRatioLocked, setAspectRatioLocked] = useState(false);
   const presentation = useBrowserSurfaceStore(
     useShallow((state) => {
-      const current = state.byTabId[tabId];
+      const current = state.byTabId[runtimeTabId];
       return {
+        content: current?.content ?? null,
         cornerRadius: current?.cornerRadius ?? 0,
         fitSourceContent: current?.fitSourceContent ?? false,
         fittedSourceContent: current?.fittedSourceContent ?? null,
-        rect: resolveBrowserSurfacePanelRect(state.byTabId, tabId),
+        rect: resolveBrowserSurfacePanelRect(state.byTabId, runtimeTabId),
         visible: current?.visible ?? false,
       };
     }),
   );
-  usePreviewBridge({ threadRef, tabId });
+  usePreviewBridge({ threadRef, tabId, runtimeTabId });
 
   useEffect(() => {
     crashRecoveryRef.current = INITIAL_WEBVIEW_CRASH_RECOVERY_STATE;
-    const lease = acquireDesktopTab(tabId);
+    const lease = acquireDesktopTab(runtimeTabId);
     tabLeaseRef.current = lease;
     return () => {
       if (tabLeaseRef.current === lease) tabLeaseRef.current = null;
       lease.release();
     };
-  }, [tabId]);
+  }, [runtimeTabId]);
 
   const [webviewGeneration, setWebviewGeneration] = useState(0);
   const [recoverySrc, setRecoverySrc] = useState(initialSrc);
@@ -107,7 +113,7 @@ export function HostedBrowserWebview(props: {
           if (disposed || webviewRef.current !== webview) return;
           const webContentsId = webview.getWebContentsId();
           if (Number.isInteger(webContentsId) && webContentsId > 0) {
-            await bridge.registerWebview(tabId, webContentsId);
+            await bridge.registerWebview(runtimeTabId, webContentsId);
           }
         } catch {
           // did-attach/dom-ready will retry if the guest was not ready yet.
@@ -138,7 +144,7 @@ export function HostedBrowserWebview(props: {
       webview.removeEventListener("dom-ready", register);
       webview.removeEventListener("render-process-gone", recoverGuest);
     };
-  }, [config, initialSrc, tabId, webviewGeneration]);
+  }, [config, initialSrc, runtimeTabId, webviewGeneration]);
 
   const active = presentation.visible && presentation.rect !== null;
   const lastRect = presentation.rect;
@@ -152,13 +158,22 @@ export function HostedBrowserWebview(props: {
   const handleAspectRatioChange = useCallback((aspectRatio: number | null) => {
     setAspectRatioLocked(aspectRatio !== null);
   }, []);
+  const hiddenContentSize = presentation.content
+    ? {
+        width: presentation.content.width / presentation.content.scale,
+        height: presentation.content.height / presentation.content.scale,
+      }
+    : null;
   const hiddenSize =
     viewport._tag !== "fill"
       ? {
           width: viewport.width * normalizedZoomFactor,
           height: viewport.height * normalizedZoomFactor,
         }
-      : { width: lastRect?.width ?? 1280, height: lastRect?.height ?? 800 };
+      : {
+          width: hiddenContentSize?.width ?? lastRect?.width ?? 1280,
+          height: hiddenContentSize?.height ?? lastRect?.height ?? 800,
+        };
   const containerSize = active && lastRect ? lastRect : hiddenSize;
   const deviceToolbarVisible = active && viewport._tag !== "fill" && !presentation.fitSourceContent;
   const {
@@ -169,7 +184,7 @@ export function HostedBrowserWebview(props: {
     handleResizePointerDown,
     layout: viewportLayout,
   } = useBrowserViewportResize({
-    tabId,
+    tabId: runtimeTabId,
     viewport,
     zoomFactor,
     containerSize,
@@ -178,31 +193,11 @@ export function HostedBrowserWebview(props: {
   });
   const fittedSourceViewport =
     presentation.fitSourceContent && lastRect
-      ? presentation.fittedSourceContent
-        ? {
-            _tag: "freeform" as const,
-            width: Math.max(
-              1,
-              Math.round(
-                presentation.fittedSourceContent.width /
-                  presentation.fittedSourceContent.scale /
-                  normalizedZoomFactor,
-              ),
-            ),
-            height: Math.max(
-              1,
-              Math.round(
-                presentation.fittedSourceContent.height /
-                  presentation.fittedSourceContent.scale /
-                  normalizedZoomFactor,
-              ),
-            ),
-          }
-        : {
-            _tag: "freeform" as const,
-            width: viewport._tag === "fill" ? 1280 : viewport.width,
-            height: viewport._tag === "fill" ? 800 : viewport.height,
-          }
+      ? resolveFittedBrowserViewport(
+          viewport,
+          presentation.fittedSourceContent,
+          normalizedZoomFactor,
+        )
       : null;
   const layout =
     fittedSourceViewport && lastRect
@@ -212,7 +207,7 @@ export function HostedBrowserWebview(props: {
   const syncContentPresentation = useCallback(() => {
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
-    useBrowserSurfaceStore.getState().presentContent(tabId, {
+    useBrowserSurfaceStore.getState().presentContent(runtimeTabId, {
       x: layout.viewportX,
       y: layout.viewportY,
       width: layout.viewportWidth,
@@ -221,7 +216,7 @@ export function HostedBrowserWebview(props: {
       scrollLeft: wrapper.scrollLeft,
       scrollTop: wrapper.scrollTop,
     });
-  }, [layout, tabId]);
+  }, [layout, runtimeTabId]);
 
   useEffect(() => {
     const frameId = window.requestAnimationFrame(syncContentPresentation);
@@ -232,7 +227,7 @@ export function HostedBrowserWebview(props: {
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
     wrapper.scrollTo({ left: 0, top: 0 });
-  }, [tabId, viewport._tag, viewportHeight, viewportWidth]);
+  }, [runtimeTabId, viewport._tag, viewportHeight, viewportWidth]);
 
   if (!config) return null;
 
@@ -249,7 +244,7 @@ export function HostedBrowserWebview(props: {
       className="fixed overflow-hidden bg-muted/35"
       style={{ ...wrapperStyle, overscrollBehavior: "contain" }}
       onScroll={syncContentPresentation}
-      data-preview-viewport={tabId}
+      data-preview-viewport={runtimeTabId}
     >
       <div className="relative" style={{ width: layout.canvasWidth, height: layout.canvasHeight }}>
         {deviceToolbarVisible && effectiveViewport._tag !== "fill" ? (
@@ -268,7 +263,8 @@ export function HostedBrowserWebview(props: {
           partition={config.partition}
           webpreferences={config.webPreferences}
           {...(config.preloadUrl ? { preload: config.preloadUrl } : {})}
-          data-preview-tab={tabId}
+          data-preview-tab={runtimeTabId}
+          data-preview-server-tab={tabId}
           data-preview-viewport-mode={effectiveViewport._tag}
           data-preview-viewport-key={browserViewportSettingKey(effectiveViewport)}
           data-preview-css-width={

--- a/apps/web/src/browser/browserRecording.test.ts
+++ b/apps/web/src/browser/browserRecording.test.ts
@@ -89,7 +89,9 @@ import {
   BROWSER_RECORDING_FIRST_FRAME_SIZE_TIMEOUT_MS,
   BROWSER_RECORDING_STARTUP_SETTLE_TIMEOUT_MS,
   BrowserRecordingConflictError,
+  findActiveBrowserRecordingRuntimeTabId,
   readActiveBrowserRecordingTabIds,
+  readActiveBrowserRecordingTargets,
   startBrowserRecording,
   stopBrowserRecording,
 } from "./browserRecording";
@@ -364,7 +366,7 @@ describe("browser recording", () => {
     expect(save).toHaveBeenCalledTimes(2);
   });
 
-  it("reports the server-local tab id while capturing through a scoped desktop slot", async () => {
+  it("keeps a recording reachable through its runtime id after a server epoch changes", async () => {
     const threadRef = {
       environmentId: EnvironmentId.make("environment-recording"),
       threadId: ThreadId.make("thread-recording-scoped"),
@@ -389,7 +391,17 @@ describe("browser recording", () => {
     await startBrowserRecording(runtimeTabId, threadRef, "tab_1");
 
     expect(startScreencast).toHaveBeenCalledWith(runtimeTabId);
-    expect(readActiveBrowserRecordingTabIds(threadRef)).toEqual(new Set(["tab_1"]));
+    expect(readActiveBrowserRecordingTabIds(threadRef)).toEqual(new Set([runtimeTabId]));
+    expect(readActiveBrowserRecordingTargets(threadRef)).toEqual([
+      { runtimeTabId, serverTabId: "tab_1" },
+    ]);
+    expect(findActiveBrowserRecordingRuntimeTabId(threadRef, "tab_1")).toBe(runtimeTabId);
+
+    const replacementRuntimeTabId = previewRuntimeTabId(threadRef, "epoch-b", "tab_1");
+    await expect(
+      startBrowserRecording(replacementRuntimeTabId, threadRef, "tab_1"),
+    ).rejects.toBeInstanceOf(BrowserRecordingConflictError);
+    expect(startScreencast).toHaveBeenCalledTimes(1);
 
     await stopBrowserRecording(runtimeTabId);
   });

--- a/apps/web/src/browser/browserRecording.test.ts
+++ b/apps/web/src/browser/browserRecording.test.ts
@@ -93,6 +93,7 @@ import {
   startBrowserRecording,
   stopBrowserRecording,
 } from "./browserRecording";
+import { previewRuntimeTabId } from "./previewRuntimeTabId";
 
 class FakeMediaRecorder {
   static isTypeSupported(): boolean {
@@ -361,6 +362,36 @@ describe("browser recording", () => {
     await stopBrowserRecording("recording-tab-2");
     expect(readActiveBrowserRecordingTabIds()).toEqual(new Set());
     expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the server-local tab id while capturing through a scoped desktop slot", async () => {
+    const threadRef = {
+      environmentId: EnvironmentId.make("environment-recording"),
+      threadId: ThreadId.make("thread-recording-scoped"),
+    };
+    const runtimeTabId = previewRuntimeTabId(threadRef, "epoch-a", "tab_1");
+    surfaceState.byTabId = {
+      [runtimeTabId]: {
+        visible: false,
+        rect: { x: 0, y: 0, width: 1280, height: 800 },
+        content: {
+          x: 0,
+          y: 0,
+          width: 1280,
+          height: 800,
+          scale: 1,
+          scrollLeft: 0,
+          scrollTop: 0,
+        },
+      },
+    };
+
+    await startBrowserRecording(runtimeTabId, threadRef, "tab_1");
+
+    expect(startScreencast).toHaveBeenCalledWith(runtimeTabId);
+    expect(readActiveBrowserRecordingTabIds(threadRef)).toEqual(new Set(["tab_1"]));
+
+    await stopBrowserRecording(runtimeTabId);
   });
 
   it("does not report success for a second start while the first is still starting", async () => {

--- a/apps/web/src/browser/browserRecording.ts
+++ b/apps/web/src/browser/browserRecording.ts
@@ -102,6 +102,11 @@ interface ActiveRecording {
   lifecycle: BrowserRecordingLifecycle;
 }
 
+export interface ActiveBrowserRecordingTarget {
+  readonly runtimeTabId: string;
+  readonly serverTabId: string;
+}
+
 interface ActiveBrowserRecordingIndex {
   readonly tabIds: ReadonlySet<string>;
 }
@@ -128,10 +133,32 @@ export function readActiveBrowserRecordingTabIds(threadRef?: ScopedThreadRef): R
       (recording.threadRef?.environmentId === threadRef.environmentId &&
         recording.threadRef.threadId === threadRef.threadId)
     ) {
-      tabIds.add(recording.serverTabId);
+      tabIds.add(recording.tabId);
     }
   }
   return tabIds;
+}
+
+export function readActiveBrowserRecordingTargets(
+  threadRef: ScopedThreadRef,
+): ReadonlyArray<ActiveBrowserRecordingTarget> {
+  return Array.from(activeRecordings.values()).flatMap((recording) =>
+    recording.threadRef?.environmentId === threadRef.environmentId &&
+    recording.threadRef.threadId === threadRef.threadId
+      ? [{ runtimeTabId: recording.tabId, serverTabId: recording.serverTabId }]
+      : [],
+  );
+}
+
+export function findActiveBrowserRecordingRuntimeTabId(
+  threadRef: ScopedThreadRef,
+  serverTabId: string,
+): string | null {
+  return (
+    readActiveBrowserRecordingTargets(threadRef).find(
+      (recording) => recording.serverTabId === serverTabId,
+    )?.runtimeTabId ?? null
+  );
 }
 
 const preferredMimeType = (): string => {
@@ -298,6 +325,14 @@ export async function startBrowserRecording(
     throw new BrowserRecordingConflictError({
       requestedTabId: tabId,
       activeTabId: activeRecording.tabId,
+    });
+  }
+  const activeLogicalRecording =
+    threadRef === null ? null : findActiveBrowserRecordingRuntimeTabId(threadRef, serverTabId);
+  if (activeLogicalRecording !== null) {
+    throw new BrowserRecordingConflictError({
+      requestedTabId: tabId,
+      activeTabId: activeLogicalRecording,
     });
   }
   const surface = useBrowserSurfaceStore.getState().byTabId[tabId];

--- a/apps/web/src/browser/browserRecording.ts
+++ b/apps/web/src/browser/browserRecording.ts
@@ -82,7 +82,10 @@ type BrowserRecordingLifecycle =
     };
 
 interface ActiveRecording {
+  /** Desktop-scoped identity used by capture and surface stores. */
   readonly tabId: string;
+  /** Server-local identity returned by preview automation tools. */
+  readonly serverTabId: string;
   readonly threadRef: ScopedThreadRef | null;
   readonly canvas: HTMLCanvasElement;
   readonly context: CanvasRenderingContext2D;
@@ -125,7 +128,7 @@ export function readActiveBrowserRecordingTabIds(threadRef?: ScopedThreadRef): R
       (recording.threadRef?.environmentId === threadRef.environmentId &&
         recording.threadRef.threadId === threadRef.threadId)
     ) {
-      tabIds.add(recording.tabId);
+      tabIds.add(recording.serverTabId);
     }
   }
   return tabIds;
@@ -283,6 +286,7 @@ const isStartupWaitTimeout = (error: unknown): error is BrowserRecordingOperatio
 export async function startBrowserRecording(
   tabId: string,
   threadRef: ScopedThreadRef | null = null,
+  serverTabId = tabId,
 ): Promise<string> {
   const bridge = previewBridge;
   if (!bridge) throw new BrowserRecordingUnavailableError({ tabId });
@@ -321,6 +325,7 @@ export async function startBrowserRecording(
   });
   const recording: ActiveRecording = {
     tabId,
+    serverTabId,
     threadRef,
     canvas,
     context,

--- a/apps/web/src/browser/browserSurfaceStore.test.ts
+++ b/apps/web/src/browser/browserSurfaceStore.test.ts
@@ -86,7 +86,7 @@ describe("browserSurfaceStore", () => {
     });
   });
 
-  it("uses the live panel rect for a hidden background tab", () => {
+  it("keeps a hidden background tab on its own last rect", () => {
     const staleRect = { x: 0, y: 0, width: 500, height: 700 };
     const liveRect = { x: 10, y: 20, width: 900, height: 640 };
     expect(
@@ -115,7 +115,7 @@ describe("browserSurfaceStore", () => {
         },
         "hidden",
       ),
-    ).toEqual(liveRect);
+    ).toEqual(staleRect);
   });
 
   it("ignores updates and releases from a stale surface lease", () => {

--- a/apps/web/src/browser/browserSurfaceStore.ts
+++ b/apps/web/src/browser/browserSurfaceStore.ts
@@ -52,19 +52,7 @@ export function resolveBrowserSurfacePanelRect(
   tabId: string,
 ): BrowserSurfaceRect | null {
   const current = byTabId[tabId];
-  if (current?.visible && current.rect) return current.rect;
-
-  let latestVisible: BrowserSurfacePresentation | undefined;
-  for (const presentation of Object.values(byTabId)) {
-    if (
-      presentation.visible &&
-      presentation.rect &&
-      (!latestVisible || presentation.updatedAt > latestVisible.updatedAt)
-    ) {
-      latestVisible = presentation;
-    }
-  }
-  return latestVisible?.rect ?? current?.rect ?? null;
+  return current?.rect ?? null;
 }
 
 const rectEquals = (left: BrowserSurfaceRect | null, right: BrowserSurfaceRect): boolean =>

--- a/apps/web/src/browser/browserViewportActions.test.ts
+++ b/apps/web/src/browser/browserViewportActions.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import {
   BROWSER_VIEWPORT_COMMIT_TIMEOUT_MS,
   commitBrowserViewportChange,
+  runBrowserViewportMutation,
   subscribeBrowserViewportChange,
 } from "./browserViewportActions";
 
@@ -68,6 +69,33 @@ describe("browserViewportActions", () => {
     releaseFirst?.();
     await Promise.all([first, second]);
     expect(calls).toEqual([800, 900]);
+    unsubscribe();
+  });
+
+  it("serializes background mutations with visible viewport commits", async () => {
+    let releaseBackground: (() => void) | undefined;
+    const backgroundPending = new Promise<void>((resolve) => {
+      releaseBackground = resolve;
+    });
+    const calls: string[] = [];
+    const background = runBrowserViewportMutation("tab-shared", async () => {
+      calls.push("background");
+      await backgroundPending;
+    });
+    const unsubscribe = subscribeBrowserViewportChange("tab-shared", async () => {
+      calls.push("visible");
+    });
+    const visible = commitBrowserViewportChange("tab-shared", {
+      _tag: "freeform",
+      width: 900,
+      height: 700,
+    });
+
+    await vi.waitFor(() => expect(calls).toEqual(["background"]));
+    releaseBackground?.();
+    await Promise.all([background, visible]);
+
+    expect(calls).toEqual(["background", "visible"]);
     unsubscribe();
   });
 

--- a/apps/web/src/browser/browserViewportActions.ts
+++ b/apps/web/src/browser/browserViewportActions.ts
@@ -15,6 +15,41 @@ export class BrowserViewportCommitTimeoutError extends Error {
 const handlers = new Map<string, BrowserViewportHandler>();
 const commitTails = new Map<string, Promise<void>>();
 
+const queueBrowserViewportMutation = <A>(
+  tabId: string,
+  start: () => Promise<A>,
+): {
+  readonly started: Promise<{ readonly operation: Promise<A> }>;
+  readonly execution: Promise<A>;
+} => {
+  const previous = commitTails.get(tabId) ?? Promise.resolve();
+  const started = previous
+    .catch(() => undefined)
+    .then(() => ({
+      operation: Promise.resolve().then(start),
+    }));
+  const execution = started.then(({ operation }) => operation);
+  const tail = execution.then(() => undefined);
+  commitTails.set(tabId, tail);
+  const clear = () => {
+    if (commitTails.get(tabId) === tail) commitTails.delete(tabId);
+  };
+  void tail.then(clear, clear);
+  return { started, execution };
+};
+
+/**
+ * Serializes every server-side viewport mutation for one desktop runtime tab.
+ * Both visible UI commits and background automation use this queue so a
+ * compensating rollback cannot overtake a newer resize.
+ */
+export function runBrowserViewportMutation<A>(
+  tabId: string,
+  mutation: () => Promise<A>,
+): Promise<A> {
+  return queueBrowserViewportMutation(tabId, mutation).execution;
+}
+
 const runHandlerWithTimeout = (tabId: string, operation: Promise<void>): Promise<void> => {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
@@ -42,25 +77,14 @@ export function commitBrowserViewportChange(
   tabId: string,
   setting: PreviewViewportSetting,
 ): Promise<void> {
-  const previous = commitTails.get(tabId) ?? Promise.resolve();
-  const started = previous
-    .catch(() => undefined)
-    .then(() => {
-      const handler = handlers.get(tabId);
-      const operation = handler
-        ? Promise.resolve().then(() => handler(setting))
-        : Promise.reject(new Error(`No visible browser viewport handler for tab ${tabId}`));
-      return { operation };
-    });
-  // The queue follows the real handler lifetime, not the caller-facing timeout.
-  // A slow commit therefore cannot time out, release the queue, and overwrite a
-  // newer viewport after that newer request has already completed.
-  const execution = started.then(({ operation }) => operation);
+  const { started } = queueBrowserViewportMutation(tabId, () => {
+    const handler = handlers.get(tabId);
+    return handler
+      ? handler(setting)
+      : Promise.reject(new Error(`No visible browser viewport handler for tab ${tabId}`));
+  });
+  // The queue follows the real handler lifetime, while the caller-facing
+  // timeout starts only once this commit reaches the front of that queue.
   const result = started.then(({ operation }) => runHandlerWithTimeout(tabId, operation));
-  commitTails.set(tabId, execution);
-  const clear = () => {
-    if (commitTails.get(tabId) === execution) commitTails.delete(tabId);
-  };
-  void execution.then(clear, clear);
   return result;
 }

--- a/apps/web/src/browser/browserViewportLayout.test.ts
+++ b/apps/web/src/browser/browserViewportLayout.test.ts
@@ -4,11 +4,27 @@ import {
   resizeBrowserViewportFromRail,
   resizeFreeformViewport,
   resolveBrowserDeviceViewportLayout,
+  resolveFittedBrowserViewport,
   resolveBrowserViewportLayout,
   resolveResponsiveBrowserViewportSize,
 } from "./browserViewportLayout";
 
 describe("resolveBrowserViewportLayout", () => {
+  it("uses the current fixed viewport instead of stale fitted source dimensions", () => {
+    expect(
+      resolveFittedBrowserViewport(
+        { _tag: "freeform", width: 900, height: 600 },
+        { width: 1280, height: 800, scale: 1 },
+      ),
+    ).toEqual({ _tag: "freeform", width: 900, height: 600 });
+  });
+
+  it("preserves the last logical viewport when fitting a fill-mode surface", () => {
+    expect(
+      resolveFittedBrowserViewport({ _tag: "fill" }, { width: 320, height: 200, scale: 0.25 }),
+    ).toEqual({ _tag: "freeform", width: 1280, height: 800 });
+  });
+
   it("fills the available surface in fill mode", () => {
     expect(resolveBrowserViewportLayout({ width: 700, height: 500 }, { _tag: "fill" })).toEqual({
       canvasWidth: 700,

--- a/apps/web/src/browser/browserViewportLayout.ts
+++ b/apps/web/src/browser/browserViewportLayout.ts
@@ -40,6 +40,33 @@ export const browserViewportSettingKey = (setting: PreviewViewportSetting): stri
 const normalizeZoomFactor = (zoomFactor: number): number =>
   Number.isFinite(zoomFactor) && zoomFactor > 0 ? zoomFactor : 1;
 
+export function resolveFittedBrowserViewport(
+  setting: PreviewViewportSetting,
+  sourceContent: {
+    readonly width: number;
+    readonly height: number;
+    readonly scale: number;
+  } | null,
+  zoomFactor = 1,
+): Exclude<PreviewViewportSetting, { readonly _tag: "fill" }> {
+  if (setting._tag !== "fill") return setting;
+  const normalizedZoomFactor = normalizeZoomFactor(zoomFactor);
+  if (sourceContent) {
+    return {
+      _tag: "freeform",
+      width: Math.max(
+        1,
+        Math.round(sourceContent.width / sourceContent.scale / normalizedZoomFactor),
+      ),
+      height: Math.max(
+        1,
+        Math.round(sourceContent.height / sourceContent.scale / normalizedZoomFactor),
+      ),
+    };
+  }
+  return { _tag: "freeform", width: 1280, height: 800 };
+}
+
 export function resolveBrowserDeviceViewportArea(container: {
   readonly width: number;
   readonly height: number;

--- a/apps/web/src/browser/desktopTabLifetime.test.ts
+++ b/apps/web/src/browser/desktopTabLifetime.test.ts
@@ -1,3 +1,4 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const { closeTab, createTab, stopBrowserRecording } = vi.hoisted(() => ({
@@ -15,6 +16,7 @@ vi.mock("./browserRecording", () => ({
 }));
 
 import { acquireDesktopTab } from "./desktopTabLifetime";
+import { previewRuntimeTabId } from "./previewRuntimeTabId";
 
 describe("desktopTabLifetime", () => {
   beforeEach(() => {
@@ -53,6 +55,39 @@ describe("desktopTabLifetime", () => {
     resolveCreation?.();
     await first.ready;
     expect(ready).toBe(true);
+  });
+
+  it("keeps identical server tab ids from two environments in separate desktop slots", async () => {
+    vi.useFakeTimers();
+    createTab.mockResolvedValue(undefined);
+    const tabA = previewRuntimeTabId(
+      {
+        environmentId: EnvironmentId.make("environment-a"),
+        threadId: ThreadId.make("thread-a"),
+      },
+      "epoch-a",
+      "tab_1",
+    );
+    const tabB = previewRuntimeTabId(
+      {
+        environmentId: EnvironmentId.make("environment-b"),
+        threadId: ThreadId.make("thread-b"),
+      },
+      "epoch-b",
+      "tab_1",
+    );
+
+    const first = acquireDesktopTab(tabA);
+    const second = acquireDesktopTab(tabB);
+    await Promise.all([first.ready, second.ready]);
+
+    expect(createTab).toHaveBeenCalledWith(tabA);
+    expect(createTab).toHaveBeenCalledWith(tabB);
+    expect(createTab).toHaveBeenCalledTimes(2);
+
+    first.release();
+    second.release();
+    await vi.advanceTimersByTimeAsync(0);
   });
 
   it("stops recording before closing the final desktop tab lease", async () => {

--- a/apps/web/src/browser/previewRuntimeTabId.test.ts
+++ b/apps/web/src/browser/previewRuntimeTabId.test.ts
@@ -1,0 +1,35 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { previewRuntimeTabId } from "./previewRuntimeTabId";
+
+describe("previewRuntimeTabId", () => {
+  it("scopes process-local tab ids to their environment, thread, and server epoch", () => {
+    const base = {
+      environmentId: EnvironmentId.make("environment-a"),
+      threadId: ThreadId.make("thread-a"),
+    };
+
+    expect(previewRuntimeTabId(base, "epoch-a", "tab_1")).not.toBe(
+      previewRuntimeTabId(
+        { ...base, environmentId: EnvironmentId.make("environment-b") },
+        "epoch-a",
+        "tab_1",
+      ),
+    );
+    expect(previewRuntimeTabId(base, "epoch-a", "tab_1")).not.toBe(
+      previewRuntimeTabId({ ...base, threadId: ThreadId.make("thread-b") }, "epoch-a", "tab_1"),
+    );
+    expect(previewRuntimeTabId(base, "epoch-a", "tab_1")).not.toBe(
+      previewRuntimeTabId(base, "epoch-b", "tab_1"),
+    );
+  });
+
+  it("is stable for the same runtime tab", () => {
+    const ref = {
+      environmentId: EnvironmentId.make("environment-a"),
+      threadId: ThreadId.make("thread-a"),
+    };
+    expect(previewRuntimeTabId(ref, null, "tab_1")).toBe(previewRuntimeTabId(ref, null, "tab_1"));
+  });
+});

--- a/apps/web/src/browser/previewRuntimeTabId.test.ts
+++ b/apps/web/src/browser/previewRuntimeTabId.test.ts
@@ -1,7 +1,7 @@
 import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { previewRuntimeTabId } from "./previewRuntimeTabId";
+import { isCurrentPreviewRuntimeTab, previewRuntimeTabId } from "./previewRuntimeTabId";
 
 describe("previewRuntimeTabId", () => {
   it("scopes process-local tab ids to their environment, thread, and server epoch", () => {
@@ -31,5 +31,16 @@ describe("previewRuntimeTabId", () => {
       threadId: ThreadId.make("thread-a"),
     };
     expect(previewRuntimeTabId(ref, null, "tab_1")).toBe(previewRuntimeTabId(ref, null, "tab_1"));
+  });
+
+  it("rejects a pinned operation target after the server epoch changes", () => {
+    const ref = {
+      environmentId: EnvironmentId.make("environment-a"),
+      threadId: ThreadId.make("thread-a"),
+    };
+    const runtimeTabId = previewRuntimeTabId(ref, "epoch-a", "tab_1");
+
+    expect(isCurrentPreviewRuntimeTab(ref, "epoch-a", "tab_1", runtimeTabId)).toBe(true);
+    expect(isCurrentPreviewRuntimeTab(ref, "epoch-b", "tab_1", runtimeTabId)).toBe(false);
   });
 });

--- a/apps/web/src/browser/previewRuntimeTabId.ts
+++ b/apps/web/src/browser/previewRuntimeTabId.ts
@@ -1,0 +1,14 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+/**
+ * The server only guarantees preview tab ids are unique within one process.
+ * Desktop resources live across every connected environment, so they need a
+ * stronger identity that also changes when a server process restarts.
+ */
+export function previewRuntimeTabId(
+  threadRef: ScopedThreadRef,
+  serverEpoch: string | null,
+  tabId: string,
+): string {
+  return JSON.stringify([threadRef.environmentId, threadRef.threadId, serverEpoch, tabId]);
+}

--- a/apps/web/src/browser/previewRuntimeTabId.ts
+++ b/apps/web/src/browser/previewRuntimeTabId.ts
@@ -12,3 +12,12 @@ export function previewRuntimeTabId(
 ): string {
   return JSON.stringify([threadRef.environmentId, threadRef.threadId, serverEpoch, tabId]);
 }
+
+export function isCurrentPreviewRuntimeTab(
+  threadRef: ScopedThreadRef,
+  serverEpoch: string | null,
+  tabId: string,
+  runtimeTabId: string,
+): boolean {
+  return previewRuntimeTabId(threadRef, serverEpoch, tabId) === runtimeTabId;
+}

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -38,6 +38,7 @@ import {
 } from "~/browser/browserRecording";
 import { resolveBrowserRecordingStopTarget } from "~/browser/browserRecordingScope";
 import { useBrowserSurfaceStore } from "~/browser/browserSurfaceStore";
+import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 import { isElectron } from "~/env";
 import { useEnvironments } from "~/state/environments";
 import { previewEnvironment } from "~/state/preview";
@@ -54,6 +55,7 @@ import {
   PreviewAutomationViewportTimeoutError,
 } from "./previewAutomationErrors";
 import {
+  previewAutomationDefaultViewport,
   previewAutomationOpenNeedsOverlay,
   shouldOpenPreviewMiniPlayer,
 } from "./previewAutomationOpenReadiness";
@@ -65,6 +67,22 @@ import {
   resolvePreviewAutomationTarget,
 } from "./previewAutomationTarget";
 import { isPreviewViewportReady } from "./previewViewportReadiness";
+import { shouldRollbackPreviewViewport } from "./previewViewportRollback";
+
+const PREVIEW_PRESENTATION_SETTLE_TIMEOUT_MS = 500;
+
+const waitForPreviewPresentation = async (
+  threadRef: ScopedThreadRef,
+  tabId: string,
+): Promise<void> => {
+  const deadline = Date.now() + PREVIEW_PRESENTATION_SETTLE_TIMEOUT_MS;
+  while (Date.now() <= deadline) {
+    const state = readThreadPreviewState(threadRef);
+    const runtimeTabId = previewRuntimeTabId(threadRef, state.serverEpoch, tabId);
+    if (useBrowserSurfaceStore.getState().byTabId[runtimeTabId]?.visible) return;
+    await new Promise<void>((resolve) => window.setTimeout(resolve, 16));
+  }
+};
 
 const waitForDesktopOverlay = async (
   threadRef: ScopedThreadRef,
@@ -76,7 +94,9 @@ const waitForDesktopOverlay = async (
   while (Date.now() <= deadline) {
     const state = readThreadPreviewState(threadRef);
     if (state.desktopByTabId[tabId] && previewBridge) {
-      const status = await previewBridge.automation.status(tabId);
+      const status = await previewBridge.automation.status(
+        previewRuntimeTabId(threadRef, state.serverEpoch, tabId),
+      );
       if (status.available) return;
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
@@ -100,13 +120,15 @@ const waitForNavigationReadiness = async (
   if (!previewBridge || targetReadiness === "none") return;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
+    const state = readThreadPreviewState(threadRef);
+    const runtimeTabId = previewRuntimeTabId(threadRef, state.serverEpoch, tabId);
     if (targetReadiness === "domContentLoaded") {
-      const readyState = await previewBridge.automation.evaluate(tabId, {
+      const readyState = await previewBridge.automation.evaluate(runtimeTabId, {
         expression: "document.readyState",
       });
       if (readyState === "interactive" || readyState === "complete") return;
     } else {
-      const status = await previewBridge.automation.status(tabId);
+      const status = await previewBridge.automation.status(runtimeTabId);
       if (!status.loading) return;
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
@@ -148,8 +170,10 @@ const readWebviewViewport = async (
     : null;
 };
 
-const readRenderedViewport = async (tabId: string): Promise<PreviewRenderedViewportSize | null> => {
-  const webview = findPreviewWebview(tabId);
+const readRenderedViewport = async (
+  runtimeTabId: string,
+): Promise<PreviewRenderedViewportSize | null> => {
+  const webview = findPreviewWebview(runtimeTabId);
   if (!webview) return null;
   return await readWebviewViewport(webview);
 };
@@ -165,6 +189,7 @@ const readDeclaredViewport = (
 };
 
 const waitForRenderedViewport = async (
+  threadRef: ScopedThreadRef,
   tabId: string,
   setting: PreviewViewportSetting,
   timeoutMs: number,
@@ -177,7 +202,9 @@ const waitForRenderedViewport = async (
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
     try {
-      const webview = findPreviewWebview(tabId);
+      const state = readThreadPreviewState(threadRef);
+      const runtimeTabId = previewRuntimeTabId(threadRef, state.serverEpoch, tabId);
+      const webview = findPreviewWebview(runtimeTabId);
       const appliedSettingKey = webview?.getAttribute("data-preview-viewport-key") ?? null;
       const declaredViewport = readDeclaredViewport(webview);
       const renderedViewport = webview ? await readWebviewViewport(webview) : null;
@@ -211,18 +238,19 @@ const currentStatus = async (
 ): Promise<PreviewAutomationStatus> => {
   const state = readThreadPreviewState(threadRef);
   const { snapshot, tabId } = resolvePreviewAutomationTarget(state, requestedTabId);
-  const visible = tabId
-    ? (useBrowserSurfaceStore.getState().byTabId[tabId]?.visible ?? false)
+  const runtimeTabId = tabId ? previewRuntimeTabId(threadRef, state.serverEpoch, tabId) : null;
+  const visible = runtimeTabId
+    ? (useBrowserSurfaceStore.getState().byTabId[runtimeTabId]?.visible ?? false)
     : false;
   const viewportSetting = snapshot ? (snapshot.viewport ?? FILL_PREVIEW_VIEWPORT) : undefined;
-  const viewport = tabId ? await readRenderedViewport(tabId).catch(() => null) : null;
+  const viewport = runtimeTabId ? await readRenderedViewport(runtimeTabId).catch(() => null) : null;
   const viewportStatus = {
     ...(viewportSetting === undefined ? {} : { viewportSetting }),
     ...(viewport === null ? {} : { viewport }),
   };
-  if (tabId && previewBridge && state.desktopByTabId[tabId]) {
-    const status = await previewBridge.automation.status(tabId);
-    return { ...status, visible, ...viewportStatus };
+  if (runtimeTabId && tabId && previewBridge && state.desktopByTabId[tabId]) {
+    const status = await previewBridge.automation.status(runtimeTabId);
+    return { ...status, tabId, visible, ...viewportStatus };
   }
   const navStatus = snapshot?.navStatus;
   return {
@@ -341,7 +369,12 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
           }
           await waitForDesktopOverlay(threadRef, request.requestId, readyTabId, request.timeoutMs);
-          return { bridge, tabId: readyTabId };
+          const readyState = readThreadPreviewState(threadRef);
+          return {
+            bridge,
+            tabId: readyTabId,
+            runtimeTabId: previewRuntimeTabId(threadRef, readyState.serverEpoch, readyTabId),
+          };
         };
         switch (request.operation) {
           case "status":
@@ -381,7 +414,29 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               activeSnapshot = snapshot;
               tabId = activeTabId;
             }
-            if (shouldOpenPreviewMiniPlayer(input)) {
+            if (activeSnapshot) {
+              const defaultViewport = previewAutomationDefaultViewport(
+                reusedExistingTab,
+                activeSnapshot,
+              );
+              if (defaultViewport) {
+                const resizeResult = await resize({
+                  environmentId,
+                  input: {
+                    threadId: request.threadId,
+                    tabId: activeTabId,
+                    viewport: defaultViewport,
+                  },
+                });
+                if (resizeResult._tag === "Failure") {
+                  return raiseAtomCommandFailure(resizeResult);
+                }
+                activeSnapshot = resizeResult.value;
+                updatePreviewServerSnapshot(threadRef, resizeResult.value);
+              }
+            }
+            const shouldPresentPreview = shouldOpenPreviewMiniPlayer(input);
+            if (shouldPresentPreview) {
               usePreviewMiniPlayerStore.getState().open(threadRef, activeTabId);
             }
             if (activeSnapshot && previewAutomationOpenNeedsOverlay(input, activeSnapshot)) {
@@ -392,8 +447,19 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 request.timeoutMs,
               );
             }
+            if (shouldPresentPreview) {
+              // React commits the thread-bound surface asynchronously. Settle
+              // briefly so active-thread opens report visible=true, without
+              // turning a background thread's offscreen mini player into an
+              // operation failure.
+              await waitForPreviewPresentation(threadRef, activeTabId);
+            }
             if (reusedExistingTab && resolvedInputUrl && previewBridge) {
-              await previewBridge.navigate(activeTabId, resolvedInputUrl);
+              const activeState = readThreadPreviewState(threadRef);
+              await previewBridge.navigate(
+                previewRuntimeTabId(threadRef, activeState.serverEpoch, activeTabId),
+                resolvedInputUrl,
+              );
               await waitForNavigationReadiness(
                 threadRef,
                 request.requestId,
@@ -414,7 +480,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 url: input.url!,
               },
             );
-            await ready.bridge.navigate(ready.tabId, resolution.resolvedUrl);
+            await ready.bridge.navigate(ready.runtimeTabId, resolution.resolvedUrl);
             await waitForNavigationReadiness(
               threadRef,
               request.requestId,
@@ -428,6 +494,9 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const ready = await requireReadyTab();
             const input = request.input as PreviewAutomationResizeInput;
             const setting = resolvePreviewViewport(input);
+            const previousSetting =
+              readThreadPreviewState(threadRef).sessions[ready.tabId]?.viewport ??
+              FILL_PREVIEW_VIEWPORT;
             const result = await resize({
               environmentId,
               input: {
@@ -440,16 +509,38 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               return raiseAtomCommandFailure(result);
             }
             updatePreviewServerSnapshot(threadRef, result.value);
-            const viewport = await waitForRenderedViewport(
-              ready.tabId,
-              setting,
-              input.timeoutMs ?? request.timeoutMs,
-              {
-                requestId: request.requestId,
-                environmentId,
-                threadId: request.threadId,
-              },
-            );
+            let viewport: PreviewRenderedViewportSize;
+            try {
+              viewport = await waitForRenderedViewport(
+                threadRef,
+                ready.tabId,
+                setting,
+                input.timeoutMs ?? request.timeoutMs,
+                {
+                  requestId: request.requestId,
+                  environmentId,
+                  threadId: request.threadId,
+                },
+              );
+            } catch (cause) {
+              const latestSetting =
+                readThreadPreviewState(threadRef).sessions[ready.tabId]?.viewport ??
+                FILL_PREVIEW_VIEWPORT;
+              if (shouldRollbackPreviewViewport(previousSetting, setting, latestSetting)) {
+                const rollback = await resize({
+                  environmentId,
+                  input: {
+                    threadId: request.threadId,
+                    tabId: ready.tabId,
+                    viewport: previousSetting,
+                  },
+                });
+                if (rollback._tag !== "Failure") {
+                  updatePreviewServerSnapshot(threadRef, rollback.value);
+                }
+              }
+              throw cause;
+            }
             return {
               tabId: ready.tabId,
               setting,
@@ -459,7 +550,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           case "setColorScheme": {
             const ready = await requireReadyTab();
             const input = request.input as PreviewAutomationSetColorSchemeInput;
-            await ready.bridge.setColorScheme(ready.tabId, input.colorScheme);
+            await ready.bridge.setColorScheme(ready.runtimeTabId, input.colorScheme);
             return {
               tabId: ready.tabId,
               colorScheme: input.colorScheme,
@@ -467,53 +558,57 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           }
           case "snapshot": {
             const ready = await requireReadyTab();
-            return await ready.bridge.automation.snapshot(ready.tabId);
+            return await ready.bridge.automation.snapshot(ready.runtimeTabId);
           }
           case "click": {
             const ready = await requireReadyTab();
             return await ready.bridge.automation.click(
-              ready.tabId,
+              ready.runtimeTabId,
               request.input as Parameters<typeof ready.bridge.automation.click>[1],
             );
           }
           case "type": {
             const ready = await requireReadyTab();
             return await ready.bridge.automation.type(
-              ready.tabId,
+              ready.runtimeTabId,
               request.input as Parameters<typeof ready.bridge.automation.type>[1],
             );
           }
           case "press": {
             const ready = await requireReadyTab();
             return await ready.bridge.automation.press(
-              ready.tabId,
+              ready.runtimeTabId,
               request.input as Parameters<typeof ready.bridge.automation.press>[1],
             );
           }
           case "scroll": {
             const ready = await requireReadyTab();
             return await ready.bridge.automation.scroll(
-              ready.tabId,
+              ready.runtimeTabId,
               request.input as Parameters<typeof ready.bridge.automation.scroll>[1],
             );
           }
           case "evaluate": {
             const ready = await requireReadyTab();
             return await ready.bridge.automation.evaluate(
-              ready.tabId,
+              ready.runtimeTabId,
               request.input as Parameters<typeof ready.bridge.automation.evaluate>[1],
             );
           }
           case "waitFor": {
             const ready = await requireReadyTab();
             return await ready.bridge.automation.waitFor(
-              ready.tabId,
+              ready.runtimeTabId,
               request.input as Parameters<typeof ready.bridge.automation.waitFor>[1],
             );
           }
           case "recordingStart": {
             const ready = await requireReadyTab();
-            const startedAt = await startBrowserRecording(ready.tabId, threadRef);
+            const startedAt = await startBrowserRecording(
+              ready.runtimeTabId,
+              threadRef,
+              ready.tabId,
+            );
             return {
               tabId: ready.tabId,
               recording: true,
@@ -528,8 +623,15 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               request.tabIdExplicit ? request.tabId : undefined,
             );
             tabId = stopTabId ?? tabId;
-            const artifact = stopTabId ? await stopBrowserRecording(stopTabId) : null;
-            if (!artifact) {
+            const stopRuntimeTabId = stopTabId
+              ? previewRuntimeTabId(
+                  threadRef,
+                  readThreadPreviewState(threadRef).serverEpoch,
+                  stopTabId,
+                )
+              : null;
+            const artifact = stopRuntimeTabId ? await stopBrowserRecording(stopRuntimeTabId) : null;
+            if (!artifact || !stopTabId) {
               return raisePreviewAutomationHostError(
                 new PreviewAutomationRecordingNotActiveError({
                   requestId: request.requestId,
@@ -539,7 +641,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 }),
               );
             }
-            return artifact;
+            return { ...artifact, tabId: stopTabId };
           }
         }
       } catch (cause) {

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -32,13 +32,14 @@ import {
 import { usePreviewMiniPlayerStore } from "~/previewMiniPlayerStore";
 import { resolveBrowserNavigationTarget } from "~/browser/browserTargetResolver";
 import {
-  readActiveBrowserRecordingTabIds,
+  readActiveBrowserRecordingTargets,
   startBrowserRecording,
   stopBrowserRecording,
 } from "~/browser/browserRecording";
 import { resolveBrowserRecordingStopTarget } from "~/browser/browserRecordingScope";
 import { useBrowserSurfaceStore } from "~/browser/browserSurfaceStore";
-import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
+import { runBrowserViewportMutation } from "~/browser/browserViewportActions";
+import { isCurrentPreviewRuntimeTab, previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 import { isElectron } from "~/env";
 import { useEnvironments } from "~/state/environments";
 import { previewEnvironment } from "~/state/preview";
@@ -71,32 +72,53 @@ import { shouldRollbackPreviewViewport } from "./previewViewportRollback";
 
 const PREVIEW_PRESENTATION_SETTLE_TIMEOUT_MS = 500;
 
-const waitForPreviewPresentation = async (
-  threadRef: ScopedThreadRef,
-  tabId: string,
-): Promise<void> => {
+const waitForPreviewPresentation = async (runtimeTabId: string): Promise<void> => {
   const deadline = Date.now() + PREVIEW_PRESENTATION_SETTLE_TIMEOUT_MS;
   while (Date.now() <= deadline) {
-    const state = readThreadPreviewState(threadRef);
-    const runtimeTabId = previewRuntimeTabId(threadRef, state.serverEpoch, tabId);
     if (useBrowserSurfaceStore.getState().byTabId[runtimeTabId]?.visible) return;
     await new Promise<void>((resolve) => window.setTimeout(resolve, 16));
   }
+};
+
+const assertPreviewRuntimeCurrent = (
+  threadRef: ScopedThreadRef,
+  tabId: string,
+  runtimeTabId: string,
+  request: Pick<PreviewAutomationRequest, "operation" | "requestId">,
+) => {
+  const state = readThreadPreviewState(threadRef);
+  if (
+    state.sessions[tabId] &&
+    isCurrentPreviewRuntimeTab(threadRef, state.serverEpoch, tabId, runtimeTabId)
+  ) {
+    return state;
+  }
+  throw new PreviewAutomationTargetUnavailableError({
+    requestId: request.requestId,
+    operation: request.operation,
+    environmentId: threadRef.environmentId,
+    threadId: threadRef.threadId,
+    tabId,
+    bridgeAvailable: Boolean(previewBridge),
+  });
 };
 
 const waitForDesktopOverlay = async (
   threadRef: ScopedThreadRef,
   requestId: string,
   tabId: string,
+  runtimeTabId: string,
+  operation: PreviewAutomationRequest["operation"],
   timeoutMs: number,
 ): Promise<void> => {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
-    const state = readThreadPreviewState(threadRef);
+    const state = assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, {
+      operation,
+      requestId,
+    });
     if (state.desktopByTabId[tabId] && previewBridge) {
-      const status = await previewBridge.automation.status(
-        previewRuntimeTabId(threadRef, state.serverEpoch, tabId),
-      );
+      const status = await previewBridge.automation.status(runtimeTabId);
       if (status.available) return;
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
@@ -113,6 +135,8 @@ const waitForNavigationReadiness = async (
   threadRef: ScopedThreadRef,
   requestId: string,
   tabId: string,
+  runtimeTabId: string,
+  operation: PreviewAutomationRequest["operation"],
   readiness: PreviewAutomationNavigateInput["readiness"],
   timeoutMs: number,
 ): Promise<void> => {
@@ -120,8 +144,7 @@ const waitForNavigationReadiness = async (
   if (!previewBridge || targetReadiness === "none") return;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
-    const state = readThreadPreviewState(threadRef);
-    const runtimeTabId = previewRuntimeTabId(threadRef, state.serverEpoch, tabId);
+    assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, { operation, requestId });
     if (targetReadiness === "domContentLoaded") {
       const readyState = await previewBridge.automation.evaluate(runtimeTabId, {
         expression: "document.readyState",
@@ -129,7 +152,7 @@ const waitForNavigationReadiness = async (
       if (readyState === "interactive" || readyState === "complete") return;
     } else {
       const status = await previewBridge.automation.status(runtimeTabId);
-      if (!status.loading) return;
+      if (status.available && !status.loading) return;
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
   }
@@ -191,19 +214,20 @@ const readDeclaredViewport = (
 const waitForRenderedViewport = async (
   threadRef: ScopedThreadRef,
   tabId: string,
+  runtimeTabId: string,
   setting: PreviewViewportSetting,
   timeoutMs: number,
   context: {
     readonly requestId: PreviewAutomationRequest["requestId"];
+    readonly operation: PreviewAutomationRequest["operation"];
     readonly environmentId: EnvironmentId;
     readonly threadId: PreviewAutomationRequest["threadId"];
   },
 ): Promise<PreviewRenderedViewportSize> => {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
+    assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, context);
     try {
-      const state = readThreadPreviewState(threadRef);
-      const runtimeTabId = previewRuntimeTabId(threadRef, state.serverEpoch, tabId);
       const webview = findPreviewWebview(runtimeTabId);
       const appliedSettingKey = webview?.getAttribute("data-preview-viewport-key") ?? null;
       const declaredViewport = readDeclaredViewport(webview);
@@ -368,12 +392,20 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           if (!bridge || !readyTabId) {
             throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
           }
-          await waitForDesktopOverlay(threadRef, request.requestId, readyTabId, request.timeoutMs);
           const readyState = readThreadPreviewState(threadRef);
+          const runtimeTabId = previewRuntimeTabId(threadRef, readyState.serverEpoch, readyTabId);
+          await waitForDesktopOverlay(
+            threadRef,
+            request.requestId,
+            readyTabId,
+            runtimeTabId,
+            request.operation,
+            request.timeoutMs,
+          );
           return {
             bridge,
             tabId: readyTabId,
-            runtimeTabId: previewRuntimeTabId(threadRef, readyState.serverEpoch, readyTabId),
+            runtimeTabId,
           };
         };
         switch (request.operation) {
@@ -414,20 +446,36 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               activeSnapshot = snapshot;
               tabId = activeTabId;
             }
+            const activeRuntimeTabId = previewRuntimeTabId(
+              threadRef,
+              readThreadPreviewState(threadRef).serverEpoch,
+              activeTabId,
+            );
             if (activeSnapshot) {
               const defaultViewport = previewAutomationDefaultViewport(
                 reusedExistingTab,
                 activeSnapshot,
               );
               if (defaultViewport) {
-                const resizeResult = await resize({
-                  environmentId,
-                  input: {
-                    threadId: request.threadId,
-                    tabId: activeTabId,
-                    viewport: defaultViewport,
+                const resizeResult = await runBrowserViewportMutation(
+                  activeRuntimeTabId,
+                  async () => {
+                    assertPreviewRuntimeCurrent(
+                      threadRef,
+                      activeTabId,
+                      activeRuntimeTabId,
+                      request,
+                    );
+                    return await resize({
+                      environmentId,
+                      input: {
+                        threadId: request.threadId,
+                        tabId: activeTabId,
+                        viewport: defaultViewport,
+                      },
+                    });
                   },
-                });
+                );
                 if (resizeResult._tag === "Failure") {
                   return raiseAtomCommandFailure(resizeResult);
                 }
@@ -444,6 +492,8 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 threadRef,
                 request.requestId,
                 activeTabId,
+                activeRuntimeTabId,
+                request.operation,
                 request.timeoutMs,
               );
             }
@@ -452,18 +502,17 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               // briefly so active-thread opens report visible=true, without
               // turning a background thread's offscreen mini player into an
               // operation failure.
-              await waitForPreviewPresentation(threadRef, activeTabId);
+              await waitForPreviewPresentation(activeRuntimeTabId);
             }
             if (reusedExistingTab && resolvedInputUrl && previewBridge) {
-              const activeState = readThreadPreviewState(threadRef);
-              await previewBridge.navigate(
-                previewRuntimeTabId(threadRef, activeState.serverEpoch, activeTabId),
-                resolvedInputUrl,
-              );
+              assertPreviewRuntimeCurrent(threadRef, activeTabId, activeRuntimeTabId, request);
+              await previewBridge.navigate(activeRuntimeTabId, resolvedInputUrl);
               await waitForNavigationReadiness(
                 threadRef,
                 request.requestId,
                 activeTabId,
+                activeRuntimeTabId,
+                request.operation,
                 "load",
                 request.timeoutMs,
               );
@@ -485,6 +534,8 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               threadRef,
               request.requestId,
               ready.tabId,
+              ready.runtimeTabId,
+              request.operation,
               input.readiness ?? "load",
               input.timeoutMs ?? request.timeoutMs,
             );
@@ -494,51 +545,74 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const ready = await requireReadyTab();
             const input = request.input as PreviewAutomationResizeInput;
             const setting = resolvePreviewViewport(input);
-            const previousSetting =
-              readThreadPreviewState(threadRef).sessions[ready.tabId]?.viewport ??
-              FILL_PREVIEW_VIEWPORT;
-            const result = await resize({
-              environmentId,
-              input: {
-                threadId: request.threadId,
-                tabId: ready.tabId,
-                viewport: setting,
-              },
+            const applied = await runBrowserViewportMutation(ready.runtimeTabId, async () => {
+              const operationState = assertPreviewRuntimeCurrent(
+                threadRef,
+                ready.tabId,
+                ready.runtimeTabId,
+                request,
+              );
+              const previousSetting =
+                operationState.sessions[ready.tabId]?.viewport ?? FILL_PREVIEW_VIEWPORT;
+              const result = await resize({
+                environmentId,
+                input: {
+                  threadId: request.threadId,
+                  tabId: ready.tabId,
+                  viewport: setting,
+                },
+              });
+              if (result._tag === "Failure") {
+                return raiseAtomCommandFailure(result);
+              }
+              updatePreviewServerSnapshot(threadRef, result.value);
+              return {
+                previousSetting,
+                serverEpoch: operationState.serverEpoch,
+              };
             });
-            if (result._tag === "Failure") {
-              return raiseAtomCommandFailure(result);
-            }
-            updatePreviewServerSnapshot(threadRef, result.value);
             let viewport: PreviewRenderedViewportSize;
             try {
               viewport = await waitForRenderedViewport(
                 threadRef,
                 ready.tabId,
+                ready.runtimeTabId,
                 setting,
                 input.timeoutMs ?? request.timeoutMs,
                 {
                   requestId: request.requestId,
+                  operation: request.operation,
                   environmentId,
                   threadId: request.threadId,
                 },
               );
             } catch (cause) {
-              const latestSetting =
-                readThreadPreviewState(threadRef).sessions[ready.tabId]?.viewport ??
-                FILL_PREVIEW_VIEWPORT;
-              if (shouldRollbackPreviewViewport(previousSetting, setting, latestSetting)) {
-                const rollback = await resize({
-                  environmentId,
-                  input: {
-                    threadId: request.threadId,
-                    tabId: ready.tabId,
-                    viewport: previousSetting,
-                  },
-                });
-                if (rollback._tag !== "Failure") {
-                  updatePreviewServerSnapshot(threadRef, rollback.value);
+              await runBrowserViewportMutation(ready.runtimeTabId, async () => {
+                const latestState = readThreadPreviewState(threadRef);
+                const latestSetting =
+                  latestState.sessions[ready.tabId]?.viewport ?? FILL_PREVIEW_VIEWPORT;
+                if (
+                  shouldRollbackPreviewViewport(
+                    applied.previousSetting,
+                    setting,
+                    latestSetting,
+                    applied.serverEpoch,
+                    latestState.serverEpoch,
+                  )
+                ) {
+                  const rollback = await resize({
+                    environmentId,
+                    input: {
+                      threadId: request.threadId,
+                      tabId: ready.tabId,
+                      viewport: applied.previousSetting,
+                    },
+                  });
+                  if (rollback._tag !== "Failure") {
+                    updatePreviewServerSnapshot(threadRef, rollback.value);
+                  }
                 }
-              }
+              });
               throw cause;
             }
             return {
@@ -616,20 +690,19 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             };
           }
           case "recordingStop": {
-            const activeTabIds = readActiveBrowserRecordingTabIds(threadRef);
+            const activeRecordings = readActiveBrowserRecordingTargets(threadRef);
+            const activeTabIds = new Set(
+              activeRecordings.map((recording) => recording.serverTabId),
+            );
             const stopTabId = resolveBrowserRecordingStopTarget(
               activeTabIds,
               tabId,
               request.tabIdExplicit ? request.tabId : undefined,
             );
             tabId = stopTabId ?? tabId;
-            const stopRuntimeTabId = stopTabId
-              ? previewRuntimeTabId(
-                  threadRef,
-                  readThreadPreviewState(threadRef).serverEpoch,
-                  stopTabId,
-                )
-              : null;
+            const stopRuntimeTabId =
+              activeRecordings.find((recording) => recording.serverTabId === stopTabId)
+                ?.runtimeTabId ?? null;
             const artifact = stopRuntimeTabId ? await stopBrowserRecording(stopRuntimeTabId) : null;
             if (!artifact || !stopTabId) {
               return raisePreviewAutomationHostError(

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -39,7 +39,7 @@ import {
 import { resolveBrowserRecordingStopTarget } from "~/browser/browserRecordingScope";
 import { useBrowserSurfaceStore } from "~/browser/browserSurfaceStore";
 import { runBrowserViewportMutation } from "~/browser/browserViewportActions";
-import { isCurrentPreviewRuntimeTab, previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
+import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 import { isElectron } from "~/env";
 import { useEnvironments } from "~/state/environments";
 import { previewEnvironment } from "~/state/preview";
@@ -48,7 +48,6 @@ import { useAtomCommand } from "~/state/use-atom-command";
 
 import { previewBridge } from "./previewBridge";
 import {
-  PreviewAutomationNavigationTimeoutError,
   PreviewAutomationOperationError,
   PreviewAutomationOverlayTimeoutError,
   PreviewAutomationRecordingNotActiveError,
@@ -60,6 +59,10 @@ import {
   previewAutomationOpenNeedsOverlay,
   shouldOpenPreviewMiniPlayer,
 } from "./previewAutomationOpenReadiness";
+import {
+  assertPreviewRuntimeCurrent,
+  waitForNavigationReadiness,
+} from "./previewNavigationReadiness";
 import { createPreviewAutomationRequestConsumerAtom } from "./previewAutomationRequestConsumer";
 import { createPreviewAutomationClientId } from "./previewAutomationClientId";
 import {
@@ -78,29 +81,6 @@ const waitForPreviewPresentation = async (runtimeTabId: string): Promise<void> =
     if (useBrowserSurfaceStore.getState().byTabId[runtimeTabId]?.visible) return;
     await new Promise<void>((resolve) => window.setTimeout(resolve, 16));
   }
-};
-
-const assertPreviewRuntimeCurrent = (
-  threadRef: ScopedThreadRef,
-  tabId: string,
-  runtimeTabId: string,
-  request: Pick<PreviewAutomationRequest, "operation" | "requestId">,
-) => {
-  const state = readThreadPreviewState(threadRef);
-  if (
-    state.sessions[tabId] &&
-    isCurrentPreviewRuntimeTab(threadRef, state.serverEpoch, tabId, runtimeTabId)
-  ) {
-    return state;
-  }
-  throw new PreviewAutomationTargetUnavailableError({
-    requestId: request.requestId,
-    operation: request.operation,
-    environmentId: threadRef.environmentId,
-    threadId: threadRef.threadId,
-    tabId,
-    bridgeAvailable: Boolean(previewBridge),
-  });
 };
 
 const waitForDesktopOverlay = async (
@@ -127,41 +107,6 @@ const waitForDesktopOverlay = async (
     requestId,
     environmentId: threadRef.environmentId,
     threadId: threadRef.threadId,
-    timeoutMs,
-  });
-};
-
-const waitForNavigationReadiness = async (
-  threadRef: ScopedThreadRef,
-  requestId: string,
-  tabId: string,
-  runtimeTabId: string,
-  operation: PreviewAutomationRequest["operation"],
-  readiness: PreviewAutomationNavigateInput["readiness"],
-  timeoutMs: number,
-): Promise<void> => {
-  const targetReadiness = readiness ?? "load";
-  if (!previewBridge || targetReadiness === "none") return;
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
-    assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, { operation, requestId });
-    if (targetReadiness === "domContentLoaded") {
-      const readyState = await previewBridge.automation.evaluate(runtimeTabId, {
-        expression: "document.readyState",
-      });
-      if (readyState === "interactive" || readyState === "complete") return;
-    } else {
-      const status = await previewBridge.automation.status(runtimeTabId);
-      if (status.available && !status.loading) return;
-    }
-    await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
-  }
-  throw new PreviewAutomationNavigationTimeoutError({
-    requestId,
-    environmentId: threadRef.environmentId,
-    threadId: threadRef.threadId,
-    tabId,
-    readiness: targetReadiness,
     timeoutMs,
   });
 };

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -90,6 +90,7 @@ vi.mock("~/state/use-atom-command", () => ({
 }));
 
 vi.mock("~/browser/browserRecording", () => ({
+  findActiveBrowserRecordingRuntimeTabId: vi.fn(() => null),
   startBrowserRecording: vi.fn(),
   stopBrowserRecording: vi.fn(),
   useActiveBrowserRecordingTabIds: () => new Set(),

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -188,6 +188,13 @@ vi.mock("./useLoadingProgress", () => ({ useLoadingProgress: () => 0 }));
 vi.mock("./usePreviewSession", () => ({ usePreviewSession: vi.fn() }));
 
 import { PreviewView } from "./PreviewView";
+import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
+
+const TEST_THREAD_REF = {
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: ThreadId.make("thread-1"),
+} as const;
+const TEST_RUNTIME_TAB_ID = previewRuntimeTabId(TEST_THREAD_REF, null, "tab-1");
 
 describe("PreviewView navigation", () => {
   beforeEach(() => {
@@ -230,7 +237,9 @@ describe("PreviewView navigation", () => {
     expect(mocks.submittedUrl).not.toBeNull();
     mocks.submittedUrl?.(submitted);
 
-    await vi.waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith("tab-1", expected));
+    await vi.waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith(TEST_RUNTIME_TAB_ID, expected),
+    );
     expect(mocks.rememberPreviewUrl).toHaveBeenCalledWith(
       {
         environmentId: "environment-1",
@@ -258,7 +267,7 @@ describe("PreviewView navigation", () => {
 
     await vi.waitFor(() =>
       expect(mocks.navigate).toHaveBeenCalledWith(
-        "tab-1",
+        TEST_RUNTIME_TAB_ID,
         "http://172.25.85.75:5173/app?mode=test#top",
       ),
     );
@@ -306,11 +315,15 @@ describe("PreviewView navigation", () => {
 
     renderToStaticMarkup(<PreviewView {...props} />);
     mocks.toggleNativePictureInPicture?.();
-    await vi.waitFor(() => expect(mocks.openPictureInPicture).toHaveBeenCalledWith("tab-1"));
+    await vi.waitFor(() =>
+      expect(mocks.openPictureInPicture).toHaveBeenCalledWith(TEST_RUNTIME_TAB_ID),
+    );
 
     mocks.pictureInPicture = true;
     renderToStaticMarkup(<PreviewView {...props} />);
     mocks.toggleNativePictureInPicture?.();
-    await vi.waitFor(() => expect(mocks.closePictureInPicture).toHaveBeenCalledWith("tab-1"));
+    await vi.waitFor(() =>
+      expect(mocks.closePictureInPicture).toHaveBeenCalledWith(TEST_RUNTIME_TAB_ID),
+    );
   });
 });

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -48,6 +48,7 @@ import { usePreviewSession } from "./usePreviewSession";
 import { ZoomIndicator } from "./ZoomIndicator";
 import { AgentBrowserCursor } from "./AgentBrowserCursor";
 import {
+  findActiveBrowserRecordingRuntimeTabId,
   startBrowserRecording,
   stopBrowserRecording,
   useActiveBrowserRecordingTabIds,
@@ -97,6 +98,12 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
   const runtimeTabId = tabId
     ? previewRuntimeTabId(threadRef, previewState.serverEpoch, tabId)
     : null;
+  const recordingRuntimeTabId =
+    tabId && runtimeTabId
+      ? activeRecordingTabIds.has(runtimeTabId)
+        ? runtimeTabId
+        : findActiveBrowserRecordingRuntimeTabId(threadRef, tabId)
+      : null;
   const snapshot = tabId ? (previewState.sessions[tabId] ?? null) : null;
   const desktopOverlay = tabId ? (previewState.desktopByTabId[tabId] ?? null) : null;
   const navStatus = snapshot?.navStatus ?? { _tag: "Idle" as const };
@@ -264,9 +271,8 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
     (record: boolean) => {
       if (!previewBridge || !runtimeTabId || !tabId) return;
       const bridge = previewBridge;
-      const recordingThisTab = activeRecordingTabIds.has(runtimeTabId);
-      if (recordingThisTab) {
-        void stopBrowserRecording(runtimeTabId).then(
+      if (recordingRuntimeTabId) {
+        void stopBrowserRecording(recordingRuntimeTabId).then(
           (artifact) => {
             if (!artifact) return;
             let pathCopied = false;
@@ -497,7 +503,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         },
       );
     },
-    [activeRecordingTabIds, runtimeTabId, tabId, threadRef],
+    [recordingRuntimeTabId, runtimeTabId, tabId, threadRef],
   );
 
   const handlePickElement = useCallback(() => {
@@ -619,7 +625,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         onOpenInBrowser={tabId ? handleOpenInBrowser : undefined}
         onCapture={previewBridge && tabId ? handleCapture : undefined}
         captureDisabled={!desktopOverlay || isUnreachable}
-        recording={runtimeTabId !== null && activeRecordingTabIds.has(runtimeTabId)}
+        recording={recordingRuntimeTabId !== null}
         onPictureInPicture={previewBridge && tabId ? handlePictureInPicture : undefined}
         pictureInPicture={miniPlayer?.tabId === tabId}
         pictureInPictureDisabled={!desktopOverlay?.hasWebContents || isUnreachable}

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -37,6 +37,7 @@ import {
   subscribeBrowserViewportChange,
 } from "~/browser/browserViewportActions";
 import { resolveResponsiveBrowserViewportSize } from "~/browser/browserViewportLayout";
+import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 import { PreviewUnreachable } from "./PreviewUnreachable";
 import { revealInFileExplorerLabel } from "./fileExplorerLabel";
 import { shouldShowPreviewEmptyState } from "./previewEmptyStateLogic";
@@ -93,6 +94,9 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
   }, []);
 
   const tabId = requestedTabId ?? previewState.activeTabId;
+  const runtimeTabId = tabId
+    ? previewRuntimeTabId(threadRef, previewState.serverEpoch, tabId)
+    : null;
   const snapshot = tabId ? (previewState.sessions[tabId] ?? null) : null;
   const desktopOverlay = tabId ? (previewState.desktopByTabId[tabId] ?? null) : null;
   const navStatus = snapshot?.navStatus ?? { _tag: "Idle" as const };
@@ -115,15 +119,15 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
       : undefined;
   const viewport = snapshot?.viewport ?? FILL_PREVIEW_VIEWPORT;
   const panelRect = useBrowserSurfaceStore((state) =>
-    tabId ? (state.byTabId[tabId]?.rect ?? null) : null,
+    runtimeTabId ? (state.byTabId[runtimeTabId]?.rect ?? null) : null,
   );
 
   const navigateToResolvedUrl = useCallback(
     async (resolvedUrl: string) => {
-      if (tabId && previewBridge) {
+      if (runtimeTabId && previewBridge) {
         // Drive the webview imperatively; `usePreviewBridge` mirrors the
         // resolved URL back to the server so other clients stay in sync.
-        await previewBridge.navigate(tabId, resolvedUrl);
+        await previewBridge.navigate(runtimeTabId, resolvedUrl);
         rememberPreviewUrl(threadRef, resolvedUrl);
       } else {
         await openPreviewSession({
@@ -133,7 +137,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         });
       }
     },
-    [open, tabId, threadRef],
+    [open, runtimeTabId, threadRef],
   );
 
   const handleSubmitUrl = useCallback(
@@ -159,20 +163,20 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
   );
 
   const handleRefresh = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.refresh(tabId);
-  }, [tabId]);
+    if (previewBridge && runtimeTabId) void previewBridge.refresh(runtimeTabId);
+  }, [runtimeTabId]);
 
   const handleZoomIn = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.zoomIn(tabId);
-  }, [tabId]);
+    if (previewBridge && runtimeTabId) void previewBridge.zoomIn(runtimeTabId);
+  }, [runtimeTabId]);
 
   const handleZoomOut = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.zoomOut(tabId);
-  }, [tabId]);
+    if (previewBridge && runtimeTabId) void previewBridge.zoomOut(runtimeTabId);
+  }, [runtimeTabId]);
 
   const handleResetZoom = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.resetZoom(tabId);
-  }, [tabId]);
+    if (previewBridge && runtimeTabId) void previewBridge.resetZoom(runtimeTabId);
+  }, [runtimeTabId]);
 
   const handleViewportChange = useCallback(
     async (nextViewport: PreviewViewportSetting) => {
@@ -200,32 +204,32 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
   );
 
   const handleToggleDeviceToolbar = () => {
-    if (!tabId) return;
+    if (!runtimeTabId) return;
     if (viewport._tag !== "fill") {
-      void commitBrowserViewportChange(tabId, FILL_PREVIEW_VIEWPORT).catch(() => undefined);
+      void commitBrowserViewportChange(runtimeTabId, FILL_PREVIEW_VIEWPORT).catch(() => undefined);
       return;
     }
 
     const responsiveSize = panelRect
       ? resolveResponsiveBrowserViewportSize(panelRect, desktopOverlay?.zoomFactor)
       : { width: 1024, height: 768 };
-    void commitBrowserViewportChange(tabId, { _tag: "freeform", ...responsiveSize }).catch(
+    void commitBrowserViewportChange(runtimeTabId, { _tag: "freeform", ...responsiveSize }).catch(
       () => undefined,
     );
   };
 
   useEffect(() => {
-    if (!tabId) return;
-    return subscribeBrowserViewportChange(tabId, handleViewportChange);
-  }, [handleViewportChange, tabId]);
+    if (!runtimeTabId) return;
+    return subscribeBrowserViewportChange(runtimeTabId, handleViewportChange);
+  }, [handleViewportChange, runtimeTabId]);
 
   const handleBack = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.goBack(tabId);
-  }, [tabId]);
+    if (previewBridge && runtimeTabId) void previewBridge.goBack(runtimeTabId);
+  }, [runtimeTabId]);
 
   const handleForward = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.goForward(tabId);
-  }, [tabId]);
+    if (previewBridge && runtimeTabId) void previewBridge.goForward(runtimeTabId);
+  }, [runtimeTabId]);
 
   const handleOpenInBrowser = useCallback(() => {
     if (!localApi || !url) return;
@@ -243,26 +247,26 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
   }, [miniPlayer?.tabId, tabId, threadRef]);
 
   const handleNativePictureInPicture = useCallback(() => {
-    if (!previewBridge || !tabId) return;
+    if (!previewBridge || !runtimeTabId) return;
     const operation = desktopOverlay?.pictureInPicture
       ? previewBridge.pictureInPicture.close
       : previewBridge.pictureInPicture.open;
-    void operation(tabId).catch((error) => {
+    void operation(runtimeTabId).catch((error) => {
       toastManager.add({
         type: "error",
         title: "Unable to update popped-out preview",
         description: error instanceof Error ? error.message : "An error occurred.",
       });
     });
-  }, [desktopOverlay?.pictureInPicture, tabId]);
+  }, [desktopOverlay?.pictureInPicture, runtimeTabId]);
 
   const handleCapture = useCallback(
     (record: boolean) => {
-      if (!previewBridge || !tabId) return;
+      if (!previewBridge || !runtimeTabId || !tabId) return;
       const bridge = previewBridge;
-      const recordingThisTab = activeRecordingTabIds.has(tabId);
+      const recordingThisTab = activeRecordingTabIds.has(runtimeTabId);
       if (recordingThisTab) {
-        void stopBrowserRecording(tabId).then(
+        void stopBrowserRecording(runtimeTabId).then(
           (artifact) => {
             if (!artifact) return;
             let pathCopied = false;
@@ -354,7 +358,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         return;
       }
       if (record) {
-        void startBrowserRecording(tabId, threadRef).catch((error) => {
+        void startBrowserRecording(runtimeTabId, threadRef, tabId).catch((error) => {
           toastManager.add({
             type: "error",
             title: "Unable to start recording",
@@ -363,7 +367,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         });
         return;
       }
-      void bridge.captureScreenshot(tabId).then(
+      void bridge.captureScreenshot(runtimeTabId).then(
         (artifact) => {
           const revealAction = {
             children: revealInFileExplorerLabel(navigator.platform),
@@ -493,13 +497,13 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         },
       );
     },
-    [activeRecordingTabIds, tabId, threadRef],
+    [activeRecordingTabIds, runtimeTabId, tabId, threadRef],
   );
 
   const handlePickElement = useCallback(() => {
-    if (!previewBridge || !tabId) return;
+    if (!previewBridge || !runtimeTabId) return;
     if (pickActiveRef.current) {
-      void previewBridge.cancelPickElement(tabId).catch(() => undefined);
+      void previewBridge.cancelPickElement(runtimeTabId).catch(() => undefined);
       return;
     }
     // Snapshot whatever the user was focused on (typically the chat
@@ -513,7 +517,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
     setPickActive(true);
     void (async () => {
       try {
-        const annotation = await previewBridge.pickElement(tabId);
+        const annotation = await previewBridge.pickElement(runtimeTabId);
         if (!annotation) return;
         addPreviewAnnotation(threadRef, annotation);
         const screenshotFile = await previewAnnotationScreenshotFile(annotation);
@@ -551,7 +555,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         }
       }
     })();
-  }, [addImage, addPreviewAnnotation, tabId, threadRef]);
+  }, [addImage, addPreviewAnnotation, runtimeTabId, threadRef]);
 
   // If the active tab changes mid-pick (close, thread switch, hot restart),
   // tell main to tear down the in-flight session AND reset our local toggle
@@ -560,12 +564,12 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
     return () => {
       if (!pickActiveRef.current) return;
       pickActiveRef.current = false;
-      if (previewBridge && tabId) {
-        void previewBridge.cancelPickElement(tabId).catch(() => undefined);
+      if (previewBridge && runtimeTabId) {
+        void previewBridge.cancelPickElement(runtimeTabId).catch(() => undefined);
       }
       if (isMountedRef.current) setPickActive(false);
     };
-  }, [tabId]);
+  }, [runtimeTabId]);
 
   // Subscribe only while visible; `toggle-panel` is owned by ChatView's
   // URL-aware handler regardless of whether the panel is currently mounted.
@@ -615,7 +619,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         onOpenInBrowser={tabId ? handleOpenInBrowser : undefined}
         onCapture={previewBridge && tabId ? handleCapture : undefined}
         captureDisabled={!desktopOverlay || isUnreachable}
-        recording={tabId !== null && activeRecordingTabIds.has(tabId)}
+        recording={runtimeTabId !== null && activeRecordingTabIds.has(runtimeTabId)}
         onPictureInPicture={previewBridge && tabId ? handlePictureInPicture : undefined}
         pictureInPicture={miniPlayer?.tabId === tabId}
         pictureInPictureDisabled={!desktopOverlay?.hasWebContents || isUnreachable}
@@ -631,7 +635,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         trailingActions={
           previewBridge ? (
             <PreviewMoreMenu
-              tabId={tabId}
+              tabId={runtimeTabId}
               hasWebContents={desktopOverlay?.hasWebContents ?? false}
               zoomFactor={desktopOverlay?.zoomFactor ?? 1}
               colorScheme={desktopOverlay?.colorScheme ?? "system"}
@@ -645,10 +649,10 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
       />
 
       <div className="relative min-h-0 flex-1 overflow-hidden">
-        {tabId && snapshot && !showEmptyState ? (
+        {runtimeTabId && snapshot && !showEmptyState ? (
           <BrowserSurfaceSlot
-            key={tabId}
-            tabId={tabId}
+            key={runtimeTabId}
+            tabId={runtimeTabId}
             visible={visible && !isUnreachable}
             className="absolute inset-0 h-full w-full"
           />
@@ -664,9 +668,9 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         {snapshot && desktopOverlay ? (
           <ZoomIndicator zoomFactor={desktopOverlay.zoomFactor} />
         ) : null}
-        {tabId && desktopOverlay && !showEmptyState && !isUnreachable ? (
+        {runtimeTabId && desktopOverlay && !showEmptyState && !isUnreachable ? (
           <AgentBrowserCursor
-            tabId={tabId}
+            tabId={runtimeTabId}
             zoomFactor={desktopOverlay.zoomFactor}
             controller={controller}
           />

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -5,6 +5,7 @@ import { PanelRightIcon, PictureInPicture2, XIcon } from "lucide-react";
 import { type PointerEvent as ReactPointerEvent, useLayoutEffect, useRef } from "react";
 
 import { BrowserSurfaceSlot } from "~/browser/BrowserSurfaceSlot";
+import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 import { Button } from "~/components/ui/button";
 import { toastManager } from "~/components/ui/toast";
 import { useThreadPreviewState } from "~/previewStateStore";
@@ -49,6 +50,7 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
   );
   const previewState = useThreadPreviewState(threadRef);
   const snapshot = previewState.sessions[tabId] ?? null;
+  const runtimeTabId = previewRuntimeTabId(threadRef, previewState.serverEpoch, tabId);
   const desktopOverlay = previewState.desktopByTabId[tabId] ?? null;
   const position = miniPlayer?.tabId === tabId ? miniPlayer.position : null;
   const size =
@@ -69,7 +71,7 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
     const operation = desktopOverlay?.pictureInPicture
       ? previewBridge.pictureInPicture.close
       : previewBridge.pictureInPicture.open;
-    void operation(tabId).catch((error) => {
+    void operation(runtimeTabId).catch((error) => {
       toastManager.add({
         type: "error",
         title: "Unable to update popped-out preview",
@@ -284,7 +286,7 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
       <div className="relative h-full min-h-0">
         <div className="absolute inset-0 z-[29] rounded-xl bg-muted shadow-2xl/35" />
         <BrowserSurfaceSlot
-          tabId={tabId}
+          tabId={runtimeTabId}
           visible={Boolean(desktopOverlay?.hasWebContents)}
           cornerRadius={12}
           fitSourceContent

--- a/apps/web/src/components/preview/previewAutomationOpenReadiness.test.ts
+++ b/apps/web/src/components/preview/previewAutomationOpenReadiness.test.ts
@@ -2,6 +2,8 @@ import type { PreviewAutomationOpenInput, PreviewSessionSnapshot } from "@t3tool
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  DEFAULT_PREVIEW_AUTOMATION_VIEWPORT,
+  previewAutomationDefaultViewport,
   previewAutomationOpenNeedsOverlay,
   shouldOpenPreviewMiniPlayer,
 } from "./previewAutomationOpenReadiness";
@@ -57,5 +59,21 @@ describe("preview automation open readiness", () => {
         }),
       ),
     ).toBe(true);
+  });
+
+  it("gives newly-created automation tabs a stable desktop viewport", () => {
+    expect(previewAutomationDefaultViewport(false, snapshot({ _tag: "Idle" }))).toEqual(
+      DEFAULT_PREVIEW_AUTOMATION_VIEWPORT,
+    );
+  });
+
+  it("preserves reused and already-fixed browser viewports", () => {
+    expect(previewAutomationDefaultViewport(true, snapshot({ _tag: "Idle" }))).toBeNull();
+    expect(
+      previewAutomationDefaultViewport(false, {
+        ...snapshot({ _tag: "Idle" }),
+        viewport: { _tag: "freeform", width: 900, height: 600 },
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/components/preview/previewAutomationOpenReadiness.ts
+++ b/apps/web/src/components/preview/previewAutomationOpenReadiness.ts
@@ -1,4 +1,15 @@
-import type { PreviewAutomationOpenInput, PreviewSessionSnapshot } from "@t3tools/contracts";
+import {
+  FILL_PREVIEW_VIEWPORT,
+  type PreviewAutomationOpenInput,
+  type PreviewSessionSnapshot,
+  type PreviewViewportSetting,
+} from "@t3tools/contracts";
+
+export const DEFAULT_PREVIEW_AUTOMATION_VIEWPORT = {
+  _tag: "freeform",
+  width: 1280,
+  height: 800,
+} as const satisfies PreviewViewportSetting;
 
 export function shouldOpenPreviewMiniPlayer(input: PreviewAutomationOpenInput): boolean {
   return input.open ?? input.show ?? true;
@@ -9,4 +20,14 @@ export function previewAutomationOpenNeedsOverlay(
   snapshot: PreviewSessionSnapshot,
 ): boolean {
   return input.url !== undefined || snapshot.navStatus._tag !== "Idle";
+}
+
+export function previewAutomationDefaultViewport(
+  reusedExistingTab: boolean,
+  snapshot: PreviewSessionSnapshot,
+): PreviewViewportSetting | null {
+  const viewport = snapshot.viewport ?? FILL_PREVIEW_VIEWPORT;
+  return !reusedExistingTab && viewport._tag === "fill"
+    ? DEFAULT_PREVIEW_AUTOMATION_VIEWPORT
+    : null;
 }

--- a/apps/web/src/components/preview/previewNavigationReadiness.test.ts
+++ b/apps/web/src/components/preview/previewNavigationReadiness.test.ts
@@ -1,0 +1,56 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  readThreadPreviewState: vi.fn(),
+}));
+
+vi.mock("~/previewStateStore", () => ({
+  applyPreviewServerSnapshot: vi.fn(),
+  readThreadPreviewState: mocks.readThreadPreviewState,
+  reconcilePreviewServerSessions: vi.fn(),
+  updatePreviewServerSnapshot: vi.fn(),
+}));
+
+vi.mock("./previewBridge", () => ({
+  previewBridge: {
+    automation: {
+      evaluate: vi.fn(),
+      status: vi.fn(),
+    },
+  },
+}));
+
+import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
+
+import { PreviewAutomationTargetUnavailableError } from "./previewAutomationErrors";
+import { waitForNavigationReadiness } from "./previewNavigationReadiness";
+
+describe("waitForNavigationReadiness", () => {
+  it("rejects a replaced runtime target even when readiness polling is disabled", async () => {
+    const threadRef = {
+      environmentId: EnvironmentId.make("environment-2"),
+      threadId: ThreadId.make("thread-1"),
+    };
+    const tabId = "tab_1";
+    const staleRuntimeTabId = previewRuntimeTabId(threadRef, "epoch-1", tabId);
+    mocks.readThreadPreviewState.mockReturnValue({
+      serverEpoch: "epoch-2",
+      sessions: {
+        [tabId]: { tabId },
+      },
+    });
+
+    await expect(
+      waitForNavigationReadiness(
+        threadRef,
+        "request-1",
+        tabId,
+        staleRuntimeTabId,
+        "navigate",
+        "none",
+        100,
+      ),
+    ).rejects.toBeInstanceOf(PreviewAutomationTargetUnavailableError);
+  });
+});

--- a/apps/web/src/components/preview/previewNavigationReadiness.ts
+++ b/apps/web/src/components/preview/previewNavigationReadiness.ts
@@ -1,0 +1,74 @@
+import {
+  type PreviewAutomationNavigateInput,
+  type PreviewAutomationRequest,
+  type ScopedThreadRef,
+} from "@t3tools/contracts";
+
+import { isCurrentPreviewRuntimeTab } from "~/browser/previewRuntimeTabId";
+import { readThreadPreviewState } from "~/previewStateStore";
+
+import { previewBridge } from "./previewBridge";
+import {
+  PreviewAutomationNavigationTimeoutError,
+  PreviewAutomationTargetUnavailableError,
+} from "./previewAutomationErrors";
+
+export function assertPreviewRuntimeCurrent(
+  threadRef: ScopedThreadRef,
+  tabId: string,
+  runtimeTabId: string,
+  request: Pick<PreviewAutomationRequest, "operation" | "requestId">,
+) {
+  const state = readThreadPreviewState(threadRef);
+  if (
+    state.sessions[tabId] &&
+    isCurrentPreviewRuntimeTab(threadRef, state.serverEpoch, tabId, runtimeTabId)
+  ) {
+    return state;
+  }
+  throw new PreviewAutomationTargetUnavailableError({
+    requestId: request.requestId,
+    operation: request.operation,
+    environmentId: threadRef.environmentId,
+    threadId: threadRef.threadId,
+    tabId,
+    bridgeAvailable: Boolean(previewBridge),
+  });
+}
+
+export async function waitForNavigationReadiness(
+  threadRef: ScopedThreadRef,
+  requestId: string,
+  tabId: string,
+  runtimeTabId: string,
+  operation: PreviewAutomationRequest["operation"],
+  readiness: PreviewAutomationNavigateInput["readiness"],
+  timeoutMs: number,
+): Promise<void> {
+  const targetReadiness = readiness ?? "load";
+  if (!previewBridge) return;
+  assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, { operation, requestId });
+  if (targetReadiness === "none") return;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, { operation, requestId });
+    if (targetReadiness === "domContentLoaded") {
+      const readyState = await previewBridge.automation.evaluate(runtimeTabId, {
+        expression: "document.readyState",
+      });
+      if (readyState === "interactive" || readyState === "complete") return;
+    } else {
+      const status = await previewBridge.automation.status(runtimeTabId);
+      if (status.available && !status.loading) return;
+    }
+    await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
+  }
+  throw new PreviewAutomationNavigationTimeoutError({
+    requestId,
+    environmentId: threadRef.environmentId,
+    threadId: threadRef.threadId,
+    tabId,
+    readiness: targetReadiness,
+    timeoutMs,
+  });
+}

--- a/apps/web/src/components/preview/previewViewportRollback.test.ts
+++ b/apps/web/src/components/preview/previewViewportRollback.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { shouldRollbackPreviewViewport } from "./previewViewportRollback";
+
+describe("shouldRollbackPreviewViewport", () => {
+  const fill = { _tag: "fill" } as const;
+  const requested = { _tag: "freeform", width: 900, height: 600 } as const;
+
+  it("rolls back a timed-out request that still owns the latest setting", () => {
+    expect(shouldRollbackPreviewViewport(fill, requested, requested)).toBe(true);
+  });
+
+  it("does not overwrite a newer resize or repeat an identical setting", () => {
+    expect(
+      shouldRollbackPreviewViewport(fill, requested, {
+        _tag: "freeform",
+        width: 1024,
+        height: 768,
+      }),
+    ).toBe(false);
+    expect(shouldRollbackPreviewViewport(requested, requested, requested)).toBe(false);
+  });
+});

--- a/apps/web/src/components/preview/previewViewportRollback.test.ts
+++ b/apps/web/src/components/preview/previewViewportRollback.test.ts
@@ -7,17 +7,30 @@ describe("shouldRollbackPreviewViewport", () => {
   const requested = { _tag: "freeform", width: 900, height: 600 } as const;
 
   it("rolls back a timed-out request that still owns the latest setting", () => {
-    expect(shouldRollbackPreviewViewport(fill, requested, requested)).toBe(true);
+    expect(shouldRollbackPreviewViewport(fill, requested, requested, "server-a", "server-a")).toBe(
+      true,
+    );
   });
 
-  it("does not overwrite a newer resize or repeat an identical setting", () => {
+  it("does not overwrite a newer resize, replacement server, or repeated setting", () => {
     expect(
-      shouldRollbackPreviewViewport(fill, requested, {
-        _tag: "freeform",
-        width: 1024,
-        height: 768,
-      }),
+      shouldRollbackPreviewViewport(
+        fill,
+        requested,
+        {
+          _tag: "freeform",
+          width: 1024,
+          height: 768,
+        },
+        "server-a",
+        "server-a",
+      ),
     ).toBe(false);
-    expect(shouldRollbackPreviewViewport(requested, requested, requested)).toBe(false);
+    expect(shouldRollbackPreviewViewport(fill, requested, requested, "server-a", "server-b")).toBe(
+      false,
+    );
+    expect(
+      shouldRollbackPreviewViewport(requested, requested, requested, "server-a", "server-a"),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/preview/previewViewportRollback.ts
+++ b/apps/web/src/components/preview/previewViewportRollback.ts
@@ -1,0 +1,15 @@
+import type { PreviewViewportSetting } from "@t3tools/contracts";
+
+import { browserViewportSettingKey } from "~/browser/browserViewportLayout";
+
+export function shouldRollbackPreviewViewport(
+  previous: PreviewViewportSetting,
+  requested: PreviewViewportSetting,
+  latest: PreviewViewportSetting,
+): boolean {
+  const requestedKey = browserViewportSettingKey(requested);
+  return (
+    browserViewportSettingKey(latest) === requestedKey &&
+    browserViewportSettingKey(previous) !== requestedKey
+  );
+}

--- a/apps/web/src/components/preview/previewViewportRollback.ts
+++ b/apps/web/src/components/preview/previewViewportRollback.ts
@@ -6,9 +6,12 @@ export function shouldRollbackPreviewViewport(
   previous: PreviewViewportSetting,
   requested: PreviewViewportSetting,
   latest: PreviewViewportSetting,
+  operationServerEpoch: string | null,
+  currentServerEpoch: string | null,
 ): boolean {
   const requestedKey = browserViewportSettingKey(requested);
   return (
+    currentServerEpoch === operationServerEpoch &&
     browserViewportSettingKey(latest) === requestedKey &&
     browserViewportSettingKey(previous) !== requestedKey
   );

--- a/apps/web/src/components/preview/usePreviewBridge.ts
+++ b/apps/web/src/components/preview/usePreviewBridge.ts
@@ -19,8 +19,12 @@ import { previewBridge } from "./previewBridge";
  * Mirrors low-latency desktop state into the store and reflects navigation
  * events back to the server. Webview lifetime is owned by ElectronBrowserHost.
  */
-export function usePreviewBridge(input: { threadRef: ScopedThreadRef; tabId: string }): void {
-  const { threadRef, tabId } = input;
+export function usePreviewBridge(input: {
+  threadRef: ScopedThreadRef;
+  tabId: string;
+  runtimeTabId: string;
+}): void {
+  const { threadRef, tabId, runtimeTabId } = input;
   const clearBrowserPointer = useBrowserPointerStore((state) => state.clear);
   const reportStatus = useAtomCommand(previewEnvironment.reportStatus, "preview status report");
   const bridge = previewBridge;
@@ -36,9 +40,9 @@ export function usePreviewBridge(input: { threadRef: ScopedThreadRef; tabId: str
     lastReportedKind.current = null;
     lastDesktopNavStatus.current = null;
     const unsubscribe = bridge.onStateChange((changedTabId, state) => {
-      if (changedTabId !== tabId) return;
+      if (changedTabId !== runtimeTabId) return;
       if (shouldClearBrowserPointer(lastDesktopNavStatus.current, state.navStatus)) {
-        clearBrowserPointer(tabId);
+        clearBrowserPointer(runtimeTabId);
       }
       lastDesktopNavStatus.current = state.navStatus;
       applyPreviewDesktopState(threadRef, tabId, projectDesktopState(state));
@@ -58,7 +62,7 @@ export function usePreviewBridge(input: { threadRef: ScopedThreadRef; tabId: str
       });
     });
     return unsubscribe;
-  }, [bridge, clearBrowserPointer, reportStatus, tabId, threadRef]);
+  }, [bridge, clearBrowserPointer, reportStatus, runtimeTabId, tabId, threadRef]);
 }
 
 function shouldClearBrowserPointer(

--- a/apps/web/src/components/preview/usePreviewSession.ts
+++ b/apps/web/src/components/preview/usePreviewSession.ts
@@ -39,7 +39,6 @@ const previewSessionSyncAtom = Atom.family((threadKey: string) => {
 
   return Atom.make((get) => {
     let disposed = false;
-    let sessionsVersion = 0;
     let eventsVersion = 0;
 
     const reconcileSessions = (result: Atom.Type<typeof sessionsAtom>) => {
@@ -60,10 +59,8 @@ const previewSessionSyncAtom = Atom.family((threadKey: string) => {
     get.addFinalizer(() => {
       disposed = true;
     });
-    const initialSessions = get.once(sessionsAtom);
     const initialEvent = get.once(eventsAtom);
     get.subscribe(sessionsAtom, (result) => {
-      sessionsVersion += 1;
       reconcileSessions(result);
     });
     get.subscribe(eventsAtom, (result) => {
@@ -72,7 +69,10 @@ const previewSessionSyncAtom = Atom.family((threadKey: string) => {
     });
     queueMicrotask(() => {
       if (disposed) return;
-      if (sessionsVersion === 0) reconcileSessions(initialSessions);
+      // The cached list can predate an automation-created tab. Keep the local
+      // snapshot visible until an authoritative refresh arrives instead of
+      // reconciling against a stale empty result when the panel first mounts.
+      get.refresh(sessionsAtom);
       if (eventsVersion === 0) applyLatestEvent(initialEvent);
     });
   }).pipe(Atom.setIdleTTL(1_000), Atom.withLabel(`preview:session-sync:${threadKey}`));

--- a/apps/web/src/previewStateStore.test.ts
+++ b/apps/web/src/previewStateStore.test.ts
@@ -480,6 +480,48 @@ describe("previewStateStore (single-tab)", () => {
     expect(state.serverRevision).toBe(0);
   });
 
+  it("does not carry raw-tab state across a server restart", () => {
+    const previous = makeSnapshot({
+      navStatus: { _tag: "Success", url: "https://old.example", title: "Old" },
+      updatedAt: "2026-01-01T00:00:02.000Z",
+    });
+    applyPreviewServerEventImpl(ref, {
+      type: "opened",
+      threadId: "thread-1",
+      tabId: previous.tabId,
+      createdAt: previous.updatedAt,
+      serverEpoch,
+      revision: 12,
+      snapshot: previous,
+    });
+    beginPreviewSessionClose(ref, previous.tabId);
+    applyPreviewDesktopState(ref, previous.tabId, {
+      hasWebContents: true,
+      canGoBack: false,
+      canGoForward: false,
+      loading: false,
+      zoomFactor: 1,
+      pictureInPicture: false,
+      colorScheme: "system",
+      controller: "none",
+    });
+    const restarted = makeSnapshot({
+      navStatus: { _tag: "Success", url: "https://new.example", title: "New" },
+      updatedAt: "2026-01-01T00:00:01.000Z",
+    });
+    reconcilePreviewServerSessions(ref, {
+      sessions: [restarted],
+      serverEpoch: "server-b",
+      revision: 0,
+    });
+
+    const state = readThreadPreviewState(ref);
+    expect(state.sessions[restarted.tabId]).toEqual(restarted);
+    expect(state.suppressedTabIds).toEqual(new Set());
+    expect(state.desktopByTabId).toEqual({});
+    expect(state.desktopOverlay).toBeNull();
+  });
+
   it("applyServerSnapshot null clears snapshot for a thread that had one", () => {
     const snapshot = makeSnapshot();
     applyPreviewServerSnapshot(ref, snapshot);

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -323,10 +323,11 @@ export function reconcilePreviewServerSessions(
     if (sameServer && result.revision < current.serverRevision) return current;
     const snapshots = result.sessions;
     const sessions: Record<string, PreviewSessionSnapshot> = {};
+    const currentSuppressedTabIds = sameServer ? current.suppressedTabIds : new Set<string>();
     let recentlySeenUrls = current.recentlySeenUrls;
     for (const snapshot of snapshots) {
-      if (current.suppressedTabIds.has(snapshot.tabId)) continue;
-      const existing = current.sessions[snapshot.tabId];
+      if (currentSuppressedTabIds.has(snapshot.tabId)) continue;
+      const existing = sameServer ? current.sessions[snapshot.tabId] : undefined;
       const next = existing && existing.updatedAt > snapshot.updatedAt ? existing : snapshot;
       sessions[next.tabId] = next;
       recentlySeenUrls = rememberSnapshotUrl(recentlySeenUrls, next);
@@ -338,11 +339,13 @@ export function reconcilePreviewServerSessions(
         ? current.activeTabId
         : (fallback?.tabId ?? null);
     const snapshot = activeTabId ? (sessions[activeTabId] ?? null) : null;
-    const desktopByTabId = Object.fromEntries(
-      Object.entries(current.desktopByTabId).filter(([tabId]) => sessions[tabId] !== undefined),
-    );
+    const desktopByTabId = sameServer
+      ? Object.fromEntries(
+          Object.entries(current.desktopByTabId).filter(([tabId]) => sessions[tabId] !== undefined),
+        )
+      : {};
     const suppressedTabIds = new Set(
-      [...current.suppressedTabIds].filter((tabId) =>
+      [...currentSuppressedTabIds].filter((tabId) =>
         snapshots.some((snapshot) => snapshot.tabId === tabId),
       ),
     );


### PR DESCRIPTION
## Summary

- scope Electron preview resources by environment, thread, and server epoch while keeping one physical desktop host available to every connected environment
- give agent-created tabs a stable 1280×800 logical viewport and preserve it across inline PiP, right-panel docking, hidden capture, and native PiP
- prevent hidden tabs from borrowing another tabs panel rect, roll back timed-out resizes safely, and clear stale raw-tab overlays/suppression after a server restart
- preserve native PiP area across portrait/landscape changes and refresh authoritative sessions when docking a newly created inline preview

## Verification

- `vp test run` on 12 focused desktop/web files: 117 tests passed
- targeted `vp lint --report-unused-disable-directives`
- targeted `vp fmt --check`
- `vp run --filter @t3tools/web --filter @t3tools/desktop typecheck`
- React Doctor: 98/100
- integrated Electron pass: one clean `preview_open` created one tab, defaulted to 1280×800, returned `visible: true`, retained 1280×800 after inline-to-panel docking, and rendered at the same 16:10 source aspect in both inline and native PiP

## Architecture note

A desktop app connected to environment 1 can still serve as the physical browser automation engine for a headless environment 2. The broker continues to register/rout each environment through that shared renderer; the new runtime tab key only prevents process-local ids such as `tab_1` from colliding across environments or server restarts.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize preview PiP viewport identity by routing all operations through runtime tab IDs
> - Introduces `previewRuntimeTabId` — a deterministic ID combining environment, thread, server epoch, and tab ID — so that all preview operations target the currently active webview rather than a potentially stale server tab ID.
> - Updates `PreviewView`, `PreviewAutomationHosts`, `HostedBrowserWebview`, and `usePreviewBridge` to use `runtimeTabId` for bridge calls, viewport mutations, surface-store lookups, PiP operations, and recording start/stop.
> - Adds `assertPreviewRuntimeCurrent` and `waitForNavigationReadiness` to fail fast when an automation target has been replaced mid-operation.
> - Resets per-tab desktop state and suppressed tab IDs in `reconcilePreviewServerSessions` when the server epoch changes, preventing stale state from carrying over after a restart.
> - Fixes `fitPictureInPictureContentSize` to preserve content area across aspect-ratio changes, and adds an epsilon guard to suppress spurious ratio-change updates.
> - Risk: all callers that previously passed server tab IDs to bridge/viewport APIs now receive different (runtime-scoped) IDs; any code outside this PR that pins server tab IDs will target the wrong webview after an epoch change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00d11b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview automation, webview identity, and server-epoch reconciliation; runtime tab keys change on restart and can remount webviews, but changes are well-tested and scoped.
> 
> **Overview**
> Desktop preview resources are now keyed by **`previewRuntimeTabId`** (environment, thread, `serverEpoch`, and server `tabId`) instead of the server-local tab id alone. **Hosted webviews**, the **surface store**, **recordings**, **desktop tab lifetime**, and **preview bridge** calls route through that runtime id while server APIs still use the logical `tabId`.
> 
> When **`serverEpoch`** changes, session reconciliation **drops stale desktop overlays and suppression** instead of carrying them forward. Automation **rejects stale runtime targets** during navigation and overlay waits, and **resize** runs through a shared per-tab queue with **conditional rollback** on render timeout.
> 
> **Native PiP** sizing preserves content **area** across aspect-ratio flips (with ratio **epsilon** to avoid jitter). New automation tabs default to **1280×800**; hidden tabs no longer **borrow another tab’s panel rect**; background and visible viewport mutations **serialize** on the same queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00d11b1bda103b22b59a3db5b39561fe65df579a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->