### PR TITLE
fix(web): prevent diff panel scroll jumping

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -877,7 +877,7 @@ export default function DiffPanel({
                 <AnnotatableCodeView
                   viewerRef={codeViewRef}
                   key={collapseScopeKey ?? reviewSectionId}
-                  className="diff-render-surface h-full min-h-0 overflow-auto [&>div>div:last-child]:top-0! [&>div>div:last-child]:bottom-auto!"
+                  className="diff-render-surface h-full min-h-0 overflow-auto"
                   files={codeViewFiles}
                   sectionId={reviewSectionId}
                   sectionTitle={reviewSectionTitle}
@@ -923,7 +923,8 @@ export default function DiffPanel({
                     themeType: resolvedTheme as DiffThemeType,
                     unsafeCSS: DIFF_PANEL_UNSAFE_CSS,
                     stickyHeaders: true,
-                    layout: { paddingTop: 8, paddingBottom: 8, gap: 8 },
+                    itemMetrics: { diffHeaderHeight: 33 },
+                    layout: { paddingTop: 0, paddingBottom: 8, gap: 8 },
                   }}
                 />
               </div>


### PR DESCRIPTION
## What Changed

- Restored the diff virtualizer’s dynamic sticky positioning.
- Removed the extra top padding from the diff layout.
- Configured the virtualizer’s header-height metric to match the rendered 33px header.

## Why

The diff panel could freeze, jump, or appear to teleport while scrolling through multiple files. A CSS override forced the virtualizer’s sticky container to remain at the top, preventing `@pierre/diffs` from applying the dynamic offsets required for smooth virtual scrolling.

Simply removing that override exposed a visual gap and incorrect layout estimates. Setting the top padding to zero and matching the header-height metric preserves the existing appearance while allowing the virtualizer to manage scrolling correctly.

## UI Changes

Before:

- Scrolling through multi-file diffs could freeze or jump between rendered sections.
- Removing the sticky override alone left a gap above the first diff.

https://github.com/user-attachments/assets/9dee4541-7ffd-458c-bca6-954480abdd8b

After:

- Multi-file diffs scroll continuously in both directions.
- The first diff remains flush with the top of the panel.
- Collapsing and expanding files preserves the correct layout.

https://github.com/user-attachments/assets/b2e07752-0319-45f9-9f85-0a0a79af9e47

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized diff-panel rendering and virtualizer options only; no auth, data, or API changes.
> 
> **Overview**
> **Fixes scroll freeze, jump, and teleport behavior** when scrolling through multi-file diffs in the diff panel.
> 
> The `AnnotatableCodeView` wrapper no longer applies a Tailwind override that pinned the virtualizer’s sticky layer to `top: 0`, which blocked `@pierre/diffs` from updating sticky offsets during virtual scrolling.
> 
> To keep the first file flush with the panel top after removing that override, **`layout.paddingTop` is set to `0`** (was `8`) and **`itemMetrics.diffHeaderHeight` is set to `33`** so height estimates match the ~33px file headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0998eef2bf7a47edbfae6f2f24890fa01724031c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix scroll jumping in `DiffPanel` by removing sticky positioning overrides
> Removes custom Tailwind selectors that forced last-child sticky positioning in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/4724/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3), replacing them with built-in `itemMetrics` (`diffHeaderHeight: 33`) and setting `paddingTop` to 0. Sticky header behavior now relies on the component's own metrics rather than CSS overrides.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0998eef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->