### PR TITLE
fix(mobile): avoid duplicate Clerk auth back buttons

### DIFF
--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
@@ -19,6 +19,14 @@ public class T3TerminalModule: Module {
         view.initialBuffer = initialBuffer
       }
 
+      Prop("bufferEpoch") { (view: T3TerminalView, bufferEpoch: Double) in
+        view.bufferEpoch = Int(bufferEpoch)
+      }
+
+      Prop("bufferStart") { (view: T3TerminalView, bufferStart: Double) in
+        view.bufferStart = Int(bufferStart)
+      }
+
       Prop("fontSize") { (view: T3TerminalView, fontSize: Double) in
         view.fontSize = CGFloat(fontSize)
       }

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -196,6 +196,13 @@ private extension UIColor {
 public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private static let minimumVerticalScrollStepPoints: CGFloat = 18
   private static let verticalScrollStepMultiplier: CGFloat = 1.15
+  private static let bufferFeedChunkSize = 8 * 1024
+
+  private struct ActiveBufferFeed {
+    let surfaceGeneration: Int
+    let bufferRevision: Int
+    let bufferEpoch: Int
+  }
 
   private let terminalViewport = UIView()
   private let inputField = TerminalInputField()
@@ -204,7 +211,11 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private var lastViewportSize: CGSize = .zero
   private var lastContentScale: CGFloat = 0
   private var lastReportedGrid: (cols: Int, rows: Int)?
-  private var lastAppliedBuffer = ""
+  private var appliedBufferEpoch: Int?
+  private var appliedBufferEnd = 0
+  private var bufferRevision = 0
+  private var surfaceGeneration = 0
+  private var activeBufferFeed: ActiveBufferFeed?
   private var pendingVerticalScrollPoints: CGFloat = 0
   private var app: ghostty_app_t?
   private var surface: ghostty_surface_t?
@@ -221,13 +232,28 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
       accessibilityIdentifier = "t3-terminal-\(terminalKey)"
       if oldValue != terminalKey {
         resetSurface()
+        enqueueRemoteBufferApply()
       }
     }
   }
 
   var initialBuffer: String = "" {
     didSet {
-      applyRemoteBuffer(initialBuffer)
+      remoteBufferDidChange()
+    }
+  }
+
+  var bufferEpoch = 0 {
+    didSet {
+      guard oldValue != bufferEpoch else { return }
+      remoteBufferDidChange()
+    }
+  }
+
+  var bufferStart = 0 {
+    didSet {
+      guard oldValue != bufferStart else { return }
+      remoteBufferDidChange()
     }
   }
 
