### PR TITLE
fix(clients): disable add project while disconnected

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.logic.test.ts
+++ b/apps/mobile/src/features/projects/AddProjectScreen.logic.test.ts
@@ -1,0 +1,41 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveAddProjectEnvironment } from "./AddProjectScreen.logic";
+
+const ENVIRONMENT_A = EnvironmentId.make("environment-a");
+const ENVIRONMENT_B = EnvironmentId.make("environment-b");
+
+function environment(environmentId: EnvironmentId, connectionState: EnvironmentConnectionPhase) {
+  return { environmentId, connectionState };
+}
+
+describe("resolveAddProjectEnvironment", () => {
+  it("does not redirect an explicit unavailable environment to another environment", () => {
+    expect(
+      resolveAddProjectEnvironment(
+        [environment(ENVIRONMENT_A, "offline"), environment(ENVIRONMENT_B, "connected")],
+        ENVIRONMENT_A,
+      ),
+    ).toBeNull();
+  });
+
+  it("resolves an explicit connected environment", () => {
+    expect(
+      resolveAddProjectEnvironment(
+        [environment(ENVIRONMENT_A, "connected"), environment(ENVIRONMENT_B, "connected")],
+        ENVIRONMENT_A,
+      )?.environmentId,
+    ).toBe(ENVIRONMENT_A);
+  });
+
+  it("defaults to the first connected environment when no environment is requested", () => {
+    expect(
+      resolveAddProjectEnvironment(
+        [environment(ENVIRONMENT_A, "offline"), environment(ENVIRONMENT_B, "connected")],
+        null,
+      )?.environmentId,
+    ).toBe(ENVIRONMENT_B);
+  });
+});

--- a/apps/mobile/src/features/projects/AddProjectScreen.logic.ts
+++ b/apps/mobile/src/features/projects/AddProjectScreen.logic.ts
@@ -1,0 +1,26 @@
+import { canCreateProjectInEnvironment } from "@t3tools/client-runtime/operations/projects";
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
+import type { EnvironmentId } from "@t3tools/contracts";
+
+export function resolveAddProjectEnvironment<
+  T extends {
+    readonly environmentId: EnvironmentId;
+    readonly connectionState: EnvironmentConnectionPhase;
+  },
+>(environmentOptions: ReadonlyArray<T>, requestedEnvironmentId: EnvironmentId | null): T | null {
+  if (requestedEnvironmentId !== null) {
+    return (
+      environmentOptions.find(
+        (environment) =>
+          environment.environmentId === requestedEnvironmentId &&
+          canCreateProjectInEnvironment(environment.connectionState),
+      ) ?? null
+    );
+  }
+
+  return (
+    environmentOptions.find((environment) =>
+      canCreateProjectInEnvironment(environment.connectionState),
+    ) ?? null
+  );
+}

--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -4,12 +4,17 @@ import {
   addProjectRemoteSourceProvider,
   buildAddProjectRemoteSourceReadiness,
   buildProjectCreateCommand,
+  canCreateProjectInEnvironment,
   findExistingAddProject,
   getAddProjectInitialQuery,
   resolveAddProjectPath,
   sortAddProjectProviderSources,
   type AddProjectRemoteSource,
 } from "@t3tools/client-runtime/operations/projects";
