### PR TITLE
perf(server): fix N+1 PowerShell process query and reduce sampling frequency

### DIFF
--- a/apps/server/src/diagnostics/ProcessDiagnostics.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.ts
@@ -443,11 +443,11 @@ function readWindowsProcessRows(): Effect.Effect<
   ChildProcessSpawner.ChildProcessSpawner
 > {
   const command = [
-    "$processes = Get-CimInstance Win32_Process | ForEach-Object {",
-    '$perf = Get-CimInstance Win32_PerfFormattedData_PerfProc_Process -Filter "IDProcess = $($_.ProcessId)" -ErrorAction SilentlyContinue;',
-    "[pscustomobject]@{ ProcessId = $_.ProcessId; ParentProcessId = $_.ParentProcessId; Name = $_.Name; CommandLine = $_.CommandLine; Status = $_.Status; WorkingSetSize = $_.WorkingSetSize; PercentProcessorTime = if ($perf) { $perf.PercentProcessorTime } else { 0 } }",
-    "};",
-    "$processes | ConvertTo-Json -Compress -Depth 3",
+    "$perfData=@{};Get-CimInstance Win32_PerfFormattedData_PerfProc_Process -ErrorAction SilentlyContinue|ForEach-Object{$perfData[$_.IDProcess]=$_};",
+    "Get-CimInstance Win32_Process|ForEach-Object{",
+    "$perf=$perfData[$_.ProcessId];",
+    "[pscustomobject]@{ProcessId=$_.ProcessId;ParentProcessId=$_.ParentProcessId;Name=$_.Name;CommandLine=$_.CommandLine;Status=$_.Status;WorkingSetSize=$_.WorkingSetSize;PercentProcessorTime=if($perf){$perf.PercentProcessorTime}else{0}}",
+    "}|ConvertTo-Json -Compress -Depth 3",
   ].join(" ");
 
   return runProcess({

--- a/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
@@ -118,8 +118,8 @@ describe("ProcessResourceMonitor", () => {
       expect(result.topProcesses).toHaveLength(1);
       expect(result.topProcesses[0]?.avgCpuPercent).toBe(20);
       expect(result.topProcesses[0]?.maxCpuPercent).toBe(30);
-      expect(result.topProcesses[0]?.cpuSecondsApprox).toBe(2);
-      expect(result.totalCpuSecondsApprox).toBe(2);
+      expect(result.topProcesses[0]?.cpuSecondsApprox).toBe(6);
+      expect(result.totalCpuSecondsApprox).toBe(6);
       expect(result.buckets.some((bucket) => bucket.maxCpuPercent === 30)).toBe(true);
     }),
   );

--- a/apps/server/src/diagnostics/ProcessResourceMonitor.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.ts
@@ -17,7 +17,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 
 import * as ProcessDiagnostics from "./ProcessDiagnostics.ts";
 
-const SAMPLE_INTERVAL_MS = 5_000;
+const SAMPLE_INTERVAL_MS = 15_000;
 const RETENTION_MS = 60 * 60_000;
 const MAX_RETAINED_SAMPLES = 20_000;
 


### PR DESCRIPTION
## What Changed

Eliminated two sources of excessive CPU usage in the Windows process resource monitor:

1. N+1 PowerShell CIM query to bulk query (`ProcessDiagnostics.ts`): The Windows process reader was querying `Win32_PerfFormattedData_PerfProc_Process` individually for each process via an IDProcess filter inside a ForEach-Object loop. Changed to query all perf counter data once into a hashtable, then join with the process list. Reduced from 1+N CIM queries to exactly 2.
2. Sampling interval 5s to 15s (ProcessResourceMonitor.ts): Tripled the interval between resource samples, reducing overhead 3x while maintaining adequate granularity for multi-second bucket aggregation.

## Why

On Windows machines with 200+ processes, ProcessResourceMonitor was spawning powershell.exe every 5 seconds with an N+1 WMI query pattern. Each cycle issued 1+N CIM queries (e.g., 206 queries for 205 processes). The old command consistently timed out after 60 seconds on a typical development machine, pegging CPU indefinitely.

Metric | Before | After | Improvement
-- | -- | -- | --
Per-query time | >60s (timed out) | ~2.7s | ≥22x+
CIM queries per cycle | 1+N (e.g., 206) | 2 | ~100x
Sampling interval | 5s | 15s | 3x
Effective overhead | 100% CPU (never finishes) | ~18% for 2.7s | ≥66x

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only changes on Windows sampling path; behavior is coarser metrics (15s) but lower server CPU load, with no auth or data-path impact.
> 
> **Overview**
> Reduces Windows process diagnostics overhead by fixing how PowerShell loads CPU perf data and by sampling less often.
> 
> **Windows process query:** `readWindowsProcessRows` no longer runs a filtered `Win32_PerfFormattedData_PerfProc_Process` CIM call inside the per-process loop. It loads all perf rows once into a hashtable keyed by `IDProcess`, then walks `Win32_Process` and joins in memory—**two CIM queries per cycle** instead of **1+N**.
> 
> **Resource monitor:** `SAMPLE_INTERVAL_MS` moves from **5s to 15s**, so the background sampler runs three times less often. Approximate CPU-second rollups use the new interval; tests now expect **6** instead of **2** for the same two-sample scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9363e3d4b7016127366951bc0e4211bbf3a1a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix N+1 PowerShell process query and increase sampling interval to 15s
> - Rewrites `readWindowsProcessRows` in [ProcessDiagnostics.ts](https://github.com/pingdotgg/t3code/pull/4829/files#diff-3976428399caa24c646f345343c779cdea0f12d571dd49a947e677d81f460ced) to preload all `Win32_PerfFormattedData_PerfProc_Process` entries into a hashtable keyed by `IDProcess`, eliminating a per-process WMI query.
> - Increases `SAMPLE_INTERVAL_MS` in [ProcessResourceMonitor.ts](https://github.com/pingdotgg/t3code/pull/4829/files#diff-531add2e9c8cf312f695a676a24b959ff83264a563fac3914620ab8e1f516d6b) from 5,000 ms to 15,000 ms to reduce polling overhead.
> - Behavioral Change: process CPU metrics are now refreshed every 15s instead of every 5s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d9363e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->