### PR TITLE
feat(web): preview workspace images from chat and diffs

### DIFF
--- a/apps/web/src/browser/openFileInPreview.test.ts
+++ b/apps/web/src/browser/openFileInPreview.test.ts
@@ -1,0 +1,134 @@
+import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import type { PreviewSessionSnapshot, ScopedThreadRef } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { readThreadPreviewState, resetPreviewStateForTests } from "~/previewStateStore";
+import { selectThreadRightPanelState, useRightPanelStore } from "~/rightPanelStore";
+
+import {
+  BrowserPreviewUnavailableError,
+  isBrowserPreviewAssetUrlInvalidError,
+  type OpenPreviewMutation,
+  openFileInPreview,
+  openUrlInPreview,
+} from "./openFileInPreview";
+
+const threadRef = {
+  environmentId: "environment-1" as ScopedThreadRef["environmentId"],
+  threadId: "thread-1" as ScopedThreadRef["threadId"],
+};
+
+const snapshot = (tabId: string, url: string): PreviewSessionSnapshot => ({
+  threadId: threadRef.threadId,
+  tabId,
+  navStatus: { _tag: "Success", url, title: "" },
+  canGoBack: false,
+  canGoForward: false,
+  updatedAt: "2026-06-21T00:00:00.000Z",
+});
+
+beforeEach(() => {
+  resetPreviewStateForTests();
+  useRightPanelStore.setState({ byThreadKey: {} });
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("openFileInPreview", () => {
+  it("reports an unavailable runtime with thread context", async () => {
+    vi.stubGlobal("window", {});
+
+    const result = await openFileInPreview({
+      threadRef,
+      filePath: "docs/report.pdf",
+      httpBaseUrl: "https://environment.test",
+      createAssetUrl: vi.fn(),
+      openPreview: vi.fn(),
+    });
+    const error = result._tag === "Failure" ? Cause.squash(result.cause) : undefined;
+
+    expect(error).toEqual(
+      new BrowserPreviewUnavailableError({
+        environmentId: "environment-1",
+        threadId: "thread-1",
+      }),
+    );
+    expect(error).toMatchObject({
+      message: "The integrated browser is unavailable in this runtime.",
+    });
+  });
+
+  it("reports invalid asset URLs with safe context and the exact parser cause", async () => {
+    vi.stubGlobal("window", { desktopBridge: { preview: {} } });
+    const parserCause = new TypeError("invalid URL");
+    const InvalidUrl = vi.fn(function InvalidUrl() {
+      throw parserCause;
+    });
+    vi.stubGlobal("URL", InvalidUrl);
+    const openPreview = vi.fn();
+    const httpBaseUrl = "not a URL";
+    const relativeUrl = "/api/assets/signed-secret-token/docs/report.pdf";
+    const expiresAt = Date.now();
+
+    const result = await openFileInPreview({
+      threadRef,
+      filePath: "docs/report.pdf",
+      httpBaseUrl,
+      createAssetUrl: async () => AsyncResult.success({ relativeUrl, expiresAt }),
+      openPreview,
+    });
+    const error = result._tag === "Failure" ? Cause.squash(result.cause) : undefined;
+
+    expect(isBrowserPreviewAssetUrlInvalidError(error)).toBe(true);
+    if (!isBrowserPreviewAssetUrlInvalidError(error)) {
+      throw new Error("Expected BrowserPreviewAssetUrlInvalidError");
+    }
+    expect(error).toMatchObject({
+      environmentId: "environment-1",
+      threadId: "thread-1",
+      filePath: "docs/report.pdf",
+      httpBaseUrlLength: httpBaseUrl.length,
+      relativeUrlLength: relativeUrl.length,
+      expiresAt,
+    });
+    expect(error.cause).toBe(parserCause);
+    expect(error.message).toBe("The environment returned an invalid asset URL.");
+    expect(error).not.toHaveProperty("httpBaseUrl");
+    expect(error).not.toHaveProperty("relativeUrl");
+    expect(JSON.stringify(error)).not.toContain("signed-secret-token");
+    expect(openPreview).not.toHaveBeenCalled();
+  });
+
+  it("does not apply an older preview response after another caller starts a newer request", async () => {
+    const firstSnapshot = snapshot("tab-1", "https://assets.test/first.png");
+    const secondSnapshot = snapshot("tab-2", "https://assets.test/second.png");
+    let resolveFirst!: (result: AtomCommandResult<PreviewSessionSnapshot, never>) => void;
+    const openPreview: OpenPreviewMutation<never> = ({ input }) =>
+      input.url === "https://assets.test/first.png"
+        ? new Promise<AtomCommandResult<PreviewSessionSnapshot, never>>((resolve) => {
+            resolveFirst = resolve;
+          })
+        : Promise.resolve(AsyncResult.success(secondSnapshot));
+
+    const firstRequest = openUrlInPreview({
+      threadRef,
+      url: "https://assets.test/first.png",
+      openPreview,
+    });
+
+    await openUrlInPreview({
+      threadRef,
+      url: "https://assets.test/second.png",
+      openPreview,
+    });
+    resolveFirst(AsyncResult.success(firstSnapshot));
+    await firstRequest;
+
+    expect(readThreadPreviewState(threadRef).snapshot).toEqual(secondSnapshot);
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, threadRef).surfaces,
+    ).toEqual([{ id: "browser:tab-2", kind: "preview", resourceId: "tab-2" }]);
+  });
+});

