### PR TITLE
Show origin ref in branch trigger label

### DIFF
--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -9,6 +9,7 @@ import {
   resolveDraftEnvModeAfterBranchChange,
   resolveEffectiveEnvMode,
   resolveEnvModeLabel,
+  resolveBranchTriggerLabel,
   resolveBranchToolbarPrBranch,
   resolveBranchToolbarValue,
   resolveLockedWorkspaceLabel,
@@ -171,6 +172,60 @@ describe("resolveBranchToolbarValue", () => {
         currentGitBranch: "main",
       }),
     ).toBe("main");
+  });
+});
+
+describe("resolveBranchTriggerLabel", () => {
+  it("shows the origin ref when a new worktree will start from origin", () => {
+    expect(
+      resolveBranchTriggerLabel({
+        activeWorktreePath: null,
+        effectiveEnvMode: "worktree",
+        resolvedActiveBranch: "main",
+        startFromOrigin: true,
+      }),
+    ).toBe("From origin/main");
+  });
+
+  it("shows the local ref when start from origin is disabled", () => {
+    expect(
+      resolveBranchTriggerLabel({
+        activeWorktreePath: null,
+        effectiveEnvMode: "worktree",
+        resolvedActiveBranch: "main",
+        startFromOrigin: false,
+      }),
+    ).toBe("From main");
+  });
+
+  it("does not duplicate the origin prefix for an explicit remote ref", () => {
+    expect(
+      resolveBranchTriggerLabel({
+        activeWorktreePath: null,
+        effectiveEnvMode: "worktree",
+        resolvedActiveBranch: "origin/feature/demo",
+        startFromOrigin: true,
+      }),
+    ).toBe("From origin/feature/demo");
+  });
+
+  it("keeps current-checkout labels and empty state unchanged", () => {
+    expect(
+      resolveBranchTriggerLabel({
+        activeWorktreePath: null,
+        effectiveEnvMode: "local",
+        resolvedActiveBranch: "main",
+        startFromOrigin: true,
+      }),
+    ).toBe("main");
+    expect(
+      resolveBranchTriggerLabel({
+        activeWorktreePath: null,
+        effectiveEnvMode: "worktree",
+        resolvedActiveBranch: null,
+        startFromOrigin: true,
+      }),
+    ).toBe("Select ref");
   });
 });
 

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -182,9 +182,22 @@ describe("resolveBranchTriggerLabel", () => {
         activeWorktreePath: null,
         effectiveEnvMode: "worktree",
         resolvedActiveBranch: "main",
+        resolvedActiveBranchIsRemote: false,
         startFromOrigin: true,
       }),
     ).toBe("From origin/main");
+  });
+
+  it("shows the origin ref for local branch names that contain slashes", () => {
+    expect(
+      resolveBranchTriggerLabel({
+        activeWorktreePath: null,
+        effectiveEnvMode: "worktree",
+        resolvedActiveBranch: "feature/demo",
+        resolvedActiveBranchIsRemote: false,
+        startFromOrigin: true,
+      }),
+    ).toBe("From origin/feature/demo");
   });
 
   it("shows the local ref when start from origin is disabled", () => {
@@ -193,6 +206,7 @@ describe("resolveBranchTriggerLabel", () => {
         activeWorktreePath: null,
         effectiveEnvMode: "worktree",
         resolvedActiveBranch: "main",
+        resolvedActiveBranchIsRemote: false,
         startFromOrigin: false,
       }),
     ).toBe("From main");
@@ -204,9 +218,22 @@ describe("resolveBranchTriggerLabel", () => {
         activeWorktreePath: null,
         effectiveEnvMode: "worktree",
         resolvedActiveBranch: "origin/feature/demo",
+        resolvedActiveBranchIsRemote: true,
         startFromOrigin: true,
       }),
     ).toBe("From origin/feature/demo");
+  });
+
+  it("preserves an explicit ref from a non-origin remote", () => {
+    expect(
+      resolveBranchTriggerLabel({
+        activeWorktreePath: null,
+        effectiveEnvMode: "worktree",
+        resolvedActiveBranch: "upstream/feature/demo",
+        resolvedActiveBranchIsRemote: true,
+        startFromOrigin: true,
+      }),
+    ).toBe("From upstream/feature/demo");
   });
 
   it("keeps current-checkout labels and empty state unchanged", () => {
@@ -215,6 +242,7 @@ describe("resolveBranchTriggerLabel", () => {
         activeWorktreePath: null,
         effectiveEnvMode: "local",
         resolvedActiveBranch: "main",
+        resolvedActiveBranchIsRemote: false,
         startFromOrigin: true,
       }),
     ).toBe("main");
@@ -223,9 +251,22 @@ describe("resolveBranchTriggerLabel", () => {
         activeWorktreePath: null,
         effectiveEnvMode: "worktree",
         resolvedActiveBranch: null,
+        resolvedActiveBranchIsRemote: null,
         startFromOrigin: true,
       }),
     ).toBe("Select ref");
