### PR TITLE
fix(composer): hide default Codex service tier

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.test.ts
+++ b/apps/web/src/components/chat/TraitsPicker.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { ProviderOptionDescriptor } from "@t3tools/contracts";
+import { ProviderDriverKind, type ProviderOptionDescriptor } from "@t3tools/contracts";
 import { buildTraitsTriggerDisplay } from "./TraitsPicker";
 
 function selectDescriptor(
   id: string,
-  options: ReadonlyArray<{ id: string; label: string }>,
+  options: ReadonlyArray<{ id: string; label: string; isDefault?: boolean }>,
   currentValue: string,
 ): Extract<ProviderOptionDescriptor, { type: "select" }> {
   return { id, label: id, type: "select", options: [...options], currentValue };
@@ -17,7 +17,7 @@ function fastModeDescriptor(
 }
 
 const EFFORT = selectDescriptor(
-  "effort",
+  "reasoningEffort",
   [
     { id: "high", label: "High" },
     { id: "max", label: "Max" },
@@ -33,10 +33,13 @@ const CONTEXT_WINDOW = selectDescriptor(
   "1m",
 );
 
+const CODEX = ProviderDriverKind.make("codex");
+
 function display(descriptors: ReadonlyArray<ProviderOptionDescriptor>, fastModeEnabled: boolean) {
   return buildTraitsTriggerDisplay({
+    provider: CODEX,
     descriptors,
-    primarySelectDescriptorId: "effort",
+    primarySelectDescriptorId: "reasoningEffort",
     ultrathinkPromptControlled: false,
     fastModeEnabled,
   });
@@ -55,6 +58,16 @@ describe("buildTraitsTriggerDisplay", () => {
       label: "High · 1M",
       showFastModeIcon: true,
     });
+  });
+
+  it("omits Codex's default Standard tier beside reasoning", () => {
+    const serviceTier = selectDescriptor(
+      "serviceTier",
+      [{ id: "default", label: "Standard", isDefault: true }],
+      "default",
+    );
+
+    expect(display([EFFORT, serviceTier], false).label).toBe("High");
   });
 
   it("keeps non-fastMode booleans as text labels", () => {
@@ -100,8 +113,9 @@ describe("buildTraitsTriggerDisplay", () => {
   it("still renders the prompt-controlled ultrathink label alongside the bolt", () => {
     expect(
       buildTraitsTriggerDisplay({
+        provider: CODEX,
         descriptors: [EFFORT, fastModeDescriptor(true)],
-        primarySelectDescriptorId: "effort",
+        primarySelectDescriptorId: "reasoningEffort",
         ultrathinkPromptControlled: true,
         fastModeEnabled: true,
       }),

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -388,6 +388,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
  * chevron) would leave the trigger unreadable.
  */
 export function buildTraitsTriggerDisplay(input: {
+  provider: ProviderDriverKind;
   descriptors: ReadonlyArray<ProviderOptionDescriptor>;
   primarySelectDescriptorId: string | null;
   ultrathinkPromptControlled: boolean;
@@ -399,6 +400,18 @@ export function buildTraitsTriggerDisplay(input: {
     if (descriptor.id === "fastMode" && descriptor.type === "boolean") {
       hasFastMode = true;
       continue;
+    }
+    if (
+      input.provider === "codex" &&
+      descriptor.id === "serviceTier" &&
+      descriptor.type === "select" &&
+      input.descriptors.some(({ id }) => id === "reasoningEffort")
+    ) {
+      const currentValue = getProviderOptionCurrentValue(descriptor);
+      const currentOption = descriptor.options.find((option) => option.id === currentValue);
+      if (currentOption?.id === "default" && currentOption.isDefault === true) {
+        continue;
+      }
     }
     const label =
       input.ultrathinkPromptControlled && descriptor.id === input.primarySelectDescriptorId
@@ -457,6 +470,7 @@ export const TraitsPicker = memo(function TraitsPicker({
   }
 
   const { label: triggerLabel, showFastModeIcon } = buildTraitsTriggerDisplay({
+    provider,
     descriptors,
     primarySelectDescriptorId: primarySelectDescriptor?.id ?? null,
     ultrathinkPromptControlled,


### PR DESCRIPTION
## What Changed

- Hide "Standard" from the web Codex composer label when it is the default service tier beside reasoning.

## Why

fast makes sense but "standard" is redundant, it's default and obvious

## UI Changes

https://github.com/user-attachments/assets/dc26a9c0-0a28-401e-907f-e332814eca8b

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only logic in the traits trigger label with targeted unit tests; no API or persistence changes.
> 
> **Overview**
> The Codex composer **traits trigger** no longer shows **Standard** when `serviceTier` is on the default option and **reasoning** (`reasoningEffort`) is also present—e.g. **High** instead of **High · Standard**. Non-default tiers (e.g. Fast) still appear in the label.
> 
> `buildTraitsTriggerDisplay` now takes **`provider`** and applies this skip only for **`codex`**. `TraitsPicker` passes `provider` through; tests use `reasoningEffort` and add coverage for the default tier case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0853caf3a33ed06ec7cf773eed065cf5e9b21711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide default 'Standard' service tier label in Codex composer trigger
> When the active provider is `codex` and the `serviceTier` select is set to its default option (`id: 'default'`, `isDefault: true`), `buildTraitsTriggerDisplay` now skips adding the 'Standard' tier text to the trigger label. The label then reflects only the active reasoning effort (e.g. 'High'). All other providers and non-default tiers are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0853caf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->