### PR TITLE
perf: stop tracing every command-path probe and bound git spawns

### DIFF
--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -1,5 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -45,6 +46,49 @@ const captureProcessResult = (
   );
 
 describe("VcsProcess.run", () => {
+  it.effect("bounds how many processes it spawns at once", () =>
+    Effect.gen(function* () {
+      const release = yield* Deferred.make<void>();
+      let inFlight = 0;
+      let peakInFlight = 0;
+
+      const service = yield* VcsProcess.make.pipe(
+        Effect.provideService(
+          ProcessRunner.ProcessRunner,
+          ProcessRunner.ProcessRunner.of({
+            run: () =>
+              Effect.gen(function* () {
+                inFlight += 1;
+                peakInFlight = Math.max(peakInFlight, inFlight);
+                yield* Deferred.await(release);
+                inFlight -= 1;
+                return {
+                  code: 0,
+                  stdout: "",
+                  stderr: "",
+                  stdoutTruncated: false,
+                  stderrTruncated: false,
+                } as ProcessRunner.ProcessRunOutput;
+              }),
+          }),
+        ),
+      );
+
+      const fibers = yield* Effect.forEach(
+        Array.from({ length: 40 }, (_, index) => index),
+        () => Effect.forkChild(service.run(baseInput), { startImmediately: true }),
+      );
+      // Every fiber started eagerly and ran until it blocked, either on a
+      // permit or on the release latch.
+      expect(peakInFlight).toBeLessThanOrEqual(16);
+      expect(peakInFlight).toBeLessThan(40);
+
+      yield* Deferred.succeed(release, undefined);
+      yield* Fiber.awaitAll(fibers);
+      expect(peakInFlight).toBeLessThanOrEqual(16);
+    }),
+  );
+
   it.effect("collects stdout", () =>
     Effect.gen(function* () {
       const result = yield* run({

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -1,7 +1,10 @@
+import * as NodeOS from "node:os";
+
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Match from "effect/Match";
+import * as Semaphore from "effect/Semaphore";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
@@ -86,8 +89,24 @@ const classifyNonZeroExit = (command: string, stderr: string): VcsProcessExitFai
   return "command-failed";
 };
 
+// A single workspace refresh can ask for refs across every worktree at once, and
+// each request spawns several git processes. Unbounded, that starves the event
+// loop badly enough that unrelated work (provider health checks, HTTP requests)
+// blows past its own timeouts. Bound the spawns instead; queued commands wait
+// for a permit rather than competing.
+// ponytail: one global limit, make it per-repository if a busy repo ever starves
+// the others.
+// The bound scales with the host: a single git command costs ~1s on a large
+// repository, so too low a limit turns a refresh into a queue, while too high a
+// limit is what caused the starvation in the first place.
+const MAX_CONCURRENT_VCS_PROCESSES = Math.max(
+  4,
+  Math.min(16, Math.floor(NodeOS.availableParallelism() / 4)),
+);
+
 export const make = Effect.gen(function* () {
   const processRunner = yield* ProcessRunner.ProcessRunner;
+  const spawnPermits = yield* Semaphore.make(MAX_CONCURRENT_VCS_PROCESSES);
 
   const run = Effect.fn("VcsProcess.run")(function* (input: VcsProcessInput) {
     const baseError = {
@@ -112,6 +131,9 @@ export const make = Effect.gen(function* () {
         timeoutBehavior: "error",
       })
       .pipe(
+        // Take the permit around the spawn only, so waiting in the queue never
+        // counts against the command's own timeout.
+        spawnPermits.withPermits(1),
         Effect.mapError(
           Match.valueTags({
             ProcessSpawnError: (error) =>

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -2,9 +2,12 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  clearCommandPathCache,
   extractPathFromShellOutput,
   CommandAvailability,
   type CommandAvailabilityChecker,
@@ -363,6 +366,32 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
 
       expect(result._tag).toBe("Failure");
     }),
+  );
+
+  it.effect("reuses a resolution until the cache is cleared", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fs.makeTempDirectoryScoped();
+      const toolPath = path.join(directory, "tool.cmd");
+      yield* fs.writeFileString(toolPath, "@echo off\n");
+      const env = { PATH: directory, PATHEXT: ".CMD" };
+      const resolve = () =>
+        resolveCommandPath("tool", { env }).pipe(
+          Effect.provideService(HostProcessPlatform, "win32"),
+          Effect.result,
+        );
+
+      clearCommandPathCache();
+      const resolved = yield* resolve();
+      expect(resolved._tag).toBe("Success");
+
+      yield* fs.remove(toolPath);
+      expect(yield* resolve()).toStrictEqual(resolved);
+
+      clearCommandPathCache();
+      expect((yield* resolve())._tag).toBe("Failure");
+    }).pipe(Effect.scoped),
   );
 });
 

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -3,6 +3,7 @@ import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 import * as NodeChildProcess from "node:child_process";
 import * as NodeFS from "node:fs";
+import * as Clock from "effect/Clock";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -491,7 +492,9 @@ function resolveCommandCandidates(
   return Array.from(new Set(candidates));
 }
 
-const isExecutableFile = Effect.fn("shell.isExecutableFile")(function* (
+// Called once per PATH x PATHEXT candidate, so a single miss on Windows probes
+// hundreds of paths. Keep it untraced: a span per probe floods the tracer.
+const isExecutableFile = Effect.fnUntraced(function* (
   filePath: string,
   platform: NodeJS.Platform,
   windowsPathExtensions: ReadonlyArray<string>,
@@ -510,7 +513,21 @@ const isExecutableFile = Effect.fn("shell.isExecutableFile")(function* (
   return canExecuteFile(filePath);
 });
 
-const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlatform")(function* (
+// A miss on Windows probes every PATH entry against every PATHEXT variant, and
+// editor/provider refreshes resolve the same commands over and over. Cache the
+// outcome briefly; the TTL keeps a newly installed CLI discoverable.
+const COMMAND_PATH_CACHE_TTL_MS = 30_000;
+
+const commandPathCache = new Map<
+  string,
+  { readonly expiresAt: number; readonly resolved: string | null }
+>();
+
+export function clearCommandPathCache(): void {
+  commandPathCache.clear();
+}
+
+const resolveCommandPathUncached = Effect.fn("shell.resolveCommandPathForPlatform")(function* (
   command: string,
   options: CommandAvailabilityOptions & { readonly platform: NodeJS.Platform },
 ): Effect.fn.Return<string, CommandResolutionError, FileSystem.FileSystem | Path.Path> {
@@ -555,6 +572,36 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
     }
   }
   return yield* new CommandResolutionError({ command, reason: "not-found" });
+});
+
+const resolveCommandPathForPlatform = Effect.fnUntraced(function* (
+  command: string,
+  options: CommandAvailabilityOptions & { readonly platform: NodeJS.Platform },
+): Effect.fn.Return<string, CommandResolutionError, FileSystem.FileSystem | Path.Path> {
+  const env = options.env ?? process.env;
+  const cacheKey = [
+    options.platform,
+    command,
+    resolvePathEnvironmentVariable(env),
+    env.PATHEXT ?? "",
+  ].join("\u0000");
+  const now = yield* Clock.currentTimeMillis;
+  const cached = commandPathCache.get(cacheKey);
+  if (cached !== undefined && cached.expiresAt > now) {
+    if (cached.resolved === null) {
+      return yield* new CommandResolutionError({ command, reason: "not-found" });
+    }
+    return cached.resolved;
+  }
+
+  const resolved = yield* resolveCommandPathUncached(command, options).pipe(
+    Effect.catchTag("CommandResolutionError", () => Effect.succeed(null)),
+  );
+  commandPathCache.set(cacheKey, { expiresAt: now + COMMAND_PATH_CACHE_TTL_MS, resolved });
+  if (resolved === null) {
+    return yield* new CommandResolutionError({ command, reason: "not-found" });
+  }
+  return resolved;
 });
 
 export const resolveCommandPath = Effect.fn("shell.resolveCommandPath")(function* (


### PR DESCRIPTION
## Problem

On a Windows host with several projects open, the desktop app became unusable for tens of seconds at a time: `Timed out while checking Codex app-server provider status`, `Git command timed out` warnings, and a client stuck in `Failed to connect. Reconnecting…` because `/.well-known/t3/environment` exceeded its 10s connection-setup budget.

Tracing pointed at two independent causes.

### 1. A span per command-path probe

`resolveCommandPathForPlatform` walks every PATH entry against every PATHEXT candidate, and `isExecutableFile` was an `Effect.fn` — one span per probe. With a 57-entry PATH and 14 PATHEXT entries that is ~800 probes (~1600 with the lower-case variants) per lookup.

One 13.7s trace window contained **28,698 spans, of which 28,577 were `shell.isExecutableFile`** — produced by just 22 `resolveCommandPath` calls. The trace file rotated at 10 MB every ~40s. Serializing that volume starved the event loop; unrelated fibers then blew past their own timeouts (a `discoverClaudeSkills` span read 79s while the work it does measures ~93ms).

Editor detection and provider health checks re-resolve the same commands on every refresh, and uninstalled CLIs (`cursor-agent`, `grok` here) pay the full miss every time.

**Fix:** make the per-candidate probe untraced, and cache resolution outcomes — hits and misses — for 30s, keyed on platform, command, PATH and PATHEXT. The TTL rather than a permanent cache so a newly installed CLI is still discovered.

Resolving 21 commands, five times, on the real PATH:

| | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|
| before | 3809ms | 3566 | 3700 | 3369 | 3401 |
| after | 3264ms | **1** | **1** | **4** | **1** |

### 2. Unbounded git spawns

A workspace refresh requests refs and status for every project and worktree at once, and each `listRefs` spawns six git processes (`branchNoColor`, `defaultRef`, `remoteBranches`, `remoteNames`, `worktreeList`, `readBranchRecency`). `VcsProcess` has timeouts but no concurrency bound.

One observed refresh issued **1,055 git spawns**. Commands that take ~0.9s in isolation (and stay under 500ms at 12-way concurrency) took **6.5s** under that load; `ws.rpc.vcs.listRefs` spans ran **51s**, and the environment endpoint took 14.2s — past the client's 10s budget, so it reconnected and re-triggered the storm.

**Fix:** gate the spawn behind a semaphore sized from `availableParallelism()` (4–16 permits). The permit is taken around the spawn only, so queue time never counts against the command's own timeout.

## Verification

Both fixes were built into a desktop artifact and run against the same workload that produced the traces above:

| | before | after |
|---|---|---|
| `shell.isExecutableFile` spans | 28,577 per 13.7s | **0** |
| `/.well-known/t3/environment` | 14,215ms | 76–393ms typical |
| git spawn concurrency | unbounded | capped |

Tests:

- `packages/shared/src/shell.test.ts` — resolve, delete the file, resolve again (still cached), `clearCommandPathCache()`, resolve fails.
- `apps/server/src/vcs/VcsProcess.test.ts` — 40 competing fibers; peak in-flight stays within the bound. Verified to fail without the semaphore (`expected 40 to be 8`).
- `vp test apps/server/src/vcs` — 71 passed.
- `vp run typecheck` and `vp check` clean.

Six pre-existing Windows test failures (`relayClient` ×4, `logging`, `t3-sqlite-state`) fail identically on an unmodified checkout and are unrelated.

## Not addressed

The refresh still issues a lot of git work — 384 commands in one window, ~145 of them repeated metadata lookups (`readConfigValue`, `resolveCurrentUpstream`, `listRemoteNames`, `resolveDefaultBranchName`). Caching those, or fetching refs only for visible projects, would reduce the work rather than just bounding it. Happy to follow up if that direction seems right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared spawn/path resolution and global VCS concurrency; mis-tuning could delay refreshes or briefly serve stale “command not found” until cache TTL expires.
> 
> **Overview**
> Addresses event-loop starvation that caused provider health checks, HTTP endpoints, and git commands to time out under heavy refresh load.
> 
> **Command path resolution (`shell.ts`)** stops emitting a trace span on every PATH/PATHEXT file probe by making `isExecutableFile` and the caching wrapper untraced. Adds a **30s TTL cache** (platform, command, PATH, PATHEXT) for both hits and misses, plus `clearCommandPathCache()` for tests.
> 
> **VCS process spawning (`VcsProcess.ts`)** wraps each `processRunner.run` in a **global semaphore** (4–16 permits from `availableParallelism() / 4`) so workspace refreshes cannot launch unbounded git processes; queue time does not count toward per-command timeouts.
> 
> Tests cover cache reuse after the binary is removed and that 40 concurrent runs stay at or below the spawn cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7f1727a639c987efbd3d4dbe595494ed6f5e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache command path resolutions and bound concurrent git process spawns
> - `resolveCommandPathForPlatform` in [shell.ts](https://github.com/pingdotgg/t3code/pull/4778/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) now caches results (hit or not-found) for 30s per `(platform, command, PATH, PATHEXT)` tuple, avoiding repeated filesystem probes. A new `clearCommandPathCache()` export forces re-resolution.
> - `isExecutableFile` is changed to use `Effect.fnUntraced` to avoid generating a trace span on every probe call.
> - `VcsProcess.run` in [VcsProcess.ts](https://github.com/pingdotgg/t3code/pull/4778/files#diff-42ce5a28bf0b16d9cc4fdfbca0e82279f369588e696972ab8b199fe9df69336d) now acquires a semaphore permit before spawning a child process, capping concurrency at `max(4, min(16, floor(parallelism/4)))` based on `NodeOS.availableParallelism()`.
> - Behavioral Change: git spawns that exceed the concurrency cap now queue and wait for a permit rather than spawning immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dc7f172. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->