### PR TITLE
build(desktop): reduce installed app size by ~300MB

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -13,7 +13,8 @@ import {
   createStageWorkspaceConfig,
   createStagePatchedDependencies,
   createBuildConfig,
-  DESKTOP_ASAR_UNPACK,
+  DESKTOP_ELECTRON_LANGUAGES,
+  DESKTOP_FILE_EXCLUSIONS,
   InvalidMacPasskeyRpDomainError,
   InvalidMacPasskeyPublishableKeyError,
   InvalidMockUpdateServerPortError,
@@ -37,6 +38,7 @@ import {
   resolvePackageManagerUserAgent,
   stageLinuxIconSize,
   STAGE_INSTALL_ARGS,
+  WINDOWS_ASAR_UNPACK,
 } from "./build-desktop-artifact.ts";
 import { BRAND_ASSET_PATHS } from "./lib/brand-assets.ts";
 import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
@@ -303,9 +305,52 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     );
   });
 
-  it("unpacks the fff shared library for filesystem and FFI access", () => {
-    assert.deepStrictEqual(DESKTOP_ASAR_UNPACK, ["node_modules/@ff-labs/fff-bin-*/**/*"]);
+  it("limits Electron locales and excludes the unused Claude SDK executable", () => {
+    assert.deepStrictEqual(DESKTOP_ELECTRON_LANGUAGES, ["en-US"]);
+    assert.deepStrictEqual(DESKTOP_FILE_EXCLUSIONS, [
+      "!**/node_modules/@anthropic-ai/claude-agent-sdk-*/**/*",
+    ]);
   });
+
+  it.effect("applies platform-specific packaging to the build config", () =>
+    Effect.gen(function* () {
+      const mac = yield* createBuildConfig(
+        "mac",
+        "dmg",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+      const linux = yield* createBuildConfig(
+        "linux",
+        "AppImage",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+      const win = yield* createBuildConfig(
+        "win",
+        "nsis",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+
+      assert.notProperty(mac, "asarUnpack");
+      assert.notProperty(linux, "asarUnpack");
+      assert.deepStrictEqual(win.asarUnpack, WINDOWS_ASAR_UNPACK);
+      for (const config of [mac, linux, win]) {
+        assert.deepStrictEqual(config.electronLanguages, DESKTOP_ELECTRON_LANGUAGES);
+        assert.deepStrictEqual(config.files, DESKTOP_FILE_EXCLUSIONS);
+      }
+    }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
+  );
 
   it.effect("preserves both Linux icon resize failures with structural context", () => {
     const commands: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -579,7 +579,20 @@ interface StagePackageJson {
 }
 
 export const STAGE_INSTALL_ARGS = ["install", "--prod"] as const;
-export const DESKTOP_ASAR_UNPACK = ["node_modules/@ff-labs/fff-bin-*/**/*"] as const;
+export const DESKTOP_ELECTRON_LANGUAGES = ["en-US"] as const;
+export const DESKTOP_FILE_EXCLUSIONS = [
+  // T3 Code always passes the user's installed Claude executable to the SDK,
+  // so the SDK's optional platform packages (each a ~200MB bundled executable)
+  // are dead weight. The trailing dash keeps the SDK's own JS package.
+  "!**/node_modules/@anthropic-ai/claude-agent-sdk-*/**/*",
+] as const;
+// The WSL backend launches the server with plain `wsl.exe -- node`, which
+// cannot read inside an asar archive — and the server bundle externalizes its
+// runtime deps, so the whole node_modules tree must be unpacked, not just the
+// bundle (otherwise ERR_MODULE_NOT_FOUND: "Cannot find package 'effect'").
+// The Windows primary backend reads the same files through the asar redirect,
+// so nothing is duplicated.
+export const WINDOWS_ASAR_UNPACK = ["apps/server/dist/**", "**/node_modules/**"] as const;
 
 export interface MacPasskeySigningConfiguration {
   readonly appId: string;
@@ -1390,23 +1403,15 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     appId: DESKTOP_APP_ID,
     productName: resolveDesktopProductName(version),
     artifactName: "T3-Code-${version}-${arch}.${ext}",
+    electronLanguages: [...DESKTOP_ELECTRON_LANGUAGES],
+    files: [...DESKTOP_FILE_EXCLUSIONS],
     directories: {
       buildResources: "apps/desktop/resources",
     },
-    // The Windows primary backend runs the server bundle through
-    // ELECTRON_RUN_AS_NODE (asar-aware), so it reads bin.mjs straight out of
-    // app.asar. The WSL backend instead launches plain `wsl.exe -- node`, which
-    // cannot read inside an asar archive, so everything it loads must be on the
-    // real filesystem. The server bundle externalizes its runtime dependencies
-    // (effect, @effect/*, node-pty, ...) to node_modules rather than inlining
-    // them, so unpacking just the bundle + node-pty isn't enough — the Linux Node
-    // fails with ERR_MODULE_NOT_FOUND (e.g. "Cannot find package 'effect'") before
-    // it even reaches node-pty. Unpack the server bundle AND the whole
-    // node_modules tree so every import resolves (this also covers the fff native
-    // binaries in DESKTOP_ASAR_UNPACK). The Windows primary keeps reading the same
-    // files through the asar (transparently redirected to the unpacked copy), so
-    // there's no duplication.
-    asarUnpack: [...DESKTOP_ASAR_UNPACK, "apps/server/dist/**", "**/node_modules/**"],
+    // Only the Windows WSL backend needs files outside the asar (see
+    // WINDOWS_ASAR_UNPACK); macOS and Linux stay packed — smart unpack
+    // extracts native libraries, which fff-node finds in app.asar.unpacked.
+    ...(platform === "win" ? { asarUnpack: [...WINDOWS_ASAR_UNPACK] } : {}),
   };
   const updateChannel = resolveDesktopUpdateChannel(version);
   const publishConfig = yield* resolveGitHubPublishConfig(updateChannel);


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Desktop app builds now:
- Omit unused binaries from Claude SDK
- Drop unused language packs (T3 Code is en-US only) 
- Pack dependencies into ASAR on compatible platforms (macOS/Linux) and retain the Windows-only unpacking for WSL

<!-- Describe the change clearly and keep scope tight. -->

## Why

The current version of the T3 Code desktop app is unreasonably huge: ~737 MB on arm64 macOS. This made me wonder why it's this big, and turns out it's pretty trivial to fix.

This PR brings it down to ~424 MB without any functional changes:

<img width="545" height="135" alt="image" src="https://github.com/user-attachments/assets/879c9fa0-8fad-4834-8955-4543692622c7" />


<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes
None.
<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Packaging-only change with a behavioral shift on macOS/Linux (no explicit asarUnpack); risk is native/runtime loading if anything still expected unpacked paths outside smart unpack—Windows WSL path remains explicitly unpacked.
> 
> **Overview**
> **Cuts installed desktop size (~737MB → ~424MB on arm64 macOS)** by tightening electron-builder packaging in `createBuildConfig`, without changing runtime behavior for normal macOS/Linux backends.
> 
> **Locale and dependency trimming:** All platforms now set `electronLanguages` to `en-US` and add `files` exclusions that drop optional `@anthropic-ai/claude-agent-sdk-*` platform bundles (the app uses the user’s Claude binary, so those ~200MB packages are unused).
> 
> **Platform-specific ASAR unpacking:** `asarUnpack` is applied **only on Windows** via `WINDOWS_ASAR_UNPACK` (`apps/server/dist/**` and `**/node_modules/**` for the WSL backend). macOS and Linux builds no longer set `asarUnpack`; the old global `DESKTOP_ASAR_UNPACK` for `@ff-labs/fff-bin-*` is removed, with comments that native libs are handled via smart unpack / `app.asar.unpacked` (aligned with the fff-node patch).
> 
> Tests were updated to assert the new constants and that mac/linux configs omit `asarUnpack` while Windows keeps the WSL unpack list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f424416a0766f441c508afd77c1ae76ccb4ad86c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce desktop app installed size by ~300MB
> - Limits Electron locales to `en-US` via `electronLanguages` in `createBuildConfig`, dropping unused locale files.
> - Excludes optional Claude SDK platform bundles (`@anthropic-ai/claude-agent-sdk-*`) from packaged files via new `DESKTOP_FILE_EXCLUSIONS` constant.
> - Makes `asarUnpack` Windows-only using `WINDOWS_ASAR_UNPACK`; macOS and Linux builds no longer unpack asar contents.
> - Removes the old `DESKTOP_ASAR_UNPACK` constant that unconditionally unpacked `@ff-labs/fff-bin-*` on all platforms.
> - Behavioral Change: macOS and Linux builds no longer include `asarUnpack`, which may affect native module loading if any path relied on unpacked asar access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f424416.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->