### PR TITLE
feat(web): add chat font size setting

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1544,7 +1544,7 @@ function ChatMarkdown({
   return (
     <div
       className={cn(
-        "chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80",
+        "chat-markdown w-full min-w-0 chat-text-sm leading-relaxed text-foreground/80",
         className,
       )}
       onCopy={handleCopy}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -53,6 +53,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
 } from "react";
 import { flushSync } from "react-dom";
 import { useNavigate } from "@tanstack/react-router";
@@ -3871,6 +3872,7 @@ function ChatViewContent(props: ChatViewProps) {
   // so the banner and the sidebar row never disagree.
   const activeThreadShell = useThreadShell(isServerThread ? activeThreadRef : null);
   const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
+  const chatFontScale = useClientSettings((settings) => settings.chatFontScale);
   const activeThreadPr = resolveThreadPr({
     threadBranch: activeThread?.branch ?? null,
     gitStatus: gitStatusQuery.data ?? null,
@@ -5645,6 +5647,7 @@ function ChatViewContent(props: ChatViewProps) {
           rightPanelMaximized ? "w-0 flex-none" : "flex-1",
         )}
         data-chat-column-maximized-away={rightPanelMaximized ? "true" : "false"}
+        style={{ "--chat-font-scale": chatFontScale / 100 } as CSSProperties}
       >
         {/* Top bar */}
         <header

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1516,7 +1516,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
   const reviewCommentSegments = parseReviewCommentMessageSegments(props.text);
   if (reviewCommentSegments.some((segment) => segment.kind === "review-comment")) {
     return (
-      <div className="space-y-3 text-sm leading-relaxed text-foreground">
+      <div className="space-y-3 chat-text-sm leading-relaxed text-foreground">
         {reviewCommentSegments.map((segment) =>
           segment.kind === "text" ? (
             segment.text.trim().length > 0 ? (
@@ -1585,7 +1585,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
         }
 
         return (
-          <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
+          <div className="whitespace-pre-wrap wrap-break-word chat-text-sm leading-relaxed text-foreground">
             {inlineNodes}
           </div>
         );
@@ -1623,7 +1623,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
     }
 
     return (
-      <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
+      <div className="whitespace-pre-wrap wrap-break-word chat-text-sm leading-relaxed text-foreground">
         {inlineNodes}
       </div>
     );

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -22,7 +22,9 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 import {
   DEFAULT_UNIFIED_SETTINGS,
+  MAX_CHAT_FONT_SCALE,
   MAX_GLASS_OPACITY,
+  MIN_CHAT_FONT_SCALE,
   MIN_GLASS_OPACITY,
 } from "@t3tools/contracts/settings";
 import { createModelSelection } from "@t3tools/shared/model";
@@ -401,6 +403,9 @@ export function useSettingsRestore(onRestored?: () => void) {
     () => [
       ...(theme !== "system" ? ["Theme"] : []),
       ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? ["Glass opacity"] : []),
+      ...(settings.chatFontScale !== DEFAULT_UNIFIED_SETTINGS.chatFontScale
+        ? ["Chat font size"]
+        : []),
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
@@ -457,6 +462,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
       settings.glassOpacity,
+      settings.chatFontScale,
       settings.automaticGitFetchInterval,
       settings.enableAssistantStreaming,
       settings.enableProviderUpdateChecks,
@@ -484,6 +490,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
+      chatFontScale: DEFAULT_UNIFIED_SETTINGS.chatFontScale,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
@@ -520,6 +527,12 @@ export function GeneralSettingsPanel() {
   const glassOpacitySliderStyle = {
     "--glass-slider-progress": `${glassOpacityRatio * 100}%`,
     "--glass-slider-fill-offset": `${0.5 - glassOpacityRatio}rem`,
+  } as CSSProperties;
+  const chatFontScaleRatio =
+    (settings.chatFontScale - MIN_CHAT_FONT_SCALE) / (MAX_CHAT_FONT_SCALE - MIN_CHAT_FONT_SCALE);
+  const chatFontScaleSliderStyle = {
+    "--glass-slider-progress": `${chatFontScaleRatio * 100}%`,
+    "--glass-slider-fill-offset": `${0.5 - chatFontScaleRatio}rem`,
   } as CSSProperties;
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
@@ -629,6 +642,52 @@ export function GeneralSettingsPanel() {
                 style={glassOpacitySliderStyle}
                 type="range"
                 value={settings.glassOpacity}
+              />
+            </div>
+          }
+        />
+
+        <SettingsRow
+          title="Chat font size"
+          description="Control the size of message text in the chat. Sidebar and other UI stay the same size."
+          resetAction={
+            settings.chatFontScale !== DEFAULT_UNIFIED_SETTINGS.chatFontScale ? (
+              <SettingResetButton
+                label="chat font size"
+                onClick={() =>
+                  updateSettings({ chatFontScale: DEFAULT_UNIFIED_SETTINGS.chatFontScale })
+                }
+              />
+            ) : null
+          }
+          control={
+            <div className="flex w-full items-center gap-3 sm:w-52">
+              <output
+                className="min-w-12 rounded-md bg-muted px-2 py-1 text-center font-mono text-xs font-medium tabular-nums text-foreground"
+                htmlFor="chat-font-scale"
+              >
+                {settings.chatFontScale}%
+              </output>
+              <input
+                aria-label="Chat font size"
+                className="chat-font-scale-slider min-w-0 flex-1"
+                id="chat-font-scale"
+                max={MAX_CHAT_FONT_SCALE}
+                min={MIN_CHAT_FONT_SCALE}
+                onChange={(event) => {
+                  const chatFontScale = Number(event.currentTarget.value);
+                  if (
+                    Number.isInteger(chatFontScale) &&
+                    chatFontScale >= MIN_CHAT_FONT_SCALE &&
+                    chatFontScale <= MAX_CHAT_FONT_SCALE
+                  ) {
+                    updateSettings({ chatFontScale });
+                  }
+                }}
+                step={10}
+                style={chatFontScaleSliderStyle}
+                type="range"
+                value={settings.chatFontScale}
               />
             </div>
           }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -638,7 +638,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     background: color-mix(in srgb, var(--background) 64%, transparent);
   }
 
-  .glass-opacity-slider {
+  .glass-opacity-slider,
+  .chat-font-scale-slider {
     --glass-slider-progress: 0%;
     --glass-slider-fill-offset: 0.5rem;
     --glass-slider-fill-position: calc(
@@ -650,7 +651,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     cursor: pointer;
   }
 
-  .glass-opacity-slider::-webkit-slider-runnable-track {
+  .glass-opacity-slider::-webkit-slider-runnable-track,
+  .chat-font-scale-slider::-webkit-slider-runnable-track {
     height: 0.375rem;
     border-radius: 9999px;
     background: linear-gradient(
@@ -662,20 +664,23 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border) 55%, transparent);
   }
 
-  .glass-opacity-slider::-moz-range-track {
+  .glass-opacity-slider::-moz-range-track,
+  .chat-font-scale-slider::-moz-range-track {
     height: 0.375rem;
     border-radius: 9999px;
     background: color-mix(in srgb, var(--muted-foreground) 22%, transparent);
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border) 55%, transparent);
   }
 
-  .glass-opacity-slider::-moz-range-progress {
+  .glass-opacity-slider::-moz-range-progress,
+  .chat-font-scale-slider::-moz-range-progress {
     height: 0.375rem;
     border-radius: 9999px;
     background: var(--primary);
   }
 
-  .glass-opacity-slider::-webkit-slider-thumb {
+  .glass-opacity-slider::-webkit-slider-thumb,
+  .chat-font-scale-slider::-webkit-slider-thumb {
     appearance: none;
     width: 1rem;
     height: 1rem;
@@ -689,7 +694,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
       box-shadow 120ms ease;
   }
 
-  .glass-opacity-slider::-moz-range-thumb {
+  .glass-opacity-slider::-moz-range-thumb,
+  .chat-font-scale-slider::-moz-range-thumb {
     width: 1rem;
     height: 1rem;
     border: 2px solid var(--primary);
@@ -701,54 +707,67 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
       box-shadow 120ms ease;
   }
 
-  .glass-opacity-slider:hover::-webkit-slider-thumb {
+  .glass-opacity-slider:hover::-webkit-slider-thumb,
+  .chat-font-scale-slider:hover::-webkit-slider-thumb {
     transform: scale(1.08);
     box-shadow: 0 1px 3px color-mix(in srgb, var(--foreground) 20%, transparent);
   }
 
-  .glass-opacity-slider:hover::-moz-range-thumb {
+  .glass-opacity-slider:hover::-moz-range-thumb,
+  .chat-font-scale-slider:hover::-moz-range-thumb {
     transform: scale(1.08);
     box-shadow: 0 1px 3px color-mix(in srgb, var(--foreground) 20%, transparent);
   }
 
-  .glass-opacity-slider:active::-webkit-slider-thumb {
+  .glass-opacity-slider:active::-webkit-slider-thumb,
+  .chat-font-scale-slider:active::-webkit-slider-thumb {
     transform: scale(0.94);
   }
 
-  .glass-opacity-slider:active::-moz-range-thumb {
+  .glass-opacity-slider:active::-moz-range-thumb,
+  .chat-font-scale-slider:active::-moz-range-thumb {
     transform: scale(0.94);
   }
 
-  .glass-opacity-slider:focus-visible {
+  .glass-opacity-slider:focus-visible,
+  .chat-font-scale-slider:focus-visible {
     outline: none;
   }
 
-  .glass-opacity-slider:focus-visible::-webkit-slider-thumb {
+  .glass-opacity-slider:focus-visible::-webkit-slider-thumb,
+  .chat-font-scale-slider:focus-visible::-webkit-slider-thumb {
     box-shadow:
       0 0 0 3px var(--background),
       0 0 0 5px var(--ring);
   }
 
-  .glass-opacity-slider:focus-visible::-moz-range-thumb {
+  .glass-opacity-slider:focus-visible::-moz-range-thumb,
+  .chat-font-scale-slider:focus-visible::-moz-range-thumb {
     box-shadow:
       0 0 0 3px var(--background),
       0 0 0 5px var(--ring);
   }
 
   @media (forced-colors: active) {
-    .glass-opacity-slider {
+    .glass-opacity-slider,
+    .chat-font-scale-slider {
       appearance: auto;
       accent-color: Highlight;
     }
 
     .glass-opacity-slider::-webkit-slider-runnable-track,
-    .glass-opacity-slider::-webkit-slider-thumb {
+    .chat-font-scale-slider::-webkit-slider-runnable-track,
+    .glass-opacity-slider::-webkit-slider-thumb,
+    .chat-font-scale-slider::-webkit-slider-thumb {
       all: revert;
     }
 
     .glass-opacity-slider::-moz-range-track,
+    .chat-font-scale-slider::-moz-range-track,
     .glass-opacity-slider::-moz-range-progress,
-    .glass-opacity-slider::-moz-range-thumb {
+    .chat-font-scale-slider::-moz-range-progress,
+    .glass-opacity-slider::-moz-range-thumb,
+    .chat-font-scale-slider::-moz-range-thumb {
       all: revert;
     }
   }
@@ -1128,6 +1147,10 @@ label:has(> select#reasoning-effort) select {
   height: 100%;
 }
 
+.chat-text-sm {
+  font-size: calc(0.875rem * var(--chat-font-scale, 1));
+}
+
 /* Chat markdown rendering */
 .chat-markdown {
   min-width: 0;
@@ -1165,21 +1188,21 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown h1 {
-  font-size: 1.25rem;
+  font-size: calc(1.25rem * var(--chat-font-scale, 1));
 }
 
 .chat-markdown h2 {
-  font-size: 1.125rem;
+  font-size: calc(1.125rem * var(--chat-font-scale, 1));
 }
 
 .chat-markdown h3 {
-  font-size: 1rem;
+  font-size: calc(1rem * var(--chat-font-scale, 1));
 }
 
 .chat-markdown h4,
 .chat-markdown h5,
 .chat-markdown h6 {
-  font-size: 0.875rem;
+  font-size: calc(0.875rem * var(--chat-font-scale, 1));
 }
 
 .chat-markdown h6 {
@@ -1262,7 +1285,7 @@ label:has(> select#reasoning-effort) select {
   border-top: 1px solid var(--border);
   padding-top: 0.75rem;
   color: var(--muted-foreground);
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--chat-font-scale, 1));
 }
 
 .chat-markdown section[data-footnotes] ol {
@@ -1282,7 +1305,7 @@ label:has(> select#reasoning-effort) select {
   justify-content: center;
   border-radius: 0.25rem;
   text-decoration: none;
-  font-size: 0.6875rem;
+  font-size: calc(0.6875rem * var(--chat-font-scale, 1));
   font-weight: 600;
 }
 
@@ -1292,7 +1315,7 @@ label:has(> select#reasoning-effort) select {
   background: var(--muted);
   padding: 0.1rem 0.35rem;
   color: var(--foreground);
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--chat-font-scale, 1));
 }
 
 .chat-markdown a.chat-markdown-file-link {
@@ -1323,7 +1346,7 @@ label:has(> select#reasoning-effort) select {
   border: none;
   background: transparent;
   padding: 0;
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--chat-font-scale, 1));
 }
 
 .chat-markdown pre {
@@ -1387,7 +1410,7 @@ label:has(> select#reasoning-effort) select {
   align-items: center;
   gap: 0.4rem;
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: 0.6875rem;
+  font-size: calc(0.6875rem * var(--chat-font-scale, 1));
 }
 
 .chat-markdown .chat-markdown-chrome-action {
@@ -1430,7 +1453,7 @@ label:has(> select#reasoning-effort) select {
   border-collapse: collapse;
   overflow-wrap: normal;
   word-break: normal;
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--chat-font-scale, 1));
 }
 
 .chat-markdown th,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -59,6 +59,17 @@ export const GlassOpacity = Schema.Int.check(
 export type GlassOpacity = typeof GlassOpacity.Type;
 export const DEFAULT_GLASS_OPACITY: GlassOpacity = 80;
 
+export const MIN_CHAT_FONT_SCALE = 90;
+export const MAX_CHAT_FONT_SCALE = 150;
+export const ChatFontScale = Schema.Int.check(
+  Schema.isBetween({
+    minimum: MIN_CHAT_FONT_SCALE,
+    maximum: MAX_CHAT_FONT_SCALE,
+  }),
+);
+export type ChatFontScale = typeof ChatFontScale.Type;
+export const DEFAULT_CHAT_FONT_SCALE: ChatFontScale = 100;
+
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -69,6 +80,9 @@ export const ClientSettingsSchema = Schema.Struct({
   diffIgnoreWhitespace: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   glassOpacity: GlassOpacity.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_GLASS_OPACITY)),
+  ),
+  chatFontScale: ChatFontScale.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_CHAT_FONT_SCALE)),
   ),
   // Model favorites. Historically keyed by provider kind, now
   // widened to `ProviderInstanceId` so users can favorite a specific model
@@ -612,6 +626,7 @@ export const ClientSettingsPatch = Schema.Struct({
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
   glassOpacity: Schema.optionalKey(GlassOpacity),
+  chatFontScale: Schema.optionalKey(ChatFontScale),
   favorites: Schema.optionalKey(
     Schema.Array(
       Schema.Struct({


### PR DESCRIPTION
I find the conversation text quite small (yes I have quite bad eyesight) and although I can do cmd+ in the browser, that increases the entire UI which is not what I want because it leaves too little free space for the conversation itself. So instead a hooked a custom settings to tweak the text font size of the main conversation.

---

## Summary
- Adds a "Chat font size" slider (90-150%, default 100%) in Settings -> General, modeled on the existing Glass opacity control.
- Scopes a `--chat-font-scale` CSS variable to the chat column so message text (plain and markdown) scales independently of sidebar, settings, and composer chrome.
- Setting persists via the existing client settings store.

## Test plan
- [x] Typecheck/build passes
- [x] Settings -> General shows the new slider next to Glass opacity
- [x] Reset button only appears when non-default
- [x] Dragging slider (tested at 150%) resizes message text — plain text, headings, inline code, fenced code blocks, tables — while sidebar/settings/composer stay fixed
- [x] Setting persists across page reload
- [x] No layout overflow when toggling sidebar or right panel at non-default scale


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only appearance setting with schema defaults; no auth, data, or server behavior changes.
> 
> **Overview**
> Adds a **Chat font size** preference (90–150%, default 100%) in Settings → Appearance, alongside the existing glass opacity control, with reset and “restore defaults” support.
> 
> The chat column sets `--chat-font-scale` from the persisted `chatFontScale` client setting. Message body text uses a new `chat-text-sm` class instead of Tailwind `text-sm`, and `.chat-markdown` typography (headings, code, tables, footnotes) scales via `calc(... * var(--chat-font-scale, 1))` so conversation text grows without resizing sidebar, header, or composer chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa5ff65269781a3db0b86e8e2c2ad5cb7b75848. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add chat font size setting to general settings panel
> - Adds a `chatFontScale` field to `ClientSettingsSchema` and `ClientSettingsPatch` in [settings.ts](https://github.com/pingdotgg/t3code/pull/4719/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), with bounds of 90–150 and a default of 100.
> - Adds a range slider in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/4719/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) to adjust chat font size; restoring defaults resets it to 100.
> - [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4719/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) reads `chatFontScale` and sets the `--chat-font-scale` CSS variable inline on the chat column container.
> - [index.css](https://github.com/pingdotgg/t3code/pull/4719/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) introduces `.chat-text-sm` and updates all `.chat-markdown` typography rules to scale via `calc(... * var(--chat-font-scale, 1))`.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afa5ff6.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->