### PR TITLE
perf(server): gzip large thread snapshots

### DIFF
--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vite-plus/test";
+import { expect, it } from "@effect/vitest";
+import * as NodeZlib from "node:zlib";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { HttpServerResponse } from "effect/unstable/http";
+import { describe } from "vite-plus/test";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import { compressHttpResponse, isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -23,5 +28,51 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("http compression", () => {
+  it.effect("gzips large JSON responses when the client accepts it", () =>
+    Effect.gen(function* () {
+      const body = `{"value":"${"compressible".repeat(1_000)}"}`;
+      const response = compressHttpResponse(
+        HttpServerResponse.text(body, { contentType: "application/json" }),
+        "br, gzip, deflate",
+      );
+
+      expect(response.headers["content-encoding"]).toBe("gzip");
+      expect(response.headers["content-length"]).toBeUndefined();
+      expect(response.headers.vary).toBe("Accept-Encoding");
+      expect(response.body._tag).toBe("Stream");
+      if (response.body._tag === "Stream") {
+        const chunks = yield* Stream.runCollect(Stream.orDie(response.body.stream));
+        expect(NodeZlib.gunzipSync(Buffer.concat(Array.from(chunks))).toString()).toBe(body);
+      }
+    }),
+  );
+
+  it("keeps the original body when gzip is declined", () => {
+    const response = compressHttpResponse(
+      HttpServerResponse.text("x".repeat(2_000), { contentType: "application/json" }),
+      "gzip;q=0, *;q=1",
+    );
+
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.headers["content-length"]).toBe("2000");
+    expect(response.headers.vary).toBe("Accept-Encoding");
+  });
+
+  it("preserves existing Vary semantics", () => {
+    const makeResponse = (vary: string) =>
+      compressHttpResponse(
+        HttpServerResponse.text("x".repeat(2_000), {
+          contentType: "application/json",
+          headers: { vary },
+        }),
+        undefined,
+      );
+
+    expect(makeResponse("*").headers.vary).toBe("*");
+    expect(makeResponse("Origin, accept-encoding").headers.vary).toBe("Origin, accept-encoding");
   });
 });

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -12,8 +12,10 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Stream from "effect/Stream";
 import { cast } from "effect/Function";
 import {
+  Headers,
   HttpBody,
   HttpClient,
   HttpClientResponse,
@@ -42,6 +44,76 @@ import { browserApiCorsAllowedHeaders, browserApiCorsAllowedMethods } from "./ht
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 const DESKTOP_RENDERER_ORIGINS = ["t3code://app", "t3code-dev://app"];
+const GZIP_MIN_BYTES = 1024;
+
+function acceptsGzip(value: string | undefined): boolean {
+  if (!value) return false;
+
+  const accepted = new Map(
+    value.split(",").map((entry) => {
+      const [coding = "", ...parameters] = entry.trim().toLowerCase().split(";");
+      const quality = parameters
+        .map((parameter) => parameter.trim().match(/^q=(.+)$/)?.[1])
+        .find((parameter) => parameter !== undefined);
+      return [coding, quality === undefined ? 1 : Number(quality)] as const;
+    }),
+  );
+  return (accepted.get("gzip") ?? accepted.get("*") ?? 0) > 0;
+}
+
+function varyByAcceptEncoding(value: string | undefined): string {
+  if (!value) return "Accept-Encoding";
+  const values = new Set(value.split(",").map((entry) => entry.trim().toLowerCase()));
+  return values.has("*") || values.has("accept-encoding") ? value : `${value}, Accept-Encoding`;
+}
+
+export function compressHttpResponse(
+  response: HttpServerResponse.HttpServerResponse,
+  acceptEncoding: string | undefined,
+): HttpServerResponse.HttpServerResponse {
+  const body = response.body;
+  if (
+    body._tag !== "Uint8Array" ||
+    body.contentLength < GZIP_MIN_BYTES ||
+    !body.contentType.startsWith("application/json") ||
+    response.headers["content-encoding"]
+  ) {
+    return response;
+  }
+
+  const variedResponse = HttpServerResponse.setHeader(
+    response,
+    "vary",
+    varyByAcceptEncoding(response.headers.vary),
+  );
+  if (!acceptsGzip(acceptEncoding)) return variedResponse;
+
+  const compressedBody = Stream.fromReadableStream({
+    evaluate: () => new Response(body.body).body!.pipeThrough(new CompressionStream("gzip")),
+    onError: (cause) => cause,
+  });
+  const headers = Headers.set(
+    Headers.remove(variedResponse.headers, "content-length"),
+    "content-encoding",
+    "gzip",
+  );
+  return HttpServerResponse.stream(compressedBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    cookies: response.cookies,
+    contentType: body.contentType,
+  });
+}
+
+export const httpCompressionLayer = HttpRouter.middleware(
+  (httpEffect) =>
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      return compressHttpResponse(yield* httpEffect, request.headers["accept-encoding"]);
+    }),
+  { global: true },
+);
 
 export const browserApiCorsLayer = Layer.unwrap(
   Effect.gen(function* () {

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1287,6 +1287,35 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("compresses large JSON responses through the composed routes", () =>
+    Effect.gen(function* () {
+      const descriptor = {
+        ...testEnvironmentDescriptor,
+        label: "Test environment".repeat(100),
+      };
+      yield* buildAppUnderTest({
+        layers: {
+          serverEnvironment: {
+            getDescriptor: Effect.succeed(descriptor),
+          },
+        },
+      });
+
+      const url = yield* getHttpServerUrl("/.well-known/t3/environment");
+      const response = yield* fetchEffect(url, {
+        headers: {
+          "accept-encoding": "gzip",
+        },
+      });
+      const body = yield* responseJsonEffect<typeof descriptor>(response);
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers["content-encoding"], "gzip");
+      assert.equal(response.headers.vary, "Accept-Encoding");
+      assert.deepEqual(body, descriptor);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("includes CORS headers on public environment descriptor responses", () =>
     Effect.gen(function* () {
       yield* buildAppUnderTest();

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -11,6 +11,7 @@ import {
   serverEnvironmentHttpApiLayer,
   staticAndDevRouteLayer,
   browserApiCorsLayer,
+  httpCompressionLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
@@ -372,6 +373,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   Layer.provide(PreviewAutomationBroker.layer),
   Layer.provide(ServerSelfUpdate.layer),
   Layer.provide(browserApiCorsLayer),
+  Layer.provide(httpCompressionLayer),
 );
 
 export const makeServerLayer = Layer.unwrap(


### PR DESCRIPTION
Thread snapshots still crossed HTTP uncompressed, so large histories remained expensive to load even after activity payload projection.

This adds content-negotiated gzip for JSON responses above 1 KB. On cloned real T3 data, a 6,852,257-byte thread snapshot was delivered in 1,306,499 bytes (80.9% smaller), and decompression reproduced the original payload byte-for-byte. Browser, desktop, and React Native clients use their native HTTP stacks to decode it transparently.

Tests:
- vp test run apps/server/src/http.test.ts apps/server/test/ActivityPayloadProjection.test.ts apps/server/src/server.test.ts --testNamePattern='http compression|projectActivityPayload|negotiates permessage-deflate'
- vp run --filter t3 typecheck

Built with GPT-5.6-sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global middleware changes how every large JSON response is sent (streaming body, no Content-Length when compressed), which can affect caching and clients that assume fixed-length bodies.
> 
> **Overview**
> Adds **global HTTP middleware** that gzip-compresses eligible **`application/json`** responses (≥1 KB, in-memory body, no existing `Content-Encoding`) when the client’s **`Accept-Encoding`** allows gzip, using a streaming **`CompressionStream('gzip')`** body and dropping **`Content-Length`**.
> 
> Eligible responses always get **`Vary: Accept-Encoding`**, merged with any existing **`Vary`** without changing `*` or duplicate values. Clients that decline gzip keep the original body; only **`Vary`** may be added.
> 
> **`httpCompressionLayer`** is wired into the composed server stack so all routes get this behavior. Unit tests cover **`compressHttpResponse`** and an integration test hits a real route with **`accept-encoding: gzip`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b51dd02d4a6e71a2f8b90690f9b3f5676dd28418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add gzip compression middleware for large JSON thread snapshots in the server
> - Adds `compressHttpResponse` in [http.ts](https://github.com/pingdotgg/t3code/pull/4788/files#diff-55fb49cf72ecef123d8f2fa7061526dadb37cf93f8e9dd9e7f0d4f8cd4ff9f6d) that gzip-compresses JSON responses ≥1024 bytes when the client sends `Accept-Encoding: gzip`, using a streaming `CompressionStream('gzip')` body.
> - Always sets a `Vary: Accept-Encoding` header on eligible responses, preserving any existing `Vary` value (including `*`).
> - Wires in `httpCompressionLayer` as a global middleware in [server.ts](https://github.com/pingdotgg/t3code/pull/4788/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) so all routes benefit automatically.
> - Behavioral Change: compressed responses drop `Content-Length` and switch to a streaming body; uncompressed responses are unchanged except for the added `Vary` header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b51dd02.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic gzip compression for eligible large JSON responses when the client supports it.
  * Updated compression handling to set the correct negotiation headers (including `Vary: Accept-Encoding`) and stream compressed output.
  * Preserves existing `Vary` headers and avoids recompressing responses already encoded.

* **Tests**
  * Added HTTP and router-level coverage for gzip-compressed responses, accurate decompression, and correct behavior when gzip is declined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->