### PR TITLE
Add custom snooze times

### DIFF
--- a/apps/web/src/components/Sidebar.snooze.test.ts
+++ b/apps/web/src/components/Sidebar.snooze.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveSnoozePresets, snoozeWakeDescription, snoozeWakeLabel } from "./Sidebar.snooze";
+import {
+  defaultCustomSnoozeDateTime,
+  formatSnoozeDateTimeLocal,
+  parseCustomSnoozeDateTime,
+  resolveSnoozePresets,
+  snoozeWakeDescription,
+  snoozeWakeLabel,
+} from "./Sidebar.snooze";
 
 // Local-time constructor so preset math is timezone-stable in tests.
 function localDate(year: number, month: number, day: number, hour: number, minute = 0): Date {
@@ -61,6 +68,29 @@ describe("resolveSnoozePresets", () => {
     const nextWeek = new Date(presets.find((preset) => preset.id === "next-week")!.snoozedUntil);
     expect(nextWeek.getDay()).toBe(1);
     expect(nextWeek.getDate()).toBe(13);
+  });
+});
+
+describe("custom snooze time", () => {
+  it("formats a local wall-clock value without adding a timezone suffix", () => {
+    expect(formatSnoozeDateTimeLocal(localDate(2026, 4, 8, 9, 5))).toBe("2026-04-08T09:05");
+  });
+
+  it("defaults to at least an hour ahead on a quarter-hour boundary", () => {
+    const now = localDate(2026, 4, 8, 10, 7);
+    const value = defaultCustomSnoozeDateTime(now);
+    const wakeAt = new Date(value);
+    expect(wakeAt.getTime()).toBeGreaterThanOrEqual(now.getTime() + 60 * 60_000);
+    expect(wakeAt.getMinutes() % 15).toBe(0);
+  });
+
+  it("converts a future local value to ISO and rejects invalid or past values", () => {
+    const now = localDate(2026, 4, 8, 10);
+    const future = "2026-04-08T12:30";
+    expect(parseCustomSnoozeDateTime(future, now)).toBe(new Date(future).toISOString());
+    expect(parseCustomSnoozeDateTime("", now)).toBeNull();
+    expect(parseCustomSnoozeDateTime("not-a-date", now)).toBeNull();
+    expect(parseCustomSnoozeDateTime("2026-04-08T09:59", now)).toBeNull();
   });
 });
 

--- a/apps/web/src/components/Sidebar.snooze.test.ts
+++ b/apps/web/src/components/Sidebar.snooze.test.ts
@@ -10,8 +10,29 @@ import {
 } from "./Sidebar.snooze";
 
 // Local-time constructor so preset math is timezone-stable in tests.
