### PR TITLE
Fix mobile showcase workflow without Clerk

### DIFF
--- a/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
+++ b/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
@@ -24,13 +24,7 @@ import { availableCloudEnvironmentPresentation } from "../cloud/cloudEnvironment
 import { ConnectionStatusDot } from "./ConnectionStatusDot";
 import { type RelayEnvironmentView, useConnectionController } from "./useConnectionController";
 
-/**
- * "T3 Connect" section: every environment published to the signed-in account,
- * with connect switches, availability status, refresh, and loading/error
- * states. Shared between the Settings environments screen and the T3 Connect
- * onboarding sheet.
- */
-export function CloudEnvironmentRows(props: {
+interface CloudEnvironmentRowsProps {
   readonly connectedCloudEnvironments: ReadonlyArray<ConnectedEnvironmentSummary>;
   readonly onReconnectEnvironment: (environmentId: EnvironmentId) => void;
   readonly showcaseAvailableEnvironments?: ReadonlyArray<RelayEnvironmentView>;
@@ -41,8 +35,31 @@ export function CloudEnvironmentRows(props: {
    * pull-to-refresh).
    */
   readonly showHeader?: boolean;
-}) {
+}
+
+/**
+ * "T3 Connect" section: every environment published to the signed-in account,
+ * with connect switches, availability status, refresh, and loading/error
+ * states. Shared between the Settings environments screen and the T3 Connect
+ * onboarding sheet.
+ */
+export function CloudEnvironmentRows(props: CloudEnvironmentRowsProps) {
+  // Showcase captures run without a Clerk publishable key, so `ClerkProvider`
+  // is never mounted and any `useAuth` call throws — the fixture states whether
+  // the rows are signed in instead of asking Clerk.
+  if (props.showcaseSignedIn !== undefined) {
+    return props.showcaseSignedIn ? <CloudEnvironmentRowsContent {...props} /> : null;
+  }
+  return <SignedInCloudEnvironmentRows {...props} />;
+}
+
+function SignedInCloudEnvironmentRows(props: CloudEnvironmentRowsProps) {
   const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false });
+  if (!isSignedIn) return null;
+  return <CloudEnvironmentRowsContent {...props} />;
+}
+
+function CloudEnvironmentRowsContent(props: CloudEnvironmentRowsProps) {
   const controller = useConnectionController();
   const iconColor = useThemeColor("--color-icon");
   const availableCloudEnvironments =
@@ -66,8 +83,6 @@ export function CloudEnvironmentRows(props: {
   }, []);
 
   const showHeader = props.showHeader ?? true;
-
-  if (!(props.showcaseSignedIn ?? isSignedIn)) return null;
 
   return (
     <View collapsable={false} className={cn("gap-3", showHeader && "mt-5")}>


### PR DESCRIPTION
## What Changed

- Allow cloud environment rows to render showcase fixtures without requiring Clerk authentication.
- Default Thread List v2 on development and preview variants, while keeping production on v1.
- Preserve explicit device preferences and hold v1 while preferences load.
- Update focused tests for variant defaults and loading behavior.

## Why

Showcase captures run without a Clerk publishable key, so authentication hooks could fail even when fixture data supplied the signed-in state. The thread-list default now matches the intended mobile release variants while avoiding startup remounts before preferences finish loading.

## UI Changes

The mobile cloud environment showcase can now render without Clerk. No before/after screenshots or interaction video are included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized connection/settings UI change with a clear showcase vs production split; no auth or data-path changes for signed-in users.
> 
> **Overview**
> **Fixes mobile showcase crashes** when rendering T3 Connect cloud environment rows without a Clerk publishable key.
> 
> `CloudEnvironmentRows` now branches before any auth hook: if `showcaseSignedIn` is passed (showcase fixtures), it renders or hides the list from that flag alone. Normal app usage goes through a small `SignedInCloudEnvironmentRows` wrapper that calls `useAuth` and only then mounts the shared `CloudEnvironmentRowsContent` UI. Props are typed via a dedicated `CloudEnvironmentRowsProps` interface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8197e77b074c8a5fc6db150a7e54a3a6763b56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile showcase workflow in `CloudEnvironmentRows` when Clerk auth is unavailable
> - Refactors [`CloudEnvironmentRows`](https://github.com/pingdotgg/t3code/pull/4718/files#diff-4cef1403115ee4104e1b4091fd6d9cb40f706018cded921ef15c068051e8c924) to branch on a new `showcaseSignedIn` prop: when provided, the component skips the `useAuth` hook entirely and renders or returns null based on that flag alone.
> - Extracts a new `SignedInCloudEnvironmentRows` wrapper that isolates the `useAuth` call for non-showcase flows, and a `CloudEnvironmentRowsContent` component that handles all rendering logic.
> - Behavioral Change: when `showcaseSignedIn` is defined, `useAuth` is never called, so showcase screens no longer depend on Clerk being present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae8197e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->