### PR TITLE
fix(server): update Codex through its CLI

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -44,7 +44,8 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
-  makeSelfUpdatingProviderMaintenanceResolver,
+  makeProviderMaintenanceCapabilities,
+  type ProviderMaintenanceCapabilitiesResolver,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
@@ -60,14 +61,17 @@ import {
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("codex");
-const UPDATE = makeSelfUpdatingProviderMaintenanceResolver({
-  provider: DRIVER_KIND,
-  packageName: "@openai/codex",
-  executable: "codex",
-  args: ["update"],
-  lockKey: "codex-self-update",
-  minimumVersion: "0.126.0",
-});
+const UPDATE: ProviderMaintenanceCapabilitiesResolver = {
+  resolve: (options) =>
+    makeProviderMaintenanceCapabilities({
+      provider: DRIVER_KIND,
+      packageName: "@openai/codex",
+      updateExecutable: options?.binaryPath?.trim() || "codex",
+      updateArgs: ["update"],
+      updateLockKey: "codex-self-update",
+      updateMinimumVersion: "0.126.0",
+    }),
+};
 
 /**
  * Services the driver needs to materialize an instance. Surfaced as the

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -68,6 +68,7 @@ const UPDATE: ProviderMaintenanceCapabilitiesResolver = {
       packageName: "@openai/codex",
       updateExecutable: options?.binaryPath?.trim() || "codex",
       updateArgs: ["update"],
+      ...(options?.env ? { updateEnv: options.env } : {}),
       updateLockKey: "codex-self-update",
       updateMinimumVersion: "0.126.0",
     }),

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -44,7 +44,7 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
-  makePackageManagedProviderMaintenanceResolver,
+  makeSelfUpdatingProviderMaintenanceResolver,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
@@ -60,11 +60,13 @@ import {
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("codex");
-const UPDATE = makePackageManagedProviderMaintenanceResolver({
+const UPDATE = makeSelfUpdatingProviderMaintenanceResolver({
   provider: DRIVER_KIND,
-  npmPackageName: "@openai/codex",
-  homebrewFormula: "codex",
-  nativeUpdate: null,
+  packageName: "@openai/codex",
+  executable: "codex",
+  args: ["update"],
+  lockKey: "codex-self-update",
+  minimumVersion: "0.126.0",
 });
 
 /**

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -14,7 +14,6 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   makePackageManagedProviderMaintenanceResolver,
   makeProviderMaintenanceCapabilities,
-  makeSelfUpdatingProviderMaintenanceResolver,
   makeStaticProviderMaintenanceResolver,
   normalizeCommandPath,
   ProviderVersionCache,
@@ -69,14 +68,16 @@ const staticToolUpdate = makeStaticProviderMaintenanceResolver(
     updateLockKey: "static-tool",
   }),
 );
-const selfUpdatingTool = makeSelfUpdatingProviderMaintenanceResolver({
-  provider: driver("selfUpdatingTool"),
-  packageName: "@example/self-updating-tool",
-  executable: "self-updating-tool",
-  args: ["update"],
-  lockKey: "self-updating-tool",
-  minimumVersion: "2.0.0",
-});
+const selfUpdatingTool = makeStaticProviderMaintenanceResolver(
+  makeProviderMaintenanceCapabilities({
+    provider: driver("selfUpdatingTool"),
+    packageName: "@example/self-updating-tool",
+    updateExecutable: "self-updating-tool",
+    updateArgs: ["update"],
+    updateLockKey: "self-updating-tool",
+    updateMinimumVersion: "2.0.0",
+  }),
+);
 const installedPackageToolProvider: ServerProvider = {
   instanceId: ProviderInstanceId.make("packageTool"),
   driver: driver("packageTool"),
@@ -203,25 +204,6 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         args: ["update"],
 
         lockKey: "static-tool",
-      },
-    });
-  });
-
-  it("uses the resolved provider binary for self-updates", () => {
-    expect(
-      selfUpdatingTool.resolve({
-        binaryPath: "self-updating-tool",
-        resolvedCommandPath: "/opt/tools/self-updating-tool",
-      }),
-    ).toEqual({
-      provider: driver("selfUpdatingTool"),
-      packageName: "@example/self-updating-tool",
-      update: {
-        command: "/opt/tools/self-updating-tool update",
-        executable: "/opt/tools/self-updating-tool",
-        args: ["update"],
-        lockKey: "self-updating-tool",
-        minimumVersion: "2.0.0",
       },
     });
   });

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -14,6 +14,7 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   makePackageManagedProviderMaintenanceResolver,
   makeProviderMaintenanceCapabilities,
+  makeSelfUpdatingProviderMaintenanceResolver,
   makeStaticProviderMaintenanceResolver,
   normalizeCommandPath,
   ProviderVersionCache,
@@ -68,6 +69,14 @@ const staticToolUpdate = makeStaticProviderMaintenanceResolver(
     updateLockKey: "static-tool",
   }),
 );
+const selfUpdatingTool = makeSelfUpdatingProviderMaintenanceResolver({
+  provider: driver("selfUpdatingTool"),
+  packageName: "@example/self-updating-tool",
+  executable: "self-updating-tool",
+  args: ["update"],
+  lockKey: "self-updating-tool",
+  minimumVersion: "2.0.0",
+});
 const installedPackageToolProvider: ServerProvider = {
   instanceId: ProviderInstanceId.make("packageTool"),
   driver: driver("packageTool"),
@@ -195,6 +204,56 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
 
         lockKey: "static-tool",
       },
+    });
+  });
+
+  it("uses the resolved provider binary for self-updates", () => {
+    expect(
+      selfUpdatingTool.resolve({
+        binaryPath: "self-updating-tool",
+        resolvedCommandPath: "/opt/tools/self-updating-tool",
+      }),
+    ).toEqual({
+      provider: driver("selfUpdatingTool"),
+      packageName: "@example/self-updating-tool",
+      update: {
+        command: "/opt/tools/self-updating-tool update",
+        executable: "/opt/tools/self-updating-tool",
+        args: ["update"],
+        lockKey: "self-updating-tool",
+        minimumVersion: "2.0.0",
+      },
+    });
+  });
+
+  it("keeps self-update guidance manual below the supported provider version", () => {
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("selfUpdatingTool"),
+        currentVersion: "1.9.9",
+        latestVersion: "2.1.0",
+        maintenanceCapabilities: selfUpdatingTool.resolve(),
+      }),
+    ).toMatchObject({
+      status: "behind_latest",
+      updateCommand: null,
+      canUpdate: false,
+      message: "Update this provider manually, then refresh provider status.",
+    });
+  });
+
+  it("enables self-updates at the minimum supported provider version", () => {
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("selfUpdatingTool"),
+        currentVersion: "2.0.0",
+        latestVersion: "2.1.0",
+        maintenanceCapabilities: selfUpdatingTool.resolve(),
+      }),
+    ).toMatchObject({
+      status: "behind_latest",
+      updateCommand: "self-updating-tool update",
+      canUpdate: true,
     });
   });
 

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -239,6 +239,20 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  it("keeps self-update guidance manual when the provider version is not semver", () => {
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("selfUpdatingTool"),
+        currentVersion: "unknown",
+        latestVersion: "2.1.0",
+        maintenanceCapabilities: selfUpdatingTool.resolve(),
+      }),
+    ).toMatchObject({
+      updateCommand: null,
+      canUpdate: false,
+    });
+  });
+
   it.effect(
     "switches package-managed providers to vite-plus updates when the resolved binary lives in vite-plus global bin",
     () =>

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -3,7 +3,7 @@ import {
   type ServerProvider,
   type ServerProviderVersionAdvisory,
 } from "@t3tools/contracts";
-import { compareSemverVersions } from "@t3tools/shared/semver";
+import { compareSemverVersions, parseSemver } from "@t3tools/shared/semver";
 import { resolveCommandPath } from "@t3tools/shared/shell";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
@@ -47,6 +47,7 @@ export interface ProviderMaintenanceCommandAction {
   readonly command: string;
   readonly executable: string;
   readonly args: ReadonlyArray<string>;
+  readonly env?: NodeJS.ProcessEnv;
   readonly lockKey: string;
   readonly minimumVersion?: string;
 }
@@ -100,6 +101,7 @@ export function makeProviderMaintenanceCapabilities(input: {
   readonly packageName: string | null;
   readonly updateExecutable: string | null;
   readonly updateArgs: ReadonlyArray<string>;
+  readonly updateEnv?: NodeJS.ProcessEnv;
   readonly updateLockKey: string | null;
   readonly updateMinimumVersion?: string;
 }): ProviderMaintenanceCapabilities {
@@ -110,6 +112,7 @@ export function makeProviderMaintenanceCapabilities(input: {
           command: [input.updateExecutable, ...input.updateArgs].join(" "),
           executable: input.updateExecutable,
           args: input.updateArgs,
+          ...(input.updateEnv ? { env: input.updateEnv } : {}),
           lockKey: input.updateLockKey,
           ...(input.updateMinimumVersion ? { minimumVersion: input.updateMinimumVersion } : {}),
         };
@@ -438,11 +441,10 @@ export function canRunProviderMaintenanceUpdate(
   if (!update.minimumVersion) {
     return true;
   }
-  return (
-    currentVersion !== null &&
-    currentVersion !== undefined &&
-    compareSemverVersions(currentVersion, update.minimumVersion) >= 0
-  );
+  if (!currentVersion || !parseSemver(currentVersion) || !parseSemver(update.minimumVersion)) {
+    return false;
+  }
+  return compareSemverVersions(currentVersion, update.minimumVersion) >= 0;
 }
 
 const fetchNpmLatestVersion = Effect.fn("fetchNpmLatestVersion")(function* (packageName: string) {

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -120,30 +120,6 @@ export function makeProviderMaintenanceCapabilities(input: {
   };
 }
 
-export function makeSelfUpdatingProviderMaintenanceResolver(input: {
-  readonly provider: ProviderDriverKind;
-  readonly packageName: string | null;
-  readonly executable: string;
-  readonly args: ReadonlyArray<string>;
-  readonly lockKey: string;
-  readonly minimumVersion?: string;
-}): ProviderMaintenanceCapabilitiesResolver {
-  return {
-    resolve: (options) =>
-      makeProviderMaintenanceCapabilities({
-        provider: input.provider,
-        packageName: input.packageName,
-        updateExecutable:
-          nonEmptyString(options?.resolvedCommandPath) ??
-          nonEmptyString(options?.binaryPath) ??
-          input.executable,
-        updateArgs: input.args,
-        updateLockKey: input.lockKey,
-        ...(input.minimumVersion ? { updateMinimumVersion: input.minimumVersion } : {}),
-      }),
-  };
-}
-
 export function makeManualOnlyProviderMaintenanceCapabilities(input: {
   readonly provider: ProviderDriverKind;
   readonly packageName: string | null;

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -48,6 +48,7 @@ export interface ProviderMaintenanceCommandAction {
   readonly executable: string;
   readonly args: ReadonlyArray<string>;
   readonly lockKey: string;
+  readonly minimumVersion?: string;
 }
 
 export interface ProviderMaintenanceCapabilityResolutionOptions {
@@ -100,6 +101,7 @@ export function makeProviderMaintenanceCapabilities(input: {
   readonly updateExecutable: string | null;
   readonly updateArgs: ReadonlyArray<string>;
   readonly updateLockKey: string | null;
+  readonly updateMinimumVersion?: string;
 }): ProviderMaintenanceCapabilities {
   const update =
     input.updateExecutable === null || input.updateLockKey === null
@@ -109,11 +111,36 @@ export function makeProviderMaintenanceCapabilities(input: {
           executable: input.updateExecutable,
           args: input.updateArgs,
           lockKey: input.updateLockKey,
+          ...(input.updateMinimumVersion ? { minimumVersion: input.updateMinimumVersion } : {}),
         };
   return {
     provider: input.provider,
     packageName: input.packageName,
     update,
+  };
+}
+
+export function makeSelfUpdatingProviderMaintenanceResolver(input: {
+  readonly provider: ProviderDriverKind;
+  readonly packageName: string | null;
+  readonly executable: string;
+  readonly args: ReadonlyArray<string>;
+  readonly lockKey: string;
+  readonly minimumVersion?: string;
+}): ProviderMaintenanceCapabilitiesResolver {
+  return {
+    resolve: (options) =>
+      makeProviderMaintenanceCapabilities({
+        provider: input.provider,
+        packageName: input.packageName,
+        updateExecutable:
+          nonEmptyString(options?.resolvedCommandPath) ??
+          nonEmptyString(options?.binaryPath) ??
+          input.executable,
+        updateArgs: input.args,
+        updateLockKey: input.lockKey,
+        ...(input.minimumVersion ? { updateMinimumVersion: input.minimumVersion } : {}),
+      }),
   };
 }
 
@@ -408,16 +435,38 @@ export function createProviderVersionAdvisory(input: {
     currentVersion: input.currentVersion,
     latestVersion,
   });
+  const canUpdate = canRunProviderMaintenanceUpdate(capabilities, input.currentVersion);
 
   return {
     status: advisory.status,
     currentVersion: input.currentVersion,
     latestVersion,
-    updateCommand: capabilities.update?.command ?? null,
-    canUpdate: capabilities.update !== null,
+    updateCommand: canUpdate ? (capabilities.update?.command ?? null) : null,
+    canUpdate,
     checkedAt: input.checkedAt ?? null,
-    message: advisory.message,
+    message:
+      advisory.status === "behind_latest" && !canUpdate
+        ? "Update this provider manually, then refresh provider status."
+        : advisory.message,
   };
+}
+
+export function canRunProviderMaintenanceUpdate(
+  maintenanceCapabilities: ProviderMaintenanceCapabilities,
+  currentVersion: string | null | undefined,
+): boolean {
+  const update = maintenanceCapabilities.update;
+  if (!update) {
+    return false;
+  }
+  if (!update.minimumVersion) {
+    return true;
+  }
+  return (
+    currentVersion !== null &&
+    currentVersion !== undefined &&
+    compareSemverVersions(currentVersion, update.minimumVersion) >= 0
+  );
 }
 
 const fetchNpmLatestVersion = Effect.fn("fetchNpmLatestVersion")(function* (packageName: string) {

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -129,6 +129,10 @@ function mockSpawnerLayer(
   handler: (
     command: string,
     args: ReadonlyArray<string>,
+    options: {
+      readonly env?: Record<string, string | undefined>;
+      readonly extendEnv?: boolean;
+    },
   ) => {
     readonly stdout?: string;
     readonly stderr?: string;
@@ -142,8 +146,14 @@ function mockSpawnerLayer(
       const childProcess = command as unknown as {
         readonly command: string;
         readonly args: ReadonlyArray<string>;
+        readonly options: {
+          readonly env?: Record<string, string | undefined>;
+          readonly extendEnv?: boolean;
+        };
       };
-      return Effect.succeed(mockHandle(handler(childProcess.command, childProcess.args)));
+      return Effect.succeed(
+        mockHandle(handler(childProcess.command, childProcess.args, childProcess.options)),
+      );
     }),
   );
 }
@@ -334,6 +344,66 @@ describe("providerMaintenanceRunner", () => {
           latestVersionHttpClient("0.126.0"),
           mockSpawnerLayer((command, args) => {
             calls.push({ command, args });
+            return { stdout: "updated" };
+          }),
+        ),
+      ),
+    );
+  });
+
+  it.effect("preserves the provider environment when running a self-update", () => {
+    const calls: Array<{
+      command: string;
+      args: ReadonlyArray<string>;
+      env: Record<string, string | undefined> | undefined;
+      extendEnv: boolean | undefined;
+    }> = [];
+    const updateEnv = {
+      PATH: "/custom/codex/bin",
+      CODEX_HOME: "/custom/codex/home",
+    };
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry({
+        ...baseProvider,
+        version: "0.126.0",
+      });
+      const updater = yield* makeTestRunner({
+        ...registry,
+        getProviderMaintenanceCapabilitiesForInstance: () =>
+          Effect.succeed(
+            makeProviderMaintenanceCapabilities({
+              provider: CODEX_DRIVER,
+              packageName: "@openai/codex",
+              updateExecutable: "codex",
+              updateArgs: ["update"],
+              updateEnv,
+              updateLockKey: "codex-self-update",
+              updateMinimumVersion: "0.126.0",
+            }),
+          ),
+      });
+
+      yield* updater.updateProvider(CODEX_DRIVER);
+      assert.deepStrictEqual(calls, [
+        {
+          command: "codex",
+          args: ["update"],
+          env: updateEnv,
+          extendEnv: true,
+        },
+      ]);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.126.0"),
+          mockSpawnerLayer((command, args, options) => {
+            calls.push({
+              command,
+              args,
+              env: options.env,
+              extendEnv: options.extendEnv,
+            });
             return { stdout: "updated" };
           }),
         ),

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -299,6 +299,48 @@ describe("providerMaintenanceRunner", () => {
     );
   });
 
+  it.effect("requires manual updates below a provider self-update minimum version", () => {
+    const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry({
+        ...baseProvider,
+        version: "0.125.0",
+      });
+      const updater = yield* makeTestRunner({
+        ...registry,
+        getProviderMaintenanceCapabilitiesForInstance: () =>
+          Effect.succeed(
+            makeProviderMaintenanceCapabilities({
+              provider: CODEX_DRIVER,
+              packageName: "@openai/codex",
+              updateExecutable: "codex",
+              updateArgs: ["update"],
+              updateLockKey: "codex-self-update",
+              updateMinimumVersion: "0.126.0",
+            }),
+          ),
+      });
+
+      const exit = yield* updater.updateProvider(CODEX_DRIVER).pipe(Effect.exit);
+      assert(Exit.isFailure(exit));
+      const error = Cause.squash(exit.cause);
+      assert(isServerProviderUpdateError(error));
+      assert.strictEqual(error.reason, "This installed provider version must be updated manually.");
+      assert.deepStrictEqual(calls, []);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.126.0"),
+          mockSpawnerLayer((command, args) => {
+            calls.push({ command, args });
+            return { stdout: "updated" };
+          }),
+        ),
+      ),
+    );
+  });
+
   it.effect(
     "runs update commands through Effect ChildProcess when no test runner is injected",
     () => {

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -76,6 +76,7 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
     readonly spawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
     readonly command: string;
     readonly args: ReadonlyArray<string>;
+    readonly env?: NodeJS.ProcessEnv;
   }) {
     const collectCommandResult = Effect.fn("ProviderMaintenanceRunner.collectCommandResult")(
       function* () {
@@ -84,9 +85,18 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
         // which a bare ChildProcess.spawn cannot launch (spawn npm ENOENT);
         // resolveSpawnCommand finds the real `.cmd` and routes it through the
         // shell. On Linux/macOS (incl. the WSL backend) this is a no-op.
-        const resolved = yield* resolveSpawnCommand(input.command, input.args);
+        const resolved = yield* resolveSpawnCommand(
+          input.command,
+          input.args,
+          input.env ? { env: input.env, extendEnv: true } : {},
+        );
         const child = yield* input.spawner
-          .spawn(ChildProcess.make(resolved.command, resolved.args, { shell: resolved.shell }))
+          .spawn(
+            ChildProcess.make(resolved.command, resolved.args, {
+              ...(input.env ? { env: input.env, extendEnv: true } : {}),
+              shell: resolved.shell,
+            }),
+          )
           .pipe(
             Effect.mapError(
               (cause) =>
@@ -204,11 +214,16 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
   const providerRegistry = yield* ProviderRegistry;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
-  const runMaintenanceCommand = (command: string, args: ReadonlyArray<string>) =>
+  const runMaintenanceCommand = (
+    command: string,
+    args: ReadonlyArray<string>,
+    env?: NodeJS.ProcessEnv,
+  ) =>
     runProviderMaintenanceCommandWithSpawner({
       spawner,
       command,
       args,
+      ...(env ? { env } : {}),
     });
   const commandCoordinator = yield* makeProviderMaintenanceCommandCoordinator({
     makeAlreadyRunningError: () =>
@@ -351,7 +366,7 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
               }),
             );
 
-            const result = yield* runMaintenanceCommand(update.executable, update.args);
+            const result = yield* runMaintenanceCommand(update.executable, update.args, update.env);
             const finishedAt = yield* nowIso;
             if (result.timedOut || result.exitCode !== 0) {
               return yield* finish(

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -23,7 +23,10 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { ProviderRegistry } from "./Services/ProviderRegistry.ts";
 import { makeProviderMaintenanceCommandCoordinator } from "./providerMaintenanceCommandCoordinator.ts";
-import { enrichProviderSnapshotWithVersionAdvisory } from "./providerMaintenance.ts";
+import {
+  canRunProviderMaintenanceUpdate,
+  enrichProviderSnapshotWithVersionAdvisory,
+} from "./providerMaintenance.ts";
 import type { ProviderMaintenanceCapabilities } from "./providerMaintenance.ts";
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
 const isServerProviderUpdateError = Schema.is(ServerProviderUpdateError);
@@ -302,6 +305,15 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
       return yield* new ServerProviderUpdateError({
         provider,
         reason: "This provider does not support one-click updates.",
+      });
+    }
+    const currentProvider = (yield* providerRegistry.getProviders).find(
+      (candidate) => candidate.driver === provider && candidate.instanceId === instanceId,
+    );
+    if (!canRunProviderMaintenanceUpdate(capabilities, currentProvider?.version)) {
+      return yield* new ServerProviderUpdateError({
+        provider,
+        reason: "This installed provider version must be updated manually.",
       });
     }
 


### PR DESCRIPTION
## What Changed

- Use the configured Codex binary’s `update` command.
- Limited one-click updates to Codex 0.126.0 (released April) and newer.
- Older or unknown Codex versions now show manual-update guidance.
- Added server-side enforcement so the update RPC cannot bypass the version requirement.

## Why

Support updating codex when installed with install.sh script.
Previously T3 would install an additional version of codex.

Versions before 0.126.0 do not support the update subcommand and may interpret `update` as an interactive prompt, so those versions remain manual-only.

Verification:

- 31 focused provider-maintenance tests pass.
- Targeted lint passes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes; screenshots are not applicable
- [x] No animation or interaction changes; video is not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider update execution and RPC eligibility for Codex; incorrect version gating or env handling could block valid updates or run the wrong binary, but scope is limited to maintenance paths with added tests.
> 
> **Overview**
> Codex maintenance no longer routes through package-manager global installs; it runs the **configured Codex binary** with `codex update`, using the instance **environment** when spawning the update process.
> 
> Provider maintenance now supports an optional **minimum installed version** for self-updates. Version advisories hide the one-click command and show manual-update guidance when the installed version is below that threshold (or not valid semver). The update RPC enforces the same rule via `canRunProviderMaintenanceUpdate`, so clients cannot bypass the gate.
> 
> Codex is wired with `updateMinimumVersion: "0.126.0"` because older Codex builds do not support the `update` subcommand reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69fe6105b14dab792ac1683ae457daeee52991d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex self-update to enforce minimum version `0.126.0` and pass through environment
> - [CodexDriver](https://github.com/pingdotgg/t3code/pull/4857/files#diff-c705233bf69322a30e4a04be3428cd51dc6fa014d5a03b852da94c6ab9b6ae35) now declares self-update capabilities using `makeProviderMaintenanceCapabilities` with `packageName '@openai/codex'`, `updateArgs ['update']`, and `updateMinimumVersion '0.126.0'`.
> - `createProviderVersionAdvisory` in [providerMaintenance.ts](https://github.com/pingdotgg/t3code/pull/4857/files#diff-e29fae218a488cafd27faaeea37f0b7c1dccd03ba4a994975736ddf89e3bde14) sets `canUpdate=false` and suppresses the update command when the installed version is below the declared minimum or is not valid semver, instead showing a manual update message.
> - [providerMaintenanceRunner.ts](https://github.com/pingdotgg/t3code/pull/4857/files#diff-53af42bf8411ec1355506cb2396e258735619c36076bec3d8d708d8b697275dc) guards `updateProvider` with `canRunProviderMaintenanceUpdate` and returns a `ServerProviderUpdateError` with reason `'This installed provider version must be updated manually.'` when the version check fails.
> - Update commands now forward `update.env` to the spawned process with `extendEnv=true` so the provider environment is preserved during self-update.
> - Behavioral Change: providers below their declared minimum version will no longer surface a one-click update command and will require a manual update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69fe610.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->