### PR TITLE
fix(desktop): restore T3 Connect sign-in

### DIFF
--- a/apps/web/src/components/clerk/authRedirect.test.ts
+++ b/apps/web/src/components/clerk/authRedirect.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveClerkAuthRedirectUrl } from "./authRedirect";
+
+describe("resolveClerkAuthRedirectUrl", () => {
+  it("preserves the current browser URL", () => {
+    const href = "https://app.t3.codes/connect?state=state-1#details";
+    expect(resolveClerkAuthRedirectUrl(href, false)).toBe(href);
+  });
+
+  it("uses the allowlisted packaged desktop callback", () => {
+    expect(resolveClerkAuthRedirectUrl("t3code://app/continue#/settings/general", true)).toBe(
+      "t3code://app/",
+    );
+  });
+
+  it("uses the allowlisted development desktop callback", () => {
+    expect(resolveClerkAuthRedirectUrl("t3code-dev://app/continue#/settings/general", true)).toBe(
+      "t3code-dev://app/",
+    );
+  });
+});

--- a/apps/web/src/components/clerk/authRedirect.test.ts
+++ b/apps/web/src/components/clerk/authRedirect.test.ts
@@ -1,22 +1,18 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveClerkAuthRedirectUrl } from "./authRedirect";
+import { resolveClerkSignInProps } from "./authRedirect";
 
