### PR TITLE
fix(diff-panel): keep live previews synchronized

### DIFF
--- a/apps/server/src/review/ReviewService.test.ts
+++ b/apps/server/src/review/ReviewService.test.ts
@@ -1,19 +1,31 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import { type OrchestrationProject, ProjectId } from "@t3tools/contracts";
 
 import { ServerConfig } from "../config.ts";
+import { ProjectionSnapshotQuery } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as VcsDriver from "../vcs/VcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 import * as ReviewService from "./ReviewService.ts";
+import * as ReviewWatcher from "./ReviewWatcher.ts";
 
 function makeLayer(input: {
   readonly workspaceRoot: string;
   readonly baseDir: string;
   readonly detectCalls?: Array<{ readonly cwd: string }>;
+  readonly registeredProject?: OrchestrationProject;
 }) {
   return ReviewService.layer.pipe(
     Layer.provide(
@@ -28,7 +40,18 @@ function makeLayer(input: {
       }),
     ),
     Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)({})),
+    Layer.provide(
+      Layer.mock(ProjectionSnapshotQuery)({
+        getActiveProjectByWorkspaceRoot: (workspaceRoot) =>
+          Effect.succeed(
+            workspaceRoot === input.registeredProject?.workspaceRoot
+              ? Option.some(input.registeredProject)
+              : Option.none(),
+          ),
+      }),
+    ),
     Layer.provide(ServerConfig.layerTest(input.workspaceRoot, input.baseDir)),
+    Layer.provide(Layer.succeed(ReviewWatcher.ReviewWatcher, { watch: () => Stream.never })),
     Layer.provideMerge(NodeServices.layer),
   );
 }
