### PR TITLE
Fix Android showcase capture and rebuild v2 queued rows

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -39,9 +39,10 @@ import {
 import { ThreadListV2PendingRow, ThreadListV2Row } from "../threads/thread-list-v2-items";
 import {
   buildThreadListV2Items,
+  buildThreadListV2ListItems,
   THREAD_LIST_V2_SETTLED_INITIAL_COUNT,
   THREAD_LIST_V2_SETTLED_PAGE_COUNT,
-  type ThreadListV2Item,
+  type ThreadListV2ListItem,
 } from "../threads/threadListV2";
 import type { HomeListFilterMenuEnvironment } from "./home-list-filter-menu";
 import {
@@ -549,50 +550,98 @@ export function HomeScreen(props: HomeScreenProps) {
     // unchanged: after a clamped fire (wake beyond the 32-bit setTimeout
     // range) the boundary string is identical and the chain would die.
   }, [nextSnoozeWakeAt, snoozeWakeTick]);
-  const threadListV2Items = threadListV2Layout.items;
+  // Queued tasks are not thread shells, so the v2 partition never sees them;
+  // they are spliced in below the active block and stay visible and deletable
+  // while their environment is offline. Same environment scope and search
+  // filter as the list itself.
+  const v2SearchQuery = props.searchQuery.trim().toLocaleLowerCase();
+  const v2PendingTasks = useMemo(
+    () =>
+      props.pendingTasks.filter(
+        (pendingTask) =>
+          (props.selectedEnvironmentId === null ||
+            pendingTask.message.environmentId === props.selectedEnvironmentId) &&
+          (v2ScopedProjectKeys === null ||
+            v2ScopedProjectKeys.has(
+              scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
+            )) &&
+          (v2SearchQuery.length === 0 ||
+            pendingTask.title.toLocaleLowerCase().includes(v2SearchQuery)),
+      ),
+    [props.pendingTasks, props.selectedEnvironmentId, v2ScopedProjectKeys, v2SearchQuery],
+  );
+  const threadListV2Items = useMemo(
+    () =>
+      buildThreadListV2ListItems({
+        items: threadListV2Layout.items,
+        pendingTasks: v2PendingTasks,
+      }),
+    [threadListV2Layout.items, v2PendingTasks],
+  );
 
   const renderV2Item = useCallback(
-    ({ item }: { readonly item: ThreadListV2Item }) => (
-      <ThreadListV2Row
-        thread={item.thread}
-        variant={item.variant}
-        showSettledDivider={item.showSettledDivider}
-        project={
-          projectByKey.get(scopedProjectKey(item.thread.environmentId, item.thread.projectId)) ??
-          null
-        }
-        projectTitle={v2ProjectTitleByProjectKey.get(
-          scopedProjectKey(item.thread.environmentId, item.thread.projectId),
-        )}
-        providerDriver={
-          serverConfigs
-            .get(item.thread.environmentId)
-            ?.providers.find(
-              (provider) =>
-                provider.instanceId ===
-                (item.thread.session?.providerInstanceId ?? item.thread.modelSelection.instanceId),
-            )?.driver ?? null
-        }
-        environmentLabel={
-          Object.keys(props.savedConnectionsById).length > 1
-            ? (props.savedConnectionsById[item.thread.environmentId]?.environmentLabel ?? null)
-            : null
-        }
-        onSelectThread={props.onSelectThread}
-        onDeleteThread={handleDeleteThread}
-        onArchiveThread={props.onArchiveThread}
-        settlementSupported={settlementEnvironmentIds.has(item.thread.environmentId)}
-        onSettleThread={handleSettleThread}
-        onUnsettleThread={handleUnsettleThread}
-        onChangeRequestState={handleChangeRequestState}
-        projectCwd={
-          projectCwdByKey.get(scopedProjectKey(item.thread.environmentId, item.thread.projectId)) ??
-          null
-        }
-        onSwipeableClose={handleSwipeableClose}
-        onSwipeableWillOpen={handleSwipeableWillOpen}
-      />
-    ),
+    ({ item }: { readonly item: ThreadListV2ListItem }) => {
+      if (item.type === "v2-pending") {
+        const pendingScopeKey = scopedProjectKey(
+          item.pendingTask.message.environmentId,
+          item.pendingTask.creation.projectId,
+        );
+        return (
+          <ThreadListV2PendingRow
+            pendingTask={item.pendingTask}
+            project={projectByKey.get(pendingScopeKey) ?? null}
+            projectTitle={v2ProjectTitleByProjectKey.get(pendingScopeKey)}
+            environmentLabel={
+              props.savedConnectionsById[item.pendingTask.message.environmentId]
+                ?.environmentLabel ?? null
+            }
+            showPendingDivider={item.showPendingDivider}
+            onSelectPendingTask={props.onSelectPendingTask}
+            onDeletePendingTask={props.onDeletePendingTask}
+          />
+        );
+      }
+      const thread = item.item.thread;
+      return (
+        <ThreadListV2Row
+          thread={thread}
+          variant={item.item.variant}
+          showSettledDivider={item.item.showSettledDivider}
+          project={
+            projectByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ?? null
+          }
+          projectTitle={v2ProjectTitleByProjectKey.get(
+            scopedProjectKey(thread.environmentId, thread.projectId),
+          )}
+          providerDriver={
+            serverConfigs
+              .get(thread.environmentId)
+              ?.providers.find(
+                (provider) =>
+                  provider.instanceId ===
+                  (thread.session?.providerInstanceId ?? thread.modelSelection.instanceId),
+              )?.driver ?? null
+          }
+          environmentLabel={
+            Object.keys(props.savedConnectionsById).length > 1
+              ? (props.savedConnectionsById[thread.environmentId]?.environmentLabel ?? null)
+              : null
+          }
+          onSelectThread={props.onSelectThread}
+          onDeleteThread={handleDeleteThread}
+          onArchiveThread={props.onArchiveThread}
+          settlementSupported={settlementEnvironmentIds.has(thread.environmentId)}
+          onSettleThread={handleSettleThread}
+          onUnsettleThread={handleUnsettleThread}
+          onChangeRequestState={handleChangeRequestState}
+          projectCwd={
+            projectCwdByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ?? null
+          }
+          onSwipeableClose={handleSwipeableClose}
+          onSwipeableWillOpen={handleSwipeableWillOpen}
+        />
+      );
+    },
     [
       handleChangeRequestState,
       handleDeleteThread,
@@ -603,6 +652,8 @@ export function HomeScreen(props: HomeScreenProps) {
       projectByKey,
       projectCwdByKey,
       props.onArchiveThread,
+      props.onDeletePendingTask,
+      props.onSelectPendingTask,
       props.onSelectThread,
       props.savedConnectionsById,
       serverConfigs,
@@ -610,10 +661,7 @@ export function HomeScreen(props: HomeScreenProps) {
       v2ProjectTitleByProjectKey,
     ],
   );
-  const v2KeyExtractor = useCallback(
-    (item: ThreadListV2Item) => `${item.thread.environmentId}:${item.thread.id}`,
-    [],
-  );
+  const v2KeyExtractor = useCallback((item: ThreadListV2ListItem) => item.key, []);
 
   const extraData = useMemo(
     () => ({ savedConnectionsById: props.savedConnectionsById, projectCwdByKey }),
@@ -788,48 +836,9 @@ export function HomeScreen(props: HomeScreenProps) {
     </>
   );
 
-  // v2 renders queued offline tasks above the thread cards — they are not
-  // thread shells, so the v2 item builder never sees them, but they must
-  // stay visible and deletable while their environment is offline. They
-  // respect the same environment scope and search filter as the list.
-  const v2SearchQuery = props.searchQuery.trim().toLocaleLowerCase();
-  const v2PendingTasks = props.pendingTasks.filter(
-    (pendingTask) =>
-      (props.selectedEnvironmentId === null ||
-        pendingTask.message.environmentId === props.selectedEnvironmentId) &&
-      (v2ScopedProjectKeys === null ||
-        v2ScopedProjectKeys.has(
-          scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
-        )) &&
-      (v2SearchQuery.length === 0 || pendingTask.title.toLocaleLowerCase().includes(v2SearchQuery)),
-  );
   // Project scoping lives in the header filter menu (no inline chip row on
   // mobile — the menu is the one filter surface).
-  const v2ListHeader = (
-    <>
-      {listHeader}
-      {v2PendingTasks.map((pendingTask, index) => (
-        <ThreadListV2PendingRow
-          key={pendingTask.message.messageId}
-          pendingTask={pendingTask}
-          project={
-            projectByKey.get(
-              scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
-            ) ?? null
-          }
-          projectTitle={v2ProjectTitleByProjectKey.get(
-            scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
-          )}
-          environmentLabel={
-            props.savedConnectionsById[pendingTask.message.environmentId]?.environmentLabel ?? null
-          }
-          showPendingDivider={index === 0}
-          onSelectPendingTask={props.onSelectPendingTask}
-          onDeletePendingTask={props.onDeletePendingTask}
-        />
-      ))}
-    </>
-  );
+  const v2ListHeader = listHeader;
 
   const listEmpty = !hasResults ? (
     hasSearchQuery ? (
@@ -853,37 +862,33 @@ export function HomeScreen(props: HomeScreenProps) {
   // is empty. Search outranks the scope — "No results" names the actionable
   // fact when a query is active. Snoozed threads outrank the rest: "No
   // threads yet" over an inbox that is merely all-snoozed reads as data
-  // loss. Pending tasks render in the header, so the list showing them
-  // isn't empty in the user's eyes.
+  // loss.
   const v2SnoozedCount = threadListV2Layout.snoozedCount;
-  const v2ListEmpty =
-    v2PendingTasks.length > 0 ? null : hasSearchQuery ? (
-      v2SnoozedCount > 0 ? (
-        // The snoozed threads already passed this search filter: "No
-        // results" would claim nothing matched when matches are merely
-        // parked.
-        <EmptyState
-          title={
-            v2SnoozedCount === 1 ? "1 matching thread snoozed" : `All matching threads snoozed`
-          }
-          detail={`Threads matching "${props.searchQuery}" are snoozed and return when their wake time passes.`}
-        />
-      ) : (
-        <EmptyState title="No results" detail={`No threads matching "${props.searchQuery}".`} />
-      )
-    ) : v2SnoozedCount > 0 ? (
+  const v2ListEmpty = hasSearchQuery ? (
+    v2SnoozedCount > 0 ? (
+      // The snoozed threads already passed this search filter: "No
+      // results" would claim nothing matched when matches are merely
+      // parked.
       <EmptyState
-        title={v2SnoozedCount === 1 ? "1 thread snoozed" : `${v2SnoozedCount} threads snoozed`}
-        detail="Snoozed threads return when their wake time passes."
-      />
-    ) : v2ScopedProjectGroup !== null ? (
-      <EmptyState
-        title={`No threads in ${v2ScopedProjectGroup.title}`}
-        detail="Choose another project or create a new task."
+        title={v2SnoozedCount === 1 ? "1 matching thread snoozed" : `All matching threads snoozed`}
+        detail={`Threads matching "${props.searchQuery}" are snoozed and return when their wake time passes.`}
       />
     ) : (
-      listEmpty
-    );
+      <EmptyState title="No results" detail={`No threads matching "${props.searchQuery}".`} />
+    )
+  ) : v2SnoozedCount > 0 ? (
+    <EmptyState
+      title={v2SnoozedCount === 1 ? "1 thread snoozed" : `${v2SnoozedCount} threads snoozed`}
+      detail="Snoozed threads return when their wake time passes."
+    />
+  ) : v2ScopedProjectGroup !== null ? (
+    <EmptyState
+      title={`No threads in ${v2ScopedProjectGroup.title}`}
+      detail="Choose another project or create a new task."
+    />
+  ) : (
+    listEmpty
+  );
 
   if (threadListV2Enabled) {
     return (

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -36,7 +36,7 @@ import {
   ThreadListRow,
   ThreadListShowMoreRow,
 } from "../threads/thread-list-items";
-import { ThreadListV2Row } from "../threads/thread-list-v2-items";
+import { ThreadListV2PendingRow, ThreadListV2Row } from "../threads/thread-list-v2-items";
 import {
   buildThreadListV2Items,
   THREAD_LIST_V2_SETTLED_INITIAL_COUNT,
@@ -809,14 +809,21 @@ export function HomeScreen(props: HomeScreenProps) {
     <>
       {listHeader}
       {v2PendingTasks.map((pendingTask, index) => (
-        <PendingTaskListRow
+        <ThreadListV2PendingRow
           key={pendingTask.message.messageId}
-          variant="compact"
           pendingTask={pendingTask}
+          project={
+            projectByKey.get(
+              scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
+            ) ?? null
+          }
+          projectTitle={v2ProjectTitleByProjectKey.get(
+            scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
+          )}
           environmentLabel={
             props.savedConnectionsById[pendingTask.message.environmentId]?.environmentLabel ?? null
           }
-          isLast={index === v2PendingTasks.length - 1}
+          showPendingDivider={index === 0}
           onSelectPendingTask={props.onSelectPendingTask}
           onDeletePendingTask={props.onDeletePendingTask}
         />

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -592,8 +592,10 @@ export function HomeScreen(props: HomeScreenProps) {
             project={projectByKey.get(pendingScopeKey) ?? null}
             projectTitle={v2ProjectTitleByProjectKey.get(pendingScopeKey)}
             environmentLabel={
-              props.savedConnectionsById[item.pendingTask.message.environmentId]
-                ?.environmentLabel ?? null
+              Object.keys(props.savedConnectionsById).length > 1
+                ? (props.savedConnectionsById[item.pendingTask.message.environmentId]
+                    ?.environmentLabel ?? null)
+                : null
             }
             showPendingDivider={item.showPendingDivider}
             onSelectPendingTask={props.onSelectPendingTask}
@@ -900,6 +902,8 @@ export function HomeScreen(props: HomeScreenProps) {
             keyExtractor={v2KeyExtractor}
             extraData={{
               projectByKey,
+              projectCwdByKey,
+              projectTitleByProjectKey: v2ProjectTitleByProjectKey,
               serverConfigs,
               savedConnectionsById: props.savedConnectionsById,
             }}

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -676,13 +676,26 @@ function ThreadNavigationSidebarPane(
     onScroll: handleScroll,
     onScrollBeginDrag: handleScrollBeginDrag,
   });
+  // Project shells load after the first rows draw, so the maps they feed have
+  // to bust the recycler's memoization — otherwise a row keeps the blank
+  // favicon and fallback title it was first rendered with.
   const listExtraData = useMemo(
     () => ({
       selectedThreadKey: props.selectedThreadKey ?? "",
+      projectByKey,
+      projectCwdByKey,
+      projectTitleByProjectKey,
       savedConnectionsById,
       serverConfigs,
     }),
-    [props.selectedThreadKey, savedConnectionsById, serverConfigs],
+    [
+      props.selectedThreadKey,
+      projectByKey,
+      projectCwdByKey,
+      projectTitleByProjectKey,
+      savedConnectionsById,
+      serverConfigs,
+    ],
   );
   const sidebarItemsAreEqual = useCallback(
     (previous: SidebarListItem, item: SidebarListItem): boolean => {
@@ -748,8 +761,10 @@ function ThreadNavigationSidebarPane(
               project={projectByKey.get(pendingScopeKey) ?? null}
               projectTitle={projectTitleByProjectKey.get(pendingScopeKey)}
               environmentLabel={
-                savedConnectionsById[item.pendingTask.message.environmentId]?.environmentLabel ??
-                null
+                Object.keys(savedConnectionsById).length > 1
+                  ? (savedConnectionsById[item.pendingTask.message.environmentId]
+                      ?.environmentLabel ?? null)
+                  : null
               }
               pane="sidebar"
               showPendingDivider={item.showPendingDivider}

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -26,7 +26,7 @@ import { useThemeColor } from "../../lib/useThemeColor";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { useThreadListV2Enabled } from "./use-thread-list-v2-enabled";
 import { environmentServerConfigsAtom } from "../../state/server";
-import { usePendingNewTasks, type PendingNewTask } from "../../state/use-pending-new-tasks";
+import { usePendingNewTasks } from "../../state/use-pending-new-tasks";
 import { useWorkspaceState } from "../../state/workspace";
 import { useSavedRemoteConnections } from "../../state/use-remote-environment-registry";
 import { useHardwareKeyboardCommand } from "../keyboard/hardwareKeyboardCommands";
@@ -65,24 +65,18 @@ import {
 import { ThreadListV2PendingRow, ThreadListV2Row } from "./thread-list-v2-items";
 import {
   buildThreadListV2Items,
+  buildThreadListV2ListItems,
   THREAD_LIST_V2_SETTLED_INITIAL_COUNT,
   THREAD_LIST_V2_SETTLED_PAGE_COUNT,
-  type ThreadListV2Item,
+  type ThreadListV2ListItem,
 } from "./threadListV2";
 
 /** The sidebar list serves both lists: v1 grouped items or, when the Thread
-    List v2 beta is on, queued offline tasks, flat v2 rows, and a settled
+    List v2 beta is on, flat v2 rows with queued tasks spliced in, and a settled
     "Show more" pager. */
 type SidebarListItem =
   | HomeListItem
-  | {
-      readonly type: "v2-pending-task";
-      readonly key: string;
-      readonly pendingTask: PendingNewTask;
-      /** Only the leading queued row draws the "Pending" divider. */
-      readonly isFirst: boolean;
-    }
-  | { readonly type: "v2-thread"; readonly key: string; readonly item: ThreadListV2Item }
+  | ThreadListV2ListItem
   | { readonly type: "v2-show-more"; readonly key: string; readonly hiddenCount: number };
 
 /**
@@ -474,11 +468,11 @@ function ThreadNavigationSidebarPane(
   }, [nextSnoozeWakeAt, snoozeWakeTick]);
   const listItems = useMemo<readonly SidebarListItem[]>(() => {
     if (!threadListV2Enabled) return listLayout.items;
-    // Queued offline tasks render above the thread rows (mirrors the
-    // compact Home v2 list): they are not thread shells, so the v2 item
-    // builder never sees them, but they must stay visible and deletable
-    // while their environment is offline. Same environment scope and
-    // search filter as the list.
+    // Queued offline tasks are not thread shells, so the v2 item builder
+    // never sees them; the shared splice puts them below the active block
+    // (mirrors the compact Home v2 list) where they stay visible and
+    // deletable while their environment is offline. Same environment scope
+    // and search filter as the list.
     const v2SearchQuery = props.searchQuery.trim().toLocaleLowerCase();
     const v2PendingTasks = pendingTasks.filter(
       (pendingTask) =>
@@ -491,19 +485,10 @@ function ThreadNavigationSidebarPane(
         (v2SearchQuery.length === 0 ||
           pendingTask.title.toLocaleLowerCase().includes(v2SearchQuery)),
     );
-    const items: SidebarListItem[] = v2PendingTasks.map((pendingTask, index) => ({
-      type: "v2-pending-task" as const,
-      key: `v2-pending:${pendingTask.message.messageId}`,
-      pendingTask,
-      isFirst: index === 0,
-    }));
-    for (const item of threadListV2Layout.items) {
-      items.push({
-        type: "v2-thread" as const,
-        key: scopedThreadKey(item.thread.environmentId, item.thread.id),
-        item,
-      });
-    }
+    const items: SidebarListItem[] = buildThreadListV2ListItems({
+      items: threadListV2Layout.items,
+      pendingTasks: v2PendingTasks,
+    });
     if (threadListV2Layout.hiddenSettledCount > 0) {
       items.push({
         type: "v2-show-more",
@@ -712,16 +697,19 @@ function ThreadNavigationSidebarPane(
       if (previous.type === "v2-show-more" && item.type === "v2-show-more") {
         return previous.hiddenCount === item.hiddenCount;
       }
-      if (previous.type === "v2-pending-task" && item.type === "v2-pending-task") {
-        return previous.pendingTask === item.pendingTask && previous.isFirst === item.isFirst;
+      if (previous.type === "v2-pending" && item.type === "v2-pending") {
+        return (
+          previous.pendingTask === item.pendingTask &&
+          previous.showPendingDivider === item.showPendingDivider
+        );
       }
       if (
         previous.type === "v2-thread" ||
         previous.type === "v2-show-more" ||
-        previous.type === "v2-pending-task" ||
+        previous.type === "v2-pending" ||
         item.type === "v2-thread" ||
         item.type === "v2-show-more" ||
-        item.type === "v2-pending-task"
+        item.type === "v2-pending"
       ) {
         return false;
       }
@@ -749,7 +737,7 @@ function ThreadNavigationSidebarPane(
   const renderListItem = useCallback(
     ({ item }: { readonly item: SidebarListItem }) => {
       switch (item.type) {
-        case "v2-pending-task": {
+        case "v2-pending": {
           const pendingScopeKey = scopedProjectKey(
             item.pendingTask.message.environmentId,
             item.pendingTask.creation.projectId,
@@ -764,7 +752,7 @@ function ThreadNavigationSidebarPane(
                 null
               }
               pane="sidebar"
-              showPendingDivider={item.isFirst}
+              showPendingDivider={item.showPendingDivider}
               onSelectPendingTask={openPendingTask}
               onDeletePendingTask={confirmDeletePendingTask}
             />

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -62,7 +62,7 @@ import {
   ThreadListRow,
   ThreadListShowMoreRow,
 } from "./thread-list-items";
-import { ThreadListV2Row } from "./thread-list-v2-items";
+import { ThreadListV2PendingRow, ThreadListV2Row } from "./thread-list-v2-items";
 import {
   buildThreadListV2Items,
   THREAD_LIST_V2_SETTLED_INITIAL_COUNT,
@@ -79,7 +79,8 @@ type SidebarListItem =
       readonly type: "v2-pending-task";
       readonly key: string;
       readonly pendingTask: PendingNewTask;
-      readonly isLast: boolean;
+      /** Only the leading queued row draws the "Pending" divider. */
+      readonly isFirst: boolean;
     }
   | { readonly type: "v2-thread"; readonly key: string; readonly item: ThreadListV2Item }
   | { readonly type: "v2-show-more"; readonly key: string; readonly hiddenCount: number };
@@ -494,7 +495,7 @@ function ThreadNavigationSidebarPane(
       type: "v2-pending-task" as const,
       key: `v2-pending:${pendingTask.message.messageId}`,
       pendingTask,
-      isLast: index === v2PendingTasks.length - 1,
+      isFirst: index === 0,
     }));
     for (const item of threadListV2Layout.items) {
       items.push({
@@ -712,7 +713,7 @@ function ThreadNavigationSidebarPane(
         return previous.hiddenCount === item.hiddenCount;
       }
       if (previous.type === "v2-pending-task" && item.type === "v2-pending-task") {
-        return previous.pendingTask === item.pendingTask && previous.isLast === item.isLast;
+        return previous.pendingTask === item.pendingTask && previous.isFirst === item.isFirst;
       }
       if (
         previous.type === "v2-thread" ||
@@ -748,20 +749,27 @@ function ThreadNavigationSidebarPane(
   const renderListItem = useCallback(
     ({ item }: { readonly item: SidebarListItem }) => {
       switch (item.type) {
-        case "v2-pending-task":
+        case "v2-pending-task": {
+          const pendingScopeKey = scopedProjectKey(
+            item.pendingTask.message.environmentId,
+            item.pendingTask.creation.projectId,
+          );
           return (
-            <PendingTaskListRow
-              variant="sidebar"
+            <ThreadListV2PendingRow
               pendingTask={item.pendingTask}
+              project={projectByKey.get(pendingScopeKey) ?? null}
+              projectTitle={projectTitleByProjectKey.get(pendingScopeKey)}
               environmentLabel={
                 savedConnectionsById[item.pendingTask.message.environmentId]?.environmentLabel ??
                 null
               }
-              isLast={item.isLast}
+              pane="sidebar"
+              showPendingDivider={item.isFirst}
               onSelectPendingTask={openPendingTask}
               onDeletePendingTask={confirmDeletePendingTask}
             />
           );
+        }
         case "v2-thread": {
           const thread = item.item.thread;
           const scopeKey = scopedProjectKey(thread.environmentId, thread.projectId);

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -141,7 +141,10 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
         </Text>
         <Text className="text-xs text-foreground-tertiary">Queued</Text>
       </View>
-      <Text className="mt-1 text-base font-t3-medium text-foreground" numberOfLines={2}>
+      {/* One line, unlike the two an active row allows: a queued title is
+          derived from the whole prompt rather than written as a title, so the
+          second line is usually a stray word or emoji rather than meaning. */}
+      <Text className="mt-1 text-base font-t3-medium text-foreground" numberOfLines={1}>
         {pendingTask.title}
       </Text>
       {branch || props.environmentLabel ? (

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -14,6 +14,7 @@ import { ProviderIcon } from "../../components/ProviderIcon";
 import { cn } from "../../lib/cn";
 import { relativeTime } from "../../lib/time";
 import { useThemeColor } from "../../lib/useThemeColor";
+import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 import { useThreadPr } from "../../state/use-thread-pr";
 import { ThreadSwipeable } from "../home/thread-swipe-actions";
 import { resolveThreadListV2Status, type ThreadListV2Status } from "./threadListV2";
@@ -68,20 +69,137 @@ const LEGACY_MENU_ACTIONS: MenuAction[] = [
 /** Rounded-row radius shared with the v1 sidebar rows. */
 const SIDEBAR_V2_ROW_RADIUS = 12;
 
-export const ThreadListV2SettledDivider = memo(function ThreadListV2SettledDivider(props: {
+/** Section label + rule: the only structure in an otherwise flat list. */
+export const ThreadListV2SectionDivider = memo(function ThreadListV2SectionDivider(props: {
+  readonly label: string;
   readonly pane?: "screen" | "sidebar";
+  /** Leading sections sit right under the list header and need no top gap. */
+  readonly first?: boolean;
 }) {
   const borderColor = useThemeColor("--color-border");
   return (
     <View
       className={cn(
-        "mb-1.5 mt-4 flex-row items-center gap-2.5",
+        "mb-1.5 flex-row items-center gap-2.5",
+        props.first ? "mt-1" : "mt-4",
         props.pane === "sidebar" ? "px-3" : "px-5",
       )}
     >
-      <Text className="text-xs font-t3-medium text-foreground-tertiary">Settled</Text>
+      <Text className="text-xs font-t3-medium text-foreground-tertiary">{props.label}</Text>
       <View className="h-px flex-1" style={{ backgroundColor: borderColor }} />
     </View>
+  );
+});
+
+const PENDING_TASK_MENU_ACTIONS: MenuAction[] = [
+  { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
+];
+
+/**
+ * A queued new task, in the same idiom as an active v2 row: it is work the
+ * user wrote, so it reads like the threads it will become. "Queued" takes
+ * the status slot — the state is the one thing that differs — and stays
+ * uncolored because nothing is asked of the user; the environment is simply
+ * not reachable yet.
+ */
+export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props: {
+  readonly pendingTask: PendingNewTask;
+  readonly project: EnvironmentProject | null;
+  readonly projectTitle?: string;
+  readonly environmentLabel: string | null;
+  readonly pane?: "screen" | "sidebar";
+  /** Draws the "Pending" divider above the first queued row. */
+  readonly showPendingDivider: boolean;
+  readonly onSelectPendingTask: (pendingTask: PendingNewTask) => void;
+  readonly onDeletePendingTask: (pendingTask: PendingNewTask) => void;
+}) {
+  const { pendingTask, onSelectPendingTask, onDeletePendingTask } = props;
+  const drawerColor = useThemeColor("--color-drawer");
+  const pressedBackgroundColor = useThemeColor("--color-subtle");
+  const sidebarPane = props.pane === "sidebar";
+  const projectTitle =
+    props.projectTitle ?? props.project?.title ?? pendingTask.creation.projectTitle ?? "";
+  const branch = pendingTask.creation.branch;
+
+  const handleMenuAction = useCallback(
+    ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
+      if (nativeEvent.event === "delete") onDeletePendingTask(pendingTask);
+    },
+    [onDeletePendingTask, pendingTask],
+  );
+
+  const rowContent = (
+    <>
+      <View className="flex-row items-center gap-1.5">
+        {props.project ? (
+          <ProjectFavicon
+            environmentId={pendingTask.message.environmentId}
+            size={15}
+            projectTitle={projectTitle}
+            workspaceRoot={props.project.workspaceRoot}
+          />
+        ) : null}
+        <Text className="flex-1 text-sm font-t3-medium text-foreground-muted" numberOfLines={1}>
+          {projectTitle}
+        </Text>
+        <Text className="text-xs text-foreground-tertiary">Queued</Text>
+      </View>
+      <Text className="mt-1 text-base font-t3-medium text-foreground" numberOfLines={2}>
+        {pendingTask.title}
+      </Text>
+      {branch || props.environmentLabel ? (
+        <Text className="mt-1 text-xs text-foreground-muted" numberOfLines={1}>
+          {branch ? (
+            <Text className="text-xs text-foreground-muted" style={{ fontFamily: MONO_FONT }}>
+              {branch}
+            </Text>
+          ) : null}
+          {branch && props.environmentLabel ? "  ·  " : null}
+          {props.environmentLabel ? (
+            <Text className="text-xs text-foreground-tertiary">{props.environmentLabel}</Text>
+          ) : null}
+        </Text>
+      ) : null}
+    </>
+  );
+
+  return (
+    <>
+      {props.showPendingDivider ? (
+        <ThreadListV2SectionDivider first label="Pending" pane={props.pane} />
+      ) : null}
+      <ControlPillMenu
+        actions={PENDING_TASK_MENU_ACTIONS}
+        onPressAction={handleMenuAction}
+        shouldOpenOnLongPress
+      >
+        <Pressable
+          accessibilityHint="Opens the queued task for editing"
+          accessibilityLabel={pendingTask.title}
+          accessibilityRole="button"
+          onPress={() => onSelectPendingTask(pendingTask)}
+          style={
+            sidebarPane
+              ? ({ pressed }) => ({
+                  backgroundColor: pressed ? pressedBackgroundColor : drawerColor,
+                  borderRadius: SIDEBAR_V2_ROW_RADIUS,
+                  paddingHorizontal: 12,
+                  paddingVertical: 10,
+                })
+              : ({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })
+          }
+        >
+          {sidebarPane ? (
+            rowContent
+          ) : (
+            <View className="bg-screen">
+              <View className="px-5 py-2.5">{rowContent}</View>
+              <View className="ml-5 h-px bg-border-subtle" />
+            </View>
+          )}
+        </Pressable>
+      </ControlPillMenu>
+    </>
   );
 });
 
@@ -423,7 +541,9 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
 
   return (
     <>
-      {props.showSettledDivider ? <ThreadListV2SettledDivider pane={props.pane} /> : null}
+      {props.showSettledDivider ? (
+        <ThreadListV2SectionDivider label="Settled" pane={props.pane} />
+      ) : null}
       <ThreadSwipeable
         backgroundColor={sidebarPane ? drawerColor : screenColor}
         compactActions={variant === "slim"}

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -73,15 +73,12 @@ const SIDEBAR_V2_ROW_RADIUS = 12;
 export const ThreadListV2SectionDivider = memo(function ThreadListV2SectionDivider(props: {
   readonly label: string;
   readonly pane?: "screen" | "sidebar";
-  /** Leading sections sit right under the list header and need no top gap. */
-  readonly first?: boolean;
 }) {
   const borderColor = useThemeColor("--color-border");
   return (
     <View
       className={cn(
-        "mb-1.5 flex-row items-center gap-2.5",
-        props.first ? "mt-1" : "mt-4",
+        "mb-1.5 mt-4 flex-row items-center gap-2.5",
         props.pane === "sidebar" ? "px-3" : "px-5",
       )}
     >
@@ -166,7 +163,7 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
   return (
     <>
       {props.showPendingDivider ? (
-        <ThreadListV2SectionDivider first label="Pending" pane={props.pane} />
+        <ThreadListV2SectionDivider label="Pending" pane={props.pane} />
       ) : null}
       <ControlPillMenu
         actions={PENDING_TASK_MENU_ACTIONS}

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -1,9 +1,19 @@
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
-import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId, TurnId } from "@t3tools/contracts";
+import {
+  CommandId,
+  EnvironmentId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
+import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 import {
   buildThreadListV2Items,
+  buildThreadListV2ListItems,
   resolveThreadListV2Enabled,
   resolveThreadListV2Status,
   sortThreadsForListV2,
@@ -337,6 +347,91 @@ describe("buildThreadListV2Items settled paging", () => {
       "active",
       "settled-3",
       "settled-2",
+    ]);
+  });
+});
+
+function makePendingTask(id: string): PendingNewTask {
+  return {
+    message: {
+      environmentId,
+      threadId: ThreadId.make(`thread-${id}`),
+      messageId: MessageId.make(id),
+      commandId: CommandId.make(`command-${id}`),
+      text: id,
+      attachments: [],
+      createdAt: NOW,
+      creation: {
+        projectId: ProjectId.make("project-1"),
+        workspaceMode: "worktree",
+        branch: null,
+        worktreePath: null,
+      },
+    },
+    creation: {
+      projectId: ProjectId.make("project-1"),
+      workspaceMode: "worktree",
+      branch: null,
+      worktreePath: null,
+    },
+    title: id,
+  };
+}
+
+describe("buildThreadListV2ListItems", () => {
+  const layout = buildThreadListV2Items({
+    threads: [
+      makeThread({ id: ThreadId.make("active"), title: "active" }),
+      makeThread({
+        id: ThreadId.make("settled"),
+        title: "settled",
+        settledOverride: "settled",
+        settledAt: NOW,
+      }),
+    ],
+    environmentId: null,
+    searchQuery: "",
+    now: NOW,
+  });
+
+  it("splices queued tasks between the active block and the settled tail", () => {
+    const items = buildThreadListV2ListItems({
+      items: layout.items,
+      pendingTasks: [makePendingTask("queued-1"), makePendingTask("queued-2")],
+    });
+
+    expect(
+      items.map((item) =>
+        item.type === "v2-pending" ? item.pendingTask.title : item.item.thread.id,
+      ),
+    ).toEqual(["active", "queued-1", "queued-2", "settled"]);
+    // Only the leading queued row labels the section, exactly like Settled.
+    expect(
+      items.filter((item) => item.type === "v2-pending" && item.showPendingDivider),
+    ).toHaveLength(1);
+  });
+
+  it("ends the list with queued tasks when nothing has settled yet", () => {
+    const activeOnly = buildThreadListV2Items({
+      threads: [makeThread({ id: ThreadId.make("active"), title: "active" })],
+      environmentId: null,
+      searchQuery: "",
+      now: NOW,
+    });
+    const items = buildThreadListV2ListItems({
+      items: activeOnly.items,
+      pendingTasks: [makePendingTask("queued-1")],
+    });
+
+    expect(items.map((item) => item.type)).toEqual(["v2-thread", "v2-pending"]);
+  });
+
+  it("leaves the thread order untouched when nothing is queued", () => {
+    const items = buildThreadListV2ListItems({ items: layout.items, pendingTasks: [] });
+
+    expect(items.map((item) => item.key)).toEqual([
+      `v2-thread:${environmentId}:active`,
+      `v2-thread:${environmentId}:settled`,
     ]);
   });
 });

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -2,6 +2,8 @@ import { effectiveSettled, effectiveSnoozed } from "@t3tools/client-runtime/stat
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
 
+import type { PendingNewTask } from "../../state/use-pending-new-tasks";
+
 /**
  * Thread List v2 model, ported from the web sidebar v2
  * (apps/web/src/components/Sidebar.logic.ts + SidebarV2.tsx).
@@ -111,6 +113,60 @@ export interface ThreadListV2Layout {
       a timeout at this boundary so the list re-partitions the moment a
       snooze expires instead of on the next minute tick. */
   readonly nextSnoozeWakeAt: string | null;
+}
+
+export interface ThreadListV2ThreadListItem {
+  readonly type: "v2-thread";
+  readonly key: string;
+  readonly item: ThreadListV2Item;
+}
+
+export interface ThreadListV2PendingListItem {
+  readonly type: "v2-pending";
+  readonly key: string;
+  readonly pendingTask: PendingNewTask;
+  /** First queued row after the active block draws the PENDING divider. */
+  readonly showPendingDivider: boolean;
+}
+
+export type ThreadListV2ListItem = ThreadListV2ThreadListItem | ThreadListV2PendingListItem;
+
+/**
+ * Splices queued tasks between the active block and the settled tail, so the
+ * list reads active → pending → settled. Queued work sits below the live
+ * threads because nothing can happen to it until its environment returns:
+ * it is waiting, not asking. Shared by the compact Home list and the iPad
+ * sidebar so both order and label the sections identically.
+ */
+export function buildThreadListV2ListItems(input: {
+  readonly items: ReadonlyArray<ThreadListV2Item>;
+  readonly pendingTasks: ReadonlyArray<PendingNewTask>;
+}): ThreadListV2ListItem[] {
+  const threadItems = input.items.map(
+    (item): ThreadListV2ListItem => ({
+      type: "v2-thread",
+      key: `v2-thread:${item.thread.environmentId}:${item.thread.id}`,
+      item,
+    }),
+  );
+  if (input.pendingTasks.length === 0) return threadItems;
+
+  const pendingItems = input.pendingTasks.map(
+    (pendingTask, index): ThreadListV2ListItem => ({
+      type: "v2-pending",
+      key: `v2-pending:${pendingTask.message.messageId}`,
+      pendingTask,
+      showPendingDivider: index === 0,
+    }),
+  );
+  // The settled tail begins at the row that draws the SETTLED divider; with
+  // no settled rows the queued block simply ends the list.
+  const settledStart = threadItems.findIndex(
+    (entry) => entry.type === "v2-thread" && entry.item.showSettledDivider,
+  );
+  return settledStart === -1
+    ? [...threadItems, ...pendingItems]
+    : [...threadItems.slice(0, settledStart), ...pendingItems, ...threadItems.slice(settledStart)];
 }
 
 /**

--- a/scripts/mobile-showcase-environment.ts
+++ b/scripts/mobile-showcase-environment.ts
@@ -201,16 +201,42 @@ export const SHOWCASE_THREADS = [
     response:
       "The plan groups milestones without changing the underlying log stream, preserves plain-text output, and adds zero work to the hot path.",
   },
+  // Finished work, settled by hand: the list keeps it as a receded tail so
+  // the active block above reads as everything still in flight. The active
+  // block stays small enough that the settled tail begins above the fold —
+  // a store screenshot has to show that history exists, not just imply it.
   {
-    id: "scheduler-breathe",
-    projectId: "linux",
-    title: "Let the scheduler breathe",
-    branch: "perf/scheduler-breathe",
-    minutesAgo: 76,
-    request:
-      "Find a calmer balancing strategy for bursty mixed workloads without hurting tail latency.",
+    id: "handoff-haptics",
+    projectId: "t3code",
+    title: "Tune the handoff haptics",
+    branch: "feat/handoff-haptics",
+    minutesAgo: 5 * 60,
+    settled: true,
+    request: "Give the desktop-to-phone handoff a haptic that lands with the animation.",
     response:
-      "The new heuristic reduces needless migrations during short bursts while preserving the existing latency guardrails.",
+      "The handoff now taps once as the thread lands and stays silent on failure, so the phone never celebrates a handoff that did not happen.",
+  },
+  {
+    id: "streaming-shell",
+    projectId: "react",
+    title: "Stream the shell before the data",
+    branch: "feat/streaming-shell",
+    minutesAgo: 28 * 60,
+    settled: true,
+    request: "Get the app shell painted before any data request resolves.",
+    response:
+      "The shell now flushes on first byte and the data boundaries hydrate underneath it, so the first paint no longer waits on the slowest query.",
+  },
+  {
+    id: "quieter-oom",
+    projectId: "linux",
+    title: "Make the OOM killer explain itself",
+    branch: "feat/quieter-oom",
+    minutesAgo: 2 * 24 * 60,
+    settled: true,
+    request: "Make out-of-memory kills legible without adding a single allocation to the hot path.",
+    response:
+      "Kills now report the winning heuristic and the runner-up alongside the usual dump, assembled entirely from data the path already had.",
   },
 ] as const;
 
@@ -300,6 +326,7 @@ function insertThread(
     readonly branch: string;
     readonly minutesAgo: number;
     readonly state?: "working" | "approval" | "plan";
+    readonly settled?: boolean;
     readonly workspaceRoot: string;
   },
 ): void {
@@ -312,8 +339,8 @@ function insertThread(
         thread_id, project_id, title, model_selection_json, runtime_mode, interaction_mode,
         branch, worktree_path, latest_turn_id, latest_user_message_at, pending_approval_count,
         pending_user_input_count, has_actionable_proposed_plan, created_at, updated_at,
-        archived_at, deleted_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, NULL)`,
+        archived_at, deleted_at, settled_override, settled_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, NULL, ?, ?)`,
     )
     .run(
       input.id,
@@ -330,6 +357,8 @@ function insertThread(
       input.state === "plan" ? 1 : 0,
       minutesBefore(now, input.minutesAgo + 120),
       updatedAt,
+      input.settled ? "settled" : null,
+      input.settled ? updatedAt : null,
     );
   database
     .prepare(
@@ -365,7 +394,11 @@ function seedDatabase(
   threads: ReadonlyArray<(typeof SHOWCASE_THREADS)[number]>,
   now: number,
 ): void {
-  const database = new NodeSqlite.DatabaseSync(dbPath);
+  // The environment server is already running against this file and keeps
+  // writing (migrations, projections) while we seed, so the write lock is
+  // genuinely contended — without a busy timeout `BEGIN IMMEDIATE` fails
+  // instantly with SQLITE_BUSY on a loaded machine.
+  const database = new NodeSqlite.DatabaseSync(dbPath, { timeout: 30_000 });
   try {
     database.exec("BEGIN IMMEDIATE");
     for (const table of [
@@ -506,7 +539,14 @@ function seedDatabase(
     }
     database.exec("COMMIT");
   } catch (error) {
-    database.exec("ROLLBACK");
+    // A failed BEGIN (or an error SQLite already auto-rolled back) leaves no
+    // transaction, and the rollback's own "cannot rollback" error would then
+    // replace the one that actually explains the failure.
+    try {
+      database.exec("ROLLBACK");
+    } catch {
+      // Nothing to roll back.
+    }
     throw error;
   } finally {
     database.close();

--- a/scripts/mobile-showcase.test.ts
+++ b/scripts/mobile-showcase.test.ts
@@ -272,8 +272,23 @@ it("seeds a playful multi-environment project spectrum", () => {
     SHOWCASE_ENVIRONMENTS.map((environment) => environment.label),
     ["Moonbase Terminal", "Suspense Station", "Kernel Cabin"],
   );
-  assert.equal(SHOWCASE_THREADS.length, 6);
+  assert.equal(SHOWCASE_THREADS.length, 8);
   assert.equal(new Set(SHOWCASE_THREADS.map((thread) => thread.projectId)).size, 3);
+  // Every project contributes to both the active block and the settled tail,
+  // so each list scope screenshots with the same two-part structure.
+  for (const project of SHOWCASE_PROJECTS) {
+    const projectThreads = SHOWCASE_THREADS.filter((thread) => thread.projectId === project.id);
+    assert.equal(
+      projectThreads.some((thread) => "settled" in thread && thread.settled),
+      true,
+      `${project.title} has no settled thread`,
+    );
+    assert.equal(
+      projectThreads.some((thread) => !("settled" in thread && thread.settled)),
+      true,
+      `${project.title} has no active thread`,
+    );
+  }
   assert.equal(
     SHOWCASE_PROJECTS.every((project) => project.favicon.includes("<svg")),
     true,

--- a/scripts/mobile-showcase.ts
+++ b/scripts/mobile-showcase.ts
@@ -1338,7 +1338,12 @@ async function main(): Promise<void> {
 
 if (import.meta.main) {
   void main().catch((error: unknown) => {
-    NodeProcess.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    // Stack over message: the harness only fails in CI, where the line that
+    // threw is the whole diagnosis and there is nobody at a terminal to
+    // re-run it with more output.
+    NodeProcess.stderr.write(
+      `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+    );
     NodeProcess.exit(1);
   });
 }


### PR DESCRIPTION
## Android showcase capture

The Android job failed two seconds after the environment server started, printing a single line with no stack:

```
cannot rollback - no transaction is active
```

That is the masking error, not the failure. The seed opens `state.sqlite` while the server it just started is still writing, so `BEGIN IMMEDIATE` loses the write-lock race and returns `database is locked` — and the `catch` block's unguarded `ROLLBACK` then threw over it. A local probe against a freshly-started server reproduces both strings verbatim:

```json
{ "ok": 39, "busy": 1,
  "firstError": { "original": "Error: database is locked",
                  "masked":   "Error: cannot rollback - no transaction is active" } }
```

1 failure in 40 attempts on an idle Mac; 0 in 120 once the connection carries a busy timeout. On a Linux runner with an emulator saturating the CPU it hit on the first try. So: a 30s busy timeout on the seed connection, a guarded rollback so the real error survives, and stack output from the harness — it only fails in CI, where the line that threw is the whole diagnosis.

## Queued rows in Thread List v2

Queued tasks rendered in v2 with the v1 row design — bold `text-lg` title, zinc "Pending" pill, chevron — so the one row you *cannot* act on shouted louder than the live work above it. They now use the v2 card idiom (project line, title, `branch · machine`) under a "Pending" divider mirroring "Settled", with `Queued` in the status slot. The label stays uncolored: v2 reserves hue for act-now, in-motion, and broken, and a queued task asks nothing of the user. v1 keeps its own row unchanged.

## Showcase fixture

The fixture had no settled threads, so the list screenshotted as one undifferentiated block. Three are seeded now (one per project, 5h / 28h / 2d) with an explicit `settled_override`, and the oldest unlabeled active thread was dropped so the settled tail starts above the fold on a phone. The fixture test asserts every project contributes to both the active block and the settled tail.

## Verification

`environments` and `threads` scenes captured locally on iPhone 6.9 and iPad 13 — pending, active, and settled all render, on both the compact list and the split-view sidebar. Android was not captured locally (build cancelled); this branch needs a workflow run to confirm that leg.

Typecheck, lint, format, and 760 tests (scripts + mobile) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to mobile thread-list UI (v1 unchanged) and dev/CI showcase seeding; no auth, payments, or server API behavior.
> 
> **Overview**
> **Thread List v2** moves offline queued tasks out of the list header and into the flat list via shared `buildThreadListV2ListItems`, ordered **active → pending → settled** with a **Pending** section divider (same pattern as **Settled**). Home and the iPad sidebar both render them with new **`ThreadListV2PendingRow`** instead of v1 `PendingTaskListRow`. **`ThreadListV2SettledDivider`** becomes **`ThreadListV2SectionDivider`** with a `label` prop.
> 
> The v2 empty state no longer treats pending-only queues as “non-empty” (those rows live in the list body now). FlatList/LegendList **`extraData`** also includes project maps so rows refresh when project shells load after first paint.
> 
> **Showcase / CI:** seeding opens SQLite with a **30s busy timeout**, uses a **guarded `ROLLBACK`** so lock errors aren’t masked, seeds **settled** threads for screenshots, and the showcase harness prints **stacks** on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4962aafd19a8df1ea2b3d388b8d51d703c4af3f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android showcase capture and render queued pending tasks inline in thread list v2
> - Introduces `ThreadListV2PendingRow` in [thread-list-v2-items.tsx](https://github.com/pingdotgg/t3code/pull/4730/files#diff-2cea439fc4533a1bdf479cb7688682b3833ed6dbb1ce83c425862cd1af610fb2) to display queued pending tasks with project info, status label, branch, and a delete action via context menu.
> - Adds `buildThreadListV2ListItems` in [threadListV2.ts](https://github.com/pingdotgg/t3code/pull/4730/files#diff-d629687d2b79a927cf01be39191d0e3fc66435674cd6f8a588469b55c70210ed) to splice pending tasks between active and settled thread items, marking the first pending item to draw a 'Pending' section divider.
> - Updates both [HomeScreen](https://github.com/pingdotgg/t3code/pull/4730/files#diff-b6e075b3065ae370669290cbaa8476a852399968002468571cd914d06a32fd40) and [ThreadNavigationSidebar](https://github.com/pingdotgg/t3code/pull/4730/files#diff-4431208d7dda139d19919302f332d6a63788b9d114b4b7a410d89a727b9ed455) to use the new builder, replacing manual list construction and adding project metadata to `extraData` for correct row invalidation.
> - Extends the showcase seed script to support settled threads and fixes `SQLITE_BUSY` resilience and ROLLBACK error masking in [mobile-showcase-environment.ts](https://github.com/pingdotgg/t3code/pull/4730/files#diff-95c0bb2e3bb85661aaa22b8a7ac77c72bf3d7f5d49b3e0594a3c67522bedb111).
> - Behavioral Change: FlatList item shapes in v2 lists change to a discriminated union (`v2-thread` | `v2-pending`) with a new `item.key` extractor; pending task rows move from the header into the list body.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4962aaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->