### PR TITLE
fix(web): align and space file search

### DIFF
--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -34,7 +34,9 @@ const TREE_UNSAFE_CSS = `
     --trees-border-color-override: color-mix(in srgb, currentColor 14%, transparent);
     --trees-font-family-override: var(--font-sans);
     --trees-font-size-override: 12px;
+    --trees-padding-inline-override: 12px;
   }
+  [data-file-tree-search-container] { padding-block-start: 4px; }
   button[data-type='item'] { border-radius: 5px; }
 `;
 


### PR DESCRIPTION
## Summary

- add a small top inset above the workspace file search so it is not flush with the file-tree boundary
- align the search field and tree with the Files panel 12px horizontal inset

## Root cause

The tree search container had no top padding, while `@pierre/trees` also defaulted to a 16px inline inset rather than the Files panel header spacing.

## Validation

- integrated web preview: search container has 4px top padding; the input begins 5px below the tree boundary including its existing 1px margin
- integrated web preview: search input and Files content share the same 12px horizontal inset
- `vp fmt --check apps/web/src/components/files/FileBrowserPanel.tsx`
- `vp lint apps/web/src/components/files/FileBrowserPanel.tsx`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`

This is a CSS-only layout change; file search behavior is unchanged.

Before:
<img width="534" height="95" alt="image" src="https://github.com/user-attachments/assets/9df0e079-c4ed-413d-85d5-09f876134391" />

After:
<img width="343" height="128" alt="image" src="https://github.com/user-attachments/assets/af218cec-3db4-4f89-9cd4-f17f69a6c91c" />

## Current main compatibility

- based on `3c50a648`
- targeted web type checking passed
- targeted formatting and lint passed
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout overrides in the file browser; no behavior or data-path changes.
> 
> **Overview**
> Tweaks **Pierre file tree** shadow-DOM overrides in `FileBrowserPanel` so the workspace file search matches the Files panel layout.
> 
> Sets `--trees-padding-inline-override` to **12px** (same as the panel header’s `px-3`) so the search field and tree rows share that horizontal inset instead of the library’s default **16px**. Adds **4px** `padding-block-start` on `[data-file-tree-search-container]` so the search is not flush against the top of the tree area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ca583d0cb7d03fc1a553cb99a721586db52dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->