### PR TITLE
optimize thread shell summary updates

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -3,7 +3,6 @@ import {
   type ChatAttachment,
   type OrchestrationEvent,
   type OrchestrationSessionStatus,
-  ThreadId,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -130,6 +129,18 @@ function isStalePendingApprovalFailureDetail(detail: string | null): boolean {
   );
 }
 
+function isStalePendingUserInputFailureDetail(detail: string | null): boolean {
+  if (detail === null) {
+    return false;
+  }
+  return (
+    detail.includes("stale pending user-input request") ||
+    detail.includes("unknown pending user-input request") ||
+    detail.includes("unknown pending user input request") ||
+    detail.includes("unknown pending codex user input request")
+  );
+}
+
 function derivePendingUserInputCountFromActivities(
   activities: ReadonlyArray<ProjectionThreadActivity>,
 ): number {
@@ -163,11 +174,7 @@ function derivePendingUserInputCountFromActivities(
 
     if (
       activity.kind === "provider.user-input.respond.failed" &&
-      detail !== null &&
-      (detail.includes("stale pending user-input request") ||
-        detail.includes("unknown pending user-input request") ||
-        detail.includes("unknown pending user input request") ||
-        detail.includes("unknown pending codex user input request"))
+      isStalePendingUserInputFailureDetail(detail)
     ) {
       openRequestIds.delete(requestId);
     }
@@ -544,51 +551,6 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
       }
     });
 
-    const refreshThreadShellSummary = Effect.fn("refreshThreadShellSummary")(function* (
-      threadId: ThreadId,
-    ) {
-      const existingRow = yield* projectionThreadRepository.getById({
-        threadId,
-      });
-      if (Option.isNone(existingRow)) {
-        return;
-      }
-
-      const [messages, proposedPlans, activities, pendingApprovals] = yield* Effect.all([
-        projectionThreadMessageRepository.listByThreadId({ threadId }),
-        projectionThreadProposedPlanRepository.listByThreadId({ threadId }),
-        projectionThreadActivityRepository.listByThreadId({ threadId }),
-        projectionPendingApprovalRepository.listByThreadId({ threadId }),
-      ]);
-
-      let latestUserMessageAt: string | null = null;
-      for (const message of messages) {
-        if (
-          message.role === "user" &&
-          (latestUserMessageAt === null || message.createdAt > latestUserMessageAt)
-        ) {
-          latestUserMessageAt = message.createdAt;
-        }
-      }
-
-      const pendingApprovalCount = pendingApprovals.filter(
-        (approval) => approval.status === "pending",
-      ).length;
-      const pendingUserInputCount = derivePendingUserInputCountFromActivities(activities);
-      const hasActionableProposedPlan = deriveHasActionableProposedPlan({
-        latestTurnId: existingRow.value.latestTurnId,
-        proposedPlans,
-      });
-
-      yield* projectionThreadRepository.upsert({
-        ...existingRow.value,
-        latestUserMessageAt,
-        pendingApprovalCount,
-        pendingUserInputCount,
-        hasActionableProposedPlan: hasActionableProposedPlan ? 1 : 0,
-      });
-    });
-
     const applyThreadsProjection: ProjectorDefinition["apply"] = Effect.fn(
       "applyThreadsProjection",
     )(function* (event, attachmentSideEffects) {
@@ -792,11 +754,93 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           if (Option.isNone(existingRow)) {
             return;
           }
+          let latestUserMessageAt = existingRow.value.latestUserMessageAt;
+          let pendingApprovalCount = existingRow.value.pendingApprovalCount;
+          let pendingUserInputCount = existingRow.value.pendingUserInputCount;
+          let hasActionableProposedPlan = existingRow.value.hasActionableProposedPlan;
+
+          switch (event.type) {
+            case "thread.message-sent":
+              if (
+                event.payload.role === "user" &&
+                (latestUserMessageAt === null || event.payload.createdAt > latestUserMessageAt)
+              ) {
+                latestUserMessageAt = event.payload.createdAt;
+              }
+              break;
+
+            case "thread.proposed-plan-upserted": {
+              const proposedPlans = yield* projectionThreadProposedPlanRepository.listByThreadId({
+                threadId: event.payload.threadId,
+              });
+              hasActionableProposedPlan = deriveHasActionableProposedPlan({
+                latestTurnId: existingRow.value.latestTurnId,
+                proposedPlans,
+              })
+                ? 1
+                : 0;
+              break;
+            }
+
+            case "thread.activity-appended": {
+              const payload =
+                typeof event.payload.activity.payload === "object" &&
+                event.payload.activity.payload !== null
+                  ? (event.payload.activity.payload as Record<string, unknown>)
+                  : null;
+              const detail =
+                typeof payload?.detail === "string" ? payload.detail.toLowerCase() : null;
+
+              if (
+                event.payload.activity.kind === "approval.requested" ||
+                event.payload.activity.kind === "approval.resolved" ||
+                (event.payload.activity.kind === "provider.approval.respond.failed" &&
+                  isStalePendingApprovalFailureDetail(detail))
+              ) {
+                const pendingApprovals = yield* projectionPendingApprovalRepository.listByThreadId({
+                  threadId: event.payload.threadId,
+                });
+                pendingApprovalCount = pendingApprovals.filter(
+                  (approval) => approval.status === "pending",
+                ).length;
+              }
+
+              if (
+                event.payload.activity.kind === "user-input.requested" ||
+                event.payload.activity.kind === "user-input.resolved" ||
+                (event.payload.activity.kind === "provider.user-input.respond.failed" &&
+                  isStalePendingUserInputFailureDetail(detail))
+              ) {
+                const activities = yield* projectionThreadActivityRepository.listByThreadId({
+                  threadId: event.payload.threadId,
+                });
+                pendingUserInputCount = derivePendingUserInputCountFromActivities(activities);
+              }
+              break;
+            }
+
+            case "thread.approval-response-requested": {
+              const pendingApprovals = yield* projectionPendingApprovalRepository.listByThreadId({
+                threadId: event.payload.threadId,
+              });
+              pendingApprovalCount = pendingApprovals.filter(
+                (approval) => approval.status === "pending",
+              ).length;
+              break;
+            }
+
+            case "thread.user-input-response-requested":
+              break;
+          }
+
           yield* projectionThreadRepository.upsert({
             ...existingRow.value,
             updatedAt: event.occurredAt,
+            latestUserMessageAt,
+            pendingApprovalCount,
+            pendingUserInputCount,
+            hasActionableProposedPlan,
           });
-          yield* refreshThreadShellSummary(event.payload.threadId);
           return;
         }
 
@@ -807,12 +851,21 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           if (Option.isNone(existingRow)) {
             return;
           }
+          const proposedPlans = yield* projectionThreadProposedPlanRepository.listByThreadId({
+            threadId: event.payload.threadId,
+          });
+          const latestTurnId = event.payload.session.activeTurnId;
           yield* projectionThreadRepository.upsert({
             ...existingRow.value,
-            latestTurnId: event.payload.session.activeTurnId,
+            latestTurnId,
             updatedAt: event.occurredAt,
+            hasActionableProposedPlan: deriveHasActionableProposedPlan({
+              latestTurnId,
+              proposedPlans,
+            })
+              ? 1
+              : 0,
           });
-          yield* refreshThreadShellSummary(event.payload.threadId);
           return;
         }
 
