### PR TITLE
fix(web): persist closed plan sidebar state

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1503,6 +1503,9 @@ function ChatViewContent(props: ChatViewProps) {
   const rightPanelState = useRightPanelStore((state) =>
     selectThreadRightPanelState(state.byThreadKey, activeThreadRef),
   );
+  const rightPanelIsOpen = rightPanelState.isOpen;
+  const rightPanelSurfaceCount = rightPanelState.surfaces.length;
+  const planSidebarAutoOpenDisabled = rightPanelState.planSidebarAutoOpenDisabled;
   const activeRightPanelSurface = useRightPanelStore((state) =>
     selectActiveRightPanelSurface(state.byThreadKey, activeThreadRef),
   );
@@ -3827,10 +3830,10 @@ function ChatViewContent(props: ChatViewProps) {
     if (!autoOpenPlanSidebar) return;
     if (!activePlan) return;
     if (planSidebarOpen) return;
-    if (rightPanelState.planSidebarAutoOpenDisabled) return;
+    if (planSidebarAutoOpenDisabled) return;
     // A closed panel with remembered surfaces is an explicit user preference,
     // even when the Plan surface is no longer in the list.
-    if (rightPanelState.surfaces.length > 0 && !rightPanelState.isOpen) return;
+    if (rightPanelSurfaceCount > 0 && !rightPanelIsOpen) return;
     const latestTurnId = activeLatestTurn?.turnId ?? null;
     if (latestTurnId && activePlan.turnId !== latestTurnId) return;
     const turnKey = activePlan.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
@@ -3844,7 +3847,9 @@ function ChatViewContent(props: ChatViewProps) {
     activeThreadRef,
     autoOpenPlanSidebar,
     planSidebarOpen,
-    rightPanelState,
+    planSidebarAutoOpenDisabled,
+    rightPanelIsOpen,
+    rightPanelSurfaceCount,
     sidebarProposedPlan?.turnId,
   ]);
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1503,8 +1503,6 @@ function ChatViewContent(props: ChatViewProps) {
   const rightPanelState = useRightPanelStore((state) =>
     selectThreadRightPanelState(state.byThreadKey, activeThreadRef),
   );
-  const rightPanelIsOpen = rightPanelState.isOpen;
-  const rightPanelSurfaceCount = rightPanelState.surfaces.length;
   const planSidebarAutoOpenDisabled = rightPanelState.planSidebarAutoOpenDisabled;
   const activeRightPanelSurface = useRightPanelStore((state) =>
     selectActiveRightPanelSurface(state.byThreadKey, activeThreadRef),
@@ -3831,9 +3829,6 @@ function ChatViewContent(props: ChatViewProps) {
     if (!activePlan) return;
     if (planSidebarOpen) return;
     if (planSidebarAutoOpenDisabled) return;
-    // A closed panel with remembered surfaces is an explicit user preference,
-    // even when the Plan surface is no longer in the list.
-    if (rightPanelSurfaceCount > 0 && !rightPanelIsOpen) return;
     const latestTurnId = activeLatestTurn?.turnId ?? null;
     if (latestTurnId && activePlan.turnId !== latestTurnId) return;
     const turnKey = activePlan.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
@@ -3848,8 +3843,6 @@ function ChatViewContent(props: ChatViewProps) {
     autoOpenPlanSidebar,
     planSidebarOpen,
     planSidebarAutoOpenDisabled,
-    rightPanelIsOpen,
-    rightPanelSurfaceCount,
     sidebarProposedPlan?.turnId,
   ]);
 
@@ -5258,12 +5251,7 @@ function ChatViewContent(props: ChatViewProps) {
         if (
           nextInteractionMode === "default" &&
           autoOpenPlanSidebar &&
-          !currentRightPanelState?.planSidebarAutoOpenDisabled &&
-          !(
-            currentRightPanelState &&
-            currentRightPanelState.surfaces.length > 0 &&
-            !currentRightPanelState.isOpen
-          )
+          !currentRightPanelState?.planSidebarAutoOpenDisabled
         ) {
           planSidebarDismissedForTurnRef.current = null;
           if (activeThreadRef) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5243,13 +5243,22 @@ function ChatViewContent(props: ChatViewProps) {
       }
 
       if (failure === null) {
+        const currentRightPanelState = activeThreadRef
+          ? selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, activeThreadRef)
+          : null;
+
         // Optimistically open the plan sidebar when implementing (not refining).
         // "default" mode here means the agent is executing the plan, which produces
         // step-tracking activities that the sidebar will display.
         if (
           nextInteractionMode === "default" &&
           autoOpenPlanSidebar &&
-          !rightPanelState.planSidebarAutoOpenDisabled
+          !currentRightPanelState?.planSidebarAutoOpenDisabled &&
+          !(
+            currentRightPanelState &&
+            currentRightPanelState.surfaces.length > 0 &&
+            !currentRightPanelState.isOpen
+          )
         ) {
           planSidebarDismissedForTurnRef.current = null;
           if (activeThreadRef) {
@@ -5290,7 +5299,6 @@ function ChatViewContent(props: ChatViewProps) {
       autoOpenPlanSidebar,
       environmentId,
       composerRef,
-      rightPanelState.planSidebarAutoOpenDisabled,
     ],
   );
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3827,6 +3827,10 @@ function ChatViewContent(props: ChatViewProps) {
     if (!autoOpenPlanSidebar) return;
     if (!activePlan) return;
     if (planSidebarOpen) return;
+    if (rightPanelState.planSidebarAutoOpenDisabled) return;
+    // A closed panel with remembered surfaces is an explicit user preference,
+    // even when the Plan surface is no longer in the list.
+    if (rightPanelState.surfaces.length > 0 && !rightPanelState.isOpen) return;
     const latestTurnId = activeLatestTurn?.turnId ?? null;
     if (latestTurnId && activePlan.turnId !== latestTurnId) return;
     const turnKey = activePlan.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
@@ -3840,6 +3844,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeThreadRef,
     autoOpenPlanSidebar,
     planSidebarOpen,
+    rightPanelState,
     sidebarProposedPlan?.turnId,
   ]);
 
@@ -5241,7 +5246,11 @@ function ChatViewContent(props: ChatViewProps) {
         // Optimistically open the plan sidebar when implementing (not refining).
         // "default" mode here means the agent is executing the plan, which produces
         // step-tracking activities that the sidebar will display.
-        if (nextInteractionMode === "default" && autoOpenPlanSidebar) {
+        if (
+          nextInteractionMode === "default" &&
+          autoOpenPlanSidebar &&
+          !rightPanelState.planSidebarAutoOpenDisabled
+        ) {
           planSidebarDismissedForTurnRef.current = null;
           if (activeThreadRef) {
             useRightPanelStore.getState().open(activeThreadRef, "plan");
@@ -5281,6 +5290,7 @@ function ChatViewContent(props: ChatViewProps) {
       autoOpenPlanSidebar,
       environmentId,
       composerRef,
+      rightPanelState.planSidebarAutoOpenDisabled,
     ],
   );
 

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -126,6 +126,32 @@ describe("rightPanelStore", () => {
     });
   });
 
+  it("infers a closed Plan dismissal when migrating storage version 7", () => {
+    expect(
+      migratePersistedRightPanelState(
+        {
+          byThreadKey: {
+            "env-1:thread-A": {
+              isOpen: false,
+              activeSurfaceId: "plan",
+              surfaces: [{ id: "plan", kind: "plan" }],
+            },
+          },
+        },
+        7,
+      ),
+    ).toEqual({
+      byThreadKey: {
+        "env-1:thread-A": {
+          isOpen: false,
+          activeSurfaceId: "plan",
+          surfaces: [{ id: "plan", kind: "plan" }],
+          planSidebarAutoOpenDisabled: true,
+        },
+      },
+    });
+  });
+
   it("open sets the active panel for a thread", () => {
     useRightPanelStore.getState().open(refA, "preview");
     expect(selectActiveRightPanel(useRightPanelStore.getState().byThreadKey, refA)).toBe("preview");

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -530,6 +530,21 @@ describe("rightPanelStore", () => {
     });
   });
 
+  it("does not reopen dismissed Plan as a close-surface fallback", () => {
+    useRightPanelStore.getState().open(refA, "plan");
+    useRightPanelStore.getState().close(refA);
+    useRightPanelStore.getState().openBrowser(refA, "tab-a");
+
+    useRightPanelStore.getState().closeSurface(refA, "browser:tab-a");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: false,
+      activeSurfaceId: "plan",
+      surfaces: [{ id: "plan", kind: "plan" }],
+      planSidebarAutoOpenDisabled: true,
+    });
+  });
+
   it("closing all surfaces closes the panel", () => {
     useRightPanelStore.getState().openBrowser(refA, "tab-a");
     useRightPanelStore.getState().openFile(refA, "src/index.ts");

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -126,27 +126,37 @@ describe("rightPanelStore", () => {
     });
   });
 
-  it("infers a closed Plan dismissal when migrating storage version 7", () => {
-    expect(
-      migratePersistedRightPanelState(
-        {
-          byThreadKey: {
-            "env-1:thread-A": {
-              isOpen: false,
-              activeSurfaceId: "plan",
-              surfaces: [{ id: "plan", kind: "plan" }],
-            },
-          },
+  it("infers a closed Plan dismissal when migrating pre-v8 storage", () => {
+    const persistedState = {
+      byThreadKey: {
+        "env-1:thread-A": {
+          isOpen: false,
+          activeSurfaceId: "plan",
+          surfaces: [{ id: "plan", kind: "plan" }],
         },
-        7,
-      ),
-    ).toEqual({
+      },
+    };
+    const expectedState = {
       byThreadKey: {
         "env-1:thread-A": {
           isOpen: false,
           activeSurfaceId: "plan",
           surfaces: [{ id: "plan", kind: "plan" }],
           planSidebarAutoOpenDisabled: true,
+        },
+      },
+    };
+
+    for (const version of [6, 7]) {
+      expect(migratePersistedRightPanelState(persistedState, version)).toEqual(expectedState);
+    }
+
+    expect(migratePersistedRightPanelState(persistedState, 8)).toEqual({
+      byThreadKey: {
+        "env-1:thread-A": {
+          isOpen: false,
+          activeSurfaceId: "plan",
+          surfaces: [{ id: "plan", kind: "plan" }],
         },
       },
     });

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -102,6 +102,30 @@ describe("rightPanelStore", () => {
     });
   });
 
+  it("preserves a saved Plan auto-open dismissal", () => {
+    expect(
+      migratePersistedRightPanelState({
+        byThreadKey: {
+          "env-1:thread-A": {
+            isOpen: false,
+            activeSurfaceId: null,
+            surfaces: [],
+            planSidebarAutoOpenDisabled: true,
+          },
+        },
+      }),
+    ).toEqual({
+      byThreadKey: {
+        "env-1:thread-A": {
+          isOpen: false,
+          activeSurfaceId: null,
+          surfaces: [],
+          planSidebarAutoOpenDisabled: true,
+        },
+      },
+    });
+  });
+
   it("open sets the active panel for a thread", () => {
     useRightPanelStore.getState().open(refA, "preview");
     expect(selectActiveRightPanel(useRightPanelStore.getState().byThreadKey, refA)).toBe("preview");
@@ -233,6 +257,26 @@ describe("rightPanelStore", () => {
     expect(selectActiveRightPanel(useRightPanelStore.getState().byThreadKey, refA)).toBeNull();
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
       isOpen: false,
+      activeSurfaceId: "plan",
+      surfaces: [{ id: "plan", kind: "plan" }],
+      planSidebarAutoOpenDisabled: true,
+    });
+  });
+
+  it("remembers when the user closes Plan so auto-open does not override it", () => {
+    useRightPanelStore.getState().open(refA, "plan");
+    useRightPanelStore.getState().closeSurface(refA, "plan");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: false,
+      activeSurfaceId: null,
+      surfaces: [],
+      planSidebarAutoOpenDisabled: true,
+    });
+
+    useRightPanelStore.getState().open(refA, "plan");
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: true,
       activeSurfaceId: "plan",
       surfaces: [{ id: "plan", kind: "plan" }],
     });

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -444,6 +444,21 @@ describe("rightPanelStore", () => {
     });
   });
 
+  it("does not reopen dismissed Plan when closing the final terminal pane", () => {
+    useRightPanelStore.getState().open(refA, "plan");
+    useRightPanelStore.getState().close(refA);
+    useRightPanelStore.getState().openTerminal(refA, "term-1");
+
+    useRightPanelStore.getState().closeTerminal(refA, "terminal:term-1", "term-1");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: false,
+      activeSurfaceId: "plan",
+      surfaces: [{ id: "plan", kind: "plan" }],
+      planSidebarAutoOpenDisabled: true,
+    });
+  });
+
   it("closing the active surface activates a neighboring surface", () => {
     useRightPanelStore.getState().openBrowser(refA, "tab-a");
     useRightPanelStore.getState().openTerminal(refA, "term-1");
@@ -569,5 +584,35 @@ describe("rightPanelStore", () => {
         (surface) => surface.id,
       ),
     ).toEqual(["terminal:term-1", "browser:tab-b", "browser:tab-c"]);
+  });
+
+  it("does not reopen dismissed Plan when browser surfaces reconcile away", () => {
+    useRightPanelStore.getState().open(refA, "plan");
+    useRightPanelStore.getState().close(refA);
+    useRightPanelStore.getState().openBrowser(refA, "tab-a");
+
+    useRightPanelStore.getState().reconcileBrowserSurfaces(refA, []);
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: false,
+      activeSurfaceId: "plan",
+      surfaces: [{ id: "plan", kind: "plan" }],
+      planSidebarAutoOpenDisabled: true,
+    });
+  });
+
+  it("does not reopen dismissed Plan when file surfaces reconcile away", () => {
+    useRightPanelStore.getState().open(refA, "plan");
+    useRightPanelStore.getState().close(refA);
+    useRightPanelStore.getState().openFile(refA, "src/index.ts");
+
+    useRightPanelStore.getState().reconcileFileSurfaces(refA, false);
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: false,
+      activeSurfaceId: "plan",
+      surfaces: [{ id: "plan", kind: "plan" }],
+      planSidebarAutoOpenDisabled: true,
+    });
   });
 });

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -451,6 +451,21 @@ describe("rightPanelStore", () => {
     });
   });
 
