### PR TITLE
fix(desktop): reduce update restart time

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -204,7 +204,7 @@ const bootstrap = Effect.gen(function* () {
     // app feels responsive instead of presenting no window until WSL is ready.
     // (Dual mode opens fast off the Windows primary, so no splash there.)
     if (settings.wslOnly === true && settings.wslBackendEnabled === true) {
-      yield* desktopWindow.showConnectingSplash;
+      yield* desktopWindow.showConnectingSplash("wsl");
     }
     yield* primaryBackend.start;
     yield* logBootstrapInfo("bootstrap backend start requested");
@@ -256,7 +256,7 @@ const startup = Effect.gen(function* () {
     ),
   );
   if (isUpdateRelaunch) {
-    yield* desktopWindow.showConnectingSplash;
+    yield* desktopWindow.showConnectingSplash("update-relaunch");
   }
   yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));
 }).pipe(Effect.withSpan("desktop.startup"));

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -24,6 +24,7 @@ import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopShellEnvironment from "../shell/DesktopShellEnvironment.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
+import * as DesktopUpdateRelaunch from "../updates/DesktopUpdateRelaunch.ts";
 import * as DesktopWslBackend from "../wsl/DesktopWslBackend.ts";
 
 const DEFAULT_DESKTOP_BACKEND_PORT = 3773;
@@ -224,6 +225,7 @@ const startup = Effect.gen(function* () {
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
   const updates = yield* DesktopUpdates.DesktopUpdates;
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
   yield* shellEnvironment.installIntoProcess;
@@ -248,6 +250,14 @@ const startup = Effect.gen(function* () {
   yield* appIdentity.configure;
   yield* applicationMenu.configure;
   yield* updates.configure;
+  const isUpdateRelaunch = yield* DesktopUpdateRelaunch.consume.pipe(
+    Effect.catch(() =>
+      logStartupError("could not consume the update relaunch marker").pipe(Effect.as(false)),
+    ),
+  );
+  if (isUpdateRelaunch) {
+    yield* desktopWindow.showConnectingSplash;
+  }
   yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));
 }).pipe(Effect.withSpan("desktop.startup"));
 

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -73,7 +73,7 @@ describe("DesktopLifecycle", () => {
         revealOrCreateMain: Effect.die("unexpected window creation"),
         activate: Effect.void,
         createMainIfBackendReady: Effect.void,
-        showConnectingSplash: Effect.void,
+        showConnectingSplash: () => Effect.void,
         handleBackendReady: () => Effect.void,
         handleBackendNotReady: Effect.void,
         flushMainWindowBounds: Effect.void,

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -86,7 +86,7 @@ function makePoolLayer(
           revealOrCreateMain: Effect.die("unexpected window reveal"),
           activate: Effect.die("unexpected window activate"),
           createMainIfBackendReady: Effect.die("unexpected window create"),
-          showConnectingSplash: Effect.void,
+          showConnectingSplash: () => Effect.void,
           handleBackendReady: () => Effect.void,
           handleBackendNotReady: Effect.void,
           flushMainWindowBounds: Effect.void,

--- a/apps/desktop/src/electron/ElectronUpdater.test.ts
+++ b/apps/desktop/src/electron/ElectronUpdater.test.ts
@@ -2,7 +2,7 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { beforeEach, vi } from "vite-plus/test";
 
-const { autoUpdaterMock } = vi.hoisted(() => ({
+const { autoUpdaterMock, nativeAutoUpdaterMock } = vi.hoisted(() => ({
   autoUpdaterMock: {
     allowDowngrade: false,
     allowPrerelease: false,
@@ -18,6 +18,14 @@ const { autoUpdaterMock } = vi.hoisted(() => ({
     removeListener: vi.fn(),
     setFeedURL: vi.fn(),
   },
+  nativeAutoUpdaterMock: {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+vi.mock("electron", () => ({
+  autoUpdater: nativeAutoUpdaterMock,
 }));
 
 vi.mock("electron-updater", () => ({
@@ -43,6 +51,8 @@ describe("ElectronUpdater", () => {
     autoUpdaterMock.quitAndInstall.mockClear();
     autoUpdaterMock.removeListener.mockClear();
     autoUpdaterMock.setFeedURL.mockClear();
+    nativeAutoUpdaterMock.on.mockClear();
+    nativeAutoUpdaterMock.removeListener.mockClear();
   });
 
   it.effect("scopes updater event listeners", () =>
@@ -58,6 +68,24 @@ describe("ElectronUpdater", () => {
 
       assert.deepEqual(autoUpdaterMock.on.mock.calls, [["update-available", listener]]);
       assert.deepEqual(autoUpdaterMock.removeListener.mock.calls, [["update-available", listener]]);
+    }).pipe(Effect.provide(ElectronUpdater.layer)),
+  );
+
+  it.effect("scopes native macOS readiness listeners", () =>
+    Effect.gen(function* () {
+      const listener = vi.fn();
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const updater = yield* ElectronUpdater.ElectronUpdater;
+          yield* updater.onNativeUpdateDownloaded(listener);
+        }),
+      );
+
+      assert.deepEqual(nativeAutoUpdaterMock.on.mock.calls, [["update-downloaded", listener]]);
+      assert.deepEqual(nativeAutoUpdaterMock.removeListener.mock.calls, [
+        ["update-downloaded", listener],
+      ]);
     }).pipe(Effect.provide(ElectronUpdater.layer)),
   );
 

--- a/apps/desktop/src/electron/ElectronUpdater.ts
+++ b/apps/desktop/src/electron/ElectronUpdater.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 
+import { autoUpdater as nativeAutoUpdater } from "electron";
 import { autoUpdater } from "electron-updater";
 
 type AutoUpdater = typeof autoUpdater;
@@ -77,6 +78,9 @@ export class ElectronUpdater extends Context.Service<
     readonly on: <Args extends ReadonlyArray<unknown>>(
       eventName: string,
       listener: (...args: Args) => void,
+    ) => Effect.Effect<void, never, Scope.Scope>;
+    readonly onNativeUpdateDownloaded: (
+      listener: () => void,
     ) => Effect.Effect<void, never, Scope.Scope>;
   }
 >()("@t3tools/desktop/electron/ElectronUpdater") {}
@@ -167,6 +171,16 @@ export const make = ElectronUpdater.of({
         }),
     ).pipe(Effect.asVoid);
   },
+  onNativeUpdateDownloaded: (listener) =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        nativeAutoUpdater.on("update-downloaded", listener);
+      }),
+      () =>
+        Effect.sync(() => {
+          nativeAutoUpdater.removeListener("update-downloaded", listener);
+        }),
+    ).pipe(Effect.asVoid),
 });
 
 export const layer = Layer.succeed(ElectronUpdater, make);

--- a/apps/desktop/src/updates/DesktopUpdateRelaunch.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdateRelaunch.test.ts
@@ -1,0 +1,58 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+
+import * as DesktopConfig from "../app/DesktopConfig.ts";
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopUpdateRelaunch from "./DesktopUpdateRelaunch.ts";
+
+const withRelaunchMarker = <A, E>(
+  effect: Effect.Effect<A, E, DesktopEnvironment.DesktopEnvironment | FileSystem.FileSystem>,
+) =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+      prefix: "t3-desktop-update-relaunch-test-",
+    });
+    const environmentLayer = DesktopEnvironment.layer({
+      dirname: "/repo/apps/desktop/src",
+      homeDirectory: baseDir,
+      platform: "linux",
+      processArch: "x64",
+      appVersion: "1.2.3",
+      appPath: "/repo",
+      isPackaged: true,
+      resourcesPath: "/repo/resources",
+      runningUnderArm64Translation: false,
+    }).pipe(
+      Layer.provide(
+        Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({ T3CODE_HOME: baseDir })),
+      ),
+    );
+    return yield* effect.pipe(Effect.provide(Layer.merge(NodeServices.layer, environmentLayer)));
+  }).pipe(Effect.provide(NodeServices.layer), Effect.scoped);
+
+describe("DesktopUpdateRelaunch", () => {
+  it.effect("persists a marker that can be consumed exactly once", () =>
+    withRelaunchMarker(
+      Effect.gen(function* () {
+        assert.isFalse(yield* DesktopUpdateRelaunch.consume);
+        yield* DesktopUpdateRelaunch.mark;
+        assert.isTrue(yield* DesktopUpdateRelaunch.consume);
+        assert.isFalse(yield* DesktopUpdateRelaunch.consume);
+      }),
+    ),
+  );
+
+  it.effect("clears a marker after an aborted install", () =>
+    withRelaunchMarker(
+      Effect.gen(function* () {
+        yield* DesktopUpdateRelaunch.mark;
+        yield* DesktopUpdateRelaunch.clear;
+        assert.isFalse(yield* DesktopUpdateRelaunch.consume);
+      }),
+    ),
+  );
+});

