### PR TITLE
feat(connect): let hosts set their display name

### DIFF
--- a/apps/mobile/src/state/environments.ts
+++ b/apps/mobile/src/state/environments.ts
@@ -24,7 +24,7 @@ export function projectEnvironmentPresentation(
   return {
     ...presentation,
     environmentId,
-    label: presentation.entry.target.label,
+    label: presentation.serverConfig?.environment.label ?? presentation.entry.target.label,
     displayUrl: connectionCatalogDisplayUrl(presentation.entry),
     relayManaged: presentation.entry.target._tag === "RelayConnectionTarget",
   };

--- a/apps/server/src/cli/connect.ts
+++ b/apps/server/src/cli/connect.ts
@@ -46,6 +46,7 @@ import { headlessRelayClientTracingLayer } from "../cloud/relayTracing.ts";
 import * as ServerConfig from "../config.ts";
 import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
 import * as ExternalLauncher from "../process/externalLauncher.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import { readPersistedServerRuntimeState } from "../serverRuntimeState.ts";
 import { projectLocationFlags, resolveCliAuthConfig } from "./config.ts";
 import { resolveCliCommand } from "./invocation.ts";
@@ -433,6 +434,7 @@ const runCloudCommand = Effect.fn("cloud.cli.run_cloud_command")(function* <A, E
     | Prompt.Environment
     | ServerConfig.ServerConfig
     | ServerEnvironment.ServerEnvironment
+    | ServerSettings.ServerSettingsService
   >,
   options?: {
     readonly quietLogs?: boolean;
@@ -449,7 +451,9 @@ const runCloudCommand = Effect.fn("cloud.cli.run_cloud_command")(function* <A, E
     ),
     RelayClient.layerCloudflared({ baseDir: config.baseDir }),
     EnvironmentAuth.runtimeLayer,
-    ServerEnvironment.layer.pipe(Layer.provide(ServerSecretStore.layer)),
+    ServerEnvironment.layer.pipe(
+      Layer.provideMerge(ServerSettings.layer.pipe(Layer.provideMerge(ServerSecretStore.layer))),
+    ),
     bootServiceLayer(config),
     headlessRelayClientTracingLayer,
   ).pipe(

--- a/apps/server/src/cloud/http.test.ts
+++ b/apps/server/src/cloud/http.test.ts
@@ -203,6 +203,9 @@ describe("reconcileDesiredCloudLink", () => {
         ServerEnvironment.ServerEnvironment.of({
           getEnvironmentId: unusedSecretStoreOperation(),
           getDescriptor: unusedSecretStoreOperation(),
+          getDescriptorForSettings: () => {
+            throw new Error("unused");
+          },
         }),
       ),
       Effect.provideService(
@@ -295,6 +298,9 @@ describe("releaseManagedTunnelOnShutdown", () => {
           ServerEnvironment.ServerEnvironment.of({
             getEnvironmentId: Effect.succeed(EnvironmentId.make("env_123")),
             getDescriptor: Effect.die("unused"),
+            getDescriptorForSettings: () => {
+              throw new Error("unused");
+            },
           }),
         ),
         Effect.provideService(

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -14,6 +14,7 @@ import {
   RELAY_URL_SECRET,
 } from "../cloud/config.ts";
 import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as ServerEnvironment from "./ServerEnvironment.ts";
 
 const isServerEnvironmentIdPersistenceError = Schema.is(
@@ -22,6 +23,7 @@ const isServerEnvironmentIdPersistenceError = Schema.is(
 
 const makeServerEnvironmentLayer = (baseDir: string) =>
   ServerEnvironment.layer.pipe(
+    Layer.provideMerge(ServerSettings.layerTest()),
     Layer.provide(ServerSecretStore.layer),
     Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir)),
   );
@@ -142,6 +144,28 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
     }),
   );
 
+  it.effect("applies configured environment label updates without a restart", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-environment-label-test-",
+      });
+      yield* Effect.gen(function* () {
+        const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
+        const serverSettings = yield* ServerSettings.ServerSettingsService;
+        const initial = yield* serverEnvironment.getDescriptor;
+
+        yield* serverSettings.updateSettings({ environmentLabel: "Studio Mac" });
+        const renamed = yield* serverEnvironment.getDescriptor;
+        yield* serverSettings.updateSettings({ environmentLabel: "" });
+        const reset = yield* serverEnvironment.getDescriptor;
+
+        expect(renamed).toEqual({ ...initial, label: "Studio Mac" });
+        expect(reset).toEqual(initial);
+      }).pipe(Effect.provide(makeServerEnvironmentLayer(baseDir)));
+    }),
+  );
+
   it.effect("structures persisted environment id filesystem failures", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
@@ -181,6 +205,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
         }).pipe(
           Effect.provide(
             ServerEnvironment.layer.pipe(
+              Layer.provideMerge(ServerSettings.layerTest()),
               Layer.provide(emptySecretStoreLayer),
               Layer.provide(Layer.merge(ServerConfig.layer(serverConfig), failingFileSystemLayer)),
             ),

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -104,10 +104,11 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       const baseDir = yield* fileSystem.makeTempDirectoryScoped({
         prefix: "t3-server-environment-publish-test-",
       });
-      const testLayer = Layer.mergeAll(
-        ServerEnvironment.layer.pipe(Layer.provide(ServerSecretStore.layer)),
-        ServerSecretStore.layer,
-      ).pipe(Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir)));
+      const testLayer = ServerEnvironment.layer.pipe(
+        Layer.provideMerge(ServerSettings.layerTest()),
+        Layer.provideMerge(ServerSecretStore.layer),
+        Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir)),
+      );
 
       yield* Effect.gen(function* () {
         const secrets = yield* ServerSecretStore.ServerSecretStore;
@@ -157,10 +158,14 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
 
         yield* serverSettings.updateSettings({ environmentLabel: "Studio Mac" });
         const renamed = yield* serverEnvironment.getDescriptor;
+        const renamedFromSnapshot = serverEnvironment.getDescriptorForSettings({
+          environmentLabel: "Studio Mac",
+        });
         yield* serverSettings.updateSettings({ environmentLabel: "" });
         const reset = yield* serverEnvironment.getDescriptor;
 
         expect(renamed).toEqual({ ...initial, label: "Studio Mac" });
+        expect(renamedFromSnapshot).toEqual(renamed);
         expect(reset).toEqual(initial);
       }).pipe(Effect.provide(makeServerEnvironmentLayer(baseDir)));
     }),

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -15,6 +15,7 @@ import { resolveServerSelfUpdateCapability } from "../cloud/selfUpdate.ts";
 import { resolveServiceLauncherMode } from "../cloud/serviceLauncherClient.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProcessRunner from "../processRunner.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import { resolveServerEnvironmentLabel } from "./ServerEnvironmentLabel.ts";
 
 export class ServerEnvironmentIdPersistenceError extends Schema.TaggedErrorClass<ServerEnvironmentIdPersistenceError>()(
@@ -69,6 +70,7 @@ export const make = Effect.gen(function* () {
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig.ServerConfig;
   const secrets = yield* ServerSecretStore.ServerSecretStore;
+  const serverSettings = yield* ServerSettings.ServerSettingsService;
   const crypto = yield* Crypto.Crypto;
   const hostPlatform = yield* HostProcessPlatform;
   const hostArchitecture = yield* HostProcessArchitecture;
@@ -128,16 +130,16 @@ export const make = Effect.gen(function* () {
 
   const environmentId = EnvironmentId.make(environmentIdRaw);
   const cwdBaseName = path.basename(serverConfig.cwd).trim();
-  const label = yield* resolveServerEnvironmentLabel({ cwdBaseName });
+  const defaultLabel = yield* resolveServerEnvironmentLabel({ cwdBaseName });
   const launcher = yield* resolveServiceLauncherMode();
   const serverSelfUpdate = resolveServerSelfUpdateCapability({
     desktopManaged: serverConfig.mode === "desktop",
     launcherManaged: launcher.managed,
   });
 
-  const descriptor: ExecutionEnvironmentDescriptor = {
+  const defaultDescriptor: ExecutionEnvironmentDescriptor = {
     environmentId,
-    label,
+    label: defaultLabel,
     platform: {
       os: platformOs(hostPlatform),
       arch: platformArch(hostArchitecture),
@@ -162,11 +164,28 @@ export const make = Effect.gen(function* () {
     // The publish opt-in and relay link change at runtime (`t3 connect
     // publish`, the client settings toggle), so the capability is read per
     // descriptor request rather than baked in at startup.
-    getDescriptor: readAgentActivityPublishingActive(secrets).pipe(
-      Effect.map((agentActivityPublishing) => ({
-        ...descriptor,
-        capabilities: { ...descriptor.capabilities, agentActivityPublishing },
-      })),
+    getDescriptor: serverSettings.getSettings.pipe(
+      Effect.map(
+        (settings): ExecutionEnvironmentDescriptor => ({
+          ...defaultDescriptor,
+          label: settings.environmentLabel || defaultLabel,
+        }),
+      ),
+      Effect.catch((error) =>
+        Effect.logWarning("Failed to read the configured environment label.", {
+          settingsPath: error.settingsPath,
+          operation: error.operation,
+          cause: error.cause,
+        }).pipe(Effect.as(defaultDescriptor)),
+      ),
+      Effect.flatMap((descriptor) =>
+        readAgentActivityPublishingActive(secrets).pipe(
+          Effect.map((agentActivityPublishing) => ({
+            ...descriptor,
+            capabilities: { ...descriptor.capabilities, agentActivityPublishing },
+          })),
+        ),
+      ),
     ),
   });
 });

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -36,6 +36,9 @@ export class ServerEnvironment extends Context.Service<
   {
     readonly getEnvironmentId: Effect.Effect<EnvironmentId>;
     readonly getDescriptor: Effect.Effect<ExecutionEnvironmentDescriptor>;
+    readonly getDescriptorForSettings: (settings: {
+      readonly environmentLabel: string;
+    }) => ExecutionEnvironmentDescriptor;
   }
 >()("t3/environment/ServerEnvironment") {}
 
@@ -158,6 +161,11 @@ export const make = Effect.gen(function* () {
       ...(serverSelfUpdate === "boot-service" ? { serverSelfUpdateProgress: true } : {}),
     },
   };
+  const getDescriptorForSettings = (settings: { readonly environmentLabel: string }) => ({
+    ...defaultDescriptor,
+    label: settings.environmentLabel || defaultLabel,
+    capabilities: { ...defaultDescriptor.capabilities, agentActivityPublishing: false },
+  });
 
   return ServerEnvironment.of({
     getEnvironmentId: Effect.succeed(environmentId),
@@ -165,12 +173,7 @@ export const make = Effect.gen(function* () {
     // publish`, the client settings toggle), so the capability is read per
     // descriptor request rather than baked in at startup.
     getDescriptor: serverSettings.getSettings.pipe(
-      Effect.map(
-        (settings): ExecutionEnvironmentDescriptor => ({
-          ...defaultDescriptor,
-          label: settings.environmentLabel || defaultLabel,
-        }),
-      ),
+      Effect.map(getDescriptorForSettings),
       Effect.catch((error) =>
         Effect.logWarning("Failed to read the configured environment label.", {
           settingsPath: error.settingsPath,
@@ -187,6 +190,7 @@ export const make = Effect.gen(function* () {
         ),
       ),
     ),
+    getDescriptorForSettings,
   });
 });
 

--- a/apps/server/src/mcp/McpSessionRegistry.test.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.test.ts
@@ -17,6 +17,9 @@ const fakeHttpServer = makeFakeHttpServer("127.0.0.1");
 const fakeEnvironment = ServerEnvironment.ServerEnvironment.of({
   getEnvironmentId: Effect.succeed(environmentId),
   getDescriptor: Effect.die("unused"),
+  getDescriptorForSettings: () => {
+    throw new Error("unused");
+  },
 });
 
 const makeRegistry = (now: () => number, httpServer = fakeHttpServer) =>

--- a/apps/server/src/relay/AgentAwarenessRelay.test.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.test.ts
@@ -511,6 +511,10 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
           Layer.succeed(ServerEnvironment.ServerEnvironment, {
             getEnvironmentId: Effect.succeed(environmentId),
             getDescriptor: Effect.succeed(descriptor),
+            getDescriptorForSettings: (settings) => ({
+              ...descriptor,
+              label: settings.environmentLabel || descriptor.label,
+            }),
           }),
           Layer.succeed(OrchestrationEngineService, orchestrationEngine),
           Layer.succeed(ProjectionSnapshotQuery, snapshotQuery),
@@ -661,6 +665,10 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
           Layer.succeed(ServerEnvironment.ServerEnvironment, {
             getEnvironmentId: Effect.succeed(environmentId),
             getDescriptor: Effect.succeed(descriptor),
+            getDescriptorForSettings: (settings) => ({
+              ...descriptor,
+              label: settings.environmentLabel || descriptor.label,
+            }),
           }),
           Layer.succeed(OrchestrationEngineService, {
             readEvents: () => Stream.empty,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -912,6 +912,12 @@ const buildAppUnderTest = (options?: {
           getEnvironmentId: Effect.succeed(testEnvironmentDescriptor.environmentId),
           getDescriptor: Effect.succeed(testEnvironmentDescriptor),
           ...options?.layers?.serverEnvironment,
+          getDescriptorForSettings:
+            options?.layers?.serverEnvironment?.getDescriptorForSettings ??
+            ((settings) => ({
+              ...testEnvironmentDescriptor,
+              label: settings.environmentLabel || testEnvironmentDescriptor.label,
+            })),
         }),
       ),
       Layer.provide(
@@ -4586,6 +4592,43 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         type: "keybindingsUpdated",
         payload: { keybindings: [], issues: [] },
       });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("uses the emitted settings snapshot for environment label updates", () =>
+    Effect.gen(function* () {
+      const updatedSettings = {
+        ...DEFAULT_SERVER_SETTINGS,
+        environmentLabel: "Studio Mac",
+      };
+      yield* buildAppUnderTest({
+        layers: {
+          serverSettings: {
+            streamChanges: Stream.succeed(updatedSettings),
+          },
+          serverEnvironment: {
+            getDescriptor: Effect.succeed(testEnvironmentDescriptor),
+            getDescriptorForSettings: (settings) => ({
+              ...testEnvironmentDescriptor,
+              label: settings.environmentLabel || testEnvironmentDescriptor.label,
+            }),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const events = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[WS_METHODS.subscribeServerConfig]({}).pipe(Stream.take(2), Stream.runCollect),
+        ),
+      );
+
+      const update = Array.from(events)[1];
+      assert.equal(update?.type, "settingsUpdated");
+      if (update?.type === "settingsUpdated") {
+        assert.equal(update.payload.settings.environmentLabel, "Studio Mac");
+        assert.equal(update.payload.environment?.label, "Studio Mac");
+      }
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2199,13 +2199,18 @@ const makeWsRpcLayer = (
                 Stream.debounce(Duration.millis(PROVIDER_STATUS_DEBOUNCE_MS)),
               );
               const settingsUpdates = serverSettings.streamChanges.pipe(
-                Stream.map((settings) => ServerSettings.redactServerSettingsForClient(settings)),
                 Stream.mapEffect((settings) =>
                   serverEnvironment.getDescriptor.pipe(
                     Effect.map((environment) => ({
                       version: 1 as const,
                       type: "settingsUpdated" as const,
-                      payload: { settings, environment },
+                      payload: {
+                        settings: ServerSettings.redactServerSettingsForClient(settings),
+                        environment: {
+                          ...serverEnvironment.getDescriptorForSettings(settings),
+                          capabilities: environment.capabilities,
+                        },
+                      },
                     })),
                   ),
                 ),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2200,11 +2200,15 @@ const makeWsRpcLayer = (
               );
               const settingsUpdates = serverSettings.streamChanges.pipe(
                 Stream.map((settings) => ServerSettings.redactServerSettingsForClient(settings)),
-                Stream.map((settings) => ({
-                  version: 1 as const,
-                  type: "settingsUpdated" as const,
-                  payload: { settings },
-                })),
+                Stream.mapEffect((settings) =>
+                  serverEnvironment.getDescriptor.pipe(
+                    Effect.map((environment) => ({
+                      version: 1 as const,
+                      type: "settingsUpdated" as const,
+                      payload: { settings, environment },
+                    })),
+                  ),
+                ),
               );
 
               yield* providerRegistry

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -83,6 +83,7 @@ import { Switch } from "../ui/switch";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { Button } from "../ui/button";
+import { DraftInput } from "../ui/draft-input";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
 import { AnimatedHeight } from "../AnimatedHeight";
 import { Textarea } from "../ui/textarea";
@@ -126,6 +127,7 @@ import {
 } from "~/state/environments";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { serverEnvironment } from "~/state/server";
+import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
 import { ConnectionStatusDot } from "../ConnectionStatusDot";
 import { ServerUpdateAction, ServerUpdateProgress } from "../ServerUpdateAction";
 import { CloudEnvironmentConnectRows } from "../cloud/CloudEnvironmentConnectList";
@@ -1747,6 +1749,8 @@ export function ConnectionsSettings() {
   const desktopBridge = window.desktopBridge;
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
+  const environmentLabel = usePrimarySettings((settings) => settings.environmentLabel);
+  const updatePrimarySettings = useUpdatePrimarySettings();
   const connectPairing = useAtomCommand(connectPairingAtom, { reportFailure: false });
   const connectSshEnvironment = useAtomCommand(connectSshEnvironmentAtom, {
     reportFailure: false,
@@ -1880,6 +1884,8 @@ export function ConnectionsSettings() {
   );
   const canManageLocalBackend = currentSessionScopes?.includes(AuthAccessWriteScope) ?? false;
   const canManageRelay = currentSessionScopes?.includes(AuthRelayWriteScope) ?? false;
+  const canEditEnvironmentLabel =
+    currentSessionScopes?.includes(AuthOrchestrationOperateScope) ?? false;
   const authAccessChanges = useEnvironmentQuery(
     canManageLocalBackend && primaryEnvironmentId !== null
       ? authEnvironment.accessChanges({
@@ -2575,6 +2581,23 @@ export function ConnectionsSettings() {
       aria-label="Enable network access"
     />
   );
+  const renderEnvironmentLabelRow = () => (
+    <SettingsRow
+      title="Host name"
+      description="Shown in T3 Connect and used as the default name for new manual connections. Clear it to use this computer’s name."
+      control={
+        <DraftInput
+          className="w-full sm:w-64"
+          value={environmentLabel}
+          onCommit={(next) => updatePrimarySettings({ environmentLabel: next })}
+          placeholder="Use this computer’s name"
+          aria-label="Host name"
+          disabled={!canEditEnvironmentLabel}
+          spellCheck={false}
+        />
+      }
+    />
+  );
   const renderEndpointRows = (presentation: AccessSectionPresentation) =>
     isAdvertisedEndpointListExpanded
       ? visibleDesktopNetworkAdvertisedEndpoints.map((endpoint) => {
@@ -3060,6 +3083,7 @@ export function ConnectionsSettings() {
                 }
               />
             ) : null}
+            {renderEnvironmentLabelRow()}
             {desktopBridge ? (
               <>
                 {renderNetworkAccessRow()}
@@ -3372,6 +3396,7 @@ export function ConnectionsSettings() {
         </>
       ) : (
         <SettingsSection title="This environment">
+          {renderEnvironmentLabelRow()}
           <SettingsRow
             title="Administrative access"
             description="Pairing links and client-session management require the access:write scope for this backend."

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1885,7 +1885,8 @@ export function ConnectionsSettings() {
   const canManageLocalBackend = currentSessionScopes?.includes(AuthAccessWriteScope) ?? false;
   const canManageRelay = currentSessionScopes?.includes(AuthRelayWriteScope) ?? false;
   const canEditEnvironmentLabel =
-    currentSessionScopes?.includes(AuthOrchestrationOperateScope) ?? false;
+    primaryEnvironmentId !== null &&
+    (currentSessionScopes?.includes(AuthOrchestrationOperateScope) ?? false);
   const authAccessChanges = useEnvironmentQuery(
     canManageLocalBackend && primaryEnvironmentId !== null
       ? authEnvironment.accessChanges({

--- a/apps/web/src/state/environments.ts
+++ b/apps/web/src/state/environments.ts
@@ -29,7 +29,7 @@ function projectEnvironmentPresentation(
   return {
     ...presentation,
     environmentId,
-    label: presentation.entry.target.label,
+    label: presentation.serverConfig?.environment.label ?? presentation.entry.target.label,
     displayUrl: connectionCatalogDisplayUrl(presentation.entry),
     relayManaged: presentation.entry.target._tag === "RelayConnectionTarget",
   };

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -32,6 +32,15 @@ That gives you:
 - transport security at the network layer
 - less exposure than opening the server to the public internet
 
+## Naming This Host
+
+In the web or desktop app, open **Settings** → **Connections** and edit **Host name** under
+**This environment**. T3 Code uses that name in T3 Connect and as the default label when another
+client adds the environment through a manual pairing connection.
+
+Clear the field to return to the name detected from the host operating system. This setting changes
+the environment name shown by T3 Code; it does not change the machine's operating-system hostname.
+
 ## Enabling Network Access
 
 There are three ways to reach your server from another device: expose the desktop app's backend,

--- a/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
@@ -86,6 +86,7 @@ function makeEnvironmentLinks(
     listPublicKeysForEnvironment: () => Effect.succeed([]),
     listForUser: () => Effect.succeed([]),
     getForUser: () => Effect.succeed(null),
+    updateLabelForUser: () => Effect.void,
     revokeForUser: () => Effect.succeed(false),
     ...overrides,
   };

--- a/infra/relay/src/agentActivity/MobileRegistrations.test.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.test.ts
@@ -108,6 +108,7 @@ function makeEnvironmentLinks(
     listPublicKeysForEnvironment: () => Effect.succeed([]),
     listForUser: () => Effect.succeed([]),
     getForUser: () => Effect.succeed(null),
+    updateLabelForUser: () => Effect.void,
     revokeForUser: () => Effect.succeed(false),
     ...overrides,
   };

--- a/infra/relay/src/environments/EnvironmentConnector.test.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.test.ts
@@ -365,6 +365,7 @@ describe("EnvironmentConnector", () => {
           userId: "user_123",
           environmentId: "env-connector-test",
           label: "Studio Mac",
+          checkedAt: expect.any(String),
         },
       ]);
     }).pipe(

--- a/infra/relay/src/environments/EnvironmentConnector.test.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.test.ts
@@ -226,6 +226,7 @@ function makeLinks(
         environmentPublicKey: environmentKeyPair.publicKey,
         ...overrides,
       }),
+    updateLabelForUser: () => Effect.void,
     revokeForUser: () => Effect.succeed(false),
   };
 }
@@ -321,6 +322,64 @@ describe("EnvironmentConnector", () => {
         },
       });
     }).pipe(Effect.provide(connectorTestLayer(execute)));
+  });
+
+  it.effect("persists a label reported by a verified environment health response", () => {
+    const updates: Array<{ userId: string; environmentId: string; label: string }> = [];
+    const execute = (request: HttpClientRequest.HttpClientRequest) =>
+      Effect.sync(() => {
+        const healthRequest = decodeHealthRequestBody(requestBodyText(request));
+        return HttpClientResponse.fromWeb(
+          request,
+          Response.json(
+            signHealthResponse(
+              healthRequest,
+              environmentKeyPair.privateKey,
+              {},
+              {
+                descriptor: {
+                  environmentId: "env-connector-test" as never,
+                  label: "Studio Mac",
+                  platform: { os: "darwin", arch: "arm64" },
+                  serverVersion: "0.0.0-test",
+                  capabilities: { repositoryIdentity: true },
+                },
+              },
+            ),
+            { status: 200 },
+          ),
+        );
+      });
+    const links = makeLinks();
+
+    return Effect.gen(function* () {
+      const connector = yield* EnvironmentConnector.EnvironmentConnector;
+      const result = yield* connector.status({
+        userId: "user_123",
+        environmentId: "env-connector-test",
+      });
+
+      expect(result.descriptor?.label).toBe("Studio Mac");
+      expect(updates).toEqual([
+        {
+          userId: "user_123",
+          environmentId: "env-connector-test",
+          label: "Studio Mac",
+        },
+      ]);
+    }).pipe(
+      Effect.provide(
+        connectorTestLayer(execute, {
+          links: {
+            ...links,
+            updateLabelForUser: (input) =>
+              Effect.sync(() => {
+                updates.push(input);
+              }),
+          },
+        }),
+      ),
+    );
   });
 
   it.effect("rejects manual endpoints before sending a health request", () => {

--- a/infra/relay/src/environments/EnvironmentConnector.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.ts
@@ -530,6 +530,23 @@ const make = Effect.gen(function* () {
           operation: "status",
         });
       }
+      if (decoded.descriptor.label !== link.label) {
+        yield* links
+          .updateLabelForUser({
+            userId: input.userId,
+            environmentId: input.environmentId,
+            label: decoded.descriptor.label,
+          })
+          .pipe(
+            Effect.tapError((error) =>
+              Effect.logWarning("managed environment label persistence failed", {
+                environmentId: input.environmentId,
+                errorTag: error._tag,
+              }),
+            ),
+            Effect.ignore,
+          );
+      }
       return {
         environmentId: link.environmentId,
         endpoint,

--- a/infra/relay/src/environments/EnvironmentConnector.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.ts
@@ -536,6 +536,7 @@ const make = Effect.gen(function* () {
             userId: input.userId,
             environmentId: input.environmentId,
             label: decoded.descriptor.label,
+            checkedAt: decoded.checkedAt,
           })
           .pipe(
             Effect.tapError((error) =>

--- a/infra/relay/src/environments/EnvironmentLinker.test.ts
+++ b/infra/relay/src/environments/EnvironmentLinker.test.ts
@@ -128,6 +128,7 @@ function testLayer(input?: {
           listPublicKeysForEnvironment: () => Effect.succeed([]),
           listForUser: () => Effect.succeed([]),
           getForUser: () => Effect.succeed(null),
+          updateLabelForUser: () => Effect.void,
           revokeForUser: () => Effect.succeed(false),
         }),
         Layer.succeed(EnvironmentCredentials.EnvironmentCredentials, {

--- a/infra/relay/src/environments/EnvironmentLinks.test.ts
+++ b/infra/relay/src/environments/EnvironmentLinks.test.ts
@@ -42,6 +42,51 @@ describe("EnvironmentLinks", () => {
     );
   });
 
+  it.effect("updates the active link label owned by the requesting user", () => {
+    const updateValues: Array<Record<string, unknown>> = [];
+    const whereConditions: Array<unknown> = [];
+    const fakeDb = {
+      update: (table: unknown) => {
+        expect(table).toBe(relayEnvironmentLinks);
+        return {
+          set: (values: Record<string, unknown>) => {
+            updateValues.push(values);
+            return {
+              where: (condition: unknown) => {
+                whereConditions.push(condition);
+                return Effect.void;
+              },
+            };
+          },
+        };
+      },
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const links = yield* EnvironmentLinks.EnvironmentLinks;
+      yield* links.updateLabelForUser({
+        userId: "user-1",
+        environmentId: "env-1",
+        label: "Studio Mac",
+      });
+
+      expect(updateValues).toHaveLength(1);
+      expect(updateValues[0]?.environmentLabel).toBe("Studio Mac");
+      expect(typeof updateValues[0]?.updatedAt).toBe("string");
+      expect(whereConditions).toHaveLength(1);
+
+      const query = new PgDialect().sqlToQuery(whereConditions[0] as never);
+      expect(query.sql).toContain('"relay_environment_links"."user_id" = $1');
+      expect(query.sql).toContain('"relay_environment_links"."environment_id" = $2');
+      expect(query.sql).toContain('"relay_environment_links"."revoked_at" is null');
+      expect(query.params).toEqual(["user-1", "env-1"]);
+    }).pipe(
+      Effect.provide(
+        EnvironmentLinks.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb))),
+      ),
+    );
+  });
+
   it.effect("identifies delivery-user list failures without retaining key material", () => {
     const cause = new Error("database unavailable");
     const fakeDb = {

--- a/infra/relay/src/environments/EnvironmentLinks.test.ts
+++ b/infra/relay/src/environments/EnvironmentLinks.test.ts
@@ -68,18 +68,20 @@ describe("EnvironmentLinks", () => {
         userId: "user-1",
         environmentId: "env-1",
         label: "Studio Mac",
+        checkedAt: "2026-08-20T12:00:00.000Z",
       });
 
       expect(updateValues).toHaveLength(1);
       expect(updateValues[0]?.environmentLabel).toBe("Studio Mac");
-      expect(typeof updateValues[0]?.updatedAt).toBe("string");
+      expect(updateValues[0]?.updatedAt).toBe("2026-08-20T12:00:00.000Z");
       expect(whereConditions).toHaveLength(1);
 
       const query = new PgDialect().sqlToQuery(whereConditions[0] as never);
       expect(query.sql).toContain('"relay_environment_links"."user_id" = $1');
       expect(query.sql).toContain('"relay_environment_links"."environment_id" = $2');
       expect(query.sql).toContain('"relay_environment_links"."revoked_at" is null');
-      expect(query.params).toEqual(["user-1", "env-1"]);
+      expect(query.sql).toContain('"relay_environment_links"."updated_at" <= $3');
+      expect(query.params).toEqual(["user-1", "env-1", "2026-08-20T12:00:00.000Z"]);
     }).pipe(
       Effect.provide(
         EnvironmentLinks.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb))),

--- a/infra/relay/src/environments/EnvironmentLinks.ts
+++ b/infra/relay/src/environments/EnvironmentLinks.ts
@@ -9,7 +9,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
-import { and, eq, isNull, or } from "drizzle-orm";
+import { and, eq, isNull, lte, or } from "drizzle-orm";
 
 import * as RelayDb from "../db.ts";
 import { relayEnvironmentLinks } from "../persistence/schema.ts";
@@ -150,6 +150,7 @@ export class EnvironmentLinks extends Context.Service<
       readonly userId: string;
       readonly environmentId: string;
       readonly label: string;
+      readonly checkedAt: string;
     }) => Effect.Effect<void, EnvironmentLinkLabelUpdatePersistenceError>;
     readonly revokeForUser: (input: {
       readonly userId: string;
@@ -419,18 +420,18 @@ const make = Effect.gen(function* () {
         yield* Effect.annotateCurrentSpan({
           "relay.environment_id": input.environmentId,
         });
-        const updatedAt = DateTime.formatIso(yield* DateTime.now);
         yield* db
           .update(relayEnvironmentLinks)
           .set({
             environmentLabel: input.label,
-            updatedAt,
+            updatedAt: input.checkedAt,
           })
           .where(
             and(
               eq(relayEnvironmentLinks.userId, input.userId),
               eq(relayEnvironmentLinks.environmentId, input.environmentId),
               isNull(relayEnvironmentLinks.revokedAt),
+              lte(relayEnvironmentLinks.updatedAt, input.checkedAt),
             ),
           )
           .pipe(

--- a/infra/relay/src/environments/EnvironmentLinks.ts
+++ b/infra/relay/src/environments/EnvironmentLinks.ts
@@ -88,6 +88,19 @@ export class EnvironmentLinkLookupPersistenceError extends Schema.TaggedErrorCla
   }
 }
 
+export class EnvironmentLinkLabelUpdatePersistenceError extends Schema.TaggedErrorClass<EnvironmentLinkLabelUpdatePersistenceError>()(
+  "EnvironmentLinkLabelUpdatePersistenceError",
+  {
+    userId: Schema.String,
+    environmentId: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to update the environment label for user '${this.userId}', environment '${this.environmentId}'`;
+  }
+}
+
 export class EnvironmentLinkRevokePersistenceError extends Schema.TaggedErrorClass<EnvironmentLinkRevokePersistenceError>()(
   "EnvironmentLinkRevokePersistenceError",
   {
@@ -133,6 +146,11 @@ export class EnvironmentLinks extends Context.Service<
       readonly userId: string;
       readonly environmentId: string;
     }) => Effect.Effect<RelayLinkedEnvironmentRecord | null, EnvironmentLinkLookupPersistenceError>;
+    readonly updateLabelForUser: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+      readonly label: string;
+    }) => Effect.Effect<void, EnvironmentLinkLabelUpdatePersistenceError>;
     readonly revokeForUser: (input: {
       readonly userId: string;
       readonly environmentId: string;
@@ -395,6 +413,38 @@ const make = Effect.gen(function* () {
           ),
         );
     }),
+
+    updateLabelForUser: Effect.fn("relay.environment_links.update_label_for_user")(
+      function* (input) {
+        yield* Effect.annotateCurrentSpan({
+          "relay.environment_id": input.environmentId,
+        });
+        const updatedAt = DateTime.formatIso(yield* DateTime.now);
+        yield* db
+          .update(relayEnvironmentLinks)
+          .set({
+            environmentLabel: input.label,
+            updatedAt,
+          })
+          .where(
+            and(
+              eq(relayEnvironmentLinks.userId, input.userId),
+              eq(relayEnvironmentLinks.environmentId, input.environmentId),
+              isNull(relayEnvironmentLinks.revokedAt),
+            ),
+          )
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new EnvironmentLinkLabelUpdatePersistenceError({
+                  userId: input.userId,
+                  environmentId: input.environmentId,
+                  cause,
+                }),
+            ),
+          );
+      },
+    ),
 
     revokeForUser: Effect.fn("relay.environment_links.revoke_for_user")(function* (input) {
       yield* Effect.annotateCurrentSpan({

--- a/infra/relay/src/http/Api.test.ts
+++ b/infra/relay/src/http/Api.test.ts
@@ -185,6 +185,7 @@ function relayUnlinkTestLayer(input?: {
         listPublicKeysForEnvironment: () => Effect.die("unused listPublicKeysForEnvironment"),
         listForUser: () => Effect.die("unused listForUser"),
         getForUser: input?.getForUser ?? (() => Effect.succeed(null)),
+        updateLabelForUser: () => Effect.die("unused updateLabelForUser"),
         revokeForUser: input?.revokeForUser ?? (() => Effect.succeed(false)),
       }),
     ),

--- a/packages/client-runtime/src/relay/discovery.test.ts
+++ b/packages/client-runtime/src/relay/discovery.test.ts
@@ -46,12 +46,24 @@ const environments = [
 function status(
   environment: RelayClientEnvironmentRecord,
   value: "online" | "offline",
+  label?: string,
 ): RelayEnvironmentStatusResponse {
   return {
     environmentId: environment.environmentId,
     endpoint: environment.endpoint,
     status: value,
     checkedAt: "2026-06-01T00:00:00.000Z",
+    ...(label
+      ? {
+          descriptor: {
+            environmentId: environment.environmentId,
+            label,
+            platform: { os: "darwin", arch: "arm64" },
+            serverVersion: "0.0.0-test",
+            capabilities: { repositoryIdentity: true },
+          },
+        }
+      : {}),
   };
 }
 
@@ -190,7 +202,7 @@ describe("RelayEnvironmentDiscovery", () => {
         const requests = yield* Ref.get(harness.statusRequests);
         yield* Deferred.succeed(
           requests.get(environments[1]!.environmentId)!,
-          status(environments[1]!, "online"),
+          status(environments[1]!, "online", "Renamed Environment"),
         );
 
         const partiallyResolved = yield* SubscriptionRef.changes(discovery.state).pipe(
@@ -204,6 +216,9 @@ describe("RelayEnvironmentDiscovery", () => {
         expect(
           partiallyResolved.environments.get(environments[0]!.environmentId)?.availability,
         ).toBe("checking");
+        expect(
+          partiallyResolved.environments.get(environments[1]!.environmentId)?.environment.label,
+        ).toBe("Renamed Environment");
 
         yield* Deferred.succeed(
           requests.get(environments[0]!.environmentId)!,

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -186,6 +186,12 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
       }
       yield* updateEnvironment(generation, environment.environmentId, (current) => ({
         ...current,
+        environment: result.success.descriptor
+          ? {
+              ...current.environment,
+              label: result.success.descriptor.label,
+            }
+          : current.environment,
         availability: result.success.status,
         status: Option.some(result.success),
         error: Option.none(),
@@ -240,7 +246,7 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
           }));
           return;
         }
-        return yield* Effect.fail(failure);
+        return yield* failure;
       }
       const clerkToken = tokenResult.success;
       if ((yield* Ref.get(accountGeneration)) !== generation) {

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -271,14 +271,19 @@ describe("server state projection", () => {
       config: CONFIG,
     });
     const settings = { ...CONFIG.settings };
+    const environment = {
+      ...CONFIG.environment,
+      label: "Renamed environment",
+    } as ServerConfig["environment"];
     const projected = applyServerConfigProjection(snapshot, {
       version: 1,
       type: "settingsUpdated",
-      payload: { settings },
+      payload: { settings, environment },
     });
 
     const result = Option.getOrThrow(projected);
     expect(result.config.settings).toBe(settings);
+    expect(result.config.environment).toBe(environment);
     expect(result.latestEvent.type).toBe("settingsUpdated");
   });
 

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -289,6 +289,7 @@ export function applyServerConfigProjection(
         config: {
           ...projection.config,
           settings: event.payload.settings,
+          environment: event.payload.environment ?? projection.config.environment,
         },
         latestEvent: event,
         source: "live",

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -496,6 +496,7 @@ export type ServerConfigProviderStatusesPayload = typeof ServerConfigProviderSta
 
 export const ServerConfigSettingsUpdatedPayload = Schema.Struct({
   settings: ServerSettings,
+  environment: Schema.optionalKey(ExecutionEnvironmentDescriptor),
 });
 export type ServerConfigSettingsUpdatedPayload = typeof ServerConfigSettingsUpdatedPayload.Type;
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -231,6 +231,19 @@ describe("ServerSettings worktree defaults", () => {
   });
 });
 
+describe("ServerSettings environment label", () => {
+  it("uses an empty override for legacy configs", () => {
+    expect(decodeServerSettings({}).environmentLabel).toBe("");
+  });
+
+  it("trims environment label updates and allows clearing the override", () => {
+    expect(decodeServerSettingsPatch({ environmentLabel: "  Studio Mac  " }).environmentLabel).toBe(
+      "Studio Mac",
+    );
+    expect(decodeServerSettingsPatch({ environmentLabel: "   " }).environmentLabel).toBe("");
+  });
+});
+
 describe("ServerSettings.sourceControlWritingStyle", () => {
   it("defaults all style settings for legacy configs", () => {
     const settings = decodeServerSettings({});
@@ -291,6 +304,7 @@ describe("ServerSettingsPatch.providerInstances", () => {
 describe("ServerSettingsPatch string normalization", () => {
   it("trims string settings while decoding patches", () => {
     const patch = decodeServerSettingsPatch({
+      environmentLabel: "  Studio Mac  ",
       addProjectBaseDirectory: "  ~/Development  ",
       textGenerationModelSelection: { model: "  gpt-5.4-mini  " },
       observability: {
@@ -312,6 +326,7 @@ describe("ServerSettingsPatch string normalization", () => {
       },
     });
 
+    expect(patch.environmentLabel).toBe("Studio Mac");
     expect(patch.addProjectBaseDirectory).toBe("~/Development");
     expect(patch.textGenerationModelSelection?.model).toBe("gpt-5.4-mini");
     expect(patch.observability?.otlpTracesUrl).toBe("http://localhost:4318/v1/traces");

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -587,6 +587,7 @@ export const BackgroundActivitySettings = Schema.Struct({
 export type BackgroundActivitySettings = typeof BackgroundActivitySettings.Type;
 
 export const ServerSettings = Schema.Struct({
+  environmentLabel: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   // Legacy token-by-token assistant output. Deliberately a fresh key (was
   // `enableAssistantStreaming`): decoding drops the old key, so everyone,
   // including prior opt-ins, resets to the buffered default.
@@ -811,6 +812,7 @@ const OpenCodeSettingsPatch = Schema.Struct({
 
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
+  environmentLabel: Schema.optionalKey(TrimmedString),
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
   enableProviderUpdateChecks: Schema.optionalKey(Schema.Boolean),
   enableAgentBrowserAccess: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
## Summary

- add a host-local **Host name** setting under Settings → Connections for web and desktop
- use the configured name in live environment descriptors and as the default for newly paired manual connections
- refresh relay-managed environment labels from verified health responses so renamed hosts propagate to other clients
- fall back to the existing OS-detected computer name when the setting is cleared
- keep web and mobile environment presentation in sync with the live server descriptor

## Why

T3 Connect environment names were derived from the host operating system with no supported override. Relay-managed machines, especially remote hosts, could not choose a useful display name from the host itself.

## Before / After

### Before

<img width="1060" alt="Connections settings before host naming" src="https://raw.githubusercontent.com/PixPMusic/t3code/pr-assets-connect-host-name/.pr-assets/connect-host-name-before-vector-v3.svg">

### After

<img width="1060" alt="Connections settings after setting a neutral host display name" src="https://raw.githubusercontent.com/PixPMusic/t3code/pr-assets-connect-host-name/.pr-assets/connect-host-name-after-vector-v3.svg">

The screenshots use an isolated test environment and the neutral example “Studio Mac”; no real machine hostname is shown.

## Verification

- `vp test run packages/contracts/src/settings.test.ts apps/server/src/environment/ServerEnvironment.test.ts packages/client-runtime/src/state/server.test.ts packages/client-runtime/src/relay/discovery.test.ts infra/relay/src/environments/EnvironmentConnector.test.ts infra/relay/src/environments/EnvironmentLinks.test.ts infra/relay/src/agentActivity/AgentActivityPublisher.test.ts infra/relay/src/agentActivity/MobileRegistrations.test.ts infra/relay/src/environments/EnvironmentLinker.test.ts infra/relay/src/http/Api.test.ts` — 105 tests passed
- `vp run --filter @t3tools/contracts --filter @t3tools/client-runtime --filter t3 --filter @t3tools/web --filter @t3tools/mobile --filter t3code-relay --concurrency-limit 2 typecheck`
- targeted formatting and lint for all changed files
- `git diff --check`
- isolated `test-t3-app` pass: verified the new row is absent on `main`, setting “Studio Mac” persists, and Connections renders the configured name without exposing the system hostname

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I added regression coverage
- [x] I included before/after UI evidence



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `environmentLabel` to `ServerSettings` and let hosts set their display name
> - Adds `environmentLabel` to `ServerSettings` and `ServerSettingsPatch` schemas in [settings.ts](https://github.com/pingdotgg/t3code/pull/4850/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), defaulting to an empty trimmed string so legacy configs decode unchanged.
> - `ServerEnvironment.getDescriptor` now reads the current configured label at runtime (no restart), and the new `getDescriptorForSettings` returns a descriptor snapshot for a given settings object in [ServerEnvironment.ts](https://github.com/pingdotgg/t3code/pull/4850/files#diff-28d9690cbe59a84cd86ea9e149972794d5eec454e166270a91c12f5b656ecfd6).
> - The `settingsUpdated` websocket event includes an `environment` descriptor in [ws.ts](https://github.com/pingdotgg/t3code/pull/4850/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125), and clients project it into config state in [server.ts](https://github.com/pingdotgg/t3code/pull/4850/files#diff-e89d2e49b487037c2e7108610cb27c1e8ad8800a8f2e66427f7e783a4fc1d428).
> - Web users with orchestration-operate scope can edit the "Host name" field in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/4850/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9); mobile and web presentation utils now prefer the server-reported label.
> - The relay persists label updates from verified health responses via `EnvironmentLinks.updateLabelForUser` in [EnvironmentConnector.ts](https://github.com/pingdotgg/t3code/pull/4850/files#diff-daaf372c559c827b12300f3a42993cf71f6255d8e5c4de83d2b45b08fc680e6f), and client discovery updates labels from status descriptors in [discovery.ts](https://github.com/pingdotgg/t3code/pull/4850/files#diff-369c203ffefe19f8f7f69500106593a7d8f82927adb2eb1ce564d30dcab3a6a8).
> - Behavioral Change: `ServerEnvironment.getDescriptor` now depends on `ServerSettings`; if settings cannot be read it logs a warning and falls back to `defaultDescriptor`. The `ServerConfigSettingsUpdatedPayload` schema gains an optional `environment` field that older clients will ignore.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ae38b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live server descriptors, WebSocket config events, and relay link persistence. Label updates are gated by verified health responses and a timestamp compare-and-set, but still change shared environment identity shown across clients.
> 
> **Overview**
> Hosts can now set a **Host name** in Settings → Connections. That override is stored as `environmentLabel` in server settings, applied live to the environment descriptor, and used as the default name for new manual connections. Clearing it falls back to the OS-detected computer name.
> 
> `settingsUpdated` WebSocket events now include the environment descriptor so web/mobile presentation tracks the live label without a restart. Relay health checks persist a renamed label onto the user’s environment link (`updateLabelForUser`) when the verified descriptor differs, so T3 Connect clients pick up the new name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ae38b7f11cc6f7c7e19b0bf439f603d353bbbe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->