### PR TITLE
fix(mobile): restore iOS Threads branding

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,7 +11,7 @@
     "start:dev": "APP_VARIANT=development expo start",
     "start:preview": "APP_VARIANT=preview expo start",
     "start:prod": "APP_VARIANT=production expo start",
-    "showcase": "APP_VARIANT=development EXPO_PUBLIC_SHOWCASE=1 expo start --dev-client --scheme t3code-dev --clear",
+    "showcase": "APP_VARIANT=production EXPO_PUBLIC_SHOWCASE=1 expo start --dev-client --scheme t3code --clear",
     "screenshots": "node ../../scripts/mobile-showcase.ts",
     "android": "EXPO_NO_GIT_STATUS=1 expo prebuild --clean --platform android && expo run:android",
     "android:dev": "APP_VARIANT=development EXPO_NO_GIT_STATUS=1 expo prebuild --clean --platform android && REACT_NATIVE_PACKAGER_HOSTNAME=localhost expo run:android",

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -15,6 +15,7 @@ import { DynamicColorIOS, Platform, Pressable, ScrollView, StyleSheet } from "re
 import { useResolveClassNames } from "uniwind";
 
 import { AppText as Text } from "./components/AppText";
+import { renderCompactBrandTitle } from "./components/CompactBrandTitle";
 import { ArchivedThreadsRouteScreen } from "./features/archive/ArchivedThreadsRouteScreen";
 import { useAgentNotificationNavigation } from "./features/agent-awareness/notificationNavigation";
 import { ClerkSettingsSheetDetentProvider } from "./features/cloud/ClerkSettingsSheetDetent";
@@ -383,6 +384,7 @@ export const RootStack = createNativeStackNavigator({
         ...GLASS_HEADER_OPTIONS,
         contentStyle: { backgroundColor: "transparent" },
         headerBackVisible: false,
+        headerTitle: renderCompactBrandTitle,
         title: "Threads",
       },
     }),

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -15,7 +15,7 @@ import { DynamicColorIOS, Platform, Pressable, ScrollView, StyleSheet } from "re
 import { useResolveClassNames } from "uniwind";
 
 import { AppText as Text } from "./components/AppText";
-import { renderCompactBrandTitle } from "./components/CompactBrandTitle";
+import { getCompactBrandHeaderOptions } from "./components/CompactBrandTitle";
 import { ArchivedThreadsRouteScreen } from "./features/archive/ArchivedThreadsRouteScreen";
 import { useAgentNotificationNavigation } from "./features/agent-awareness/notificationNavigation";
 import { ClerkSettingsSheetDetentProvider } from "./features/cloud/ClerkSettingsSheetDetent";
