### PR TITLE
Fix inline Markdown image previews in chat

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -889,6 +889,8 @@ function normalizeMarkdownLinkHrefKey(href: string): string {
   return rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
 }
 
+const MarkdownImageInsideLinkContext = React.createContext(false);
+
 function markdownImageName(src: string, alt: string | undefined): string {
   const trimmedAlt = alt?.trim();
   if (trimmedAlt) return trimmedAlt;
@@ -1028,6 +1030,8 @@ function MarkdownImage({
   readonly threadRef: ScopedThreadRef | undefined;
   readonly onExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }) {
+  const insideLink = use(MarkdownImageInsideLinkContext);
+  const imageExpand = insideLink ? undefined : onExpand;
   if (!src) return null;
   const localFile = resolveMarkdownImageFile(src, cwd);
   const name = localFile?.name ?? markdownImageName(src, alt);
@@ -1039,11 +1043,11 @@ function MarkdownImage({
         name={alt?.trim() || name}
         alt={alt}
         imageProps={props}
-        onExpand={onExpand}
+        onExpand={imageExpand}
       />
     );
   }
-  return <MarkdownImagePreview {...props} src={src} alt={alt} name={name} onExpand={onExpand} />;
+  return <MarkdownImagePreview {...props} src={src} alt={alt} name={name} onExpand={imageExpand} />;
 }
 
 const MARKDOWN_LINK_FAVICON_CLASS_NAME = "block size-full shrink-0 select-none";
@@ -1713,13 +1717,15 @@ function ChatMarkdown({
                 });
               }}
             >
