### PR TITLE
Add a self-contained Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,7 @@
             # Electron's postinstall download is useless in a sandbox; point
             # the tooling at the nixpkgs build instead.
             ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-            ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron}/libexec/electron";
+            ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron_41}/libexec/electron";
 
             shellHook = ''
               echo "T3 Code dev shell: node $(node --version), pnpm $(pnpm --version)"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,136 @@
+{
+  description = "T3 Code - development shell and desktop package built from this checkout";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }: let
+    # The client-only desktop implementation is maintained independently. Only
+    # expose its package/overlay when that implementation is in the source.
+    clientModeSupported =
+      builtins.pathExists ./apps/desktop/src/app/DesktopBackendMode.ts;
+    systems = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  in
+    flake-utils.lib.eachSystem systems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+
+      pnpm = pkgs.pnpm_11;
+      nodejs = pkgs.nodejs_24;
+      buildCommit =
+        if self ? rev
+        then self.rev
+        else if self ? dirtyRev
+        then pkgs.lib.removeSuffix "-dirty" self.dirtyRev
+        else "";
+      t3codePackages = import ./nix/package.nix {
+        inherit buildCommit pkgs self;
+      };
+      android = import ./nix/android.nix {
+        inherit buildCommit nixpkgs self system;
+      };
+    in {
+      packages = t3codePackages;
+
+      apps = pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        build-android = android.app;
+      };
+
+      # Launch the packaged app headlessly and fail on a renderer crash.
+      #
+      # A dropped import is a runtime ReferenceError, not a bundler error, so a
+      # green `nix build` says nothing about whether the app boots. That has
+      # shipped a build whose first paint was "Something went wrong:
+      # useEnvironmentSettings is not defined". This check catches that class.
+      checks = pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        smoke =
+          pkgs.runCommand "t3code-smoke" {
+            nativeBuildInputs = [pkgs.xvfb-run pkgs.dbus];
+          } ''
+            export HOME=$(mktemp -d)
+            export XDG_RUNTIME_DIR=$(mktemp -d)
+            set +e
+            timeout 20 xvfb-run -a ${pkgs.dbus}/bin/dbus-run-session \
+              --config-file=${pkgs.dbus}/share/dbus-1/session.conf -- \
+              ${t3codePackages.t3code}/bin/t3code-desktop \
+                ${nixpkgs.lib.optionalString clientModeSupported "--backend-mode=client-only"} \
+                --no-sandbox \
+              > "$HOME/out.log" 2>&1
+            app_status=$?
+            set -e
+
+            echo "--- app output ---"; cat "$HOME/out.log" || true
+
+            # A healthy Electron main process stays up until the timeout. An
+            # early exit means the launcher failed before the renderer could be
+            # checked (for example, a broken D-Bus session).
+            if [ "$app_status" -ne 124 ]; then
+              echo "SMOKE FAILED: app exited before the timeout (status $app_status)" >&2
+              exit 1
+            fi
+
+            # Electron logs renderer exceptions to stderr; any of these means the
+            # UI failed to mount even if the process exited 0.
+            if grep -qE "is not defined|ReferenceError|Something went wrong" "$HOME/out.log"; then
+              echo "SMOKE FAILED: renderer crashed on boot" >&2
+              exit 1
+            fi
+            touch $out
+          '';
+      };
+
+      devShells =
+        {
+          default = pkgs.mkShell {
+            packages = [nodejs pnpm pkgs.git];
+
+            # Electron's postinstall download is useless in a sandbox; point
+            # the tooling at the nixpkgs build instead.
+            ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+            ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron}/libexec/electron";
+
+            shellHook = ''
+              echo "T3 Code dev shell: node $(node --version), pnpm $(pnpm --version)"
+            '';
+          };
+        }
+        // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          android = android.devShell;
+        };
+
+      formatter = pkgs.alejandra;
+    })
+    // {
+      overlays =
+        {
+          # Build this checkout in place of nixpkgs's released source.
+          default = final: _previous: {
+            t3code = self.packages.${final.stdenv.hostPlatform.system}.t3code;
+          };
+        }
+        // nixpkgs.lib.optionalAttrs clientModeSupported {
+          # Desktop-client installations can opt out of the managed local backend
+          # without imposing that policy on every flake consumer.
+          client = final: _previous: {
+            t3code = self.packages.${final.stdenv.hostPlatform.system}.client;
+          };
+        };
+
+      homeManagerModules = {
+        default = self.homeManagerModules.t3code-server;
+        t3code-server = import ./nix/home-manager/t3code-server.nix {inherit self;};
+      };
+    };
+}

