### PR TITLE
Make mobile Thread List v2 the default

### DIFF
--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -40,43 +40,21 @@ function makeThread(
 const NOW = "2026-06-02T00:00:00.000Z";
 
 describe("resolveThreadListV2Enabled", () => {
-  it.each(["development", "preview"])("defaults on for the %s variant", (appVariant) => {
-    expect(
-      resolveThreadListV2Enabled({ preference: undefined, preferencesLoaded: true, appVariant }),
-    ).toBe(true);
+  it("defaults on when the device has never chosen", () => {
+    expect(resolveThreadListV2Enabled({ preference: undefined, preferencesLoaded: true })).toBe(
+      true,
+    );
   });
 
-  it.each(["production", undefined])("defaults off for the %s variant", (appVariant) => {
-    expect(
-      resolveThreadListV2Enabled({ preference: undefined, preferencesLoaded: true, appVariant }),
-    ).toBe(false);
+  it("honors an explicit device opt-out", () => {
+    expect(resolveThreadListV2Enabled({ preference: false, preferencesLoaded: true })).toBe(false);
+    expect(resolveThreadListV2Enabled({ preference: true, preferencesLoaded: true })).toBe(true);
   });
 
-  it("prefers an explicit device choice over the variant default", () => {
-    expect(
-      resolveThreadListV2Enabled({
-        preference: false,
-        preferencesLoaded: true,
-        appVariant: "preview",
-      }),
-    ).toBe(false);
-    expect(
-      resolveThreadListV2Enabled({
-        preference: true,
-        preferencesLoaded: true,
-        appVariant: "production",
-      }),
-    ).toBe(true);
-  });
-
-  it("holds v1 while preferences are still loading so the list does not remount", () => {
-    expect(
-      resolveThreadListV2Enabled({
-        preference: undefined,
-        preferencesLoaded: false,
-        appVariant: "development",
-      }),
-    ).toBe(false);
+  it("holds the default while preferences are still loading so the list does not remount", () => {
+    expect(resolveThreadListV2Enabled({ preference: undefined, preferencesLoaded: false })).toBe(
+      true,
+    );
   });
 });
 

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -19,34 +19,23 @@ export const THREAD_LIST_V2_SETTLED_INITIAL_COUNT = 10;
 export const THREAD_LIST_V2_SETTLED_PAGE_COUNT = 25;
 
 /**
- * Whether Thread List v2 is on by default for an app variant. The `development`
- * and `preview` variants are mobile's nightly equivalents and opt in;
- * `production` stays on v1. Counterpart of web's `resolveSidebarV2Default`.
- */
-export function resolveThreadListV2Default(appVariant: unknown): boolean {
-  return appVariant === "development" || appVariant === "preview";
-}
-
-/**
- * Resolved Thread List v2 state: the device-local preference if the user has
- * set one, otherwise the default for this app variant. Preferences persist as
- * sparse patches, so `undefined` genuinely means "never chosen".
+ * Thread List v2 is on by default on every app variant; the Settings → Beta
+ * toggle is an opt-out. Preferences persist as sparse patches, so `undefined`
+ * genuinely means "never chosen".
  *
  * `preferencesLoaded` guards the startup window: preferences load
- * asynchronously, and treating "still loading" as "never chosen" would mount
- * v2 on a development build and then flip to v1 once a stored opt-out arrives,
- * remounting the whole list. While loading, hold v1 — the state both variants
- * already start from.
+ * asynchronously, and rendering one list before the stored choice arrives would
+ * remount the whole thing a tick later. While loading, hold the default — that
+ * is where every device without an explicit opt-out lands anyway.
  */
 export function resolveThreadListV2Enabled(input: {
   readonly preference: boolean | undefined;
   readonly preferencesLoaded: boolean;
-  readonly appVariant: unknown;
 }): boolean {
   if (!input.preferencesLoaded) {
-    return false;
+    return true;
   }
-  return input.preference ?? resolveThreadListV2Default(input.appVariant);
+  return input.preference ?? true;
 }
 
 export function resolveThreadListV2Status(

--- a/apps/mobile/src/features/threads/use-thread-list-v2-enabled.ts
+++ b/apps/mobile/src/features/threads/use-thread-list-v2-enabled.ts
@@ -1,18 +1,13 @@
 import { useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
-import Constants from "expo-constants";
 
 import { mobilePreferencesAtom } from "../../state/preferences";
 import { resolveThreadListV2Enabled } from "./threadListV2";
 
 /**
  * Resolved Thread List v2 state: the device-local preference if the user has
- * set one, otherwise the default for this app variant (on for development and
- * preview, off for production). Every consumer must read through this rather
- * than the raw preference, which is undefined until explicitly chosen.
- *
- * Kept out of `state/preferences.ts` so that module stays importable from node
- * test environments, which have no `__DEV__` for expo-constants.
+ * set one, otherwise the default (on). Every consumer must read through this
+ * rather than the raw preference, which is undefined until explicitly chosen.
  */
 export function useThreadListV2Enabled(): boolean {
   const preferencesResult = useAtomValue(mobilePreferencesAtom);
@@ -20,6 +15,5 @@ export function useThreadListV2Enabled(): boolean {
   return resolveThreadListV2Enabled({
     preference: loaded ? preferencesResult.value.threadListV2Enabled : undefined,
     preferencesLoaded: loaded,
-    appVariant: Constants.expoConfig?.extra?.appVariant,
   });
 }

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -25,9 +25,9 @@ export interface Preferences {
   readonly projectGroupingEnabled?: boolean;
   /**
    * Device-local mirror of the web beta's `sidebarV2Enabled`. Mobile has no
-   * client-settings sync, so the flat v2 thread list is opted into per
-   * device. Undefined means the user has never chosen, in which case the app
-   * variant decides — see `resolveThreadListV2Enabled`.
+   * client-settings sync, so the flat v2 thread list is opted out of per
+   * device. Undefined means the user has never chosen, which resolves to on —
+   * see `resolveThreadListV2Enabled`.
    */
   readonly threadListV2Enabled?: boolean;
 }


### PR DESCRIPTION
## What Changed

- Enabled Thread List v2 by default across all mobile app variants.
- Changed the device preference to act as an opt-out toggle.
- Updated loading behavior and tests to preserve the enabled default while preferences load.

## Why

Thread List v2 is now the standard mobile experience. This removes variant-specific defaults while preserving an explicit device-level opt-out for users who prefer the previous list.

## UI Changes

This changes the default mobile thread-list experience. No screenshots or video were included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production users get a new default thread-list UI; behavior is mitigated by an explicit device opt-out and stable resolution during async preference load.
> 
> **Overview**
> **Thread List v2 is now the default mobile thread list on every app variant** (including production). The Settings → Beta `threadListV2Enabled` preference is treated as an **opt-out** when set to `false`; when unset it resolves to **on**.
> 
> `resolveThreadListV2Default` and **`appVariant`** are removed from `resolveThreadListV2Enabled`. While preferences are still loading, resolution **stays on v2** (`true`) instead of temporarily forcing v1, so the list does not remount when stored prefs arrive. `useThreadListV2Enabled` no longer reads `expo-constants` for variant. Tests and preference comments are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fcd08d695200b98f7692657844e8932c7470399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make mobile Thread List v2 the default for all app variants
> - `resolveThreadListV2Enabled` in [threadListV2.ts](https://github.com/pingdotgg/t3code/pull/4717/files#diff-d629687d2b79a927cf01be39191d0e3fc66435674cd6f8a588469b55c70210ed) now returns `true` by default regardless of app variant, replacing the previous variant-based logic (`development`/`preview` → on, otherwise off).
> - The `resolveThreadListV2Default` helper function is removed; the hook no longer reads `appVariant` from `expo-constants`.
> - While preferences are still loading, the resolver now returns `true` (hold the default) instead of `false`.
> - Behavioral Change: Thread List v2 is now opt-out for all users; previously it was only on by default for development and preview builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fcd08d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->