--- a/apps/web/src/browser/openFileInPreview.ts
+++ b/apps/web/src/browser/openFileInPreview.ts
@@ -6,15 +6,20 @@ import type {
   PreviewSessionSnapshot,
   ScopedThreadRef,
 } from "@t3tools/contracts";
+import { scopedThreadKey } from "@t3tools/client-runtime/environment";
 import {
   type AtomCommandResult,
   mapAtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
+import {
+  isWorkspaceBrowserPreviewPath,
+  isWorkspaceImagePreviewPath,
+  isWorkspacePreviewEntryPath,
+} from "@t3tools/shared/filePreview";
 import * as Cause from "effect/Cause";
-import * as Data from "effect/Data";
+import * as Schema from "effect/Schema";
 import { AsyncResult } from "effect/unstable/reactivity";
 
-import { resolveAssetUrl } from "~/assets/assetUrls";
 import {
   applyPreviewServerSnapshot,
   isPreviewSupportedInRuntime,
@@ -22,34 +27,126 @@ import {
 } from "~/previewStateStore";
 import { useRightPanelStore } from "~/rightPanelStore";
 
-export const isBrowserPreviewFile = (path: string): boolean =>
-  /\.(?:html?|pdf)$/i.test(path.split(/[?#]/, 1)[0] ?? "");
+export const isBrowserPreviewFile = isWorkspaceBrowserPreviewPath;
+export const isImagePreviewFile = isWorkspaceImagePreviewPath;
+export const isWorkspacePreviewFile = isWorkspacePreviewEntryPath;
 
-export class BrowserPreviewUnavailableError extends Data.TaggedError(
+export class BrowserPreviewUnavailableError extends Schema.TaggedErrorClass<BrowserPreviewUnavailableError>()(
   "BrowserPreviewUnavailableError",
-)<{
-  readonly message: string;
-}> {}
+  {
+    environmentId: Schema.String,
+    threadId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "The integrated browser is unavailable in this runtime.";
+  }
+}
+
+export class BrowserPreviewThreadContextUnavailableError extends Schema.TaggedErrorClass<BrowserPreviewThreadContextUnavailableError>()(
+  "BrowserPreviewThreadContextUnavailableError",
+  {},
+) {
+  override get message(): string {
+    return "Thread context is unavailable.";
+  }
+}
+
+export class BrowserPreviewEnvironmentDisconnectedError extends Schema.TaggedErrorClass<BrowserPreviewEnvironmentDisconnectedError>()(
+  "BrowserPreviewEnvironmentDisconnectedError",
+  {
+    environmentId: Schema.String,
+    threadId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "Environment is not connected.";
+  }
+}
+
+export class BrowserPreviewAssetUrlInvalidError extends Schema.TaggedErrorClass<BrowserPreviewAssetUrlInvalidError>()(
+  "BrowserPreviewAssetUrlInvalidError",
+  {
+    environmentId: Schema.String,
+    threadId: Schema.String,
+    filePath: Schema.String,
+    httpBaseUrlLength: Schema.Int,
+    relativeUrlLength: Schema.Int,
+    expiresAt: Schema.Int,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "The environment returned an invalid asset URL.";
+  }
+}
+
+export const isBrowserPreviewAssetUrlInvalidError = Schema.is(BrowserPreviewAssetUrlInvalidError);
 
 export type OpenPreviewMutation<E = unknown> = (input: {
   readonly environmentId: EnvironmentId;
   readonly input: PreviewOpenInput;
 }) => Promise<AtomCommandResult<PreviewSessionSnapshot, E>>;
 
-export async function openUrlInPreview<E>(input: {
-  readonly threadRef: ScopedThreadRef;
-  readonly url: string;
-  readonly openPreview: OpenPreviewMutation<E>;
-}): Promise<AtomCommandResult<void, E>> {
+interface PreviewRequest {
+  readonly isCurrent: () => boolean;
+  readonly complete: () => void;
+}
+
+const activePreviewRequestByThread = new Map<string, symbol>();
+
+const beginPreviewRequest = (
+  threadRef: ScopedThreadRef,
+  signal: AbortSignal | undefined,
+): PreviewRequest => {
+  const threadKey = scopedThreadKey(threadRef);
+  const requestId = Symbol();
+  activePreviewRequestByThread.set(threadKey, requestId);
+  return {
+    isCurrent: () =>
+      activePreviewRequestByThread.get(threadKey) === requestId && signal?.aborted !== true,
+    complete: () => {
+      if (activePreviewRequestByThread.get(threadKey) === requestId) {
+        activePreviewRequestByThread.delete(threadKey);
+      }
+    },
+  };
+};
+
+const openUrlForPreviewRequest = async <E>(
+  input: {
+    readonly threadRef: ScopedThreadRef;
+    readonly url: string;
+    readonly openPreview: OpenPreviewMutation<E>;
+  },
+  request: PreviewRequest,
+): Promise<AtomCommandResult<void, E>> => {
   const result = await input.openPreview({
     environmentId: input.threadRef.environmentId,
     input: { threadId: input.threadRef.threadId, url: input.url },
   });
+  if (!request.isCurrent()) {
+    return AsyncResult.success(undefined);
+  }
   return mapAtomCommandResult(result, (snapshot) => {
     applyPreviewServerSnapshot(input.threadRef, snapshot);
     rememberPreviewUrl(input.threadRef, input.url);
     useRightPanelStore.getState().openBrowser(input.threadRef, snapshot.tabId);
   });
+};
+
+export async function openUrlInPreview<E>(input: {
+  readonly threadRef: ScopedThreadRef;
+  readonly url: string;
+  readonly openPreview: OpenPreviewMutation<E>;
+  readonly signal?: AbortSignal;
+}): Promise<AtomCommandResult<void, E>> {
+  const request = beginPreviewRequest(input.threadRef, input.signal);
+  try {
+    return await openUrlForPreviewRequest(input, request);
+  } finally {
+    request.complete();
+  }
 }
 
 export async function openFileInPreview<AssetError, PreviewError>(input: {
@@ -61,38 +158,68 @@ export async function openFileInPreview<AssetError, PreviewError>(input: {
     readonly input: { readonly resource: AssetResource };
   }) => Promise<AtomCommandResult<AssetCreateUrlResult, AssetError>>;
   readonly openPreview: OpenPreviewMutation<PreviewError>;
-}): Promise<AtomCommandResult<void, AssetError | PreviewError | BrowserPreviewUnavailableError>> {
-  if (!isPreviewSupportedInRuntime()) {
-    return AsyncResult.failure(
-      Cause.fail(
-        new BrowserPreviewUnavailableError({
-          message: "The integrated browser is unavailable in this runtime.",
-        }),
-      ),
-    );
-  }
-  const assetResult = await input.createAssetUrl({
-    environmentId: input.threadRef.environmentId,
-    input: {
-      resource: {
-        _tag: "workspace-file",
-        threadId: input.threadRef.threadId,
-        path: input.filePath,
+  readonly signal?: AbortSignal;
+}): Promise<
+  AtomCommandResult<
+    void,
+    AssetError | PreviewError | BrowserPreviewUnavailableError | BrowserPreviewAssetUrlInvalidError
+  >
+> {
+  const request = beginPreviewRequest(input.threadRef, input.signal);
+  try {
+    if (!isPreviewSupportedInRuntime()) {
+      return AsyncResult.failure(
+        Cause.fail(
+          new BrowserPreviewUnavailableError({
+            environmentId: input.threadRef.environmentId,
+            threadId: input.threadRef.threadId,
+          }),
+        ),
+      );
+    }
+    const assetResult = await input.createAssetUrl({
+      environmentId: input.threadRef.environmentId,
+      input: {
+        resource: {
+          _tag: "workspace-file",
+          threadId: input.threadRef.threadId,
+          path: input.filePath,
+        },
       },
-    },
-  });
-  if (assetResult._tag === "Failure") {
-    return AsyncResult.failure(assetResult.cause);
-  }
-  const assetUrl = resolveAssetUrl(input.httpBaseUrl, assetResult.value.relativeUrl);
-  if (assetUrl === null) {
-    return AsyncResult.failure(
-      Cause.die(new Error("The environment returned an invalid asset URL.")),
+    });
+    if (!request.isCurrent()) {
+      return AsyncResult.success(undefined);
+    }
+    if (assetResult._tag === "Failure") {
+      return AsyncResult.failure(assetResult.cause);
+    }
+    let assetUrl: string;
+    try {
+      assetUrl = new URL(assetResult.value.relativeUrl, input.httpBaseUrl).toString();
+    } catch (cause) {
+      return AsyncResult.failure(
+        Cause.fail(
+          new BrowserPreviewAssetUrlInvalidError({
+            environmentId: input.threadRef.environmentId,
+            threadId: input.threadRef.threadId,
+            filePath: input.filePath,
+            httpBaseUrlLength: input.httpBaseUrl.length,
+            relativeUrlLength: assetResult.value.relativeUrl.length,
+            expiresAt: assetResult.value.expiresAt,
+            cause,
+          }),
+        ),
+      );
+    }
+    return await openUrlForPreviewRequest(
+      {
+        threadRef: input.threadRef,
+        url: assetUrl,
+        openPreview: input.openPreview,
+      },
+      request,
     );
+  } finally {
+    request.complete();
   }
-  return openUrlInPreview({
-    threadRef: input.threadRef,
-    url: assetUrl,
-    openPreview: input.openPreview,
-  });
 }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -83,10 +83,11 @@ import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import {
-  isBrowserPreviewFile,
+  isWorkspacePreviewFile,
   openFileInPreview,
   openUrlInPreview,
-  BrowserPreviewUnavailableError,
+  BrowserPreviewEnvironmentDisconnectedError,
+  BrowserPreviewThreadContextUnavailableError,
 } from "../browser/openFileInPreview";
 
 class CodeHighlightErrorBoundary extends React.Component<
@@ -748,7 +749,9 @@ interface MarkdownFileLinkProps {
   theme: "light" | "dark";
   threadRef?: ScopedThreadRef | undefined;
   onOpen: (targetPath: string) => Promise<AtomCommandResult<unknown, unknown>>;
-  onOpenInBrowser?: (() => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
+  onOpenInBrowser?:
+    | ((signal: AbortSignal) => Promise<AtomCommandResult<unknown, unknown>>)
+    | undefined;
   className?: string | undefined;
 }
 
@@ -1019,6 +1022,15 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   onOpenInBrowser,
   className,
 }: MarkdownFileLinkProps) {
+  const browserPreviewAbortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(
+    () => () => {
+      browserPreviewAbortControllerRef.current?.abort();
+    },
+    [threadRef?.environmentId, threadRef?.threadId],
+  );
+
   const handleOpenInEditor = useCallback(() => {
     void (async () => {
       try {
@@ -1066,10 +1078,20 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
     if (!onOpenInBrowser) {
       return;
     }
+    browserPreviewAbortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    browserPreviewAbortControllerRef.current = abortController;
     void (async () => {
       try {
-        const result = await onOpenInBrowser();
-        if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
+        const result = await onOpenInBrowser(abortController.signal);
+        if (abortController.signal.aborted) {
+          return;
+        }
+        if (result._tag === "Success") {
+          return;
+        }
+        if (isAtomCommandInterrupted(result)) {
+          handleOpenInFilePreview();
           return;
         }
         reportMarkdownActionFailure(
@@ -1079,26 +1101,41 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         const error = squashAtomCommandFailure(result);
         toastManager.add(
           stackedThreadToast({
-            type: "error",
-            title: "Unable to open file in browser",
-            description: error instanceof Error ? error.message : "An error occurred.",
+            type: "warning",
+            title: "Unable to open file preview",
+            description:
+              error instanceof Error
+                ? `${error.message} Opening the file instead.`
+                : "Opening the file instead.",
           }),
         );
+        handleOpenInFilePreview();
       } catch (cause) {
+        if (abortController.signal.aborted) {
+          return;
+        }
         reportMarkdownActionFailure(
           { operation: "open-file-in-browser", target: targetPath },
           cause,
         );
         toastManager.add(
           stackedThreadToast({
-            type: "error",
-            title: "Unable to open file in browser",
-            description: cause instanceof Error ? cause.message : "An error occurred.",
+            type: "warning",
+            title: "Unable to open file preview",
+            description:
+              cause instanceof Error
+                ? `${cause.message} Opening the file instead.`
+                : "Opening the file instead.",
           }),
         );
+        handleOpenInFilePreview();
+      } finally {
+        if (browserPreviewAbortControllerRef.current === abortController) {
+          browserPreviewAbortControllerRef.current = null;
+        }
       }
     })();
-  }, [onOpenInBrowser, targetPath]);
+  }, [handleOpenInFilePreview, onOpenInBrowser, targetPath]);
 
   const handleCopy = useCallback(
     (value: string, title: string) => {
@@ -1303,12 +1340,8 @@ function ChatMarkdown({
     (url: string) => {
       if (!threadRef) {
         return Promise.resolve(
-          AsyncResult.failure<void, BrowserPreviewUnavailableError>(
-            Cause.fail(
-              new BrowserPreviewUnavailableError({
-                message: "Thread context is unavailable.",
-              }),
-            ),
+          AsyncResult.failure<void, BrowserPreviewThreadContextUnavailableError>(
+            Cause.fail(new BrowserPreviewThreadContextUnavailableError()),
           ),
         );
       }
@@ -1317,13 +1350,21 @@ function ChatMarkdown({
     [openPreview, threadRef],
   );
   const openMarkdownFileInPreview = useCallback(
-    (path: string) => {
-      if (!threadRef || preparedConnection._tag === "None") {
+    (path: string, signal: AbortSignal) => {
+      if (!threadRef) {
         return Promise.resolve(
-          AsyncResult.failure<void, BrowserPreviewUnavailableError>(
+          AsyncResult.failure<void, BrowserPreviewThreadContextUnavailableError>(
+            Cause.fail(new BrowserPreviewThreadContextUnavailableError()),
+          ),
+        );
+      }
+      if (preparedConnection._tag === "None") {
+        return Promise.resolve(
+          AsyncResult.failure<void, BrowserPreviewEnvironmentDisconnectedError>(
             Cause.fail(
-              new BrowserPreviewUnavailableError({
-                message: "Environment is not connected.",
+              new BrowserPreviewEnvironmentDisconnectedError({
+                environmentId: threadRef.environmentId,
+                threadId: threadRef.threadId,
               }),
             ),
           ),
@@ -1335,6 +1376,7 @@ function ChatMarkdown({
         httpBaseUrl: preparedConnection.value.httpBaseUrl,
         createAssetUrl,
         openPreview,
+        signal,
       });
     },
     [createAssetUrl, openPreview, preparedConnection, threadRef],
@@ -1480,10 +1522,11 @@ function ChatMarkdown({
             threadRef={threadRef}
             onOpen={openInPreferredEditor}
             onOpenInBrowser={
+              fileLinkMeta.workspaceRelativePath !== null &&
               threadRef &&
               isPreviewSupportedInRuntime() &&
-              isBrowserPreviewFile(fileLinkMeta.filePath)
-                ? () => openMarkdownFileInPreview(fileLinkMeta.filePath)
+              isWorkspacePreviewFile(fileLinkMeta.filePath)
+                ? (signal) => openMarkdownFileInPreview(fileLinkMeta.filePath, signal)
                 : undefined
             }
             className={props.className}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -124,6 +124,8 @@ import {
   type RightPanelSurface,
   useRightPanelStore,
 } from "../rightPanelStore";
+import { isImagePreviewFile, openFileInPreview } from "../browser/openFileInPreview";
+import { resolvePathLinkTarget } from "../terminal-links";
 import {
   isPreviewSupportedInRuntime,
   setActivePreviewTab,
@@ -210,7 +212,12 @@ import {
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
-import { useEnvironments, usePrimaryEnvironment } from "../state/environments";
+import {
+  useEnvironmentHttpBaseUrl,
+  useEnvironments,
+  usePrimaryEnvironment,
+} from "../state/environments";
+import { assetEnvironment } from "../state/assets";
 import {
   useProject,
   useProjects,
@@ -281,6 +288,7 @@ import { sanitizeThreadErrorMessage } from "~/rpc/transportError";
 import { RightPanelSheet } from "./RightPanelSheet";
 import { previewEnvironment } from "../state/preview";
 import { useAtomCommand } from "../state/use-atom-command";
+import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { Button } from "./ui/button";
 import {
   AlertDialog,
@@ -1171,6 +1179,10 @@ function ChatViewContent(props: ChatViewProps) {
     reportFailure: false,
   });
   const openPreview = useAtomCommand(previewEnvironment.open, { reportFailure: false });
+  const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
+    reportFailure: false,
+  });
+  const filePreviewAbortControllerRef = useRef<AbortController | null>(null);
   const closePreview = useAtomCommand(previewEnvironment.close, "preview close");
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
@@ -1589,6 +1601,9 @@ function ChatViewContent(props: ChatViewProps) {
   const handleNewThreadInActiveProject = useCallback(() => {
     startNewThreadForProject(activeProjectRef, handleNewThread);
   }, [activeProjectRef, handleNewThread]);
+  const activeEnvironmentHttpBaseUrl = useEnvironmentHttpBaseUrl(
+    activeProject?.environmentId ?? null,
+  );
   const activeEnvironmentShell = useEnvironmentQuery(
     activeThread ? environmentShell.stateAtom(activeThread.environmentId) : null,
   );
@@ -3039,12 +3054,73 @@ function ChatViewContent(props: ChatViewProps) {
     if (!activeThreadRef || !activeProject) return;
     useRightPanelStore.getState().open(activeThreadRef, "files");
   }, [activeProject, activeThreadRef]);
+  useEffect(
+    () => () => {
+      filePreviewAbortControllerRef.current?.abort();
+    },
+    [activeThreadKey],
+  );
   const openFileSurface = useCallback(
     (relativePath: string) => {
       if (!activeThreadRef || !activeProject) return;
-      useRightPanelStore.getState().openFile(activeThreadRef, relativePath);
+      filePreviewAbortControllerRef.current?.abort();
+      const openFallback = () => {
+        useRightPanelStore.getState().openFile(activeThreadRef, relativePath);
+      };
+      if (
+        !isImagePreviewFile(relativePath) ||
+        !isPreviewSupportedInRuntime() ||
+        !activeWorkspaceRoot ||
+        !activeEnvironmentHttpBaseUrl
+      ) {
+        openFallback();
+        return;
+      }
+
+      const abortController = new AbortController();
+      filePreviewAbortControllerRef.current = abortController;
+      const absolutePath = resolvePathLinkTarget(relativePath, activeWorkspaceRoot);
+      void (async () => {
+        const result = await openFileInPreview({
+          threadRef: activeThreadRef,
+          filePath: absolutePath,
+          httpBaseUrl: activeEnvironmentHttpBaseUrl,
+          createAssetUrl,
+          openPreview,
+          signal: abortController.signal,
+        });
+        if (abortController.signal.aborted) {
+          return;
+        }
+        if (result._tag === "Success") {
+          return;
+        }
+        if (isAtomCommandInterrupted(result)) {
+          openFallback();
+          return;
+        }
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "warning",
+            title: "Unable to open image preview",
+            description:
+              error instanceof Error
+                ? `${error.message} Opening the file instead.`
+                : "Opening the file instead.",
+          }),
+        );
+        openFallback();
+      })();
     },
-    [activeProject, activeThreadRef],
+    [
+      activeEnvironmentHttpBaseUrl,
+      activeProject,
+      activeThreadRef,
+      activeWorkspaceRoot,
+      createAssetUrl,
+      openPreview,
+    ],
   );
   const togglePreviewPanel = useCallback(() => {
     if (!activeThreadRef || !isPreviewSupportedInRuntime()) return;

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -23,6 +23,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOpenInPreferredEditor } from "../editorPreferences";
 import { type DraftId } from "../composerDraftStore";
 import { openDiffFilePrimaryAction } from "../diffFileActions";
+import { isImagePreviewFile, openFileInPreview } from "../browser/openFileInPreview";
+import { resolvePathLinkTarget } from "../terminal-links";
+import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { useCheckpointDiff } from "~/lib/checkpointDiffState";
 import { cn } from "~/lib/utils";
 import { selectThreadDiffPanelSelection, useDiffPanelStore } from "../diffPanelStore";
@@ -67,10 +70,16 @@ import {
 } from "./ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import { useEnvironmentQuery } from "../state/query";
+import { assetEnvironment } from "../state/assets";
+import { previewEnvironment } from "../state/preview";
 import { serverEnvironment } from "../state/server";
 import { reviewEnvironment } from "../state/review";
 import { vcsEnvironment } from "../state/vcs";
+import { useEnvironmentHttpBaseUrl } from "../state/environments";
+import { useAtomCommand } from "../state/use-atom-command";
+import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { buildBaseRefChoices, filterBaseRefChoices } from "../lib/baseRefChoices";
+import { stackedThreadToast, toastManager } from "./ui/toast";
 
 type DiffRenderMode = "stacked" | "split";
 type DiffThemeType = "light" | "dark";
@@ -223,6 +232,12 @@ export default function DiffPanel({
       : null,
   );
   const activeCwd = activeThread?.worktreePath ?? activeProject?.workspaceRoot;
+  const environmentHttpBaseUrl = useEnvironmentHttpBaseUrl(activeThread?.environmentId ?? null);
+  const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
+    reportFailure: false,
+  });
+  const openPreview = useAtomCommand(previewEnvironment.open, { reportFailure: false });
+  const filePreviewAbortControllerRef = useRef<AbortController | null>(null);
   const serverConfig = useAtomValue(
     serverEnvironment.configValueAtom(activeThread?.environmentId ?? null),
   );
@@ -463,32 +478,95 @@ export default function DiffPanel({
     codeViewRef.current?.scrollTo({ type: "item", id: file.fileKey, align: "start" });
   }, [codeViewFiles, selectedFilePath, selectedFileRevealRequestId]);
 
+  useEffect(
+    () => () => {
+      filePreviewAbortControllerRef.current?.abort();
+    },
+    [routeThreadRef?.environmentId, routeThreadRef?.threadId],
+  );
+
   const openDiffFile = useCallback(
     (filePath: string) => {
-      openDiffFilePrimaryAction({
-        threadRef: routeThreadRef,
-        filePath,
-        activeCwd,
-        openInEditor: (targetPath) => {
-          void (async () => {
-            const result = await openInPreferredEditor(targetPath);
-            if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-              console.warn("Failed to open diff file in editor.", {
-                operation: "open-diff-file",
-                ...(routeThreadRef
-                  ? {
-                      environmentId: routeThreadRef.environmentId,
-                      threadId: routeThreadRef.threadId,
-                    }
-                  : {}),
-                ...safeErrorLogAttributes(squashAtomCommandFailure(result)),
-              });
-            }
-          })();
-        },
-      });
+      filePreviewAbortControllerRef.current?.abort();
+      const openFallback = () => {
+        openDiffFilePrimaryAction({
+          threadRef: routeThreadRef,
+          filePath,
+          activeCwd,
+          openInEditor: (targetPath) => {
+            void (async () => {
+              const result = await openInPreferredEditor(targetPath);
+              if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+                console.warn("Failed to open diff file in editor.", {
+                  operation: "open-diff-file",
+                  ...(routeThreadRef
+                    ? {
+                        environmentId: routeThreadRef.environmentId,
+                        threadId: routeThreadRef.threadId,
+                      }
+                    : {}),
+                  ...safeErrorLogAttributes(squashAtomCommandFailure(result)),
+                });
+              }
+            })();
+          },
+        });
+      };
+
+      if (
+        !routeThreadRef ||
+        !activeCwd ||
+        !environmentHttpBaseUrl ||
+        !isPreviewSupportedInRuntime() ||
+        !isImagePreviewFile(filePath)
+      ) {
+        openFallback();
+        return;
+      }
+
+      const abortController = new AbortController();
+      filePreviewAbortControllerRef.current = abortController;
+      void (async () => {
+        const result = await openFileInPreview({
+          threadRef: routeThreadRef,
+          filePath: resolvePathLinkTarget(filePath, activeCwd),
+          httpBaseUrl: environmentHttpBaseUrl,
+          createAssetUrl,
+          openPreview,
+          signal: abortController.signal,
+        });
+        if (abortController.signal.aborted) {
+          return;
+        }
+        if (result._tag === "Success") {
+          return;
+        }
+        if (isAtomCommandInterrupted(result)) {
+          openFallback();
+          return;
+        }
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "warning",
+            title: "Unable to open image preview",
+            description:
+              error instanceof Error
+                ? `${error.message} Opening the file instead.`
+                : "Opening the file instead.",
+          }),
+        );
+        openFallback();
+      })();
     },
-    [activeCwd, openInPreferredEditor, routeThreadRef],
+    [
+      activeCwd,
+      createAssetUrl,
+      environmentHttpBaseUrl,
+      openInPreferredEditor,
+      openPreview,
+      routeThreadRef,
+    ],
   );
   const toggleDiffFileCollapsed = useCallback(
     (fileKey: string) => {

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -16,7 +16,7 @@ import { ChevronRight, Code2, Eye, FolderTree, Globe2, LoaderCircle } from "luci
 import * as Schema from "effect/Schema";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { isBrowserPreviewFile, openFileInPreview } from "~/browser/openFileInPreview";
+import { isWorkspacePreviewFile, openFileInPreview } from "~/browser/openFileInPreview";
 import { useAssetUrlState } from "~/assets/assetUrls";
 import ChatMarkdown from "~/components/ChatMarkdown";
 import { OpenInPicker } from "~/components/chat/OpenInPicker";
@@ -682,8 +682,8 @@ export default function FilePreviewPanel({
     isMarkdown &&
     markdownView.path === relativePath &&
     (revealLine === null || markdownView.revealRequestId === revealRequestId);
-  const canOpenInBrowser =
-    relativePath !== null && isPreviewSupportedInRuntime() && isBrowserPreviewFile(relativePath);
+  const canOpenInPreview =
+    relativePath !== null && isPreviewSupportedInRuntime() && isWorkspacePreviewFile(relativePath);
   const absolutePath = relativePath ? resolvePathLinkTarget(relativePath, cwd) : null;
   const breadcrumbs = useMemo(
     () => (relativePath ? fileBreadcrumbs(projectName, relativePath) : []),
@@ -710,7 +710,7 @@ export default function FilePreviewPanel({
     });
   };
 
-  const handleOpenInBrowser = useCallback(() => {
+  const handleOpenInPreview = useCallback(() => {
     if (!absolutePath || !environmentHttpBaseUrl) return;
     void (async () => {
       const result = await openFileInPreview({
@@ -727,7 +727,7 @@ export default function FilePreviewPanel({
       toastManager.add(
         stackedThreadToast({
           type: "error",
-          title: "Unable to open file in browser",
+          title: "Unable to open file in preview",
           description: error instanceof Error ? error.message : "An error occurred.",
         }),
       );
@@ -806,15 +806,15 @@ export default function FilePreviewPanel({
               </TooltipPopup>
             </Tooltip>
           ) : null}
-          {canOpenInBrowser ? (
+          {canOpenInPreview ? (
             <Tooltip>
               <TooltipTrigger
                 render={
                   <Toggle
                     className="shrink-0"
                     pressed={false}
-                    onPressedChange={handleOpenInBrowser}
-                    aria-label="Open file in preview browser"
+                    onPressedChange={handleOpenInPreview}
+                    aria-label="Open file in preview"
                     variant="ghost"
                     size="sm"
                   >
@@ -822,7 +822,7 @@ export default function FilePreviewPanel({
                   </Toggle>
                 }
               />
-              <TooltipPopup>Open file in preview browser</TooltipPopup>
+              <TooltipPopup>Open file in preview</TooltipPopup>
             </Tooltip>
           ) : null}
           <Tooltip>


### PR DESCRIPTION
## Summary

- route workspace image files into the existing integrated preview flow
- expose image preview actions from file links and file surfaces
- keep non-image file opening behavior unchanged

## Root cause

The asset server already supports signed workspace image preview URLs, but the web client only treated HTML and PDF paths as previewable entry files.

## Impact

Screenshots and other workspace image files can be viewed in-app from file explorer, markdown links, and diff file headers. If preview opening fails, the UI falls back to the existing file surface behavior.

## Validation

- `vp test packages/shared/src/filePreview.test.ts apps/web/src/diffFileActions.test.ts`
- `vp check`
- `vp run typecheck`
- `python3 /home/t3code/.codex/skills/.system/skill-creator/scripts/quick_validate.py /home/t3code/.codex/skills/t3-contribute`

`vp check` reports the repository's existing unrelated warnings and no errors.

Closes #3140

## Current main compatibility

- based on `3c50a648`
- focused regression tests and targeted package type checks passed
- targeted formatting and lint passed with non-blocking nested-component warnings in `ChatMarkdown.tsx`
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview state, signed asset URL assembly, and several user-facing open paths; mitigated by latest-request guards, abort handling, and explicit fallbacks plus new tests.
> 
> **Overview**
> **Workspace images** (and other shared preview entry types) now open in the **integrated preview** from markdown file links, the file explorer, and diff file headers—not only HTML/PDF. Preview eligibility comes from `@t3tools/shared/filePreview` (`isWorkspacePreviewFile` / `isImagePreviewFile`).
> 
> `openFileInPreview` / `openUrlInPreview` gain **per-thread “latest request wins”** tracking plus optional **`AbortSignal`**, so superseded or aborted opens do not overwrite preview state or the right panel. Invalid asset URLs return a **structured, redacted** `BrowserPreviewAssetUrlInvalidError` (lengths only, no signed paths in errors/logs). Preview errors are split into clearer tagged types (thread context, disconnected environment, unavailable runtime).
> 
> **UX on failure:** markdown and image open paths show a **warning** and **fall back** to the existing in-app file surface; interrupted commands also fall back. Repeated clicks abort the prior in-flight preview request.
> 
> New unit tests cover unavailable runtime, invalid URLs, and stale concurrent preview responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 881155b22afdebfadebc2b98f946fad8227baf43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add image file preview support from chat markdown links and diff panel
> - Image files clicked in chat markdown links and the diff panel now open in the integrated browser preview when the runtime and environment are connected, with fallback to the editor on failure.
> - Preview open operations are cancellable via `AbortSignal`; stale requests from superseded calls are discarded so newer requests always win.
> - Adds structured error types (`BrowserPreviewUnavailableError`, `BrowserPreviewAssetUrlInvalidError`, etc.) with safe diagnostic fields (lengths, not raw URLs) for better error handling.
> - `isWorkspacePreviewFile` replaces scattered eligibility checks across [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/4740/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05), [FilePreviewPanel.tsx](https://github.com/pingdotgg/t3code/pull/4740/files#diff-776fa2f4352bbbf118206cfd39f4cf95c38e47b1629aa20a6c8c028cadf458ea), and [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/4740/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3).
> - Behavioral Change: interrupted or failed preview opens now show a warning toast and fall back to opening the file rather than silently failing or showing an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 881155b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->