### PR TITLE
Fix OpenCode permission approval mapping

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -320,8 +320,13 @@ function mapPermissionToRequestType(
 ): "command_execution_approval" | "file_read_approval" | "file_change_approval" | "unknown" {
   switch (permission) {
     case "bash":
+    case "webfetch":
+    case "websearch":
+    case "doom_loop":
       return "command_execution_approval";
     case "read":
+    case "codesearch":
+    case "external_directory":
       return "file_read_approval";
     case "edit":
       return "file_change_approval";

--- a/apps/server/src/provider/opencodeRuntime.permission.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.permission.test.ts
@@ -1,0 +1,80 @@
+import * as NodeAssert from "node:assert/strict";
+
+import { describe, it } from "vite-plus/test";
+
+import { buildOpenCodePermissionRules, toOpenCodePermissionReply } from "./opencodeRuntime.ts";
+
+describe("buildOpenCodePermissionRules", () => {
+  it("returns allow-all for full-access mode", () => {
+    const rules = buildOpenCodePermissionRules("full-access");
+    NodeAssert.equal(rules.length, 1);
+    NodeAssert.deepStrictEqual(rules[0], {
+      permission: "*",
+      pattern: "*",
+      action: "allow",
+    });
+  });
+
+  it("includes the permissions explicitly configured by the adapter", () => {
+    for (const mode of ["approval-required", "auto-accept-edits", "auto"] as const) {
+      const rules = buildOpenCodePermissionRules(mode);
+      const permissionNames = rules.map((r) => r.permission);
+
+      NodeAssert.ok(permissionNames.includes("*"));
+      NodeAssert.ok(permissionNames.includes("bash"));
+      NodeAssert.ok(permissionNames.includes("read"));
+      NodeAssert.ok(permissionNames.includes("edit"));
+      NodeAssert.ok(permissionNames.includes("webfetch"));
+      NodeAssert.ok(permissionNames.includes("websearch"));
+      NodeAssert.ok(permissionNames.includes("codesearch"));
+      NodeAssert.ok(permissionNames.includes("external_directory"));
+      NodeAssert.ok(permissionNames.includes("doom_loop"));
+    }
+  });
+
+  it("sets question permission to allow in non-full-access mode", () => {
+    for (const mode of ["approval-required", "auto-accept-edits", "auto"] as const) {
+      const rules = buildOpenCodePermissionRules(mode);
+      const questionRule = rules.find((r) => r.permission === "question");
+      NodeAssert.ok(questionRule);
+      NodeAssert.equal(questionRule.action, "allow");
+    }
+  });
+
+  it("asks for actions in approval-required mode", () => {
+    const rules = buildOpenCodePermissionRules("approval-required");
+    for (const rule of rules) {
+      if (rule.permission === "question") continue;
+      NodeAssert.equal(rule.action, "ask", `expected ${rule.permission} to be ask`);
+    }
+  });
+
+  it("auto-accepts edits in automatic modes while asking for commands", () => {
+    for (const mode of ["auto-accept-edits", "auto"] as const) {
+      const rules = buildOpenCodePermissionRules(mode);
+      const editRule = rules.find((rule) => rule.permission === "edit");
+      const bashRule = rules.find((rule) => rule.permission === "bash");
+
+      NodeAssert.equal(editRule?.action, "allow");
+      NodeAssert.equal(bashRule?.action, "ask");
+    }
+  });
+});
+
+describe("toOpenCodePermissionReply", () => {
+  it('maps "accept" to "once"', () => {
+    NodeAssert.equal(toOpenCodePermissionReply("accept"), "once");
+  });
+
+  it('maps "acceptForSession" to "always"', () => {
+    NodeAssert.equal(toOpenCodePermissionReply("acceptForSession"), "always");
+  });
+
+  it('maps "decline" to "reject"', () => {
+    NodeAssert.equal(toOpenCodePermissionReply("decline"), "reject");
+  });
+
+  it('maps "cancel" to "reject"', () => {
+    NodeAssert.equal(toOpenCodePermissionReply("cancel"), "reject");
+  });
+});

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -330,10 +330,14 @@ export function buildOpenCodePermissionRules(runtimeMode: RuntimeMode): Permissi
     return [{ permission: "*", pattern: "*", action: "allow" }];
   }
 
+  const editAction =
+    runtimeMode === "auto-accept-edits" || runtimeMode === "auto" ? "allow" : "ask";
+
   return [
     { permission: "*", pattern: "*", action: "ask" },
     { permission: "bash", pattern: "*", action: "ask" },
-    { permission: "edit", pattern: "*", action: "ask" },
+    { permission: "read", pattern: "*", action: "ask" },
+    { permission: "edit", pattern: "*", action: editAction },
     { permission: "webfetch", pattern: "*", action: "ask" },
     { permission: "websearch", pattern: "*", action: "ask" },
     { permission: "codesearch", pattern: "*", action: "ask" },

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -175,6 +175,55 @@ describe("derivePendingApprovals", () => {
 
     expect(derivePendingApprovals(activities)).toEqual([]);
   });
+
+  it("falls back to command requestKind when requestType is unknown", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "approval-open-unknown-type",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "approval.requested",
+        summary: "Approval requested",
+        tone: "approval",
+        payload: {
+          requestId: "req-unknown-type",
+          requestType: "unknown",
+          detail: "webfetch",
+        },
+      }),
+    ];
+
+    expect(derivePendingApprovals(activities)).toEqual([
+      {
+        requestId: "req-unknown-type",
+        requestKind: "command",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        detail: "webfetch",
+      },
+    ]);
+  });
+
+  it("falls back to command requestKind when no requestKind or requestType in payload", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "approval-open-no-kind",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "approval.requested",
+        summary: "Approval requested",
+        tone: "approval",
+        payload: {
+          requestId: "req-no-kind",
+        },
+      }),
+    ];
+
+    expect(derivePendingApprovals(activities)).toEqual([
+      {
+        requestId: "req-no-kind",
+        requestKind: "command",
+        createdAt: "2026-02-23T00:00:01.000Z",
+      },
+    ]);
+  });
 });
 
 describe("derivePendingUserInputs", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -378,10 +378,10 @@ export function derivePendingApprovals(
           : null;
     const detail = payload && typeof payload.detail === "string" ? payload.detail : undefined;
 
-    if (activity.kind === "approval.requested" && requestId && requestKind) {
+    if (activity.kind === "approval.requested" && requestId) {
       openByRequestId.set(requestId, {
         requestId,
-        requestKind,
+        requestKind: requestKind ?? "command",
         createdAt: activity.createdAt,
         ...(detail ? { detail } : {}),
       });


### PR DESCRIPTION
## Summary
- Map OpenCode web, search, loop, code-search, and external-directory permissions to the existing approval UI categories.
- Keep approval requests visible with a command fallback when a provider sends an unknown request type.
- Add an explicit read permission rule and allow edits in OpenCode automatic modes while continuing to ask for commands and other sensitive actions.
- Add regression coverage for permission rules and pending approval derivation.

## Verification
- 
 RUN  v4.1.9 /Users/drowning/Desktop/qiniu/fork.t3code


 Test Files  2 passed (2)
      Tests  70 passed (70)
   Start at  14:20:51
   Duration  461ms (transform 282ms, setup 0ms, import 712ms, tests 37ms, environment 0ms)
- 2 test files passed, 70 tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to OpenCode permission mapping, runtime rules, and approval UI derivation with test coverage; no auth or data-model changes.
> 
> **Overview**
> Fixes OpenCode permission prompts so they land in the right approval categories and stay visible in the UI when the provider sends incomplete metadata.
> 
> **Server:** `mapPermissionToRequestType` now treats `webfetch`, `websearch`, and `doom_loop` as command approvals and `codesearch` / `external_directory` as file-read approvals. `buildOpenCodePermissionRules` adds an explicit **read** rule (ask), and in `auto-accept-edits` / `auto` modes **edit** is allowed while bash and other sensitive permissions still require approval.
> 
> **Web:** `derivePendingApprovals` no longer drops open approvals when `requestType` is `unknown` or `requestKind` is missing—it defaults to **command** so prompts like webfetch still show.
> 
> Regression tests cover permission rules, reply mapping, and pending-approval derivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd09b3785e25f23160b11a1fdba4057cf9dc05fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenCode permission approval mapping for web fetch, search, and edit actions
> - Extends `mapPermissionToRequestType` in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/4709/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) to map `webfetch`, `websearch`, and `doom_loop` to `command_execution_approval`, and `codesearch` and `external_directory` to `file_read_approval`.
> - Updates `buildOpenCodePermissionRules` in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/4709/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) so `edit` actions are auto-allowed in `auto-accept-edits` and `auto` modes; `read` actions are explicitly set to `ask` in non-full-access modes.
> - Fixes `derivePendingApprovals` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/4709/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) to default unrecognized `requestKind`/`requestType` to `'command'` instead of dropping the approval entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd09b37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->