### PR TITLE
fix(release): skip scripts during Vercel installs

### DIFF
--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -30,7 +30,7 @@ export const config: VercelConfig = {
     deploymentEnabled: false,
   },
   installCommand:
-    "npm install -g vite-plus && vp install --filter '@t3tools/scripts...' --filter '@t3tools/web...'",
+    "npm install -g vite-plus && vp install --ignore-scripts --filter '@t3tools/scripts...' --filter '@t3tools/web...'",
   routes: [
     {
       src: "/__t3code/channel",


### PR DESCRIPTION
The hosted web deployment runs its filtered Vercel install command twice. Both installs invoked the root prepare lifecycle, so the persistent build cache accumulated Effect tsgo backups until it hit the 100-file limit and blocked releases.

Run the hosted web install with --ignore-scripts. That build does not need local LSP setup or commit hooks, and workspace installs outside Vercel keep their existing lifecycle behavior.

Verification:
- Ran the exact filtered Vercel install twice and confirmed the tsgo backup count remained unchanged
- Built the hosted web app and applied the nightly brand assets
- Ran targeted web typechecking, lint, formatting, and diff checks

Generated by GPT-5.6 Sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes Vercel install behavior for the hosted web app; local and non-Vercel CI installs are unchanged.
> 
> **Overview**
> Adds **`--ignore-scripts`** to the hosted web **`installCommand`** in `vercel.ts` so Vercel’s `vp install` no longer runs workspace **`prepare`** hooks (including **`effect-tsgo patch`**).
> 
> That stops repeated installs during release deploys from piling up tsgo backups in the persistent build cache and hitting the 100-file limit that blocked deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975655a5548b42ceb8e78badf7b8f2e07e9af7f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip lifecycle scripts during Vercel dependency installation
> Adds `--ignore-scripts` to the `vp install` command in the Vercel install step in [vercel.ts](https://github.com/pingdotgg/t3code/pull/4796/files#diff-1a4d1119041bfb6fb5a4ce82060d10113bf5a2236b3c00ff3e2df8f83ae5de88) to prevent package lifecycle scripts from running during CI installs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 975655a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the web deployment installation process to skip package lifecycle scripts.
  * This helps provide a more consistent and controlled build environment during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->