### PR TITLE
docs: overhaul agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,52 +1,193 @@
-# AGENTS.md
+# T3 Code
 
-## Task Completion Requirements
+T3 Code is a minimal GUI for coding agents. A Node WebSocket server wraps
+provider CLIs (Codex, Claude Code, Cursor, Grok, OpenCode) and serves web,
+desktop, and mobile clients.
 
-- Keep local verification focused on the files and packages changed. Run the smallest relevant test set; do not run the full workspace test suite as a routine completion step.
-  - Use `vp test run <test-files>` for focused built-in Vite+ tests. Use `vp run test` only when the affected package specifically requires its `test` script.
-  - Backend changes must include and run focused tests for the changed behavior.
-  - Run targeted formatting, lint, and type checks for the affected scope when available.
-- Do not run repo-wide `vp check`, `vp run typecheck`, `vp run test`, or equivalent full-suite commands locally unless the user explicitly requests them. CI is responsible for the full verification suite.
-- After frontend feature development or any user-visible frontend behavior change, the primary agent must run one integrated verification pass for each affected client surface after integrating the work:
-  - Web: use the `test-t3-app` skill. Launch one isolated environment, authenticate through the printed pairing URL, and verify the affected flow in the controlled browser.
-  - Mobile: use the `test-t3-mobile` skill. Connect one representative iOS Simulator or Android Emulator available on the host to one isolated environment and verify the affected flow. On compatible macOS hosts, prefer iOS for cross-platform changes and stream it through serve-sim in the T3 Code in-app browser or another available agent browser; use Android when it is the affected or viable platform.
-  - Subagents must not independently launch dev servers or repeat integrated client verification unless their delegated task explicitly requires it.
-  - Stop dev servers, watchers, and other long-running verification processes when the focused verification is complete.
+You can think of T3 Code as an open source "bring-your-own-subscription" alternative to apps like Claude Desktop, Codex App, Cursor Glass and Conductor.
 
-## Dev Servers
+## What makes T3 Code special?
 
-- In a linked git worktree, dev state defaults to that worktree's gitignored `.t3`. This deliberately outranks an ambient `T3CODE_HOME`, which could otherwise select the installed app's live `~/.t3/userdata` database. An explicit `--home-dir` still wins.
-- Start the web stack with `vp run dev`. Add `--share` when someone needs to open it from another device on the tailnet.
-- Browser dev is single-origin: Vite proxies `/api`, `/ws`, `/oauth`, and `/.well-known` to the backend. Do not set `VITE_HTTP_URL` or `VITE_WS_URL` for `dev`/`dev:web`.
-- Worktree paths supply stable preferred port offsets. Read the actual server and web ports from the `[dev-runner]` line because occupied ports can still shift them.
-- Before handing off a `--share` URL, open its origin in a controlled browser and confirm the app loads. A successful curl is insufficient because browsers reject some otherwise reachable ports.
+We have over 100,000 users who love T3 Code. It's important we maintain the things they love as we continue to iterate on the product. Here's a brief list of the things we can never compromise on.
 
-## Package Roles
+### 1. Open at the core
 
-- `apps/server`: Node.js WebSocket server. Wraps Codex app-server (JSON-RPC over stdio), serves the React web app, and manages provider sessions.
-- `apps/web`: React/Vite UI. Owns session UX, conversation/event rendering, and client-side state. Connects to the server via WebSocket.
-- `packages/contracts`: Shared effect/Schema schemas and TypeScript contracts for provider events, WebSocket protocol, and model/session types. Keep this package schema-only — no runtime logic.
-- `packages/shared`: Shared runtime utilities consumed by both server and client applications. Uses explicit subpath exports (e.g. `@t3tools/shared/git`) — no barrel index.
-- `packages/client-runtime`: Shared runtime package for sharing client code across web and mobile.
+T3 Code is truly open. We share our roadmap, we share how we think about things, and of course we share all our code. A large number of our users run forks. We work in the open, and should strive to stay that way.
 
-## Reference Repos
+### 2. Performance without compromise
 
-- Open-source Codex repo: https://github.com/openai/codex
+Lots of apps have gotten bogged down with bad tech decisions and "slop". We have not, and we're proud of the performance of T3 Code. We regularly audit for performance regressions, often caused by sending too much data over websockets, css animations causing gpu spikes, lists being hard to render, and more. Make sure all changes are considerate of performance impact.
 
-Use these as implementation references when designing protocol handling, UX flows, and operational safeguards.
+### 3. Remote ready
 