-function localDate(year: number, month: number, day: number, hour: number, minute = 0): Date {
-  return new Date(year, month - 1, day, hour, minute, 0, 0);
+function localDate(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute = 0,
+  second = 0,
+): Date {
+  return new Date(year, month - 1, day, hour, minute, second, 0);
+}
+
+function withTimeZone<T>(timeZone: string, run: () => T): T {
+  const previousTimeZone = process.env.TZ;
+  process.env.TZ = timeZone;
+  try {
+    return run();
+  } finally {
+    if (previousTimeZone === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = previousTimeZone;
+    }
+  }
 }
 
 describe("resolveSnoozePresets", () => {
@@ -77,11 +98,21 @@ describe("custom snooze time", () => {
   });
 
   it("defaults to at least an hour ahead on a quarter-hour boundary", () => {
-    const now = localDate(2026, 4, 8, 10, 7);
+    const now = localDate(2026, 4, 8, 10, 7, 30);
     const value = defaultCustomSnoozeDateTime(now);
     const wakeAt = new Date(value);
     expect(wakeAt.getTime()).toBeGreaterThanOrEqual(now.getTime() + 60 * 60_000);
     expect(wakeAt.getMinutes() % 15).toBe(0);
+  });
+
+  it("keeps the default valid through the repeated hour at the end of DST", () => {
+    withTimeZone("America/Los_Angeles", () => {
+      const now = new Date("2024-11-03T01:15:30-07:00");
+      const value = defaultCustomSnoozeDateTime(now);
+      const parsed = parseCustomSnoozeDateTime(value, now);
+      expect(parsed).not.toBeNull();
+      expect(new Date(parsed!).getTime()).toBeGreaterThanOrEqual(now.getTime() + 60 * 60_000);
+    });
   });
 
   it("converts a future local value to ISO and rejects invalid or past values", () => {
@@ -91,6 +122,16 @@ describe("custom snooze time", () => {
     expect(parseCustomSnoozeDateTime("", now)).toBeNull();
     expect(parseCustomSnoozeDateTime("not-a-date", now)).toBeNull();
     expect(parseCustomSnoozeDateTime("2026-04-08T09:59", now)).toBeNull();
+  });
+
+  it("rejects local wall-clock values normalized across a DST gap", () => {
+    withTimeZone("America/Los_Angeles", () => {
+      const now = new Date("2024-03-10T00:00:00-08:00");
+      expect(parseCustomSnoozeDateTime("2024-03-10T02:30", now)).toBeNull();
+      expect(parseCustomSnoozeDateTime("2024-03-10T03:30", now)).toBe(
+        new Date("2024-03-10T03:30:00-07:00").toISOString(),
+      );
+    });
   });
 });
 

--- a/apps/web/src/components/Sidebar.snooze.test.ts
+++ b/apps/web/src/components/Sidebar.snooze.test.ts
@@ -98,7 +98,7 @@ describe("custom snooze time", () => {
   });
 
   it("defaults to at least an hour ahead on a quarter-hour boundary", () => {
-    const now = localDate(2026, 4, 8, 10, 7, 30);
+    const now = new Date(2026, 3, 8, 10, 7, 59, 999);
     const value = defaultCustomSnoozeDateTime(now);
     const wakeAt = new Date(value);
     expect(wakeAt.getTime()).toBeGreaterThanOrEqual(now.getTime() + 60 * 60_000);

--- a/apps/web/src/components/Sidebar.snooze.ts
+++ b/apps/web/src/components/Sidebar.snooze.ts
@@ -28,6 +28,7 @@ const EVENING_HOUR = 18;
 const MORNING_HOUR = 9;
 const HOUR_MS = 60 * 60 * 1_000;
 const DAY_MS = 24 * HOUR_MS;
+const CUSTOM_TIME_STEP_MINUTES = 15;
 
 function atHour(base: Date, hour: number): Date {
   const next = new Date(base);
@@ -42,6 +43,48 @@ function addDays(base: Date, days: number): Date {
   const next = new Date(base);
   next.setDate(next.getDate() + days);
   return next;
+}
+
+/**
+ * Value for a native datetime-local input. Native date inputs intentionally
+ * have no timezone component; the value represents the user's wall clock.
+ */
+export function formatSnoozeDateTimeLocal(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return [
+    date.getFullYear(),
+    "-",
+    pad(date.getMonth() + 1),
+    "-",
+    pad(date.getDate()),
+    "T",
+    pad(date.getHours()),
+    ":",
+    pad(date.getMinutes()),
+  ].join("");
+}
+
+/**
+ * Start custom snoozes one hour out, rounded up to a friendly quarter-hour.
+ */
+export function defaultCustomSnoozeDateTime(now: Date): string {
+  const next = new Date(now.getTime() + HOUR_MS);
+  next.setSeconds(0, 0);
+  next.setMinutes(
+    Math.ceil(next.getMinutes() / CUSTOM_TIME_STEP_MINUTES) * CUSTOM_TIME_STEP_MINUTES,
+  );
+  return formatSnoozeDateTimeLocal(next);
+}
+
+/**
+ * Interpret a datetime-local value in the browser's local timezone and
+ * return the ISO command payload. Invalid and non-future values are rejected.
+ */
+export function parseCustomSnoozeDateTime(value: string, now: Date): string | null {
+  if (value.trim() === "") return null;
+  const wakeAt = new Date(value);
+  if (Number.isNaN(wakeAt.getTime()) || wakeAt.getTime() <= now.getTime()) return null;
+  return wakeAt.toISOString();
 }
 
 /**

--- a/apps/web/src/components/Sidebar.snooze.ts
+++ b/apps/web/src/components/Sidebar.snooze.ts
@@ -29,6 +29,7 @@ const MORNING_HOUR = 9;
 const HOUR_MS = 60 * 60 * 1_000;
 const DAY_MS = 24 * HOUR_MS;
 const CUSTOM_TIME_STEP_MINUTES = 15;
+const CUSTOM_TIME_STEP_MS = CUSTOM_TIME_STEP_MINUTES * 60_000;
 
 function atHour(base: Date, hour: number): Date {
   const next = new Date(base);
@@ -68,22 +69,57 @@ export function formatSnoozeDateTimeLocal(date: Date): string {
  * Start custom snoozes one hour out, rounded up to a friendly quarter-hour.
  */
 export function defaultCustomSnoozeDateTime(now: Date): string {
-  const next = new Date(now.getTime() + HOUR_MS);
+  const minimumWakeTime = now.getTime() + HOUR_MS;
+  const next = new Date(minimumWakeTime);
   next.setSeconds(0, 0);
+  if (next.getTime() < minimumWakeTime) {
+    next.setTime(next.getTime() + 60_000);
+  }
   next.setMinutes(
     Math.ceil(next.getMinutes() / CUSTOM_TIME_STEP_MINUTES) * CUSTOM_TIME_STEP_MINUTES,
   );
-  return formatSnoozeDateTimeLocal(next);
+
+  // datetime-local drops the timezone offset. During the repeated hour at the
+  // end of DST, formatting the later occurrence and parsing it again can pick
+  // the earlier occurrence. Advance by friendly quarter-hours until the value
+  // the form will actually submit remains at least one elapsed hour away.
+  for (;;) {
+    const value = formatSnoozeDateTimeLocal(next);
+    const parsed = parseCustomSnoozeDateTime(value, now);
+    if (parsed !== null && new Date(parsed).getTime() >= minimumWakeTime) return value;
+    next.setTime(next.getTime() + CUSTOM_TIME_STEP_MS);
+  }
 }
 
 /**
  * Interpret a datetime-local value in the browser's local timezone and
- * return the ISO command payload. Invalid and non-future values are rejected.
+ * return the ISO command payload. Invalid, normalized, and non-future values
+ * are rejected.
  */
 export function parseCustomSnoozeDateTime(value: string, now: Date): string | null {
-  if (value.trim() === "") return null;
-  const wakeAt = new Date(value);
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value.trim());
+  if (match === null) return null;
+  const [, yearText, monthText, dayText, hourText, minuteText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const wakeAt = new Date(year, month - 1, day, hour, minute, 0, 0);
   if (Number.isNaN(wakeAt.getTime()) || wakeAt.getTime() <= now.getTime()) return null;
+
+  // Date normalizes impossible wall-clock values, including the missing hour
+  // during a spring-forward transition. Reject that normalization instead of
+  // silently snoozing until a different time than the user selected.
+  if (
+    wakeAt.getFullYear() !== year ||
+    wakeAt.getMonth() !== month - 1 ||
+    wakeAt.getDate() !== day ||
+    wakeAt.getHours() !== hour ||
+    wakeAt.getMinutes() !== minute
+  ) {
+    return null;
+  }
   return wakeAt.toISOString();
 }
 

--- a/apps/web/src/components/Sidebar.snooze.ts
+++ b/apps/web/src/components/Sidebar.snooze.ts
@@ -83,12 +83,17 @@ export function defaultCustomSnoozeDateTime(now: Date): string {
   // end of DST, formatting the later occurrence and parsing it again can pick
   // the earlier occurrence. Advance by friendly quarter-hours until the value
   // the form will actually submit remains at least one elapsed hour away.
-  for (;;) {
+  for (let attempts = 0; attempts < 24 * (60 / CUSTOM_TIME_STEP_MINUTES); attempts += 1) {
     const value = formatSnoozeDateTimeLocal(next);
     const parsed = parseCustomSnoozeDateTime(value, now);
     if (parsed !== null && new Date(parsed).getTime() >= minimumWakeTime) return value;
     next.setTime(next.getTime() + CUSTOM_TIME_STEP_MS);
   }
+
+  // Valid current dates should always find a representable wall-clock value
+  // within a day. Fail closed instead of looping forever for an invalid Date
+  // or an unexpected timezone implementation.
+  return "";
 }
 
 /**

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -16,6 +16,7 @@ import type { ScopedThreadRef, SidebarProjectGroupingMode } from "@t3tools/contr
 import {
   AlarmClockIcon,
   AlarmClockOffIcon,
+  CalendarClockIcon,
   CheckIcon,
   ChevronDownIcon,
   CircleAlertIcon,
@@ -126,6 +127,9 @@ import {
   settledPrHoverColorClass,
 } from "./ThreadStatusIndicators";
 import {
+  defaultCustomSnoozeDateTime,
+  formatSnoozeDateTimeLocal,
+  parseCustomSnoozeDateTime,
   resolveSnoozePresets,
   snoozeWakeDescription,
   snoozeWakeLabel,
@@ -162,6 +166,12 @@ import { useComposerDraftStore } from "../composerDraftStore";
 // stays behind an explicit Show more.
 const SETTLED_TAIL_INITIAL_COUNT = 10;
 const SETTLED_TAIL_PAGE_COUNT = 25;
+interface CustomSnoozeRequest {
+  readonly threadRefs: ReadonlyArray<ScopedThreadRef>;
+  readonly coSnoozingKeys?: ReadonlySet<string>;
+  readonly clearSelectionOnConfirm?: boolean;
+}
+
 const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> = {
   repository: "Group by repository",
   repository_path: "Group by repository path",
@@ -310,8 +320,9 @@ function SnoozePopoverButton(props: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSnooze: (preset: SnoozePreset) => void;
+  onCustomSnooze: () => void;
 }) {
-  const { open, onOpenChange, onSnooze } = props;
+  const { open, onOpenChange, onSnooze, onCustomSnooze } = props;
   // Presets resolve at open time so "In 1 hour" is relative to the click,
   // not to when the row mounted.
   const presets = useMemo(() => (open ? resolveSnoozePresets(new Date()) : []), [open]);
@@ -348,8 +359,93 @@ function SnoozePopoverButton(props: {
             </span>
           </button>
         ))}
+        <button
+          type="button"
+          data-testid="sidebar-v2-snooze-custom"
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenChange(false);
+            onCustomSnooze();
+          }}
+          className="mt-1 flex w-full cursor-pointer items-center gap-2 border-t border-border/60 px-2 pt-2 pb-1.5 text-left text-xs text-foreground/90 hover:bg-accent hover:text-foreground"
+        >
+          <CalendarClockIcon className="size-3.5 text-muted-foreground" />
+          <span className="flex-1">Custom time…</span>
+        </button>
       </PopoverPopup>
     </Popover>
+  );
+}
+
+function CustomSnoozeDialog(props: {
+  open: boolean;
+  threadCount: number;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (snoozedUntil: string) => void;
+}) {
+  const { open, threadCount, onOpenChange, onConfirm } = props;
+  const [dateTime, setDateTime] = useState("");
+
+  useEffect(() => {
+    if (open) setDateTime(defaultCustomSnoozeDateTime(new Date()));
+  }, [open]);
+
+  const snoozedUntil = parseCustomSnoozeDateTime(dateTime, new Date());
+  const showValidation = dateTime !== "" && snoozedUntil === null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup className="max-w-sm">
+        <form
+          className="contents"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const confirmedTime = parseCustomSnoozeDateTime(dateTime, new Date());
+            if (confirmedTime !== null) onConfirm(confirmedTime);
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Snooze until</DialogTitle>
+            <DialogDescription>
+              {threadCount === 1
+                ? "Choose when this thread should return to your inbox."
+                : `Choose when these ${threadCount} threads should return to your inbox.`}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-2">
+            <label htmlFor="custom-snooze-time" className="text-sm font-medium text-foreground">
+              Date and time
+            </label>
+            <Input
+              id="custom-snooze-time"
+              data-testid="custom-snooze-time-input"
+              nativeInput
+              autoFocus
+              type="datetime-local"
+              step={60}
+              min={formatSnoozeDateTimeLocal(new Date())}
+              value={dateTime}
+              aria-invalid={showValidation || undefined}
+              aria-describedby={showValidation ? "custom-snooze-time-error" : undefined}
+              onChange={(event) => setDateTime(event.currentTarget.value)}
+            />
+            {showValidation ? (
+              <p id="custom-snooze-time-error" className="text-xs text-destructive">
+                Choose a time in the future.
+              </p>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={snoozedUntil === null}>
+              Snooze
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogPopup>
+    </Dialog>
   );
 }
 
@@ -388,6 +484,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   onSettle: (threadRef: ScopedThreadRef) => void;
   onUnsettle: (threadRef: ScopedThreadRef) => void;
   onSnooze: (threadRef: ScopedThreadRef, preset: SnoozePreset) => void;
+  onCustomSnooze: (threadRef: ScopedThreadRef) => void;
   onUnsnooze: (threadRef: ScopedThreadRef) => void;
   onChangeRequestState: (threadKey: string, state: "open" | "closed" | "merged" | null) => void;
 }) {
@@ -397,6 +494,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     onCancelRename,
     onCommitRename,
     onContextMenu,
+    onCustomSnooze,
     onRenameTitleChange,
     onSettle,
     onSnooze,
@@ -926,6 +1024,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                         open={snoozeMenuOpen}
                         onOpenChange={setSnoozeMenuOpen}
                         onSnooze={handleSnoozePreset}
+                        onCustomSnooze={() => onCustomSnooze(threadRef)}
                       />
                     ) : null}
                     {props.settlementSupported ? (
@@ -1039,6 +1138,7 @@ export default function SidebarV2() {
   const [projectActionsTarget, setProjectActionsTarget] = useState<SidebarProjectSnapshot | null>(
     null,
   );
+  const [customSnoozeRequest, setCustomSnoozeRequest] = useState<CustomSnoozeRequest | null>(null);
   const [projectScopeMenuOpen, setProjectScopeMenuOpen] = useState(false);
   const newThreadContext = useHandleNewThread();
   const openAddProjectCommandPalette = useCallback(
@@ -1769,7 +1869,7 @@ export default function SidebarV2() {
   const attemptSnooze = useCallback(
     (
       threadRef: ScopedThreadRef,
-      preset: SnoozePreset,
+      selection: Pick<SnoozePreset, "snoozedUntil">,
       opts: { coSnoozingKeys?: ReadonlySet<string> } = {},
     ) => {
       void (async () => {
@@ -1780,7 +1880,7 @@ export default function SidebarV2() {
           // Snoozing the open thread moves you forward, same as settle —
           // both park the thread you're done with for now.
           const navigateAfterSnooze = planForwardNavigation(threadKey, opts.coSnoozingKeys);
-          const result = await snoozeThread(threadRef, preset.snoozedUntil);
+          const result = await snoozeThread(threadRef, selection.snoozedUntil);
           if (result._tag === "Failure") {
             // Never navigate away from a thread that did not snooze.
             if (!isAtomCommandInterrupted(result)) {
@@ -1800,7 +1900,7 @@ export default function SidebarV2() {
           toastManager.add(
             stackedThreadToast({
               type: "success",
-              title: `Snoozed until ${snoozeWakeDescription(preset.snoozedUntil, new Date())}`,
+              title: `Snoozed until ${snoozeWakeDescription(selection.snoozedUntil, new Date())}`,
               timeout: 5_000,
               actionProps: {
                 children: "Undo",
@@ -1819,6 +1919,22 @@ export default function SidebarV2() {
       })();
     },
     [attemptUnsnooze, planForwardNavigation, snoozeThread],
+  );
+  const confirmCustomSnooze = useCallback(
+    (snoozedUntil: string) => {
+      const request = customSnoozeRequest;
+      if (request === null) return;
+      setCustomSnoozeRequest(null);
+      for (const threadRef of request.threadRefs) {
+        attemptSnooze(
+          threadRef,
+          { snoozedUntil },
+          request.coSnoozingKeys === undefined ? {} : { coSnoozingKeys: request.coSnoozingKeys },
+        );
+      }
+      if (request.clearSelectionOnConfirm) clearSelection();
+    },
+    [attemptSnooze, clearSelection, customSnoozeRequest],
   );
 
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
@@ -1857,10 +1973,13 @@ export default function SidebarV2() {
                   {
                     id: "snooze",
                     label: `Snooze (${count})`,
-                    children: snoozePresets.map((preset) => ({
-                      id: `snooze:${preset.id}`,
-                      label: `${preset.label} (${preset.whenLabel})`,
-                    })),
+                    children: [
+                      ...snoozePresets.map((preset) => ({
+                        id: `snooze:${preset.id}`,
+                        label: `${preset.label} (${preset.whenLabel})`,
+                      })),
+                      { id: "snooze:custom", label: "Custom time…" },
+                    ],
                   },
                 ]
               : []),
@@ -1871,6 +1990,17 @@ export default function SidebarV2() {
         ),
       );
       if (clicked._tag === "Failure") return;
+      if (clicked.value === "snooze:custom") {
+        const coSnoozingKeys = new Set(threadKeys);
+        setCustomSnoozeRequest({
+          threadRefs: snoozableThreads.map((thread) =>
+            scopeThreadRef(thread.environmentId, thread.id),
+          ),
+          coSnoozingKeys,
+          clearSelectionOnConfirm: true,
+        });
+        return;
+      }
       if (clicked.value?.startsWith("snooze:")) {
         const preset = snoozePresets.find(
           (candidate) => `snooze:${candidate.id}` === clicked.value,
@@ -2014,10 +2144,13 @@ export default function SidebarV2() {
                           id: "snooze",
                           label: "Snooze",
                           disabled: !canSnooze(thread, { now: new Date().toISOString() }),
-                          children: snoozePresets.map((preset) => ({
-                            id: `snooze:${preset.id}`,
-                            label: `${preset.label} (${preset.whenLabel})`,
-                          })),
+                          children: [
+                            ...snoozePresets.map((preset) => ({
+                              id: `snooze:${preset.id}`,
+                              label: `${preset.label} (${preset.whenLabel})`,
+                            })),
+                            { id: "snooze:custom", label: "Custom time…" },
+                          ],
                         },
                   ]
                 : []),
@@ -2029,6 +2162,10 @@ export default function SidebarV2() {
           ),
         );
         if (clicked._tag === "Failure") return;
+        if (clicked.value === "snooze:custom") {
+          setCustomSnoozeRequest({ threadRefs: [threadRef] });
+          return;
+        }
         if (clicked.value?.startsWith("snooze:")) {
           const preset = snoozePresets.find(
             (candidate) => `snooze:${candidate.id}` === clicked.value,
@@ -2450,6 +2587,9 @@ export default function SidebarV2() {
                       onSettle={attemptSettle}
                       onUnsettle={attemptUnsettle}
                       onSnooze={attemptSnooze}
+                      onCustomSnooze={(threadRef) =>
+                        setCustomSnoozeRequest({ threadRefs: [threadRef] })
+                      }
                       onUnsnooze={attemptUnsnooze}
                       onChangeRequestState={handleChangeRequestState}
                     />
@@ -2560,6 +2700,14 @@ export default function SidebarV2() {
           ) : null}
         </SidebarGroup>
       </SidebarContent>
+      <CustomSnoozeDialog
+        open={customSnoozeRequest !== null}
+        threadCount={customSnoozeRequest?.threadRefs.length ?? 1}
+        onOpenChange={(open) => {
+          if (!open) setCustomSnoozeRequest(null);
+        }}
+        onConfirm={confirmCustomSnooze}
+      />
       <Dialog
         open={projectActionsTarget !== null}
         onOpenChange={(open) => {

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -385,12 +385,17 @@ function CustomSnoozeDialog(props: {
 }) {
   const { open, threadCount, onOpenChange, onConfirm } = props;
   const [dateTime, setDateTime] = useState("");
+  const [validationNow, setValidationNow] = useState(() => new Date());
 
   useEffect(() => {
-    if (open) setDateTime(defaultCustomSnoozeDateTime(new Date()));
+    if (open) {
+      const now = new Date();
+      setDateTime(defaultCustomSnoozeDateTime(now));
+      setValidationNow(now);
+    }
   }, [open]);
 
-  const snoozedUntil = parseCustomSnoozeDateTime(dateTime, new Date());
+  const snoozedUntil = parseCustomSnoozeDateTime(dateTime, validationNow);
   const showValidation = dateTime !== "" && snoozedUntil === null;
 
   return (
@@ -400,8 +405,15 @@ function CustomSnoozeDialog(props: {
           className="contents"
           onSubmit={(event) => {
             event.preventDefault();
-            const confirmedTime = parseCustomSnoozeDateTime(dateTime, new Date());
-            if (confirmedTime !== null) onConfirm(confirmedTime);
+            const now = new Date();
+            const confirmedTime = parseCustomSnoozeDateTime(dateTime, now);
+            if (confirmedTime !== null) {
+              onConfirm(confirmedTime);
+            } else {
+              // Force validation against the submit-time clock. A value can
+              // expire while the dialog is open without causing a render.
+              setValidationNow(now);
+            }
           }}
         >
           <DialogHeader>
@@ -427,11 +439,14 @@ function CustomSnoozeDialog(props: {
               value={dateTime}
               aria-invalid={showValidation || undefined}
               aria-describedby={showValidation ? "custom-snooze-time-error" : undefined}
-              onChange={(event) => setDateTime(event.currentTarget.value)}
+              onChange={(event) => {
+                setDateTime(event.currentTarget.value);
+                setValidationNow(new Date());
+              }}
             />
             {showValidation ? (
               <p id="custom-snooze-time-error" className="text-xs text-destructive">
-                Choose a time in the future.
+                Choose a valid time in the future.
               </p>
             ) : null}
           </DialogPanel>


### PR DESCRIPTION
## What Changed

- add a “Custom time…” option to the sidebar snooze popover and native context menus
- let users choose a local date and time for one thread or a multi-selection
- reject invalid and past wake times before dispatching the existing snooze command
- add focused coverage for local datetime formatting, defaults, conversion, and validation

## Why

The preset snooze times cover common cases, but they cannot express a specific deadline or return time. A custom picker keeps the quick presets while allowing precise scheduling when needed.

## UI Changes

The snooze menu now includes a separated “Custom time…” action. It opens a compact date/time dialog with a future-time default, inline validation, and the existing snooze confirmation flow.

**Before**

![Snooze menu before the change](https://raw.githubusercontent.com/colonelpanic8/t3code/0f045e88016a0f16d4975020f1abfe359261f6fb/.github/pr-assets/4677/before.png)

**After**

![Snooze menu with the custom-time option](https://raw.githubusercontent.com/colonelpanic8/t3code/0f045e88016a0f16d4975020f1abfe359261f6fb/.github/pr-assets/4677/after-menu.png)

![Custom snooze date and time dialog](https://raw.githubusercontent.com/colonelpanic8/t3code/0f045e88016a0f16d4975020f1abfe359261f6fb/.github/pr-assets/4677/after-dialog.png)

## Checklist

- [x] `vp check` (passes; reports 11 existing warnings)
- [x] `vp test run apps/web/src/components/Sidebar.snooze.test.ts` (10 tests pass)
- [x] exercised the real sidebar flow in an isolated web environment
- [ ] `vp run typecheck` — blocked on current `main` by the patched `@effect/vitest` package not exporting `assert`/`describe`; this occurs before the changed web package and is unrelated to this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI and validation on top of the existing snooze command; no server or auth changes. DST handling is the main subtlety and is covered by tests.
> 
> **Overview**
> Adds **custom snooze scheduling** alongside the existing presets: users can pick an exact local date and time for one thread or a multi-selection.
> 
> **`Sidebar.snooze.ts`** introduces `formatSnoozeDateTimeLocal`, `defaultCustomSnoozeDateTime`, and `parseCustomSnoozeDateTime` for native `datetime-local` values—defaults at least one hour ahead on 15-minute steps, rejects past/invalid input, and handles DST gaps and the repeated fall hour via round-trip validation.
> 
> **`SidebarV2.tsx`** wires a **Custom time…** entry into the snooze popover and context menus, opens `CustomSnoozeDialog` with inline validation, and routes confirmed ISO timestamps through the existing snooze path (`attemptSnooze` now takes `{ snoozedUntil }` instead of a full preset). Tests cover formatting, defaults, parsing, and DST cases in `Sidebar.snooze.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b728aed7d53f1c21fd1422977e4c160803baf72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add custom snooze times to sidebar thread snooze flow
> - Adds a 'Custom time…' option to the snooze popover and context menus (single and multi-select) in [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4677/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c), opening a new `CustomSnoozeDialog` for picking an arbitrary future time.
> - `CustomSnoozeDialog` initializes to at least one hour ahead on a 15-minute boundary, validates input on change, and rejects past, invalid, or DST-gap times before submitting an ISO timestamp.
> - Adds `parseCustomSnoozeDateTime`, `formatSnoozeDateTimeLocal`, and `defaultCustomSnoozeDateTime` helpers in [Sidebar.snooze.ts](https://github.com/pingdotgg/t3code/pull/4677/files#diff-aa08b135e6021ee4769614f1b47560550d1c612002868fa231671cc6dd92189c) with full DST edge-case handling (repeated hour and gap detection via round-trip validation).
> - The internal `attemptSnooze` handler is refactored to accept a direct `snoozedUntil` timestamp object instead of a preset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b728ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->