+  it("re-enables Plan auto-open when closing other surfaces around it", () => {
+    useRightPanelStore.getState().open(refA, "plan");
+    useRightPanelStore.getState().openBrowser(refA, "tab-a");
+    useRightPanelStore.getState().activateSurface(refA, "plan");
+    useRightPanelStore.getState().close(refA);
+
+    useRightPanelStore.getState().closeOtherSurfaces(refA, "plan");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: true,
+      activeSurfaceId: "plan",
+      surfaces: [{ id: "plan", kind: "plan" }],
+    });
+  });
+
   it("closing surfaces to the right activates the selected surface when active was removed", () => {
     useRightPanelStore.getState().openBrowser(refA, "tab-a");
     useRightPanelStore.getState().openFile(refA, "src/index.ts");

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -516,6 +516,20 @@ describe("rightPanelStore", () => {
     });
   });
 
+  it("re-enables Plan auto-open when closing surfaces to the right activates Plan", () => {
+    useRightPanelStore.getState().open(refA, "plan");
+    useRightPanelStore.getState().close(refA);
+    useRightPanelStore.getState().openBrowser(refA, "tab-a");
+
+    useRightPanelStore.getState().closeSurfacesToRight(refA, "plan");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: true,
+      activeSurfaceId: "plan",
+      surfaces: [{ id: "plan", kind: "plan" }],
+    });
+  });
+
   it("closing all surfaces closes the panel", () => {
     useRightPanelStore.getState().openBrowser(refA, "tab-a");
     useRightPanelStore.getState().openFile(refA, "src/index.ts");

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -155,6 +155,24 @@ const withPlanAutoOpenEnabled = (state: ThreadRightPanelState): ThreadRightPanel
   return withoutDisabled;
 };
 
+const selectFallbackSurface = (
+  current: ThreadRightPanelState,
+  surfaces: RightPanelSurface[],
+  preferredIndex: number,
+): RightPanelSurface | null => {
+  const fallbackCandidate =
+    surfaces[Math.min(Math.max(preferredIndex, 0), surfaces.length - 1)] ?? null;
+  if (!current.planSidebarAutoOpenDisabled || fallbackCandidate?.kind !== "plan") {
+    return fallbackCandidate;
+  }
+  return surfaces.find((surface) => surface.kind !== "plan") ?? fallbackCandidate;
+};
+
+const isDismissedPlanFallback = (
+  current: ThreadRightPanelState,
+  surface: RightPanelSurface | null,
+): boolean => current.planSidebarAutoOpenDisabled === true && surface?.kind === "plan";
+
 const updateThread = (
   byThreadKey: Record<string, ThreadRightPanelState>,
   threadKey: string,
@@ -385,15 +403,18 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             if (terminalIds.length === 0) {
               const index = current.surfaces.findIndex((entry) => entry.id === surfaceId);
               const surfaces = current.surfaces.filter((entry) => entry.id !== surfaceId);
-              const fallback = surfaces[Math.min(index, surfaces.length - 1)] ?? null;
+              const fallback = selectFallbackSurface(current, surfaces, index);
+              const activeSurfaceRemoved = current.activeSurfaceId === surfaceId;
               return {
                 ...current,
-                isOpen: surfaces.length > 0 && current.isOpen,
+                isOpen:
+                  surfaces.length > 0 &&
+                  current.isOpen &&
+                  !(activeSurfaceRemoved && isDismissedPlanFallback(current, fallback)),
                 surfaces,
-                activeSurfaceId:
-                  current.activeSurfaceId === surfaceId
-                    ? (fallback?.id ?? null)
-                    : current.activeSurfaceId,
+                activeSurfaceId: activeSurfaceRemoved
+                  ? (fallback?.id ?? null)
+                  : current.activeSurfaceId,
               };
             }
             return {
@@ -433,16 +454,13 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               const next = { ...current, isOpen: surfaces.length > 0 && current.isOpen, surfaces };
               return closingPlan ? withPlanAutoOpenDisabled(next) : next;
             }
-            const fallbackCandidate = surfaces[Math.min(index, surfaces.length - 1)] ?? null;
-            const fallback =
-              current.planSidebarAutoOpenDisabled && fallbackCandidate?.kind === "plan"
-                ? (surfaces.find((surface) => surface.kind !== "plan") ?? fallbackCandidate)
-                : fallbackCandidate;
-            const fallbackIsDismissedPlan =
-              fallback?.kind === "plan" && current.planSidebarAutoOpenDisabled;
+            const fallback = selectFallbackSurface(current, surfaces, index);
             const next = {
               ...current,
-              isOpen: surfaces.length > 0 && current.isOpen && !fallbackIsDismissedPlan,
+              isOpen:
+                surfaces.length > 0 &&
+                current.isOpen &&
+                !isDismissedPlanFallback(current, fallback),
               surfaces,
               activeSurfaceId: fallback?.id ?? null,
             };
@@ -527,12 +545,20 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               (surface) => surface.id === current.activeSurfaceId,
             );
             const fallbackBrowser = surfaces.find((surface) => surface.kind === "preview");
+            const fallback = selectFallbackSurface(
+              current,
+              surfaces,
+              fallbackBrowser ? surfaces.indexOf(fallbackBrowser) : 0,
+            );
             return {
               ...current,
+              isOpen: activeStillExists
+                ? current.isOpen
+                : surfaces.length > 0 &&
+                  current.isOpen &&
+                  !isDismissedPlanFallback(current, fallback),
               surfaces,
-              activeSurfaceId: activeStillExists
-                ? current.activeSurfaceId
-                : (fallbackBrowser?.id ?? surfaces[0]?.id ?? null),
+              activeSurfaceId: activeStillExists ? current.activeSurfaceId : (fallback?.id ?? null),
             };
           }),
         })),
