### PR TITLE
feat(source-control): show Git clone progress in web and mobile

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -21,6 +21,10 @@ import {
   inferProjectTitleFromPath,
   isFilesystemBrowseQuery,
 } from "@t3tools/client-runtime/state/projects";
+import {
+  completeSourceControlCloneProgress,
+  type SourceControlCloneProgressPresentation,
+} from "@t3tools/client-runtime/state/source-control";
 import { CommandId, type EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { StackActions, useNavigation } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
@@ -190,18 +194,79 @@ function PrimaryActionButton(props: {
   readonly label: string;
   readonly disabled?: boolean;
   readonly loading?: boolean;
+  readonly progress?: SourceControlCloneProgressPresentation | null;
   readonly onPress: () => void;
 }) {
   const primaryForeground = useThemeColor("--color-primary-foreground");
+  const isComplete = props.progress?.isComplete === true;
+  const progressLabel = isComplete
+    ? "Pull complete"
+    : props.progress?.stage === "connecting"
+      ? "Connecting to remote"
+      : props.progress?.stage === "receiving"
+        ? "Receiving objects"
+        : props.progress?.stage === "resolving"
+          ? "Resolving deltas"
+          : props.progress?.stage === "checkout"
+            ? "Checking out files"
+            : props.label;
 
   return (
     <Pressable
       disabled={props.disabled}
       onPress={props.onPress}
-      className="h-12 items-center justify-center rounded-full bg-primary active:opacity-70 disabled:opacity-45"
+      accessibilityRole={props.progress ? "progressbar" : "button"}
+      accessibilityLabel={props.progress ? progressLabel : props.label}
+      accessibilityValue={
+        props.progress
+          ? {
+              min: 0,
+              max: 100,
+              now: props.progress.overallPercent,
+            }
+          : undefined
+      }
+      className={cn(
+        "relative h-12 flex-row items-center justify-center gap-2 overflow-hidden rounded-full bg-primary active:opacity-70",
+        props.loading ? "disabled:opacity-100" : "disabled:opacity-45",
+      )}
     >
       {props.loading ? (
-        <ActivityIndicator color={String(primaryForeground)} />
+        <>
+          {isComplete ? (
+            <SymbolView
+              name="checkmark"
+              size={15}
+              tintColor={String(primaryForeground)}
+              type="monochrome"
+            />
+          ) : (
+            <ActivityIndicator size="small" color={String(primaryForeground)} />
+          )}
+          {props.progress ? (
+            <>
+              <Text
+                className="text-base font-t3-bold text-primary-foreground"
+                accessibilityLiveRegion="polite"
+              >
+                {progressLabel}
+              </Text>
+              {isComplete ? null : (
+                <Text className="text-sm font-t3-medium text-primary-foreground/65">
+                  {Math.round(props.progress.overallPercent)}%
+                </Text>
+              )}
+              <View className="absolute inset-x-0 bottom-0 h-0.5 overflow-hidden bg-primary-foreground/20">
+                <View
+                  className="h-full bg-primary-foreground"
+                  style={{
+                    width: `${Math.max(0, Math.min(100, props.progress.overallPercent))}%`,
+                  }}
+                />
+              </View>
+            </>
+          ) : null}
+        </>
       ) : (
         <Text className="text-base font-t3-bold text-primary-foreground">{props.label}</Text>
       )}
@@ -750,9 +815,12 @@ export function AddProjectDestinationScreen(props: {
   readonly remoteUrl?: string | string[];
   readonly repositoryTitle?: string | string[];
 }) {
-  const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
-    reportFailure: false,
-  });
+  const cloneRepositoryWithProgress = useAtomCommand(
+    sourceControlEnvironment.cloneRepositoryWithProgress,
+    {
+      reportFailure: false,
+    },
+  );
   const environment = useEnvironmentFromParam(props.environmentId);
   const createProject = useCreateProject(environment);
   const remoteUrl = stringParam(props.remoteUrl);
@@ -761,6 +829,9 @@ export function AddProjectDestinationScreen(props: {
     getAddProjectInitialQuery(environment?.baseDirectory),
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [cloneProgress, setCloneProgress] = useState<SourceControlCloneProgressPresentation | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -782,23 +853,34 @@ export function AddProjectDestinationScreen(props: {
     }
 
     setIsSubmitting(true);
-    const cloneResult = await cloneRepository({
-      environmentId: environment.environmentId,
-      input: {
-        remoteUrl,
-        destinationPath: resolved.path,
-      },
+    setCloneProgress({
+      stage: "connecting",
+      overallPercent: 0,
+      isComplete: false,
     });
-    if (AsyncResult.isFailure(cloneResult)) {
-      setError(errorMessage(Cause.squash(cloneResult.cause)));
-    } else {
-      const createResult = await createProject(cloneResult.value.cwd);
-      if (createResult && AsyncResult.isFailure(createResult)) {
-        setError(errorMessage(Cause.squash(createResult.cause)));
+    try {
+      const cloneResult = await cloneRepositoryWithProgress({
+        environmentId: environment.environmentId,
+        input: {
+          remoteUrl,
+          destinationPath: resolved.path,
+        },
+        onProgress: setCloneProgress,
+      });
+      if (AsyncResult.isFailure(cloneResult)) {
+        setError(errorMessage(Cause.squash(cloneResult.cause)));
+      } else {
+        setCloneProgress((progress) => completeSourceControlCloneProgress(progress));
+        const createResult = await createProject(cloneResult.value.cwd);
+        if (createResult && AsyncResult.isFailure(createResult)) {
+          setError(errorMessage(Cause.squash(createResult.cause)));
+        }
       }
+    } finally {
+      setCloneProgress(null);
+      setIsSubmitting(false);
     }
-    setIsSubmitting(false);
-  }, [cloneRepository, createProject, environment, isSubmitting, pathInput, remoteUrl]);
+  }, [cloneRepositoryWithProgress, createProject, environment, isSubmitting, pathInput, remoteUrl]);
 
   return (
     <AddProjectShell>
@@ -823,6 +905,7 @@ export function AddProjectDestinationScreen(props: {
             disabled={isSubmitting || !remoteUrl}
             onPress={() => void submitPath()}
             loading={isSubmitting}
+            progress={cloneProgress}
           />
           <FolderBrowser
             environment={environment}

--- a/apps/server/src/sourceControl/CloneProgress.test.ts
+++ b/apps/server/src/sourceControl/CloneProgress.test.ts
@@ -1,0 +1,48 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import { parseGitCloneProgressLine } from "./CloneProgress.ts";
+
+describe("parseGitCloneProgressLine", () => {
+  it("parses receiving progress and normalized transfer metrics", () => {
+    assert.deepStrictEqual(
+      parseGitCloneProgressLine("Receiving objects:  64% (64/100), 18.40 MiB | 4.20 MiB/s"),
+      {
+        type: "progress",
+        stage: "receiving",
+        percent: 64,
+        completed: 64,
+        total: 100,
+        receivedBytes: 19_293_798,
+        bytesPerSecond: 4_404_019,
+      },
+    );
+  });
+
+  it("maps resolving and checkout output to stable stages", () => {
+    assert.deepStrictEqual(parseGitCloneProgressLine("Resolving deltas: 25% (5/20)"), {
+      type: "progress",
+      stage: "resolving",
+      percent: 25,
+      completed: 5,
+      total: 20,
+      receivedBytes: null,
+      bytesPerSecond: null,
+    });
+    assert.deepStrictEqual(parseGitCloneProgressLine("Updating files: 50% (10/20)"), {
+      type: "progress",
+      stage: "checkout",
+      percent: 50,
+      completed: 10,
+      total: 20,
+      receivedBytes: null,
+      bytesPerSecond: null,
+    });
+  });
+
+  it("ignores unrecognized and terminal-controlled output", () => {
+    assert.isNull(parseGitCloneProgressLine("remote: repository supplied text"));
+    assert.isNull(parseGitCloneProgressLine("remote: Receiving objects: 100% (1/1)"));
+    assert.isNull(parseGitCloneProgressLine("\u001B[2JReceiving objects: 50% (1/2)"));
+    assert.isNull(parseGitCloneProgressLine("Receiving objects: 101% (101/100)"));
+  });
+});

--- a/apps/server/src/sourceControl/CloneProgress.ts
+++ b/apps/server/src/sourceControl/CloneProgress.ts
@@ -1,0 +1,99 @@
+import type {
+  SourceControlCloneProgress,
+  SourceControlCloneProgressStage,
+} from "@t3tools/contracts";
+
+const PROGRESS_LINE =
+  /^(Receiving objects|Resolving deltas|Updating files|Checking out files):\s+(\d+)%\s+\((\d+)\/(\d+)\)(?:,\s+(.+))?$/;
+const TRANSFER_METRICS =
+  /^([\d.]+)\s+(B|KB|KiB|MB|MiB|GB|GiB)\s+\|\s+([\d.]+)\s+(B|KB|KiB|MB|MiB|GB|GiB)\/s$/;
+
+const UNIT_MULTIPLIER: Readonly<Record<string, number>> = {
+  B: 1,
+  KB: 1_000,
+  KiB: 1_024,
+  MB: 1_000_000,
+  MiB: 1_048_576,
+  GB: 1_000_000_000,
+  GiB: 1_073_741_824,
+};
+
+function parseFiniteNumber(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseBytes(value: string, unit: string): number | null {
+  const amount = parseFiniteNumber(value);
+  const multiplier = UNIT_MULTIPLIER[unit];
+  if (amount === null || multiplier === undefined) {
+    return null;
+  }
+  return Math.round(amount * multiplier);
+}
+
+function progressStage(label: string): SourceControlCloneProgressStage {
+  switch (label) {
+    case "Receiving objects":
+      return "receiving";
+    case "Resolving deltas":
+      return "resolving";
+    case "Updating files":
+    case "Checking out files":
+      return "checkout";
+    default:
+      return "connecting";
+  }
+}
+
+export function parseGitCloneProgressLine(line: string): SourceControlCloneProgress | null {
+  const match = PROGRESS_LINE.exec(line.trim());
+  if (match === null) {
+    return null;
+  }
+
+  const [, label, percentText, completedText, totalText, transferText] = match;
+  if (
+    label === undefined ||
+    percentText === undefined ||
+    completedText === undefined ||
+    totalText === undefined
+  ) {
+    return null;
+  }
+
+  const percent = parseFiniteNumber(percentText);
+  const completed = parseFiniteNumber(completedText);
+  const total = parseFiniteNumber(totalText);
+  if (
+    percent === null ||
+    completed === null ||
+    total === null ||
+    percent < 0 ||
+    percent > 100 ||
+    completed < 0 ||
+    total < 0
+  ) {
+    return null;
+  }
+
+  const transferMatch = transferText === undefined ? null : TRANSFER_METRICS.exec(transferText);
+  const receivedBytes =
+    transferMatch?.[1] !== undefined && transferMatch[2] !== undefined
+      ? parseBytes(transferMatch[1], transferMatch[2])
+      : null;
+  const bytesPerSecond =
+    transferMatch?.[3] !== undefined && transferMatch[4] !== undefined
+      ? parseBytes(transferMatch[3], transferMatch[4])
+      : null;
+
+  return {
+    type: "progress",
+    stage: progressStage(label),
+    percent,
+    completed,
+    total,
+    receivedBytes,
+    bytesPerSecond,
+  };
+}

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -8,6 +8,7 @@ import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError, SourceControlProviderError } from "@t3tools/contracts";
+import type { SourceControlCloneProgress } from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
@@ -192,6 +193,83 @@ it.effect("clones a looked-up repository into the requested destination", () =>
         }),
       ),
     );
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("publishes structured progress while cloning with forced Git progress output", () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const parent = yield* fs.makeTempDirectoryScoped({
+      prefix: "t3-source-control-clone-progress-parent-",
+    });
+    const destinationPath = `${parent}/t3code`;
+    const progressEvents: SourceControlCloneProgress[] = [];
+
+    yield* Effect.gen(function* () {
+      const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+      yield* service.cloneRepository(
+        {
+          remoteUrl: CLONE_URLS.url,
+          destinationPath,
+        },
+        {
+          publish: (progress) =>
+            Effect.sync(() => {
+              progressEvents.push(progress);
+            }),
+        },
+      );
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          git: {
+            execute: (input) =>
+              Effect.gen(function* () {
+                assert.deepStrictEqual(input.args, [
+                  "clone",
+                  "--progress",
+                  CLONE_URLS.url,
+                  "t3code",
+                ]);
+                assert.strictEqual(input.env?.LC_ALL, "C");
+                assert.strictEqual(input.progress?.includeCarriageReturnLines, true);
+                assert.strictEqual(input.maxOutputBytes, 256 * 1024);
+                assert.strictEqual(input.appendTruncationMarker, true);
+                yield* (
+                  input.progress?.onStderrLine?.(
+                    "Receiving objects: 64% (64/100), 18.40 MiB | 4.20 MiB/s",
+                  ) ?? Effect.void
+                );
+                yield* (
+                  input.progress?.onStderrLine?.("repository-controlled output") ?? Effect.void
+                );
+                return processOutput();
+              }),
+          },
+        }),
+      ),
+    );
+
+    assert.deepStrictEqual(progressEvents, [
+      {
+        type: "progress",
+        stage: "connecting",
+        percent: null,
+        completed: null,
+        total: null,
+        receivedBytes: null,
+        bytesPerSecond: null,
+      },
+      {
+        type: "progress",
+        stage: "receiving",
+        percent: 64,
+        completed: 64,
+        total: 100,
+        receivedBytes: 19_293_798,
+        bytesPerSecond: 4_404_019,
+      },
+    ]);
   }).pipe(Effect.provide(NodeServices.layer)),
 );
 

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -8,6 +8,7 @@ import * as Schema from "effect/Schema";
 
 import {
   SourceControlRepositoryError,
+  type SourceControlCloneProgress,
   type SourceControlCloneRepositoryInput,
   type SourceControlCloneRepositoryResult,
   type SourceControlCloneProtocol,
@@ -21,8 +22,13 @@ import {
 
 import { ServerConfig } from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import { parseGitCloneProgressLine } from "./CloneProgress.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 const isSourceControlRepositoryError = Schema.is(SourceControlRepositoryError);
+
+export interface SourceControlCloneProgressReporter {
+  readonly publish: (progress: SourceControlCloneProgress) => Effect.Effect<void, never>;
+}
 
 export class SourceControlRepositoryService extends Context.Service<
   SourceControlRepositoryService,
@@ -32,6 +38,7 @@ export class SourceControlRepositoryService extends Context.Service<
     ) => Effect.Effect<SourceControlRepositoryInfo, SourceControlRepositoryError>;
     readonly cloneRepository: (
       input: SourceControlCloneRepositoryInput,
+      progressReporter?: SourceControlCloneProgressReporter,
     ) => Effect.Effect<SourceControlCloneRepositoryResult, SourceControlRepositoryError>;
     readonly publishRepository: (
       input: SourceControlPublishRepositoryInput,
@@ -179,6 +186,7 @@ export const make = Effect.gen(function* () {
 
   const cloneRepository = Effect.fn("SourceControlRepositoryService.cloneRepository")(function* (
     input: SourceControlCloneRepositoryInput,
+    progressReporter?: SourceControlCloneProgressReporter,
   ) {
     const preparedDestination = yield* prepareDestination(input.destinationPath);
     let repository: SourceControlRepositoryInfo | null = null;
@@ -203,12 +211,40 @@ export const make = Effect.gen(function* () {
       });
     }
 
+    if (progressReporter !== undefined) {
+      yield* progressReporter.publish({
+        type: "progress",
+        stage: "connecting",
+        percent: null,
+        completed: null,
+        total: null,
+        receivedBytes: null,
+        bytesPerSecond: null,
+      });
+    }
+
     yield* git.execute({
       operation: "SourceControlRepositoryService.cloneRepository",
       cwd: preparedDestination.parentPath,
-      args: ["clone", remoteUrl, preparedDestination.directoryName],
+      args:
+        progressReporter === undefined
+          ? ["clone", remoteUrl, preparedDestination.directoryName]
+          : ["clone", "--progress", remoteUrl, preparedDestination.directoryName],
+      ...(progressReporter === undefined ? {} : { env: { LC_ALL: "C" } }),
+      ...(progressReporter === undefined
+        ? {}
+        : {
+            progress: {
+              includeCarriageReturnLines: true,
+              onStderrLine: (line: string) => {
+                const progress = parseGitCloneProgressLine(line);
+                return progress === null ? Effect.void : progressReporter.publish(progress);
+              },
+            },
+          }),
       timeoutMs: 120_000,
       maxOutputBytes: 256 * 1024,
+      ...(progressReporter === undefined ? {} : { appendTruncationMarker: true }),
     });
 
     return {
@@ -278,8 +314,8 @@ export const make = Effect.gen(function* () {
   return SourceControlRepositoryService.of({
     lookupRepository: (input) =>
       lookupRepository(input).pipe(mapRepositoryError("lookupRepository", input.provider)),
-    cloneRepository: (input) =>
-      cloneRepository(input).pipe(
+    cloneRepository: (input, progressReporter) =>
+      cloneRepository(input, progressReporter).pipe(
         mapRepositoryError("cloneRepository", input.provider ?? "unknown"),
       ),
     publishRepository: (input) =>

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -87,6 +87,7 @@ export interface GitPreparedCommitContext {
 export interface ExecuteGitProgress {
   readonly onStdoutLine?: (line: string) => Effect.Effect<void, never>;
   readonly onStderrLine?: (line: string) => Effect.Effect<void, never>;
+  readonly includeCarriageReturnLines?: boolean;
   readonly onHookStarted?: (hookName: string) => Effect.Effect<void, never>;
   readonly onHookFinished?: (input: {
     hookName: string;

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -134,6 +134,63 @@ it.effect("uses stable diagnostics for every parsed non-repository command", () 
   }).pipe(Effect.provide(layer));
 });
 
+it.effect("emits carriage-return-delimited progress lines when requested", () => {
+  const encoder = new TextEncoder();
+  const spawner = ChildProcessSpawner.make(() =>
+    Effect.succeed(
+      ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(2),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        unref: Effect.succeed(Effect.void),
+        stdin: Sink.drain,
+        stdout: Stream.empty,
+        stderr: Stream.fromIterable([
+          encoder.encode("Receiving objects: 1% (1/100)\rReceiving"),
+          encoder.encode(" objects: 2% (2/100)\r\nResolving deltas: 5% (1/20)\n"),
+        ]),
+        all: Stream.empty,
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+      }),
+    ),
+  );
+  const layer = GitVcsDriver.layer.pipe(
+    Layer.provide(ServerConfigLayer),
+    Layer.provideMerge(
+      Layer.merge(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.GitVcsDriver;
+    const lines: string[] = [];
+
+    yield* driver.execute({
+      operation: "GitVcsDriver.test.carriageReturnProgress",
+      cwd: process.cwd(),
+      args: ["status"],
+      progress: {
+        includeCarriageReturnLines: true,
+        onStderrLine: (line) =>
+          Effect.sync(() => {
+            lines.push(line);
+          }),
+      },
+    });
+
+    assert.deepStrictEqual(lines, [
+      "Receiving objects: 1% (1/100)",
+      "Receiving objects: 2% (2/100)",
+      "Resolving deltas: 5% (1/20)",
+    ]);
+  }).pipe(Effect.provide(layer));
+});
+
 it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   describe("process environment", () => {
     it.effect("preserves the caller locale for general Git subprocesses", () =>

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -560,6 +560,7 @@ const collectOutput = Effect.fnUntraced(function* (
   maxOutputBytes: number,
   appendTruncationMarker: boolean,
   onLine: ((line: string) => Effect.Effect<void, never>) | undefined,
+  includeCarriageReturnLines: boolean,
 ): Effect.fn.Return<{ readonly text: string; readonly truncated: boolean }, GitCommandError> {
   const decoder = new TextDecoder();
   let bytes = 0;
@@ -568,14 +569,29 @@ const collectOutput = Effect.fnUntraced(function* (
   let truncated = false;
 
   const emitCompleteLines = Effect.fnUntraced(function* (flush: boolean) {
-    let newlineIndex = lineBuffer.indexOf("\n");
-    while (newlineIndex >= 0) {
-      const line = lineBuffer.slice(0, newlineIndex).replace(/\r$/, "");
-      lineBuffer = lineBuffer.slice(newlineIndex + 1);
+    const nextSeparatorIndex = (): number => {
+      const newlineIndex = lineBuffer.indexOf("\n");
+      if (!includeCarriageReturnLines) {
+        return newlineIndex;
+      }
+      const carriageReturnIndex = lineBuffer.indexOf("\r");
+      if (newlineIndex < 0) {
+        return carriageReturnIndex;
+      }
+      if (carriageReturnIndex < 0) {
+        return newlineIndex;
+      }
+      return Math.min(newlineIndex, carriageReturnIndex);
+    };
+
+    let separatorIndex = nextSeparatorIndex();
+    while (separatorIndex >= 0) {
+      const line = lineBuffer.slice(0, separatorIndex).replace(/\r$/, "");
+      lineBuffer = lineBuffer.slice(separatorIndex + 1);
       if (line.length > 0 && onLine) {
         yield* onLine(line);
       }
-      newlineIndex = lineBuffer.indexOf("\n");
+      separatorIndex = nextSeparatorIndex();
     }
 
     if (flush) {
@@ -694,6 +710,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
               maxOutputBytes,
               appendTruncationMarker,
               input.progress?.onStdoutLine,
+              input.progress?.includeCarriageReturnLines ?? false,
             ),
             collectOutput(
               commandInput,
@@ -701,6 +718,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
               maxOutputBytes,
               appendTruncationMarker,
               input.progress?.onStderrLine,
+              input.progress?.includeCarriageReturnLines ?? false,
             ),
             child.exitCode.pipe(
               Effect.mapError(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -40,6 +40,8 @@ import {
   type ProjectEntriesFailure,
   type ProjectFileFailure,
   type ProjectFileOperation,
+  type SourceControlCloneProgressEvent,
+  type SourceControlRepositoryError,
   ProjectListEntriesError,
   ProjectReadFileError,
   ProjectSearchEntriesError,
@@ -324,6 +326,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.cloudInstallRelayClient, AuthRelayWriteScope],
   [WS_METHODS.sourceControlLookupRepository, AuthOrchestrationReadScope],
   [WS_METHODS.sourceControlCloneRepository, AuthOrchestrationOperateScope],
+  [WS_METHODS.sourceControlCloneRepositoryWithProgress, AuthOrchestrationOperateScope],
   [WS_METHODS.sourceControlPublishRepository, AuthOrchestrationOperateScope],
   [WS_METHODS.projectsListEntries, AuthOrchestrationReadScope],
   [WS_METHODS.projectsReadFile, AuthOrchestrationReadScope],
@@ -1620,6 +1623,30 @@ const makeWsRpcLayer = (
           observeRpcEffect(
             WS_METHODS.sourceControlCloneRepository,
             sourceControlRepositories.cloneRepository(input),
+            {
+              "rpc.aggregate": "source-control",
+            },
+          ),
+        [WS_METHODS.sourceControlCloneRepositoryWithProgress]: (input) =>
+          observeRpcStream(
+            WS_METHODS.sourceControlCloneRepositoryWithProgress,
+            Stream.callback<SourceControlCloneProgressEvent, SourceControlRepositoryError>(
+              (queue) =>
+                sourceControlRepositories
+                  .cloneRepository(input, {
+                    publish: (progress) => Queue.offer(queue, progress).pipe(Effect.asVoid),
+                  })
+                  .pipe(
+                    Effect.matchCauseEffect({
+                      onFailure: (cause) => Queue.failCause(queue, cause),
+                      onSuccess: (result) =>
+                        Queue.offer(queue, {
+                          type: "complete",
+                          result,
+                        }).pipe(Effect.andThen(Queue.end(queue)), Effect.asVoid),
+                    }),
+                  ),
+            ),
             {
               "rpc.aggregate": "source-control",
             },

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2,6 +2,10 @@
 
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import {
+  completeSourceControlCloneProgress,
+  type SourceControlCloneProgressPresentation,
+} from "@t3tools/client-runtime/state/source-control";
+import {
   isAtomCommandInterrupted,
   settlePromise,
   squashAtomCommandFailure,
@@ -22,10 +26,12 @@ import {
   ArrowDownIcon,
   ArrowLeftIcon,
   ArrowUpIcon,
+  CheckIcon,
   CornerLeftUpIcon,
   FolderIcon,
   FolderPlusIcon,
   LinkIcon,
+  LoaderCircleIcon,
   MessageSquareIcon,
   SettingsIcon,
   SquarePenIcon,
@@ -486,9 +492,12 @@ function OpenCommandPaletteDialog(props: {
   const lookupRepository = useAtomQueryRunner(sourceControlEnvironment.repository, {
     reportFailure: false,
   });
-  const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
-    reportFailure: false,
-  });
+  const cloneRepositoryWithProgress = useAtomCommand(
+    sourceControlEnvironment.cloneRepositoryWithProgress,
+    {
+      reportFailure: false,
+    },
+  );
   const { environments } = useEnvironments();
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
@@ -509,6 +518,8 @@ function OpenCommandPaletteDialog(props: {
   const [addProjectCloneFlow, setAddProjectCloneFlow] = useState<AddProjectCloneFlow | null>(null);
   const [isRemoteProjectLookingUp, setIsRemoteProjectLookingUp] = useState(false);
   const [isRemoteProjectCloning, setIsRemoteProjectCloning] = useState(false);
+  const [remoteProjectCloneProgress, setRemoteProjectCloneProgress] =
+    useState<SourceControlCloneProgressPresentation | null>(null);
   const projectGroupingSettings = useMemo(
     () => selectProjectGroupingSettings(clientSettings),
     [clientSettings],
@@ -1518,27 +1529,38 @@ function OpenCommandPaletteDialog(props: {
     }
 
     setIsRemoteProjectCloning(true);
-    const cloneResult = await cloneRepository({
-      environmentId: addProjectCloneFlow.environmentId,
-      input: {
-        remoteUrl: addProjectCloneFlow.remoteUrl,
-        destinationPath,
-      },
+    setRemoteProjectCloneProgress({
+      stage: "connecting",
+      overallPercent: 0,
+      isComplete: false,
     });
-    setIsRemoteProjectCloning(false);
-    if (cloneResult._tag === "Failure") {
-      if (!isAtomCommandInterrupted(cloneResult)) {
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Clone failed",
-            description: errorMessage(squashAtomCommandFailure(cloneResult)),
-          }),
-        );
+    try {
+      const cloneResult = await cloneRepositoryWithProgress({
+        environmentId: addProjectCloneFlow.environmentId,
+        input: {
+          remoteUrl: addProjectCloneFlow.remoteUrl,
+          destinationPath,
+        },
+        onProgress: setRemoteProjectCloneProgress,
+      });
+      if (cloneResult._tag === "Failure") {
+        if (!isAtomCommandInterrupted(cloneResult)) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Clone failed",
+              description: errorMessage(squashAtomCommandFailure(cloneResult)),
+            }),
+          );
+        }
+        return;
       }
-      return;
+      setRemoteProjectCloneProgress((progress) => completeSourceControlCloneProgress(progress));
+      await handleAddProject(cloneResult.value.cwd);
+    } finally {
+      setIsRemoteProjectCloning(false);
+      setRemoteProjectCloneProgress(null);
     }
-    await handleAddProject(cloneResult.value.cwd);
   }
 
   function browseTo(name: string): void {
@@ -2041,40 +2063,98 @@ function OpenCommandPaletteDialog(props: {
                     : {})}
           />
         </CommandPanel>
-        <CommandFooter className="gap-3 max-sm:flex-col max-sm:items-start">
-          <div className="flex items-center gap-3">
-            <KbdGroup className="items-center gap-1.5">
-              <Kbd>
-                <ArrowUpIcon />
-              </Kbd>
-              <Kbd>
-                <ArrowDownIcon />
-              </Kbd>
-              <span>Navigate</span>
-            </KbdGroup>
-            {addProjectCloneFlow?.step === "repository" ? (
+        <CommandFooter
+          className={cn(
+            "relative overflow-hidden gap-3 max-sm:flex-col max-sm:items-start",
+            isRemoteProjectCloning && "min-h-11 py-2.5",
+          )}
+        >
+          {isRemoteProjectCloning && remoteProjectCloneProgress !== null ? (
+            <>
+              <div className="flex min-w-0 flex-1 items-center gap-2 text-foreground">
+                <div
+                  className="flex min-w-0 items-center gap-2"
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  {remoteProjectCloneProgress.isComplete ? (
+                    <CheckIcon className="size-3.5 shrink-0 text-primary" />
+                  ) : (
+                    <LoaderCircleIcon className="size-3.5 shrink-0 animate-spin text-primary" />
+                  )}
+                  <span className="truncate font-medium">
+                    {remoteProjectCloneProgress.isComplete
+                      ? "Pull complete"
+                      : remoteProjectCloneProgress.stage === "connecting"
+                        ? "Connecting to remote"
+                        : remoteProjectCloneProgress.stage === "receiving"
+                          ? "Receiving objects"
+                          : remoteProjectCloneProgress.stage === "resolving"
+                            ? "Resolving deltas"
+                            : "Checking out files"}
+                  </span>
+                </div>
+                {remoteProjectCloneProgress.isComplete ? null : (
+                  <span className="ms-auto shrink-0 font-medium tabular-nums text-muted-foreground">
+                    {Math.round(remoteProjectCloneProgress.overallPercent)}%
+                  </span>
+                )}
+              </div>
+              <div
+                className="absolute inset-x-0 bottom-0 h-0.5 overflow-hidden bg-border/70"
+                role="progressbar"
+                aria-label="Clone progress"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={remoteProjectCloneProgress.overallPercent}
+              >
+                <div
+                  className="h-full bg-primary transition-[width] duration-200"
+                  style={{
+                    width: `${Math.max(
+                      0,
+                      Math.min(100, remoteProjectCloneProgress.overallPercent),
+                    )}%`,
+                  }}
+                />
+              </div>
+            </>
+          ) : (
+            <div className="flex items-center gap-3">
               <KbdGroup className="items-center gap-1.5">
-                <Kbd>Enter</Kbd>
-                <span>{remoteProjectButtonLabel ?? "Continue"}</span>
+                <Kbd>
+                  <ArrowUpIcon />
+                </Kbd>
+                <Kbd>
+                  <ArrowDownIcon />
+                </Kbd>
+                <span>Navigate</span>
               </KbdGroup>
-            ) : !canSubmitBrowsePath || hasHighlightedBrowseItem ? (
+              {addProjectCloneFlow?.step === "repository" ? (
+                <KbdGroup className="items-center gap-1.5">
+                  <Kbd>Enter</Kbd>
+                  <span>{remoteProjectButtonLabel ?? "Continue"}</span>
+                </KbdGroup>
+              ) : !canSubmitBrowsePath || hasHighlightedBrowseItem ? (
+                <KbdGroup className="items-center gap-1.5">
+                  <Kbd>Enter</Kbd>
+                  <span>Select</span>
+                </KbdGroup>
+              ) : null}
+              {isSubmenu ? (
+                <KbdGroup className="items-center gap-1.5">
+                  <Kbd>Backspace</Kbd>
+                  <span>Back</span>
+                </KbdGroup>
+              ) : null}
               <KbdGroup className="items-center gap-1.5">
-                <Kbd>Enter</Kbd>
-                <span>Select</span>
+                <Kbd>Esc</Kbd>
+                <span>Close</span>
               </KbdGroup>
-            ) : null}
-            {isSubmenu ? (
-              <KbdGroup className="items-center gap-1.5">
-                <Kbd>Backspace</Kbd>
-                <span>Back</span>
-              </KbdGroup>
-            ) : null}
-            <KbdGroup className="items-center gap-1.5">
-              <Kbd>Esc</Kbd>
-              <span>Close</span>
-            </KbdGroup>
-          </div>
-          {canOpenProjectFromFileManager ? (
+            </div>
+          )}
+          {canOpenProjectFromFileManager && !isRemoteProjectCloning ? (
             <Button
               variant="ghost"
               size="xs"

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -55,7 +55,8 @@ export type EnvironmentSubscriptionRpcTag =
 
 export type EnvironmentStreamCommandRpcTag =
   | typeof WS_METHODS.cloudInstallRelayClient
-  | typeof WS_METHODS.gitRunStackedAction;
+  | typeof WS_METHODS.gitRunStackedAction
+  | typeof WS_METHODS.sourceControlCloneRepositoryWithProgress;
 
 export type EnvironmentStreamRpcTag =
   | EnvironmentSubscriptionRpcTag

--- a/packages/client-runtime/src/state/sourceControl.test.ts
+++ b/packages/client-runtime/src/state/sourceControl.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import type { SourceControlCloneProgress } from "@t3tools/contracts";
+
+import {
+  advanceSourceControlCloneProgress,
+  completeSourceControlCloneProgress,
+} from "./sourceControl.ts";
+
+function progress(
+  stage: SourceControlCloneProgress["stage"],
+  percent: number | null,
+): SourceControlCloneProgress {
+  return {
+    type: "progress",
+    stage,
+    percent,
+    completed: null,
+    total: null,
+    receivedBytes: null,
+    bytesPerSecond: null,
+  };
+}
+
+describe("source control clone progress", () => {
+  it("maps Git stages onto one overall zero-to-100 range", () => {
+    const connecting = advanceSourceControlCloneProgress(null, progress("connecting", null));
+    const receiving = advanceSourceControlCloneProgress(connecting, progress("receiving", 50));
+    const resolving = advanceSourceControlCloneProgress(receiving, progress("resolving", 50));
+    const checkout = advanceSourceControlCloneProgress(resolving, progress("checkout", 50));
+    const complete = completeSourceControlCloneProgress(checkout);
+
+    expect([
+      connecting.overallPercent,
+      receiving.overallPercent,
+      resolving.overallPercent,
+      checkout.overallPercent,
+      complete.overallPercent,
+    ]).toEqual([0, 40, 87.5, 97, 100]);
+    expect(complete.isComplete).toBe(true);
+  });
+
+  it("never moves the overall progress or stage backward", () => {
+    const resolving = advanceSourceControlCloneProgress(null, progress("resolving", 75));
+    const lateReceiving = advanceSourceControlCloneProgress(resolving, progress("receiving", 100));
+
+    expect(resolving.overallPercent).toBe(91.3);
+    expect(lateReceiving).toMatchObject({
+      stage: "resolving",
+      overallPercent: 91.3,
+      isComplete: false,
+    });
+  });
+
+  it("reserves 100 percent for successful completion", () => {
+    const checkout = advanceSourceControlCloneProgress(null, progress("checkout", 100));
+
+    expect(checkout.overallPercent).toBe(99);
+    expect(completeSourceControlCloneProgress(checkout)).toMatchObject({
+      stage: "checkout",
+      overallPercent: 100,
+      isComplete: true,
+    });
+  });
+});

--- a/packages/client-runtime/src/state/sourceControl.ts
+++ b/packages/client-runtime/src/state/sourceControl.ts
@@ -1,18 +1,121 @@
-import { WS_METHODS } from "@t3tools/contracts";
+import {
+  WS_METHODS,
+  type EnvironmentId,
+  type SourceControlCloneProgress,
+  type SourceControlCloneProgressStage,
+  type SourceControlCloneRepositoryInput,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+import * as Stream from "effect/Stream";
 import { Atom } from "effect/unstable/reactivity";
 
+import { runStream } from "../rpc/client.ts";
 import {
   createAtomCommandScheduler,
   createEnvironmentRpcCommand,
   createEnvironmentRpcQueryAtomFamily,
+  createRuntimeStreamCommand,
+  runStreamInEnvironment,
 } from "./runtime.ts";
 import type { EnvironmentRegistry } from "../connection/registry.ts";
 import { vcsCommandConcurrency, vcsCommandScheduler } from "./vcsCommandScheduler.ts";
+
+const cloneProgressRanges = {
+  connecting: { start: 0, end: 0 },
+  receiving: { start: 0, end: 80 },
+  resolving: { start: 80, end: 95 },
+  checkout: { start: 95, end: 99 },
+} as const;
+
+const cloneProgressStageOrder: Readonly<Record<SourceControlCloneProgressStage, number>> = {
+  connecting: 0,
+  receiving: 1,
+  resolving: 2,
+  checkout: 3,
+};
+
+export interface SourceControlCloneProgressPresentation {
+  readonly stage: SourceControlCloneProgressStage;
+  readonly overallPercent: number;
+  readonly isComplete: boolean;
+}
+
+export function advanceSourceControlCloneProgress(
+  previous: SourceControlCloneProgressPresentation | null,
+  next: SourceControlCloneProgress,
+): SourceControlCloneProgressPresentation {
+  const range = cloneProgressRanges[next.stage];
+  const stagePercent = Math.max(0, Math.min(100, next.percent ?? 0));
+  const overallPercent =
+    Math.round((range.start + (stagePercent / 100) * (range.end - range.start)) * 10) / 10;
+  const stage =
+    previous === null ||
+    cloneProgressStageOrder[next.stage] >= cloneProgressStageOrder[previous.stage]
+      ? next.stage
+      : previous.stage;
+
+  return {
+    stage,
+    overallPercent: Math.max(previous?.overallPercent ?? 0, overallPercent),
+    isComplete: false,
+  };
+}
+
+export function completeSourceControlCloneProgress(
+  previous: SourceControlCloneProgressPresentation | null,
+): SourceControlCloneProgressPresentation {
+  return {
+    stage: previous?.stage ?? "checkout",
+    overallPercent: 100,
+    isComplete: true,
+  };
+}
 
 export function createSourceControlEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
 ) {
   const commandScheduler = createAtomCommandScheduler();
+  const cloneRepositoryWithProgress = createRuntimeStreamCommand(runtime, {
+    label: "environment-data:source-control:clone-repository-with-progress",
+    scheduler: commandScheduler,
+    concurrency: {
+      mode: "serial",
+      key: (target: { readonly environmentId: EnvironmentId }) => target.environmentId,
+    },
+    execute: (
+      target: {
+        readonly environmentId: EnvironmentId;
+        readonly input: SourceControlCloneRepositoryInput;
+        readonly onProgress?: (progress: SourceControlCloneProgressPresentation) => void;
+      },
+      _registry,
+    ) => {
+      let currentProgress: SourceControlCloneProgressPresentation | null = null;
+
+      return runStreamInEnvironment(
+        target.environmentId,
+        runStream(WS_METHODS.sourceControlCloneRepositoryWithProgress, target.input),
+      ).pipe(
+        Stream.tap((event) =>
+          event.type !== "progress" || target.onProgress === undefined
+            ? Effect.void
+            : Effect.sync(() => {
+                try {
+                  currentProgress = advanceSourceControlCloneProgress(currentProgress, event);
+                  target.onProgress?.(currentProgress);
+                } catch {
+                  // Presentation callbacks must not fail the clone operation.
+                }
+              }),
+        ),
+        Stream.filterMap((event) =>
+          event.type === "complete" ? Result.succeed(event.result) : Result.failVoid,
+        ),
+      );
+    },
+  });
+
   return {
     discovery: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:server:source-control-discovery",
@@ -31,6 +134,7 @@ export function createSourceControlEnvironmentAtoms<R, E>(
         key: ({ environmentId }) => environmentId,
       },
     }),
+    cloneRepositoryWithProgress,
     publishRepository: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:source-control:publish-repository",
       tag: WS_METHODS.sourceControlPublishRepository,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -136,6 +136,7 @@ import {
 } from "./server.ts";
 import { ServerSettings, ServerSettingsError, ServerSettingsPatch } from "./settings.ts";
 import {
+  SourceControlCloneProgressEvent,
   SourceControlCloneRepositoryInput,
   SourceControlCloneRepositoryResult,
   SourceControlDiscoveryResult,
@@ -226,6 +227,7 @@ export const WS_METHODS = {
   // Source control methods
   sourceControlLookupRepository: "sourceControl.lookupRepository",
   sourceControlCloneRepository: "sourceControl.cloneRepository",
+  sourceControlCloneRepositoryWithProgress: "sourceControl.cloneRepositoryWithProgress",
   sourceControlPublishRepository: "sourceControl.publishRepository",
 
   // Streaming subscriptions
@@ -361,6 +363,16 @@ export const WsSourceControlCloneRepositoryRpc = Rpc.make(WS_METHODS.sourceContr
   success: SourceControlCloneRepositoryResult,
   error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
 });
+
+export const WsSourceControlCloneRepositoryWithProgressRpc = Rpc.make(
+  WS_METHODS.sourceControlCloneRepositoryWithProgress,
+  {
+    payload: SourceControlCloneRepositoryInput,
+    success: SourceControlCloneProgressEvent,
+    error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
+    stream: true,
+  },
+);
 
 export const WsSourceControlPublishRepositoryRpc = Rpc.make(
   WS_METHODS.sourceControlPublishRepository,
@@ -717,6 +729,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsCloudInstallRelayClientRpc,
   WsSourceControlLookupRepositoryRpc,
   WsSourceControlCloneRepositoryRpc,
+  WsSourceControlCloneRepositoryWithProgressRpc,
   WsSourceControlPublishRepositoryRpc,
   WsProjectsListEntriesRpc,
   WsProjectsReadFileRpc,

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -80,6 +80,37 @@ export const SourceControlCloneRepositoryResult = Schema.Struct({
 });
 export type SourceControlCloneRepositoryResult = typeof SourceControlCloneRepositoryResult.Type;
 
+export const SourceControlCloneProgressStage = Schema.Literals([
+  "connecting",
+  "receiving",
+  "resolving",
+  "checkout",
+]);
+export type SourceControlCloneProgressStage = typeof SourceControlCloneProgressStage.Type;
+
+export const SourceControlCloneProgress = Schema.Struct({
+  type: Schema.Literal("progress"),
+  stage: SourceControlCloneProgressStage,
+  percent: Schema.NullOr(Schema.Number),
+  completed: Schema.NullOr(Schema.Number),
+  total: Schema.NullOr(Schema.Number),
+  receivedBytes: Schema.NullOr(Schema.Number),
+  bytesPerSecond: Schema.NullOr(Schema.Number),
+});
+export type SourceControlCloneProgress = typeof SourceControlCloneProgress.Type;
+
+export const SourceControlCloneComplete = Schema.Struct({
+  type: Schema.Literal("complete"),
+  result: SourceControlCloneRepositoryResult,
+});
+export type SourceControlCloneComplete = typeof SourceControlCloneComplete.Type;
+
+export const SourceControlCloneProgressEvent = Schema.Union([
+  SourceControlCloneProgress,
+  SourceControlCloneComplete,
+]);
+export type SourceControlCloneProgressEvent = typeof SourceControlCloneProgressEvent.Type;
+
 export const SourceControlPublishRepositoryInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   provider: SourceControlProviderKind,


### PR DESCRIPTION
## What Changed

- add a streamed source-control clone RPC that emits structured connecting, receiving, resolving, and checkout progress
- parse only allowlisted Git progress lines, including carriage-return updates, while preserving the existing unary clone RPC
- map Git's stage-local percentages onto one monotonic 0–100 progress bar shared by web and mobile
- reserve 100% for successful completion, where the compact status becomes `Pull complete`
- reject repository-controlled `remote:` sideband text, keep stages monotonic, and use a dedicated presentation model instead of rewriting protocol events
- make post-clone cleanup exception-safe and expose quieter web plus native mobile progress semantics

## Why

The existing clone flow only changed the action label to `Cloning`, so a slow clone looked stalled. The first progress implementation exposed Git's native percentage directly, but Git restarts that percentage for receiving, resolving, and checkout, which made the bar jump backward at every stage transition.

The client runtime now projects those stages onto one overall range: receiving uses 0–80, resolving 80–95, and checkout 95–99. The reducer never allows a later event to lower the current value, and only the successful terminal event advances it to 100. Arbitrary repository-controlled stderr remains excluded from the UI.

## UI

The existing compact footer/button treatment is retained in light and dark mode. During cloning it shows the current stage and the single overall percentage. At 100%, the spinner and numeric percentage are replaced by a checkmark and `Pull complete`.

Light mode:

![Clone progress in light mode](https://github.com/user-attachments/assets/4af0110c-1f9b-4abf-9ea4-fc2673688f3a)


Dark mode:

![Clone progress in dark mode](https://github.com/user-attachments/assets/2fc7e10a-59e2-4507-a2b1-a44b40764425)


Full clone flow (`pingdotgg/t3code`, 62.8 seconds; includes dark and light runs):

https://github.com/user-attachments/assets/ad24f1ef-101c-489b-b741-002b38b9ae0c

Mobile:
<img width="1080" height="2424" alt="mobile Git clone UI" src="https://github.com/user-attachments/assets/9c445fe0-b068-4eb7-8167-601ac4feadd5" />

## Validation

- focused clone progress, repository service, and Git driver tests — 44 tests passed across 4 files
- targeted type checks passed for contracts, client runtime, server, web, and mobile
- targeted formatting and lint passed for the changed scope; web retained two pre-existing warnings
- web production build passed
- two real VPS clones of `pingdotgg/t3code` completed in Chrome, one in dark mode and one in light mode
- progress sampled every 25 ms on the merged PR head remained monotonic through connecting, receiving, resolving, checkout, and `Pull complete`
- checkout remained below 100; only successful completion rendered 100
- mobile typecheck and native static checks passed; integrated mobile verification remains unavailable because this Linux host has no installed Android SDK, emulator, or connected device

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included light and dark UI evidence
- [x] I included a full-flow real clone recording
- [x] I validated the complete real clone flow

## Current main compatibility

- based on `3c50a648`
- focused regression tests and targeted package type checks passed
- targeted formatting and lint passed with two non-blocking nested-component warnings in `CommandPalette.tsx`
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches clone orchestration, WebSocket streaming, and Git subprocess stderr handling; behavior is additive with tests, but clone is a critical add-project path.
> 
> **Overview**
> Adds **live Git clone progress** for add-project flows on web and mobile, without removing the existing unary `sourceControl.cloneRepository` RPC.
> 
> The server exposes a new **streamed** `sourceControl.cloneRepositoryWithProgress` method. When a progress reporter is attached, clone runs `git clone --progress` with `LC_ALL=C`, parses only allowlisted stderr lines (including carriage-return updates), and emits structured stage events. The Git driver can split stderr on `\r` as well as `\n` so in-place progress lines are not missed.
> 
> The client runtime maps those stages onto a **single monotonic 0–100%** bar (receiving 0–80, resolving 80–95, checkout 95–99; 100% only on success) via `advanceSourceControlCloneProgress` / `completeSourceControlCloneProgress`, exposed through `cloneRepositoryWithProgress` with an `onProgress` callback.
> 
> **Web** (`CommandPalette`) and **mobile** (`AddProjectDestinationScreen`) switch to the streaming command and show stage label, percent, a bar, and **Pull complete** with a checkmark when done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ede4c6a7b34f4d1f101323527755ad7204e6f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show Git clone progress in web and mobile during repository cloning
> - Adds a streaming `cloneRepositoryWithProgress` RPC over WebSocket that emits structured progress events (stage, percent, transfer metrics) and a final completion event
> - Parses Git's `--progress` stderr output into typed `SourceControlCloneProgress` events via a new `parseGitCloneProgressLine` util in [CloneProgress.ts](https://github.com/pingdotgg/t3code/pull/4732/files#diff-95c2d3614473781707f87cf086e0d0374f71aa49d7f7fee67ddcf7bef32fce51)
> - Extends `GitVcsDriverCore` to split carriage-return-delimited lines so Git's inline progress updates reach the progress callback
> - Displays a stage label, percent, animated icon, and progress bar in the web command palette ([CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/4732/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a)) and mobile add-project screen ([AddProjectScreen.tsx](https://github.com/pingdotgg/t3code/pull/4732/files#diff-8d2af7e60f72647a590cd07374db01b9c44b29ebe1f0b9f3ba264e1c38d08bb2))
> - Client-side `advanceSourceControlCloneProgress` maps multi-stage progress into a single monotonic 0–100% range, reserving 100% for explicit completion
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ede4c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->