-## Vendored Repositories
+The architecture of T3 Code's websocket layer (npx t3) enables a lot of awesome remote features. These have become core to the product. Whether users are connecting directly over their local network, using Tailscale, or leaning in fully with T3 Connect (our tunnel solution, also in this repo), we need to make sure new features are properly supported.
 
-This project vendors external repositories under `.repos/` as read-only reference material for coding
-agents.
+### 4. Multi-surface
 
-- Prefer examples and patterns from the vendored source code over generated guesses or web search results.
-- Do not edit files under `.repos/` unless explicitly asked.
-- Do not import from `.repos/`; application code must continue importing from normal package dependencies.
-- Manage vendored subtrees with `vpr sync:repos`; use `vpr sync:repos --repo <id>` to sync one configured repository.
-- When updating a dependency with a configured vendored subtree, sync that subtree in the same change so
-  `.repos/` matches the installed dependency version.
-- When writing Effect code, read `.repos/effect-smol/LLMS.md` first and inspect `.repos/effect-smol/` for
-  examples of idiomatic usage, tests, module structure, and API design.
-- When writing relay infrastructure code with Alchemy, inspect `.repos/alchemy-effect/` for examples of
-  idiomatic usage, tests, module structure, and API design.
+T3 Code has 3 key app surfaces: **web**, **desktop**, and **mobile**.
+
+**Web** is kind of two surfaces, as we have the public facing "app.t3.codes" as well as locally hosting the web app through the `npx t3` command. Both need to be supported by all new features where reasonable.
+
+**Desktop** is the main surface most users install first. It's a full Electron app that bundles the server runner as well. The desktop app can also be used as the host server, allowing remote connections from app.t3.codes or the mobile app.
+
+**Mobile** is a React native app for both iOS and Android. The mobile app allows for connecting to any T3 Code server to control work remotely. It is still in early access (Testflight), but it is pretty close to shipping globally.
+
+## A note from Theo
+
+I like ambitious ideas, simple systems, and software that feels obvious. Do not preserve complexity just because it already exists. Do not introduce machinery because it looks architecturally impressive. Understand the real constraint, then fight for the smallest model that makes the correct behavior unsurprising.
+
+Channel both "measure twice, cut once" and "yagni". Fight scope creep. Try to honor the dev's intent in both a minimal and realistic fashion.
+
+The rest of this document is meant to help you navigate the codebase and make changes effectively. Think of these instructions less as "hard rules", more as "good defaults". The developer's preferences should be able to override anything here.
+
+Of note: Most T3 Code contributions will come from T3 Code itself, often controlled remotely. This means you should be careful about accessing data, killing dev servers, and other things that may damage the T3 Code instance that the contributor is using.
+
+## A small glossary
+
+We need to be on the same page with terminology. When communicating, use this language:
+
+- **you** means the agent reading this file and changing T3 Code.
+- **we, us, and maintainers** mean Theo, Julius and the people building T3 Code. These are who you are talking to now.
+- **user** means the person using T3 Code to direct coding agents.
+- **agent** means the coding agent a user runs inside T3 Code. Depending on context, that may also include you.
+- **provider** means the agent runtime or harness T3 Code talks to, such as Codex, Claude, Cursor, or OpenCode.
+- **client** means the web, desktop, or mobile UI.
+- **environment** means one running T3 server and the machine, filesystem, provider credentials, and state it owns.
+- **project** means an environment-local workspace record rooted at a directory.
+- **thread** means the durable conversation and work history for a project.
+- **turn** means one user-to-agent cycle, including follow-up work such as checkpointing.
+- **T3 home** means the base data directory. Runtime state normally lives below its userdata directory.
+
+## The three ways to hurt yourself
+
+1. **Killing by pattern.** Never `pkill -f`, `pgrep | kill`, or `kill` a PID you
+   found by matching a name, path, or worktree string. Your own agent process
+   has this worktree's path in its argv, and this machine runs several other dev
+   servers at once. Kill only a PID you captured at spawn, or the owner of your
+   port from `ss -H -ltnp` after confirming `/proc/<pid>/cwd` is your worktree.
+2. **Touching the live install.** `~/.t3/userdata` is the developer's real T3
+   Code database, in use while you work. Read-only inspection is fine. Never
+   start a server against it, never open it read-write, never clean it up.
+3. **Baking in origins.** Never set `VITE_HTTP_URL` or `VITE_WS_URL` for dev.
+   Dev is single-origin and Vite proxies `/api`, `/ws`, `/oauth`, and
+   `/.well-known`. Setting them bakes localhost into the bundle and silently
+   breaks every remote browser.
+
+## Hit every surface
+
+The most common defect in this repo is a change that works on the path you
+tested and is missing everywhere else. Before calling frontend work done, walk
+this list and say which entries applied:
+
+- **Entry points.** A behavior reachable from the chat view is usually also
+  reachable from Settings, the command palette, and a keybinding. Fixing one is
+  not fixing the feature.
+- **Clients.** Web, desktop (wraps web, adds Electron shell/IPC), and mobile
+  (React Native, separate navigation). Shared logic lives in
+  `packages/client-runtime`
+- **Providers.** Codex, Claude, Cursor, Grok, and OpenCode each have an adapter.
+  Provider-shaped features need a decision per adapter, even if the decision is
+  "not supported here".
+- **Contracts.** Anything crossing the wire is typed in `packages/contracts`.
+  Change the schema and the server, web, mobile, and desktop all follow.
+- **Reverse states.** If you added a way in, add the way out and the way to see
+  it. Snooze needs unsnooze. Close needs reopen. A one-way door is a bug.
+- **Connection modes.** Local, remote/relay, and tunnel behave differently.
+  Multi-device and multi-environment cases are real.
+- **Docs.** `docs/` mirrors this structure. Behavior changes that a user would
+  notice belong in `docs/user/`; architecture changes in `docs/architecture/`;
+  new vocabulary in `docs/reference/encyclopedia.md`.
+
+## Dev servers
+
+- `vp i` installs. Worktrees get this from the t3.json setup script; if module
+  resolution looks broken, it probably did not run.
+- `vp run dev` starts server and web. In a worktree, state defaults to that
+  worktree's gitignored `.t3`, which deliberately outranks an ambient
+  `T3CODE_HOME` so you cannot land on shared state by accident. An explicit
+  `--home-dir` still wins.
+- Ports derive from the worktree path and are stable across restarts, but read
+  the real ones from the `[dev-runner]` line since occupied ports shift.
+- `--share` publishes over the tailnet. Do not open the URL when you use this,
+  just send it to the user with the pairing code included in url
+- The web app requires pairing. Hand over the pairing URL, not the bare origin.
+  A URL without its token is useless to whoever you gave it to.
+- Stop what you started, by the PID you tracked. See rule 1.
+
+## Test data
+
+An empty database is a bad test. Seed your worktree's `.t3` instead of pointing
+at live state:
+
+- Copy from `~/.t3/dev`, never from `~/.t3/userdata`.
+- Copy `state.sqlite` together with its `-wal` and `-shm` siblings, and only
+  while no server has the source open. A live copy is a corrupt copy.
+- Bring `secrets` and `settings.json` only if the flow under test needs them.
+- Copy in, never symlink. Data flows one way: into your sandbox, never back out.
+
+## Verifying
+
+- Smallest proof that the change works. `vp test run <files>` for the tests you
+  touched, targeted lint and typecheck for the scope you changed.
+- **Do not run repo-wide checks.** No `vp check`, no `vp run -r test`, no
+  `vp run -r typecheck` unless I ask. CI owns the full suite.
+- Backend behavior changes ship with focused tests for that behavior.
+- The server is event-sourced and its async flows emit typed receipts. Wait on
+  receipts and worker drains, never on sleeps or polling. A test that needs a
+  timeout to pass is wrong.
+- User-visible frontend changes get one integrated pass in a real client:
+  `test-t3-app` for web, `test-t3-mobile` for mobile. The primary agent does
+  this once after integrating. Subagents do not launch their own dev servers.
+
+## Pull requests
+
+- Never make a PR unless the developer explicitly asks you to do so.
+- Conventional commit titles, plain language: `fix(web): new threads no longer
+spike CPU`.
+- Body: the problem in a sentence or two, then how you fixed it. End with the
+  model and harness that did the work.
+- **Rebase onto latest main before opening.** Stale branches conflict and burn
+  a review round.
+- UI changes need before/after images. Motion or timing needs a short video.
+- One concern per PR. If the description says "also", split it.
+- When babysitting: poll checks and comments newer than the last push, verify
+  each bot finding against the source, fix real ones, dismiss false positives
+  with a written reason. Stay quiet when nothing is new. Stop when the bots are
+  green on the latest commit.
+
+## How it works
+
+Clients send typed WebSocket requests. The server turns them into _commands_, a
+pure _decider_ turns commands into persisted _events_, and a _projector_ derives
+the read model the UI renders. Provider CLIs run as subprocesses; per-provider
+_adapters_ translate their native protocols into orchestration events. Side
+effects run in queue-backed _reactors_ that emit _receipts_ when milestones
+land. Each turn ends with a _checkpoint_, a hidden git ref, so the app can diff
+and restore.
+
+Full glossary with file links: `docs/reference/encyclopedia.md`
+
+## Where code lives
+
+- `apps/server` - WebSocket, orchestration, providers, checkpointing.
+  Effect-heavy: read `.repos/effect-smol/LLMS.md` before writing Effect code.
+- `apps/web` - React/Vite UI. `apps/desktop` wraps it, `apps/mobile` is React
+  Native, `apps/marketing` is the site.
+- `packages/contracts` - Effect/Schema contracts. Schema only, no runtime logic.
+- `packages/shared` - shared runtime utils, subpath exports, no barrel.
+- `packages/client-runtime` - client code shared by web and mobile.
+- `.repos/` - vendored read-only references. Prefer their patterns over
+  invented ones. Never edit or import from them. Sync with `vpr sync:repos`
+  when bumping the matching dependency.
+
+## Taste
+
+- Complexity belongs at the adapter boundary. Orchestration stays pure, UI
+  stays dumb.
+- Inferred types over annotations. `any` is the enemy.
+- Comments describe how a thing is used, and move when the code moves. To be used mostly to describe functions, not to annotate every line of behavior.
+- Our users drive agents all day and notice a dropped frame, a lying spinner,
+  and a stale label. No continuously repainting animations; they peg the GPU on
+  high-refresh displays.
+- If a rule here fights the task in front of you, say so loudly and get a human
+  sign-off before breaking it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ An empty database is a bad test. Seed your worktree's `.t3` instead of pointing 
 - **Do not run repo-wide checks.** No `vp check`, no `vp run -r test`, no `vp run -r typecheck` unless I ask. CI owns the full suite.
 - Backend behavior changes ship with focused tests for that behavior.
 - The server is event-sourced and its async flows emit typed receipts. Wait on receipts and worker drains, never on sleeps or polling. A test that needs a timeout to pass is wrong.
