### PR TITLE
Render shortcuts with Apple's modifier and key glyphs

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -35,7 +35,7 @@ import {
 
 import { isElectron } from "../../env";
 import { useOpenInPreferredEditor } from "../../editorPreferences";
-import { formatShortcutLabel } from "../../keybindings";
+import { formatShortcutLabel, formatShortcutTokenLabel } from "../../keybindings";
 import { cn } from "../../lib/utils";
 import {
   primaryServerAvailableEditorsAtom,
@@ -74,26 +74,11 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 function KeybindingPill({ value }: { value: string }) {
-  const parts = value.split("+");
   return (
     <KbdGroup className="bg-transparent p-0 shadow-none">
-      {parts.map((part) => (
+      {value.split("+").map((part) => (
         <Kbd key={part} className="min-w-6 justify-center px-1.5">
-          {part === "mod"
-            ? navigator.platform.toLowerCase().includes("mac")
-              ? "⌘"
-              : "Ctrl"
-            : part === "shift"
-              ? "⇧"
-              : part === "alt"
-                ? navigator.platform.toLowerCase().includes("mac")
-                  ? "⌥"
-                  : "Alt"
-                : part === "ctrl"
-                  ? "⌃"
-                  : part.length === 1
-                    ? part.toUpperCase()
-                    : part}
+          {formatShortcutTokenLabel(part)}
         </Kbd>
       ))}
     </KbdGroup>

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -652,6 +652,17 @@ describe("formatShortcutLabel", () => {
     assert.strictEqual(formatShortcutLabel(modShortcut("d", { shiftKey: true }), "Linux"), "⌃⇧D");
   });
 
+  it("separates a word-form non-mac meta key without splitting glyph runs", () => {
+    assert.strictEqual(
+      formatShortcutLabel({ ...modShortcut("b"), modKey: false, metaKey: true }, "Linux"),
+      "Super+B",
+    );
+    assert.strictEqual(
+      formatShortcutLabel(modShortcut("k", { shiftKey: true, metaKey: true }), "Linux"),
+      "⌃⇧+Super+K",
+    );
+  });
+
   it("uses Apple's key glyphs, not words", () => {
     assert.strictEqual(formatShortcutLabel(modShortcut("escape"), "Linux"), "⌃⎋");
     assert.strictEqual(formatShortcutLabel(modShortcut("backspace"), "Linux"), "⌃⌫");
@@ -675,6 +686,7 @@ describe("formatShortcutTokenLabel", () => {
     assert.strictEqual(formatShortcutTokenLabel("alt", "Linux"), "⌥");
     assert.strictEqual(formatShortcutTokenLabel("shift", "Linux"), "⇧");
     assert.strictEqual(formatShortcutTokenLabel("b", "Linux"), "B");
+    assert.strictEqual(formatShortcutTokenLabel("esc", "Linux"), "⎋");
     assert.strictEqual(formatShortcutTokenLabel("escape", "Linux"), "⎋");
     assert.strictEqual(formatShortcutTokenLabel("space", "Linux"), "␣");
   });

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@t3tools/contracts";
 import {
   formatShortcutLabel,
+  formatShortcutTokenLabel,
   isChatNewShortcut,
   isChatNewLocalShortcut,
   isDiffToggleShortcut,
@@ -308,7 +309,7 @@ describe("shortcutLabelForCommand", () => {
         platform: "Linux",
         context: { terminalFocus: false },
       }),
-      "Ctrl+Shift+\\",
+      "⌃⇧\\",
     );
   });
 
@@ -318,7 +319,7 @@ describe("shortcutLabelForCommand", () => {
       "⌘B",
     );
     assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "chat.new", "MacIntel"), "⇧⌘O");
-    assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "diff.toggle", "Linux"), "Ctrl+D");
+    assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "diff.toggle", "Linux"), "⌃D");
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "rightPanel.toggle", "MacIntel"),
       "⌥⌘B",
@@ -329,11 +330,11 @@ describe("shortcutLabelForCommand", () => {
     );
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "modelPicker.toggle", "Linux"),
-      "Ctrl+Shift+M",
+      "⌃⇧M",
     );
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "editor.openFavorite", "Linux"),
-      "Ctrl+O",
+      "⌃O",
     );
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "thread.jump.3", "MacIntel"),
@@ -341,7 +342,7 @@ describe("shortcutLabelForCommand", () => {
     );
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "thread.previous", "Linux"),
-      "Ctrl+Shift+[",
+      "⌃⇧[",
     );
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "modelPicker.jump.3", {
@@ -377,7 +378,7 @@ describe("shortcutLabelForCommand", () => {
         platform: "Linux",
         context: { terminalFocus: false },
       }),
-      "Ctrl+D",
+      "⌃D",
     );
     assert.isNull(
       shortcutLabelForCommand(bindings, "diff.toggle", {
@@ -390,7 +391,7 @@ describe("shortcutLabelForCommand", () => {
         platform: "Linux",
         context: { terminalFocus: true },
       }),
-      "Ctrl+D",
+      "⌃D",
     );
   });
 });
