### PR TITLE
feat(diff-panel): show total line additions and deletions

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -30,6 +30,7 @@ import { useTheme } from "../hooks/useTheme";
 import {
   buildFileDiffRenderKey,
   getDiffCollapseIconClassName,
+  getDiffLineStat,
   getRenderablePatch,
   resolveDiffThemeName,
   resolveFileDiffPath,
@@ -41,6 +42,7 @@ import { resolveThreadRouteRef } from "../threadRoutes";
 import { useClientSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
+import { DiffStatLabel } from "./chat/DiffStatLabel";
 import { AnnotatableCodeView, type AnnotatableCodeViewHandle } from "./diffs/AnnotatableCodeView";
 import { Button } from "./ui/button";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
@@ -452,6 +454,7 @@ export default function DiffPanel({
   );
   const diffFileKeys = useMemo(() => codeViewFiles.map((file) => file.fileKey), [codeViewFiles]);
   const allDiffFilesCollapsed = areAllDiffFilesCollapsed(diffFileKeys, collapsedDiffFileKeys);
+  const diffLineStat = useMemo(() => getDiffLineStat(renderableFiles), [renderableFiles]);
 
   useEffect(() => {
     if (!selectedFilePath) return;
@@ -713,6 +716,14 @@ export default function DiffPanel({
         )}
       </div>
       <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+        {codeViewFiles.length > 0 && (
+          <DiffStatLabel
+            additions={diffLineStat.additions}
+            deletions={diffLineStat.deletions}
+            className="mr-1 text-[11px]"
+            layout="inline"
+          />
+        )}
         {codeViewFiles.length > 0 && (
           <Tooltip>
             <TooltipTrigger

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { buildPatchCacheKey, getRenderablePatch } from "./diffRendering";
+import { buildPatchCacheKey, getDiffLineStat, getRenderablePatch } from "./diffRendering";
 
 describe("buildPatchCacheKey", () => {
   it("returns a stable cache key for identical content", () => {
@@ -80,5 +80,35 @@ describe("getRenderablePatch", () => {
     expect(parsed?.kind).toBe("files");
     if (parsed?.kind !== "files") return;
     expect(parsed.files[0]?.hunks[0]?.unifiedLineStart).toBe(47);
+  });
+});
+
+describe("getDiffLineStat", () => {
+  it("totals additions and deletions across every file and hunk", () => {
+    const patch = [
+      "diff --git a/example.ts b/example.ts",
+      "--- a/example.ts",
+      "+++ b/example.ts",
+      "@@ -1,2 +1,3 @@",
+      "-before",
+      "+after",
+      "+added",
+      " context",
+      "@@ -10,2 +11,1 @@",
+      "-removed",
+      " context",
+      "diff --git a/README.md b/README.md",
+      "--- a/README.md",
+      "+++ b/README.md",
+      "@@ -1 +1,2 @@",
+      " title",
+      "+description",
+    ].join("\n");
+
+    const parsed = getRenderablePatch(patch);
+    expect(parsed?.kind).toBe("files");
+    if (parsed?.kind !== "files") return;
+
+    expect(getDiffLineStat(parsed.files)).toEqual({ additions: 3, deletions: 2 });
   });
 });

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -52,6 +52,25 @@ export type RenderablePatch =
       reason: string;
     };
 
+export interface DiffLineStat {
+  additions: number;
+  deletions: number;
+}
+
+export function getDiffLineStat(files: ReadonlyArray<FileDiffMetadata>): DiffLineStat {
+  return files.reduce<DiffLineStat>(
+    (total, file) => {
+      for (const hunk of file.hunks) {
+        total.additions += hunk.additionLines;
+        total.deletions += hunk.deletionLines;
+      }
+
+      return total;
+    },
+    { additions: 0, deletions: 0 },
+  );
+}
+
 interface RenderablePatchOptions {
   /**
    * Pierre's partial-patch parser keeps hunk render starts in source-file


### PR DESCRIPTION
## What Changed

Added aggregate line-of-code totals to the right-side diff panel toolbar.

The toolbar now displays the total additions and deletions for the selected diff using the existing green `+` and red `-` styling. The totals update when the selected diff or whitespace setting changes.

## Why

The diff panel showed per-file statistics but did not provide an at-a-glance total for the entire diff. This makes it easier to understand the overall size of a change without manually adding the individual file counts.

The totals are calculated from the parsed diff hunk metadata, keeping them consistent with the diff currently displayed.

## UI Changes

### Before

The diff toolbar only contained scope and display controls.

<img width="640" height="375" alt="Screenshot 2026-07-27 at 21 57 00" src="https://github.com/user-attachments/assets/91c45148-5851-4d7d-aeaf-c644a056523c" />

### After

The toolbar also displays total additions and deletions, such as `+61 -1`.

<img width="542" height="311" alt="after" src="https://github.com/user-attachments/assets/8287babe-451f-4ca4-9652-f4498c0ea330" />

https://github.com/user-attachments/assets/fbe82c86-a0ba-4a73-bd93-dd046c4af6db

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI addition with a pure aggregation helper and unit test; no auth, data, or API changes.
> 
> **Overview**
> The diff panel toolbar now shows **aggregate +/− line counts** for the currently displayed patch (turn, working tree, or branch), reusing the existing `DiffStatLabel` styling used in chat.
> 
> Totals come from a new **`getDiffLineStat`** helper that sums parsed hunk `additionLines` / `deletionLines` across all files in `renderableFiles`, so they stay aligned with what’s on screen when scope or ignore-whitespace changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8fad595886b931eef784252c249c815a19acf83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show total line additions and deletions in the diff panel header
> Adds a `getDiffLineStat` utility in [diffRendering.ts](https://github.com/pingdotgg/t3code/pull/4674/files#diff-cc9236c452007592d65fe06c8cee08b0cf4e86d1d36030ac2dcfb3d43e470c2c) that sums `additionLines` and `deletionLines` across all hunks in a set of file diffs. The [DiffPanel](https://github.com/pingdotgg/t3code/pull/4674/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) header uses this to render a `DiffStatLabel` with aggregated counts when files are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0563b84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->