### PR TITLE
Fix sidebar highlighting for draft threads

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -96,7 +96,11 @@ import { threadEnvironment } from "../state/threads";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import { useAtomCommand } from "../state/use-atom-command";
-import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
+import {
+  buildThreadRouteParams,
+  resolveActiveThreadRouteRef,
+  resolveThreadRouteTarget,
+} from "../threadRoutes";
 import { formatRelativeTimeLabel, parseTimestampDate } from "../timestampFormat";
 import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
@@ -1052,7 +1056,13 @@ export default function SidebarV2() {
     strict: false,
     select: (params) => resolveThreadRouteTarget(params),
   });
-  const routeThreadRef = routeTarget?.kind === "server" ? routeTarget.threadRef : null;
+  const routeDraftThread = useComposerDraftStore((store) =>
+    routeTarget?.kind === "draft" ? store.getDraftSession(routeTarget.draftId) : null,
+  );
+  const routeThreadRef = useMemo(
+    () => resolveActiveThreadRouteRef(routeTarget, routeDraftThread),
+    [routeDraftThread, routeTarget],
+  );
   const routeThreadKey = routeThreadRef ? scopedThreadKey(routeThreadRef) : null;
   const routeTargetRef = useRef(routeTarget);
   routeTargetRef.current = routeTarget;


### PR DESCRIPTION
## What Changed

Updated sidebar route highlighting to resolve the active thread reference for draft threads, in addition to server-backed threads.

## Why

Draft thread routes were not producing a thread reference, so the corresponding sidebar item could fail to highlight. The sidebar now resolves the active reference from the draft session when the route targets a draft.

## UI Changes

The sidebar now correctly highlights the active draft thread.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI routing parity change in SidebarV2, mirroring an established Sidebar v1 pattern with no auth or data-layer impact.
> 
> **Overview**
> **Sidebar V2** now resolves the active thread from the URL the same way as v1: it loads the composer **draft session** when the route is a draft and derives `routeThreadRef` via **`resolveActiveThreadRouteRef`** instead of only handling `kind === "server"`.
> 
> That keeps **active-row highlighting** (and anything keyed off `routeThreadKey`, such as settled/snoozed shelf exceptions and keyboard navigation) correct while you are on a draft URL—especially when the draft has **`promotedTo`** a server thread, so the matching sidebar shell can light up. Unpromoted draft routes still resolve to no thread ref, matching the existing `threadRoutes` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2089260ccf64f3e768d2a6dd0574a796863dd462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar highlighting for draft threads in `SidebarV2`
> The sidebar was not highlighting the active thread when viewing a draft thread because `routeThreadRef` only resolved for server-side route targets. `SidebarV2` now uses `resolveActiveThreadRouteRef` to derive `routeThreadRef` for both `'server'` and `'draft'` route target kinds, looking up the active draft session via `useComposerDraftStore` when needed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2089260.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->