### PR TITLE
fix(desktop): link downloaded update release notes

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -133,6 +133,7 @@ import {
   shouldShowArm64IntelBuildWarning,
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
+import { showDesktopUpdateDownloadedToast } from "./desktopUpdate.toast";
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import {
@@ -3509,11 +3510,7 @@ export default function Sidebar() {
         .downloadUpdate()
         .then((result) => {
           if (result.completed) {
-            toastManager.add({
-              type: "success",
-              title: "Update downloaded",
-              description: "Restart the app from the update button to install it.",
-            });
+            showDesktopUpdateDownloadedToast(bridge, result.state.downloadedVersion);
           }
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -7,6 +7,7 @@ import {
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
   getDesktopUpdateInstallConfirmationMessage,
+  getDesktopUpdateReleaseUrl,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
@@ -158,6 +159,23 @@ describe("getDesktopUpdateActionError", () => {
 });
 
 describe("desktop update UI helpers", () => {
+  it("builds the stable release URL for a downloaded version", () => {
+    expect(getDesktopUpdateReleaseUrl("0.0.30")).toBe(
+      "https://github.com/pingdotgg/t3code/releases/tag/v0.0.30",
+    );
+  });
+
+  it("builds the nightly release URL without dropping its version suffix", () => {
+    expect(getDesktopUpdateReleaseUrl("0.0.30-nightly.20260728.931")).toBe(
+      "https://github.com/pingdotgg/t3code/releases/tag/v0.0.30-nightly.20260728.931",
+    );
+  });
+
+  it("omits the release URL when the updater does not report a version", () => {
+    expect(getDesktopUpdateReleaseUrl(null)).toBeNull();
+    expect(getDesktopUpdateReleaseUrl("  ")).toBeNull();
+  });
+
   it("toasts only for actionable updater errors", () => {
     expect(
       shouldToastDesktopUpdateActionResult({

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -3,6 +3,14 @@ import { isWindowsPlatform } from "../lib/utils";
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
+const DESKTOP_RELEASE_URL = "https://github.com/pingdotgg/t3code/releases/tag";
+
+export function getDesktopUpdateReleaseUrl(version: string | null): string | null {
+  const normalizedVersion = version?.trim();
+  if (!normalizedVersion) return null;
+  return `${DESKTOP_RELEASE_URL}/v${encodeURIComponent(normalizedVersion)}`;
+}
+
 export function resolveDesktopUpdateButtonAction(
   state: DesktopUpdateState,
 ): DesktopUpdateButtonAction {

--- a/apps/web/src/components/desktopUpdate.toast.test.ts
+++ b/apps/web/src/components/desktopUpdate.toast.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => ({
+  addToast: vi.fn(),
+}));
+
+vi.mock("./ui/toast", () => ({
+  toastManager: { add: testState.addToast },
+}));
+
+import { showDesktopUpdateDownloadedToast } from "./desktopUpdate.toast";
+
+function getReadMoreAction(): () => Promise<void> {
+  const toast = testState.addToast.mock.calls[0]?.[0] as
+    | { actionProps?: { onClick?: () => Promise<void> } }
+    | undefined;
+  const action = toast?.actionProps?.onClick;
+  expect(action).toBeTypeOf("function");
+  return action!;
+}
+
+describe("showDesktopUpdateDownloadedToast", () => {
+  beforeEach(() => {
+    testState.addToast.mockReset();
+  });
+
+  it("opens the downloaded version's release notes", async () => {
+    const openExternal = vi.fn().mockResolvedValue(true);
+
+    showDesktopUpdateDownloadedToast({ openExternal }, "0.0.30");
+    await getReadMoreAction()();
+
+    expect(openExternal).toHaveBeenCalledWith(
+      "https://github.com/pingdotgg/t3code/releases/tag/v0.0.30",
+    );
+    expect(testState.addToast).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["returns false", vi.fn().mockResolvedValue(false)],
+    ["rejects", vi.fn().mockRejectedValue(new Error("open failed"))],
+  ])("shows an error when opening release notes %s", async (_description, openExternal) => {
+    showDesktopUpdateDownloadedToast({ openExternal }, "0.0.30");
+    await getReadMoreAction()();
+
+    expect(testState.addToast).toHaveBeenLastCalledWith({
+      type: "error",
+      title: "Unable to open release notes",
+    });
+  });
+});

--- a/apps/web/src/components/desktopUpdate.toast.ts
+++ b/apps/web/src/components/desktopUpdate.toast.ts
@@ -16,7 +16,18 @@ export function showDesktopUpdateDownloadedToast(
       ? {
           actionProps: {
             children: "Read more",
-            onClick: () => void shell.openExternal(releaseUrl),
+            onClick: async () => {
+              try {
+                const opened = await shell.openExternal(releaseUrl);
+                if (opened) return;
+              } catch {
+                // Surface rejected IPC calls through the same user-visible fallback.
+              }
+              toastManager.add({
+                type: "error",
+                title: "Unable to open release notes",
+              });
+            },
           },
           data: { actionVariant: "link" as const },
         }

--- a/apps/web/src/components/desktopUpdate.toast.ts
+++ b/apps/web/src/components/desktopUpdate.toast.ts
@@ -1,0 +1,25 @@
+import type { DesktopBridge } from "@t3tools/contracts";
+
+import { getDesktopUpdateReleaseUrl } from "./desktopUpdate.logic";
+import { toastManager } from "./ui/toast";
+
+export function showDesktopUpdateDownloadedToast(
+  shell: Pick<DesktopBridge, "openExternal">,
+  downloadedVersion: string | null,
+): void {
+  const releaseUrl = getDesktopUpdateReleaseUrl(downloadedVersion);
+  toastManager.add({
+    type: "success",
+    title: "Update downloaded",
+    description: "Restart the app from the update button to install it.",
+    ...(releaseUrl
+      ? {
+          actionProps: {
+            children: "Read more",
+            onClick: () => void shell.openExternal(releaseUrl),
+          },
+          data: { actionVariant: "link" as const },
+        }
+      : {}),
+  });
+}

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -2,6 +2,7 @@ import { DownloadIcon, RotateCwIcon, TriangleAlertIcon, XIcon } from "lucide-rea
 import { useCallback, useState } from "react";
 import { isElectron } from "../../env";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
+import { showDesktopUpdateDownloadedToast } from "../desktopUpdate.toast";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import {
   getArm64IntelBuildWarningDescription,
@@ -80,11 +81,7 @@ export function SidebarUpdatePill() {
         .downloadUpdate()
         .then((result) => {
           if (result.completed) {
-            toastManager.add({
-              type: "success",
-              title: "Update downloaded",
-              description: "Restart the app from the update button to install it.",
-            });
+            showDesktopUpdateDownloadedToast(bridge, result.state.downloadedVersion);
           }
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);


### PR DESCRIPTION
## What Changed

- Add a **Read more** action to the “Update downloaded” notification.
- Open the GitHub release for the exact downloaded version through Electron's existing external-link bridge.
- Share the notification builder between the legacy and current sidebar update controls.
- Preserve the full version suffix so the link works for stable and nightly releases.

## Why

After downloading an update, users can now inspect its release notes without manually navigating to the repository's Releases page. The downloaded updater state is used directly, avoiding a stale or mismatched version.

Closes #4722.

## UI Changes

Before: the downloaded-update notification only instructed the user to restart.

After: the same notification includes a **Read more** action.

<img width="1274" height="803" alt="image" src="https://github.com/user-attachments/assets/6dddc2dd-5d8b-4f8d-be10-830b20729c0d" />

## Validation

- `vp test run apps/web/src/components/desktopUpdate.logic.test.ts apps/web/src/components/desktopUpdate.toast.test.ts` — 32 tests passed (including release-link failure handling)
- `vp fmt --check <changed files>` — passed
- `vp lint <changed files>` — passed with one pre-existing `react(no-array-index-key)` warning
- `vp run --filter @t3tools/web typecheck` — passed
- Integrated validation on an isolated T3 environment:
  - rendered the production notification helper in the real web client
  - verified the accessible `Read more` action
  - verified failed external-link opens show an `Unable to open release notes` error
  - verified a nightly version opens `https://github.com/pingdotgg/t3code/releases/tag/v0.0.30-nightly.20260728.931`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add release notes link to desktop update downloaded toast
> - Introduces `getDesktopUpdateReleaseUrl` in [desktopUpdate.logic.ts](https://github.com/pingdotgg/t3code/pull/4743/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af) to build a GitHub release URL from a downloaded version string, returning `null` for blank versions.
> - Adds `showDesktopUpdateDownloadedToast` in [desktopUpdate.toast.ts](https://github.com/pingdotgg/t3code/pull/4743/files#diff-c5b44db118736d4758c59dc620fe5a9a1ed0a035b99eb12a0aa0f66bd6a53ab4) which shows a success toast with a 'Read more' action that opens the release URL via `shell.openExternal`; failures show an error toast.
> - Updates `Sidebar` and `SidebarUpdatePill` to call `showDesktopUpdateDownloadedToast` instead of showing an inline success toast on download completion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa9952a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop UI and external-link handling only; no changes to updater core, auth, or data paths.
> 
> **Overview**
> After a desktop update finishes downloading, the success notification now offers a **Read more** action that opens the GitHub release for the exact **downloaded** version (stable or nightly suffix preserved).
> 
> Release URLs are built via new `getDesktopUpdateReleaseUrl`; `showDesktopUpdateDownloadedToast` centralizes the toast and uses Electron’s `openExternal`, with an error toast if the link cannot be opened. **Sidebar** and **SidebarUpdatePill** both call this helper instead of duplicating inline success toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9952a3be2434abfdfa390da2786c514df5eb2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->