### PR TITLE
fix(git): disable external diff for review diff previews

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2001,7 +2001,18 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         executeGit(
           "GitVcsDriver.readUntrackedReviewDiffs.diff",
           cwd,
-          ["diff", "--no-index", "--patch", "--minimal", "--", "/dev/null", relativePath],
+          [
+            "diff",
+            "--no-index",
+            "--patch",
+            "--no-color",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--minimal",
+            "--",
+            "/dev/null",
+            relativePath,
+          ],
           {
             allowNonZeroExit: true,
             maxOutputBytes: REVIEW_UNTRACKED_DIFF_MAX_OUTPUT_BYTES,
@@ -2046,6 +2057,9 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       [
         "diff",
         "--patch",
+        "--no-color",
+        "--no-ext-diff",
+        "--no-textconv",
         "--minimal",
         ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
         "HEAD",
@@ -2079,6 +2093,9 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             [
               "diff",
               "--patch",
+              "--no-color",
+              "--no-ext-diff",
+              "--no-textconv",
               "--minimal",
               ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
               `${baseRef}...HEAD`,


### PR DESCRIPTION
## What Changed

Added `--no-color --no-ext-diff --no-textconv` to the three `git diff` invocations in
`getReviewDiffPreview` (`apps/server/src/vcs/GitVcsDriverCore.ts`):

- `getReviewDiffPreview.dirtyTracked` — the Diff panel's **Working tree** scope
- `getReviewDiffPreview.base` — the Diff panel's **Branch** scope (`base...HEAD`)
- `readUntrackedReviewDiffs.diff` — untracked files, via `--no-index`

Flags are inline at each call site, matching the checkpoint diff in `GitVcsDriver.ts` and the
guidance from #1092 (no shared helper).

## Why

When a user has `diff.external` configured, `git diff` delegates to that tool and stops emitting a
unified patch, so `parsePatchFiles` can't read it and the panel falls back to
"Unsupported diff format. Showing raw patch." That's #927.

**#927 has already been fixed twice, each time for a different set of call sites, and the review
diff preview was in neither.** The flag reached the codebase piecemeal:

| Call site | Fixed by |
|---|---|
| `checkpoints.diffCheckpoints` | 5165b8c3 (#2586) — incidentally, in a perf PR |
| `prepareCommitContext.stagedPatch` | 7db03490 (#2553) — the fix that closed #927 |
| `readRangeContext.diffPatch` | 7db03490 (#2553) |
| `getReviewDiffPreview.dirtyTracked` | **still broken** |
| `getReviewDiffPreview.base` | **still broken** |
| `readUntrackedReviewDiffs.diff` | **still broken** |

The three remaining ones aren't new code — they landed in b3e8c03 (#2013) on May 29, two weeks
before #2553 — they just weren't in that PR's scope. #2352 and #1092 proposed fixes too, and their
call-site lists didn't include them either. So #927 is closed, and the two scopes users actually
look at in the Diff panel still route through the external tool.

Repro, with any external diff driver (`git config --global diff.external difft`): open the Diff
panel, switch to Working tree or Branch, and it renders raw tool output instead of a diff. Same
patch fed to `parsePatchFiles` parses to 0 files with the external driver and 1 file with
`--no-ext-diff`.

## Validation

- `vp test run apps/server/src/vcs/GitVcsDriverCore.test.ts` — 38 passed
- `tsgo --noEmit` in `apps/server` — clean
- Manual repro above, in a scratch repo with `diff.external` set

No new regression test here, matching #2553.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to git CLI flags on review preview paths; behavior only shifts when users have external diff or textconv configured, and aligns with existing fixed call sites.
> 
> **Overview**
> Adds **`--no-color`**, **`--no-ext-diff`**, and **`--no-textconv`** to the three `git diff` paths that feed the Diff panel review preview in `GitVcsDriverCore.ts`, matching flags already used on checkpoint, commit, and range diff calls.
> 
> **Working tree** (`getReviewDiffPreview.dirtyTracked`), **branch range** (`getReviewDiffPreview.base`), and **untracked** (`readUntrackedReviewDiffs` via `--no-index`) now always emit a unified patch Git can parse instead of delegating to `diff.external`, which had left the panel on “Unsupported diff format” for those scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5324f6a8c9a9b0985936a17cbe1d1b0bbe3ef535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable external diff, textconv, and color in `GitVcsDriver` review diff previews
> Adds `--no-ext-diff`, `--no-textconv`, and `--no-color` flags to all three `git diff` invocations in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/4854/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) — untracked files, dirty tracked changes, and base comparisons. This ensures raw git output is used instead of any user-configured external diff or textconv drivers.
>
> Behavioral Change: repositories with external diff tools or textconv filters configured will now see different patch output in review diff previews.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5324f6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->