-- User-visible frontend changes get one integrated pass in a real client: `test-t3-app` for web, `test-t3-mobile` for mobile. The primary agent does this once after integrating. Subagents do not launch their own dev servers.
+- Upon request, user-visible frontend changes should get one integrated pass in a real client: `test-t3-app` for web, `test-t3-mobile` for mobile. The primary agent does this once after integrating. Subagents do not launch their own dev servers. Ask permission before doing computer use or spinning up browsers.
 
 ## Pull requests
 
@@ -135,5 +135,5 @@ Full glossary with file links: `docs/reference/encyclopedia.md`
 
 ## Additional tips
 
-- Don't verify with browsers or computer use unless the user explicitly asks
-- Security is important, but should not be over-indexed on, especially for dev mode/maintainer-only features
+- Don't verify with browsers or computer use unless the user explicitly agrees or requests it.
+- Security is important, but should not be over-indexed on, especially for dev mode/maintainer-only features.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
 # T3 Code
 
-T3 Code is a minimal GUI for coding agents. A Node WebSocket server wraps
-provider CLIs (Codex, Claude Code, Cursor, Grok, OpenCode) and serves web,
-desktop, and mobile clients.
+T3 Code is a minimal GUI for coding agents. A Node WebSocket server wraps provider CLIs (Codex, Claude Code, Cursor, Grok, OpenCode) and serves web, desktop, and mobile clients.
 
 You can think of T3 Code as an open source "bring-your-own-subscription" alternative to apps like Claude Desktop, Codex App, Cursor Glass and Conductor.
 
