### PR TITLE
fix(web): retain terminal PR badges after checkout switch

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -276,7 +276,10 @@ import {
   shouldShowThreadErrorBanner,
   ThreadErrorBanner,
 } from "./chat/ThreadErrorBanner";
-import { resolveThreadPr } from "./ThreadStatusIndicators";
+import {
+  resolveDisplayedThreadPr,
+  threadChangeRequestSnapshotsAtom,
+} from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
 import { ThreadSyncStatusPill } from "./chat/ThreadSyncStatusPill";
 import {
@@ -1596,6 +1599,7 @@ function ChatViewContent(props: ChatViewProps) {
     [activeThreadEnvironmentId, activeThreadId],
   );
   const activeThreadKey = activeThreadRef ? scopedThreadKey(activeThreadRef) : null;
+  const changeRequestSnapshotByKey = useAtomValue(threadChangeRequestSnapshotsAtom);
   const [timelineAnchor, setTimelineAnchor] = useState<{
     readonly threadKey: string | null;
     readonly messageId: MessageId | null;
@@ -4124,9 +4128,11 @@ function ChatViewContent(props: ChatViewProps) {
   const activeThreadShell = useThreadShell(isServerThread ? activeThreadRef : null);
   const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
   const autoSettleOnMerge = useClientSettings((settings) => settings.sidebarAutoSettleOnMerge);
-  const activeThreadPr = resolveThreadPr({
+  const activeThreadPr = resolveDisplayedThreadPr({
     threadBranch: activeThread?.branch ?? null,
     gitStatus: gitStatusQuery.data ?? null,
+    snapshot: activeThreadKey ? changeRequestSnapshotByKey.get(activeThreadKey) : undefined,
+    retainTerminalOnBranchMismatch: activeThread?.worktreePath === null,
   });
   // The right panel offers the thread's own change request, so it can only offer it once the
   // branch has one; until then the picker says so rather than opening an empty panel.
@@ -4208,6 +4214,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeThreadShell,
     autoSettleAfterDays,
     autoSettleOnMerge,
+    changeRequestSnapshotByKey,
     nowMinute,
     supportsSettlement,
   ]);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -236,7 +236,10 @@ import {
   shouldShowProviderStatusBanner,
 } from "./chat/ProviderStatusBanner";
 import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
-import { resolveThreadPr } from "./ThreadStatusIndicators";
+import {
+  resolveDisplayedThreadPr,
+  threadChangeRequestSnapshotsAtom,
+} from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
 import {
   DRAFT_HERO_TRANSITION_ANIMATION_ID,
@@ -1471,6 +1474,7 @@ function ChatViewContent(props: ChatViewProps) {
     [activeThread],
   );
   const activeThreadKey = activeThreadRef ? scopedThreadKey(activeThreadRef) : null;
+  const changeRequestSnapshotByKey = useAtomValue(threadChangeRequestSnapshotsAtom);
   const [timelineAnchor, setTimelineAnchor] = useState<{
     readonly threadKey: string | null;
     readonly messageId: MessageId | null;
@@ -3871,9 +3875,11 @@ function ChatViewContent(props: ChatViewProps) {
   // so the banner and the sidebar row never disagree.
   const activeThreadShell = useThreadShell(isServerThread ? activeThreadRef : null);
   const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
-  const activeThreadPr = resolveThreadPr({
+  const activeThreadPr = resolveDisplayedThreadPr({
     threadBranch: activeThread?.branch ?? null,
     gitStatus: gitStatusQuery.data ?? null,
+    snapshot: activeThreadKey ? changeRequestSnapshotByKey.get(activeThreadKey) : undefined,
+    retainTerminalOnBranchMismatch: activeThread?.worktreePath === null,
   });
   const supportsSettlement = serverConfig?.environment.capabilities.threadSettlement === true;
   const supportsSnooze = serverConfig?.environment.capabilities.threadSnooze === true;
@@ -3905,6 +3911,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeThreadPr?.state,
     activeThreadShell,
     autoSettleAfterDays,
+    changeRequestSnapshotByKey,
     nowMinute,
     supportsSettlement,
   ]);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -143,10 +143,14 @@ import {
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
   ThreadWorktreeIndicator,
+  nextThreadChangeRequestSnapshot,
   prStatusIndicator,
-  resolveThreadPr,
+  resolveDisplayedThreadPr,
+  resolveDisplayedThreadPrProvider,
   settledPrHoverColorClass,
   terminalStatusFromRunningIds,
+  threadChangeRequestSnapshotsEqual,
+  type ThreadChangeRequestSnapshot,
   type TerminalStatusIndicator,
 } from "./ThreadStatusIndicators";
 import {
@@ -711,11 +715,16 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   onUnsnooze: (threadRef: ScopedThreadRef) => void;
   onUnpin: (threadRef: ScopedThreadRef) => void;
   onAcknowledgeWoke: (threadRef: ScopedThreadRef, visitedAt: string) => void;
-  onChangeRequestState: (threadKey: string, state: "open" | "closed" | "merged" | null) => void;
+  changeRequestSnapshot: ThreadChangeRequestSnapshot | null;
+  onChangeRequestSnapshot: (
+    threadKey: string,
+    snapshot: ThreadChangeRequestSnapshot | null,
+  ) => void;
 }) {
   const {
     isRenaming,
-    onChangeRequestState,
+    changeRequestSnapshot,
+    onChangeRequestSnapshot,
     onCancelRename,
     onCommitRename,
     onContextMenu,
@@ -760,9 +769,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         })
       : null,
   );
-  const pr = resolveThreadPr({
+  const pr = resolveDisplayedThreadPr({
     threadBranch: thread.branch,
     gitStatus: gitStatus.data,
+    snapshot: changeRequestSnapshot,
   });
   const prState = pr?.state ?? null;
 
@@ -856,13 +866,21 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     activeThreadBranch: thread.branch,
     currentGitBranch: gitStatus.data?.refName ?? null,
   });
-  const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
+  const prProvider = resolveDisplayedThreadPrProvider({
+    threadBranch: thread.branch,
+    gitStatus: gitStatus.data,
+    snapshot: changeRequestSnapshot,
+  });
+  const prStatus = prStatusIndicator(pr, prProvider);
   const settledPrHoverClass = pr ? settledPrHoverColorClass(pr.state) : undefined;
-  // Report the PR state so the parent can apply the configured merge rule
-  // and the always-on close rule during partitioning.
   useEffect(() => {
-    onChangeRequestState(threadKey, prState);
-  }, [onChangeRequestState, prState, threadKey]);
+    const nextSnapshot = nextThreadChangeRequestSnapshot({
+      threadBranch: thread.branch,
+      gitStatus: gitStatus.data,
+    });
+    if (nextSnapshot === undefined) return;
+    onChangeRequestSnapshot(threadKey, nextSnapshot);
+  }, [gitStatus.data, onChangeRequestSnapshot, thread.branch, threadKey]);
 
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
@@ -1825,21 +1843,24 @@ export default function Sidebar() {
   // fresh clock whenever it recomputes.
   const [snoozeWakeTick, bumpSnoozeWakeTick] = useState(0);
 
-  // PR states stream in per-row. The next partition applies the configured
-  // merge rule and the always-on close rule.
-  const [changeRequestStateByKey, setChangeRequestStateByKey] = useState<
-    ReadonlyMap<string, "open" | "closed" | "merged">
+  const [changeRequestSnapshotByKey, setChangeRequestSnapshotByKey] = useState<
+    ReadonlyMap<string, ThreadChangeRequestSnapshot>
   >(() => new Map());
-  const handleChangeRequestState = useCallback(
-    (threadKey: string, state: "open" | "closed" | "merged" | null) => {
-      setChangeRequestStateByKey((current) => {
-        if ((current.get(threadKey) ?? null) === state) return current;
-        const next = new Map(current);
-        if (state === null) {
+  const handleChangeRequestSnapshot = useCallback(
+    (threadKey: string, snapshot: ThreadChangeRequestSnapshot | null) => {
+      setChangeRequestSnapshotByKey((current) => {
+        const existing = current.get(threadKey);
+        if (snapshot === null) {
+          if (existing === undefined) return current;
+          const next = new Map(current);
           next.delete(threadKey);
-        } else {
-          next.set(threadKey, state);
+          return next;
         }
+        if (existing !== undefined && threadChangeRequestSnapshotsEqual(existing, snapshot)) {
+          return current;
+        }
+        const next = new Map(current);
+        next.set(threadKey, snapshot);
         return next;
       });
     },
@@ -1960,7 +1981,9 @@ export default function Sidebar() {
       const supportsSnooze =
         serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true;
       const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-      const changeRequestState = changeRequestStateByKey.get(threadKey) ?? null;
+      const snapshot = changeRequestSnapshotByKey.get(threadKey);
+      const changeRequestState =
+        snapshot != null && snapshot.branch === thread.branch ? snapshot.pr.state : null;
       // Snooze outranks everything, including a pin: "hide until Tuesday"
       // temporarily suspends "keep on top". The pin survives underneath —
       // and so does its pinOrderKey, so on wake the thread reappears at
@@ -2018,7 +2041,7 @@ export default function Sidebar() {
   }, [
     autoSettleAfterDays,
     autoSettleOnMerge,
-    changeRequestStateByKey,
+    changeRequestSnapshotByKey,
     nowMinute,
     scopedProjectKeys,
     serverConfigs,
@@ -3653,7 +3676,8 @@ export default function Sidebar() {
                         onUnsnooze={attemptUnsnooze}
                         onUnpin={attemptUnpin}
                         onAcknowledgeWoke={acknowledgeWoke}
-                        onChangeRequestState={handleChangeRequestState}
+                        changeRequestSnapshot={changeRequestSnapshotByKey.get(threadKey) ?? null}
+                        onChangeRequestSnapshot={handleChangeRequestSnapshot}
                       />
                     );
                   };

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -147,9 +147,10 @@ import {
   prStatusIndicator,
   resolveDisplayedThreadPr,
   resolveDisplayedThreadPrProvider,
+  setThreadChangeRequestSnapshot,
   settledPrHoverColorClass,
   terminalStatusFromRunningIds,
-  threadChangeRequestSnapshotsEqual,
+  threadChangeRequestSnapshotsAtom,
   type ThreadChangeRequestSnapshot,
   type TerminalStatusIndicator,
 } from "./ThreadStatusIndicators";
@@ -1855,29 +1856,7 @@ export default function Sidebar() {
   // fresh clock whenever it recomputes.
   const [snoozeWakeTick, bumpSnoozeWakeTick] = useState(0);
 
-  const [changeRequestSnapshotByKey, setChangeRequestSnapshotByKey] = useState<
-    ReadonlyMap<string, ThreadChangeRequestSnapshot>
-  >(() => new Map());
-  const handleChangeRequestSnapshot = useCallback(
-    (threadKey: string, snapshot: ThreadChangeRequestSnapshot | null) => {
-      setChangeRequestSnapshotByKey((current) => {
-        const existing = current.get(threadKey);
-        if (snapshot === null) {
-          if (existing === undefined) return current;
-          const next = new Map(current);
-          next.delete(threadKey);
-          return next;
-        }
-        if (existing !== undefined && threadChangeRequestSnapshotsEqual(existing, snapshot)) {
-          return current;
-        }
-        const next = new Map(current);
-        next.set(threadKey, snapshot);
-        return next;
-      });
-    },
-    [],
-  );
+  const changeRequestSnapshotByKey = useAtomValue(threadChangeRequestSnapshotsAtom);
 
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
@@ -3691,7 +3670,7 @@ export default function Sidebar() {
                         onUnpin={attemptUnpin}
                         onAcknowledgeWoke={acknowledgeWoke}
                         changeRequestSnapshot={changeRequestSnapshotByKey.get(threadKey) ?? null}
-                        onChangeRequestSnapshot={handleChangeRequestSnapshot}
+                        onChangeRequestSnapshot={setThreadChangeRequestSnapshot}
                       />
                     );
                   };

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -769,10 +769,12 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         })
       : null,
   );
+  const retainTerminalOnBranchMismatch = thread.worktreePath === null;
   const pr = resolveDisplayedThreadPr({
     threadBranch: thread.branch,
     gitStatus: gitStatus.data,
     snapshot: changeRequestSnapshot,
+    retainTerminalOnBranchMismatch,
   });
   const prState = pr?.state ?? null;
 
@@ -870,6 +872,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     threadBranch: thread.branch,
     gitStatus: gitStatus.data,
     snapshot: changeRequestSnapshot,
+    retainTerminalOnBranchMismatch,
   });
   const prStatus = prStatusIndicator(pr, prProvider);
   const settledPrHoverClass = pr ? settledPrHoverColorClass(pr.state) : undefined;
@@ -877,10 +880,19 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     const nextSnapshot = nextThreadChangeRequestSnapshot({
       threadBranch: thread.branch,
       gitStatus: gitStatus.data,
+      snapshot: changeRequestSnapshot,
+      retainTerminalOnBranchMismatch,
     });
     if (nextSnapshot === undefined) return;
     onChangeRequestSnapshot(threadKey, nextSnapshot);
-  }, [gitStatus.data, onChangeRequestSnapshot, thread.branch, threadKey]);
+  }, [
+    changeRequestSnapshot,
+    gitStatus.data,
+    onChangeRequestSnapshot,
+    retainTerminalOnBranchMismatch,
+    thread.branch,
+    threadKey,
+  ]);
 
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
@@ -1983,7 +1995,9 @@ export default function Sidebar() {
       const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
       const snapshot = changeRequestSnapshotByKey.get(threadKey);
       const changeRequestState =
-        snapshot != null && snapshot.branch === thread.branch ? snapshot.pr.state : null;
+        snapshot != null && (thread.worktreePath === null || snapshot.branch === thread.branch)
+          ? snapshot.pr.state
+          : null;
       // Snooze outranks everything, including a pin: "hide until Tuesday"
       // temporarily suspends "keep on top". The pin survives underneath —
       // and so does its pinOrderKey, so on wake the thread reappears at

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -125,7 +125,8 @@ import {
   prStatusIndicator,
   resolveDisplayedThreadPr,
   resolveDisplayedThreadPrProvider,
-  threadChangeRequestSnapshotsEqual,
+  setThreadChangeRequestSnapshot,
+  threadChangeRequestSnapshotsAtom,
   type ThreadChangeRequestSnapshot,
   settledPrHoverColorClass,
 } from "./ThreadStatusIndicators";
@@ -1191,29 +1192,7 @@ export default function SidebarV2() {
   // Full PR snapshots stream in per-row (rows own the VCS subscriptions). A
   // merged/closed PR auto-settles its thread; the snapshot retains badge
   // metadata when the shared checkout later switches away from the thread branch.
-  const [changeRequestSnapshotByKey, setChangeRequestSnapshotByKey] = useState<
-    ReadonlyMap<string, ThreadChangeRequestSnapshot>
-  >(() => new Map());
-  const handleChangeRequestSnapshot = useCallback(
-    (threadKey: string, snapshot: ThreadChangeRequestSnapshot | null) => {
-      setChangeRequestSnapshotByKey((current) => {
-        const existing = current.get(threadKey);
-        if (snapshot === null) {
-          if (existing === undefined) return current;
-          const next = new Map(current);
-          next.delete(threadKey);
-          return next;
-        }
-        if (existing !== undefined && threadChangeRequestSnapshotsEqual(existing, snapshot)) {
-          return current;
-        }
-        const next = new Map(current);
-        next.set(threadKey, snapshot);
-        return next;
-      });
-    },
-    [],
-  );
+  const changeRequestSnapshotByKey = useAtomValue(threadChangeRequestSnapshotsAtom);
 
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
@@ -2505,7 +2484,7 @@ export default function SidebarV2() {
                       onSnooze={attemptSnooze}
                       onUnsnooze={attemptUnsnooze}
                       changeRequestSnapshot={changeRequestSnapshotByKey.get(threadKey) ?? null}
-                      onChangeRequestSnapshot={handleChangeRequestSnapshot}
+                      onChangeRequestSnapshot={setThreadChangeRequestSnapshot}
                     />
                   );
                 };

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -511,15 +511,18 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     activeThreadBranch: thread.branch,
     currentGitBranch: gitStatus.data?.refName ?? null,
   });