--- a/nix/android.nix
+++ b/nix/android.nix
@@ -1,0 +1,97 @@
+{
+  buildCommit,
+  nixpkgs,
+  self,
+  system,
+}: let
+  pkgs = import nixpkgs {
+    inherit system;
+    config = {
+      allowUnfree = true;
+      android_sdk.accept_license = true;
+    };
+  };
+  lib = pkgs.lib;
+  buildToolsVersion = "36.0.0";
+  commandLineToolsVersion = "8.0";
+  ndkVersion = "27.1.12297006";
+  expoNdkVersion = "27.0.12077973";
+  composition = pkgs.androidenv.composeAndroidPackages {
+    cmdLineToolsVersion = commandLineToolsVersion;
+    toolsVersion = "26.1.1";
+    platformToolsVersion = "35.0.2";
+    buildToolsVersions = [buildToolsVersion "35.0.0" "34.0.0"];
+    platformVersions = ["35" "36"];
+    includeSources = false;
+    abiVersions = ["x86_64"];
+    includeNDK = true;
+    ndkVersions = [ndkVersion expoNdkVersion];
+    cmakeVersions = ["3.22.1"];
+    useGoogleAPIs = true;
+    useGoogleTVAddOns = false;
+  };
+  sdk = composition.androidsdk;
+  androidHome = "${sdk}/libexec/android-sdk";
+  jdk = pkgs.jdk17;
+  builder = pkgs.writeShellApplication {
+    name = "build-t3code-android";
+    runtimeInputs = with pkgs; [
+      coreutils
+      gawk
+      gnused
+      nix
+    ];
+    text =
+      ''
+        export T3CODE_SOURCE_TREE=${lib.escapeShellArg "${self}"}
+        export T3CODE_ANDROID_FLAKE=${lib.escapeShellArg "${self}"}
+        export T3CODE_SOURCE_REV=${lib.escapeShellArg (
+          if buildCommit == ""
+          then "local"
+          else builtins.substring 0 8 buildCommit
+        )}
+      ''
+      + builtins.readFile ./scripts/build-android-apk.sh;
+  };
+in {
+  app = {
+    type = "app";
+    program = lib.getExe builder;
+    meta.description = "Build a sideloadable Android APK from this checkout";
+  };
+
+  devShell = pkgs.mkShell {
+    packages = with pkgs; [
+      jdk
+      sdk
+      curl
+      git
+      gnumake
+      nodejs_24
+      pkg-config
+      python3
+      watchman
+      xz
+    ];
+
+    ANDROID_HOME = androidHome;
+    ANDROID_SDK_ROOT = androidHome;
+    ANDROID_NDK_HOME = "${androidHome}/ndk/${ndkVersion}";
+    ANDROID_NDK_ROOT = "${androidHome}/ndk/${ndkVersion}";
+    JAVA_HOME = jdk.home;
+    LC_ALL = "en_US.UTF-8";
+    LANG = "en_US.UTF-8";
+    GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidHome}/build-tools/${buildToolsVersion}/aapt2";
+    NODE_OPTIONS = "--max-old-space-size=8192";
+
+    shellHook = ''
+      export PATH="${androidHome}/platform-tools:${androidHome}/cmdline-tools/${commandLineToolsVersion}/bin:$PWD/node_modules/.bin:$PWD/apps/mobile/node_modules/.bin:$PATH"
+      echo "T3 Code Android dev shell"
+      echo "  node: $(node --version)"
+      echo "  pnpm: $(corepack pnpm --version)"
+      echo "  java: $(java -version 2>&1 | head -n 1)"
+      echo "  sdk:  $ANDROID_SDK_ROOT"
+      echo "  ndk:  $ANDROID_NDK_HOME"
+    '';
+  };
+}

--- a/nix/home-manager/t3code-server.nix
+++ b/nix/home-manager/t3code-server.nix
@@ -18,14 +18,16 @@
     export T3CODE_HOME=${lib.escapeShellArg cfg.dataDirectory}
 
     cd "$repository_root"