-              {faviconHost ? (
-                <MarkdownExternalLinkContent host={faviconHost} plainText={plainHastText(node)}>
-                  {children}
-                </MarkdownExternalLinkContent>
-              ) : (
-                children
-              )}
+              <MarkdownImageInsideLinkContext value>
+                {faviconHost ? (
+                  <MarkdownExternalLinkContent host={faviconHost} plainText={plainHastText(node)}>
+                    {children}
+                  </MarkdownExternalLinkContent>
+                ) : (
+                  children
+                )}
+              </MarkdownImageInsideLinkContext>
             </a>
           );
           if (!faviconHost || !href) {

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -5,6 +5,8 @@ import {
   ChevronRightIcon,
   CopyIcon,
   GlobeIcon,
+  ImageOffIcon,
+  LoaderCircleIcon,
   Maximize2Icon,
   Minimize2Icon,
   WrapTextIcon,
@@ -40,6 +42,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { renderSkillInlineMarkdownChildren } from "./chat/SkillInlineText";
+import type { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { CHAT_FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 import {
@@ -73,6 +76,8 @@ import {
   type MarkdownFileLinkMeta,
 } from "../markdown-links";
 import { readLocalApi } from "../localApi";
+import { useAssetUrlState } from "../assets/assetUrls";
+import { resolveMarkdownImageFile } from "../markdown-images";
 import { cn } from "../lib/utils";
 import { useRightPanelStore } from "../rightPanelStore";
 import { useActiveEnvironmentId } from "../state/entities";
@@ -122,6 +127,7 @@ interface ChatMarkdownProps {
   className?: string;
   /** Treat single newlines as hard breaks — chat-style user input. */
   lineBreaks?: boolean;
+  onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }
 
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
@@ -883,6 +889,163 @@ function normalizeMarkdownLinkHrefKey(href: string): string {
   return rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
 }
 
+function markdownImageName(src: string, alt: string | undefined): string {
+  const trimmedAlt = alt?.trim();
+  if (trimmedAlt) return trimmedAlt;
+  try {
+    const pathname = new URL(src, "https://t3.local").pathname;
+    const basename = pathname.slice(pathname.lastIndexOf("/") + 1);
+    return basename ? decodeURIComponent(basename) : "Image";
+  } catch {
+    return "Image";
+  }
+}
+
+function MarkdownImageLoading({ name }: { name: string }) {
+  return (
+    <span
+      className="my-2 flex h-32 w-56 max-w-full items-center justify-center rounded-lg bg-muted/55 text-muted-foreground"
+      role="status"
+      aria-label={`Loading ${name}`}
+    >
+      <LoaderCircleIcon className="size-5 animate-spin" aria-hidden="true" />
+    </span>
+  );
+}
+
+function MarkdownImageUnavailable({ name }: { name: string }) {
+  return (
+    <span
+      className="my-2 flex min-h-20 w-56 max-w-full items-center gap-2 rounded-lg bg-muted/55 px-3 py-2 text-xs text-muted-foreground"
+      role="img"
+      aria-label={`${name} unavailable`}
+    >
+      <ImageOffIcon className="size-4 shrink-0" aria-hidden="true" />
+      <span className="truncate">{name}</span>
+    </span>
+  );
+}
+
+interface MarkdownImagePreviewProps extends Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  "alt" | "src"
+> {
+  readonly src: string;
+  readonly alt: string | undefined;
+  readonly name: string;
+  readonly onExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
+}
+
+function MarkdownImagePreview({
+  src,
+  alt,
+  name,
+  onExpand,
+  className,
+  onError,
+  ...props
+}: MarkdownImagePreviewProps) {
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  if (failedSrc === src) {
+    return <MarkdownImageUnavailable name={name} />;
+  }
+
+  const image = (
+    <img
+      {...props}
+      src={src}
+      alt={alt ?? ""}
+      className={cn(
+        "block h-auto max-h-72 w-auto max-w-full rounded-lg object-contain outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10",
+        className,
+      )}
+      loading={props.loading ?? "lazy"}
+      decoding={props.decoding ?? "async"}
+      draggable={false}
+      onError={(event) => {
+        onError?.(event);
+        setFailedSrc(src);
+      }}
+    />
+  );
+
+  if (!onExpand) {
+    return <span className="my-2 inline-flex max-w-full rounded-lg bg-muted/35">{image}</span>;
+  }
+
+  return (
+    <button
+      type="button"
+      className="my-2 inline-flex min-h-10 min-w-10 max-w-full cursor-zoom-in overflow-hidden rounded-lg bg-muted/35 text-left shadow-[0_0_0_1px_rgba(0,0,0,0.06),0_1px_2px_-1px_rgba(0,0,0,0.06)] transition-[box-shadow,scale] duration-150 ease-out hover:shadow-[0_0_0_1px_rgba(0,0,0,0.1),0_2px_4px_rgba(0,0,0,0.08)] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 dark:shadow-[0_0_0_1px_rgba(255,255,255,0.08)] dark:hover:shadow-[0_0_0_1px_rgba(255,255,255,0.13)]"
+      aria-label={`Open ${name} larger`}
+      onClick={() => onExpand({ images: [{ src, name }], index: 0 })}
+    >
+      {image}
+    </button>
+  );
+}
+
+function WorkspaceMarkdownImage(props: {
+  readonly threadRef: ScopedThreadRef;
+  readonly path: string;
+  readonly name: string;
+  readonly alt: string | undefined;
+  readonly imageProps: Omit<React.ImgHTMLAttributes<HTMLImageElement>, "alt" | "src">;
+  readonly onExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
+}) {
+  const assetUrl = useAssetUrlState(props.threadRef.environmentId, {
+    _tag: "workspace-file",
+    threadId: props.threadRef.threadId,
+    path: props.path,
+  });
+
+  if (assetUrl._tag === "Failure") {
+    return <MarkdownImageUnavailable name={props.name} />;
+  }
+  if (assetUrl._tag === "Loading") {
+    return <MarkdownImageLoading name={props.name} />;
+  }
+  return (
+    <MarkdownImagePreview
+      {...props.imageProps}
+      src={assetUrl.url}
+      alt={props.alt}
+      name={props.name}
+      onExpand={props.onExpand}
+    />
+  );
+}
+
+function MarkdownImage({
+  src,
+  alt,
+  cwd,
+  threadRef,
+  onExpand,
+  ...props
+}: React.ImgHTMLAttributes<HTMLImageElement> & {
+  readonly cwd: string | undefined;
+  readonly threadRef: ScopedThreadRef | undefined;
+  readonly onExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
+}) {
+  if (!src) return null;
+  const localFile = resolveMarkdownImageFile(src, cwd);
+  const name = localFile?.name ?? markdownImageName(src, alt);
+  if (localFile && threadRef) {
+    return (
+      <WorkspaceMarkdownImage
+        threadRef={threadRef}
+        path={localFile.path}
+        name={alt?.trim() || name}
+        alt={alt}
+        imageProps={props}
+        onExpand={onExpand}
+      />
+    );
+  }
+  return <MarkdownImagePreview {...props} src={src} alt={alt} name={name} onExpand={onExpand} />;
+}
+
 const MARKDOWN_LINK_FAVICON_CLASS_NAME = "block size-full shrink-0 select-none";
 
 /** Hosts whose favicon request already failed this session — skip straight to the globe. */
@@ -1302,6 +1465,7 @@ function ChatMarkdown({
   skills = EMPTY_MARKDOWN_SKILLS,
   className,
   lineBreaks = false,
+  onImageExpand,
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
@@ -1490,6 +1654,18 @@ function ChatMarkdown({
           />
         );
       },
+      img({ node: _node, src, alt, ...props }) {
+        return (
+          <MarkdownImage
+            {...props}
+            src={src}
+            alt={alt}
+            cwd={cwd}
+            threadRef={threadRef}
+            onExpand={onImageExpand}
+          />
+        );
+      },
       a({ node, href, children, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
         const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
@@ -1627,6 +1803,7 @@ function ChatMarkdown({
     isStreaming,
     markdownFileLinkMetaByHref,
     onTaskListChange,
+    onImageExpand,
     openInPreferredEditor,
     openExternalLinkInPreview,
     openMarkdownFileInPreview,

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -222,7 +222,50 @@ function buildUserTimelineEntry(text: string) {
   };
 }
 
+function buildAssistantTimelineEntry(text: string) {
+  return {
+    id: "entry-assistant",
+    kind: "message" as const,
+    createdAt: MESSAGE_CREATED_AT,
+    message: {
+      id: MessageId.make("message-assistant"),
+      role: "assistant" as const,
+      text,
+      turnId: null,
+      createdAt: MESSAGE_CREATED_AT,
+      updatedAt: MESSAGE_CREATED_AT,
+      streaming: false,
+    },
+  };
+}
+
 describe("MessagesTimeline", () => {
+  it("keeps linked Markdown images under the anchor's interaction", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          buildAssistantTimelineEntry(
+            [
+              "[![Linked preview](https://example.com/linked.png)](https://example.com/docs)",
+              "",
+              "![Standalone preview](https://example.com/standalone.png)",
+            ].join("\n"),
+          ),
+        ]}
+      />,
+    );
+
+    const linkedImageAnchor = markup.match(
+      /<a\b[^>]*href="https:\/\/example\.com\/docs"[^>]*>[\s\S]*?<\/a>/,
+    )?.[0];
+    expect(linkedImageAnchor).toBeDefined();
+    expect(linkedImageAnchor).toContain('<img src="https://example.com/linked.png"');
+    expect(linkedImageAnchor).not.toContain("<button");
+    expect(linkedImageAnchor).not.toContain('aria-label="Open Linked preview larger"');
+    expect(markup).toContain('aria-label="Open Standalone preview larger"');
+  });
+
   it("uses the larger leading inset only when the top fade is enabled", () => {
     const timelineEntries = [buildUserTimelineEntry("Hello")];
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1028,6 +1028,7 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           threadRef={ctx.threadRef ?? undefined}
           isStreaming={Boolean(row.message.streaming)}
           skills={ctx.skills}
+          onImageExpand={ctx.onImageExpand}
         />
         <AssistantChangedFilesSection
           turnSummary={row.assistantTurnDiffSummary}

--- a/apps/web/src/markdown-images.test.ts
+++ b/apps/web/src/markdown-images.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveMarkdownImageFile } from "./markdown-images";
+
+describe("resolveMarkdownImageFile", () => {
+  it("resolves workspace-relative image sources against the thread cwd", () => {
+    expect(resolveMarkdownImageFile("artifacts/features.png", "/workspace/project")).toEqual({
+      path: "/workspace/project/artifacts/features.png",
+      name: "features.png",
+    });
+  });
+
+  it("keeps absolute image paths for server-side asset resolution", () => {
+    expect(
+      resolveMarkdownImageFile(
+        "/workspace/project/screenshots/cache-prices.webp",
+        "/workspace/project",
+      ),
+    ).toEqual({
+      path: "/workspace/project/screenshots/cache-prices.webp",
+      name: "cache-prices.webp",
+    });
+  });
+
+  it("supports file URLs and decodes their path", () => {
+    expect(
+      resolveMarkdownImageFile(
+        "file:///workspace/project/screenshots/privacy%20details.png",
+        "/workspace/project",
+      ),
+    ).toEqual({
+      path: "/workspace/project/screenshots/privacy details.png",
+      name: "privacy details.png",
+    });
+  });
+
+  it("leaves remote images and non-image files alone", () => {
+    expect(
+      resolveMarkdownImageFile("https://example.com/screenshot.png", "/workspace/project"),
+    ).toBe(null);
+    expect(resolveMarkdownImageFile("docs/report.md", "/workspace/project")).toBe(null);
+  });
+});

--- a/apps/web/src/markdown-images.ts
+++ b/apps/web/src/markdown-images.ts
@@ -1,0 +1,19 @@
+import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
+
+import { resolveMarkdownFileLinkMeta } from "./markdown-links";
+
+export interface MarkdownImageFile {
+  readonly path: string;
+  readonly name: string;
+}
+
+export function resolveMarkdownImageFile(
+  src: string | undefined,
+  cwd: string | undefined,
+): MarkdownImageFile | null {
+  const fileLinkMeta = resolveMarkdownFileLinkMeta(src, cwd);
+  if (!fileLinkMeta || !isWorkspaceImagePreviewPath(fileLinkMeta.filePath)) {
+    return null;
+  }
+  return { path: fileLinkMeta.filePath, name: fileLinkMeta.basename };
+}


### PR DESCRIPTION
## What Changed

- Render Markdown images in assistant messages as compact inline previews.
- Resolve workspace-local image paths through T3 Code's existing signed asset route, including relative, absolute, and `file://` paths.
- Add loading and unavailable states while preserving external image URLs.
- Reuse the existing expanded-image dialog when an inline preview is clicked.
- Keep linked Markdown images under the surrounding link's interaction instead of nesting an image-preview button inside the anchor.
- Add focused tests for Markdown image path resolution and linked-image semantics.

## Why

When the T3 Code server runs on one device and the web client is opened on another, local image paths from assistant messages cannot be loaded directly by the browser. They currently render as broken images with only their alt text visible.

Using the existing thread-scoped asset flow lets the environment that owns the workspace serve the image securely to the connected client without broadening filesystem access.

## UI Changes

### Before

Workspace-local Markdown images render as broken image icons and alt text.

_Before screenshot to be attached._

### After

Images render as compact previews with a subtle outline. Clicking a preview opens the existing expanded-image dialog, and Escape closes it again.

_After screenshot and short interaction recording to be attached._

## Verification

- `vp test run apps/web/src/markdown-images.test.ts apps/web/src/components/chat/MessagesTimeline.test.tsx` — 19 tests passed.
- `vp run --filter @t3tools/web typecheck` passed.
- Targeted formatting and linting completed without errors.
- Integrated browser verification in an isolated T3 environment confirmed that workspace images were served through `/api/assets/`; standalone images expanded and closed with Escape, while a linked image opened only its link without rendering a nested button or opening the image dialog.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat rendering and workspace file asset URLs for assistant messages; scope is bounded to image paths and existing asset APIs, but remote clients now depend on signed asset delivery for local paths.
> 
> **Overview**
> **Assistant chat Markdown** now renders `img` nodes as inline previews instead of raw broken `<img>` tags when paths point at workspace images.
> 
> Workspace-local sources (relative, absolute, and `file://`) are resolved with new `resolveMarkdownImageFile` and loaded through the existing thread-scoped signed asset route via `useAssetUrlState`, with loading and unavailable placeholders. External URLs still use direct `src`. Standalone previews can open the existing expanded-image dialog through a new `onImageExpand` prop wired from `MessagesTimeline`.
> 
> **Linked images** (`[![alt](img)](url)`) no longer nest a zoom button inside the anchor—a context flag disables expand so the link keeps sole click behavior.
> 
> Tests cover path resolution and linked-vs-standalone image semantics in the timeline markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8dbe3e2ad7d14f3c882744fec435929a183bea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix inline Markdown image previews in chat with workspace file resolution and expansion
> - Adds a custom image renderer in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/4785/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) that resolves workspace-relative image paths to asset URLs, shows loading/unavailable placeholders, and triggers an `onImageExpand` callback on click.
> - Introduces [markdown-images.ts](https://github.com/pingdotgg/t3code/pull/4785/files#diff-3adda93dcb5e1dcab131803cfb03271a7b5f55b08b580aeeb5f9b8051f724527) with `resolveMarkdownImageFile` to determine when a markdown image src refers to a workspace file eligible for asset resolution.
> - Images nested inside links (anchor tags) suppress the expansion button and remain link-clickable only, detected via a new `MarkdownImageInsideLinkContext`.
> - Wires `onImageExpand` through `AssistantTimelineRow` in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/4785/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) so assistant message images trigger the timeline's existing image expansion handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8dbe3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->