### PR TITLE
fix(orchestrator): Keep active web timeline visible while work is queued

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -12,19 +12,21 @@ import * as DateTime from "effect/DateTime";
 import { describe, expect, it } from "vite-plus/test";
 
 import type { Thread } from "../types";
-import { makeThreadFixture } from "../test-fixtures";
+import { makeThreadFixture, makeThreadProjectionFixture } from "../test-fixtures";
 import {
   MAX_HIDDEN_MOUNTED_PREVIEW_THREADS,
   MAX_HIDDEN_MOUNTED_TERMINAL_THREADS,
   branchMismatchKey,
   buildExpiredTerminalContextToastCopy,
   createLocalDispatchSnapshot,
+  deriveChatViewThreadExecution,
   deriveCommittedServerUserMessageIds,
   deriveComposerSendState,
   dismissBranchMismatchForSession,
   getStartedThreadModelChangeBlockReason,
   hasServerAcknowledgedLocalDispatch,
   isBranchMismatchDismissedForSession,
+  isChatViewThreadWorking,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
@@ -39,6 +41,52 @@ const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");
 const threadId = ThreadId.make("thread-1");
 const now = "2026-03-29T00:00:00.000Z";
+
+describe("deriveChatViewThreadExecution", () => {
+  it("keeps web activity on a running turn when a newer turn is queued", () => {
+    const projection = makeThreadProjectionFixture();
+    const timestamp = DateTime.makeUnsafe(now);
+    const runningRunId = RunId.make("run-running");
+    const queuedRunId = RunId.make("run-queued");
+    const makeRun = (runId: RunId, ordinal: number, status: "queued" | "running") => ({
+      id: runId,
+      threadId: projection.thread.id,
+      ordinal,
+      providerInstanceId: projection.thread.providerInstanceId,
+      modelSelection: projection.thread.modelSelection,
+      providerThreadId: null,
+      userMessageId: MessageId.make(`message-${runId}`),
+      rootNodeId: null,
+      activeAttemptId: null,
+      status,
+      requestedAt: timestamp,
+      startedAt: status === "queued" ? null : timestamp,
+      completedAt: null,
+      checkpointId: null,
+      contextHandoffId: null,
+    });
+    const execution = deriveChatViewThreadExecution({
+      ...projection,
+      runs: [makeRun(queuedRunId, 2, "queued"), makeRun(runningRunId, 1, "running")],
+      updatedAt: timestamp,
+    });
+
+    expect(execution.latestRun).toMatchObject({
+      runId: queuedRunId,
+      status: "queued",
+    });
+    expect(execution.activityRun).toMatchObject({
+      runId: runningRunId,
+      status: "running",
+    });
+    expect(execution.runtime).toMatchObject({
+      status: "queued",
+      activeRunId: runningRunId,
+    });
+    expect(isChatViewThreadWorking("connecting", execution.runtime)).toBe(true);
+    expect(isChatViewThreadWorking("connecting", { activeRunId: null })).toBe(false);
+  });
+});
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return makeThreadFixture({

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -3,6 +3,7 @@ import {
   isProviderDriverKind,
   ProjectId,
   type ModelSelection,
+  type OrchestrationV2ThreadProjection,
   type OrchestrationV2ProjectedTurnItem,
   type ProviderDriverKind,
   type ServerProvider,
@@ -12,7 +13,12 @@ import {
   type RunId,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
-import { presentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { presentThreadShell, type ThreadRuntimeSummary } from "@t3tools/client-runtime/state/shell";
+import {
+  deriveLatestThreadRun,
+  deriveThreadActivityRun,
+  deriveThreadRuntime,
+} from "@t3tools/client-runtime/state/thread-execution";
 import { type ChatMessage, type SessionPhase, type Thread } from "../types";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
@@ -31,6 +37,23 @@ export const MAX_HIDDEN_MOUNTED_TERMINAL_THREADS = 10;
 export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
+
+export function deriveChatViewThreadExecution(projection: OrchestrationV2ThreadProjection) {
+  return {
+    activityRun: deriveThreadActivityRun(projection),
+    latestRun: deriveLatestThreadRun(projection),
+    runtime: deriveThreadRuntime(projection),
+  };
+}
+
+export function isChatViewThreadWorking(
+  phase: SessionPhase,
+  runtime: Pick<ThreadRuntimeSummary, "activeRunId"> | null,
+): boolean {
+  return (
+    phase === "running" || (runtime?.activeRunId !== null && runtime?.activeRunId !== undefined)
+  );
+}
 
 export function startNewThreadForProject(
   projectRef: ScopedProjectRef | null,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -26,10 +26,6 @@ import {
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
 import { effectiveSettled, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
-import {
-  deriveLatestThreadRun,
-  deriveThreadRuntime,
-} from "@t3tools/client-runtime/state/thread-execution";
 import { resolveThreadProviderSession } from "@t3tools/client-runtime/state/thread-workflows";
 import { derivePendingThreadRequests } from "@t3tools/client-runtime/state/thread-requests";
 import {
@@ -277,9 +273,11 @@ import {
   collectUserMessageBlobPreviewUrls,
   createLocalDispatchSnapshot,
   deriveCommittedServerUserMessageIds,
+  deriveChatViewThreadExecution,
   deriveComposerSendState,
   dismissBranchMismatchForSession,
   hasServerAcknowledgedLocalDispatch,
+  isChatViewThreadWorking,
   isBranchMismatchDismissedForSession,
   shouldShowBranchMismatchBanner,
   getStartedThreadModelChangeBlockReason,
@@ -1468,12 +1466,8 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const isServerThread = serverThread !== null;
   const activeThread = isServerThread ? serverThread : localDraftThread;
-  const serverLatestRun = useMemo(
-    () => (serverProjection === null ? null : deriveLatestThreadRun(serverProjection)),
-    [serverProjection],
-  );
-  const serverRuntime = useMemo(
-    () => (serverProjection === null ? null : deriveThreadRuntime(serverProjection)),
+  const serverExecution = useMemo(
+    () => (serverProjection === null ? null : deriveChatViewThreadExecution(serverProjection)),
     [serverProjection],
   );
   const activeProviderSession = useMemo(
@@ -1482,8 +1476,15 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const supportsProviderSwitchingViaHandoff =
     activeProviderSession?.capabilities.sessions.supportsProviderSwitchingViaHandoff === true;
-  const activeLatestRun = isServerThread ? serverLatestRun : (activeThread?.latestRun ?? null);
-  const activeRuntime = isServerThread ? serverRuntime : (activeThread?.runtime ?? null);
+  const activeLatestRun = isServerThread
+    ? (serverExecution?.latestRun ?? null)
+    : (activeThread?.latestRun ?? null);
+  const activeActivityRun = isServerThread
+    ? (serverExecution?.activityRun ?? null)
+    : (activeThread?.latestRun ?? null);
+  const activeRuntime = isServerThread
+    ? (serverExecution?.runtime ?? null)
+    : (activeThread?.runtime ?? null);
   const parentSubagentThreadId =
     activeThread?.lineage.relationshipToParent === "subagent"
       ? activeThread.lineage.parentThreadId
@@ -1507,7 +1508,7 @@ function ChatViewContent(props: ChatViewProps) {
     [parentSubagentThread?.title, parentSubagentThreadRef],
   );
   const threadError = isServerThread
-    ? (localServerError ?? serverRuntime?.lastError ?? null)
+    ? (localServerError ?? serverExecution?.runtime?.lastError ?? null)
     : localDraftError;
   const runtimeMode = composerRuntimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const interactionMode =
@@ -1681,7 +1682,7 @@ function ChatViewContent(props: ChatViewProps) {
         : nextThreadIds;
     });
   }, [activeThreadKey, existingOpenTerminalThreadKeys, terminalUiState.terminalOpen]);
-  const latestRunSettled = isLatestRunSettled(activeLatestRun, activeRuntime);
+  const latestRunSettled = isLatestRunSettled(activeActivityRun, activeRuntime);
   const activeProjectRef = activeThread
     ? scopeProjectRef(activeThread.environmentId, activeThread.projectId)
     : null;
@@ -2161,9 +2162,13 @@ function ChatViewContent(props: ChatViewProps) {
     activePendingUserInput: activePendingUserInput?.requestId ?? null,
     threadError,
   });
-  const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const isWorking =
+    isChatViewThreadWorking(phase, activeRuntime) ||
+    isSendBusy ||
+    isConnecting ||
+    isRevertingCheckpoint;
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
-    activeLatestRun,
+    activeActivityRun,
     activeRuntime,
     localDispatchStartedAt,
   );
@@ -6020,7 +6025,7 @@ function ChatViewContent(props: ChatViewProps) {
                 activeTurnStartedAt={activeWorkStartedAt}
                 listRef={legendListRef}
                 timelineEntries={timelineEntries}
-                latestRun={activeLatestRun}
+                latestRun={activeActivityRun}
                 turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
                 activeThreadEnvironmentId={activeThread.environmentId}
                 routeThreadKey={routeThreadKey}

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -947,6 +947,35 @@ describe("resolveThreadStatusPill", () => {
     ).toMatchObject({ label: "Working", pulse: true });
   });
 
+  it("stays working when a newer run is queued behind the active run", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          runtime: {
+            ...baseThread.runtime,
+            status: "queued",
+          },
+        },
+      }),
+    ).toMatchObject({ label: "Working", pulse: true });
+  });
+
+  it("shows connecting when a queued run has no active provider work", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          runtime: {
+            ...baseThread.runtime,
+            activeRunId: null,
+            status: "queued",
+          },
+        },
+      }),
+    ).toMatchObject({ label: "Connecting", pulse: true });
+  });
+
   it("shows plan ready when a settled plan turn has a proposed plan ready for follow-up", () => {
     expect(
       resolveThreadStatusPill({

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -592,7 +592,12 @@ export function resolveThreadStatusPill(input: {
     };
   }
 
-  if (thread.runtime?.status === "running" || thread.runtime?.status === "waiting") {
+  if (
+    thread.runtime !== null &&
+    (thread.runtime.status === "running" ||
+      thread.runtime.status === "waiting" ||
+      (thread.runtime.status === "queued" && thread.runtime.activeRunId !== null))
+  ) {
     return {
       label: "Working",
       colorClass: "text-sky-600 dark:text-sky-300/80",


### PR DESCRIPTION
## Summary

- Keep a running turn's web timeline and in-thread elapsed time attached to the
  run that still owns provider work when a newer follow-up is queued.
- Keep the in-thread Working row and sidebar Working status visible for that
  provider-owning run.
- Reuse `deriveThreadActivityRun`, which is already part of the
  `t3code/codex-turn-mapping` base, while preserving the latest run for queue
  semantics.

## Problem and Fix

| Problem and Why it Happened | Fix |
| --- | --- |
| `ChatView` used the highest-ordinal run for both queue presentation and live activity. Once a newer queued run appeared, `MessagesTimeline` treated the older running turn as settled and folded its commentary and tools behind a premature "Worked for" row. Elapsed-time presentation also lost the running turn's start time. | Derive latest, activity, and runtime state together. Keep the latest run for queue semantics, but pass the shared `deriveThreadActivityRun` result to settlement, elapsed-time, and timeline presentation. |
| The in-thread Working row and sidebar status pill also followed the newer queued run's status, so live work could lose its elapsed row and appear as Connecting. | Treat a non-null active run ID as provider-owned work. Keep queued-only threads Connecting, while running-plus-queued threads remain Working. |

## Validation

- Focused web and client-runtime tests: 4 files, 160 tests passed.
- Web TypeScript check passed.
- Targeted formatting and lint checks passed.
- Matching isolated real-Codex before and after replays:
  - The base folded the turn as "Worked for 3.3s" while provider work was still
    running and hid its command rows.
  - The final branch kept the command rows visible with "Working for 38s" while
    the newer run remained queued.
  - Both replays let the queued follow-up start only after run 1 completed, and
    both runs settled successfully.
- Compatibility replay with
  [#4762 web-timeline-inflight-tool-rows](https://github.com/pingdotgg/t3code/pull/4762):
  - The combined focused suite passed 119 tests.
  - Active commentary, completed output, and a running tool row remained visible
    together above the queued follow-up.
  - No premature "Worked for" fold appeared.
- Reusable manual coverage:
  [Codex background, scenario 9](https://nam7nt0rbtm6.postplan.dev/#codex-background-9).

## UI Changes

The visible change is limited to the active-plus-queued state. The running turn
remains expanded with its in-thread Working row and sidebar Working status until
it settles. After settlement, its normal "Worked for" fold can appear.

Validated before and after active-plus-queued screenshots are attached in a PR
comment.

## Known Limitation

The sidebar's Working duration uses compact thread-shell data, which has run IDs
but no activity-run timestamps. Its timer can still restart when the queued run
becomes latest or `runtime.updatedAt` changes. The Working status itself remains
visible.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why.
- [x] I included before and after screenshots for the UI change.
- [x] A video is not applicable because this changes run selection, not
  animation or transition behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI-only run-selection logic in a core chat path; behavior change is scoped to multi-run queued states with tests, but timeline/settlement bugs are user-visible if wrong.
> 
> **Overview**
> Fixes **active + queued** threads where a newer follow-up was treated as the live turn: the running turn folded early (“Worked for…”), tool rows hid, and UI showed **Connecting** instead of **Working**.
> 
> **ChatView** now derives **latest**, **activity**, and **runtime** together via `deriveChatViewThreadExecution` (reusing `deriveThreadActivityRun`). **Latest** run still drives queue semantics; **activity** run drives settlement, elapsed time, `MessagesTimeline`’s `latestRun`, and the in-thread working row. `isChatViewThreadWorking` treats any non-null `activeRunId` as in-progress work, not only `phase === "running"`.
> 
> **Sidebar** status pills count `queued` as **Working** when `activeRunId` is set; queued-only threads stay **Connecting**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a211c7d5426a2826d9cdfa20898837725759d4b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep active web timeline visible while a run is queued behind a running run
> - Introduces `deriveChatViewThreadExecution` and `isChatViewThreadWorking` in [`ChatView.logic.ts`](https://github.com/pingdotgg/t3code/pull/4800/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) to separate the "activity run" (the currently executing provider work) from the "latest run" (which may be a newer queued run).
> - `ChatViewContent` now uses the activity run for settled checks, timers, and `MessagesTimeline.latestRun`, so the timeline stays anchored to the running run instead of jumping to the queued one.
> - `resolveThreadStatusPill` in [`Sidebar.logic.ts`](https://github.com/pingdotgg/t3code/pull/4800/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) now returns `'Working'` when `runtime.status` is `'queued'` and `activeRunId` is non-null (previously showed `'Connecting'`).
> - Behavioral Change: `isWorking` becomes `true` for a queued runtime that has an `activeRunId`, which affects loading indicators and input disabling in the chat view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a211c7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->