### PR TITLE
fix(mobile): show the correct build channel in Android's Threads page header

### DIFF
--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -1,5 +1,6 @@
 import type { EnvironmentId, SidebarThreadSortOrder } from "@t3tools/contracts";
 import type { MenuAction } from "@react-native-menu/menu";
+import Constants from "expo-constants";
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { useCallback, useMemo, useRef } from "react";
 import { Platform, Pressable, Text as RNText, TextInput, View } from "react-native";
@@ -9,6 +10,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { SymbolView } from "../../components/AppSymbol";
 import { T3Wordmark } from "../../components/T3Wordmark";
+import { HOME_HORIZONTAL_INSET } from "../../lib/layoutMetrics";
+import { resolveMobileStageLabel } from "../../lib/mobileBranding";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useThreadListV2Enabled } from "../threads/use-thread-list-v2-enabled";
 import { useHardwareKeyboardCommand } from "../keyboard/hardwareKeyboardCommands";
@@ -64,6 +67,7 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
   const insets = useSafeAreaInsets();
   const iconColor = useThemeColor("--color-icon");
   const mutedColor = useThemeColor("--color-foreground-muted");
+  const stageLabel = resolveMobileStageLabel(Constants.expoConfig?.extra?.appVariant);
   // Thread List v2 lays the list out in fixed creation order, so the
   // sort/group filter controls would be silently ignored — hide them and
   // key the "customized" icon state off the environment filter alone.
@@ -195,8 +199,9 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
     <>
       <NativeStackScreenOptions options={{ headerShown: false }} />
       <View
-        className="border-b border-header-border bg-header px-4 pb-3"
+        className="border-b border-header-border bg-header pb-3"
         style={{
+          paddingHorizontal: HOME_HORIZONTAL_INSET,
           paddingTop: Math.max(insets.top, 12),
         }}
       >
@@ -210,7 +215,7 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
               </RNText>
               <View className="rounded-full bg-subtle px-2 py-0.75">
                 <RNText className="text-[11px] font-t3-bold tracking-[1.1px] text-foreground-muted uppercase">
-                  Alpha
+                  {stageLabel}
                 </RNText>
               </View>
             </View>


### PR DESCRIPTION
## Summary

- derive the Android Threads header pill from the configured mobile build variant
- show Dev for development builds, Nightly for preview builds, and Alpha for production builds
- align the branded header with the compact thread list
- inherit the iOS split-header stabilization and production store-capture harness from #4862

> [!IMPORTANT]
> This PR is stacked on #4862 and should merge only after it.

## Why

The Android Threads header currently hard-codes `Alpha`, so development and Nightly builds present the wrong channel. This reuses the resolver introduced by #4862 and keeps the branded mobile headers consistent without changing Android routing or accessibility semantics.

## Before / After

### Android development build

| Before | After |
| --- | --- |
| <img width="480" alt="Android development build before, incorrectly showing the Alpha pill" src="https://github.com/user-attachments/assets/a03b1479-c204-419f-93bc-f59583da519b"> | <img width="480" alt="Android development build after, correctly showing the aligned Dev pill" src="https://github.com/user-attachments/assets/60ca9875-3c2f-4e9a-8193-fcae33bb2832"> |

The comparison uses the deterministic dark-mode Threads fixture with no popup.

## Verification

- `vp test run scripts/mobile-showcase.test.ts apps/mobile/src/lib/mobileBranding.test.ts apps/mobile/src/native/scrollEdgeEffects.test.ts` - 27 tests passed
- `vp run --filter @t3tools/mobile typecheck`
- targeted formatting and `git diff --check`
- deterministic development build capture showing the aligned Dev pill on Android
- production Android APK built and launched as `com.t3tools.t3code`
- upload-ready 1080x1920 Google Play Threads capture validated with the Alpha pill and no reconnect state

Store upload assets remain generated, ignored workflow artifacts under `artifacts/app-store/screenshots/`; PR proof images are not committed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I added regression coverage
- [x] I included before/after UI evidence
- [x] I kept this stacked only on the mutually compatible iOS proposal

Model: GPT-5.6 Sol | Harness: Codex in T3 Code


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only label and padding changes in the Android home header; no routing, auth, or data handling.
> 
> **Overview**
> The Android **Threads** header no longer always shows **Alpha**. It now uses **`resolveMobileStageLabel`** on `Constants.expoConfig?.extra?.appVariant`, so **Dev**, **Nightly**, and **Alpha** match the configured mobile build channel—the same mapping used elsewhere in mobile branding.
> 
> Horizontal padding on that header uses **`HOME_HORIZONTAL_INSET`** instead of Tailwind `px-4`, aligning the branded header with the compact thread list layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5cf7c53305b7bf21fdaff09008c597294f8895d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix build channel label in Android Threads page header
> Replaces the static "Alpha" badge in `AndroidHomeHeader` with a dynamic `stageLabel` derived from `appVariant` via `resolveMobileStageLabel`. Also switches horizontal padding from the fixed `px-4` Tailwind class to `HOME_HORIZONTAL_INSET` for consistency with the rest of the layout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5cf7c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