-    exec ${lib.getExe' cfg.package "t3"} serve \
-      --host ${lib.escapeShellArg cfg.host} \
-      --port ${toString cfg.port} \
+    server_args=(
+      serve
+      --host ${lib.escapeShellArg cfg.host}
+      --port ${toString cfg.port}
       ${lib.optionalString cfg.tailscaleServe.enable ''
-      --tailscale-serve \
-      --tailscale-serve-port ${toString cfg.tailscaleServe.port} \
-    ''} \
-      "$repository_root"
+      --tailscale-serve
+      --tailscale-serve-port ${toString cfg.tailscaleServe.port}
+    ''}
+    )
+    exec ${lib.getExe' cfg.package "t3"} "''${server_args[@]}"
   '';
 in {
   options.services.t3code = {

--- a/nix/home-manager/t3code-server.nix
+++ b/nix/home-manager/t3code-server.nix
@@ -1,0 +1,149 @@
+{self}: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.t3code;
+  serverCommand = pkgs.writeShellScript "t3code-headless-server" ''
+    set -eu
+
+    repository_root=${lib.escapeShellArg cfg.repositoryRoot}
+    if [ ! -d "$repository_root" ]; then
+      echo "T3 Code repository root does not exist: $repository_root" >&2
+      exit 69
+    fi
+
+    export PATH=${lib.escapeShellArg "${lib.makeBinPath ([cfg.package] ++ cfg.extraPackages)}:/run/current-system/sw/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"}
+    export T3CODE_HOME=${lib.escapeShellArg cfg.dataDirectory}
+
+    cd "$repository_root"
+    exec ${lib.getExe' cfg.package "t3"} serve \
+      --host ${lib.escapeShellArg cfg.host} \
+      --port ${toString cfg.port} \
+      ${lib.optionalString cfg.tailscaleServe.enable ''
+      --tailscale-serve \
+      --tailscale-serve-port ${toString cfg.tailscaleServe.port} \
+    ''} \
+      "$repository_root"
+  '';
+in {
+  options.services.t3code = {
+    enable = lib.mkEnableOption "a persistent T3 Code headless server";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.t3code;
+      defaultText = lib.literalExpression "inputs.t3code.packages.\${pkgs.system}.t3code";
+      description = "T3 Code package used by the service.";
+    };
+
+    repositoryRoot = lib.mkOption {
+      type = lib.types.str;
+      default = config.home.homeDirectory;
+      description = "Repository opened by the persistent T3 Code server.";
+    };
+
+    dataDirectory = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/.t3";
+      description = "Persistent T3 Code state directory.";
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Address on which the local T3 Code server listens.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3774;
+      description = "Port on which the local T3 Code server listens.";
+    };
+
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = with pkgs; [
+        bashInteractive
+        claude-code
+        codex
+        coreutils
+        findutils
+        gh
+        git
+        gnugrep
+        gnused
+        nix
+        nodejs
+        openssh
+        ripgrep
+        tailscale
+        zsh
+      ];
+      description = "Additional packages available to the server and its provider processes.";
+    };
+
+    systemdTarget = lib.mkOption {
+      type = lib.types.str;
+      default = "graphical-session.target";
+      description = "User systemd target that starts the service.";
+    };
+
+    tailscaleServe = {
+      enable = lib.mkEnableOption "Tailscale Serve publication" // {default = true;};
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 443;
+        description = "Tailnet-only HTTPS port exposed by Tailscale Serve.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      home.packages = [cfg.package];
+    }
+
+    (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
+      systemd.user.services.t3code-headless = {
+        Unit = {
+          Description = "T3 Code headless server";
+          Documentation = "https://github.com/pingdotgg/t3code/blob/main/REMOTE.md";
+          After = [cfg.systemdTarget];
+          ConditionPathIsDirectory = cfg.repositoryRoot;
+          StartLimitIntervalSec = 300;
+          StartLimitBurst = 5;
+        };
+
+        Service = {
+          Type = "simple";
+          ExecStart = "${serverCommand}";
+          Restart = "always";
+          RestartSec = 5;
+          TimeoutStopSec = 15;
+          UMask = "0077";
+        };
+
+        # Deliberately omit PartOf so the backend survives graphical logout.
+        Install.WantedBy = [cfg.systemdTarget];
+      };
+    })
+
+    (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+      launchd.agents.t3code-headless = {
+        enable = true;
+        config = {
+          ProgramArguments = ["${serverCommand}"];
+          KeepAlive = true;
+          ProcessType = "Interactive";
+          RunAtLoad = true;
+          ThrottleInterval = 5;
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/t3code-headless.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/t3code-headless.err.log";
+        };
+      };
+    })
+  ]);
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,256 @@
+{
+  buildCommit,
+  pkgs,
+  self,
+}: let
+  lib = pkgs.lib;
+  desktopPackage = builtins.fromJSON (builtins.readFile ../apps/desktop/package.json);
+  rootPackage = builtins.fromJSON (builtins.readFile ../package.json);
+  appName = desktopPackage.productName;
+  electron = pkgs.electron_41;
+  nodejs = pkgs.nodejs_24;
+  pnpm = pkgs.pnpm_11;
+  # Client-only mode is supplied by its own topic/PR. Keep this flake
+  # composable with that source without exposing a wrapper whose flag the
+  # standalone upstream app would silently ignore.
+  clientModeSupported =
+    builtins.pathExists ../apps/desktop/src/app/DesktopBackendMode.ts;
+  version =
+    "${desktopPackage.version}-source"
+    + lib.optionalString (buildCommit != "") "-${builtins.substring 0 8 buildCommit}";
+  desktopIcon =
+    if pkgs.stdenv.hostPlatform.isDarwin
+    then ../assets/prod/black-macos-1024.png
+    else ../assets/prod/black-universal-1024.png;
+
+  unwrapped = pkgs.stdenv.mkDerivation (finalAttrs: {
+    pname = "t3code-unwrapped";
+    inherit version;
+
+    src = self;
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    nativeBuildInputs =
+      [
+        pkgs.installShellFiles
+        pkgs.makeBinaryWrapper
+        pkgs.node-gyp
+        nodejs
+        pkgs.python3
+        pkgs.pnpmConfigHook
+        pnpm
+        pkgs.cacert
+      ]
+      ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+        pkgs.copyDesktopItems
+      ]
+      ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+        pkgs.cctools.libtool
+        pkgs.libicns
+        pkgs.xcbuild
+      ];
+
+    pnpmWorkspaces = [
+      "@t3tools/monorepo"
+      "t3..."
+      "@t3tools/desktop..."
+      "@t3tools/scripts..."
+    ];
+
+    pnpmDeps = pkgs.fetchPnpmDeps {
+      inherit pnpm;
+      inherit
+        (finalAttrs)
+        pname
+        version
+        src
+        pnpmWorkspaces
+        ;
+      fetcherVersion = 4;
+      # Fixed-output hash over the offline dependency closure. When
+      # pnpm-lock.yaml changes, replace this with lib.fakeHash, build
+      # .#unwrapped, and copy the reported hash here.
+      hash = "sha256-Qiwbg1EPjcVvt8YGc0YYP+1NbgBIxMkwIyTq5f3gtl4=";
+    };
+
+    env.APP_VERSION = finalAttrs.version;
+
+    postPatch = ''
+      substituteInPlace package.json \
+        --replace-fail '"packageManager": "${rootPackage.packageManager}"' \
+                       '"packageManager": "pnpm@${pnpm.version}"'
+    '';
+
+    preBuild = ''
+      node scripts/update-release-package-versions.ts ${lib.escapeShellArg finalAttrs.version}
+
+      export npm_config_nodedir=${nodejs}
+      export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+      # `vp config` needs Git, so leave the root workspace out of the pending
+      # native-module rebuild.
+      pnpm rebuild --pending "''${pnpmInstallFlags[@]}" --filter '!@t3tools/monorepo'
+    '';
+
+    # Building through the root task discovers mobile and infrastructure
+    # workspaces that are intentionally absent from pnpmWorkspaces. Build the
+    # desktop dependency chain directly instead.
+    buildPhase = ''
+      runHook preBuild
+
+      pushd apps/web
+      ../../node_modules/.bin/vp build
+      popd
+
+      node apps/server/scripts/cli.ts build --verbose
+      node apps/desktop/scripts/build-preview-annotation-css.mjs
+
+      pushd apps/desktop
+      ../../node_modules/.bin/vp pack
+      popd
+
+      runHook postBuild
+    '';
+
+    # Some dependencies vendor static binaries for non-host platforms.
+    dontPatchELF = true;
+    noAuditTmpdir = true;
+
+    installPhase =
+      ''
+        runHook preInstall
+
+        mkdir -p "$out"/libexec/t3code/apps/{desktop,server}
+        cp -r --no-preserve=mode node_modules "$out"/libexec/t3code
+        cp -r --no-preserve=mode apps/server/{node_modules,dist} \
+          "$out"/libexec/t3code/apps/server
+        cp -r --no-preserve=mode \
+          apps/desktop/{package.json,node_modules,dist-electron} \
+          "$out"/libexec/t3code/apps/desktop
+
+        mkdir -p "$out"/libexec/t3code/apps/desktop/prod-resources
+        install -m444 ${desktopIcon} \
+          "$out"/libexec/t3code/apps/desktop/prod-resources/icon.png
+
+        # app.getAppPath() resolves to apps/desktop in this unpacked layout.
+        mkdir -p "$out"/libexec/t3code/apps/desktop/apps/server/dist
+        ln -s ../../../../server/dist/client \
+          "$out"/libexec/t3code/apps/desktop/apps/server/dist/client
+
+        find "$out"/libexec/t3code -xtype l -delete
+
+        makeWrapper ${lib.getExe nodejs} "$out"/bin/t3 \
+          --add-flags "$out"/libexec/t3code/apps/server/dist/bin.mjs
+        makeWrapper ${lib.getExe electron} "$out"/bin/t3code-desktop \
+          --add-flags "$out"/libexec/t3code/apps/desktop \
+          --inherit-argv0
+      ''
+      + lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
+        find "$out"/libexec/t3code \
+          -path '*/node-pty/prebuilds/darwin-*/spawn-helper' \
+          -exec chmod 755 {} +
+
+        mkdir -p "$out/Applications/${appName}.app/Contents/"{MacOS,Resources}
+        png2icns \
+          "$out/Applications/${appName}.app/Contents/Resources/t3code.icns" \
+          ${desktopIcon}
+      ''
+      + ''
+        mkdir -p "$out"/share/icons/hicolor/scalable/apps
+        install -m444 ${desktopIcon} "$out"/share/icons/t3code.png
+        install -m444 assets/prod/logo.svg \
+          "$out"/share/icons/hicolor/scalable/apps/t3code.svg
+
+        runHook postInstall
+      '';
+
+    postInstall =
+      lib.optionalString (
+        pkgs.stdenv.buildPlatform.canExecute pkgs.stdenv.hostPlatform
+      ) ''
+        for shell in bash fish zsh; do
+          installShellCompletion --cmd t3 --"$shell" <("$out/bin/t3" --completions "$shell")
+        done
+      '';
+
+    desktopItems = [
+      (pkgs.makeDesktopItem {
+        name = "t3code";
+        desktopName = appName;
+        comment = "Minimal web GUI for coding agents";
+        exec = "t3code-desktop %U";
+        terminal = false;
+        icon = "t3code";
+        startupWMClass = "t3code";
+        categories = ["Development"];
+      })
+    ];
+
+    meta = {
+      description = "Minimal web GUI for coding agents";
+      homepage = "https://t3.codes";
+      license = lib.licenses.mit;
+      mainProgram = "t3code-desktop";
+      inherit (nodejs.meta) platforms;
+    };
+  });
+
+  runtimePackages = [
+    pkgs.codex
+    pkgs.gh
+    pkgs.git
+  ];
+
+  t3code = pkgs.symlinkJoin {
+    pname = "t3code";
+    inherit (unwrapped) version;
+    paths = [unwrapped];
+    nativeBuildInputs = [pkgs.makeBinaryWrapper];
+    postBuild =
+      ''
+        for program in "$out/bin"/*; do
+          wrapProgram "$program" \
+            --prefix PATH : "${lib.makeBinPath runtimePackages}"
+        done
+      ''
+      + lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
+        # Build the application launcher after wrapping so Finder follows the
+        # same PATH and client-mode wrappers as direct command-line launches.
+        mkdir -p "$out/Applications/${appName}.app/Contents/MacOS"
+        ${pkgs.stdenv.shell} ${lib.getExe pkgs.writeDarwinBundle} \
+          "$out" "${appName}" t3code-desktop t3code
+      '';
+    passthru = {inherit unwrapped;};
+    inherit (unwrapped) meta;
+  };
+
+  client = t3code.overrideAttrs (previousAttrs: {
+    pname = "t3code-client";
+    buildCommand =
+      previousAttrs.buildCommand
+      + lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+        # Chromium does not recognize every Linux desktop as having a native
+        # password store. Prefer Secret Service explicitly.
+        mv "$out/bin/t3code-desktop" \
+          "$out/bin/.t3code-desktop-client-unwrapped"
+        makeWrapper "$out/bin/.t3code-desktop-client-unwrapped" \
+          "$out/bin/t3code-desktop" \
+          --add-flags "--password-store=gnome-libsecret" \
+          --add-flags "--backend-mode=client-only"
+      ''
+      + lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
+        mv "$out/bin/t3code-desktop" \
+          "$out/bin/.t3code-desktop-client-unwrapped"
+        makeWrapper "$out/bin/.t3code-desktop-client-unwrapped" \
+          "$out/bin/t3code-desktop" \
+          --add-flags "--backend-mode=client-only"
+      '';
+  });
+in
+  {
+    inherit t3code unwrapped;
+    default = t3code;
+  }
+  // lib.optionalAttrs clientModeSupported {
+    inherit client;
+  }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -71,7 +71,7 @@
       # Fixed-output hash over the offline dependency closure. When
       # pnpm-lock.yaml changes, replace this with lib.fakeHash, build
       # .#unwrapped, and copy the reported hash here.
-      hash = "sha256-Qiwbg1EPjcVvt8YGc0YYP+1NbgBIxMkwIyTq5f3gtl4=";
+      hash = "sha256-2HeroptijgZF837wjMQXvHtXNTgd1OYE5TV1xfRHSgw=";
     };
 
     env.APP_VERSION = finalAttrs.version;
@@ -80,6 +80,11 @@
       substituteInPlace package.json \
         --replace-fail '"packageManager": "${rootPackage.packageManager}"' \
                        '"packageManager": "pnpm@${pnpm.version}"'
+      substituteInPlace pnpm-workspace.yaml \
+        --replace-fail 'packages:' $'injectWorkspacePackages: true\n\npackages:'
+      substituteInPlace pnpm-lock.yaml \
+        --replace-fail '  excludeLinksFromLockfile: false' \
+                       $'  excludeLinksFromLockfile: false\n  injectWorkspacePackages: true'
     '';
 
     preBuild = ''
@@ -120,13 +125,33 @@
       ''
         runHook preInstall
 
-        mkdir -p "$out"/libexec/t3code/apps/{desktop,server}
-        cp -r --no-preserve=mode node_modules "$out"/libexec/t3code
-        cp -r --no-preserve=mode apps/server/{node_modules,dist} \
+        serverDeploy="$TMPDIR/t3code-server"
+        desktopDeploy="$TMPDIR/t3code-desktop"
+        pnpm --filter t3 deploy --prod --offline --frozen-lockfile \
+          "$serverDeploy"
+        pnpm --filter @t3tools/desktop deploy \
+          --prod --offline --frozen-lockfile "$desktopDeploy"
+
+        mkdir -p "$out"/libexec/t3code/apps
+        cp -r --no-preserve=mode "$serverDeploy" \
           "$out"/libexec/t3code/apps/server
-        cp -r --no-preserve=mode \
-          apps/desktop/{package.json,node_modules,dist-electron} \
+        cp -r --no-preserve=mode "$desktopDeploy" \
           "$out"/libexec/t3code/apps/desktop
+
+        nodePtyPlatform="$(${lib.getExe nodejs} -p \
+          '`''${process.platform}-''${process.arch}`')"
+        while IFS= read -r nodePtyDir; do
+          if [ -d "$nodePtyDir/build" ]; then
+            find "$nodePtyDir/build" -mindepth 1 -maxdepth 1 \
+              ! -name Release -exec rm -rf -- {} +
+          fi
+          if [ -d "$nodePtyDir/prebuilds" ]; then
+            find "$nodePtyDir/prebuilds" -mindepth 1 -maxdepth 1 \
+              -type d ! -name "$nodePtyPlatform" -exec rm -rf -- {} +
+          fi
+          rm -rf -- "$nodePtyDir/third_party/conpty"
+        done < <(find "$out"/libexec/t3code/apps \
+          -type d -path '*/node_modules/node-pty')
 
         mkdir -p "$out"/libexec/t3code/apps/desktop/prod-resources
         install -m444 ${desktopIcon} \

--- a/nix/scripts/build-android-apk.sh
+++ b/nix/scripts/build-android-apk.sh
@@ -1,0 +1,112 @@
+# Build a debug-signed release APK from this flake's T3 Code source.
+#
+# Environment overrides:
+#   T3CODE_APK_WORKDIR  owned writable build tree (default ~/.cache/t3code-apk-build)
+#   T3CODE_APK_OUT      output directory (default ~/t3code-apk)
+#   T3CODE_APK_VARIANT  APP_VARIANT (default production)
+#   T3CODE_APK_ABIS     comma-separated Android ABIs (default arm64-v8a)
+
+workdir="${T3CODE_APK_WORKDIR:-$HOME/.cache/t3code-apk-build}"
+outdir="${T3CODE_APK_OUT:-$HOME/t3code-apk}"
+variant="${T3CODE_APK_VARIANT:-production}"
+abis="${T3CODE_APK_ABIS:-arm64-v8a}"
+
+log() {
+  printf '\n\033[1;34m==> %s\033[0m\n' "$*"
+}
+
+directory_has_entries() {
+  local directory="$1"
+  local entry
+  for entry in "$directory"/* "$directory"/.[!.]* "$directory"/..?*; do
+    if [ -e "$entry" ] || [ -L "$entry" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+home_dir="$(realpath -m -- "$HOME")"
+workdir="$(realpath -m -- "$workdir")"
+outdir="$(realpath -m -- "$outdir")"
+workdir_marker="$workdir/.t3code-apk-workdir-v1"
+
+case "$workdir" in
+  "" | "/" | "$home_dir")
+    echo "Refusing unsafe T3CODE_APK_WORKDIR: $workdir" >&2
+    exit 64
+    ;;
+esac
+
+work_parent="$(dirname "$workdir")"
+mkdir -p "$work_parent"
+
+avail_kb="$(df -Pk "$work_parent" | awk 'NR==2 {print $4}')"
+if [ "${avail_kb:-0}" -lt 20971520 ]; then
+  printf '\033[1;33mWARNING: only %s GiB free near %s; React Native builds can need 15-20 GiB.\033[0m\n' \
+    "$((avail_kb / 1048576))" "$workdir" >&2
+fi
+
+log "Refreshing writable source tree at $workdir"
+if [ -e "$workdir" ] && [ ! -d "$workdir" ]; then
+  echo "Refusing non-directory T3CODE_APK_WORKDIR: $workdir" >&2
+  exit 64
+fi
+
+if [ -d "$workdir" ]; then
+  if [ -d "$workdir_marker" ] && [ ! -L "$workdir_marker" ]; then
+    :
+  elif directory_has_entries "$workdir"; then
+    echo "Refusing unowned nonempty T3CODE_APK_WORKDIR: $workdir" >&2
+    exit 64
+  fi
+else
+  mkdir -p "$workdir"
+fi
+
+# The marker claims only this directory for repeat builds. Clean immediate
+# children rather than deleting the caller-supplied directory itself.
+mkdir -p "$workdir_marker"
+for entry in "$workdir"/* "$workdir"/.[!.]* "$workdir"/..?*; do
+  if { [ -e "$entry" ] || [ -L "$entry" ]; } && [ "$entry" != "$workdir_marker" ]; then
+    rm -rf -- "$entry"
+  fi
+done
+
+cp -a "$T3CODE_SOURCE_TREE"/. "$workdir"/
+chmod -R u+w "$workdir"
+
+log "Building the release APK"
+cd "$workdir"
+nix develop "$T3CODE_ANDROID_FLAKE#android" --command bash -euo pipefail -c '
+  CI=true corepack pnpm install \
+    --frozen-lockfile \
+    --config.enableGlobalVirtualStore=false
+
+  cd apps/mobile
+  APP_VARIANT="'"$variant"'" EXPO_NO_GIT_STATUS=1 \
+    expo prebuild --clean --platform android
+
+  cd android
+  NODE_ENV=production ./gradlew assembleRelease \
+    -PreactNativeArchitectures="'"$abis"'" \
+    -x lintVitalAnalyzeRelease \
+    -x lintVitalReportRelease \
+    -x lintVitalRelease \
+    --no-daemon \
+    --max-workers=4
+'
+
+apk="$workdir/apps/mobile/android/app/build/outputs/apk/release/app-release.apk"
+if [ ! -f "$apk" ]; then
+  echo "Expected APK not found at $apk" >&2
+  exit 1
+fi
+
+mkdir -p "$outdir"
+destination="$outdir/t3code-${variant}-${T3CODE_SOURCE_REV}.apk"
+cp -f "$apk" "$destination"
+
+log "APK ready"
+echo "$destination"
+echo "Sideload with: adb install -r \"$destination\""


### PR DESCRIPTION
## Summary

- add a self-contained Nix package for building the desktop app directly from the checkout
- provide a lightweight default development shell plus a separate Android SDK/NDK shell and APK builder
- expose default and client overlays, a headless smoke check, and a cross-platform Home Manager service module

## Why

This makes checkout builds reproducible without importing or overriding the `t3code` package from nixpkgs. Nixpkgs supplies standard tools and build dependencies, while this repository owns its workspace selection, build phases, install layout, wrappers, and desktop integration.

## Validation

- `nix fmt -- --check flake.nix nix/android.nix nix/package.nix nix/home-manager/t3code-server.nix`
- `nix flake check --no-build --all-systems`
- `nix build .#packages.x86_64-linux.unwrapped.pnpmDeps --no-link`
- `nix build .#unwrapped --no-link`
- `nix build .#checks.x86_64-linux.smoke --no-link`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New packaging and ops tooling only; no application runtime logic changes, though the Home Manager module can expose Tailscale Serve when enabled.
> 
> **Overview**
> Introduces a **Nix flake** so T3 Code can be built and run from this checkout without relying on nixpkgs’ upstream `t3code` package.
> 
> **Packages and overlays:** `nix/package.nix` drives a pnpm-based derivation (web `vp build`, server CLI build, desktop `vp pack`) and installs `t3` / `t3code-desktop` with desktop entries and optional macOS `.app`. Default and optional **client-only** overlays appear when `DesktopBackendMode.ts` exists in the tree.
> 
> **Developer and CI surfaces:** Default `nix develop` shell pins Node 24, pnpm 11, and nixpkgs Electron; Linux adds an Android SDK/NDK shell and `nix run .#build-android` (script copies the flake source, then prebuilds and Gradle-assembles a release APK). Linux **`nix flake check`** includes a headless Electron smoke test under Xvfb that fails on early exit or renderer `ReferenceError`-style boot failures.
> 
> **Deployment:** A **Home Manager** module (`services.t3code`) runs a persistent headless `t3 serve` via user systemd (Linux) or launchd (macOS), with optional Tailscale Serve and a broad default `PATH` for agent tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72f355ad28682ebac44b3ab4aeba909b11a097a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a self-contained Nix flake for building, developing, and deploying T3 Code
> - [flake.nix](https://github.com/pingdotgg/t3code/pull/4699/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) exposes packages for aarch64/x86_64 Linux and macOS: `nix build .#t3code` produces `t3` (server CLI) and `t3code-desktop` (Electron app), with a macOS `.app` bundle and a `client` variant that forces client-only backend mode.
> - `nix develop` provides a dev shell with Node 24, pnpm 11, and Electron 41 pre-configured via `ELECTRON_OVERRIDE_DIST_PATH`.
> - [nix/android.nix](https://github.com/pingdotgg/t3code/pull/4699/files#diff-f8d6404c9dfbc44029c5ff846b606ecb64546dddb3b41361e4342db18d42b83d) adds a Linux-only `nix run .#build-android` app and Android dev shell with a full SDK/NDK/JDK toolchain; [nix/scripts/build-android-apk.sh](https://github.com/pingdotgg/t3code/pull/4699/files#diff-f1d4366ba570e59b196b188f46c88df992523301121d42d889bb3ef26959bf3c) handles the full APK build and export.
> - [nix/home-manager/t3code-server.nix](https://github.com/pingdotgg/t3code/pull/4699/files#diff-feed844088a65455f698b1f88f7ed5b0edb559229b85e623e3d4d783606dc0f7) adds a Home Manager module (`services.t3code`) that runs a persistent headless server as a systemd user service (Linux) or LaunchAgent (macOS), with optional Tailscale Serve integration.
> - `nix flake check` on Linux runs a headless Xvfb smoke test that fails on early process exit or renderer `ReferenceError`s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a72f355.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->