@@ -823,12 +876,21 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           if (Option.isNone(existingRow)) {
             return;
           }
+          const proposedPlans = yield* projectionThreadProposedPlanRepository.listByThreadId({
+            threadId: event.payload.threadId,
+          });
+          const latestTurnId = event.payload.turnId;
           yield* projectionThreadRepository.upsert({
             ...existingRow.value,
-            latestTurnId: event.payload.turnId,
+            latestTurnId,
             updatedAt: event.occurredAt,
+            hasActionableProposedPlan: deriveHasActionableProposedPlan({
+              latestTurnId,
+              proposedPlans,
+            })
+              ? 1
+              : 0,
           });
-          yield* refreshThreadShellSummary(event.payload.threadId);
           return;
         }
 
@@ -861,12 +923,50 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             }
           }
 
+          const [messages, proposedPlans, activities, pendingApprovals] = yield* Effect.all(
+            [
+              projectionThreadMessageRepository.listByThreadId({
+                threadId: event.payload.threadId,
+              }),
+              projectionThreadProposedPlanRepository.listByThreadId({
+                threadId: event.payload.threadId,
+              }),
+              projectionThreadActivityRepository.listByThreadId({
+                threadId: event.payload.threadId,
+              }),
+              projectionPendingApprovalRepository.listByThreadId({
+                threadId: event.payload.threadId,
+              }),
+            ],
+            { concurrency: "unbounded" },
+          );
+
+          let latestUserMessageAt: string | null = null;
+          for (const message of messages) {
+            if (
+              message.role === "user" &&
+              (latestUserMessageAt === null || message.createdAt > latestUserMessageAt)
+            ) {
+              latestUserMessageAt = message.createdAt;
+            }
+          }
+
           yield* projectionThreadRepository.upsert({
             ...existingRow.value,
             latestTurnId,
             updatedAt: event.occurredAt,
+            latestUserMessageAt,
+            pendingApprovalCount: pendingApprovals.filter(
+              (approval) => approval.status === "pending",
+            ).length,
+            pendingUserInputCount: derivePendingUserInputCountFromActivities(activities),
+            hasActionableProposedPlan: deriveHasActionableProposedPlan({
+              latestTurnId,
+              proposedPlans,
+            })
+              ? 1
+              : 0,
           });
