### PR TITLE
fix(web): drop code fences when a selection only cuts into a code block

### DIFF
--- a/apps/web/src/markdown-clipboard.ts
+++ b/apps/web/src/markdown-clipboard.ts
@@ -19,6 +19,9 @@ const SANITIZED_HTML_SELECTOR = [
 ].join(", ");
 
 const PARTIAL_CODE_BLOCK_ATTRIBUTE = "data-markdown-partial-code";
+/** Fences already survive tidying; partially selected code needs its own guard. */
+const VERBATIM_MARKER = "\uE000";
+const VERBATIM_SPLIT_PATTERN = /(```[\s\S]*?(?:```|$)|\uE000[\s\S]*?(?:\uE000|$))/;
 
 export interface MarkdownClipboardPayload {
   text: string;
@@ -68,8 +71,11 @@ function resolveCodeBlockLanguage(pre: Element): string | null {
 function serializeCodeBlock(pre: Element): string {
   const code = (pre.textContent ?? "").replace(/\n$/, "");
   // A block the selection only cut into is not a code block the user copied;
-  // fencing it would paste delimiters they never highlighted.
-  if (pre.hasAttribute(PARTIAL_CODE_BLOCK_ATTRIBUTE)) return `${code}\n\n`;
+  // fencing it would paste delimiters they never highlighted. It still has to be
+  // guarded from `tidyMarkdown`, which would otherwise reindent and reflow it.
+  if (pre.hasAttribute(PARTIAL_CODE_BLOCK_ATTRIBUTE)) {
+    return `${VERBATIM_MARKER}${code}${VERBATIM_MARKER}\n\n`;
+  }
   const fence = codeFenceFor(code);
   return `${fence}${resolveCodeBlockLanguage(pre) ?? ""}\n${code}\n${fence}\n\n`;
 }
@@ -243,15 +249,20 @@ function serializeNode(node: Node): string {
   }
 }
 
-/** Collapses serializer spacing artifacts without touching fenced code content. */
+/** Collapses serializer spacing artifacts without touching verbatim code content. */
 function tidyMarkdown(markdown: string): string {
-  return markdown
-    .split(/(```[\s\S]*?(?:```|$))/)
-    .map((part, index) =>
-      index % 2 === 1 ? part : part.replace(/[ \t]+(?=\n)/g, "").replace(/\n{3,}/g, "\n\n"),
-    )
-    .join("")
-    .trim();
+  return (
+    markdown
+      .split(VERBATIM_SPLIT_PATTERN)
+      .map((part, index) =>
+        index % 2 === 1 ? part : part.replace(/[ \t]+(?=\n)/g, "").replace(/\n{3,}/g, "\n\n"),
+      )
+      .join("")
+      // Trimming before the markers are dropped keeps a leading indent that the
+      // user actually selected, while still trimming the payload's own padding.
+      .trim()
+      .replaceAll(VERBATIM_MARKER, "")
+  );
 }
 
 export function serializeRenderedMarkdownFragment(container: Node): string {
@@ -326,7 +337,12 @@ export function chatMarkdownClipboardPayload(
     const container = document.createElement("div");
     container.appendChild(range.cloneContents());
     markPartialCodeBlocks(range, container);
-    const text = serializeRenderedMarkdownFragment(container);
+    // A selection that stays inside one code block has no `<pre>` to mark, because
+    // `cloneContents` stops at the common ancestor. Its text is code and nothing
+    // else, so take it verbatim rather than running it through the serializer.
+    const text = isInsideCodeBlock(range.commonAncestorContainer)
+      ? range.toString()
+      : serializeRenderedMarkdownFragment(container);
     if (!text) continue;
     texts.push(text);
     htmls.push(sanitizedHtmlFrom(container));

--- a/apps/web/src/markdown-clipboard.ts
+++ b/apps/web/src/markdown-clipboard.ts
@@ -18,6 +18,8 @@ const SANITIZED_HTML_SELECTOR = [
   ...SKIPPED_CLASS_NAMES.map((className) => `.${className}`),
 ].join(", ");
 
+const PARTIAL_CODE_BLOCK_ATTRIBUTE = "data-markdown-partial-code";
+
 export interface MarkdownClipboardPayload {
   text: string;
   html: string;
@@ -65,6 +67,9 @@ function resolveCodeBlockLanguage(pre: Element): string | null {
 
 function serializeCodeBlock(pre: Element): string {
   const code = (pre.textContent ?? "").replace(/\n$/, "");
+  // A block the selection only cut into is not a code block the user copied;
+  // fencing it would paste delimiters they never highlighted.
+  if (pre.hasAttribute(PARTIAL_CODE_BLOCK_ATTRIBUTE)) return `${code}\n\n`;
   const fence = codeFenceFor(code);
   return `${fence}${resolveCodeBlockLanguage(pre) ?? ""}\n${code}\n${fence}\n\n`;
 }
@@ -291,6 +296,25 @@ function sanitizedHtmlFrom(container: Element): string {
   return `<meta charset="utf-8">${container.innerHTML}`;
 }
 
+function isInsideCodeBlock(node: Node): boolean {
+  const element = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+  return element?.closest("pre") != null;
+}
+
+/**
+ * `cloneContents` clones whole nodes except at the range's own boundaries, so a
+ * code block the selection cuts through is the fragment's first or last `<pre>`.
+ */
+function markPartialCodeBlocks(range: Range, container: Element): void {
+  const blocks = container.querySelectorAll("pre");
+  if (isInsideCodeBlock(range.startContainer)) {
+    blocks[0]?.setAttribute(PARTIAL_CODE_BLOCK_ATTRIBUTE, "");
+  }
+  if (isInsideCodeBlock(range.endContainer)) {
+    blocks[blocks.length - 1]?.setAttribute(PARTIAL_CODE_BLOCK_ATTRIBUTE, "");
+  }
+}
+
 export function chatMarkdownClipboardPayload(
   selection: Selection,
 ): MarkdownClipboardPayload | null {
@@ -301,6 +325,7 @@ export function chatMarkdownClipboardPayload(
     if (range.collapsed) continue;
     const container = document.createElement("div");
     container.appendChild(range.cloneContents());
+    markPartialCodeBlocks(range, container);
     const text = serializeRenderedMarkdownFragment(container);
     if (!text) continue;
     texts.push(text);


### PR DESCRIPTION
## What Changed

`markdown-clipboard.ts` fences every `<pre>` it serializes. `Range.cloneContents()` keeps a partially selected `<pre>` in the cloned fragment, so a selection that merely crosses a code block boundary pasted a ` ```lang ` fence around code the user never highlighted.

Blocks the range only cuts into are now marked and serialized as raw text. Blocks that sit entirely inside the selection are unchanged and keep their fence and language.

## Why

Reported in #4741: dragging a selection across a fenced block and pasting into a terminal yields an unrunnable command with fence delimiters attached.

## Notes For Review

The marker exploits a `cloneContents` guarantee: only the range's own boundary ancestors are cloned partially, so a cut block is always the fragment's first or last `<pre>`. That avoids walking or diffing the fragment against the live DOM — two `closest()` calls and one `querySelectorAll` per range, on the copy event only.

The reproduction was narrower than the issue title suggests. Selecting one line, several lines, or the whole `<code>` element already copied clean text; only selections whose **start or end** lands inside a code block were affected.

## Validation

Verified end to end through the real `onCopy` handler in a running client: a seeded thread rendering the issue's exact markdown, real `Range` objects over the rendered code block, and `document.execCommand("copy")` so the React handler runs and the clipboard payload is read back from the `copy` event.

| Selection | Before | After |
| --- | --- | --- |
| Only the command line | clean | clean |
| Both code lines | clean | clean |
| Whole code block element | fenced, `bash` | fenced, `bash` |
| Paragraph → through whole block → paragraph | fenced, `bash` | fenced, `bash` |
| **Code mid-block → into next paragraph** | **fenced** | raw code + paragraph text |
| **Paragraph → into mid-block** | **fenced** | paragraph text + raw code |

Note that `apps/web` tests run in a node environment, so this module has no DOM unit tests today; adding one would mean introducing a DOM test environment, which felt out of scope for this fix.

Also run:

- `vp run --filter @t3tools/web typecheck` — passed
- `vp run --filter @t3tools/web test` — 1634 passed; the one failure (`stashImageCompression.test.ts`, a 15s timeout) is unrelated to this change and passes in isolation
- `vp lint` / `vp fmt --check` on the changed file — clean

Closes #4741.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI change, so no screenshots (clipboard output only; before/after table above)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to clipboard serialization in chat markdown copy; no auth, data, or API changes.
> 
> **Overview**
> **Fixes chat markdown copy** so selections that only *cut into* a code block no longer paste with ` ``` ` fences around text the user never highlighted (#4741).
> 
> `chatMarkdownClipboardPayload` now marks boundary `<pre>` elements on the cloned fragment (`markPartialCodeBlocks`) and serializes those as **verbatim** text via a private marker, while fully selected blocks still get normal fenced markdown. Selections confined to a single code block bypass the serializer and use `range.toString()` directly. `tidyMarkdown` splits on both fenced blocks and verbatim regions so whitespace cleanup does not reflow partial code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc88de9d431031fad24e5d557878bd63c344361e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clipboard to drop code fences when selection partially cuts into a code block
> - When copying a selection that starts or ends inside a `<pre>` block, the boundary code block is now serialized as verbatim text (no fences) rather than a full fenced code block.
> - When the entire selection is within a single code block, the raw selected text is used directly, bypassing the markdown serializer entirely.
> - Implements this via `markPartialCodeBlocks` in [markdown-clipboard.ts](https://github.com/pingdotgg/t3code/pull/4774/files#diff-4584df63e01a8b69a0505a0836c9272794c0385577c79484ce7e43b50c06adaa), which annotates boundary `<pre>` elements on the cloned fragment before serialization, and a `VERBATIM_MARKER` guard that prevents whitespace normalization of these regions.
> - Behavioral Change: whitespace collapsing in `tidyMarkdown` now skips verbatim-guarded regions in addition to fenced code blocks.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fc88de9. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