--- a/apps/desktop/src/updates/DesktopUpdateRelaunch.ts
+++ b/apps/desktop/src/updates/DesktopUpdateRelaunch.ts
@@ -1,0 +1,39 @@
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+
+const UPDATE_RELAUNCH_MARKER_FILE_NAME = "desktop-update-relaunch";
+
+const markerPath = Effect.gen(function* () {
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  return environment.path.join(environment.stateDir, UPDATE_RELAUNCH_MARKER_FILE_NAME);
+});
+
+export const mark = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  yield* fileSystem.makeDirectory(environment.stateDir, { recursive: true });
+  yield* fileSystem.writeFileString(
+    environment.path.join(environment.stateDir, UPDATE_RELAUNCH_MARKER_FILE_NAME),
+    "pending\n",
+  );
+}).pipe(Effect.withSpan("desktop.updateRelaunch.mark"));
+
+export const clear = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* markerPath;
+  if (yield* fileSystem.exists(path)) {
+    yield* fileSystem.remove(path);
+  }
+}).pipe(Effect.withSpan("desktop.updateRelaunch.clear"));
+
+export const consume = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* markerPath;
+  if (!(yield* fileSystem.exists(path))) {
+    return false;
+  }
+  yield* fileSystem.remove(path);
+  return true;
+}).pipe(Effect.withSpan("desktop.updateRelaunch.consume"));

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -392,6 +392,43 @@ describe("DesktopUpdates", () => {
     ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
   });
 
+  it.effect("restores download progress after a stray no-update event", () => {
+    const harness = makeHarness({ platform: "darwin" });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-available", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const downloadFiber = yield* updates.download.pipe(Effect.forkScoped);
+        yield* flushCallbacks;
+        harness.emit("update-not-available");
+        yield* flushCallbacks;
+
+        const noUpdateState = yield* updates.getState;
+        assert.equal(noUpdateState.status, "up-to-date");
+        assert.isNull(noUpdateState.downloadPercent);
+
+        harness.emit("download-progress", { percent: 42 });
+        yield* flushCallbacks;
+
+        const downloadingState = yield* updates.getState;
+        assert.equal(downloadingState.status, "downloading");
+        assert.equal(downloadingState.downloadPercent, 42);
+        assert.isNull(downloadingState.message);
+
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+        harness.emit("native-update-downloaded");
+        const result = yield* Fiber.join(downloadFiber);
+        assert.isTrue(result.accepted);
+        assert.isTrue(result.completed);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
   it.effect(
     "fails macOS native preparation instead of hanging when no version is available",
     () => {

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -20,9 +20,11 @@ import * as ElectronUpdater from "../electron/ElectronUpdater.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopState from "../app/DesktopState.ts";
+import * as DesktopUpdateRelaunch from "./DesktopUpdateRelaunch.ts";
 import * as DesktopUpdates from "./DesktopUpdates.ts";
 
 interface UpdatesHarnessOptions {
+  readonly platform?: NodeJS.Platform;
   readonly checkForUpdates?: Effect.Effect<
     void,
     ElectronUpdater.ElectronUpdaterCheckForUpdatesError
@@ -36,9 +38,14 @@ interface UpdatesHarnessOptions {
 const flushCallbacks = Effect.yieldNow;
 
 function makeHarness(options: UpdatesHarnessOptions = {}) {
+  const platform = options.platform ?? "win32";
+  const platformEnv = platform === "linux" ? { APPIMAGE: "/tmp/T3-Code.AppImage" } : {};
   let checkCount = 0;
+  let destroyAllCount = 0;
+  let quitAndInstallCount = 0;
   let allowDowngrade = false;
   let fullChangelog = false;
+  const autoInstallOnAppQuitValues: boolean[] = [];
   const feedUrls: ElectronUpdater.ElectronUpdaterFeedUrl[] = [];
   const listeners = new Map<string, Set<(...args: readonly unknown[]) => void>>();
   const sentStates: DesktopUpdateState[] = [];
@@ -66,7 +73,10 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
         feedUrls.push(options);
       }),
     setAutoDownload: () => Effect.void,
-    setAutoInstallOnAppQuit: () => Effect.void,
+    setAutoInstallOnAppQuit: (value) =>
+      Effect.sync(() => {
+        autoInstallOnAppQuitValues.push(value);
+      }),
     setChannel: () => Effect.void,
     setAllowPrerelease: () => Effect.void,
     allowDowngrade: Effect.sync(() => allowDowngrade),
@@ -83,7 +93,10 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
       checkCount += 1;
     }).pipe(Effect.andThen(options.checkForUpdates ?? Effect.void)),
     downloadUpdate: Effect.void,
-    quitAndInstall: () => Effect.void,
+    quitAndInstall: () =>
+      Effect.sync(() => {
+        quitAndInstallCount += 1;
+      }),
     on: (eventName, listener) =>
       Effect.acquireRelease(
         Effect.sync(() => {
@@ -92,6 +105,16 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
         () =>
           Effect.sync(() => {
             removeListener(eventName, listener as unknown as (...args: readonly unknown[]) => void);
+          }),
+      ).pipe(Effect.asVoid),
+    onNativeUpdateDownloaded: (listener) =>
+      Effect.acquireRelease(
+        Effect.sync(() => {
+          addListener("native-update-downloaded", listener);
+        }),
+        () =>
+          Effect.sync(() => {
+            removeListener("native-update-downloaded", listener);
           }),
       ).pipe(Effect.asVoid),
   } satisfies ElectronUpdater.ElectronUpdater["Service"]);
@@ -108,7 +131,9 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
       Effect.sync(() => {
         sentStates.push(state as DesktopUpdateState);
       }),
-    destroyAll: Effect.void,
+    destroyAll: Effect.sync(() => {
+      destroyAllCount += 1;
+    }),
     syncAllAppearance: () => Effect.void,
   } satisfies ElectronWindow.ElectronWindow["Service"]);
 
@@ -132,7 +157,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
   const environmentLayer = DesktopEnvironment.layer({
     dirname: "/repo/apps/desktop/src",
     homeDirectory: `/tmp/t3-desktop-updates-home-${process.pid}`,
-    platform: "darwin",
+    platform,
     processArch: "x64",
     appVersion: "1.2.3",
     appPath: "/repo",
@@ -147,6 +172,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
           T3CODE_HOME: `/tmp/t3-desktop-updates-test-${process.pid}`,
           T3CODE_DESKTOP_MOCK_UPDATES: "true",
           T3CODE_DESKTOP_MOCK_UPDATE_SERVER_PORT: "4141",
+          ...platformEnv,
           ...options.env,
         }),
       ),
@@ -181,6 +207,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
         T3CODE_HOME: `/tmp/t3-desktop-updates-test-${process.pid}`,
         T3CODE_DESKTOP_MOCK_UPDATES: "true",
         T3CODE_DESKTOP_MOCK_UPDATE_SERVER_PORT: "4141",
+        ...platformEnv,
         ...options.env,
       }),
     ),
@@ -190,7 +217,9 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
 
   return {
     layer,
+    autoInstallOnAppQuitValues: () => autoInstallOnAppQuitValues,
     checkCount: () => checkCount,
+    destroyAllCount: () => destroyAllCount,
     feedUrls: () => feedUrls,
     fullChangelog: () => fullChangelog,
     listenerCount: () =>
@@ -198,6 +227,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
         (total, eventListeners) => total + eventListeners.size,
         0,
       ),
+    quitAndInstallCount: () => quitAndInstallCount,
     sentStates,
     emit: (eventName: string, payload?: unknown) => {
       for (const listener of listeners.get(eventName) ?? []) {
@@ -273,6 +303,90 @@ describe("DesktopUpdates", () => {
       assert.equal(harness.listenerCount(), 0);
     }).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
   });
