### PR TITLE
fix(mobile): threads load snapped to bottom on iOS

### DIFF
--- a/patches/@legendapp__list@3.2.0.patch
+++ b/patches/@legendapp__list@3.2.0.patch
@@ -204,7 +204,7 @@ index 72d3f59..435a5fc 100644
       * Number of columns to render items in.
       * @default 1
 diff --git a/react-native.js b/react-native.js
-index 8d4ff89..18f0d62 100644
+index 8d4ff89..003b2f7 100644
 --- a/react-native.js
 +++ b/react-native.js
 @@ -1195,7 +1195,7 @@ function setInitialRenderState(ctx, {
@@ -510,6 +510,15 @@ index 8d4ff89..18f0d62 100644
      onRefresh,
      onScroll: onScrollProp,
      onStartReached,
+@@ -6577,7 +6729,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+   const combinedRef = useCombinedRef(refScroller, refScrollView);
+   const keyExtractor = keyExtractorProp != null ? keyExtractorProp : ((_item, index) => index.toString());
+   const stickyHeaderIndices = stickyHeaderIndicesProp;
+-  const contentInsetEndAdjustmentResolved = Platform.OS === "web" ? contentInsetEndAdjustment : void 0;
++  const contentInsetEndAdjustmentResolved = contentInsetEndAdjustment;
+   const previousContentInsetEndAdjustmentRef = React2.useRef(contentInsetEndAdjustmentResolved);
+   const alwaysRenderIndices = React2.useMemo(() => {
+     const indices = getAlwaysRenderIndices(alwaysRender, dataProp, keyExtractor, anchoredEndSpace == null ? void 0 : anchoredEndSpace.anchorIndex);
 @@ -6710,6 +6862,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      contentContainerAlignItems: contentContainerStyle.alignItems,
      contentInset,
@@ -554,7 +563,7 @@ index 8d4ff89..18f0d62 100644
        recycleItems,
        refreshControl: refreshControlElement ? stylePaddingTopState > 0 ? React2__namespace.cloneElement(refreshControlElement, {
 diff --git a/react-native.mjs b/react-native.mjs
-index 2e96ca7..6e8913e 100644
+index 2e96ca7..fc88d4b 100644
 --- a/react-native.mjs
 +++ b/react-native.mjs
 @@ -1174,7 +1174,7 @@ function setInitialRenderState(ctx, {
@@ -860,6 +869,15 @@ index 2e96ca7..6e8913e 100644
      onRefresh,
      onScroll: onScrollProp,
      onStartReached,
+@@ -6556,7 +6708,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+   const combinedRef = useCombinedRef(refScroller, refScrollView);
+   const keyExtractor = keyExtractorProp != null ? keyExtractorProp : ((_item, index) => index.toString());
+   const stickyHeaderIndices = stickyHeaderIndicesProp;
+-  const contentInsetEndAdjustmentResolved = Platform.OS === "web" ? contentInsetEndAdjustment : void 0;
++  const contentInsetEndAdjustmentResolved = contentInsetEndAdjustment;
+   const previousContentInsetEndAdjustmentRef = useRef(contentInsetEndAdjustmentResolved);
+   const alwaysRenderIndices = useMemo(() => {
+     const indices = getAlwaysRenderIndices(alwaysRender, dataProp, keyExtractor, anchoredEndSpace == null ? void 0 : anchoredEndSpace.anchorIndex);
 @@ -6689,6 +6841,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      contentContainerAlignItems: contentContainerStyle.alignItems,
      contentInset,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ patchedDependencies:
   '@effect/vitest@4.0.0-beta.102': a607339aab944136a084a05f159aa0f5a69776934d4b835dab8f9992f1c13425
   '@expo/metro-config@56.0.14': 8cb08b5bb7051ed9d2dbe46a2c293c5a1e17f1bd6ddf30de27909e18c921ff46
   '@ff-labs/fff-node@0.9.4': 2b16019ce7ab61aec6478dd02f79ef468cc1d5c51e9d00764f7d2ab8167210c8
-  '@legendapp/list@3.2.0': 45e4cbcbeeca1b628b8480869374d7cbc77e3fbfa97ee0107a0d72c3c4a5d7f3
+  '@legendapp/list@3.2.0': 9203ec3db86574a31e157a265cefd8997b259cc420a0c4c61c580c80ed8cf78d
   '@pierre/diffs@1.3.0-beta.5': 7cb6da88544119adda056b2f46f43956f99326227732da0b345081e285a6c53a
   '@react-native-menu/menu@2.0.0': 5ea3ae4bf1d9baf5443b65c269bb09621c27a68d556f713778f37b1e8d46aaae
   '@react-navigation/native-stack@7.17.6': c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273
@@ -211,7 +211,7 @@ importers:
         version: 56.0.18(3cdc0dde9f93166d952f1e1bd0cb25c0)
       '@legendapp/list':
         specifier: 3.2.0
-        version: 3.2.0(patch_hash=45e4cbcbeeca1b628b8480869374d7cbc77e3fbfa97ee0107a0d72c3c4a5d7f3)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 3.2.0(patch_hash=9203ec3db86574a31e157a265cefd8997b259cc420a0c4c61c580c80ed8cf78d)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@noble/curves':
         specifier: 'catalog:'
         version: 1.9.1
@@ -543,7 +543,7 @@ importers:
         version: 0.9.0
       '@legendapp/list':
         specifier: 3.2.0
-        version: 3.2.0(patch_hash=45e4cbcbeeca1b628b8480869374d7cbc77e3fbfa97ee0107a0d72c3c4a5d7f3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.2.0(patch_hash=9203ec3db86574a31e157a265cefd8997b259cc420a0c4c61c580c80ed8cf78d)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@lexical/react':
         specifier: ^0.41.0
         version: 0.41.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yjs@13.6.31)
@@ -12976,7 +12976,7 @@ snapshots:
     dependencies:
       jsbi: 4.3.2
 
-  '@legendapp/list@3.2.0(patch_hash=45e4cbcbeeca1b628b8480869374d7cbc77e3fbfa97ee0107a0d72c3c4a5d7f3)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@legendapp/list@3.2.0(patch_hash=9203ec3db86574a31e157a265cefd8997b259cc420a0c4c61c580c80ed8cf78d)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
@@ -12984,7 +12984,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  '@legendapp/list@3.2.0(patch_hash=45e4cbcbeeca1b628b8480869374d7cbc77e3fbfa97ee0107a0d72c3c4a5d7f3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@legendapp/list@3.2.0(patch_hash=9203ec3db86574a31e157a265cefd8997b259cc420a0c4c61c580c80ed8cf78d)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)


### PR DESCRIPTION
The legend-list patch feeds the composer's safe-area compensation into the core list via `contentInsetEndAdjustment`, but upstream resolves that prop on web only — on iOS it was discarded, so the initial scroll-to-end landed one safe-area inset (~34px) short and the composer covered the last message's timestamp.

One-line change in the patch: resolve the prop on all platforms. Verified on an iPhone 17 Pro simulator — threads now open pinned to the bottom with the last timestamp fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vendored list scroll, clamping, and initial-render gating used by thread feeds on iOS (and end-inset behavior on web); regressions would show as wrong scroll position or flicker on open.
> 
> **Overview**
> **Fixes iOS threads opening one safe-area inset short of the bottom** so the composer no longer covers the last message timestamp.
> 
> The `@legendapp/list` patch now **honors `contentInsetEndAdjustment` on iOS** (and all platforms) instead of resolving it only on web, so keyboard/composer inset compensation from `useKeyboardChatComposerInset` / `contentInsetEndStaticAdjustment` is included in initial scroll-to-end math.
> 
> The same patch refresh also wires **`contentInsetStartAdjustment`** through the list core, **defers first paint** while an inset-end settle watchdog runs (`insetEndRevealHold`), and tracks **`onScrollBeginDrag`** so re-pin logic does not fight the user. `pnpm-lock.yaml` updates the patched dependency hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72dc1e76ace6fc1c08d46643299081702bb4280c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread list loading snapped to bottom on iOS
> Patches `@legendapp/list` to fix iOS thread lists loading scrolled to the bottom. The fix removes a `Platform.OS === 'web'` guard so that `contentInsetEndAdjustmentResolved` is set unconditionally and included in the constructed scroll props object.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72dc1e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->