@@ -547,13 +573,16 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             const activeStillExists = surfaces.some(
               (surface) => surface.id === current.activeSurfaceId,
             );
+            const fallback = selectFallbackSurface(current, surfaces, surfaces.length - 1);
             return {
               ...current,
-              isOpen: surfaces.length > 0 ? current.isOpen : false,
+              isOpen: activeStillExists
+                ? current.isOpen
+                : surfaces.length > 0 &&
+                  current.isOpen &&
+                  !isDismissedPlanFallback(current, fallback),
               surfaces,
-              activeSurfaceId: activeStillExists
-                ? current.activeSurfaceId
-                : (surfaces.at(-1)?.id ?? null),
+              activeSurfaceId: activeStillExists ? current.activeSurfaceId : (fallback?.id ?? null),
             };
           }),
         })),

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -433,10 +433,16 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               const next = { ...current, isOpen: surfaces.length > 0 && current.isOpen, surfaces };
               return closingPlan ? withPlanAutoOpenDisabled(next) : next;
             }
-            const fallback = surfaces[Math.min(index, surfaces.length - 1)] ?? null;
+            const fallbackCandidate = surfaces[Math.min(index, surfaces.length - 1)] ?? null;
+            const fallback =
+              current.planSidebarAutoOpenDisabled && fallbackCandidate?.kind === "plan"
+                ? (surfaces.find((surface) => surface.kind !== "plan") ?? fallbackCandidate)
+                : fallbackCandidate;
+            const fallbackIsDismissedPlan =
+              fallback?.kind === "plan" && current.planSidebarAutoOpenDisabled;
             const next = {
               ...current,
-              isOpen: surfaces.length > 0 && current.isOpen,
+              isOpen: surfaces.length > 0 && current.isOpen && !fallbackIsDismissedPlan,
               surfaces,
               activeSurfaceId: fallback?.id ?? null,
             };

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -467,6 +467,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
             const index = current.surfaces.findIndex((surface) => surface.id === surfaceId);
             if (index < 0 || index === current.surfaces.length - 1) return current;
