### PR TITLE
Add configurable Sidebar V2 ordering

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -30,6 +30,8 @@ const clientSettings: ClientSettings = {
   sidebarThreadSortOrder: "created_at",
   sidebarThreadPreviewCount: 6,
   sidebarV2Enabled: false,
+  sidebarV2ThreadGroupOrder: ["review", "working", "ready"],
+  sidebarV2ThreadOrderMode: "created_at",
   timestampFormat: "24-hour",
   wordWrap: true,
 };

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -1,14 +1,21 @@
 import { BlurTargetView } from "expo-blur";
 import * as Linking from "expo-linking";
 import * as SplashScreen from "expo-splash-screen";
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { StatusBar, useColorScheme } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import { createStaticNavigation, DarkTheme, DefaultTheme } from "@react-navigation/native";
+import {
+  createStaticNavigation,
+  DarkTheme,
+  DefaultTheme,
+  useNavigationContainerRef,
+  type Theme,
+} from "@react-navigation/native";
 
-import { RegistryContext } from "@effect/atom-react";
+import { RegistryContext, useAtomSet, useAtomValue } from "@effect/atom-react";
+import { AsyncResult } from "effect/unstable/reactivity";
 import { ConfirmDialogHost } from "./components/ConfirmDialogHost";
 import { CloudAuthProvider } from "./features/cloud/CloudAuthProvider";
 import { prepareNativeShowcaseCapture } from "./features/showcase/nativeShowcaseScene";
@@ -22,6 +29,12 @@ import { appAtomRegistry } from "./state/atom-registry";
 import { OverlayPortalHost } from "./components/OverlayPortal";
 import { appBlurTargetRef } from "./lib/appBlurTarget";
 import { useThemeColor } from "./lib/useThemeColor";
+import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "./state/preferences";
+import {
+  recordThreadVisit,
+  threadVisitKeyFromNavigationState,
+  type NavigationStateLike,
+} from "./features/threads/navigationThreadVisit";
 
 import "../global.css";
 
@@ -57,6 +70,64 @@ function SplashScreenCoordinator() {
   return null;
 }
 
+function AppNavigation(props: { readonly theme: Theme }) {
+  const navigationRef = useNavigationContainerRef();
+  const preferencesResult = useAtomValue(mobilePreferencesAtom);
+  const savePreferences = useAtomSet(updateMobilePreferencesAtom);
+  const pendingThreadVisitRef = useRef<{
+    readonly threadKey: string;
+    readonly visitedAt: string;
+  } | null>(null);
+  const writeThreadVisit = useCallback(
+    (current: Readonly<Record<string, string>>, threadKey: string, visitedAt: string) => {
+      savePreferences({
+        threadLastVisitedAtByKey: recordThreadVisit(current, threadKey, visitedAt),
+      });
+    },
+    [savePreferences],
+  );
+  const recordVisibleThread = useCallback(
+    (state: NavigationStateLike | undefined) => {
+      if (state === undefined) return;
+      const threadKey = threadVisitKeyFromNavigationState(state);
+      if (threadKey === null) return;
+      const visitedAt = new Date().toISOString();
+      if (!AsyncResult.isSuccess(preferencesResult)) {
+        pendingThreadVisitRef.current = { threadKey, visitedAt };
+        return;
+      }
+      writeThreadVisit(
+        preferencesResult.value.threadLastVisitedAtByKey ?? {},
+        threadKey,
+        visitedAt,
+      );
+    },
+    [preferencesResult, writeThreadVisit],
+  );
+
+  useEffect(() => {
+    if (!AsyncResult.isSuccess(preferencesResult)) return;
+    const pending = pendingThreadVisitRef.current;
+    if (pending === null) return;
+    pendingThreadVisitRef.current = null;
+    writeThreadVisit(
+      preferencesResult.value.threadLastVisitedAtByKey ?? {},
+      pending.threadKey,
+      pending.visitedAt,
+    );
+  }, [preferencesResult, writeThreadVisit]);
+
+  return (
+    <Navigation
+      ref={navigationRef}
+      linking={appLinking}
+      onReady={() => recordVisibleThread(navigationRef.getRootState())}
+      onStateChange={(state) => recordVisibleThread(state)}
+      theme={props.theme}
+    />
+  );
+}
+
 export default function App() {
   const colorScheme = useColorScheme();
   const statusBarBg = useThemeColor("--color-status-bar");
@@ -75,17 +146,14 @@ export default function App() {
                   translucent
                 />
                 {/* The navigation theme drives the NATIVE header appearance: native-stack
-                    forwards `dark` as the nav bar's overrideUserInterfaceStyle. Without
-                    this, React Navigation defaults to its light theme and every native
-                    header (glass buttons, title, materials) is forced light even when
-                    the system is in dark mode. */}
+                  forwards `dark` as the nav bar's overrideUserInterfaceStyle. Without
+                  this, React Navigation defaults to its light theme and every native
+                  header (glass buttons, title, materials) is forced light even when
+                  the system is in dark mode. */}
                 {/* Blur target for Android dropdown backdrops — see appBlurTarget.ts. */}
                 <BlurTargetView ref={appBlurTargetRef} style={{ flex: 1 }}>
                   <IncomingShareProvider>
-                    <Navigation
-                      linking={appLinking}
-                      theme={colorScheme === "dark" ? DarkTheme : DefaultTheme}
-                    />
+                    <AppNavigation theme={colorScheme === "dark" ? DarkTheme : DefaultTheme} />
                   </IncomingShareProvider>
                   <ConfirmDialogHost />
                 </BlurTargetView>

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -12,6 +12,10 @@ import type {
   SidebarProjectGroupingMode,
   SidebarThreadSortOrder,
 } from "@t3tools/contracts";
+import {
+  DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER,
+  DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE,
+} from "@t3tools/contracts";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -184,6 +188,16 @@ export function HomeScreen(props: HomeScreenProps) {
   const threadListV2Enabled =
     AsyncResult.isSuccess(preferencesResult) &&
     preferencesResult.value.threadListV2Enabled === true;
+  const threadOrderMode = AsyncResult.isSuccess(preferencesResult)
+    ? (preferencesResult.value.threadListV2ThreadOrderMode ?? DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE)
+    : DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE;
+  const threadGroupOrder = AsyncResult.isSuccess(preferencesResult)
+    ? (preferencesResult.value.threadListV2ThreadGroupOrder ??
+      DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER)
+    : DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER;
+  const lastVisitedAtByKey = AsyncResult.isSuccess(preferencesResult)
+    ? (preferencesResult.value.threadLastVisitedAtByKey ?? {})
+    : {};
   const savePreferences = useAtomSet(updateMobilePreferencesAtom);
   const openSwipeableRef = useRef<SwipeableMethods | null>(null);
   const listRef = useRef<LegendListRef | null>(null);
@@ -520,6 +534,9 @@ export function HomeScreen(props: HomeScreenProps) {
       settlementEnvironmentIds,
       snoozeEnvironmentIds,
       settledLimit: settledVisibleCount,
+      threadOrderMode,
+      threadGroupOrder,
+      lastVisitedAtByKey,
       now: `${nowMinute}:00.000Z`,
       snoozeNow: new Date().toISOString(),
     });
@@ -533,7 +550,10 @@ export function HomeScreen(props: HomeScreenProps) {
     props.searchQuery,
     props.selectedEnvironmentId,
     props.threads,
+    lastVisitedAtByKey,
+    threadGroupOrder,
     threadListV2Enabled,
+    threadOrderMode,
     v2ScopedProjectGroup,
   ]);
   // Re-partition the moment the earliest snooze expires (clamped to the
@@ -551,7 +571,6 @@ export function HomeScreen(props: HomeScreenProps) {
     // range) the boundary string is identical and the chain would die.
   }, [nextSnoozeWakeAt, snoozeWakeTick]);
   const threadListV2Items = threadListV2Layout.items;
