### PR TITLE
fix(mobile): remove Android Threads page T3 Code branding

### DIFF
--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -8,7 +8,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { ControlPillMenu } from "../../components/ControlPill";
 import { SymbolView } from "../../components/AppSymbol";
-import { T3Wordmark } from "../../components/T3Wordmark";
+import { HOME_HORIZONTAL_INSET } from "../../lib/layoutMetrics";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useThreadListV2Enabled } from "../threads/use-thread-list-v2-enabled";
 import { useHardwareKeyboardCommand } from "../keyboard/hardwareKeyboardCommands";
@@ -192,25 +192,20 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
     <>
       <NativeStackScreenOptions options={{ headerShown: false }} />
       <View
-        className="border-b border-header-border bg-header px-4 pb-3"
+        className="border-b border-header-border bg-header pb-3"
         style={{
+          paddingHorizontal: HOME_HORIZONTAL_INSET,
           paddingTop: Math.max(insets.top, 12),
         }}
       >
         <View className="w-full max-w-[720px] self-center gap-3">
           <View className="flex-row items-center gap-2.5">
-            <View className="flex-1 flex-row items-center gap-2">
-              {/* Mirrors the desktop SidebarBrand: T3 mark + muted "Code". */}
-              <T3Wordmark color={iconColor} height={15} />
-              <RNText className="-ml-0.5 text-[21px] font-t3-medium tracking-[-0.5px] text-foreground-muted">
-                Code
-              </RNText>
-              <View className="rounded-full bg-subtle px-2 py-0.75">
-                <RNText className="text-[11px] font-t3-bold tracking-[1.1px] text-foreground-muted uppercase">
-                  Alpha
-                </RNText>
-              </View>
-            </View>
+            <RNText
+              accessibilityRole="header"
+              className="flex-1 text-[21px] font-t3-bold tracking-[-0.5px] text-foreground"
+            >
+              Threads
+            </RNText>
 
             <ControlPillMenu
               actions={menuActions}

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -14,6 +14,7 @@ import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
 import { cn } from "../../lib/cn";
+import { HOME_HORIZONTAL_INSET } from "../../lib/layoutMetrics";
 import { relativeTime } from "../../lib/time";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
@@ -31,7 +32,7 @@ import { resolveThreadStatus } from "./threadPresentation";
 export type ThreadListVariant = "compact" | "sidebar";
 
 /** Left inset that aligns compact secondary rows with the title column. */
-export const THREAD_LIST_COMPACT_INSET = 20;
+export const THREAD_LIST_COMPACT_INSET = HOME_HORIZONTAL_INSET;
 const SIDEBAR_ROW_RADIUS = 12;
 
 function pullRequestTintColor(

--- a/apps/mobile/src/lib/layoutMetrics.ts
+++ b/apps/mobile/src/lib/layoutMetrics.ts
@@ -1,0 +1,1 @@
+export const HOME_HORIZONTAL_INSET = 20;


### PR DESCRIPTION
## Summary

- replace the branded Android Threads header with the plain `Threads` title used by iOS today
- align the header and compact thread list through one shared horizontal inset
- preserve the heading semantics for accessibility

Tracks the history and decision in #4864.

> [!IMPORTANT]
> This is the mutually exclusive alternative to #4862. If this direction is selected, close #4862 and #4861. Do not merge both branding-direction proposals.

## Why

Android gained a T3 Code lockup in #3774, while the final commit in #4163 later removed the equivalent iOS lockup. If the intended mobile direction is a plain page title, Android should match iOS rather than carrying a platform-only brand treatment.

## Before / After

### Android

| Before | After |
| --- | --- |
| <img width="480" alt="Android Threads page before, showing the T3 Code Alpha lockup in dark mode" src="https://github.com/user-attachments/assets/a03b1479-c204-419f-93bc-f59583da519b"> | <img width="480" alt="Android Threads page after, showing the aligned plain Threads title in dark mode" src="https://github.com/user-attachments/assets/ce3a8384-824b-45d0-9841-8423cdfb0350"> |

The comparison uses the deterministic dark-mode Threads fixture with no popup.

## Verification

- `vp run --filter @t3tools/mobile typecheck`
- targeted formatting and `git diff --check`
- deterministic dark-mode Threads capture on the Android emulator

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after UI evidence
- [x] I preserved an accessible `Threads` heading

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

---

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace Android home header wordmark with plain 'Threads' title
> - Replaces the `T3Wordmark` + 'Code' label + 'Alpha' badge in [`AndroidHomeHeader`](https://github.com/pingdotgg/t3code/pull/4863/files#diff-1ba9649b1bf1262669a23a80f40994038467f6ae019d2ce77f1bbc7e0f65e198) with a plain `RNText` title reading 'Threads', marked as `accessibilityRole='header'`.
> - Extracts `HOME_HORIZONTAL_INSET = 20` into a shared [`layoutMetrics`](https://github.com/pingdotgg/t3code/pull/4863/files#diff-1220797f14b1d97d8302a3fea13727ac81828a304ac5d44d4aed4335671d1d37) module and uses it for both the header padding and [`THREAD_LIST_COMPACT_INSET`](https://github.com/pingdotgg/t3code/pull/4863/files#diff-d7cca5a410b8a14057731c4f49de8786310bd38ded01b09dd02b4da1e3d01808) (previously a literal `20`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ee95cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