+import {
+  connectionStatusText,
+  type EnvironmentConnectionPhase,
+} from "@t3tools/client-runtime/connection";
 import {
   canPreloadBrowsePath,
   createBrowseNavigationCoordinator,
@@ -46,6 +51,7 @@ import { uuidv4 } from "../../lib/uuid";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { useAtomQueryRunner } from "../../state/use-atom-query-runner";
 import {
+  useRemoteConnectionStatus,
   useRemoteEnvironmentRuntime,
   useSavedRemoteConnections,
 } from "../../state/use-remote-environment-registry";
@@ -55,6 +61,9 @@ interface EnvironmentOption {
   readonly label: string;
   readonly platform: string;
   readonly baseDirectory: string | null;
+  readonly connectionState: EnvironmentConnectionPhase;
+  readonly connectionError: string | null;
+  readonly connectionErrorTraceId: string | null;
 }
 
 const environmentOptionOrder = Order.mapInput(
@@ -286,19 +295,27 @@ function useBrowsePathInput(environment: EnvironmentOption | null) {
 function useEnvironmentOptions(): ReadonlyArray<EnvironmentOption> {
   const serverConfigByEnvironmentId = useServerConfigs();
   const { savedConnectionsById } = useSavedRemoteConnections();
+  const { connectedEnvironments } = useRemoteConnectionStatus();
 
   return useMemo<ReadonlyArray<EnvironmentOption>>(() => {
+    const runtimeByEnvironmentId = new Map(
+      connectedEnvironments.map((environment) => [environment.environmentId, environment] as const),
+    );
     const options = Object.values(savedConnectionsById).map((connection) => {
       const config = serverConfigByEnvironmentId.get(connection.environmentId);
+      const runtime = runtimeByEnvironmentId.get(connection.environmentId);
       return {
         environmentId: connection.environmentId,
         label: connection.environmentLabel,
         platform: platformFromOs(config?.environment.platform.os ?? null),
         baseDirectory: config?.settings.addProjectBaseDirectory ?? null,
+        connectionState: runtime?.connectionState ?? "available",
+        connectionError: runtime?.connectionError ?? null,
+        connectionErrorTraceId: runtime?.connectionErrorTraceId ?? null,
       };
     });
     return Arr.sort(options, environmentOptionOrder);
-  }, [savedConnectionsById, serverConfigByEnvironmentId]);
+  }, [connectedEnvironments, savedConnectionsById, serverConfigByEnvironmentId]);
 }
 
 function useSelectedEnvironment(): {
@@ -309,8 +326,14 @@ function useSelectedEnvironment(): {
   const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
   const environmentOptions = useEnvironmentOptions();
   const selectedEnvironment =
-    environmentOptions.find((environment) => environment.environmentId === selectedEnvironmentId) ??
-    environmentOptions[0] ??
+    environmentOptions.find(
+      (environment) =>
+        environment.environmentId === selectedEnvironmentId &&
+        canCreateProjectInEnvironment(environment.connectionState),
+    ) ??
+    environmentOptions.find((environment) =>
+      canCreateProjectInEnvironment(environment.connectionState),
+    ) ??
     null;
 
   return {
@@ -325,9 +348,9 @@ function EmptyEnvironmentState() {
 
   return (
     <View className="items-center gap-3 rounded-2xl bg-card px-5 py-8">
-      <Text className="text-center text-lg font-t3-bold">No environments connected</Text>
+      <Text className="text-center text-lg font-t3-bold">Environment unavailable</Text>
       <Text className="text-center text-sm leading-normal text-foreground-muted">
-        Add an environment before adding a project.
+        Start or reconnect an environment before adding a project.
       </Text>
       <Pressable
         onPress={() => navigation.dispatch(StackActions.replace("ConnectionsNew"))}
@@ -407,17 +430,25 @@ export function AddProjectSourceScreen() {
 
   return (
     <AddProjectShell>
-      {environmentOptions.length === 0 ? <EmptyEnvironmentState /> : null}
+      {selectedEnvironment === null ? <EmptyEnvironmentState /> : null}
 
       {environmentOptions.length > 1 ? (
         <>
-          <SectionTitle>Connected environments</SectionTitle>
+          <SectionTitle>Environments</SectionTitle>
           <ListSection>
             {environmentOptions.map((environment, index) => (
               <ListRow
                 key={environment.environmentId}
                 title={environment.label}
-                subtitle={environment.environmentId}
+                subtitle={
+                  canCreateProjectInEnvironment(environment.connectionState)
+                    ? environment.environmentId
+                    : connectionStatusText({
+                        phase: environment.connectionState,
+                        error: environment.connectionError,
+                        traceId: environment.connectionErrorTraceId,
+                      })
+                }
                 icon={
                   <SymbolView
                     name="server.rack"
@@ -427,6 +458,7 @@ export function AddProjectSourceScreen() {
                   />
                 }
                 selected={environment.environmentId === selectedEnvironment?.environmentId}
+                disabled={!canCreateProjectInEnvironment(environment.connectionState)}
                 isFirst={index === 0}
                 right={
                   environment.environmentId === selectedEnvironment?.environmentId ? (
@@ -500,7 +532,7 @@ function useCreateProject(environment: EnvironmentOption | null) {
 
   return useCallback(
     async (workspaceRoot: string) => {
-      if (!environment) return;
+      if (!environment || !canCreateProjectInEnvironment(environment.connectionState)) return;
 
       const existing = findExistingAddProject({
         projects,
@@ -552,8 +584,14 @@ function useEnvironmentFromParam(
   const environmentOptions = useEnvironmentOptions();
   const environmentId = stringParam(environmentIdParam) as EnvironmentId | null;
   return (
-    environmentOptions.find((environment) => environment.environmentId === environmentId) ??
-    environmentOptions[0] ??
+    environmentOptions.find(
+      (environment) =>
+        environment.environmentId === environmentId &&
+        canCreateProjectInEnvironment(environment.connectionState),
+    ) ??
+    environmentOptions.find((environment) =>
+      canCreateProjectInEnvironment(environment.connectionState),
+    ) ??
     null
   );
 }

--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -29,7 +29,7 @@ import {
 import { CommandId, type EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { StackActions, useNavigation } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { ActivityIndicator, Alert, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as Arr from "effect/Array";
@@ -55,6 +55,7 @@ import {
   useRemoteEnvironmentRuntime,
   useSavedRemoteConnections,
 } from "../../state/use-remote-environment-registry";
+import { resolveAddProjectEnvironment } from "./AddProjectScreen.logic";
 
 interface EnvironmentOption {
   readonly environmentId: EnvironmentId;
@@ -236,10 +237,13 @@ function ProjectPathInput(props: {
 }
 
 function useBrowsePathInput(environment: EnvironmentOption | null) {
+  const environmentId = environment?.environmentId ?? null;
+  const environmentBaseDirectory = environment?.baseDirectory ?? null;
   const [pathInput, commitPathInput] = useState(() =>
-    getAddProjectInitialQuery(environment?.baseDirectory),
+    getAddProjectInitialQuery(environmentBaseDirectory),
   );
-  const environmentRuntime = useRemoteEnvironmentRuntime(environment?.environmentId ?? null);
+  const previousEnvironmentIdRef = useRef(environmentId);
+  const environmentRuntime = useRemoteEnvironmentRuntime(environmentId);
   const loadBrowsePath = useAtomQueryRunner(filesystemEnvironment.browse, {
     reportFailure: false,
     reportDefect: false,
@@ -277,10 +281,11 @@ function useBrowsePathInput(environment: EnvironmentOption | null) {
   );
 
   useEffect(() => {
-    if (environment) {
-      setPathInput(getAddProjectInitialQuery(environment.baseDirectory));
+    if (environmentId !== null && environmentId !== previousEnvironmentIdRef.current) {
+      previousEnvironmentIdRef.current = environmentId;
+      setPathInput(getAddProjectInitialQuery(environmentBaseDirectory));
     }
-  }, [environment, setPathInput]);
+  }, [environmentBaseDirectory, environmentId, setPathInput]);
 
   useEffect(
     () => () => {
@@ -583,17 +588,7 @@ function useEnvironmentFromParam(
 ): EnvironmentOption | null {
   const environmentOptions = useEnvironmentOptions();
   const environmentId = stringParam(environmentIdParam) as EnvironmentId | null;
-  return (
-    environmentOptions.find(
-      (environment) =>
-        environment.environmentId === environmentId &&
-        canCreateProjectInEnvironment(environment.connectionState),
-    ) ??
-    environmentOptions.find((environment) =>
-      canCreateProjectInEnvironment(environment.connectionState),
-    ) ??
-    null
-  );
+  return resolveAddProjectEnvironment(environmentOptions, environmentId);
 }
 
 export function AddProjectRepositoryScreen(props: {
@@ -657,26 +652,32 @@ export function AddProjectRepositoryScreen(props: {
   return (
     <AddProjectShell>
       {error ? <ErrorBanner message={error} /> : null}
-      <TextInput
-        className="h-12 min-h-12 rounded-[24px] px-4 py-0 text-base leading-snug"
-        value={repositoryInput}
-        onChangeText={setRepositoryInput}
-        autoCapitalize="none"
-        autoCorrect={false}
-        placeholder={
-          source === "url"
-            ? "https://github.com/org/repo.git"
-            : addProjectRemoteSourcePathHint(source)
-        }
-        returnKeyType="next"
-        onSubmitEditing={() => void lookupRepository()}
-      />
-      <PrimaryActionButton
-        label={source === "url" ? "Continue" : "Lookup repository"}
-        disabled={isSubmitting || repositoryInput.trim().length === 0}
-        onPress={() => void lookupRepository()}
-        loading={isSubmitting}
-      />
+      {environment ? (
+        <>
+          <TextInput
+            className="h-12 min-h-12 rounded-[24px] px-4 py-0 text-base leading-snug"
+            value={repositoryInput}
+            onChangeText={setRepositoryInput}
+            autoCapitalize="none"
+            autoCorrect={false}
+            placeholder={
+              source === "url"
+                ? "https://github.com/org/repo.git"
+                : addProjectRemoteSourcePathHint(source)
+            }
+            returnKeyType="next"
+            onSubmitEditing={() => void lookupRepository()}
+          />
+          <PrimaryActionButton
+            label={source === "url" ? "Continue" : "Lookup repository"}
+            disabled={isSubmitting || repositoryInput.trim().length === 0}
+            onPress={() => void lookupRepository()}
+            loading={isSubmitting}
+          />
+        </>
+      ) : (
+        <EmptyEnvironmentState />
+      )}
     </AddProjectShell>
   );
 }

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -203,13 +203,17 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
             title={screenTitle}
             subtitle={incomingShareSubtitle}
             onBack={layout.usesSplitView ? () => navigation.goBack() : undefined}
-            actions={[
-              {
-                accessibilityLabel: "Add project",
-                icon: "plus",
-                onPress: () => navigation.navigate("NewTaskSheet", { screen: "AddProject" }),
-              },
-            ]}
+            actions={
+              catalogState.hasReadyEnvironment
+                ? [
+                    {
+                      accessibilityLabel: "Add project",
+                      icon: "plus",
+                      onPress: () => navigation.navigate("NewTaskSheet", { screen: "AddProject" }),
+                    },
+                  ]
+                : []
+            }
           />
         </>
       ) : (
@@ -229,11 +233,13 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
                 separateBackground
               />
             ) : null}
-            <NativeHeaderToolbar.Button
-              icon="plus"
-              onPress={() => navigation.navigate("NewTaskSheet", { screen: "AddProject" })}
-              separateBackground
-            />
+            {catalogState.hasReadyEnvironment ? (
+              <NativeHeaderToolbar.Button
+                icon="plus"
+                onPress={() => navigation.navigate("NewTaskSheet", { screen: "AddProject" })}
+                separateBackground
+              />
+            ) : null}
           </NativeHeaderToolbar>
         </>
       )}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { canCreateProjectInEnvironment } from "@t3tools/client-runtime/operations/projects";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import {
   canPreloadBrowsePath,
   createBrowseNavigationCoordinator,
@@ -163,6 +165,8 @@ interface AddProjectEnvironmentOption {
   readonly environmentId: EnvironmentId;
   readonly label: string;
   readonly isPrimary: boolean;
+  readonly isConnected: boolean;
+  readonly status: string;
 }
 
 type AddProjectRemoteProviderKind = Extract<
@@ -620,6 +624,8 @@ function OpenCommandPaletteDialog(props: {
           runtimeLabel: environment.label,
         }),
         isPrimary,
+        isConnected: canCreateProjectInEnvironment(environment.connection.phase),
+        status: connectionStatusText(environment.connection),
       };
     });
 
@@ -632,10 +638,14 @@ function OpenCommandPaletteDialog(props: {
 
     return options;
   }, [environments]);
-  const defaultAddProjectEnvironmentId = addProjectEnvironmentOptions[0]?.environmentId ?? null;
+  const defaultAddProjectEnvironmentId =
+    addProjectEnvironmentOptions.find((option) => option.isConnected)?.environmentId ?? null;
   const wslAddProjectEnvironmentOption = useMemo(
     () =>
       addProjectEnvironmentOptions.find((option) => {
+        if (!option.isConnected) {
+          return false;
+        }
         const environment = environments.find(
           (candidate) => candidate.environmentId === option.environmentId,
         );
@@ -1108,6 +1118,19 @@ function OpenCommandPaletteDialog(props: {
 
   const startAddProjectSourceSelection = useCallback(
     (environmentId: EnvironmentId): void => {
+      const environment = environments.find(
+        (candidate) => candidate.environmentId === environmentId,
+      );
+      if (!canCreateProjectInEnvironment(environment?.connection.phase)) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Environment unavailable",
+            description: `${environment?.label ?? "The selected environment"} is not connected.`,
+          }),
+        );
+        return;
+      }
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow(null);
       pushPaletteView({
@@ -1123,6 +1146,7 @@ function OpenCommandPaletteDialog(props: {
     [
       browseEnvironmentId,
       buildAddProjectSourceGroups,
+      environments,
       pushPaletteView,
       sourceControlDiscovery.data,
     ],
@@ -1134,7 +1158,12 @@ function OpenCommandPaletteDialog(props: {
       value: `action:add-project:environment:${option.environmentId}`,
       searchTerms: [option.label, option.environmentId, option.isPrimary ? "this device" : ""],
       title: option.label,
-      description: option.isPrimary ? "This device" : option.environmentId,
+      description: option.isConnected
+        ? option.isPrimary
+          ? "This device"
+          : option.environmentId
+        : option.status,
+      disabled: !option.isConnected,
       icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
       keepOpen: true,
       run: async () => {
@@ -1155,7 +1184,7 @@ function OpenCommandPaletteDialog(props: {
   );
 
   const openAddProjectFlow = useCallback(() => {
-    if (addProjectEnvironmentOptions.length > 1) {
+    if (addProjectEnvironmentOptions.length > 1 || defaultAddProjectEnvironmentId === null) {
       pushPaletteView({
         addonIcon: <FolderPlusIcon className={ADDON_ICON_CLASS} />,
         groups: addProjectEnvironmentGroups,
@@ -1294,6 +1323,7 @@ function OpenCommandPaletteDialog(props: {
       "environment",
     ],
     title: "Add project",
+    disabled: defaultAddProjectEnvironmentId === null,
     icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
     keepOpen: true,
     run: async () => {
@@ -1355,6 +1385,19 @@ function OpenCommandPaletteDialog(props: {
       readonly platform: string;
       readonly currentProjectCwd: string | null;
     }) => {
+      const environment = environments.find(
+        (candidate) => candidate.environmentId === input.environmentId,
+      );
+      if (!canCreateProjectInEnvironment(environment?.connection.phase)) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Environment unavailable",
+            description: `${environment?.label ?? "The selected environment"} is not connected.`,
+          }),
+        );
+        return;
+      }
       const rawCwd = input.rawCwd;
 
       if (isUnsupportedWindowsProjectPath(rawCwd.trim(), input.platform)) {
@@ -1505,6 +1548,16 @@ function OpenCommandPaletteDialog(props: {
 
   async function submitAddProjectCloneFlow(destinationPathInput?: string): Promise<void> {
     if (!addProjectCloneFlow) {
+      return;
+    }
+    if (!canCreateProjectInEnvironment(browseEnvironment?.connection.phase)) {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Environment unavailable",
+          description: `${browseEnvironment?.label ?? "The selected environment"} is not connected.`,
+        }),
+      );
       return;
     }
 
@@ -1711,7 +1764,10 @@ function OpenCommandPaletteDialog(props: {
     getCommandPaletteInputPlaceholder(paletteMode);
   const isSubmenu = paletteMode === "submenu" || paletteMode === "submenu-browse";
   const hasHighlightedBrowseItem = highlightedItemValue?.startsWith("browse:") ?? false;
-  const canSubmitBrowsePath = isBrowsing && !relativePathNeedsActiveProject;
+  const canSubmitBrowsePath =
+    isBrowsing &&
+    !relativePathNeedsActiveProject &&
+    canCreateProjectInEnvironment(browseEnvironment?.connection.phase);
   const willCreateProjectPath =
     canSubmitBrowsePath &&
     !isBrowsePending &&
@@ -1738,6 +1794,7 @@ function OpenCommandPaletteDialog(props: {
   const canSubmitRemoteProjectFlow =
     addProjectCloneFlow?.step === "repository" &&
     query.trim().length > 0 &&
+    canCreateProjectInEnvironment(browseEnvironment?.connection.phase) &&
     !isRemoteProjectPending;
   const fileManagerName = getLocalFileManagerName(navigator.platform);
   const canOpenProjectFromFileManager =
@@ -2063,6 +2120,7 @@ function OpenCommandPaletteDialog(props: {
                     )}
                     aria-label={`${submitActionLabel} (${addShortcutLabel})`}
                     disabled={
+                      !canCreateProjectInEnvironment(browseEnvironment?.connection.phase) ||
                       relativePathNeedsActiveProject ||
                       (isCloneDestinationStep && isRemoteProjectPending)
                     }

--- a/packages/client-runtime/src/operations/projects.test.ts
+++ b/packages/client-runtime/src/operations/projects.test.ts
@@ -10,6 +10,7 @@ import * as Option from "effect/Option";
 import {
   buildAddProjectRemoteSourceReadiness,
   buildProjectCreateCommand,
+  canCreateProjectInEnvironment,
   findExistingAddProject,
   getAddProjectInitialQuery,
   resolveAddProjectPath,
@@ -18,6 +19,15 @@ import {
 import type { EnvironmentProject } from "../state/models.ts";
 
 describe("add project shared logic", () => {
+  it("only allows project creation in connected environments", () => {
+    expect(canCreateProjectInEnvironment("connected")).toBe(true);
+    expect(canCreateProjectInEnvironment("available")).toBe(false);
+    expect(canCreateProjectInEnvironment("offline")).toBe(false);
+    expect(canCreateProjectInEnvironment("connecting")).toBe(false);
+    expect(canCreateProjectInEnvironment("reconnecting")).toBe(false);
+    expect(canCreateProjectInEnvironment("error")).toBe(false);
+  });
+
   it("resolves initial browse paths from settings", () => {
     expect(getAddProjectInitialQuery("")).toBe("~/");
     expect(getAddProjectInitialQuery("/work")).toBe("/work/");

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentConnectionPhase } from "../connection/presentation.ts";
 import type {
   CommandId,
   EnvironmentId,
@@ -26,6 +27,12 @@ export type AddProjectRemoteProviderKind = Extract<
   "github" | "gitlab" | "bitbucket" | "azure-devops"
 >;
 export type AddProjectRemoteSource = AddProjectRemoteProviderKind | "url";
+
+export function canCreateProjectInEnvironment(
+  connectionPhase: EnvironmentConnectionPhase | null | undefined,
+): boolean {
+  return connectionPhase === "connected";
+}
 
 export type AddProjectRemoteSourceReadiness = Record<
   AddProjectRemoteSource,


### PR DESCRIPTION
## What changed

- disable unavailable environments in the web and mobile add-project pickers
- only select connected environments as add-project targets
- guard browse, clone, and create submission if the environment disconnects while the flow is open
- hide mobile add-project header actions when no environment is connected

## Why

Configured environments remain in the connection catalog while offline. The add-project UI treated catalog membership as availability, so users could enter a flow that could only fail when the RPC layer rejected the disconnected request.

This keeps configured environments visible where useful, but prevents project creation until the target reports a connected phase.

## Impact

Web, desktop, and mobile now consistently prevent project creation against disconnected environments. Existing RPC rejection remains as the final safety boundary.

## Validation

- `vp test run packages/client-runtime/src/operations/projects.test.ts packages/client-runtime/src/state/filesystem.test.ts`
- `vp run --filter @t3tools/client-runtime --filter @t3tools/web --filter @t3tools/mobile typecheck`
- targeted lint and formatting for the changed files

Generated by GPT-5.6-sol via the T3 Code Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable add project actions when no environment is connected
> - Adds `canCreateProjectInEnvironment` in [`packages/client-runtime/src/operations/projects.ts`](https://github.com/pingdotgg/t3code/pull/4834/files#diff-50bc4917fdd160661572e739c44cc80d565982b40d14cc5ce0a41cff3302c032) as the canonical check for whether an environment's connection phase is `'connected'`.
> - Environment option types in both the mobile and web clients are extended to include connection state; disconnected environments are disabled and annotated with status text in the add-project UI.
> - The 'Add project' button in [`NewTaskRouteScreen`](https://github.com/pingdotgg/t3code/pull/4834/files#diff-ff6990d7f3ffc05e93955c8a5c7bf5a3b77e8139e45c8b63e3a296596cd2d29e) is hidden when no ready environment exists; the command palette add-project flow blocks or shows error toasts for disconnected environments.
> - `useCreateProject` and `useEnvironmentFromParam` guard against disconnected environments, returning null instead of proceeding.
> - Behavioral Change: previously, users could attempt to add a project in a disconnected environment; now those paths are blocked with empty states or error toasts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5226075.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and client-side guards around add-project; no auth or data-model changes, with existing RPC rejection as backup.
> 
> **Overview**
> Introduces **`canCreateProjectInEnvironment`** in client-runtime so only environments in the **`connected`** phase can be used for add-project flows.
> 
> **Mobile** enriches environment options with live connection state, disables unavailable rows with status text, and picks targets via **`resolveAddProjectEnvironment`** (explicit offline IDs are not silently swapped). Repository/local/clone screens show an empty state when no connected target exists; create is blocked if the environment drops mid-flow. The new-task **Add project** header action is hidden when **`hasReadyEnvironment`** is false.
> 
> **Web** command palette mirrors this: disconnected environments are disabled with status labels, defaults and WSL options require a connected env, and browse/clone/create/submit paths toast **Environment unavailable** instead of proceeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52260751b40d0cd5783e6c5438ffb73e7aa914f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->