### PR TITLE
Use tarball archiving for hosted web deploys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -864,6 +864,7 @@ jobs:
           echo "Deploying hosted web app for $channel_name channel."
           deployment_url="$(
             vp dlx vercel@53.1.1 deploy \
+              --archive=tgz \
               --prod \
               --skip-domain \
               --yes \


### PR DESCRIPTION
## Summary

- Configure hosted web deployments to use tarball archiving.
- Reduce deployment file-limit issues with the Vercel CLI.

## Testing

- Not run (workflow-only change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI flag on the existing Vercel deploy step with no application or secret-handling changes.
> 
> **Overview**
> Adds **`--archive=tgz`** to the `vercel deploy` invocation in the release workflow’s **Deploy hosted web app** job so the hosted web app is uploaded as a single tarball instead of many loose files.
> 
> This is meant to avoid Vercel CLI **file-limit** failures on large monorepo deploys; build env vars, aliasing, and channel routing are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433da8c4f9968a7b71cd9c4f6d08ba2b09765a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--archive=tgz` to Vercel deploy command in release workflow
> Adds the `--archive=tgz` flag to the Vercel CLI deploy command in [release.yml](https://github.com/pingdotgg/t3code/pull/4669/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34), switching hosted web deploys to use tarball archiving.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 433da8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->