### PR TITLE
fix(server): stop replayed history from re-arming mouse reporting

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1702,3 +1702,27 @@ it.layer(
     }).pipe(Effect.provide(TestClock.layer())),
   );
 });
+
+const MOUSE_ENABLED_HISTORY = "$ lazygit\r\n\u001b[?1002h\u001b[?1006h";
+
+it("clears mouse reporting from a replayed history once the shell is idle", () => {
+  const replayed = TerminalManager.replaySafeTerminalHistory(MOUSE_ENABLED_HISTORY, false);
+
+  expect(replayed.startsWith(MOUSE_ENABLED_HISTORY)).toBe(true);
+  expect(replayed.slice(MOUSE_ENABLED_HISTORY.length)).toBe(
+    "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l",
+  );
+});
+
+it("leaves mouse reporting alone while a child process can still consume it", () => {
+  assert.equal(
+    TerminalManager.replaySafeTerminalHistory(MOUSE_ENABLED_HISTORY, true),
+    MOUSE_ENABLED_HISTORY,
+  );
+});
+
+it("does not touch a history that never enabled mouse reporting", () => {
+  const history = "$ echo hello\r\nhello\r\n\u001b[?2004h";
+
+  assert.equal(TerminalManager.replaySafeTerminalHistory(history, false), history);
+});

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1710,7 +1710,7 @@ it("clears mouse reporting from a replayed history once the shell is idle", () =
 
   expect(replayed.startsWith(MOUSE_ENABLED_HISTORY)).toBe(true);
   expect(replayed.slice(MOUSE_ENABLED_HISTORY.length)).toBe(
-    "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l",
+    "\u001b[?1000l\u001b[?1001l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l\u001b[?1016l",
   );
 });
 
@@ -1719,6 +1719,34 @@ it("leaves mouse reporting alone while a child process can still consume it", ()
     TerminalManager.replaySafeTerminalHistory(MOUSE_ENABLED_HISTORY, true),
     MOUSE_ENABLED_HISTORY,
   );
