### PR TITLE
fix(desktop): link release notes from the update downloaded toast

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -133,6 +133,7 @@ import {
   shouldShowArm64IntelBuildWarning,
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
+import { showDesktopUpdateDownloadedToast } from "./desktopUpdate.toast";
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import {
@@ -3509,11 +3510,7 @@ export default function Sidebar() {
         .downloadUpdate()
         .then((result) => {
           if (result.completed) {
-            toastManager.add({
-              type: "success",
-              title: "Update downloaded",
-              description: "Restart the app from the update button to install it.",
-            });
+            showDesktopUpdateDownloadedToast(bridge, result.state.downloadedVersion);
           }
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3510,7 +3510,7 @@ export default function Sidebar() {
         .downloadUpdate()
         .then((result) => {
           if (result.completed) {
-            showDesktopUpdateDownloadedToast(bridge, result.state.downloadedVersion);
+            showDesktopUpdateDownloadedToast(bridge, result.state);
           }
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -7,6 +7,7 @@ import {
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
   getDesktopUpdateInstallConfirmationMessage,
+  getDesktopUpdateReleaseUrl,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
@@ -158,6 +159,23 @@ describe("getDesktopUpdateActionError", () => {
 });
 
 describe("desktop update UI helpers", () => {
+  it("builds the stable release URL for a downloaded version", () => {
+    expect(getDesktopUpdateReleaseUrl("0.0.30")).toBe(
+      "https://github.com/pingdotgg/t3code/releases/tag/v0.0.30",
+    );
+  });
+
+  it("builds the nightly release URL without dropping its version suffix", () => {
+    expect(getDesktopUpdateReleaseUrl("0.0.30-nightly.20260728.931")).toBe(
+      "https://github.com/pingdotgg/t3code/releases/tag/v0.0.30-nightly.20260728.931",
+    );
+  });
+
+  it("omits the release URL when the updater does not report a version", () => {
+    expect(getDesktopUpdateReleaseUrl(null)).toBeNull();
+    expect(getDesktopUpdateReleaseUrl("  ")).toBeNull();
+  });
+
   it("toasts only for actionable updater errors", () => {
     expect(
       shouldToastDesktopUpdateActionResult({

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -5,6 +5,15 @@ export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
 const DESKTOP_RELEASE_TAG_URL = "https://github.com/pingdotgg/t3code/releases/tag";
 
+/**
+ * The main process fills `downloadedVersion` from the updater's `update-downloaded`
+ * event, which is dispatched on its own fiber. A download RPC can therefore resolve
+ * before that write lands, so fall back to the version the download was started for.
+ */
+export function getDesktopUpdateDownloadedVersion(state: DesktopUpdateState): string | null {
+  return state.downloadedVersion ?? state.availableVersion;
+}
+
 /** Release notes for an exact downloaded build; nightly suffixes are part of the tag. */
 export function getDesktopUpdateReleaseUrl(version: string | null): string | null {
   const normalizedVersion = version?.trim();

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -3,6 +3,15 @@ import { isWindowsPlatform } from "../lib/utils";
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
+const DESKTOP_RELEASE_TAG_URL = "https://github.com/pingdotgg/t3code/releases/tag";
+
+/** Release notes for an exact downloaded build; nightly suffixes are part of the tag. */
+export function getDesktopUpdateReleaseUrl(version: string | null): string | null {
+  const normalizedVersion = version?.trim();
+  if (!normalizedVersion) return null;
+  return `${DESKTOP_RELEASE_TAG_URL}/v${encodeURIComponent(normalizedVersion)}`;
+}
+
 export function resolveDesktopUpdateButtonAction(
   state: DesktopUpdateState,
 ): DesktopUpdateButtonAction {

--- a/apps/web/src/components/desktopUpdate.toast.test.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.test.tsx
@@ -1,0 +1,79 @@
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => ({
+  addToast: vi.fn(),
+}));
+
+vi.mock("./ui/toast", () => ({
+  toastManager: { add: testState.addToast },
+}));
+
+import { showDesktopUpdateDownloadedToast } from "./desktopUpdate.toast";
+
+type ClickableElement = ReactElement<{ readonly onClick?: () => void }>;
+
+/** Walks the rendered description, invoking function components, to find the link button. */
+function findReleaseNotesLink(node: ReactNode): ClickableElement | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findReleaseNotesLink(child);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!isValidElement(node)) return null;
+  const element = node as ReactElement<{ readonly children?: ReactNode }>;
+  if (element.type === "button") return element as ClickableElement;
+  if (typeof element.type === "function") {
+    const render = element.type as (props: unknown) => ReactNode;
+    return findReleaseNotesLink(render(element.props));
+  }
+  return findReleaseNotesLink(element.props.children);
+}
+
+function getDescription(): ReactNode {
+  const toast = testState.addToast.mock.calls[0]?.[0] as { description?: ReactNode } | undefined;
+  return toast?.description ?? null;
+}
+
+describe("showDesktopUpdateDownloadedToast", () => {
+  beforeEach(() => {
+    testState.addToast.mockReset();
+  });
+
+  it("opens the downloaded version's release notes", async () => {
+    const openExternal = vi.fn().mockResolvedValue(true);
+
+    showDesktopUpdateDownloadedToast({ openExternal }, "0.0.30");
+    const link = findReleaseNotesLink(getDescription());
+    link?.props.onClick?.();
+    await vi.waitFor(() => {
+      expect(openExternal).toHaveBeenCalledWith(
+        "https://github.com/pingdotgg/t3code/releases/tag/v0.0.30",
+      );
+    });
+    expect(testState.addToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the link when the updater does not report a version", () => {
+    showDesktopUpdateDownloadedToast({ openExternal: vi.fn() }, null);
+
+    expect(findReleaseNotesLink(getDescription())).toBeNull();
+  });
+
+  it.each([
+    ["returns false", vi.fn().mockResolvedValue(false)],
+    ["rejects", vi.fn().mockRejectedValue(new Error("open failed"))],
+  ])("shows an error when opening release notes %s", async (_description, openExternal) => {
+    showDesktopUpdateDownloadedToast({ openExternal }, "0.0.30");
+    findReleaseNotesLink(getDescription())?.props.onClick?.();
+
+    await vi.waitFor(() => {
+      expect(testState.addToast).toHaveBeenLastCalledWith({
+        type: "error",
+        title: "Unable to open release notes",
+      });
+    });
+  });
+});

--- a/apps/web/src/components/desktopUpdate.toast.test.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.test.tsx
@@ -1,5 +1,6 @@
 import { isValidElement, type ReactElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { DesktopUpdateState } from "@t3tools/contracts";
 
 const testState = vi.hoisted(() => ({
   addToast: vi.fn(),
@@ -37,6 +38,27 @@ function getDescription(): ReactNode {
   return toast?.description ?? null;
 }
 
+function downloadedState(overrides: Partial<DesktopUpdateState> = {}): DesktopUpdateState {
+  return {
+    enabled: true,
+    status: "downloaded",
+    channel: "latest",
+    currentVersion: "0.0.29",
+    hostArch: "arm64",
+    appArch: "arm64",
+    runningUnderArm64Translation: false,
+    availableVersion: "0.0.30",
+    downloadedVersion: "0.0.30",
+    releaseNotes: [],
+    downloadPercent: 100,
+    checkedAt: null,
+    message: null,
+    errorContext: null,
+    canRetry: true,
+    ...overrides,
+  };
+}
+
 describe("showDesktopUpdateDownloadedToast", () => {
   beforeEach(() => {
     testState.addToast.mockReset();
@@ -45,7 +67,7 @@ describe("showDesktopUpdateDownloadedToast", () => {
   it("opens the downloaded version's release notes", async () => {
     const openExternal = vi.fn().mockResolvedValue(true);
 
-    showDesktopUpdateDownloadedToast({ openExternal }, "0.0.30");
+    showDesktopUpdateDownloadedToast({ openExternal }, downloadedState());
     const link = findReleaseNotesLink(getDescription());
     link?.props.onClick?.();
     await vi.waitFor(() => {
@@ -56,8 +78,28 @@ describe("showDesktopUpdateDownloadedToast", () => {
     expect(testState.addToast).toHaveBeenCalledTimes(1);
   });
 
-  it("omits the link when the updater does not report a version", () => {
-    showDesktopUpdateDownloadedToast({ openExternal: vi.fn() }, null);
+  it("falls back to the version the download was started for", async () => {
+    const openExternal = vi.fn().mockResolvedValue(true);
+
+    // The `update-downloaded` event can land after the download RPC resolves.
+    showDesktopUpdateDownloadedToast(
+      { openExternal },
+      downloadedState({ downloadedVersion: null }),
+    );
+    findReleaseNotesLink(getDescription())?.props.onClick?.();
+
+    await vi.waitFor(() => {
+      expect(openExternal).toHaveBeenCalledWith(
+        "https://github.com/pingdotgg/t3code/releases/tag/v0.0.30",
+      );
+    });
+  });
+
+  it("omits the link when the updater reports no version at all", () => {
+    showDesktopUpdateDownloadedToast(
+      { openExternal: vi.fn() },
+      downloadedState({ availableVersion: null, downloadedVersion: null }),
+    );
 
     expect(findReleaseNotesLink(getDescription())).toBeNull();
   });
@@ -66,7 +108,7 @@ describe("showDesktopUpdateDownloadedToast", () => {
     ["returns false", vi.fn().mockResolvedValue(false)],
     ["rejects", vi.fn().mockRejectedValue(new Error("open failed"))],
   ])("shows an error when opening release notes %s", async (_description, openExternal) => {
-    showDesktopUpdateDownloadedToast({ openExternal }, "0.0.30");
+    showDesktopUpdateDownloadedToast({ openExternal }, downloadedState());
     findReleaseNotesLink(getDescription())?.props.onClick?.();
 
     await vi.waitFor(() => {

--- a/apps/web/src/components/desktopUpdate.toast.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.tsx
@@ -1,7 +1,10 @@
-import type { DesktopBridge } from "@t3tools/contracts";
+import type { DesktopBridge, DesktopUpdateState } from "@t3tools/contracts";
 import { ArrowRightIcon } from "lucide-react";
 
-import { getDesktopUpdateReleaseUrl } from "./desktopUpdate.logic";
+import {
+  getDesktopUpdateDownloadedVersion,
+  getDesktopUpdateReleaseUrl,
+} from "./desktopUpdate.logic";
 import { toastManager } from "./ui/toast";
 
 type DesktopUpdateShell = Pick<DesktopBridge, "openExternal">;
@@ -36,9 +39,9 @@ function ReleaseNotesLink({
 
 export function showDesktopUpdateDownloadedToast(
   shell: DesktopUpdateShell,
-  downloadedVersion: string | null,
+  state: DesktopUpdateState,
 ): void {
-  const releaseUrl = getDesktopUpdateReleaseUrl(downloadedVersion);
+  const releaseUrl = getDesktopUpdateReleaseUrl(getDesktopUpdateDownloadedVersion(state));
   toastManager.add({
     type: "success",
     title: "Update downloaded",

--- a/apps/web/src/components/desktopUpdate.toast.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.tsx
@@ -1,0 +1,52 @@
+import type { DesktopBridge } from "@t3tools/contracts";
+import { ArrowRightIcon } from "lucide-react";
+
+import { getDesktopUpdateReleaseUrl } from "./desktopUpdate.logic";
+import { toastManager } from "./ui/toast";
+
+type DesktopUpdateShell = Pick<DesktopBridge, "openExternal">;
+
+function ReleaseNotesLink({
+  shell,
+  releaseUrl,
+}: {
+  shell: DesktopUpdateShell;
+  releaseUrl: string;
+}) {
+  return (
+    <button
+      className="ml-2 inline-flex cursor-pointer items-center gap-1 align-baseline text-muted-foreground underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground"
+      onClick={() => {
+        void (async () => {
+          try {
+            if (await shell.openExternal(releaseUrl)) return;
+          } catch {
+            // Surface rejected IPC calls through the same user-visible fallback.
+          }
+          toastManager.add({ type: "error", title: "Unable to open release notes" });
+        })();
+      }}
+      type="button"
+    >
+      Read more
+      <ArrowRightIcon aria-hidden className="size-3 -rotate-45" strokeWidth={2.25} />
+    </button>
+  );
+}
+
+export function showDesktopUpdateDownloadedToast(
+  shell: DesktopUpdateShell,
+  downloadedVersion: string | null,
+): void {
+  const releaseUrl = getDesktopUpdateReleaseUrl(downloadedVersion);
+  toastManager.add({
+    type: "success",
+    title: "Update downloaded",
+    description: (
+      <>
+        Restart the app from the update button to install it.
+        {releaseUrl ? <ReleaseNotesLink releaseUrl={releaseUrl} shell={shell} /> : null}
+      </>
+    ),
+  });
+}

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -14,6 +14,7 @@ import {
   shouldShowDesktopUpdateButton,
   shouldToastDesktopUpdateActionResult,
 } from "../desktopUpdate.logic";
+import { showDesktopUpdateDownloadedToast } from "../desktopUpdate.toast";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { Separator } from "../ui/separator";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -80,11 +81,7 @@ export function SidebarUpdatePill() {
         .downloadUpdate()
         .then((result) => {
           if (result.completed) {
-            toastManager.add({
-              type: "success",
-              title: "Update downloaded",
-              description: "Restart the app from the update button to install it.",
-            });
+            showDesktopUpdateDownloadedToast(bridge, result.state.downloadedVersion);
           }
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -81,7 +81,7 @@ export function SidebarUpdatePill() {
         .downloadUpdate()
         .then((result) => {
           if (result.completed) {
-            showDesktopUpdateDownloadedToast(bridge, result.state.downloadedVersion);
+            showDesktopUpdateDownloadedToast(bridge, result.state);
           }
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);


### PR DESCRIPTION
## What Changed

- Add an inline **Read more** link to the "Update downloaded" notification, directly after the restart instruction.
- Open the GitHub release for the exact downloaded version through Electron's existing external-link bridge.
- Share the notification between the legacy sidebar control and `SidebarUpdatePill` instead of duplicating it.

## Why

After downloading an update there is no way to see what changed without navigating to the Releases page manually. The link is built from the updater's own state, so it always points at the build that was just downloaded — stable or nightly.

## Notes For Review

The version is resolved as `downloadedVersion ?? availableVersion`. `downloadedVersion` is written by the `update-downloaded` handler, which `DesktopUpdates` dispatches through `runEffect` (fire-and-forget on its own fiber), so the `download` RPC can resolve before that write lands and the link would silently disappear. `availableVersion` is the version the download was started for and is set to the same value by `reduceDesktopUpdateStateOnDownloadComplete`, so the fallback cannot point at a different release.

The link is a `<button>` rather than an `<a href>` because the release page has to leave the app through the shell. If `openExternal` returns false or rejects, an "Unable to open release notes" error toast is shown instead of failing silently.

## UI Changes

Before: the downloaded-update notification only instructed the user to restart.

After: the same sentence is followed by a dotted-underlined **Read more** link with a diagonal arrow.

<img width="401" height="128" alt="Bildschirmfoto 2026-07-28 um 20 46 54" src="https://github.com/user-attachments/assets/417f4bbe-dea1-47db-807f-de741e6a1cb6" />
<img width="410" height="150" alt="Bildschirmfoto 2026-07-28 um 20 46 19" src="https://github.com/user-attachments/assets/d88d2a1c-a763-4073-be19-7bff1d6d4c4c" />



## Validation

- `vp test run apps/web/src/components/desktopUpdate.logic.test.ts apps/web/src/components/desktopUpdate.toast.test.tsx` — 34 tests passed
- `vp run --filter @t3tools/web typecheck` — passed
- `vp run -r typecheck` — no errors
- `vp lint` — no new warnings from these files
- `vp fmt --check` — passed
- Rendered the production toast helper in a local web client: verified the accessible `Read more` action, that a nightly version opens `https://github.com/pingdotgg/t3code/releases/tag/v0.0.30-nightly.20260728.931`, and that a failing external-link call surfaces the error toast

Closes #4722.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add release notes link to the desktop update downloaded toast
> - Adds a `ReleaseNotesLink` button to the success toast shown when a desktop update finishes downloading, linking to the GitHub release page for the downloaded version.
> - Introduces `getDesktopUpdateReleaseUrl` and `getDesktopUpdateDownloadedVersion` helpers in [desktopUpdate.logic.ts](https://github.com/pingdotgg/t3code/pull/4771/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af) to compute the correct release URL, falling back to `availableVersion` when `downloadedVersion` is not yet populated.
> - Both [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/4771/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/4771/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf) are updated to call the new `showDesktopUpdateDownloadedToast` instead of the previous inline toast.
> - If `shell.openExternal` fails or returns false, an error toast is shown to the user.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43a67c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only UI around update notifications and external links; no auth, data, or core business logic changes.
> 
> **Overview**
> The **Update downloaded** success toast now includes an inline **Read more** control that opens the GitHub release for the build that just finished downloading (stable or nightly tags).
> 
> Shared helpers build the release URL from updater state (`downloadedVersion`, with fallback to `availableVersion` when the download RPC returns before the main-process event), and a new `showDesktopUpdateDownloadedToast` replaces duplicated inline toasts in the legacy sidebar handler and `SidebarUpdatePill`. The link uses `openExternal` via a button; failed opens show an error toast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43a67c0bd1faf30cb3cb86d89dd8d37c74465517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->