### PR TITLE
fix(desktop): allow updater-controlled relaunch

### DIFF
--- a/apps/desktop/src/app/DesktopAppIdentity.test.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.test.ts
@@ -63,6 +63,7 @@ const makeElectronAppLayer = (calls: ElectronAppCalls) =>
         calls.setDockIcon.push(iconPath);
       }),
     appendCommandLineSwitch: () => Effect.void,
+    onBeforeQuitForUpdate: () => Effect.void,
     on: () => Effect.void,
   } satisfies ElectronApp.ElectronApp["Service"]);
 

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -1,0 +1,123 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
+import type * as Electron from "electron";
+
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronTheme from "../electron/ElectronTheme.ts";
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+import * as DesktopLifecycle from "./DesktopLifecycle.ts";
+import * as DesktopShutdown from "./DesktopShutdown.ts";
+import * as DesktopState from "./DesktopState.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+
+describe("DesktopLifecycle", () => {
+  for (const platform of ["darwin", "win32", "linux"] satisfies ReadonlyArray<NodeJS.Platform>) {
+    it.effect(`lets the updater's quit event proceed on ${platform}`, () => {
+      const appListeners = new Map<string, (...args: readonly unknown[]) => void>();
+
+      const electronAppLayer = Layer.succeed(ElectronApp.ElectronApp, {
+        metadata: Effect.die("unexpected metadata read"),
+        name: Effect.succeed("T3 Code"),
+        whenReady: Effect.void,
+        quit: Effect.void,
+        exit: () => Effect.void,
+        relaunch: () => Effect.void,
+        setPath: () => Effect.void,
+        setName: () => Effect.void,
+        setAboutPanelOptions: () => Effect.void,
+        setAppUserModelId: () => Effect.void,
+        requestSingleInstanceLock: Effect.succeed(true),
+        isDefaultProtocolClient: () => Effect.succeed(false),
+        setAsDefaultProtocolClient: () => Effect.succeed(true),
+        setDesktopName: () => Effect.void,
+        setDockIcon: () => Effect.void,
+        appendCommandLineSwitch: () => Effect.void,
+        onBeforeQuitForUpdate: (listener) =>
+          Effect.acquireRelease(
+            Effect.sync(() => {
+              appListeners.set("before-quit-for-update", listener);
+            }),
+            () =>
+              Effect.sync(() => {
+                appListeners.delete("before-quit-for-update");
+              }),
+          ).pipe(Effect.asVoid),
+        on: (eventName, listener) =>
+          Effect.acquireRelease(
+            Effect.sync(() => {
+              appListeners.set(
+                eventName,
+                listener as unknown as (...args: readonly unknown[]) => void,
+              );
+            }),
+            () =>
+              Effect.sync(() => {
+                appListeners.delete(eventName);
+              }),
+          ).pipe(Effect.asVoid),
+      } satisfies ElectronApp.ElectronApp["Service"]);
+
+      const electronThemeLayer = Layer.succeed(ElectronTheme.ElectronTheme, {
+        shouldUseDarkColors: Effect.succeed(false),
+        setSource: () => Effect.void,
+        onUpdated: () => Effect.void,
+      });
+
+      const desktopWindowLayer = Layer.succeed(DesktopWindow.DesktopWindow, {
+        createMain: Effect.die("unexpected window creation"),
+        ensureMain: Effect.die("unexpected window creation"),
+        revealOrCreateMain: Effect.die("unexpected window creation"),
+        activate: Effect.void,
+        createMainIfBackendReady: Effect.void,
+        showConnectingSplash: Effect.void,
+        handleBackendReady: () => Effect.void,
+        handleBackendNotReady: Effect.void,
+        flushMainWindowBounds: Effect.void,
+        dispatchMenuAction: () => Effect.void,
+        syncAppearance: Effect.void,
+      });
+
+      const environmentLayer = Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
+        platform,
+        isDevelopment: false,
+      } as DesktopEnvironment.DesktopEnvironment["Service"]);
+
+      const layer = DesktopLifecycle.layer.pipe(
+        Layer.provideMerge(electronAppLayer),
+        Layer.provideMerge(electronThemeLayer),
+        Layer.provideMerge(desktopWindowLayer),
+        Layer.provideMerge(environmentLayer),
+        Layer.provideMerge(DesktopShutdown.layer),
+        Layer.provideMerge(DesktopState.layer),
+      );
+
+      return Effect.scoped(
+        Effect.gen(function* () {
+          const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
+          yield* lifecycle.register;
+
+          appListeners.get("before-quit-for-update")?.();
+
+          let prevented = false;
+          const event = {
+            preventDefault: () => {
+              prevented = true;
+            },
+          } as Electron.Event;
+          appListeners.get("before-quit")?.(event);
+
+          assert.isFalse(
+            prevented,
+            "cancelling this event prevents the updater from completing its relaunch",
+          );
+
+          const state = yield* DesktopState.DesktopState;
+          assert.isTrue(yield* Ref.get(state.quitting));
+        }),
+      ).pipe(Effect.provide(layer));
+    });
+  }
+});

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -176,16 +176,28 @@ export const make = DesktopLifecycle.of({
     const context = yield* Effect.context<DesktopLifecycleRuntimeServices>();
     const runEffect = Effect.runPromiseWith(context);
     let quitAllowed = false;
+    let updaterQuitAllowed = false;
     yield* electronTheme.onUpdated(() => {
       void runEffect(
         desktopWindow.syncAppearance.pipe(Effect.withSpan("desktop.lifecycle.themeUpdated")),
+      );
+    });
+    yield* electronApp.onBeforeQuitForUpdate(() => {
+      // Electron's updater owns the remaining quit/install/relaunch sequence.
+      // Cancelling the following app "before-quit" event breaks that sequence,
+      // most visibly on macOS where the native updater performs the relaunch.
+      updaterQuitAllowed = true;
+      void runEffect(
+        logLifecycleInfo("allowing updater-controlled quit").pipe(
+          Effect.withSpan("desktop.lifecycle.beforeQuitForUpdate"),
+        ),
       );
     });
     yield* electronApp.on("before-quit", (event: Electron.Event) => {
       handleBeforeQuit(
         event,
         runEffect,
-        () => quitAllowed,
+        () => quitAllowed || updaterQuitAllowed,
         () => {
           quitAllowed = true;
         },

--- a/apps/desktop/src/electron/ElectronApp.test.ts
+++ b/apps/desktop/src/electron/ElectronApp.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, vi } from "vite-plus/test";
 
 const {
   appendSwitchMock,
+  autoUpdaterOnMock,
+  autoUpdaterRemoveListenerMock,
   exitMock,
   getAppPathMock,
   getVersionMock,
@@ -23,6 +25,8 @@ const {
   whenReadyMock,
 } = vi.hoisted(() => ({
   appendSwitchMock: vi.fn(),
+  autoUpdaterOnMock: vi.fn(),
+  autoUpdaterRemoveListenerMock: vi.fn(),
   exitMock: vi.fn(),
   getAppPathMock: vi.fn(() => "/app"),
   getVersionMock: vi.fn(() => "1.2.3"),
@@ -43,6 +47,10 @@ const {
 }));
 
 vi.mock("electron", () => ({
+  autoUpdater: {
+    on: autoUpdaterOnMock,
+    removeListener: autoUpdaterRemoveListenerMock,
+  },
   app: {
     commandLine: {
       appendSwitch: appendSwitchMock,
@@ -77,6 +85,8 @@ import * as ElectronApp from "./ElectronApp.ts";
 describe("ElectronApp", () => {
   beforeEach(() => {
     appendSwitchMock.mockClear();
+    autoUpdaterOnMock.mockClear();
+    autoUpdaterRemoveListenerMock.mockClear();
     exitMock.mockClear();
     onMock.mockClear();
     quitMock.mockClear();
@@ -151,6 +161,24 @@ describe("ElectronApp", () => {
 
       assert.deepEqual(onMock.mock.calls, [["activate", listener]]);
       assert.deepEqual(removeListenerMock.mock.calls, [["activate", listener]]);
+    }).pipe(Effect.provide(ElectronApp.layer)),
+  );
+
+  it.effect("scopes native updater quit listeners", () =>
+    Effect.gen(function* () {
+      const listener = vi.fn();
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const electronApp = yield* ElectronApp.ElectronApp;
+          yield* electronApp.onBeforeQuitForUpdate(listener);
+        }),
+      );
+
+      assert.deepEqual(autoUpdaterOnMock.mock.calls, [["before-quit-for-update", listener]]);
+      assert.deepEqual(autoUpdaterRemoveListenerMock.mock.calls, [
+        ["before-quit-for-update", listener],
+      ]);
     }).pipe(Effect.provide(ElectronApp.layer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronApp.ts
+++ b/apps/desktop/src/electron/ElectronApp.ts
@@ -66,6 +66,9 @@ export class ElectronApp extends Context.Service<
     readonly setDesktopName: (desktopName: string) => Effect.Effect<void>;
     readonly setDockIcon: (iconPath: string) => Effect.Effect<void>;
     readonly appendCommandLineSwitch: (switchName: string, value?: string) => Effect.Effect<void>;
+    readonly onBeforeQuitForUpdate: (
+      listener: () => void,
+    ) => Effect.Effect<void, never, Scope.Scope>;
     readonly on: <Args extends ReadonlyArray<unknown>>(
       eventName: string,
       listener: (...args: Args) => void,
@@ -178,6 +181,16 @@ export const make = ElectronApp.of({
       }
       Electron.app.commandLine.appendSwitch(switchName, value);
     }),
+  onBeforeQuitForUpdate: (listener) =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        Electron.autoUpdater.on("before-quit-for-update", listener);
+      }),
+      () =>
+        Effect.sync(() => {
+          Electron.autoUpdater.removeListener("before-quit-for-update", listener);
+        }),
+    ).pipe(Effect.asVoid),
   on: addScopedAppListener,
 });
 

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -45,6 +45,7 @@ const electronAppLayer = Layer.succeed(ElectronApp.ElectronApp, {
   setDesktopName: () => Effect.void,
   setDockIcon: () => Effect.void,
   appendCommandLineSwitch: () => Effect.void,
+  onBeforeQuitForUpdate: () => Effect.void,
   on: () => Effect.void,
 } satisfies ElectronApp.ElectronApp["Service"]);
 


### PR DESCRIPTION
## What Changed

- Listen for Electron’s native `before-quit-for-update` event.
- Allow the subsequent updater-controlled quit to proceed without calling `preventDefault()`.
- Preserve the existing graceful-shutdown behavior for ordinary quits.
- Add regression coverage for macOS, Windows, and Linux.

## Why

T3 Code’s lifecycle handler cancelled every `before-quit` event, including quits initiated by Electron’s updater. On macOS, this interrupted the native install-and-relaunch sequence, causing “Restart to update” to close the app without reopening it.

Recognizing Electron’s dedicated update-quit signal keeps normal shutdown safeguards intact while allowing the updater to own its install and relaunch sequence.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — not applicable
- [x] I included a video for animation/interaction changes — not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to quit handling with platform regression tests; normal user-initiated quits still use the existing graceful shutdown path.
> 
> **Overview**
> Fixes **“Restart to update”** closing the app without relaunching (especially on macOS) by not treating updater-driven quits like user quits that need graceful shutdown.
> 
> The desktop app was calling `preventDefault()` on every `before-quit` unless a normal quit had already been allowed. Electron’s updater first emits **`before-quit-for-update`**, then **`before-quit`** as part of install/relaunch—blocking that second event breaks the updater’s sequence.
> 
> **`ElectronApp`** now exposes **`onBeforeQuitForUpdate`**, a scoped subscription to `autoUpdater`’s `before-quit-for-update` (register on acquire, remove on release). **`DesktopLifecycle`** sets an **`updaterQuitAllowed`** flag when that fires so the next `before-quit` is allowed through without `preventDefault()` or the shutdown-and-retry-quit path. Ordinary quits are unchanged.
> 
> Regression tests cover scoped updater listeners, lifecycle behavior on darwin/win32/linux, and test doubles for the new service method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed368e2620db33a3c1af192e70f9527a60b6c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow updater-controlled relaunch by not blocking `before-quit` after `before-quit-for-update`
> - Adds `onBeforeQuitForUpdate` to the `ElectronApp` service interface, implemented via `Effect.acquireRelease` to scope a listener on `Electron.autoUpdater`'s `before-quit-for-update` event in [ElectronApp.ts](https://github.com/pingdotgg/t3code/pull/4721/files#diff-b1967bf80c9bfada48edbd76cf62f126b181a23dad547e1c4c25d999e2230f1e).
> - Introduces an `updaterQuitAllowed` flag in [DesktopLifecycle.ts](https://github.com/pingdotgg/t3code/pull/4721/files#diff-e4f770e94426c2d924f6a844fa3f0e9cce3653cecebc9b95902929cad3966b6d) that is set when the updater fires `before-quit-for-update`, allowing the subsequent `before-quit` event to proceed rather than being cancelled.
> - Behavioral Change: previously, all `before-quit` events were blocked unless `quitAllowed` was set via the normal quit flow; now updater-initiated quits bypass that block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bed368e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->