### PR TITLE
Settle merged PR threads immediately

### DIFF
--- a/packages/client-runtime/src/state/threadSettled.test.ts
+++ b/packages/client-runtime/src/state/threadSettled.test.ts
@@ -163,32 +163,11 @@ describe("effectiveSettled", () => {
     ).toBe(true);
   });
 
-  it("does not re-settle a warm thread on the merge signal: a message sent in a settled thread keeps it active until idle", () => {
-    // The merge signal never clears, so without the idle guard a follow-up
-    // message would un-settle the row only until its turn completed, then
-    // snap straight back into the settled tail.
-    const justActive = makeShell({ activityAt: "2026-04-09T23:30:00.000Z" });
-    // The idle gate is strict: activity exactly one hour old is still warm.
-    const boundary = makeShell({ activityAt: "2026-04-09T23:00:00.000Z" });
-    const idle = makeShell({ activityAt: "2026-04-09T22:59:59.999Z" });
-
+  it("settles immediately when a change request merges or closes", () => {
+    const recentlyActive = makeShell({ activityAt: "2026-04-09T23:59:59.999Z" });
     for (const changeRequestState of ["merged", "closed"] as const) {
       expect(
-        effectiveSettled(justActive, {
-          now: NOW,
-          autoSettleAfterDays: null,
-          changeRequestState,
-        }),
-      ).toBe(false);
-      expect(
-        effectiveSettled(boundary, {
-          now: NOW,
-          autoSettleAfterDays: null,
-          changeRequestState,
-        }),
-      ).toBe(false);
-      expect(
-        effectiveSettled(idle, {
+        effectiveSettled(recentlyActive, {
           now: NOW,
           autoSettleAfterDays: null,
           changeRequestState,
@@ -197,14 +176,18 @@ describe("effectiveSettled", () => {
     }
   });
 
-  it("re-settles a merged-PR thread once the follow-up burst goes idle", () => {
-    // Same shell, advancing clock: active while warm, settled again after
-    // the idle window passes — the burst cools and the merge signal wins.
-    const shell = makeShell({ activityAt: "2026-04-09T23:30:00.000Z" });
-    const options = { autoSettleAfterDays: null, changeRequestState: "merged" as const };
-
-    expect(effectiveSettled(shell, { ...options, now: NOW })).toBe(false);
-    expect(effectiveSettled(shell, { ...options, now: "2026-04-10T00:30:00.001Z" })).toBe(true);
+  it("keeps an explicitly un-settled merged-PR thread active", () => {
+    const shell = makeShell({
+      settledOverride: "active",
+      activityAt: "2026-04-09T23:59:59.999Z",
+    });
+    expect(
+      effectiveSettled(shell, {
+        now: NOW,
+        autoSettleAfterDays: null,
+        changeRequestState: "merged",
+      }),
+    ).toBe(false);
   });
 
   it("never settles a starting session, even with a settled override", () => {

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -215,27 +215,13 @@ export function threadWokeAt(
 }
 
 /**
- * A merged/closed change request settles its thread only once the thread has
- * been idle this long. Without the idle guard the merge signal is permanent:
- * sending a message to a merged-PR thread would un-settle the row only until
- * its turn completed, then the still-merged PR would snap it straight back
- * into the settled tail. An hour keeps the follow-up conversation visible
- * while it is warm; once the burst goes stale the merge signal settles it
- * again. Activity timestamps can originate on another device while `now` is
- * this caller's clock: skew shortens or stretches the window by its size,
- * the same exposure the inactivity auto-settle already accepts — worst case
- * is a row changing lists early or late, never lost work.
- */
-export const CHANGE_REQUEST_SETTLE_IDLE_MS = 60 * 60 * 1_000;
-
-/**
  * Settled resolution over the server-backed settled lifecycle. Activity
  * blockers (pending approval/user-input, a live session, an unadjudicated
  * queued turn) are checked first and hold a thread active regardless of any
  * override. Past the blockers, the explicit user override (thread.settle /
  * thread.unsettle commands, projected into settledOverride + settledAt)
  * wins in both directions; without one, a thread auto-settles on a
- * merged/closed PR (once idle) or inactivity past the window. The server
+ * merged/closed PR immediately or on inactivity past the window. The server
  * un-settles on real activity (user message, session start, approval/
  * user-input request), so an override never goes stale silently.
  */
@@ -271,16 +257,7 @@ export function effectiveSettled(
   // until real activity clears it server-side.
   if (shell.settledOverride === "active") return false;
   if (options.changeRequestState === "merged" || options.changeRequestState === "closed") {
-    // Only an idle thread settles on the merge signal: the signal itself
-    // never clears, so without this guard fresh activity (a message sent in
-    // a settled thread) would re-settle the moment its turn completed.
-    const lastActivityAt = threadLastActivityAt(shell);
-    if (
-      lastActivityAt === null ||
-      Date.parse(lastActivityAt) < Date.parse(options.now) - CHANGE_REQUEST_SETTLE_IDLE_MS
-    ) {
-      return true;
-    }
+    return true;
   }
   if (options.autoSettleAfterDays === null) return false;
 


### PR DESCRIPTION
## What Changed

- Remove the one-hour idle gate from merged/closed change-request settlement.
- Settle a thread as soon as its PR is observed as merged or closed and no work blocker is active.
- Preserve explicit un-settle (`settledOverride: "active"`) precedence.
- Replace the idle-window tests with coverage for immediate settlement and explicit un-settle behavior.

## Why

PR #4309 was intended to make sending a message un-settle a thread. Merged PR state is a permanent client-derived signal, so that change added a one-hour activity heuristic to keep follow-up conversations visible after their turns completed.

That heuristic also delayed the initial merge signal: a PR could merge while its thread remained active for another hour. The merge itself should be authoritative. Pending input, queued work, and live sessions still keep a thread visible, and an explicit un-settle still pins it active; otherwise merged and closed PRs now settle immediately.

## UI Changes

Behavior-only: merged/closed PR rows move to the settled tail without the additional one-hour delay. No styling or layout changes.

## Verification

- `vp test run packages/client-runtime/src/state/threadSettled.test.ts` (178 tests)
- `vp run --filter @t3tools/client-runtime typecheck`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/mobile typecheck`
- Targeted lint and formatting checks

An integrated browser/mobile pass was attempted in an isolated environment, but the collaborative browser could not navigate and this Linux host has no Android SDK/emulator.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable; there are no visual design changes
- [x] Video is not applicable; there are no animation changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side list partitioning logic only; blockers and user overrides are unchanged, so risk is limited to inbox ordering timing for merged PR threads.
> 
> **Overview**
> **Merged/closed PR threads settle as soon as blockers clear**, not after an hour of inactivity. `effectiveSettled` no longer uses `CHANGE_REQUEST_SETTLE_IDLE_MS` or `threadLastActivityAt` for the merge/close signal—`changeRequestState` of `merged` or `closed` returns settled directly after the usual activity blockers and override checks.
> 
> **Explicit keep-active still wins:** `settledOverride: "active"` continues to suppress auto-settle on merged PRs. Pending approvals, user input, live sessions, and queued turn starts are unchanged.
> 
> Tests drop the idle-window scenarios and add cases for immediate settlement on recent activity and for the active override on merged PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808e8dea0bbda1bc6614a48cf691351365ad3d16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Settle merged or closed PR threads immediately in `effectiveSettled`
> Previously, threads with a `changeRequestState` of `merged` or `closed` only settled after an idle threshold of one hour. Now they settle immediately unless `settledOverride` is `"active"` or another activity blocker applies.
>
> - Removes the `CHANGE_REQUEST_SETTLE_IDLE_MS` constant and its idle-guard logic from [`threadSettled.ts`](https://github.com/pingdotgg/t3code/pull/4704/files#diff-89ad1700cfc6c0784f0813b572a6b6110e04b480f108c404b4c755705748083c)
> - Updates tests in [`threadSettled.test.ts`](https://github.com/pingdotgg/t3code/pull/4704/files#diff-2f780912851376be025101fd2a448500fd72b2d37ee7c1a422d1482bb7edd43a) to assert immediate settlement and remove the old idle-guard behavior tests
> - Behavioral Change: merged/closed PR threads now settle as soon as the merge/close signal arrives, even if there was very recent activity
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 808e8de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->