### PR TITLE
fix(web): stop the status label stacking on the row's settle actions

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -17,6 +17,7 @@ import {
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveSidebarV2Status,
+  resolveSidebarV2StatusSlotClassNames,
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
   formatWorkingDurationLabel,
@@ -651,6 +652,55 @@ describe("resolveSidebarV2Status", () => {
 
   it("defaults to ready with no session", () => {
     expect(resolveSidebarV2Status({ ...idle, session: null })).toBe("ready");
+  });
+});
+
+describe("resolveSidebarV2StatusSlotClassNames", () => {
+  // The label and the actions share one slot, so the states must be
+  // mutually exclusive: a variant that reveals the actions without fading
+  // the label leaves "Working" stacked on top of "Settle".
+  const revealVariants = (className: string): ReadonlyArray<string> =>
+    className
+      .split(" ")
+      .filter((candidate) => candidate.endsWith(":opacity-100"))
+      .map((candidate) => candidate.slice(0, -":opacity-100".length));
+
+  it("fades the status label out for every variant that reveals the actions", () => {
+    for (const snoozeMenuOpen of [false, true]) {
+      const { statusClassName, actionsClassName } = resolveSidebarV2StatusSlotClassNames({
+        snoozeMenuOpen,
+      });
+      const variants = revealVariants(actionsClassName);
+      expect(variants.length).toBeGreaterThan(0);
+      for (const variant of variants) {
+        expect(statusClassName).toContain(`${variant}:opacity-0`);
+      }
+    }
+  });
+
+  it("never takes the status label out of flow while it is still visible", () => {
+    const { statusClassName } = resolveSidebarV2StatusSlotClassNames({ snoozeMenuOpen: false });
+    const outOfFlowVariants = statusClassName
+      .split(" ")
+      .filter((candidate) => candidate.endsWith(":absolute"))
+      .map((candidate) => candidate.slice(0, -":absolute".length));
+
+    expect(outOfFlowVariants).toContain("group-focus-within/v2-status-slot");
+    expect(outOfFlowVariants).toContain("group-hover/v2-row");
+    for (const variant of outOfFlowVariants) {
+      expect(statusClassName).toContain(`${variant}:opacity-0`);
+    }
+  });
+
+  it("swaps both halves while the snooze popover holds the row open", () => {
+    const { statusClassName, actionsClassName } = resolveSidebarV2StatusSlotClassNames({
+      snoozeMenuOpen: true,
+    });
+
+    expect(statusClassName).toContain("opacity-0");
+    expect(statusClassName).toContain("absolute");
+    expect(actionsClassName).toContain("static");
+    expect(actionsClassName).toContain("opacity-100");
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -424,6 +424,29 @@ export function resolveSidebarV2Status(thread: SidebarV2StatusInput): SidebarV2S
   return "ready";
 }
 
+/** The v2 card's status label and its hover actions share one slot, so they
+    must never be visible together. Both class strings live here because the
+    invariant is a pairing, not two independent styles: every variant that
+    promotes the actions has to fade the label out, and taking the label out
+    of flow without fading it leaves "Working" stacked on top of Settle.
+    Written as literals — Tailwind scans source text, so these cannot be
+    assembled from a shared list of variants. */
+export function resolveSidebarV2StatusSlotClassNames(input: { snoozeMenuOpen: boolean }): {
+  statusClassName: string;
+  actionsClassName: string;
+} {
+  return {
+    statusClassName: cn(
+      "self-center justify-self-end tabular-nums text-muted-foreground/65 transition-opacity group-focus-within/v2-status-slot:absolute group-focus-within/v2-status-slot:right-0 group-focus-within/v2-status-slot:opacity-0 group-hover/v2-row:absolute group-hover/v2-row:right-0 group-hover/v2-row:opacity-0",
+      input.snoozeMenuOpen && "absolute right-0 opacity-0",
+    ),
+    actionsClassName: cn(
+      "absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity group-focus-within/v2-status-slot:static group-focus-within/v2-status-slot:opacity-100 group-hover/v2-row:static group-hover/v2-row:opacity-100",
+      input.snoozeMenuOpen && "static opacity-100",
+    ),
+  };
+}
+
 /** NaN-safe Date.parse for sort comparators: a malformed timestamp must not
     poison the whole ordering, so it sinks to the epoch instead. */
 export function parseTimestampMs(isoDate: string): number {

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -113,6 +113,7 @@ import {
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarV2Status,
+  resolveSidebarV2StatusSlotClassNames,
   resolveWorkingStartedAt,
   shouldNavigateAfterProjectRemoval,
   sortLogicalProjectsForSidebar,
@@ -648,6 +649,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   useEffect(() => {
     if (!showSnoozeButton) setSnoozeMenuOpen(false);
   }, [showSnoozeButton]);
+  const statusSlotClassNames = resolveSidebarV2StatusSlotClassNames({ snoozeMenuOpen });
   const handlePrClick = useCallback(
     (event: ReactMouseEvent<HTMLElement>) => {
       if (pr?.url) openPrLink(event, pr.url);
@@ -890,25 +892,25 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                   the hidden state out of flow lets the project label reclaim
                   space without either state overlapping it. */}
               <span className="group/v2-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
-                <span
-                  className={cn(
-                    "self-center justify-self-end tabular-nums text-muted-foreground/65 transition-opacity group-focus-within/v2-status-slot:absolute group-focus-within/v2-status-slot:right-0 group-hover/v2-row:absolute group-hover/v2-row:right-0 group-hover/v2-row:opacity-0",
-                    snoozeMenuOpen && "absolute right-0 opacity-0",
-                  )}
-                >
+                <span className={statusSlotClassNames.statusClassName}>
+                  {/* Baseline, not center: an inline-flex takes its baseline
+                      from the first item, so the leading icon used to drag the
+                      label 2px above the project title and the duration next
+                      to it. The icon opts out with self-center and rides the
+                      text's line box instead. */}
                   {topStatus ? (
                     <span
                       className={cn(
-                        "inline-flex items-center gap-1 font-medium",
+                        "inline-flex items-baseline gap-1 font-medium",
                         topStatus.className,
                       )}
                     >
                       {topStatus.icon === "working" ? (
-                        <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
+                        <CircleDashedIcon aria-hidden className="size-4 shrink-0 self-center" />
                       ) : topStatus.icon === "done" ? (
-                        <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
+                        <CircleCheckIcon aria-hidden className="size-4 shrink-0 self-center" />
                       ) : topStatus.icon === "woke" ? (
-                        <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
+                        <AlarmClockIcon aria-hidden className="size-4 shrink-0 self-center" />
                       ) : null}
                       {/* The label alone is the live region: a role="status"
                           wrapper around the ticking duration would make
@@ -925,12 +927,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                   )}
                 </span>
                 {props.settlementSupported || showSnoozeButton ? (
-                  <span
-                    className={cn(
-                      "absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity focus-within:static focus-within:opacity-100 group-hover/v2-row:static group-hover/v2-row:opacity-100",
-                      snoozeMenuOpen && "static opacity-100",
-                    )}
-                  >
+                  <span className={statusSlotClassNames.actionsClassName}>
                     {showSnoozeButton ? (
                       <SnoozePopoverButton
                         open={snoozeMenuOpen}


### PR DESCRIPTION
## What Changed

Two things in the v2 sidebar row's status slot:

1. The status label no longer stays visible when focus promotes the settle/snooze actions into the same slot.
2. The label aligns to the row's baseline, with its leading icon optically centred on the text.

## Why

### The overlap (#4817)

The label and the hover actions share one slot and are meant to be mutually exclusive. The hover branch was symmetric — the label gets `opacity-0`, the actions get `opacity-100`. The focus branch was not: `group-focus-within` pulled the label out of flow with `absolute right-0` but never faded it, so the actions came up to full opacity underneath a label that was still fully opaque and pinned right.

That explains why the report reads as intermittent and hover-driven when it is neither. Focus is sticky: clicking Settle or Snooze leaves focus on the button, and dismissing the snooze popover returns focus to its trigger, at which point `snoozeMenuOpen` stops forcing the label transparent while focus keeps the actions promoted. The overlap then outlives the pointer. Keyboard tabbing reaches it too. In the reporter's screenshot the affected row is the *active* row, not a hovered one — which is what pointed at focus rather than hover.

Because the correctness property is a *pairing* — every variant that promotes the actions must fade the label — both class strings now live in one helper, and the tests assert that pairing generically instead of matching literal strings. Removing the new `opacity-0` fails them.

### The alignment

An `inline-flex` derives its baseline from its first flex item, and an SVG has none, so the leading 16px icon was setting the label's baseline and lifting "Working" above the project title. The text run now aligns on the baseline and the icon opts out with `self-center`, so it rides the centre of the text's line box. No pixel nudges.

## Validation

Measured in a running client on a seeded working row, toggling the classes live to get a real before/after:

**Alignment** — baselines in page coordinates:

| | project label | "Working" | duration | icon centre | label box centre |
| --- | --- | --- | --- | --- | --- |
| before | 243 | 241 | — | 237 | 237 |
| after | 243 | 243 | 243 | 239 | 239 |

Off by 2px before, exactly aligned after; the icon stays centred on the text in both.

**The overlap** — computed styles with focus inside the slot:

| | label opacity | actions opacity | both visible |
| --- | --- | --- | --- |
| without the fix | 1 (absolute, right-0) | 1 | **yes** |
| with the fix | 0 | 1 | no |

Idle is unchanged: label 1, actions 0.

- `vp run --filter @t3tools/web test` — 1644 passed
- `vp run --filter @t3tools/web typecheck` — no errors
- `vp lint` / `vp fmt --check` on the changed files — clean

## Notes For Review

The actions' `focus-within:` is restated as `group-focus-within/v2-status-slot:` so both halves key off the identical condition. Behaviourally equivalent here — the action buttons are the only focusable elements in the slot — but it makes the pairing checkable.

The slim settled/snoozed row has a similar `inline-flex items-center` badge. It never renders the working state, so it is untouched.

Closes #4817.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots — the issue carries the "before"; an "after" still needs attaching, so this stays draft until then

Before
<img width="656" height="344" alt="image" src="https://github.com/user-attachments/assets/1535ddd5-bb0f-4b97-99bc-b1e1136486af" />

After with alignment fix

https://github.com/user-attachments/assets/e777d10a-c475-4961-b5b0-6fd985171339




<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> > > [!NOTE]
> ### Fix status label overlapping settle actions in sidebar rows
> - Introduces `resolveSidebarV2StatusSlotClassNames` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/4826/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to compute paired Tailwind class names for the status label and action buttons in a shared slot.
> - The status label fades out and moves out of flow on group hover/focus or when the snooze popover is open; actions become visible and in-flow under the same conditions.
> - Updates [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4826/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) to use the new utility, replacing the previous inline class logic that caused the label and actions to stack.
> - Also fixes a 2px vertical drift by aligning the status container to `items-baseline` with `self-center` on leading icons.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9c2058.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/CSS in sidebar v2 rows with regression tests on the class pairing; no auth, data, or API changes.
> 
> **Overview**
> Fixes **v2 sidebar card rows** where the status text (e.g. "Working") could sit on top of **Settle/Snooze** after focus stayed on those controls—the focus path promoted actions but did not fade the label, unlike hover.
> 
> **`resolveSidebarV2StatusSlotClassNames`** in `Sidebar.logic.ts` now returns paired Tailwind classes for the label and action halves of the shared status slot (hover, `group-focus-within/v2-status-slot`, and open snooze popover). `SidebarV2.tsx` uses that helper instead of inline `cn(...)` on each span. Action visibility keys off the same `group-focus-within/v2-status-slot` condition as the label hide.
> 
> Also adjusts status **vertical alignment**: `items-baseline` on the label row and `self-center` on leading icons so the working icon no longer pulls the text ~2px above the project title.
> 
> Unit tests assert the pairing invariant (every action-reveal variant must apply matching `opacity-0` on the label).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c205898ef6533b629e985d127c0f2f708b1a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