@@ -384,8 +384,7 @@ export const RootStack = createNativeStackNavigator({
         ...GLASS_HEADER_OPTIONS,
         contentStyle: { backgroundColor: "transparent" },
         headerBackVisible: false,
-        headerTitle: renderCompactBrandTitle,
-        title: "Threads",
+        ...getCompactBrandHeaderOptions(),
       },
     }),
     Thread: createNativeStackScreen({

--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -34,8 +34,8 @@ export function CompactBrandTitle() {
         style={{
           color: mutedColor,
           fontFamily: "DMSans-Medium",
-          fontSize: 18,
-          letterSpacing: -0.45,
+          fontSize: 21,
+          letterSpacing: -0.5,
         }}
       >
         Code

--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -29,13 +29,13 @@ export function CompactBrandTitle() {
         marginLeft: Platform.OS === "ios" && Platform.isPad ? IPAD_HOME_TITLE_OFFSET : 0,
       }}
     >
-      <T3Wordmark color={iconColor} height={11} />
+      <T3Wordmark color={iconColor} height={15} />
       <Text
         style={{
           color: mutedColor,
           fontFamily: "DMSans-Medium",
-          fontSize: 14,
-          letterSpacing: -0.35,
+          fontSize: 18,
+          letterSpacing: -0.45,
         }}
       >
         Code

--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -1,0 +1,69 @@
+import Constants from "expo-constants";
+import { Platform, View } from "react-native";
+
+import { AppText as Text } from "./AppText";
+import { T3Wordmark } from "./T3Wordmark";
+import { IPAD_HOME_TITLE_OFFSET } from "../lib/layoutMetrics";
+import { resolveMobileStageLabel } from "../lib/mobileBranding";
+import { useThemeColor } from "../lib/useThemeColor";
+
+/**
+ * Compact brand lockup sized for native navigation bars.
+ */
+export function CompactBrandTitle() {
+  const iconColor = useThemeColor("--color-icon");
+  const mutedColor = useThemeColor("--color-foreground-muted");
+  const subtleColor = useThemeColor("--color-subtle");
+  const stageLabel = resolveMobileStageLabel(Constants.expoConfig?.extra?.appVariant);
+
+  return (
+    <View
+      aria-level={1}
+      accessibilityLabel="T3 Code, Threads"
+      accessible
+      role="heading"
+      style={{
+        alignItems: "center",
+        flexDirection: "row",
+        gap: 6,
+        marginLeft: Platform.OS === "ios" && Platform.isPad ? IPAD_HOME_TITLE_OFFSET : 0,
+      }}
+    >
+      <T3Wordmark color={iconColor} height={11} />
+      <Text
+        style={{
+          color: mutedColor,
+          fontFamily: "DMSans-Medium",
+          fontSize: 14,
+          letterSpacing: -0.35,
+        }}
+      >
+        Code
+      </Text>
+      <View
+        style={{
+          backgroundColor: subtleColor,
+          borderRadius: 999,
+          paddingHorizontal: 6,
+          paddingVertical: 2,
+        }}
+      >
+        <Text
+          style={{
+            color: mutedColor,
+            fontFamily: "DMSans-Bold",
+            fontSize: 9,
+            letterSpacing: 0.9,
+            textTransform: "uppercase",
+          }}
+        >
+          {stageLabel}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+export function renderCompactBrandTitle() {
+  return <CompactBrandTitle />;
+}

--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -1,4 +1,8 @@
 import Constants from "expo-constants";
+import type {
+  NativeStackHeaderItem,
+  NativeStackNavigationOptions,
+} from "@react-navigation/native-stack";
 import { Platform, View } from "react-native";
 
 import { AppText as Text } from "./AppText";
@@ -6,15 +10,34 @@ import { T3Wordmark } from "./T3Wordmark";
 import { IPAD_HOME_TITLE_OFFSET } from "../lib/layoutMetrics";
 import { resolveMobileStageLabel } from "../lib/mobileBranding";
 import { useThemeColor } from "../lib/useThemeColor";
+import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../native/native-glass";
+
+// Native leading items inherit different UIKit margins than title views.
+const IOS_NATIVE_LEADING_TITLE_OFFSET = -6;
+const IPAD_NATIVE_LEADING_TITLE_OFFSET = 7;
 
 /**
  * Compact brand lockup sized for native navigation bars.
  */
-export function CompactBrandTitle() {
+export function CompactBrandTitle(
+  props: {
+    readonly nativeLeadingItem?: boolean;
+  } = {},
+) {
   const iconColor = useThemeColor("--color-icon");
   const mutedColor = useThemeColor("--color-foreground-muted");
   const subtleColor = useThemeColor("--color-subtle");
   const stageLabel = resolveMobileStageLabel(Constants.expoConfig?.extra?.appVariant);
+  const titleOffset =
+    Platform.OS !== "ios"
+      ? 0
+      : props.nativeLeadingItem
+        ? Platform.isPad
+          ? IPAD_NATIVE_LEADING_TITLE_OFFSET
+          : IOS_NATIVE_LEADING_TITLE_OFFSET
+        : Platform.isPad
+          ? IPAD_HOME_TITLE_OFFSET
+          : 0;
 
   return (
     <View
@@ -26,7 +49,7 @@ export function CompactBrandTitle() {
         alignItems: "center",
         flexDirection: "row",
         gap: 6,
-        marginLeft: Platform.OS === "ios" && Platform.isPad ? IPAD_HOME_TITLE_OFFSET : 0,
+        marginLeft: titleOffset,
       }}
     >
       <T3Wordmark color={iconColor} height={15} />
@@ -66,4 +89,33 @@ export function CompactBrandTitle() {
 
 export function renderCompactBrandTitle() {
   return <CompactBrandTitle />;
+}
+
+export function renderCompactBrandHeaderItems(): NativeStackHeaderItem[] {
+  return [
+    {
+      element: <CompactBrandTitle nativeLeadingItem />,
+      hidesSharedBackground: true,
+      type: "custom",
+    },
+  ];
+}
+
+export function getCompactBrandHeaderOptions(
+  fallbackTitleStyle?: NativeStackNavigationOptions["headerTitleStyle"],
+): NativeStackNavigationOptions {
+  if (Platform.OS === "ios" && NATIVE_LIQUID_GLASS_SUPPORTED) {
+    return {
+      headerTitle: "Threads",
+      headerTitleStyle: { color: "transparent", fontSize: 18, fontWeight: "800" },
+      title: "Threads",
+      unstable_headerLeftItems: renderCompactBrandHeaderItems,
+    };
+  }
+
+  return {
+    headerTitle: renderCompactBrandTitle,
+    headerTitleStyle: fallbackTitleStyle,
+    title: "Threads",
+  };
 }

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -3,6 +3,7 @@ import * as Order from "effect/Order";
 import { useNavigation } from "@react-navigation/native";
 import { useEffect, useMemo, useState } from "react";
 
+import { renderCompactBrandTitle } from "../../components/CompactBrandTitle";
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { usePendingNewTasks } from "../../state/use-pending-new-tasks";
@@ -107,8 +108,10 @@ export function HomeRouteScreen() {
       onStartNewTask={() => navigation.navigate("NewTaskSheet", { screen: "NewTask" })}
     >
       <>
-        {/* Restore the compact title in case the split branch blanked it. */}
-        <NativeStackScreenOptions options={{ title: "Threads", headerTitle: "Threads" }} />
+        {/* Restore the compact title after the split branch blanks the detail header. */}
+        <NativeStackScreenOptions
+          options={{ title: "Threads", headerTitle: renderCompactBrandTitle }}
+        />
         <HomeHeader
           environments={environments}
           projects={projectFilterOptions}

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -3,7 +3,7 @@ import * as Order from "effect/Order";
 import { useNavigation } from "@react-navigation/native";
 import { useEffect, useMemo, useState } from "react";
 
-import { renderCompactBrandTitle } from "../../components/CompactBrandTitle";
+import { getCompactBrandHeaderOptions } from "../../components/CompactBrandTitle";
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { usePendingNewTasks } from "../../state/use-pending-new-tasks";
@@ -109,9 +109,7 @@ export function HomeRouteScreen() {
     >
       <>
         {/* Restore the compact title after the split branch blanks the detail header. */}
-        <NativeStackScreenOptions
-          options={{ title: "Threads", headerTitle: renderCompactBrandTitle }}
-        />
+        <NativeStackScreenOptions options={getCompactBrandHeaderOptions()} />
         <HomeHeader
           environments={environments}
           projects={projectFilterOptions}

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -86,7 +86,9 @@ export function HomeRouteScreen() {
   if (layout.usesSplitView) {
     return (
       <>
-        <NativeStackScreenOptions options={{ title: "", headerTitle: "" }} />
+        <NativeStackScreenOptions
+          options={{ title: "", headerTitle: "", unstable_headerLeftItems: () => [] }}
+        />
         <WorkspaceSidebarToolbar
           afterSidebarButton={
             <NativeHeaderToolbar.Button

--- a/apps/mobile/src/features/threads/sidebar-navigation-shell.tsx
+++ b/apps/mobile/src/features/threads/sidebar-navigation-shell.tsx
@@ -11,6 +11,7 @@ import {
 import type { ReactNode } from "react";
 import { Platform, useColorScheme } from "react-native";
 
+import { renderCompactBrandTitle } from "../../components/CompactBrandTitle";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { nativeHeaderScrollEdgeEffects } from "../../native/StackHeader";
 
@@ -35,6 +36,7 @@ const SIDEBAR_SCREEN_OPTIONS: SidebarScreenOptions = {
   headerShadowVisible: false,
   headerShown: true,
   headerStyle: NATIVE_LIQUID_GLASS_SUPPORTED ? { backgroundColor: "transparent" } : undefined,
+  headerTitle: renderCompactBrandTitle,
   headerTitleStyle: { fontSize: 18, fontWeight: "800" },
   headerTransparent: NATIVE_LIQUID_GLASS_SUPPORTED,
   scrollEdgeEffects: NATIVE_LIQUID_GLASS_SUPPORTED ? SCROLL_EDGE_EFFECTS : undefined,

--- a/apps/mobile/src/features/threads/sidebar-navigation-shell.tsx
+++ b/apps/mobile/src/features/threads/sidebar-navigation-shell.tsx
@@ -11,7 +11,7 @@ import {
 import type { ReactNode } from "react";
 import { Platform, useColorScheme } from "react-native";
 
-import { renderCompactBrandTitle } from "../../components/CompactBrandTitle";
+import { getCompactBrandHeaderOptions } from "../../components/CompactBrandTitle";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { nativeHeaderScrollEdgeEffects } from "../../native/StackHeader";
 
@@ -36,11 +36,9 @@ const SIDEBAR_SCREEN_OPTIONS: SidebarScreenOptions = {
   headerShadowVisible: false,
   headerShown: true,
   headerStyle: NATIVE_LIQUID_GLASS_SUPPORTED ? { backgroundColor: "transparent" } : undefined,
-  headerTitle: renderCompactBrandTitle,
-  headerTitleStyle: { fontSize: 18, fontWeight: "800" },
+  ...getCompactBrandHeaderOptions({ fontSize: 18, fontWeight: "800" }),
   headerTransparent: NATIVE_LIQUID_GLASS_SUPPORTED,
   scrollEdgeEffects: NATIVE_LIQUID_GLASS_SUPPORTED ? SCROLL_EDGE_EFFECTS : undefined,
-  title: "Threads",
   unstable_navigationItemStyle: NATIVE_LIQUID_GLASS_SUPPORTED ? "editor" : undefined,
 };
 

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -14,6 +14,7 @@ import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
 import { cn } from "../../lib/cn";
+import { HOME_HORIZONTAL_INSET } from "../../lib/layoutMetrics";
 import { relativeTime } from "../../lib/time";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
@@ -31,7 +32,7 @@ import { resolveThreadStatus } from "./threadPresentation";
 export type ThreadListVariant = "compact" | "sidebar";
 
 /** Left inset that aligns compact secondary rows with the title column. */
-export const THREAD_LIST_COMPACT_INSET = 20;
+export const THREAD_LIST_COMPACT_INSET = HOME_HORIZONTAL_INSET;
 const SIDEBAR_ROW_RADIUS = 12;
 
 function pullRequestTintColor(

--- a/apps/mobile/src/lib/layoutMetrics.ts
+++ b/apps/mobile/src/lib/layoutMetrics.ts
@@ -1,0 +1,5 @@
+/** Horizontal inset shared by the home header and compact thread list. */
+export const HOME_HORIZONTAL_INSET = 20;
+
+/** Compensates for the tighter native sidebar title margin on iPad. */
+export const IPAD_HOME_TITLE_OFFSET = 10;

--- a/apps/mobile/src/lib/mobileBranding.test.ts
+++ b/apps/mobile/src/lib/mobileBranding.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveMobileStageLabel } from "./mobileBranding";
+
+describe("resolveMobileStageLabel", () => {
+  it.each([
+    ["development", "Dev"],
+    ["preview", "Nightly"],
+    ["production", "Alpha"],
+    [undefined, "Alpha"],
+  ])("maps %s builds to %s", (appVariant, expected) => {
+    expect(resolveMobileStageLabel(appVariant)).toBe(expected);
+  });
+});

--- a/apps/mobile/src/lib/mobileBranding.ts
+++ b/apps/mobile/src/lib/mobileBranding.ts
@@ -1,0 +1,7 @@
+export type MobileStageLabel = "Alpha" | "Dev" | "Nightly";
+
+export function resolveMobileStageLabel(appVariant: unknown): MobileStageLabel {
+  if (appVariant === "development") return "Dev";
+  if (appVariant === "preview") return "Nightly";
+  return "Alpha";
+}

--- a/apps/mobile/src/native/StackHeader.tsx
+++ b/apps/mobile/src/native/StackHeader.tsx
@@ -364,7 +364,8 @@ function NativeHeaderToolbarRoot(props: {
   const navigation = useNativeStackNavigation();
   const items = useMemo(() => collectToolbarItems(props.children), [props.children]);
 
-  useEffect(() => {
+  // Swap toolbar owners before paint so split and compact headers cannot clear each other.
+  useLayoutEffect(() => {
     if (!navigation) {
       return;
     }

--- a/docs/operations/mobile-app-store-screenshots.md
+++ b/docs/operations/mobile-app-store-screenshots.md
@@ -41,7 +41,7 @@ Captures wait for the real environment snapshot to hydrate and for the requested
 active. Both platforms record readiness in the simulator/emulator app container. A final settle
 delay allows native terminal and Git review data to finish rendering.
 
-A full capture regenerates the selected native project with Expo's clean development prebuild before
+A full capture regenerates the selected native project with Expo's clean production prebuild before
 building it. Use --skip-build for repeated captures after the first build.
 
 The harness uses its own Metro port (8199 by default), so an ordinary mobile server or another

--- a/scripts/mobile-showcase.test.ts
+++ b/scripts/mobile-showcase.test.ts
@@ -244,22 +244,19 @@ it("selects a reachable LAN IPv4 address", () => {
 });
 
 it("maps capture scenes to the real application routes", () => {
-  assert.equal(showcaseSceneUrl("threads", "environment-1"), "t3code-dev://");
-  assert.equal(
-    showcaseSceneUrl("environments", "environment-1"),
-    "t3code-dev://settings/environments",
-  );
+  assert.equal(showcaseSceneUrl("threads", "environment-1"), "t3code://");
+  assert.equal(showcaseSceneUrl("environments", "environment-1"), "t3code://settings/environments");
   assert.equal(
     showcaseSceneUrl("thread", "environment-1"),
-    "t3code-dev://threads/environment-1/remote-command-center",
+    "t3code://threads/environment-1/remote-command-center",
   );
   assert.equal(
     showcaseSceneUrl("terminal", "environment-1"),
-    "t3code-dev://threads/environment-1/remote-command-center/terminal?terminalId=term-1",
+    "t3code://threads/environment-1/remote-command-center/terminal?terminalId=term-1",
   );
   assert.equal(
     showcaseSceneUrl("review", "environment-1"),
-    "t3code-dev://threads/environment-1/remote-command-center/review",
+    "t3code://threads/environment-1/remote-command-center/review",
   );
 });
 

--- a/scripts/mobile-showcase.ts
+++ b/scripts/mobile-showcase.ts
@@ -31,14 +31,14 @@ import {
 
 const REPO_ROOT = NodePath.resolve(NodePath.dirname(NodeURL.fileURLToPath(import.meta.url)), "..");
 const MOBILE_ROOT = NodePath.join(REPO_ROOT, "apps/mobile");
-const ANDROID_PACKAGE = "com.t3tools.t3code.dev";
-const APP_SCHEME = "t3code-dev";
+const ANDROID_PACKAGE = "com.t3tools.t3code";
+const APP_SCHEME = "t3code";
 const IOS_READY_FILENAME = "T3ShowcaseReadyScene";
 const SERVER_HOST = "0.0.0.0";
 const IOS_SIMULATOR_ARCH = NodeProcess.arch === "arm64" ? "arm64" : "x86_64";
 const IOS_APP_PATH = NodePath.join(
   MOBILE_ROOT,
-  ".showcase/ios-derived-data/Build/Products/Debug-iphonesimulator/T3CodeDev.app",
+  ".showcase/ios-derived-data/Build/Products/Debug-iphonesimulator/T3Code.app",
 );
 const ANDROID_APK_PATH = NodePath.join(
   MOBILE_ROOT,
@@ -58,7 +58,7 @@ const ANDROID_SDK_ROOT = resolveAndroidSdkRoot(NodeProcess.env);
 const MOBILE_BUILD_ENV = {
   ...NodeProcess.env,
   ANDROID_HOME: ANDROID_SDK_ROOT,
-  APP_VARIANT: "development",
+  APP_VARIANT: "production",
   EXPO_NO_GIT_STATUS: "1",
   JAVA_HOME:
     NodeProcess.env.JAVA_HOME ??
@@ -664,9 +664,9 @@ async function buildIos(): Promise<string> {
     "xcodebuild",
     [
       "-workspace",
-      NodePath.join(MOBILE_ROOT, "ios/T3CodeDev.xcworkspace"),
+      NodePath.join(MOBILE_ROOT, "ios/T3Code.xcworkspace"),
       "-scheme",
-      "T3CodeDev",
+      "T3Code",
       "-configuration",
       "Debug",
       "-sdk",


### PR DESCRIPTION
## Summary

- restore the compact T3 Code brand lockup on the iPhone and iPadOS Threads page
- label development, preview, and production builds as Dev, Nightly, and Alpha
- align the lockup with the compact thread list and match Android/desktop proportions
- preserve the native `Threads` route title, accessibility identity, and iOS scroll-edge fade
- prevent split and compact headers from clearing each other's toolbar items
- generate official store screenshots from the production app variant so they show Alpha

Fixes: #4864.

> [!IMPORTANT]
> Merge #4861 **after** this to correct the Android build-channel pill.

## Why

Android gained branded Threads navigation in #3774 and iOS followed in #4025. The final commit in #4163 removed only the iOS lockup while renaming mobile navigation headers to `Threads`, leaving the two platforms inconsistent.

The first restoration also replaced the native title directly, which broke iOS scrollfade. This version keeps `Threads` as the native route title for UIKit, accessibility, routing, and deep links, then presents the visible “T3 Code” lockup as an accessible leading heading. Split detail mode explicitly clears that item, and toolbar ownership changes run before paint so rotating or changing layouts cannot pop the brand into the wrong pane.

## Before / After

### iPhone

| Before | After |
| --- | --- |
| <img width="540" alt="iPhone Threads page before, showing the plain Threads title in dark mode" src="https://github.com/user-attachments/assets/054d0eb8-1000-4b83-8e62-c42fa3e933a1"> | <img width="540" alt="iPhone Threads page after, showing the aligned T3 Code Dev lockup in dark mode" src="https://github.com/user-attachments/assets/05ca9a43-135d-4452-bf09-35275ffb4782"> |

### iPadOS

| Before | After |
| --- | --- |
| <img width="420" alt="iPadOS Threads sidebar before, showing the plain title left of the thread-list inset" src="https://github.com/user-attachments/assets/a9644f59-d761-496f-b707-a2bcbd514edf"> | <img width="420" alt="iPadOS Threads sidebar after, showing the aligned T3 Code Dev lockup" src="https://github.com/user-attachments/assets/13fe385c-aab9-4e84-b721-a1c409e5ddb5"> |

Both comparisons use the deterministic dark-mode Threads fixture with no popup.

## Verification

- `vp test run scripts/mobile-showcase.test.ts apps/mobile/src/lib/mobileBranding.test.ts apps/mobile/src/native/scrollEdgeEffects.test.ts` - 27 tests passed
- `vp run --filter @t3tools/mobile typecheck`
- targeted formatting and `git diff --check`
- iPhone portrait baseline and scrollfade with list content behind the header
- iPadOS portrait/landscape baselines, landscape scrollfade, and Show/Hide Sidebar with no popping or misplaced brand
- 30 upload-ready Apple screenshots validated for iPhone 6.9, iPhone 6.5, and iPad 13 in light/dark mode
- production Apple and Android store captures show Alpha and contain no reconnect state

Store upload assets remain generated, ignored workflow artifacts under `artifacts/app-store/screenshots/`; PR proof images are not committed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I added regression coverage
- [x] I included before/after UI evidence
- [x] I preserved routing, deep linking, accessible page identity, and native scrollfade

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to mobile navigation chrome, layout metrics, and internal showcase scripts; routing and deep links stay on the production scheme with no auth or data-path changes.
> 
> **Overview**
> Restores the compact **T3 Code** navigation lockup (wordmark, “Code”, and a build-stage chip) on iPhone and iPad Threads instead of the plain **Threads** title, while keeping route/linking identity as **Threads** and accessible heading **“T3 Code, Threads”**.
> 
> Adds `CompactBrandTitle` and `getCompactBrandHeaderOptions`, which on iOS liquid glass injects the lockup as a custom leading header item and otherwise uses a custom `headerTitle`. Stage labels map app variant to **Dev**, **Nightly**, or **Alpha** via `resolveMobileStageLabel`. Shared `HOME_HORIZONTAL_INSET` / iPad offsets align the header with compact thread-list content.
> 
> `HomeRouteScreen` clears left header items in split detail mode and reapplies brand options on phone; sidebar shell and main `Stack` Home screen use the same helper. `NativeHeaderToolbarRoot` switches to `useLayoutEffect` so split vs compact layouts do not race on header toolbar registration.
> 
> Showcase/screenshot tooling switches from development (`t3code-dev`, `T3CodeDev`) to **production** (`t3code`, `T3Code`, `APP_VARIANT=production`) so captures match store branding (e.g. **Alpha** chip).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 077cbed8a3e6419dd0942610fa684c4e36f42644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore iOS Threads branding in navigation headers using a compact brand lockup component
> - Adds `CompactBrandTitle` component that renders a T3 wordmark, 'Code' label, and a dynamic stage badge ('Alpha', 'Dev', 'Nightly') based on app variant.
> - Adds `getCompactBrandHeaderOptions()` which selects between a transparent title with a native leading item (iOS liquid glass) or a custom `headerTitle` component for other platforms.
> - Updates the Home screen, sidebar, and `HomeRouteScreen` to use `getCompactBrandHeaderOptions()` instead of static title strings.
> - Fixes split-view layouts in `HomeRouteScreen` to explicitly clear `unstable_headerLeftItems` to prevent stale header items.
> - Switches `useEffect` to `useLayoutEffect` in `NativeHeaderToolbarRoot` so toolbar items are applied before paint, reducing interim header flicker.
> - Updates the showcase build scripts and tests to target the production app variant, package, and scheme instead of development.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 077cbed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
