### PR TITLE
fix: cache project favicons across web and mobile

### DIFF
--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -101,7 +101,10 @@ function ProjectFaviconImage(props: {
             if (props.cacheKey) loadedFaviconKeys.add(props.cacheKey);
             setStatus("loaded");
           }}
-          onError={() => setStatus("error")}
+          onError={() => {
+            if (props.cacheKey) loadedFaviconKeys.delete(props.cacheKey);
+            setStatus("error");
+          }}
         />
       ) : null}
     </View>

--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -1,6 +1,6 @@
 import { SymbolView } from "./AppSymbol";
 import { Image } from "expo-image";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { View } from "react-native";
 import type { EnvironmentId } from "@t3tools/contracts";
 import {
@@ -10,9 +10,11 @@ import {
 import { useThemeColor } from "../lib/useThemeColor";
 import { useAssetUrl } from "../state/assets";
 import {
+  beginProjectFaviconRequest,
   hasLoadedProjectFavicon,
   markProjectFaviconFailed,
   markProjectFaviconLoaded,
+  type ProjectFaviconRequest,
 } from "./projectFaviconCache";
 
 /* ─── Component ──────────────────────────────────────────────────────── */
@@ -56,6 +58,15 @@ function ProjectFaviconImage(props: {
   readonly size: number;
 }) {
   const iconMuted = useThemeColor("--color-icon-subtle");
+  const faviconRequestRef = useRef<ProjectFaviconRequest | null>(null);
+  if (
+    faviconRequestRef.current === null ||
+    faviconRequestRef.current.cacheKey !== props.cacheKey ||
+    faviconRequestRef.current.faviconUrl !== props.faviconUrl
+  ) {
+    faviconRequestRef.current = beginProjectFaviconRequest(props.cacheKey, props.faviconUrl);
+  }
+  const faviconRequest = faviconRequestRef.current;
 
   const [status, setStatus] = useState<"loading" | "loaded" | "error">(() =>
     hasLoadedProjectFavicon(props.cacheKey) ? "loaded" : "loading",
@@ -101,11 +112,11 @@ function ProjectFaviconImage(props: {
           }}
           contentFit="contain"
           onLoad={() => {
-            markProjectFaviconLoaded(props.cacheKey, props.faviconUrl);
+            if (!markProjectFaviconLoaded(faviconRequest)) return;
             setStatus("loaded");
           }}
           onError={() => {
-            if (!markProjectFaviconFailed(props.cacheKey, props.faviconUrl)) return;
+            if (!markProjectFaviconFailed(faviconRequest)) return;
             setStatus("error");
           }}
         />

--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -9,9 +9,11 @@ import {
 } from "@t3tools/shared/projectFavicon";
 import { useThemeColor } from "../lib/useThemeColor";
 import { useAssetUrl } from "../state/assets";
-
-/* ─── Favicon cache (matches web pattern) ────────────────────────────── */
-const loadedFaviconKeys = new Set<string>();
+import {
+  hasLoadedProjectFavicon,
+  markProjectFaviconFailed,
+  markProjectFaviconLoaded,
+} from "./projectFaviconCache";
 
 /* ─── Component ──────────────────────────────────────────────────────── */
 export function ProjectFavicon(props: {
@@ -56,7 +58,7 @@ function ProjectFaviconImage(props: {
   const iconMuted = useThemeColor("--color-icon-subtle");
 
   const [status, setStatus] = useState<"loading" | "loaded" | "error">(() =>
-    props.cacheKey && loadedFaviconKeys.has(props.cacheKey) ? "loaded" : "loading",
+    hasLoadedProjectFavicon(props.cacheKey) ? "loaded" : "loading",
   );
 
   const showImage = props.faviconUrl !== null && status === "loaded";
@@ -83,6 +85,7 @@ function ProjectFaviconImage(props: {
       {/* Favicon image (hidden until loaded) */}
       {props.faviconUrl ? (
         <Image
+          key={props.faviconUrl}
           source={{
             uri: props.faviconUrl,
             ...(props.cacheKey ? { cacheKey: props.cacheKey } : {}),
@@ -98,11 +101,11 @@ function ProjectFaviconImage(props: {
           }}
           contentFit="contain"
           onLoad={() => {
-            if (props.cacheKey) loadedFaviconKeys.add(props.cacheKey);
+            markProjectFaviconLoaded(props.cacheKey, props.faviconUrl);
             setStatus("loaded");
           }}
           onError={() => {
-            if (props.cacheKey) loadedFaviconKeys.delete(props.cacheKey);
+            if (!markProjectFaviconFailed(props.cacheKey, props.faviconUrl)) return;
             setStatus("error");
           }}
         />

--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -62,15 +62,21 @@ function ProjectFaviconImage(props: {
     () => createProjectFaviconRequest(props.cacheKey, props.faviconUrl),
     [props.cacheKey, props.faviconUrl],
   );
+  const [activeFaviconRequest, setActiveFaviconRequest] = useState<typeof faviconRequest>(null);
   useLayoutEffect(() => {
-    beginProjectFaviconRequest(faviconRequest);
+    if (faviconRequest === null) return;
+
+    const endRequest = beginProjectFaviconRequest(faviconRequest);
+    setActiveFaviconRequest(faviconRequest);
+    return endRequest;
   }, [faviconRequest]);
 
   const [status, setStatus] = useState<"loading" | "loaded" | "error">(() =>
     hasLoadedProjectFavicon(props.cacheKey) ? "loaded" : "loading",
   );
 
-  const showImage = props.faviconUrl !== null && status === "loaded";
+  const requestIsActive = faviconRequest !== null && activeFaviconRequest === faviconRequest;
+  const showImage = requestIsActive && status === "loaded";
 
   return (
     <View
@@ -92,15 +98,15 @@ function ProjectFaviconImage(props: {
       ) : null}
 
       {/* Favicon image (hidden until loaded) */}
-      {props.faviconUrl ? (
+      {requestIsActive ? (
         <Image
-          key={props.faviconUrl}
+          key={faviconRequest.faviconUrl}
           source={{
-            uri: props.faviconUrl,
-            ...(props.cacheKey ? { cacheKey: props.cacheKey } : {}),
+            uri: faviconRequest.faviconUrl,
+            cacheKey: faviconRequest.cacheKey,
           }}
           cachePolicy="memory-disk"
-          recyclingKey={props.cacheKey}
+          recyclingKey={faviconRequest.cacheKey}
           accessibilityLabel={`${props.projectTitle} favicon`}
           style={{
             width: props.size,

--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -3,12 +3,15 @@ import { Image } from "expo-image";
 import { useState } from "react";
 import { View } from "react-native";
 import type { EnvironmentId } from "@t3tools/contracts";
-import { isProjectFaviconFallbackUrl } from "@t3tools/shared/projectFavicon";
+import {
+  getProjectFaviconCacheKey,
+  isProjectFaviconFallbackUrl,
+} from "@t3tools/shared/projectFavicon";
 import { useThemeColor } from "../lib/useThemeColor";
 import { useAssetUrl } from "../state/assets";
 
 /* ─── Favicon cache (matches web pattern) ────────────────────────────── */
-const loadedFaviconUrls = new Set<string>();
+const loadedFaviconKeys = new Set<string>();
 
 /* ─── Component ──────────────────────────────────────────────────────── */
 export function ProjectFavicon(props: {
@@ -26,10 +29,15 @@ export function ProjectFavicon(props: {
       : { _tag: "project-favicon", cwd: props.workspaceRoot },
   );
   const renderableFaviconUrl = isProjectFaviconFallbackUrl(faviconUrl) ? null : faviconUrl;
+  const cacheKey =
+    renderableFaviconUrl && props.workspaceRoot
+      ? getProjectFaviconCacheKey(props.environmentId, props.workspaceRoot, renderableFaviconUrl)
+      : null;
 
   return (
     <ProjectFaviconImage
-      key={faviconUrl}
+      key={cacheKey}
+      cacheKey={cacheKey}
       faviconUrl={renderableFaviconUrl}
       open={props.open}
       projectTitle={props.projectTitle}
@@ -39,6 +47,7 @@ export function ProjectFavicon(props: {
 }
 
 function ProjectFaviconImage(props: {
+  readonly cacheKey: string | null;
   readonly faviconUrl: string | null;
   readonly open?: boolean;
   readonly projectTitle: string;
@@ -47,7 +56,7 @@ function ProjectFaviconImage(props: {
   const iconMuted = useThemeColor("--color-icon-subtle");
 
   const [status, setStatus] = useState<"loading" | "loaded" | "error">(() =>
-    props.faviconUrl && loadedFaviconUrls.has(props.faviconUrl) ? "loaded" : "loading",
+    props.cacheKey && loadedFaviconKeys.has(props.cacheKey) ? "loaded" : "loading",
   );
 
   const showImage = props.faviconUrl !== null && status === "loaded";
@@ -76,7 +85,10 @@ function ProjectFaviconImage(props: {
         <Image
           source={{
             uri: props.faviconUrl,
+            ...(props.cacheKey ? { cacheKey: props.cacheKey } : {}),
           }}
+          cachePolicy="memory-disk"
+          recyclingKey={props.cacheKey}
           accessibilityLabel={`${props.projectTitle} favicon`}
           style={{
             width: props.size,
@@ -86,7 +98,7 @@ function ProjectFaviconImage(props: {
           }}
           contentFit="contain"
           onLoad={() => {
-            if (props.faviconUrl) loadedFaviconUrls.add(props.faviconUrl);
+            if (props.cacheKey) loadedFaviconKeys.add(props.cacheKey);
             setStatus("loaded");
           }}
           onError={() => setStatus("error")}

--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -1,6 +1,6 @@
 import { SymbolView } from "./AppSymbol";
 import { Image } from "expo-image";
-import { useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useState } from "react";
 import { View } from "react-native";
 import type { EnvironmentId } from "@t3tools/contracts";
 import {
@@ -11,10 +11,10 @@ import { useThemeColor } from "../lib/useThemeColor";
 import { useAssetUrl } from "../state/assets";
 import {
   beginProjectFaviconRequest,
+  createProjectFaviconRequest,
   hasLoadedProjectFavicon,
   markProjectFaviconFailed,
   markProjectFaviconLoaded,
-  type ProjectFaviconRequest,
 } from "./projectFaviconCache";
 
 /* ─── Component ──────────────────────────────────────────────────────── */
@@ -58,15 +58,13 @@ function ProjectFaviconImage(props: {
   readonly size: number;
 }) {
   const iconMuted = useThemeColor("--color-icon-subtle");
-  const faviconRequestRef = useRef<ProjectFaviconRequest | null>(null);
-  if (
-    faviconRequestRef.current === null ||
-    faviconRequestRef.current.cacheKey !== props.cacheKey ||
-    faviconRequestRef.current.faviconUrl !== props.faviconUrl
-  ) {
-    faviconRequestRef.current = beginProjectFaviconRequest(props.cacheKey, props.faviconUrl);
-  }
-  const faviconRequest = faviconRequestRef.current;
+  const faviconRequest = useMemo(
+    () => createProjectFaviconRequest(props.cacheKey, props.faviconUrl),
+    [props.cacheKey, props.faviconUrl],
+  );
+  useLayoutEffect(() => {
+    beginProjectFaviconRequest(faviconRequest);
+  }, [faviconRequest]);
 
   const [status, setStatus] = useState<"loading" | "loaded" | "error">(() =>
     hasLoadedProjectFavicon(props.cacheKey) ? "loaded" : "loading",

--- a/apps/mobile/src/components/projectFaviconCache.test.ts
+++ b/apps/mobile/src/components/projectFaviconCache.test.ts
@@ -15,28 +15,33 @@ describe("project favicon cache", () => {
     const refreshedUrl = "https://environment.example/api/assets/refreshed/v1-favicon.svg";
 
     const expiredRequest = createProjectFaviconRequest(cacheKey, expiredUrl);
-    beginProjectFaviconRequest(expiredRequest);
+    const endExpiredRequest = beginProjectFaviconRequest(expiredRequest);
     markProjectFaviconLoaded(expiredRequest);
     const refreshedRequest = createProjectFaviconRequest(cacheKey, refreshedUrl);
-    beginProjectFaviconRequest(refreshedRequest);
+    const endRefreshedRequest = beginProjectFaviconRequest(refreshedRequest);
 
     expect(markProjectFaviconLoaded(expiredRequest)).toBe(false);
     expect(markProjectFaviconFailed(expiredRequest)).toBe(false);
     expect(hasLoadedProjectFavicon(cacheKey)).toBe(true);
     expect(markProjectFaviconFailed(refreshedRequest)).toBe(true);
     expect(hasLoadedProjectFavicon(cacheKey)).toBe(false);
+
+    endRefreshedRequest();
+    endExpiredRequest();
   });
 
   it("evicts the URL that actually failed", () => {
     const cacheKey = "environment-1:/workspace:v2-favicon.svg";
     const faviconUrl = "https://environment.example/api/assets/current/v2-favicon.svg";
     const request = createProjectFaviconRequest(cacheKey, faviconUrl);
-    beginProjectFaviconRequest(request);
+    const endRequest = beginProjectFaviconRequest(request);
 
     markProjectFaviconLoaded(request);
 
     expect(markProjectFaviconFailed(request)).toBe(true);
     expect(hasLoadedProjectFavicon(cacheKey)).toBe(false);
+
+    endRequest();
   });
 
   it("does not supersede a request until the next request begins", () => {
@@ -44,11 +49,60 @@ describe("project favicon cache", () => {
     const committedUrl = "https://environment.example/api/assets/current/v3-favicon.svg";
     const abandonedUrl = "https://environment.example/api/assets/abandoned/v3-favicon.svg";
     const committedRequest = createProjectFaviconRequest(cacheKey, committedUrl);
-    beginProjectFaviconRequest(committedRequest);
+    const endCommittedRequest = beginProjectFaviconRequest(committedRequest);
 
     createProjectFaviconRequest(cacheKey, abandonedUrl);
 
     expect(markProjectFaviconLoaded(committedRequest)).toBe(true);
     expect(hasLoadedProjectFavicon(cacheKey)).toBe(true);
+
+    endCommittedRequest();
+  });
+
+  it("requires a cache key before creating a URL-bearing request", () => {
+    const firstUrl = "https://environment.example/api/assets/first/favicon.svg";
+    const secondUrl = "https://environment.example/api/assets/second/favicon.svg";
+
+    expect(createProjectFaviconRequest(null, firstUrl)).toBeNull();
+    expect(createProjectFaviconRequest(null, secondUrl)).toBeNull();
+  });
+
+  it("restores the remaining active URL when a newer request ends", () => {
+    const cacheKey = "environment-1:/workspace:v4-favicon.svg";
+    const firstRequest = createProjectFaviconRequest(
+      cacheKey,
+      "https://environment.example/api/assets/first/v4-favicon.svg",
+    );
+    const secondRequest = createProjectFaviconRequest(
+      cacheKey,
+      "https://environment.example/api/assets/second/v4-favicon.svg",
+    );
+    const endFirstRequest = beginProjectFaviconRequest(firstRequest);
+    const endSecondRequest = beginProjectFaviconRequest(secondRequest);
+
+    expect(markProjectFaviconLoaded(firstRequest)).toBe(false);
+    endSecondRequest();
+    expect(markProjectFaviconLoaded(firstRequest)).toBe(true);
+    endFirstRequest();
+    expect(markProjectFaviconLoaded(firstRequest)).toBe(false);
+  });
+
+  it("bounds remembered loaded revisions", () => {
+    const firstCacheKey = "environment-1:/workspace:revision-0";
+    let lastCacheKey = firstCacheKey;
+
+    for (let revision = 0; revision < 300; revision++) {
+      lastCacheKey = `environment-1:/workspace:revision-${revision}`;
+      const request = createProjectFaviconRequest(
+        lastCacheKey,
+        `https://environment.example/api/assets/revision-${revision}/favicon.svg`,
+      );
+      const endRequest = beginProjectFaviconRequest(request);
+      markProjectFaviconLoaded(request);
+      endRequest();
+    }
+
+    expect(hasLoadedProjectFavicon(firstCacheKey)).toBe(false);
+    expect(hasLoadedProjectFavicon(lastCacheKey)).toBe(true);
   });
 });

--- a/apps/mobile/src/components/projectFaviconCache.test.ts
+++ b/apps/mobile/src/components/projectFaviconCache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   beginProjectFaviconRequest,
+  createProjectFaviconRequest,
   hasLoadedProjectFavicon,
   markProjectFaviconFailed,
   markProjectFaviconLoaded,
@@ -13,9 +14,11 @@ describe("project favicon cache", () => {
     const expiredUrl = "https://environment.example/api/assets/expired/v1-favicon.svg";
     const refreshedUrl = "https://environment.example/api/assets/refreshed/v1-favicon.svg";
 
-    const expiredRequest = beginProjectFaviconRequest(cacheKey, expiredUrl);
+    const expiredRequest = createProjectFaviconRequest(cacheKey, expiredUrl);
+    beginProjectFaviconRequest(expiredRequest);
     markProjectFaviconLoaded(expiredRequest);
-    const refreshedRequest = beginProjectFaviconRequest(cacheKey, refreshedUrl);
+    const refreshedRequest = createProjectFaviconRequest(cacheKey, refreshedUrl);
+    beginProjectFaviconRequest(refreshedRequest);
 
     expect(markProjectFaviconLoaded(expiredRequest)).toBe(false);
     expect(markProjectFaviconFailed(expiredRequest)).toBe(false);
@@ -27,11 +30,25 @@ describe("project favicon cache", () => {
   it("evicts the URL that actually failed", () => {
     const cacheKey = "environment-1:/workspace:v2-favicon.svg";
     const faviconUrl = "https://environment.example/api/assets/current/v2-favicon.svg";
-    const request = beginProjectFaviconRequest(cacheKey, faviconUrl);
+    const request = createProjectFaviconRequest(cacheKey, faviconUrl);
+    beginProjectFaviconRequest(request);
 
     markProjectFaviconLoaded(request);
 
     expect(markProjectFaviconFailed(request)).toBe(true);
     expect(hasLoadedProjectFavicon(cacheKey)).toBe(false);
+  });
+
+  it("does not supersede a request until the next request begins", () => {
+    const cacheKey = "environment-1:/workspace:v3-favicon.svg";
+    const committedUrl = "https://environment.example/api/assets/current/v3-favicon.svg";
+    const abandonedUrl = "https://environment.example/api/assets/abandoned/v3-favicon.svg";
+    const committedRequest = createProjectFaviconRequest(cacheKey, committedUrl);
+    beginProjectFaviconRequest(committedRequest);
+
+    createProjectFaviconRequest(cacheKey, abandonedUrl);
+
+    expect(markProjectFaviconLoaded(committedRequest)).toBe(true);
+    expect(hasLoadedProjectFavicon(cacheKey)).toBe(true);
   });
 });

--- a/apps/mobile/src/components/projectFaviconCache.test.ts
+++ b/apps/mobile/src/components/projectFaviconCache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  hasLoadedProjectFavicon,
+  markProjectFaviconFailed,
+  markProjectFaviconLoaded,
+} from "./projectFaviconCache";
+
+describe("project favicon cache", () => {
+  it("ignores an old URL error after a refreshed URL loads", () => {
+    const cacheKey = "environment-1:/workspace:v1-favicon.svg";
+    const expiredUrl = "https://environment.example/api/assets/expired/v1-favicon.svg";
+    const refreshedUrl = "https://environment.example/api/assets/refreshed/v1-favicon.svg";
+
+    markProjectFaviconLoaded(cacheKey, expiredUrl);
+    markProjectFaviconLoaded(cacheKey, refreshedUrl);
+
+    expect(markProjectFaviconFailed(cacheKey, expiredUrl)).toBe(false);
+    expect(hasLoadedProjectFavicon(cacheKey)).toBe(true);
+  });
+
+  it("evicts the URL that actually failed", () => {
+    const cacheKey = "environment-1:/workspace:v2-favicon.svg";
+    const faviconUrl = "https://environment.example/api/assets/current/v2-favicon.svg";
+
+    markProjectFaviconLoaded(cacheKey, faviconUrl);
+
+    expect(markProjectFaviconFailed(cacheKey, faviconUrl)).toBe(true);
+    expect(hasLoadedProjectFavicon(cacheKey)).toBe(false);
+  });
+});

--- a/apps/mobile/src/components/projectFaviconCache.test.ts
+++ b/apps/mobile/src/components/projectFaviconCache.test.ts
@@ -1,31 +1,37 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  beginProjectFaviconRequest,
   hasLoadedProjectFavicon,
   markProjectFaviconFailed,
   markProjectFaviconLoaded,
 } from "./projectFaviconCache";
 
 describe("project favicon cache", () => {
-  it("ignores an old URL error after a refreshed URL loads", () => {
+  it("ignores callbacks from a superseded URL", () => {
     const cacheKey = "environment-1:/workspace:v1-favicon.svg";
     const expiredUrl = "https://environment.example/api/assets/expired/v1-favicon.svg";
     const refreshedUrl = "https://environment.example/api/assets/refreshed/v1-favicon.svg";
 
-    markProjectFaviconLoaded(cacheKey, expiredUrl);
-    markProjectFaviconLoaded(cacheKey, refreshedUrl);
+    const expiredRequest = beginProjectFaviconRequest(cacheKey, expiredUrl);
+    markProjectFaviconLoaded(expiredRequest);
+    const refreshedRequest = beginProjectFaviconRequest(cacheKey, refreshedUrl);
 
-    expect(markProjectFaviconFailed(cacheKey, expiredUrl)).toBe(false);
+    expect(markProjectFaviconLoaded(expiredRequest)).toBe(false);
+    expect(markProjectFaviconFailed(expiredRequest)).toBe(false);
     expect(hasLoadedProjectFavicon(cacheKey)).toBe(true);
+    expect(markProjectFaviconFailed(refreshedRequest)).toBe(true);
+    expect(hasLoadedProjectFavicon(cacheKey)).toBe(false);
   });
 
   it("evicts the URL that actually failed", () => {
     const cacheKey = "environment-1:/workspace:v2-favicon.svg";
     const faviconUrl = "https://environment.example/api/assets/current/v2-favicon.svg";
+    const request = beginProjectFaviconRequest(cacheKey, faviconUrl);
 
-    markProjectFaviconLoaded(cacheKey, faviconUrl);
+    markProjectFaviconLoaded(request);
 
-    expect(markProjectFaviconFailed(cacheKey, faviconUrl)).toBe(true);
+    expect(markProjectFaviconFailed(request)).toBe(true);
     expect(hasLoadedProjectFavicon(cacheKey)).toBe(false);
   });
 });

--- a/apps/mobile/src/components/projectFaviconCache.ts
+++ b/apps/mobile/src/components/projectFaviconCache.ts
@@ -1,47 +1,94 @@
 export interface ProjectFaviconRequest {
-  readonly cacheKey: string | null;
-  readonly faviconUrl: string | null;
+  readonly cacheKey: string;
+  readonly faviconUrl: string;
 }
 
-const currentFaviconUrls = new Map<string, string>();
-const loadedFaviconKeys = new Set<string>();
+interface ActiveFaviconRequests {
+  readonly urls: Map<string, number>;
+  currentUrl: string;
+}
 
+const MAX_LOADED_FAVICONS = 256;
+const activeFaviconRequests = new Map<string, ActiveFaviconRequests>();
+const loadedFaviconKeys = new Map<string, true>();
+
+export function createProjectFaviconRequest(
+  cacheKey: string,
+  faviconUrl: string,
+): ProjectFaviconRequest;
+export function createProjectFaviconRequest(
+  cacheKey: string | null,
+  faviconUrl: string | null,
+): ProjectFaviconRequest | null;
 export function createProjectFaviconRequest(cacheKey: string | null, faviconUrl: string | null) {
+  if (!cacheKey || !faviconUrl) return null;
   return { cacheKey, faviconUrl };
 }
 
 export function beginProjectFaviconRequest(request: ProjectFaviconRequest) {
-  if (request.cacheKey && request.faviconUrl) {
-    currentFaviconUrls.set(request.cacheKey, request.faviconUrl);
+  let activeRequests = activeFaviconRequests.get(request.cacheKey);
+  if (!activeRequests) {
+    activeRequests = { currentUrl: request.faviconUrl, urls: new Map() };
+    activeFaviconRequests.set(request.cacheKey, activeRequests);
   }
+
+  const activeCount = activeRequests.urls.get(request.faviconUrl) ?? 0;
+  activeRequests.urls.delete(request.faviconUrl);
+  activeRequests.urls.set(request.faviconUrl, activeCount + 1);
+  activeRequests.currentUrl = request.faviconUrl;
+
+  let ended = false;
+  return () => {
+    if (ended) return;
+    ended = true;
+
+    const remainingCount = (activeRequests.urls.get(request.faviconUrl) ?? 1) - 1;
+    if (remainingCount > 0) {
+      activeRequests.urls.set(request.faviconUrl, remainingCount);
+      return;
+    }
+
+    activeRequests.urls.delete(request.faviconUrl);
+    if (activeRequests.urls.size === 0) {
+      if (activeFaviconRequests.get(request.cacheKey) === activeRequests) {
+        activeFaviconRequests.delete(request.cacheKey);
+      }
+      return;
+    }
+
+    if (activeRequests.currentUrl === request.faviconUrl) {
+      activeRequests.currentUrl = Array.from(activeRequests.urls.keys()).at(-1)!;
+    }
+  };
 }
 
 export function hasLoadedProjectFavicon(cacheKey: string | null) {
   return cacheKey !== null && loadedFaviconKeys.has(cacheKey);
 }
 
-export function markProjectFaviconLoaded(request: ProjectFaviconRequest) {
-  if (
-    request.cacheKey &&
-    request.faviconUrl &&
-    currentFaviconUrls.get(request.cacheKey) !== request.faviconUrl
-  ) {
-    return false;
-  }
+function isCurrentProjectFaviconRequest(request: ProjectFaviconRequest) {
+  return activeFaviconRequests.get(request.cacheKey)?.currentUrl === request.faviconUrl;
+}
 
-  if (request.cacheKey) loadedFaviconKeys.add(request.cacheKey);
+function rememberLoadedProjectFavicon(cacheKey: string) {
+  loadedFaviconKeys.delete(cacheKey);
+  loadedFaviconKeys.set(cacheKey, true);
+
+  if (loadedFaviconKeys.size > MAX_LOADED_FAVICONS) {
+    loadedFaviconKeys.delete(loadedFaviconKeys.keys().next().value!);
+  }
+}
+
+export function markProjectFaviconLoaded(request: ProjectFaviconRequest) {
+  if (!isCurrentProjectFaviconRequest(request)) return false;
+
+  rememberLoadedProjectFavicon(request.cacheKey);
   return true;
 }
 
 export function markProjectFaviconFailed(request: ProjectFaviconRequest) {
-  if (
-    request.cacheKey &&
-    request.faviconUrl &&
-    currentFaviconUrls.get(request.cacheKey) !== request.faviconUrl
-  ) {
-    return false;
-  }
+  if (!isCurrentProjectFaviconRequest(request)) return false;
 
-  if (request.cacheKey) loadedFaviconKeys.delete(request.cacheKey);
+  loadedFaviconKeys.delete(request.cacheKey);
   return true;
 }

--- a/apps/mobile/src/components/projectFaviconCache.ts
+++ b/apps/mobile/src/components/projectFaviconCache.ts
@@ -1,19 +1,34 @@
-const loadedFaviconUrls = new Map<string, string>();
+export interface ProjectFaviconRequest {
+  readonly cacheKey: string | null;
+  readonly faviconUrl: string | null;
+}
+
+const currentFaviconRequests = new Map<string, ProjectFaviconRequest>();
+const loadedFaviconKeys = new Set<string>();
+
+export function beginProjectFaviconRequest(cacheKey: string | null, faviconUrl: string | null) {
+  const currentRequest = cacheKey ? currentFaviconRequests.get(cacheKey) : undefined;
+  if (currentRequest?.faviconUrl === faviconUrl) return currentRequest;
+
+  const request = { cacheKey, faviconUrl };
+  if (cacheKey && faviconUrl) currentFaviconRequests.set(cacheKey, request);
+  return request;
+}
 
 export function hasLoadedProjectFavicon(cacheKey: string | null) {
-  return cacheKey !== null && loadedFaviconUrls.has(cacheKey);
+  return cacheKey !== null && loadedFaviconKeys.has(cacheKey);
 }
 
-export function markProjectFaviconLoaded(cacheKey: string | null, faviconUrl: string | null) {
-  if (cacheKey && faviconUrl) loadedFaviconUrls.set(cacheKey, faviconUrl);
+export function markProjectFaviconLoaded(request: ProjectFaviconRequest) {
+  if (request.cacheKey && currentFaviconRequests.get(request.cacheKey) !== request) return false;
+
+  if (request.cacheKey) loadedFaviconKeys.add(request.cacheKey);
+  return true;
 }
 
-export function markProjectFaviconFailed(cacheKey: string | null, faviconUrl: string | null) {
-  if (!cacheKey) return true;
+export function markProjectFaviconFailed(request: ProjectFaviconRequest) {
+  if (request.cacheKey && currentFaviconRequests.get(request.cacheKey) !== request) return false;
 
-  const loadedUrl = loadedFaviconUrls.get(cacheKey);
-  if (loadedUrl !== undefined && loadedUrl !== faviconUrl) return false;
-
-  loadedFaviconUrls.delete(cacheKey);
+  if (request.cacheKey) loadedFaviconKeys.delete(request.cacheKey);
   return true;
 }

--- a/apps/mobile/src/components/projectFaviconCache.ts
+++ b/apps/mobile/src/components/projectFaviconCache.ts
@@ -1,0 +1,19 @@
+const loadedFaviconUrls = new Map<string, string>();
+
+export function hasLoadedProjectFavicon(cacheKey: string | null) {
+  return cacheKey !== null && loadedFaviconUrls.has(cacheKey);
+}
+
+export function markProjectFaviconLoaded(cacheKey: string | null, faviconUrl: string | null) {
+  if (cacheKey && faviconUrl) loadedFaviconUrls.set(cacheKey, faviconUrl);
+}
+
+export function markProjectFaviconFailed(cacheKey: string | null, faviconUrl: string | null) {
+  if (!cacheKey) return true;
+
+  const loadedUrl = loadedFaviconUrls.get(cacheKey);
+  if (loadedUrl !== undefined && loadedUrl !== faviconUrl) return false;
+
+  loadedFaviconUrls.delete(cacheKey);
+  return true;
+}

--- a/apps/mobile/src/components/projectFaviconCache.ts
+++ b/apps/mobile/src/components/projectFaviconCache.ts
@@ -3,16 +3,17 @@ export interface ProjectFaviconRequest {
   readonly faviconUrl: string | null;
 }
 
-const currentFaviconRequests = new Map<string, ProjectFaviconRequest>();
+const currentFaviconUrls = new Map<string, string>();
 const loadedFaviconKeys = new Set<string>();
 
-export function beginProjectFaviconRequest(cacheKey: string | null, faviconUrl: string | null) {
-  const currentRequest = cacheKey ? currentFaviconRequests.get(cacheKey) : undefined;
-  if (currentRequest?.faviconUrl === faviconUrl) return currentRequest;
+export function createProjectFaviconRequest(cacheKey: string | null, faviconUrl: string | null) {
+  return { cacheKey, faviconUrl };
+}
 
-  const request = { cacheKey, faviconUrl };
-  if (cacheKey && faviconUrl) currentFaviconRequests.set(cacheKey, request);
-  return request;
+export function beginProjectFaviconRequest(request: ProjectFaviconRequest) {
+  if (request.cacheKey && request.faviconUrl) {
+    currentFaviconUrls.set(request.cacheKey, request.faviconUrl);
+  }
 }
 
 export function hasLoadedProjectFavicon(cacheKey: string | null) {
@@ -20,14 +21,26 @@ export function hasLoadedProjectFavicon(cacheKey: string | null) {
 }
 
 export function markProjectFaviconLoaded(request: ProjectFaviconRequest) {
-  if (request.cacheKey && currentFaviconRequests.get(request.cacheKey) !== request) return false;
+  if (
+    request.cacheKey &&
+    request.faviconUrl &&
+    currentFaviconUrls.get(request.cacheKey) !== request.faviconUrl
+  ) {
+    return false;
+  }
 
   if (request.cacheKey) loadedFaviconKeys.add(request.cacheKey);
   return true;
 }
 
 export function markProjectFaviconFailed(request: ProjectFaviconRequest) {
-  if (request.cacheKey && currentFaviconRequests.get(request.cacheKey) !== request) return false;
+  if (
+    request.cacheKey &&
+    request.faviconUrl &&
+    currentFaviconUrls.get(request.cacheKey) !== request.faviconUrl
+  ) {
+    return false;
+  }
 
   if (request.cacheKey) loadedFaviconKeys.delete(request.cacheKey);
   return true;

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -2,11 +2,13 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { ThreadId } from "@t3tools/contracts";
 import { PROJECT_FAVICON_FALLBACK_MARKER } from "@t3tools/shared/projectFavicon";
 import { describe, expect, it } from "@effect/vitest";
+import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
+import * as TestClock from "effect/testing/TestClock";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import * as ServerConfig from "../config.ts";
@@ -259,6 +261,31 @@ describe("AssetAccess", () => {
           fallbackSuffix.slice(fallbackSeparatorIndex + 1),
         ),
       ).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("buckets project favicon expiry after content hashing", () =>
+    Effect.gen(function* () {
+      const crypto = yield* Crypto.Crypto;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-expiry-",
+      });
+      yield* fileSystem.writeFileString(path.join(root, "favicon.svg"), "<svg />");
+
+      const bucketMs = 30 * 60 * 1000;
+      yield* TestClock.setTime(bucketMs - 1);
+      const crossingCrypto = Crypto.make({
+        randomBytes: (size) => new Uint8Array(size),
+        digest: (algorithm, data) =>
+          TestClock.adjust("2 millis").pipe(Effect.andThen(crypto.digest(algorithm, data))),
+      });
+      const result = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root },
+      }).pipe(Effect.provideService(Crypto.Crypto, crossingCrypto));
+
+      expect(result.expiresAt).toBe(3 * bucketMs);
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -214,13 +214,16 @@ describe("AssetAccess", () => {
         prefix: "t3-asset-favicon-",
       });
       const faviconPath = path.join(root, "favicon.svg");
-      yield* fileSystem.writeFileString(faviconPath, "<svg />");
+      const initialFavicon = "<svg>a</svg>";
+      const updatedFavicon = "<svg>b</svg>";
+      expect(updatedFavicon).toHaveLength(initialFavicon.length);
+      yield* fileSystem.writeFileString(faviconPath, initialFavicon);
       const canonicalFaviconPath = yield* fileSystem.realPath(faviconPath);
 
       const faviconResult = yield* issueAssetUrl({
         resource: { _tag: "project-favicon", cwd: root },
       });
-      expect(faviconResult.relativeUrl).toMatch(/\/v[0-9a-z]+-[0-9a-z]+-favicon\.svg$/);
+      expect(faviconResult.relativeUrl).toMatch(/\/v[0-9a-f]{64}-favicon\.svg$/);
       expect(
         yield* issueAssetUrl({
           resource: { _tag: "project-favicon", cwd: root },
@@ -235,7 +238,7 @@ describe("AssetAccess", () => {
         ),
       ).toEqual({ kind: "file", path: canonicalFaviconPath });
 
-      yield* fileSystem.writeFileString(faviconPath, "<svg>updated favicon</svg>");
+      yield* fileSystem.writeFileString(faviconPath, updatedFavicon);
       const updatedFaviconResult = yield* issueAssetUrl({
         resource: { _tag: "project-favicon", cwd: root },
       });

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -220,6 +220,12 @@ describe("AssetAccess", () => {
       const faviconResult = yield* issueAssetUrl({
         resource: { _tag: "project-favicon", cwd: root },
       });
+      expect(faviconResult.relativeUrl).toMatch(/\/v[0-9a-z]+-[0-9a-z]+-favicon\.svg$/);
+      expect(
+        yield* issueAssetUrl({
+          resource: { _tag: "project-favicon", cwd: root },
+        }),
+      ).toEqual(faviconResult);
       const faviconSuffix = faviconResult.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
       const faviconSeparatorIndex = faviconSuffix.indexOf("/");
       expect(
@@ -228,6 +234,14 @@ describe("AssetAccess", () => {
           faviconSuffix.slice(faviconSeparatorIndex + 1),
         ),
       ).toEqual({ kind: "file", path: canonicalFaviconPath });
+
+      yield* fileSystem.writeFileString(faviconPath, "<svg>updated favicon</svg>");
+      const updatedFaviconResult = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root },
+      });
+      expect(
+        updatedFaviconResult.relativeUrl.slice(updatedFaviconResult.relativeUrl.lastIndexOf("/")),
+      ).not.toBe(faviconResult.relativeUrl.slice(faviconResult.relativeUrl.lastIndexOf("/")));
 
       yield* fileSystem.remove(faviconPath);
       const fallbackResult = yield* issueAssetUrl({

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -170,7 +170,6 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
   readonly resource: AssetResource;
   readonly workspaceRoot?: string;
 }) {
-  const crypto = yield* Crypto.Crypto;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
@@ -335,6 +334,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         expiresAt,
       };
       if (relativePath && canonicalFaviconPath) {
+        const crypto = yield* Crypto.Crypto;
         const faviconBytes = yield* fileSystem.readFile(canonicalFaviconPath).pipe(
           Effect.mapError(
             (cause) =>

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -44,6 +44,8 @@ export const ASSET_ROUTE_PREFIX = "/api/assets";
 
 const SIGNING_SECRET_NAME = "asset-access-signing-key";
 const ASSET_TOKEN_TTL_MS = 60 * 60 * 1000;
+const PROJECT_FAVICON_TOKEN_BUCKET_MS = 30 * 60 * 1000;
+const PROJECT_FAVICON_VERSION_PREFIX = "v";
 const PREVIEW_ASSET_EXTENSIONS = new Set([
   ...WORKSPACE_BROWSER_PREVIEW_EXTENSIONS,
   ...WORKSPACE_IMAGE_PREVIEW_EXTENSIONS,
@@ -169,7 +171,12 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
-  const expiresAt = (yield* Clock.currentTimeMillis) + ASSET_TOKEN_TTL_MS;
+  const issuedAt = yield* Clock.currentTimeMillis;
+  const expiresAt =
+    input.resource._tag === "project-favicon"
+      ? (Math.floor(issuedAt / PROJECT_FAVICON_TOKEN_BUCKET_MS) + 2) *
+        PROJECT_FAVICON_TOKEN_BUCKET_MS
+      : issuedAt + ASSET_TOKEN_TTL_MS;
   let claims: AssetClaims;
   let fileName: string;
 
@@ -293,18 +300,18 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         ),
       );
       const relativePath = faviconPath ? path.relative(workspaceRoot, faviconPath) : null;
-      if (
-        relativePath &&
-        !(yield* resolveCanonicalWorkspaceFile({ workspaceRoot, relativePath }).pipe(
-          Effect.mapError(
-            (cause) =>
-              new AssetProjectFaviconInspectionError({
-                resource: input.resource,
-                cause,
-              }),
-          ),
-        ))
-      ) {
+      const canonicalFaviconPath = relativePath
+        ? yield* resolveCanonicalWorkspaceFile({ workspaceRoot, relativePath }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new AssetProjectFaviconInspectionError({
+                  resource: input.resource,
+                  cause,
+                }),
+            ),
+          )
+        : null;
+      if (relativePath && !canonicalFaviconPath) {
         return yield* new AssetProjectFaviconNotFoundError({
           resource: input.resource,
         });
@@ -324,7 +331,22 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         relativePath,
         expiresAt,
       };
-      fileName = relativePath ? path.basename(relativePath) : PROJECT_FAVICON_FALLBACK_MARKER;
+      if (relativePath && canonicalFaviconPath) {
+        const faviconInfo = yield* fileSystem.stat(canonicalFaviconPath).pipe(
+          Effect.mapError(
+            (cause) =>
+              new AssetProjectFaviconInspectionError({
+                resource: input.resource,
+                cause,
+              }),
+          ),
+        );
+        const modifiedAt = Option.getOrUndefined(faviconInfo.mtime)?.getTime() ?? 0;
+        const revision = `${modifiedAt.toString(36)}-${faviconInfo.size.toString(36)}`;
+        fileName = `${PROJECT_FAVICON_VERSION_PREFIX}${revision}-${path.basename(relativePath)}`;
+      } else {
+        fileName = PROJECT_FAVICON_FALLBACK_MARKER;
+      }
       break;
     }
   }

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -173,12 +173,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
-  const issuedAt = yield* Clock.currentTimeMillis;
-  const expiresAt =
-    input.resource._tag === "project-favicon"
-      ? (Math.floor(issuedAt / PROJECT_FAVICON_TOKEN_BUCKET_MS) + 2) *
-        PROJECT_FAVICON_TOKEN_BUCKET_MS
-      : issuedAt + ASSET_TOKEN_TTL_MS;
+  let expiresAt = (yield* Clock.currentTimeMillis) + ASSET_TOKEN_TTL_MS;
   let claims: AssetClaims;
   let fileName: string;
 
@@ -372,6 +367,13 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         }),
     ),
   );
+  if (claims.kind === "project-favicon") {
+    const issuedAt = yield* Clock.currentTimeMillis;
+    expiresAt =
+      (Math.floor(issuedAt / PROJECT_FAVICON_TOKEN_BUCKET_MS) + 2) *
+      PROJECT_FAVICON_TOKEN_BUCKET_MS;
+    claims = { ...claims, expiresAt };
+  }
   const encodedPayload = base64UrlEncode(encodeAssetClaims(claims));
   const token = `${encodedPayload}.${signPayload(encodedPayload, signingSecret)}`;
   return {

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -21,7 +21,9 @@ import {
 } from "@t3tools/shared/filePreview";
 import { PROJECT_FAVICON_FALLBACK_MARKER } from "@t3tools/shared/projectFavicon";
 import * as Clock from "effect/Clock";
+import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
+import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
@@ -168,6 +170,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
   readonly resource: AssetResource;
   readonly workspaceRoot?: string;
 }) {
+  const crypto = yield* Crypto.Crypto;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
@@ -332,7 +335,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         expiresAt,
       };
       if (relativePath && canonicalFaviconPath) {
-        const faviconInfo = yield* fileSystem.stat(canonicalFaviconPath).pipe(
+        const faviconBytes = yield* fileSystem.readFile(canonicalFaviconPath).pipe(
           Effect.mapError(
             (cause) =>
               new AssetProjectFaviconInspectionError({
@@ -341,8 +344,16 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
               }),
           ),
         );
-        const modifiedAt = Option.getOrUndefined(faviconInfo.mtime)?.getTime() ?? 0;
-        const revision = `${modifiedAt.toString(36)}-${faviconInfo.size.toString(36)}`;
+        const revision = yield* crypto.digest("SHA-256", faviconBytes).pipe(
+          Effect.map(Encoding.encodeHex),
+          Effect.mapError(
+            (cause) =>
+              new AssetProjectFaviconInspectionError({
+                resource: input.resource,
+                cause,
+              }),
+          ),
+        );
         fileName = `${PROJECT_FAVICON_VERSION_PREFIX}${revision}-${path.basename(relativePath)}`;
       } else {
         fileName = PROJECT_FAVICON_FALLBACK_MARKER;

--- a/apps/web/src/components/ProjectFavicon.test.tsx
+++ b/apps/web/src/components/ProjectFavicon.test.tsx
@@ -1,0 +1,128 @@
+import type { ComponentType, Dispatch, ReactElement, SetStateAction } from "react";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { EnvironmentId } from "@t3tools/contracts";
+
+const testState = vi.hoisted(() => ({
+  faviconUrl: "https://environment.test/api/assets/token-a/v1-20-favicon.svg",
+}));
+
+const hooks = vi.hoisted(() => {
+  let cursor = 0;
+  let slots: unknown[] = [];
+  const nextIndex = () => cursor++;
+
+  return {
+    beginRender() {
+      cursor = 0;
+    },
+    reset() {
+      cursor = 0;
+      slots = [];
+    },
+    useMemoCache(size: number): unknown[] {
+      const index = nextIndex();
+      if (!slots[index]) {
+        slots[index] = Array.from({ length: size }, () => Symbol.for("react.memo_cache_sentinel"));
+      }
+      return slots[index] as unknown[];
+    },
+    useState<T>(initialValue: T | (() => T)): [T, Dispatch<SetStateAction<T>>] {
+      const index = nextIndex();
+      if (index >= slots.length) {
+        slots[index] =
+          typeof initialValue === "function" ? (initialValue as () => T)() : initialValue;
+      }
+      const setValue: Dispatch<SetStateAction<T>> = (nextValue) => {
+        const previous = slots[index] as T;
+        slots[index] =
+          typeof nextValue === "function" ? (nextValue as (value: T) => T)(previous) : nextValue;
+      };
+      return [slots[index] as T, setValue];
+    },
+  };
+});
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useState: hooks.useState,
+  };
+});
+
+vi.mock("react/compiler-runtime", () => ({ c: hooks.useMemoCache }));
+vi.mock("../assets/assetUrls", () => ({
+  useAssetUrl: () => testState.faviconUrl,
+}));
+
+import { ProjectFavicon } from "./ProjectFavicon";
+
+type ProjectFaviconImageProps = {
+  readonly cacheKey: string;
+  readonly src: string;
+  readonly className?: string | undefined;
+  readonly fallbackIcon: ComponentType<{ className?: string }>;
+};
+
+type ImageElement = ReactElement<{
+  readonly src: string;
+  readonly onLoad?: () => void;
+  readonly onError?: () => void;
+}>;
+
+type ProjectFaviconImageElement = ReactElement<{
+  readonly children: [ReactElement | null, ImageElement | null, ImageElement | null];
+}>;
+
+function resolveImageComponent(): {
+  readonly Component: (props: ProjectFaviconImageProps) => ProjectFaviconImageElement;
+  readonly props: ProjectFaviconImageProps;
+} {
+  hooks.beginRender();
+  const element = ProjectFavicon({
+    environmentId: "environment-test" as EnvironmentId,
+    cwd: "/workspace-test",
+  }) as ReactElement<ProjectFaviconImageProps>;
+  hooks.reset();
+
+  return {
+    Component: element.type as (props: ProjectFaviconImageProps) => ProjectFaviconImageElement,
+    props: element.props,
+  };
+}
+
+function renderImage(
+  Component: (props: ProjectFaviconImageProps) => ProjectFaviconImageElement,
+  props: ProjectFaviconImageProps,
+): ProjectFaviconImageElement {
+  hooks.beginRender();
+  return Component(props);
+}
+
+describe("ProjectFavicon", () => {
+  beforeEach(() => {
+    hooks.reset();
+  });
+
+  it("falls back when the displayed favicon fails without discarding a valid older image early", () => {
+    const { Component, props } = resolveImageComponent();
+    const initialLoadingImage = renderImage(Component, props).props.children[2];
+    initialLoadingImage?.props.onLoad?.();
+
+    const refreshedProps = {
+      ...props,
+      src: "https://environment.test/api/assets/token-b/v1-20-favicon.svg",
+    };
+    const refreshing = renderImage(Component, refreshedProps).props.children;
+    expect(refreshing[1]?.props.src).toBe(props.src);
+    refreshing[2]?.props.onError?.();
+
+    const afterRefreshError = renderImage(Component, refreshedProps).props.children;
+    expect(afterRefreshError[1]?.props.src).toBe(props.src);
+    afterRefreshError[1]?.props.onError?.();
+
+    const afterDisplayedError = renderImage(Component, refreshedProps).props.children;
+    expect(afterDisplayedError[0]).not.toBeNull();
+    expect(afterDisplayedError[1]).toBeNull();
+  });
+});

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -65,6 +65,12 @@ function ProjectFaviconImage({
     () => loadedProjectFaviconSrcs.get(cacheKey) ?? null,
   );
   const isLoading = displayedSrc !== src;
+  const handleLoadError = (failedSrc: string) => {
+    if (loadedProjectFaviconSrcs.get(cacheKey) === failedSrc) {
+      loadedProjectFaviconSrcs.delete(cacheKey);
+    }
+    setDisplayedSrc((currentSrc) => (currentSrc === failedSrc ? null : currentSrc));
+  };
 
   return (
     <>
@@ -76,6 +82,7 @@ function ProjectFaviconImage({
           src={displayedSrc}
           alt=""
           className={cn("size-3.5 shrink-0 rounded-sm object-contain", className)}
+          onError={() => handleLoadError(displayedSrc)}
         />
       ) : null}
       {isLoading ? (
@@ -87,6 +94,7 @@ function ProjectFaviconImage({
             loadedProjectFaviconSrcs.set(cacheKey, src);
             setDisplayedSrc(src);
           }}
+          onError={() => handleLoadError(src)}
         />
       ) : null}
     </>

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -1,12 +1,15 @@
 import type { EnvironmentId } from "@t3tools/contracts";
-import { isProjectFaviconFallbackUrl } from "@t3tools/shared/projectFavicon";
+import {
+  getProjectFaviconCacheKey,
+  isProjectFaviconFallbackUrl,
+} from "@t3tools/shared/projectFavicon";
 import { FolderIcon } from "lucide-react";
 import type { ComponentType } from "react";
 import { useState } from "react";
 import { useAssetUrl } from "../assets/assetUrls";
 import { cn } from "~/lib/utils";
 
-const loadedProjectFaviconSrcs = new Set<string>();
+const loadedProjectFaviconSrcs = new Map<string, string>();
 
 export function ProjectFavicon(input: {
   environmentId: EnvironmentId;
@@ -24,9 +27,12 @@ export function ProjectFavicon(input: {
     return <ProjectFaviconFallback className={input.className} icon={FallbackIcon} />;
   }
 
+  const cacheKey = getProjectFaviconCacheKey(input.environmentId, input.cwd, src);
+
   return (
     <ProjectFaviconImage
-      key={src}
+      key={cacheKey}
+      cacheKey={cacheKey}
       src={src}
       className={input.className}
       fallbackIcon={FallbackIcon}
@@ -45,37 +51,44 @@ function ProjectFaviconFallback({
 }
 
 function ProjectFaviconImage({
+  cacheKey,
   src,
   className,
   fallbackIcon: FallbackIcon,
 }: {
+  readonly cacheKey: string;
   readonly src: string;
   readonly className?: string | undefined;
   readonly fallbackIcon: ComponentType<{ className?: string }>;
 }) {
-  const [status, setStatus] = useState<"loading" | "loaded" | "error">(() =>
-    loadedProjectFaviconSrcs.has(src) ? "loaded" : "loading",
+  const [displayedSrc, setDisplayedSrc] = useState<string | null>(
+    () => loadedProjectFaviconSrcs.get(cacheKey) ?? null,
   );
+  const isLoading = displayedSrc !== src;
 
   return (
     <>
-      {status !== "loaded" ? (
+      {displayedSrc === null ? (
         <ProjectFaviconFallback className={className} icon={FallbackIcon} />
       ) : null}
-      <img
-        src={src}
-        alt=""
-        className={cn(
-          "size-3.5 shrink-0 rounded-sm object-contain",
-          status !== "loaded" && "hidden",
-          className,
-        )}
-        onLoad={() => {
-          loadedProjectFaviconSrcs.add(src);
-          setStatus("loaded");
-        }}
-        onError={() => setStatus("error")}
-      />
+      {displayedSrc ? (
+        <img
+          src={displayedSrc}
+          alt=""
+          className={cn("size-3.5 shrink-0 rounded-sm object-contain", className)}
+        />
+      ) : null}
+      {isLoading ? (
+        <img
+          src={src}
+          alt=""
+          className="hidden"
+          onLoad={() => {
+            loadedProjectFaviconSrcs.set(cacheKey, src);
+            setDisplayedSrc(src);
+          }}
+        />
+      ) : null}
     </>
   );
 }

--- a/packages/shared/src/projectFavicon.test.ts
+++ b/packages/shared/src/projectFavicon.test.ts
@@ -1,8 +1,32 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { isProjectFaviconFallbackUrl, PROJECT_FAVICON_FALLBACK_MARKER } from "./projectFavicon.ts";
+import {
+  getProjectFaviconCacheKey,
+  isProjectFaviconFallbackUrl,
+  PROJECT_FAVICON_FALLBACK_MARKER,
+} from "./projectFavicon.ts";
 
 describe("project favicon", () => {
+  it("uses the project and versioned filename as the cache identity", () => {
+    const firstUrl = "https://environment.example/api/assets/first-signed-token/v1-20-favicon.svg";
+    const refreshedUrl =
+      "https://environment.example/api/assets/refreshed-signed-token/v1-20-favicon.svg";
+
+    expect(getProjectFaviconCacheKey("environment-1", "/workspace", firstUrl)).toBe(
+      getProjectFaviconCacheKey("environment-1", "/workspace", refreshedUrl),
+    );
+    expect(getProjectFaviconCacheKey("environment-1", "/workspace", firstUrl)).not.toBe(
+      getProjectFaviconCacheKey(
+        "environment-1",
+        "/workspace",
+        "https://environment.example/api/assets/refreshed-signed-token/v2-20-favicon.svg",
+      ),
+    );
+    expect(getProjectFaviconCacheKey("environment-1", "/workspace", firstUrl)).not.toBe(
+      getProjectFaviconCacheKey("environment-2", "/workspace", firstUrl),
+    );
+  });
+
   it("identifies fallback asset URLs by their dedicated filename", () => {
     expect(
       isProjectFaviconFallbackUrl(

--- a/packages/shared/src/projectFavicon.ts
+++ b/packages/shared/src/projectFavicon.ts
@@ -1,5 +1,22 @@
 export const PROJECT_FAVICON_FALLBACK_MARKER = "project-favicon-missing";
 
+export function getProjectFaviconCacheKey(
+  environmentId: string,
+  workspaceRoot: string,
+  url: string,
+): string {
+  let revision = url;
+
+  try {
+    const pathname = new URL(url, "https://t3.invalid").pathname;
+    revision = pathname.slice(pathname.lastIndexOf("/") + 1);
+  } catch {
+    // Keep the full value as a safe fallback for malformed URLs.
+  }
+
+  return JSON.stringify([environmentId, workspaceRoot, revision]);
+}
+
 export function isProjectFaviconFallbackUrl(url: string | null | undefined): boolean {
   if (!url) return false;
 

--- a/packages/shared/src/projectFavicon.ts
+++ b/packages/shared/src/projectFavicon.ts
@@ -4,7 +4,7 @@ export function getProjectFaviconCacheKey(
   environmentId: string,
   workspaceRoot: string,
   url: string,
-): string {
+) {
   let revision = url;
 
   try {


### PR DESCRIPTION
## What Changed

- Added versioned project favicon asset URLs based on file modification time and size.
- Added shared cache-key generation scoped to environment, workspace, and favicon revision.
- Enabled persistent favicon caching on mobile and reused loaded favicon URLs on web.
- Added coverage for stable URLs, cache identity, and favicon updates.

## Why

Signed asset URLs change as tokens rotate, which caused browsers and mobile clients to reload unchanged project favicons. Versioning the asset by the favicon's file metadata provides a stable cache identity while still invalidating the cache when the favicon changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signed asset URL shape and expiry for project favicons plus client caching behavior; scope is limited to favicon assets and is covered by new tests, but incorrect hashing or cache logic could show stale or missing icons.
> 
> **Overview**
> Signed project favicon URLs change whenever tokens rotate, which forced web and mobile to reload unchanged icons. This PR makes **asset filenames content-addressed** (SHA-256 hash in the path) and aligns favicon token **expiry to 30-minute buckets**, so the same file keeps a stable URL identity across re-issues.
> 
> **Shared** `getProjectFaviconCacheKey` ties cache identity to environment, workspace root, and the versioned filename—not the signed token.
> 
> **Web** keeps showing the last successfully loaded favicon while a new URL loads in a hidden `<img>`, and only drops to the folder icon when the *displayed* image errors.
> 
> **Mobile** adds a small request lifecycle cache so stale `onLoad`/`onError` from superseded URLs are ignored, and wires **expo-image** with `cacheKey`, `recyclingKey`, and `memory-disk` policy.
> 
> Tests cover bucketed expiry, hash-based filenames, cache-key stability, refresh/fallback behavior, and mobile supersession.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0779cf74b2d7a5524c1ddd24bfa0a982c4c00f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache project favicons by content-hash key across web and mobile
> - Adds `getProjectFaviconCacheKey` in [`packages/shared/src/projectFavicon.ts`](https://github.com/pingdotgg/t3code/pull/4767/files#diff-d98cde42eca25287dcbb31cdb8d19636183750abb43d8de676195155d4d61a5c) to derive a stable cache identity from `environmentId`, workspace root, and a versioned filename, independent of transient signed tokens.
> - Server-side favicon URLs now include a SHA-256 content-hash in the filename and use bucketed 30-minute expiry, so repeated calls return the same URL until file content changes.
> - Web's `ProjectFaviconImage` holds the previous image on screen while preloading a refreshed URL, only swapping on success and guarding error handlers by src match.
> - Mobile's `ProjectFaviconImage` replaces a local Set-based cache with coordinated per-`cacheKey` request tracking, ignoring load/error callbacks from superseded URLs.
> - Behavioral Change: favicon token expiry on the server is now aligned to 30-minute buckets rather than the general token TTL, which may extend the lifetime of issued URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d0779c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project favicon caching with deterministic cache keys and smarter reuse, so refreshes can retain the last working favicon and only discard it when the matching request fails.
  * Updated server-issued project-favicon URL expiry and filename generation to be time-bucketed and content-hashed, producing stable signed fallback behavior.
* **Tests**
  * Expanded server, web, shared, and mobile test coverage for cache-key identity, refresh/failure fallback behavior, request supersession/eviction, and bucketed expiry plus filename signing stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->