@@ -51,9 +74,40 @@ describe("ReviewService", () => {
       assert.strictEqual(error.operation, "ReviewService.getDiffPreview");
       assert.match(
         "detail" in error ? error.detail : "",
-        /must stay within the configured workspace root/,
+        /must stay within a configured or registered workspace root/,
       );
       assert.deepStrictEqual(detectCalls, []);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("allows diff preview cwd for an active registered project", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const workspaceRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-workspace-" });
+      const projectRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-project-" });
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-base-" });
+      const detectCalls: Array<{ readonly cwd: string }> = [];
+      const registeredProject: OrchestrationProject = {
+        id: ProjectId.make("registered-project"),
+        title: "Registered project",
+        workspaceRoot: projectRoot,
+        defaultModelSelection: null,
+        scripts: [],
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        deletedAt: null,
+      };
+
+      const result = yield* Effect.gen(function* () {
+        const review = yield* ReviewService.ReviewService;
+        return yield* review.getDiffPreview({ cwd: projectRoot });
+      }).pipe(
+        Effect.provide(makeLayer({ workspaceRoot, baseDir, detectCalls, registeredProject })),
+      );
+
+      assert.strictEqual(result.cwd, projectRoot);
+      assert.deepStrictEqual(result.sources, []);
+      assert.deepStrictEqual(detectCalls, [{ cwd: projectRoot }]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -72,6 +126,255 @@ describe("ReviewService", () => {
       assert.strictEqual(result.cwd, workspaceRoot);
       assert.deepStrictEqual(result.sources, []);
       assert.deepStrictEqual(detectCalls, [{ cwd: workspaceRoot }]);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("streams an initial branch preview before metadata watchers attach", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const workspaceRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-workspace-" });
+      const commonMetadataRoot = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-review-common-gitdir-",
+      });
+      const worktreeMetadataRoot = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-review-worktree-gitdir-",
+      });
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-base-" });
+      const currentDiff = yield* Ref.make("before");
+      const previewCalls = yield* Ref.make(0);
+      const initialPreviewEmitted = yield* Deferred.make<void>();
+      const allowWatcherStartup = yield* Deferred.make<void>();
+      const watchTargets: ReadonlyArray<ReviewWatcher.ReviewWatchTarget>[] = [];
+      const testReviewWatcher = {
+        watch: (targets: ReadonlyArray<ReviewWatcher.ReviewWatchTarget>) => {
+          watchTargets.push(targets);
+          return Stream.fromEffect(Deferred.await(allowWatcherStartup)).pipe(
+            Stream.map(() => ({ _tag: "Ready" as const })),
+          );
+        },
+      };
+      const driver: VcsDriver.VcsDriver["Service"] = {
+        capabilities: {
+          kind: "git",
+          supportsWorktrees: true,
+          supportsBookmarks: false,
+          supportsAtomicSnapshot: false,
+          supportsPushDefaultRemote: true,
+          ignoreClassifier: "native",
+        },
+        execute: () =>
+          Effect.succeed({
+            exitCode: ChildProcessSpawner.ExitCode(0),
+            stdout: `${worktreeMetadataRoot}\n`,
+            stderr: "",
+            stdoutTruncated: false,
+            stderrTruncated: false,
+          }),
+        detectRepository: () => Effect.die("unexpected repository detection"),
+        isInsideWorkTree: () => Effect.die("unexpected worktree query"),
+        listWorkspaceFiles: () => Effect.die("unexpected workspace file listing"),
+        listRemotes: () => Effect.die("unexpected remote listing"),
+        filterIgnoredPaths: () => Effect.die("unexpected ignore filtering"),
+        initRepository: () => Effect.die("unexpected repository initialization"),
+        getDiffPreview: (input) =>
+          Effect.gen(function* () {
+            yield* Ref.update(previewCalls, (count) => count + 1);
+            const diff = yield* Ref.get(currentDiff);
+            return {
+              cwd: input.cwd,
+              generatedAt: yield* DateTime.now,
+              sources: [
+                {
+                  id: "working-tree",
+                  kind: "working-tree",
+                  title: "Dirty worktree",
+                  baseRef: "HEAD",
+                  headRef: null,
+                  diff,
+                  diffHash: diff.length > 0 ? diff : "clean",
+                  truncated: false,
+                },
+              ],
+            };
+          }),
+      };
+      const repository = {
+        kind: "git" as const,
+        rootPath: workspaceRoot,
+        metadataPath: commonMetadataRoot,
+        freshness: {
+          source: "live-local" as const,
+          observedAt: DateTime.nowUnsafe(),
+          expiresAt: Option.none(),
+        },
+      };
+      const layer = ReviewService.layer.pipe(
+        Layer.provide(
+          Layer.mock(VcsDriverRegistry.VcsDriverRegistry)({
+            get: () => Effect.succeed(driver),
+            detect: () => Effect.succeed({ kind: "git", repository, driver }),
+            resolve: () => Effect.succeed({ kind: "git", repository, driver }),
+          }),
+        ),
+        Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)({})),
+        Layer.provide(
+          Layer.mock(ProjectionSnapshotQuery)({
+            getActiveProjectByWorkspaceRoot: () => Effect.succeed(Option.none()),
+          }),
+        ),
+        Layer.provide(Layer.succeed(ReviewWatcher.ReviewWatcher, testReviewWatcher)),
+        Layer.provide(ServerConfig.layerTest(workspaceRoot, baseDir)),
+        Layer.provideMerge(NodeServices.layer),
+      );
+
+      const previews = yield* Effect.gen(function* () {
+        const review = yield* ReviewService.ReviewService;
+        const fiber = yield* review
+          .streamDiffPreview({ cwd: workspaceRoot, sourceKind: "branch-range" })
+          .pipe(
+            Stream.tap((preview) =>
+              preview.sources[0]?.diff === "before"
+                ? Deferred.succeed(initialPreviewEmitted, undefined)
+                : Effect.void,
+            ),
+            Stream.take(2),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+        yield* Deferred.await(initialPreviewEmitted);
+        assert.strictEqual(yield* Ref.get(previewCalls), 1);
+        yield* Ref.set(currentDiff, "");
+        yield* Deferred.succeed(allowWatcherStartup, undefined);
+        return yield* Fiber.join(fiber);
+      }).pipe(Effect.provide(layer), Effect.timeout("5 seconds"));
+
+      assert.deepStrictEqual(
+        Array.from(previews, (preview) => preview.sources[0]?.diff),
+        ["before", ""],
+      );
+      assert.deepStrictEqual(watchTargets, [
+        [
+          {
+            path: commonMetadataRoot,
+            ignoredPaths: [`${commonMetadataRoot}/logs`, `${commonMetadataRoot}/objects`],
+          },
+          {
+            path: worktreeMetadataRoot,
+            ignoredPaths: [`${worktreeMetadataRoot}/logs`, `${worktreeMetadataRoot}/objects`],
+          },
+        ],
+      ]);
+      assert.strictEqual(yield* Ref.get(previewCalls), 2);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("does not recompute diffs for ignored workspace event batches", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const workspaceRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-workspace-" });
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-base-" });
+      const initialPreviewRead = yield* Deferred.make<void>();
+      const ignoredPathsChecked = yield* Deferred.make<void>();
+      const previewCalls = yield* Ref.make(0);
+      const testReviewWatcher = {
+        watch: () =>
+          Stream.fromEffect(Deferred.await(initialPreviewRead)).pipe(
+            Stream.flatMap(() =>
+              Stream.fromIterable(
+                Array.from(
+                  { length: 10_000 },
+                  () => ({ _tag: "Update", path: "node_modules/generated.js" }) as const,
+                ),
+              ),
+            ),
+          ),
+      };
+      const driver: VcsDriver.VcsDriver["Service"] = {
+        capabilities: {
+          kind: "git",
+          supportsWorktrees: true,
+          supportsBookmarks: false,
+          supportsAtomicSnapshot: false,
+          supportsPushDefaultRemote: true,
+          ignoreClassifier: "native",
+        },
+        execute: () =>
+          Effect.succeed({
+            exitCode: ChildProcessSpawner.ExitCode(0),
+            stdout: `${workspaceRoot}\n`,
+            stderr: "",
+            stdoutTruncated: false,
+            stderrTruncated: false,
+          }),
+        detectRepository: () => Effect.die("unexpected repository detection"),
+        isInsideWorkTree: () => Effect.die("unexpected worktree query"),
+        listWorkspaceFiles: () => Effect.die("unexpected workspace file listing"),
+        listRemotes: () => Effect.die("unexpected remote listing"),
+        filterIgnoredPaths: (_cwd, relativePaths) =>
+          Effect.gen(function* () {
+            assert.deepStrictEqual(relativePaths, ["node_modules/generated.js"]);
+            yield* Deferred.succeed(ignoredPathsChecked, undefined);
+            return [];
+          }),
+        initRepository: () => Effect.die("unexpected repository initialization"),
+        getDiffPreview: (input) =>
+          Effect.gen(function* () {
+            yield* Ref.update(previewCalls, (count) => count + 1);
+            yield* Deferred.succeed(initialPreviewRead, undefined);
+            return {
+              cwd: input.cwd,
+              generatedAt: yield* DateTime.now,
+              sources: [
+                {
+                  id: "working-tree",
+                  kind: "working-tree",
+                  title: "Dirty worktree",
+                  baseRef: "HEAD",
+                  headRef: null,
+                  diff: "before",
+                  diffHash: "before",
+                  truncated: false,
+                },
+              ],
+            };
+          }),
+      };
+      const repository = {
+        kind: "git" as const,
+        rootPath: workspaceRoot,
+        metadataPath: workspaceRoot,
+        freshness: {
+          source: "live-local" as const,
+          observedAt: DateTime.nowUnsafe(),
+          expiresAt: Option.none(),
+        },
+      };
+      const layer = ReviewService.layer.pipe(
+        Layer.provide(
+          Layer.mock(VcsDriverRegistry.VcsDriverRegistry)({
+            get: () => Effect.succeed(driver),
+            detect: () => Effect.succeed({ kind: "git", repository, driver }),
+            resolve: () => Effect.succeed({ kind: "git", repository, driver }),
+          }),
+        ),
+        Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)({})),
+        Layer.provide(
+          Layer.mock(ProjectionSnapshotQuery)({
+            getActiveProjectByWorkspaceRoot: () => Effect.succeed(Option.none()),
+          }),
+        ),
+        Layer.provide(Layer.succeed(ReviewWatcher.ReviewWatcher, testReviewWatcher)),
+        Layer.provide(ServerConfig.layerTest(workspaceRoot, baseDir)),
+        Layer.provideMerge(NodeServices.layer),
+      );
+
+      yield* Effect.gen(function* () {
+        const review = yield* ReviewService.ReviewService;
+        yield* review.streamDiffPreview({ cwd: workspaceRoot }).pipe(Stream.runDrain);
+        yield* Deferred.await(ignoredPathsChecked);
+      }).pipe(Effect.provide(layer), Effect.timeout("5 seconds"));
+
+      assert.strictEqual(yield* Ref.get(previewCalls), 1);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 

--- a/apps/server/src/review/ReviewService.ts
+++ b/apps/server/src/review/ReviewService.ts
@@ -1,9 +1,12 @@
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Stream from "effect/Stream";
 
 import {
   VcsRepositoryDetectionError,
@@ -14,8 +17,10 @@ import {
 } from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
+import { ProjectionSnapshotQuery } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import { ReviewWatcher, type ReviewWatchTarget } from "./ReviewWatcher.ts";
 
 export class ReviewService extends Context.Service<
   ReviewService,
@@ -23,15 +28,48 @@ export class ReviewService extends Context.Service<
     readonly getDiffPreview: (
       input: ReviewDiffPreviewInput,
     ) => Effect.Effect<ReviewDiffPreviewResult, ReviewDiffPreviewError>;
+    readonly streamDiffPreview: (
+      input: ReviewDiffPreviewInput,
+    ) => Stream.Stream<ReviewDiffPreviewResult, ReviewDiffPreviewError>;
   }
 >()("t3/review/ReviewService") {}
+
+const hasSameDiffPreview = (
+  left: ReviewDiffPreviewResult,
+  right: ReviewDiffPreviewResult,
+): boolean =>
+  left.cwd === right.cwd &&
+  left.sources.length === right.sources.length &&
+  left.sources.every((source, index) => {
+    const other = right.sources[index];
+    return (
+      other !== undefined &&
+      source.id === other.id &&
+      source.kind === other.kind &&
+      source.title === other.title &&
+      source.baseRef === other.baseRef &&
+      source.headRef === other.headRef &&
+      source.diffHash === other.diffHash &&
+      source.truncated === other.truncated
+    );
+  });
+
+type DiffPreviewWatchSource = "workspace" | "metadata" | "ready";
+
+interface DiffPreviewWatchTarget {
+  readonly path: string;
+  readonly source: DiffPreviewWatchSource;
+  readonly ignoredPaths: ReadonlyArray<string>;
+}
 
 export const make = Effect.gen(function* () {
   const config = yield* ServerConfig.ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
   const git = yield* GitVcsDriver.GitVcsDriver;
+  const reviewWatcher = yield* ReviewWatcher;
 
   const canonicalizePath = (value: string) => {
     const resolvedPath = path.resolve(value);
@@ -70,10 +108,27 @@ export const make = Effect.gen(function* () {
       return;
     }
 
+    const registeredProject = yield* projectionSnapshotQuery
+      .getActiveProjectByWorkspaceRoot(path.resolve(cwd))
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new VcsRepositoryDetectionError({
+              operation: "ReviewService.assertWorkspaceBoundCwd.resolveProject",
+              cwd,
+              detail: "Failed to resolve the registered review workspace.",
+              cause,
+            }),
+        ),
+      );
+    if (Option.isSome(registeredProject)) {
+      return;
+    }
+
     return yield* new VcsRepositoryDetectionError({
       operation: "ReviewService.getDiffPreview",
       cwd,
-      detail: "Review diff preview cwd must stay within the configured workspace root.",
+      detail: "Review diff preview cwd must stay within a configured or registered workspace root.",
     });
   });
 
@@ -106,8 +161,172 @@ export const make = Effect.gen(function* () {
     return yield* getDriverDiffPreview(input);
   });
 
+  const resolveDiffPreviewWatchPaths = Effect.fn("ReviewService.resolveDiffPreviewWatchPaths")(
+    function* (input: ReviewDiffPreviewInput) {
+      yield* assertWorkspaceBoundCwd(input.cwd);
+      const workspaceRoot = yield* canonicalizePath(input.cwd);
+      const handle = yield* vcsRegistry.detect({ cwd: input.cwd, requestedKind: "auto" });
+      if (!handle) {
+        return {
+          workspaceRoot,
+          handle,
+          watchTargets: [
+            { path: workspaceRoot, source: "workspace", ignoredPaths: [] },
+          ] satisfies DiffPreviewWatchTarget[],
+        };
+      }
+
+      const metadataPaths = new Set<string>();
+      if (handle.repository.metadataPath) {
+        metadataPaths.add(handle.repository.metadataPath);
+      }
+      if (handle.kind === "git") {
+        const gitDir = yield* handle.driver
+          .execute({
+            operation: "ReviewService.resolveDiffPreviewWatchPaths.gitDir",
+            cwd: input.cwd,
+            args: ["rev-parse", "--absolute-git-dir"],
+          })
+          .pipe(
+            Effect.map((result) => result.stdout.trim() || null),
+            Effect.orElseSucceed(() => null),
+          );
+        if (gitDir) {
+          metadataPaths.add(gitDir);
+        }
+      }
+
+      const canonicalMetadataPaths: string[] = [];
+      for (const metadataPath of metadataPaths) {
+        const canonicalMetadataPath = yield* canonicalizePath(
+          path.isAbsolute(metadataPath) ? metadataPath : path.resolve(input.cwd, metadataPath),
+        );
+        if (!canonicalMetadataPaths.includes(canonicalMetadataPath)) {
+          canonicalMetadataPaths.push(canonicalMetadataPath);
+        }
+      }
+
+      const ignoredWorkspacePaths =
+        input.sourceKind === "branch-range" || handle.kind !== "git"
+          ? []
+          : yield* handle.driver
+              .execute({
+                operation: "ReviewService.resolveDiffPreviewWatchPaths.ignoredDirectories",
+                cwd: input.cwd,
+                args: ["ls-files", "--others", "--ignored", "--directory", "--exclude-standard"],
+              })
+              .pipe(
+                Effect.map((result) =>
+                  result.stdout
+                    .split("\n")
+                    .filter((entry) => entry.endsWith("/"))
+                    .map((entry) => path.resolve(workspaceRoot, entry)),
+                ),
+                Effect.orElseSucceed(() => []),
+              );
+      const targets: DiffPreviewWatchTarget[] =
+        input.sourceKind === "branch-range"
+          ? []
+          : [
+              {
+                path: workspaceRoot,
+                source: "workspace",
+                ignoredPaths: [...ignoredWorkspacePaths, ...canonicalMetadataPaths],
+              },
+            ];
+      for (const metadataPath of canonicalMetadataPaths) {
+        targets.push({
+          path: metadataPath,
+          source: "metadata",
+          ignoredPaths: [path.join(metadataPath, "logs"), path.join(metadataPath, "objects")],
+        });
+      }
+      return { workspaceRoot, handle, watchTargets: targets };
+    },
+  );
+
+  const shouldRefreshForChanges = Effect.fn("ReviewService.shouldRefreshForChanges")(function* (
+    input: ReviewDiffPreviewInput,
+    workspaceRoot: string,
+    handle: VcsDriverRegistry.VcsDriverHandle | null,
+    changes: ReadonlyArray<{
+      readonly source: DiffPreviewWatchSource;
+      readonly path: string;
+    }>,
+  ) {
+    if (changes.some((change) => change.source !== "workspace") || !handle) {
+      return true;
+    }
+
+    const relativePaths = [
+      ...new Set(
+        changes.map((change) =>
+          path.isAbsolute(change.path) ? path.relative(workspaceRoot, change.path) : change.path,
+        ),
+      ),
+    ].filter((relativePath) => relativePath.length > 0 && relativePath !== ".");
+    if (relativePaths.length === 0) {
+      return true;
+    }
+
+    return yield* handle.driver.filterIgnoredPaths(input.cwd, relativePaths).pipe(
+      Effect.map((includedPaths) => includedPaths.length > 0),
+      Effect.orElseSucceed(() => true),
+    );
+  });
+
+  const makeWatchedDiffPreviewStream = (input: ReviewDiffPreviewInput) =>
+    Stream.unwrap(
+      resolveDiffPreviewWatchPaths(input).pipe(
+        Effect.map(({ handle, workspaceRoot, watchTargets }) => {
+          const watcherTargets: ReviewWatchTarget[] = watchTargets.map(
+            ({ path: targetPath, ignoredPaths }) => ({ path: targetPath, ignoredPaths }),
+          );
+          const fileChanges = reviewWatcher.watch(watcherTargets).pipe(
+            Stream.map((event) => {
+              if (event._tag === "Ready") {
+                return { source: "ready" as const, path: workspaceRoot };
+              }
+              const metadataTarget = watchTargets.find(
+                (target) => target.source === "metadata" && isWithinRoot(event.path, target.path),
+              );
+              return {
+                source: metadataTarget?.source ?? "workspace",
+                path: event.path,
+              };
+            }),
+            Stream.mapError(
+              (cause) =>
+                new VcsRepositoryDetectionError({
+                  operation: "ReviewService.streamDiffPreview.watch",
+                  cwd: input.cwd,
+                  detail: "Failed to watch the review workspace for changes.",
+                  cause,
+                }),
+            ),
+            Stream.groupedWithin(10_000, Duration.millis(150)),
+            Stream.filterEffect((changes) =>
+              shouldRefreshForChanges(input, workspaceRoot, handle, Array.from(changes)),
+            ),
+            Stream.map(() => undefined),
+          );
+
+          return fileChanges.pipe(
+            Stream.mapEffect(() => getDiffPreview(input), { concurrency: 1 }),
+          );
+        }),
+      ),
+    );
+
+  const streamDiffPreview: ReviewService["Service"]["streamDiffPreview"] = (input) =>
+    Stream.fromEffect(getDiffPreview(input)).pipe(
+      Stream.concat(makeWatchedDiffPreviewStream(input)),
+      Stream.changesWith(hasSameDiffPreview),
+    );
+
   return ReviewService.of({
     getDiffPreview,
+    streamDiffPreview,
   });
 });
 