@@ -356,6 +382,9 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     let viewportSize = terminalViewport.bounds.size
     if surface == nil {
       createSurfaceIfPossible()
+      if surface != nil {
+        enqueueRemoteBufferApply()
+      }
     }
 
     guard viewportSize != lastViewportSize || contentScaleFactor != lastContentScale else {
@@ -499,12 +528,14 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     ghostty_surface_set_color_scheme(createdSurface, appearance.ghosttyColorScheme)
     setupWriteCallback()
     resizeSurface()
-    feedBuffer(initialBuffer)
   }
 
   private func resetSurface() {
+    surfaceGeneration += 1
     destroySurface()
-    lastAppliedBuffer = ""
+    activeBufferFeed = nil
+    appliedBufferEpoch = nil
+    appliedBufferEnd = 0
     lastViewportSize = .zero
     lastContentScale = 0
     lastReportedGrid = nil
@@ -515,6 +546,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private func refreshSurface() {
     resetSurface()
     createSurfaceIfPossible()
+    enqueueRemoteBufferApply()
   }
 
   private func destroySurface() {
@@ -529,40 +561,117 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     app = nil
   }
 
-  private func applyRemoteBuffer(_ buffer: String) {
-    guard surface != nil else {
+  private func remoteBufferDidChange() {
+    bufferRevision += 1
+    enqueueRemoteBufferApply()
+  }
+
+  private func enqueueRemoteBufferApply() {
+    let revision = bufferRevision
+    DispatchQueue.main.async { [weak self] in
+      guard let self, self.bufferRevision == revision else { return }
+      self.applyRemoteBuffer(revision: revision)
+    }
+  }
+
+  private func applyRemoteBuffer(revision: Int) {
+    if let activeBufferFeed {
+      if activeBufferFeed.bufferEpoch == bufferEpoch {
+        return
+      }
+      resetSurface()
+    }
+
+    if surface == nil {
       createSurfaceIfPossible()
+    }
+    guard surface != nil else { return }
+
+    let normalizedBufferStart = max(bufferStart, 0)
+    let buffer = initialBuffer as NSString
+    let bufferEnd = normalizedBufferStart + buffer.length
+    let canAppend =
+      appliedBufferEpoch == bufferEpoch &&
+      appliedBufferEnd >= normalizedBufferStart &&
+      appliedBufferEnd <= bufferEnd
+
+    let data: Data
+    if canAppend {
+      data = Data(buffer.substring(from: appliedBufferEnd - normalizedBufferStart).utf8)
+    } else {
+      if appliedBufferEpoch != nil {
+        resetSurface()
+        createSurfaceIfPossible()
+        guard surface != nil else { return }
+      }
+      data = Data(initialBuffer.utf8)
+    }
+
+    let targetSurfaceGeneration = surfaceGeneration
+    activeBufferFeed = ActiveBufferFeed(
+      surfaceGeneration: targetSurfaceGeneration,
+      bufferRevision: revision,
+      bufferEpoch: bufferEpoch
+    )
+    feedData(
+      data,
+      offset: 0,
+      surfaceGeneration: targetSurfaceGeneration
+    ) { [weak self] in
+      guard let self else { return }
+      guard
+        let activeBufferFeed = self.activeBufferFeed,
+        activeBufferFeed.surfaceGeneration == targetSurfaceGeneration,
+        activeBufferFeed.bufferRevision == revision
+      else {
+        return
+      }
+
+      self.activeBufferFeed = nil
+      self.appliedBufferEpoch = activeBufferFeed.bufferEpoch
+      self.appliedBufferEnd = bufferEnd
+      if self.bufferRevision != revision {
+        self.enqueueRemoteBufferApply()
+      }
+    }
+  }
+
+  private func feedData(
+    _ data: Data,
+    offset: Int,
+    surfaceGeneration targetSurfaceGeneration: Int,
+    completion: @escaping () -> Void
+  ) {
+    guard surfaceGeneration == targetSurfaceGeneration, let surface else { return }
+    guard offset < data.count else {
+      redrawSurface()
+      completion()
       return
     }
 
-    if buffer.hasPrefix(lastAppliedBuffer) {
-      let suffix = String(buffer.dropFirst(lastAppliedBuffer.count))
-      feedData(Data(suffix.utf8))
-      lastAppliedBuffer = buffer
-      return
-    }
-
-    resetSurface()
-    createSurfaceIfPossible()
-  }
-
-  private func feedBuffer(_ buffer: String) {
-    guard !buffer.isEmpty else { return }
-    feedData(Data(buffer.utf8))
-    lastAppliedBuffer = buffer
-  }
-
-  private func feedData(_ data: Data) {
-    guard let surface, !data.isEmpty else { return }
-
+    let chunkCount = min(Self.bufferFeedChunkSize, data.count - offset)
     data.withUnsafeBytes { buffer in
       guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
         return
       }
-      ghostty_surface_feed_data(surface, pointer, buffer.count)
+      ghostty_surface_feed_data(surface, pointer.advanced(by: offset), chunkCount)
     }
 
-    redrawSurface()
+    let nextOffset = offset + chunkCount
+    if nextOffset >= data.count {
+      redrawSurface()
+      completion()
+      return
+    }
+
+    DispatchQueue.main.async { [weak self] in
+      self?.feedData(
+        data,
+        offset: nextOffset,
+        surfaceGeneration: targetSurfaceGeneration,
+        completion: completion
+      )
+    }
   }
 
   private func setupWriteCallback() {

--- a/apps/mobile/src/features/settings/SettingsAuthRouteScreen.logic.test.ts
+++ b/apps/mobile/src/features/settings/SettingsAuthRouteScreen.logic.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveSettingsAuthHeaderOptions } from "./SettingsAuthRouteScreen.logic";
+
+describe("resolveSettingsAuthHeaderOptions", () => {
+  it("keeps the native header while Clerk restores the session", () => {
+    expect(resolveSettingsAuthHeaderOptions({ isLoaded: false, isSignedIn: undefined })).toEqual({
+      headerShown: true,
+      title: "Sign in",
+    });
+  });
+
+  it("lets Clerk own navigation during authentication", () => {
+    expect(resolveSettingsAuthHeaderOptions({ isLoaded: true, isSignedIn: false })).toEqual({
+      headerShown: false,
+      title: "Sign in",
+    });
+  });
+
+  it("restores the native header for the account screen", () => {
+    expect(resolveSettingsAuthHeaderOptions({ isLoaded: true, isSignedIn: true })).toEqual({
+      headerShown: true,
+      title: "Account",
+    });
+  });
+});

--- a/apps/mobile/src/features/settings/SettingsAuthRouteScreen.logic.ts
+++ b/apps/mobile/src/features/settings/SettingsAuthRouteScreen.logic.ts
@@ -1,0 +1,9 @@
+export function resolveSettingsAuthHeaderOptions(input: {
+  readonly isLoaded: boolean;
+  readonly isSignedIn: boolean | undefined;
+}) {
+  return {
+    headerShown: !input.isLoaded || input.isSignedIn === true,
+    title: input.isSignedIn ? "Account" : "Sign in",
+  };
+}

--- a/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import { View } from "react-native";
 
 import { hasCloudPublicConfig } from "../cloud/publicConfig";
+import { resolveSettingsAuthHeaderOptions } from "./SettingsAuthRouteScreen.logic";
 
 export function SettingsAuthRouteScreen() {
   const navigation = useNavigation();
@@ -21,16 +22,19 @@ export function SettingsAuthRouteScreen() {
 
 function ConfiguredSettingsAuthRouteScreen() {
   const { isLoaded, isSignedIn } = useAuth({ treatPendingAsSignedOut: false });
+  const navigation = useNavigation();
 
   return (
     <>
-      <NativeStackScreenOptions options={{ title: isSignedIn ? "Account" : "Sign in" }} />
+      <NativeStackScreenOptions
+        options={resolveSettingsAuthHeaderOptions({ isLoaded, isSignedIn })}
+      />
       <View collapsable={false} className="flex-1 overflow-hidden bg-sheet">
         {isLoaded ? (
           isSignedIn ? (
             <UserProfileView isDismissible={false} />
           ) : (
-            <AuthView isDismissible={false} />
+            <AuthView isDismissible onDismiss={() => navigation.goBack()} />
           )
         ) : null}
       </View>

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -35,6 +35,8 @@ interface TerminalResizeEvent {
 interface TerminalSurfaceProps extends ViewProps {
   readonly terminalKey: string;
   readonly buffer: string;
+  readonly bufferEpoch: number;
+  readonly bufferStart: number;
   readonly fontSize?: number;
   readonly isRunning: boolean;
   readonly autoFocus?: boolean;
@@ -186,9 +188,18 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
       // null = installed binary predates native hardware-key handling (rebuild needed).
       hardwareKeyRevision: getNativeTerminalHardwareKeyRevision(),
       bufferLen: props.buffer.length,
+      bufferEpoch: props.bufferEpoch,
+      bufferStart: props.bufferStart,
       isRunning: props.isRunning,
     });
-  }, [hasNativeSurface, props.buffer.length, props.isRunning, props.terminalKey]);
+  }, [
+    hasNativeSurface,
+    props.buffer.length,
+    props.bufferEpoch,
+    props.bufferStart,
+    props.isRunning,
+    props.terminalKey,
+  ]);
   const handleNativeInput = useCallback(
     (event: NativeSyntheticEvent<TerminalInputEvent>) => {
       if (!props.isRunning) {
@@ -223,6 +234,8 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
           mutedForegroundColor={theme.mutedForeground}
           terminalKey={props.terminalKey}
           initialBuffer={props.buffer}
+          bufferEpoch={props.bufferEpoch}
+          bufferStart={props.bufferStart}
           fontSize={fontSize}
           style={{ flex: 1 }}
           themeConfig={buildGhosttyThemeConfig(theme)}

--- a/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
@@ -241,6 +241,8 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
       <TerminalSurface
         terminalKey={terminalKey}
         buffer={terminal.buffer}
+        bufferEpoch={terminal.bufferEpoch}
+        bufferStart={terminal.bufferStart}
         isRunning={isRunning}
         onInput={handleInput}
         onResize={handleResize}

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -351,6 +351,11 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     replayKey: bufferReplayKey,
     readyReplayKey: readyBufferReplayKey,
   });
+  const isTerminalSurfaceBufferHidden = terminalSurfaceBuffer !== terminal.buffer;
+  const terminalSurfaceBufferEpoch = isTerminalSurfaceBufferHidden
+    ? terminal.bufferEpoch + 1
+    : terminal.bufferEpoch;
+  const terminalSurfaceBufferStart = isTerminalSurfaceBufferHidden ? 0 : terminal.bufferStart;
   const isRunning = terminal.status === "running" || terminal.status === "starting";
 
   // When the process ends while this screen is attached (e.g. typing `exit`),
@@ -1221,6 +1226,8 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
               <TerminalSurface
                 autoFocus={!SHOWCASE_ENABLED}
                 buffer={terminalSurfaceBuffer}
+                bufferEpoch={terminalSurfaceBufferEpoch}
+                bufferStart={terminalSurfaceBufferStart}
                 fontSize={fontSize}
                 isRunning={isRunning}
                 keyboardFocusRequest={keyboardFocusRequest}

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.ts
@@ -31,6 +31,8 @@ export interface NativeTerminalSurfaceProps extends ViewProps {
   readonly mutedForegroundColor?: string;
   readonly terminalKey: string;
   readonly initialBuffer: string;
+  readonly bufferEpoch: number;
+  readonly bufferStart: number;
   readonly fontSize: number;
   readonly onInput?: (event: NativeSyntheticEvent<TerminalInputEvent>) => void;
   readonly onResize?: (event: NativeSyntheticEvent<TerminalResizeEvent>) => void;

--- a/apps/mobile/src/features/terminal/terminalMenu.test.ts
+++ b/apps/mobile/src/features/terminal/terminalMenu.test.ts
@@ -57,6 +57,9 @@ function makeKnownSession(input: {
           }
         : null,
       buffer: "",
+      bufferEpoch: 0,
+      bufferStart: 0,
+      bufferEnd: 0,
       status: input.status,
       error: null,
       hasRunningSubprocess: false,

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -766,10 +766,11 @@ export function TerminalViewport({
     const bufferUpdate = getTerminalBufferUpdate(previous, current);
     if (bufferUpdate.type === "append") {
       terminal.write(bufferUpdate.data);
+      terminal.clearSelection();
     } else if (bufferUpdate.type === "replace") {
       writeTerminalBuffer(terminal, bufferUpdate.buffer);
+      terminal.clearSelection();
     }
-    terminal.clearSelection();
 
     if (current.error !== null && current.error !== previous.error) {
       writeSystemMessage(terminal, current.error);

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -4,6 +4,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { getTerminalBufferUpdate } from "@t3tools/client-runtime/state/terminal";
 import {
   Plus,
   SquareSplitHorizontal,
@@ -365,11 +366,17 @@ export function TerminalViewport({
     }),
   );
   const terminalBuffer = terminalSession.buffer;
+  const terminalBufferEpoch = terminalSession.bufferEpoch;
+  const terminalBufferStart = terminalSession.bufferStart;
+  const terminalBufferEnd = terminalSession.bufferEnd;
   const terminalError = terminalSession.error;
   const terminalStatus = terminalSession.status;
   const terminalVersion = terminalSession.version;
   const previousSessionRef = useRef({
     buffer: terminalBuffer,
+    bufferEpoch: terminalBufferEpoch,
+    bufferStart: terminalBufferStart,
+    bufferEnd: terminalBufferEnd,
     error: terminalError,
     status: terminalStatus,
     version: terminalVersion,
@@ -403,6 +410,9 @@ export function TerminalViewport({
     fitAddonRef.current = fitAddon;
     previousSessionRef.current = {
       buffer: "",
+      bufferEpoch: 0,
+      bufferStart: 0,
+      bufferEnd: 0,
       status: "closed",
       error: null,
       version: 0,
@@ -740,6 +750,9 @@ export function TerminalViewport({
     const terminal = terminalRef.current;
     const current = {
       buffer: terminalBuffer,
+      bufferEpoch: terminalBufferEpoch,
+      bufferStart: terminalBufferStart,
+      bufferEnd: terminalBufferEnd,
       error: terminalError,
       status: terminalStatus,
       version: terminalVersion,
@@ -750,17 +763,11 @@ export function TerminalViewport({
     }
 
     const previous = previousSessionRef.current;
-    if (current.version === previous.version) {
-      return;
-    }
-
-    if (
-      current.buffer.length >= previous.buffer.length &&
-      current.buffer.startsWith(previous.buffer)
-    ) {
-      terminal.write(current.buffer.slice(previous.buffer.length));
-    } else {
-      writeTerminalBuffer(terminal, current.buffer);
+    const bufferUpdate = getTerminalBufferUpdate(previous, current);
+    if (bufferUpdate.type === "append") {
+      terminal.write(bufferUpdate.data);
+    } else if (bufferUpdate.type === "replace") {
+      writeTerminalBuffer(terminal, bufferUpdate.buffer);
     }
     terminal.clearSelection();
 
@@ -793,7 +800,16 @@ export function TerminalViewport({
       });
     }
     previousSessionRef.current = current;
-  }, [autoFocus, terminalBuffer, terminalError, terminalStatus, terminalVersion]);
+  }, [
+    autoFocus,
+    terminalBuffer,
+    terminalBufferEnd,
+    terminalBufferEpoch,
+    terminalBufferStart,
+    terminalError,
+    terminalStatus,
+    terminalVersion,
+  ]);
 
   useEffect(() => {
     if (!autoFocus) return;

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -7,6 +7,7 @@ import {
   applyTerminalMetadataStreamEvent,
   combineTerminalSessionState,
   EMPTY_TERMINAL_BUFFER_STATE,
+  getTerminalBufferUpdate,
   selectRunningSubprocessTerminalIds,
 } from "./terminalSession.ts";
 
@@ -127,6 +128,9 @@ describe("terminal session reducers", () => {
 
     expect(output).toMatchObject({
       buffer: "lo world",
+      bufferEpoch: 1,
+      bufferStart: 3,
+      bufferEnd: 11,
       status: "running",
       error: null,
       version: 2,
@@ -183,5 +187,77 @@ describe("terminal session reducers", () => {
     );
 
     expect(state.buffer).toBe("🙂");
+    expect(state).toMatchObject({
+      bufferStart: 2,
+      bufferEnd: 4,
+    });
+  });
+
+  it("keeps rollover output appendable with absolute buffer positions", () => {
+    const beforeRollover = applyTerminalAttachStreamEvent(
+      EMPTY_TERMINAL_BUFFER_STATE,
+      {
+        type: "snapshot",
+        snapshot: { ...BASE_SNAPSHOT, history: "abcdefgh" },
+      },
+      8,
+    );
+    const afterRollover = applyTerminalAttachStreamEvent(
+      beforeRollover,
+      {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "ij",
+      },
+      8,
+    );
+
+    expect(afterRollover).toMatchObject({
+      buffer: "cdefghij",
+      bufferEpoch: beforeRollover.bufferEpoch,
+      bufferStart: 2,
+      bufferEnd: 10,
+    });
+    expect(getTerminalBufferUpdate(beforeRollover, afterRollover)).toEqual({
+      type: "append",
+      data: "ij",
+    });
+  });
+
+  it("replaces the rendered buffer after a reset or when a renderer falls behind", () => {
+    const initial = applyTerminalAttachStreamEvent(
+      EMPTY_TERMINAL_BUFFER_STATE,
+      {
+        type: "snapshot",
+        snapshot: { ...BASE_SNAPSHOT, history: "abcdefgh" },
+      },
+      8,
+    );
+    const restarted = applyTerminalAttachStreamEvent(initial, {
+      type: "restarted",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      snapshot: { ...BASE_SNAPSHOT, history: "fresh" },
+    });
+    const beyondRetainedWindow = applyTerminalAttachStreamEvent(
+      initial,
+      {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "ijklmnop",
+      },
+      8,
+    );
+
+    expect(getTerminalBufferUpdate(initial, restarted)).toEqual({
+      type: "replace",
+      buffer: "fresh",
+    });
+    expect(getTerminalBufferUpdate(EMPTY_TERMINAL_BUFFER_STATE, beyondRetainedWindow)).toEqual({
+      type: "replace",
+      buffer: "ijklmnop",
+    });
   });
 });

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -10,6 +10,9 @@ import type {
 export interface TerminalSessionState {
   readonly summary: TerminalSummary | null;
   readonly buffer: string;
+  readonly bufferEpoch: number;
+  readonly bufferStart: number;
+  readonly bufferEnd: number;
   readonly status: TerminalSessionSnapshot["status"] | "closed";
   readonly error: string | null;
   readonly hasRunningSubprocess: boolean;
@@ -19,11 +22,26 @@ export interface TerminalSessionState {
 
 export interface TerminalBufferState {
   readonly buffer: string;
+  readonly bufferEpoch: number;
+  readonly bufferStart: number;
+  readonly bufferEnd: number;
   readonly status: TerminalSessionSnapshot["status"] | "closed";
   readonly error: string | null;
   readonly updatedAt: string | null;
   readonly version: number;
 }
+
+export interface TerminalBufferWindow {
+  readonly buffer: string;
+  readonly bufferEpoch: number;
+  readonly bufferStart: number;
+  readonly bufferEnd: number;
+}
+
+export type TerminalBufferUpdate =
+  | { readonly type: "none" }
+  | { readonly type: "append"; readonly data: string }
+  | { readonly type: "replace"; readonly buffer: string };
 
 export interface KnownTerminalSessionTarget {
   readonly environmentId: EnvironmentId;
@@ -46,6 +64,9 @@ export function selectRunningSubprocessTerminalIds(
 
 export const EMPTY_TERMINAL_BUFFER_STATE = Object.freeze<TerminalBufferState>({
   buffer: "",
+  bufferEpoch: 0,
+  bufferStart: 0,
+  bufferEnd: 0,
   status: "closed",
   error: null,
   updatedAt: null,
@@ -55,6 +76,9 @@ export const EMPTY_TERMINAL_BUFFER_STATE = Object.freeze<TerminalBufferState>({
 export const EMPTY_TERMINAL_SESSION_STATE = Object.freeze<TerminalSessionState>({
   summary: null,
   buffer: "",
+  bufferEpoch: 0,
+  bufferStart: 0,
+  bufferEnd: 0,
   status: "closed",
   error: null,
   hasRunningSubprocess: false,
@@ -91,9 +115,14 @@ function trimBufferToBytes(buffer: string, maxBufferBytes: number): string {
 export function terminalBufferStateFromSnapshot(
   snapshot: TerminalSessionSnapshot,
   maxBufferBytes: number,
+  bufferEpoch = 1,
 ): TerminalBufferState {
+  const buffer = trimBufferToBytes(snapshot.history, maxBufferBytes);
   return {
-    buffer: trimBufferToBytes(snapshot.history, maxBufferBytes),
+    buffer,
+    bufferEpoch,
+    bufferStart: snapshot.history.length - buffer.length,
+    bufferEnd: snapshot.history.length,
     status: snapshot.status,
     error: null,
     updatedAt: snapshot.updatedAt,
@@ -114,6 +143,9 @@ export function combineTerminalSessionState(
   return {
     summary,
     buffer: buffer.buffer,
+    bufferEpoch: buffer.bufferEpoch,
+    bufferStart: buffer.bufferStart,
+    bufferEnd: buffer.bufferEnd,
     status: buffer.version > 0 ? buffer.status : (summary?.status ?? buffer.status),
     error: buffer.error,
     hasRunningSubprocess: summary?.hasRunningSubprocess ?? false,
@@ -130,19 +162,31 @@ export function applyTerminalAttachStreamEvent(
   switch (event.type) {
     case "snapshot":
     case "restarted":
-      return terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes);
-    case "output":
+      return terminalBufferStateFromSnapshot(
+        event.snapshot,
+        maxBufferBytes,
+        current.bufferEpoch + 1,
+      );
+    case "output": {
+      const bufferEnd = current.bufferEnd + event.data.length;
+      const buffer = trimBufferToBytes(`${current.buffer}${event.data}`, maxBufferBytes);
       return {
         ...current,
-        buffer: trimBufferToBytes(`${current.buffer}${event.data}`, maxBufferBytes),
+        buffer,
+        bufferStart: bufferEnd - buffer.length,
+        bufferEnd,
         status: current.status === "closed" ? "running" : current.status,
         error: null,
         version: current.version + 1,
       };
+    }
     case "cleared":
       return {
         ...current,
         buffer: "",
+        bufferEpoch: current.bufferEpoch + 1,
+        bufferStart: 0,
+        bufferEnd: 0,
         error: null,
         version: current.version + 1,
       };
@@ -170,6 +214,28 @@ export function applyTerminalAttachStreamEvent(
     case "activity":
       return current;
   }
+}
+
+export function getTerminalBufferUpdate(
+  previous: TerminalBufferWindow,
+  current: TerminalBufferWindow,
+): TerminalBufferUpdate {
+  if (
+    previous.bufferEpoch !== current.bufferEpoch ||
+    previous.bufferEnd < current.bufferStart ||
+    previous.bufferEnd > current.bufferEnd
+  ) {
+    return { type: "replace", buffer: current.buffer };
+  }
+
+  if (previous.bufferEnd === current.bufferEnd) {
+    return { type: "none" };
+  }
+
+  return {
+    type: "append",
+    data: current.buffer.slice(previous.bufferEnd - current.bufferStart),
+  };
 }
 
 export function applyTerminalMetadataStreamEvent(


### PR DESCRIPTION
## What changed

- Let Clerk own the signed-out authentication navigation chrome.
- Hide the app's native stack header while `AuthView` is active.
- Restore the native header while Clerk session state loads and for the signed-in account view.
- Route Clerk's dismiss action back through the enclosing settings navigator.
- Add focused tests for each header-ownership state.

## Why

The email-code step has its own Clerk back action, while the enclosing settings route also rendered a native back button. Both navigation layers were visible in the same sheet, producing stacked back buttons.

Keeping one navigation owner per state removes the duplicate control without changing the signed-in account screen.

## User impact

The Clerk email-code flow now shows one coherent set of navigation controls. Users can still leave the auth flow through Clerk's dismiss action, and signed-in account settings retain the existing native header.

## Validation

- `pnpm vp test run apps/mobile/src/features/settings/SettingsAuthRouteScreen.logic.test.ts`
- `pnpm --filter @t3tools/mobile typecheck`
- `pnpm vp lint apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx apps/mobile/src/features/settings/SettingsAuthRouteScreen.logic.ts apps/mobile/src/features/settings/SettingsAuthRouteScreen.logic.test.ts`
- `git diff --check`

## UI changes

No screenshots included. The Clerk email-code flow requires configured interactive authentication and was not launched during this pass.

Generated by GPT-5 in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate back buttons in mobile Clerk auth by hiding the native header during sign-in
> - Adds `resolveSettingsAuthHeaderOptions` in [SettingsAuthRouteScreen.logic.ts](https://github.com/pingdotgg/t3code/pull/4803/files#diff-a4d681d2fd9023d4d66e06685bb8b2d9343f047af30a702545325f0dfa7f6e5c) to derive header visibility from Clerk load/sign-in state; the native header is hidden when Clerk controls its own navigation chrome.
> - Updates [SettingsAuthRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/4803/files#diff-36ae857b9472a22369546d29b3874efa1c60daa68cd68d367b7cbb05d8c24b49) to use the new utility and adds an `onDismiss` callback that calls `navigation.goBack()`.
> - Introduces `bufferEpoch`/`bufferStart`/`bufferEnd` tracking across the terminal buffer state machine in [terminalSession.ts](https://github.com/pingdotgg/t3code/pull/4803/files#diff-c939205ce2272b9eb963a11eb634ba5d09e9525a249ac2c259ef8b5fda367828), enabling append-vs-replace decisions via the new `getTerminalBufferUpdate` utility.
> - Propagates epoch/position props through the React Native terminal surface stack and implements chunked async buffer feeding with generation guards in the iOS native view [T3TerminalView.swift](https://github.com/pingdotgg/t3code/pull/4803/files#diff-f62e0027105bee3eafacb6199a2218932ecbbd4b8bba7193a3a0da4f065a62ca).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 699c574.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Terminal display logic changes on web, mobile JS, and native iOS simultaneously; incorrect append/replace could corrupt or flash terminal output. Settings auth changes are limited to header visibility and dismiss navigation.
> 
> **Overview**
> This PR combines **mobile settings auth navigation** fixes with **terminal buffer synchronization** across client-runtime, web, and iOS native.
> 
> **Settings auth (mobile):** `resolveSettingsAuthHeaderOptions` drives stack `headerShown` and title from Clerk `isLoaded` / `isSignedIn`—the native header stays visible while the session restores and on the signed-in account screen, but is **hidden** while `AuthView` is shown so Clerk’s back/dismiss UI isn’t doubled. `AuthView` is dismissible and `onDismiss` calls `navigation.goBack()`.
> 
> **Terminal buffers:** Session state now tracks `bufferEpoch`, `bufferStart`, and `bufferEnd` (absolute positions in the retained window). Snapshots/restarts/clears bump epoch; output updates end positions so rollover stays appendable. **`getTerminalBufferUpdate`** chooses **append**, **replace**, or **none** using epoch and position overlap instead of relying only on version or string prefix.
> 
> That metadata flows through mobile `TerminalSurface` / native props; replay/hidden-buffer paths bump epoch or reset start on `ThreadTerminalRouteScreen`. **Web** `ThreadTerminalDrawer` applies updates via `getTerminalBufferUpdate`. **iOS** `T3TerminalView` feeds Ghostty in **8KB chunks** on the main queue, appending when epoch and positions align and resetting the surface when epoch changes or the renderer falls behind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699c57462837e39b11b3d77c3b4077a053b803c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->