### PR TITLE
fix: allow review diffs for registered projects

### DIFF
--- a/apps/server/src/review/ReviewService.test.ts
+++ b/apps/server/src/review/ReviewService.test.ts
@@ -1,19 +1,36 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
+import { type OrchestrationProject, ProjectId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 
 import { ServerConfig } from "../config.ts";
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 import * as ReviewService from "./ReviewService.ts";
+
+function makeProject(workspaceRoot: string): OrchestrationProject {
+  return {
+    id: ProjectId.make("project-1"),
+    title: "Project",
+    workspaceRoot,
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    deletedAt: null,
+  };
+}
 
 function makeLayer(input: {
   readonly workspaceRoot: string;
   readonly baseDir: string;
   readonly detectCalls?: Array<{ readonly cwd: string }>;
+  readonly registeredProjectRoots?: ReadonlyArray<string>;
 }) {
   return ReviewService.layer.pipe(
     Layer.provide(
@@ -28,6 +45,16 @@ function makeLayer(input: {
       }),
     ),
     Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)({})),
+    Layer.provide(
+      Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+        getActiveProjectByWorkspaceRoot: (workspaceRoot) =>
+          Effect.succeed(
+            input.registeredProjectRoots?.includes(workspaceRoot) === true
+              ? Option.some(makeProject(workspaceRoot))
+              : Option.none(),
+          ),
+      }),
+    ),
     Layer.provide(ServerConfig.layerTest(input.workspaceRoot, input.baseDir)),
     Layer.provideMerge(NodeServices.layer),
   );