+            const surface = current.surfaces[index];
             const surfaces = current.surfaces.slice(0, index + 1);
             const activeStillExists = surfaces.some(
               (surface) => surface.id === current.activeSurfaceId,
@@ -476,6 +477,9 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               surfaces,
               activeSurfaceId: activeStillExists ? current.activeSurfaceId : surfaceId,
             };
+            if (!activeStillExists && surface?.kind === "plan") {
+              return withPlanAutoOpenEnabled(next);
+            }
             return current.surfaces.some((entry) => entry.kind === "plan") &&
               !surfaces.some((entry) => entry.kind === "plan")
               ? withPlanAutoOpenDisabled(next)

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -260,7 +260,8 @@ export function migratePersistedRightPanelState(
                   : activeSurfaceId !== null;
               const planSidebarAutoOpenDisabled =
                 validThreadState?.planSidebarAutoOpenDisabled === true ||
-                (version === RIGHT_PANEL_STORAGE_VERSION - 1 &&
+                (typeof version === "number" &&
+                  version < RIGHT_PANEL_STORAGE_VERSION &&
                   validThreadState?.isOpen === false &&
                   validThreadState?.activeSurfaceId === "plan" &&
                   surfaces.some((surface) => surface.kind === "plan"));

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -449,7 +449,9 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             return current.surfaces.some((entry) => entry.kind === "plan") &&
               surface.kind !== "plan"
               ? withPlanAutoOpenDisabled(next)
-              : next;
+              : surface.kind === "plan"
+                ? withPlanAutoOpenEnabled(next)
+                : next;
           }),
         })),
       closeSurfacesToRight: (ref, surfaceId) =>

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -40,12 +40,14 @@ export type RightPanelSurface =
   | { id: "plan"; kind: "plan" };
 
 const RIGHT_PANEL_STORAGE_KEY = "t3code:right-panel-state:v2";
