### PR TITLE
Add OTA update checks to mobile settings

### DIFF
--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -9,10 +9,19 @@ import { SymbolView } from "../../components/AppSymbol";
 import * as Effect from "effect/Effect";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
-import { Alert, Linking, Platform, ScrollView, View } from "react-native";
+import {
+  ActivityIndicator,
+  Alert,
+  Linking,
+  Platform,
+  Pressable,
+  ScrollView,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import {
+  type AtomCommandResult,
   isAtomCommandInterrupted,
   reportAtomCommandResult,
   settleAsyncResult,
@@ -570,8 +579,11 @@ function BetaSettingsSection() {
   );
 }
 
+type UpdateCheckState = "idle" | "checking" | "downloading" | "restarting" | "current";
+
 function AppSettingsSection() {
   const icon = useThemeColor("--color-icon");
+  const [updateState, setUpdateState] = useState<UpdateCheckState>("idle");
 
   const version = Constants.expoConfig?.version ?? "0.0.0";
   // Fall back to "production" to match resolveAppVariant in app.config.ts, so a
@@ -590,28 +602,122 @@ function AppSettingsSection() {
         : null
     : null;
 
+  const busy =
+    updateState === "checking" || updateState === "downloading" || updateState === "restarting";
+
+  // "Up to date" is a transient acknowledgement, not a state worth persisting —
+  // drop back to the bundle label so the row keeps answering "what am I running?".
+  useEffect(() => {
+    if (updateState !== "current") return;
+    const timer = setTimeout(() => setUpdateState("idle"), 3000);
+    return () => clearTimeout(timer);
+  }, [updateState]);
+
+  const checkForUpdate = useCallback(async () => {
+    setUpdateState("checking");
+    const check = await settlePromise(() => Updates.checkForUpdateAsync());
+    if (check._tag === "Failure") {
+      reportUpdateFailure(check, "Could not check for updates.");
+      setUpdateState("idle");
+      return;
+    }
+    if (!check.value.isAvailable) {
+      setUpdateState("current");
+      return;
+    }
+
+    setUpdateState("downloading");
+    const fetched = await settlePromise(() => Updates.fetchUpdateAsync());
+    if (fetched._tag === "Failure") {
+      reportUpdateFailure(fetched, "Could not download the update.");
+      setUpdateState("idle");
+      return;
+    }
+    if (!fetched.value.isNew) {
+      setUpdateState("current");
+      return;
+    }
+
+    setUpdateState("restarting");
+    // reloadAsync never resolves on success — the JS context is torn down — so
+    // reaching the failure branch below is the only way this returns.
+    const reloaded = await settlePromise(() => Updates.reloadAsync());
+    if (reloaded._tag === "Failure") {
+      reportUpdateFailure(reloaded, "Downloaded, but could not restart the app.");
+      setUpdateState("idle");
+    }
+  }, []);
+
+  const statusLabel =
+    updateState === "checking"
+      ? "Checking…"
+      : updateState === "downloading"
+        ? "Downloading…"
+        : updateState === "restarting"
+          ? "Restarting…"
+          : updateState === "current"
+            ? "Up to date"
+            : bundleLabel;
+
+  const versionRow = (
+    <View className="flex-row items-center gap-4 p-4">
+      <SymbolView
+        name="info.circle"
+        size={22}
+        tintColor={icon}
+        type="monochrome"
+        weight="regular"
+      />
+      <Text className="flex-1 text-lg text-foreground">Version</Text>
+      <View className="items-end">
+        <Text className="text-lg text-foreground-muted">{versionLabel}</Text>
+        {statusLabel ? (
+          <Text className="text-xs text-foreground-muted/70">{statusLabel}</Text>
+        ) : null}
+      </View>
+      {Updates.isEnabled ? (
+        <View className="w-[22px] items-center">
+          {busy ? (
+            <ActivityIndicator color={icon} size="small" />
+          ) : (
+            <SymbolView
+              name="arrow.clockwise"
+              size={18}
+              tintColor={icon}
+              type="monochrome"
+              weight="semibold"
+            />
+          )}
+        </View>
+      ) : null}
+    </View>
+  );
+
   return (
     <SettingsSection title="App">
       <SettingsRow icon="internaldrive" label="Client Storage" target="SettingsClientStorage" />
       <SettingsRow icon="doc.text" label="Legal" fullScreenTarget="SettingsLegal" />
-      <View className="flex-row items-center gap-4 p-4">
-        <SymbolView
-          name="info.circle"
-          size={22}
-          tintColor={icon}
-          type="monochrome"
-          weight="regular"
-        />
-        <Text className="flex-1 text-lg text-foreground">Version</Text>
-        <View className="items-end">
-          <Text className="text-lg text-foreground-muted">{versionLabel}</Text>
-          {bundleLabel ? (
-            <Text className="text-xs text-foreground-muted/70">{bundleLabel}</Text>
-          ) : null}
-        </View>
-      </View>
+      {Updates.isEnabled ? (
+        <Pressable
+          accessibilityLabel="Check for updates"
+          accessibilityRole="button"
+          disabled={busy}
+          onPress={() => void checkForUpdate()}
+        >
+          {versionRow}
+        </Pressable>
+      ) : (
+        versionRow
+      )}
     </SettingsSection>
   );
+}
+
+function reportUpdateFailure(result: AtomCommandResult<unknown, unknown>, fallback: string): void {
+  reportAtomCommandResult(result, { label: "app update check" });
+  if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) return;
+  const error = squashAtomCommandFailure(result);
+  Alert.alert("Update failed", error instanceof Error ? error.message : fallback);
 }
 
 function capitalize(value: string): string {

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -8,7 +8,7 @@ import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { SymbolView } from "../../components/AppSymbol";
 import * as Effect from "effect/Effect";
 import { AsyncResult } from "effect/unstable/reactivity";
-import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -584,6 +584,7 @@ type UpdateCheckState = "idle" | "checking" | "downloading" | "restarting" | "cu
 function AppSettingsSection() {
   const icon = useThemeColor("--color-icon");
   const [updateState, setUpdateState] = useState<UpdateCheckState>("idle");
+  const updateInFlight = useRef(false);
 
   const version = Constants.expoConfig?.version ?? "0.0.0";
   // Fall back to "production" to match resolveAppVariant in app.config.ts, so a
@@ -614,37 +615,14 @@ function AppSettingsSection() {
   }, [updateState]);
 
   const checkForUpdate = useCallback(async () => {
-    setUpdateState("checking");
-    const check = await settlePromise(() => Updates.checkForUpdateAsync());
-    if (check._tag === "Failure") {
-      reportUpdateFailure(check, "Could not check for updates.");
-      setUpdateState("idle");
-      return;
-    }
-    if (!check.value.isAvailable) {
-      setUpdateState("current");
-      return;
-    }
-
-    setUpdateState("downloading");
-    const fetched = await settlePromise(() => Updates.fetchUpdateAsync());
-    if (fetched._tag === "Failure") {
-      reportUpdateFailure(fetched, "Could not download the update.");
-      setUpdateState("idle");
-      return;
-    }
-    if (!fetched.value.isNew) {
-      setUpdateState("current");
-      return;
-    }
-
-    setUpdateState("restarting");
-    // reloadAsync never resolves on success — the JS context is torn down — so
-    // reaching the failure branch below is the only way this returns.
-    const reloaded = await settlePromise(() => Updates.reloadAsync());
-    if (reloaded._tag === "Failure") {
-      reportUpdateFailure(reloaded, "Downloaded, but could not restart the app.");
-      setUpdateState("idle");
+    // `disabled={busy}` only takes effect on the next render, so two taps in the
+    // same frame would both get through. The ref closes that window.
+    if (updateInFlight.current) return;
+    updateInFlight.current = true;
+    try {
+      await runUpdateCheck(setUpdateState);
+    } finally {
+      updateInFlight.current = false;
     }
   }, []);
 
@@ -711,6 +689,45 @@ function AppSettingsSection() {
       )}
     </SettingsSection>
   );
+}
+
+async function runUpdateCheck(setUpdateState: (state: UpdateCheckState) => void): Promise<void> {
+  setUpdateState("checking");
+  const check = await settlePromise(() => Updates.checkForUpdateAsync());
+  if (check._tag === "Failure") {
+    reportUpdateFailure(check, "Could not check for updates.");
+    setUpdateState("idle");
+    return;
+  }
+  // A rollback directive (`eas update:rollback`) arrives as isAvailable: false
+  // with isRollBackToEmbedded: true — there is nothing newer to install, but the
+  // running OTA still has to be dropped for the embedded bundle.
+  if (!check.value.isAvailable && !check.value.isRollBackToEmbedded) {
+    setUpdateState("current");
+    return;
+  }
+
+  setUpdateState("downloading");
+  const fetched = await settlePromise(() => Updates.fetchUpdateAsync());
+  if (fetched._tag === "Failure") {
+    reportUpdateFailure(fetched, "Could not download the update.");
+    setUpdateState("idle");
+    return;
+  }
+  // isNew is always false for a rollback, so it can't be the sole gate here either.
+  if (!fetched.value.isNew && !fetched.value.isRollBackToEmbedded) {
+    setUpdateState("current");
+    return;
+  }
+
+  setUpdateState("restarting");
+  // reloadAsync never resolves on success — the JS context is torn down — so
+  // reaching the failure branch below is the only way this returns.
+  const reloaded = await settlePromise(() => Updates.reloadAsync());
+  if (reloaded._tag === "Failure") {
+    reportUpdateFailure(reloaded, "Downloaded, but could not restart the app.");
+    setUpdateState("idle");
+  }
 }
 
 function reportUpdateFailure(result: AtomCommandResult<unknown, unknown>, fallback: string): void {


### PR DESCRIPTION
## What Changed

Added an interactive version row in mobile Settings that lets users check for, download, and apply available OTA updates. The row now displays checking, downloading, restarting, and up-to-date states, with a loading indicator while an update is being processed. Update failures are reported with an alert.

## Why

Users need a discoverable way to receive OTA updates without waiting for an automatic check. Reusing the existing Version row keeps the control compact while clearly communicating update progress and failures.

## UI Changes

The Version row is now pressable when OTA updates are enabled and includes a refresh icon or activity indicator. No screenshots or video were provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-triggered OTA fetch and app reload can disrupt an active session; logic is localized to Settings but touches the update delivery path.
> 
> **Overview**
> When **expo-updates** is enabled, the Settings **Version** row is now tappable and runs a full manual update flow: check → download → `reloadAsync`, with inline status text and a spinner while work is in flight.
> 
> Idle state still shows the embedded vs OTA bundle hint; during a check it cycles through *Checking…*, *Downloading…*, *Restarting…*, or a brief *Up to date* before reverting after three seconds. A ref blocks double-taps before `disabled` re-renders.
> 
> `runUpdateCheck` also handles **EAS rollback-to-embedded** (`isRollBackToEmbedded`) when `isAvailable` / `isNew` would otherwise look like “nothing to do.” Failures go through `reportUpdateFailure` (logging plus a native alert).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a43228041a3dde19ab8fe0a714f1eb3a7bfd608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OTA update checks to the mobile settings version row
> - Tapping the Version row in [SettingsRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/4686/files#diff-2f7a2e66b652454e7fd1b30226a5146d595dfe05945b34d90ffd5f3a5037cb1e) triggers an OTA update check via Expo Updates when `Updates.isEnabled` is true.
> - UI transitions through 'Checking…', 'Downloading…', 'Restarting…', and 'Up to date' states, showing a spinner while busy; 'Up to date' auto-clears after 3 seconds.
> - Handles both normal OTA updates and rollback-to-embedded directives; a successful reload tears down the JS context with no resolution.
> - Failures are reported through existing telemetry and surfaced to the user via an `Alert`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a43228.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->