@@ -60,134 +58,77 @@ We need to be on the same page with terminology. When communicating, use this la
 
 ## The three ways to hurt yourself
 
-1. **Killing by pattern.** Never `pkill -f`, `pgrep | kill`, or `kill` a PID you
-   found by matching a name, path, or worktree string. Your own agent process
-   has this worktree's path in its argv, and this machine runs several other dev
-   servers at once. Kill only a PID you captured at spawn, or the owner of your
-   port from `ss -H -ltnp` after confirming `/proc/<pid>/cwd` is your worktree.
-2. **Touching the live install.** `~/.t3/userdata` is the developer's real T3
-   Code database, in use while you work. Read-only inspection is fine. Never
-   start a server against it, never open it read-write, never clean it up.
-3. **Baking in origins.** Never set `VITE_HTTP_URL` or `VITE_WS_URL` for dev.
-   Dev is single-origin and Vite proxies `/api`, `/ws`, `/oauth`, and
-   `/.well-known`. Setting them bakes localhost into the bundle and silently
-   breaks every remote browser.
+1. **Killing by pattern.** Never `pkill -f`, `pgrep | kill`, or `kill` a PID you found by matching a name, path, or worktree string. Your own agent process has this worktree's path in its argv, and this machine runs several other dev servers at once. Kill only a PID you captured at spawn, or the owner of your port from `ss -H -ltnp` after confirming `/proc/<pid>/cwd` is your worktree.
+2. **Touching the live install.** `~/.t3/userdata` is the developer's real T3 Code database, in use while you work. Read-only inspection is fine. Never start a server against it, never open it read-write, never clean it up.
+3. **Baking in origins.** Never set `VITE_HTTP_URL` or `VITE_WS_URL` for dev. Dev is single-origin and Vite proxies `/api`, `/ws`, `/oauth`, and `/.well-known`. Setting them bakes localhost into the bundle and silently breaks every remote browser.
 
 ## Hit every surface
 
