### PR TITLE
Fix relay credential lookup for unlinked environments

### DIFF
--- a/infra/relay/src/db.ts
+++ b/infra/relay/src/db.ts
@@ -7,6 +7,7 @@ import * as RemovalPolicy from "alchemy/RemovalPolicy";
 import type { EffectPgDatabase } from "drizzle-orm/effect-postgres";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 
 import { relayDatabaseMode } from "./dbConfig.ts";
 
@@ -16,6 +17,23 @@ export class RelayDb extends Context.Service<
     readonly $client: PgClient;
   }
 >()("t3code-relay/db/RelayDb") {}
+
+export class RelayTransactions extends Context.Service<
+  RelayTransactions,
+  {
+    readonly withTransaction: RelayDb["Service"]["$client"]["withTransaction"];
+  }
+>()("t3code-relay/db/RelayTransactions") {
+  static readonly layer = Layer.effect(
+    RelayTransactions,
+    Effect.gen(function* () {
+      const db = yield* RelayDb;
+      return RelayTransactions.of({
+        withTransaction: db.$client.withTransaction,
+      });
+    }),
+  );
+}
 
 export const PlanetscaleDatabase = Effect.gen(function* () {
   const { stage } = yield* Alchemy.Stack;

--- a/infra/relay/src/environments/EnvironmentConnector.test.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.test.ts
@@ -198,7 +198,9 @@ function makeAllocations(
     recordDns: () => Effect.die("unused"),
     markReady: () => Effect.die("unused"),
     claimRelease: () => Effect.die("unused"),
+    claimDeprovision: () => Effect.die("unused"),
     remove: () => Effect.die("unused"),
+    removeClaimed: () => Effect.die("unused"),
   };
 }
 

--- a/infra/relay/src/environments/EnvironmentCredentials.test.ts
+++ b/infra/relay/src/environments/EnvironmentCredentials.test.ts
@@ -1,6 +1,6 @@
 import * as NodeCryptoLayer from "@effect/platform-node/NodeCrypto";
 import { describe, expect, it } from "@effect/vitest";
-import { PgDialect, QueryBuilder } from "drizzle-orm/pg-core";
+import { PgDialect } from "drizzle-orm/pg-core";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
@@ -58,13 +58,17 @@ describe("EnvironmentCredentials", () => {
   it.effect("does not retain credential tokens when lookup persistence fails", () => {
     const cause = new Error("database unavailable");
     const token = "t3env_sensitive-credential-token";
+    const whereConditions: Array<unknown> = [];
     const fakeDb = {
       select: () => ({
         from: (table: unknown) => {
           expect(table).toBe(relayEnvironmentCredentials);
           return {
-            where: () => ({
-              limit: () => Effect.fail(cause),
+            where: (condition: unknown) => ({
+              limit: () => {
+                whereConditions.push(condition);
+                return Effect.fail(cause);
+              },
             }),
           };
         },
@@ -81,6 +85,13 @@ describe("EnvironmentCredentials", () => {
       });
       expect(error.cause).toBe(cause);
       expect(error).not.toHaveProperty("token");
+      expect(whereConditions).toHaveLength(1);
+
+      const query = new PgDialect().sqlToQuery(whereConditions[0] as never);
+      expect(query.sql).toContain("exists");
+      expect(query.sql).toContain('"relay_environment_links"."environment_id"');
+      expect(query.sql).toContain('"relay_environment_links"."environment_public_key"');
+      expect(query.sql).toContain('"relay_environment_links"."revoked_at" is null');
     }).pipe(
       Effect.provide(
         EnvironmentCredentials.layer.pipe(
@@ -180,7 +191,6 @@ describe("EnvironmentCredentials", () => {
     const updateValues: Array<Record<string, unknown>> = [];
     const whereConditions: Array<unknown> = [];
     const fakeDb = {
-      select: (fields: Parameters<QueryBuilder["select"]>[0]) => new QueryBuilder().select(fields),
       update: (table: unknown) => {
         expect(table).toBe(relayEnvironmentCredentials);
         return {

--- a/infra/relay/src/environments/EnvironmentCredentials.ts
+++ b/infra/relay/src/environments/EnvironmentCredentials.ts
@@ -6,7 +6,8 @@ import * as Encoding from "effect/Encoding";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
-import { and, eq, isNull, ne, notExists } from "drizzle-orm";
+import { and, eq, exists, isNull, ne, notExists } from "drizzle-orm";
+import { QueryBuilder } from "drizzle-orm/pg-core";
 
 import * as RelayDb from "../db.ts";
 import { relayEnvironmentCredentials, relayEnvironmentLinks } from "../persistence/schema.ts";
@@ -196,6 +197,24 @@ const make = Effect.gen(function* () {
           and(
             eq(relayEnvironmentCredentials.credentialHash, credentialHash),
             isNull(relayEnvironmentCredentials.revokedAt),
+            exists(
+              new QueryBuilder()
+                .select({ userId: relayEnvironmentLinks.userId })
+                .from(relayEnvironmentLinks)
+                .where(
+                  and(
+                    eq(
+                      relayEnvironmentLinks.environmentId,
+                      relayEnvironmentCredentials.environmentId,
+                    ),
+                    eq(
+                      relayEnvironmentLinks.environmentPublicKey,
+                      relayEnvironmentCredentials.environmentPublicKey,
+                    ),
+                    isNull(relayEnvironmentLinks.revokedAt),
+                  ),
+                ),
+            ),
           ),
         )
         .limit(1)
@@ -238,7 +257,7 @@ const make = Effect.gen(function* () {
             eq(relayEnvironmentCredentials.environmentPublicKey, input.environmentPublicKey),
             isNull(relayEnvironmentCredentials.revokedAt),
             notExists(
-              db
+              new QueryBuilder()
                 .select({ userId: relayEnvironmentLinks.userId })
                 .from(relayEnvironmentLinks)
                 .where(

--- a/infra/relay/src/environments/EnvironmentLinker.test.ts
+++ b/infra/relay/src/environments/EnvironmentLinker.test.ts
@@ -136,6 +136,7 @@ function testLayer(input?: {
           revokeForEnvironmentPublicKey: () => Effect.succeed(false),
         }),
         Layer.succeed(ManagedEndpointProvider.ManagedEndpointProvider, {
+          prepareDeprovision: () => Effect.succeed(null),
           deprovision: input?.deprovision ?? (() => Effect.void),
           release: () => Effect.succeed(true),
           provision: () =>

--- a/infra/relay/src/environments/ManagedEndpointAllocations.test.ts
+++ b/infra/relay/src/environments/ManagedEndpointAllocations.test.ts
@@ -10,6 +10,61 @@ const layerWithDb = (db: RelayDb.RelayDb["Service"]) =>
   ManagedEndpointAllocations.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, db)));
 
 describe("ManagedEndpointAllocations", () => {
+  it.effect("returns a claim generation only when deprovision wins the allocation CAS", () => {
+    let claimedAt: string | undefined;
+    const fakeDb = {
+      update: (table: unknown) => {
+        expect(table).toBe(relayManagedEndpointAllocations);
+        return {
+          set: (values: { readonly updatedAt: string }) => {
+            claimedAt = values.updatedAt;
+            return {
+              where: () => ({
+                returning: () => Effect.succeed([{ userId: "user-1" }]),
+              }),
+            };
+          },
+        };
+      },
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const allocations = yield* ManagedEndpointAllocations.ManagedEndpointAllocations;
+      const generation = yield* allocations.claimDeprovision({
+        userId: "user-1",
+        environmentId: "environment-1",
+        updatedAt: "captured-generation",
+      });
+
+      expect(generation).toBe(claimedAt);
+      expect(generation).not.toBeNull();
+    }).pipe(Effect.provide(layerWithDb(fakeDb)));
+  });
+
+  it.effect("does not remove an allocation superseded after a deprovision claim", () => {
+    const fakeDb = {
+      delete: (table: unknown) => {
+        expect(table).toBe(relayManagedEndpointAllocations);
+        return {
+          where: () => ({
+            returning: () => Effect.succeed([]),
+          }),
+        };
+      },
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const allocations = yield* ManagedEndpointAllocations.ManagedEndpointAllocations;
+      expect(
+        yield* allocations.removeClaimed({
+          userId: "user-1",
+          environmentId: "environment-1",
+          updatedAt: "outdated-claim-generation",
+        }),
+      ).toBe(false);
+    }).pipe(Effect.provide(layerWithDb(fakeDb)));
+  });
+
   it.effect("retains database failures with allocation operation and identity", () => {
     const cause = new Error("database unavailable");
     const fakeDb = {

--- a/infra/relay/src/environments/ManagedEndpointAllocations.ts
+++ b/infra/relay/src/environments/ManagedEndpointAllocations.ts
@@ -51,7 +51,9 @@ export class ManagedEndpointAllocationPersistenceError extends Schema.TaggedErro
       "record-dns",
       "mark-ready",
       "claim-release",
+      "claim-deprovision",
       "remove",
+      "remove-claimed",
     ]),
     stage: Schema.Literals(["database-request", "resolve-reservation"]),
     userId: Schema.String,
@@ -91,6 +93,14 @@ interface ClaimManagedEndpointReleaseInput extends ManagedEndpointAllocationKey 
   readonly updatedAt: string;
 }
 
+interface ClaimManagedEndpointDeprovisionInput extends ManagedEndpointAllocationKey {
+  readonly updatedAt: string;
+}
+
+interface RemoveClaimedManagedEndpointAllocationInput extends ManagedEndpointAllocationKey {
+  readonly updatedAt: string;
+}
+
 export class ManagedEndpointAllocations extends Context.Service<
   ManagedEndpointAllocations,
   {
@@ -119,9 +129,22 @@ export class ManagedEndpointAllocations extends Context.Service<
     readonly claimRelease: (
       input: ClaimManagedEndpointReleaseInput,
     ) => Effect.Effect<boolean, ManagedEndpointAllocationPersistenceError>;
+    /**
+     * Claims the complete allocation for teardown only if its generation still
+     * matches the snapshot captured by the unlink operation.
+     *
+     * Returns the claim generation used by `removeClaimed`, or null when a
+     * concurrent provision has already superseded the snapshot.
+     */
+    readonly claimDeprovision: (
+      input: ClaimManagedEndpointDeprovisionInput,
+    ) => Effect.Effect<string | null, ManagedEndpointAllocationPersistenceError>;
     readonly remove: (
       input: ManagedEndpointAllocationKey,
     ) => Effect.Effect<void, ManagedEndpointAllocationPersistenceError>;
+    readonly removeClaimed: (
+      input: RemoveClaimedManagedEndpointAllocationInput,
+    ) => Effect.Effect<boolean, ManagedEndpointAllocationPersistenceError>;
   }
 >()("t3code-relay/environments/ManagedEndpointAllocations") {}
 
@@ -321,6 +344,35 @@ export const make = Effect.gen(function* () {
         );
       return claimed;
     }),
+    claimDeprovision: Effect.fn("relay.managed_endpoint_allocations.claim_deprovision")(function* (
+      input: ClaimManagedEndpointDeprovisionInput,
+    ) {
+      const claimedAt = DateTime.formatIso(yield* DateTime.now);
+      const claimed = yield* db
+        .update(relayManagedEndpointAllocations)
+        .set({ updatedAt: claimedAt })
+        .where(
+          and(
+            whereAllocation(input),
+            eq(relayManagedEndpointAllocations.updatedAt, input.updatedAt),
+          ),
+        )
+        .returning({ userId: relayManagedEndpointAllocations.userId })
+        .pipe(
+          Effect.map((rows) => rows.length > 0),
+          Effect.mapError(
+            (cause) =>
+              new ManagedEndpointAllocationPersistenceError({
+                operation: "claim-deprovision",
+                stage: "database-request",
+                userId: input.userId,
+                environmentId: input.environmentId,
+                cause,
+              }),
+          ),
+        );
+      return claimed ? claimedAt : null;
+    }),
     remove: Effect.fn("relay.managed_endpoint_allocations.remove")(function* (
       input: ManagedEndpointAllocationKey,
     ) {
@@ -334,6 +386,32 @@ export const make = Effect.gen(function* () {
                 operation: "remove",
                 stage: "database-request",
                 ...input,
+                cause,
+              }),
+          ),
+        );
+    }),
+    removeClaimed: Effect.fn("relay.managed_endpoint_allocations.remove_claimed")(function* (
+      input: RemoveClaimedManagedEndpointAllocationInput,
+    ) {
+      return yield* db
+        .delete(relayManagedEndpointAllocations)
+        .where(
+          and(
+            whereAllocation(input),
+            eq(relayManagedEndpointAllocations.updatedAt, input.updatedAt),
+          ),
+        )
+        .returning({ userId: relayManagedEndpointAllocations.userId })
+        .pipe(
+          Effect.map((rows) => rows.length > 0),
+          Effect.mapError(
+            (cause) =>
+              new ManagedEndpointAllocationPersistenceError({
+                operation: "remove-claimed",
+                stage: "database-request",
+                userId: input.userId,
+                environmentId: input.environmentId,
                 cause,
               }),
           ),

--- a/infra/relay/src/environments/ManagedEndpointProvider.test.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.test.ts
@@ -50,7 +50,9 @@ interface AllocationCall {
     | "recordDns"
     | "markReady"
     | "claimRelease"
-    | "remove";
+    | "claimDeprovision"
+    | "remove"
+    | "removeClaimed";
   readonly input: unknown;
 }
 
@@ -226,10 +228,30 @@ function makeAllocations(calls: AllocationCall[] = []) {
         mutate(allocationKey(input), (current) => current);
         return true;
       }),
+    claimDeprovision: (input) =>
+      Effect.sync(() => {
+        calls.push({ operation: "claimDeprovision", input });
+        const allocation = allocations.get(allocationKey(input));
+        if (allocation === undefined || allocation.updatedAt !== input.updatedAt) {
+          return null;
+        }
+        mutate(allocationKey(input), (current) => current);
+        return allocations.get(allocationKey(input))?.updatedAt ?? null;
+      }),
     remove: (input) =>
       Effect.sync(() => {
         calls.push({ operation: "remove", input });
         allocations.delete(allocationKey(input));
+      }),
+    removeClaimed: (input) =>
+      Effect.sync(() => {
+        calls.push({ operation: "removeClaimed", input });
+        const allocation = allocations.get(allocationKey(input));
+        if (allocation === undefined || allocation.updatedAt !== input.updatedAt) {
+          return false;
+        }
+        allocations.delete(allocationKey(input));
+        return true;
       }),
   });
 }
@@ -774,11 +796,53 @@ describe("ManagedEndpointProvider", () => {
           "recordDns",
           "markReady",
           "get",
-          "remove",
+          "claimDeprovision",
+          "removeClaimed",
         ]);
       }).pipe(Effect.provide(layer));
     },
   );
+
+  it.effect("does not deprovision an allocation superseded by a concurrent relink", () => {
+    const tunnelCalls: TunnelCall[] = [];
+    const dnsCalls: DnsCall[] = [];
+    const allocationCalls: AllocationCall[] = [];
+    const layer = providerLayer(
+      makePersistentTunnelClient(tunnelCalls),
+      makeDnsClient(dnsCalls),
+      makeAllocations(allocationCalls),
+    );
+
+    return Effect.gen(function* () {
+      const provider = yield* ManagedEndpointProvider.ManagedEndpointProvider;
+      const key = { userId: "user_ABC", environmentId: "env_ABC" } as const;
+      const request = {
+        ...key,
+        origin: { localHttpHost: "127.0.0.1", localHttpPort: 3773 },
+      } as const;
+      yield* provider.provision(request);
+      const unlinkTarget = yield* provider.prepareDeprovision(key);
+      expect(unlinkTarget).not.toBeNull();
+      if (unlinkTarget === null) {
+        return;
+      }
+
+      // A relink refreshes the allocation generation after unlink captured its
+      // target but before unlink begins external teardown.
+      yield* provider.provision(request);
+      const tunnelCallCount = tunnelCalls.length;
+      const dnsCallCount = dnsCalls.length;
+      const allocationCallCount = allocationCalls.length;
+
+      yield* provider.deprovision({ ...key, target: unlinkTarget });
+
+      expect(tunnelCalls).toHaveLength(tunnelCallCount);
+      expect(dnsCalls).toHaveLength(dnsCallCount);
+      expect(allocationCalls.slice(allocationCallCount).map((call) => call.operation)).toEqual([
+        "claimDeprovision",
+      ]);
+    }).pipe(Effect.provide(layer));
+  });
 
   it.effect("releases the tunnel while keeping the allocation, DNS record, and hostname", () => {
     const tunnelCalls: TunnelCall[] = [];
@@ -1004,8 +1068,10 @@ describe("ManagedEndpointProvider", () => {
         "recordDns",
         "markReady",
         "get",
+        "claimDeprovision",
         "get",
-        "remove",
+        "claimDeprovision",
+        "removeClaimed",
       ]);
     }).pipe(Effect.provide(layer));
   });
@@ -1046,7 +1112,7 @@ describe("ManagedEndpointProvider", () => {
       });
       yield* provider.deprovision(key);
 
-      expect(allocationCalls.map((call) => call.operation)).toContain("remove");
+      expect(allocationCalls.map((call) => call.operation)).toContain("removeClaimed");
     }).pipe(Effect.provide(layer));
   });
 

--- a/infra/relay/src/environments/ManagedEndpointProvider.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.ts
@@ -77,6 +77,7 @@ export class ManagedEndpointProvisioningFailed extends Schema.TaggedErrorClass<M
 const ManagedEndpointDeprovisioningStage = Schema.Literals([
   "load-allocation",
   "claim-release",
+  "claim-deprovision",
   "delete-dns-record",
   "delete-tunnel",
   "remove-allocation",
@@ -123,6 +124,8 @@ export interface ManagedEndpointProvisioningResult {
   readonly runtime: RelayManagedEndpointRuntimeConfig;
 }
 
+export type ManagedEndpointDeprovisionTarget = ManagedEndpointAllocations.ManagedEndpointAllocation;
+
 export class ManagedEndpointProvider extends Context.Service<
   ManagedEndpointProvider,
   {
@@ -131,9 +134,22 @@ export class ManagedEndpointProvider extends Context.Service<
       readonly environmentId: string;
       readonly origin: RelayManagedEndpointOrigin;
     }) => Effect.Effect<ManagedEndpointProvisioningResult, ManagedEndpointProviderError>;
+    /**
+     * Captures the allocation generation owned by an unlink before its link
+     * revocation commits. Passing this target to `deprovision` prevents a
+     * concurrent relink from having its newer allocation torn down.
+     */
+    readonly prepareDeprovision: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+    }) => Effect.Effect<
+      ManagedEndpointDeprovisionTarget | null,
+      ManagedEndpointDeprovisioningFailed
+    >;
     readonly deprovision: (input: {
       readonly userId: string;
       readonly environmentId: string;
+      readonly target?: ManagedEndpointDeprovisionTarget | null;
     }) => Effect.Effect<void, ManagedEndpointDeprovisioningFailed>;
     /**
      * Deletes the provisioned Cloudflare tunnel while keeping the allocation
@@ -424,13 +440,9 @@ export const make = Effect.gen(function* () {
     );
   });
 
-  return ManagedEndpointProvider.of({
-    deprovision: Effect.fn("relay.managed_endpoint_provider.deprovision")(function* (input) {
-      yield* Effect.annotateCurrentSpan({
-        "relay.user_id": input.userId,
-        "relay.environment_id": input.environmentId,
-      });
-      const allocation = yield* allocations.get(input).pipe(
+  const prepareDeprovision = Effect.fn("relay.managed_endpoint_provider.prepare_deprovision")(
+    function* (input: { readonly userId: string; readonly environmentId: string }) {
+      return yield* allocations.get(input).pipe(
         Effect.mapError(
           (cause) =>
             new ManagedEndpointDeprovisioningFailed({
@@ -440,7 +452,40 @@ export const make = Effect.gen(function* () {
             }),
         ),
       );
+    },
+  );
+
+  return ManagedEndpointProvider.of({
+    prepareDeprovision,
+    deprovision: Effect.fn("relay.managed_endpoint_provider.deprovision")(function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "relay.user_id": input.userId,
+        "relay.environment_id": input.environmentId,
+      });
+      const allocation =
+        input.target === undefined ? yield* prepareDeprovision(input) : input.target;
       if (allocation === null) {
+        return;
+      }
+      const claimedAt = yield* allocations
+        .claimDeprovision({
+          userId: input.userId,
+          environmentId: input.environmentId,
+          updatedAt: allocation.updatedAt,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ManagedEndpointDeprovisioningFailed({
+                ...input,
+                stage: "claim-deprovision",
+                ...(allocation.tunnelId === null ? {} : { tunnelId: allocation.tunnelId }),
+                ...(allocation.dnsRecordId === null ? {} : { dnsRecordId: allocation.dnsRecordId }),
+                cause,
+              }),
+          ),
+        );
+      if (claimedAt === null) {
         return;
       }
       const dnsRecordId = allocation.dnsRecordId;
@@ -471,18 +516,24 @@ export const make = Effect.gen(function* () {
           ),
         );
       }
-      yield* allocations.remove(input).pipe(
-        Effect.mapError(
-          (cause) =>
-            new ManagedEndpointDeprovisioningFailed({
-              ...input,
-              stage: "remove-allocation",
-              ...(allocation.tunnelId === null ? {} : { tunnelId: allocation.tunnelId }),
-              ...(allocation.dnsRecordId === null ? {} : { dnsRecordId: allocation.dnsRecordId }),
-              cause,
-            }),
-        ),
-      );
+      yield* allocations
+        .removeClaimed({
+          userId: input.userId,
+          environmentId: input.environmentId,
+          updatedAt: claimedAt,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ManagedEndpointDeprovisioningFailed({
+                ...input,
+                stage: "remove-allocation",
+                ...(allocation.tunnelId === null ? {} : { tunnelId: allocation.tunnelId }),
+                ...(allocation.dnsRecordId === null ? {} : { dnsRecordId: allocation.dnsRecordId }),
+                cause,
+              }),
+          ),
+        );
     }),
     release: Effect.fn("relay.managed_endpoint_provider.release")(function* (input) {
       yield* Effect.annotateCurrentSpan({

--- a/infra/relay/src/environments/ManagedTunnelLimits.test.ts
+++ b/infra/relay/src/environments/ManagedTunnelLimits.test.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 
 import * as RelayDb from "../db.ts";
 import {
+  relayEnvironmentLinks,
   relayManagedEndpointAllocations,
   relayManagedTunnelLimits,
 } from "../persistence/schema.ts";
@@ -28,7 +29,16 @@ function makeFakeDb(input: {
         }
         expect(table).toBe(relayManagedEndpointAllocations);
         return {
-          where: () => input.countRows ?? Effect.succeed([{ activeTunnels: 0 }]),
+          innerJoin: (table: unknown, condition: unknown) => {
+            expect(table).toBe(relayEnvironmentLinks);
+            expect(condition).toBeDefined();
+            return {
+              where: (where: unknown) => {
+                expect(where).toBeDefined();
+                return input.countRows ?? Effect.succeed([{ activeTunnels: 0 }]);
+              },
+            };
+          },
         };
       },
     }),

--- a/infra/relay/src/environments/ManagedTunnelLimits.ts
+++ b/infra/relay/src/environments/ManagedTunnelLimits.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, ne } from "drizzle-orm";
+import { and, count, eq, isNull, ne } from "drizzle-orm";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -6,6 +6,7 @@ import * as Schema from "effect/Schema";
 
 import * as RelayDb from "../db.ts";
 import {
+  relayEnvironmentLinks,
   relayManagedEndpointAllocations,
   relayManagedTunnelLimits,
 } from "../persistence/schema.ts";
@@ -81,10 +82,19 @@ export const make = Effect.gen(function* () {
       const counted = yield* db
         .select({ activeTunnels: count() })
         .from(relayManagedEndpointAllocations)
+        .innerJoin(
+          relayEnvironmentLinks,
+          and(
+            eq(relayEnvironmentLinks.userId, relayManagedEndpointAllocations.userId),
+            eq(relayEnvironmentLinks.environmentId, relayManagedEndpointAllocations.environmentId),
+          ),
+        )
         .where(
           and(
             eq(relayManagedEndpointAllocations.userId, input.userId),
             ne(relayManagedEndpointAllocations.environmentId, input.environmentId),
+            isNull(relayEnvironmentLinks.revokedAt),
+            eq(relayEnvironmentLinks.managedTunnelsEnabled, true),
           ),
         )
         .pipe(

--- a/infra/relay/src/http/Api.test.ts
+++ b/infra/relay/src/http/Api.test.ts
@@ -233,9 +233,25 @@ describe("relay environment unlink", () => {
           return true;
         }),
     } as unknown as EnvironmentCredentials.EnvironmentCredentials["Service"];
+    const deprovisionTarget = {
+      userId: "user-1",
+      environmentId: "environment-1",
+      hostname: "environment-1.example.test",
+      tunnelId: "tunnel-1",
+      tunnelName: "environment-1-tunnel",
+      dnsRecordId: "dns-1",
+      readyAt: "2026-07-28T00:00:00.000Z",
+      updatedAt: "generation-before-unlink",
+    } satisfies ManagedEndpointProvider.ManagedEndpointDeprovisionTarget;
     const managedEndpointProvider = {
-      deprovision: () =>
+      prepareDeprovision: () =>
         Effect.sync(() => {
+          calls.push("prepare");
+          return deprovisionTarget;
+        }),
+      deprovision: (input: { readonly target?: unknown }) =>
+        Effect.sync(() => {
+          expect(input.target).toBe(deprovisionTarget);
           calls.push("deprovision");
         }),
     } as unknown as ManagedEndpointProvider.ManagedEndpointProvider["Service"];
@@ -251,7 +267,14 @@ describe("relay environment unlink", () => {
           environmentId: "environment-1",
         }),
       ).toBe(true);
-      expect(calls).toEqual(["lookup", "transaction", "link", "credential", "deprovision"]);
+      expect(calls).toEqual([
+        "prepare",
+        "lookup",
+        "transaction",
+        "link",
+        "credential",
+        "deprovision",
+      ]);
     });
   });
 
@@ -288,6 +311,11 @@ describe("relay environment unlink", () => {
         }).pipe(Effect.andThen(Effect.fail(failure))),
     } as unknown as EnvironmentCredentials.EnvironmentCredentials["Service"];
     const managedEndpointProvider = {
+      prepareDeprovision: () =>
+        Effect.sync(() => {
+          calls.push("prepare");
+          return null;
+        }),
       deprovision: () =>
         Effect.sync(() => {
           calls.push("deprovision");
@@ -307,7 +335,7 @@ describe("relay environment unlink", () => {
           }),
         ),
       ).toBe(failure);
-      expect(calls).toEqual(["transaction", "link", "credential"]);
+      expect(calls).toEqual(["prepare", "transaction", "link", "credential"]);
     });
   });
 
@@ -317,6 +345,11 @@ describe("relay environment unlink", () => {
       getForUser: () => Effect.succeed(null),
     } as unknown as EnvironmentLinks.EnvironmentLinks["Service"];
     const managedEndpointProvider = {
+      prepareDeprovision: () =>
+        Effect.sync(() => {
+          calls.push("prepare");
+          return null;
+        }),
       deprovision: () =>
         Effect.sync(() => {
           calls.push("deprovision");
@@ -334,7 +367,7 @@ describe("relay environment unlink", () => {
           environmentId: "environment-1",
         }),
       ).toBe(false);
-      expect(calls).toEqual(["deprovision"]);
+      expect(calls).toEqual(["prepare", "deprovision"]);
     });
   });
 });

--- a/infra/relay/src/http/Api.test.ts
+++ b/infra/relay/src/http/Api.test.ts
@@ -22,12 +22,15 @@ import {
   relayDocsRedirectRoute,
   relayEnvironmentAuthLayer,
   relayNotFoundRoute,
+  revokeEnvironmentLinkRecord,
   traceRelayHttpRequestWith,
   verifyRelayClientBearerToken,
   withoutCapturedParentSpan,
 } from "./Api.ts";
 import * as RelayConfiguration from "../Config.ts";
+import * as RelayDb from "../db.ts";
 import * as EnvironmentCredentials from "../environments/EnvironmentCredentials.ts";
+import * as EnvironmentLinks from "../environments/EnvironmentLinks.ts";
 
 vi.mock("@clerk/backend", () => ({
   createClerkClient: vi.fn(),
@@ -152,6 +155,48 @@ describe("relay environment authentication", () => {
       ),
       Effect.scoped,
     );
+  });
+});
+
+describe("relay environment unlink", () => {
+  it.effect("revokes the link and its credentials in one database transaction", () => {
+    const calls: Array<string> = [];
+    const db = {
+      $client: {
+        withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => {
+          calls.push("transaction");
+          return effect;
+        },
+      },
+    } as unknown as RelayDb.RelayDb["Service"];
+    const links = {
+      revokeForUser: () =>
+        Effect.sync(() => {
+          calls.push("link");
+          return true;
+        }),
+    } as unknown as EnvironmentLinks.EnvironmentLinks["Service"];
+    const credentials = {
+      revokeForEnvironmentPublicKey: () =>
+        Effect.sync(() => {
+          calls.push("credential");
+          return true;
+        }),
+    } as unknown as EnvironmentCredentials.EnvironmentCredentials["Service"];
+
+    return Effect.gen(function* () {
+      expect(
+        yield* revokeEnvironmentLinkRecord({
+          db,
+          links,
+          credentials,
+          userId: "user-1",
+          environmentId: "environment-1",
+          environmentPublicKey: "public-key",
+        }),
+      ).toBe(true);
+      expect(calls).toEqual(["transaction", "link", "credential"]);
+    });
   });
 });
 

--- a/infra/relay/src/http/Api.test.ts
+++ b/infra/relay/src/http/Api.test.ts
@@ -24,6 +24,7 @@ import {
   relayNotFoundRoute,
   revokeEnvironmentLinkRecord,
   traceRelayHttpRequestWith,
+  unlinkEnvironmentRecord,
   verifyRelayClientBearerToken,
   withoutCapturedParentSpan,
 } from "./Api.ts";
@@ -31,6 +32,7 @@ import * as RelayConfiguration from "../Config.ts";
 import * as RelayDb from "../db.ts";
 import * as EnvironmentCredentials from "../environments/EnvironmentCredentials.ts";
 import * as EnvironmentLinks from "../environments/EnvironmentLinks.ts";
+import * as ManagedEndpointProvider from "../environments/ManagedEndpointProvider.ts";
 
 vi.mock("@clerk/backend", () => ({
   createClerkClient: vi.fn(),
@@ -196,6 +198,143 @@ describe("relay environment unlink", () => {
         }),
       ).toBe(true);
       expect(calls).toEqual(["transaction", "link", "credential"]);
+    });
+  });
+
+  it.effect("commits database revocation before deprovisioning the managed endpoint", () => {
+    const calls: Array<string> = [];
+    const db = {
+      $client: {
+        withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => {
+          calls.push("transaction");
+          return effect;
+        },
+      },
+    } as unknown as RelayDb.RelayDb["Service"];
+    const links = {
+      getForUser: () =>
+        Effect.sync(() => {
+          calls.push("lookup");
+          return {
+            environmentId: "environment-1",
+            environmentPublicKey: "public-key",
+          };
+        }),
+      revokeForUser: () =>
+        Effect.sync(() => {
+          calls.push("link");
+          return true;
+        }),
+    } as unknown as EnvironmentLinks.EnvironmentLinks["Service"];
+    const credentials = {
+      revokeForEnvironmentPublicKey: () =>
+        Effect.sync(() => {
+          calls.push("credential");
+          return true;
+        }),
+    } as unknown as EnvironmentCredentials.EnvironmentCredentials["Service"];
+    const managedEndpointProvider = {
+      deprovision: () =>
+        Effect.sync(() => {
+          calls.push("deprovision");
+        }),
+    } as unknown as ManagedEndpointProvider.ManagedEndpointProvider["Service"];
+
+    return Effect.gen(function* () {
+      expect(
+        yield* unlinkEnvironmentRecord({
+          db,
+          links,
+          credentials,
+          managedEndpointProvider,
+          userId: "user-1",
+          environmentId: "environment-1",
+        }),
+      ).toBe(true);
+      expect(calls).toEqual(["lookup", "transaction", "link", "credential", "deprovision"]);
+    });
+  });
+
+  it.effect("does not deprovision when database revocation fails", () => {
+    const calls: Array<string> = [];
+    const failure = new EnvironmentCredentials.EnvironmentCredentialRevokePersistenceError({
+      environmentId: "environment-1",
+      cause: "database unavailable",
+    });
+    const db = {
+      $client: {
+        withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => {
+          calls.push("transaction");
+          return effect;
+        },
+      },
+    } as unknown as RelayDb.RelayDb["Service"];
+    const links = {
+      getForUser: () =>
+        Effect.succeed({
+          environmentId: "environment-1",
+          environmentPublicKey: "public-key",
+        }),
+      revokeForUser: () =>
+        Effect.sync(() => {
+          calls.push("link");
+          return true;
+        }),
+    } as unknown as EnvironmentLinks.EnvironmentLinks["Service"];
+    const credentials = {
+      revokeForEnvironmentPublicKey: () =>
+        Effect.sync(() => {
+          calls.push("credential");
+        }).pipe(Effect.andThen(Effect.fail(failure))),
+    } as unknown as EnvironmentCredentials.EnvironmentCredentials["Service"];
+    const managedEndpointProvider = {
+      deprovision: () =>
+        Effect.sync(() => {
+          calls.push("deprovision");
+        }),
+    } as unknown as ManagedEndpointProvider.ManagedEndpointProvider["Service"];
+
+    return Effect.gen(function* () {
+      expect(
+        yield* Effect.flip(
+          unlinkEnvironmentRecord({
+            db,
+            links,
+            credentials,
+            managedEndpointProvider,
+            userId: "user-1",
+            environmentId: "environment-1",
+          }),
+        ),
+      ).toBe(failure);
+      expect(calls).toEqual(["transaction", "link", "credential"]);
+    });
+  });
+
+  it.effect("retries deprovisioning after the link is already revoked", () => {
+    const calls: Array<string> = [];
+    const links = {
+      getForUser: () => Effect.succeed(null),
+    } as unknown as EnvironmentLinks.EnvironmentLinks["Service"];
+    const managedEndpointProvider = {
+      deprovision: () =>
+        Effect.sync(() => {
+          calls.push("deprovision");
+        }),
+    } as unknown as ManagedEndpointProvider.ManagedEndpointProvider["Service"];
+
+    return Effect.gen(function* () {
+      expect(
+        yield* unlinkEnvironmentRecord({
+          db: {} as RelayDb.RelayDb["Service"],
+          links,
+          credentials: {} as EnvironmentCredentials.EnvironmentCredentials["Service"],
+          managedEndpointProvider,
+          userId: "user-1",
+          environmentId: "environment-1",
+        }),
+      ).toBe(false);
+      expect(calls).toEqual(["deprovision"]);
     });
   });
 });

--- a/infra/relay/src/http/Api.test.ts
+++ b/infra/relay/src/http/Api.test.ts
@@ -14,6 +14,7 @@ import * as Tracer from "effect/Tracer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { EnvironmentId } from "@t3tools/contracts";
 import { RelayEnvironmentAuth } from "@t3tools/contracts/relay";
 
 import {
@@ -160,79 +161,101 @@ describe("relay environment authentication", () => {
   });
 });
 
+function relayUnlinkTestLayer(input?: {
+  readonly withTransaction?: RelayDb.RelayTransactions["Service"]["withTransaction"];
+  readonly getForUser?: EnvironmentLinks.EnvironmentLinks["Service"]["getForUser"];
+  readonly revokeForUser?: EnvironmentLinks.EnvironmentLinks["Service"]["revokeForUser"];
+  readonly revokeCredential?: EnvironmentCredentials.EnvironmentCredentials["Service"]["revokeForEnvironmentPublicKey"];
+  readonly prepareDeprovision?: ManagedEndpointProvider.ManagedEndpointProvider["Service"]["prepareDeprovision"];
+  readonly deprovision?: ManagedEndpointProvider.ManagedEndpointProvider["Service"]["deprovision"];
+}) {
+  return Layer.mergeAll(
+    Layer.succeed(
+      RelayDb.RelayTransactions,
+      RelayDb.RelayTransactions.of({
+        withTransaction: input?.withTransaction ?? ((effect) => effect),
+      }),
+    ),
+    Layer.succeed(
+      EnvironmentLinks.EnvironmentLinks,
+      EnvironmentLinks.EnvironmentLinks.of({
+        upsert: () => Effect.die("unused upsert"),
+        listUsersForEnvironment: () => Effect.die("unused listUsersForEnvironment"),
+        listDeliveryUsersForEnvironment: () => Effect.die("unused listDeliveryUsersForEnvironment"),
+        listPublicKeysForEnvironment: () => Effect.die("unused listPublicKeysForEnvironment"),
+        listForUser: () => Effect.die("unused listForUser"),
+        getForUser: input?.getForUser ?? (() => Effect.succeed(null)),
+        revokeForUser: input?.revokeForUser ?? (() => Effect.succeed(false)),
+      }),
+    ),
+    Layer.succeed(
+      EnvironmentCredentials.EnvironmentCredentials,
+      EnvironmentCredentials.EnvironmentCredentials.of({
+        create: () => Effect.die("unused create"),
+        authenticate: () => Effect.die("unused authenticate"),
+        revokeForEnvironmentPublicKey: input?.revokeCredential ?? (() => Effect.succeed(false)),
+      }),
+    ),
+    Layer.succeed(
+      ManagedEndpointProvider.ManagedEndpointProvider,
+      ManagedEndpointProvider.ManagedEndpointProvider.of({
+        provision: () => Effect.die("unused provision"),
+        prepareDeprovision: input?.prepareDeprovision ?? (() => Effect.succeed(null)),
+        deprovision: input?.deprovision ?? (() => Effect.void),
+        release: () => Effect.die("unused release"),
+      }),
+    ),
+  );
+}
+
+const linkedEnvironmentRecord = {
+  environmentId: EnvironmentId.make("environment-1"),
+  label: "Environment 1",
+  endpoint: {
+    httpBaseUrl: "https://environment-1.example.test/",
+    wsBaseUrl: "wss://environment-1.example.test/ws",
+    providerKind: "cloudflare_tunnel",
+  },
+  environmentPublicKey: "public-key",
+  linkedAt: "2026-07-28T00:00:00.000Z",
+} as const;
+
 describe("relay environment unlink", () => {
   it.effect("revokes the link and its credentials in one database transaction", () => {
     const calls: Array<string> = [];
-    const db = {
-      $client: {
-        withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => {
-          calls.push("transaction");
-          return effect;
-        },
-      },
-    } as unknown as RelayDb.RelayDb["Service"];
-    const links = {
-      revokeForUser: () =>
-        Effect.sync(() => {
-          calls.push("link");
-          return true;
-        }),
-    } as unknown as EnvironmentLinks.EnvironmentLinks["Service"];
-    const credentials = {
-      revokeForEnvironmentPublicKey: () =>
-        Effect.sync(() => {
-          calls.push("credential");
-          return true;
-        }),
-    } as unknown as EnvironmentCredentials.EnvironmentCredentials["Service"];
-
     return Effect.gen(function* () {
       expect(
         yield* revokeEnvironmentLinkRecord({
-          db,
-          links,
-          credentials,
           userId: "user-1",
           environmentId: "environment-1",
           environmentPublicKey: "public-key",
         }),
       ).toBe(true);
       expect(calls).toEqual(["transaction", "link", "credential"]);
-    });
+    }).pipe(
+      Effect.provide(
+        relayUnlinkTestLayer({
+          withTransaction: (effect) => {
+            calls.push("transaction");
+            return effect;
+          },
+          revokeForUser: () =>
+            Effect.sync(() => {
+              calls.push("link");
+              return true;
+            }),
+          revokeCredential: () =>
+            Effect.sync(() => {
+              calls.push("credential");
+              return true;
+            }),
+        }),
+      ),
+    );
   });
 
   it.effect("commits database revocation before deprovisioning the managed endpoint", () => {
     const calls: Array<string> = [];
-    const db = {
-      $client: {
-        withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => {
-          calls.push("transaction");
-          return effect;
-        },
-      },
-    } as unknown as RelayDb.RelayDb["Service"];
-    const links = {
-      getForUser: () =>
-        Effect.sync(() => {
-          calls.push("lookup");
-          return {
-            environmentId: "environment-1",
-            environmentPublicKey: "public-key",
-          };
-        }),
-      revokeForUser: () =>
-        Effect.sync(() => {
-          calls.push("link");
-          return true;
-        }),
-    } as unknown as EnvironmentLinks.EnvironmentLinks["Service"];
-    const credentials = {
-      revokeForEnvironmentPublicKey: () =>
-        Effect.sync(() => {
-          calls.push("credential");
-          return true;
-        }),
-    } as unknown as EnvironmentCredentials.EnvironmentCredentials["Service"];
     const deprovisionTarget = {
       userId: "user-1",
       environmentId: "environment-1",
@@ -243,26 +266,10 @@ describe("relay environment unlink", () => {
       readyAt: "2026-07-28T00:00:00.000Z",
       updatedAt: "generation-before-unlink",
     } satisfies ManagedEndpointProvider.ManagedEndpointDeprovisionTarget;
-    const managedEndpointProvider = {
-      prepareDeprovision: () =>
-        Effect.sync(() => {
-          calls.push("prepare");
-          return deprovisionTarget;
-        }),
-      deprovision: (input: { readonly target?: unknown }) =>
-        Effect.sync(() => {
-          expect(input.target).toBe(deprovisionTarget);
-          calls.push("deprovision");
-        }),
-    } as unknown as ManagedEndpointProvider.ManagedEndpointProvider["Service"];
 
     return Effect.gen(function* () {
       expect(
         yield* unlinkEnvironmentRecord({
-          db,
-          links,
-          credentials,
-          managedEndpointProvider,
           userId: "user-1",
           environmentId: "environment-1",
         }),
@@ -275,7 +282,41 @@ describe("relay environment unlink", () => {
         "credential",
         "deprovision",
       ]);
-    });
+    }).pipe(
+      Effect.provide(
+        relayUnlinkTestLayer({
+          withTransaction: (effect) => {
+            calls.push("transaction");
+            return effect;
+          },
+          getForUser: () =>
+            Effect.sync(() => {
+              calls.push("lookup");
+              return linkedEnvironmentRecord;
+            }),
+          revokeForUser: () =>
+            Effect.sync(() => {
+              calls.push("link");
+              return true;
+            }),
+          revokeCredential: () =>
+            Effect.sync(() => {
+              calls.push("credential");
+              return true;
+            }),
+          prepareDeprovision: () =>
+            Effect.sync(() => {
+              calls.push("prepare");
+              return deprovisionTarget;
+            }),
+          deprovision: (request) =>
+            Effect.sync(() => {
+              expect(request.target).toBe(deprovisionTarget);
+              calls.push("deprovision");
+            }),
+        }),
+      ),
+    );
   });
 
   it.effect("does not deprovision when database revocation fails", () => {
@@ -284,91 +325,73 @@ describe("relay environment unlink", () => {
       environmentId: "environment-1",
       cause: "database unavailable",
     });
-    const db = {
-      $client: {
-        withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => {
-          calls.push("transaction");
-          return effect;
-        },
-      },
-    } as unknown as RelayDb.RelayDb["Service"];
-    const links = {
-      getForUser: () =>
-        Effect.succeed({
-          environmentId: "environment-1",
-          environmentPublicKey: "public-key",
-        }),
-      revokeForUser: () =>
-        Effect.sync(() => {
-          calls.push("link");
-          return true;
-        }),
-    } as unknown as EnvironmentLinks.EnvironmentLinks["Service"];
-    const credentials = {
-      revokeForEnvironmentPublicKey: () =>
-        Effect.sync(() => {
-          calls.push("credential");
-        }).pipe(Effect.andThen(Effect.fail(failure))),
-    } as unknown as EnvironmentCredentials.EnvironmentCredentials["Service"];
-    const managedEndpointProvider = {
-      prepareDeprovision: () =>
-        Effect.sync(() => {
-          calls.push("prepare");
-          return null;
-        }),
-      deprovision: () =>
-        Effect.sync(() => {
-          calls.push("deprovision");
-        }),
-    } as unknown as ManagedEndpointProvider.ManagedEndpointProvider["Service"];
 
     return Effect.gen(function* () {
       expect(
         yield* Effect.flip(
           unlinkEnvironmentRecord({
-            db,
-            links,
-            credentials,
-            managedEndpointProvider,
             userId: "user-1",
             environmentId: "environment-1",
           }),
         ),
       ).toBe(failure);
       expect(calls).toEqual(["prepare", "transaction", "link", "credential"]);
-    });
+    }).pipe(
+      Effect.provide(
+        relayUnlinkTestLayer({
+          withTransaction: (effect) => {
+            calls.push("transaction");
+            return effect;
+          },
+          getForUser: () => Effect.succeed(linkedEnvironmentRecord),
+          revokeForUser: () =>
+            Effect.sync(() => {
+              calls.push("link");
+              return true;
+            }),
+          revokeCredential: () =>
+            Effect.sync(() => {
+              calls.push("credential");
+            }).pipe(Effect.andThen(Effect.fail(failure))),
+          prepareDeprovision: () =>
+            Effect.sync(() => {
+              calls.push("prepare");
+              return null;
+            }),
+          deprovision: () =>
+            Effect.sync(() => {
+              calls.push("deprovision");
+            }),
+        }),
+      ),
+    );
   });
 
   it.effect("retries deprovisioning after the link is already revoked", () => {
     const calls: Array<string> = [];
-    const links = {
-      getForUser: () => Effect.succeed(null),
-    } as unknown as EnvironmentLinks.EnvironmentLinks["Service"];
-    const managedEndpointProvider = {
-      prepareDeprovision: () =>
-        Effect.sync(() => {
-          calls.push("prepare");
-          return null;
-        }),
-      deprovision: () =>
-        Effect.sync(() => {
-          calls.push("deprovision");
-        }),
-    } as unknown as ManagedEndpointProvider.ManagedEndpointProvider["Service"];
-
     return Effect.gen(function* () {
       expect(
         yield* unlinkEnvironmentRecord({
-          db: {} as RelayDb.RelayDb["Service"],
-          links,
-          credentials: {} as EnvironmentCredentials.EnvironmentCredentials["Service"],
-          managedEndpointProvider,
           userId: "user-1",
           environmentId: "environment-1",
         }),
       ).toBe(false);
       expect(calls).toEqual(["prepare", "deprovision"]);
-    });
+    }).pipe(
+      Effect.provide(
+        relayUnlinkTestLayer({
+          prepareDeprovision: () =>
+            Effect.sync(() => {
+              calls.push("prepare");
+              return null;
+            }),
+          deprovision: () =>
+            Effect.sync(() => {
+              calls.push("deprovision");
+            }),
+        }),
+      ),
+    );
   });
 });
 

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -439,6 +439,10 @@ export const unlinkEnvironmentRecord = Effect.fn("relay.api.client.unlinkEnviron
     readonly userId: string;
     readonly environmentId: string;
   }) {
+    const deprovisionTarget = yield* input.managedEndpointProvider.prepareDeprovision({
+      userId: input.userId,
+      environmentId: input.environmentId,
+    });
     const link = yield* input.links.getForUser({
       userId: input.userId,
       environmentId: input.environmentId,
@@ -462,6 +466,7 @@ export const unlinkEnvironmentRecord = Effect.fn("relay.api.client.unlinkEnviron
     yield* input.managedEndpointProvider.deprovision({
       userId: input.userId,
       environmentId: input.environmentId,
+      target: deprovisionTarget,
     });
     return unlinked;
   },

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -403,6 +403,33 @@ export const healthApi = HttpApiBuilder.group(
   }),
 );
 
+export const revokeEnvironmentLinkRecord = Effect.fn(
+  "relay.api.client.revokeEnvironmentLinkRecord",
+)(function* (input: {
+  readonly db: RelayDb.RelayDb["Service"];
+  readonly links: EnvironmentLinks.EnvironmentLinks["Service"];
+  readonly credentials: EnvironmentCredentials.EnvironmentCredentials["Service"];
+  readonly userId: string;
+  readonly environmentId: string;
+  readonly environmentPublicKey: string;
+}) {
+  return yield* input.db.$client.withTransaction(
+    Effect.gen(function* () {
+      const revoked = yield* input.links.revokeForUser({
+        userId: input.userId,
+        environmentId: input.environmentId,
+      });
+      if (revoked) {
+        yield* input.credentials.revokeForEnvironmentPublicKey({
+          environmentId: input.environmentId,
+          environmentPublicKey: input.environmentPublicKey,
+        });
+      }
+      return revoked;
+    }),
+  );
+});
+
 export const mobileApi = HttpApiBuilder.group(
   RelayApi,
   "mobile",
@@ -472,6 +499,7 @@ export const clientApi = HttpApiBuilder.group(
     const managedEndpointProvider = yield* ManagedEndpointProvider.ManagedEndpointProvider;
     const credentials = yield* EnvironmentCredentials.EnvironmentCredentials;
     const devices = yield* Devices.Devices;
+    const db = yield* RelayDb.RelayDb;
     return handlers
       .handle(
         "listEnvironments",
@@ -605,16 +633,14 @@ export const clientApi = HttpApiBuilder.group(
           if (link === null) {
             return { ok: false };
           }
-          const unlinked = yield* links.revokeForUser({
+          const unlinked = yield* revokeEnvironmentLinkRecord({
+            db,
+            links,
+            credentials,
             userId,
-            environmentId: params.environmentId,
-          });
-          if (unlinked) {
-            yield* credentials.revokeForEnvironmentPublicKey({
-              environmentId: link.environmentId,
-              environmentPublicKey: link.environmentPublicKey,
-            });
-          }
+            environmentId: link.environmentId,
+            environmentPublicKey: link.environmentPublicKey,
+          }).pipe(Effect.catchTag("SqlError", () => relayInternalErrorResponse("internal_error")));
           return { ok: unlinked };
         }, mapRelayCommonApiErrors("not_authorized")),
       )

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -406,21 +406,21 @@ export const healthApi = HttpApiBuilder.group(
 export const revokeEnvironmentLinkRecord = Effect.fn(
   "relay.api.client.revokeEnvironmentLinkRecord",
 )(function* (input: {
-  readonly db: RelayDb.RelayDb["Service"];
-  readonly links: EnvironmentLinks.EnvironmentLinks["Service"];
-  readonly credentials: EnvironmentCredentials.EnvironmentCredentials["Service"];
   readonly userId: string;
   readonly environmentId: string;
   readonly environmentPublicKey: string;
 }) {
-  return yield* input.db.$client.withTransaction(
+  const transactions = yield* RelayDb.RelayTransactions;
+  const links = yield* EnvironmentLinks.EnvironmentLinks;
+  const credentials = yield* EnvironmentCredentials.EnvironmentCredentials;
+  return yield* transactions.withTransaction(
     Effect.gen(function* () {
-      const revoked = yield* input.links.revokeForUser({
+      const revoked = yield* links.revokeForUser({
         userId: input.userId,
         environmentId: input.environmentId,
       });
       if (revoked) {
-        yield* input.credentials.revokeForEnvironmentPublicKey({
+        yield* credentials.revokeForEnvironmentPublicKey({
           environmentId: input.environmentId,
           environmentPublicKey: input.environmentPublicKey,
         });
@@ -431,19 +431,14 @@ export const revokeEnvironmentLinkRecord = Effect.fn(
 });
 
 export const unlinkEnvironmentRecord = Effect.fn("relay.api.client.unlinkEnvironmentRecord")(
-  function* (input: {
-    readonly db: RelayDb.RelayDb["Service"];
-    readonly links: EnvironmentLinks.EnvironmentLinks["Service"];
-    readonly credentials: EnvironmentCredentials.EnvironmentCredentials["Service"];
-    readonly managedEndpointProvider: ManagedEndpointProvider.ManagedEndpointProvider["Service"];
-    readonly userId: string;
-    readonly environmentId: string;
-  }) {
-    const deprovisionTarget = yield* input.managedEndpointProvider.prepareDeprovision({
+  function* (input: { readonly userId: string; readonly environmentId: string }) {
+    const links = yield* EnvironmentLinks.EnvironmentLinks;
+    const managedEndpointProvider = yield* ManagedEndpointProvider.ManagedEndpointProvider;
+    const deprovisionTarget = yield* managedEndpointProvider.prepareDeprovision({
       userId: input.userId,
       environmentId: input.environmentId,
     });
-    const link = yield* input.links.getForUser({
+    const link = yield* links.getForUser({
       userId: input.userId,
       environmentId: input.environmentId,
     });
@@ -451,9 +446,6 @@ export const unlinkEnvironmentRecord = Effect.fn("relay.api.client.unlinkEnviron
       link === null
         ? false
         : yield* revokeEnvironmentLinkRecord({
-            db: input.db,
-            links: input.links,
-            credentials: input.credentials,
             userId: input.userId,
             environmentId: link.environmentId,
             environmentPublicKey: link.environmentPublicKey,
@@ -463,7 +455,7 @@ export const unlinkEnvironmentRecord = Effect.fn("relay.api.client.unlinkEnviron
     // revocation commits so a database failure leaves a fully usable active
     // link. Still run teardown when the link is already revoked, allowing a
     // retry to finish cleanup after an earlier Cloudflare failure.
-    yield* input.managedEndpointProvider.deprovision({
+    yield* managedEndpointProvider.deprovision({
       userId: input.userId,
       environmentId: input.environmentId,
       target: deprovisionTarget,
@@ -539,9 +531,7 @@ export const clientApi = HttpApiBuilder.group(
     const linker = yield* EnvironmentLinker.EnvironmentLinker;
     const links = yield* EnvironmentLinks.EnvironmentLinks;
     const managedEndpointProvider = yield* ManagedEndpointProvider.ManagedEndpointProvider;
-    const credentials = yield* EnvironmentCredentials.EnvironmentCredentials;
     const devices = yield* Devices.Devices;
-    const db = yield* RelayDb.RelayDb;
     return handlers
       .handle(
         "listEnvironments",
@@ -663,10 +653,6 @@ export const clientApi = HttpApiBuilder.group(
           const { params } = args;
           const { userId } = yield* RelayClientPrincipal;
           const unlinked = yield* unlinkEnvironmentRecord({
-            db,
-            links,
-            credentials,
-            managedEndpointProvider,
             userId,
             environmentId: params.environmentId,
           }).pipe(

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -430,6 +430,43 @@ export const revokeEnvironmentLinkRecord = Effect.fn(
   );
 });
 
+export const unlinkEnvironmentRecord = Effect.fn("relay.api.client.unlinkEnvironmentRecord")(
+  function* (input: {
+    readonly db: RelayDb.RelayDb["Service"];
+    readonly links: EnvironmentLinks.EnvironmentLinks["Service"];
+    readonly credentials: EnvironmentCredentials.EnvironmentCredentials["Service"];
+    readonly managedEndpointProvider: ManagedEndpointProvider.ManagedEndpointProvider["Service"];
+    readonly userId: string;
+    readonly environmentId: string;
+  }) {
+    const link = yield* input.links.getForUser({
+      userId: input.userId,
+      environmentId: input.environmentId,
+    });
+    const unlinked =
+      link === null
+        ? false
+        : yield* revokeEnvironmentLinkRecord({
+            db: input.db,
+            links: input.links,
+            credentials: input.credentials,
+            userId: input.userId,
+            environmentId: link.environmentId,
+            environmentPublicKey: link.environmentPublicKey,
+          });
+
+    // External teardown cannot share the SQL transaction. Run it only after
+    // revocation commits so a database failure leaves a fully usable active
+    // link. Still run teardown when the link is already revoked, allowing a
+    // retry to finish cleanup after an earlier Cloudflare failure.
+    yield* input.managedEndpointProvider.deprovision({
+      userId: input.userId,
+      environmentId: input.environmentId,
+    });
+    return unlinked;
+  },
+);
+
 export const mobileApi = HttpApiBuilder.group(
   RelayApi,
   "mobile",
@@ -620,27 +657,20 @@ export const clientApi = HttpApiBuilder.group(
         Effect.fn("relay.api.client.unlinkEnvironment")(function* (args) {
           const { params } = args;
           const { userId } = yield* RelayClientPrincipal;
-          yield* managedEndpointProvider
-            .deprovision({
-              userId,
-              environmentId: params.environmentId,
-            })
-            .pipe(Effect.catch(() => relayInternalErrorResponse("upstream_unavailable")));
-          const link = yield* links.getForUser({
-            userId,
-            environmentId: params.environmentId,
-          });
-          if (link === null) {
-            return { ok: false };
-          }
-          const unlinked = yield* revokeEnvironmentLinkRecord({
+          const unlinked = yield* unlinkEnvironmentRecord({
             db,
             links,
             credentials,
+            managedEndpointProvider,
             userId,
-            environmentId: link.environmentId,
-            environmentPublicKey: link.environmentPublicKey,
-          }).pipe(Effect.catchTag("SqlError", () => relayInternalErrorResponse("internal_error")));
+            environmentId: params.environmentId,
+          }).pipe(
+            Effect.catchTags({
+              SqlError: () => relayInternalErrorResponse("internal_error"),
+              ManagedEndpointDeprovisioningFailed: () =>
+                relayInternalErrorResponse("upstream_unavailable"),
+            }),
+          );
           return { ok: unlinked };
         }, mapRelayCommonApiErrors("not_authorized")),
       )

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -217,7 +217,11 @@ export const ApiLive = Api.make(
       Layer.provideMerge(LiveActivities.layer),
       Layer.provideMerge(DeliveryAttempts.layer),
       Layer.provideMerge(RelayTokens.layer),
-      Layer.provideMerge(Layer.succeed(RelayDb.RelayDb, db)),
+      Layer.provideMerge(
+        RelayDb.RelayTransactions.layer.pipe(
+          Layer.provideMerge(Layer.succeed(RelayDb.RelayDb, db)),
+        ),
+      ),
       Layer.provideMerge(Layer.effect(RelayConfiguration.RelayConfiguration, loadSettings)),
       Layer.provideMerge(webcryptoLayer),
     );


### PR DESCRIPTION
## Summary

Fixes `t3 connect unlink` returning HTTP 500 and closes two partial-state paths that could leave an account unable to reconnect until its managed-tunnel limit was raised.

The original failure came from building correlated Drizzle `EXISTS` / `NOT EXISTS` clauses with the outer query builder. Alchemy's SQL serializer recursively traversed the shared builder state until `RangeError: Maximum call stack size exceeded`.

Follow-up investigation of Theo's “4 relays, 2 revoked, reconnect only worked after bumping my limit” report found two additional consistency problems:

1. Environment-link revocation and credential revocation were separate commits. The observed failure happened after the link mutation had already succeeded.
2. Tunnel capacity counted every allocation row, including allocations whose link was revoked or whose link flow failed after provisioning.

## Fix

- Build credential-authentication `EXISTS` and credential-revocation `NOT EXISTS` subqueries with standalone `QueryBuilder` instances.
- Require an active matching environment link when authenticating an environment credential.
- Revoke the environment link and matching credential inside one PostgreSQL transaction.
- Commit database revocation before external tunnel teardown; an already-revoked retry still performs teardown.
- Capture the allocation generation before revocation and require teardown to win a compare-and-swap claim on that exact generation.
- Remove the allocation only when the teardown claim still owns it, preserving any allocation refreshed by a concurrent relink.
- Acquire unlink dependencies from the Effect environment and provide a typed `RelayTransactions` layer derived from `RelayDb`; tests use typed service layers rather than cast dependency injection.
- Count only allocations joined to an active link with `managed_tunnels_enabled = true`.
- Add focused regression coverage for SQL shape, transactional unlink coordination, and active-link-aware quota counting.

Follow-up commits: [`f9411e390f`](https://github.com/pingdotgg/t3code/commit/f9411e390f), [`b2203faf36`](https://github.com/pingdotgg/t3code/commit/b2203faf36), [`baa3abd264`](https://github.com/pingdotgg/t3code/commit/baa3abd264), [`7800b336ec`](https://github.com/pingdotgg/t3code/commit/7800b336ec)

## Before: production failure

CLI output (environment identifier redacted):

```text
$ npx t3@nightly connect unlink
T3 Connect is disabled locally.
WARN: T3 Connect disconnect operation failed.
  operation: relay-environment-unlink
  clearAuthorization: false
  cause: HttpClientError: non 2xx status code
    (500 DELETE https://relay.t3.codes/v1/client/environment-links/[environment-id])

Could not revoke the relay-side environment record yet.
Run `t3 connect unlink` again when the relay is reachable.
```

Axiom evidence:

- Dataset: `t3-code-relay-traces-prod`
- Trace ID: `aad65b02f6b77b69df12fce7d93304dd`
- [Axiom query page](https://app.axiom.co/ping-labs-gb3x/query)
- `deprovision`, `get_for_user`, and `revoke_for_user` completed successfully.
- `revoke_for_environment_public_key` failed with `RangeError: Maximum call stack size exceeded`.
- The stack repeatedly entered `SQL.buildQueryFromSourceParams`, then propagated to the DELETE handler as HTTP 500.

That span order proves the link revocation had already committed before credential revocation failed. Because retries only look up active links, the old flow could not complete the missed credential cleanup on retry.

Before the follow-up fix, quota was effectively:

```sql
SELECT count(*)
FROM relay_managed_endpoint_allocations
WHERE user_id = $user
  AND environment_id <> $requested_environment;
```

This counted durable allocation rows independently of whether their environment link was active. That matches the reported recovery when Theo's limit was raised.

## After: live relay verification

Deployed the branch to personal stage `dev_julius` at `https://relay-dev-julius.t3.codes`.

Deployment console:

```text
Plan: 1 to update, 15 to noop
[Api] updating
[Api] Uploading worker (4.39 MB) ...
[Api] Reconciling custom domains (1) ...
[Api] updated
Done: 2 succeeded
```

The earlier live link/unlink run against this stage returned:

```text
$ t3 connect unlink
T3 Connect is disabled locally.
Revoked the relay-side environment record.
```

The DELETE returned HTTP 200.

Axiom evidence:

- Dataset: `t3-code-relay-traces-dev-julius`
- Trace ID: `78bc9812afd5d5c2c8e16b8952914d2c`
- [Axiom query page](https://app.axiom.co/ping-labs-gb3x/query)
- `http.server DELETE` completed with status 200.
- `revoke_for_user` and `revoke_for_environment_public_key` both completed with status `OK`.
- No recursive SQL-builder failure occurred.

After the follow-up fix, capacity is derived only from usable managed links:

```sql
SELECT count(*)
FROM relay_managed_endpoint_allocations AS allocation
JOIN relay_environment_links AS link
  ON link.user_id = allocation.user_id
 AND link.environment_id = allocation.environment_id
WHERE allocation.user_id = $user
  AND allocation.environment_id <> $requested_environment
  AND link.revoked_at IS NULL
  AND link.managed_tunnels_enabled = true;
```

The link and credential revocations execute within `PgClient.withTransaction`, so either both database mutations commit or both roll back. Cloudflare cleanup remains external and cannot share the SQL transaction, so it now runs only after database revocation commits. If SQL fails, the fully usable active link and tunnel remain intact. If Cloudflare cleanup fails, the link and credential remain revoked, and a later unlink retry still runs deprovisioning even though no active link remains. Unlink captures the pre-revocation allocation generation; if a concurrent relink refreshes that allocation before teardown claims it, the compare-and-swap fails and teardown skips all DNS, tunnel, and allocation deletion. Final allocation removal is conditional on the teardown claim still owning the generation.

Use this APL with the corresponding dataset and trace ID:

```apl
['dataset']
| where trace_id == 'trace'
| project _time, name, trace_id, span_id, parent_span_id,
    ['attributes.http.response.status_code'], error,
    ['status.code'], ['status.message'], events
| order by _time asc
```

## Verification

- Focused backend tests: 55/55 passing across:
  - `EnvironmentCredentials.test.ts`
  - `ManagedTunnelLimits.test.ts`
  - `ManagedEndpointAllocations.test.ts`
  - `ManagedEndpointProvider.test.ts`
  - `EnvironmentLinker.test.ts`
  - `Api.test.ts`
- Relay typecheck passing
- Targeted lint and formatting passing
- `git diff --check` passing
- Personal-stage deployment succeeded
- Original live link/unlink returned HTTP 200
- Before/after behavior confirmed in Axiom
- Ordering tests prove revocation precedes teardown, SQL failure prevents teardown, and already-revoked retries still clean up
- Race regression proves a concurrent relink that supersedes the captured generation prevents DNS, tunnel, and allocation teardown
- Allocation tests cover successful generation claims and conditional removal losing to a newer generation
- Effect service-convention fix removes explicit service parameters and `as unknown as Service` test injection
- Latest transaction-layer wiring deployed successfully to `dev_julius`
- Follow-up commits pushed to the PR branch

No secrets, authorization values, user IDs, environment IDs, or public-key material are included above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication rules, transactional unlink ordering, managed endpoint teardown CAS, and tunnel quota counting—security- and infrastructure-critical paths with subtle concurrency behavior.
> 
> **Overview**
> Fixes relay **unlink** HTTP 500s and partial state where links could revoke without credentials, orphaned allocations could block tunnel limits, and concurrent relinks could lose tunnels to stale teardown.
> 
> **Credential auth/revoke SQL** now builds `EXISTS` / `NOT EXISTS` subqueries with standalone `QueryBuilder` instances (avoids Drizzle recursive stack overflow). **Authenticate** only succeeds when a non-revoked `relay_environment_links` row matches the credential’s environment and public key.
> 
> **Unlink** is centralized in `revokeEnvironmentLinkRecord` / `unlinkEnvironmentRecord`: link + credential revocation run in one `RelayTransactions.withTransaction` commit; Cloudflare teardown runs only after DB success (or on retry when the link is already revoked). **Deprovision** snapshots the allocation via `prepareDeprovision`, wins a generation **CAS** with `claimDeprovision`, then deletes with `removeClaimed` so a concurrent relink is not torn down.
> 
> **Tunnel quota** counts allocations only when joined to an active link with `managed_tunnels_enabled = true`. Regression tests cover SQL shape, unlink ordering, CAS races, and quota joins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7800b336ec363ed4b6cab9793e92e0cdf18bf39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix relay credential lookup to require an active environment link on authenticate
> - `EnvironmentCredentials.authenticate` now filters results with an `EXISTS` subquery against `relay_environment_links`, requiring a non-revoked link matching the credential's `environmentId` and `environmentPublicKey`.
> - The `unlinkEnvironment` endpoint is refactored to revoke the link and credentials in a single transaction before triggering external deprovision, ensuring DB state commits before teardown.
> - `ManagedEndpointProvider.deprovision` now uses CAS-based claim (`claimDeprovision`) to skip teardown if a concurrent relink has superseded the captured allocation generation.
> - `ManagedTunnelLimits.ensureCapacity` now only counts allocations joined to active (non-revoked, managed-tunnels-enabled) environment links.
> - Behavioral Change: credentials for unlinked environments are no longer returned by `authenticate`, and tunnel capacity counts now exclude revoked or disabled links.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7800b33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
