### PR TITLE
Fix Connect sign-in settings label

### DIFF
--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -166,7 +166,7 @@ function ConfiguredSettingsRouteScreen() {
   const environmentCount = connections.length;
   const accountLabel = useMemo(() => {
     if (!isLoaded) return "Checking";
-    if (!isSignedIn) return "Request access";
+    if (!isSignedIn) return "Sign in";
     return user?.primaryEmailAddress?.emailAddress ?? "Signed in";
   }, [isLoaded, isSignedIn, user?.primaryEmailAddress?.emailAddress]);
 


### PR DESCRIPTION
## What changed

- Update the signed-out T3 Account row in mobile Settings from “Request access” to “Sign in”.

## Why

Connect is generally available now, but this remaining waitlist-era label still implied that users needed approval before signing in.

## Impact

Signed-out mobile users now see copy that matches the GA authentication flow.

## Validation

- `vp fmt --check apps/mobile/src/features/settings/SettingsRouteScreen.tsx`
- `vp run --filter @t3tools/mobile typecheck`
- `vp lint --report-unused-disable-directives apps/mobile/src/features/settings/SettingsRouteScreen.tsx`
- iOS Simulator accessibility snapshot confirmed `T3 Account, Sign in`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix account label to show 'Sign in' instead of 'Request access' in Connect settings
> Corrects the `accountLabel` in [`SettingsRouteScreen.tsx`](https://github.com/pingdotgg/t3code/pull/4806/files#diff-2f7a2e66b652454e7fd1b30226a5146d595dfe05945b34d90ffd5f3a5037cb1e) so the not-signed-in state displays 'Sign in' rather than the incorrect 'Request access'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba303c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to a settings label with no auth, navigation, or data-handling impact.
> 
> **Overview**
> Updates the **T3 Account** row subtitle in mobile Settings so signed-out users see **Sign in** instead of the waitlist-era **Request access**, matching GA Connect auth.
> 
> Only `accountLabel` in `SettingsRouteScreen` changes when Clerk is loaded and the user is not signed in; loading and signed-in labels are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba303c63fdcb14cf245754a58ba7df93b0a4c3fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->