-The most common defect in this repo is a change that works on the path you
-tested and is missing everywhere else. Before calling frontend work done, walk
-this list and say which entries applied:
+The most common defect in this repo is a change that works on the path you tested and is missing everywhere else. Before calling frontend work done, walk this list and say which entries applied:
 
-- **Entry points.** A behavior reachable from the chat view is usually also
-  reachable from Settings, the command palette, and a keybinding. Fixing one is
-  not fixing the feature.
-- **Clients.** Web, desktop (wraps web, adds Electron shell/IPC), and mobile
-  (React Native, separate navigation). Shared logic lives in
-  `packages/client-runtime`
-- **Providers.** Codex, Claude, Cursor, Grok, and OpenCode each have an adapter.
-  Provider-shaped features need a decision per adapter, even if the decision is
-  "not supported here".
-- **Contracts.** Anything crossing the wire is typed in `packages/contracts`.
-  Change the schema and the server, web, mobile, and desktop all follow.
-- **Reverse states.** If you added a way in, add the way out and the way to see
-  it. Snooze needs unsnooze. Close needs reopen. A one-way door is a bug.
-- **Connection modes.** Local, remote/relay, and tunnel behave differently.
-  Multi-device and multi-environment cases are real.
-- **Docs.** `docs/` mirrors this structure. Behavior changes that a user would
-  notice belong in `docs/user/`; architecture changes in `docs/architecture/`;
-  new vocabulary in `docs/reference/encyclopedia.md`.
+- **Entry points.** A behavior reachable from the chat view is usually also reachable from Settings, the command palette, and a keybinding. Fixing one is not fixing the feature.
+- **Clients.** Web, desktop (wraps web, adds Electron shell/IPC), and mobile (React Native, separate navigation). Shared logic lives in `packages/client-runtime`
+- **Providers.** Codex, Claude, Cursor, Grok, and OpenCode each have an adapter. Provider-shaped features need a decision per adapter, even if the decision is "not supported here".
+- **Contracts.** Anything crossing the wire is typed in `packages/contracts`. Change the schema and the server, web, mobile, and desktop all follow.
+- **Reverse states.** If you added a way in, add the way out and the way to see it. Snooze needs unsnooze. Close needs reopen. A one-way door is a bug.
+- **Connection modes.** Local, remote/relay, and tunnel behave differently. Multi-device and multi-environment cases are real.
+- **Docs.** `docs/` mirrors this structure. Behavior changes that a user would notice belong in `docs/user/`; architecture changes in `docs/architecture/`; new vocabulary in `docs/reference/encyclopedia.md`.
 
 ## Dev servers
 
-- `vp i` installs. Worktrees get this from the t3.json setup script; if module
-  resolution looks broken, it probably did not run.
-- `vp run dev` starts server and web. In a worktree, state defaults to that
-  worktree's gitignored `.t3`, which deliberately outranks an ambient
-  `T3CODE_HOME` so you cannot land on shared state by accident. An explicit
-  `--home-dir` still wins.
-- Ports derive from the worktree path and are stable across restarts, but read
-  the real ones from the `[dev-runner]` line since occupied ports shift.
-- `--share` publishes over the tailnet. Do not open the URL when you use this,
-  just send it to the user with the pairing code included in url
-- The web app requires pairing. Hand over the pairing URL, not the bare origin.
-  A URL without its token is useless to whoever you gave it to.
+- `vp i` installs. Worktrees get this from the t3.json setup script; if module resolution looks broken, it probably did not run.
+- `vp run dev` starts server and web. In a worktree, state defaults to that worktree's gitignored `.t3`, which deliberately outranks an ambient `T3CODE_HOME` so you cannot land on shared state by accident. An explicit `--home-dir` still wins.
+- Ports derive from the worktree path and are stable across restarts, but read the real ones from the `[dev-runner]` line since occupied ports shift.
+- `--share` publishes over the tailnet. Do not open the URL when you use this, just send it to the user with the pairing code included in url
+- The web app requires pairing. Hand over the pairing URL, not the bare origin. A URL without its token is useless to whoever you gave it to.
 - Stop what you started, by the PID you tracked. See rule 1.
 
 ## Test data
 