@@ -72,6 +99,34 @@ describe("ReviewService", () => {
       assert.strictEqual(result.cwd, workspaceRoot);
       assert.deepStrictEqual(result.sources, []);
       assert.deepStrictEqual(detectCalls, [{ cwd: workspaceRoot }]);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("allows diff preview cwd matching a registered project workspace root", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const workspaceRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-workspace-" });
+      const projectRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-project-" });
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-base-" });
+      const detectCalls: Array<{ readonly cwd: string }> = [];
+
+      const result = yield* Effect.gen(function* () {
+        const review = yield* ReviewService.ReviewService;
+        return yield* review.getDiffPreview({ cwd: projectRoot });
+      }).pipe(
+        Effect.provide(
+          makeLayer({
+            workspaceRoot,
+            baseDir,
+            detectCalls,
+            registeredProjectRoots: [projectRoot],
+          }),
+        ),
+      );
+
+      assert.strictEqual(result.cwd, projectRoot);
+      assert.deepStrictEqual(result.sources, []);
+      assert.deepStrictEqual(detectCalls, [{ cwd: projectRoot }]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 

--- a/apps/server/src/review/ReviewService.ts
+++ b/apps/server/src/review/ReviewService.ts
@@ -3,6 +3,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 
 import {
@@ -14,6 +15,7 @@ import {
 } from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 
@@ -30,6 +32,7 @@ export const make = Effect.gen(function* () {
   const config = yield* ServerConfig.ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
   const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
   const git = yield* GitVcsDriver.GitVcsDriver;
 
@@ -67,6 +70,25 @@ export const make = Effect.gen(function* () {
     ]);
 
     if (isWithinRoot(candidate, workspaceRoot) || isWithinRoot(candidate, worktreesRoot)) {
+      return;
+    }
+
+    const registeredProject = yield* projectionSnapshotQuery
+      .getActiveProjectByWorkspaceRoot(cwd)
+      .pipe(
+        Effect.map(Option.isSome),
+        Effect.mapError(
+          (cause) =>
+            new VcsRepositoryDetectionError({
+              operation: "ReviewService.assertWorkspaceBoundCwd.resolveRegisteredProject",
+              cwd,
+              detail:
+                "Failed to resolve the registered project while validating the review workspace.",
+              cause,
+            }),
+        ),
+      );
+    if (registeredProject) {
       return;
     }
 

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -328,7 +328,7 @@ export default function DiffPanel({
     },
     { enabled: isGitRepo && selectedTurn !== undefined },
   );
-  const primaryBranchDiffPreview = useEnvironmentQuery(
+  const branchDiffPreview = useEnvironmentQuery(
     selectedTurnId === null && activeThread && activeCwd
       ? reviewEnvironment.diffPreview({
           environmentId: activeThread.environmentId,
@@ -340,26 +340,6 @@ export default function DiffPanel({
         })
       : null,
   );
-  const shouldRetryBranchDiffAtEnvironmentCwd =
-    selectedTurnId === null &&
-    primaryBranchDiffPreview.error?.includes("configured workspace root") === true &&
-    serverConfig?.cwd !== undefined &&
-    serverConfig.cwd !== activeCwd;
-  const fallbackBranchDiffPreview = useEnvironmentQuery(
-    shouldRetryBranchDiffAtEnvironmentCwd && activeThread && serverConfig
-      ? reviewEnvironment.diffPreview({
-          environmentId: activeThread.environmentId,
-          input: {
-            cwd: serverConfig.cwd,
-            ...(selectedBaseRef ? { baseRef: selectedBaseRef } : {}),
-            ignoreWhitespace: diffIgnoreWhitespace,
-          },
-        })
-      : null,
-  );
-  const branchDiffPreview = shouldRetryBranchDiffAtEnvironmentCwd
-    ? fallbackBranchDiffPreview
-    : primaryBranchDiffPreview;
   const selectedGitSource = branchDiffPreview.data?.sources.find(
     (source) => source.kind === (selectedGitScope === "unstaged" ? "working-tree" : "branch-range"),
   );


### PR DESCRIPTION
## Summary

- allow review diff previews for exact workspace roots of active registered projects
- retain the existing configured-cwd and managed-worktree boundaries for all other paths
- stop retrying failed diff previews against the server process cwd, which could silently render an unrelated empty result

## Root cause

Packaged desktop servers use the user's home directory as `ServerConfig.cwd`. `ReviewService` only trusted that directory and T3's managed worktree directory, so in-place projects on another drive or outside the home directory were rejected before VCS detection. The web client then retried against `ServerConfig.cwd`, hiding the authorization error behind an empty diff from the wrong directory.

## Impact

Working-tree and branch scopes now query the registered project's repository while preserving the arbitrary-cwd guard for unregistered paths. If validation genuinely fails, the original error remains visible instead of being replaced by an unrelated fallback result.

Closes #4022.

## Validation

- `vp test run apps/server/src/review/ReviewService.test.ts` (4 tests passed, including the outside-configured-root regression)
- `vp run --filter t3 typecheck`
- `vp run --filter @t3tools/web typecheck`
- `vp lint --report-unused-disable-directives apps/server/src/review/ReviewService.ts apps/server/src/review/ReviewService.test.ts apps/web/src/components/DiffPanel.tsx`
- `vp fmt apps/server/src/review/ReviewService.ts apps/server/src/review/ReviewService.test.ts apps/web/src/components/DiffPanel.tsx --check`
- `git diff --check`
- live isolated server started with an unrelated configured cwd and accepted registration of an external dirty Git fixture; browser interaction could not be completed because the T3 collaborative preview reported that no automation host was available

## Current main compatibility

- based on `3c50a648`
- focused regression tests and targeted package type checks passed
- targeted formatting and lint passed
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches review path authorization and removes a client workaround; behavior change is intentional but affects who can request diffs and what errors users see.
> 
> **Overview**
> **Review diff previews** can use the **exact workspace root of an active registered project**, even when that path is outside `ServerConfig.cwd` or the managed worktrees directory. `ReviewService.assertWorkspaceBoundCwd` still rejects arbitrary unregistered paths.
> 
> On the web side, **`DiffPanel` no longer retries** branch/working-tree diff previews against the server process `cwd` after a “configured workspace root” failure. That fallback could show an **empty diff from the wrong repo** instead of the real error.
> 
> Tests mock `ProjectionSnapshotQuery` and cover the registered-project-root allow path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06bf6d40184fc83b3460ed014fd1a6fcf1e93b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow review diffs for registered projects outside configured workspace
> - `ReviewService.assertWorkspaceBoundCwd` now consults `ProjectionSnapshotQuery.getActiveProjectByWorkspaceRoot` when a `cwd` falls outside the configured workspace and worktrees directories, treating a matching registered project root as valid.
> - [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/4733/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) removes the fallback retry logic that reissued `diffPreview` with `serverConfig.cwd` on workspace root errors — the server-side fix makes this unnecessary.
> - Behavioral Change: `getDiffPreview` now accepts cwds that match a registered project root, expanding the set of valid inputs beyond the previously configured workspace boundaries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d06bf6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->