### PR TITLE
fix(web): align remote server update action

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1426,19 +1426,11 @@ function SavedBackendListRow({
             <p className="text-xs text-muted-foreground">{metadataBits.join(" · ")}</p>
           ) : null}
           {versionMismatch ? (
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="flex items-center gap-1 text-warning text-xs">
-                <TriangleAlertIcon className="size-3.5 shrink-0" />
-                Version drift: client {versionMismatch.clientVersion}, server{" "}
-                {versionMismatch.serverVersion}.
-              </p>
-              <ServerUpdateAction
-                environmentId={environmentId}
-                serverLabel={`${environment.label} server`}
-                selfUpdate={resolveServerSelfUpdateCapability(environment.serverConfig)}
-                targetVersion={versionMismatch.clientVersion}
-              />
-            </div>
+            <p className="flex items-center gap-1 text-warning text-xs">
+              <TriangleAlertIcon className="size-3.5 shrink-0" />
+              Version drift: client {versionMismatch.clientVersion}, server{" "}
+              {versionMismatch.serverVersion}.
+            </p>
           ) : null}
           {environment.connection.error ? (
             <p className="flex min-w-0 items-center gap-2 text-destructive text-xs">
@@ -1456,6 +1448,14 @@ function SavedBackendListRow({
           ) : null}
         </div>
         <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
+          {versionMismatch ? (
+            <ServerUpdateAction
+              environmentId={environmentId}
+              serverLabel={`${environment.label} server`}
+              selfUpdate={resolveServerSelfUpdateCapability(environment.serverConfig)}
+              targetVersion={versionMismatch.clientVersion}
+            />
+          ) : null}
           {isWslEnvironment ? (
             <Tooltip>
               <TooltipTrigger


### PR DESCRIPTION
## Summary

- move the remote server update control into the row's right-aligned action rail
- keep the version-drift warning in the content column
- render the update action only while a version mismatch exists
- preserve the existing semantic warning and button tokens in light and dark themes

## Root cause

`ServerUpdateAction` was rendered inline beside the version-drift message, while `Disconnect` lived in the row's dedicated action column. The two controls therefore used unrelated alignment contexts.

## Validation

- `corepack pnpm exec vp fmt --check apps/web/src/components/settings/ConnectionsSettings.tsx`
- `corepack pnpm exec vp lint apps/web/src/components/settings/ConnectionsSettings.tsx --report-unused-disable-directives`
- `corepack pnpm exec vp run --filter @t3tools/web typecheck`
- `corepack pnpm exec vp test run src/components/ServerUpdateAction.test.tsx --project unit` from `apps/web` (3 tests passed)
- isolated web verification against a live mismatched remote backend in light and dark themes
- verified the real `Updating...` state keeps the update and disconnect controls aligned
- verified a matching-version remote renders neither the drift warning nor an update action

## Screenshots

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Before in light mode](https://github.com/user-attachments/assets/1f56fe80-53c7-4fe9-9de4-1a20757f3f7f) | ![After in light mode](https://github.com/user-attachments/assets/8902d513-3e91-428f-9897-f6b1299c613b) |
| Dark | ![Before in dark mode](https://github.com/user-attachments/assets/925701de-e25b-4779-bd8a-21dcc33b1206) | ![After in dark mode](https://github.com/user-attachments/assets/f00fcb54-c151-4f29-8ffb-01d67434df49) |

## Current main compatibility

- based on `3c50a648`
- focused regression tests and targeted package type checks passed
- targeted formatting and lint passed
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only JSX move in Connections settings; no change to update logic or server interaction.
> 
> **Overview**
> **Saved remote environment rows** in Connections settings now keep the version-drift warning in the left content column and place **`ServerUpdateAction`** in the same right-aligned action rail as Connect/Disconnect/Remove.
> 
> Previously the update control sat inline next to the warning while disconnect lived in the action column, so the two controls could misalign (including during **Updating…**). Behavior is unchanged: the warning and update UI still appear only when `resolveServerConfigVersionMismatch` reports a mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c74038b93d132f93e1fac9b47182157047c286e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move server update action button to the actions area in remote server list rows
> In `SavedBackendListRow`, the `ServerUpdateAction` button was previously rendered inline with the version drift warning text. It is now rendered in the right-side actions section alongside other row action buttons, matching the layout of the rest of the row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c74038.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->