### PR TITLE
fix(server): detect repositories after initialization

### DIFF
--- a/apps/server/src/vcs/VcsDriverRegistry.test.ts
+++ b/apps/server/src/vcs/VcsDriverRegistry.test.ts
@@ -92,4 +92,49 @@ describe("VcsDriverRegistry", () => {
       );
     }).pipe(Effect.provide(layer));
   });
+
+  it.effect("detects a repository created after a negative lookup", () => {
+    let insideWorkTreeChecks = 0;
+    const layer = Layer.effect(VcsDriverRegistry.VcsDriverRegistry, VcsDriverRegistry.make).pipe(
+      Layer.provide(NodeServices.layer),
+      Layer.provide(
+        Layer.mock(VcsProjectConfig.VcsProjectConfig)({
+          resolveKind: (input) => Effect.succeed(input.requestedKind ?? "auto"),
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.sync(() => {
+              const command = normalizeGitArgs(input.args).join(" ");
+              if (command === "rev-parse --is-inside-work-tree") {
+                insideWorkTreeChecks += 1;
+                return insideWorkTreeChecks === 1
+                  ? {
+                      ...processOutput(""),
+                      exitCode: ChildProcessSpawner.ExitCode(128),
+                      stderr: "fatal: not a git repository",
+                    }
+                  : processOutput("true\n");
+              }
+              if (command === "rev-parse --show-toplevel") {
+                return processOutput("/repo\n");
+              }
+              if (command === "rev-parse --git-common-dir") {
+                return processOutput("/repo/.git\n");
+              }
+              return processOutput("");
+            }),
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+
+      assert.equal(yield* registry.detect({ cwd: "/repo" }), null);
+      assert.equal((yield* registry.detect({ cwd: "/repo" }))?.repository.rootPath, "/repo");
+      assert.equal(insideWorkTreeChecks, 2);
+    }).pipe(Effect.provide(layer));
+  });
 });

--- a/apps/server/src/vcs/VcsDriverRegistry.ts
+++ b/apps/server/src/vcs/VcsDriverRegistry.ts
@@ -115,7 +115,10 @@ export const make = Effect.gen(function* () {
     (key) => detectResolvedKind(parseDetectionCacheKey(key)),
     {
       capacity: DETECTION_CACHE_CAPACITY,
-      timeToLive: (exit) => (Exit.isSuccess(exit) ? DETECTION_CACHE_TTL : Duration.zero),
+      timeToLive: Exit.match({
+        onSuccess: (detected) => (detected === null ? Duration.zero : DETECTION_CACHE_TTL),
+        onFailure: () => Duration.zero,
+      }),
     },
   );
 


### PR DESCRIPTION
## Problem

Initializing Git from a fresh thread creates the repository, but the immediate status refresh can reuse a cached negative repository detection. The UI then continues to show "Initialize Git" until another event, such as the first agent turn completing, refreshes Git status.

## Fix

Cache successful repository detections for the existing two-second TTL, but do not retain negative detections. This lets the status refresh following `git init` discover the repository immediately while preserving the positive detection cache.

A focused registry test covers a path transitioning from non-repository to repository between consecutive detections.

## Validation

- `vp test run apps/server/src/vcs/VcsDriverRegistry.test.ts apps/server/src/vcs/VcsProvisioningService.test.ts apps/server/src/vcs/VcsStatusBroadcaster.test.ts`
- `vp run --filter t3 typecheck`
- Reproduced in an isolated T3 instance before the fix: `.git` existed within 100 ms, while the UI remained stale for 10+ seconds and updated only when the first agent turn completed.

Generated with GPT-5.6-Sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted cache TTL change in VCS detection with a regression test; no auth or data-path changes.
> 
> **Overview**
> Fixes stale **Initialize Git** UI after `git init` by changing how **VCS repository detection** is cached in `VcsDriverRegistry`.
> 
> **Successful** detections still use the existing **2s TTL**, but **negative** results (`null`, no repo) are no longer cached—they get **zero TTL** so the next status refresh re-runs detection. Failures also skip retention. A new test asserts that a second `detect` call sees a repo after the first call returned non-repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f609a4da2af6f1bd5b5bc077488e5c18954657cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix repository detection cache to not cache null results in `VcsDriverRegistry`
> Previously, a null result from repository detection (e.g. "not a git repository") was cached with the full TTL, preventing a subsequent positive detection. Now, only non-null detection results are cached; null results and failures expire immediately (TTL of zero). A new test in [VcsDriverRegistry.test.ts](https://github.com/pingdotgg/t3code/pull/4848/files#diff-6800374e0ad08ac06f233cf660cdc696b7fd268f0f53858c96147dcd98a92993) verifies that a negative lookup followed by a positive one returns the correct repository on the second attempt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f609a4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->