### PR TITLE
Persist assistant image attachments in chat

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -220,6 +220,8 @@ describe("ProviderRuntimeIngestion", () => {
 
   async function createHarness(options?: { serverSettings?: Partial<ServerSettings> }) {
     const workspaceRoot = makeTempDir("t3-provider-project-");
+    const serverBaseDir = makeTempDir("t3-provider-server-");
+    const attachmentsDir = NodePath.join(serverBaseDir, "userdata", "attachments");
     NodeFS.mkdirSync(NodePath.join(workspaceRoot, ".git"));
     const provider = createProviderServiceHarness();
     const orchestrationLayer = OrchestrationEngineLive.pipe(
@@ -240,7 +242,7 @@ describe("ProviderRuntimeIngestion", () => {
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
       Layer.provideMerge(makeTestServerSettingsLayer(options?.serverSettings)),
-      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), serverBaseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);
@@ -316,6 +318,7 @@ describe("ProviderRuntimeIngestion", () => {
       emit: provider.emit,
       setProviderSession: provider.setSession,
       drain,
+      attachmentsDir,
     };
   }
 
@@ -359,6 +362,93 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(thread.session?.status).toBe("error");
     expect(thread.session?.lastError).toBe("turn failed");
+  });
+
+  it("persists completed image views as assistant message attachments", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const sourceDir = makeTempDir("t3-provider-assistant-image-");
+    const sourcePath = NodePath.join(sourceDir, "filter-manager.png");
+    NodeFS.writeFileSync(sourcePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    const turnId = asTurnId("turn-assistant-image");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-assistant-image"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      turnId,
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-image-completed-assistant-image"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: "2026-01-01T00:00:01.000Z",
+      turnId,
+      itemId: asItemId("item-image-assistant-image"),
+      payload: {
+        itemType: "image_view",
+        status: "completed",
+        detail: sourcePath,
+        data: {
+          item: {
+            type: "imageView",
+            path: sourcePath,
+          },
+        },
+      },
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-assistant-image"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: "2026-01-01T00:00:02.000Z",
+      turnId,
+      itemId: asItemId("item-message-assistant-image"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "Screenshot attached.",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-message-completed-assistant-image"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: "2026-01-01T00:00:03.000Z",
+      turnId,
+      itemId: asItemId("item-message-assistant-image"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message) =>
+          message.role === "assistant" &&
+          message.text === "Screenshot attached." &&
+          message.attachments?.length === 1 &&
+          message.attachments[0]?.name === "filter-manager.png",
+      ),
+    );
+    const message = thread.messages.find(
+      (entry) => entry.role === "assistant" && entry.text === "Screenshot attached.",
+    );
+    const attachment = message?.attachments?.[0];
+    expect(attachment).toMatchObject({
+      type: "image",
+      name: "filter-manager.png",
+      mimeType: "image/png",
+      sizeBytes: 4,
+    });
+    expect(attachment).toBeDefined();
+    expect(
+      NodeFS.readFileSync(NodePath.join(harness.attachmentsDir, `${attachment!.id}.png`)),
+    ).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
   });
 
   it("applies provider session.state.changed transitions directly", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1,5 +1,6 @@
 import {
   ApprovalRequestId,
+  type ChatAttachment,
   type AssistantDeliveryMode,
   CommandId,
   MessageId,
@@ -16,17 +17,23 @@ import {
   type OrchestrationThread,
   type OrchestrationThreadActivity,
   type ProviderRuntimeEvent,
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
+import { createAttachmentId, resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import { IMAGE_EXTENSION_BY_MIME_TYPE, SAFE_IMAGE_FILE_EXTENSIONS } from "../../imageMime.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
@@ -122,6 +129,32 @@ function sameId(left: string | null | undefined, right: string | null | undefine
     return false;
   }
   return left === right;
+}
+
+const IMAGE_MIME_TYPE_BY_EXTENSION = new Map<string, string>();
+for (const [mimeType, extension] of Object.entries(IMAGE_EXTENSION_BY_MIME_TYPE)) {
+  if (!IMAGE_MIME_TYPE_BY_EXTENSION.has(extension)) {
+    IMAGE_MIME_TYPE_BY_EXTENSION.set(extension, mimeType);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function resolveImageViewPath(event: ProviderRuntimeEvent): string | undefined {
+  if (event.type !== "item.completed" || event.payload.itemType !== "image_view") {
+    return undefined;
+  }
+  const data = isRecord(event.payload.data) ? event.payload.data : undefined;
+  const item = data && isRecord(data.item) ? data.item : undefined;
+  const candidates = [item?.path, data?.path, event.payload.detail];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue;
+    const trimmed = candidate.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return undefined;
 }
 
 function hasAssistantMessageForTurn(
@@ -688,10 +721,13 @@ export function runtimeEventToActivities(
 
 const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
+  const fileSystem = yield* FileSystem.FileSystem;
   const orchestrationEngine = yield* OrchestrationEngineService;
+  const path = yield* Path.Path;
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const providerService = yield* ProviderService;
   const projectionTurnRepository = yield* ProjectionTurnRepository;
+  const serverConfig = yield* ServerConfig;
   const serverSettingsService = yield* ServerSettingsService;
   const providerCommandId = (event: ProviderRuntimeEvent, tag: string) =>
     crypto.randomUUIDv4.pipe(
@@ -937,6 +973,57 @@ const make = Effect.gen(function* () {
 
   const clearAssistantMessageState = (messageId: MessageId) =>
     clearBufferedAssistantText(messageId);
+
+  const persistAssistantImageAttachment = Effect.fn("persistAssistantImageAttachment")(function* (
+    event: ProviderRuntimeEvent,
+    threadId: ThreadId,
+  ) {
+    const sourcePath = resolveImageViewPath(event);
+    if (!sourcePath || !path.isAbsolute(sourcePath)) {
+      return undefined;
+    }
+
+    const extension = path.extname(sourcePath).toLowerCase();
+    if (!SAFE_IMAGE_FILE_EXTENSIONS.has(extension)) {
+      return undefined;
+    }
+
+    const fileInfo = yield* fileSystem.stat(sourcePath).pipe(Effect.orElseSucceed(() => null));
+    const sizeBytes = fileInfo ? Number(fileInfo.size) : 0;
+    if (
+      !fileInfo ||
+      fileInfo.type !== "File" ||
+      !Number.isSafeInteger(sizeBytes) ||
+      sizeBytes <= 0 ||
+      sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
+    ) {
+      return undefined;
+    }
+
+    const mimeType = IMAGE_MIME_TYPE_BY_EXTENSION.get(extension);
+    const attachmentId = createAttachmentId(threadId);
+    if (!mimeType || !attachmentId) {
+      return undefined;
+    }
+
+    const attachment = {
+      type: "image" as const,
+      id: attachmentId,
+      name: path.basename(sourcePath),
+      mimeType,
+      sizeBytes,
+    } satisfies ChatAttachment;
+    const destinationPath = resolveAttachmentPath({
+      attachmentsDir: serverConfig.attachmentsDir,
+      attachment,
+    });
+    if (!destinationPath) {
+      return undefined;
+    }
+
+    yield* fileSystem.copyFile(sourcePath, destinationPath);
+    return attachment;
+  });
 
   const flushBufferedAssistantMessage = (input: {
     event: ProviderRuntimeEvent;
@@ -1495,6 +1582,42 @@ const make = Effect.gen(function* () {
             threadId: thread.id,
             messageId: assistantMessageId,
             delta: assistantDelta,
+            ...(turnId ? { turnId } : {}),
+            createdAt: now,
+          });
+        }
+      }
+
+      if (event.type === "item.completed" && event.payload.itemType === "image_view") {
+        const imageAttachment = yield* persistAssistantImageAttachment(event, thread.id).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("provider runtime ingestion failed to persist assistant image", {
+              eventId: event.eventId,
+              threadId: thread.id,
+              cause: Cause.pretty(cause),
+            }).pipe(Effect.as(undefined)),
+          ),
+        );
+        if (imageAttachment) {
+          const turnId = toTurnId(event.turnId);
+          const assistantMessageId = yield* getOrCreateAssistantMessageId({
+            threadId: thread.id,
+            event,
+            ...(turnId ? { turnId } : {}),
+          });
+          if (turnId) {
+            yield* rememberAssistantMessageId(thread.id, turnId, assistantMessageId);
+          }
+          const detailedThread = yield* getLoadedThreadDetail();
+          const existingAttachments =
+            findMessageById(detailedThread?.messages ?? [], assistantMessageId)?.attachments ?? [];
+          yield* orchestrationEngine.dispatch({
+            type: "thread.message.assistant.delta",
+            commandId: yield* providerCommandId(event, "assistant-image-attachment"),
+            threadId: thread.id,
+            messageId: assistantMessageId,
+            delta: "",
+            attachments: [...existingAttachments, imageAttachment],
             ...(turnId ? { turnId } : {}),
             createdAt: now,
           });

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1010,6 +1010,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           messageId: command.messageId,
           role: "assistant",
           text: command.delta,
+          ...(command.attachments !== undefined ? { attachments: command.attachments } : {}),
           turnId: command.turnId ?? null,
           streaming: true,
           createdAt: command.createdAt,

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -296,6 +296,46 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("1 changed file");
   });
 
+  it("renders assistant image attachments inline", () => {
+    const turnId = TurnId.make("turn-with-image");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-assistant-with-image",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: MessageId.make("message-assistant-with-image"),
+              role: "assistant",
+              text: "Screenshot attached.",
+              attachments: [
+                {
+                  type: "image",
+                  id: "assistant-image-1",
+                  name: "filter-manager.png",
+                  mimeType: "image/png",
+                  sizeBytes: 4,
+                  previewUrl: "https://t3.example.test/api/assets/filter-manager.png",
+                },
+              ],
+              turnId,
+              createdAt: MESSAGE_CREATED_AT,
+              updatedAt: MESSAGE_CREATED_AT,
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Preview filter-manager.png"');
+    expect(markup).toContain('alt="filter-manager.png"');
+    expect(markup).toContain("https://t3.example.test/api/assets/filter-manager.png");
+    expect(markup).toContain("Screenshot attached.");
+  });
+
   it("uses LegendList isNearEnd when deciding whether the live edge is visible", async () => {
     const {
       resolveTimelineIsAtEnd,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -866,6 +866,49 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
   );
 });
 
+function MessageImageGrid({
+  images,
+  className,
+  imageClassName,
+}: {
+  images: ReadonlyArray<NonNullable<TimelineMessage["attachments"]>[number]>;
+  className: string;
+  imageClassName: string;
+}) {
+  const ctx = use(TimelineRowCtx);
+  if (images.length === 0) return null;
+
+  return (
+    <div className={className}>
+      {images.map((image) => (
+        <div
+          key={image.id}
+          className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
+        >
+          {image.previewUrl ? (
+            <button
+              type="button"
+              className="h-full w-full cursor-zoom-in"
+              aria-label={`Preview ${image.name}`}
+              onClick={() => {
+                const preview = buildExpandedImagePreview(images, image.id);
+                if (!preview) return;
+                ctx.onImageExpand(preview);
+              }}
+            >
+              <img src={image.previewUrl} alt={image.name} className={imageClassName} />
+            </button>
+          ) : (
+            <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
+              {image.name}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);
   const userImages = row.message.attachments ?? [];
@@ -891,39 +934,11 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   return (
     <div className="group flex flex-col items-end gap-1">
       <div className="relative max-w-[80%] rounded-2xl bg-accent p-3">
-        {regularImages.length > 0 && (
-          <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
-            {regularImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (
-              <div
-                key={image.id}
-                className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
-              >
-                {image.previewUrl ? (
-                  <button
-                    type="button"
-                    className="h-full w-full cursor-zoom-in"
-                    aria-label={`Preview ${image.name}`}
-                    onClick={() => {
-                      const preview = buildExpandedImagePreview(regularImages, image.id);
-                      if (!preview) return;
-                      ctx.onImageExpand(preview);
-                    }}
-                  >
-                    <img
-                      src={image.previewUrl}
-                      alt={image.name}
-                      className="block h-auto max-h-[220px] w-full object-cover"
-                    />
-                  </button>
-                ) : (
-                  <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
-                    {image.name}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
+        <MessageImageGrid
+          images={regularImages}
+          className="mb-2 grid max-w-[420px] grid-cols-2 gap-2"
+          imageClassName="block h-auto max-h-[220px] w-full object-cover"
+        />
         {previewAnnotations.map((annotation, index) => (
           <UserMessagePreviewAnnotationCard
             key={annotation.id}
@@ -1018,10 +1033,16 @@ function TurnFoldTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "turn-
 function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);
   const messageText = row.message.text || (row.message.streaming ? "" : "(empty response)");
+  const assistantImages = row.message.attachments ?? [];
 
   return (
     <>
       <div className="relative min-w-0 px-1 py-0.5">
+        <MessageImageGrid
+          images={assistantImages}
+          className="mb-3 grid max-w-[640px] grid-cols-1 gap-2 sm:grid-cols-2"
+          imageClassName="block h-auto max-h-[360px] w-full object-contain"
+        />
         <ChatMarkdown
           text={messageText}
           cwd={ctx.markdownCwd}

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -808,6 +808,7 @@ const ThreadMessageAssistantDeltaCommand = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
   delta: Schema.String,
+  attachments: Schema.optional(Schema.Array(ChatAttachment)),
   turnId: Schema.optional(TurnId),
   createdAt: IsoDateTime,
 });


### PR DESCRIPTION
## What

- Persist completed provider image-view results as assistant-message image attachments.
- Store image bytes in thread attachment storage and project them with assistant messages.
- Render assistant image attachments in the timeline with expandable previews.

## Why

Codex `view_image` results were represented only as collapsed work entries, so images did not appear in the conversation.

## Verification

- `corepack pnpm exec vitest run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts apps/web/src/components/chat/MessagesTimeline.test.tsx --reporter=verbose` — 61 tests passed.
- Live deployment acceptance on t3.skofo.ca: a `view_image` result rendered directly in the assistant message.
- Deployed package: `0.0.31-skofo.20260729.ff321da`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist assistant image attachments in chat and render them inline
> - When a provider emits an `image_view` item, `ProviderRuntimeIngestion` validates the file (type, size, safe extension), copies it into the server attachments directory, and appends a `ChatAttachment` to the assistant message via `thread.message.assistant.delta`.
> - `decideOrchestrationCommand` now forwards `attachments` from assistant delta commands through to the resulting `thread.message-sent` event payload.
> - Assistant messages in `MessagesTimeline` render attached images as zoomable thumbnails (or filename placeholders) above the message text, reusing a new shared `MessageImageGrid` component also used for user messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ff321da. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->