-const RIGHT_PANEL_STORAGE_VERSION = 7;
+const RIGHT_PANEL_STORAGE_VERSION = 8;
 
 export interface ThreadRightPanelState {
   isOpen: boolean;
   activeSurfaceId: string | null;
   surfaces: RightPanelSurface[];
+  /** Set after the user closes Plan so automatic plan updates do not reopen it. */
+  planSidebarAutoOpenDisabled?: boolean;
 }
 
 interface RightPanelStoreState {
@@ -124,13 +126,34 @@ const upsertSurface = (
   current: ThreadRightPanelState,
   surface: RightPanelSurface,
   activate = true,
-): ThreadRightPanelState => ({
-  isOpen: true,
-  surfaces: current.surfaces.some((entry) => entry.id === surface.id)
-    ? current.surfaces
-    : [...current.surfaces, surface],
-  activeSurfaceId: activate ? surface.id : current.activeSurfaceId,
+): ThreadRightPanelState => {
+  const next = {
+    ...current,
+    isOpen: true,
+    surfaces: current.surfaces.some((entry) => entry.id === surface.id)
+      ? current.surfaces
+      : [...current.surfaces, surface],
+    activeSurfaceId: activate ? surface.id : current.activeSurfaceId,
+  };
+
+  if (surface.kind === "plan") {
+    const { planSidebarAutoOpenDisabled: _disabled, ...withoutDisabled } = next;
+    return withoutDisabled;
+  }
+
+  return next;
+};
+
+const withPlanAutoOpenDisabled = (state: ThreadRightPanelState): ThreadRightPanelState => ({
+  ...state,
+  planSidebarAutoOpenDisabled: true,
 });
+
+const withPlanAutoOpenEnabled = (state: ThreadRightPanelState): ThreadRightPanelState => {
+  if (!state.planSidebarAutoOpenDisabled) return state;
+  const { planSidebarAutoOpenDisabled: _disabled, ...withoutDisabled } = state;
+  return withoutDisabled;
+};
 
 const updateThread = (
   byThreadKey: Record<string, ThreadRightPanelState>,
@@ -139,7 +162,12 @@ const updateThread = (
 ): Record<string, ThreadRightPanelState> => {
   const current = byThreadKey[threadKey] ?? EMPTY_THREAD_STATE;
   const next = updater(current);
-  if (!next.isOpen && next.activeSurfaceId === null && next.surfaces.length === 0) {
+  if (
+    !next.isOpen &&
+    next.activeSurfaceId === null &&
+    next.surfaces.length === 0 &&
+    !next.planSidebarAutoOpenDisabled
+  ) {
     if (!(threadKey in byThreadKey)) return byThreadKey;
     const { [threadKey]: _removed, ...rest } = byThreadKey;
     return rest;
@@ -227,7 +255,17 @@ export function migratePersistedRightPanelState(persistedState: unknown): {
                 typeof validThreadState?.isOpen === "boolean"
                   ? validThreadState.isOpen
                   : activeSurfaceId !== null;
-              return [threadKey, { isOpen, surfaces, activeSurfaceId }];
+              const planSidebarAutoOpenDisabled =
+                validThreadState?.planSidebarAutoOpenDisabled === true;
+              return [
+                threadKey,
+                {
+                  isOpen,
+                  surfaces,
+                  activeSurfaceId,
+                  ...(planSidebarAutoOpenDisabled ? { planSidebarAutoOpenDisabled: true } : {}),
+                },
+              ];
             },
           ),
         )
@@ -275,7 +313,8 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               normalizeRevealLine(line),
               (existing?.revealRequestId ?? 0) + 1,
             );
-            return {
+            const next = {
+              ...current,
               isOpen: true,
               activeSurfaceId: surface.id,
               surfaces: existing
@@ -284,6 +323,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
                   )
                 : [...withoutStandaloneExplorer, surface],
             };
+            return next;
           }),
         })),
       openTerminal: (ref, terminalId) =>