-An empty database is a bad test. Seed your worktree's `.t3` instead of pointing
-at live state:
+An empty database is a bad test. Seed your worktree's `.t3` instead of pointing at live state:
 
 - Copy from `~/.t3/dev`, never from `~/.t3/userdata`.
-- Copy `state.sqlite` together with its `-wal` and `-shm` siblings, and only
-  while no server has the source open. A live copy is a corrupt copy.
+- Copy `state.sqlite` together with its `-wal` and `-shm` siblings, and only while no server has the source open. A live copy is a corrupt copy.
 - Bring `secrets` and `settings.json` only if the flow under test needs them.
 - Copy in, never symlink. Data flows one way: into your sandbox, never back out.
 
 ## Verifying
 
-- Smallest proof that the change works. `vp test run <files>` for the tests you
-  touched, targeted lint and typecheck for the scope you changed.
-- **Do not run repo-wide checks.** No `vp check`, no `vp run -r test`, no
-  `vp run -r typecheck` unless I ask. CI owns the full suite.
+- Smallest proof that the change works. `vp test run <files>` for the tests you touched, targeted lint and typecheck for the scope you changed.
+- **Do not run repo-wide checks.** No `vp check`, no `vp run -r test`, no `vp run -r typecheck` unless I ask. CI owns the full suite.
 - Backend behavior changes ship with focused tests for that behavior.
-- The server is event-sourced and its async flows emit typed receipts. Wait on
-  receipts and worker drains, never on sleeps or polling. A test that needs a
-  timeout to pass is wrong.
-- User-visible frontend changes get one integrated pass in a real client:
-  `test-t3-app` for web, `test-t3-mobile` for mobile. The primary agent does
-  this once after integrating. Subagents do not launch their own dev servers.
+- The server is event-sourced and its async flows emit typed receipts. Wait on receipts and worker drains, never on sleeps or polling. A test that needs a timeout to pass is wrong.
+- User-visible frontend changes get one integrated pass in a real client: `test-t3-app` for web, `test-t3-mobile` for mobile. The primary agent does this once after integrating. Subagents do not launch their own dev servers.
 
 ## Pull requests
 
 - Never make a PR unless the developer explicitly asks you to do so.
-- Conventional commit titles, plain language: `fix(web): new threads no longer
-spike CPU`.
-- Body: the problem in a sentence or two, then how you fixed it. End with the
-  model and harness that did the work.
-- **Rebase onto latest main before opening.** Stale branches conflict and burn
-  a review round.
+- Conventional commit titles, plain language: `fix(web): new threads no longer spike CPU`.
+- Body: the problem in a sentence or two, then how you fixed it. End with the model and harness that did the work.
+- **Rebase onto latest main before opening.** Stale branches conflict and burn a review round.
 - UI changes need before/after images. Motion or timing needs a short video.
 - One concern per PR. If the description says "also", split it.
-- When babysitting: poll checks and comments newer than the last push, verify
-  each bot finding against the source, fix real ones, dismiss false positives
-  with a written reason. Stay quiet when nothing is new. Stop when the bots are
-  green on the latest commit.
+- When babysitting: poll checks and comments newer than the last push, verify each bot finding against the source, fix real ones, dismiss false positives with a written reason. Stay quiet when nothing is new. Stop when the bots are green on the latest commit.
 
 ## How it works
 
