### PR TITLE
fix(web): create new threads in the selected sidebar project

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -76,15 +76,17 @@ import {
 } from "../logicalProject";
 import {
   buildSidebarProjectSnapshots,
+  resolveSidebarProjectTargetRef,
   type SidebarProjectGroupMember,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
+import { useSidebarProjectScopeStore } from "../sidebarProjectScopeStore";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
-import { startNewThreadFromContext } from "../lib/chatThreadActions";
+import { resolveNewThreadAction, resolveThreadActionProjectRef } from "../lib/chatThreadActions";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
@@ -1180,7 +1182,8 @@ export default function SidebarV2() {
 
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
-  const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
+  const projectScopeKey = useSidebarProjectScopeStore((store) => store.projectScopeKey);
+  const setProjectScopeKey = useSidebarProjectScopeStore((store) => store.setProjectScopeKey);
   const scopedProjectGroup = useMemo(
     () =>
       projectScopeKey === null
@@ -1203,7 +1206,13 @@ export default function SidebarV2() {
     if (projectScopeKey !== null && scopedProjectGroup === null) {
       setProjectScopeKey(null);
     }
-  }, [projectScopeKey, scopedProjectGroup]);
+  }, [projectScopeKey, scopedProjectGroup, setProjectScopeKey]);
+  useEffect(
+    () => () => {
+      setProjectScopeKey(null);
+    },
+    [setProjectScopeKey],
+  );
   // Scope flips drop the selection: rows selected under the old scope may be
   // hidden now, and bulk actions must never count or touch invisible rows.
   useEffect(() => {
@@ -2193,25 +2202,60 @@ export default function SidebarV2() {
     autoAnimate(node, { duration: 150, easing: "ease-out" });
   }, []);
 
-  // New thread defaults to the project you're in (active thread's project,
-  // falling back to the top project) — same resolution the command palette
-  // uses. The command palette already offers a "New thread in..." submenu
-  // for multi-project setups.
-  const handleNewThreadClick = useCallback(() => {
-    // One project: nothing to pick, create immediately.
-    if (projectGroups.length <= 1) {
-      if (isMobile) setOpenMobile(false);
-      void startNewThreadFromContext({
+  const contextualProjectRef = useMemo(
+    () =>
+      resolveThreadActionProjectRef({
         activeDraftThread: newThreadContext.activeDraftThread,
         activeThread: newThreadContext.activeThread ?? undefined,
         defaultProjectRef: newThreadContext.defaultProjectRef,
         handleNewThread: newThreadContext.handleNewThread,
-      });
+      }),
+    [
+      newThreadContext.activeDraftThread,
+      newThreadContext.activeThread,
+      newThreadContext.defaultProjectRef,
+      newThreadContext.handleNewThread,
+    ],
+  );
+  const scopedNewThreadProjectRef = useMemo(
+    () =>
+      scopedProjectGroup
+        ? resolveSidebarProjectTargetRef({
+            group: scopedProjectGroup,
+            preferredProjectRef: contextualProjectRef,
+          })
+        : null,
+    [contextualProjectRef, scopedProjectGroup],
+  );
+
+  // A selected filter is an explicit project choice, so creation can start
+  // immediately. "All projects" still opens the picker when there is a real
+  // choice to make.
+  const handleNewThreadClick = useCallback(() => {
+    const action = resolveNewThreadAction({
+      sidebarV2Enabled: true,
+      projectGroupCount: projectGroups.length,
+      scopedProjectRef: scopedNewThreadProjectRef,
+      contextualProjectRef,
+      pickProjectWhenAmbiguous: true,
+    });
+    if (action.kind === "start") {
+      if (isMobile) setOpenMobile(false);
+      void newThreadContext.handleNewThread(action.projectRef);
       return;
     }
-    if (isMobile) setOpenMobile(false);
-    openCommandPalette({ open: "new-thread-in" });
-  }, [isMobile, newThreadContext, projectGroups.length, setOpenMobile]);
+    if (action.kind === "pick-project") {
+      if (isMobile) setOpenMobile(false);
+      openCommandPalette({ open: "new-thread-in" });
+    }
+  }, [
+    contextualProjectRef,
+    isMobile,
+    newThreadContext.handleNewThread,
+    projectGroups.length,
+    scopedNewThreadProjectRef,
+    setOpenMobile,
+  ]);
 
   const commandPaletteShortcutLabel = shortcutLabelForCommand(keybindings, "commandPalette.toggle");
   // Same resolution as v1: prefer the local-thread binding, fall back to

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -375,6 +375,44 @@ describe("environment grouping", () => {
     });
   });
 
