### PR TITLE
faster desktop startup

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -1,6 +1,7 @@
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Option from "effect/Option";
 import * as Random from "effect/Random";
 import * as Ref from "effect/Ref";
@@ -21,6 +22,7 @@ import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopShellEnvironment from "../shell/DesktopShellEnvironment.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
 
 const DEFAULT_DESKTOP_BACKEND_PORT = 3773;
 const MAX_TCP_PORT = 65_535;
@@ -129,7 +131,9 @@ const handleFatalStartupError = Effect.fn("desktop.startup.handleFatalStartupErr
 const fatalStartupCause = <E>(stage: string, cause: Cause.Cause<E>) =>
   handleFatalStartupError(stage, Cause.pretty(cause)).pipe(Effect.andThen(Effect.failCause(cause)));
 
-const bootstrap = Effect.gen(function* () {
+const bootstrap = Effect.fn("desktop.bootstrap")(function* (
+  shellEnvironmentInstalled: Fiber.Fiber<void>,
+) {
   const backendManager = yield* DesktopBackendManager.DesktopBackendManager;
   const state = yield* DesktopState.DesktopState;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
@@ -177,11 +181,14 @@ const bootstrap = Effect.gen(function* () {
   yield* installDesktopIpcHandlers;
   yield* logBootstrapInfo("bootstrap ipc handlers registered");
 
+  // The backend child inherits the hydrated PATH, so it must be ready before spawning.
+  yield* Fiber.join(shellEnvironmentInstalled);
+
   if (!(yield* Ref.get(state.quitting))) {
     yield* backendManager.start;
     yield* logBootstrapInfo("bootstrap backend start requested");
   }
-}).pipe(Effect.withSpan("desktop.bootstrap"));
+});
 
 const startup = Effect.gen(function* () {
   const appIdentity = yield* DesktopAppIdentity.DesktopAppIdentity;
@@ -193,8 +200,9 @@ const startup = Effect.gen(function* () {
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
 
-  yield* shellEnvironment.installIntoProcess;
+  const shellEnvironmentInstalled = yield* Effect.forkScoped(shellEnvironment.installIntoProcess);
   const userDataPath = yield* appIdentity.resolveUserDataPath;
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
@@ -215,8 +223,14 @@ const startup = Effect.gen(function* () {
   yield* appIdentity.configure;
   yield* applicationMenu.configure;
   yield* electronProtocol.registerDesktopFileProtocol;
+  yield* desktopWindow.ensureMain.pipe(
+    Effect.catchCause((cause) => fatalStartupCause("window", cause)),
+  );
+  yield* logStartupInfo("startup window created");
   yield* updates.configure;
-  yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));
+  yield* bootstrap(shellEnvironmentInstalled).pipe(
+    Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)),
+  );
 }).pipe(Effect.withSpan("desktop.startup"));
 
 const scopedProgram = Effect.scoped(

--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -133,7 +133,6 @@ function makeManagerLayer(input: {
           ensureMain: Effect.die("unexpected ensureMain"),
           revealOrCreateMain: Effect.die("unexpected revealOrCreateMain"),
           activate: Effect.void,
-          createMainIfBackendReady: Effect.void,
           handleBackendReady: Effect.void,
           dispatchMenuAction: () => Effect.void,
           syncAppearance: Effect.void,

--- a/apps/desktop/src/ipc/menuActionInbox.test.ts
+++ b/apps/desktop/src/ipc/menuActionInbox.test.ts
@@ -1,0 +1,44 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import { makeMenuActionInbox } from "./menuActionInbox.ts";
+
+describe("makeMenuActionInbox", () => {
+  it("replays actions delivered before a listener subscribes", () => {
+    const inbox = makeMenuActionInbox();
+    inbox.deliver("open-settings");
+    inbox.deliver("new-thread");
+
+    const received: string[] = [];
+    inbox.subscribe((action) => received.push(action));
+
+    assert.deepEqual(received, ["open-settings", "new-thread"]);
+  });
+
+  it("delivers directly once subscribed and replays nothing twice", () => {
+    const inbox = makeMenuActionInbox();
+    inbox.deliver("open-settings");
+
+    const first: string[] = [];
+    const unsubscribe = inbox.subscribe((action) => first.push(action));
+    inbox.deliver("new-thread");
+    unsubscribe();
+
+    const second: string[] = [];
+    inbox.subscribe((action) => second.push(action));
+
+    assert.deepEqual(first, ["open-settings", "new-thread"]);
+    assert.deepEqual(second, []);
+  });
+
+  it("buffers again after unsubscribing", () => {
+    const inbox = makeMenuActionInbox();
+    const unsubscribe = inbox.subscribe(() => {});
+    unsubscribe();
+    inbox.deliver("open-settings");
+
+    const received: string[] = [];
+    inbox.subscribe((action) => received.push(action));
+
+    assert.deepEqual(received, ["open-settings"]);
+  });
+});

--- a/apps/desktop/src/ipc/menuActionInbox.ts
+++ b/apps/desktop/src/ipc/menuActionInbox.ts
@@ -1,0 +1,36 @@
+export interface MenuActionInbox {
+  readonly deliver: (action: string) => void;
+  readonly subscribe: (listener: (action: string) => void) => () => void;
+}
+
+/**
+ * Buffers menu actions that arrive before the renderer subscribes, so actions
+ * triggered while the startup splash is up are replayed once the app mounts.
+ */
+export function makeMenuActionInbox(): MenuActionInbox {
+  const pending: string[] = [];
+  let listener: ((action: string) => void) | undefined;
+
+  return {
+    deliver: (action) => {
+      if (listener === undefined) {
+        pending.push(action);
+        return;
+      }
+      listener(action);
+    },
+    subscribe: (nextListener) => {
+      listener = nextListener;
+      const replayed = pending.splice(0, pending.length);
+      for (const action of replayed) {
+        nextListener(action);
+      }
+
+      return () => {
+        if (listener === nextListener) {
+          listener = undefined;
+        }
+      };
+    },
+  };
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -2,6 +2,13 @@ import type { DesktopBridge } from "@t3tools/contracts";
 import { contextBridge, ipcRenderer } from "electron";
 
 import * as IpcChannels from "./ipc/channels.ts";
+import { makeMenuActionInbox } from "./ipc/menuActionInbox.ts";
+
+const menuActionInbox = makeMenuActionInbox();
+ipcRenderer.on(IpcChannels.MENU_ACTION_CHANNEL, (_event, action: unknown) => {
+  if (typeof action !== "string") return;
+  menuActionInbox.deliver(action);
+});
 
 function unwrapEnsureSshEnvironmentResult(result: unknown) {
   if (
@@ -96,17 +103,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ...(position === undefined ? {} : { position }),
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
-  onMenuAction: (listener) => {
-    const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
-      if (typeof action !== "string") return;
-      listener(action);
-    };
-
-    ipcRenderer.on(IpcChannels.MENU_ACTION_CHANNEL, wrappedListener);
-    return () => {
-      ipcRenderer.removeListener(IpcChannels.MENU_ACTION_CHANNEL, wrappedListener);
-    };
-  },
+  onMenuAction: (listener) => menuActionInbox.subscribe(listener),
   getUpdateState: () => ipcRenderer.invoke(IpcChannels.UPDATE_GET_STATE_CHANNEL),
   setUpdateChannel: (channel) =>
     ipcRenderer.invoke(IpcChannels.UPDATE_SET_CHANNEL_CHANNEL, channel),

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -69,7 +69,6 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     ensureMain: Effect.die("unexpected ensureMain"),
     revealOrCreateMain: Effect.die("unexpected revealOrCreateMain"),
     activate: Effect.void,
-    createMainIfBackendReady: Effect.void,
     handleBackendReady: Effect.void,
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
     syncAppearance: Effect.void,

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -18,6 +18,7 @@ import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
+import { STARTUP_SPLASH_MESSAGE } from "./startupSplash.ts";
 
 const environmentInput = {
   dirname: "/repo/apps/desktop/dist-electron",
@@ -48,7 +49,7 @@ function makeFakeBrowserWindow() {
     isDestroyed: vi.fn(() => false),
     isMinimized: vi.fn(() => false),
     isVisible: vi.fn(() => true),
-    loadURL: vi.fn(() => Promise.resolve()),
+    loadURL: vi.fn((_url: string) => Promise.resolve()),
     on: vi.fn(),
     once: vi.fn(),
     restore: vi.fn(),
@@ -154,7 +155,7 @@ function makeTestLayer(input: {
 }
 
 describe("DesktopWindow", () => {
-  it.effect("does not open a development window until the backend is ready", () =>
+  it.effect("shows the startup splash before the backend is ready", () =>
     Effect.gen(function* () {
       const fakeWindow = makeFakeBrowserWindow();
       const createCount = yield* Ref.make(0);
@@ -167,13 +168,42 @@ describe("DesktopWindow", () => {
 
       yield* Effect.gen(function* () {
         const desktopWindow = yield* DesktopWindow.DesktopWindow;
-        yield* desktopWindow.activate;
-        assert.equal(yield* Ref.get(createCount), 0);
+        yield* desktopWindow.ensureMain;
+        assert.equal(yield* Ref.get(createCount), 1);
+        const splashUrl = fakeWindow.loadURL.mock.calls[0]?.[0] ?? "";
+        assert.isTrue(splashUrl.startsWith("data:text/html;charset=utf-8,"));
+        assert.include(decodeURIComponent(splashUrl), STARTUP_SPLASH_MESSAGE);
+        assert.equal(fakeWindow.openDevTools.mock.calls.length, 0);
 
         yield* desktopWindow.handleBackendReady;
         assert.equal(yield* Ref.get(createCount), 1);
-        assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["http://127.0.0.1:5733/"]);
+        assert.deepEqual(fakeWindow.loadURL.mock.calls[1], ["http://127.0.0.1:5733/"]);
         assert.equal(fakeWindow.openDevTools.mock.calls.length, 1);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("loads the app directly when the backend is already ready", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady;
+        assert.equal(yield* Ref.get(createCount), 1);
+        assert.deepEqual(fakeWindow.loadURL.mock.calls[1], ["http://127.0.0.1:5733/"]);
+
+        yield* Ref.set(mainWindow, Option.none());
+        yield* desktopWindow.activate;
+        assert.equal(yield* Ref.get(createCount), 2);
+        assert.deepEqual(fakeWindow.loadURL.mock.calls[3], ["http://127.0.0.1:5733/"]);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -17,6 +17,11 @@ import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as IpcChannels from "../ipc/channels.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
+import {
+  renderStartupSplashHtml,
+  STARTUP_SPLASH_MESSAGE,
+  toStartupSplashUrl,
+} from "./startupSplash.ts";
 
 const TITLEBAR_HEIGHT = 40;
 const TITLEBAR_COLOR = "#01000000"; // #00000000 does not work correctly on Linux
@@ -55,7 +60,6 @@ export interface DesktopWindowShape {
   readonly ensureMain: Effect.Effect<Electron.BrowserWindow, DesktopWindowError>;
   readonly revealOrCreateMain: Effect.Effect<Electron.BrowserWindow, DesktopWindowError>;
   readonly activate: Effect.Effect<void, DesktopWindowError>;
-  readonly createMainIfBackendReady: Effect.Effect<void, DesktopWindowError>;
   readonly handleBackendReady: Effect.Effect<void, DesktopWindowError>;
   readonly dispatchMenuAction: (action: string) => Effect.Effect<void, DesktopWindowError>;
   readonly syncAppearance: Effect.Effect<void>;
@@ -156,9 +160,31 @@ const make = Effect.gen(function* () {
   const context = yield* Effect.context<DesktopWindowRuntimeServices>();
   const runPromise = Effect.runPromiseWith(context);
 
-  const createWindow = Effect.fn("desktop.window.createWindow")(function* (
-    backendHttpUrl: URL,
-  ): Effect.fn.Return<Electron.BrowserWindow, DesktopWindowError> {
+  const resolveAppUrl = Effect.gen(function* () {
+    if (environment.isDevelopment) {
+      return yield* resolveDesktopDevServerUrl(environment);
+    }
+    const backendConfig = yield* serverExposure.backendConfig;
+    return backendConfig.httpBaseUrl.href;
+  });
+
+  const loadApp = Effect.fn("desktop.window.loadApp")(function* (
+    window: Electron.BrowserWindow,
+  ): Effect.fn.Return<void, DesktopWindowError> {
+    if (window.isDestroyed()) {
+      return;
+    }
+    const appUrl = yield* resolveAppUrl;
+    void window.loadURL(appUrl);
+    if (environment.isDevelopment) {
+      window.webContents.openDevTools({ mode: "detach" });
+    }
+  });
+
+  const createWindow = Effect.fn("desktop.window.createWindow")(function* (): Effect.fn.Return<
+    Electron.BrowserWindow,
+    DesktopWindowError
+  > {
     const iconPaths = yield* assets.iconPaths;
     const iconOption = getIconOption(iconPaths);
     const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
@@ -275,13 +301,15 @@ const make = Effect.gen(function* () {
       void runPromise(electronWindow.reveal(window));
     });
 
-    if (environment.isDevelopment) {
-      const devServerUrl = yield* resolveDesktopDevServerUrl(environment);
-      void window.loadURL(devServerUrl);
-      window.webContents.openDevTools({ mode: "detach" });
-    } else {
-      void window.loadURL(backendHttpUrl.href);
-    }
+    void window.loadURL(
+      toStartupSplashUrl(
+        renderStartupSplashHtml({
+          displayName: environment.displayName,
+          shouldUseDarkColors,
+          message: STARTUP_SPLASH_MESSAGE,
+        }),
+      ),
+    );
 
     window.on("closed", () => {
       void runPromise(electronWindow.clearMain(Option.some(window)));
@@ -291,10 +319,12 @@ const make = Effect.gen(function* () {
   });
 
   const createMain = Effect.gen(function* () {
-    const backendConfig = yield* serverExposure.backendConfig;
-    const window = yield* createWindow(backendConfig.httpBaseUrl);
+    const window = yield* createWindow();
     yield* electronWindow.setMain(window);
     yield* logWindowInfo("main window created");
+    if (yield* Ref.get(state.backendReady)) {
+      yield* loadApp(window);
+    }
     return window;
   }).pipe(Effect.withSpan("desktop.window.createMain"));
 
@@ -312,31 +342,20 @@ const make = Effect.gen(function* () {
     return window;
   }).pipe(Effect.withSpan("desktop.window.revealOrCreateMain"));
 
-  const createMainIfBackendReady = Effect.gen(function* () {
-    const backendReady = yield* Ref.get(state.backendReady);
-    if (!backendReady) return;
-    const existingWindow = yield* electronWindow.currentMainOrFirst;
-    if (Option.isSome(existingWindow)) return;
-    yield* createMain;
-  }).pipe(Effect.withSpan("desktop.window.createMainIfBackendReady"));
-
   return DesktopWindow.of({
     createMain,
     ensureMain,
     revealOrCreateMain,
-    activate: Effect.gen(function* () {
-      const existingWindow = yield* electronWindow.currentMainOrFirst;
-      if (Option.isSome(existingWindow)) {
-        yield* electronWindow.reveal(existingWindow.value);
-      } else {
-        yield* createMainIfBackendReady;
-      }
-    }).pipe(Effect.withSpan("desktop.window.activate")),
-    createMainIfBackendReady,
+    activate: revealOrCreateMain.pipe(Effect.asVoid, Effect.withSpan("desktop.window.activate")),
     handleBackendReady: Effect.gen(function* () {
       yield* Ref.set(state.backendReady, true);
       yield* logWindowInfo("backend ready", { source: "http" });
-      yield* createMainIfBackendReady;
+      const existingWindow = yield* electronWindow.currentMainOrFirst;
+      if (Option.isNone(existingWindow)) {
+        yield* createMain;
+        return;
+      }
+      yield* loadApp(existingWindow.value);
     }).pipe(Effect.withSpan("desktop.window.handleBackendReady")),
     dispatchMenuAction: Effect.fn("desktop.window.dispatchMenuAction")(function* (action) {
       yield* Effect.annotateCurrentSpan({ action });
@@ -348,6 +367,12 @@ const make = Effect.gen(function* () {
         targetWindow.webContents.send(IpcChannels.MENU_ACTION_CHANNEL, action);
         void runPromise(electronWindow.reveal(targetWindow));
       };
+
+      // The splash document cannot handle menu actions; wait for the app to load.
+      if (!(yield* Ref.get(state.backendReady))) {
+        targetWindow.webContents.once("did-finish-load", send);
+        return;
+      }
 
       if (targetWindow.webContents.isLoadingMainFrame()) {
         targetWindow.webContents.once("did-finish-load", send);

--- a/apps/desktop/src/window/startupSplash.test.ts
+++ b/apps/desktop/src/window/startupSplash.test.ts
@@ -1,0 +1,56 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import {
+  renderStartupSplashHtml,
+  STARTUP_SPLASH_MESSAGE,
+  toStartupSplashUrl,
+} from "./startupSplash.ts";
+
+describe("startupSplash", () => {
+  it("renders the display name and message", () => {
+    const html = renderStartupSplashHtml({
+      displayName: "T3 Code (Alpha)",
+      shouldUseDarkColors: false,
+      message: STARTUP_SPLASH_MESSAGE,
+    });
+
+    assert.include(html, "T3 Code (Alpha)");
+    assert.include(html, STARTUP_SPLASH_MESSAGE);
+    assert.include(html, "#ffffff");
+  });
+
+  it("uses dark colors when requested", () => {
+    const html = renderStartupSplashHtml({
+      displayName: "T3 Code",
+      shouldUseDarkColors: true,
+      message: STARTUP_SPLASH_MESSAGE,
+    });
+
+    assert.include(html, "#0a0a0a");
+    assert.notInclude(html, "background: #ffffff");
+  });
+
+  it("escapes the display name", () => {
+    const html = renderStartupSplashHtml({
+      displayName: '<img src=x onerror="alert(1)">',
+      shouldUseDarkColors: false,
+      message: STARTUP_SPLASH_MESSAGE,
+    });
+
+    assert.notInclude(html, "<img");
+    assert.include(html, "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
+  });
+
+  it("encodes the document as a data url", () => {
+    const url = toStartupSplashUrl(
+      renderStartupSplashHtml({
+        displayName: "T3 Code",
+        shouldUseDarkColors: false,
+        message: STARTUP_SPLASH_MESSAGE,
+      }),
+    );
+
+    assert.isTrue(url.startsWith("data:text/html;charset=utf-8,"));
+    assert.include(decodeURIComponent(url), STARTUP_SPLASH_MESSAGE);
+  });
+});

--- a/apps/desktop/src/window/startupSplash.ts
+++ b/apps/desktop/src/window/startupSplash.ts
@@ -1,0 +1,99 @@
+export interface StartupSplashInput {
+  readonly displayName: string;
+  readonly shouldUseDarkColors: boolean;
+  readonly message: string;
+}
+
+export const STARTUP_SPLASH_MESSAGE = "Starting local server…";
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function renderStartupSplashHtml(input: StartupSplashInput): string {
+  const background = input.shouldUseDarkColors ? "#0a0a0a" : "#ffffff";
+  const foreground = input.shouldUseDarkColors ? "#f8fafc" : "#1f2937";
+  const muted = input.shouldUseDarkColors ? "#94a3b8" : "#64748b";
+  const track = input.shouldUseDarkColors ? "#1e293b" : "#e2e8f0";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'" />
+    <title>${escapeHtml(input.displayName)}</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: ${background};
+        color: ${foreground};
+        font-family: ui-sans-serif, -apple-system, "Segoe UI", system-ui, sans-serif;
+        -webkit-user-select: none;
+        user-select: none;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 14px;
+        -webkit-app-region: drag;
+      }
+      .name {
+        font-size: 15px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+      .message {
+        font-size: 13px;
+        color: ${muted};
+      }
+      .bar {
+        width: 168px;
+        height: 2px;
+        border-radius: 999px;
+        background: ${track};
+        overflow: hidden;
+      }
+      .bar::after {
+        content: "";
+        display: block;
+        width: 40%;
+        height: 100%;
+        border-radius: inherit;
+        background: ${muted};
+        animation: slide 1.2s ease-in-out infinite;
+      }
+      @keyframes slide {
+        0% {
+          transform: translateX(-100%);
+        }
+        100% {
+          transform: translateX(250%);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .bar::after {
+          animation: none;
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="name">${escapeHtml(input.displayName)}</div>
+    <div class="message">${escapeHtml(input.message)}</div>
+    <div class="bar"></div>
+  </body>
+</html>`;
+}
+
+export function toStartupSplashUrl(html: string): string {
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -316,7 +316,11 @@ export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {
     const config = yield* ServerConfig;
 
-    fixPath();
+    // The desktop app hydrates the login-shell environment before spawning this process,
+    // so probing a second login shell here would only block startup.
+    if (config.mode !== "desktop") {
+      fixPath();
+    }
 
     const httpListeningLayer = Layer.effectDiscard(
       Effect.gen(function* () {


### PR DESCRIPTION
## What Changed

Three changes to the desktop cold-start path, all scoped to `apps/desktop` plus one line in `apps/server`:

**1. The window no longer waits for the backend.** `DesktopWindow.createWindow` loads a self-contained "Starting local server…" splash (a `data:text/html` document rendered by the new `startupSplash.ts`), and `DesktopApp.startup` creates the window right after `app.whenReady()`. `handleBackendReady` now navigates the existing window to the app URL instead of being the thing that creates it:

```diff
-createMainIfBackendReady: if (!backendReady) return; ... createMain   // window only after the HTTP probe
+startup:            whenReady -> ensureMain (splash) -> updates.configure -> bootstrap
+handleBackendReady: backendReady = true; existing window ? loadApp(window) : createMain
```

`createMain` loads the app URL directly when the backend is already ready, so windows created later (dock activate, menu action) behave exactly as before.

**2. The login-shell probe runs off the critical path.** `shellEnvironment.installIntoProcess` is forked at startup instead of being awaited before `app.whenReady()`, and joined in `bootstrap` right before the backend child is spawned (the child inherits the hydrated `PATH`, so that ordering still has to hold).

**3. The backend no longer re-probes.** `makeServerLayer` skips `fixPath()` when `config.mode === "desktop"`. That call is a synchronous `execFileSync($SHELL, ["-ilc", …], { timeout: 5000 })` that blocks the backend's event loop before the HTTP listener comes up, redoing work the desktop parent already did. Web/CLI mode is unchanged.

Supporting fix: menu actions triggered while the splash is up are buffered in the preload (`ipc/menuActionInbox.ts`) and replayed when the renderer subscribes. `dispatchMenuAction` defers the send to the app document's `did-finish-load`, but the renderer subscribes in a React effect that runs *after* load, so without the buffer the action lands on a channel with no listener and is dropped. (The pre-existing `isLoadingMainFrame()` branch has the same shape, so this was latent before — the splash just makes it the always-taken path.)

## Why

Cold start and post-update relaunch have a long blank period: nothing renders until the backend child answers `GET /.well-known/t3/environment`, and everything before that is serial and invisible — Electron boot → login-shell probe → port scan → backend spawn → *second, synchronous* login-shell probe → the full Effect layer graph (SQLite migrations, provider hydration, git/VCS, PTY, auth) → readiness poll → window creation → renderer boot.

(1) removes the blank period from the user's perspective. (2) and (3) remove one of the two serial login-shell probes, which cost 0.2–3 s each on setups with heavy `.zshrc` (nvm / oh-my-zsh / mise) and, in the backend's case, block its event loop before it listens.

Deliberately **not** included, to keep this small: serving readiness before the heavy layer graph, and trimming the packaged bundle (`bun install --production` ships the full server dep tree with no `files` / asar / compression tuning, and macOS builds both dmg and zip). Both look worthwhile but are far more invasive.

## UI Changes

New splash state between window creation and backend readiness — previously there was no window at all. Light/dark aware, animated progress bar, drag region so the window can be moved while it loads.

Measured on Linux via the dev runner, sampling window state every 0.4 s against main-process log timestamps:

| before (`main`) | after |
|---|---|
| no window until `backend ready` (`backend ready 19:56:07.176` → `main window created 19:56:07.207`) | splash present 2.47 s **before** `backend ready` (`startup window created 19:57:36.914` → `backend ready 19:57:39.383`) |

The same window then navigates itself to the app UI — exactly one window in `wmctrl -l` throughout, no `did-fail-load` / fatal-startup / backend-exit entries in the main-process log, and closing the window still quits cleanly.

<!-- Paste the splash screenshot and the startup recording here. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes
