### PR TITLE
fix(mobile): bound thread resume replay

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5975,6 +5975,240 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 
+  it.effect("subscribeThread bounds replay to the captured server head gap", () =>
+    Effect.gen(function* () {
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+      let readEventsCalls = 0;
+      let replayAfterSequence: number | undefined;
+      let replayLimit: number | undefined;
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            latestSequence: Effect.succeed(50),
+            readEvents: (afterSequence, limit) => {
+              readEventsCalls += 1;
+              replayAfterSequence = afterSequence;
+              replayLimit = limit;
+              return Stream.empty;
+            },
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.succeed(Option.some({ snapshotSequence: 1, thread })),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const first = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+            afterSequence: 7,
+            requestCompletionMarker: true,
+          }).pipe(Stream.runHead),
+        ),
+      );
+
+      // The replay is bounded to the captured head gap (50 - 7 = 43), never
+      // Number.MAX_SAFE_INTEGER, and the empty-replay marker carries the head.
+      assert.equal(readEventsCalls, 1);
+      assert.equal(replayAfterSequence, 7);
+      assert.equal(replayLimit, 43);
+      assert.deepEqual(Option.getOrThrow(first), { kind: "synchronized", sequence: 50 });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("subscribeThread replays only this thread's events from the bounded global range", () =>
+    Effect.gen(function* () {
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+      const otherThreadId = ThreadId.make("thread-other");
+      const now = "2026-01-01T00:00:00.000Z";
+      let scanned = 0;
+      let replayLimit: number | undefined;
+
+      const messageEvent = (sequence: number, threadId: ThreadId): OrchestrationEvent =>
+        ({
+          sequence,
+          eventId: EventId.make(`event-${sequence}`),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: null,
+          causationEventId: null,
+          correlationId: null,
+          metadata: {},
+          type: "thread.message-sent",
+          payload: {
+            threadId,
+            messageId: MessageId.make(`message-${sequence}`),
+            role: "user",
+            text: `message ${sequence}`,
+            turnId: null,
+            streaming: false,
+            createdAt: now,
+            updatedAt: now,
+          },
+        }) satisfies OrchestrationEvent;
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            latestSequence: Effect.succeed(10),
+            readEvents: (_afterSequence, limit) => {
+              replayLimit = limit;
+              return Stream.fromIterable([
+                messageEvent(8, otherThreadId),
+                messageEvent(9, defaultThreadId),
+                messageEvent(10, otherThreadId),
+              ]).pipe(Stream.tap(() => Effect.sync(() => (scanned += 1))));
+            },
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.succeed(Option.some({ snapshotSequence: 1, thread })),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const items = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+            afterSequence: 7,
+            requestCompletionMarker: true,
+          }).pipe(Stream.take(2), Stream.runCollect),
+        ),
+      );
+
+      // The global store scans all 3 events in the bounded range, but only the
+      // matching thread's event is emitted before the synchronized marker.
+      assert.equal(scanned, 3);
+      assert.equal(replayLimit, 3);
+      assert.equal(items[0]?.kind, "event");
+      assert.equal(items[0]?.kind === "event" ? items[0].event.sequence : null, 9);
+      assert.deepEqual(items[1], { kind: "synchronized", sequence: 10 });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("subscribeThread marks an empty catch-up replay as synchronized with the head", () =>
+    Effect.gen(function* () {
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            latestSequence: Effect.succeed(12),
+            readEvents: () => Stream.empty,
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.succeed(Option.some({ snapshotSequence: 1, thread })),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const first = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+            afterSequence: 12,
+            requestCompletionMarker: true,
+          }).pipe(Stream.runHead),
+        ),
+      );
+
+      // Empty replay (cursor already at the head) still emits the marker, and
+      // the marker carries the captured head so a quiet thread can advance.
+      assert.deepEqual(Option.getOrThrow(first), { kind: "synchronized", sequence: 12 });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("subscribeThread sends a fresh snapshot instead of replaying a large gap", () =>
+    Effect.gen(function* () {
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+      let readEventsCalls = 0;
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            latestSequence: Effect.succeed(100_000),
+            readEvents: () =>
+              Stream.sync(() => {
+                readEventsCalls += 1;
+                return {} as OrchestrationEvent;
+              }),
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.succeed(Option.some({ snapshotSequence: 100_000, thread })),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const items = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+            afterSequence: 5,
+            requestCompletionMarker: true,
+          }).pipe(Stream.take(2), Stream.runCollect),
+        ),
+      );
+
+      // Large gap => fresh thread snapshot, and the unbounded replay is never
+      // started. The marker still carries the captured head.
+      assert.equal(items[0]?.kind, "snapshot");
+      assert.deepEqual(items[1], { kind: "synchronized", sequence: 100_000 });
+      assert.equal(readEventsCalls, 0);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("subscribeThread replaces a cursor ahead of the authoritative head", () =>
+    Effect.gen(function* () {
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+      let readEventsCalls = 0;
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            latestSequence: Effect.succeed(5),
+            readEvents: () =>
+              Stream.sync(() => {
+                readEventsCalls += 1;
+                return {} as OrchestrationEvent;
+              }),
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.succeed(Option.some({ snapshotSequence: 5, thread })),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const items = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+            afterSequence: 10,
+            requestCompletionMarker: true,
+          }).pipe(Stream.take(2), Stream.runCollect),
+        ),
+      );
+
+      // Cursor ahead of the head is invalid; reset with a fresh snapshot and
+      // never start the replay.
+      assert.equal(items[0]?.kind, "snapshot");
+      assert.deepEqual(items[1], { kind: "synchronized", sequence: 5 });
+      assert.equal(readEventsCalls, 0);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("subscribeShell sends a fresh snapshot instead of replaying a large gap", () =>
     Effect.gen(function* () {
       let readEventsCalls = 0;

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -294,6 +294,15 @@ const PROVIDER_STATUS_DEBOUNCE_MS = 200;
 // Matches the event store's default page size (DEFAULT_READ_FROM_SEQUENCE_LIMIT).
 const SHELL_RESUME_MAX_GAP = 1_000;
 
+// Same bound as SHELL_RESUME_MAX_GAP, applied to per-thread resume replay. A
+// resuming mobile client passes its last applied sequence; the global event
+// store pages and decodes every event in the range before the per-thread filter
+// runs, so an unbounded replay (the old Number.MAX_SAFE_INTEGER) re-scans the
+// whole store on every foreground resubscribe. Bounding to the captured head
+// gap keeps quiet threads from re-reading the same suffix forever, and a gap
+// past this bound falls back to a single thread-detail snapshot.
+const THREAD_RESUME_MAX_GAP = 1_000;
+
 function toAuthAccessStreamEvent(
   change: PairingGrantStore.BootstrapCredentialChange | SessionStore.SessionCredentialChange,
   revision: number,
@@ -1263,33 +1272,88 @@ const makeWsRpcLayer = (
               // catch-up followed by the buffered/ongoing live events. Overlapping
               // events are deduped by sequence on the client.
               //
-              // Read the full range after the cursor (not the store's default
-              // page-bounded limit): the range is normally tiny (a fresh HTTP
-              // snapshot sequence) and the per-thread filter runs after reading,
-              // so a global cap could otherwise omit this thread's events.
+              // Capture the authoritative server head *before* replay and bound
+              // the read to that head gap. The global store pages and decodes
+              // every event in the range before the per-thread filter runs, so an
+              // unbounded replay would re-scan the whole store on every
+              // resubscribe; the bound also keeps a moving event-store head from
+              // growing the live buffer indefinitely while waiting for an empty
+              // page. The captured head travels on the completion marker so a
+              // quiet thread (catch-up emits no thread events) can still advance
+              // its cursor and avoid re-reading the same suffix next time.
               if (input.afterSequence !== undefined) {
                 const afterSequence = input.afterSequence;
-                const catchUpStream = orchestrationEngine
-                  .readEvents(afterSequence, Number.MAX_SAFE_INTEGER)
-                  .pipe(
-                    Stream.filter(isThisThreadDetailEvent),
-                    Stream.map((event) => ({
-                      kind: "event" as const,
-                      event: projectActivityEvent(event),
-                    })),
-                    Stream.mapError(
-                      (cause) =>
-                        new OrchestrationGetSnapshotError({
-                          message: `Failed to replay thread ${input.threadId} events`,
-                          cause,
-                        }),
-                    ),
+                const headSequence = yield* orchestrationEngine.latestSequence;
+                const replayGap = headSequence - afterSequence;
+
+                // Cursor ahead of the authoritative head, or gap too large to
+                // replay per-event: send a fresh thread detail snapshot (the
+                // same path as no-afterSequence) followed by the buffered live
+                // tail. The snapshot's snapshotSequence becomes the new cursor;
+                // the marker still carries the captured head for uniformity.
+                if (replayGap < 0 || replayGap > THREAD_RESUME_MAX_GAP) {
+                  const snapshot = yield* projectionSnapshotQuery
+                    .getThreadDetailSnapshot(input.threadId)
+                    .pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new OrchestrationGetSnapshotError({
+                            message: `Failed to load thread ${input.threadId}`,
+                            cause,
+                          }),
+                      ),
+                    );
+
+                  if (Option.isNone(snapshot)) {
+                    return yield* new OrchestrationGetSnapshotError({
+                      message: `Thread ${input.threadId} was not found`,
+                      cause: input.threadId,
+                    });
+                  }
+
+                  const afterSnapshot =
+                    input.requestCompletionMarker === true
+                      ? Stream.concat(
+                          Stream.fromEffect(
+                            Queue.offer(liveBuffer, {
+                              kind: "synchronized" as const,
+                              sequence: headSequence,
+                            }),
+                          ).pipe(Stream.drain),
+                          bufferedLiveStream,
+                        )
+                      : bufferedLiveStream;
+                  return Stream.concat(
+                    Stream.make({
+                      kind: "snapshot" as const,
+                      snapshot: projectThreadDetailSnapshot(snapshot.value),
+                    }),
+                    afterSnapshot,
                   );
+                }
+
+                const catchUpStream = orchestrationEngine.readEvents(afterSequence, replayGap).pipe(
+                  Stream.filter(isThisThreadDetailEvent),
+                  Stream.map((event) => ({
+                    kind: "event" as const,
+                    event: projectActivityEvent(event),
+                  })),
+                  Stream.mapError(
+                    (cause) =>
+                      new OrchestrationGetSnapshotError({
+                        message: `Failed to replay thread ${input.threadId} events`,
+                        cause,
+                      }),
+                  ),
+                );
                 const afterCatchUp =
                   input.requestCompletionMarker === true
                     ? Stream.concat(
                         Stream.fromEffect(
-                          Queue.offer(liveBuffer, { kind: "synchronized" as const }),
+                          Queue.offer(liveBuffer, {
+                            kind: "synchronized" as const,
+                            sequence: headSequence,
+                          }),
                         ).pipe(Stream.drain),
                         bufferedLiveStream,
                       )

--- a/packages/client-runtime/src/state/threads-sync.test.ts
+++ b/packages/client-runtime/src/state/threads-sync.test.ts
@@ -273,6 +273,11 @@ const snapshot = (thread: OrchestrationThread): OrchestrationThreadStreamItem =>
 
 const synchronized = (): OrchestrationThreadStreamItem => ({ kind: "synchronized" });
 
+const synchronizedWithHead = (sequence: number): OrchestrationThreadStreamItem => ({
+  kind: "synchronized",
+  sequence,
+});
+
 const titleUpdated = (title: string, sequence = 2): OrchestrationThreadStreamItem => ({
   kind: "event",
   event: {
@@ -696,6 +701,64 @@ describe("EnvironmentThreads", () => {
         (value) => value.status === "live" && Option.isSome(value.data),
       );
       expect(Option.getOrThrow(live.data).title).toBe("Latest title");
+    }),
+  );
+
+  it.effect("advances the resume cursor from a synchronized marker head on a quiet thread", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ cached: BASE_THREAD, completionMarker: true });
+      yield* awaitThreadState(
+        harness.observed,
+        (value) => value.status === "synchronizing" && Option.isSome(value.data),
+      );
+
+      // Quiet thread: catch-up emits no thread events, only the completion
+      // marker carrying the captured server head. The client must advance its
+      // resume cursor to that head so the next foreground resubscribe does not
+      // re-scan the same suffix from the stale cached sequence.
+      yield* Queue.offer(harness.inputs, synchronizedWithHead(20));
+      yield* awaitThreadState(
+        harness.observed,
+        (value) => value.status === "live" && Option.isSome(value.data),
+      );
+
+      yield* Queue.offer(harness.wakeups, "application-active");
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if ((yield* Ref.get(harness.subscriptionCount)) >= 2) break;
+        yield* Effect.yieldNow;
+      }
+
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(2);
+      expect(yield* Ref.get(harness.lastSubscribeAfterSequence)).toBe(20);
+      expect(yield* Ref.get(harness.loaderCalls)).toBe(0);
+    }),
+  );
+
+  it.effect("accepts a synchronized marker without a sequence without advancing the cursor", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ cached: BASE_THREAD, completionMarker: true });
+      yield* awaitThreadState(
+        harness.observed,
+        (value) => value.status === "synchronizing" && Option.isSome(value.data),
+      );
+
+      // Older servers emit the marker without a sequence. The client stays live
+      // and keeps its existing cursor (the cached snapshot sequence) rather than
+      // regressing or failing on the missing field.
+      yield* Queue.offer(harness.inputs, synchronized());
+      yield* awaitThreadState(
+        harness.observed,
+        (value) => value.status === "live" && Option.isSome(value.data),
+      );
+
+      yield* Queue.offer(harness.wakeups, "application-active");
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if ((yield* Ref.get(harness.subscriptionCount)) >= 2) break;
+        yield* Effect.yieldNow;
+      }
+
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(2);
+      expect(yield* Ref.get(harness.lastSubscribeAfterSequence)).toBe(CACHED_SNAPSHOT_SEQUENCE);
     }),
   );
 });

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -184,6 +184,17 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
   ) {
     if (item.kind === "synchronized") {
       yield* Ref.set(awaitingCompletion, false);
+      // A quiet thread's catch-up may emit no thread events, so the marker is
+      // the only signal of how far the server's authoritative head has moved.
+      // Advance the resume cursor to the captured head when present so the next
+      // foreground resubscribe starts from here instead of re-scanning the same
+      // suffix. Older servers omit the sequence and are left unchanged.
+      if (item.sequence !== undefined) {
+        const currentSequence = yield* SubscriptionRef.get(lastSequence);
+        if (item.sequence > currentSequence) {
+          yield* SubscriptionRef.set(lastSequence, item.sequence);
+        }
+      }
       yield* SubscriptionRef.update(state, (current) =>
         Option.isSome(current.data) && current.status !== "deleted"
           ? { ...current, status: "live" as const, error: Option.none() }

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1264,6 +1264,15 @@ export type OrchestrationEvent = typeof OrchestrationEvent.Type;
 export const OrchestrationThreadStreamItem = Schema.Union([
   Schema.Struct({
     kind: Schema.Literal("synchronized"),
+    /**
+     * The authoritative server event-store head captured before this
+     * subscription's catch-up replay. On a quiet thread the catch-up may emit
+     * no thread events, so without this head the client would keep its stale
+     * cursor and re-scan the same suffix on every resubscribe. Clients advance
+     * their resume cursor to this sequence when present; older servers that
+     * omit it are accepted unchanged.
+     */
+    sequence: Schema.optionalKey(NonNegativeInt),
   }),
   Schema.Struct({
     kind: Schema.Literal("snapshot"),


### PR DESCRIPTION
## Problem

Returning the mobile app to the foreground resubscribes the selected thread from its last sequence. A quiet thread could keep an old cursor because the `synchronized` marker did not carry the server's current head sequence.

The server also requested the remaining global event stream with `Number.MAX_SAFE_INTEGER`. The event store scanned and decoded that suffix before filtering it to the subscribed thread.

## Change

- Capture a fixed event-store head before catch-up and bound replay to the cursor gap.
- Fall back to the existing thread-detail snapshot when the gap exceeds 1,000 events or the client cursor is ahead.
- Add an optional head sequence to the `synchronized` marker and advance the client cursor monotonically.
- Cover bounded scanning, filtered emission, empty catch-up, snapshot fallback, and old-marker compatibility.

## Verification

- `vp test run apps/server/src/server.test.ts -t subscribeThread`: 5 passed, 116 skipped. Receipt `20260729-202920-work-verify-2dbe58`.
- `vp test run packages/client-runtime/src/state/threads-sync.test.ts`: 16 passed. Receipt `20260729-202940-work-verify-8c25e5`.
- Independent contract review found no blocking findings. Receipt `20260729-201536-9fe6a4a8`.
- `git diff HEAD^ HEAD --check`: clean.

## Not run locally

The full test suite, Android build, repository-wide typecheck or build, live-device integration, and wall-clock performance benchmark were not run.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound thread resume replay to server head gap in `subscribeThread`
> - Introduces `THREAD_RESUME_MAX_GAP` (1,000) in [ws.ts](https://github.com/pingdotgg/t3code/pull/4868/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125): if the client cursor is ahead of the server head or the gap exceeds this limit, the server sends a fresh thread snapshot instead of replaying events.
> - The `synchronized` marker now carries the server's captured `headSequence`, allowing clients to advance their resume cursor to the authoritative head rather than the last replayed event.
> - Client-side, [threads.ts](https://github.com/pingdotgg/t3code/pull/4868/files#diff-3389d9e86e5f65222bc1be800d0aa21f5356629eaf916680112dcbd606822815) reads the optional `sequence` field on `synchronized` items and advances `lastSequence` if it is greater than the current value; markers without `sequence` (older servers) leave the cursor unchanged.
> - The `synchronized` variant in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/4868/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af) is extended with an optional `sequence: NonNegativeInt` field.
> - Behavioral Change: prior behavior read up to `Number.MAX_SAFE_INTEGER` events and emitted a `synchronized` marker without a sequence; now replay is bounded and the marker carries the head sequence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8227a50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->