--- a/apps/server/src/review/ReviewWatcher.test.ts
+++ b/apps/server/src/review/ReviewWatcher.test.ts
@@ -1,0 +1,102 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
+import * as Stream from "effect/Stream";
+
+import * as ReviewWatcher from "./ReviewWatcher.ts";
+
+describe("ReviewWatcher", () => {
+  it.effect("signals readiness before reporting subsequent workspace changes", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-watcher-" });
+      const ignoredRoot = `${root}/ignored`;
+      yield* fs.makeDirectory(ignoredRoot);
+      const ready = yield* Deferred.make<void>();
+      const watcher = yield* ReviewWatcher.ReviewWatcher;
+      const fiber = yield* watcher.watch([{ path: root, ignoredPaths: [ignoredRoot] }]).pipe(
+        Stream.tap((event) =>
+          event._tag === "Ready" ? Deferred.succeed(ready, undefined) : Effect.void,
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* Deferred.await(ready);
+      yield* fs.writeFileString(`${ignoredRoot}/ignored.txt`, "ignored");
+      yield* fs.writeFileString(`${root}/changed.txt`, "changed");
+      const events = Array.from(yield* Fiber.join(fiber));
+
+      assert.deepStrictEqual(
+        events.map((event) => event._tag),
+        ["Ready", "Update"],
+      );
+      const update = events[1];
+      assert.isDefined(update);
+      assert.strictEqual(update._tag, "Update");
+      if (update._tag === "Update") {
+        assert.strictEqual(update.path, `${root}/changed.txt`);
+      }
+    }).pipe(Effect.provide(NodeServices.layer), Effect.timeout("5 seconds")),
+  );
+
+  it.effect("isolates concurrent workspace subscriptions", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const firstRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-watcher-a-" });
+      const secondRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-watcher-b-" });
+      const firstReady = yield* Deferred.make<void>();
+      const secondReady = yield* Deferred.make<void>();
+      const secondFinished = yield* Deferred.make<void>();
+      const watcher = yield* ReviewWatcher.ReviewWatcher;
+      const firstFiber = yield* watcher.watch([{ path: firstRoot, ignoredPaths: [] }]).pipe(
+        Stream.tap((event) =>
+          event._tag === "Ready" ? Deferred.succeed(firstReady, undefined) : Effect.void,
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const secondEvents: ReviewWatcher.ReviewWatchEvent[] = [];
+      const secondFiber = yield* watcher.watch([{ path: secondRoot, ignoredPaths: [] }]).pipe(
+        Stream.tap((event) =>
+          Effect.gen(function* () {
+            secondEvents.push(event);
+            if (event._tag === "Ready") {
+              yield* Deferred.succeed(secondReady, undefined);
+            } else if (event.path === `${secondRoot}/third.txt`) {
+              yield* Deferred.succeed(secondFinished, undefined);
+            }
+          }),
+        ),
+        Stream.runDrain,
+        Effect.forkChild,
+      );
+
+      yield* Effect.all([Deferred.await(firstReady), Deferred.await(secondReady)]);
+      yield* fs.writeFileString(`${firstRoot}/first.txt`, "first");
+      yield* fs.writeFileString(`${secondRoot}/second.txt`, "second");
+      const firstEvents = Array.from(yield* Fiber.join(firstFiber));
+      yield* fs.writeFileString(`${secondRoot}/third.txt`, "third");
+      yield* Deferred.await(secondFinished);
+      yield* Fiber.interrupt(secondFiber);
+
+      assert.deepStrictEqual(
+        firstEvents.map((event) => event._tag),
+        ["Ready", "Update"],
+      );
+      assert.deepStrictEqual(
+        [
+          ...new Set(
+            secondEvents.filter((event) => event._tag === "Update").map((event) => event.path),
+          ),
+        ].sort(),
+        [`${secondRoot}/second.txt`, `${secondRoot}/third.txt`],
+      );
+    }).pipe(Effect.provide(NodeServices.layer), Effect.timeout("5 seconds")),
+  );
+});

