### PR TITLE
perf(mobile): smooth workspace resume

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -1,7 +1,9 @@
 import { BlurTargetView } from "expo-blur";
 import * as Linking from "expo-linking";
 import * as SplashScreen from "expo-splash-screen";
-import { useEffect } from "react";
+import { useAtomValue } from "@effect/atom-react";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { useEffect, useState } from "react";
 import { StatusBar, useColorScheme } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
@@ -22,6 +24,8 @@ import { appAtomRegistry } from "./state/atom-registry";
 import { OverlayPortalHost } from "./components/OverlayPortal";
 import { appBlurTargetRef } from "./lib/appBlurTarget";
 import { useThemeColor } from "./lib/useThemeColor";
+import { environmentCatalog } from "./connection/catalog";
+import { environmentShellSummaryAtom } from "./state/shell";
 
 import "../global.css";
 
@@ -29,7 +33,7 @@ if (process.env.EXPO_PUBLIC_SHOWCASE === "1") {
   prepareNativeShowcaseCapture();
 }
 
-void SplashScreen.preventAutoHideAsync().catch(() => {
+const splashScreenPrevention = SplashScreen.preventAutoHideAsync().catch(() => {
   // The native module can be unavailable in non-native test environments.
 });
 
@@ -46,13 +50,31 @@ const appLinking = {
 };
 
 const Navigation = createStaticNavigation(RootStack);
+const BOOTSTRAP_HYDRATION_BUDGET_MS = 750;
 
 function SplashScreenCoordinator() {
   const { isReady } = useAppearancePreferences();
+  const catalogResult = useAtomValue(environmentCatalog.catalogAtom);
+  const shellSummary = useAtomValue(environmentShellSummaryAtom);
+  const [hydrationBudgetElapsed, setHydrationBudgetElapsed] = useState(false);
+  const connectionBootstrapReady =
+    AsyncResult.isFailure(catalogResult) || shellSummary.areShellCachesHydrated;
+  const bootstrapReady = isReady && (connectionBootstrapReady || hydrationBudgetElapsed);
 
   useEffect(() => {
-    if (isReady) void SplashScreen.hide();
-  }, [isReady]);
+    if (connectionBootstrapReady) return;
+    const timeout = setTimeout(
+      () => setHydrationBudgetElapsed(true),
+      BOOTSTRAP_HYDRATION_BUDGET_MS,
+    );
+    return () => clearTimeout(timeout);
+  }, [connectionBootstrapReady]);
+
+  useEffect(() => {
+    if (bootstrapReady) {
+      void splashScreenPrevention.then(() => SplashScreen.hide());
+    }
+  }, [bootstrapReady]);
 
   return null;
 }

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -66,8 +66,7 @@ import {
   type HomeProjectSortOrder,
 } from "./homeThreadList";
 import { SwipeableScrollGateProvider, useSwipeableScrollGate } from "./thread-swipe-actions";
-import { WorkspaceConnectionStatus } from "./WorkspaceConnectionStatus";
-import { shouldShowWorkspaceConnectionStatus } from "./workspace-connection-status";
+import { WorkspaceConnectionStatusOverlay } from "./WorkspaceConnectionStatus";
 
 /* ─── Types ──────────────────────────────────────────────────────────── */
 