-Clients send typed WebSocket requests. The server turns them into _commands_, a
-pure _decider_ turns commands into persisted _events_, and a _projector_ derives
-the read model the UI renders. Provider CLIs run as subprocesses; per-provider
-_adapters_ translate their native protocols into orchestration events. Side
-effects run in queue-backed _reactors_ that emit _receipts_ when milestones
-land. Each turn ends with a _checkpoint_, a hidden git ref, so the app can diff
-and restore.
+Clients send typed WebSocket requests. The server turns them into _commands_, a pure _decider_ turns commands into persisted _events_, and a _projector_ derives the read model the UI renders. Provider CLIs run as subprocesses; per-provider _adapters_ translate their native protocols into orchestration events. Side effects run in queue-backed _reactors_ that emit _receipts_ when milestones land. Each turn ends with a _checkpoint_, a hidden git ref, so the app can diff and restore.
 
 Full glossary with file links: `docs/reference/encyclopedia.md`
 
 ## Where code lives
 
-- `apps/server` - WebSocket, orchestration, providers, checkpointing.
-  Effect-heavy: read `.repos/effect-smol/LLMS.md` before writing Effect code.
-- `apps/web` - React/Vite UI. `apps/desktop` wraps it, `apps/mobile` is React
-  Native, `apps/marketing` is the site.
+- `apps/server` - WebSocket, orchestration, providers, checkpointing. Effect-heavy: read `.repos/effect-smol/LLMS.md` before writing Effect code.
+- `apps/web` - React/Vite UI. `apps/desktop` wraps it, `apps/mobile` is React Native, `apps/marketing` is the site.
 - `packages/contracts` - Effect/Schema contracts. Schema only, no runtime logic.
 - `packages/shared` - shared runtime utils, subpath exports, no barrel.
 - `packages/client-runtime` - client code shared by web and mobile.
-- `.repos/` - vendored read-only references. Prefer their patterns over
-  invented ones. Never edit or import from them. Sync with `vpr sync:repos`
-  when bumping the matching dependency.
+- `.repos/` - vendored read-only references. Prefer their patterns over invented ones. Never edit or import from them. Sync with `vpr sync:repos` when bumping the matching dependency.
 
 ## Taste
 
-- Complexity belongs at the adapter boundary. Orchestration stays pure, UI
-  stays dumb.
+- Complexity belongs at the adapter boundary. Orchestration stays pure, UI stays dumb.
 - Inferred types over annotations. `any` is the enemy.
 - Comments describe how a thing is used, and move when the code moves. To be used mostly to describe functions, not to annotate every line of behavior.
-- Our users drive agents all day and notice a dropped frame, a lying spinner,
-  and a stale label. No continuously repainting animations; they peg the GPU on
-  high-refresh displays.
-- If a rule here fights the task in front of you, say so loudly and get a human
-  sign-off before breaking it.
+- Our users drive agents all day and notice a dropped frame, a lying spinner, and a stale label. No continuously repainting animations; they peg the GPU on high-refresh displays.
+- If a rule here fights the task in front of you, say so loudly and get a human sign-off before breaking it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,8 @@ Full glossary with file links: `docs/reference/encyclopedia.md`
 - Comments describe how a thing is used, and move when the code moves. To be used mostly to describe functions, not to annotate every line of behavior.
 - Our users drive agents all day and notice a dropped frame, a lying spinner, and a stale label. No continuously repainting animations; they peg the GPU on high-refresh displays.
 - If a rule here fights the task in front of you, say so loudly and get a human sign-off before breaking it.
+
+## Additional tips
+
+- Don't verify with browsers or computer use unless the user explicitly asks
+- Security is important, but should not be over-indexed on, especially for dev mode/maintainer-only features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Full glossary with file links: `docs/reference/encyclopedia.md`
 
 ## Where code lives
 
-- `apps/server` - WebSocket, orchestration, providers, checkpointing. Effect-heavy: read `.repos/effect-smol/LLMS.md` before writing Effect code.
+- `apps/server` - WebSocket, orchestration, providers, checkpointing. Effect-heavy: read `.repos/effect-smol/LLMS.md` and `docs/operations/effect-fn-checklist.md` before writing Effect code.
 - `apps/web` - React/Vite UI. `apps/desktop` wraps it, `apps/mobile` is React Native, `apps/marketing` is the site.
 - `packages/contracts` - Effect/Schema contracts. Schema only, no runtime logic.
 - `packages/shared` - shared runtime utils, subpath exports, no barrel.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
 # T3 Code
 
