### PR TITLE
fix(web): keep a long path from running under the folder picker button

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import type { Thread } from "../types";
 import {
+  browseInputEndPaddingClass,
   buildBrowseGroups,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
@@ -9,6 +10,35 @@ import {
   reduceCommandPaletteUiState,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
+
+describe("browseInputEndPaddingClass", () => {
+  it("reserves the widest space for the create action", () => {
+    expect(
+      browseInputEndPaddingClass({
+        willCreateProjectPath: true,
+        hasHighlightedBrowseItem: false,
+      }),
+    ).toContain("pe-38");
+  });
+
+  it("reserves space for the wider highlighted-item shortcut", () => {
+    expect(
+      browseInputEndPaddingClass({
+        willCreateProjectPath: false,
+        hasHighlightedBrowseItem: true,
+      }),
+    ).toContain("pe-30");
+  });
+
+  it("keeps the compact reserve for the normal add action", () => {
+    expect(
+      browseInputEndPaddingClass({
+        willCreateProjectPath: false,
+        hasHighlightedBrowseItem: false,
+      }),
+    ).toContain("pe-24");
+  });
+});
 
 describe("reduceCommandPaletteUiState", () => {
   const closedState = { open: false, mode: "command", openIntent: null } as const;

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -15,6 +15,19 @@ export const RECENT_THREAD_LIMIT = 12;
 export const ITEM_ICON_CLASS = "size-4 text-icon-muted";
 export const ADDON_ICON_CLASS = "size-4";
 
+export function browseInputEndPaddingClass(input: {
+  readonly willCreateProjectPath: boolean;
+  readonly hasHighlightedBrowseItem: boolean;
+}): string {
+  if (input.willCreateProjectPath) {
+    return "*:data-[slot=autocomplete-input]:pe-38!";
+  }
+  if (input.hasHighlightedBrowseItem) {
+    return "*:data-[slot=autocomplete-input]:pe-30!";
+  }
+  return "*:data-[slot=autocomplete-input]:pe-24!";
+}
+
 /**
  * The global search overlay hosts three mutually exclusive surfaces: the
  * command palette (⌘K), the project file picker (⌘P), and project content

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -98,6 +98,7 @@ import {
 } from "../wslPaths";
 import {
   ADDON_ICON_CLASS,
+  browseInputEndPaddingClass,
   buildBrowseGroups,
   buildProjectActionItems,
   buildRootGroups,
@@ -2351,9 +2352,10 @@ function OpenCommandPaletteDialog(props: {
           addProjectCloneFlow?.step === "repository"
             ? "*:data-[slot=autocomplete-input]:pe-32!"
             : isBrowsing
-              ? willCreateProjectPath
-                ? "*:data-[slot=autocomplete-input]:pe-38!"
-                : "*:data-[slot=autocomplete-input]:pe-24!"
+              ? browseInputEndPaddingClass({
+                  willCreateProjectPath,
+                  hasHighlightedBrowseItem,
+                })
               : undefined,
         placeholder: inputPlaceholder,
         wrapperClassName: isSubmenu

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2345,13 +2345,15 @@ function OpenCommandPaletteDialog(props: {
       footerTrailing={footerTrailing}
       inputAccessory={inputAccessory}
       inputProps={{
+        // The submit button is absolutely positioned over the field, so the
+        // inner input must reserve enough room for the full action label.
         className:
           addProjectCloneFlow?.step === "repository"
-            ? "pe-32"
+            ? "*:data-[slot=autocomplete-input]:pe-32!"
             : isBrowsing
               ? willCreateProjectPath
-                ? "pe-36"
-                : "pe-16"
+                ? "*:data-[slot=autocomplete-input]:pe-38!"
+                : "*:data-[slot=autocomplete-input]:pe-24!"
               : undefined,
         placeholder: inputPlaceholder,
         wrapperClassName: isSubmenu

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1987,13 +1987,16 @@ function OpenCommandPaletteDialog(props: {
       >
         <div className="relative">
           <CommandInput
+            // The submit button is absolutely positioned over the field, so the
+            // input has to reserve room for it or a long path runs underneath.
+            // Padding has to reach the inner input; on the wrapper it does nothing.
             className={
               addProjectCloneFlow?.step === "repository"
-                ? "pe-32"
+                ? "*:data-[slot=autocomplete-input]:pe-32!"
                 : isBrowsing
                   ? willCreateProjectPath
-                    ? "pe-36"
-                    : "pe-16"
+                    ? "*:data-[slot=autocomplete-input]:pe-38!"
+                    : "*:data-[slot=autocomplete-input]:pe-24!"
                   : undefined
             }
             placeholder={inputPlaceholder}


### PR DESCRIPTION
## What Changed

The folder picker input now reserves enough room for the submit button that sits on top of it, and the reservation actually reaches the input element.

## Why

Reported in #4819: a long absolute path runs into the action area and hides the Add button and its shortcut.

Two things were wrong:

1. `CommandInput` forwards `className` to `AutocompleteInput`, which is the field *wrapper* — not the inner `<input>`. The `pe-16` / `pe-36` / `pe-32` the palette passed never applied to the text field. Measured on `main`, the input's computed `padding-inline-end` was 11px, i.e. its own `px-*` and nothing else. The component already solves this for the other side with `*:data-[slot=autocomplete-input]:ps-9!`, so the end padding now uses the same mechanism.
2. Even applied, `pe-16` (64px) was too small. The button is absolutely positioned with `inset-e-2.5`, and measured in the running app it spans 83px over the input for "Add" and 137px for "Create & Add".

Sizes are therefore `pe-24` (96px) and `pe-38` (152px), leaving 13px and 15px between the text edge and the button.

## Notes For Review

I kept the existing class-based approach rather than measuring the button at runtime, since the labels are a closed set. The trade-off is that a much longer label — a future wording change or a localisation — would need the padding revisited. If you would rather have it derived from the button's real width, say so and I will switch it.

The `repository` step (`pe-32`, "Continue" / "Lookup") is wired through the same way but I did not exercise that flow, so its 128px is unverified — it was not part of the report.

## Validation

Measured in a running client, browse mode, before and after:

| Variant | Button spans over input | Reserved before | Reserved after | Clearance after |
| --- | --- | --- | --- | --- |
| `Add (Enter)` | 83px | 11px | 96px | 13px |
| `Create & Add (Enter)` | 137px | 11px | 152px | 15px |

- `vp run --filter @t3tools/web test` — 1641 passed
- `vp run --filter @t3tools/web typecheck` — no errors
- `vp lint` — no new warnings (two pre-existing `no-unstable-nested-components` in this file are untouched)
- `vp fmt --check` — clean

Closes #4819.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots — the issue carries the "before"; an "after" still needs attaching, so this stays draft until then
Before:
<img width="1284" height="638" alt="image" src="https://github.com/user-attachments/assets/6d3cc3f0-f324-41cf-9873-bfcc2786889b" />
After:

https://github.com/user-attachments/assets/a243aef2-ada5-4aea-a5c4-0ba1b71b3591



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix long path text from overlapping the folder picker button in the command palette
> The autocomplete input in the command palette now uses slot-targeted, `!`-priority end-padding classes so the inner `<input>` element reserves space behind the absolutely-positioned submit button. A new `browseInputEndPaddingClass` utility in [CommandPalette.logic.ts](https://github.com/pingdotgg/t3code/pull/4823/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e) returns `pe-38` when creating a project path, `pe-30` when a browse item is highlighted, and `pe-24` otherwise, replacing the previous single ternary that used `pe-36`/`pe-16` on the wrapper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba838f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Tailwind class changes in the command palette with unit tests on the new helper; no auth, data, or API behavior.
> 
> **Overview**
> Fixes **#4819** by reserving enough **end padding on the real autocomplete `<input>`** in add-project browse mode so long paths no longer slide under the absolutely positioned **Add** / **Create & Add** control.
> 
> Browse-mode padding is centralized in **`browseInputEndPaddingClass`**, which picks `pe-24`, `pe-30`, or `pe-38` from whether the user will create a path or has a highlighted directory (wider shortcut label). Classes use the same **`*:data-[slot=autocomplete-input]:…!`** pattern as the command field’s start padding, because `className` on `CommandInput` only hit the wrapper before. The remote **repository** step’s **Continue/Lookup** field is updated the same way (`pe-32`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba838f75b80ace07a47acdc57b2b3697b7e7b39e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