@@ -647,16 +648,39 @@ describe("formatShortcutLabel", () => {
     );
   });
 
-  it("formats labels for non-macOS", () => {
-    assert.strictEqual(
-      formatShortcutLabel(modShortcut("d", { shiftKey: true }), "Linux"),
-      "Ctrl+Shift+D",
-    );
+  it("formats labels for non-macOS with the same glyphs", () => {
+    assert.strictEqual(formatShortcutLabel(modShortcut("d", { shiftKey: true }), "Linux"), "⌃⇧D");
+  });
+
+  it("uses Apple's key glyphs, not words", () => {
+    assert.strictEqual(formatShortcutLabel(modShortcut("escape"), "Linux"), "⌃⎋");
+    assert.strictEqual(formatShortcutLabel(modShortcut("backspace"), "Linux"), "⌃⌫");
+    assert.strictEqual(formatShortcutLabel(modShortcut("tab"), "MacIntel"), "⌘⇥");
+    assert.strictEqual(formatShortcutLabel(modShortcut("arrowup"), "Linux"), "⌃↑");
+    // No established glyph, so the word survives.
+    assert.strictEqual(formatShortcutLabel(modShortcut("f1"), "Linux"), "⌃F1");
   });
 
   it("formats labels for plus key", () => {
     assert.strictEqual(formatShortcutLabel(modShortcut("+"), "MacIntel"), "⌘+");
-    assert.strictEqual(formatShortcutLabel(modShortcut("+"), "Linux"), "Ctrl++");
+    assert.strictEqual(formatShortcutLabel(modShortcut("+"), "Linux"), "⌃+");
+  });
+});
+
+describe("formatShortcutTokenLabel", () => {
+  it("maps binding tokens to Apple glyphs", () => {
+    assert.strictEqual(formatShortcutTokenLabel("mod", "Linux"), "⌃");
+    assert.strictEqual(formatShortcutTokenLabel("mod", "MacIntel"), "⌘");
+    assert.strictEqual(formatShortcutTokenLabel("ctrl", "Linux"), "⌃");
+    assert.strictEqual(formatShortcutTokenLabel("alt", "Linux"), "⌥");
+    assert.strictEqual(formatShortcutTokenLabel("shift", "Linux"), "⇧");
+    assert.strictEqual(formatShortcutTokenLabel("b", "Linux"), "B");
+    assert.strictEqual(formatShortcutTokenLabel("escape", "Linux"), "⎋");
+  });
+
+  it("keeps a word for a non-mac meta key, which has no Apple glyph", () => {
+    assert.strictEqual(formatShortcutTokenLabel("meta", "Linux"), "Super");
+    assert.strictEqual(formatShortcutTokenLabel("meta", "MacIntel"), "⌘");
   });
 });
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -676,6 +676,7 @@ describe("formatShortcutTokenLabel", () => {
     assert.strictEqual(formatShortcutTokenLabel("shift", "Linux"), "⇧");
     assert.strictEqual(formatShortcutTokenLabel("b", "Linux"), "B");
     assert.strictEqual(formatShortcutTokenLabel("escape", "Linux"), "⎋");
+    assert.strictEqual(formatShortcutTokenLabel("space", "Linux"), "␣");
   });
 
   it("keeps a word for a non-mac meta key, which has no Apple glyph", () => {

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -232,6 +232,7 @@ const SHORTCUT_KEY_SYMBOLS: Readonly<Record<string, string>> = {
   delete: "⌦",
   end: "↘",
   enter: "⏎",
+  esc: "⎋",
   escape: "⎋",
   home: "↖",
   pagedown: "⇟",
@@ -273,20 +274,26 @@ export function formatShortcutTokenLabel(token: string, platform = navigator.pla
  * Shortcuts render Apple-style everywhere: modifier and key glyphs in Apple's
  * canonical order with no separators, on every platform. `mod+shift+e` is
  * `⌃⇧E` on Linux/Windows and `⇧⌘E` on macOS. A non-mac meta/super key has no
- * Apple glyph, so it stays a word rather than borrowing `⌘`.
+ * Apple glyph, so it stays a `+`-delimited word rather than borrowing `⌘`.
  */
 export function formatShortcutLabel(
   shortcut: KeybindingShortcut,
   platform = navigator.platform,
 ): string {
   const useMetaForMod = isMacPlatform(platform);
-  return [
+  const glyphModifiers = [
     shortcut.ctrlKey || (shortcut.modKey && !useMetaForMod) ? "⌃" : "",
     shortcut.altKey ? "⌥" : "",
     shortcut.shiftKey ? "⇧" : "",
-    shortcut.metaKey || (shortcut.modKey && useMetaForMod) ? (useMetaForMod ? "⌘" : "Super") : "",
-    formatShortcutKeyLabel(shortcut.key),
+    useMetaForMod && (shortcut.metaKey || shortcut.modKey) ? "⌘" : "",
   ].join("");
+  const keyLabel = formatShortcutKeyLabel(shortcut.key);
+
+  if (!useMetaForMod && shortcut.metaKey) {
+    return [glyphModifiers, "Super", keyLabel].filter(Boolean).join("+");
+  }
+
+  return `${glyphModifiers}${keyLabel}`;
 }
 
 export function shortcutLabelForCommand(

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -216,39 +216,76 @@ export function resolveShortcutCommand(
   return null;
 }
 
+/**
+ * Apple's glyphs for the non-letter keys, from Apple's Human Interface
+ * Guidelines. Keys with no established glyph (function keys, punctuation) keep
+ * their word form.
+ */
+const SHORTCUT_KEY_SYMBOLS: Readonly<Record<string, string>> = {
+  " ": "␣",
+  arrowdown: "↓",
+  arrowleft: "←",
+  arrowright: "→",
+  arrowup: "↑",
+  backspace: "⌫",
+  delete: "⌦",
+  end: "↘",
+  enter: "⏎",
+  escape: "⎋",
+  home: "↖",
+  pagedown: "⇟",
+  pageup: "⇞",
+  return: "⏎",
+  tab: "⇥",
+};
+
 function formatShortcutKeyLabel(key: string): string {
-  if (key === " ") return "Space";
+  const symbol = SHORTCUT_KEY_SYMBOLS[key];
+  if (symbol) return symbol;
   if (key.length === 1) return key.toUpperCase();
-  if (key === "escape") return "Esc";
-  if (key === "arrowup") return "Up";
-  if (key === "arrowdown") return "Down";
-  if (key === "arrowleft") return "Left";
-  if (key === "arrowright") return "Right";
   return key.slice(0, 1).toUpperCase() + key.slice(1);
 }
 
+/**
+ * Apple-style glyph for one token of a raw binding string ("mod+shift+b"), for
+ * surfaces that render a chord as separate chips rather than one label.
+ */
+export function formatShortcutTokenLabel(token: string, platform = navigator.platform): string {
+  const useMetaForMod = isMacPlatform(platform);
+  switch (token) {
+    case "mod":
+      return useMetaForMod ? "⌘" : "⌃";
+    case "meta":
+      return useMetaForMod ? "⌘" : "Super";
+    case "ctrl":
+      return "⌃";
+    case "alt":
+      return "⌥";
+    case "shift":
+      return "⇧";
+    default:
+      return formatShortcutKeyLabel(token);
+  }
+}
+
+/**
+ * Shortcuts render Apple-style everywhere: modifier and key glyphs in Apple's
+ * canonical order with no separators, on every platform. `mod+shift+e` is
+ * `⌃⇧E` on Linux/Windows and `⇧⌘E` on macOS. A non-mac meta/super key has no
+ * Apple glyph, so it stays a word rather than borrowing `⌘`.
+ */
 export function formatShortcutLabel(
   shortcut: KeybindingShortcut,
   platform = navigator.platform,
 ): string {
-  const keyLabel = formatShortcutKeyLabel(shortcut.key);
   const useMetaForMod = isMacPlatform(platform);
-  const showMeta = shortcut.metaKey || (shortcut.modKey && useMetaForMod);
-  const showCtrl = shortcut.ctrlKey || (shortcut.modKey && !useMetaForMod);
-  const showAlt = shortcut.altKey;
-  const showShift = shortcut.shiftKey;
-
-  if (useMetaForMod) {
-    return `${showCtrl ? "\u2303" : ""}${showAlt ? "\u2325" : ""}${showShift ? "\u21e7" : ""}${showMeta ? "\u2318" : ""}${keyLabel}`;
-  }
-
-  const parts: string[] = [];
-  if (showCtrl) parts.push("Ctrl");
-  if (showAlt) parts.push("Alt");
-  if (showShift) parts.push("Shift");
-  if (showMeta) parts.push("Meta");
-  parts.push(keyLabel);
-  return parts.join("+");
+  return [
+    shortcut.ctrlKey || (shortcut.modKey && !useMetaForMod) ? "⌃" : "",
+    shortcut.altKey ? "⌥" : "",
+    shortcut.shiftKey ? "⇧" : "",
+    shortcut.metaKey || (shortcut.modKey && useMetaForMod) ? (useMetaForMod ? "⌘" : "Super") : "",
+    formatShortcutKeyLabel(shortcut.key),
+  ].join("");
 }
 
 export function shortcutLabelForCommand(

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -223,6 +223,7 @@ export function resolveShortcutCommand(
  */
 const SHORTCUT_KEY_SYMBOLS: Readonly<Record<string, string>> = {
   " ": "␣",
+  space: "␣",
   arrowdown: "↓",
   arrowleft: "←",
   arrowright: "→",


### PR DESCRIPTION
## What

Shortcut labels spelled modifiers out on Linux and Windows (`Ctrl+Shift+E`) while already using Apple's glyphs on macOS. This uses one representation everywhere.

| | Linux / Windows | macOS |
|---|---|---|
| `mod+shift+e` | `⌃⇧E` | `⇧⌘E` |
| `mod+alt+k` | `⌃⌥K` | `⌥⌘K` |
| `mod+backspace` | `⌃⌫` | `⌘⌫` |
| `mod+escape` | `⌃⎋` | `⌘⎋` |

`⌃⌥⇧` for control, option and shift on every platform, `⌘` for command on macOS, in Apple's canonical order with no separators.

## Details

- **Key glyphs too**, not just modifiers: `⎋ ⇥ ⏎ ⌫ ⌦ ␣ ↑ ↓ ← → ⇞ ⇟ ↖ ↘`. Keys with no established glyph — function keys, punctuation — keep their word, so `mod+f1` stays `⌃F1`.
- **A non-mac meta/super key stays `Super`.** Apple has no glyph for it, and borrowing `⌘` would be a lie about which key to press.
- **The keybindings settings table** rendered each token as its own chip through a separate platform conditional, which had already drifted from the label formatter — it showed `Ctrl` beside `⇧` in the same row. It now shares one `formatShortcutTokenLabel`, so the two can't disagree again.

## Screenshots

The keybindings settings table, whose per-token chips now share the same formatter (previously `Ctrl` beside `⇧` in one row):

![Keybindings settings table with Apple glyphs](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/shortcut-hints/keybindings-settings.png)

The composer's hold-modifier keycaps from #4271, which is what the width buys:

![Composer keycaps showing full chords](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/shortcut-hints/composer-hints-held.png)

## Why

Consistency across platforms, and horizontal space in every chip and keycap that shows a shortcut. `⌃⇧E` is roughly a third the width of `Ctrl+Shift+E`, which is what makes the composer's hold-modifier keycaps in #4271 fit inside a control's disclosure-chevron slot instead of needing their own row.

Affected surfaces: command palette, sidebar chips, terminal tooltips, keybindings settings, and the composer hints in #4271.

## Tests

Updated the label expectations in `apps/web/src/keybindings.test.ts` and added coverage for key glyphs, the word fallback for keys without one, and the token formatter including the non-mac meta case. Typecheck, lint, and the `apps/web` suite pass (1606 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes to shortcut formatting; key matching behavior is unchanged.
> 
> **Overview**
> **Shortcut labels now use Apple-style modifier and key glyphs everywhere**, not word forms like `Ctrl+Shift+D` on Linux/Windows. Chords are shown in canonical order with no `+` separators (e.g. `⌃⇧D` on non-mac, `⇧⌘D` on macOS).
> 
> `formatShortcutLabel` in `keybindings.ts` is reworked around a `SHORTCUT_KEY_SYMBOLS` map (escape, tab, arrows, etc.) and glyph modifiers. **Non-mac Super/meta** still renders as the word `Super` with `+` when there is no Apple glyph. A new **`formatShortcutTokenLabel`** maps raw binding tokens for chip-style UI.
> 
> **Keybindings settings** `KeybindingPill` drops inline platform conditionals and calls `formatShortcutTokenLabel` so the table matches other shortcut surfaces. Tests in `keybindings.test.ts` are updated and extended for glyphs, tokens, and the Super edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0975c27145b75db359ff58726ff67e1b33e1a56d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render keyboard shortcuts with Apple modifier and key glyphs across all platforms
> - Replaces word-based modifier labels (e.g. `Ctrl`, `Shift`) with Apple-style glyphs (⌃, ⇧, ⌘, ⌥) in shortcut displays on all platforms, including non-mac.
> - Adds `SHORTCUT_KEY_SYMBOLS` map and `formatShortcutTokenLabel` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/4701/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385) to convert individual tokens to glyphs; refactors `formatShortcutLabel` to concatenate glyphs without separators.
> - Updates `KeybindingPill` in [KeybindingsSettings.tsx](https://github.com/pingdotgg/t3code/pull/4701/files#diff-12068495a79a13f54503fa3061aafb91f05537621626906b290ed059e660d4d4) to use `formatShortcutTokenLabel` instead of manual platform checks.
> - Behavioral Change: On non-mac, `meta` key renders as `Super` with `+` separators (e.g. `⌃⇧+Super+K`); all other modifiers use glyphs with no separators.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0975c27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
