### PR TITLE
fix(web): refit the terminal when its container is resized

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -843,6 +843,10 @@ export function TerminalViewport({
         const terminal = terminalRef.current;
         const fitAddon = fitAddonRef.current;
         if (!terminal || !fitAddon) return;
+        // A hidden ancestor collapses the box to 0x0, and fitting to that would
+        // hand the PTY a minimal grid: the running program reflows its output
+        // for a viewport nobody can see, and keeps it until the drawer returns.
+        if (container.clientWidth === 0 || container.clientHeight === 0) return;
         const previous = { cols: terminal.cols, rows: terminal.rows };
         const size = refitTerminal(terminal, fitAddon);
         // Pixel changes rarely move the grid; only tell the PTY when they do.

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -93,6 +93,19 @@ function writeTerminalBuffer(terminal: Terminal, buffer: string): void {
   }
 }
 
+/**
+ * Fit to the container and report the resulting grid. Keeps the viewport pinned
+ * to the bottom when it already was, so a resize never scrolls output away.
+ */
+function refitTerminal(terminal: Terminal, fitAddon: FitAddon): { cols: number; rows: number } {
+  const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
+  fitTerminalSafely(fitAddon);
+  if (wasAtBottom) {
+    terminal.scrollToBottom();
+  }
+  return { cols: terminal.cols, rows: terminal.rows };
+}
+
 function fitTerminalSafely(fitAddon: FitAddon): boolean {
   try {
     fitAddon.fit();
@@ -707,13 +720,8 @@ export function TerminalViewport({
       const activeTerminal = terminalRef.current;
       const activeFitAddon = fitAddonRef.current;
       if (!activeTerminal || !activeFitAddon) return;
-      const wasAtBottom =
-        activeTerminal.buffer.active.viewportY >= activeTerminal.buffer.active.baseY;
-      fitTerminalSafely(activeFitAddon);
-      if (wasAtBottom) {
-        activeTerminal.scrollToBottom();
-      }
-      void resizeTerminal(activeTerminal.cols, activeTerminal.rows);
+      const size = refitTerminal(activeTerminal, activeFitAddon);
+      void resizeTerminal(size.cols, size.rows);
     }, 30);
 
     return () => {
@@ -811,18 +819,43 @@ export function TerminalViewport({
     const terminal = terminalRef.current;
     const fitAddon = fitAddonRef.current;
     if (!terminal || !fitAddon) return;
-    const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
     const frame = window.requestAnimationFrame(() => {
-      fitTerminalSafely(fitAddon);
-      if (wasAtBottom) {
-        terminal.scrollToBottom();
-      }
-      void resizeTerminal(terminal.cols, terminal.rows);
+      const size = refitTerminal(terminal, fitAddon);
+      void resizeTerminal(size.cols, size.rows);
     });
     return () => {
       window.cancelAnimationFrame(frame);
     };
   }, [drawerHeight, environmentId, resizeEpoch, terminalId, threadId]);
+
+  // The props above only cover resizes the drawer knows about. Dragging a
+  // divider, resizing the window, or any surrounding reflow changes the
+  // container without changing them, and the grid would keep its mount size.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    let frame = 0;
+    const observer = new ResizeObserver(() => {
+      window.cancelAnimationFrame(frame);
+      // A drag emits a callback per frame; coalesce them so one gesture costs
+      // one fit instead of one per pixel.
+      frame = window.requestAnimationFrame(() => {
+        const terminal = terminalRef.current;
+        const fitAddon = fitAddonRef.current;
+        if (!terminal || !fitAddon) return;
+        const previous = { cols: terminal.cols, rows: terminal.rows };
+        const size = refitTerminal(terminal, fitAddon);
+        // Pixel changes rarely move the grid; only tell the PTY when they do.
+        if (size.cols === previous.cols && size.rows === previous.rows) return;
+        void resizeTerminal(size.cols, size.rows);
+      });
+    });
+    observer.observe(container);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, []);
   return (
     <div
       ref={containerRef}


### PR DESCRIPTION
## What Changed

`TerminalViewport` now observes its container's size and refits from there, instead of relying only on props and a post-mount timer.

## Why

Reported in #4842. The existing refits cover `drawerHeight`, `resizeEpoch`, and a `setTimeout` after mount. None of them observe the container itself, so a resize that leaves those props untouched — dragging a divider, resizing the window, any surrounding reflow — left the grid at its mount dimensions. Output stayed wrapped to the old column count and the PTY kept a stale size.

## Notes For Review

Three details that are deliberate rather than incidental:

- **Coalescing.** A drag emits a `ResizeObserver` callback per frame. They collapse into one `requestAnimationFrame`, so a gesture costs one fit rather than one per pixel.
- **Reporting only on real changes.** Pixel changes usually leave the character grid where it was. The PTY is told only when `cols`/`rows` actually move, so a drag does not spray identical resize RPCs across the socket.
- **One helper instead of three copies.** The read-viewport / fit / pin-to-bottom / report sequence existed three times. It is now `refitTerminal`, which returns the resulting grid and lets each caller decide whether to report. Keeping the report outside the helper matters: the mount path must report even when the fit changes nothing, or the PTY would never learn its initial size.

The `ResizeObserver` also fires once on `observe`. That is harmless — a fit is idempotent, and the dedup means no RPC follows.

## Validation

Measured in a running client: opened the drawer, then changed **only** the container's width, leaving every prop the existing refits depend on untouched.

| | container | `.xterm-screen` | columns |
| --- | --- | --- | --- |
| before | 1016px | 1001px | 139 |
| narrowed | 520px | 504px | 70 |
| restored | 1016px | 1001px | 139 |

Columns derived from `.xterm-char-measure-element` (32-character sample). Nothing else in the component observes width, so on `main` this transition produces no refit at all.

- `vp run --filter @t3tools/web test` — 1663 passed
- `vp run --filter @t3tools/web typecheck` — no errors
- `vp lint` / `vp fmt --check` on the changed file — clean

Closes #4842.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual change to screenshot; the before/after is the grid geometry above


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refit terminal in `TerminalViewport` when its container is resized
> - Adds a `ResizeObserver` effect in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/4845/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) that watches the terminal container for size changes not covered by existing props (e.g. window or layout changes).
> - Coalesces rapid resize callbacks via `requestAnimationFrame`, skips fitting when the container is hidden (0×0), and only notifies the PTY when cols/rows actually change.
> - Extracts a `refitTerminal` helper that fits the xterm instance and preserves bottom-pinned scroll position, returning the resulting `{cols, rows}`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 461f863.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only terminal sizing fix in ThreadTerminalDrawer with no auth, data, or API contract changes.
> 
> **Overview**
> **`TerminalViewport`** now keeps the xterm grid aligned when the DOM container changes size without updating drawer props (window resize, divider drag, layout reflow).
> 
> A **`refitTerminal`** helper centralizes fit + bottom-scroll preservation and returns `{cols, rows}`; mount and prop-driven refit paths use it instead of duplicated logic.
> 
> A **`ResizeObserver`** on the container coalesces callbacks with `requestAnimationFrame`, skips 0×0 hidden layouts, and calls **`resizeTerminal`** only when cols/rows actually change (avoiding redundant PTY RPCs during pixel-only resizes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 461f863e91c1a5bd988b9a029b09c5c2d71595b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->