@@ -367,28 +407,32 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       activateSurface: (ref, surfaceId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
-            current.surfaces.some((surface) => surface.id === surfaceId)
-              ? { ...current, isOpen: true, activeSurfaceId: surfaceId }
-              : current,
-          ),
+          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+            const surface = current.surfaces.find((entry) => entry.id === surfaceId);
+            if (!surface) return current;
+            const next = { ...current, isOpen: true, activeSurfaceId: surfaceId };
+            return surface.kind === "plan" ? withPlanAutoOpenEnabled(next) : next;
+          }),
         })),
       closeSurface: (ref, surfaceId) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
             const index = current.surfaces.findIndex((surface) => surface.id === surfaceId);
             if (index < 0) return current;
+            const closingPlan = current.surfaces[index]?.kind === "plan";
             const surfaces = current.surfaces.filter((surface) => surface.id !== surfaceId);
             if (current.activeSurfaceId !== surfaceId) {
-              return { ...current, isOpen: surfaces.length > 0 && current.isOpen, surfaces };
+              const next = { ...current, isOpen: surfaces.length > 0 && current.isOpen, surfaces };
+              return closingPlan ? withPlanAutoOpenDisabled(next) : next;
             }
             const fallback = surfaces[Math.min(index, surfaces.length - 1)] ?? null;