+  const retainTerminalOnBranchMismatch = thread.worktreePath === null;
   const pr = resolveDisplayedThreadPr({
     threadBranch: thread.branch,
     gitStatus: gitStatus.data,
     snapshot: changeRequestSnapshot,
+    retainTerminalOnBranchMismatch,
   });
   const prProvider = resolveDisplayedThreadPrProvider({
     threadBranch: thread.branch,
     gitStatus: gitStatus.data,
     snapshot: changeRequestSnapshot,
+    retainTerminalOnBranchMismatch,
   });
   const prStatus = prStatusIndicator(pr, prProvider);
   const settledPrHoverClass = pr ? settledPrHoverColorClass(pr.state) : undefined;
@@ -529,10 +532,19 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     const nextSnapshot = nextThreadChangeRequestSnapshot({
       threadBranch: thread.branch,
       gitStatus: gitStatus.data,
+      snapshot: changeRequestSnapshot,
+      retainTerminalOnBranchMismatch,
     });
     if (nextSnapshot === undefined) return;
     onChangeRequestSnapshot(threadKey, nextSnapshot);
-  }, [gitStatus.data, onChangeRequestSnapshot, thread.branch, threadKey]);
+  }, [
+    gitStatus.data,
+    changeRequestSnapshot,
+    onChangeRequestSnapshot,
+    retainTerminalOnBranchMismatch,
+    thread.branch,
+    threadKey,
+  ]);
 
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
@@ -1420,10 +1432,13 @@ export default function SidebarV2() {
         serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true;
       const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
       const snapshot = changeRequestSnapshotByKey.get(threadKey);
-      // Same resolved terminal PR the row displays: retain merged/closed for
-      // this thread's branch even after the shared checkout switches away.
+      // Same resolved terminal PR the row displays: local thread branch
+      // metadata follows the shared checkout, while worktree snapshots remain
+      // scoped to the worktree's branch.
       const changeRequestState =
-        snapshot != null && snapshot.branch === thread.branch ? snapshot.pr.state : null;
+        snapshot != null && (thread.worktreePath === null || snapshot.branch === thread.branch)
+          ? snapshot.pr.state
+          : null;
       // Snooze outranks settled classification: an explicitly snoozed thread
       // belongs to the shelf even if it would also auto-settle (the shelf's
       // wake time is a stronger statement about when it matters again).

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -121,8 +121,12 @@ import {
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
+  nextThreadChangeRequestSnapshot,
   prStatusIndicator,
-  resolveThreadPr,
+  resolveDisplayedThreadPr,
+  resolveDisplayedThreadPrProvider,
+  threadChangeRequestSnapshotsEqual,
+  type ThreadChangeRequestSnapshot,
   settledPrHoverColorClass,
 } from "./ThreadStatusIndicators";
 import {
@@ -391,11 +395,16 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   onUnsettle: (threadRef: ScopedThreadRef) => void;
   onSnooze: (threadRef: ScopedThreadRef, preset: SnoozePreset) => void;
   onUnsnooze: (threadRef: ScopedThreadRef) => void;
-  onChangeRequestState: (threadKey: string, state: "open" | "closed" | "merged" | null) => void;
+  changeRequestSnapshot: ThreadChangeRequestSnapshot | null;
+  onChangeRequestSnapshot: (
+    threadKey: string,
+    snapshot: ThreadChangeRequestSnapshot | null,
+  ) => void;
 }) {
   const {
     isRenaming,
-    onChangeRequestState,
+    changeRequestSnapshot,
+    onChangeRequestSnapshot,
     onCancelRename,
     onCommitRename,
     onContextMenu,
@@ -502,18 +511,28 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     activeThreadBranch: thread.branch,
     currentGitBranch: gitStatus.data?.refName ?? null,
   });
