### PR TITLE
Prevent draft thread detail polling before shell registration

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -234,7 +234,7 @@ export const BranchToolbar = memo(function BranchToolbar({
     () => scopeThreadRef(environmentId, threadId),
     [environmentId, threadId],
   );
-  const serverThread = useThread(threadRef);
+  const serverThread = useThread(threadRef, { waitForShell: draftId !== undefined });
   const draftThread = useComposerDraftStore((store) =>
     draftId ? store.getDraftSession(draftId) : store.getDraftThreadByRef(threadRef),
   );

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -234,10 +234,10 @@ export const BranchToolbar = memo(function BranchToolbar({
     () => scopeThreadRef(environmentId, threadId),
     [environmentId, threadId],
   );
-  const serverThread = useThread(threadRef, { waitForShell: draftId !== undefined });
   const draftThread = useComposerDraftStore((store) =>
     draftId ? store.getDraftSession(draftId) : store.getDraftThreadByRef(threadRef),
   );
+  const serverThread = useThread(threadRef, { waitForShell: draftThread !== null });
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
   const activeProjectRef = serverThread
     ? scopeProjectRef(serverThread.environmentId, serverThread.projectId)

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -129,7 +129,7 @@ export function BranchToolbarBranchSelector({
     () => scopeThreadRef(environmentId, threadId),
     [environmentId, threadId],
   );
-  const serverThread = useThread(threadRef);
+  const serverThread = useThread(threadRef, { waitForShell: draftId !== undefined });
   const serverSession = serverThread?.session ?? null;
   const draftThread = useComposerDraftStore((store) =>
     draftId ? store.getDraftSession(draftId) : store.getDraftThreadByRef(threadRef),

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -129,11 +129,11 @@ export function BranchToolbarBranchSelector({
     () => scopeThreadRef(environmentId, threadId),
     [environmentId, threadId],
   );
-  const serverThread = useThread(threadRef, { waitForShell: draftId !== undefined });
-  const serverSession = serverThread?.session ?? null;
   const draftThread = useComposerDraftStore((store) =>
     draftId ? store.getDraftSession(draftId) : store.getDraftThreadByRef(threadRef),
   );
+  const serverThread = useThread(threadRef, { waitForShell: draftThread !== null });
+  const serverSession = serverThread?.session ?? null;
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
 
   const activeProjectRef = serverThread

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -620,8 +620,8 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const openTerminal = useAtomCommand(terminalEnvironment.open, "terminal open");
   const writeTerminal = useAtomCommand(terminalEnvironment.write, "terminal write");
   const closeTerminalMutation = useAtomCommand(terminalEnvironment.close, "terminal close");
-  const serverThread = useThread(threadRef);
   const draftThread = useComposerDraftStore((store) => store.getDraftThreadByRef(threadRef));
+  const serverThread = useThread(threadRef, { waitForShell: draftThread !== null });
   const projectRef = serverThread
     ? scopeProjectRef(serverThread.environmentId, serverThread.projectId)
     : draftThread
@@ -976,8 +976,8 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
   newShortcutLabel,
   closeShortcutLabel,
 }: PersistentThreadTerminalPanelProps) {
-  const serverThread = useThread(threadRef);
   const draftThread = useComposerDraftStore((store) => store.getDraftThreadByRef(threadRef));
+  const serverThread = useThread(threadRef, { waitForShell: draftThread !== null });
   const projectRef = serverThread
     ? scopeProjectRef(serverThread.environmentId, serverThread.projectId)
     : draftThread
@@ -1181,7 +1181,7 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const composerDraftTarget: ScopedThreadRef | DraftId =
     routeKind === "server" ? routeThreadRef : props.draftId;
-  const serverThread = useThread(routeThreadRef);
+  const serverThread = useThread(routeThreadRef, { waitForShell: routeKind === "draft" });
   const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
   const activeThreadLastVisitedAt = useUiStateStore(
     (store) => store.threadLastVisitedAtById[routeThreadKey],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1181,7 +1181,14 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const composerDraftTarget: ScopedThreadRef | DraftId =
     routeKind === "server" ? routeThreadRef : props.draftId;
-  const serverThread = useThread(routeThreadRef, { waitForShell: routeKind === "draft" });
+  const draftThread = useComposerDraftStore((store) =>
+    routeKind === "server"
+      ? store.getDraftSessionByRef(routeThreadRef)
+      : draftId
+        ? store.getDraftSession(draftId)
+        : null,
+  );
+  const serverThread = useThread(routeThreadRef, { waitForShell: draftThread !== null });
   const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
   const activeThreadLastVisitedAt = useUiStateStore(
     (store) => store.threadLastVisitedAtById[routeThreadKey],
@@ -1233,13 +1240,6 @@ function ChatViewContent(props: ChatViewProps) {
   const getDraftSession = useComposerDraftStore((store) => store.getDraftSession);
   const setLogicalProjectDraftThreadId = useComposerDraftStore(
     (store) => store.setLogicalProjectDraftThreadId,
-  );
-  const draftThread = useComposerDraftStore((store) =>
-    routeKind === "server"
-      ? store.getDraftSessionByRef(routeThreadRef)
-      : draftId
-        ? store.getDraftSession(draftId)
-        : null,
   );
   const promptRef = useRef("");
   const composerImagesRef = useRef<ComposerImageAttachment[]>([]);

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -986,7 +986,9 @@ export default function GitActionsControl({
     () => (activeThreadRef ? { threadRef: activeThreadRef } : undefined),
     [activeThreadRef],
   );
-  const activeServerThread = useThread(activeThreadRef);
+  const activeServerThread = useThread(activeThreadRef, {
+    waitForShell: draftId !== undefined,
+  });
   const activeDraftThread = useComposerDraftStore((store) =>
     draftId
       ? store.getDraftSession(draftId)

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -986,9 +986,6 @@ export default function GitActionsControl({
     () => (activeThreadRef ? { threadRef: activeThreadRef } : undefined),
     [activeThreadRef],
   );
-  const activeServerThread = useThread(activeThreadRef, {
-    waitForShell: draftId !== undefined,
-  });
   const activeDraftThread = useComposerDraftStore((store) =>
     draftId
       ? store.getDraftSession(draftId)
@@ -996,6 +993,9 @@ export default function GitActionsControl({
         ? store.getDraftThreadByRef(activeThreadRef)
         : null,
   );
+  const activeServerThread = useThread(activeThreadRef, {
+    waitForShell: activeDraftThread !== null,
+  });
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
   const [isCommitDialogOpen, setIsCommitDialogOpen] = useState(false);
   const [dialogCommitMessage, setDialogCommitMessage] = useState("");

--- a/apps/web/src/state/entities.test.ts
+++ b/apps/web/src/state/entities.test.ts
@@ -1,0 +1,36 @@
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveThreadDetailRef } from "./entities";
+
+const threadRef = scopeThreadRef(EnvironmentId.make("environment-1"), ThreadId.make("thread-1"));
+
+describe("resolveThreadDetailRef", () => {
+  it("does not subscribe to a reserved draft thread before it enters the shell index", () => {
+    expect(
+      resolveThreadDetailRef(threadRef, {
+        shellExists: false,
+        waitForShell: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("subscribes once the reserved draft thread enters the shell index", () => {
+    expect(
+      resolveThreadDetailRef(threadRef, {
+        shellExists: true,
+        waitForShell: true,
+      }),
+    ).toBe(threadRef);
+  });
+
+  it("keeps direct server-thread lookups enabled when the shell has not loaded it", () => {
+    expect(
+      resolveThreadDetailRef(threadRef, {
+        shellExists: false,
+        waitForShell: false,
+      }),
+    ).toBe(threadRef);
+  });
+});

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -152,10 +152,35 @@ export function useThreadStatus(ref: ScopedThreadRef | null): EnvironmentThreadS
   );
 }
 
+export function resolveThreadDetailRef(
+  ref: ScopedThreadRef | null,
+  options: {
+    shellExists: boolean;
+    waitForShell: boolean;
+  },
+): ScopedThreadRef | null {
+  return ref !== null && (!options.waitForShell || options.shellExists) ? ref : null;
+}
+
 /** Detail collections composed with shell-authoritative thread/workspace metadata. */
-export function useThread(ref: ScopedThreadRef | null): EnvironmentThread | null {
+export function useThread(
+  ref: ScopedThreadRef | null,
+  options?: {
+    /**
+     * Client-reserved draft thread ids do not exist on the server until the
+     * first send. Waiting for the shell index avoids polling the detail
+     * endpoint for an intentionally missing thread during that window.
+     */
+    waitForShell?: boolean;
+  },
+): EnvironmentThread | null {
   const shell = useThreadShell(ref);
-  const detail = useThreadDetail(ref);
+  const detail = useThreadDetail(
+    resolveThreadDetailRef(ref, {
+      shellExists: shell !== null,
+      waitForShell: options?.waitForShell === true,
+    }),
+  );
   return useMemo(() => mergeEnvironmentThread(detail, shell), [detail, shell]);
 }
 


### PR DESCRIPTION
## Summary

- Delay draft thread detail lookups until the thread is present in the shell index.
- Apply the guarded lookup across chat, branch, and Git action components.
- Add coverage for draft and direct server-thread lookup behavior.

## Testing

- Added unit tests in `apps/web/src/state/entities.test.ts`.
- Not run: project test and lint commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized subscription gating with existing draft fallbacks; no auth or server contract changes beyond fewer premature detail requests.
> 
> **Overview**
> Stops **polling the thread detail API** for client-reserved draft thread IDs before the server has created the thread. Draft IDs exist only in local draft state until the first send; hitting detail early produced pointless 404/poll traffic.
> 
> **`useThread`** now accepts optional **`waitForShell`**. When true, **`resolveThreadDetailRef`** skips the detail subscription until the thread appears in the **shell index** (`useThreadShell` is non-null). Shell lookup still runs; only detail is gated.
> 
> Draft-aware surfaces pass **`waitForShell: draftThread !== null`** in **`BranchToolbar`**, **`BranchToolbarBranchSelector`**, **`ChatView`** (including reordering draft resolution ahead of `useThread`), **`GitActionsControl`**, and terminal panels. **`serverThread` stays `null`** in the gap between draft creation and shell registration—call sites already fall back to draft context.
> 
> Unit tests in **`entities.test.ts`** cover the three **`resolveThreadDetailRef`** cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed78b3f3b1cba717d649dbb82423887e5d3a887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent draft thread detail polling before shell registration in `useThread`
> - Adds a `waitForShell` option to the `useThread` hook in [entities.ts](https://github.com/pingdotgg/t3code/pull/4670/files#diff-03d4a7bdd760faa2d76b1234f8bde0583a404e4647e6cc1f6c1d4a67e0eb6eba) via a new `resolveThreadDetailRef` helper that returns `null` until the shell index confirms the thread exists.
> - Updates `BranchToolbar`, `BranchToolbarBranchSelector`, `ChatView`, and `GitActionsControl` to pass `waitForShell: draftThread !== null`, so detail polling is suppressed for draft threads until they appear in the shell index.
> - Behavioral Change: components using `useThread` with `waitForShell: true` will receive `null` for server thread data until shell registration completes, whereas previously detail fetches could fire immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ed78b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->