+  });
+
+  it("does not fabricate an origin ref while branch metadata is loading", () => {
+    expect(
+      resolveBranchTriggerLabel({
+        activeWorktreePath: null,
+        effectiveEnvMode: "worktree",
+        resolvedActiveBranch: "upstream/feature/demo",
+        resolvedActiveBranchIsRemote: null,
+        startFromOrigin: true,
+      }),
+    ).toBe("From upstream/feature/demo");
   });
 });
 

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -156,6 +156,26 @@ export function resolveBranchToolbarValue(input: {
   return currentGitBranch ?? activeThreadBranch;
 }
 
+export function resolveBranchTriggerLabel(input: {
+  activeWorktreePath: string | null;
+  effectiveEnvMode: EnvMode;
+  resolvedActiveBranch: string | null;
+  startFromOrigin: boolean;
+}): string {
+  const { activeWorktreePath, effectiveEnvMode, resolvedActiveBranch, startFromOrigin } = input;
+  if (!resolvedActiveBranch) {
+    return "Select ref";
+  }
+  if (effectiveEnvMode === "worktree" && !activeWorktreePath) {
+    const baseRef =
+      startFromOrigin && !resolvedActiveBranch.startsWith("origin/")
+        ? `origin/${resolvedActiveBranch}`
+        : resolvedActiveBranch;
+    return `From ${baseRef}`;
+  }
+  return resolvedActiveBranch;
+}
+
 export function resolveBranchToolbarPrBranch(input: {
   activeThreadBranch: string | null;
   resolvedActiveBranch: string | null;

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -160,15 +160,22 @@ export function resolveBranchTriggerLabel(input: {
   activeWorktreePath: string | null;
   effectiveEnvMode: EnvMode;
   resolvedActiveBranch: string | null;
+  resolvedActiveBranchIsRemote: boolean | null;
   startFromOrigin: boolean;
 }): string {
-  const { activeWorktreePath, effectiveEnvMode, resolvedActiveBranch, startFromOrigin } = input;
+  const {
+    activeWorktreePath,
+    effectiveEnvMode,
+    resolvedActiveBranch,
+    resolvedActiveBranchIsRemote,
+    startFromOrigin,
+  } = input;
   if (!resolvedActiveBranch) {
     return "Select ref";
   }
   if (effectiveEnvMode === "worktree" && !activeWorktreePath) {
     const baseRef =
-      startFromOrigin && !resolvedActiveBranch.startsWith("origin/")
+      startFromOrigin && resolvedActiveBranchIsRemote === false
         ? `origin/${resolvedActiveBranch}`
         : resolvedActiveBranch;
     return `From ${baseRef}`;

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -294,6 +294,29 @@ export function BranchToolbarBranchSelector({
     canonicalActiveBranch,
     (_currentBranch: string | null, optimisticBranch: string | null) => optimisticBranch,
   );
+  const listedActiveBranch =
+    resolvedActiveBranch === null ? null : (branchByName.get(resolvedActiveBranch) ?? null);
+  const activeBranchRefQuery = useEnvironmentQuery(
+    branchCwd !== null && resolvedActiveBranch !== null
+      ? vcsEnvironment.listRefs({
+          environmentId,
+          input: {
+            cwd: branchCwd,
+            query: resolvedActiveBranch,
+            limit: 10,
+          },
+        })
+      : null,
+  );
+  const queriedActiveBranch = activeBranchRefQuery.data?.refs.find(
+    (refName) => refName.name === resolvedActiveBranch,
+  );
+  const resolvedActiveBranchIsRemote =
+    listedActiveBranch !== null
+      ? listedActiveBranch.isRemote === true
+      : queriedActiveBranch
+        ? queriedActiveBranch.isRemote === true
+        : null;
   const [isBranchActionPending, startBranchActionTransition] = useTransition();
   const totalBranchCount = branchRefState.data?.totalCount ?? 0;
   const branchStatusText = isInitialBranchesLoadPending
@@ -574,6 +597,7 @@ export function BranchToolbarBranchSelector({
     activeWorktreePath,
     effectiveEnvMode,
     resolvedActiveBranch,
+    resolvedActiveBranchIsRemote,
     startFromOrigin,
   });
 

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -35,6 +35,7 @@ import { parsePullRequestReference } from "../pullRequestReference";
 import { getSourceControlPresentation } from "../sourceControlPresentation";
 import {
   deriveLocalBranchNameFromRemoteRef,
+  resolveBranchTriggerLabel,
   resolveBranchToolbarPrBranch,
   resolveBranchSelectionTarget,
   resolveBranchToolbarValue,
@@ -79,21 +80,6 @@ interface BranchToolbarBranchSelectorProps {
 
 function toBranchActionErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "An error occurred.";
-}
-
-function getBranchTriggerLabel(input: {
-  activeWorktreePath: string | null;
-  effectiveEnvMode: "local" | "worktree";
-  resolvedActiveBranch: string | null;
-}): string {
-  const { activeWorktreePath, effectiveEnvMode, resolvedActiveBranch } = input;
-  if (!resolvedActiveBranch) {
-    return "Select ref";
-  }
-  if (effectiveEnvMode === "worktree" && !activeWorktreePath) {
-    return `From ${resolvedActiveBranch}`;
-  }
-  return resolvedActiveBranch;
 }
 
 export function BranchToolbarBranchSelector({
@@ -584,10 +570,11 @@ export function BranchToolbarBranchSelector({
     maybeFetchNextBranchPage();
   }, [refs.length, maybeFetchNextBranchPage]);
 
-  const triggerLabel = getBranchTriggerLabel({
+  const triggerLabel = resolveBranchTriggerLabel({
     activeWorktreePath,
     effectiveEnvMode,
     resolvedActiveBranch,
+    startFromOrigin,
   });
 
   // PR pill shown next to the branch selector when the active branch has one.


### PR DESCRIPTION
## What Changed

- Show `From origin/<branch>` in the branch trigger when a new worktree starts from origin.
- Preserve existing labels for local checkouts, explicit remote refs, and empty selections.
- Extract the label resolution logic and add focused tests.

## Why

When creating a new worktree from origin, the branch trigger previously displayed only the local branch name, making the actual starting ref ambiguous. The updated label makes the source ref explicit without duplicating the `origin/` prefix.

## UI Changes

The branch trigger now displays `From origin/<branch>` when `startFromOrigin` is enabled for a new worktree. No screenshots or video are included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only label and ref-metadata wiring in the branch selector; no auth, checkout, or worktree creation behavior changes.
> 
> **Overview**
> The branch toolbar trigger label now reflects **start from origin** when picking a base ref for a **new worktree**: with the toggle on and a **local** branch selected, it shows `From origin/<branch>` instead of only the branch name.
> 
> Label logic moves into **`resolveBranchTriggerLabel`** in shared branch-toolbar logic (replacing the inline helper). The selector resolves whether the active ref is remote (picker list or a small **`listRefs`** lookup) so the UI does not double-prefix `origin/` on explicit remote refs, keeps non-origin remotes as-is, and avoids inventing `origin/` while remote/local metadata is still unknown.
> 
> Existing behavior is unchanged for **current checkout** labels, empty selection, and `From <ref>` when start-from-origin is off. Unit tests cover slashes in branch names and loading edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d91aa21abc5cf1e7e27485e2eada50bd041f83e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show origin-prefixed ref in branch selector trigger label for new worktree creation
> - Extracts a new `resolveBranchTriggerLabel` utility in [BranchToolbar.logic.ts](https://github.com/pingdotgg/t3code/pull/4680/files#diff-22eaeeb6cc7f6e680a66d29924a8aa6c56a51450578462389a4b649102ea655f) that computes the branch selector trigger label, replacing the local `getBranchTriggerLabel` helper in [BranchToolbarBranchSelector.tsx](https://github.com/pingdotgg/t3code/pull/4680/files#diff-95e72064c321265e2363abda12fd803f217db7d06a32a076ea7337d942367734).
> - When creating a new worktree with `startFromOrigin` enabled, the label now shows `From origin/<branch>` instead of `From <branch>` for local branches.
> - To determine if the active branch is local or remote, the component checks `branchByName` first, then falls back to a `vcsEnvironment.listRefs` query when the branch status is unknown.
> - Explicit remote refs (e.g. `remote/branch`) are preserved as-is; non-origin remotes are not prefixed with `origin/`.
> - Behavioral Change: the component may now issue an additional `listRefs` query when the active branch is not found in the local branch list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d91aa21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->