-  const pr = resolveThreadPr({
+  const pr = resolveDisplayedThreadPr({
     threadBranch: thread.branch,
     gitStatus: gitStatus.data,
+    snapshot: changeRequestSnapshot,
   });
-  const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
+  const prProvider = resolveDisplayedThreadPrProvider({
+    threadBranch: thread.branch,
+    gitStatus: gitStatus.data,
+    snapshot: changeRequestSnapshot,
+  });
+  const prStatus = prStatusIndicator(pr, prProvider);
   const settledPrHoverClass = pr ? settledPrHoverColorClass(pr.state) : undefined;
-  // Report the PR state up: the parent partitions rows with effectiveSettled,
-  // and a merged/closed PR auto-settles a thread — data only rows have.
-  const prState = pr?.state ?? null;
+  // Authoritative VCS updates only: a checkout on another branch must not
+  // clear a previously verified terminal PR for this thread.
   useEffect(() => {
-    onChangeRequestState(threadKey, prState);
-  }, [onChangeRequestState, prState, threadKey]);
+    const nextSnapshot = nextThreadChangeRequestSnapshot({
+      threadBranch: thread.branch,
+      gitStatus: gitStatus.data,
+    });
+    if (nextSnapshot === undefined) return;
+    onChangeRequestSnapshot(threadKey, nextSnapshot);
+  }, [gitStatus.data, onChangeRequestSnapshot, thread.branch, threadKey]);
 
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
@@ -1157,21 +1176,27 @@ export default function SidebarV2() {
   // fresh clock whenever it recomputes.
   const [snoozeWakeTick, bumpSnoozeWakeTick] = useState(0);
 
-  // PR states stream in per-row (rows own the VCS subscriptions); a merged or
-  // closed PR auto-settles its thread on the next partition.
-  const [changeRequestStateByKey, setChangeRequestStateByKey] = useState<
-    ReadonlyMap<string, "open" | "closed" | "merged">
+  // Full PR snapshots stream in per-row (rows own the VCS subscriptions). A
+  // merged/closed PR auto-settles its thread; the snapshot retains badge
+  // metadata when the shared checkout later switches away from the thread branch.
+  const [changeRequestSnapshotByKey, setChangeRequestSnapshotByKey] = useState<
+    ReadonlyMap<string, ThreadChangeRequestSnapshot>
   >(() => new Map());
-  const handleChangeRequestState = useCallback(
-    (threadKey: string, state: "open" | "closed" | "merged" | null) => {
-      setChangeRequestStateByKey((current) => {
-        if ((current.get(threadKey) ?? null) === state) return current;
-        const next = new Map(current);
-        if (state === null) {
+  const handleChangeRequestSnapshot = useCallback(
+    (threadKey: string, snapshot: ThreadChangeRequestSnapshot | null) => {
+      setChangeRequestSnapshotByKey((current) => {
+        const existing = current.get(threadKey);
+        if (snapshot === null) {
+          if (existing === undefined) return current;
+          const next = new Map(current);
           next.delete(threadKey);
-        } else {
-          next.set(threadKey, state);
+          return next;
         }
+        if (existing !== undefined && threadChangeRequestSnapshotsEqual(existing, snapshot)) {
+          return current;
+        }
+        const next = new Map(current);
+        next.set(threadKey, snapshot);
         return next;
       });
     },
@@ -1394,7 +1419,11 @@ export default function SidebarV2() {
       const supportsSnooze =
         serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true;
       const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-      const changeRequestState = changeRequestStateByKey.get(threadKey) ?? null;
+      const snapshot = changeRequestSnapshotByKey.get(threadKey);
+      // Same resolved terminal PR the row displays: retain merged/closed for
+      // this thread's branch even after the shared checkout switches away.
+      const changeRequestState =
+        snapshot != null && snapshot.branch === thread.branch ? snapshot.pr.state : null;
       // Snooze outranks settled classification: an explicitly snoozed thread
       // belongs to the shelf even if it would also auto-settle (the shelf's
       // wake time is a stronger statement about when it matters again).
@@ -1422,7 +1451,7 @@ export default function SidebarV2() {
     };
   }, [
     autoSettleAfterDays,
-    changeRequestStateByKey,
+    changeRequestSnapshotByKey,
     nowMinute,
     scopedProjectKeys,
     serverConfigs,
@@ -2460,7 +2489,8 @@ export default function SidebarV2() {
                       onUnsettle={attemptUnsettle}
                       onSnooze={attemptSnooze}
                       onUnsnooze={attemptUnsnooze}
-                      onChangeRequestState={handleChangeRequestState}
+                      changeRequestSnapshot={changeRequestSnapshotByKey.get(threadKey) ?? null}
+                      onChangeRequestSnapshot={handleChangeRequestSnapshot}
                     />
                   );
                 };

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -1,8 +1,9 @@
 import { effectiveSettled } from "@t3tools/client-runtime/state/thread-settled";
 import type { OrchestrationThreadShell } from "@t3tools/contracts";
 import { ProjectId, ProviderInstanceId, ThreadId, type VcsStatusResult } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
 import { AtomRegistry } from "effect/unstable/reactivity";
-import { describe, expect, it } from "vite-plus/test";
 
 import {
   nextThreadChangeRequestSnapshot,
@@ -390,21 +391,25 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
 });
 
 describe("threadChangeRequestSnapshotsAtom", () => {
-  it("retains snapshots while sidebar and chat consumers are unmounted", () => {
-    const registry = AtomRegistry.make();
-    const threadKey = "environment-1:thread-1";
-    const snapshot = snapshotFor("feature/current", mergedFeaturePr());
+  it.effect("retains snapshots while sidebar and chat consumers are unmounted", () =>
+    Effect.gen(function* () {
+      const registry = AtomRegistry.make();
+      const threadKey = "environment-1:thread-1";
+      const snapshot = snapshotFor("feature/current", mergedFeaturePr());
 
-    const unmount = registry.mount(threadChangeRequestSnapshotsAtom);
-    registry.set(threadChangeRequestSnapshotsAtom, new Map([[threadKey, snapshot]]));
-    unmount();
+      const unmount = registry.mount(threadChangeRequestSnapshotsAtom);
+      registry.set(threadChangeRequestSnapshotsAtom, new Map([[threadKey, snapshot]]));
+      unmount();
 
-    const remount = registry.mount(threadChangeRequestSnapshotsAtom);
-    expect(registry.get(threadChangeRequestSnapshotsAtom).get(threadKey)).toEqual(snapshot);
+      yield* Effect.yieldNow;
 
-    remount();
-    registry.dispose();
-  });
+      const remount = registry.mount(threadChangeRequestSnapshotsAtom);
+      expect(registry.get(threadChangeRequestSnapshotsAtom).get(threadKey)).toEqual(snapshot);
+
+      remount();
+      registry.dispose();
+    }),
+  );
 });
 
 describe("prStatusIndicator", () => {

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -116,6 +116,7 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: featureBranch,
         gitStatus,
         snapshot: undefined,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toBe(mergedPr);
     expect(
@@ -123,6 +124,7 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: featureBranch,
         gitStatus,
         snapshot: undefined,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toEqual(provider);
   });
@@ -136,6 +138,8 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
     const cached = nextThreadChangeRequestSnapshot({
       threadBranch: featureBranch,
       gitStatus: matchingStatus,
+      snapshot: undefined,
+      retainTerminalOnBranchMismatch: true,
     });
     expect(cached).toEqual(snapshotFor(featureBranch, mergedPr, provider));
 
@@ -158,6 +162,7 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: featureBranch,
         gitStatus: mainStatus,
         snapshot: cached as ThreadChangeRequestSnapshot,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toEqual(mergedPr);
     expect(
@@ -165,6 +170,7 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: featureBranch,
         gitStatus: mainStatus,
         snapshot: cached as ThreadChangeRequestSnapshot,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toEqual(provider);
   });
@@ -183,12 +189,15 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: featureBranch,
         gitStatus: status({ refName: "main", pr: mainPr }),
         snapshot: undefined,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toBeNull();
     expect(
       nextThreadChangeRequestSnapshot({
         threadBranch: featureBranch,
         gitStatus: status({ refName: "main", pr: mainPr }),
+        snapshot: undefined,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toBeUndefined();
   });
@@ -205,6 +214,7 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: featureBranch,
         gitStatus: status({ refName: "main", pr: null }),
         snapshot: openSnapshot,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toBeNull();
   });
@@ -218,11 +228,42 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: featureBranch,
         gitStatus: status({ refName: "main", pr: null }),
         snapshot: closedSnapshot,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toEqual(closedPr);
   });
 
-  it("rejects a snapshot stored for another branch", () => {
+  it("does not retain or display a terminal PR when a worktree switches branches", () => {
+    const terminalSnapshot = snapshotFor(featureBranch, mergedPr, provider);
+    const mismatchedStatus = status({ refName: "feature/other", pr: null });
+
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: featureBranch,
+        gitStatus: mismatchedStatus,
+        snapshot: terminalSnapshot,
+        retainTerminalOnBranchMismatch: false,
+      }),
+    ).toBeNull();
+    expect(
+      resolveDisplayedThreadPrProvider({
+        threadBranch: featureBranch,
+        gitStatus: mismatchedStatus,
+        snapshot: terminalSnapshot,
+        retainTerminalOnBranchMismatch: false,
+      }),
+    ).toBeUndefined();
+    expect(
+      nextThreadChangeRequestSnapshot({
+        threadBranch: featureBranch,
+        gitStatus: mismatchedStatus,
+        snapshot: terminalSnapshot,
+        retainTerminalOnBranchMismatch: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("retains a local terminal snapshot when thread metadata follows the new branch", () => {
     const otherBranchSnapshot = snapshotFor("feature/other", mergedPr, provider);
 
     expect(
@@ -230,15 +271,41 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: featureBranch,
         gitStatus: status({ refName: "main", pr: null }),
         snapshot: otherBranchSnapshot,
+        retainTerminalOnBranchMismatch: true,
       }),
-    ).toBeNull();
+    ).toEqual(mergedPr);
   });
 
-  it("clears the snapshot when returning to the matching branch with no PR", () => {
+  it("retains a terminal snapshot when a local thread and status move to a branch with no PR", () => {
+    const terminalSnapshot = snapshotFor(featureBranch, mergedPr, provider);
+
     expect(
       nextThreadChangeRequestSnapshot({
-        threadBranch: featureBranch,
-        gitStatus: status({ refName: featureBranch, pr: null }),
+        threadBranch: "main",
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: terminalSnapshot,
+        retainTerminalOnBranchMismatch: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: "main",
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: terminalSnapshot,
+        retainTerminalOnBranchMismatch: true,
+      }),
+    ).toEqual(mergedPr);
+  });
+
+  it("clears an open snapshot when a local thread moves to a branch with no PR", () => {
+    const openSnapshot = snapshotFor(featureBranch, { ...mergedPr, state: "open" });
+
+    expect(
+      nextThreadChangeRequestSnapshot({
+        threadBranch: "main",
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: openSnapshot,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toBeNull();
   });
@@ -250,6 +317,8 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
       nextThreadChangeRequestSnapshot({
         threadBranch: featureBranch,
         gitStatus: null,
+        snapshot: terminalSnapshot,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toBeUndefined();
     expect(
@@ -257,6 +326,7 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: featureBranch,
         gitStatus: null,
         snapshot: terminalSnapshot,
+        retainTerminalOnBranchMismatch: true,
       }),
     ).toEqual(mergedPr);
   });
@@ -270,15 +340,18 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
     const cached = nextThreadChangeRequestSnapshot({
       threadBranch: featureBranch,
       gitStatus: matchingStatus,
+      snapshot: undefined,
+      retainTerminalOnBranchMismatch: true,
     });
     expect(cached).not.toBeNull();
     expect(cached).not.toBeUndefined();
 
     const mainStatus = status({ refName: "main", pr: null, isDefaultRef: true });
     const displayed = resolveDisplayedThreadPr({
-      threadBranch: featureBranch,
+      threadBranch: "main",
       gitStatus: mainStatus,
       snapshot: cached as ThreadChangeRequestSnapshot,
+      retainTerminalOnBranchMismatch: true,
     });
     expect(displayed?.state).toBe("merged");
 
@@ -289,7 +362,7 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
       modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
       runtimeMode: "full-access",
       interactionMode: "default",
-      branch: featureBranch,
+      branch: "main",
       worktreePath: null,
       latestTurn: null,
       session: null,

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -1,6 +1,7 @@
 import { effectiveSettled } from "@t3tools/client-runtime/state/thread-settled";
 import type { OrchestrationThreadShell } from "@t3tools/contracts";
 import { ProjectId, ProviderInstanceId, ThreadId, type VcsStatusResult } from "@t3tools/contracts";
+import { AtomRegistry } from "effect/unstable/reactivity";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
@@ -10,6 +11,7 @@ import {
   resolveDisplayedThreadPrProvider,
   resolveThreadPr,
   settledPrHoverColorClass,
+  threadChangeRequestSnapshotsAtom,
   type ThreadChangeRequestSnapshot,
 } from "./ThreadStatusIndicators";
 
@@ -384,6 +386,24 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         changeRequestState: displayed?.state ?? null,
       }),
     ).toBe(true);
+  });
+});
+
+describe("threadChangeRequestSnapshotsAtom", () => {
+  it("retains snapshots while sidebar and chat consumers are unmounted", () => {
+    const registry = AtomRegistry.make();
+    const threadKey = "environment-1:thread-1";
+    const snapshot = snapshotFor("feature/current", mergedFeaturePr());
+
+    const unmount = registry.mount(threadChangeRequestSnapshotsAtom);
+    registry.set(threadChangeRequestSnapshotsAtom, new Map([[threadKey, snapshot]]));
+    unmount();
+
+    const remount = registry.mount(threadChangeRequestSnapshotsAtom);
+    expect(registry.get(threadChangeRequestSnapshotsAtom).get(threadKey)).toEqual(snapshot);
+
+    remount();
+    registry.dispose();
   });
 });
 

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -337,6 +337,22 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         retainTerminalOnBranchMismatch: true,
       }),
     ).toBeNull();
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: null,
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: terminalSnapshot,
+        retainTerminalOnBranchMismatch: true,
+      }),
+    ).toBeNull();
+    expect(
+      resolveDisplayedThreadPrProvider({
+        threadBranch: null,
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: terminalSnapshot,
+        retainTerminalOnBranchMismatch: true,
+      }),
+    ).toBeUndefined();
   });
 
   it("does not erase a terminal snapshot when VCS data is missing", () => {

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -1,10 +1,16 @@
-import type { VcsStatusResult } from "@t3tools/contracts";
+import { effectiveSettled } from "@t3tools/client-runtime/state/thread-settled";
+import type { OrchestrationThreadShell } from "@t3tools/contracts";
+import { ProjectId, ProviderInstanceId, ThreadId, type VcsStatusResult } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  nextThreadChangeRequestSnapshot,
   prStatusIndicator,
+  resolveDisplayedThreadPr,
+  resolveDisplayedThreadPrProvider,
   resolveThreadPr,
   settledPrHoverColorClass,
+  type ThreadChangeRequestSnapshot,
 } from "./ThreadStatusIndicators";
 
 function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
@@ -28,6 +34,25 @@ function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
     },
     ...overrides,
   };