--- a/apps/server/src/review/ReviewWatcher.ts
+++ b/apps/server/src/review/ReviewWatcher.ts
@@ -1,0 +1,172 @@
+import * as NodeWorkerThreads from "node:worker_threads";
+
+import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as PlatformError from "effect/PlatformError";
+import * as Queue from "effect/Queue";
+import * as Stream from "effect/Stream";
+
+export type ReviewWatchEvent =
+  | { readonly _tag: "Ready" }
+  | { readonly _tag: "Update"; readonly path: string };
+
+export interface ReviewWatchTarget {
+  readonly path: string;
+  readonly ignoredPaths: ReadonlyArray<string>;
+}
+
+type ReviewWatchWorkerMessage =
+  | { readonly id: number; readonly type: "ready" }
+  | { readonly id: number; readonly type: "change"; readonly path: string }
+  | { readonly id: number; readonly type: "error"; readonly message: string };
+
+const workerSource = `
+const { parentPort } = require("node:worker_threads");
+const { watch } = require("node:fs");
+const { isAbsolute, relative, resolve } = require("node:path");
+
+const subscriptions = new Map();
+const isWithin = (candidate, root) => {
+  const path = relative(root, candidate);
+  return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+};
+const isIgnored = (candidate, target) =>
+  target.ignoredPaths.some((ignoredPath) => isWithin(candidate, ignoredPath));
+const [nodeMajor, nodeMinor] = process.versions.node.split(".").map(Number);
+const supportsNativeIgnore = nodeMajor > 24 || (nodeMajor === 24 && nodeMinor >= 16);
+
+const start = (id, targets) => {
+  try {
+    const watchers = targets.map((target) => {
+      const ignored = (candidate) => isIgnored(resolve(target.path, candidate), target);
+      const watcher = watch(target.path, {
+        encoding: "utf8",
+        persistent: false,
+        recursive: true,
+        ...(supportsNativeIgnore ? { ignore: ignored } : {}),
+      }, (_event, filename) => {
+        const changedPath = filename === null ? target.path : resolve(target.path, filename);
+        if (!isIgnored(changedPath, target)) {
+          parentPort.postMessage({ id, type: "change", path: changedPath });
+        }
+      });
+      watcher.on("error", (error) => {
+        parentPort.postMessage({ id, type: "error", message: error.message });
+      });
+      return watcher;
+    });
+    subscriptions.set(id, watchers);
+    parentPort.postMessage({ id, type: "ready" });
+  } catch (error) {
+    parentPort.postMessage({
+      id,
+      type: "error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+const stop = (id) => {
+  const watchers = subscriptions.get(id);
+  subscriptions.delete(id);
+  if (watchers) {
+    for (const watcher of watchers) {
+      watcher.close();
+    }
+  }
+};
+
+parentPort.on("message", (message) => {
+  if (message.type === "watch") start(message.id, message.targets);
+  if (message.type === "unwatch") stop(message.id);
+});
+`;
+
+interface ActiveSubscription {
+  readonly queue: Queue.Queue<ReviewWatchEvent, Cause.Done<void> | PlatformError.PlatformError>;
+  readonly paths: string;
+}
+
+const subscriptions = new Map<number, ActiveSubscription>();
+let nextSubscriptionId = 0;
+let worker: NodeWorkerThreads.Worker | null = null;
+
+const fail = (subscription: ActiveSubscription, cause: unknown) =>
+  Queue.failCauseUnsafe(
+    subscription.queue,
+    Cause.fail(
+      PlatformError.systemError({
+        _tag: "Unknown",
+        module: "FileSystem",
+        method: "watch",
+        pathOrDescriptor: subscription.paths,
+        cause,
+      }),
+    ),
+  );
+
+const getWorker = () => {
+  if (worker !== null) return worker;
+
+  const nextWorker = new NodeWorkerThreads.Worker(workerSource, { eval: true });
+  nextWorker.unref();
+  nextWorker.on("message", (message: ReviewWatchWorkerMessage) => {
+    const subscription = subscriptions.get(message.id);
+    if (!subscription) return;
+
+    switch (message.type) {
+      case "ready":
+        Queue.offerUnsafe(subscription.queue, { _tag: "Ready" });
+        break;
+      case "change":
+        Queue.offerUnsafe(subscription.queue, { _tag: "Update", path: message.path });
+        break;
+      case "error":
+        fail(subscription, new Error(message.message));
+        break;
+    }
+  });
+  nextWorker.on("error", (cause) => {
+    for (const subscription of subscriptions.values()) {
+      fail(subscription, cause);
+    }
+  });
+  nextWorker.on("exit", (code) => {
+    if (worker !== nextWorker) return;
+    worker = null;
+    for (const subscription of subscriptions.values()) {
+      fail(subscription, new Error(`Review watcher worker exited with code ${code}.`));
+    }
+  });
+  worker = nextWorker;
+  return nextWorker;
+};
+
+const watch = (targets: ReadonlyArray<ReviewWatchTarget>) =>
+  Stream.callback<ReviewWatchEvent, PlatformError.PlatformError>((queue) =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        const id = nextSubscriptionId++;
+        subscriptions.set(id, {
+          queue,
+          paths: targets.map((target) => target.path).join(", "),
+        });
+        getWorker().postMessage({ type: "watch", id, targets }, []);
+        return id;
+      }),
+      (id) =>
+        Effect.sync(() => {
+          subscriptions.delete(id);
+          worker?.postMessage({ type: "unwatch", id }, []);
+        }),
+    ),
+  );
+
+export class ReviewWatcher extends Context.Reference<{
+  readonly watch: (
+    targets: ReadonlyArray<ReviewWatchTarget>,
+  ) => Stream.Stream<ReviewWatchEvent, PlatformError.PlatformError>;
+}>("t3/review/ReviewWatcher", {
+  defaultValue: () => ({ watch }),
+}) {}

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4885,6 +4885,33 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
   it.effect("routes websocket rpc git methods", () =>
     Effect.gen(function* () {
+      const makeDiffPreview = (cwd: string) => ({
+        cwd,
+        generatedAt: DateTime.nowUnsafe(),
+        sources: [
+          {
+            id: "working-tree",
+            kind: "working-tree" as const,
+            title: "Dirty worktree",
+            baseRef: "HEAD",
+            headRef: null,
+            diff: "dirty-diff",
+            diffHash: "hash-dirty",
+            truncated: false,
+          },
+          {
+            id: "branch-range",
+            kind: "branch-range" as const,
+            title: "Against main",
+            baseRef: "main",
+            headRef: "feature/demo",
+            diff: "base-diff",
+            diffHash: "hash-base",
+            truncated: false,
+          },
+        ],
+      });
+
       yield* buildAppUnderTest({
         config: {
           cwd: "/tmp/repo",
@@ -5045,33 +5072,8 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
               }),
           },
           reviewService: {
-            getDiffPreview: (input) =>
-              Effect.succeed({
-                cwd: input.cwd,
-                generatedAt: DateTime.nowUnsafe(),
-                sources: [
-                  {
-                    id: "working-tree",
-                    kind: "working-tree",
-                    title: "Dirty worktree",
-                    baseRef: "HEAD",
-                    headRef: null,
-                    diff: "dirty-diff",
-                    diffHash: "hash-dirty",
-                    truncated: false,
-                  },
-                  {
-                    id: "branch-range",
-                    kind: "branch-range",
-                    title: "Against main",
-                    baseRef: "main",
-                    headRef: "feature/demo",
-                    diff: "base-diff",
-                    diffHash: "hash-base",
-                    truncated: false,
-                  },
-                ],
-              }),
+            getDiffPreview: (input) => Effect.succeed(makeDiffPreview(input.cwd)),
+            streamDiffPreview: (input) => Stream.make(makeDiffPreview(input.cwd)),
           },
         },
       });