-            return {
+            const next = {
               ...current,
               isOpen: surfaces.length > 0 && current.isOpen,
               surfaces,
               activeSurfaceId: fallback?.id ?? null,
             };
+            return closingPlan ? withPlanAutoOpenDisabled(next) : next;
           }),
         })),
       closeOtherSurfaces: (ref, surfaceId) =>
@@ -396,12 +440,16 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
             const surface = current.surfaces.find((entry) => entry.id === surfaceId);
             if (!surface || current.surfaces.length === 1) return current;
-            return {
+            const next = {
               ...current,
               isOpen: true,
               surfaces: [surface],
               activeSurfaceId: surface.id,
             };
+            return current.surfaces.some((entry) => entry.kind === "plan") &&
+              surface.kind !== "plan"
+              ? withPlanAutoOpenDisabled(next)
+              : next;
           }),
         })),
       closeSurfacesToRight: (ref, surfaceId) =>
@@ -413,11 +461,15 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             const activeStillExists = surfaces.some(
               (surface) => surface.id === current.activeSurfaceId,
             );
-            return {
+            const next = {
               ...current,
               surfaces,
               activeSurfaceId: activeStillExists ? current.activeSurfaceId : surfaceId,
             };
+            return current.surfaces.some((entry) => entry.kind === "plan") &&
+              !surfaces.some((entry) => entry.kind === "plan")
+              ? withPlanAutoOpenDisabled(next)
+              : next;
           }),
         })),
       closeAllSurfaces: (ref) =>
@@ -425,7 +477,14 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
             current.surfaces.length === 0
               ? current
-              : { ...current, isOpen: false, surfaces: [], activeSurfaceId: null },
+              : current.surfaces.some((surface) => surface.kind === "plan")
+                ? withPlanAutoOpenDisabled({
+                    ...current,
+                    isOpen: false,
+                    surfaces: [],
+                    activeSurfaceId: null,
+                  })
+                : { ...current, isOpen: false, surfaces: [], activeSurfaceId: null },
           ),
         })),
       reconcileBrowserSurfaces: (ref, tabIds) =>
@@ -481,19 +540,37 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
       show: (ref) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
-            current.isOpen ? current : { ...current, isOpen: true },
+            current.isOpen
+              ? current
+              : current.surfaces.find((entry) => entry.id === current.activeSurfaceId)?.kind ===
+                  "plan"
+                ? { ...withPlanAutoOpenEnabled(current), isOpen: true }
+                : { ...current, isOpen: true },
           ),
         })),
       close: (ref) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
-            current.isOpen ? { ...current, isOpen: false } : current,
+            current.isOpen
+              ? {
+                  ...(current.surfaces.find((entry) => entry.id === current.activeSurfaceId)
+                    ?.kind === "plan"
+                    ? withPlanAutoOpenDisabled(current)
+                    : current),
+                  isOpen: false,
+                }
+              : current,
           ),
         })),
       toggleVisibility: (ref) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => ({
-            ...current,
+            ...(current.isOpen
+              ? current
+              : current.surfaces.find((entry) => entry.id === current.activeSurfaceId)?.kind ===
+                  "plan"
+                ? withPlanAutoOpenEnabled(current)
+                : current),
             isOpen: !current.isOpen,
           })),
         })),