+  it("uses manual project order for a remote-only group's fallback target", () => {
+    const firstRemote = makeProject({
+      id: ProjectId.make("project-remote-first"),
+      environmentId: EnvironmentId.make("env-remote-first"),
+      repositoryIdentity,
+    });
+    const preferredRemote = makeProject({
+      id: ProjectId.make("project-remote-preferred"),
+      environmentId: EnvironmentId.make("env-remote-preferred"),
+      repositoryIdentity,
+    });
+    const orderedProjects = orderItemsByPreferredIds({
+      items: [firstRemote, preferredRemote],
+      preferredIds: [getProjectOrderKey(preferredRemote)],
+      getId: getProjectOrderKey,
+      getPreferenceIds: (project) => [
+        getProjectOrderKey(project),
+        legacyProjectCwdPreferenceKey(project.workspaceRoot),
+      ],
+    });
+    const [group] = buildSidebarProjectSnapshots({
+      projects: orderedProjects,
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => null,
+    });
+
+    expect(
+      resolveSidebarProjectTargetRef({
+        group: group!,
+        preferredProjectRef: null,
+      }),
+    ).toEqual({
+      environmentId: preferredRemote.environmentId,
+      projectId: preferredRemote.id,
+    });
+  });
+
   it("keeps manual project order when building grouped sidebar entries", () => {
     const primary = makeProject({ repositoryIdentity });
     const remote = makeProject({

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -12,6 +12,7 @@ import {
   buildPhysicalToLogicalProjectKeyMap,
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
+  resolveSidebarProjectTargetRef,
 } from "./sidebarProjectGrouping";
 import { orderItemsByPreferredIds } from "./components/Sidebar.logic";
 import { legacyProjectCwdPreferenceKey } from "./uiStateStore";
@@ -316,6 +317,62 @@ describe("environment grouping", () => {
     });
     expect(entries[0]?.isPreferred).toBe(true);
     expect(entries[1]?.group.displayName).toBe("separate");
+  });
+
+  it("resolves a selected project group to its preferred physical project", () => {
+    const primary = makeProject({ repositoryIdentity });
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+    const [group] = buildSidebarProjectSnapshots({
+      projects: [primary, remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => null,
+    });
+
+    expect(
+      resolveSidebarProjectTargetRef({
+        group: group!,
+        preferredProjectRef: {
+          environmentId: remoteEnvironmentId,
+          projectId: remote.id,
+        },
+      }),
+    ).toEqual({
+      environmentId: remoteEnvironmentId,
+      projectId: remote.id,
+    });
+  });
+
+  it("falls back to the representative project when the context is outside the selected group", () => {
+    const primary = makeProject({ repositoryIdentity });
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+    const [group] = buildSidebarProjectSnapshots({
+      projects: [remote, primary],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => null,
+    });
+
+    expect(
+      resolveSidebarProjectTargetRef({
+        group: group!,
+        preferredProjectRef: {
+          environmentId: primaryEnvironmentId,
+          projectId: ProjectId.make("another-project"),
+        },
+      }),
+    ).toEqual({
+      environmentId: primaryEnvironmentId,
+      projectId: primary.id,
+    });
   });
 
   it("keeps manual project order when building grouped sidebar entries", () => {

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -2,6 +2,7 @@ import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
+  resolveNewThreadAction,
   resolveThreadActionProjectRef,
   resolveNewDraftStartFromOrigin,
   startNewThreadFromContext,
@@ -72,6 +73,66 @@ describe("chatThreadActions", () => {
     );
 
     expect(projectRef).toEqual(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID));
+  });
+
+  it("starts in the selected sidebar scope instead of the contextual project", () => {
+    const scopedProjectRef = scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID);
+
+    expect(
+      resolveNewThreadAction({
+        sidebarV2Enabled: true,
+        projectGroupCount: 2,
+        scopedProjectRef,
+        contextualProjectRef: scopeProjectRef(ENVIRONMENT_ID, FALLBACK_PROJECT_ID),
+        pickProjectWhenAmbiguous: true,
+      }),
+    ).toEqual({ kind: "start", projectRef: scopedProjectRef });
+  });
+
+  it("opens the project picker for an ambiguous all-projects action", () => {
+    expect(
+      resolveNewThreadAction({
+        sidebarV2Enabled: true,
+        projectGroupCount: 2,
+        scopedProjectRef: null,
+        contextualProjectRef: scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID),
+        pickProjectWhenAmbiguous: true,
+      }),
+    ).toEqual({ kind: "pick-project" });
+  });
+
+  it("keeps an all-projects local action contextual", () => {
+    const contextualProjectRef = scopeProjectRef(ENVIRONMENT_ID, FALLBACK_PROJECT_ID);
+
+    expect(
+      resolveNewThreadAction({
+        sidebarV2Enabled: true,
+        projectGroupCount: 2,
+        scopedProjectRef: null,
+        contextualProjectRef,
+        pickProjectWhenAmbiguous: false,
+      }),
+    ).toEqual({
+      kind: "start",
+      projectRef: contextualProjectRef,
+    });
+  });
+
+  it("ignores sidebar v2 scope state while sidebar v1 is active", () => {
+    const contextualProjectRef = scopeProjectRef(ENVIRONMENT_ID, FALLBACK_PROJECT_ID);
+
+    expect(
+      resolveNewThreadAction({
+        sidebarV2Enabled: false,
+        projectGroupCount: 2,
+        scopedProjectRef: scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID),
+        contextualProjectRef,
+        pickProjectWhenAmbiguous: true,
+      }),
+    ).toEqual({
+      kind: "start",
+      projectRef: contextualProjectRef,
+    });
   });
 
   it("inherits only the project from context, never branch or worktree state", async () => {

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -26,6 +26,11 @@ export interface ChatThreadActionContext {
   readonly handleNewThread: NewThreadHandler;
 }
 
+export type NewThreadAction =
+  | { readonly kind: "start"; readonly projectRef: ScopedProjectRef }
+  | { readonly kind: "pick-project" }
+  | { readonly kind: "none" };
+
 export function resolveNewDraftStartFromOrigin(input: {
   envMode: DraftThreadEnvMode;
   newWorktreesStartFromOrigin: boolean;
@@ -46,6 +51,24 @@ export function resolveThreadActionProjectRef(
     );
   }
   return context.defaultProjectRef;
+}
+
+export function resolveNewThreadAction(input: {
+  sidebarV2Enabled: boolean;
+  projectGroupCount: number;
+  scopedProjectRef: ScopedProjectRef | null;
+  contextualProjectRef: ScopedProjectRef | null;
+  pickProjectWhenAmbiguous: boolean;
+}): NewThreadAction {
+  if (input.sidebarV2Enabled && input.scopedProjectRef) {
+    return { kind: "start", projectRef: input.scopedProjectRef };
+  }
+  if (input.sidebarV2Enabled && input.pickProjectWhenAmbiguous && input.projectGroupCount > 1) {
+    return { kind: "pick-project" };
+  }
+  return input.contextualProjectRef
+    ? { kind: "start", projectRef: input.contextualProjectRef }
+    : { kind: "none" };
 }
 
 // New threads inherit only the *project* from the current context. Branch,

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -8,10 +8,14 @@ import { openCommandPalette } from "../commandPaletteBus";
 import { useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
-import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
+import {
+  buildSidebarProjectSnapshots,
+  resolveSidebarProjectTargetRef,
+} from "../sidebarProjectGrouping";
+import { useSidebarProjectScopeStore } from "../sidebarProjectScopeStore";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import { startNewThreadFromContext } from "../lib/chatThreadActions";
+import { resolveNewThreadAction, resolveThreadActionProjectRef } from "../lib/chatThreadActions";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { resolveShortcutCommand } from "../keybindings";
@@ -32,16 +36,39 @@ function ChatRouteGlobalShortcuts() {
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const projectGroupCount = useMemo(
+  const projectGroups = useMemo(
     () =>
       buildSidebarProjectSnapshots({
         projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
         resolveEnvironmentLabel: () => null,
-      }).length,
+      }),
     [primaryEnvironmentId, projectGroupingSettings, projects],
   );
+  const projectScopeKey = useSidebarProjectScopeStore((store) => store.projectScopeKey);
+  const contextualProjectRef = useMemo(
+    () =>
+      resolveThreadActionProjectRef({
+        activeDraftThread,
+        activeThread: activeThread ?? undefined,
+        defaultProjectRef,
+        handleNewThread,
+      }),
+    [activeDraftThread, activeThread, defaultProjectRef, handleNewThread],
+  );
+  const scopedNewThreadProjectRef = useMemo(() => {
+    const scopedProjectGroup =
+      projectScopeKey === null
+        ? null
+        : (projectGroups.find((project) => project.projectKey === projectScopeKey) ?? null);
+    return scopedProjectGroup
+      ? resolveSidebarProjectTargetRef({
+          group: scopedProjectGroup,
+          preferredProjectRef: contextualProjectRef,
+        })
+      : null;
+  }, [contextualProjectRef, projectGroups, projectScopeKey]);
   const terminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
@@ -77,34 +104,21 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
-      if (command === "chat.newLocal") {
+      if (command === "chat.newLocal" || command === "chat.new") {
         event.preventDefault();
         event.stopPropagation();
-        void startNewThreadFromContext({
-          activeDraftThread,
-          activeThread: activeThread ?? undefined,
-          defaultProjectRef,
-          handleNewThread,
+        const action = resolveNewThreadAction({
+          sidebarV2Enabled,
+          projectGroupCount: projectGroups.length,
+          scopedProjectRef: scopedNewThreadProjectRef,
+          contextualProjectRef,
+          pickProjectWhenAmbiguous: command === "chat.new",
         });
-        return;
-      }
-
-      if (command === "chat.new") {
-        event.preventDefault();
-        event.stopPropagation();
-        // Sidebar v2 routes creation through the command palette whenever
-        // there is a real choice to make; v1 (and single-project setups)
-        // keep the immediate contextual create.
-        if (sidebarV2Enabled && projectGroupCount > 1) {
+        if (action.kind === "start") {
+          void handleNewThread(action.projectRef);
+        } else if (action.kind === "pick-project") {
           openCommandPalette({ open: "new-thread-in" });
-          return;
         }
-        void startNewThreadFromContext({
-          activeDraftThread,
-          activeThread: activeThread ?? undefined,
-          defaultProjectRef,
-          handleNewThread,
-        });
         return;
       }
 
@@ -157,16 +171,15 @@ function ChatRouteGlobalShortcuts() {
       window.removeEventListener("keydown", onWindowKeyDown);
     };
   }, [
-    activeDraftThread,
-    activeThread,
     clearSelection,
+    contextualProjectRef,
     handleNewThread,
     keybindings,
-    defaultProjectRef,
     previewOpen,
-    projectGroupCount,
+    projectGroups.length,
     routeThreadRef,
     selectedThreadKeysSize,
+    scopedNewThreadProjectRef,
     sidebarV2Enabled,
     terminalOpen,
   ]);

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -6,13 +6,14 @@ import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useSidebarV2Enabled } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
 import { useProjects } from "../state/entities";
-import { usePrimaryEnvironmentId } from "../state/environments";
-import { selectProjectGroupingSettings } from "../logicalProject";
+import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import { getProjectOrderKey, selectProjectGroupingSettings } from "../logicalProject";
 import {
   buildSidebarProjectSnapshots,
   resolveSidebarProjectTargetRef,
 } from "../sidebarProjectGrouping";
 import { useSidebarProjectScopeStore } from "../sidebarProjectScopeStore";
+import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { resolveNewThreadAction, resolveThreadActionProjectRef } from "../lib/chatThreadActions";
@@ -23,6 +24,7 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
+import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { stackedThreadToast, toastManager } from "~/components/ui/toast";
 import { primaryServerKeybindingsAtom } from "~/state/server";
 
@@ -34,17 +36,47 @@ function ChatRouteGlobalShortcuts() {
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const sidebarV2Enabled = useSidebarV2Enabled();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
+  const sidebarProjectSortOrder = useClientSettings((settings) => settings.sidebarProjectSortOrder);
   const projects = useProjects();
+  const projectOrder = useUiStateStore((store) => store.projectOrder);
+  const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const environmentLabelById = useMemo(
+    () =>
+      new Map(
+        environments.map((environment) => [environment.environmentId, environment.label] as const),
+      ),
+    [environments],
+  );
+  const orderedProjects = useMemo(
+    () =>
+      orderItemsByPreferredIds({
+        items: projects,
+        preferredIds: projectOrder,
+        getId: getProjectOrderKey,
+        getPreferenceIds: (project) => [
+          getProjectOrderKey(project),
+          legacyProjectCwdPreferenceKey(project.workspaceRoot),
+        ],
+      }),
+    [projectOrder, projects],
+  );
   const projectGroups = useMemo(
     () =>
       buildSidebarProjectSnapshots({
-        projects,
+        projects: sidebarProjectSortOrder === "manual" ? orderedProjects : projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
-        resolveEnvironmentLabel: () => null,
+        resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
       }),
-    [primaryEnvironmentId, projectGroupingSettings, projects],
+    [
+      environmentLabelById,
+      orderedProjects,
+      primaryEnvironmentId,
+      projectGroupingSettings,
+      projects,
+      sidebarProjectSortOrder,
+    ],
   );
   const projectScopeKey = useSidebarProjectScopeStore((store) => store.projectScopeKey);
   const contextualProjectRef = useMemo(

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -260,3 +260,14 @@ export function buildSidebarProjectPickerEntries(input: {
     ...entries.slice(preferredIndex + 1),
   ];
 }
+
+export function resolveSidebarProjectTargetRef(input: {
+  group: SidebarProjectSnapshot;
+  preferredProjectRef: ScopedProjectRef | null;
+}): ScopedProjectRef | null {
+  const [entry] = buildSidebarProjectPickerEntries({
+    groups: [input.group],
+    preferredProjectRef: input.preferredProjectRef,
+  });
+  return entry ? scopeProjectRef(entry.targetProject.environmentId, entry.targetProject.id) : null;
+}

--- a/apps/web/src/sidebarProjectScopeStore.ts
+++ b/apps/web/src/sidebarProjectScopeStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface SidebarProjectScopeStore {
+  projectScopeKey: string | null;
+  setProjectScopeKey: (projectScopeKey: string | null) => void;
+}
+
+export const useSidebarProjectScopeStore = create<SidebarProjectScopeStore>((set) => ({
+  projectScopeKey: null,
+  setProjectScopeKey: (projectScopeKey) => set({ projectScopeKey }),
+}));


### PR DESCRIPTION
## What Changed

- Make the Sidebar V2 “New thread” button create the draft in the selected project filter.
- Apply the same behavior to both `chat.new` and `chat.newLocal` shortcuts.
- Preserve the preferred physical project and environment when a selected logical project contains grouped entries.
- Keep “All projects” unchanged: multi-project setups still open the project picker when an explicit choice is required.
- Reset the sidebar project scope when Sidebar V2 unmounts so it does not leak across Settings, Sidebar V1, or app-shell remounts.
- Centralize the new-thread decision and cover it with focused behavioral tests.

## Why

The Sidebar V2 project filter previously affected only the visible thread list. Starting a new thread still used the active thread context or opened the project picker, even though the user had already selected a specific project in the sidebar.

A selected project filter is now treated as an explicit project choice. “All projects” retains the existing behavior, and Sidebar V1 remains unaffected.

There are no visual layout, styling, motion, or animation changes.

## Testing

- `vp test run apps/web/src/environmentGrouping.test.ts apps/web/src/lib/chatThreadActions.test.ts`
- `vp run --filter @t3tools/web typecheck`
- Type-aware linting of the changed files
- Formatting and `git diff --check`
- Integrated desktop verification:
  - “All projects” opens the picker from the button and `⌘N`
  - A selected filter is respected by the button, `⌘N`, and `⇧⌘N`
  - Returning from Settings resets the filter to “All projects”
- Integrated responsive verification:
  - The selected project is respected
  - The mobile sidebar closes after creating the draft
- No console errors or Vite error overlay observed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because this changes behavior only, without visual changes
- [x] Video is not applicable because this does not change motion or animation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible new-thread routing across sidebar and global shortcuts for multi-project setups; logic is centralized and covered by tests but wrong project targeting would be a noticeable product bug.
> 
> **Overview**
> **New-thread creation in Sidebar V2 now honors the project filter** instead of only filtering the thread list. When a specific project group is selected, the New thread control and keyboard shortcuts start (or draft) in that group’s resolved physical project/environment; **All projects** still opens the project picker when multiple groups exist and an explicit choice is required.
> 
> Scope is shared via a small **Zustand store** (`sidebarProjectScopeStore`) so `_chat` shortcuts and Sidebar V2 stay aligned, and the filter **clears when Sidebar V2 unmounts** so it does not leak after Settings or v1. **`resolveNewThreadAction`** centralizes start vs picker vs no-op; **`resolveSidebarProjectTargetRef`** picks the right member inside a grouped logical project (preferred context, representative fallback, manual order). Sidebar v1 ignores v2 scope state. **`chat.new`** vs **`chat.newLocal`** differ only in whether ambiguous all-projects flows open the picker (`pickProjectWhenAmbiguous`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36df63cad8fa1aee664b93aab52b391081d71833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix new thread creation to respect the selected sidebar project scope
> - New thread actions in the sidebar ([SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4748/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c)) and keyboard shortcuts ([_chat.tsx](https://github.com/pingdotgg/t3code/pull/4748/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691)) now resolve the target project using a shared Zustand scope store ([sidebarProjectScopeStore.ts](https://github.com/pingdotgg/t3code/pull/4748/files#diff-e26d74bbfe10d0e06d3c8bae69097d4fb141307e98186aab6870a9afa19fe023)).
> - Adds `resolveNewThreadAction` in [chatThreadActions.ts](https://github.com/pingdotgg/t3code/pull/4748/files#diff-6e655e056adaf8605b1381f1a37651405db18539fe8abe8eb1e810e5f95608e1) to decide between starting immediately in a scoped/contextual project, opening the project picker when ambiguous, or doing nothing.
> - Adds `resolveSidebarProjectTargetRef` in [sidebarProjectGrouping.ts](https://github.com/pingdotgg/t3code/pull/4748/files#diff-56beffcb94c48f4ebb0f187f3a8be66f26b116bb7a3e13fd196af3753e10d9a9) to resolve a group's concrete target project from picker entries.
> - The scope is reset when `SidebarV2` unmounts to avoid stale state across navigations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36df63c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->