### PR TITLE
fix(mobile): accept Android clipboard images in composer

### DIFF
--- a/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
+++ b/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
@@ -7,6 +7,7 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Typeface
+import android.net.Uri
 import android.text.Editable
 import android.text.InputType
 import android.text.Spanned
@@ -14,11 +15,18 @@ import android.text.TextWatcher
 import android.text.style.ReplacementSpan
 import android.view.Gravity
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import androidx.core.view.ContentInfoCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.inputmethod.InputConnectionCompat
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
+import java.io.File
+import java.util.UUID
 import org.json.JSONObject
 import kotlin.math.max
 
@@ -451,9 +459,26 @@ private class SelectionAwareEditText(context: Context) : EditText(context) {
   var selectionListener: ((Int, Int) -> Unit)? = null
   var pasteImagesListener: ((List<String>) -> Unit)? = null
 
+  init {
+    ViewCompat.setOnReceiveContentListener(this, SUPPORTED_IMAGE_MIME_TYPES) { _, payload ->
+      val cachedImageUris = cacheReceivedImages(payload)
+      if (cachedImageUris.isEmpty()) {
+        payload
+      } else {
+        pasteImagesListener?.invoke(cachedImageUris)
+        null
+      }
+    }
+  }
+
   override fun onSelectionChanged(selStart: Int, selEnd: Int) {
     super.onSelectionChanged(selStart, selEnd)
     selectionListener?.invoke(selStart, selEnd)
+  }
+
+  override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
+    val inputConnection = super.onCreateInputConnection(outAttrs) ?: return null
+    return InputConnectionCompat.createWrapper(this, inputConnection, outAttrs)
   }
 
   override fun onTextContextMenuItem(id: Int): Boolean {
@@ -476,5 +501,57 @@ private class SelectionAwareEditText(context: Context) : EditText(context) {
       }
     }
     return super.onTextContextMenuItem(id)
+  }
+
+  private fun cacheReceivedImages(payload: ContentInfoCompat): List<String> = buildList {
+    for (index in 0 until payload.clip.itemCount) {
+      val uri = payload.clip.getItemAt(index).uri ?: continue
+      val mimeType = context.contentResolver.getType(uri)?.lowercase() ?: continue
+      val extension = fileExtensionForImageMimeType(mimeType) ?: continue
+      cacheReceivedImage(uri, extension)?.let(::add)
+    }
+  }
+
+  private fun cacheReceivedImage(uri: Uri, extension: String): String? {
+    val pasteDirectory = File(context.cacheDir, OWNED_PASTED_IMAGE_DIRECTORY)
+    if (!pasteDirectory.exists() && !pasteDirectory.mkdirs()) {
+      return null
+    }
+
+    val destination = File(pasteDirectory, "${UUID.randomUUID()}.$extension")
+    return try {
+      val input = context.contentResolver.openInputStream(uri) ?: return null
+      input.use { source ->
+        destination.outputStream().use { output ->
+          source.copyTo(output)
+        }
+      }
+      Uri.fromFile(destination).toString()
+    } catch (_: Exception) {
+      destination.delete()
+      null
+    }
+  }
+
+  private companion object {
+    const val OWNED_PASTED_IMAGE_DIRECTORY = "t3-composer-paste"
+
+    val SUPPORTED_IMAGE_MIME_TYPES = arrayOf(
+      "image/png",
+      "image/jpeg",
+      "image/gif",
+      "image/webp",
+      "image/heic",
+      "image/heif",
+    )
+
+    fun fileExtensionForImageMimeType(mimeType: String): String? = when (mimeType) {
+      "image/png" -> "png"
+      "image/jpeg", "image/jpg" -> "jpg"
+      "image/gif" -> "gif"
+      "image/webp" -> "webp"
+      "image/heic", "image/heif" -> "heic"
+      else -> null
+    }
   }
 }


### PR DESCRIPTION
## What Changed

Add Android rich-content handling to the native composer editor so images selected from the keyboard's clipboard history are attached to the draft.

Received images are copied into the composer's owned temporary directory and then passed through the existing attachment conversion, size validation, and cleanup path. Existing text paste behavior and the `+` image picker flow are unchanged.

## Why

The Android editor already handled image URIs from the long-press Paste action, but keyboard clipboard-history images arrive through the IME `commitContent`/receive-content API instead of `onTextContextMenuItem`. Because the editor did not advertise or receive rich image content, Android reported those clipboard images as unsupported.

Using AndroidX receive-content support covers the IME path while keeping all attachment processing in the established composer pipeline.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

## Validation

- `node scripts/mobile-native-static-check.ts`
- `vp run typecheck` from `apps/mobile`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept Android clipboard images in the mobile composer editor
> - Adds a `ViewCompat.setOnReceiveContentListener` to `SelectionAwareEditText` in [T3ComposerEditorView.kt](https://github.com/pingdotgg/t3code/pull/4833/files#diff-dbf8b69facaf4bfdba7369705927677e0a538325ec8355999f2a34f3b9d32e30) that intercepts image content (JPEG, PNG, GIF, WebP) pasted from IMEs or drag-and-drop.
> - Received images are copied into a dedicated app cache subdirectory (`t3-composer-paste`) with UUID-based filenames, then passed to `pasteImagesListener` as file URIs.
> - Wraps the base `InputConnection` with `InputConnectionCompat.createWrapper` in `onCreateInputConnection` to enable rich content input compatibility on older Android versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e86f3bf. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->