+
+  it.effect("enables native pre-staging only on macOS", () =>
+    Effect.gen(function* () {
+      for (const [platform, expected] of [
+        ["darwin", true],
+        ["win32", false],
+        ["linux", false],
+      ] as const) {
+        const harness = makeHarness({ platform });
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const updates = yield* DesktopUpdates.DesktopUpdates;
+            yield* updates.configure;
+            assert.deepEqual(harness.autoInstallOnAppQuitValues(), [expected]);
+            assert.equal(harness.listenerCount(), platform === "darwin" ? 7 : 6);
+          }),
+        ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+      }
+    }),
+  );
+
+  it.effect("withholds the macOS restart action until native staging is complete", () => {
+    const harness = makeHarness({ platform: "darwin" });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-available", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const downloadFiber = yield* updates.download.pipe(Effect.forkScoped);
+        yield* flushCallbacks;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const preparingState = yield* updates.getState;
+        assert.equal(preparingState.status, "downloading");
+        assert.equal(preparingState.downloadPercent, 100);
+        assert.equal(preparingState.message, "Preparing update…");
+        assert.isUndefined(downloadFiber.pollUnsafe());
+
+        harness.emit("native-update-downloaded");
+        const result = yield* Fiber.join(downloadFiber);
+        assert.isTrue(result.accepted);
+        assert.isTrue(result.completed);
+
+        const readyState = yield* updates.getState;
+        assert.equal(readyState.status, "downloaded");
+        assert.equal(readyState.downloadedVersion, "1.2.4");
+        assert.isNull(readyState.message);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("only force-destroys windows for the Windows installer", () =>
+    Effect.gen(function* () {
+      for (const platform of ["darwin", "win32", "linux"] as const) {
+        const harness = makeHarness({ platform });
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const updates = yield* DesktopUpdates.DesktopUpdates;
+            yield* updates.configure;
+            harness.emit("update-downloaded", { version: "1.2.4" });
+            if (platform === "darwin") {
+              yield* flushCallbacks;
+              harness.emit("native-update-downloaded");
+            }
+            yield* flushCallbacks;
+
+            const result = yield* updates.install;
+            assert.isTrue(result.accepted);
+            assert.equal(
+              result.state.message,
+              "Preparing update… T3 Code will restart automatically.",
+            );
+            assert.equal(harness.quitAndInstallCount(), 1);
+            assert.equal(harness.destroyAllCount(), platform === "win32" ? 1 : 0);
+            yield* DesktopUpdateRelaunch.clear;
+          }),
+        ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+      }
+    }),
+  );
 
   it.effect("updates and broadcasts state from updater events", () => {
     const harness = makeHarness();

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -29,6 +29,7 @@ interface UpdatesHarnessOptions {
     void,
     ElectronUpdater.ElectronUpdaterCheckForUpdatesError
   >;
+  readonly downloadUpdate?: Effect.Effect<void, ElectronUpdater.ElectronUpdaterDownloadUpdateError>;
   readonly setUpdateChannelError?: DesktopAppSettings.DesktopSettingsWriteError;
   readonly setDisableDifferentialDownload?: Effect.Effect<void>;
   readonly stopBackend?: Effect.Effect<void>;
@@ -93,7 +94,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
     checkForUpdates: Effect.sync(() => {
       checkCount += 1;
     }).pipe(Effect.andThen(options.checkForUpdates ?? Effect.void)),
-    downloadUpdate: Effect.void,
+    downloadUpdate: options.downloadUpdate ?? Effect.void,
     quitAndInstall: () =>
       Effect.sync(() => {
         quitAndInstallCount += 1;
@@ -489,6 +490,38 @@ describe("DesktopUpdates", () => {
     },
   );
 
+  it.effect("ignores native readiness after a macOS download failure", () => {
+    const downloadError = new ElectronUpdater.ElectronUpdaterDownloadUpdateError({
+      channel: null,
+      cause: new Error("simulated download failure"),
+    });
+    const harness = makeHarness({
+      platform: "darwin",
+      downloadUpdate: Effect.fail(downloadError),
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-available", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const result = yield* updates.download;
+        assert.isTrue(result.accepted);
+        assert.isFalse(result.completed);
+        const failedState = yield* updates.getState;
+        assert.equal(failedState.errorContext, "download");
+        assert.isTrue(failedState.canRetry);
+
+        harness.emit("native-update-downloaded");
+        yield* flushCallbacks;
+
+        assert.deepEqual(yield* updates.getState, failedState);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
   it.effect("only force-destroys windows for the Windows installer", () =>
     Effect.gen(function* () {
       for (const platform of ["darwin", "win32", "linux"] as const) {
@@ -497,10 +530,21 @@ describe("DesktopUpdates", () => {
           Effect.gen(function* () {
             const updates = yield* DesktopUpdates.DesktopUpdates;
             yield* updates.configure;
-            harness.emit("update-downloaded", { version: "1.2.4" });
+            harness.emit("update-available", { version: "1.2.4" });
+            yield* flushCallbacks;
+
             if (platform === "darwin") {
+              const downloadFiber = yield* updates.download.pipe(Effect.forkScoped);
+              yield* flushCallbacks;
+              harness.emit("update-downloaded", { version: "1.2.4" });
               yield* flushCallbacks;
               harness.emit("native-update-downloaded");
+              const downloadResult = yield* Fiber.join(downloadFiber);
+              assert.isTrue(downloadResult.completed);
+            } else {
+              const downloadResult = yield* updates.download;
+              assert.isTrue(downloadResult.completed);
+              harness.emit("update-downloaded", { version: "1.2.4" });
             }
             yield* flushCallbacks;
 

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -49,6 +49,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
   const feedUrls: ElectronUpdater.ElectronUpdaterFeedUrl[] = [];
   const listeners = new Map<string, Set<(...args: readonly unknown[]) => void>>();
   const sentStates: DesktopUpdateState[] = [];
+  const stateWaiters = new Set<(state: DesktopUpdateState) => void>();
 
   const addListener = (eventName: string, listener: (...args: readonly unknown[]) => void) => {
     const eventListeners = listeners.get(eventName) ?? new Set();
@@ -129,7 +130,11 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
     reveal: () => Effect.void,
     sendAll: (_channel, state) =>
       Effect.sync(() => {
-        sentStates.push(state as DesktopUpdateState);
+        const updateState = state as DesktopUpdateState;
+        sentStates.push(updateState);
+        for (const waiter of stateWaiters) {
+          waiter(updateState);
+        }
       }),
     destroyAll: Effect.sync(() => {
       destroyAllCount += 1;
@@ -218,6 +223,22 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
   return {
     layer,
     autoInstallOnAppQuitValues: () => autoInstallOnAppQuitValues,
+    awaitState: (predicate: (state: DesktopUpdateState) => boolean) =>
+      Effect.promise(() => {
+        if (sentStates.some(predicate)) {
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          const waiter = (state: DesktopUpdateState) => {
+            if (!predicate(state)) {
+              return;
+            }
+            stateWaiters.delete(waiter);
+            resolve();
+          };
+          stateWaiters.add(waiter);
+        });
+      }),
     checkCount: () => checkCount,
     destroyAllCount: () => destroyAllCount,
     feedUrls: () => feedUrls,
@@ -345,6 +366,12 @@ describe("DesktopUpdates", () => {
         assert.equal(preparingState.message, "Preparing update…");
         assert.isUndefined(downloadFiber.pollUnsafe());
 
+        harness.emit("download-progress", { percent: 100 });
+        yield* flushCallbacks;
+        const stateAfterLateProgress = yield* updates.getState;
+        assert.equal(stateAfterLateProgress.status, "downloading");
+        assert.equal(stateAfterLateProgress.message, "Preparing update…");
+
         harness.emit("native-update-downloaded");
         const result = yield* Fiber.join(downloadFiber);
         assert.isTrue(result.accepted);
@@ -354,9 +381,48 @@ describe("DesktopUpdates", () => {
         assert.equal(readyState.status, "downloaded");
         assert.equal(readyState.downloadedVersion, "1.2.4");
         assert.isNull(readyState.message);
+
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+        const stateAfterDuplicateCompletion = yield* updates.getState;
+        assert.equal(stateAfterDuplicateCompletion.status, "downloaded");
+        assert.equal(stateAfterDuplicateCompletion.downloadedVersion, "1.2.4");
+        assert.isNull(stateAfterDuplicateCompletion.message);
       }),
     ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
   });
+
+  it.effect(
+    "fails macOS native preparation instead of hanging when no version is available",
+    () => {
+      const harness = makeHarness({ platform: "darwin" });
+
+      return Effect.scoped(
+        Effect.gen(function* () {
+          const updates = yield* DesktopUpdates.DesktopUpdates;
+          yield* updates.configure;
+          harness.emit("update-available", { version: "1.2.4" });
+          yield* flushCallbacks;
+
+          const downloadFiber = yield* updates.download.pipe(Effect.forkScoped);
+          yield* flushCallbacks;
+          harness.emit("update-not-available");
+          yield* flushCallbacks;
+          harness.emit("native-update-downloaded");
+
+          const result = yield* Fiber.join(downloadFiber);
+          assert.isTrue(result.accepted);
+          assert.isFalse(result.completed);
+          assert.equal(result.state.status, "error");
+          assert.equal(result.state.errorContext, "download");
+          assert.equal(
+            result.state.message,
+            "Desktop updater download operation reported an error.",
+          );
+        }),
+      ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+    },
+  );
 
   it.effect("only force-destroys windows for the Windows installer", () =>
     Effect.gen(function* () {
@@ -619,6 +685,35 @@ describe("DesktopUpdates", () => {
 
         const changedState = yield* updates.setChannel("nightly");
         assert.equal(changedState.channel, "nightly");
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("clears the relaunch marker after an updater-reported install failure", () => {
+    const harness = makeHarness();
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const desktopState = yield* DesktopState.DesktopState;
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const installResult = yield* updates.install;
+        assert.isTrue(installResult.accepted);
+        assert.isTrue(yield* DesktopUpdateRelaunch.consume);
+        yield* DesktopUpdateRelaunch.mark;
+
+        harness.emit("error", new Error("native installer failed"));
+        yield* harness.awaitState((state) => state.errorContext === "install");
+
+        const failedState = yield* updates.getState;
+        assert.equal(failedState.status, "downloaded");
+        assert.equal(failedState.errorContext, "install");
+        assert.equal(failedState.message, "Desktop updater install operation reported an error.");
+        assert.isFalse(yield* Ref.get(desktopState.quitting));
+        assert.isFalse(yield* DesktopUpdateRelaunch.consume);
       }),
     ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
   });

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -277,6 +277,9 @@ describe("DesktopUpdates", () => {
       operation: "download",
       cause,
     });
+    const nativePreparationError = new DesktopUpdates.DesktopUpdateNativePreparationError({
+      stage: "resolve-version",
+    });
     const unexpectedActionError = new DesktopUpdates.DesktopUpdateUnexpectedActionError({
       action: "install",
       cause,
@@ -291,6 +294,12 @@ describe("DesktopUpdates", () => {
     assert.strictEqual(reportedError.cause, cause);
     assert.equal(reportedError.operation, "download");
     assert.equal(reportedError.message, "Desktop updater download operation reported an error.");
+    assert.equal(nativePreparationError.stage, "resolve-version");
+    assert.equal(
+      nativePreparationError.message,
+      "Native macOS update preparation completed without an update version.",
+    );
+    assert.notProperty(nativePreparationError, "cause");
     assert.strictEqual(unexpectedActionError.cause, cause);
     assert.equal(unexpectedActionError.action, "install");
     assert.equal(
@@ -483,7 +492,7 @@ describe("DesktopUpdates", () => {
           assert.equal(result.state.errorContext, "download");
           assert.equal(
             result.state.message,
-            "Desktop updater download operation reported an error.",
+            "Native macOS update preparation completed without an update version.",
           );
         }),
       ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -392,6 +392,34 @@ describe("DesktopUpdates", () => {
     ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
   });
 
+  it.effect("keeps the macOS update ready when completion callbacks race", () => {
+    const harness = makeHarness({ platform: "darwin" });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-available", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const downloadFiber = yield* updates.download.pipe(Effect.forkScoped);
+        yield* flushCallbacks;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        harness.emit("native-update-downloaded");
+
+        const result = yield* Fiber.join(downloadFiber);
+        assert.isTrue(result.accepted);
+        assert.isTrue(result.completed);
+        yield* flushCallbacks;
+
+        const readyState = yield* updates.getState;
+        assert.equal(readyState.status, "downloaded");
+        assert.equal(readyState.downloadedVersion, "1.2.4");
+        assert.isNull(readyState.message);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
   it.effect("restores download progress after a stray no-update event", () => {
     const harness = makeHarness({ platform: "darwin" });
 

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -808,6 +808,16 @@ export const make = Effect.gen(function* () {
 
   const handleNativeUpdateDownloaded = Effect.fn("desktop.updates.handleNativeUpdateDownloaded")(
     function* () {
+      const downloadInFlight = yield* Ref.get(updateDownloadInFlightRef);
+      const nativePreparationDeferred = yield* Ref.get(nativePreparationDeferredRef);
+      if (!downloadInFlight || Option.isNone(nativePreparationDeferred)) {
+        yield* logUpdaterInfo("ignoring native macOS update readiness outside active download");
+        return;
+      }
+      if (yield* Deferred.isDone(nativePreparationDeferred.value)) {
+        yield* logUpdaterInfo("ignoring duplicate native macOS update readiness");
+        return;
+      }
       const state = yield* Ref.get(updateStateRef);
       const pendingVersion = yield* Ref.get(nativePreparationVersionRef);
       const version = Option.getOrUndefined(pendingVersion) ?? state.availableVersion;
@@ -816,20 +826,26 @@ export const make = Effect.gen(function* () {
           operation: "download",
           cause: new Error("Native macOS update became ready without a version."),
         });
-        const nativePreparationDeferred = yield* Ref.get(nativePreparationDeferredRef);
-        if (Option.isSome(nativePreparationDeferred)) {
-          yield* Deferred.fail(nativePreparationDeferred.value, error);
-        }
+        yield* Deferred.fail(nativePreparationDeferred.value, error);
         yield* logUpdaterWarning(
           "native macOS update became ready without an available update version",
         );
         return;
       }
-      yield* setState(reduceDesktopUpdateStateOnDownloadComplete(state, version));
-      const nativePreparationDeferred = yield* Ref.get(nativePreparationDeferredRef);
-      if (Option.isSome(nativePreparationDeferred)) {
-        yield* Deferred.succeed(nativePreparationDeferred.value, undefined);
+      const transitionedToDownloaded = yield* Ref.modify(updateStateRef, (current) => {
+        if (current.errorContext === "download") {
+          return [false, current] as const;
+        }
+        return [true, reduceDesktopUpdateStateOnDownloadComplete(current, version)] as const;
+      });
+      if (!transitionedToDownloaded) {
+        yield* logUpdaterInfo("ignoring native macOS update readiness after download failure", {
+          version,
+        });
+        return;
       }
+      yield* emitState;
+      yield* Deferred.succeed(nativePreparationDeferred.value, undefined);
       yield* logUpdaterInfo("native macOS update prepared", { version });
     },
   );

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -757,28 +757,38 @@ export const make = Effect.gen(function* () {
     yield* decodeUpdateInfo(raw).pipe(
       Effect.flatMap(
         Effect.fn("desktop.updates.applyUpdateDownloaded")(function* (info) {
-          const state = yield* Ref.get(updateStateRef);
           if (environment.platform === "darwin") {
-            if (state.status === "downloaded") {
+            yield* Ref.set(nativePreparationVersionRef, Option.some(info.version));
+            const transitionedToPreparing = yield* Ref.modify(updateStateRef, (current) => {
+              if (current.status === "downloaded") {
+                return [false, current] as const;
+              }
+              return [
+                true,
+                {
+                  ...current,
+                  status: "downloading",
+                  downloadPercent: 100,
+                  message: "Preparing update…",
+                  errorContext: null,
+                  canRetry: false,
+                },
+              ] as const;
+            });
+            if (!transitionedToPreparing) {
+              yield* Ref.set(nativePreparationVersionRef, Option.none());
               yield* logUpdaterInfo("ignoring duplicate macOS download completion event", {
                 version: info.version,
               });
               return;
             }
-            yield* Ref.set(nativePreparationVersionRef, Option.some(info.version));
-            yield* setState({
-              ...state,
-              status: "downloading",
-              downloadPercent: 100,
-              message: "Preparing update…",
-              errorContext: null,
-              canRetry: false,
-            });
+            yield* emitState;
             yield* logUpdaterInfo("download complete; preparing native macOS update", {
               version: info.version,
             });
             return;
           }
+          const state = yield* Ref.get(updateStateRef);
           yield* setState(reduceDesktopUpdateStateOnDownloadComplete(state, info.version));
           yield* logUpdaterInfo("update downloaded", { version: info.version });
         }),

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -719,7 +719,8 @@ export const make = Effect.gen(function* () {
         Effect.fn("desktop.updates.applyDownloadProgress")(function* (progress) {
           const state = yield* Ref.get(updateStateRef);
           const percent = Math.floor(progress.percent);
-          if (state.status !== "downloading") {
+          const downloadInFlight = yield* Ref.get(updateDownloadInFlightRef);
+          if (!downloadInFlight || state.status === "downloaded") {
             return;
           }
           const nativePreparationVersion = yield* Ref.get(nativePreparationVersionRef);

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -9,6 +9,7 @@ import {
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -27,6 +28,7 @@ import * as ElectronUpdater from "../electron/ElectronUpdater.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as IpcChannels from "../ipc/channels.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
+import * as DesktopUpdateRelaunch from "./DesktopUpdateRelaunch.ts";
 import { normalizeDesktopUpdateReleaseNotes } from "./releaseNotes.ts";
 import { resolveDefaultDesktopUpdateChannel } from "./updateChannels.ts";
 import {
@@ -253,6 +255,15 @@ export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const fileSystem = yield* FileSystem.FileSystem;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
+  const provideRelaunchMarkerServices = <A, E>(
+    effect: Effect.Effect<A, E, FileSystem.FileSystem | DesktopEnvironment.DesktopEnvironment>,
+  ) =>
+    effect.pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(DesktopEnvironment.DesktopEnvironment, environment),
+    );
+  const markUpdateRelaunch = provideRelaunchMarkerServices(DesktopUpdateRelaunch.mark);
+  const clearUpdateRelaunch = provideRelaunchMarkerServices(DesktopUpdateRelaunch.clear);
 
   const appUpdateYmlConfigRef = yield* Ref.make<Option.Option<AppUpdateYmlConfig>>(Option.none());
   const updateCheckInFlightRef = yield* Ref.make(false);
@@ -260,6 +271,10 @@ export const make = Effect.gen(function* () {
   const updateInstallInFlightRef = yield* Ref.make(false);
   const updaterConfiguredRef = yield* Ref.make(false);
   const lastLoggedDownloadMilestoneRef = yield* Ref.make(-1);
+  const nativePreparationDeferredRef = yield* Ref.make<
+    Option.Option<Deferred.Deferred<void, DesktopUpdaterReportedError>>
+  >(Option.none());
+  const nativePreparationVersionRef = yield* Ref.make<Option.Option<string>>(Option.none());
   const updateStateRef = yield* Ref.make<DesktopUpdateState>(
     createInitialDesktopUpdateState(
       environment.appVersion,
@@ -398,6 +413,11 @@ export const make = Effect.gen(function* () {
     }
 
     yield* Ref.set(updateDownloadInFlightRef, true);
+    const nativePreparationDeferred =
+      environment.platform === "darwin"
+        ? Option.some(yield* Deferred.make<void, DesktopUpdaterReportedError>())
+        : Option.none<Deferred.Deferred<void, DesktopUpdaterReportedError>>();
+    yield* Ref.set(nativePreparationDeferredRef, nativePreparationDeferred);
     return yield* Effect.gen(function* () {
       yield* setState(reduceDesktopUpdateStateOnDownloadStart(state));
       yield* electronUpdater.setDisableDifferentialDownload(
@@ -405,6 +425,9 @@ export const make = Effect.gen(function* () {
       );
       yield* logUpdaterInfo("downloading update");
       yield* electronUpdater.downloadUpdate;
+      if (Option.isSome(nativePreparationDeferred)) {
+        yield* Deferred.await(nativePreparationDeferred.value);
+      }
       return { accepted: true, completed: true };
     }).pipe(
       Effect.catchTags({
@@ -417,6 +440,14 @@ export const make = Effect.gen(function* () {
               errorTag: error._tag,
               channel: error.channel,
             });
+            return { accepted: true, completed: false };
+          },
+        ),
+        DesktopUpdaterReportedError: Effect.fn("desktop.updates.handleNativePreparationFailure")(
+          function* (error) {
+            yield* updateState((current) =>
+              reduceDesktopUpdateStateOnDownloadFailure(current, error.message),
+            );
             return { accepted: true, completed: false };
           },
         ),
@@ -442,12 +473,25 @@ export const make = Effect.gen(function* () {
           return { accepted: true, completed: false };
         });
       }),
-      Effect.ensuring(Ref.set(updateDownloadInFlightRef, false)),
+      Effect.ensuring(
+        Effect.all(
+          [
+            Ref.set(updateDownloadInFlightRef, false),
+            Ref.set(nativePreparationDeferredRef, Option.none()),
+            Ref.set(nativePreparationVersionRef, Option.none()),
+          ],
+          { discard: true },
+        ),
+      ),
     );
   }).pipe(Effect.withSpan("desktop.updates.downloadAvailableUpdate"));
 
   const resetInstallAction = Effect.all(
-    [Ref.set(updateInstallInFlightRef, false), Ref.set(desktopState.quitting, false)],
+    [
+      Ref.set(updateInstallInFlightRef, false),
+      Ref.set(desktopState.quitting, false),
+      clearUpdateRelaunch.pipe(Effect.ignore),
+    ],
     { discard: true },
   );
 
@@ -465,6 +509,17 @@ export const make = Effect.gen(function* () {
     yield* Ref.set(updateInstallInFlightRef, true);
 
     return yield* Effect.gen(function* () {
+      yield* updateState((current) => ({
+        ...current,
+        message: "Preparing update… T3 Code will restart automatically.",
+      }));
+      yield* markUpdateRelaunch.pipe(
+        Effect.catch(() =>
+          logUpdaterWarning(
+            "could not persist the update relaunch marker; continuing with installation",
+          ),
+        ),
+      );
       // Stop every backend in the pool, not just the primary. With
       // parallel WSL + Windows backends, leaving the WSL instance up
       // means quitAndInstall's app.quit() exits before the pool's
@@ -478,7 +533,12 @@ export const make = Effect.gen(function* () {
         (instance) => instance.stop({ timeout: Duration.seconds(5) }),
         { concurrency: "unbounded" },
       );
-      yield* electronWindow.destroyAll;
+      // NSIS needs all BrowserWindows gone before it can replace the Windows
+      // executable. Squirrel.Mac and AppImage own their normal quit lifecycle,
+      // so keep the preparing UI visible until those updaters take over.
+      if (environment.platform === "win32") {
+        yield* electronWindow.destroyAll;
+      }
       yield* electronUpdater.quitAndInstall({
         isSilent: true,
         isForceRunAfter: true,
@@ -627,6 +687,11 @@ export const make = Effect.gen(function* () {
       return;
     }
 
+    const nativePreparationDeferred = yield* Ref.get(nativePreparationDeferredRef);
+    if (Option.isSome(nativePreparationDeferred)) {
+      yield* Deferred.fail(nativePreparationDeferred.value, error);
+    }
+
     if (!(yield* Ref.get(updateCheckInFlightRef)) && !(yield* Ref.get(updateDownloadInFlightRef))) {
       const errorContext = yield* resolveUpdaterErrorContext;
       const checkedAt = yield* currentIsoTimestamp;
@@ -686,6 +751,21 @@ export const make = Effect.gen(function* () {
       Effect.flatMap(
         Effect.fn("desktop.updates.applyUpdateDownloaded")(function* (info) {
           const state = yield* Ref.get(updateStateRef);
+          if (environment.platform === "darwin") {
+            yield* Ref.set(nativePreparationVersionRef, Option.some(info.version));
+            yield* setState({
+              ...state,
+              status: "downloading",
+              downloadPercent: 100,
+              message: "Preparing update…",
+              errorContext: null,
+              canRetry: false,
+            });
+            yield* logUpdaterInfo("download complete; preparing native macOS update", {
+              version: info.version,
+            });
+            return;
+          }
           yield* setState(reduceDesktopUpdateStateOnDownloadComplete(state, info.version));
           yield* logUpdaterInfo("update downloaded", { version: info.version });
         }),
@@ -702,6 +782,26 @@ export const make = Effect.gen(function* () {
       }),
     );
   });
+
+  const handleNativeUpdateDownloaded = Effect.fn("desktop.updates.handleNativeUpdateDownloaded")(
+    function* () {
+      const state = yield* Ref.get(updateStateRef);
+      const pendingVersion = yield* Ref.get(nativePreparationVersionRef);
+      const version = Option.getOrUndefined(pendingVersion) ?? state.availableVersion;
+      if (version === null) {
+        yield* logUpdaterWarning(
+          "native macOS update became ready without an available update version; ignoring event",
+        );
+        return;
+      }
+      yield* setState(reduceDesktopUpdateStateOnDownloadComplete(state, version));
+      const nativePreparationDeferred = yield* Ref.get(nativePreparationDeferredRef);
+      if (Option.isSome(nativePreparationDeferred)) {
+        yield* Deferred.succeed(nativePreparationDeferred.value, undefined);
+      }
+      yield* logUpdaterInfo("native macOS update prepared", { version });
+    },
+  );
 
   return DesktopUpdates.of({
     getState: Ref.get(updateStateRef),
@@ -732,7 +832,11 @@ export const make = Effect.gen(function* () {
       yield* Ref.set(updaterConfiguredRef, true);
 
       yield* electronUpdater.setAutoDownload(false);
-      yield* electronUpdater.setAutoInstallOnAppQuit(false);
+      // On macOS this starts Squirrel's expensive unzip/signature preparation
+      // as part of the explicit download action. The Restart action is not
+      // exposed until Electron's native updater confirms the staged app is
+      // ready. Windows and Linux retain their existing install-on-click flow.
+      yield* electronUpdater.setAutoInstallOnAppQuit(environment.platform === "darwin");
       yield* applyAutoUpdaterChannel(settings.updateChannel);
       yield* electronUpdater.setDisableDifferentialDownload(
         isArm64HostRunningIntelBuild(environment.runtimeInfo),
@@ -766,6 +870,11 @@ export const make = Effect.gen(function* () {
       yield* electronUpdater.on("update-downloaded", (info: unknown) => {
         runEffect(handleUpdateDownloaded(info));
       });
+      if (environment.platform === "darwin") {
+        yield* electronUpdater.onNativeUpdateDownloaded(() => {
+          runEffect(handleNativeUpdateDownloaded());
+        });
+      }
 
       yield* startUpdatePollers;
     }).pipe(Effect.withSpan("desktop.updates.configure")),

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -675,8 +675,7 @@ export const make = Effect.gen(function* () {
       cause,
     });
     if (yield* Ref.get(updateInstallInFlightRef)) {
-      yield* Ref.set(updateInstallInFlightRef, false);
-      yield* Ref.set(desktopState.quitting, false);
+      yield* resetInstallAction;
       yield* updateState((current) =>
         reduceDesktopUpdateStateOnInstallFailure(current, error.message),
       );
@@ -720,6 +719,13 @@ export const make = Effect.gen(function* () {
         Effect.fn("desktop.updates.applyDownloadProgress")(function* (progress) {
           const state = yield* Ref.get(updateStateRef);
           const percent = Math.floor(progress.percent);
+          if (state.status !== "downloading") {
+            return;
+          }
+          const nativePreparationVersion = yield* Ref.get(nativePreparationVersionRef);
+          if (Option.isSome(nativePreparationVersion)) {
+            return;
+          }
           if (shouldBroadcastDownloadProgress(state, progress.percent) || state.message !== null) {
             yield* setState(reduceDesktopUpdateStateOnDownloadProgress(state, progress.percent));
           }
@@ -752,6 +758,12 @@ export const make = Effect.gen(function* () {
         Effect.fn("desktop.updates.applyUpdateDownloaded")(function* (info) {
           const state = yield* Ref.get(updateStateRef);
           if (environment.platform === "darwin") {
+            if (state.status === "downloaded") {
+              yield* logUpdaterInfo("ignoring duplicate macOS download completion event", {
+                version: info.version,
+              });
+              return;
+            }
             yield* Ref.set(nativePreparationVersionRef, Option.some(info.version));
             yield* setState({
               ...state,
@@ -789,8 +801,16 @@ export const make = Effect.gen(function* () {
       const pendingVersion = yield* Ref.get(nativePreparationVersionRef);
       const version = Option.getOrUndefined(pendingVersion) ?? state.availableVersion;
       if (version === null) {
+        const error = new DesktopUpdaterReportedError({
+          operation: "download",
+          cause: new Error("Native macOS update became ready without a version."),
+        });
+        const nativePreparationDeferred = yield* Ref.get(nativePreparationDeferredRef);
+        if (Option.isSome(nativePreparationDeferred)) {
+          yield* Deferred.fail(nativePreparationDeferred.value, error);
+        }
         yield* logUpdaterWarning(
-          "native macOS update became ready without an available update version; ignoring event",
+          "native macOS update became ready without an available update version",
         );
         return;
       }

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -127,6 +127,17 @@ export class DesktopUpdaterReportedError extends Schema.TaggedErrorClass<Desktop
   }
 }
 
+export class DesktopUpdateNativePreparationError extends Schema.TaggedErrorClass<DesktopUpdateNativePreparationError>()(
+  "DesktopUpdateNativePreparationError",
+  {
+    stage: Schema.Literals(["resolve-version"]),
+  },
+) {
+  override get message(): string {
+    return "Native macOS update preparation completed without an update version.";
+  }
+}
+
 export class DesktopUpdateUnexpectedActionError extends Schema.TaggedErrorClass<DesktopUpdateUnexpectedActionError>()(
   "DesktopUpdateUnexpectedActionError",
   {
@@ -272,7 +283,9 @@ export const make = Effect.gen(function* () {
   const updaterConfiguredRef = yield* Ref.make(false);
   const lastLoggedDownloadMilestoneRef = yield* Ref.make(-1);
   const nativePreparationDeferredRef = yield* Ref.make<
-    Option.Option<Deferred.Deferred<void, DesktopUpdaterReportedError>>
+    Option.Option<
+      Deferred.Deferred<void, DesktopUpdaterReportedError | DesktopUpdateNativePreparationError>
+    >
   >(Option.none());
   const nativePreparationVersionRef = yield* Ref.make<Option.Option<string>>(Option.none());
   const updateStateRef = yield* Ref.make<DesktopUpdateState>(
@@ -415,8 +428,18 @@ export const make = Effect.gen(function* () {
     yield* Ref.set(updateDownloadInFlightRef, true);
     const nativePreparationDeferred =
       environment.platform === "darwin"
-        ? Option.some(yield* Deferred.make<void, DesktopUpdaterReportedError>())
-        : Option.none<Deferred.Deferred<void, DesktopUpdaterReportedError>>();
+        ? Option.some(
+            yield* Deferred.make<
+              void,
+              DesktopUpdaterReportedError | DesktopUpdateNativePreparationError
+            >(),
+          )
+        : Option.none<
+            Deferred.Deferred<
+              void,
+              DesktopUpdaterReportedError | DesktopUpdateNativePreparationError
+            >
+          >();
     yield* Ref.set(nativePreparationDeferredRef, nativePreparationDeferred);
     return yield* Effect.gen(function* () {
       yield* setState(reduceDesktopUpdateStateOnDownloadStart(state));
@@ -451,6 +474,14 @@ export const make = Effect.gen(function* () {
             return { accepted: true, completed: false };
           },
         ),
+        DesktopUpdateNativePreparationError: Effect.fn(
+          "desktop.updates.handleNativePreparationInvariantFailure",
+        )(function* (error) {
+          yield* updateState((current) =>
+            reduceDesktopUpdateStateOnDownloadFailure(current, error.message),
+          );
+          return { accepted: true, completed: false };
+        }),
       }),
       Effect.onInterrupt(() =>
         updateState((current) => (current.status === "downloading" ? state : current)).pipe(
@@ -822,9 +853,8 @@ export const make = Effect.gen(function* () {
       const pendingVersion = yield* Ref.get(nativePreparationVersionRef);
       const version = Option.getOrUndefined(pendingVersion) ?? state.availableVersion;
       if (version === null) {
-        const error = new DesktopUpdaterReportedError({
-          operation: "download",
-          cause: new Error("Native macOS update became ready without a version."),
+        const error = new DesktopUpdateNativePreparationError({
+          stage: "resolve-version",
         });
         yield* Deferred.fail(nativePreparationDeferred.value, error);
         yield* logUpdaterWarning(

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -75,7 +75,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     revealOrCreateMain: Effect.die("unexpected revealOrCreateMain"),
     activate: Effect.void,
     createMainIfBackendReady: Effect.void,
-    showConnectingSplash: Effect.void,
+    showConnectingSplash: () => Effect.void,
     handleBackendReady: () => Effect.void,
     handleBackendNotReady: Effect.void,
     flushMainWindowBounds: Effect.void,

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -86,7 +86,7 @@ function makeFakeBrowserWindow() {
     isMaximized: vi.fn(() => false),
     isMinimized: vi.fn(() => false),
     isVisible: vi.fn(() => true),
-    loadURL: vi.fn(() => Promise.resolve()),
+    loadURL: vi.fn((_url: string) => Promise.resolve()),
     maximize: vi.fn(),
     on: vi.fn((eventName: string, listener: (...args: readonly unknown[]) => void) => {
       windowListeners.set(eventName, listener);
@@ -995,6 +995,30 @@ describe("DesktopWindow", () => {
     }),
   );
 
+  it.effect("shows startup copy for the active splash reason", () =>
+    Effect.gen(function* () {
+      for (const [reason, expectedMessage] of [
+        ["wsl", "Connecting to WSL…"],
+        ["update-relaunch", "Starting T3 Code…"],
+      ] as const) {
+        const splash = makeFakeBrowserWindow();
+        const scenario = yield* makeSplashScenario([splash.window]);
+
+        yield* Effect.gen(function* () {
+          const desktopWindow = yield* DesktopWindow.DesktopWindow;
+          yield* desktopWindow.showConnectingSplash(reason);
+        }).pipe(Effect.provide(scenario.layer));
+
+        const splashUrl = splash.loadURL.mock.calls[0]?.[0];
+        assert.isDefined(splashUrl);
+        assert.include(
+          decodeURIComponent(splashUrl),
+          `<div class="label">${expectedMessage}</div>`,
+        );
+      }
+    }),
+  );
+
   it.effect(
     "retries opening the real main on activate when a failed post-readiness open left only the splash",
     () =>
@@ -1009,7 +1033,7 @@ describe("DesktopWindow", () => {
           const desktopWindow = yield* DesktopWindow.DesktopWindow;
 
           // 1. WSL-only boot shows the connecting splash.
-          yield* desktopWindow.showConnectingSplash;
+          yield* desktopWindow.showConnectingSplash("wsl");
           assert.equal(yield* Ref.get(scenario.createCalls), 1);
 
           // 2. Backend reports ready, but opening the real main fails. The pool
@@ -1045,7 +1069,7 @@ describe("DesktopWindow", () => {
         yield* Effect.gen(function* () {
           const desktopWindow = yield* DesktopWindow.DesktopWindow;
 
-          yield* desktopWindow.showConnectingSplash;
+          yield* desktopWindow.showConnectingSplash("wsl");
           assert.equal(yield* Ref.get(scenario.createCalls), 1);
 
           // Taskbar/dock activation during cold boot must bring the splash back
@@ -1066,7 +1090,7 @@ describe("DesktopWindow", () => {
       yield* Effect.gen(function* () {
         const desktopWindow = yield* DesktopWindow.DesktopWindow;
 
-        yield* desktopWindow.showConnectingSplash;
+        yield* desktopWindow.showConnectingSplash("wsl");
         yield* desktopWindow.dispatchMenuAction("open-settings");
 
         assert.equal(yield* Ref.get(scenario.createCalls), 1);
@@ -1085,7 +1109,7 @@ describe("DesktopWindow", () => {
       yield* Effect.gen(function* () {
         const desktopWindow = yield* DesktopWindow.DesktopWindow;
 
-        yield* desktopWindow.showConnectingSplash;
+        yield* desktopWindow.showConnectingSplash("wsl");
         const readyExit = yield* Effect.exit(
           desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773")),
         );

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -1019,6 +1019,28 @@ describe("DesktopWindow", () => {
     }),
   );
 
+  it.effect("updates an existing relaunch splash for WSL cold boot", () =>
+    Effect.gen(function* () {
+      const splash = makeFakeBrowserWindow();
+      const scenario = yield* makeSplashScenario([splash.window]);
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.showConnectingSplash("update-relaunch");
+        yield* desktopWindow.showConnectingSplash("wsl");
+      }).pipe(Effect.provide(scenario.layer));
+
+      assert.equal(yield* Ref.get(scenario.createCalls), 1);
+      assert.equal(splash.loadURL.mock.calls.length, 2);
+      const updatedSplashUrl = splash.loadURL.mock.calls.at(-1)?.[0];
+      assert.isDefined(updatedSplashUrl);
+      assert.include(
+        decodeURIComponent(updatedSplashUrl),
+        '<div class="label">Connecting to WSL…</div>',
+      );
+    }),
+  );
+
   it.effect(
     "retries opening the real main on activate when a failed post-readiness open left only the splash",
     () =>

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -142,15 +142,15 @@ export function resolveInitialMainWindowBounds(
   return DesktopAppSettings.DEFAULT_MAIN_WINDOW_SIZE;
 }
 
-// A self-contained "Connecting to WSL" splash, shown immediately in wsl-only
-// mode while the WSL backend (which serves the renderer) cold-boots. Inlined as
-// a data URL so it needs no bundled asset and no backend — pure CSS, no JS.
+// A self-contained startup splash, shown while a slow backend cold-boots or
+// while the first launch after an update reconnects. Inlined as a data URL so
+// it needs no bundled asset and no backend — pure CSS, no JS.
 function buildConnectingSplashDataUrl(shouldUseDarkColors: boolean): string {
   const background = getInitialWindowBackgroundColor(shouldUseDarkColors);
   const label = shouldUseDarkColors ? "#9ca3af" : "#6b7280";
   const accent = shouldUseDarkColors ? "#f8fafc" : "#1f2937";
   const track = shouldUseDarkColors ? "rgba(248,250,252,0.18)" : "rgba(31,41,55,0.18)";
-  const html = `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><style>html,body{margin:0;height:100%}body{background:${background};color:${label};font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;-webkit-user-select:none;user-select:none;-webkit-app-region:drag}.spinner{width:26px;height:26px;border:3px solid ${track};border-top-color:${accent};border-radius:50%;animation:spin .8s linear infinite}.label{font-size:13px}@keyframes spin{to{transform:rotate(360deg)}}</style></head><body><div class="spinner"></div><div class="label">Connecting to WSL…</div></body></html>`;
+  const html = `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><style>html,body{margin:0;height:100%}body{background:${background};color:${label};font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;-webkit-user-select:none;user-select:none;-webkit-app-region:drag}.spinner{width:26px;height:26px;border:3px solid ${track};border-top-color:${accent};border-radius:50%;animation:spin .8s linear infinite}.label{font-size:13px}@keyframes spin{to{transform:rotate(360deg)}}</style></head><body><div class="spinner"></div><div class="label">Starting T3 Code…</div></body></html>`;
   return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
 }
 

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -54,6 +54,8 @@ export type DesktopWindowError =
   | ElectronWindow.ElectronWindowCreateError
   | PreviewManager.PreviewManagerError;
 
+export type ConnectingSplashReason = "update-relaunch" | "wsl";
+
 export class DesktopWindow extends Context.Service<
   DesktopWindow,
   {
@@ -62,10 +64,9 @@ export class DesktopWindow extends Context.Service<
     readonly revealOrCreateMain: Effect.Effect<Electron.BrowserWindow, DesktopWindowError>;
     readonly activate: Effect.Effect<void, DesktopWindowError>;
     readonly createMainIfBackendReady: Effect.Effect<void, DesktopWindowError>;
-    // Show a lightweight "Connecting to WSL" splash window immediately (wsl-only
-    // mode), before the WSL backend that serves the renderer is ready. It is
-    // dismissed automatically once the real main window reveals.
-    readonly showConnectingSplash: Effect.Effect<void>;
+    // Show a lightweight startup splash while WSL cold-boots or an updated app
+    // reconnects. It is dismissed automatically once the real main window reveals.
+    readonly showConnectingSplash: (reason: ConnectingSplashReason) => Effect.Effect<void>;
     // Marks the primary backend as ready so `createMainIfBackendReady` and the
     // macOS "activate without windows" path may open the real main window. The
     // renderer now always loads the local client URL (getDesktopUrl) and connects
@@ -145,12 +146,16 @@ export function resolveInitialMainWindowBounds(
 // A self-contained startup splash, shown while a slow backend cold-boots or
 // while the first launch after an update reconnects. Inlined as a data URL so
 // it needs no bundled asset and no backend — pure CSS, no JS.
-function buildConnectingSplashDataUrl(shouldUseDarkColors: boolean): string {
+function buildConnectingSplashDataUrl(
+  shouldUseDarkColors: boolean,
+  reason: ConnectingSplashReason,
+): string {
   const background = getInitialWindowBackgroundColor(shouldUseDarkColors);
   const label = shouldUseDarkColors ? "#9ca3af" : "#6b7280";
   const accent = shouldUseDarkColors ? "#f8fafc" : "#1f2937";
   const track = shouldUseDarkColors ? "rgba(248,250,252,0.18)" : "rgba(31,41,55,0.18)";
-  const html = `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><style>html,body{margin:0;height:100%}body{background:${background};color:${label};font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;-webkit-user-select:none;user-select:none;-webkit-app-region:drag}.spinner{width:26px;height:26px;border:3px solid ${track};border-top-color:${accent};border-radius:50%;animation:spin .8s linear infinite}.label{font-size:13px}@keyframes spin{to{transform:rotate(360deg)}}</style></head><body><div class="spinner"></div><div class="label">Starting T3 Code…</div></body></html>`;
+  const message = reason === "wsl" ? "Connecting to WSL…" : "Starting T3 Code…";
+  const html = `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><style>html,body{margin:0;height:100%}body{background:${background};color:${label};font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;-webkit-user-select:none;user-select:none;-webkit-app-region:drag}.spinner{width:26px;height:26px;border:3px solid ${track};border-top-color:${accent};border-radius:50%;animation:spin .8s linear infinite}.label{font-size:13px}@keyframes spin{to{transform:rotate(360deg)}}</style></head><body><div class="spinner"></div><div class="label">${message}</div></body></html>`;
   return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
 }
 
@@ -252,8 +257,8 @@ export const make = Effect.gen(function* () {
   // createMainIfBackendReady, which gates the post-readiness window
   // open in development and the macOS "activate without windows" path.
   const backendReadyRef = yield* Ref.make(false);
-  // The transient "Connecting to WSL" splash window, tracked separately so it
-  // is never mistaken for the real main window.
+  // The transient startup splash window, tracked separately so it is never
+  // mistaken for the real main window.
   const splashWindowRef = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
   const context = yield* Effect.context<DesktopWindowRuntimeServices>();
   const runFork = Effect.runForkWith(context);
@@ -682,50 +687,50 @@ export const make = Effect.gen(function* () {
     yield* createMain;
   }).pipe(Effect.withSpan("desktop.window.createMainIfBackendReady"));
 
-  const showConnectingSplash = Effect.gen(function* () {
-    // Only when nothing is shown yet: no real window, no existing splash.
-    const existingSplash = yield* Ref.get(splashWindowRef);
-    if (Option.isSome(existingSplash)) return;
-    const existingWindow = yield* electronWindow.currentMainOrFirst;
-    if (Option.isSome(existingWindow)) return;
+  const showConnectingSplash = Effect.fn("desktop.window.showConnectingSplash")(
+    function* (reason: ConnectingSplashReason) {
+      // Only when nothing is shown yet: no real window, no existing splash.
+      const existingSplash = yield* Ref.get(splashWindowRef);
+      if (Option.isSome(existingSplash)) return;
+      const existingWindow = yield* electronWindow.currentMainOrFirst;
+      if (Option.isSome(existingWindow)) return;
 
-    const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
-    const splash = yield* electronWindow.create({
-      width: 360,
-      height: 220,
-      resizable: false,
-      minimizable: false,
-      maximizable: false,
-      fullscreenable: false,
-      frame: false,
-      center: true,
-      show: false,
-      skipTaskbar: false,
-      backgroundColor: getInitialWindowBackgroundColor(shouldUseDarkColors),
-      title: environment.displayName,
-      webPreferences: {
-        contextIsolation: true,
-        nodeIntegration: false,
-        sandbox: true,
-      },
-    });
-    yield* Ref.set(splashWindowRef, Option.some(splash));
-    splash.once("closed", () => {
-      void runPromise(Ref.set(splashWindowRef, Option.none()));
-    });
-    splash.once("ready-to-show", () => {
-      if (!splash.isDestroyed()) {
-        splash.show();
-      }
-    });
-    void splash.loadURL(buildConnectingSplashDataUrl(shouldUseDarkColors));
-    yield* logWindowInfo("connecting splash shown");
-  }).pipe(
+      const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
+      const splash = yield* electronWindow.create({
+        width: 360,
+        height: 220,
+        resizable: false,
+        minimizable: false,
+        maximizable: false,
+        fullscreenable: false,
+        frame: false,
+        center: true,
+        show: false,
+        skipTaskbar: false,
+        backgroundColor: getInitialWindowBackgroundColor(shouldUseDarkColors),
+        title: environment.displayName,
+        webPreferences: {
+          contextIsolation: true,
+          nodeIntegration: false,
+          sandbox: true,
+        },
+      });
+      yield* Ref.set(splashWindowRef, Option.some(splash));
+      splash.once("closed", () => {
+        void runPromise(Ref.set(splashWindowRef, Option.none()));
+      });
+      splash.once("ready-to-show", () => {
+        if (!splash.isDestroyed()) {
+          splash.show();
+        }
+      });
+      void splash.loadURL(buildConnectingSplashDataUrl(shouldUseDarkColors, reason));
+      yield* logWindowInfo("connecting splash shown");
+    },
     // The splash is best-effort UX — never let it fail startup.
     Effect.catch((error) =>
       logWindowWarning("failed to show connecting splash", { message: error.message }),
     ),
-    Effect.withSpan("desktop.window.showConnectingSplash"),
   );
 
   return DesktopWindow.of({

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -689,9 +689,20 @@ export const make = Effect.gen(function* () {
 
   const showConnectingSplash = Effect.fn("desktop.window.showConnectingSplash")(
     function* (reason: ConnectingSplashReason) {
-      // Only when nothing is shown yet: no real window, no existing splash.
+      // Reuse an existing splash while allowing a more specific startup phase
+      // (such as WSL cold boot after an update relaunch) to refresh its copy.
       const existingSplash = yield* Ref.get(splashWindowRef);
-      if (Option.isSome(existingSplash)) return;
+      if (Option.isSome(existingSplash) && !existingSplash.value.isDestroyed()) {
+        const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
+        void existingSplash.value.loadURL(
+          buildConnectingSplashDataUrl(shouldUseDarkColors, reason),
+        );
+        yield* logWindowInfo("connecting splash updated", { reason });
+        return;
+      }
+      if (Option.isSome(existingSplash)) {
+        yield* Ref.set(splashWindowRef, Option.none());
+      }
       const existingWindow = yield* electronWindow.currentMainOrFirst;
       if (Option.isSome(existingWindow)) return;
 

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -8,6 +8,8 @@ import {
   getDesktopUpdateButtonTooltip,
   getDesktopUpdateInstallConfirmationMessage,
   isDesktopUpdateButtonDisabled,
+  isDesktopUpdatePreparing,
+  isDesktopUpdatePreparingToInstall,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
   shouldShowDesktopUpdateButton,
@@ -104,6 +106,45 @@ describe("desktop update button state", () => {
     expect(shouldShowDesktopUpdateButton(state)).toBe(true);
     expect(isDesktopUpdateButtonDisabled(state)).toBe(true);
     expect(getDesktopUpdateButtonTooltip(state)).toContain("42%");
+  });
+
+  it("disables restart and reports preparation while the updater is taking over", () => {
+    const state: DesktopUpdateState = {
+      ...baseState,
+      status: "downloaded",
+      availableVersion: "1.1.0",
+      downloadedVersion: "1.1.0",
+      message: "Preparing update… T3 Code will restart automatically.",
+    };
+    expect(isDesktopUpdatePreparingToInstall(state)).toBe(true);
+    expect(isDesktopUpdateButtonDisabled(state)).toBe(true);
+    expect(getDesktopUpdateButtonTooltip(state)).toBe(state.message);
+  });
+
+  it("reports native staging as preparation instead of a stuck 100% download", () => {
+    const state: DesktopUpdateState = {
+      ...baseState,
+      status: "downloading",
+      availableVersion: "1.1.0",
+      downloadPercent: 100,
+      message: "Preparing update…",
+    };
+    expect(isDesktopUpdatePreparing(state)).toBe(true);
+    expect(getDesktopUpdateButtonTooltip(state)).toBe("Preparing update…");
+  });
+
+  it("keeps failed installs retryable", () => {
+    const state: DesktopUpdateState = {
+      ...baseState,
+      status: "downloaded",
+      availableVersion: "1.1.0",
+      downloadedVersion: "1.1.0",
+      message: "Install failed.",
+      errorContext: "install",
+      canRetry: true,
+    };
+    expect(isDesktopUpdatePreparingToInstall(state)).toBe(false);
+    expect(isDesktopUpdateButtonDisabled(state)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -34,8 +34,20 @@ export function shouldShowArm64IntelBuildWarning(state: DesktopUpdateState | nul
   return state?.hostArch === "arm64" && state.appArch === "x64";
 }
 
+export function isDesktopUpdatePreparing(state: DesktopUpdateState | null): boolean {
+  return (
+    (state?.status === "downloading" || state?.status === "downloaded") &&
+    state.errorContext === null &&
+    typeof state.message === "string"
+  );
+}
+
+export function isDesktopUpdatePreparingToInstall(state: DesktopUpdateState | null): boolean {
+  return state?.status === "downloaded" && isDesktopUpdatePreparing(state);
+}
+
 export function isDesktopUpdateButtonDisabled(state: DesktopUpdateState | null): boolean {
-  return state?.status === "downloading";
+  return state?.status === "downloading" || isDesktopUpdatePreparingToInstall(state);
 }
 
 export function getArm64IntelBuildWarningDescription(state: DesktopUpdateState): string {
@@ -58,11 +70,17 @@ export function getDesktopUpdateButtonTooltip(state: DesktopUpdateState): string
     return `Update ${state.availableVersion ?? "available"} ready to download`;
   }
   if (state.status === "downloading") {
+    if (isDesktopUpdatePreparing(state)) {
+      return state.message ?? "Preparing update…";
+    }
     const progress =
       typeof state.downloadPercent === "number" ? ` (${Math.floor(state.downloadPercent)}%)` : "";
     return `Downloading update${progress}`;
   }
   if (state.status === "downloaded") {
+    if (isDesktopUpdatePreparingToInstall(state)) {
+      return state.message ?? "Preparing update…";
+    }
     return `Update ${state.downloadedVersion ?? state.availableVersion ?? "ready"} downloaded. Click to restart and install.`;
   }
   if (state.status === "error") {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -53,6 +53,7 @@ import {
   getDesktopUpdateButtonTooltip,
   getDesktopUpdateInstallConfirmationMessage,
   isDesktopUpdateButtonDisabled,
+  isDesktopUpdatePreparing,
   resolveDesktopUpdateButtonAction,
 } from "../../components/desktopUpdate.logic";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
@@ -461,8 +462,9 @@ function AboutVersionSection() {
     downloading: "Downloading…",
     "up-to-date": "Up to Date",
   };
-  const buttonLabel =
-    actionLabel[action] ?? statusLabel[updateState?.status ?? ""] ?? "Check for Updates";
+  const buttonLabel = isDesktopUpdatePreparing(updateState)
+    ? "Preparing…"
+    : (actionLabel[action] ?? statusLabel[updateState?.status ?? ""] ?? "Check for Updates");
   const description =
     action === "download" || action === "install"
       ? "Update available."

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -9,6 +9,7 @@ import {
   getDesktopUpdateButtonTooltip,
   getDesktopUpdateInstallConfirmationMessage,
   isDesktopUpdateButtonDisabled,
+  isDesktopUpdatePreparing,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
   shouldShowDesktopUpdateButton,
@@ -169,7 +170,12 @@ export function SidebarUpdatePill() {
                   className="update-main relative flex h-full flex-1 items-center gap-2 px-2 enabled:cursor-pointer"
                   onClick={handleAction}
                 >
-                  {action === "install" ? (
+                  {isDesktopUpdatePreparing(state) ? (
+                    <>
+                      <RotateCwIcon className="size-3.5 animate-spin" />
+                      <span>Preparing update…</span>
+                    </>
+                  ) : action === "install" ? (
                     <>
                       <RotateCwIcon className="size-3.5" />
                       <span>Restart to update</span>


### PR DESCRIPTION
## What Changed

- Pre-stage macOS updates during the download phase so the Restart action is only enabled once Squirrel has finished preparing the update.
- Show a clear “Preparing update…” state while the updater is taking over.
- Only force-destroy application windows on Windows, where NSIS requires it. macOS and Linux retain their normal quit lifecycle.
- Show an immediate startup splash when reopening after an update.
- Keep JavaScript dependencies inside ASAR on macOS and Linux while preserving the existing broad unpacking required for Windows WSL support.
- Continue unpacking native modules and executables such as Claude, node-pty, passkeys, ffi-rs, and fff.

## Why

Restarting after an update could appear to do nothing for around 20 seconds or longer.

Most of that delay came from two bottlenecks:

1. Squirrel’s native update preparation did not begin until the user clicked Restart.
2. The packaged application contained roughly 14,500 unpacked files, all of which Squirrel had to process individually.

This change moves native macOS preparation into the download flow and reduces the unpacked application tree to 184 files in a test package. The remaining restart flow is primarily normal application and backend startup, while the user receives visible feedback throughout the transition.

The platform-specific behavior is preserved:

- macOS uses native pre-staging.
- Windows retains the unpacking and window shutdown behavior required by WSL and NSIS.
- Linux continues using its existing AppImage installation lifecycle.

## UI Changes

- The update control now displays “Preparing update…” instead of appearing stuck at 100% downloaded.
- The update action is disabled while the updater is taking over, preventing duplicate restart attempts.
- The first launch after an update immediately displays a “Starting T3 Code…” splash while the backend reconnects.

<!-- Add before/after screenshots here. -->

<!-- Add a short recording of the download → preparing → restart flow here. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes - not applicable
- [ ] I included a video for animation/interaction changes - not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core desktop update and quit/relaunch paths across platforms with new async coordination on macOS; behavior is heavily tested in this PR but regressions would affect all packaged users during updates.
> 
> **Overview**
> **Moves macOS Squirrel native staging into the download flow** so Restart is only offered after `electron.autoUpdater` reports the staged app is ready, with a **“Preparing update…”** state instead of looking stuck at 100% downloaded.
> 
> **Install/relaunch behavior** now persists a **one-shot relaunch marker** before `quitAndInstall`, clears it on failed installs, shows a **“Starting T3 Code…”** startup splash when the marker is consumed, and **only force-destroys windows on Windows** (NSIS); macOS and Linux keep their normal quit lifecycle. **`autoInstallOnAppQuit`** is enabled **only on darwin** to drive native pre-staging.
> 
> **Startup splash** `showConnectingSplash` takes a reason (`wsl` vs `update-relaunch`) and can refresh copy on an existing splash. **Web update UI** disables actions and shows “Preparing…” during staging and pre-install takeover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff79a9b36f4fa6f52a7358c6f232d39f410e2a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce update restart time by pre-staging macOS updates natively and showing a preparing splash
> - On macOS, the update download now waits for the native Electron `autoUpdater` `update-downloaded` event before completing, enabling OS-level pre-staging before restart.
> - A persistent relaunch marker (`DesktopUpdateRelaunch`) is written before quit and consumed at startup to show a `'Starting T3 Code…'` splash instead of a cold-boot splash.
> - `showConnectingSplash` in [DesktopWindow.ts](https://github.com/pingdotgg/t3code/pull/4777/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) now takes a `ConnectingSplashReason` (`'wsl'` | `'update-relaunch'`) and can refresh an existing splash in-place when the reason changes.
> - UI surfaces (sidebar pill, settings button, tooltips) show a `'Preparing…'` state during native staging via new `isDesktopUpdatePreparing` and `isDesktopUpdatePreparingToInstall` helpers.
> - Behavioral Change: on macOS, windows are no longer force-destroyed before quit; on Windows the existing destroy behavior is retained.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff79a9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->