-
   const renderV2Item = useCallback(
     ({ item }: { readonly item: ThreadListV2Item }) => (
       <ThreadListV2Row

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -10,6 +10,7 @@ import * as Effect from "effect/Effect";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import {
+  AccessibilityInfo,
   ActivityIndicator,
   Alert,
   Linking,
@@ -28,6 +29,12 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import {
+  DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER,
+  DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE,
+  type SidebarV2ThreadGroup,
+  type SidebarV2ThreadGroupOrder,
+} from "@t3tools/contracts";
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { AppText as Text } from "../../components/AppText";
 import { supportsAgentAwarenessPush } from "../agent-awareness/capabilities";
@@ -53,6 +60,36 @@ import { SettingsSwitchRow } from "./components/SettingsSwitchRow";
 
 type NotificationStatus = "checking" | "enabled" | "disabled" | "unsupported";
 type LiveActivityStatus = "checking" | "enabled" | "disabled" | "signed-out" | "linking";
+
+const THREAD_GROUP_DETAILS: Record<
+  SidebarV2ThreadGroup,
+  { readonly label: string; readonly description: string }
+> = {
+  review: {
+    label: "Needs review",
+    description: "Finished, blocked, failed, or waiting for you",
+  },
+  working: {
+    label: "Working",
+    description: "Threads with an agent currently running",
+  },
+  ready: {
+    label: "Other active",
+    description: "Ready threads without a current attention signal",
+  },
+};
+
+function moveThreadGroup(
+  groups: SidebarV2ThreadGroupOrder,
+  index: number,
+  direction: -1 | 1,
+): SidebarV2ThreadGroupOrder {
+  const destination = index + direction;
+  if (destination < 0 || destination >= groups.length) return groups;
+  const next = [...groups];
+  [next[index], next[destination]] = [next[destination]!, next[index]!];
+  return next;
+}
 
 // Reflects whether the relay actually accepted this device's registration.
 // The notification and Live Activity switches are gated on this so they can
@@ -557,9 +594,28 @@ function GeneralSettingsSection() {
 function BetaSettingsSection() {
   const preferencesResult = useAtomValue(mobilePreferencesAtom);
   const savePreferences = useAtomSet(updateMobilePreferencesAtom);
+  const iconColor = useThemeColor("--color-icon");
   const threadListV2Enabled = AsyncResult.isSuccess(preferencesResult)
     ? preferencesResult.value.threadListV2Enabled === true
     : false;
+  const threadOrderMode = AsyncResult.isSuccess(preferencesResult)
+    ? (preferencesResult.value.threadListV2ThreadOrderMode ?? DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE)
+    : DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE;
+  const threadGroupOrder = AsyncResult.isSuccess(preferencesResult)
+    ? (preferencesResult.value.threadListV2ThreadGroupOrder ??
+      DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER)
+    : DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER;
+  const reorderThreadGroup = (index: number, direction: -1 | 1) => {
+    const nextOrder = moveThreadGroup(threadGroupOrder, index, direction);
+    const destination = index + direction;
+    const movedGroup = nextOrder[destination];
+    savePreferences({ threadListV2ThreadGroupOrder: nextOrder });
+    if (movedGroup) {
+      AccessibilityInfo.announceForAccessibility(
+        `${THREAD_GROUP_DETAILS[movedGroup].label} moved to position ${destination + 1}`,
+      );
+    }
+  };
 
   return (
     <View className="gap-3">
@@ -570,11 +626,82 @@ function BetaSettingsSection() {
           value={threadListV2Enabled}
           onValueChange={(value) => savePreferences({ threadListV2Enabled: value })}
         />
+        {threadListV2Enabled ? (
+          <SettingsSwitchRow
+            icon="arrow.up.arrow.down"
+            label="Automatic status order"
+            value={threadOrderMode === "automatic"}
+            onValueChange={(value) =>
+              savePreferences({
+                threadListV2ThreadOrderMode: value ? "automatic" : "created_at",
+              })
+            }
+          />
+        ) : null}
       </SettingsSection>
       <Text className="px-2 text-sm text-foreground-muted">
-        One flat thread list in creation order. Active work renders as cards; settled threads
-        collapse to compact rows. Switch back any time.
+        {threadOrderMode === "automatic" && threadListV2Enabled
+          ? "Active threads regroup as their status changes. Recently finished items stay in Needs review until you open them."
+          : "One flat thread list in newest-created-first order. Status changes do not move active threads."}
       </Text>
+      {threadListV2Enabled && threadOrderMode === "automatic" ? (
+        <SettingsSection title="Automatic group priority" card>
+          {threadGroupOrder.map((group, index) => {
+            const details = THREAD_GROUP_DETAILS[group];
+            return (
+              <View key={group} className="flex-row items-center gap-3 px-4 py-3">
+                <View className="size-7 items-center justify-center rounded-full bg-secondary">
+                  <Text className="font-t3-mono text-xs text-foreground-muted">{index + 1}</Text>
+                </View>
+                <View className="min-w-0 flex-1">
+                  <Text className="text-base font-t3-medium text-foreground">{details.label}</Text>
+                  <Text className="text-xs text-foreground-muted">{details.description}</Text>
+                </View>
+                <Pressable
+                  accessibilityLabel={`Move ${details.label} up, currently position ${index + 1} of ${threadGroupOrder.length}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ disabled: index === 0 }}
+                  disabled={index === 0}
+                  onPress={() => reorderThreadGroup(index, -1)}
+                  className={
+                    index === 0
+                      ? "size-11 items-center justify-center opacity-30"
+                      : "size-11 items-center justify-center"
+                  }
+                >
+                  <SymbolView
+                    name="arrow.up"
+                    size={17}
+                    tintColor={iconColor}
+                    type="monochrome"
+                    weight="semibold"
+                  />
+                </Pressable>
+                <Pressable
+                  accessibilityLabel={`Move ${details.label} down, currently position ${index + 1} of ${threadGroupOrder.length}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ disabled: index === threadGroupOrder.length - 1 }}
+                  disabled={index === threadGroupOrder.length - 1}
+                  onPress={() => reorderThreadGroup(index, 1)}
+                  className={
+                    index === threadGroupOrder.length - 1
+                      ? "size-11 items-center justify-center opacity-30"
+                      : "size-11 items-center justify-center"
+                  }
+                >
+                  <SymbolView
+                    name="arrow.down"
+                    size={17}
+                    tintColor={iconColor}
+                    type="monochrome"
+                    weight="semibold"
+                  />
+                </Pressable>
+              </View>
+            );
+          })}
+        </SettingsSection>
+      ) : null}
     </View>
   );
 }

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -7,7 +7,11 @@ import { LegendList } from "@legendapp/list/react-native";
 import type { MenuAction } from "@react-native-menu/menu";
 import { useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
-import type { EnvironmentId } from "@t3tools/contracts";
+import {
+  DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER,
+  DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE,
+  type EnvironmentId,
+} from "@t3tools/contracts";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from "react-native";
 import { Platform, Pressable, StyleSheet, TextInput, View, useColorScheme } from "react-native";
@@ -200,6 +204,16 @@ function ThreadNavigationSidebarPane(
   const threadListV2Enabled =
     AsyncResult.isSuccess(preferencesResult) &&
     preferencesResult.value.threadListV2Enabled === true;
+  const threadOrderMode = AsyncResult.isSuccess(preferencesResult)
+    ? (preferencesResult.value.threadListV2ThreadOrderMode ?? DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE)
+    : DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE;
+  const threadGroupOrder = AsyncResult.isSuccess(preferencesResult)
+    ? (preferencesResult.value.threadListV2ThreadGroupOrder ??
+      DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER)
+    : DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER;
+  const lastVisitedAtByKey = AsyncResult.isSuccess(preferencesResult)
+    ? (preferencesResult.value.threadLastVisitedAtByKey ?? {})
+    : {};
   const pendingTasks = usePendingNewTasks();
   const { openPendingTask, confirmDeletePendingTask } = usePendingTaskListActions();
   const environments = useMemo(
@@ -445,11 +459,15 @@ function ThreadNavigationSidebarPane(
       settlementEnvironmentIds,
       snoozeEnvironmentIds,
       settledLimit: settledVisibleCount,
+      threadOrderMode,
+      threadGroupOrder,
+      lastVisitedAtByKey,
       now: `${nowMinute}:00.000Z`,
       snoozeNow: new Date().toISOString(),
     });
   }, [
     changeRequestStateByKey,
+    lastVisitedAtByKey,
     nowMinute,
     snoozeWakeTick,
     options.selectedEnvironmentId,
@@ -457,7 +475,9 @@ function ThreadNavigationSidebarPane(
     settledVisibleCount,
     settlementEnvironmentIds,
     snoozeEnvironmentIds,
+    threadGroupOrder,
     threadListV2Enabled,
+    threadOrderMode,
     threads,
     selectedProjectScope,
   ]);

--- a/apps/mobile/src/features/threads/navigationThreadVisit.test.ts
+++ b/apps/mobile/src/features/threads/navigationThreadVisit.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { recordThreadVisit, threadVisitKeyFromNavigationState } from "./navigationThreadVisit";
+
+describe("recordThreadVisit", () => {
+  it("updates a visit and prunes the oldest markers at the requested limit", () => {
+    expect(
+      recordThreadVisit(
+        {
+          oldest: "2026-06-01T08:00:00.000Z",
+          middle: "2026-06-01T09:00:00.000Z",
+        },
+        "newest",
+        "2026-06-01T10:00:00.000Z",
+        2,
+      ),
+    ).toEqual({
+      middle: "2026-06-01T09:00:00.000Z",
+      newest: "2026-06-01T10:00:00.000Z",
+    });
+  });
+});
+
+describe("threadVisitKeyFromNavigationState", () => {
+  it("tracks direct and auxiliary thread destinations", () => {
+    expect(
+      threadVisitKeyFromNavigationState({
+        index: 1,
+        routes: [
+          { name: "Home" },
+          {
+            name: "Thread",
+            params: { environmentId: "environment-1", threadId: "thread-1" },
+          },
+        ],
+      }),
+    ).toBe("environment-1:thread-1");
+
+    expect(
+      threadVisitKeyFromNavigationState({
+        routes: [
+          {
+            name: "ThreadReview",
+            params: { environmentId: ["environment-2"], threadId: ["thread-2"] },
+          },
+        ],
+      }),
+    ).toBe("environment-2:thread-2");
+  });
+
+  it("uses the deepest active route in restored nested state", () => {
+    expect(
+      threadVisitKeyFromNavigationState({
+        routes: [
+          {
+            name: "Root",
+            state: {
+              index: 1,
+              routes: [
+                { name: "Home" },
+                {
+                  name: "ThreadFiles",
+                  params: { environmentId: "environment-3", threadId: "thread-3" },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toBe("environment-3:thread-3");
+  });
+
+  it("tracks git destinations that do not use the Thread route prefix", () => {
+    for (const routeName of ["GitOverview", "GitCommit", "GitBranches", "GitConfirm"]) {
+      expect(
+        threadVisitKeyFromNavigationState({
+          routes: [
+            {
+              name: routeName,
+              params: { environmentId: "environment-git", threadId: "thread-git" },
+            },
+          ],
+        }),
+      ).toBe("environment-git:thread-git");
+    }
+  });
+
+  it("ignores non-thread destinations", () => {
+    expect(
+      threadVisitKeyFromNavigationState({
+        routes: [
+          {
+            name: "SettingsSheet",
+            state: {
+              routes: [{ name: "Settings", params: { environmentId: "env", threadId: "thread" } }],
+            },
+          },
+        ],
+      }),
+    ).toBeNull();
+    expect(threadVisitKeyFromNavigationState({ routes: [{ name: "Home" }] })).toBeNull();
+  });
+
+  it("ignores malformed thread params", () => {
+    expect(
+      threadVisitKeyFromNavigationState({
+        routes: [{ name: "Thread", params: { environmentId: "environment-1" } }],
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/threads/navigationThreadVisit.ts
+++ b/apps/mobile/src/features/threads/navigationThreadVisit.ts
@@ -1,0 +1,75 @@
+import { scopedThreadKey } from "../../lib/scopedEntities";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+
+interface NavigationRouteLike {
+  readonly name: string;
+  readonly params?: unknown;
+  readonly state?: NavigationStateLike;
+}
+
+export interface NavigationStateLike {
+  readonly index?: number;
+  readonly routes: readonly NavigationRouteLike[];
+}
+
+const THREAD_DESTINATION_ROUTES = new Set([
+  "Thread",
+  "ThreadTerminal",
+  "ThreadReview",
+  "ThreadReviewComment",
+  "ThreadFiles",
+  "ThreadFile",
+  "GitOverview",
+  "GitCommit",
+  "GitBranches",
+  "GitConfirm",
+]);
+
+function activeRoute(state: NavigationStateLike): NavigationRouteLike | null {
+  const route = state.routes[state.index ?? state.routes.length - 1] ?? null;
+  if (route?.state === undefined) return route;
+  return activeRoute(route.state) ?? route;
+}
+
+function firstString(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return null;
+  return typeof value[0] === "string" ? value[0] : null;
+}
+
+function parseTimestampMs(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function recordThreadVisit(
+  current: Readonly<Record<string, string>>,
+  threadKey: string,
+  visitedAt: string,
+  limit = 500,
+): Readonly<Record<string, string>> {
+  const next = { ...current, [threadKey]: visitedAt };
+  const entries = Object.entries(next);
+  if (entries.length <= limit) return next;
+  return Object.fromEntries(
+    entries
+      .sort((left, right) => parseTimestampMs(right[1]) - parseTimestampMs(left[1]))
+      .slice(0, limit),
+  );
+}
+
+/**
+ * Resolves the visible thread destination from React Navigation state.
+ * Auxiliary thread routes (review, files, terminal, and git) count as visits
+ * because the user is actively inspecting that thread there too.
+ */
+export function threadVisitKeyFromNavigationState(state: NavigationStateLike): string | null {
+  const route = activeRoute(state);
+  if (route === null || !THREAD_DESTINATION_ROUTES.has(route.name)) return null;
+  if (typeof route.params !== "object" || route.params === null) return null;
+  const params = route.params as Record<string, unknown>;
+  const environmentId = firstString(params.environmentId);
+  const threadId = firstString(params.threadId);
+  if (environmentId === null || threadId === null) return null;
+  return scopedThreadKey(EnvironmentId.make(environmentId), ThreadId.make(threadId));
+}

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -74,9 +74,209 @@ describe("sortThreadsForListV2", () => {
     ]);
     expect(sorted.map((thread) => thread.id)).toEqual(["newest", "middle", "oldest"]);
   });
+
+  it("orders configurable groups and keeps review items newest-attention-first", () => {
+    const items = [
+      { id: "ready", createdAt: "2026-06-01T12:00:00.000Z", group: "ready", attention: 0 },
+      {
+        id: "older-review",
+        createdAt: "2026-06-01T11:00:00.000Z",
+        group: "review",
+        attention: 10,
+      },
+      {
+        id: "newer-review",
+        createdAt: "2026-06-01T10:00:00.000Z",
+        group: "review",
+        attention: 20,
+      },
+      {
+        id: "working",
+        createdAt: "2026-06-01T09:00:00.000Z",
+        group: "working",
+        attention: 30,
+      },
+    ] as const;
+
+    const sorted = sortThreadsForListV2(items, {
+      groupOrder: ["review", "working", "ready"],
+      getGroup: (item) => item.group,
+      getAttentionTimestamp: (item) => item.attention,
+    });
+
+    expect(sorted.map((item) => item.id)).toEqual([
+      "newer-review",
+      "older-review",
+      "working",
+      "ready",
+    ]);
+  });
 });
 
 describe("buildThreadListV2Items", () => {
+  it("puts unseen completions above working threads in automatic mode", () => {
+    const completed = makeThread({
+      id: ThreadId.make("completed"),
+      title: "Completed",
+      createdAt: "2026-06-01T08:00:00.000Z",
+      latestTurn: {
+        turnId: TurnId.make("completed-turn"),
+        state: "completed",
+        requestedAt: "2026-06-01T09:00:00.000Z",
+        startedAt: "2026-06-01T09:01:00.000Z",
+        completedAt: "2026-06-01T10:00:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const working = makeThread({
+      id: ThreadId.make("working"),
+      title: "Working",
+      createdAt: "2026-06-01T12:00:00.000Z",
+      session: {
+        threadId: ThreadId.make("working"),
+        status: "running",
+        providerName: "Codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: "2026-06-01T12:30:00.000Z",
+      },
+    });
+
+    const layout = buildThreadListV2Items({
+      threads: [working, completed],
+      environmentId: null,
+      searchQuery: "",
+      threadOrderMode: "automatic",
+      threadGroupOrder: ["review", "working", "ready"],
+      lastVisitedAtByKey: {
+        [`${environmentId}:completed`]: "2026-06-01T09:30:00.000Z",
+      },
+      now: NOW,
+    });
+
+    expect(layout.items.map((item) => item.thread.id)).toEqual(["completed", "working"]);
+  });
+
+  it("moves a reviewed completion back to its configured non-review group", () => {
+    const completed = makeThread({
+      id: ThreadId.make("completed"),
+      title: "Completed",
+      createdAt: "2026-06-01T08:00:00.000Z",
+      latestTurn: {
+        turnId: TurnId.make("completed-turn"),
+        state: "completed",
+        requestedAt: "2026-06-01T09:00:00.000Z",
+        startedAt: "2026-06-01T09:01:00.000Z",
+        completedAt: "2026-06-01T10:00:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const working = makeThread({
+      id: ThreadId.make("working"),
+      title: "Working",
+      createdAt: "2026-06-01T12:00:00.000Z",
+      session: {
+        threadId: ThreadId.make("working"),
+        status: "running",
+        providerName: "Codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: "2026-06-01T12:30:00.000Z",
+      },
+    });
+
+    const layout = buildThreadListV2Items({
+      threads: [completed, working],
+      environmentId: null,
+      searchQuery: "",
+      threadOrderMode: "automatic",
+      threadGroupOrder: ["review", "working", "ready"],
+      lastVisitedAtByKey: {
+        [`${environmentId}:completed`]: "2026-06-01T10:30:00.000Z",
+      },
+      now: NOW,
+    });
+
+    expect(layout.items.map((item) => item.thread.id)).toEqual(["working", "completed"]);
+  });
+
+  it("moves a reviewed wake back to its configured non-review group after a visit", () => {
+    const woken = makeThread({
+      id: ThreadId.make("woken"),
+      title: "Woken",
+      createdAt: "2026-06-01T08:00:00.000Z",
+      snoozedAt: "2026-06-01T09:00:00.000Z",
+      snoozedUntil: "2026-06-01T10:00:00.000Z",
+    });
+    const working = makeThread({
+      id: ThreadId.make("working"),
+      title: "Working",
+      createdAt: "2026-06-01T12:00:00.000Z",
+      session: {
+        threadId: ThreadId.make("working"),
+        status: "running",
+        providerName: "Codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: "2026-06-01T12:30:00.000Z",
+      },
+    });
+    const build = (lastVisitedAt: string) =>
+      buildThreadListV2Items({
+        threads: [woken, working],
+        environmentId: null,
+        searchQuery: "",
+        threadOrderMode: "automatic",
+        threadGroupOrder: ["review", "working", "ready"],
+        lastVisitedAtByKey: {
+          [`${environmentId}:woken`]: lastVisitedAt,
+        },
+        now: NOW,
+      }).items.map((item) => item.thread.id);
+
+    expect(build("2026-06-01T09:59:59.999Z")).toEqual(["woken", "working"]);
+    expect(build("2026-06-01T10:00:00.000Z")).toEqual(["working", "woken"]);
+  });
+
+  it("honors a user-selected automatic group priority", () => {
+    const review = makeThread({
+      id: ThreadId.make("review"),
+      title: "Review",
+      hasPendingApprovals: true,
+    });
+    const working = makeThread({
+      id: ThreadId.make("working"),
+      title: "Working",
+      session: {
+        threadId: ThreadId.make("working"),
+        status: "running",
+        providerName: "Codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: NOW,
+      },
+    });
+
+    const layout = buildThreadListV2Items({
+      threads: [review, working],
+      environmentId: null,
+      searchQuery: "",
+      threadOrderMode: "automatic",
+      threadGroupOrder: ["working", "review", "ready"],
+      now: NOW,
+    });
+
+    expect(layout.items.map((item) => item.thread.id)).toEqual(["working", "review"]);
+  });
+
   it("hides snoozed threads and counts them — visibility parity with web", () => {
     const layout = buildThreadListV2Items({
       threads: [

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -1,6 +1,19 @@
-import { effectiveSettled, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
+import {
+  effectiveSettled,
+  effectiveSnoozed,
+  hasUnseenWake,
+  threadWokeAt,
+} from "@t3tools/client-runtime/state/thread-settled";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
-import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import {
+  DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER,
+  DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE,
+  type EnvironmentId,
+  type ProjectId,
+  type SidebarV2ThreadGroup,
+  type SidebarV2ThreadGroupOrder,
+  type SidebarV2ThreadOrderMode,
+} from "@t3tools/contracts";
 
 /**
  * Thread List v2 model, ported from the web sidebar v2
@@ -62,13 +75,79 @@ function firstValidTimestampMs(...candidates: ReadonlyArray<string | null | unde
  */
 export function sortThreadsForListV2<T extends { readonly id: string; readonly createdAt: string }>(
   threads: readonly T[],
+  options?: {
+    readonly groupOrder: SidebarV2ThreadGroupOrder;
+    readonly getGroup: (thread: T) => SidebarV2ThreadGroup;
+    readonly getAttentionTimestamp: (thread: T) => number;
+  },
 ): T[] {
   // .sort() on a copy, not .toSorted(): Hermes doesn't ship the ES2023
   // change-by-copy array methods.
-  return [...threads].sort(
-    (left, right) =>
-      parseTimestampMs(right.createdAt) - parseTimestampMs(left.createdAt) ||
-      left.id.localeCompare(right.id),
+  const byCreation = (left: T, right: T) =>
+    parseTimestampMs(right.createdAt) - parseTimestampMs(left.createdAt) ||
+    left.id.localeCompare(right.id);
+  if (options === undefined) return [...threads].sort(byCreation);
+
+  const groupRank = new Map(options.groupOrder.map((group, index) => [group, index] as const));
+  return [...threads].sort((left, right) => {
+    const leftGroup = options.getGroup(left);
+    const rightGroup = options.getGroup(right);
+    const byGroup =
+      (groupRank.get(leftGroup) ?? options.groupOrder.length) -
+      (groupRank.get(rightGroup) ?? options.groupOrder.length);
+    if (byGroup !== 0) return byGroup;
+    if (leftGroup === "review") {
+      const byAttention =
+        options.getAttentionTimestamp(right) - options.getAttentionTimestamp(left);
+      if (byAttention !== 0) return byAttention;
+    }
+    return byCreation(left, right);
+  });
+}
+
+function hasUnseenCompletion(
+  thread: Pick<EnvironmentThreadShell, "latestTurn">,
+  lastVisitedAt: string | undefined,
+): boolean {
+  if (thread.latestTurn?.completedAt == null || lastVisitedAt === undefined) return false;
+  const completedAt = Date.parse(thread.latestTurn.completedAt);
+  if (Number.isNaN(completedAt)) return false;
+  const visitedAt = Date.parse(lastVisitedAt);
+  return Number.isNaN(visitedAt) || completedAt > visitedAt;
+}
+
+function resolveAutomaticGroup(
+  thread: EnvironmentThreadShell,
+  lastVisitedAt: string | undefined,
+  now: string,
+): SidebarV2ThreadGroup {
+  const status = resolveThreadListV2Status(thread);
+  const wokeAt = threadWokeAt(thread, { now });
+  if (
+    status === "approval" ||
+    status === "input" ||
+    status === "failed" ||
+    thread.hasActionableProposedPlan ||
+    hasUnseenWake(wokeAt, lastVisitedAt) ||
+    hasUnseenCompletion(thread, lastVisitedAt)
+  ) {
+    return "review";
+  }
+  return status === "working" ? "working" : "ready";
+}
+
+function attentionTimestamp(thread: EnvironmentThreadShell, now: string): number {
+  return Math.max(
+    ...[
+      threadWokeAt(thread, { now }),
+      thread.session?.updatedAt,
+      thread.latestTurn?.completedAt,
+      thread.latestTurn?.startedAt,
+      thread.latestTurn?.requestedAt,
+      thread.latestUserMessageAt,
+      thread.updatedAt,
+      thread.createdAt,
+    ].map((candidate) => (candidate == null ? 0 : parseTimestampMs(candidate))),
   );
 }
 
@@ -119,6 +198,10 @@ export function buildThreadListV2Items(input: {
   readonly autoSettleAfterDays?: number;
   /** Max settled rows to render; the rest are counted, not built. */
   readonly settledLimit?: number;
+  /** Device-local active-thread ordering controls. */
+  readonly threadOrderMode?: SidebarV2ThreadOrderMode;
+  readonly threadGroupOrder?: SidebarV2ThreadGroupOrder;
+  readonly lastVisitedAtByKey?: Readonly<Record<string, string>>;
   /** Injectable for tests; defaults to now. */
   readonly now?: string;
   /** Second-precise clock for snooze classification. Callers pass a
@@ -175,7 +258,21 @@ export function buildThreadListV2Items(input: {
     }
   }
 
-  const orderedActive = sortThreadsForListV2(active);
+  const threadOrderMode = input.threadOrderMode ?? DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE;
+  const threadGroupOrder = input.threadGroupOrder ?? DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER;
+  const orderedActive =
+    threadOrderMode === "automatic"
+      ? sortThreadsForListV2(active, {
+          groupOrder: threadGroupOrder,
+          getGroup: (thread) =>
+            resolveAutomaticGroup(
+              thread,
+              input.lastVisitedAtByKey?.[`${thread.environmentId}:${thread.id}`],
+              snoozeNow,
+            ),
+          getAttentionTimestamp: (thread) => attentionTimestamp(thread, snoozeNow),
+        })
+      : sortThreadsForListV2(active);
   const orderedSettled = [...settled].sort(
     (left, right) =>
       firstValidTimestampMs(right.latestUserMessageAt, right.updatedAt) -

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -5,6 +5,11 @@ import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
+import {
+  DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER,
+  type SidebarV2ThreadGroup,
+  type SidebarV2ThreadOrderMode,
+} from "@t3tools/contracts";
 
 import * as MobileDatabase from "./mobile-database";
 import * as MobileSecureStorage from "./mobile-secure-storage";
@@ -29,6 +34,13 @@ export interface Preferences {
    * device.
    */
   readonly threadListV2Enabled?: boolean;
+  readonly threadListV2ThreadOrderMode?: SidebarV2ThreadOrderMode;
+  readonly threadListV2ThreadGroupOrder?: readonly SidebarV2ThreadGroup[];
+  /**
+   * Device-local visit markers used by automatic ordering to keep newly
+   * completed threads in Needs review until this device opens them.
+   */
+  readonly threadLastVisitedAtByKey?: Readonly<Record<string, string>>;
 }
 
 export class MobilePreferencesLoadError extends Schema.TaggedErrorClass<MobilePreferencesLoadError>()(
@@ -80,6 +92,9 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     collapsedProjectGroups?: readonly string[];
     projectGroupingEnabled?: boolean;
     threadListV2Enabled?: boolean;
+    threadListV2ThreadOrderMode?: SidebarV2ThreadOrderMode;
+    threadListV2ThreadGroupOrder?: readonly SidebarV2ThreadGroup[];
+    threadLastVisitedAtByKey?: Readonly<Record<string, string>>;
   } = {};
 
   if (typeof parsed.liveActivitiesEnabled === "boolean") {
@@ -111,6 +126,35 @@ function sanitizePreferences(parsed: Preferences): Preferences {
   }
   if (typeof parsed.threadListV2Enabled === "boolean") {
     preferences.threadListV2Enabled = parsed.threadListV2Enabled;
+  }
+  if (
+    parsed.threadListV2ThreadOrderMode === "created_at" ||
+    parsed.threadListV2ThreadOrderMode === "automatic"
+  ) {
+    preferences.threadListV2ThreadOrderMode = parsed.threadListV2ThreadOrderMode;
+  }
+  if (
+    Array.isArray(parsed.threadListV2ThreadGroupOrder) &&
+    parsed.threadListV2ThreadGroupOrder.length === DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER.length &&
+    new Set(parsed.threadListV2ThreadGroupOrder).size ===
+      DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER.length &&
+    DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER.every((group) =>
+      parsed.threadListV2ThreadGroupOrder?.includes(group),
+    )
+  ) {
+    preferences.threadListV2ThreadGroupOrder = parsed.threadListV2ThreadGroupOrder;
+  }
+  if (
+    typeof parsed.threadLastVisitedAtByKey === "object" &&
+    parsed.threadLastVisitedAtByKey !== null &&
+    !Array.isArray(parsed.threadLastVisitedAtByKey)
+  ) {
+    preferences.threadLastVisitedAtByKey = Object.fromEntries(
+      Object.entries(parsed.threadLastVisitedAtByKey).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[1] === "string" && !Number.isNaN(Date.parse(entry[1])),
+      ),
+    );
   }
   return preferences;
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -95,7 +95,7 @@ import {
   togglePendingUserInputOptionSelection,
   type PendingUserInputDraftAnswer,
 } from "../pendingUserInput";
-import { useUiStateStore } from "../uiStateStore";
+import { resolveThreadVisitTimestamp, useUiStateStore } from "../uiStateStore";
 import {
   buildPlanImplementationThreadTitle,
   buildPlanImplementationPrompt,
@@ -1190,9 +1190,6 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const serverThread = useThread(routeThreadRef, { waitForShell: draftThread !== null });
   const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
-  const activeThreadLastVisitedAt = useUiStateStore(
-    (store) => store.threadLastVisitedAtById[routeThreadKey],
-  );
   const settings = useEnvironmentSettings(environmentId);
   // New-thread defaults live in the primary environment's settings.json (the
   // settings UI never writes to remote environments), so read them from the
@@ -1809,22 +1806,14 @@ function ChatViewContent(props: ChatViewProps) {
 
   useEffect(() => {
     if (!serverThread?.id) return;
-    const threadUpdatedAt = Date.parse(serverThread.updatedAt);
-    if (Number.isNaN(threadUpdatedAt)) return;
-    const lastVisitedAt = activeThreadLastVisitedAt ? Date.parse(activeThreadLastVisitedAt) : NaN;
-    if (!Number.isNaN(lastVisitedAt) && lastVisitedAt >= threadUpdatedAt) return;
+    const visitedAt = resolveThreadVisitTimestamp(serverThread.updatedAt, new Date().toISOString());
+    if (visitedAt === null) return;
 
     markThreadVisited(
       scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
-      serverThread.updatedAt,
+      visitedAt,
     );
-  }, [
-    activeThreadLastVisitedAt,
-    markThreadVisited,
-    serverThread?.environmentId,
-    serverThread?.id,
-    serverThread?.updatedAt,
-  ]);
+  }, [markThreadVisited, serverThread?.environmentId, serverThread?.id, serverThread?.updatedAt]);
 
   const selectedProviderByThreadId = composerActiveProvider ?? null;
   const threadProvider =

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -678,6 +678,155 @@ describe("sortThreadsForSidebarV2", () => {
 
     expect(sorted.map((thread) => thread.id)).toEqual(["a", "b"]);
   });
+
+  const automaticThread = (input: {
+    id: string;
+    createdAt: string;
+    completedAt?: string | null;
+    sessionStatus?: "ready" | "running" | "error";
+    sessionUpdatedAt?: string;
+    hasPendingApprovals?: boolean;
+  }) => ({
+    id: input.id,
+    createdAt: input.createdAt,
+    updatedAt: input.sessionUpdatedAt ?? input.createdAt,
+    latestUserMessageAt: null,
+    latestTurn:
+      input.completedAt === undefined
+        ? null
+        : makeLatestTurn({
+            completedAt: input.completedAt,
+            startedAt: input.createdAt,
+          }),
+    session:
+      input.sessionStatus === undefined
+        ? null
+        : {
+            threadId: ThreadId.make(input.id),
+            status: input.sessionStatus,
+            providerName: "Codex",
+            providerInstanceId: ProviderInstanceId.make("codex"),
+            runtimeMode: DEFAULT_RUNTIME_MODE,
+            activeTurnId: null,
+            lastError: input.sessionStatus === "error" ? "boom" : null,
+            updatedAt: input.sessionUpdatedAt ?? input.createdAt,
+          },
+    hasPendingApprovals: input.hasPendingApprovals ?? false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    interactionMode: DEFAULT_INTERACTION_MODE,
+  });
+
+  it("automatically promotes newly finished work above newer working threads", () => {
+    const lastVisitedAtById = new Map([
+      ["done-newer", "2026-03-09T09:00:00.000Z"],
+      ["done-older", "2026-03-09T09:00:00.000Z"],
+    ]);
+    const sorted = sortThreadsForSidebarV2(
+      [
+        automaticThread({
+          id: "working-newest",
+          createdAt: "2026-03-09T13:00:00.000Z",
+          sessionStatus: "running",
+        }),
+        automaticThread({
+          id: "done-older",
+          createdAt: "2026-03-09T08:00:00.000Z",
+          completedAt: "2026-03-09T10:00:00.000Z",
+        }),
+        automaticThread({
+          id: "done-newer",
+          createdAt: "2026-03-09T07:00:00.000Z",
+          completedAt: "2026-03-09T12:00:00.000Z",
+        }),
+      ],
+      {
+        mode: "automatic",
+        groupOrder: ["review", "working", "ready"],
+        getLastVisitedAt: (thread) => lastVisitedAtById.get(thread.id),
+        getWokeAt: () => null,
+      },
+    );
+
+    expect(sorted.map((thread) => thread.id)).toEqual([
+      "done-newer",
+      "done-older",
+      "working-newest",
+    ]);
+  });
+
+  it("stops prioritising a woken thread after it is visited", () => {
+    const woken = automaticThread({
+      id: "woken",
+      createdAt: "2026-03-09T08:00:00.000Z",
+    });
+    const working = automaticThread({
+      id: "working",
+      createdAt: "2026-03-09T10:00:00.000Z",
+      sessionStatus: "running",
+    });
+    const sort = (lastVisitedAt: string) =>
+      sortThreadsForSidebarV2([woken, working], {
+        mode: "automatic",
+        groupOrder: ["review", "working", "ready"],
+        getLastVisitedAt: (thread) => (thread.id === "woken" ? lastVisitedAt : undefined),
+        getWokeAt: (thread) => (thread.id === "woken" ? "2026-03-09T12:00:00.000Z" : null),
+      }).map((thread) => thread.id);
+
+    expect(sort("2026-03-09T11:59:59.999Z")).toEqual(["woken", "working"]);
+    expect(sort("2026-03-09T12:00:00.000Z")).toEqual(["working", "woken"]);
+  });
+
+  it("uses the user-selected automatic group priority", () => {
+    const sorted = sortThreadsForSidebarV2(
+      [
+        automaticThread({
+          id: "working",
+          createdAt: "2026-03-09T10:00:00.000Z",
+          sessionStatus: "running",
+        }),
+        automaticThread({
+          id: "approval",
+          createdAt: "2026-03-09T09:00:00.000Z",
+          hasPendingApprovals: true,
+        }),
+        automaticThread({
+          id: "ready",
+          createdAt: "2026-03-09T11:00:00.000Z",
+        }),
+      ],
+      {
+        mode: "automatic",
+        groupOrder: ["working", "ready", "review"],
+        getLastVisitedAt: () => undefined,
+        getWokeAt: () => null,
+      },
+    );
+
+    expect(sorted.map((thread) => thread.id)).toEqual(["working", "ready", "approval"]);
+  });
+
+  it("moves a reviewed completion back to the ready group", () => {
+    const reviewed = automaticThread({
+      id: "reviewed",
+      createdAt: "2026-03-09T08:00:00.000Z",
+      completedAt: "2026-03-09T10:00:00.000Z",
+    });
+    const working = automaticThread({
+      id: "working",
+      createdAt: "2026-03-09T09:00:00.000Z",
+      sessionStatus: "running",
+    });
+    const sorted = sortThreadsForSidebarV2([reviewed, working], {
+      mode: "automatic",
+      groupOrder: ["review", "working", "ready"],
+      getLastVisitedAt: (thread) =>
+        thread.id === "reviewed" ? "2026-03-09T10:01:00.000Z" : undefined,
+      getWokeAt: () => null,
+    });
+
+    expect(sorted.map((thread) => thread.id)).toEqual(["working", "reviewed"]);
+  });
 });
 
 describe("sortSettledThreadsForSidebarV2", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,6 +1,12 @@
 import * as React from "react";
+import { hasUnseenWake } from "@t3tools/client-runtime/state/thread-settled";
 import type { ContextMenuItem } from "@t3tools/contracts";
-import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import type {
+  SidebarProjectSortOrder,
+  SidebarThreadSortOrder,
+  SidebarV2ThreadGroup,
+  SidebarV2ThreadGroupOrder,
+} from "@t3tools/contracts/settings";
 import {
   getThreadSortTimestamp,
   sortThreads,
@@ -457,18 +463,121 @@ export function firstValidTimestamp(
   return null;
 }
 
-// v2 sort: static creation order, newest thread on top. Activity NEVER
-// reorders the list — a row holds its position from open until settled, so
-// the screen only moves at lifecycle transitions. Status (including pending
-// approval) is carried by each card's edge strip, not by position.
+type SidebarV2AutomaticSortInput = Pick<
+  SidebarThreadSummary,
+  | "createdAt"
+  | "hasActionableProposedPlan"
+  | "hasPendingApprovals"
+  | "hasPendingUserInput"
+  | "interactionMode"
+  | "latestTurn"
+  | "latestUserMessageAt"
+  | "session"
+  | "updatedAt"
+> & {
+  readonly id: string;
+};
+
+export interface SidebarV2AutomaticSortOptions<T extends SidebarV2AutomaticSortInput> {
+  readonly mode: "automatic";
+  readonly groupOrder: SidebarV2ThreadGroupOrder;
+  readonly getLastVisitedAt: (thread: T) => string | undefined;
+  readonly getWokeAt: (thread: T) => string | null;
+}
+
+function resolveSidebarV2ThreadGroup<T extends SidebarV2AutomaticSortInput>(
+  thread: T,
+  options: SidebarV2AutomaticSortOptions<T>,
+): SidebarV2ThreadGroup {
+  const status = resolveSidebarV2Status(thread);
+  const lastVisitedAt = options.getLastVisitedAt(thread);
+  const needsReview =
+    status === "approval" ||
+    status === "input" ||
+    status === "failed" ||
+    thread.hasActionableProposedPlan ||
+    hasUnseenWake(options.getWokeAt(thread), lastVisitedAt) ||
+    hasUnseenCompletion({
+      ...thread,
+      lastVisitedAt,
+    });
+  if (needsReview) return "review";
+  if (status === "working") return "working";
+  return "ready";
+}
+
+function sidebarV2AttentionTimestamp<T extends SidebarV2AutomaticSortInput>(
+  thread: T,
+  options: SidebarV2AutomaticSortOptions<T>,
+): number {
+  return Math.max(
+    ...[
+      options.getWokeAt(thread),
+      thread.session?.updatedAt,
+      thread.latestTurn?.completedAt,
+      thread.latestTurn?.startedAt,
+      thread.latestTurn?.requestedAt,
+      thread.latestUserMessageAt,
+      thread.updatedAt,
+      thread.createdAt,
+    ].map((candidate) =>
+      candidate === null || candidate === undefined ? 0 : parseTimestampMs(candidate),
+    ),
+  );
+}
+
+// By default v2 keeps its original static creation order: activity never
+// moves a card. Automatic mode instead groups cards by the user's status
+// priority; review cards order by their newest attention event while working
+// and ready cards retain stable creation order inside their groups.
 export function sortThreadsForSidebarV2<
   T extends { readonly id: string; readonly createdAt: string },
->(threads: readonly T[]): T[] {
-  return [...threads].toSorted(
-    (left, right) =>
-      parseTimestampMs(right.createdAt) - parseTimestampMs(left.createdAt) ||
-      left.id.localeCompare(right.id),
-  );
+>(threads: readonly T[]): T[];
+export function sortThreadsForSidebarV2<T extends SidebarV2AutomaticSortInput>(
+  threads: readonly T[],
+  options: SidebarV2AutomaticSortOptions<T>,
+): T[];
+export function sortThreadsForSidebarV2<
+  T extends { readonly id: string; readonly createdAt: string },
+>(
+  threads: readonly T[],
+  options?: SidebarV2AutomaticSortOptions<T & SidebarV2AutomaticSortInput>,
+): T[] {
+  return sortThreadsForSidebarV2Implementation(threads, options);
+}
+
+function sortThreadsForSidebarV2Implementation<
+  T extends { readonly id: string; readonly createdAt: string },
+>(
+  threads: readonly T[],
+  options?: SidebarV2AutomaticSortOptions<T & SidebarV2AutomaticSortInput>,
+): T[] {
+  const byCreation = (left: T, right: T) =>
+    parseTimestampMs(right.createdAt) - parseTimestampMs(left.createdAt) ||
+    left.id.localeCompare(right.id);
+  if (options === undefined) {
+    return [...threads].toSorted(byCreation);
+  }
+
+  const groupRank = new Map(options.groupOrder.map((group, index) => [group, index] as const));
+  return [...threads].toSorted((left, right) => {
+    const leftGroup = resolveSidebarV2ThreadGroup(left as T & SidebarV2AutomaticSortInput, options);
+    const rightGroup = resolveSidebarV2ThreadGroup(
+      right as T & SidebarV2AutomaticSortInput,
+      options,
+    );
+    const byGroup =
+      (groupRank.get(leftGroup) ?? options.groupOrder.length) -
+      (groupRank.get(rightGroup) ?? options.groupOrder.length);
+    if (byGroup !== 0) return byGroup;
+    if (leftGroup === "review") {
+      const byAttention =
+        sidebarV2AttentionTimestamp(right as T & SidebarV2AutomaticSortInput, options) -
+        sidebarV2AttentionTimestamp(left as T & SidebarV2AutomaticSortInput, options);
+      if (byAttention !== 0) return byAttention;
+    }
+    return byCreation(left, right);
+  });
 }
 
 type SettledTimestampInput = Pick<

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -4,6 +4,7 @@ import {
   canSnooze,
   effectiveSettled,
   effectiveSnoozed,
+  hasUnseenWake,
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
@@ -101,7 +102,7 @@ import {
   resolveActiveThreadRouteRef,
   resolveThreadRouteTarget,
 } from "../threadRoutes";
-import { formatRelativeTimeLabel, parseTimestampDate } from "../timestampFormat";
+import { formatRelativeTimeLabel } from "../timestampFormat";
 import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import {
@@ -426,12 +427,8 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   // A woken thread reappears at its original position (the sort is
   // deliberately static), so the pill has to carry the weight. Snoozing is
   // an explicit act, so unlike Done, a never-visited woke thread still
-  // shows the pill; visiting clears it. An unparseable visit timestamp
-  // counts as never-visited — corrupt local data must not eat the wake
-  // signal.
-  const lastVisitedDate = lastVisitedAt === undefined ? null : parseTimestampDate(lastVisitedAt);
-  const wokeAtDate = props.wokeAt === null ? null : parseTimestampDate(props.wokeAt);
-  const isWoke = wokeAtDate !== null && (lastVisitedDate === null || lastVisitedDate < wokeAtDate);
+  // shows the pill; visiting clears it.
+  const isWoke = hasUnseenWake(props.wokeAt, lastVisitedAt);
   // In-flight rows (working, or waiting on approval/input) fade as a whole:
   // there is nothing for the user to do yet, so prominence is reserved for
   // rows that need a human — done (unread), read-but-unsettled, failed, and
@@ -1005,7 +1002,10 @@ export default function SidebarV2() {
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
+  const sidebarV2ThreadGroupOrder = useClientSettings((s) => s.sidebarV2ThreadGroupOrder);
+  const sidebarV2ThreadOrderMode = useClientSettings((s) => s.sidebarV2ThreadOrderMode);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
+  const threadLastVisitedAtById = useUiStateStore((state) => state.threadLastVisitedAtById);
   const { settleThread, unsettleThread, snoozeThread, unsnoozeThread, deleteThread } =
     useThreadActions();
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
@@ -1407,8 +1407,20 @@ export default function SidebarV2() {
         active.push(thread);
       }
     }
+    const activeThreads =
+      sidebarV2ThreadOrderMode === "automatic"
+        ? sortThreadsForSidebarV2(active, {
+            mode: "automatic",
+            groupOrder: sidebarV2ThreadGroupOrder,
+            getLastVisitedAt: (thread) =>
+              threadLastVisitedAtById[
+                scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))
+              ],
+            getWokeAt: (thread) => threadWokeAt(thread, { now: preciseNow }),
+          })
+        : sortThreadsForSidebarV2(active);
     return {
-      activeThreads: sortThreadsForSidebarV2(active),
+      activeThreads,
       // Soonest wake first: "what comes back next" is the shelf's question.
       snoozedThreads: snoozed.toSorted(
         (left, right) =>
@@ -1424,7 +1436,10 @@ export default function SidebarV2() {
     nowMinute,
     scopedProjectKeys,
     serverConfigs,
+    sidebarV2ThreadGroupOrder,
+    sidebarV2ThreadOrderMode,
     snoozeWakeTick,
+    threadLastVisitedAtById,
     threads,
   ]);
 

--- a/apps/web/src/components/settings/BetaSettingsPanel.tsx
+++ b/apps/web/src/components/settings/BetaSettingsPanel.tsx
@@ -1,13 +1,49 @@
+import type { SidebarV2ThreadGroup, SidebarV2ThreadOrderMode } from "@t3tools/contracts/settings";
+import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { useClientSettings, useUpdateClientSettings } from "../../hooks/useSettings";
+import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
 import { SettingsPageContainer, SettingsRow, SettingsSection } from "./settingsLayout";
 
 const AUTO_SETTLE_MIN_DAYS = 1;
 const AUTO_SETTLE_MAX_DAYS = 90;
 const AUTO_SETTLE_DEFAULT_DAYS = 3;
+const THREAD_ORDER_MODE_LABELS: Record<SidebarV2ThreadOrderMode, string> = {
+  created_at: "Static creation order",
+  automatic: "Automatic status order",
+};
+const THREAD_GROUP_DETAILS: Record<SidebarV2ThreadGroup, { label: string; description: string }> = {
+  review: {
+    label: "Needs review",
+    description: "Done, approval, input, failed, plan-ready, and freshly woken threads.",
+  },
+  working: {
+    label: "Working",
+    description: "Threads whose agent session is running or connecting.",
+  },
+  ready: {
+    label: "Other active",
+    description: "Idle threads and completed threads you have already reviewed.",
+  },
+};
+
+function moveThreadGroup(
+  groups: ReadonlyArray<SidebarV2ThreadGroup>,
+  index: number,
+  offset: -1 | 1,
+): SidebarV2ThreadGroup[] {
+  const targetIndex = index + offset;
+  if (targetIndex < 0 || targetIndex >= groups.length) return [...groups];
+  const reordered = [...groups];
+  const [group] = reordered.splice(index, 1);
+  if (group === undefined) return reordered;
+  reordered.splice(targetIndex, 0, group);
+  return reordered;
+}
 
 function AutoSettleDaysInput({
   value,
@@ -55,6 +91,12 @@ export function BetaSettingsPanel() {
   const sidebarAutoSettleAfterDays = useClientSettings(
     (settings) => settings.sidebarAutoSettleAfterDays,
   );
+  const sidebarV2ThreadGroupOrder = useClientSettings(
+    (settings) => settings.sidebarV2ThreadGroupOrder,
+  );
+  const sidebarV2ThreadOrderMode = useClientSettings(
+    (settings) => settings.sidebarV2ThreadOrderMode,
+  );
   const updateSettings = useUpdateClientSettings();
 
   return (
@@ -62,7 +104,7 @@ export function BetaSettingsPanel() {
       <SettingsSection title="Beta features">
         <SettingsRow
           title="Sidebar v2"
-          description="One flat thread list in creation order. Active work renders as rich cards; settled threads collapse to compact rows. Settling requires an up-to-date server — on older servers threads simply stay active. Switch back any time."
+          description="One flat thread list with configurable ordering. Active work renders as rich cards; settled threads collapse to compact rows. Settling requires an up-to-date server — on older servers threads simply stay active. Switch back any time."
           control={
             <Switch
               checked={sidebarV2Enabled}
@@ -73,6 +115,102 @@ export function BetaSettingsPanel() {
         />
         {sidebarV2Enabled ? (
           <>
+            <SettingsRow
+              title="Thread ordering"
+              description={
+                sidebarV2ThreadOrderMode === "automatic"
+                  ? "Automatically regroup active threads as their status changes. Within Needs review, the most recent attention event appears first."
+                  : "Keep active threads in newest-created-first order. Status changes do not move them."
+              }
+              control={
+                <Select
+                  value={sidebarV2ThreadOrderMode}
+                  onValueChange={(value) => {
+                    if (value === "created_at" || value === "automatic") {
+                      updateSettings({ sidebarV2ThreadOrderMode: value });
+                    }
+                  }}
+                >
+                  <SelectTrigger className="w-full sm:w-52" aria-label="Sidebar thread ordering">
+                    <SelectValue>{THREAD_ORDER_MODE_LABELS[sidebarV2ThreadOrderMode]}</SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup align="end" alignItemWithTrigger={false}>
+                    <SelectItem hideIndicator value="created_at">
+                      {THREAD_ORDER_MODE_LABELS.created_at}
+                    </SelectItem>
+                    <SelectItem hideIndicator value="automatic">
+                      {THREAD_ORDER_MODE_LABELS.automatic}
+                    </SelectItem>
+                  </SelectPopup>
+                </Select>
+              }
+            />
+            {sidebarV2ThreadOrderMode === "automatic" ? (
+              <SettingsRow
+                title="Automatic group priority"
+                description="Arrange the active-thread groups from top to bottom. Threads move automatically when their status changes."
+              >
+                <ol className="mt-3 space-y-1 pb-3.5">
+                  {sidebarV2ThreadGroupOrder.map((group, index) => {
+                    const details = THREAD_GROUP_DETAILS[group];
+                    return (
+                      <li
+                        key={group}
+                        className="flex items-center gap-3 rounded-lg border border-border/70 bg-background/40 px-3 py-2"
+                      >
+                        <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted font-mono text-[11px] text-muted-foreground">
+                          {index + 1}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm font-medium text-foreground">{details.label}</div>
+                          <div className="text-xs leading-5 text-muted-foreground/80">
+                            {details.description}
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-0.5">
+                          <Button
+                            size="icon-xs"
+                            variant="ghost"
+                            disabled={index === 0}
+                            aria-label={`Move ${details.label} up`}
+                            title={`Move ${details.label} up`}
+                            onClick={() =>
+                              updateSettings({
+                                sidebarV2ThreadGroupOrder: moveThreadGroup(
+                                  sidebarV2ThreadGroupOrder,
+                                  index,
+                                  -1,
+                                ),
+                              })
+                            }
+                          >
+                            <ArrowUpIcon className="size-3.5" />
+                          </Button>
+                          <Button
+                            size="icon-xs"
+                            variant="ghost"
+                            disabled={index === sidebarV2ThreadGroupOrder.length - 1}
+                            aria-label={`Move ${details.label} down`}
+                            title={`Move ${details.label} down`}
+                            onClick={() =>
+                              updateSettings({
+                                sidebarV2ThreadGroupOrder: moveThreadGroup(
+                                  sidebarV2ThreadGroupOrder,
+                                  index,
+                                  1,
+                                ),
+                              })
+                            }
+                          >
+                            <ArrowDownIcon className="size-3.5" />
+                          </Button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </SettingsRow>
+            ) : null}
             <SettingsRow
               title="Auto-settle inactive threads"
               description="Threads with no activity for this long settle automatically. Threads on merged or closed PRs always settle."

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -1,4 +1,5 @@
 import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { hasUnseenWake } from "@t3tools/client-runtime/state/thread-settled";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -11,6 +12,7 @@ import {
   persistState,
   reorderProjects,
   resolveProjectExpanded,
+  resolveThreadVisitTimestamp,
   setDefaultAdvertisedEndpointKey,
   setProjectExpanded,
   setThreadChangedFilesExpanded,
@@ -29,6 +31,17 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
 }
 
 describe("uiStateStore pure functions", () => {
+  it("records an actual visit after a timer wake when the server did not emit a wake event", () => {
+    const wakeAt = "2026-02-25T12:30:00.000Z";
+    const visitedAt = resolveThreadVisitTimestamp(
+      "2026-02-25T12:00:00.000Z",
+      "2026-02-25T12:30:01.000Z",
+    );
+
+    expect(visitedAt).toBe("2026-02-25T12:30:01.000Z");
+    expect(hasUnseenWake(wakeAt, visitedAt ?? undefined)).toBe(false);
+  });
+
   it("stores server timestamps without moving visit state backwards", () => {
     const threadId = ThreadId.make("thread-1");
     const initialState = makeUiState();

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -220,6 +220,21 @@ export function persistState(state: UiState): void {
   }
 }
 
+export function resolveThreadVisitTimestamp(
+  threadUpdatedAt: string,
+  visitedAt: string,
+): string | null {
+  const threadUpdatedAtMs = Date.parse(threadUpdatedAt);
+  const visitedAtMs = Date.parse(visitedAt);
+  if (!Number.isFinite(threadUpdatedAtMs)) {
+    return Number.isFinite(visitedAtMs) ? visitedAt : null;
+  }
+  if (!Number.isFinite(visitedAtMs) || threadUpdatedAtMs >= visitedAtMs) {
+    return threadUpdatedAt;
+  }
+  return visitedAt;
+}
+
 const debouncedPersistState = new Debouncer(persistState, { wait: 500 });
 
 export function markThreadVisited(state: UiState, threadId: string, visitedAt: string): UiState {

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -215,6 +215,22 @@ export function threadWokeAt(
 }
 
 /**
+ * Whether a derived wake signal is newer than the client's last visit.
+ *
+ * `threadWokeAt` intentionally keeps returning the historical wake timestamp
+ * after the user opens the thread, so every consumer must compare it with the
+ * device-local visit marker before presenting or prioritising the signal.
+ */
+export function hasUnseenWake(wokeAt: string | null, lastVisitedAt: string | undefined): boolean {
+  if (wokeAt === null) return false;
+  const wokeAtMs = Date.parse(wokeAt);
+  if (Number.isNaN(wokeAtMs)) return false;
+  if (lastVisitedAt === undefined) return true;
+  const lastVisitedAtMs = Date.parse(lastVisitedAt);
+  return Number.isNaN(lastVisitedAtMs) || lastVisitedAtMs < wokeAtMs;
+}
+
+/**
  * A merged/closed change request settles its thread only once the thread has
  * been idle this long. Without the idle guard the merge signal is permanent:
  * sending a message to a merged-PR thread would un-settle the row only until

--- a/packages/client-runtime/src/state/threadSnoozed.test.ts
+++ b/packages/client-runtime/src/state/threadSnoozed.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   canSnooze,
   effectiveSnoozed,
+  hasUnseenWake,
   threadRaisedHandWhileSnoozed,
   threadWokeAt,
   type ThreadSnoozeShell,
@@ -233,5 +234,20 @@ describe("threadWokeAt", () => {
         { now: NOW },
       ),
     ).toBe("2026-04-10T09:30:00.000Z");
+  });
+});
+
+describe("hasUnseenWake", () => {
+  it("clears a valid wake after the thread is visited", () => {
+    expect(hasUnseenWake(PAST_WAKE, undefined)).toBe(true);
+    expect(hasUnseenWake(PAST_WAKE, "2026-04-10T09:59:59.999Z")).toBe(true);
+    expect(hasUnseenWake(PAST_WAKE, PAST_WAKE)).toBe(false);
+    expect(hasUnseenWake(PAST_WAKE, "2026-04-10T10:00:00.001Z")).toBe(false);
+  });
+
+  it("does not manufacture a wake from missing or malformed wake data", () => {
+    expect(hasUnseenWake(null, undefined)).toBe(false);
+    expect(hasUnseenWake("not-a-date", undefined)).toBe(false);
+    expect(hasUnseenWake(PAST_WAKE, "not-a-date")).toBe(true);
   });
 });

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -50,10 +50,12 @@ describe("ClientSettings glass opacity", () => {
 });
 
 describe("ClientSettings sidebar v2", () => {
-  it("defaults the beta off with a three-day auto-settle threshold", () => {
+  it("defaults the beta off with static ordering and a three-day auto-settle threshold", () => {
     const settings = decodeClientSettings({});
     expect(settings.sidebarV2Enabled).toBe(false);
     expect(settings.sidebarAutoSettleAfterDays).toBe(3);
+    expect(settings.sidebarV2ThreadOrderMode).toBe("created_at");
+    expect(settings.sidebarV2ThreadGroupOrder).toEqual(["review", "working", "ready"]);
   });
 
   it("allows auto-settle by inactivity to be disabled", () => {
@@ -65,6 +67,26 @@ describe("ClientSettings sidebar v2", () => {
   it.each([-1, 0, 91])("rejects an auto-settle threshold outside 1..90: %s", (value) => {
     expect(() => decodeClientSettings({ sidebarAutoSettleAfterDays: value })).toThrow();
     expect(() => decodeClientSettingsPatch({ sidebarAutoSettleAfterDays: value })).toThrow();
+  });
+
+  it("accepts automatic ordering with a custom group priority", () => {
+    const input = {
+      sidebarV2ThreadOrderMode: "automatic",
+      sidebarV2ThreadGroupOrder: ["working", "review", "ready"],
+    } as const;
+
+    expect(decodeClientSettings(input)).toMatchObject(input);
+    expect(decodeClientSettingsPatch(input)).toEqual(input);
+  });
+
+  it.each([
+    { value: [] },
+    { value: ["review", "working"] },
+    { value: ["review", "review", "ready"] },
+    { value: ["review", "working", "ready", "review"] },
+  ])("rejects an invalid automatic group order: $value", ({ value }) => {
+    expect(() => decodeClientSettings({ sidebarV2ThreadGroupOrder: value })).toThrow();
+    expect(() => decodeClientSettingsPatch({ sidebarV2ThreadGroupOrder: value })).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -21,6 +21,31 @@ export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 
+export const SidebarV2ThreadOrderMode = Schema.Literals(["created_at", "automatic"]);
+export type SidebarV2ThreadOrderMode = typeof SidebarV2ThreadOrderMode.Type;
+export const DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE: SidebarV2ThreadOrderMode = "created_at";
+
+export const SidebarV2ThreadGroup = Schema.Literals(["review", "working", "ready"]);
+export type SidebarV2ThreadGroup = typeof SidebarV2ThreadGroup.Type;
+const sidebarV2ThreadGroupOrderFilter = Schema.makeFilter(
+  (groups: ReadonlyArray<SidebarV2ThreadGroup>) =>
+    (groups.length === 3 &&
+      new Set(groups).size === 3 &&
+      groups.includes("review") &&
+      groups.includes("working") &&
+      groups.includes("ready")) ||
+    "Sidebar v2 thread group order must contain review, working, and ready exactly once.",
+);
+export const SidebarV2ThreadGroupOrder = Schema.Array(SidebarV2ThreadGroup).check(
+  sidebarV2ThreadGroupOrderFilter,
+);
+export type SidebarV2ThreadGroupOrder = typeof SidebarV2ThreadGroupOrder.Type;
+export const DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER: SidebarV2ThreadGroupOrder = [
+  "review",
+  "working",
+  "ready",
+];
+
 export const SidebarProjectGroupingMode = Schema.Literals([
   "repository",
   "repository_path",
@@ -115,6 +140,12 @@ export const ClientSettingsSchema = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
   ),
   sidebarV2Enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  sidebarV2ThreadGroupOrder: SidebarV2ThreadGroupOrder.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_V2_THREAD_GROUP_ORDER)),
+  ),
+  sidebarV2ThreadOrderMode: SidebarV2ThreadOrderMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_V2_THREAD_ORDER_MODE)),
+  ),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
   ),
@@ -636,6 +667,8 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   sidebarV2Enabled: Schema.optionalKey(Schema.Boolean),
+  sidebarV2ThreadGroupOrder: Schema.optionalKey(SidebarV2ThreadGroupOrder),
+  sidebarV2ThreadOrderMode: Schema.optionalKey(SidebarV2ThreadOrderMode),
   timestampFormat: Schema.optionalKey(TimestampFormat),
   wordWrap: Schema.optionalKey(Schema.Boolean),
 });


### PR DESCRIPTION
## What Changed

Adds an opt-in automatic ordering mode to Sidebar V2 on web/desktop and Thread List V2 on mobile.

- Keeps the existing newest-created-first order as the default.
- Adds a user-configurable group priority for Needs review, Working, and Other active.
- Orders Needs review by its latest attention event so recently finished work rises to the top.
- Clears completion/wake priority after that device opens the thread.
- Tracks mobile visits from navigation state so taps, deep links, restored routes, new tasks, and auxiliary thread screens behave consistently.

Closes #4695.

## Why

Sidebar V2 currently leaves recently completed work below agents that are still working. Automatic mode turns it into an attention queue while preserving the existing static behavior for users who prefer it.

This is one cross-platform preference and ordering model, but it necessarily touches both independently implemented clients. The diff is expected to receive `size:XL`; it is not presented as a small PR.

## UI Changes

### Before: static creation order

<img width="402" alt="Mobile Sidebar V2 before automatic ordering" src="https://raw.githubusercontent.com/saphid/t3code/pr-media/sidebar-v2-ordering/mobile-sidebar-before-ordering.png" />

### After: Needs review above Working

<img width="402" alt="Mobile Sidebar V2 with Needs review above Working" src="https://raw.githubusercontent.com/saphid/t3code/pr-media/sidebar-v2-ordering/mobile-sidebar-after-ordering.png" />

### Ordering controls

<img width="1200" alt="Web automatic Sidebar V2 ordering settings" src="https://raw.githubusercontent.com/saphid/t3code/pr-media/sidebar-v2-ordering/web-settings-automatic-review-first.png" />

### Web sidebar result

<img width="1200" alt="Web Sidebar V2 with review work above working agents" src="https://raw.githubusercontent.com/saphid/t3code/pr-media/sidebar-v2-ordering/web-sidebar-automatic-review-first.png" />

[Short mobile interaction video](https://raw.githubusercontent.com/saphid/t3code/pr-media/sidebar-v2-ordering/sidebar-ordering.mp4)

## Verification

- `pnpm exec vp test run apps/web/src/uiStateStore.test.ts packages/client-runtime/src/state/threadSnoozed.test.ts apps/web/src/components/Sidebar.logic.test.ts apps/mobile/src/features/threads/threadListV2.test.ts apps/mobile/src/features/threads/navigationThreadVisit.test.ts apps/mobile/src/state/preferences.test.ts packages/contracts/src/settings.test.ts apps/desktop/src/settings/DesktopClientSettings.test.ts` — 8 files, 190 tests passed.
- Targeted typechecks passed for `@t3tools/client-runtime`, `@t3tools/contracts`, `@t3tools/web`, `@t3tools/mobile`, and `@t3tools/desktop`.
- Targeted lint and formatting passed; `pnpm lint:mobile` exited 0 (optional SwiftLint, ktlint, and detekt tools were not installed and were skipped).
- Web integrated pass verified persisted automatic mode, configurable priority, and seeded sidebar ordering.
- iOS Simulator integrated pass verified settings persistence, review-first ordering, and visit-marker persistence for normal and auxiliary deep links.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] I included a video for interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable Sidebar V2 thread ordering with automatic group classification
> - Adds two new client settings (`sidebarV2ThreadOrderMode` and `sidebarV2ThreadGroupOrder`) that control whether threads are sorted by creation time or automatically grouped into `review`, `working`, and `ready` buckets with user-configurable priority.
> - The automatic mode classifies threads based on unseen wakes, unseen completions, actionable proposed plans, and resolved status; within the `review` group, threads are ordered by attention recency.
> - Adds settings UI on both web ([BetaSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/4702/files#diff-7cc018b55a78281318b114e44898712836d74582a8148368ac46409808a9260c)) and mobile ([SettingsRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/4702/files#diff-2f7a2e66b652454e7fd1b30226a5146d595dfe05945b34d90ffd5f3a5037cb1e)) for toggling mode and reordering group priority.
> - Mobile navigation now records per-thread last-visited timestamps into device-local preferences on startup and on every navigation state change, used to determine whether wakes/completions are unseen.
> - Behavioral Change: `markThreadVisited` on web now stores a timestamp resolved by `resolveThreadVisitTimestamp` rather than unconditionally using `serverThread.updatedAt`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7a0960a. 13 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->