-describe("resolveClerkAuthRedirectUrl", () => {
-  it("preserves the current browser URL", () => {
+describe("resolveClerkSignInProps", () => {
+  it("returns to the current browser URL on the web", () => {
     const href = "https://app.t3.codes/connect?state=state-1#details";
-    expect(resolveClerkAuthRedirectUrl(href, false)).toBe(href);
+    expect(resolveClerkSignInProps(href, false)).toEqual({ forceRedirectUrl: href });
   });
 
-  it("uses the allowlisted packaged desktop callback", () => {
-    expect(resolveClerkAuthRedirectUrl("t3code://app/continue#/settings/general", true)).toBe(
-      "t3code://app/",
-    );
+  it("omits the redirect override on packaged desktop", () => {
+    expect(resolveClerkSignInProps("t3code://app/#/settings/general", true)).toEqual({});
   });
 
-  it("uses the allowlisted development desktop callback", () => {
-    expect(resolveClerkAuthRedirectUrl("t3code-dev://app/continue#/settings/general", true)).toBe(
-      "t3code-dev://app/",
-    );
+  it("omits the redirect override on development desktop", () => {
+    expect(resolveClerkSignInProps("t3code-dev://app/#/settings/general", true)).toEqual({});
   });
 });

--- a/apps/web/src/components/clerk/authRedirect.ts
+++ b/apps/web/src/components/clerk/authRedirect.ts
@@ -1,4 +1,12 @@
-export function resolveClerkAuthRedirectUrl(href: string, isElectron: boolean): string {
-  if (!isElectron) return href;
-  return new URL("/", href).toString();
+export interface ClerkSignInProps {
+  forceRedirectUrl?: string;
+}
+
+// Clerk's native-app allowlist only authorizes the bare renderer root
+// (t3code://app/), which @clerk/electron's OAuth transport already supplies,
+// so any page-derived redirect override gets the whole sign-in request
+// rejected. On Electron, omit the override and let Clerk use its defaults.
+export function resolveClerkSignInProps(href: string, isElectron: boolean): ClerkSignInProps {
+  if (isElectron) return {};
+  return { forceRedirectUrl: href };
 }

--- a/apps/web/src/components/clerk/authRedirect.ts
+++ b/apps/web/src/components/clerk/authRedirect.ts
@@ -1,0 +1,4 @@
+export function resolveClerkAuthRedirectUrl(href: string, isElectron: boolean): string {
+  if (!isElectron) return href;
+  return new URL("/", href).toString();
+}

--- a/apps/web/src/components/clerk/useT3ConnectAuthPrompt.tsx
+++ b/apps/web/src/components/clerk/useT3ConnectAuthPrompt.tsx
@@ -1,9 +1,14 @@
 import { useClerk } from "@clerk/react";
 
+import { isElectron } from "../../env";
+import { resolveClerkAuthRedirectUrl } from "./authRedirect";
+
 export function useT3ConnectAuthPrompt() {
   const clerk = useClerk();
   const openAuthPrompt = () => {
-    clerk.openSignIn({ forceRedirectUrl: window.location.href });
+    clerk.openSignIn({
+      forceRedirectUrl: resolveClerkAuthRedirectUrl(window.location.href, isElectron),
+    });
   };
   return { authPrompt: null, openAuthPrompt };
 }

--- a/apps/web/src/components/clerk/useT3ConnectAuthPrompt.tsx
+++ b/apps/web/src/components/clerk/useT3ConnectAuthPrompt.tsx
@@ -1,14 +1,12 @@
 import { useClerk } from "@clerk/react";
 
 import { isElectron } from "../../env";
-import { resolveClerkAuthRedirectUrl } from "./authRedirect";
+import { resolveClerkSignInProps } from "./authRedirect";
 
 export function useT3ConnectAuthPrompt() {
   const clerk = useClerk();
   const openAuthPrompt = () => {
-    clerk.openSignIn({
-      forceRedirectUrl: resolveClerkAuthRedirectUrl(window.location.href, isElectron),
-    });
+    clerk.openSignIn(resolveClerkSignInProps(window.location.href, isElectron));
   };
   return { authPrompt: null, openAuthPrompt };
 }

--- a/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
+++ b/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
@@ -8,8 +8,10 @@ import {
   readConnectCliCallbackResult,
   rememberConnectCliAuthState,
 } from "../../cloud/connectCliAuth";
+import { isElectron } from "../../env";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { AuthSurfaceShell } from "../auth/AuthSurfaceShell";
+import { resolveClerkAuthRedirectUrl } from "../clerk/authRedirect";
 import { Button } from "../ui/button";
 
 function ConnectCliAuthMessage({
@@ -59,7 +61,9 @@ export function ConnectCliAuthorizeSurface() {
     if (!isSignedIn) {
       if (!signInOpened.current) {
         signInOpened.current = true;
-        clerk.openSignIn({ forceRedirectUrl: window.location.href });
+        clerk.openSignIn({
+          forceRedirectUrl: resolveClerkAuthRedirectUrl(window.location.href, isElectron),
+        });
       }
       return;
     }
@@ -95,7 +99,11 @@ export function ConnectCliAuthorizeSurface() {
         <div className="mt-6">
           <Button
             type="button"
-            onClick={() => clerk.openSignIn({ forceRedirectUrl: window.location.href })}
+            onClick={() =>
+              clerk.openSignIn({
+                forceRedirectUrl: resolveClerkAuthRedirectUrl(window.location.href, isElectron),
+              })
+            }
           >
             Sign in
           </Button>

--- a/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
+++ b/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
@@ -11,7 +11,7 @@ import {
 import { isElectron } from "../../env";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { AuthSurfaceShell } from "../auth/AuthSurfaceShell";
-import { resolveClerkAuthRedirectUrl } from "../clerk/authRedirect";
+import { resolveClerkSignInProps } from "../clerk/authRedirect";
 import { Button } from "../ui/button";
 
 function ConnectCliAuthMessage({
@@ -61,9 +61,7 @@ export function ConnectCliAuthorizeSurface() {
     if (!isSignedIn) {
       if (!signInOpened.current) {
         signInOpened.current = true;
-        clerk.openSignIn({
-          forceRedirectUrl: resolveClerkAuthRedirectUrl(window.location.href, isElectron),
-        });
+        clerk.openSignIn(resolveClerkSignInProps(window.location.href, isElectron));
       }
       return;
     }
@@ -100,9 +98,7 @@ export function ConnectCliAuthorizeSurface() {
           <Button
             type="button"
             onClick={() =>
-              clerk.openSignIn({
-                forceRedirectUrl: resolveClerkAuthRedirectUrl(window.location.href, isElectron),
-              })
+              clerk.openSignIn(resolveClerkSignInProps(window.location.href, isElectron))
             }
           >
             Sign in


### PR DESCRIPTION
## What changed

- Normalize Electron Clerk sign-in redirects to the registered renderer root.
- Preserve the full current URL for hosted web and CLI authorization flows.
- Share the redirect policy across T3 Connect sign-in entry points.
- Add focused coverage for packaged desktop, desktop development, and hosted web URLs.

## Why

The Connect GA change forced `window.location.href` as the post-auth redirect. During desktop authentication Clerk uses `/continue`, which produced `t3code://app/continue#/settings/general`. Clerk only authorizes the Electron bridge callback at `t3code://app/`, so both stable 0.30 and Nightly rejected the sign-in request.

Using the stable renderer root on Electron keeps the request aligned with the native redirect allowlist while leaving browser redirects unchanged.

## User impact

Desktop users can sign in to T3 Connect again in stable and Nightly builds without receiving an unauthorized redirect URI error.

## Validation

- `vp test run src/components/clerk/authRedirect.test.ts --project unit` — 3 tests passed
- Targeted formatting and lint passed for all changed files
- `vp run --filter @t3tools/web typecheck` passed
- `git diff --check` passed

## UI changes

No screenshots included. This changes the native authentication redirect rather than rendered UI, and the production Clerk flow was not launched during this pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I added regression coverage

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication redirect behavior on Electron and web; incorrect policy could break sign-in or post-auth navigation, but scope is small and covered by targeted tests.
> 
> **Overview**
> Fixes desktop T3 Connect sign-in failures caused by passing **`forceRedirectUrl: window.location.href`** into Clerk. On Electron, page-derived URLs (paths, hashes, or `/continue` handoff URLs) fall outside Clerk’s native allowlist, which only accepts the renderer root **`t3code://app/`** (or **`t3code-dev://app/`** in dev).
> 
> Introduces **`resolveClerkSignInProps`**, which returns an empty props object on Electron so Clerk/@clerk/electron use their default OAuth redirect, and still sets **`forceRedirectUrl`** to the full current URL on hosted web.
> 
> **`useT3ConnectAuthPrompt`** and **`ConnectCliAuthSurface`** (auto sign-in and the Sign in button) now call **`openSignIn`** through that helper. Unit tests cover web, packaged desktop, and dev desktop cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2dd22bdc0001e5bc494c0f99373201e69de6b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix T3 Connect sign-in redirect on desktop by skipping `forceRedirectUrl` under Electron
> Introduces a `resolveClerkSignInProps` utility in [authRedirect.ts](https://github.com/pingdotgg/t3code/pull/4809/files#diff-d0f4434ba038bdd299ddd72076e3e2510ce426d266111b0ddd5cfb089dba5d02) that returns `{}` when running under Electron and `{forceRedirectUrl: href}` on web. Updates [useT3ConnectAuthPrompt.tsx](https://github.com/pingdotgg/t3code/pull/4809/files#diff-64619e2c27e9d42f439324bd8ff9fd66e5defba49548f765720c253131bfc1eb) and [ConnectCliAuthSurface.tsx](https://github.com/pingdotgg/t3code/pull/4809/files#diff-4d2edee788842fd8bde98fe5bae1e43d591e62e8b9ab9351fb37abb8b4c9acff) to use this resolver instead of unconditionally setting `forceRedirectUrl`, fixing the broken sign-in flow in the desktop app.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2dd22b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->