@@ -5186,6 +5188,16 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         ),
       );
       assert.equal(diffPreview.sources[0]?.diff, "dirty-diff");
+
+      const streamedDiffPreview = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[WS_METHODS.reviewSubscribeDiffPreview]({ cwd: "/tmp/repo" }).pipe(
+            Stream.runHead,
+            Effect.map(Option.getOrThrow),
+          ),
+        ),
+      );
+      assert.equal(streamedDiffPreview.sources[0]?.diff, "dirty-diff");
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -125,11 +125,13 @@ it.effect("uses stable diagnostics for every parsed non-repository command", () 
     yield* driver.statusDetailsLocal(cwd);
     yield* driver.statusDetailsRemote(cwd, { refreshUpstream: false });
     yield* driver.listRefs({ cwd });
+    yield* driver.getReviewDiffPreview({ cwd, sourceKind: "working-tree" });
 
     assert.deepStrictEqual(commands, [
-      { args: ["status", "--porcelain=2", "--branch"], lcAll: "C" },
+      { args: ["--no-optional-locks", "status", "--porcelain=2", "--branch"], lcAll: "C" },
       { args: ["rev-parse", "--abbrev-ref", "HEAD"], lcAll: "C" },
       { args: ["branch", "--no-color", "--no-column"], lcAll: "C" },
+      { args: ["rev-parse", "--is-inside-work-tree"], lcAll: "C" },
     ]);
   }).pipe(Effect.provide(layer));
 });
@@ -303,6 +305,15 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           baseRef: initialBranch,
           ignoreWhitespace: true,
         });
+        const workingTreeOnly = yield* driver.getReviewDiffPreview({
+          cwd,
+          sourceKind: "working-tree",
+        });
+        const branchRangeOnly = yield* driver.getReviewDiffPreview({
+          cwd,
+          baseRef: initialBranch,
+          sourceKind: "branch-range",
+        });
 
         assert.isNotEmpty(included.sources.find((source) => source.kind === "working-tree")?.diff);
         assert.isNotEmpty(included.sources.find((source) => source.kind === "branch-range")?.diff);
@@ -314,6 +325,48 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           ignored.sources.find((source) => source.kind === "branch-range")?.diff,
           "",
         );
+        assert.deepStrictEqual(
+          workingTreeOnly.sources.map((source) => source.kind),
+          ["working-tree"],
+        );
+        assert.deepStrictEqual(
+          branchRangeOnly.sources.map((source) => source.kind),
+          ["branch-range"],
+        );
+      }),
+    );
+
+    it.effect("bounds aggregate untracked diff work", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        for (let index = 0; index < 101; index += 1) {
+          yield* writeTextFile(cwd, `untracked/${index}.txt`, "");
+        }
+
+        const preview = yield* driver.getReviewDiffPreview({
+          cwd,
+          sourceKind: "working-tree",
+        });
+
+        assert.strictEqual(preview.sources[0]?.truncated, true);
+      }),
+    );
+
+    it.effect("previews untracked files before the first commit", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* driver.initRepo({ cwd });
+        yield* writeTextFile(cwd, "untracked.txt", "before first commit\n");
+
+        const preview = yield* driver.getReviewDiffPreview({
+          cwd,
+          sourceKind: "working-tree",
+        });
+
+        assert.include(preview.sources[0]?.diff, "untracked.txt");
       }),
     );
   });

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -46,6 +46,7 @@ const RANGE_DIFF_SUMMARY_MAX_OUTPUT_BYTES = 19_000;
 const RANGE_DIFF_PATCH_MAX_OUTPUT_BYTES = 59_000;
 const REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES = 120_000;
 const REVIEW_UNTRACKED_DIFF_MAX_OUTPUT_BYTES = 80_000;
+const REVIEW_UNTRACKED_DIFF_MAX_FILES = 100;
 const WORKSPACE_FILES_MAX_OUTPUT_BYTES = 120_000;
 const STATUS_UPSTREAM_REFRESH_INTERVAL = Duration.seconds(15);
 const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
@@ -1313,7 +1314,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     const statusResult = yield* executeGitWithStableDiagnostics(
       "GitVcsDriver.statusDetails.status",
       cwd,
-      ["status", "--porcelain=2", "--branch"],
+      ["--no-optional-locks", "status", "--porcelain=2", "--branch"],
       {
         allowNonZeroExit: true,
       },
@@ -1336,7 +1337,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         ...gitCommandContext({
           operation: "GitVcsDriver.statusDetails.status",
           cwd,
-          args: ["status", "--porcelain=2", "--branch"],
+          args: ["--no-optional-locks", "status", "--porcelain=2", "--branch"],
         }),
         detail: "Git status failed.",
         exitCode: statusResult.exitCode,
@@ -1829,35 +1830,87 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       return { diff: "", truncated: untrackedResult.stdoutTruncated };
     }
 
