### PR TITLE
fix(web): remember the rendered-markdown choice across threads

### DIFF
--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -685,14 +685,20 @@ export default function FilePreviewPanel({
   // Reading markdown rendered is a preference, not a property of one file. Keeping
   // it on the panel meant a thread switch dropped it and forced source back.
   const [renderMarkdownPreferred, setRenderMarkdownPreferred] = useState(initialRenderMarkdown);
-  const [revealHandledRequestId, setRevealHandledRequestId] = useState<number | null>(null);
+  // Paired with the path on purpose: each file surface counts its reveals from
+  // one, so a bare id would let a dismissed reveal on one file swallow the first
+  // reveal on the next.
+  const [handledReveal, setHandledReveal] = useState<{ path: string; requestId: number } | null>(
+    null,
+  );
   const breadcrumbRef = useRef<HTMLDivElement>(null);
   const isMarkdown = relativePath ? isMarkdownPreviewFile(relativePath) : false;
   // A reveal still wins over the preference: the line only exists in the source.
   const renderMarkdown =
     isMarkdown &&
     renderMarkdownPreferred &&
-    (revealLine === null || revealHandledRequestId === revealRequestId);
+    (revealLine === null ||
+      (handledReveal?.path === relativePath && handledReveal.requestId === revealRequestId));
   const canOpenInBrowser =
     relativePath !== null && isPreviewSupportedInRuntime() && isBrowserPreviewFile(relativePath);
   const absolutePath = relativePath ? resolvePathLinkTarget(relativePath, cwd) : null;
@@ -800,7 +806,11 @@ export default function FilePreviewPanel({
                     pressed={renderMarkdown}
                     onPressedChange={(pressed) => {
                       setRenderMarkdownPreferred(pressed);
-                      setRevealHandledRequestId(pressed ? revealRequestId : null);
+                      setHandledReveal(
+                        pressed && relativePath !== null
+                          ? { path: relativePath, requestId: revealRequestId }
+                          : null,
+                      );
                       try {
                         setLocalStorageItem(RENDER_MARKDOWN_STORAGE_KEY, pressed, Schema.Boolean);
                       } catch (error) {

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -79,6 +79,7 @@ interface FilePreviewPanelProps {
 }
 
 const FILE_EXPLORER_STORAGE_KEY = "t3code.fileExplorerOpen";
+const RENDER_MARKDOWN_STORAGE_KEY = "t3code.renderMarkdown";
 const FILE_SAVE_DEBOUNCE_MS = 500;
 const FILE_LINK_REVEAL_ATTRIBUTE = "data-file-link-reveal";
 const FILE_LINK_REVEAL_UNSAFE_CSS = `
@@ -645,6 +646,15 @@ function initialExplorerOpen(): boolean {
   }
 }
 
+function initialRenderMarkdown(): boolean {
+  try {
+    return getLocalStorageItem(RENDER_MARKDOWN_STORAGE_KEY, Schema.Boolean) ?? false;
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+}
+
 export default function FilePreviewPanel({
   environmentId,
   cwd,
@@ -672,16 +682,17 @@ export default function FilePreviewPanel({
   const isImage = relativePath !== null && isWorkspaceImagePreviewPath(relativePath);
   const file = useProjectFileQuery(environmentId, cwd, relativePath, !isImage);
   const [explorerOpen, setExplorerOpen] = useState(initialExplorerOpen);
-  const [markdownView, setMarkdownView] = useState<{
-    path: string | null;
-    revealRequestId: number | null;
-  }>({ path: null, revealRequestId: null });
+  // Reading markdown rendered is a preference, not a property of one file. Keeping
+  // it on the panel meant a thread switch dropped it and forced source back.
+  const [renderMarkdownPreferred, setRenderMarkdownPreferred] = useState(initialRenderMarkdown);
+  const [revealHandledRequestId, setRevealHandledRequestId] = useState<number | null>(null);
   const breadcrumbRef = useRef<HTMLDivElement>(null);
   const isMarkdown = relativePath ? isMarkdownPreviewFile(relativePath) : false;
+  // A reveal still wins over the preference: the line only exists in the source.
   const renderMarkdown =
     isMarkdown &&
-    markdownView.path === relativePath &&
-    (revealLine === null || markdownView.revealRequestId === revealRequestId);
+    renderMarkdownPreferred &&
+    (revealLine === null || revealHandledRequestId === revealRequestId);
   const canOpenInBrowser =
     relativePath !== null && isPreviewSupportedInRuntime() && isBrowserPreviewFile(relativePath);
   const absolutePath = relativePath ? resolvePathLinkTarget(relativePath, cwd) : null;
@@ -788,10 +799,13 @@ export default function FilePreviewPanel({
                     className="shrink-0"
                     pressed={renderMarkdown}
                     onPressedChange={(pressed) => {
-                      setMarkdownView({
-                        path: pressed ? relativePath : null,
-                        revealRequestId: pressed ? revealRequestId : null,
-                      });
+                      setRenderMarkdownPreferred(pressed);
+                      setRevealHandledRequestId(pressed ? revealRequestId : null);
+                      try {
+                        setLocalStorageItem(RENDER_MARKDOWN_STORAGE_KEY, pressed, Schema.Boolean);
+                      } catch (error) {
+                        console.error(error);
+                      }
                     }}
                     aria-label={renderMarkdown ? "Show markdown source" : "Show rendered markdown"}
                     variant="ghost"

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -22,7 +22,7 @@ import ChatMarkdown from "~/components/ChatMarkdown";
 import { OpenInPicker } from "~/components/chat/OpenInPicker";
 import { useClientSettings } from "~/hooks/useSettings";
 import { useTheme } from "~/hooks/useTheme";
-import { getLocalStorageItem, setLocalStorageItem } from "~/hooks/useLocalStorage";
+import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "~/hooks/useLocalStorage";
 import { resolveDiffThemeName } from "~/lib/diffRendering";
 import { cn } from "~/lib/utils";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
@@ -646,15 +646,6 @@ function initialExplorerOpen(): boolean {
   }
 }
 
-function initialRenderMarkdown(): boolean {
-  try {
-    return getLocalStorageItem(RENDER_MARKDOWN_STORAGE_KEY, Schema.Boolean) ?? false;
-  } catch (error) {
-    console.error(error);
-    return false;
-  }
-}
-
 export default function FilePreviewPanel({
   environmentId,
   cwd,
@@ -684,7 +675,11 @@ export default function FilePreviewPanel({
   const [explorerOpen, setExplorerOpen] = useState(initialExplorerOpen);
   // Reading markdown rendered is a preference, not a property of one file. Keeping
   // it on the panel meant a thread switch dropped it and forced source back.
-  const [renderMarkdownPreferred, setRenderMarkdownPreferred] = useState(initialRenderMarkdown);
+  const [renderMarkdownPreferred, setRenderMarkdownPreferred] = useLocalStorage(
+    RENDER_MARKDOWN_STORAGE_KEY,
+    false,
+    Schema.Boolean,
+  );
   // Paired with the path on purpose: each file surface counts its reveals from
   // one, so a bare id would let a dismissed reveal on one file swallow the first
   // reveal on the next.
@@ -811,11 +806,6 @@ export default function FilePreviewPanel({
                           ? { path: relativePath, requestId: revealRequestId }
                           : null,
                       );
-                      try {
-                        setLocalStorageItem(RENDER_MARKDOWN_STORAGE_KEY, pressed, Schema.Boolean);
-                      } catch (error) {
-                        console.error(error);
-                      }
                     }}
                     aria-label={renderMarkdown ? "Show markdown source" : "Show rendered markdown"}
                     variant="ghost"


### PR DESCRIPTION
## What Changed

The rendered-markdown choice in the file preview panel is now a persisted preference instead of panel state tied to one file path.

## Why

Reported in #4645. The state was:

```ts
const [markdownView, setMarkdownView] = useState<{ path: string | null; revealRequestId: number | null }>(...)
const renderMarkdown = isMarkdown && markdownView.path === relativePath && ...
```

It said "rendered is on for *this file*", so leaving the thread tore the panel down and returning showed source again. The reporter describes it as a preference — "once I've said I want to read markdown rendered, that's my preference until I toggle it back" — so it now persists the way this same panel already persists its explorer state (`FILE_EXPLORER_STORAGE_KEY` / `initialExplorerOpen`), rather than introducing a new mechanism or touching the settings schema.

A line reveal still wins over the preference, because a line only exists in the source. It no longer clears the preference on the way past, so toggling once returns you to rendered.

## Notes For Review

**A limitation worth knowing, which this PR does not change.** `rightPanelStore` keeps `revealLine` / `revealRequestId` as durable surface state and rehydrates them. So if the last thing you did with a file surface was jump to a line, returning to it still shows source: the stored reveal is indistinguishable, at mount, from a fresh one, and treating it as already handled would break the case the reveal exists for — clicking a line link while the panel is closed.

That is not a regression. Before this change, returning showed source in *every* case; now it shows source only in that one. Making it complete means letting the store consume a reveal once it has been applied, which changes shared surface semantics and its persistence, so it felt like a separate change rather than something to fold in here.

## Validation

Driven in a running client, on a markdown file whose own content links back to itself so the reveal path can be exercised:

| step | expected | observed |
| --- | --- | --- |
| Toggle rendered | preference stored | `t3code.renderMarkdown` = `true`, view rendered |
| Click a `README.md:9` link while rendered | source, line revealed | toggle flipped to source; preference still `true` |
| Toggle back | rendered | rendered |
| Leave the thread and return, no pending reveal | rendered | rendered — verified by the reporter |

The last row is the reported scenario. I could not reproduce it myself: the file explorer in my seeded fixture workspace lists no files, so I had no way to open a markdown file without going through a line link. It was checked by the reporter on a real project instead, and I am flagging that rather than implying I measured it.

- `vp run --filter @t3tools/web test` — 1663 passed
- `vp run --filter @t3tools/web typecheck` — no errors
- `vp lint` / `vp fmt --check` on the changed file — clean

Closes #4645.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual change beyond which of the two existing views is shown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI preference persistence in the file preview panel only; no auth, data, or API changes.
> 
> **Overview**
> Fixes #4645 by persisting the file preview **rendered markdown** toggle in `localStorage` (`t3code.renderMarkdown`) via `useLocalStorage`, matching how explorer open/close is already stored—not per-file panel state that reset when switching threads.
> 
> **Line reveals** still force **source** view (the line only exists there). A new `handledReveal` state pairs path with `revealRequestId` so a reveal handled on one file does not block reveals on another; toggling rendered again records the current reveal as handled without clearing the stored preference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3238bcb4f5763aa4568d9290f02b7b6711ae62ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist rendered-markdown toggle choice across threads in `FilePreviewPanel`
> - Replaces the local `markdownView` state with a `useLocalStorage`-backed preference keyed at `t3code.renderMarkdown`, so the toggle choice survives navigation between threads and files.
> - When a line reveal is active for a file and hasn't been marked as handled for that path/requestId, the panel forces source view regardless of the stored preference.
> - Toggling to rendered markdown records the current file path and requestId as handled, preventing the reveal logic from overriding the preference again for the same request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3238bcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->