### PR TITLE
fix Android new thread keyboard overlap

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -2,7 +2,11 @@ import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, usePreventRemove } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, InteractionManager, Platform, View, useColorScheme } from "react-native";
-import { KeyboardAvoidingView, useKeyboardState } from "react-native-keyboard-controller";
+import {
+  KeyboardAvoidingView,
+  KeyboardStickyView,
+  useKeyboardState,
+} from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useFontFamily } from "../../lib/useFontFamily";
@@ -1053,9 +1057,11 @@ export function NewTaskDraftScreen(props: {
         <NativeStackScreenOptions options={{ headerShown: false }} />
         <AndroidScreenHeader title="New Thread" onBack={() => navigation.goBack()} />
 
-        <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
-          <View className="flex-1" />
-
+        <View className="flex-1" />
+        <KeyboardStickyView
+          style={{ position: "absolute", right: 0, bottom: 0, left: 0 }}
+          offset={{ closed: 0, opened: 0 }}
+        >
           <View
             className="px-4 pt-2"
             style={{
@@ -1119,7 +1125,7 @@ export function NewTaskDraftScreen(props: {
               </ComposerToolbarRow>
             ) : null}
           </View>
-        </KeyboardAvoidingView>
+        </KeyboardStickyView>
       </View>
     );
   }


### PR DESCRIPTION
## What Changed

Use `KeyboardStickyView` for the Android new-thread composer so the composer stays synchronized with the IME and grows upward while typing.

The change is scoped to the existing Android render branch. The iOS new-thread layout continues to use `KeyboardAvoidingView` unchanged.

## Why

The first-message composer used padding-based keyboard avoidance, while composers in established threads already use the keyboard controller's frame-synchronized sticky view. On Android, the initial composer could therefore be partially covered or clipped by the software keyboard even though subsequent thread messages behaved correctly.

Reusing the established sticky-composer pattern keeps the initial composer above the keyboard without changing global keyboard settings or iOS behavior.

## UI Changes

Before/after screenshots

### Before
<img width="945" height="2048" alt="2" src="https://github.com/user-attachments/assets/e52a69ba-a9ab-454a-8c99-eebbba930b72" />

### After
<img width="924" height="1929" alt="1" src="https://github.com/user-attachments/assets/ccc117bd-c45d-4091-ba3a-cee59d261ba5" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Validation

- `vp lint apps/mobile/src/features/threads/NewTaskDraftScreen.tsx --report-unused-disable-directives`
- `vp fmt --check apps/mobile/src/features/threads/NewTaskDraftScreen.tsx`
- `vp run typecheck` from `apps/mobile`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keyboard overlap in Android new thread composer
> On Android, replaces `KeyboardAvoidingView` with `KeyboardStickyView` in [NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/4757/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2) to correctly anchor the bottom composer to the keyboard. The composer is now positioned absolutely at the screen bottom and tracks keyboard visibility, with a flex filler view occupying the remaining space. The non-Android path is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 724eb2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Android UI/layout change in one screen branch; no auth, data, or API changes.
> 
> **Overview**
> Fixes Android software keyboard covering or clipping the **new thread** first-message composer by dropping padding-based `KeyboardAvoidingView` on that platform-only branch.
> 
> The Android layout now uses **`KeyboardStickyView`** with the composer anchored absolutely at the bottom (and a flex spacer above), matching the sticky-composer approach already used elsewhere in the app (e.g. thread composer). **iOS** still uses `KeyboardAvoidingView` and is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724eb2c22a5bcdfe6ad3cf17b1e1c97cea30aef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->