-    const diffs = yield* Effect.forEach(
-      untrackedPaths,
-      (relativePath) =>
-        executeGit(
-          "GitVcsDriver.readUntrackedReviewDiffs.diff",
-          cwd,
-          ["diff", "--no-index", "--patch", "--minimal", "--", "/dev/null", relativePath],
-          {
-            allowNonZeroExit: true,
-            maxOutputBytes: REVIEW_UNTRACKED_DIFF_MAX_OUTPUT_BYTES,
-            appendTruncationMarker: true,
-          },
-        ),
-      { concurrency: 4 },
-    );
+    const diffs: GitVcsDriver.ExecuteGitResult[] = [];
+    let outputBytes = 0;
+    for (
+      let index = 0;
+      index < untrackedPaths.length &&
+      index < REVIEW_UNTRACKED_DIFF_MAX_FILES &&
+      outputBytes < REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES;
+      index += 1
+    ) {
+      const result = yield* executeGit(
+        "GitVcsDriver.readUntrackedReviewDiffs.diff",
+        cwd,
+        ["diff", "--no-index", "--patch", "--minimal", "--", "/dev/null", untrackedPaths[index]!],
+        {
+          allowNonZeroExit: true,
+          maxOutputBytes: Math.min(
+            REVIEW_UNTRACKED_DIFF_MAX_OUTPUT_BYTES,
+            REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES - outputBytes,
+          ),
+          appendTruncationMarker: true,
+        },
+      );
+      diffs.push(result);
+      outputBytes += new TextEncoder().encode(result.stdout).byteLength;
+    }
 
     return {
       diff: Arr.filterMap(diffs, (result) =>
         result.stdout.trim().length > 0 ? Result.succeed(result.stdout) : Result.failVoid,
       ).join("\n"),
-      truncated: untrackedResult.stdoutTruncated || diffs.some((result) => result.stdoutTruncated),
+      truncated:
+        untrackedResult.stdoutTruncated ||
+        diffs.length < untrackedPaths.length ||
+        diffs.some((result) => result.stdoutTruncated),
     };
   });
 
   const getReviewDiffPreview = Effect.fn("getReviewDiffPreview")(function* (
     input: ReviewDiffPreviewInput,
   ) {
-    const details = yield* statusDetailsLocal(input.cwd);
-    if (!details.isRepo) {
+    const includeWorkingTree = input.sourceKind !== "branch-range";
+    const includeBranchRange = input.sourceKind !== "working-tree";
+    const workTreeResult = yield* executeGitWithStableDiagnostics(
+      "GitVcsDriver.getReviewDiffPreview.workTree",
+      input.cwd,
+      ["rev-parse", "--is-inside-work-tree"],
+      { allowNonZeroExit: true },
+    ).pipe(
+      Effect.catchTags({
+        GitCommandError: (error) =>
+          isMissingGitCwdError(error) ? Effect.succeed(null) : Effect.fail(error),
+      }),
+    );
+    if (workTreeResult === null) {
+      return {
+        cwd: input.cwd,
+        generatedAt: yield* DateTime.now,
+        sources: [],
+      };
+    }
+    if (workTreeResult.exitCode !== 0) {
+      if (isNonRepositoryGitStderr(workTreeResult.stderr)) {
+        return {
+          cwd: input.cwd,
+          generatedAt: yield* DateTime.now,
+          sources: [],
+        };
+      }
+      return yield* new GitCommandError({
+        ...gitCommandContext({
+          operation: "GitVcsDriver.getReviewDiffPreview.workTree",
+          cwd: input.cwd,
+          args: ["rev-parse", "--is-inside-work-tree"],
+        }),
+        detail: "Failed to identify the Git work tree.",
+        exitCode: workTreeResult.exitCode,
+        stdoutLength: workTreeResult.stdout.length,
+        stderrLength: workTreeResult.stderr.length,
+      });
+    }
+    if (workTreeResult.stdout.trim() !== "true") {
       return {
         cwd: input.cwd,
         generatedAt: yield* DateTime.now,
@@ -1865,48 +1918,27 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       };
     }
 
-    const branch = details.branch;
-    const baseRef =
-      input.baseRef ??
-      (branch
-        ? yield* resolveBaseBranchForNoUpstream(input.cwd, branch).pipe(
-            Effect.orElseSucceed(() => null),
-          )
-        : null);
-
-    const dirtyTrackedResult = yield* executeGit(
-      "GitVcsDriver.getReviewDiffPreview.dirtyTracked",
-      input.cwd,
-      [
-        "diff",
-        "--patch",
-        "--minimal",
-        ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
-        "HEAD",
-        "--",
-      ],
-      {
-        maxOutputBytes: REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES,
-        appendTruncationMarker: true,
-      },
-    ).pipe(
-      Effect.orElseSucceed(() => ({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-        stdoutTruncated: false,
-        stderrTruncated: false,
-      })),
-    );
-    const dirtyUntracked = yield* readUntrackedReviewDiffs(input.cwd).pipe(
-      Effect.orElseSucceed(() => ({ diff: "", truncated: false })),
-    );
-    const dirtyDiff = [dirtyTrackedResult.stdout.trimEnd(), dirtyUntracked.diff.trimEnd()]
-      .filter((diff) => diff.length > 0)
-      .join("\n");
+    const branch = includeBranchRange
+      ? yield* executeGit(
+          "GitVcsDriver.getReviewDiffPreview.branch",
+          input.cwd,
+          ["symbolic-ref", "--quiet", "--short", "HEAD"],
+          { allowNonZeroExit: true },
+        ).pipe(
+          Effect.map((result) => (result.exitCode === 0 ? result.stdout.trim() || null : null)),
+        )
+      : null;
+    const baseRef = includeBranchRange
+      ? (input.baseRef ??
+        (branch
+          ? yield* resolveBaseBranchForNoUpstream(input.cwd, branch).pipe(
+              Effect.orElseSucceed(() => null),
+            )
+          : null))
+      : null;
 
     const baseResult =
-      baseRef && branch
+      includeBranchRange && baseRef && branch
         ? yield* executeGit(
             "GitVcsDriver.getReviewDiffPreview.base",
             input.cwd,
@@ -1946,33 +1978,61 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             }),
         ),
       );
-    const [dirtyDiffHash, baseDiffHash] = yield* Effect.all([
-      hashDiff(dirtyDiff),
-      hashDiff(baseDiff),
-    ]);
-
-    const sources: ReviewDiffPreviewSource[] = [
-      {
+    const sources: ReviewDiffPreviewSource[] = [];
+    if (includeWorkingTree) {
+      const dirtyTrackedResult = yield* executeGit(
+        "GitVcsDriver.getReviewDiffPreview.dirtyTracked",
+        input.cwd,
+        [
+          "diff",
+          "--patch",
+          "--minimal",
+          ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
+          "HEAD",
+          "--",
+        ],
+        {
+          maxOutputBytes: REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES,
+          appendTruncationMarker: true,
+        },
+      ).pipe(
+        Effect.orElseSucceed(() => ({
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        })),
+      );
+      const dirtyUntracked = yield* readUntrackedReviewDiffs(input.cwd).pipe(
+        Effect.orElseSucceed(() => ({ diff: "", truncated: false })),
+      );
+      const dirtyDiff = [dirtyTrackedResult.stdout.trimEnd(), dirtyUntracked.diff.trimEnd()]
+        .filter((diff) => diff.length > 0)
+        .join("\n");
+      sources.push({
         id: "working-tree",
         kind: "working-tree",
         title: "Dirty worktree",
         baseRef: "HEAD",
         headRef: null,
         diff: dirtyDiff,
-        diffHash: dirtyDiffHash,
+        diffHash: yield* hashDiff(dirtyDiff),
         truncated: dirtyTrackedResult.stdoutTruncated || dirtyUntracked.truncated,
-      },
-      {
+      });
+    }
+    if (includeBranchRange) {
+      sources.push({
         id: "branch-range",
         kind: "branch-range",
         title: baseRef ? `Against ${baseRef}` : "Against base branch",
         baseRef,
         headRef: branch ?? "HEAD",
         diff: baseDiff,
-        diffHash: baseDiffHash,
+        diffHash: yield* hashDiff(baseDiff),
         truncated: baseResult?.stdoutTruncated ?? false,
-      },
-    ];
+      });
+    }
 
     return {
       cwd: input.cwd,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -345,6 +345,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.vcsSwitchRef, AuthOrchestrationOperateScope],
   [WS_METHODS.vcsInit, AuthOrchestrationOperateScope],
   [WS_METHODS.reviewGetDiffPreview, AuthReviewWriteScope],
+  [WS_METHODS.reviewSubscribeDiffPreview, AuthReviewWriteScope],
   [WS_METHODS.terminalOpen, AuthTerminalOperateScope],
   [WS_METHODS.terminalAttach, AuthTerminalOperateScope],
   [WS_METHODS.terminalWrite, AuthTerminalOperateScope],