@@ -504,7 +581,9 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               (surface) => surface.id === current.activeSurfaceId,
             );
             if (current.isOpen && active?.kind === kind) {
-              return { ...current, isOpen: false };
+              return kind === "plan"
+                ? withPlanAutoOpenDisabled({ ...current, isOpen: false })
+                : { ...current, isOpen: false };
             }
             if (kind === "preview") {
               const existing = current.surfaces.find((surface) => surface.kind === "preview");

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -181,7 +181,10 @@ function normalizeRevealLine(line: number | undefined): number | null {
   return Math.max(1, Math.trunc(line));
 }
 
-export function migratePersistedRightPanelState(persistedState: unknown): {
+export function migratePersistedRightPanelState(
+  persistedState: unknown,
+  version?: number,
+): {
   byThreadKey: Record<string, ThreadRightPanelState>;
 } {
   if (!persistedState || typeof persistedState !== "object") {
@@ -256,7 +259,11 @@ export function migratePersistedRightPanelState(persistedState: unknown): {
                   ? validThreadState.isOpen
                   : activeSurfaceId !== null;
               const planSidebarAutoOpenDisabled =
-                validThreadState?.planSidebarAutoOpenDisabled === true;
+                validThreadState?.planSidebarAutoOpenDisabled === true ||
+                (version === RIGHT_PANEL_STORAGE_VERSION - 1 &&
+                  validThreadState?.isOpen === false &&
+                  validThreadState?.activeSurfaceId === "plan" &&
+                  surfaces.some((surface) => surface.kind === "plan"));
               return [
                 threadKey,
                 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Install and first run](./user/install.md)
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
+- [Plan sidebar](./user/plan-sidebar.md)
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)

--- a/docs/user/plan-sidebar.md
+++ b/docs/user/plan-sidebar.md
@@ -1,0 +1,11 @@
+# Plan Sidebar
+
+When **Auto-open task panel** is enabled in Settings, T3 Code can open the Plan
+sidebar when plan or task steps arrive for the current turn.
+
+Closing Plan is remembered for that thread. The preference is stored locally,
+survives reloads, and prevents later plan updates from opening the sidebar
+automatically. Closing the right panel while Plan is active has the same effect.
+
+To turn automatic opening back on for the thread, manually open or select the
+Plan surface. That explicit action clears the dismissal preference.


### PR DESCRIPTION
## What changed

- Persist a per-thread Plan sidebar dismissal in the right-panel state.
- Make Plan auto-open behavior respect that persisted user preference.
- Clear the dismissal when the user manually reopens Plan.
- Preserve the preference through right-panel state migration.

## Why

The Plan tab was reopening after the user closed it because the auto-open effect ignored the right-panel state persisted in local storage. Plan activity updates or a thread remount could therefore override the user's choice.

## User impact

Closing Plan now keeps it closed across plan updates and thread remounts. Manually opening Plan still works as an explicit opt-in.

## Validation

- `pnpm exec vp test run apps/web/src/rightPanelStore.test.ts` — 29 passed
- `pnpm --filter @t3tools/web typecheck`
- Targeted lint and formatting checks
- No visual layout change; this is a behavior-only persistence fix, so before/after images are not applicable.

Surface coverage: web and desktop wrapper (shared web client); mobile does not use this right-panel surface.

Model/harness: GPT-5.6 Luna via Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist Plan sidebar closed state to prevent auto-reopening across sessions
> - Adds a `planSidebarAutoOpenDisabled` flag to `ThreadRightPanelState` in [rightPanelStore.ts](https://github.com/pingdotgg/t3code/pull/4865/files#diff-c23667fc6a40049fa00d6fba14ae4a097ed3561fcdfb9ec172bc8216cd9f82eb) that is set when the user closes the Plan sidebar and cleared when they explicitly reopen it.
> - Updates all close/toggle/reconcile methods in the store to set or clear this flag appropriately, and skips Plan when selecting a fallback surface if dismissal is active.
> - Gates the Plan sidebar auto-open effect and optimistic open in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4865/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) on the new flag.
> - Bumps `RIGHT_PANEL_STORAGE_VERSION` to 8 and updates migration to infer dismissal for v6/v7 states that were closed on the Plan surface.
> - Behavioral Change: threads that previously had no surfaces and `isOpen: false` are now retained in storage if they carry a dismissal flag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c1324a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plan sidebar auto-opening now respects when it has been manually dismissed.
  * Closing the Plan sidebar no longer causes it to reopen unexpectedly.
  * Reopening the Plan surface correctly restores its active state and re-enables automatic opening.
  * Improved preservation of Plan sidebar preferences across saved and migrated sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local UI persistence and right-panel behavior only; no auth, data, or API changes.
> 
> **Overview**
> Fixes the Plan sidebar reopening after the user closed it when plan/todo updates or thread remounts triggered auto-open.
> 
> Adds a per-thread **`planSidebarAutoOpenDisabled`** flag in persisted right-panel state. Closing Plan (closing the surface, the panel while Plan is active, or toggling Plan off) sets the flag; explicitly opening or activating Plan clears it. **`ChatView`** skips plan auto-open effects and optimistic opens on implement when the flag is set.
> 
> Right-panel store logic avoids falling back to a dismissed Plan surface when other surfaces close or reconcile. Storage version bumps to **8**, with migration inferring dismissal from pre-v8 state where the panel was closed with Plan still selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1324a7c31eca53e5ae17364e699b6feae4cbfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->