-          yield* refreshThreadShellSummary(event.payload.threadId);
           return;
         }
 


### PR DESCRIPTION
## What Changed

- Update thread shell summary fields only for events that can change them.
- Use the event timestamp directly for new user messages.
- Recalculate approvals, proposed plans, and pending user input only from their relevant projections.
- Keep the full concurrent summary recalculation only for thread reverts.

## Why

`refreshThreadShellSummary` previously loaded and decoded messages, proposed plans, activities, and approvals on every relevant thread event.

Its cost grew with thread history and blocked the global command queue. Most events did not need most of those reads.

## Performance

Benchmarked the new pipeline against the original refresh logic using independent SQLite online backups of the same 863 MB real-world database.

| Thread size | Measurement | Before | After | Speedup |
|---|---|---:|---:|---:|
| 116 MB, 2,931 messages, 17,812 activities | `applyThreadsProjection` | 1,632 ms | 3.9 ms | 423× |
| Same thread | Full `thread.turn.start` command | 1,663 ms | 21 ms | 80× |
| 35 MB, 7,758 activities | `applyThreadsProjection` | 475 ms | 5.1 ms | 94× |
| Same thread | Full `thread.turn.start` command | 492 ms | 82 ms | 6× |

The end-to-end CLI request for the 116 MB thread also dropped from 5.59 seconds to 3.18 seconds, despite still serializing the unchanged full thread response.

Opening and rendering the complete 116 MB transcript remains slow and is outside this PR scope.

## Verification

- Focused projection tests: 25 passed
- Server typecheck passed
- Targeted lint passed
- Tested against the real-world database copy in a fresh Aperture session
- Confirmed that a new event updates the large thread sidebar timestamp to `just now`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because there are no UI changes
- [x] Video is not applicable because there are no interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path projection logic for sidebar/shell metadata; behavior must stay equivalent to the old full refresh except where event-specific paths intentionally skip work (e.g. `thread.user-input-response-requested`).
> 
> **Overview**
> **Thread shell summary fields** (`latestUserMessageAt`, pending approval/user-input counts, `hasActionableProposedPlan`) are no longer rebuilt by loading every message, plan, activity, and approval on each relevant event. The shared **`refreshThreadShellSummary`** helper is removed.
> 
> Updates now happen **inline in `applyThreadsProjection`**, keyed by event type: user messages bump `latestUserMessageAt` from the event timestamp; turn/session changes refresh actionable-plan state from proposed plans; approval- and user-input-related activities (plus approval-response events) trigger **targeted** list queries only when those kinds change counts. Stale user-input failure matching is centralized in **`isStalePendingUserInputFailureDetail`**.
> 
> **`thread.reverted`** still performs the full concurrent reload of messages, plans, activities, and approvals to recompute all shell fields after history is truncated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 853818a08026f64d174d43fd2e21af7868e8de13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize thread shell summary updates to avoid full recomputation on each event
> - Removes `refreshThreadShellSummary` from [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/4756/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4), which previously reloaded all thread data and recomputed all summary fields on every applicable event.
> - Most events now update only the specific summary field they affect: `thread.message-sent` updates `latestUserMessageAt`, `thread.proposed-plan-upserted`/`thread.session-set`/`thread.turn-diff-completed` recompute `hasActionableProposedPlan`, and `thread.activity-appended` selectively updates `pendingApprovalCount` and/or `pendingUserInputCount` based on activity kind.
> - `thread.reverted` retains full recomputation since it can affect all summary fields.
> - Adds `isStalePendingUserInputFailureDetail` helper to centralize stale/unknown failure-detail detection for `provider.user-input.respond.failed` activities.
> - Behavioral Change: `thread.user-input-response-requested` no longer triggers any summary field update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 853818a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->