### PR TITLE
fix(mobile): accept Android clipboard images in composer

### DIFF
--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -1,5 +1,6 @@
 import { collectComposerInlineTokens } from "@t3tools/shared/composerInlineTokens";
 import { requireNativeView } from "expo";
+import { TextInputWrapper } from "expo-paste-input";
 import {
   useCallback,
   useEffect,
@@ -9,12 +10,13 @@ import {
   useState,
   type Ref,
 } from "react";
-import type { NativeSyntheticEvent, StyleProp, ViewProps, ViewStyle } from "react-native";
+import type { NativeSyntheticEvent, ViewProps } from "react-native";
 import { Image, StyleSheet } from "react-native";
 
 import { markdownFileIconSource } from "@t3tools/mobile-markdown-text/file-icons";
 import { resolveMarkdownFileIcon } from "@t3tools/mobile-markdown-text/links";
 import { MOBILE_TYPOGRAPHY } from "../lib/typography";
+import { useNativePaste } from "../lib/useNativePaste";
 import { useFontFamily } from "../lib/useFontFamily";
 import { useThemeColor } from "../lib/useThemeColor";
 import {
@@ -117,6 +119,7 @@ export function ComposerEditor({
   const skillBorder = useThemeColor("--color-inline-skill-border");
   const skillText = useThemeColor("--color-inline-skill-foreground");
   const fileTint = useThemeColor("--color-icon-muted");
+  const handlePaste = useNativePaste((uris) => onPasteImages?.(uris));
 
   useImperativeHandle(
     ref,
@@ -221,61 +224,63 @@ export function ComposerEditor({
   const resolvedTextStyle = StyleSheet.flatten(textStyle) ?? {};
   const regularFontFamily = useFontFamily("regular");
   return (
-    <NativeView
-      ref={nativeRef}
-      controlledDocumentJson={controlledDocumentJson}
-      themeJson={themeJson}
-      placeholder={props.placeholder ?? ""}
-      fontFamily={
-        typeof resolvedTextStyle.fontFamily === "string"
-          ? resolvedTextStyle.fontFamily
-          : regularFontFamily
-      }
-      fontSize={
-        typeof resolvedTextStyle.fontSize === "number"
-          ? resolvedTextStyle.fontSize
-          : MOBILE_TYPOGRAPHY.body.fontSize
-      }
-      lineHeight={
-        typeof resolvedTextStyle.lineHeight === "number"
-          ? resolvedTextStyle.lineHeight
-          : MOBILE_TYPOGRAPHY.body.lineHeight
-      }
-      contentInsetVertical={contentInsetVertical}
-      singleLineCentered={props.singleLineCentered ?? false}
-      editable={props.editable ?? true}
-      scrollEnabled={props.scrollEnabled ?? true}
-      autoFocus={props.autoFocus ?? false}
-      autoCorrect={props.autoCorrect ?? true}
-      spellCheck={props.spellCheck ?? true}
-      style={style as StyleProp<ViewStyle>}
-      onComposerChange={(event) => {
-        const acknowledgedEventCount = acceptNativeEvent(
-          event.nativeEvent.eventCount,
-          event.nativeEvent.value,
-          event.nativeEvent.selection,
-        );
-        if (acknowledgedEventCount === false) return;
-        onChangeText(event.nativeEvent.value);
-        onSelectionChange?.(event.nativeEvent.selection);
-        setMostRecentEventCount(acknowledgedEventCount);
-        setNativeEventSequence((sequence) => sequence + 1);
-      }}
-      onComposerSelectionChange={(event) => {
-        const acknowledgedEventCount = acceptNativeEvent(
-          event.nativeEvent.eventCount,
-          event.nativeEvent.value,
-          event.nativeEvent.selection,
-        );
-        if (acknowledgedEventCount === false) return;
-        onSelectionChange?.(event.nativeEvent.selection);
-        setMostRecentEventCount(acknowledgedEventCount);
-        setNativeEventSequence((sequence) => sequence + 1);
-      }}
-      onComposerPasteImages={(event) => onPasteImages?.(event.nativeEvent.uris)}
-      onComposerFocus={onFocus}
-      onComposerBlur={onBlur}
-    />
+    <TextInputWrapper onPaste={handlePaste} style={[{ minHeight: 0 }, style]}>
+      <NativeView
+        ref={nativeRef}
+        controlledDocumentJson={controlledDocumentJson}
+        themeJson={themeJson}
+        placeholder={props.placeholder ?? ""}
+        fontFamily={
+          typeof resolvedTextStyle.fontFamily === "string"
+            ? resolvedTextStyle.fontFamily
+            : regularFontFamily
+        }
+        fontSize={
+          typeof resolvedTextStyle.fontSize === "number"
+            ? resolvedTextStyle.fontSize
+            : MOBILE_TYPOGRAPHY.body.fontSize
+        }
+        lineHeight={
+          typeof resolvedTextStyle.lineHeight === "number"
+            ? resolvedTextStyle.lineHeight
+            : MOBILE_TYPOGRAPHY.body.lineHeight
+        }
+        contentInsetVertical={contentInsetVertical}
+        singleLineCentered={props.singleLineCentered ?? false}
+        editable={props.editable ?? true}
+        scrollEnabled={props.scrollEnabled ?? true}
+        autoFocus={props.autoFocus ?? false}
+        autoCorrect={props.autoCorrect ?? true}
+        spellCheck={props.spellCheck ?? true}
+        style={{ flex: 1, minHeight: 0 }}
+        onComposerChange={(event) => {
+          const acknowledgedEventCount = acceptNativeEvent(
+            event.nativeEvent.eventCount,
+            event.nativeEvent.value,
+            event.nativeEvent.selection,
+          );
+          if (acknowledgedEventCount === false) return;
+          onChangeText(event.nativeEvent.value);
+          onSelectionChange?.(event.nativeEvent.selection);
+          setMostRecentEventCount(acknowledgedEventCount);
+          setNativeEventSequence((sequence) => sequence + 1);
+        }}
+        onComposerSelectionChange={(event) => {
+          const acknowledgedEventCount = acceptNativeEvent(
+            event.nativeEvent.eventCount,
+            event.nativeEvent.value,
+            event.nativeEvent.selection,
+          );
+          if (acknowledgedEventCount === false) return;
+          onSelectionChange?.(event.nativeEvent.selection);
+          setMostRecentEventCount(acknowledgedEventCount);
+          setNativeEventSequence((sequence) => sequence + 1);
+        }}
+        onComposerPasteImages={(event) => onPasteImages?.(event.nativeEvent.uris)}
+        onComposerFocus={onFocus}
+        onComposerBlur={onBlur}
+      />
+    </TextInputWrapper>
   );
 }
 


### PR DESCRIPTION
## What Changed

- Wrap the Android native composer with the existing `TextInputWrapper` clipboard integration.
- Route pasted image URIs through the existing composer attachment flow without changing iOS behavior.

## Why

Android keyboards and clipboard history can send images through the platform receive-content API instead of a normal text paste. The native composer was not connected to the repository's existing paste-input integration, so Android reported those images as unsupported.

Reusing the established wrapper keeps the change focused and avoids a second native content parsing and caching implementation.

## Validation

- `vp check apps/mobile/src/native/T3ComposerEditor.native.tsx`
- `vp run typecheck` (from `apps/mobile`)
- `git diff --check origin/main...HEAD`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept Android clipboard images in the mobile composer
> - Wraps the native composer view in a `TextInputWrapper` (from `expo-paste-input`) and adds a `useNativePaste` hook in [T3ComposerEditor.native.tsx](https://github.com/pingdotgg/t3code/pull/4836/files#diff-713805a2470d470287c4d2a11eafef4c6b9d4d8397caf53923053dd64462f0a7) to intercept paste events and forward image URIs to `onPasteImages`.
> - The existing native `onComposerPasteImages` path is retained alongside the new hook-based path.
> - Behavioral Change: the external `style` prop now applies to `TextInputWrapper` instead of `NativeView`; `NativeView` always uses `{ flex: 1, minHeight: 0 }`, which may affect layout in some screens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75d0e1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused mobile UI integration reusing an established paste helper; main review surface is possible composer layout regressions from moving `style` to the wrapper.
> 
> **Overview**
> **Android clipboard images** in the native composer now go through the same `expo-paste-input` path as other mobile inputs: `TextInputWrapper` plus `useNativePaste`, forwarding image URIs to the existing `onPasteImages` attachment flow. The native `onComposerPasteImages` handler is unchanged for platforms that still emit it.
> 
> **Layout:** the composer’s external `style` prop applies to `TextInputWrapper` (with `minHeight: 0`); the inner `NativeView` always uses `{ flex: 1, minHeight: 0 }` instead of inheriting that style directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d0e1d0a74f6e46f479701d786939c290da95f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->