### PR TITLE
fix: speed up Windows process diagnostics

### DIFF
--- a/apps/server/src/diagnostics/ProcessDiagnostics.test.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
+import { TestClock } from "effect/testing";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
@@ -16,10 +19,11 @@ function mockHandle(result: {
   readonly stdout?: string;
   readonly stderr?: string;
   readonly code?: number;
+  readonly exitCode?: Effect.Effect<ChildProcessSpawner.ExitCode>;
 }) {
   return ChildProcessSpawner.makeHandle({
     pid: ChildProcessSpawner.ProcessId(1),
-    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(result.code ?? 0)),
+    exitCode: result.exitCode ?? Effect.succeed(ChildProcessSpawner.ExitCode(result.code ?? 0)),
     isRunning: Effect.succeed(false),
     kill: () => Effect.void,
     unref: Effect.succeed(Effect.void),
@@ -208,6 +212,7 @@ describe("ProcessDiagnostics", () => {
       const diagnostics = yield* Effect.service(ProcessDiagnostics.ProcessDiagnostics).pipe(
         Effect.flatMap((pd) => pd.read),
         Effect.provide(layer),
+        Effect.provideService(HostProcessPlatform, "linux"),
       );
 
       expect(diagnostics.processes.map((process) => process.pid)).toEqual([4242]);
@@ -217,6 +222,140 @@ describe("ProcessDiagnostics", () => {
           args: ["-axo", "pid=,ppid=,pgid=,stat=,pcpu=,rss=,etime=,command="],
         },
       ]);
+    }),
+  );
+
+  it.effect("builds two bulk Windows CIM queries and parses their joined output", () =>
+    Effect.gen(function* () {
+      const commands: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> =
+        [];
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make((command) => {
+          const childProcess = command as unknown as {
+            readonly command: string;
+            readonly args: ReadonlyArray<string>;
+          };
+          commands.push({ command: childProcess.command, args: childProcess.args });
+          return Effect.succeed(
+            mockHandle({
+              stdout: JSON.stringify([
+                {
+                  ProcessId: 4242,
+                  ParentProcessId: process.pid,
+                  Name: "agent.exe",
+                  CommandLine: "agent.exe run",
+                  Status: null,
+                  WorkingSetSize: 4096,
+                  PercentProcessorTime: 12,
+                },
+              ]),
+            }),
+          );
+        }),
+      );
+
+      const rows = yield* ProcessDiagnostics.readProcessRows.pipe(
+        Effect.provide(spawnerLayer),
+        Effect.provideService(HostProcessPlatform, "win32"),
+      );
+
+      expect(rows).toEqual([
+        {
+          pid: 4242,
+          ppid: process.pid,
+          pgid: null,
+          status: "Live",
+          cpuPercent: 12,
+          rssBytes: 4096,
+          elapsed: "",
+          command: "agent.exe run",
+        },
+      ]);
+      expect(commands).toHaveLength(1);
+      expect(commands[0]?.command).toBe("powershell.exe");
+      expect(commands[0]?.args.slice(0, 3)).toEqual(["-NoProfile", "-NonInteractive", "-Command"]);
+      const powershellCommand = commands[0]?.args[3] ?? "";
+      expect(
+        powershellCommand.match(/Get-CimInstance Win32_PerfFormattedData_PerfProc_Process/g),
+      ).toHaveLength(1);
+      expect(powershellCommand.match(/Get-CimInstance Win32_Process\s+\|/g)).toHaveLength(1);
+      expect(powershellCommand).toContain(
+        "$perfByPid[[uint32]$_.IDProcess] = $_.PercentProcessorTime",
+      );
+      expect(powershellCommand).toContain("$perfByPid.ContainsKey([uint32]$_.ProcessId)");
+      expect(powershellCommand).toContain("$perfByPid[[uint32]$_.ProcessId]");
+      expect(powershellCommand).toContain("else { 0 }");
+      expect(powershellCommand).not.toContain("-Filter");
+    }),
+  );
+
+  it.effect("runs scoped child cleanup when the Windows deadline interrupts the query", () =>
+    Effect.gen(function* () {
+      let cleanupCalls = 0;
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.acquireRelease(
+            Effect.succeed(
+              mockHandle({
+                exitCode: Effect.never,
+              }),
+            ),
+            () => Effect.sync(() => cleanupCalls++),
+          ),
+        ),
+      );
+      const errorFiber = yield* ProcessDiagnostics.readProcessRows.pipe(
+        Effect.provide(spawnerLayer),
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.flip,
+        Effect.forkScoped,
+      );
+
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust(Duration.seconds(1));
+      const error = yield* Fiber.join(errorFiber);
+
+      expect(error).toMatchObject({
+        _tag: "ProcessDiagnosticsQueryTimeoutError",
+        command: "powershell.exe",
+        argCount: 4,
+        cwd: process.cwd(),
+        timeoutMillis: 1_000,
+      });
+      expect(cleanupCalls).toBe(1);
+    }),
+  );
+
+  it.effect("returns a bounded diagnostics result after a Windows query timeout", () =>
+    Effect.gen(function* () {
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.succeed(
+            mockHandle({
+              exitCode: Effect.never,
+            }),
+          ),
+        ),
+      );
+      const layer = ProcessDiagnostics.layer.pipe(Layer.provide(spawnerLayer));
+      const resultFiber = yield* Effect.service(ProcessDiagnostics.ProcessDiagnostics).pipe(
+        Effect.flatMap((pd) => pd.read),
+        Effect.provide(layer),
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.forkScoped,
+      );
+
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust(Duration.seconds(1));
+      const result = yield* Fiber.join(resultFiber);
+
+      expect(result.processes).toEqual([]);
+      expect(Option.getOrThrow(result.error).message).toBe(
+        `Process diagnostics query 'powershell.exe' timed out after 1000ms in '${process.cwd()}'.`,
+      );
     }),
   );
 