@@ -1869,6 +1870,10 @@ const makeWsRpcLayer = (
           ),
         [WS_METHODS.reviewGetDiffPreview]: (input) =>
           observeRpcEffect(WS_METHODS.reviewGetDiffPreview, review.getDiffPreview(input), {
+            "rpc.aggregate": "review",
+          }),
+        [WS_METHODS.reviewSubscribeDiffPreview]: (input) =>
+          observeRpcStream(WS_METHODS.reviewSubscribeDiffPreview, review.streamDiffPreview(input), {
             "rpc.aggregate": "review",
           }),
         [WS_METHODS.terminalOpen]: (input) =>

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -200,6 +200,7 @@ export default function DiffPanel({
   const [diffRenderMode, setDiffRenderMode] = useState<DiffRenderMode>("stacked");
   const [wordWrap, setWordWrap] = useState(settings.wordWrap);
   const [diffIgnoreWhitespace, setDiffIgnoreWhitespace] = useState(settings.diffIgnoreWhitespace);
+  const [baseRefPickerOpen, setBaseRefPickerOpen] = useState(false);
   const [baseRefQuery, setBaseRefQuery] = useState("");
   const [collapsedDiffFiles, setCollapsedDiffFiles] = useState<CollapsedDiffFilesState>(() => ({
     scopeKey: null,
@@ -328,7 +329,7 @@ export default function DiffPanel({
     },
     { enabled: isGitRepo && selectedTurn !== undefined },
   );
-  const primaryBranchDiffPreview = useEnvironmentQuery(
+  const branchDiffPreview = useEnvironmentQuery(
     selectedTurnId === null && activeThread && activeCwd
       ? reviewEnvironment.diffPreview({
           environmentId: activeThread.environmentId,
@@ -336,36 +337,18 @@ export default function DiffPanel({
             cwd: activeCwd,
             ...(selectedBaseRef ? { baseRef: selectedBaseRef } : {}),
             ignoreWhitespace: diffIgnoreWhitespace,
+            sourceKind: selectedGitScope === "unstaged" ? "working-tree" : "branch-range",
           },
         })
       : null,
   );
-  const shouldRetryBranchDiffAtEnvironmentCwd =
-    selectedTurnId === null &&
-    primaryBranchDiffPreview.error?.includes("configured workspace root") === true &&
-    serverConfig?.cwd !== undefined &&
-    serverConfig.cwd !== activeCwd;
-  const fallbackBranchDiffPreview = useEnvironmentQuery(
-    shouldRetryBranchDiffAtEnvironmentCwd && activeThread && serverConfig
-      ? reviewEnvironment.diffPreview({
-          environmentId: activeThread.environmentId,
-          input: {
-            cwd: serverConfig.cwd,
-            ...(selectedBaseRef ? { baseRef: selectedBaseRef } : {}),
-            ignoreWhitespace: diffIgnoreWhitespace,
-          },
-        })
-      : null,
-  );
-  const branchDiffPreview = shouldRetryBranchDiffAtEnvironmentCwd
-    ? fallbackBranchDiffPreview
-    : primaryBranchDiffPreview;
   const selectedGitSource = branchDiffPreview.data?.sources.find(
     (source) => source.kind === (selectedGitScope === "unstaged" ? "working-tree" : "branch-range"),
   );
   const localBranchRefs = useEnvironmentQuery(
     selectedTurnId === null &&
       selectedGitScope === "branch" &&
+      baseRefPickerOpen &&
       activeThread &&
       branchDiffPreview.data?.cwd
       ? vcsEnvironment.listRefs({
@@ -383,6 +366,7 @@ export default function DiffPanel({
   const remoteBranchRefs = useEnvironmentQuery(
     selectedTurnId === null &&
       selectedGitScope === "branch" &&
+      baseRefPickerOpen &&
       activeThread &&
       branchDiffPreview.data?.cwd
       ? vcsEnvironment.listRefs({
@@ -415,9 +399,9 @@ export default function DiffPanel({
 
   const selectedPatch = selectedTurn ? activeCheckpointDiff.data?.diff : gitDiff;
   const isSelectedPatchTruncated = !selectedTurn && selectedGitSource?.truncated === true;
-  const isLoadingSelectedPatch = selectedTurn
-    ? activeCheckpointDiff.isPending
-    : branchDiffPreview.isPending;
+  const isLoadingSelectedPatch =
+    (selectedTurn ? activeCheckpointDiff.isPending : branchDiffPreview.isPending) &&
+    selectedPatch === undefined;
   const selectedPatchError = selectedTurn ? activeCheckpointDiff.error : branchDiffPreview.error;
   const hasResolvedPatch = typeof selectedPatch === "string";
   const hasNoNetChanges = hasResolvedPatch && selectedPatch.trim().length === 0;
@@ -614,6 +598,7 @@ export default function DiffPanel({
               filteredItems={filteredBaseRefItems}
               value={selectedBaseRef ?? AUTOMATIC_BASE_REF}
               onOpenChange={(open) => {
+                setBaseRefPickerOpen(open);
                 if (!open) setBaseRefQuery("");
               }}
               onValueChange={(value) => {

--- a/apps/web/src/components/diffs/AnnotatableCodeView.tsx
+++ b/apps/web/src/components/diffs/AnnotatableCodeView.tsx
@@ -149,7 +149,7 @@ export function AnnotatableCodeView({
           annotations,
           collapsed,
           version: fnv1a32(
-            `${collapsed ? "1" : "0"}:${annotations
+            `${fileDiff.cacheKey ?? ""}:${collapsed ? "1" : "0"}:${annotations
               .flatMap((annotation) =>
                 annotation.metadata.entries.map(
                   (entry) => `${entry.id}:${entry.rangeLabel}:${entry.text}`,

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
-import { buildPatchCacheKey, getDiffLineStat, getRenderablePatch } from "./diffRendering";
+import {
+  buildFileDiffRenderKey,
+  buildPatchCacheKey,
+  getDiffLineStat,
+  getRenderablePatch,
+} from "./diffRendering";
 
 describe("buildPatchCacheKey", () => {
   it("returns a stable cache key for identical content", () => {
@@ -31,6 +36,44 @@ describe("buildPatchCacheKey", () => {
 });
 
 describe("getRenderablePatch", () => {
+  it("keeps file identities stable while changing only affected file cache keys", () => {
+    const before = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1 +1 @@",
+      "-before a",
+      "+after a",
+      "diff --git a/b.ts b/b.ts",
+      "--- a/b.ts",
+      "+++ b/b.ts",
+      "@@ -1 +1 @@",
+      "-before b",
+      "+after b",
+    ].join("\n");
+    const after = [
+      "diff --git a/aa.ts b/aa.ts",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/aa.ts",
+      "@@ -0,0 +1 @@",
+      "+new file",
+      before.replace("+after a", "+after a again"),
+    ].join("\n");
+
+    const parsedBefore = getRenderablePatch(before, "live-diff");
+    const parsedAfter = getRenderablePatch(after, "live-diff");
+    expect(parsedBefore?.kind).toBe("files");
+    expect(parsedAfter?.kind).toBe("files");
+    if (parsedBefore?.kind !== "files" || parsedAfter?.kind !== "files") return;
+
+    expect(buildFileDiffRenderKey(parsedBefore.files[0]!)).toBe(
+      buildFileDiffRenderKey(parsedAfter.files[1]!),
+    );
+    expect(parsedBefore.files[0]?.cacheKey).not.toBe(parsedAfter.files[1]?.cacheKey);
+    expect(parsedBefore.files[1]?.cacheKey).toBe(parsedAfter.files[2]?.cacheKey);
+  });
+
   it("compacts partial hunk render offsets for virtualized review diffs", () => {
     const patch = [
       "diff --git a/example.ts b/example.ts",

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -116,15 +116,20 @@ export function getRenderablePatch(
   if (normalizedPatch.length === 0) return null;
 
   try {
-    const parsedPatches = parsePatchFiles(
-      normalizedPatch,
-      buildPatchCacheKey(normalizedPatch, cacheScope),
-    );
-    const files = parsedPatches.flatMap((parsedPatch) =>
-      options.compactPartialHunkOffsets
-        ? parsedPatch.files.map(compactPartialHunkOffsets)
-        : parsedPatch.files,
-    );
+    const parsedPatches = parsePatchFiles(normalizedPatch, undefined);
+    const files = parsedPatches
+      .flatMap((parsedPatch) =>
+        options.compactPartialHunkOffsets
+          ? parsedPatch.files.map(compactPartialHunkOffsets)
+          : parsedPatch.files,
+      )
+      .map((file) => {
+        const { cacheKey: _cacheKey, ...metadata } = file;
+        return {
+          ...file,
+          cacheKey: buildPatchCacheKey(JSON.stringify(metadata), `${cacheScope}:file`),
+        };
+      });
     if (files.length > 0) {
       return { kind: "files", files };
     }
@@ -152,7 +157,7 @@ export function resolveFileDiffPath(fileDiff: FileDiffMetadata): string {
 }
 
 export function buildFileDiffRenderKey(fileDiff: FileDiffMetadata): string {
-  return fileDiff.cacheKey ?? `${fileDiff.prevName ?? "none"}:${fileDiff.name}`;
+  return JSON.stringify([fileDiff.prevName ?? null, fileDiff.name]);
 }
 
 export function getDiffCollapseIconClassName(fileDiff: FileDiffMetadata): string {

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -51,6 +51,7 @@ export type EnvironmentSubscriptionRpcTag =
   | typeof WS_METHODS.subscribeDiscoveredLocalServers
   | typeof WS_METHODS.previewAutomationConnect
   | typeof WS_METHODS.subscribeVcsStatus
+  | typeof WS_METHODS.reviewSubscribeDiffPreview
   | typeof WS_METHODS.terminalAttach;
 
 export type EnvironmentStreamCommandRpcTag =

--- a/packages/client-runtime/src/state/review.ts
+++ b/packages/client-runtime/src/state/review.ts
@@ -1,17 +1,17 @@
 import { WS_METHODS } from "@t3tools/contracts";
 import { Atom } from "effect/unstable/reactivity";
 
-import { createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
+import { createEnvironmentRpcSubscriptionAtomFamily } from "./runtime.ts";
 import type { EnvironmentRegistry } from "../connection/registry.ts";
 
 export function createReviewEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
 ) {
   return {
-    diffPreview: createEnvironmentRpcQueryAtomFamily(runtime, {
+    diffPreview: createEnvironmentRpcSubscriptionAtomFamily(runtime, {
       label: "environment-data:review:diff-preview",
-      tag: WS_METHODS.reviewGetDiffPreview,
-      staleTimeMs: 5_000,
+      tag: WS_METHODS.reviewSubscribeDiffPreview,
+      idleTtlMs: 0,
     }),
   };
 }

--- a/packages/client-runtime/src/state/vcs.ts
+++ b/packages/client-runtime/src/state/vcs.ts
@@ -151,7 +151,7 @@ export function createVcsEnvironmentAtoms<R, E>(
       return runtime
         .atom(cachedVcsRefsChanges(environmentId, input))
         .pipe(
-          Atom.setIdleTTL(5 * 60_000),
+          Atom.setIdleTTL(0),
           Atom.withLabel(`environment-data:vcs:list-refs:${environmentId}:${inputKey}`),
         );
     }),

--- a/packages/contracts/src/review.ts
+++ b/packages/contracts/src/review.ts
@@ -3,15 +3,16 @@ import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { GitCommandError } from "./git.ts";
 import { VcsError } from "./vcs.ts";
 
+export const ReviewDiffPreviewSourceKind = Schema.Literals(["working-tree", "branch-range"]);
+export type ReviewDiffPreviewSourceKind = typeof ReviewDiffPreviewSourceKind.Type;
+
 export const ReviewDiffPreviewInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   baseRef: Schema.optional(TrimmedNonEmptyString),
   ignoreWhitespace: Schema.optionalKey(Schema.Boolean),
+  sourceKind: Schema.optionalKey(ReviewDiffPreviewSourceKind),
 });
 export type ReviewDiffPreviewInput = typeof ReviewDiffPreviewInput.Type;
-
-export const ReviewDiffPreviewSourceKind = Schema.Literals(["working-tree", "branch-range"]);
-export type ReviewDiffPreviewSourceKind = typeof ReviewDiffPreviewSourceKind.Type;
 
 export const ReviewDiffPreviewSource = Schema.Struct({
   id: TrimmedNonEmptyString,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -181,6 +181,7 @@ export const WS_METHODS = {
 
   // Review methods
   reviewGetDiffPreview: "review.getDiffPreview",
+  reviewSubscribeDiffPreview: "review.subscribeDiffPreview",
 
   // Terminal methods
   terminalOpen: "terminal.open",
@@ -495,6 +496,13 @@ export const WsReviewGetDiffPreviewRpc = Rpc.make(WS_METHODS.reviewGetDiffPrevie
   error: Schema.Union([ReviewDiffPreviewError, EnvironmentAuthorizationError]),
 });
 
+export const WsReviewSubscribeDiffPreviewRpc = Rpc.make(WS_METHODS.reviewSubscribeDiffPreview, {
+  payload: ReviewDiffPreviewInput,
+  success: ReviewDiffPreviewResult,
+  error: Schema.Union([ReviewDiffPreviewError, EnvironmentAuthorizationError]),
+  stream: true,
+});
+
 export const WsTerminalOpenRpc = Rpc.make(WS_METHODS.terminalOpen, {
   payload: TerminalOpenInput,
   success: TerminalSessionSnapshot,
@@ -738,6 +746,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsVcsSwitchRefRpc,
   WsVcsInitRpc,
   WsReviewGetDiffPreviewRpc,
+  WsReviewSubscribeDiffPreviewRpc,
   WsTerminalOpenRpc,
   WsTerminalAttachRpc,
   WsTerminalWriteRpc,


### PR DESCRIPTION
## What Changed

- Replace the diff panel's one-shot working-tree/branch query with a project-scoped stream that sends an initial snapshot and then refreshes from workspace and Git metadata changes.
- Run recursive Node filesystem watchers in one multiplexed worker, coalesce related events, suppress unchanged snapshots, and reconcile once watcher registration is complete.
- Generate only the selected diff source, bound untracked-file patch work, and mount branch-ref queries only while the picker is open.
- Keep the last resolved patch visible during refreshes and give each file stable render identity so live updates preserve collapse and scroll state.
- Keep the existing one-shot RPC for compatibility.

## Why

The diff panel captured a snapshot when it mounted. Files changed afterward could remain stale until another UI action recreated the query, while reopening or changing scope could show a loading skeleton even when a valid snapshot was already available.

The new stream authorizes the requested project and emits its initial result before watcher setup. A shared worker owns recursive watchers, and a reconciliation pass after watcher readiness closes the setup race. Each refresh requests only the active source, and unchanged hashes are not emitted.

## Performance

Measured with synthetic repositories on Node 24.18.0:

- **Branch scope:** In a worktree with 60 modified and 240 untracked files, requesting only the branch range took 21.10 ms median and 28.85 ms p95. Generating both sources took 362.59 ms median and 525.79 ms p95.
- **Untracked work:** A replica of the replaced unbounded 240-file patch loop took 230.44 ms median. The bounded path took 161.60 ms, a 29.9% reduction, and reports truncation explicitly.
- **Filesystem refresh:** 20 writes reached the watcher stream in 0.14 ms median, 0.42 ms p95, and 0.70 ms max.
- **Remount lifecycle:** 50 subscribe/unsubscribe cycles completed at 0.13 ms median / 0.51 ms p95 readiness with no additional worker threads after the first subscription.

## Verification

- `vp test run apps/server/src/review/ReviewWatcher.test.ts apps/server/src/review/ReviewService.test.ts apps/server/src/vcs/GitVcsDriverCore.test.ts`: 39 tests passed
- `vp test run apps/server/src/server.test.ts -t "routes websocket rpc git methods"`: focused RPC integration passed
- `vp test run apps/web/src/lib/diffRendering.test.ts apps/web/src/lib/diffCollapse.test.ts packages/client-runtime/src/state/vcs.test.ts`: 15 tests passed
- Server, web, contracts, and client-runtime type checks passed
- Targeted lint, formatting, `git diff --check`, and `pnpm --filter t3 build:bundle` passed
- Isolated browser verification covered initial load, filesystem-driven refresh, preserved collapsed state, close/reopen, branch scope, and switching back to the working tree

## UI Changes

This PR keeps the existing layout. Filesystem changes update the diff automatically without resetting viewer state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