@@ -862,20 +861,28 @@ export function HomeScreen(props: HomeScreenProps) {
       ? null
       : (props.savedConnectionsById[props.selectedEnvironmentId]?.environmentLabel ??
         "this environment");
-  const shouldShowConnectionStatus = shouldShowWorkspaceConnectionStatus(props.catalogState);
   const emptyState = deriveEmptyState({
     catalogState: props.catalogState,
     projectCount: props.projects.length,
   });
-  const connectionStatus =
-    shouldShowConnectionStatus && Platform.OS !== "ios" ? (
-      <View
-        className="absolute left-0 right-0 items-center"
-        style={{ bottom: Math.max(insets.bottom, 18) + 76 }}
-      >
-        <WorkspaceConnectionStatus state={props.catalogState} onPress={props.onOpenEnvironments} />
-      </View>
-    ) : null;
+  const emptyAction = !props.catalogState.hasConnections
+    ? { label: "Add environment", onPress: props.onAddConnection }
+    : !props.catalogState.hasReadyEnvironment &&
+        !props.catalogState.hasConnectingEnvironment &&
+        !props.catalogState.isLoadingConnections
+      ? { label: "Environment settings", onPress: props.onOpenEnvironments }
+      : null;
+  const connectionStatus = (
+    <WorkspaceConnectionStatusOverlay
+      state={props.catalogState}
+      onPress={props.onOpenEnvironments}
+      bottomOffset={
+        Platform.OS === "android"
+          ? Math.max(insets.bottom, 18) + 76
+          : Math.max(insets.bottom, 18) + 72
+      }
+    />
+  );
 
   if (!hasAnyThreads) {
     return (
@@ -890,22 +897,13 @@ export function HomeScreen(props: HomeScreenProps) {
           <EmptyState
             title={emptyState.title}
             detail={emptyState.detail}
-            actionLabel={!props.catalogState.hasReadyEnvironment ? "Add environment" : undefined}
-            onAction={!props.catalogState.hasReadyEnvironment ? props.onAddConnection : undefined}
+            actionLabel={emptyAction?.label}
+            onAction={emptyAction?.onPress}
             variant="plain"
           />
-          {emptyState.loading && !shouldShowConnectionStatus ? (
+          {emptyState.loading ? (
             <View className="mt-4 items-center">
               <ActivityIndicator color={accentColor} />
-            </View>
-          ) : null}
-          {shouldShowConnectionStatus && Platform.OS === "ios" ? (
-            <View className="mt-4">
-              <WorkspaceConnectionStatus
-                state={props.catalogState}
-                onPress={props.onOpenEnvironments}
-                variant="sidebar"
-              />
             </View>
           ) : null}
         </View>
@@ -914,21 +912,7 @@ export function HomeScreen(props: HomeScreenProps) {
     );
   }
 
-  const listHeader = (
-    <>
-      {Platform.OS === "ios" ? null : <HomeTopContentSpacer />}
-
-      {shouldShowConnectionStatus && Platform.OS === "ios" ? (
-        <View className="pb-4">
-          <WorkspaceConnectionStatus
-            state={props.catalogState}
-            onPress={props.onOpenEnvironments}
-            variant="sidebar"
-          />
-        </View>
-      ) : null}
-    </>
-  );
+  const listHeader = <>{Platform.OS === "ios" ? null : <HomeTopContentSpacer />}</>;
 
   // Project scoping lives in the header filter menu (no inline chip row on
   // mobile — the menu is the one filter surface).

--- a/apps/mobile/src/features/home/WorkspaceConnectionStatus.test.ts
+++ b/apps/mobile/src/features/home/WorkspaceConnectionStatus.test.ts
@@ -4,6 +4,7 @@ import type { WorkspaceState } from "../../state/workspaceModel";
 import {
   shouldShowWorkspaceConnectionStatus,
   workspaceConnectionStatusLabel,
+  workspaceConnectionStatusPresentation,
 } from "./workspace-connection-status";
 
 function workspaceState(overrides: Partial<WorkspaceState> = {}): WorkspaceState {
@@ -27,6 +28,7 @@ function workspaceState(overrides: Partial<WorkspaceState> = {}): WorkspaceState
 describe("workspace connection status", () => {
   it("stays hidden while a ready environment is connected", () => {
     expect(shouldShowWorkspaceConnectionStatus(workspaceState())).toBe(false);
+    expect(workspaceConnectionStatusPresentation(workspaceState())).toBe("hidden");
   });
 
   it("surfaces offline snapshots", () => {
@@ -34,6 +36,7 @@ describe("workspace connection status", () => {
 
     expect(shouldShowWorkspaceConnectionStatus(state)).toBe(true);
     expect(workspaceConnectionStatusLabel(state)).toBe("You are offline");
+    expect(workspaceConnectionStatusPresentation(state)).toBe("immediate");
   });
 
   it("names the environment while reconnecting", () => {
@@ -55,6 +58,27 @@ describe("workspace connection status", () => {
 
     expect(shouldShowWorkspaceConnectionStatus(state)).toBe(true);
     expect(workspaceConnectionStatusLabel(state)).toBe("Reconnecting to Julius’s Mac mini");
+    expect(workspaceConnectionStatusPresentation(state)).toBe("deferred");
+  });
+
+  it("distinguishes an initial connection from a reconnect", () => {
+    const state = workspaceState({
+      hasConnectingEnvironment: true,
+      hasReadyEnvironment: false,
+      connectingEnvironments: [
+        {
+          environmentId: "environment-1" as never,
+          environmentLabel: "Julius’s Mac mini",
+          displayUrl: "",
+          isRelayManaged: false,
+          connectionState: "connecting",
+          connectionError: null,
+          connectionErrorTraceId: null,
+        },
+      ],
+    });
+
+    expect(workspaceConnectionStatusLabel(state)).toBe("Connecting to Julius’s Mac mini");
   });
 
   it("surfaces connection errors before the generic disconnected fallback", () => {
@@ -66,6 +90,7 @@ describe("workspace connection status", () => {
 
     expect(shouldShowWorkspaceConnectionStatus(state)).toBe(true);
     expect(workspaceConnectionStatusLabel(state)).toBe("Could not reach Julius’s Mac mini");
+    expect(workspaceConnectionStatusPresentation(state)).toBe("immediate");
   });
 
   it("shows shell catch-up while cached threads remain visible", () => {

--- a/apps/mobile/src/features/home/WorkspaceConnectionStatus.tsx
+++ b/apps/mobile/src/features/home/WorkspaceConnectionStatus.tsx
@@ -1,10 +1,17 @@
 import { SymbolView } from "../../components/AppSymbol";
-import { ActivityIndicator, Pressable } from "react-native";
+import { useEffect, useState } from "react";
+import { ActivityIndicator, Pressable, View } from "react-native";
+import Animated, { FadeInUp, FadeOutDown } from "react-native-reanimated";
 
 import { AppText as Text } from "../../components/AppText";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { WorkspaceState } from "../../state/workspaceModel";
-import { workspaceConnectionStatusLabel } from "./workspace-connection-status";
+import {
+  workspaceConnectionStatusLabel,
+  workspaceConnectionStatusPresentation,
+} from "./workspace-connection-status";
+
+const TRANSIENT_STATUS_DELAY_MS = 350;
 
 export function WorkspaceConnectionStatus(props: {
   readonly state: WorkspaceState;
@@ -22,6 +29,7 @@ export function WorkspaceConnectionStatus(props: {
     <Pressable
       accessibilityHint="Opens environment settings"
       accessibilityLabel={workspaceConnectionStatusLabel(props.state)}
+      accessibilityLiveRegion="polite"
       accessibilityRole="button"
       onPress={props.onPress}
       className={
@@ -52,5 +60,57 @@ export function WorkspaceConnectionStatus(props: {
         <SymbolView name="chevron.right" size={11} tintColor={iconColor} type="monochrome" />
       ) : null}
     </Pressable>
+  );
+}
+
+/**
+ * Connection chrome that never participates in list or empty-state layout.
+ * Transient recovery is delayed to suppress healthy sub-350ms reconnect
+ * flashes; persistent and actionable states appear immediately.
+ */
+export function WorkspaceConnectionStatusOverlay(props: {
+  readonly state: WorkspaceState;
+  readonly onPress: () => void;
+  readonly bottomOffset: number;
+}) {
+  const presentation = workspaceConnectionStatusPresentation(props.state);
+  const [presented, setPresented] = useState(presentation === "immediate");
+  const [displayedState, setDisplayedState] = useState(props.state);
+
+  useEffect(() => {
+    if (presentation !== "hidden") {
+      setDisplayedState(props.state);
+    }
+  }, [presentation, props.state]);
+
+  useEffect(() => {
+    if (presentation === "hidden") {
+      setPresented(false);
+      return;
+    }
+    if (presentation === "immediate" || presented) {
+      setPresented(true);
+      return;
+    }
+    const timeout = setTimeout(() => setPresented(true), TRANSIENT_STATUS_DELAY_MS);
+    return () => clearTimeout(timeout);
+  }, [presentation, presented]);
+
+  if (!presented) return null;
+
+  return (
+    <View
+      className="absolute inset-x-4 z-20 items-center"
+      pointerEvents="box-none"
+      style={{ bottom: props.bottomOffset }}
+    >
+      <Animated.View
+        className="w-full max-w-[430px]"
+        entering={FadeInUp.duration(180)}
+        exiting={FadeOutDown.duration(140)}
+      >
+        <WorkspaceConnectionStatus state={displayedState} onPress={props.onPress} />
+      </Animated.View>
+    </View>
   );
 }

--- a/apps/mobile/src/features/home/workspace-connection-status.ts
+++ b/apps/mobile/src/features/home/workspace-connection-status.ts
@@ -10,13 +10,42 @@ export function shouldShowWorkspaceConnectionStatus(state: WorkspaceState): bool
   );
 }
 
+export type WorkspaceConnectionStatusPresentation = "hidden" | "deferred" | "immediate";
+
+/**
+ * Brief reconnects are delayed so a healthy foreground probe never flashes
+ * transient chrome. Offline/error states remain immediate because they are
+ * actionable and may persist.
+ */
+export function workspaceConnectionStatusPresentation(
+  state: WorkspaceState,
+): WorkspaceConnectionStatusPresentation {
+  if (!shouldShowWorkspaceConnectionStatus(state)) return "hidden";
+  if (
+    state.networkStatus === "offline" ||
+    state.connectionError !== null ||
+    (!state.hasConnectingEnvironment && !state.hasPendingShellSnapshot)
+  ) {
+    return "immediate";
+  }
+  return "deferred";
+}
+
 export function workspaceConnectionStatusLabel(state: WorkspaceState): string {
   if (state.networkStatus === "offline") return "You are offline";
   if (state.connectingEnvironments.length === 1) {
-    return `Reconnecting to ${state.connectingEnvironments[0]!.environmentLabel}`;
+    const environment = state.connectingEnvironments[0]!;
+    return environment.connectionState === "connecting"
+      ? `Connecting to ${environment.environmentLabel}`
+      : `Reconnecting to ${environment.environmentLabel}`;
   }
   if (state.connectingEnvironments.length > 1) {
-    return `Reconnecting ${state.connectingEnvironments.length} environments`;
+    const isInitialConnection = state.connectingEnvironments.every(
+      (environment) => environment.connectionState === "connecting",
+    );
+    return `${isInitialConnection ? "Connecting to" : "Reconnecting"} ${
+      state.connectingEnvironments.length
+    } environments`;
   }
   if (state.connectionError !== null) return state.connectionError;
   if (state.hasPendingShellSnapshot) {

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -55,8 +55,7 @@ import { buildHomeProjectScopes, buildHomeThreadGroups } from "../home/homeThrea
 import { SwipeableScrollGateProvider, useSwipeableScrollGate } from "../home/thread-swipe-actions";
 import { usePendingTaskListActions } from "../home/usePendingTaskListActions";
 import { useThreadListActions } from "../home/useThreadListActions";
-import { WorkspaceConnectionStatus } from "../home/WorkspaceConnectionStatus";
-import { shouldShowWorkspaceConnectionStatus } from "../home/workspace-connection-status";
+import { WorkspaceConnectionStatusOverlay } from "../home/WorkspaceConnectionStatus";
 import { SidebarHeaderActions } from "./sidebar-header-actions";
 import { SidebarFilterButton } from "./sidebar-filter-button";
 import { createSidebarHeaderItems } from "./sidebar-native-header-items";
@@ -550,7 +549,6 @@ function ThreadNavigationSidebarPane(
     threadListV2Enabled,
     threadListV2Layout,
   ]);
-  const showsConnectionStatus = shouldShowWorkspaceConnectionStatus(catalogState);
   const listMenuActions = useMemo<MenuAction[]>(
     () => [
       {
@@ -1114,21 +1112,15 @@ function ThreadNavigationSidebarPane(
                 scrollEventThrottle={16}
                 showsVerticalScrollIndicator={false}
                 style={styles.threadList}
-                ListHeaderComponent={
-                  showsConnectionStatus ? (
-                    <View className="px-1.5 pt-0.5 pb-2">
-                      <WorkspaceConnectionStatus
-                        onPress={props.onOpenEnvironmentSettings}
-                        state={catalogState}
-                        variant="sidebar"
-                      />
-                    </View>
-                  ) : null
-                }
                 ListEmptyComponent={listEmpty}
               />
             </GestureDetector>
           </SwipeableScrollGateProvider>
+          <WorkspaceConnectionStatusOverlay
+            state={catalogState}
+            onPress={props.onOpenEnvironmentSettings}
+            bottomOffset={Math.max(insets.bottom, 12) + 8}
+          />
         </View>
       </>
     );
@@ -1246,17 +1238,12 @@ function ThreadNavigationSidebarPane(
             value={props.searchQuery}
           />
         </View>
-
-        {showsConnectionStatus ? (
-          <View className="px-3.5 pt-2.5">
-            <WorkspaceConnectionStatus
-              onPress={props.onOpenEnvironmentSettings}
-              state={catalogState}
-              variant="sidebar"
-            />
-          </View>
-        ) : null}
       </View>
+      <WorkspaceConnectionStatusOverlay
+        state={catalogState}
+        onPress={props.onOpenEnvironmentSettings}
+        bottomOffset={Math.max(insets.bottom, 12) + 8}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/state/workspaceModel.test.ts
+++ b/apps/mobile/src/state/workspaceModel.test.ts
@@ -51,6 +51,7 @@ const EMPTY_SHELL_SUMMARY: EnvironmentShellSummary = {
   hasSynchronizingShell: false,
   hasCachedShell: false,
   hasLiveShell: false,
+  areShellCachesHydrated: true,
   firstError: null,
   latestSnapshotUpdatedAt: null,
 };

--- a/packages/client-runtime/src/state/entities.test.ts
+++ b/packages/client-runtime/src/state/entities.test.ts
@@ -146,6 +146,7 @@ function shellState(snapshot: OrchestrationShellSnapshot): EnvironmentShellState
     snapshot: Option.some(snapshot),
     status: "live",
     error: Option.none(),
+    cacheHydrated: true,
   };
 }
 

--- a/packages/client-runtime/src/state/shell-sync.test.ts
+++ b/packages/client-runtime/src/state/shell-sync.test.ts
@@ -150,7 +150,7 @@ describe("environment shell synchronization", () => {
     }),
   );
 
-  it.effect("replaces a warm shell cache with an authoritative HTTP snapshot", () =>
+  it.effect("resumes a warm shell cache without a redundant HTTP snapshot", () =>
     Effect.gen(function* () {
       const cachedSnapshot: OrchestrationShellSnapshot = {
         snapshotSequence: 5,
@@ -225,12 +225,12 @@ describe("environment shell synchronization", () => {
         Stream.runHead,
       );
 
-      expect(yield* SubscriptionRef.get(capturedAfterSequence)).toBe(9);
+      expect(yield* SubscriptionRef.get(capturedAfterSequence)).toBe(5);
       expect(yield* Ref.get(capturedCompletionMarker)).toBe(true);
-      expect(yield* SubscriptionRef.get(loaderCalls)).toBe(1);
+      expect(yield* SubscriptionRef.get(loaderCalls)).toBe(0);
       const synchronizing = yield* SubscriptionRef.get(shellState);
       expect(synchronizing.status).toBe("synchronizing");
-      expect(Option.getOrThrow(synchronizing.snapshot)).toEqual(httpSnapshot);
+      expect(Option.getOrThrow(synchronizing.snapshot)).toEqual(cachedSnapshot);
 
       yield* Queue.offer(events, { kind: "synchronized" });
       yield* SubscriptionRef.changes(shellState).pipe(
@@ -240,16 +240,21 @@ describe("environment shell synchronization", () => {
     }),
   );
 
-  it.effect("refreshes the authoritative shell snapshot when the app becomes active", () =>
+  it.effect("resumes the in-memory shell cursor when the app becomes active", () =>
     Effect.gen(function* () {
       const events = yield* Queue.unbounded<OrchestrationShellStreamItem>();
       const wakeups = yield* Queue.unbounded<ConnectionWakeups.ConnectionWakeup>();
       const loaderCalls = yield* Ref.make(0);
       const subscriptionCount = yield* Ref.make(0);
+      const subscriptionSequences = yield* Ref.make<ReadonlyArray<number | undefined>>([]);
       const client = {
-        [ORCHESTRATION_WS_METHODS.subscribeShell]: () =>
+        [ORCHESTRATION_WS_METHODS.subscribeShell]: (input: { readonly afterSequence?: number }) =>
           Stream.unwrap(
-            Ref.update(subscriptionCount, (count) => count + 1).pipe(
+            Ref.update(subscriptionSequences, (sequences) => [
+              ...sequences,
+              input.afterSequence,
+            ]).pipe(
+              Effect.andThen(Ref.update(subscriptionCount, (count) => count + 1)),
               Effect.as(Stream.fromQueue(events)),
             ),
           ),
@@ -296,15 +301,10 @@ describe("environment shell synchronization", () => {
         ),
       );
 
-      yield* SubscriptionRef.changes(shellState).pipe(
-        Stream.filter(
-          (value) =>
-            value.status === "synchronizing" &&
-            Option.isSome(value.snapshot) &&
-            value.snapshot.value.snapshotSequence === 10,
-        ),
-        Stream.runHead,
-      );
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if ((yield* Ref.get(subscriptionCount)) >= 1) break;
+        yield* Effect.yieldNow;
+      }
       yield* Queue.offer(events, { kind: "synchronized" });
       yield* SubscriptionRef.changes(shellState).pipe(
         Stream.filter((value) => value.status === "live"),
@@ -312,38 +312,36 @@ describe("environment shell synchronization", () => {
       );
 
       yield* Queue.offer(wakeups, "application-active");
-      yield* SubscriptionRef.changes(shellState).pipe(
-        Stream.filter(
-          (value) =>
-            value.status === "synchronizing" &&
-            Option.isSome(value.snapshot) &&
-            value.snapshot.value.snapshotSequence === 20,
-        ),
-        Stream.runHead,
-      );
-
       for (let attempt = 0; attempt < 100; attempt += 1) {
         if ((yield* Ref.get(subscriptionCount)) >= 2) break;
         yield* Effect.yieldNow;
       }
+      yield* Queue.offer(events, { kind: "synchronized" });
+      yield* SubscriptionRef.changes(shellState).pipe(
+        Stream.filter((value) => value.status === "live"),
+        Stream.runHead,
+      );
 
-      expect(yield* Ref.get(loaderCalls)).toBe(2);
+      expect(yield* Ref.get(loaderCalls)).toBe(0);
       expect(yield* Ref.get(subscriptionCount)).toBe(2);
+      expect(yield* Ref.get(subscriptionSequences)).toEqual([1, 1]);
 
       yield* Queue.offer(wakeups, "application-active-probe");
       for (let attempt = 0; attempt < 100; attempt += 1) {
         if ((yield* Ref.get(subscriptionCount)) >= 3) break;
         yield* Effect.yieldNow;
       }
-      expect(yield* Ref.get(loaderCalls)).toBe(3);
+      expect(yield* Ref.get(loaderCalls)).toBe(0);
       expect(yield* Ref.get(subscriptionCount)).toBe(3);
+      expect(yield* Ref.get(subscriptionSequences)).toEqual([1, 1, 1]);
 
       yield* Queue.offer(wakeups, "application-active-reconnect");
       for (let attempt = 0; attempt < 10; attempt += 1) {
         yield* Effect.yieldNow;
       }
-      expect(yield* Ref.get(loaderCalls)).toBe(3);
+      expect(yield* Ref.get(loaderCalls)).toBe(0);
       expect(yield* Ref.get(subscriptionCount)).toBe(3);
+      expect(yield* Ref.get(subscriptionSequences)).toEqual([1, 1, 1]);
     }),
   );
 });

--- a/packages/client-runtime/src/state/shell.test.ts
+++ b/packages/client-runtime/src/state/shell.test.ts
@@ -28,6 +28,7 @@ function shellState(input: {
   readonly updatedAt?: string;
   readonly error?: string;
   readonly snapshotSequence?: number;
+  readonly cacheHydrated?: boolean;
 }): EnvironmentShellState {
   return {
     snapshot:
@@ -41,6 +42,7 @@ function shellState(input: {
           }),
     status: input.status,
     error: input.error === undefined ? Option.none() : Option.some(input.error),
+    cacheHydrated: input.cacheHydrated ?? true,
   };
 }
 
@@ -97,6 +99,7 @@ describe("environment shell projections", () => {
       hasSynchronizingShell: true,
       hasCachedShell: true,
       hasLiveShell: false,
+      areShellCachesHydrated: true,
       firstError: "Retrying.",
       latestSnapshotUpdatedAt: "2026-06-02T00:00:00.000Z",
     });
@@ -111,6 +114,22 @@ describe("environment shell projections", () => {
     );
 
     expect(harness.registry.get(harness.summaryAtom)).toBe(summary);
+  });
+
+  it("reports cache hydration only after every catalog environment has loaded", () => {
+    const harness = makeHarness();
+
+    harness.registry.set(
+      harness.shellStateAtom(OTHER_ENVIRONMENT_ID),
+      shellState({ status: "empty", cacheHydrated: false }),
+    );
+    expect(harness.registry.get(harness.summaryAtom).areShellCachesHydrated).toBe(false);
+
+    harness.registry.set(
+      harness.shellStateAtom(OTHER_ENVIRONMENT_ID),
+      shellState({ status: "empty", cacheHydrated: true }),
+    );
+    expect(harness.registry.get(harness.summaryAtom).areShellCachesHydrated).toBe(true);
   });
 
   it("preserves server-config map identity until a config reference changes", () => {

--- a/packages/client-runtime/src/state/shell.ts
+++ b/packages/client-runtime/src/state/shell.ts
@@ -32,12 +32,15 @@ export interface EnvironmentShellState {
   readonly snapshot: Option.Option<OrchestrationShellSnapshot>;
   readonly status: EnvironmentShellStatus;
   readonly error: Option.Option<string>;
+  /** True once the persisted shell cache has been read for this environment. */
+  readonly cacheHydrated: boolean;
 }
 
 const EMPTY_SHELL_STATE: EnvironmentShellState = {
   snapshot: Option.none(),
   status: "empty",
   error: Option.none(),
+  cacheHydrated: false,
 };
 
 function shellStatusForSnapshot(
@@ -69,6 +72,7 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
     snapshot: cachedSnapshot,
     status: shellStatusForSnapshot(cachedSnapshot),
     error: Option.none(),
+    cacheHydrated: true,
   });
   const awaitingCompletion = yield* Ref.make(false);
   const persistence = yield* Queue.sliding<OrchestrationShellSnapshot>(1);
@@ -165,6 +169,7 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
       snapshot: Option.some(nextSnapshot),
       status: waiting ? "synchronizing" : "live",
       error: Option.none(),
+      cacheHydrated: true,
     });
     yield* Queue.offer(persistence, nextSnapshot);
   });
@@ -187,6 +192,21 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
         yield* Ref.set(awaitingCompletion, supportsCompletionMarker);
         yield* setSynchronizing;
 
+        const current = yield* SubscriptionRef.get(state);
+        // Modern servers make a cached cursor authoritative: they replay a
+        // small gap, replace an invalid/old cursor with a fresh snapshot, and
+        // emit a completion marker after buffered live events. Reusing that
+        // cursor avoids a redundant full HTTP shell download on every app
+        // foreground while preserving deletion/catch-up correctness.
+        if (supportsCompletionMarker && Option.isSome(current.snapshot)) {
+          return {
+            afterSequence: current.snapshot.value.snapshotSequence,
+            requestCompletionMarker: true as const,
+          };
+        }
+
+        // Cold caches and older servers still use the authoritative HTTP
+        // snapshot path before subscribing.
         const prepared = yield* SubscriptionRef.get(supervisor.prepared).pipe(
           Effect.flatMap(
             Option.match({
@@ -248,6 +268,8 @@ export interface EnvironmentShellSummary {
   readonly hasSynchronizingShell: boolean;
   readonly hasCachedShell: boolean;
   readonly hasLiveShell: boolean;
+  /** True once every catalog environment has completed its local cache read. */
+  readonly areShellCachesHydrated: boolean;
   readonly firstError: string | null;
   readonly latestSnapshotUpdatedAt: string | null;
 }
@@ -257,6 +279,7 @@ const EMPTY_ENVIRONMENT_SHELL_SUMMARY: EnvironmentShellSummary = Object.freeze({
   hasSynchronizingShell: false,
   hasCachedShell: false,
   hasLiveShell: false,
+  areShellCachesHydrated: false,
   firstError: null,
   latestSnapshotUpdatedAt: null,
 });
@@ -272,6 +295,7 @@ function shellSummariesEqual(
     left.hasSynchronizingShell === right.hasSynchronizingShell &&
     left.hasCachedShell === right.hasCachedShell &&
     left.hasLiveShell === right.hasLiveShell &&
+    left.areShellCachesHydrated === right.areShellCachesHydrated &&
     left.firstError === right.firstError &&
     left.latestSnapshotUpdatedAt === right.latestSnapshotUpdatedAt
   );
@@ -295,18 +319,21 @@ export function createEnvironmentShellSummaryAtom(input: {
 }) {
   let previousSummary = EMPTY_ENVIRONMENT_SHELL_SUMMARY;
   return Atom.make((get) => {
+    const catalog = get(input.catalogValueAtom);
     let hasSnapshot = false;
     let hasSynchronizingShell = false;
     let hasCachedShell = false;
     let hasLiveShell = false;
+    let areShellCachesHydrated = catalog.isReady;
     let firstError: string | null = null;
     let latestSnapshotUpdatedAt: string | null = null;
 
-    for (const environmentId of get(input.catalogValueAtom).entries.keys()) {
+    for (const environmentId of catalog.entries.keys()) {
       const state = get(input.shellStateValueAtom(environmentId));
       hasSynchronizingShell ||= state.status === "synchronizing";
       hasCachedShell ||= state.status === "cached";
       hasLiveShell ||= state.status === "live";
+      areShellCachesHydrated &&= state.cacheHydrated;
       if (firstError === null) {
         firstError = Option.getOrNull(state.error);
       }
@@ -325,6 +352,7 @@ export function createEnvironmentShellSummaryAtom(input: {
       hasSynchronizingShell,
       hasCachedShell,
       hasLiveShell,
+      areShellCachesHydrated,
       firstError,
       latestSnapshotUpdatedAt,
     };


### PR DESCRIPTION
## Problem

Reopening the mobile app could briefly reveal an incomplete workspace, reload a shell snapshot that was already cached, and insert temporary connection status into list layouts. Warm resumes therefore felt slower than necessary and could flash or shift content even when recovery was quick.

## Fix

- Track when each environment has finished reading its persisted shell cache. Keep the splash screen visible until appearance preferences and those caches are ready, with a 750 ms cap so startup cannot wait indefinitely.
- Keep cached threads and projects visible while live state catches up.
- When the server supports completion markers and a cached snapshot exists, resume the shell stream from that saved sequence instead of downloading another HTTP snapshot. Cold caches and older servers retain the existing full-snapshot fallback.
- Render workspace connection status as an animated bottom overlay instead of placing it inside thread lists or empty states.
- Delay transient connecting and synchronizing status by 350 ms so short recoveries do not flash. Offline, error, and disconnected states remain immediate.
- Distinguish initial “Connecting” states from “Reconnecting” states and route empty-state actions to either Add environment or Environment settings as appropriate.

The connection supervisor is intentionally unchanged. Mobile foreground wakeups, probe timing, lease replacement, and retry behavior are owned by #4878 on `main`.

## User impact

Warm app resumes retain useful workspace content, avoid a redundant snapshot request, and no longer move the interface when connection status appears or disappears.

## Verification

- 25 focused mobile and client-runtime tests
- Targeted formatting and lint
- `@t3tools/client-runtime` typecheck
- `@t3tools/mobile` typecheck
- Preview build and Metro bundle exercised on a physical iPhone

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for UI changes
- [ ] I included a video for animation or timing changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile bootstrap timing, shell stream resumption semantics, and workspace connection UI; incorrect hydration or cursor resume could show stale data or flash wrong chrome, but connection supervisor behavior is intentionally unchanged.
> 
> **Overview**
> **Startup** keeps the splash screen up until saved environment shell caches finish hydrating (or the catalog fails), capped at **750 ms**, so the first frame can show cached threads instead of an empty shell.
> 
> **Shell sync** in `client-runtime` resumes WebSocket subscriptions from the **cached snapshot sequence** when the server supports completion markers, skipping redundant HTTP shell downloads on warm cache and app foreground. Cold caches and older servers still use the HTTP snapshot path. **`cacheHydrated`** / **`areShellCachesHydrated`** track per-environment cache reads for bootstrap gating.
> 
> **Connection status UI** moves to a **floating overlay** (`WorkspaceConnectionStatusOverlay`) on home and the thread sidebar so reconnect/sync banners do not push lists or empty states. Transient connecting/sync states are **delayed 350 ms**; offline and errors show immediately. Labels distinguish **Connecting** vs **Reconnecting**, and empty-state actions route to add environment or environment settings when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c7cdc3b7316f6eaf5b58a886fb2b0c50d2b007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Smooth mobile reconnect UI and resume shells from cached snapshots
> - Environments with a cached shell snapshot now resubscribe using the cached cursor and request a completion marker, skipping redundant HTTP snapshot downloads on reconnect.
> - A new `WorkspaceConnectionStatusOverlay` replaces inline connection status in [HomeScreen](https://github.com/pingdotgg/t3code/pull/4760/files#diff-b6e075b3065ae370669290cbaa8476a852399968002468571cd914d06a32fd40) and [ThreadNavigationSidebar](https://github.com/pingdotgg/t3code/pull/4760/files#diff-4431208d7dda139d19919302f332d6a63788b9d114b4b7a410d89a727b9ed455), positioning the status banner as a floating overlay to avoid layout shifts.
> - Transient reconnect states are deferred 350ms before showing the overlay to prevent brief flashes; offline/error states appear immediately.
> - The splash screen in [App.tsx](https://github.com/pingdotgg/t3code/pull/4760/files#diff-e3abdca4ddbcdc4795e133268b958f77db78c542464c78af36855eead657f8a9) now waits until appearance preferences are ready and either all shell caches are hydrated or a 750ms budget elapses before dismissing.
> - Connection status labels now distinguish initial 'Connecting' from 'Reconnecting' based on each environment's prior connection state.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 06c7cdc. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

---

Model: GPT-5.6 Sol  
Harness: Codex in T3 Code