### PR TITLE
Prevent sidebar row labels from truncating

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -213,7 +213,11 @@ function WorkingDuration(props: { startedAt: string | null }) {
     return () => window.clearInterval(id);
   }, [startedMs]);
   if (Number.isNaN(startedMs)) return null;
-  return <span className="tabular-nums">{formatWorkingDurationLabel(Date.now() - startedMs)}</span>;
+  return (
+    <span className="font-mono tabular-nums">
+      {formatWorkingDurationLabel(Date.now() - startedMs)}
+    </span>
+  );
 }
 
 function SidebarV2ThreadTooltip({
@@ -881,11 +885,15 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               ) : (
                 <span className="flex-1" />
               )}
-              <span className="relative ml-auto flex h-5 min-w-8 shrink-0 items-center justify-end pl-1 text-xs">
+              {/* The visible state owns this slot's width: status at rest,
+                  actions on hover/focus or while the popover is open. Keeping
+                  the hidden state out of flow lets the project label reclaim
+                  space without either state overlapping it. */}
+              <span className="group/v2-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
                 <span
                   className={cn(
-                    "tabular-nums text-muted-foreground/65 transition-opacity group-hover/v2-row:opacity-0",
-                    snoozeMenuOpen && "opacity-0",
+                    "self-center justify-self-end tabular-nums text-muted-foreground/65 transition-opacity group-focus-within/v2-status-slot:absolute group-focus-within/v2-status-slot:right-0 group-hover/v2-row:absolute group-hover/v2-row:right-0 group-hover/v2-row:opacity-0",
+                    snoozeMenuOpen && "absolute right-0 opacity-0",
                   )}
                 >
                   {topStatus ? (
@@ -919,8 +927,8 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 {props.settlementSupported || showSnoozeButton ? (
                   <span
                     className={cn(
-                      "absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity focus-within:opacity-100 group-hover/v2-row:opacity-100",
-                      snoozeMenuOpen && "opacity-100",
+                      "absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity focus-within:static focus-within:opacity-100 group-hover/v2-row:static group-hover/v2-row:opacity-100",
+                      snoozeMenuOpen && "static opacity-100",
                     )}
                   >
                     {showSnoozeButton ? (


### PR DESCRIPTION
## What Changed

Adjusted sidebar row status and action slots so hidden hover/focus controls no longer reserve or overlap label space. Working duration labels now use a monospace font for consistent width.

## Why

Sidebar project labels could truncate unnecessarily because status and action elements competed for the same layout space. The updated positioning lets labels reclaim available width while preserving status visibility and hover/focus actions.

## UI Changes

No before/after screenshots were provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CSS/layout changes in SidebarV2 with no API or data-layer impact.
> 
> **Overview**
> Sidebar v2 **card** rows no longer let the project title truncate early because snooze/settle controls sat in the same right slot as the status/time label.
> 
> At rest, only the status (or relative time) reserves width on the right. On row **hover**, **focus-within**, or while the snooze popover is open, that label is taken **out of flow** (`absolute`) and the action buttons use **in-flow** layout (`static`) so they define the slot width without overlapping the project name. Inline comments document this “visible state owns the slot width” behavior.
> 
> **Working** duration ticks now render in **`font-mono`** with **`tabular-nums`** so the elapsed timer keeps a stable width as it updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df171f462d866b62b5ef6f6d8c09e064fb2d2fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent sidebar row labels from truncating on hover and focus
> - The status/actions slot in `SidebarV2Row` now switches layout on row hover or focus: the status label fades out and becomes absolutely positioned, while action controls switch to static positioning and become fully visible.
> - When the snooze menu is open, actions remain in-flow and the status label is hidden at the right edge, preventing layout shifts that caused label truncation.
> - `WorkingDuration` now renders with `font-mono` in addition to `tabular-nums` for consistent character width during live updates.
> - Behavioral Change: spacing within the slot changes due to `items-stretch` replacing `items-center` and removal of left padding (`pl-1`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7df171f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->