-T3 Code is a minimal web GUI for coding agents (currently Codex, Claude, Cursor, and OpenCode, more coming soon).
+T3 Code is a "agent harness control surface". It enables control of the agents on your machine with a best-in-class mobile app, [web app](https://app.t3.codes) and [Electron-based desktop app](https://t3.codes).
+
+Works with your subscriptions on Claude Code, Codex, Cursor, Grok Build, and OpenCode. If they're set up on your computer, T3 Code can control them.
+
+## "Wait, what are you selling me?"
+
+Nothing. We built T3 Code because we wanted the best possible development experience with agents. We were inspired by existing solutions like the Codex desktop app, Conductor, Claude Desktop and Cursor Glass, but none met our bar.
+
+We wanted something performant, remote-ready, and truly open. If we ever go the wrong direction, we want you to have everything you need to fork and build the editor that you want.
 
 ## Installation
 
 > [!WARNING]
-> T3 Code currently supports Codex, Claude, Cursor, and OpenCode.
-> Install and authenticate at least one provider before use:
+> T3 Code currently supports Codex, Claude, Cursor, Grok Build and OpenCode. Install and authenticate at least one provider before use:
 >
 > - Codex: install [Codex CLI](https://developers.openai.com/codex/cli) and run `codex login`
 > - Claude: install [Claude Code](https://claude.com/product/claude-code) and run `claude auth login`
 > - Cursor: install [Cursor CLI](https://cursor.com/cli) and run `cursor-agent login`
+> - Grok Build: install [Grok Build CLI](https://x.ai/cli) and run `grok login`
 > - OpenCode: install [OpenCode](https://opencode.ai) and run `opencode auth login`
 
-### Run without installing
+### Try it out (install-free)
+
+The easiest way to test T3 Code is to run the server in your terminal:
 
 ```bash
 npx t3@latest
 ```
+
+This will launch T3 Code's backend on your machine as well as the local web app to control your agents.
 
 Tip: Use `npx t3@latest --help` for the full CLI reference.
 
@@ -47,7 +59,7 @@ yay -S t3code-bin
 
 We are very very early in this project. Expect bugs.
 
-We are not accepting contributions yet.
+We are (mostly) not accepting contributions yet. Small fixes may be considered. Big features will not be.
 
 There's no public docs site yet, checkout the miscellaneous markdown files in [docs](./docs).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # T3 Code
 
-T3 Code is a "agent harness control surface". It enables control of the agents on your machine with a best-in-class mobile app, [web app](https://app.t3.codes) and [Electron-based desktop app](https://t3.codes).
+T3 Code is an "agent harness control surface". It enables control of the agents on your machine with a best-in-class mobile app, [web app](https://app.t3.codes) and [Electron-based desktop app](https://t3.codes).
 
 Works with your subscriptions on Claude Code, Codex, Cursor, Grok Build, and OpenCode. If they're set up on your computer, T3 Code can control them.
 


### PR DESCRIPTION
The existing agent guidance did not capture enough of T3 Code's architecture, product constraints, or the operational hazards of developing the app from inside itself.

This replaces it with focused guidance on terminology, multi-surface changes, remote behavior, isolated dev state, verification, pull requests, architecture, and repository taste. The Markdown uses one physical line per paragraph and list item so editors can handle visual wrapping without noisy reflow diffs.

Validation: `deno fmt --check --prose-wrap never AGENTS.md` and `git diff --check`.

Authored with gpt-5.6-sol in the Codex harness.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to `AGENTS.md` and `README.md`; no runtime, API, or security behavior changes.
> 
> **Overview**
> **Replaces the short `AGENTS.md` checklist with a full agent contributor guide** aimed at coding inside T3 Code: product principles (open, performance, remote, multi-surface), shared glossary, operational hazards (safe process kills, isolated `.t3` vs live `userdata`, no dev origin env vars), a **hit every surface** checklist, dev/test-data/verification defaults, PR etiquette, and a concise architecture + repo map. The old package-roles-only structure is folded into broader guidance; formatting is one physical line per paragraph/list item to reduce reflow noise.
> 
> **`README.md` is updated in parallel** to pitch T3 Code as an agent harness control surface, add **Grok Build** to supported providers and install warnings, expand the install-free `npx t3@latest` quick start, and soften the contribution stance (small fixes maybe; large features not).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 488374fe9ea0e2252546767f7b9d6907e783550e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Overhaul AGENTS.md and README.md contributor and product documentation
> - Rewrites [AGENTS.md](https://github.com/pingdotgg/t3code/pull/4782/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to replace task-focused guidelines with a full contributor guide covering architecture overview, coding standards, surfaces to verify, PR process, integration testing policy, and security guidance.
> - Updates [README.md](https://github.com/pingdotgg/t3code/pull/4782/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to reframe the project as an agent harness control surface, expand provider support (adding Grok Build), clarify the quick-start flow, and soften the contribution policy to accept small fixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 488374f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->