### PR TITLE
fix(preview): bound automation waits and screenshot captures

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -749,10 +749,30 @@ describe("PreviewManager", () => {
           /\/browser-artifacts\/browser-screenshot-example-com-[^.]+\.png$/,
         );
 
+        // Chromium reports UnknownVizError while a hidden guest warms its
+        // first compositor frame, so transient failures are retried.
+        capturePage.mockClear();
+        capturePage.mockRejectedValueOnce(new Error("UnknownVizError"));
+        capturePage.mockRejectedValueOnce(new Error("UnknownVizError"));
+        const retriedFiber = yield* Effect.exit(manager.captureScreenshot("tab_1")).pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* TestClock.adjust(1_000);
+        const retriedExit = yield* Fiber.join(retriedFiber);
+        expect(Exit.isSuccess(retriedExit)).toBe(true);
+        expect(capturePage).toHaveBeenCalledTimes(3);
+
+        // A persistent failure still surfaces once the retries are spent.
+        capturePage.mockClear();
         const captureCause = new Error("capture failed");
-        capturePage.mockRejectedValueOnce(captureCause);
-        const exit = yield* Effect.exit(manager.captureScreenshot("tab_1"));
+        capturePage.mockRejectedValue(captureCause);
+        const failingFiber = yield* Effect.exit(manager.captureScreenshot("tab_1")).pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* TestClock.adjust(1_000);
+        const exit = yield* Fiber.join(failingFiber);
         expect(Exit.isFailure(exit)).toBe(true);
+        expect(capturePage).toHaveBeenCalledTimes(3);
         if (Exit.isSuccess(exit)) return;
         const error = Option.getOrThrow(Cause.findErrorOption(exit.cause));
         expect(error).toMatchObject({

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -786,6 +786,36 @@ describe("PreviewManager", () => {
     ),
   );
 
+  effectIt.effect("stops capture retries when the tab swaps to another guest", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const capturePage = vi.fn(async () => ({
+          toPNG: () => Buffer.from("png"),
+          toJPEG: () => Buffer.from("jpeg"),
+          getSize: () => ({ width: 100, height: 80 }),
+        }));
+        fromId.mockReturnValue(makeTestPreviewWebContents(capturePage, 42));
+        yield* manager.createTab("tab_1");
+        yield* manager.registerWebview("tab_1", 42);
+
+        // Fail persistently, then swap the tab onto a different web contents:
+        // retrying against the detached guest would capture the wrong page.
+        capturePage.mockClear();
+        capturePage.mockRejectedValue(new Error("UnknownVizError"));
+        const fiber = yield* Effect.exit(manager.captureScreenshot("tab_1")).pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        fromId.mockReturnValue(makeTestPreviewWebContents(capturePage, 43));
+        yield* manager.registerWebview("tab_1", 43);
+        yield* TestClock.adjust(1_000);
+        const exit = yield* Fiber.join(fiber);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(capturePage).toHaveBeenCalledTimes(1);
+      }),
+    ),
+  );
+
   effectIt.effect("captures hidden preview recordings independently for concurrent tabs", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -1987,10 +1987,30 @@ describe("PreviewManager", () => {
           /\/browser-artifacts\/browser-screenshot-example-com-[^.]+\.png$/,
         );
 
+        // Chromium reports UnknownVizError while a hidden guest warms its
+        // first compositor frame, so transient failures are retried.
+        capturePage.mockClear();
+        capturePage.mockRejectedValueOnce(new Error("UnknownVizError"));
+        capturePage.mockRejectedValueOnce(new Error("UnknownVizError"));
+        const retriedFiber = yield* Effect.exit(manager.captureScreenshot("tab_1")).pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* TestClock.adjust(1_000);
+        const retriedExit = yield* Fiber.join(retriedFiber);
+        expect(Exit.isSuccess(retriedExit)).toBe(true);
+        expect(capturePage).toHaveBeenCalledTimes(3);
+
+        // A persistent failure still surfaces once the retries are spent.
+        capturePage.mockClear();
         const captureCause = new Error("capture failed");
-        capturePage.mockRejectedValueOnce(captureCause);
-        const exit = yield* Effect.exit(manager.captureScreenshot("tab_1"));
+        capturePage.mockRejectedValue(captureCause);
+        const failingFiber = yield* Effect.exit(manager.captureScreenshot("tab_1")).pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* TestClock.adjust(1_000);
+        const exit = yield* Fiber.join(failingFiber);
         expect(Exit.isFailure(exit)).toBe(true);
+        expect(capturePage).toHaveBeenCalledTimes(3);
         if (Exit.isSuccess(exit)) return;
         const error = Option.getOrThrow(Cause.findErrorOption(exit.cause));
         expect(error).toMatchObject({

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -2344,7 +2344,7 @@ describe("PreviewManager", () => {
     ),
   );
 
-  effectIt.effect("stops capture retries when the tab swaps to another guest", () =>
+  effectIt.effect("stops capture retries when the tab swaps during the retry delay", () =>
     withManager((manager) =>
       Effect.gen(function* () {
         const capturePage = vi.fn(async () => ({
@@ -2356,13 +2356,13 @@ describe("PreviewManager", () => {
         yield* manager.createTab("tab_1");
         yield* manager.registerWebview("tab_1", 42);
 
-        // Fail persistently, then swap the tab onto a different web contents:
-        // retrying against the detached guest would capture the wrong page.
-        capturePage.mockClear();
-        capturePage.mockRejectedValue(new Error("UnknownVizError"));
+        capturePage.mockRejectedValueOnce(new Error("UnknownVizError"));
         const fiber = yield* Effect.exit(manager.captureScreenshot("tab_1")).pipe(
           Effect.forkChild({ startImmediately: true }),
         );
+        // Let the rejection schedule its retry before replacing the guest.
+        yield* TestClock.adjust(60);
+        expect(capturePage).toHaveBeenCalledTimes(1);
         fromId.mockReturnValue(makeTestPreviewWebContents(capturePage, 43));
         yield* manager.registerWebview("tab_1", 43);
         yield* TestClock.adjust(1_000);
@@ -2370,6 +2370,97 @@ describe("PreviewManager", () => {
 
         expect(Exit.isFailure(exit)).toBe(true);
         expect(capturePage).toHaveBeenCalledTimes(1);
+        expect(writeFile).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+
+  effectIt.effect("discards a screenshot that resolves after its guest is replaced", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const image = {
+          toPNG: () => Buffer.from("stale-png"),
+          toJPEG: () => Buffer.from("stale-jpeg"),
+          getSize: () => ({ width: 100, height: 80 }),
+        };
+        const pending = Promise.withResolvers<typeof image>();
+        const capturePage = vi.fn(() => pending.promise);
+        fromId.mockReturnValue(makeTestPreviewWebContents(capturePage, 42));
+        yield* manager.createTab("tab_1");
+        yield* manager.registerWebview("tab_1", 42);
+
+        const fiber = yield* Effect.exit(manager.captureScreenshot("tab_1")).pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* TestClock.adjust(0);
+        expect(capturePage).toHaveBeenCalledOnce();
+        fromId.mockReturnValue(makeTestPreviewWebContents(capturePage, 43));
+        yield* manager.registerWebview("tab_1", 43);
+        pending.resolve(image);
+        const exit = yield* Fiber.join(fiber);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(capturePage).toHaveBeenCalledOnce();
+        expect(writeFile).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+
+  effectIt.effect("releases snapshot control when every capture attempt stalls", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const capturePage = vi.fn(() => new Promise<TestCapturedPreviewImage>(() => {}));
+        const wc = makeTestPreviewWebContents(capturePage);
+        Object.assign(wc, { isDevToolsOpened: () => false });
+        Object.assign(wc.debugger, {
+          sendCommand: vi.fn(async (method: string, params?: Record<string, unknown>) => {
+            if (method === "Runtime.evaluate") {
+              return {
+                result: {
+                  value:
+                    params?.["expression"] === "42"
+                      ? 42
+                      : {
+                          url: "https://example.com",
+                          title: "Example",
+                          loading: false,
+                          visibleText: "Example",
+                          interactiveElements: [],
+                        },
+                },
+              };
+            }
+            return method === "Accessibility.getFullAXTree" ? { nodes: [] } : undefined;
+          }),
+        });
+        fromId.mockReturnValue(wc);
+        yield* manager.createTab("tab_1");
+        yield* manager.registerWebview("tab_1", 42);
+
+        const snapshot = yield* Effect.exit(manager.automationSnapshot("tab_1")).pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* TestClock.adjust(100);
+        expect(capturePage).toHaveBeenCalledOnce();
+        const evaluate = yield* manager
+          .automationEvaluate("tab_1", { expression: "42" })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        expect(evaluate.pollUnsafe()).toBeUndefined();
+
+        yield* TestClock.adjust(4_000);
+        const exit = yield* Fiber.join(snapshot);
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(capturePage).toHaveBeenCalledTimes(3);
+        if (Exit.isSuccess(exit)) return;
+        const error = Option.getOrThrow(Cause.findErrorOption(exit.cause));
+        expect(error).toMatchObject({
+          _tag: "PreviewOperationError",
+          operation: "automationSnapshot.capturePage",
+          tabId: "tab_1",
+          webContentsId: 42,
+          cause: { _tag: "TimeoutError" },
+        });
+        expect(yield* Fiber.join(evaluate)).toBe(42);
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -2344,6 +2344,36 @@ describe("PreviewManager", () => {
     ),
   );
 
+  effectIt.effect("stops capture retries when the tab swaps to another guest", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const capturePage = vi.fn(async () => ({
+          toPNG: () => Buffer.from("png"),
+          toJPEG: () => Buffer.from("jpeg"),
+          getSize: () => ({ width: 100, height: 80 }),
+        }));
+        fromId.mockReturnValue(makeTestPreviewWebContents(capturePage, 42));
+        yield* manager.createTab("tab_1");
+        yield* manager.registerWebview("tab_1", 42);
+
+        // Fail persistently, then swap the tab onto a different web contents:
+        // retrying against the detached guest would capture the wrong page.
+        capturePage.mockClear();
+        capturePage.mockRejectedValue(new Error("UnknownVizError"));
+        const fiber = yield* Effect.exit(manager.captureScreenshot("tab_1")).pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        fromId.mockReturnValue(makeTestPreviewWebContents(capturePage, 43));
+        yield* manager.registerWebview("tab_1", 43);
+        yield* TestClock.adjust(1_000);
+        const exit = yield* Fiber.join(fiber);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(capturePage).toHaveBeenCalledTimes(1);
+      }),
+    ),
+  );
+
   effectIt.effect("grants each concurrent preview recording its own tab frame", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -522,14 +522,29 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   /**
    * capturePage for one-shot captures (snapshots, screenshots), retrying the
    * transient compositor warm-up failure instead of surfacing it to callers.
+   *
+   * Retries stop as soon as the tab no longer points at this guest, so a
+   * webview swap during the retry window surfaces the original failure instead
+   * of capturing from a detached web contents.
    */
-  const capturePageWithRetry = (errorContext: PreviewOperationContext, wc: Electron.WebContents) =>
-    attemptPromise(errorContext, () => wc.capturePage()).pipe(
+  const capturePageWithRetry = (
+    errorContext: PreviewOperationContext,
+    tabId: string,
+    wc: Electron.WebContents,
+  ) => {
+    const guestIsCurrent = Effect.gen(function* () {
+      if (wc.isDestroyed()) return false;
+      const tabs = yield* SynchronizedRef.get(tabsRef);
+      return tabs.get(tabId)?.webContentsId === wc.id;
+    });
+    return attemptPromise(errorContext, () => wc.capturePage()).pipe(
       Effect.retry({
         times: CAPTURE_PAGE_RETRY_ATTEMPTS - 1,
         schedule: Schedule.spaced(CAPTURE_PAGE_RETRY_DELAY_MS),
+        while: () => guestIsCurrent,
       }),
     );
+  };
   const currentIso = DateTime.now.pipe(Effect.map(DateTime.formatIso));
   const currentMillis = Clock.currentTimeMillis;
   const encodeJson = (errorContext: PreviewOperationContext, value: unknown) =>
@@ -1973,6 +1988,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           tabId,
           webContentsId: wc.id,
         },
+        tabId,
         wc,
       ),
     ]);
@@ -2647,6 +2663,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             tabId,
             webContentsId: wc.id,
           },
+          tabId,
           wc,
         ),
         Ref.get(diagnosticsRef),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -44,6 +44,7 @@ import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
+import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
@@ -98,6 +99,14 @@ const MAX_EVALUATION_BYTES = 64_000;
 const MAX_VISIBLE_TEXT_LENGTH = 20_000;
 const MAX_INTERACTIVE_ELEMENTS = 200;
 const MAX_SCREENSHOT_WIDTH = 1280;
+/**
+ * Chromium reports UnknownVizError while a hidden or freshly attached guest is
+ * warming its first compositor frame. Background frame capture already rides
+ * this out via its scheduled loop; one-shot captures need their own retry or a
+ * snapshot taken against a backgrounded preview fails outright.
+ */
+const CAPTURE_PAGE_RETRY_ATTEMPTS = 3;
+const CAPTURE_PAGE_RETRY_DELAY_MS = 120;
 const RECORDING_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
 const RECORDING_JPEG_QUALITY = 80;
 const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
@@ -510,6 +519,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       try: evaluate,
       catch: (cause) => new PreviewOperationError({ ...errorContext, cause }),
     });
+  /**
+   * capturePage for one-shot captures (snapshots, screenshots), retrying the
+   * transient compositor warm-up failure instead of surfacing it to callers.
+   */
+  const capturePageWithRetry = (errorContext: PreviewOperationContext, wc: Electron.WebContents) =>
+    attemptPromise(errorContext, () => wc.capturePage()).pipe(
+      Effect.retry({
+        times: CAPTURE_PAGE_RETRY_ATTEMPTS - 1,
+        schedule: Schedule.spaced(CAPTURE_PAGE_RETRY_DELAY_MS),
+      }),
+    );
   const currentIso = DateTime.now.pipe(Effect.map(DateTime.formatIso));
   const currentMillis = Clock.currentTimeMillis;
   const encodeJson = (errorContext: PreviewOperationContext, value: unknown) =>
@@ -1947,13 +1967,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const [createdAt, millis, image] = yield* Effect.all([
       currentIso,
       currentMillis,
-      attemptPromise(
+      capturePageWithRetry(
         {
           operation: "captureScreenshot.capturePage",
           tabId,
           webContentsId: wc.id,
         },
-        () => wc.capturePage(),
+        wc,
       ),
     ]);
     const id = `browser-screenshot-${artifactSiteSlug(wc.getURL())}-${millis.toString(36)}`;
@@ -2621,13 +2641,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       );
       const [accessibility, sourceImage, diagnostics, timelines] = yield* Effect.all([
         send("Accessibility.getFullAXTree"),
-        attemptPromise(
+        capturePageWithRetry(
           {
             operation: "automationSnapshot.capturePage",
             tabId,
             webContentsId: wc.id,
           },
-          () => wc.capturePage(),
+          wc,
         ),
         Ref.get(diagnosticsRef),
         Ref.get(actionTimelineRef),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -115,13 +115,12 @@ const RECORDING_ARM_GRACE_MS = 10_000;
 const PICTURE_IN_PICTURE_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
 const PICTURE_IN_PICTURE_JPEG_QUALITY = 80;
 /**
- * Chromium reports UnknownVizError while a hidden or freshly attached guest is
- * warming its first compositor frame. Background frame capture already rides
- * this out via its scheduled loop; one-shot captures need their own retry or a
- * snapshot taken against a backgrounded preview fails outright.
+ * Cold guests can reject capturePage with UnknownVizError or never settle it.
+ * Bound each attempt so snapshots release control even when Chromium stalls.
  */
 const CAPTURE_PAGE_RETRY_ATTEMPTS = 3;
 const CAPTURE_PAGE_RETRY_DELAY_MS = 120;
+const CAPTURE_PAGE_ATTEMPT_TIMEOUT_MS = 1_000;
 const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
 const PICTURE_IN_PICTURE_INITIAL_HEIGHT = 320;
 const PICTURE_IN_PICTURE_MIN_WIDTH = 240;
@@ -664,32 +663,41 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       try: evaluate,
       catch: (cause) => new PreviewOperationError({ ...errorContext, cause }),
     });
-  /**
-   * capturePage for one-shot captures (snapshots, screenshots), retrying the
-   * transient compositor warm-up failure instead of surfacing it to callers.
-   *
-   * Retries stop as soon as the tab no longer points at this guest, so a
-   * webview swap during the retry window surfaces the original failure instead
-   * of capturing from a detached web contents.
-   */
-  const capturePageWithRetry = (
+  const capturePageWithRetry = Effect.fn("PreviewManager.capturePageWithRetry")(function* (
     errorContext: PreviewOperationContext,
     tabId: string,
     wc: Electron.WebContents,
-  ) => {
-    const guestIsCurrent = Effect.gen(function* () {
-      if (wc.isDestroyed()) return false;
+  ) {
+    const requireCurrentGuest = Effect.gen(function* () {
       const tabs = yield* SynchronizedRef.get(tabsRef);
-      return tabs.get(tabId)?.webContentsId === wc.id;
+      if (wc.isDestroyed() || tabs.get(tabId)?.webContentsId !== wc.id) {
+        return yield* new PreviewWebContentsNotFoundError({ tabId, webContentsId: wc.id });
+      }
     });
-    return attemptPromise(errorContext, () => wc.capturePage()).pipe(
+    const capture = Effect.gen(function* () {
+      // Check after the retry delay, and again before accepting its result.
+      yield* requireCurrentGuest;
+      const image = yield* Effect.tryPromise({
+        // An abort-signal parameter makes a stalled promise interruptible.
+        try: (_signal) => wc.capturePage(),
+        catch: (cause) => new PreviewOperationError({ ...errorContext, cause }),
+      }).pipe(
+        Effect.timeout(CAPTURE_PAGE_ATTEMPT_TIMEOUT_MS),
+        Effect.catchTag("TimeoutError", (cause) =>
+          Effect.fail(new PreviewOperationError({ ...errorContext, cause })),
+        ),
+      );
+      yield* requireCurrentGuest;
+      return image;
+    });
+    return yield* capture.pipe(
       Effect.retry({
         times: CAPTURE_PAGE_RETRY_ATTEMPTS - 1,
         schedule: Schedule.spaced(CAPTURE_PAGE_RETRY_DELAY_MS),
-        while: () => guestIsCurrent,
+        while: isPreviewOperationError,
       }),
     );
-  };
+  });
   const currentIso = DateTime.now.pipe(Effect.map(DateTime.formatIso));
   const currentMillis = Clock.currentTimeMillis;
   const encodeJson = (errorContext: PreviewOperationContext, value: unknown) =>

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -667,9 +667,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         catch: (cause) => new PreviewOperationError({ ...errorContext, cause }),
       }).pipe(
         Effect.timeout(CAPTURE_PAGE_ATTEMPT_TIMEOUT_MS),
-        Effect.catchTag("TimeoutError", (cause) =>
-          Effect.fail(new PreviewOperationError({ ...errorContext, cause })),
-        ),
+        Effect.catchTags({
+          TimeoutError: (cause) =>
+            Effect.fail(new PreviewOperationError({ ...errorContext, cause })),
+        }),
       );
       yield* requireCurrentGuest;
       return image;

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -667,14 +667,29 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   /**
    * capturePage for one-shot captures (snapshots, screenshots), retrying the
    * transient compositor warm-up failure instead of surfacing it to callers.
+   *
+   * Retries stop as soon as the tab no longer points at this guest, so a
+   * webview swap during the retry window surfaces the original failure instead
+   * of capturing from a detached web contents.
    */
-  const capturePageWithRetry = (errorContext: PreviewOperationContext, wc: Electron.WebContents) =>
-    attemptPromise(errorContext, () => wc.capturePage()).pipe(
+  const capturePageWithRetry = (
+    errorContext: PreviewOperationContext,
+    tabId: string,
+    wc: Electron.WebContents,
+  ) => {
+    const guestIsCurrent = Effect.gen(function* () {
+      if (wc.isDestroyed()) return false;
+      const tabs = yield* SynchronizedRef.get(tabsRef);
+      return tabs.get(tabId)?.webContentsId === wc.id;
+    });
+    return attemptPromise(errorContext, () => wc.capturePage()).pipe(
       Effect.retry({
         times: CAPTURE_PAGE_RETRY_ATTEMPTS - 1,
         schedule: Schedule.spaced(CAPTURE_PAGE_RETRY_DELAY_MS),
+        while: () => guestIsCurrent,
       }),
     );
+  };
   const currentIso = DateTime.now.pipe(Effect.map(DateTime.formatIso));
   const currentMillis = Clock.currentTimeMillis;
   const encodeJson = (errorContext: PreviewOperationContext, value: unknown) =>
@@ -2717,6 +2732,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           tabId,
           webContentsId: wc.id,
         },
+        tabId,
         wc,
       ),
     ]);
@@ -3582,6 +3598,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             tabId,
             webContentsId: wc.id,
           },
+          tabId,
           wc,
         ),
         Ref.get(diagnosticsRef),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -48,6 +48,7 @@ import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
+import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
@@ -113,6 +114,14 @@ const MAX_SCREENSHOT_WIDTH = 1280;
 const RECORDING_ARM_GRACE_MS = 10_000;
 const PICTURE_IN_PICTURE_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
 const PICTURE_IN_PICTURE_JPEG_QUALITY = 80;
+/**
+ * Chromium reports UnknownVizError while a hidden or freshly attached guest is
+ * warming its first compositor frame. Background frame capture already rides
+ * this out via its scheduled loop; one-shot captures need their own retry or a
+ * snapshot taken against a backgrounded preview fails outright.
+ */
+const CAPTURE_PAGE_RETRY_ATTEMPTS = 3;
+const CAPTURE_PAGE_RETRY_DELAY_MS = 120;
 const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
 const PICTURE_IN_PICTURE_INITIAL_HEIGHT = 320;
 const PICTURE_IN_PICTURE_MIN_WIDTH = 240;
@@ -655,6 +664,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       try: evaluate,
       catch: (cause) => new PreviewOperationError({ ...errorContext, cause }),
     });
+  /**
+   * capturePage for one-shot captures (snapshots, screenshots), retrying the
+   * transient compositor warm-up failure instead of surfacing it to callers.
+   */
+  const capturePageWithRetry = (errorContext: PreviewOperationContext, wc: Electron.WebContents) =>
+    attemptPromise(errorContext, () => wc.capturePage()).pipe(
+      Effect.retry({
+        times: CAPTURE_PAGE_RETRY_ATTEMPTS - 1,
+        schedule: Schedule.spaced(CAPTURE_PAGE_RETRY_DELAY_MS),
+      }),
+    );
   const currentIso = DateTime.now.pipe(Effect.map(DateTime.formatIso));
   const currentMillis = Clock.currentTimeMillis;
   const encodeJson = (errorContext: PreviewOperationContext, value: unknown) =>
@@ -2691,13 +2711,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const [createdAt, millis, image] = yield* Effect.all([
       currentIso,
       currentMillis,
-      attemptPromise(
+      capturePageWithRetry(
         {
           operation: "captureScreenshot.capturePage",
           tabId,
           webContentsId: wc.id,
         },
-        () => wc.capturePage(),
+        wc,
       ),
     ]);
     const id = `browser-screenshot-${artifactSiteSlug(wc.getURL())}-${millis.toString(36)}`;
@@ -3556,13 +3576,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       );
       const [accessibility, sourceImage, diagnostics, timelines] = yield* Effect.all([
         send("Accessibility.getFullAXTree"),
-        attemptPromise(
+        capturePageWithRetry(
           {
             operation: "automationSnapshot.capturePage",
             tabId,
             webContentsId: wc.id,
           },
-          () => wc.capturePage(),
+          wc,
         ),
         Ref.get(diagnosticsRef),
         Ref.get(actionTimelineRef),

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -70,6 +70,7 @@ import {
   resolvePreviewAutomationOpenTab,
   resolvePreviewAutomationTarget,
 } from "./previewAutomationTarget";
+import { resolveHostWaitBudgetMs } from "./previewAutomationHostBudget";
 import { isPreviewViewportReady } from "./previewViewportReadiness";
 import { shouldRollbackPreviewViewport } from "./previewViewportRollback";
 
@@ -91,7 +92,10 @@ const waitForDesktopOverlay = async (
   operation: PreviewAutomationRequest["operation"],
   timeoutMs: number,
 ): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
+  // Expire before the broker does, so an unavailable overlay surfaces as
+  // PreviewAutomationOverlayTimeoutError rather than a bare broker timeout.
+  const waitBudgetMs = resolveHostWaitBudgetMs(timeoutMs);
+  const deadline = Date.now() + waitBudgetMs;
   while (Date.now() <= deadline) {
     const state = assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, {
       operation,
@@ -107,7 +111,7 @@ const waitForDesktopOverlay = async (
     requestId,
     environmentId: threadRef.environmentId,
     threadId: threadRef.threadId,
-    timeoutMs,
+    timeoutMs: waitBudgetMs,
   });
 };
 

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -76,7 +76,7 @@ import {
   resolvePreviewAutomationOpenTab,
   resolvePreviewAutomationTarget,
 } from "./previewAutomationTarget";
-import { resolveHostWaitBudgetMs } from "./previewAutomationHostBudget";
+import { resolveHostWaitBudgetMs, waitForHostReadiness } from "./previewAutomationHostBudget";
 import { isPreviewViewportReady } from "./previewViewportReadiness";
 import { shouldRollbackPreviewViewport } from "./previewViewportRollback";
 
@@ -96,23 +96,21 @@ const waitForDesktopOverlay = async (
   tabId: string,
   runtimeTabId: string,
   operation: PreviewAutomationRequest["operation"],
-  timeoutMs: number,
+  deadlineMs: number,
 ): Promise<void> => {
-  // Expire before the broker does, so an unavailable overlay surfaces as
-  // PreviewAutomationOverlayTimeoutError rather than a bare broker timeout.
-  const waitBudgetMs = resolveHostWaitBudgetMs(timeoutMs);
-  const deadline = Date.now() + waitBudgetMs;
-  while (Date.now() <= deadline) {
+  const waitBudgetMs = Math.max(0, deadlineMs - Date.now());
+  const ready = await waitForHostReadiness(deadlineMs, async () => {
     const state = assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, {
       operation,
       requestId,
     });
     if (state.desktopByTabId[tabId] && previewBridge && isPreviewWebviewRendering(runtimeTabId)) {
       const status = await previewBridge.automation.status(runtimeTabId);
-      if (status.available) return;
+      return status.available;
     }
-    await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
-  }
+    return false;
+  });
+  if (ready) return;
   throw new PreviewAutomationOverlayTimeoutError({
     requestId,
     environmentId: threadRef.environmentId,
@@ -321,6 +319,8 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
 
   const handleRequest = useCallback(
     async (request: PreviewAutomationRequest): Promise<unknown> => {
+      // Session sync and tab creation consume the same budget as overlay registration.
+      const hostDeadlineMs = Date.now() + resolveHostWaitBudgetMs(request.timeoutMs);
       const threadRef: ScopedThreadRef = {
         environmentId,
         threadId: request.threadId,
@@ -382,7 +382,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             readyTabId,
             runtimeTabId,
             request.operation,
-            request.timeoutMs,
+            hostDeadlineMs,
           );
           return {
             bridge,

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -76,6 +76,7 @@ import {
   resolvePreviewAutomationOpenTab,
   resolvePreviewAutomationTarget,
 } from "./previewAutomationTarget";
+import { resolveHostWaitBudgetMs } from "./previewAutomationHostBudget";
 import { isPreviewViewportReady } from "./previewViewportReadiness";
 import { shouldRollbackPreviewViewport } from "./previewViewportRollback";
 
@@ -97,7 +98,10 @@ const waitForDesktopOverlay = async (
   operation: PreviewAutomationRequest["operation"],
   timeoutMs: number,
 ): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
+  // Expire before the broker does, so an unavailable overlay surfaces as
+  // PreviewAutomationOverlayTimeoutError rather than a bare broker timeout.
+  const waitBudgetMs = resolveHostWaitBudgetMs(timeoutMs);
+  const deadline = Date.now() + waitBudgetMs;
   while (Date.now() <= deadline) {
     const state = assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, {
       operation,
@@ -113,7 +117,7 @@ const waitForDesktopOverlay = async (
     requestId,
     environmentId: threadRef.environmentId,
     threadId: threadRef.threadId,
-    timeoutMs,
+    timeoutMs: waitBudgetMs,
   });
 };
 

--- a/apps/web/src/components/preview/previewAutomationHostBudget.test.ts
+++ b/apps/web/src/components/preview/previewAutomationHostBudget.test.ts
@@ -6,24 +6,33 @@ import {
 } from "./previewAutomationHostBudget";
 
 describe("resolveHostWaitBudgetMs", () => {
-  it("expires before the broker deadline so the host failure wins the race", () => {
-    const requestTimeoutMs = 15_000;
-    const budget = resolveHostWaitBudgetMs(requestTimeoutMs);
-
-    expect(budget).toBeLessThan(requestTimeoutMs);
-    expect(requestTimeoutMs - budget).toBe(PREVIEW_HOST_RESPONSE_MARGIN_MS);
+  it("always expires before the broker deadline, at every request budget", () => {
+    // The whole point of the helper: the host must lose no race, at any scale.
+    for (const requestTimeoutMs of [1, 2, 10, 100, 249, 250, 999, 1_500, 3_000, 15_000, 60_000]) {
+      expect(resolveHostWaitBudgetMs(requestTimeoutMs)).toBeLessThan(requestTimeoutMs);
+    }
   });
 
-  it("keeps a usable wait for short request budgets", () => {
-    expect(resolveHostWaitBudgetMs(1_000)).toBeGreaterThan(0);
-    expect(resolveHostWaitBudgetMs(1_000)).toBeLessThan(1_000);
-    expect(resolveHostWaitBudgetMs(10)).toBeGreaterThan(0);
-    expect(resolveHostWaitBudgetMs(10)).toBeLessThan(PREVIEW_HOST_RESPONSE_MARGIN_MS);
+  it("reserves the full response margin once the request budget allows it", () => {
+    expect(resolveHostWaitBudgetMs(15_000)).toBe(15_000 - PREVIEW_HOST_RESPONSE_MARGIN_MS);
+    expect(resolveHostWaitBudgetMs(60_000)).toBe(60_000 - PREVIEW_HOST_RESPONSE_MARGIN_MS);
   });
 
-  it("falls back to a positive budget for invalid input", () => {
-    expect(resolveHostWaitBudgetMs(0)).toBeGreaterThan(0);
-    expect(resolveHostWaitBudgetMs(-5)).toBeGreaterThan(0);
-    expect(resolveHostWaitBudgetMs(Number.NaN)).toBeGreaterThan(0);
+  it("keeps most of a short request budget instead of collapsing it", () => {
+    expect(resolveHostWaitBudgetMs(1_000)).toBe(800);
+    expect(resolveHostWaitBudgetMs(100)).toBe(80);
+  });
+
+  it("grows monotonically with the request budget", () => {
+    const budgets = [1, 10, 100, 1_000, 3_000, 15_000].map(resolveHostWaitBudgetMs);
+    for (let index = 1; index < budgets.length; index += 1) {
+      expect(budgets[index]!).toBeGreaterThanOrEqual(budgets[index - 1]!);
+    }
+  });
+
+  it("returns a non-negative budget for invalid input", () => {
+    for (const invalid of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(resolveHostWaitBudgetMs(invalid)).toBeGreaterThanOrEqual(0);
+    }
   });
 });

--- a/apps/web/src/components/preview/previewAutomationHostBudget.test.ts
+++ b/apps/web/src/components/preview/previewAutomationHostBudget.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  PREVIEW_HOST_RESPONSE_MARGIN_MS,
+  resolveHostWaitBudgetMs,
+} from "./previewAutomationHostBudget";
+
+describe("resolveHostWaitBudgetMs", () => {
+  it("expires before the broker deadline so the host failure wins the race", () => {
+    const requestTimeoutMs = 15_000;
+    const budget = resolveHostWaitBudgetMs(requestTimeoutMs);
+
+    expect(budget).toBeLessThan(requestTimeoutMs);
+    expect(requestTimeoutMs - budget).toBe(PREVIEW_HOST_RESPONSE_MARGIN_MS);
+  });
+
+  it("keeps a usable wait for short request budgets", () => {
+    expect(resolveHostWaitBudgetMs(1_000)).toBeGreaterThan(0);
+    expect(resolveHostWaitBudgetMs(1_000)).toBeLessThan(1_000);
+    expect(resolveHostWaitBudgetMs(10)).toBeGreaterThan(0);
+    expect(resolveHostWaitBudgetMs(10)).toBeLessThan(PREVIEW_HOST_RESPONSE_MARGIN_MS);
+  });
+
+  it("falls back to a positive budget for invalid input", () => {
+    expect(resolveHostWaitBudgetMs(0)).toBeGreaterThan(0);
+    expect(resolveHostWaitBudgetMs(-5)).toBeGreaterThan(0);
+    expect(resolveHostWaitBudgetMs(Number.NaN)).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/preview/previewAutomationHostBudget.test.ts
+++ b/apps/web/src/components/preview/previewAutomationHostBudget.test.ts
@@ -90,7 +90,23 @@ describe("waitForHostReadiness", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("bounds a stalled status probe and does not poll again if it completes late", async () => {
+  it.each([false, true])(
+    "keeps a probe result of %s that wins the deadline race",
+    async (ready) => {
+      const isReady = vi.fn(
+        () => new Promise<boolean>((resolve) => setTimeout(() => resolve(ready), 80)),
+      );
+      const result = waitForHostReadiness(80, isReady);
+
+      await vi.advanceTimersByTimeAsync(80);
+
+      expect(await result).toBe(ready);
+      expect(isReady).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("bounds a stalled status probe and ignores a late ready result", async () => {
     let completeProbe!: (ready: boolean) => void;
     const isReady = vi.fn(
       () =>
@@ -104,7 +120,7 @@ describe("waitForHostReadiness", () => {
     expect(await result).toBe(false);
     expect(vi.getTimerCount()).toBe(0);
 
-    completeProbe(false);
+    completeProbe(true);
     await vi.runAllTimersAsync();
     expect(isReady).toHaveBeenCalledTimes(1);
     expect(vi.getTimerCount()).toBe(0);

--- a/apps/web/src/components/preview/previewAutomationHostBudget.test.ts
+++ b/apps/web/src/components/preview/previewAutomationHostBudget.test.ts
@@ -1,18 +1,12 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   PREVIEW_HOST_RESPONSE_MARGIN_MS,
   resolveHostWaitBudgetMs,
+  waitForHostReadiness,
 } from "./previewAutomationHostBudget";
 
 describe("resolveHostWaitBudgetMs", () => {
-  it("always expires before the broker deadline, at every request budget", () => {
-    // The whole point of the helper: the host must lose no race, at any scale.
-    for (const requestTimeoutMs of [1, 2, 10, 100, 249, 250, 999, 1_500, 3_000, 15_000, 60_000]) {
-      expect(resolveHostWaitBudgetMs(requestTimeoutMs)).toBeLessThan(requestTimeoutMs);
-    }
-  });
-
   it("reserves the full response margin once the request budget allows it", () => {
     expect(resolveHostWaitBudgetMs(15_000)).toBe(15_000 - PREVIEW_HOST_RESPONSE_MARGIN_MS);
     expect(resolveHostWaitBudgetMs(60_000)).toBe(60_000 - PREVIEW_HOST_RESPONSE_MARGIN_MS);
@@ -23,16 +17,104 @@ describe("resolveHostWaitBudgetMs", () => {
     expect(resolveHostWaitBudgetMs(100)).toBe(80);
   });
 
-  it("grows monotonically with the request budget", () => {
-    const budgets = [1, 10, 100, 1_000, 3_000, 15_000].map(resolveHostWaitBudgetMs);
-    for (let index = 1; index < budgets.length; index += 1) {
-      expect(budgets[index]!).toBeGreaterThanOrEqual(budgets[index - 1]!);
-    }
-  });
-
   it("returns a non-negative budget for invalid input", () => {
     for (const invalid of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
       expect(resolveHostWaitBudgetMs(invalid)).toBeGreaterThanOrEqual(0);
     }
+  });
+});
+
+describe("waitForHostReadiness", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([1, 10, 100, 250, 1_000, 15_000])(
+    "stops unavailable-overlay polling before a %ims broker timeout",
+    async (requestTimeoutMs) => {
+      const deadlineMs = Date.now() + resolveHostWaitBudgetMs(requestTimeoutMs);
+      let finishedAt: number | undefined;
+      const result = waitForHostReadiness(deadlineMs, async () => false).then((ready) => {
+        finishedAt = Date.now();
+        return ready;
+      });
+
+      await vi.advanceTimersByTimeAsync(requestTimeoutMs);
+
+      expect(await result).toBe(false);
+      expect(finishedAt).toBeLessThan(requestTimeoutMs);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("includes session setup in the deadline instead of starting a fresh wait budget", async () => {
+    const deadlineMs = Date.now() + resolveHostWaitBudgetMs(15_000);
+    await vi.advanceTimersByTimeAsync(2_000);
+    let finished = false;
+    const result = waitForHostReadiness(deadlineMs, async () => false).then((ready) => {
+      finished = true;
+      return ready;
+    });
+
+    await vi.advanceTimersByTimeAsync(11_499);
+    expect(finished).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await result).toBe(false);
+    expect(Date.now()).toBe(deadlineMs);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("skips readiness probes when setup has already exhausted the deadline", async () => {
+    const deadlineMs = Date.now() + resolveHostWaitBudgetMs(100);
+    await vi.advanceTimersByTimeAsync(100);
+    const isReady = vi.fn(async () => false);
+
+    expect(await waitForHostReadiness(deadlineMs, isReady)).toBe(false);
+    expect(isReady).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns as soon as the overlay is ready and clears its timeout", async () => {
+    const isReady = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const result = waitForHostReadiness(800, isReady);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(await result).toBe(true);
+    expect(isReady).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("bounds a stalled status probe and does not poll again if it completes late", async () => {
+    let completeProbe!: (ready: boolean) => void;
+    const isReady = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          completeProbe = resolve;
+        }),
+    );
+    const result = waitForHostReadiness(80, isReady);
+
+    await vi.advanceTimersByTimeAsync(80);
+    expect(await result).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+
+    completeProbe(false);
+    await vi.runAllTimersAsync();
+    expect(isReady).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves probe failures and clears the pending timeout", async () => {
+    const error = new Error("Preview target was replaced");
+    const isReady = vi.fn().mockRejectedValue(error);
+
+    await expect(waitForHostReadiness(800, isReady)).rejects.toBe(error);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/apps/web/src/components/preview/previewAutomationHostBudget.ts
+++ b/apps/web/src/components/preview/previewAutomationHostBudget.ts
@@ -1,0 +1,21 @@
+/**
+ * Reserve for delivering the host's response back to the broker once a wait
+ * gives up. Without it a host wait that runs the full request budget always
+ * loses the race to the broker's own deadline, so the agent sees an opaque
+ * "timed out" instead of the specific failure the host was about to report.
+ */
+export const PREVIEW_HOST_RESPONSE_MARGIN_MS = 1_500;
+
+/** Smallest useful wait; below this a slow first poll would fail instantly. */
+const MIN_HOST_WAIT_MS = 250;
+
+/**
+ * Budget a host-side wait so it expires before the broker's deadline for the
+ * same request.
+ */
+export function resolveHostWaitBudgetMs(requestTimeoutMs: number): number {
+  if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
+    return MIN_HOST_WAIT_MS;
+  }
+  return Math.max(MIN_HOST_WAIT_MS, requestTimeoutMs - PREVIEW_HOST_RESPONSE_MARGIN_MS);
+}

--- a/apps/web/src/components/preview/previewAutomationHostBudget.ts
+++ b/apps/web/src/components/preview/previewAutomationHostBudget.ts
@@ -6,16 +6,24 @@
  */
 export const PREVIEW_HOST_RESPONSE_MARGIN_MS = 1_500;
 
-/** Smallest useful wait; below this a slow first poll would fail instantly. */
-const MIN_HOST_WAIT_MS = 250;
+/**
+ * Share of the request budget reserved when the request is too short for the
+ * full margin, so the host still expires first rather than being clamped past
+ * the broker's deadline.
+ */
+const HOST_RESPONSE_MARGIN_FRACTION = 0.2;
 
 /**
- * Budget a host-side wait so it expires before the broker's deadline for the
- * same request.
+ * Budget a host-side wait so it always expires before the broker's deadline
+ * for the same request.
  */
 export function resolveHostWaitBudgetMs(requestTimeoutMs: number): number {
   if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
-    return MIN_HOST_WAIT_MS;
+    return 0;
   }
-  return Math.max(MIN_HOST_WAIT_MS, requestTimeoutMs - PREVIEW_HOST_RESPONSE_MARGIN_MS);
+  const reservedMs = Math.min(
+    PREVIEW_HOST_RESPONSE_MARGIN_MS,
+    Math.ceil(requestTimeoutMs * HOST_RESPONSE_MARGIN_FRACTION),
+  );
+  return Math.max(0, requestTimeoutMs - reservedMs);
 }

--- a/apps/web/src/components/preview/previewAutomationHostBudget.ts
+++ b/apps/web/src/components/preview/previewAutomationHostBudget.ts
@@ -32,8 +32,8 @@ export async function waitForHostReadiness(
     } finally {
       clearTimeout(timeout);
     }
-    if (ready === null || Date.now() >= deadlineMs) return false;
     if (ready) return true;
+    if (ready === null || Date.now() >= deadlineMs) return false;
     await new Promise<void>((resolve) =>
       setTimeout(resolve, Math.min(50, deadlineMs - Date.now())),
     );

--- a/apps/web/src/components/preview/previewAutomationHostBudget.ts
+++ b/apps/web/src/components/preview/previewAutomationHostBudget.ts
@@ -1,22 +1,8 @@
-/**
- * Reserve for delivering the host's response back to the broker once a wait
- * gives up. Without it a host wait that runs the full request budget always
- * loses the race to the broker's own deadline, so the agent sees an opaque
- * "timed out" instead of the specific failure the host was about to report.
- */
+/** Allow time to deliver an overlay failure before the broker times out. */
 export const PREVIEW_HOST_RESPONSE_MARGIN_MS = 1_500;
 
-/**
- * Share of the request budget reserved when the request is too short for the
- * full margin, so the host still expires first rather than being clamped past
- * the broker's deadline.
- */
 const HOST_RESPONSE_MARGIN_FRACTION = 0.2;
 
-/**
- * Budget a host-side wait so it always expires before the broker's deadline
- * for the same request.
- */
 export function resolveHostWaitBudgetMs(requestTimeoutMs: number): number {
   if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
     return 0;
@@ -26,4 +12,31 @@ export function resolveHostWaitBudgetMs(requestTimeoutMs: number): number {
     Math.ceil(requestTimeoutMs * HOST_RESPONSE_MARGIN_FRACTION),
   );
   return Math.max(0, requestTimeoutMs - reservedMs);
+}
+
+/** Both readiness probes and polling delays share the request's host deadline. */
+export async function waitForHostReadiness(
+  deadlineMs: number,
+  isReady: () => Promise<boolean>,
+): Promise<boolean> {
+  while (Date.now() < deadlineMs) {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let ready: boolean | null;
+    try {
+      ready = await Promise.race([
+        isReady(),
+        new Promise<null>((resolve) => {
+          timeout = setTimeout(() => resolve(null), Math.max(0, deadlineMs - Date.now()));
+        }),
+      ]);
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (ready === null || Date.now() >= deadlineMs) return false;
+    if (ready) return true;
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, Math.min(50, deadlineMs - Date.now())),
+    );
+  }
+  return false;
 }


### PR DESCRIPTION
Preview automation could lose an unavailable-overlay error to the broker's timeout, fail on a transient Chromium capture error, or hold the tab's control session indefinitely when `capturePage()` never settled.

This change reserves response time before the broker deadline and uses one host deadline across setup and overlay polling. Polling sleeps and status probes share that deadline. One-shot screenshots and snapshots retry up to three times, with 120 ms between attempts and a one-second timeout per attempt. Guest identity is checked before each attempt and after capture, so replacement cannot produce a stale screenshot.

Verification

- 84 focused `PreviewManager` tests and 16 host-budget/readiness tests pass. Desktop and web typechecks, scoped formatting, and scoped lint pass. Web lint retains an existing React refs warning.
- Regression tests fail without the fixes: replacement during retry delay and during capture incorrectly succeeds; an indefinitely pending capture blocks a queued evaluation. The fixed snapshot path releases control after its capture attempts expire. A new boundary regression fails before the fix and passes after it: a ready status that wins the deadline race is accepted, while a status arriving after the timeout is ignored.
- Authenticated the isolated web app through its pairing URL. Browser probes with a 100 ms request budget returned unavailable/stalled at 80 ms and available immediately.
- Ran the rebuilt Electron 43.4.1 app on Linux against disposable state. The screenshot button saved an image. A background preview snapshot returned a complete 483×700 image in 128 ms, subsequent interaction succeeded, and the guest returned offscreen after activity ended. Verification processes were stopped.

Timing evidence from the previous implementation and this revision, using deterministic timers:

| 100 ms request, overlay unavailable | Before | After |
| --- | ---: | ---: |
| No setup delay | 100 ms | 80 ms |
| 30 ms setup delay | 130 ms | 80 ms |

There is no layout change. The captured image below is additional runtime evidence from the background snapshot path.

![Image returned by a background preview snapshot in the rebuilt Electron app](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b34121f23ced9bde/background-snapshot.png)

The capture timeout bounds the image-capture portion. Other debugger operations and navigation/viewport waits retain their existing behavior. Electron does not expose cancellation for the native capture operation; late results are ignored. Background guest placement already exists on main and is reused here.


Prepared with GPT-6 in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and failure modes for preview automation screenshots and overlay readiness—core agent browser control paths—but behavior is heavily regression-tested and failures become bounded rather than hanging.
> 
> **Overview**
> Preview automation and desktop capture paths get **bounded, deadline-aware waits** so broker timeouts and hung Chromium compositors do not mask real failures or block the tab control session.
> 
> **Desktop (`PreviewManager`)** adds `capturePageWithRetry` and wires **`captureScreenshot`** and **`automationSnapshot`** through it instead of a single `capturePage()` call. Each operation gets up to **three attempts** (120 ms apart) with a **1 s per-attempt timeout**, retries transient errors like `UnknownVizError`, and **verifies the tab still owns the same guest** before and after capture so swapped webviews cannot persist stale images or keep retrying after replacement.
> 
> **Web (`PreviewAutomationHosts`)** introduces **`resolveHostWaitBudgetMs`** and **`waitForHostReadiness`**: one **absolute host deadline** (request timeout minus a response margin) covers session sync, tab setup, and overlay polling. `waitForDesktopOverlay` races status probes against that deadline and stops before the broker times out, so unavailable-overlay errors can still be reported.
> 
> Tests extend **`Manager.test`** for retry success/failure, guest swap during retry or in-flight capture, and snapshot control release when capture stalls; new **`previewAutomationHostBudget`** tests cover budget math and polling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643cef6eaa1874b2843cfbcc73d15f396ba7d842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound preview screenshot captures to 3 retries and add deadline to automation host waits
> - Adds `capturePageWithRetry` to `PreviewManager` with a 1,000 ms per-attempt timeout, three attempts, and 120 ms spacing; both `captureScreenshot` and `automationSnapshot` now use it instead of unbounded `capturePage` calls
> - Capture results from a destroyed or replaced guest web contents are rejected so stale artifacts are never written
> - Replaces per-phase timeouts in `PreviewAutomationHost` with a single absolute deadline shared across session sync, tab setup, and overlay readiness; `resolveHostWaitBudgetMs` reserves the smaller of 1,500 ms or 20% of the request timeout
> - `waitForHostReadiness` now polls at 50 ms intervals, races each probe against the remaining deadline, and returns `false` on expiry instead of waiting indefinitely on stalled probes
> - Behavioral Change: `capturePage` attempts that previously hung forever now fail after ~1,100 ms; automation requests that previously gave each phase a full timeout now share one budget, so slow session-sync or tab-setup can reduce the time left for overlay readiness
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 643cef6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->