+}
+
+function mergedFeaturePr(): NonNullable<VcsStatusResult["pr"]> {
+  return {
+    number: 42,
+    title: "Feature PR",
+    url: "https://github.com/pingdotgg/t3code/pull/42",
+    baseRef: "main",
+    headRef: "feature/current",
+    state: "merged",
+  };
+}
+
+function snapshotFor(
+  branch: string,
+  pr: NonNullable<VcsStatusResult["pr"]>,
+  sourceControlProvider?: VcsStatusResult["sourceControlProvider"],
+): ThreadChangeRequestSnapshot {
+  return { branch, pr, sourceControlProvider };
 }
 
 describe("resolveThreadPr", () => {
@@ -67,6 +92,225 @@ describe("resolveThreadPr", () => {
         gitStatus,
       }),
     ).toBe(gitStatus.pr);
+  });
+});
+
+describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
+  const featureBranch = "feature/current";
+  const mergedPr = mergedFeaturePr();
+  const provider = {
+    kind: "github" as const,
+    name: "GitHub",
+    baseUrl: "https://github.com",
+  };
+
+  it("returns the live merged PR when the checkout matches the feature branch", () => {
+    const gitStatus = status({
+      refName: featureBranch,
+      pr: mergedPr,
+      sourceControlProvider: provider,
+    });
+
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: featureBranch,
+        gitStatus,
+        snapshot: undefined,
+      }),
+    ).toBe(mergedPr);
+    expect(
+      resolveDisplayedThreadPrProvider({
+        threadBranch: featureBranch,
+        gitStatus,
+        snapshot: undefined,
+      }),
+    ).toEqual(provider);
+  });
+
+  it("after caching a merged PR, resolves main status back to the cached feature PR", () => {
+    const matchingStatus = status({
+      refName: featureBranch,
+      pr: mergedPr,
+      sourceControlProvider: provider,
+    });
+    const cached = nextThreadChangeRequestSnapshot({
+      threadBranch: featureBranch,
+      gitStatus: matchingStatus,
+    });
+    expect(cached).toEqual(snapshotFor(featureBranch, mergedPr, provider));
+
+    const mainStatus = status({
+      refName: "main",
+      isDefaultRef: true,
+      pr: {
+        number: 99,
+        title: "Unrelated main PR",
+        url: "https://github.com/pingdotgg/t3code/pull/99",
+        baseRef: "main",
+        headRef: "main",
+        state: "open",
+      },
+      sourceControlProvider: provider,
+    });
+
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: featureBranch,
+        gitStatus: mainStatus,
+        snapshot: cached as ThreadChangeRequestSnapshot,
+      }),
+    ).toEqual(mergedPr);
+    expect(
+      resolveDisplayedThreadPrProvider({
+        threadBranch: featureBranch,
+        gitStatus: mainStatus,
+        snapshot: cached as ThreadChangeRequestSnapshot,
+      }),
+    ).toEqual(provider);
+  });
+
+  it("never attaches a PR reported by main to the feature thread", () => {
+    const mainPr = {
+      number: 99,
+      title: "Unrelated main PR",
+      url: "https://github.com/pingdotgg/t3code/pull/99",
+      baseRef: "develop",
+      headRef: "main",
+      state: "merged" as const,
+    };
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: featureBranch,
+        gitStatus: status({ refName: "main", pr: mainPr }),
+        snapshot: undefined,
+      }),
+    ).toBeNull();
+    expect(
+      nextThreadChangeRequestSnapshot({
+        threadBranch: featureBranch,
+        gitStatus: status({ refName: "main", pr: mainPr }),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not show a cached open PR across a branch mismatch", () => {
+    const openSnapshot = snapshotFor(featureBranch, {
+      ...mergedPr,
+      state: "open",
+      title: "Still open",
+    });
+
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: featureBranch,
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: openSnapshot,
+      }),
+    ).toBeNull();
+  });
+
+  it("retains a cached closed PR across a branch mismatch", () => {
+    const closedPr = { ...mergedPr, state: "closed" as const, title: "Closed feature" };
+    const closedSnapshot = snapshotFor(featureBranch, closedPr, provider);
+
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: featureBranch,
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: closedSnapshot,
+      }),
+    ).toEqual(closedPr);
+  });
+
+  it("rejects a snapshot stored for another branch", () => {
+    const otherBranchSnapshot = snapshotFor("feature/other", mergedPr, provider);
+
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: featureBranch,
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: otherBranchSnapshot,
+      }),
+    ).toBeNull();
+  });
+
+  it("clears the snapshot when returning to the matching branch with no PR", () => {
+    expect(
+      nextThreadChangeRequestSnapshot({
+        threadBranch: featureBranch,
+        gitStatus: status({ refName: featureBranch, pr: null }),
+      }),
+    ).toBeNull();
+  });
+
+  it("does not erase a terminal snapshot when VCS data is missing", () => {
+    const terminalSnapshot = snapshotFor(featureBranch, mergedPr, provider);
+
+    expect(
+      nextThreadChangeRequestSnapshot({
+        threadBranch: featureBranch,
+        gitStatus: null,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveDisplayedThreadPr({
+        threadBranch: featureBranch,
+        gitStatus: null,
+        snapshot: terminalSnapshot,
+      }),
+    ).toEqual(mergedPr);
+  });
+
+  it("keeps effectiveSettled true for a retained merged PR after a main checkout", () => {
+    const matchingStatus = status({
+      refName: featureBranch,
+      pr: mergedPr,
+      sourceControlProvider: provider,
+    });
+    const cached = nextThreadChangeRequestSnapshot({
+      threadBranch: featureBranch,
+      gitStatus: matchingStatus,
+    });
+    expect(cached).not.toBeNull();
+    expect(cached).not.toBeUndefined();
+
+    const mainStatus = status({ refName: "main", pr: null, isDefaultRef: true });
+    const displayed = resolveDisplayedThreadPr({
+      threadBranch: featureBranch,
+      gitStatus: mainStatus,
+      snapshot: cached as ThreadChangeRequestSnapshot,
+    });
+    expect(displayed?.state).toBe("merged");
+
+    const shell = {
+      id: ThreadId.make("thread-1"),
+      projectId: ProjectId.make("project-1"),
+      title: "Feature thread",
+      modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      branch: featureBranch,
+      worktreePath: null,
+      latestTurn: null,
+      session: null,
+      createdAt: "2026-04-09T00:00:00.000Z",
+      updatedAt: "2026-04-09T00:00:00.000Z",
+      archivedAt: null,
+      settledAt: null,
+      settledOverride: null,
+      latestUserMessageAt: "2026-04-09T00:00:00.000Z",
+      hasPendingApprovals: false,
+      hasPendingUserInput: false,
+      hasActionableProposedPlan: false,
+    } as OrchestrationThreadShell;
+
+    expect(
+      effectiveSettled(shell, {
+        now: "2026-04-10T00:00:00.000Z",
+        autoSettleAfterDays: null,
+        changeRequestState: displayed?.state ?? null,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -202,7 +202,7 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         snapshot: undefined,
         retainTerminalOnBranchMismatch: true,
       }),
-    ).toBeUndefined();
+    ).toBeNull();
   });
 
   it("does not show a cached open PR across a branch mismatch", () => {
@@ -308,6 +308,32 @@ describe("resolveDisplayedThreadPr + nextThreadChangeRequestSnapshot", () => {
         threadBranch: "main",
         gitStatus: status({ refName: "main", pr: null }),
         snapshot: openSnapshot,
+        retainTerminalOnBranchMismatch: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("clears an open snapshot when a local checkout moves to a different branch", () => {
+    const openSnapshot = snapshotFor(featureBranch, { ...mergedPr, state: "open" });
+
+    expect(
+      nextThreadChangeRequestSnapshot({
+        threadBranch: featureBranch,
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: openSnapshot,
+        retainTerminalOnBranchMismatch: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("clears a retained snapshot when the thread branch is cleared", () => {
+    const terminalSnapshot = snapshotFor(featureBranch, mergedPr, provider);
+
+    expect(
+      nextThreadChangeRequestSnapshot({
+        threadBranch: null,
+        gitStatus: status({ refName: "main", pr: null }),
+        snapshot: terminalSnapshot,
         retainTerminalOnBranchMismatch: true,
       }),
     ).toBeNull();

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -169,19 +169,31 @@ export function threadChangeRequestSnapshotsEqual(
 
 /**
  * Authoritative snapshot update from live VCS status.
- * - `undefined`: branch mismatch or missing status — leave the map alone
- * - `null`: matching branch reports no PR — clear the snapshot
+ * - `undefined`: missing status, or a local checkout retaining a terminal PR — leave the map alone
+ * - `null`: no PR (without a retained terminal snapshot), or a worktree mismatch — clear
  * - snapshot: matching branch reports a PR — store/replace
  */
 export function nextThreadChangeRequestSnapshot(input: {
   threadBranch: string | null;
   gitStatus: VcsStatusResult | null;
+  snapshot: ThreadChangeRequestSnapshot | null | undefined;
+  retainTerminalOnBranchMismatch: boolean;
 }): ThreadChangeRequestSnapshot | null | undefined {
-  const { threadBranch, gitStatus } = input;
-  if (threadBranch === null || gitStatus === null || gitStatus.refName !== threadBranch) {
+  const { threadBranch, gitStatus, snapshot, retainTerminalOnBranchMismatch } = input;
+  if (threadBranch === null || gitStatus === null) {
     return undefined;
   }
+  if (gitStatus.refName !== threadBranch) {
+    return retainTerminalOnBranchMismatch ? undefined : null;
+  }
   if (gitStatus.pr == null) {
+    if (
+      retainTerminalOnBranchMismatch &&
+      snapshot != null &&
+      isTerminalChangeRequestState(snapshot.pr.state)
+    ) {
+      return undefined;
+    }
     return null;
   }
   return {
@@ -192,23 +204,31 @@ export function nextThreadChangeRequestSnapshot(input: {
 }
 
 /**
- * Live PR when the checkout matches the thread branch; otherwise a cached
- * merged/closed PR for that same branch. Open PRs are never retained across
- * a mismatch — their state can still change.
+ * Live PR when the checkout matches the thread branch; otherwise, for local
+ * checkouts only, a cached merged/closed PR for the thread. Local thread
+ * metadata follows the shared checkout, so the cached branch intentionally
+ * survives that metadata changing to the newly checked-out branch. Open PRs
+ * are never retained — their state can still change.
  */
 export function resolveDisplayedThreadPr(input: {
   threadBranch: string | null;
   gitStatus: VcsStatusResult | null;
   snapshot: ThreadChangeRequestSnapshot | null | undefined;
+  retainTerminalOnBranchMismatch: boolean;
 }): ThreadPr | null {
-  const { threadBranch, gitStatus, snapshot } = input;
-  if (threadBranch !== null && gitStatus !== null && gitStatus.refName === threadBranch) {
-    return gitStatus.pr ?? null;
+  const { threadBranch, gitStatus, snapshot, retainTerminalOnBranchMismatch } = input;
+  if (
+    threadBranch !== null &&
+    gitStatus !== null &&
+    gitStatus.refName === threadBranch &&
+    gitStatus.pr != null
+  ) {
+    return gitStatus.pr;
   }
 
   if (
+    retainTerminalOnBranchMismatch &&
     snapshot != null &&
-    snapshot.branch === threadBranch &&
     isTerminalChangeRequestState(snapshot.pr.state)
   ) {
     return snapshot.pr;
@@ -221,15 +241,21 @@ export function resolveDisplayedThreadPrProvider(input: {
   threadBranch: string | null;
   gitStatus: VcsStatusResult | null;
   snapshot: ThreadChangeRequestSnapshot | null | undefined;
+  retainTerminalOnBranchMismatch: boolean;
 }): VcsStatusResult["sourceControlProvider"] | undefined {
-  const { threadBranch, gitStatus, snapshot } = input;
-  if (threadBranch !== null && gitStatus !== null && gitStatus.refName === threadBranch) {
+  const { threadBranch, gitStatus, snapshot, retainTerminalOnBranchMismatch } = input;
+  if (
+    threadBranch !== null &&
+    gitStatus !== null &&
+    gitStatus.refName === threadBranch &&
+    gitStatus.pr != null
+  ) {
     return gitStatus.sourceControlProvider;
   }
 
   if (
+    retainTerminalOnBranchMismatch &&
     snapshot != null &&
-    snapshot.branch === threadBranch &&
     isTerminalChangeRequestState(snapshot.pr.state)
   ) {
     return snapshot.sourceControlProvider;

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -261,6 +261,7 @@ export function resolveDisplayedThreadPr(input: {
   }
 
   if (
+    threadBranch !== null &&
     retainTerminalOnBranchMismatch &&
     snapshot != null &&
     isTerminalChangeRequestState(snapshot.pr.state)
@@ -288,6 +289,7 @@ export function resolveDisplayedThreadPrProvider(input: {
   }
 
   if (
+    threadBranch !== null &&
     retainTerminalOnBranchMismatch &&
     snapshot != null &&
     isTerminalChangeRequestState(snapshot.pr.state)

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -140,7 +140,7 @@ export interface ThreadChangeRequestSnapshot {
 
 export const threadChangeRequestSnapshotsAtom = Atom.make<
   ReadonlyMap<string, ThreadChangeRequestSnapshot>
->(new Map()).pipe(Atom.withLabel("sidebar:thread-change-request-snapshots"));
+>(new Map()).pipe(Atom.keepAlive, Atom.withLabel("sidebar:thread-change-request-snapshots"));
 
 function isTerminalChangeRequestState(
   state: NonNullable<ThreadPr>["state"],

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -197,7 +197,7 @@ export function setThreadChangeRequestSnapshot(
 /**
  * Authoritative snapshot update from live VCS status.
  * - `undefined`: missing status, or a local checkout retaining a terminal PR — leave the map alone
- * - `null`: no PR (without a retained terminal snapshot), or a worktree mismatch — clear
+ * - `null`: no PR (without a retained terminal snapshot), a cleared branch, or a mismatch without a terminal PR — clear
  * - snapshot: matching branch reports a PR — store/replace
  */
 export function nextThreadChangeRequestSnapshot(input: {
@@ -207,11 +207,18 @@ export function nextThreadChangeRequestSnapshot(input: {
   retainTerminalOnBranchMismatch: boolean;
 }): ThreadChangeRequestSnapshot | null | undefined {
   const { threadBranch, gitStatus, snapshot, retainTerminalOnBranchMismatch } = input;
-  if (threadBranch === null || gitStatus === null) {
+  if (gitStatus === null) {
     return undefined;
   }
+  if (threadBranch === null) {
+    return null;
+  }
   if (gitStatus.refName !== threadBranch) {
-    return retainTerminalOnBranchMismatch ? undefined : null;
+    return retainTerminalOnBranchMismatch &&
+      snapshot != null &&
+      isTerminalChangeRequestState(snapshot.pr.state)
+      ? undefined
+      : null;
   }
   if (gitStatus.pr == null) {
     if (

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -4,8 +4,10 @@ import {
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
 import type { VcsStatusResult } from "@t3tools/contracts";
+import { Atom } from "effect/unstable/reactivity";
 import { CloudIcon, FolderGit2Icon, GitPullRequestIcon, TerminalIcon } from "lucide-react";
 import { useMemo } from "react";
+import { appAtomRegistry } from "../rpc/atomRegistry";
 import { useEnvironment, usePrimaryEnvironmentId } from "../state/environments";
 import { useProject } from "../state/entities";
 import { useEnvironmentQuery } from "../state/query";
@@ -136,6 +138,10 @@ export interface ThreadChangeRequestSnapshot {
   readonly sourceControlProvider: VcsStatusResult["sourceControlProvider"] | undefined;
 }
 
+export const threadChangeRequestSnapshotsAtom = Atom.make<
+  ReadonlyMap<string, ThreadChangeRequestSnapshot>
+>(new Map()).pipe(Atom.withLabel("sidebar:thread-change-request-snapshots"));
+
 function isTerminalChangeRequestState(
   state: NonNullable<ThreadPr>["state"],
 ): state is "merged" | "closed" {
@@ -165,6 +171,27 @@ export function threadChangeRequestSnapshotsEqual(
     left.pr.state === right.pr.state &&
     sourceControlProvidersEqual(left.sourceControlProvider, right.sourceControlProvider)
   );
+}
+
+export function setThreadChangeRequestSnapshot(
+  threadKey: string,
+  snapshot: ThreadChangeRequestSnapshot | null,
+): void {
+  appAtomRegistry.modify(threadChangeRequestSnapshotsAtom, (current) => {
+    const existing = current.get(threadKey);
+    if (snapshot === null) {
+      if (existing === undefined) return [false, current];
+      const next = new Map(current);
+      next.delete(threadKey);
+      return [true, next];
+    }
+    if (existing !== undefined && threadChangeRequestSnapshotsEqual(existing, snapshot)) {
+      return [false, current];
+    }
+    const next = new Map(current);
+    next.set(threadKey, snapshot);
+    return [true, next];
+  });
 }
 
 /**

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -126,6 +126,118 @@ export function resolveThreadPr(input: {
   return gitStatus.pr ?? null;
 }
 
+/**
+ * Parent-held PR snapshot for Sidebar V2. Rows remount when settlement
+ * partitions move them, so terminal PR metadata must live above the row.
+ */
+export interface ThreadChangeRequestSnapshot {
+  readonly branch: string;
+  readonly pr: NonNullable<ThreadPr>;
+  readonly sourceControlProvider: VcsStatusResult["sourceControlProvider"] | undefined;
+}
+
+function isTerminalChangeRequestState(
+  state: NonNullable<ThreadPr>["state"],
+): state is "merged" | "closed" {
+  return state === "merged" || state === "closed";
+}
+
+function sourceControlProvidersEqual(
+  left: VcsStatusResult["sourceControlProvider"] | undefined,
+  right: VcsStatusResult["sourceControlProvider"] | undefined,
+): boolean {
+  if (left === right) return true;
+  if (left == null || right == null) return left == null && right == null;
+  return left.kind === right.kind && left.name === right.name && left.baseUrl === right.baseUrl;
+}
+
+export function threadChangeRequestSnapshotsEqual(
+  left: ThreadChangeRequestSnapshot,
+  right: ThreadChangeRequestSnapshot,
+): boolean {
+  return (
+    left.branch === right.branch &&
+    left.pr.number === right.pr.number &&
+    left.pr.title === right.pr.title &&
+    left.pr.url === right.pr.url &&
+    left.pr.baseRef === right.pr.baseRef &&
+    left.pr.headRef === right.pr.headRef &&
+    left.pr.state === right.pr.state &&
+    sourceControlProvidersEqual(left.sourceControlProvider, right.sourceControlProvider)
+  );
+}
+
+/**
+ * Authoritative snapshot update from live VCS status.
+ * - `undefined`: branch mismatch or missing status — leave the map alone
+ * - `null`: matching branch reports no PR — clear the snapshot
+ * - snapshot: matching branch reports a PR — store/replace
+ */
+export function nextThreadChangeRequestSnapshot(input: {
+  threadBranch: string | null;
+  gitStatus: VcsStatusResult | null;
+}): ThreadChangeRequestSnapshot | null | undefined {
+  const { threadBranch, gitStatus } = input;
+  if (threadBranch === null || gitStatus === null || gitStatus.refName !== threadBranch) {
+    return undefined;
+  }
+  if (gitStatus.pr == null) {
+    return null;
+  }
+  return {
+    branch: threadBranch,
+    pr: gitStatus.pr,
+    sourceControlProvider: gitStatus.sourceControlProvider,
+  };
+}
+
+/**
+ * Live PR when the checkout matches the thread branch; otherwise a cached
+ * merged/closed PR for that same branch. Open PRs are never retained across
+ * a mismatch — their state can still change.
+ */
+export function resolveDisplayedThreadPr(input: {
+  threadBranch: string | null;
+  gitStatus: VcsStatusResult | null;
+  snapshot: ThreadChangeRequestSnapshot | null | undefined;
+}): ThreadPr | null {
+  const { threadBranch, gitStatus, snapshot } = input;
+  if (threadBranch !== null && gitStatus !== null && gitStatus.refName === threadBranch) {
+    return gitStatus.pr ?? null;
+  }
+
+  if (
+    snapshot != null &&
+    snapshot.branch === threadBranch &&
+    isTerminalChangeRequestState(snapshot.pr.state)
+  ) {
+    return snapshot.pr;
+  }
+
+  return null;
+}
+
+export function resolveDisplayedThreadPrProvider(input: {
+  threadBranch: string | null;
+  gitStatus: VcsStatusResult | null;
+  snapshot: ThreadChangeRequestSnapshot | null | undefined;
+}): VcsStatusResult["sourceControlProvider"] | undefined {
+  const { threadBranch, gitStatus, snapshot } = input;
+  if (threadBranch !== null && gitStatus !== null && gitStatus.refName === threadBranch) {
+    return gitStatus.sourceControlProvider;
+  }
+
+  if (
+    snapshot != null &&
+    snapshot.branch === threadBranch &&
+    isTerminalChangeRequestState(snapshot.pr.state)
+  ) {
+    return snapshot.sourceControlProvider;
+  }
+
+  return undefined;
+}
+
 export function terminalStatusFromRunningIds(
   runningTerminalIds: ReadonlyArray<string>,
 ): TerminalStatusIndicator | null {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Fixes [#4752](https://github.com/pingdotgg/t3code/issues/4752).

Sidebar V2 now keeps a parent-level PR snapshot (branch, full PR object, provider) instead of only `"open" | "merged" | "closed"`.

- Snapshots update only when live VCS status matches the thread branch.
- Branch mismatch / missing VCS data leaves the snapshot alone.
- Display and settlement both use one resolver: live PR on match; cached merged/closed PR on mismatch.
- Open PRs are not retained across a checkout switch.

## Why

After a local-checkout thread’s PR was observed as merged/closed, switching the shared checkout to `main` made `resolveThreadPr` return `null` (branch mismatch). That cleared the parent map, unssettled the thread, and dropped the PR badge. Retaining the previously verified terminal PR at the Sidebar V2 parent is enough; no contracts/server changes.

## UI Changes

Settled local-checkout rows keep their PR number, link, title, provider terminology, and terminal color after switching away from the thread branch. No layout changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain merged/closed PR badges for local threads after branch checkout switch
> - Introduces `ThreadChangeRequestSnapshot` in [ThreadStatusIndicators.tsx](https://github.com/pingdotgg/t3code/pull/4755/files#diff-91746549eb55de0a3ac6a473f89804fbe3db8852968122b4b12cebad10625189) to cache per-thread PR state (branch, PR, provider) in a global keep-alive atom (`threadChangeRequestSnapshotsAtom`).
> - Adds `resolveDisplayedThreadPr` and `nextThreadChangeRequestSnapshot` to decide when to show a live PR vs. a retained terminal (merged/closed) PR for local checkouts where the branch no longer matches.
> - Updates `ChatView` and `Sidebar` to read from the global atom and pass snapshots down to thread rows, replacing per-mount local state with shared atom state that survives remounts.
> - Worktree threads do not retain terminal PRs on branch mismatch; only local checkouts do.
> - Behavioral Change: threads previously showing no PR badge after a branch switch may now show the last merged/closed PR badge until the snapshot is explicitly cleared.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6361523.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sidebar settlement partitioning and chat PR/settlement inputs via new retained-state rules; logic is well-tested but incorrect retention could mis-settle threads or show wrong PR metadata.
> 
> **Overview**
> Fixes sidebar and chat losing **merged/closed** PR badges when a local-checkout thread’s shared repo is checked out on another branch (e.g. `main`).
> 
> **Thread change-request snapshots** replace per-row PR state callbacks: a `threadChangeRequestSnapshotsAtom` holds branch, full PR, and provider per thread key so data survives row remounts and navigation. Rows call `nextThreadChangeRequestSnapshot` from live VCS; **Sidebar** partitioning and **ChatView** settlement/PR UI both use `resolveDisplayedThreadPr` (and provider helper) with `retainTerminalOnBranchMismatch` for local threads (`worktreePath === null`).
> 
> **Rules:** live PR when checkout matches thread branch; retain only **terminal** (merged/closed) snapshots across mismatch for local checkouts; never attach unrelated PRs from the current branch; worktrees do not retain; open PRs clear on mismatch. Extensive tests cover resolvers, atom keep-alive, and `effectiveSettled` with retained merge state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6361523c6bff472984f92840ce0477978281e6e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->