@@ -278,6 +417,7 @@ describe("ProcessDiagnostics", () => {
       const result = yield* Effect.service(ProcessDiagnostics.ProcessDiagnostics).pipe(
         Effect.flatMap((pd) => pd.signal({ pid: 4242, signal: "SIGINT" })),
         Effect.provide(layer),
+        Effect.provideService(HostProcessPlatform, "linux"),
       );
 
       expect(result).toEqual({

--- a/apps/server/src/diagnostics/ProcessDiagnostics.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.ts
@@ -443,9 +443,10 @@ function readWindowsProcessRows(): Effect.Effect<
   ChildProcessSpawner.ChildProcessSpawner
 > {
   const command = [
+    "$perfByPid = @{};",
+    "Get-CimInstance Win32_PerfFormattedData_PerfProc_Process -ErrorAction SilentlyContinue | ForEach-Object { $perfByPid[[uint32]$_.IDProcess] = $_.PercentProcessorTime };",
     "$processes = Get-CimInstance Win32_Process | ForEach-Object {",
-    '$perf = Get-CimInstance Win32_PerfFormattedData_PerfProc_Process -Filter "IDProcess = $($_.ProcessId)" -ErrorAction SilentlyContinue;',
-    "[pscustomobject]@{ ProcessId = $_.ProcessId; ParentProcessId = $_.ParentProcessId; Name = $_.Name; CommandLine = $_.CommandLine; Status = $_.Status; WorkingSetSize = $_.WorkingSetSize; PercentProcessorTime = if ($perf) { $perf.PercentProcessorTime } else { 0 } }",
+    "[pscustomobject]@{ ProcessId = $_.ProcessId; ParentProcessId = $_.ParentProcessId; Name = $_.Name; CommandLine = $_.CommandLine; Status = $_.Status; WorkingSetSize = $_.WorkingSetSize; PercentProcessorTime = if ($perfByPid.ContainsKey([uint32]$_.ProcessId)) { $perfByPid[[uint32]$_.ProcessId] } else { 0 } }",
     "};",
     "$processes | ConvertTo-Json -Compress -Depth 3",
   ].join(" ");


### PR DESCRIPTION
## Summary

- replace the Windows per-process performance CIM lookup with one bulk performance query
- join process and performance snapshots by PID in PowerShell
- add deterministic coverage for command shape, parsing, timeout cleanup, and bounded error recovery

## Root cause

The Windows diagnostics command queried `Win32_PerfFormattedData_PerfProc_Process` once for every `Win32_Process` row. That N+1 CIM pattern routinely exceeded the existing 1,000 ms diagnostics deadline.

The optimized command completed in all 25 local fresh-PowerShell samples (674–735 ms in the initial sample; 670 ms min, 701 ms median, 730 ms p95, and 733 ms max across the expanded 20-run sample). None exceeded 1,000 ms. This change intentionally keeps the existing deadline and limits scope to eliminating the expensive query pattern; a timeout increase can be considered separately if cross-machine evidence warrants it.

## Impact

Windows process diagnostics now issue two CIM queries regardless of process count while preserving the existing output shape and zero CPU fallback when performance data is unavailable. POSIX behavior and all timeout values are unchanged.

## Validation

- `vp test run apps/server/src/diagnostics/ProcessDiagnostics.test.ts` (9 passed)
- `vp lint apps/server/src/diagnostics/ProcessDiagnostics.ts apps/server/src/diagnostics/ProcessDiagnostics.test.ts --report-unused-disable-directives`
- `vp run typecheck` from `apps/server`
- targeted `vp fmt ... --check`
- `git diff --check`

Related: #3610

## Current main compatibility

- based on `3c50a648`
- focused regression tests and targeted package type checks passed
- targeted formatting and lint passed
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is isolated to the Windows PowerShell diagnostics script and test harness; POSIX paths and the 1s timeout are unchanged.
> 
> **Overview**
> **Windows process diagnostics** no longer run a per-process CIM performance lookup inside the `Win32_Process` loop. The PowerShell command now loads all `Win32_PerfFormattedData_PerfProc_Process` rows once into a `$perfByPid` hashtable, then joins CPU by PID when building each process object (still defaulting to `0` when perf data is missing).
> 
> Tests pin **linux** explicitly where POSIX `ps` is expected, extend the process mock for hung exits, and add Windows coverage for the bulk query shape (single perf CIM call, no `-Filter`), JSON parsing, scoped cleanup on the 1s timeout, and bounded empty results with an error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cf0bbc9abe0cea6955893a62b5fa736d2153c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up Windows process diagnostics by replacing per-process CIM queries with a bulk query
> - `readWindowsProcessRows` in [ProcessDiagnostics.ts](https://github.com/pingdotgg/t3code/pull/4736/files#diff-3976428399caa24c646f345343c779cdea0f12d571dd49a947e677d81f460ced) previously issued a separate `Get-CimInstance Win32_PerfFormattedData_PerfProc_Process -Filter "IDProcess = ..."` call for every process.
> - Now performs a single bulk query of `Win32_PerfFormattedData_PerfProc_Process`, materializes results into a hashtable keyed by `IDProcess`, then joins with a single `Win32_Process` iteration using `ContainsKey`.
> - New tests cover the bulk query command structure, timeout/deadline behavior with scoped cleanup, and bounded results after a timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6cf0bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->