### PR TITLE
perf(server): trim stale context-window rows and drop dead replay RPC

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -201,6 +201,31 @@ export function projectActivityPayload(
   };
 }
 
+/**
+ * Drops all but the last context-window activity from a snapshot. Clients only
+ * ever read the latest usage value (walking the array backwards), so shipping
+ * the full history — often thousands of rows on long threads — buys nothing.
+ * Live `thread.activity-appended` events are untouched: newer updates still
+ * stream through and supersede the retained row on the client.
+ */
+function dropStaleContextWindowActivities(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ReadonlyArray<OrchestrationThreadActivity> {
+  let latestIndex = -1;
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    if (activities[index]?.kind === "context-window.updated") {
+      latestIndex = index;
+      break;
+    }
+  }
+  if (latestIndex === -1) {
+    return activities;
+  }
+  return activities.filter(
+    (activity, index) => activity.kind !== "context-window.updated" || index === latestIndex,
+  );
+}
+
 export function projectThreadDetailSnapshot(
   snapshot: OrchestrationThreadDetailSnapshot,
 ): OrchestrationThreadDetailSnapshot {
@@ -208,7 +233,9 @@ export function projectThreadDetailSnapshot(
     ...snapshot,
     thread: {
       ...snapshot.thread,
-      activities: snapshot.thread.activities.map(projectActivityPayload),
+      activities: dropStaleContextWindowActivities(snapshot.thread.activities).map(
+        projectActivityPayload,
+      ),
     },
   };
 }

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -202,27 +202,31 @@ export function projectActivityPayload(
 }
 
 /**
- * Drops all but the last context-window activity from a snapshot. Clients only
- * ever read the latest usage value (walking the array backwards), so shipping
- * the full history — often thousands of rows on long threads — buys nothing.
- * Live `thread.activity-appended` events are untouched: newer updates still
- * stream through and supersede the retained row on the client.
+ * Drops all but the last context-window activity per turn from a snapshot.
+ * Clients only ever read the latest usage value (walking the array backwards),
+ * so shipping the full history — often thousands of rows on long threads —
+ * buys nothing. Retention is per turn rather than per thread because a live
+ * `thread.reverted` makes the client discard whole turns; keeping each turn's
+ * latest row means the meter can still resolve a value from the turns that
+ * survive. Live `thread.activity-appended` events are untouched: newer updates
+ * still stream through and supersede the retained rows on the client.
  */
 function dropStaleContextWindowActivities(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): ReadonlyArray<OrchestrationThreadActivity> {
-  let latestIndex = -1;
-  for (let index = activities.length - 1; index >= 0; index -= 1) {
+  const latestIndexByTurn = new Map<string | null, number>();
+  for (let index = 0; index < activities.length; index += 1) {
     if (activities[index]?.kind === "context-window.updated") {
-      latestIndex = index;
-      break;
+      latestIndexByTurn.set(activities[index]!.turnId, index);
     }
   }
-  if (latestIndex === -1) {
+  if (latestIndexByTurn.size === 0) {
     return activities;
   }
   return activities.filter(
-    (activity, index) => activity.kind !== "context-window.updated" || index === latestIndex,
+    (activity, index) =>
+      activity.kind !== "context-window.updated" ||
+      latestIndexByTurn.get(activity.turnId) === index,
   );
 }
 

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -202,21 +202,38 @@ export function projectActivityPayload(
 }
 
 /**
- * Drops all but the last context-window activity per turn from a snapshot.
- * Clients only ever read the latest usage value (walking the array backwards),
- * so shipping the full history — often thousands of rows on long threads —
- * buys nothing. Retention is per turn rather than per thread because a live
- * `thread.reverted` makes the client discard whole turns; keeping each turn's
- * latest row means the meter can still resolve a value from the turns that
- * survive. Live `thread.activity-appended` events are untouched: newer updates
- * still stream through and supersede the retained rows on the client.
+ * Matches the validity rule in the web client's
+ * `deriveLatestContextWindowSnapshot`: rows without a finite, non-negative
+ * `usedTokens` are skipped during its backward walk, so they must not shadow
+ * an earlier resolvable row here.
+ */
+function isResolvableContextWindowActivity(activity: OrchestrationThreadActivity): boolean {
+  if (activity.kind !== "context-window.updated") {
+    return false;
+  }
+  const payload = asRecord(activity.payload);
+  const usedTokens = payload?.usedTokens;
+  return typeof usedTokens === "number" && Number.isFinite(usedTokens) && usedTokens >= 0;
+}
+
+/**
+ * Drops all but the last resolvable context-window activity per turn from a
+ * snapshot. Clients only ever read the latest usage value (walking the array
+ * backwards), so shipping the full history — often thousands of rows on long
+ * threads — buys nothing. Retention is per turn rather than per thread because
+ * a live `thread.reverted` makes the client discard whole turns; keeping each
+ * turn's latest row means the meter can still resolve a value from the turns
+ * that survive. Malformed rows pass through untouched rather than shadowing a
+ * valid earlier row. Live `thread.activity-appended` events are untouched:
+ * newer updates still stream through and supersede the retained rows on the
+ * client.
  */
 function dropStaleContextWindowActivities(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): ReadonlyArray<OrchestrationThreadActivity> {
   const latestIndexByTurn = new Map<string | null, number>();
   for (let index = 0; index < activities.length; index += 1) {
-    if (activities[index]?.kind === "context-window.updated") {
+    if (isResolvableContextWindowActivity(activities[index]!)) {
       latestIndexByTurn.set(activities[index]!.turnId, index);
     }
   }
@@ -225,7 +242,7 @@ function dropStaleContextWindowActivities(
   }
   return activities.filter(
     (activity, index) =>
-      activity.kind !== "context-window.updated" ||
+      !isResolvableContextWindowActivity(activity) ||
       latestIndexByTurn.get(activity.turnId) === index,
   );
 }

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5690,15 +5690,6 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         ),
       );
       assert.equal(fullDiffResult.diff, "full-diff");
-
-      const replayResult = yield* Effect.scoped(
-        withWsRpcClient(wsUrl, (client) =>
-          client[ORCHESTRATION_WS_METHODS.replayEvents]({
-            fromSequenceExclusive: 0,
-          }),
-        ),
-      );
-      assert.deepEqual(replayResult, []);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
@@ -6358,73 +6349,6 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       const [first] = Array.from(items);
       assert.equal(first?.kind, "project-removed");
       assert.equal(first?.kind === "project-removed" ? first.projectId : null, projectId);
-    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
-  );
-
-  it.effect("enriches replayed project events with repository identity metadata", () =>
-    Effect.gen(function* () {
-      const repositoryIdentity = {
-        canonicalKey: "github.com/t3tools/t3code",
-        locator: {
-          source: "git-remote" as const,
-          remoteName: "origin",
-          remoteUrl: "git@github.com:T3Tools/t3code.git",
-        },
-        displayName: "T3Tools/t3code",
-        provider: "github",
-        owner: "T3Tools",
-        name: "t3code",
-      };
-
-      yield* buildAppUnderTest({
-        layers: {
-          orchestrationEngine: {
-            readEvents: (_fromSequenceExclusive) =>
-              Stream.make({
-                sequence: 1,
-                eventId: EventId.make("event-1"),
-                aggregateKind: "project",
-                aggregateId: defaultProjectId,
-                occurredAt: "2026-04-05T00:00:00.000Z",
-                commandId: null,
-                causationEventId: null,
-                correlationId: null,
-                metadata: {},
-                type: "project.created",
-                payload: {
-                  projectId: defaultProjectId,
-                  title: "Default Project",
-                  workspaceRoot: "/tmp/default-project",
-                  defaultModelSelection,
-                  scripts: [],
-                  createdAt: "2026-04-05T00:00:00.000Z",
-                  updatedAt: "2026-04-05T00:00:00.000Z",
-                },
-              } satisfies Extract<OrchestrationEvent, { type: "project.created" }>),
-          },
-          repositoryIdentityResolver: {
-            resolve: () => Effect.succeed(repositoryIdentity),
-          },
-        },
-      });
-
-      const wsUrl = yield* getWsServerUrl("/ws");
-      const replayResult = yield* Effect.scoped(
-        withWsRpcClient(wsUrl, (client) =>
-          client[ORCHESTRATION_WS_METHODS.replayEvents]({
-            fromSequenceExclusive: 0,
-          }),
-        ),
-      );
-
-      const replayedEvent = replayResult[0];
-      assert.equal(replayedEvent?.type, "project.created");
-      assert.deepEqual(
-        replayedEvent && replayedEvent.type === "project.created"
-          ? replayedEvent.payload.repositoryIdentity
-          : null,
-        repositoryIdentity,
-      );
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -46,7 +46,6 @@ import {
   ProjectWriteFileError,
   RelayClientInstallFailedError,
   type RelayClientInstallProgressEvent,
-  OrchestrationReplayEventsError,
   type FilesystemBrowseFailure,
   FilesystemBrowseError,
   AssetWorkspaceContextNotFoundError,
@@ -60,7 +59,6 @@ import {
   WS_METHODS,
   WsRpcGroup,
 } from "@t3tools/contracts";
-import { clamp } from "effect/Number";
 import { HttpRouter, HttpServerRequest, HttpServerRespondable } from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 
@@ -99,7 +97,6 @@ import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as ReviewService from "./review/ReviewService.ts";
 import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts";
-import * as RepositoryIdentityResolver from "./project/RepositoryIdentityResolver.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
@@ -302,7 +299,6 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [ORCHESTRATION_WS_METHODS.dispatchCommand, AuthOrchestrationOperateScope],
   [ORCHESTRATION_WS_METHODS.getTurnDiff, AuthOrchestrationReadScope],
   [ORCHESTRATION_WS_METHODS.getFullThreadDiff, AuthOrchestrationReadScope],
-  [ORCHESTRATION_WS_METHODS.replayEvents, AuthOrchestrationReadScope],
   [ORCHESTRATION_WS_METHODS.subscribeShell, AuthOrchestrationReadScope],
   [ORCHESTRATION_WS_METHODS.getArchivedShellSnapshot, AuthOrchestrationReadScope],
   [ORCHESTRATION_WS_METHODS.subscribeThread, AuthOrchestrationReadScope],
@@ -441,8 +437,6 @@ const makeWsRpcLayer = (
       const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
       const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
       const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
-      const repositoryIdentityResolver =
-        yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
       const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
       const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
       const sourceControlDiscovery = yield* SourceControlDiscovery.SourceControlDiscovery;
@@ -591,53 +585,6 @@ const makeWsRpcLayer = (
               cause,
             });
       };
-
-      const enrichProjectEvent = (
-        event: OrchestrationEvent,
-      ): Effect.Effect<OrchestrationEvent, never, never> => {
-        switch (event.type) {
-          case "project.created":
-            return repositoryIdentityResolver.resolve(event.payload.workspaceRoot).pipe(
-              Effect.map((repositoryIdentity) => ({
-                ...event,
-                payload: {
-                  ...event.payload,
-                  repositoryIdentity,
-                },
-              })),
-            );
-          case "project.meta-updated":
-            return Effect.gen(function* () {
-              const workspaceRoot =
-                event.payload.workspaceRoot ??
-                Option.match(
-                  yield* projectionSnapshotQuery.getProjectShellById(event.payload.projectId),
-                  {
-                    onNone: () => null,
-                    onSome: (project) => project.workspaceRoot,
-                  },
-                ) ??
-                null;
-              if (workspaceRoot === null) {
-                return event;
-              }
-
-              const repositoryIdentity = yield* repositoryIdentityResolver.resolve(workspaceRoot);
-              return {
-                ...event,
-                payload: {
-                  ...event.payload,
-                  repositoryIdentity,
-                },
-              } satisfies OrchestrationEvent;
-            }).pipe(Effect.orElseSucceed(() => event));
-          default:
-            return Effect.succeed(event);
-        }
-      };
-
-      const enrichOrchestrationEvents = (events: ReadonlyArray<OrchestrationEvent>) =>
-        Effect.forEach(events, enrichProjectEvent, { concurrency: 4 });
 
       const toShellStreamEvent = (
         event: OrchestrationEvent,
@@ -1209,30 +1156,6 @@ const makeWsRpcLayer = (
                 (cause) =>
                   new OrchestrationGetFullThreadDiffError({
                     message: "Failed to load full thread diff",
-                    cause,
-                  }),
-              ),
-            ),
-            { "rpc.aggregate": "orchestration" },
-          ),
-        [ORCHESTRATION_WS_METHODS.replayEvents]: (input) =>
-          observeRpcEffect(
-            ORCHESTRATION_WS_METHODS.replayEvents,
-            Stream.runCollect(
-              orchestrationEngine.readEvents(
-                clamp(input.fromSequenceExclusive, {
-                  maximum: Number.MAX_SAFE_INTEGER,
-                  minimum: 0,
-                }),
-              ),
-            ).pipe(
-              Effect.map((events) => Array.from(events)),
-              Effect.flatMap(enrichOrchestrationEvents),
-              Effect.map((events) => events.map(projectActivityEvent)),
-              Effect.mapError(
-                (cause) =>
-                  new OrchestrationReplayEventsError({
-                    message: "Failed to replay orchestration events",
                     cause,
                   }),
               ),

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -305,6 +305,29 @@ describe("context-window snapshot dedup", () => {
     );
   });
 
+  it("does not let a malformed row shadow an earlier valid row in the same turn", () => {
+    const valid = makeContextWindowActivity("ctx-valid", 5_000, "turn-a");
+    const malformed: OrchestrationThreadActivity = {
+      ...makeContextWindowActivity("ctx-broken", 0, "turn-a"),
+      payload: { usedTokens: null },
+    };
+
+    const projected = projectThreadDetailSnapshot({
+      snapshotSequence: 7,
+      thread: makeThread([valid, malformed]),
+    });
+
+    // The malformed row passes through, the valid row survives, and the
+    // client's backward walk resolves the same value as with full history.
+    expect(projected.thread.activities.map((activity) => activity.id)).toEqual([
+      valid.id,
+      malformed.id,
+    ]);
+    expect(deriveLatestContextWindowSnapshot(projected.thread.activities)).toEqual(
+      deriveLatestContextWindowSnapshot([valid, malformed]),
+    );
+  });
+
   it("leaves snapshots without context-window activities untouched", () => {
     const projected = projectThreadDetailSnapshot({
       snapshotSequence: 7,

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -234,36 +234,60 @@ describe("projectActivityPayload", () => {
 });
 
 describe("context-window snapshot dedup", () => {
-  function makeContextWindowActivity(id: string, usedTokens: number): OrchestrationThreadActivity {
+  function makeContextWindowActivity(
+    id: string,
+    usedTokens: number,
+    turn = `turn-${id}`,
+  ): OrchestrationThreadActivity {
     return {
       id: EventId.make(id),
       tone: "info",
       kind: "context-window.updated",
       summary: "Context window updated",
       payload: { usedTokens, maxTokens: 200_000 },
-      turnId: TurnId.make(`turn-${id}`),
+      turnId: TurnId.make(turn),
       createdAt: "2026-07-27T00:00:00.000Z",
     };
   }
 
-  it("keeps only the latest context-window activity in snapshots", () => {
-    const stale1 = makeContextWindowActivity("ctx-1", 1_000);
-    const stale2 = makeContextWindowActivity("ctx-2", 2_000);
-    const latest = makeContextWindowActivity("ctx-3", 3_000);
+  it("keeps only the latest context-window activity per turn in snapshots", () => {
+    const stale1 = makeContextWindowActivity("ctx-1", 1_000, "turn-a");
+    const latestA = makeContextWindowActivity("ctx-2", 2_000, "turn-a");
+    const latestB = makeContextWindowActivity("ctx-3", 3_000, "turn-b");
     const tool = fixtures[0]!;
 
     const projected = projectThreadDetailSnapshot({
       snapshotSequence: 7,
-      thread: makeThread([stale1, tool, stale2, latest]),
+      thread: makeThread([stale1, tool, latestA, latestB]),
     });
 
     expect(projected.thread.activities.map((activity) => activity.id)).toEqual([
       tool.id,
-      latest.id,
+      latestA.id,
+      latestB.id,
     ]);
-    // The retained row keeps its payload untouched — the tool-data projection
-    // only rewrites payloads with a `data` record.
-    expect(projected.thread.activities[1]?.payload).toEqual(latest.payload);
+    // The retained rows keep their payloads untouched — the tool-data
+    // projection only rewrites payloads with a `data` record.
+    expect(projected.thread.activities[2]?.payload).toEqual(latestB.payload);
+  });
+
+  it("still resolves a meter value after the client reverts the newest turn", () => {
+    // A live thread.reverted makes the client drop all activities from
+    // discarded turns; each surviving turn must keep a usable row.
+    const olderTurn = makeContextWindowActivity("ctx-old", 1_500, "turn-kept");
+    const revertedTurn = makeContextWindowActivity("ctx-new", 9_000, "turn-reverted");
+
+    const projected = projectThreadDetailSnapshot({
+      snapshotSequence: 7,
+      thread: makeThread([olderTurn, revertedTurn]),
+    });
+    const afterRevert = projected.thread.activities.filter(
+      (activity) => activity.turnId === TurnId.make("turn-kept"),
+    );
+
+    expect(deriveLatestContextWindowSnapshot(afterRevert)).toEqual(
+      deriveLatestContextWindowSnapshot([olderTurn]),
+    );
   });
 
   it("matches what the web client derives from the full history", () => {

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -11,6 +11,7 @@ import {
 import { describe, expect, it } from "vite-plus/test";
 
 import { buildThreadFeed, type ThreadFeedActivity } from "../../mobile/src/lib/threadActivity.ts";
+import { deriveLatestContextWindowSnapshot } from "../../web/src/lib/contextWindow.ts";
 import { deriveWorkLogEntries } from "../../web/src/session-logic.ts";
 import {
   projectActivityEvent,
@@ -229,5 +230,87 @@ describe("projectActivityPayload", () => {
         : undefined,
     ).toEqual(projectActivityPayload(activity));
     expect(event.payload.activity).toBe(activity);
+  });
+});
+
+describe("context-window snapshot dedup", () => {
+  function makeContextWindowActivity(id: string, usedTokens: number): OrchestrationThreadActivity {
+    return {
+      id: EventId.make(id),
+      tone: "info",
+      kind: "context-window.updated",
+      summary: "Context window updated",
+      payload: { usedTokens, maxTokens: 200_000 },
+      turnId: TurnId.make(`turn-${id}`),
+      createdAt: "2026-07-27T00:00:00.000Z",
+    };
+  }
+
+  it("keeps only the latest context-window activity in snapshots", () => {
+    const stale1 = makeContextWindowActivity("ctx-1", 1_000);
+    const stale2 = makeContextWindowActivity("ctx-2", 2_000);
+    const latest = makeContextWindowActivity("ctx-3", 3_000);
+    const tool = fixtures[0]!;
+
+    const projected = projectThreadDetailSnapshot({
+      snapshotSequence: 7,
+      thread: makeThread([stale1, tool, stale2, latest]),
+    });
+
+    expect(projected.thread.activities.map((activity) => activity.id)).toEqual([
+      tool.id,
+      latest.id,
+    ]);
+    // The retained row keeps its payload untouched — the tool-data projection
+    // only rewrites payloads with a `data` record.
+    expect(projected.thread.activities[1]?.payload).toEqual(latest.payload);
+  });
+
+  it("matches what the web client derives from the full history", () => {
+    const activities = [
+      makeContextWindowActivity("ctx-1", 1_000),
+      makeContextWindowActivity("ctx-2", 2_000),
+    ];
+    const projected = projectThreadDetailSnapshot({
+      snapshotSequence: 7,
+      thread: makeThread(activities),
+    });
+
+    expect(deriveLatestContextWindowSnapshot(projected.thread.activities)).toEqual(
+      deriveLatestContextWindowSnapshot(activities),
+    );
+  });
+
+  it("leaves snapshots without context-window activities untouched", () => {
+    const projected = projectThreadDetailSnapshot({
+      snapshotSequence: 7,
+      thread: makeThread([fixtures[4]!]),
+    });
+    expect(projected.thread.activities).toEqual([fixtures[4]]);
+  });
+
+  it("does not filter live activity-appended events", () => {
+    const activity = makeContextWindowActivity("ctx-live", 4_000);
+    const event = {
+      sequence: 9,
+      eventId: EventId.make("event-ctx"),
+      aggregateKind: "thread",
+      aggregateId: ThreadId.make("thread-projection"),
+      occurredAt: "2026-07-27T00:00:02.000Z",
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      type: "thread.activity-appended",
+      payload: {
+        threadId: ThreadId.make("thread-projection"),
+        activity,
+      },
+    } satisfies Extract<OrchestrationEvent, { type: "thread.activity-appended" }>;
+
+    const projected = projectActivityEvent(event);
+    expect(
+      projected.type === "thread.activity-appended" ? projected.payload.activity : undefined,
+    ).toEqual(activity);
   });
 });

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -26,7 +26,6 @@ export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
   getTurnDiff: "orchestration.getTurnDiff",
   getFullThreadDiff: "orchestration.getFullThreadDiff",
-  replayEvents: "orchestration.replayEvents",
   getArchivedShellSnapshot: "orchestration.getArchivedShellSnapshot",
   subscribeShell: "orchestration.subscribeShell",
   subscribeThread: "orchestration.subscribeThread",
@@ -1363,14 +1362,6 @@ export type OrchestrationGetFullThreadDiffInput = typeof OrchestrationGetFullThr
 export const OrchestrationGetFullThreadDiffResult = ThreadTurnDiff;
 export type OrchestrationGetFullThreadDiffResult = typeof OrchestrationGetFullThreadDiffResult.Type;
 
-export const OrchestrationReplayEventsInput = Schema.Struct({
-  fromSequenceExclusive: NonNegativeInt,
-});
-export type OrchestrationReplayEventsInput = typeof OrchestrationReplayEventsInput.Type;
-
-const OrchestrationReplayEventsResult = Schema.Array(OrchestrationEvent);
-export type OrchestrationReplayEventsResult = typeof OrchestrationReplayEventsResult.Type;
-
 export const OrchestrationRpcSchemas = {
   dispatchCommand: {
     input: ClientOrchestrationCommand,
@@ -1383,10 +1374,6 @@ export const OrchestrationRpcSchemas = {
   getFullThreadDiff: {
     input: OrchestrationGetFullThreadDiffInput,
     output: OrchestrationGetFullThreadDiffResult,
-  },
-  replayEvents: {
-    input: OrchestrationReplayEventsInput,
-    output: OrchestrationReplayEventsResult,
   },
   getArchivedShellSnapshot: {
     input: Schema.Struct({}),
@@ -1428,14 +1415,6 @@ export class OrchestrationGetTurnDiffError extends Schema.TaggedErrorClass<Orche
 
 export class OrchestrationGetFullThreadDiffError extends Schema.TaggedErrorClass<OrchestrationGetFullThreadDiffError>()(
   "OrchestrationGetFullThreadDiffError",
-  {
-    message: TrimmedNonEmptyString,
-    cause: Schema.optional(Schema.Defect()),
-  },
-) {}
-
-export class OrchestrationReplayEventsError extends Schema.TaggedErrorClass<OrchestrationReplayEventsError>()(
-  "OrchestrationReplayEventsError",
   {
     message: TrimmedNonEmptyString,
     cause: Schema.optional(Schema.Defect()),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -54,8 +54,6 @@ import {
   OrchestrationGetSnapshotError,
   OrchestrationGetTurnDiffError,
   OrchestrationGetTurnDiffInput,
-  OrchestrationReplayEventsError,
-  OrchestrationReplayEventsInput,
   OrchestrationRpcSchemas,
 } from "./orchestration.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
@@ -631,12 +629,6 @@ export const WsOrchestrationGetFullThreadDiffRpc = Rpc.make(
   },
 );
 
-export const WsOrchestrationReplayEventsRpc = Rpc.make(ORCHESTRATION_WS_METHODS.replayEvents, {
-  payload: OrchestrationReplayEventsInput,
-  success: OrchestrationRpcSchemas.replayEvents.output,
-  error: Schema.Union([OrchestrationReplayEventsError, EnvironmentAuthorizationError]),
-});
-
 export const WsOrchestrationGetArchivedShellSnapshotRpc = Rpc.make(
   ORCHESTRATION_WS_METHODS.getArchivedShellSnapshot,
   {
@@ -765,7 +757,6 @@ export const WsRpcGroup = RpcGroup.make(
   WsOrchestrationDispatchCommandRpc,
   WsOrchestrationGetTurnDiffRpc,
   WsOrchestrationGetFullThreadDiffRpc,
-  WsOrchestrationReplayEventsRpc,
   WsOrchestrationGetArchivedShellSnapshotRpc,
   WsOrchestrationSubscribeShellRpc,
   WsOrchestrationSubscribeThreadRpc,


### PR DESCRIPTION
Thread detail snapshots shipped every `context-window.updated` activity a thread ever produced, while both web and mobile only read the latest row (web walks the array backwards in `deriveLatestContextWindowSnapshot`; mobile skips the kind entirely). On long threads that history was 24–37% of snapshot bytes.

Snapshots now retain only the newest context-window row. Live `thread.activity-appended` events are untouched, so streaming updates still flow and supersede the retained row client-side. Verified on cloned real data that the served row is byte-identical to the latest stored row and that `deriveLatestContextWindowSnapshot` returns the same result before and after.

Measured on real thread snapshots (uncompressed HTTP bytes):

| thread | before | after | |
|---|---|---|---|
| 4206468e (10.6k activities) | 6.85 MB | 4.83 MB | -29.5% |
| 31e722de | 1.83 MB | 1.19 MB | -35.2% |
| 0fc086cc | 1.74 MB | 1.11 MB | -36.5% |
| 292eb4be | 0.83 MB | 0.59 MB | -29.0% |

This also removes the `orchestration.replayEvents` websocket RPC. No client in any released version calls it (checked v0.0.20 through v0.0.29 plus current web/mobile/desktop/client-runtime), and it let a single call serialize the entire event store uncompressed. The project-event enrichment helpers in `ws.ts` existed only for that handler and go with it.

Stacks cleanly with #4788 (HTTP gzip): these cut bytes at the source, gzip compresses what remains; on the largest thread the combined result is 6.85 MB → ~0.9 MB gzip.

Tests:
- `vp test apps/server/src/server.test.ts apps/server/test/ packages/contracts packages/client-runtime` (801 passed)
- typecheck across server, contracts, client-runtime, web, mobile

Built with Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Snapshot shaping must stay equivalent to client meter logic; removing a public RPC is a breaking change for any external caller, though shipped clients reportedly never used it.
> 
> **Overview**
> **Thread detail snapshots** now drop redundant `context-window.updated` activities before payload projection, keeping only the **latest resolvable row per turn** (aligned with the web client’s `deriveLatestContextWindowSnapshot` rules). Live `thread.activity-appended` events are unchanged, so streaming updates still apply on the client.
> 
> **The `orchestration.replayEvents` WebSocket RPC** is removed from contracts and the server, along with project-event repository-identity enrichment that existed only for that handler. Related server tests are deleted or trimmed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22bd5607166e914d3c7c0d2b420d194546d9c51d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trim stale context-window rows from thread snapshots and remove the `replayEvents` RPC
> - Adds `dropStaleContextWindowActivities` in [`ActivityPayloadProjection.ts`](https://github.com/pingdotgg/t3code/pull/4791/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130) to keep only the last valid `context-window.updated` activity per turn in thread snapshots, preventing malformed rows from shadowing earlier valid ones.
> - Removes the `orchestration.replayEvents` RPC from contracts, server routing, and auth scope — including all event-enrichment helpers that resolved repository identity.
> - Behavioral Change: thread snapshots now omit superseded `context-window.updated` rows; clients previously receiving multiple rows per turn will see only the latest resolvable one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22bd560.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->