+});
+
+it("detects mouse reporting enabled through a combined DECSET", () => {
+  const history = "$ lazygit\r\n\u001b[?1002;1006h";
+
+  expect(TerminalManager.replaySafeTerminalHistory(history, false)).not.toBe(history);
+});
+
+it("detects mouse reporting enabled through an 8-bit CSI introducer", () => {
+  const history = "$ lazygit\r\n\u009b?1003h";
+
+  expect(TerminalManager.replaySafeTerminalHistory(history, false)).not.toBe(history);
+});
+
+it("ignores an encoding mode that cannot make the terminal report on its own", () => {
+  const history = "$ echo hi\r\n\u001b[?1006h";
+
+  expect(TerminalManager.replaySafeTerminalHistory(history, false)).toBe(history);
+});
+
+it("resets every mouse mode it recognises as an enable", () => {
+  const reset = TerminalManager.replaySafeTerminalHistory("\u001b[?1002h", false).slice(
+    "\u001b[?1002h".length,
+  );
+
+  for (const mode of [1000, 1001, 1002, 1003, 1006, 1015, 1016]) {
+    expect(reset).toContain(`\u001b[?${mode}l`);
+  }
 });
 
 it("does not touch a history that never enabled mouse reporting", () => {

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1710,7 +1710,7 @@ it("clears mouse reporting from a replayed history once the shell is idle", () =
 
   expect(replayed.startsWith(MOUSE_ENABLED_HISTORY)).toBe(true);
   expect(replayed.slice(MOUSE_ENABLED_HISTORY.length)).toBe(
-    "\u001b[?1000l\u001b[?1001l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l\u001b[?1016l",
+    "\u001b[?9l\u001b[?1000l\u001b[?1001l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l\u001b[?1016l",
   );
 });
 
@@ -1733,6 +1733,12 @@ it("detects mouse reporting enabled through an 8-bit CSI introducer", () => {
   expect(TerminalManager.replaySafeTerminalHistory(history, false)).not.toBe(history);
 });
 
+it("detects the X10 tracking mode", () => {
+  const history = "$ some-tui\r\n\u001b[?9h";
+
+  expect(TerminalManager.replaySafeTerminalHistory(history, false)).not.toBe(history);
+});
+
 it("ignores an encoding mode that cannot make the terminal report on its own", () => {
   const history = "$ echo hi\r\n\u001b[?1006h";
 
@@ -1744,7 +1750,7 @@ it("resets every mouse mode it recognises as an enable", () => {
     "\u001b[?1002h".length,
   );
 
-  for (const mode of [1000, 1001, 1002, 1003, 1006, 1015, 1016]) {
+  for (const mode of [9, 1000, 1001, 1002, 1003, 1006, 1015, 1016]) {
     expect(reset).toContain(`\u001b[?${mode}l`);
   }
 });

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -324,7 +324,7 @@ function terminalWireLabel(session: TerminalSessionState): string {
 }
 
 /** Only a tracking mode makes a terminal emit reports; an encoding just shapes them. */
-const MOUSE_TRACKING_MODES: ReadonlyArray<number> = [1000, 1001, 1002, 1003];
+const MOUSE_TRACKING_MODES: ReadonlyArray<number> = [9, 1000, 1001, 1002, 1003];
 const MOUSE_ENCODING_MODES: ReadonlyArray<number> = [1006, 1015, 1016];
 const MOUSE_REPORTING_RESET = [...MOUSE_TRACKING_MODES, ...MOUSE_ENCODING_MODES]
   .map((mode) => `\u001b[?${mode}l`)

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -323,11 +323,32 @@ function terminalWireLabel(session: TerminalSessionState): string {
   return truncateTerminalWireLabel(getTerminalLabel(session.terminalId));
 }
 
-/** Tracking modes plus the SGR encoding that reports arrive in. */
-const MOUSE_REPORTING_RESET = "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l";
-const MOUSE_REPORTING_ENABLES = ["1000", "1001", "1002", "1003", "1015", "1016"].map(
-  (mode) => `\u001b[?${mode}h`,
-);
+/** Only a tracking mode makes a terminal emit reports; an encoding just shapes them. */
+const MOUSE_TRACKING_MODES: ReadonlyArray<number> = [1000, 1001, 1002, 1003];
+const MOUSE_ENCODING_MODES: ReadonlyArray<number> = [1006, 1015, 1016];
+const MOUSE_REPORTING_RESET = [...MOUSE_TRACKING_MODES, ...MOUSE_ENCODING_MODES]
+  .map((mode) => `\u001b[?${mode}l`)
+  .join("");
+// A DECSET can carry several parameters at once (`ESC[?1002;1006h`) and may use the
+// 7-bit `ESC [` or the 8-bit `\u009b` introducer, so match the shape of the sequence
+// rather than a handful of single-parameter spellings.
+// eslint-disable-next-line no-control-regex -- matching DECSET requires its control introducer.
+const DECSET_PATTERN = /(?:\u001b\[|\u009b)\?([\d;]*)h/g;
+
+function enablesMouseReporting(history: string): boolean {
+  DECSET_PATTERN.lastIndex = 0;
+  for (
+    let match = DECSET_PATTERN.exec(history);
+    match !== null;
+    match = DECSET_PATTERN.exec(history)
+  ) {
+    const parameters = (match[1] ?? "").split(";");
+    if (parameters.some((parameter) => MOUSE_TRACKING_MODES.includes(Number(parameter)))) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /**
  * Mouse reporting is terminal state, not text. Replaying a history whose TUI was
@@ -338,7 +359,7 @@ const MOUSE_REPORTING_ENABLES = ["1000", "1001", "1002", "1003", "1015", "1016"]
  */
 export function replaySafeTerminalHistory(history: string, hasRunningSubprocess: boolean): string {
   if (hasRunningSubprocess) return history;
-  if (!MOUSE_REPORTING_ENABLES.some((sequence) => history.includes(sequence))) return history;
+  if (!enablesMouseReporting(history)) return history;
   return `${history}${MOUSE_REPORTING_RESET}`;
 }
 
@@ -2389,6 +2410,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         return attachEvent ? listener(attachEvent) : Effect.void;
       });
 
+      // The cached subprocess flag is only refreshed by a poller, so gating the replay
+      // on it would use state up to one interval old. Refresh first: a TUI that just
+      // started must keep its mouse reporting, and one that just exited must not leave
+      // it armed.
+      yield* pollSubprocessActivity();
       const initialSnapshot = yield* openOrAttachForStream(input);
 
       yield* listener({

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -323,6 +323,25 @@ function terminalWireLabel(session: TerminalSessionState): string {
   return truncateTerminalWireLabel(getTerminalLabel(session.terminalId));
 }
 
+/** Tracking modes plus the SGR encoding that reports arrive in. */
+const MOUSE_REPORTING_RESET = "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l";
+const MOUSE_REPORTING_ENABLES = ["1000", "1001", "1002", "1003", "1015", "1016"].map(
+  (mode) => `\u001b[?${mode}h`,
+);
+
+/**
+ * Mouse reporting is terminal state, not text. Replaying a history whose TUI was
+ * killed before it could restore the mode re-arms reporting on the fresh terminal,
+ * and every pointer move then echoes into the shell as a literal `ESC[<…M`. A live
+ * child process may still legitimately want the mode, so only clear it for an
+ * idle shell, where nothing is left to read the reports.
+ */
+export function replaySafeTerminalHistory(history: string, hasRunningSubprocess: boolean): string {
+  if (hasRunningSubprocess) return history;
+  if (!MOUSE_REPORTING_ENABLES.some((sequence) => history.includes(sequence))) return history;
+  return `${history}${MOUSE_REPORTING_RESET}`;
+}
+
 function snapshot(session: TerminalSessionState): TerminalSessionSnapshot {
   return {
     threadId: session.threadId,
@@ -331,7 +350,7 @@ function snapshot(session: TerminalSessionState): TerminalSessionSnapshot {
     worktreePath: session.worktreePath,
     status: session.status,
     pid: session.pid,
-    history: session.history,
+    history: replaySafeTerminalHistory(session.history, session.hasRunningSubprocess),
     exitCode: session.exitCode,
     exitSignal: session.exitSignal,
     label: terminalWireLabel(session),


### PR DESCRIPTION
## What Changed

`snapshot()` now clears the mouse tracking modes at the end of a replayed terminal history — but only when the session has no running child process.

## Why

Reported in #4776: reopening the terminal occasionally fills it with sequences like `^[[<35;65;13M`.

Those are SGR mouse reports (mode 1006) — something a terminal sends *to* a program, never the reverse. Seeing them as text means reporting is armed while nothing is left to consume it, so the tty echoes each pointer move into the shell. That also explains why Ctrl-C does not help and why only killing the shell does: it is terminal state, not a stuck process.

Mouse reporting is state, not text, but the history replays it as text. A TUI killed before it could restore the mode leaves the enabling sequence in the retained history, and every reopen — including switching threads and coming back — replays it into a fresh xterm.

The gate matters: a live TUI (vim, htop, lazygit) legitimately depends on the replay restoring its mouse support after a thread switch. Clearing unconditionally would have broken that silently. With a child process running the history is passed through untouched.

## Notes For Review

`sanitizeTerminalHistoryChunk` already defends against this class of replay hazard — it strips DSR, CPR, DA and OSC colour *queries* so a replay cannot make the terminal answer into the shell. Mode setting is the same hazard in a different shape, but it cannot be stripped on the way in, because at record time the mode may still be wanted. The decision belongs at replay time, which is why this sits in `snapshot()`.

Only the retained history is touched; live output still reaches the client verbatim.

## Validation

The trigger is intermittent and I could not make it fire on demand, so here is what is measured rather than assumed:

1. **The mechanism reproduces exactly.** Driving a real `xterm.js` instance through the same steps `writeTerminalBuffer` performs — write `ESC c`, then a history containing `ESC[?1002h ESC[?1006h` — a fresh terminal emits nothing on pointer events before the replay and `ESC[<0;14;3M`, `ESC[<32;25;4M` after it. Same shape as the reported screenshot. With the reset appended, it emits nothing again.
2. **Private modes really do survive into the persisted history.** A live session log contains `ESC[?2004h` (bracketed paste), confirming DECSET sequences reach the replayed buffer.
3. **The reporter's dev server is not the source.** `next dev` (Next.js 16.2.9, Turbopack) captured under a real PTY emits no private mode sequences at all, so the stale enable comes from something else in the long-lived session — consistent with a hard-killed TUI.

Also run:

- `vp test run apps/server/src/terminal/Manager.test.ts` — 53 passed, including three new cases (clears when idle, passes through with a running child, untouched when no mouse mode was ever set)
- `vp run --filter t3 test` — 1673 passed, 7 skipped
- `vp run --filter t3 typecheck` — no errors
- `vp lint` / `vp fmt --check` on the changed files — clean

Closes #4776.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI change, so no screenshots (terminal byte stream only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal snapshot replay semantics for all reconnects; incorrect subprocess detection could strip mouse modes from an active TUI, though attach now refreshes that flag first.
> 
> **Overview**
> Fixes **#4776**, where reconnecting to a terminal could flood the shell with literal mouse report sequences (`^[[<…M`) after a TUI exited without restoring terminal modes.
> 
> **Replay-time sanitization:** `snapshot()` now runs history through `replaySafeTerminalHistory` before clients receive it. If the retained transcript contains a DECSET that enabled mouse **tracking** (modes 9, 1000–1003), the server appends matching `DECRST` sequences for tracking and related encoding modes. Encoding-only enables (e.g. `1006` alone) are left unchanged. When `hasRunningSubprocess` is true, history is passed through so live TUIs still get mouse support after a thread switch.
> 
> **Attach freshness:** `attachStream` calls `pollSubprocessActivity()` immediately before the initial snapshot so the idle-vs-child gate does not rely on a stale poller interval.
> 
> Unit tests cover idle reset, active-child passthrough, combined/8-bit CSI, X10 mode, and no-op histories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add5fa2be2571cb7dd1f304223bd445f0b4cb92d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop replayed terminal history from re-arming mouse reporting on reconnect
> - Adds `replaySafeTerminalHistory` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/4821/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e) that appends DECSET reset sequences for mouse tracking modes (9, 1000–1003) and encoding modes (1006, 1015, 1016) when replaying history that enabled mouse reporting.
> - The reset is only appended when no subprocess is running; if a subprocess is active the history is left unchanged to avoid disrupting live sessions.
> - Refreshes the subprocess activity state via `pollSubprocessActivity` immediately before emitting the initial snapshot so the replay decision reflects current state.
> - Behavioral Change: clients reconnecting to an idle terminal that had mouse reporting enabled will now receive reset sequences, clearing mouse mode from their terminal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized add5fa2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
