### PR TITLE
fix(mobile): defer filesystem navigation

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -11,6 +11,8 @@ import {
   type AddProjectRemoteSource,
 } from "@t3tools/client-runtime/operations/projects";
 import {
+  canPreloadBrowsePath,
+  createBrowseNavigationCoordinator,
   filterFilesystemBrowseEntries,
   getFilesystemBrowsePath,
 } from "@t3tools/client-runtime/state/filesystem";
@@ -43,7 +45,10 @@ import { useThemeColor } from "../../lib/useThemeColor";
 import { uuidv4 } from "../../lib/uuid";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { useAtomQueryRunner } from "../../state/use-atom-query-runner";
-import { useSavedRemoteConnections } from "../../state/use-remote-environment-registry";
+import {
+  useRemoteEnvironmentRuntime,
+  useSavedRemoteConnections,
+} from "../../state/use-remote-environment-registry";
 
 interface EnvironmentOption {
   readonly environmentId: EnvironmentId;
@@ -219,6 +224,55 @@ function ProjectPathInput(props: {
       onSubmitEditing={props.onSubmit}
     />
   );
+}
+
+function useBrowsePathInput(environment: EnvironmentOption | null) {
+  const [pathInput, commitPathInput] = useState(() =>
+    getAddProjectInitialQuery(environment?.baseDirectory),
+  );
+  const environmentRuntime = useRemoteEnvironmentRuntime(environment?.environmentId ?? null);
+  const loadBrowsePath = useAtomQueryRunner(filesystemEnvironment.browse, {
+    reportFailure: false,
+    reportDefect: false,
+  });
+  const [browseNavigation] = useState(createBrowseNavigationCoordinator);
+  const setPathInput = useCallback(
+    (path: string) => {
+      browseNavigation.invalidate();
+      commitPathInput(path);
+    },
+    [browseNavigation],
+  );
+  const navigateToBrowsePath = useCallback(
+    (path: string) =>
+      browseNavigation.run(
+        async () => {
+          if (environment && canPreloadBrowsePath(environmentRuntime?.connectionState)) {
+            await loadBrowsePath({
+              environmentId: environment.environmentId,
+              input: { partialPath: path },
+            });
+          }
+        },
+        () => commitPathInput(path),
+      ),
+    [browseNavigation, environment, environmentRuntime?.connectionState, loadBrowsePath],
+  );
+
+  useEffect(() => {
+    if (environment) {
+      setPathInput(getAddProjectInitialQuery(environment.baseDirectory));
+    }
+  }, [environment, setPathInput]);
+
+  useEffect(
+    () => () => {
+      browseNavigation.invalidate();
+    },
+    [browseNavigation],
+  );
+
+  return { pathInput, setPathInput, navigateToBrowsePath };
 }
 
 function useEnvironmentOptions(): ReadonlyArray<EnvironmentOption> {
@@ -585,6 +639,7 @@ function FolderBrowser(props: {
   readonly environment: EnvironmentOption;
   readonly pathInput: string;
   readonly setPathInput: (path: string) => void;
+  readonly navigateToBrowsePath: (path: string) => Promise<boolean>;
 }) {
   const accentColor = useThemeColor("--color-icon-muted");
   const browsePath = useMemo(
@@ -633,7 +688,7 @@ function FolderBrowser(props: {
             right={null}
             onPress={() => {
               if (browsePath.parentPath) {
-                props.setPathInput(browsePath.parentPath);
+                void props.navigateToBrowsePath(browsePath.parentPath);
               }
             }}
           />
@@ -650,7 +705,7 @@ function FolderBrowser(props: {
                 browsePath.directoryPath.length > 0
                   ? appendBrowsePathSegment(browsePath.directoryPath, entry.name)
                   : ensureBrowseDirectoryPath(entry.fullPath);
-              props.setPathInput(nextPath);
+              void props.navigateToBrowsePath(nextPath);
             }}
           />
         ))}
@@ -662,16 +717,9 @@ function FolderBrowser(props: {
 export function AddProjectLocalFolderScreen(props: { readonly environmentId?: string | string[] }) {
   const environment = useEnvironmentFromParam(props.environmentId);
   const createProject = useCreateProject(environment);
-  const [pathInput, setPathInput] = useState(() =>
-    getAddProjectInitialQuery(environment?.baseDirectory),
-  );
+  const { navigateToBrowsePath, pathInput, setPathInput } = useBrowsePathInput(environment);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!environment) return;
-    setPathInput(getAddProjectInitialQuery(environment.baseDirectory));
-  }, [environment]);
 
   const submitPath = useCallback(async () => {
     if (!environment || isSubmitting) return;
@@ -712,6 +760,7 @@ export function AddProjectLocalFolderScreen(props: { readonly environmentId?: st
           />
           <FolderBrowser
             environment={environment}
+            navigateToBrowsePath={navigateToBrowsePath}
             pathInput={pathInput}
             setPathInput={setPathInput}
           />
@@ -735,16 +784,9 @@ export function AddProjectDestinationScreen(props: {
   const createProject = useCreateProject(environment);
   const remoteUrl = stringParam(props.remoteUrl);
   const repositoryTitle = stringParam(props.repositoryTitle);
-  const [pathInput, setPathInput] = useState(() =>
-    getAddProjectInitialQuery(environment?.baseDirectory),
-  );
+  const { navigateToBrowsePath, pathInput, setPathInput } = useBrowsePathInput(environment);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!environment) return;
-    setPathInput(getAddProjectInitialQuery(environment.baseDirectory));
-  }, [environment]);
 
   const submitPath = useCallback(async () => {
     if (!environment || !remoteUrl || isSubmitting) return;
@@ -804,6 +846,7 @@ export function AddProjectDestinationScreen(props: {
           />
           <FolderBrowser
             environment={environment}
+            navigateToBrowsePath={navigateToBrowsePath}
             pathInput={pathInput}
             setPathInput={setPathInput}
           />

--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -236,16 +236,19 @@ function useBrowsePathInput(environment: EnvironmentOption | null) {
     reportDefect: false,
   });
   const [browseNavigation] = useState(createBrowseNavigationCoordinator);
+  const [isBrowseNavigating, setIsBrowseNavigating] = useState(false);
   const setPathInput = useCallback(
     (path: string) => {
       browseNavigation.invalidate();
+      setIsBrowseNavigating(false);
       commitPathInput(path);
     },
     [browseNavigation],
   );
   const navigateToBrowsePath = useCallback(
-    (path: string) =>
-      browseNavigation.run(
+    async (path: string) => {
+      setIsBrowseNavigating(true);
+      const committed = await browseNavigation.run(
         async () => {
           if (environment && canPreloadBrowsePath(environmentRuntime?.connectionState)) {
             await loadBrowsePath({
@@ -255,7 +258,12 @@ function useBrowsePathInput(environment: EnvironmentOption | null) {
           }
         },
         () => commitPathInput(path),
-      ),
+      );
+      if (committed) {
+        setIsBrowseNavigating(false);
+      }
+      return committed;
+    },
     [browseNavigation, environment, environmentRuntime?.connectionState, loadBrowsePath],
   );
 
@@ -272,7 +280,7 @@ function useBrowsePathInput(environment: EnvironmentOption | null) {
     [browseNavigation],
   );
 
-  return { pathInput, setPathInput, navigateToBrowsePath };
+  return { isBrowseNavigating, pathInput, setPathInput, navigateToBrowsePath };
 }
 
 function useEnvironmentOptions(): ReadonlyArray<EnvironmentOption> {
@@ -717,12 +725,13 @@ function FolderBrowser(props: {
 export function AddProjectLocalFolderScreen(props: { readonly environmentId?: string | string[] }) {
   const environment = useEnvironmentFromParam(props.environmentId);
   const createProject = useCreateProject(environment);
-  const { navigateToBrowsePath, pathInput, setPathInput } = useBrowsePathInput(environment);
+  const { isBrowseNavigating, navigateToBrowsePath, pathInput, setPathInput } =
+    useBrowsePathInput(environment);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const submitPath = useCallback(async () => {
-    if (!environment || isSubmitting) return;
+    if (!environment || isBrowseNavigating || isSubmitting) return;
     setError(null);
     const resolved = resolveAddProjectPath({
       rawPath: pathInput,
@@ -740,7 +749,7 @@ export function AddProjectLocalFolderScreen(props: { readonly environmentId?: st
       setError(errorMessage(Cause.squash(result.cause)));
     }
     setIsSubmitting(false);
-  }, [createProject, environment, isSubmitting, pathInput]);
+  }, [createProject, environment, isBrowseNavigating, isSubmitting, pathInput]);
 
   return (
     <AddProjectShell>
@@ -754,7 +763,7 @@ export function AddProjectLocalFolderScreen(props: { readonly environmentId?: st
           />
           <PrimaryActionButton
             label="Add project"
-            disabled={isSubmitting}
+            disabled={isBrowseNavigating || isSubmitting}
             onPress={() => void submitPath()}
             loading={isSubmitting}
           />
@@ -784,12 +793,13 @@ export function AddProjectDestinationScreen(props: {
   const createProject = useCreateProject(environment);
   const remoteUrl = stringParam(props.remoteUrl);
   const repositoryTitle = stringParam(props.repositoryTitle);
-  const { navigateToBrowsePath, pathInput, setPathInput } = useBrowsePathInput(environment);
+  const { isBrowseNavigating, navigateToBrowsePath, pathInput, setPathInput } =
+    useBrowsePathInput(environment);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const submitPath = useCallback(async () => {
-    if (!environment || !remoteUrl || isSubmitting) return;
+    if (!environment || !remoteUrl || isBrowseNavigating || isSubmitting) return;
     setError(null);
     const resolved = resolveAddProjectPath({
       rawPath: pathInput,
@@ -818,7 +828,15 @@ export function AddProjectDestinationScreen(props: {
       }
     }
     setIsSubmitting(false);
-  }, [cloneRepository, createProject, environment, isSubmitting, pathInput, remoteUrl]);
+  }, [
+    cloneRepository,
+    createProject,
+    environment,
+    isBrowseNavigating,
+    isSubmitting,
+    pathInput,
+    remoteUrl,
+  ]);
 
   return (
     <AddProjectShell>
@@ -840,7 +858,7 @@ export function AddProjectDestinationScreen(props: {
           />
           <PrimaryActionButton
             label="Clone project"
-            disabled={isSubmitting || !remoteUrl}
+            disabled={isBrowseNavigating || isSubmitting || !remoteUrl}
             onPress={() => void submitPath()}
             loading={isSubmitting}
           />


### PR DESCRIPTION
## What changed

Mobile currently commits a folder tap before the destination browse data is ready, replacing the current directory with an intermediate loading state. This PR brings the deferred-navigation behavior from web to the mobile add-project and clone-destination browsers.

Connected environments preload the destination before committing the path. The shared latest-intent coordinator prevents slower overlapping taps from overwriting a newer navigation, while typed path edits invalidate pending navigation. Offline environments skip preloading and still navigate immediately instead of waiting on a query that may never settle.

#4797 has merged, and this branch is now restacked directly on its merge commit in `main`. The diff changes one mobile file only.

## Validation

- `vp test run packages/client-runtime/src/state/filesystem.test.ts` — 4 tests passed
- `vp run --filter @t3tools/mobile typecheck`
- targeted `vp lint --report-unused-disable-directives apps/mobile/src/features/projects/AddProjectScreen.tsx`
- `vp run lint:mobile` — SwiftLint, ktlint, and detekt passed before restacking; the mobile patch is byte-for-byte equivalent after rebase
- `vp fmt --check apps/mobile/src/features/projects/AddProjectScreen.tsx`
- React Doctor changed-file scan — 89/100 with no findings

Simulator/video verification is pending explicit approval to launch the mobile test environment.

GPT-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UX change to mobile add-project browsing only; reuses existing client-runtime navigation helpers with no auth, data, or API surface changes.
> 
> **Overview**
> Mobile add-project and clone-destination folder browsers no longer update the path immediately on folder taps, which was showing an intermediate loading state before the destination listing was ready.
> 
> A shared **`useBrowsePathInput`** hook centralizes path state and routes **`FolderBrowser`** navigation through **`navigateToBrowsePath`**. When the remote environment is connected, the destination browse query is preloaded before the path commits; offline environments skip preload and commit right away. **`createBrowseNavigationCoordinator`** serializes overlapping taps so only the latest navigation wins, and manual path edits invalidate pending navigation. Primary actions stay disabled while navigation is in flight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91f32fc20d5bcdc7dad8c7d26c4a6aabc923e4e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer filesystem navigation in mobile project screens to preload directory entries before committing path
> - Introduces a `useBrowsePathInput` hook that coordinates folder navigation: when possible, it preloads directory entries via `loadBrowsePath` before updating the displayed path, and exposes an `isBrowseNavigating` flag.
> - Updates `FolderBrowser` to delegate 'up one level' and entry selection to the new `navigateToBrowsePath` prop instead of immediately setting path state.
> - Blocks form submission and disables the primary action button in `AddProjectLocalFolderScreen` and `AddProjectDestinationScreen` while navigation is in progress.
> - Behavioral Change: folder navigation is now asynchronous and may introduce a brief delay before the path updates, depending on connection state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91f32fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->