### PR TITLE
perf(mobile): reconnect environments immediately on resume

### DIFF
--- a/apps/mobile/src/connection/app-state-wakeups.test.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  MOBILE_BACKGROUND_RECONNECT_AFTER_MS,
+  mobileApplicationActiveWakeup,
+} from "./app-state-wakeups";
+
+describe("mobileApplicationActiveWakeup", () => {
+  it("uses a fast probe after a short interruption", () => {
+    expect(mobileApplicationActiveWakeup(null, 20_000)).toBe("application-active-probe");
+    expect(
+      mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS - 1),
+    ).toBe("application-active-probe");
+  });
+
+  it("replaces the session after a meaningful background suspension", () => {
+    expect(
+      mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS),
+    ).toBe("application-active-reconnect");
+  });
+});

--- a/apps/mobile/src/connection/app-state-wakeups.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.ts
@@ -1,0 +1,18 @@
+import type { Wakeups } from "@t3tools/client-runtime/connection";
+
+export const MOBILE_BACKGROUND_RECONNECT_AFTER_MS = 10_000;
+
+export type MobileApplicationActiveWakeup = Extract<
+  Wakeups.ConnectionWakeup,
+  "application-active-probe" | "application-active-reconnect"
+>;
+
+export function mobileApplicationActiveWakeup(
+  backgroundedAtMs: number | null,
+  activeAtMs: number,
+): MobileApplicationActiveWakeup {
+  return backgroundedAtMs !== null &&
+    activeAtMs - backgroundedAtMs >= MOBILE_BACKGROUND_RECONNECT_AFTER_MS
+    ? "application-active-reconnect"
+    : "application-active-probe";
+}

--- a/apps/mobile/src/connection/platform.ts
+++ b/apps/mobile/src/connection/platform.ts
@@ -30,6 +30,7 @@ import * as MobileStorage from "../persistence/mobile-storage";
 import { appAtomRegistry } from "../state/atom-registry";
 import { clearThreadOutboxEnvironment } from "../state/thread-outbox";
 import { clearComposerDraftsEnvironment } from "../state/use-composer-drafts";
+import { mobileApplicationActiveWakeup } from "./app-state-wakeups";
 import { connectionStorageLayer } from "./storage";
 
 function networkStatus(state: Network.NetworkState): "unknown" | "offline" | "online" {
@@ -54,27 +55,53 @@ const connectivityLayer = Connectivity.layer({
   ),
   changes: Stream.callback((queue) =>
     Effect.acquireRelease(
-      Effect.sync(() =>
-        Network.addNetworkStateListener((state) => {
+      Effect.sync(() => {
+        let active = true;
+        const networkSubscription = Network.addNetworkStateListener((state) => {
           Queue.offerUnsafe(queue, networkStatus(state));
-        }),
-      ),
-      (subscription) => Effect.sync(() => subscription.remove()),
+        });
+        const appStateSubscription = AppState.addEventListener("change", (state) => {
+          if (state !== "active") {
+            return;
+          }
+          void Network.getNetworkStateAsync()
+            .then((current) => {
+              if (active) {
+                Queue.offerUnsafe(queue, networkStatus(current));
+              }
+            })
+            .catch(() => undefined);
+        });
+        return {
+          close: () => {
+            active = false;
+            networkSubscription.remove();
+            appStateSubscription.remove();
+          },
+        };
+      }),
+      ({ close }) => Effect.sync(close),
     ).pipe(Effect.asVoid),
   ),
 });
 
 const wakeupsLayer = Wakeups.layer({
   changes: Stream.merge(
-    Stream.callback<"application-active">((queue) =>
+    Stream.callback<"application-active-probe" | "application-active-reconnect">((queue) =>
       Effect.acquireRelease(
-        Effect.sync(() =>
-          AppState.addEventListener("change", (state) => {
-            if (state === "active") {
-              Queue.offerUnsafe(queue, "application-active");
+        Effect.sync(() => {
+          let backgroundedAtMs = AppState.currentState === "background" ? Date.now() : null;
+          return AppState.addEventListener("change", (state) => {
+            if (state === "background") {
+              backgroundedAtMs = Date.now();
+              return;
             }
-          }),
-        ),
+            if (state === "active") {
+              Queue.offerUnsafe(queue, mobileApplicationActiveWakeup(backgroundedAtMs, Date.now()));
+              backgroundedAtMs = null;
+            }
+          });
+        }),
         (subscription) => Effect.sync(() => subscription.remove()),
       ).pipe(Effect.asVoid),
     ),

--- a/docs/architecture/connection-runtime.md
+++ b/docs/architecture/connection-runtime.md
@@ -40,6 +40,9 @@ The supervisor is the only retry owner.
    seconds.
 5. Connectivity changes, application activation, credential changes, and
    explicit user retry interrupt the current wait and trigger a fresh attempt.
+   Application activation also resets the backoff ladder. Mobile briefly probes
+   a session after short interruptions and replaces it immediately after a
+   meaningful background suspension.
 6. Authentication or configuration failures remain blocked until an external
    wakeup changes the relevant input.
 7. An involuntary session close keeps the registration and cache, then retries.

--- a/packages/client-runtime/src/authorization/layer.test.ts
+++ b/packages/client-runtime/src/authorization/layer.test.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+import * as TestClock from "effect/testing/TestClock";
 
 import * as ManagedRelay from "../relay/managedRelay.ts";
 import { remoteHttpClientLayer } from "../rpc/http.ts";
@@ -184,6 +185,48 @@ describe("RemoteEnvironmentAuthorization", () => {
       ).toHaveLength(1);
       expect(
         harness.fetch.calls.filter(([url]) => String(url).endsWith("/api/auth/websocket-ticket")),
+      ).toHaveLength(2);
+    }),
+  );
+
+  it.effect("revalidates a bearer descriptor after the cache expires", () =>
+    Effect.gen(function* () {
+      const reassignedEnvironmentId = EnvironmentId.make("environment-2");
+      const harness = yield* makeHarness({
+        responses: [
+          Response.json(DESCRIPTOR),
+          websocketTicket("first-ticket"),
+          Response.json({
+            ...DESCRIPTOR,
+            environmentId: reassignedEnvironmentId,
+          }),
+        ],
+      });
+
+      const failure = yield* Effect.gen(function* () {
+        const remote = yield* RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization;
+        const authorize = () =>
+          remote.authorizeBearer({
+            expectedEnvironmentId: ENVIRONMENT_ID,
+            httpBaseUrl: ENDPOINT.httpBaseUrl,
+            wsBaseUrl: ENDPOINT.wsBaseUrl,
+            bearerToken: "bearer-token",
+          });
+
+        yield* authorize();
+        yield* TestClock.adjust("10 seconds");
+        return yield* authorize().pipe(Effect.flip);
+      }).pipe(Effect.provide(Layer.merge(harness.layer, TestClock.layer())));
+
+      expect(failure).toEqual(
+        expect.objectContaining({
+          _tag: "ConnectionBlockedError",
+          reason: "configuration",
+          detail: `Connected environment ${reassignedEnvironmentId} does not match ${ENVIRONMENT_ID}.`,
+        }),
+      );
+      expect(
+        harness.fetch.calls.filter(([url]) => String(url).endsWith("/.well-known/t3/environment")),
       ).toHaveLength(2);
     }),
   );

--- a/packages/client-runtime/src/authorization/layer.test.ts
+++ b/packages/client-runtime/src/authorization/layer.test.ts
@@ -155,6 +155,39 @@ const makeHarness = Effect.fn("TestRemoteAuthorization.makeHarness")(function* (
 });
 
 describe("RemoteEnvironmentAuthorization", () => {
+  it.effect("reuses a validated bearer descriptor while issuing fresh websocket tickets", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        responses: [
+          Response.json(DESCRIPTOR),
+          websocketTicket("first-ticket"),
+          websocketTicket("second-ticket"),
+        ],
+      });
+
+      const [first, second] = yield* Effect.gen(function* () {
+        const remote = yield* RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization;
+        const authorize = () =>
+          remote.authorizeBearer({
+            expectedEnvironmentId: ENVIRONMENT_ID,
+            httpBaseUrl: ENDPOINT.httpBaseUrl,
+            wsBaseUrl: ENDPOINT.wsBaseUrl,
+            bearerToken: "bearer-token",
+          });
+        return [yield* authorize(), yield* authorize()] as const;
+      }).pipe(Effect.provide(harness.layer));
+
+      expect(first.socketUrl).toContain("wsTicket=first-ticket");
+      expect(second.socketUrl).toContain("wsTicket=second-ticket");
+      expect(
+        harness.fetch.calls.filter(([url]) => String(url).endsWith("/.well-known/t3/environment")),
+      ).toHaveLength(1);
+      expect(
+        harness.fetch.calls.filter(([url]) => String(url).endsWith("/api/auth/websocket-ticket")),
+      ).toHaveLength(2);
+    }),
+  );
+
   it.effect("reuses a valid persisted environment token without contacting the relay", () =>
     Effect.gen(function* () {
       const cached = new TokenStore.RemoteDpopAccessToken({
@@ -265,7 +298,7 @@ describe("RemoteEnvironmentAuthorization", () => {
     }),
   );
 
-  it.effect("refreshes a cached endpoint after consecutive transient failures", () =>
+  it.effect("refreshes a cached endpoint after its first transient failure", () =>
     Effect.gen(function* () {
       const cached = new TokenStore.RemoteDpopAccessToken({
         environmentId: ENVIRONMENT_ID,
@@ -279,7 +312,6 @@ describe("RemoteEnvironmentAuthorization", () => {
         initialToken: cached,
         responses: [
           new Response("endpoint unavailable", { status: 503 }),
-          new Response("endpoint still unavailable", { status: 503 }),
           Response.json(DESCRIPTOR),
           accessToken("replacement-access-token"),
           websocketTicket("replacement-ticket"),
@@ -288,17 +320,6 @@ describe("RemoteEnvironmentAuthorization", () => {
 
       const authorized = yield* Effect.gen(function* () {
         const remote = yield* RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization;
-        const firstFailure = yield* remote
-          .authorizeDpop({
-            expectedEnvironmentId: ENVIRONMENT_ID,
-            obtainBootstrap: harness.obtainBootstrap,
-          })
-          .pipe(Effect.flip);
-
-        expect(firstFailure._tag).toBe("ConnectionTransientError");
-        expect(yield* Ref.get(harness.bootstrapCalls)).toBe(0);
-        expect((yield* Ref.get(harness.tokens)).get(ENVIRONMENT_ID)).toBe(cached);
-
         return yield* remote.authorizeDpop({
           expectedEnvironmentId: ENVIRONMENT_ID,
           obtainBootstrap: harness.obtainBootstrap,
@@ -312,7 +333,7 @@ describe("RemoteEnvironmentAuthorization", () => {
           accessToken: "replacement-access-token",
         }),
       );
-      expect(harness.fetch.calls).toHaveLength(5);
+      expect(harness.fetch.calls).toHaveLength(4);
     }),
   );
 

--- a/packages/client-runtime/src/authorization/service.ts
+++ b/packages/client-runtime/src/authorization/service.ts
@@ -59,6 +59,7 @@ export class RemoteEnvironmentAuthorization extends Context.Service<
 
 const TOKEN_EXPIRY_SAFETY_MARGIN_MS = 60_000;
 const CACHED_ENDPOINT_SOCKET_TIMEOUT_MS = 3_000;
+const BEARER_DESCRIPTOR_CACHE_TTL_MS = 10_000;
 
 function mapDpopSocketError(error: RemoteEnvironmentAuthError | ConnectionAttemptError) {
   return error._tag === "ConnectionTransientError" || error._tag === "ConnectionBlockedError"
@@ -85,6 +86,7 @@ export const make = Effect.gen(function* () {
       {
         readonly httpBaseUrl: string;
         readonly descriptor: ExecutionEnvironmentDescriptor;
+        readonly validatedAtEpochMs: number;
       }
     >
   >(new Map());
@@ -98,25 +100,29 @@ export const make = Effect.gen(function* () {
       readonly wsBaseUrl: string;
       readonly bearerToken: string;
     }) {
+      const now = yield* Clock.currentTimeMillis;
       const cachedDescriptor = (yield* Ref.get(bearerDescriptors)).get(input.expectedEnvironmentId);
-      const descriptor =
-        cachedDescriptor?.httpBaseUrl === input.httpBaseUrl
-          ? cachedDescriptor.descriptor
-          : yield* fetchDescriptor(input.httpBaseUrl).pipe(
-              Effect.provideService(HttpClient.HttpClient, httpClient),
-            );
+      const canReuseDescriptor =
+        cachedDescriptor?.httpBaseUrl === input.httpBaseUrl &&
+        cachedDescriptor.validatedAtEpochMs + BEARER_DESCRIPTOR_CACHE_TTL_MS > now;
+      const descriptor = canReuseDescriptor
+        ? cachedDescriptor.descriptor
+        : yield* fetchDescriptor(input.httpBaseUrl).pipe(
+            Effect.provideService(HttpClient.HttpClient, httpClient),
+          );
       if (descriptor.environmentId !== input.expectedEnvironmentId) {
         return yield* environmentMismatchError({
           expected: input.expectedEnvironmentId,
           actual: descriptor.environmentId,
         });
       }
-      if (cachedDescriptor?.httpBaseUrl !== input.httpBaseUrl) {
+      if (!canReuseDescriptor) {
         yield* Ref.update(bearerDescriptors, (current) => {
           const next = new Map(current);
           next.set(input.expectedEnvironmentId, {
             httpBaseUrl: input.httpBaseUrl,
             descriptor,
+            validatedAtEpochMs: now,
           });
           return next;
         });

--- a/packages/client-runtime/src/authorization/service.ts
+++ b/packages/client-runtime/src/authorization/service.ts
@@ -1,4 +1,4 @@
-import { EnvironmentId } from "@t3tools/contracts";
+import { EnvironmentId, type ExecutionEnvironmentDescriptor } from "@t3tools/contracts";
 import type { RelayManagedEndpoint } from "@t3tools/contracts/relay";
 import {
   exchangeRemoteDpopAccessToken,
@@ -58,7 +58,7 @@ export class RemoteEnvironmentAuthorization extends Context.Service<
 >()("@t3tools/client-runtime/authorization/service/RemoteEnvironmentAuthorization") {}
 
 const TOKEN_EXPIRY_SAFETY_MARGIN_MS = 60_000;
-const CACHED_ENDPOINT_FAILURE_THRESHOLD = 2;
+const CACHED_ENDPOINT_SOCKET_TIMEOUT_MS = 3_000;
 
 function mapDpopSocketError(error: RemoteEnvironmentAuthError | ConnectionAttemptError) {
   return error._tag === "ConnectionTransientError" || error._tag === "ConnectionBlockedError"
@@ -79,25 +79,15 @@ export const make = Effect.gen(function* () {
   const presentation = yield* ClientCapabilities.ClientPresentation;
   const tokenStore = yield* TokenStore.RemoteDpopAccessTokenStore;
   const httpClient = yield* HttpClient.HttpClient;
-  const cachedEndpointFailures = yield* Ref.make<ReadonlyMap<string, number>>(new Map());
-
-  const resetCachedEndpointFailures = (environmentId: string) =>
-    Ref.update(cachedEndpointFailures, (current) => {
-      if (!current.has(environmentId)) {
-        return current;
+  const bearerDescriptors = yield* Ref.make<
+    ReadonlyMap<
+      EnvironmentId,
+      {
+        readonly httpBaseUrl: string;
+        readonly descriptor: ExecutionEnvironmentDescriptor;
       }
-      const next = new Map(current);
-      next.delete(environmentId);
-      return next;
-    });
-
-  const recordCachedEndpointFailure = (environmentId: string) =>
-    Ref.modify(cachedEndpointFailures, (current) => {
-      const failureCount = (current.get(environmentId) ?? 0) + 1;
-      const next = new Map(current);
-      next.set(environmentId, failureCount);
-      return [failureCount, next] as const;
-    });
+    >
+  >(new Map());
 
   const authorizeBearer = Effect.fn("clientRuntime.connection.remote.authorizeBearer")(
     function* (input: {
@@ -108,13 +98,27 @@ export const make = Effect.gen(function* () {
       readonly wsBaseUrl: string;
       readonly bearerToken: string;
     }) {
-      const descriptor = yield* fetchDescriptor(input.httpBaseUrl).pipe(
-        Effect.provideService(HttpClient.HttpClient, httpClient),
-      );
+      const cachedDescriptor = (yield* Ref.get(bearerDescriptors)).get(input.expectedEnvironmentId);
+      const descriptor =
+        cachedDescriptor?.httpBaseUrl === input.httpBaseUrl
+          ? cachedDescriptor.descriptor
+          : yield* fetchDescriptor(input.httpBaseUrl).pipe(
+              Effect.provideService(HttpClient.HttpClient, httpClient),
+            );
       if (descriptor.environmentId !== input.expectedEnvironmentId) {
         return yield* environmentMismatchError({
           expected: input.expectedEnvironmentId,
           actual: descriptor.environmentId,
+        });
+      }
+      if (cachedDescriptor?.httpBaseUrl !== input.httpBaseUrl) {
+        yield* Ref.update(bearerDescriptors, (current) => {
+          const next = new Map(current);
+          next.set(input.expectedEnvironmentId, {
+            httpBaseUrl: input.httpBaseUrl,
+            descriptor,
+          });
+          return next;
         });
       }
       const socketUrl = yield* resolveRemoteWebSocketConnectionUrl({
@@ -139,7 +143,7 @@ export const make = Effect.gen(function* () {
   );
 
   const createDpopSocketUrl = Effect.fn("clientRuntime.connection.remote.createDpopSocketUrl")(
-    function* (token: TokenStore.RemoteDpopAccessToken) {
+    function* (token: TokenStore.RemoteDpopAccessToken, timeoutMs?: number) {
       const ticketProof = yield* signer
         .createProof({
           method: "POST",
@@ -160,6 +164,7 @@ export const make = Effect.gen(function* () {
         httpBaseUrl: token.endpoint.httpBaseUrl,
         accessToken: token.accessToken,
         dpopProof: ticketProof,
+        ...(timeoutMs === undefined ? {} : { timeoutMs }),
       }).pipe(Effect.provideService(HttpClient.HttpClient, httpClient));
     },
   );
@@ -196,9 +201,11 @@ export const make = Effect.gen(function* () {
         yield* Effect.annotateCurrentSpan({
           "connection.remote_token_cache": "hit",
         });
-        const cachedSocket = yield* createDpopSocketUrl(cached.value).pipe(Effect.result);
+        const cachedSocket = yield* createDpopSocketUrl(
+          cached.value,
+          CACHED_ENDPOINT_SOCKET_TIMEOUT_MS,
+        ).pipe(Effect.result);
         if (Result.isSuccess(cachedSocket)) {
-          yield* resetCachedEndpointFailures(input.expectedEnvironmentId);
           return {
             environmentId: cached.value.environmentId,
             label: cached.value.label,
@@ -213,20 +220,11 @@ export const make = Effect.gen(function* () {
         if (cachedSocket.failure._tag === "ConnectionBlockedError") {
           return yield* mapDpopSocketError(cachedSocket.failure);
         }
-        const mappedFailure = mapDpopSocketError(cachedSocket.failure);
-        if (mappedFailure._tag === "ConnectionTransientError") {
-          const failureCount = yield* recordCachedEndpointFailure(input.expectedEnvironmentId);
-          if (failureCount < CACHED_ENDPOINT_FAILURE_THRESHOLD) {
-            return yield* mappedFailure;
-          }
-        }
         yield* tokenStore
           .remove(input.expectedEnvironmentId)
           .pipe(Effect.withSpan("environment.authorization.accessToken.remove"));
-        yield* resetCachedEndpointFailures(input.expectedEnvironmentId);
       }
 
-      yield* resetCachedEndpointFailures(input.expectedEnvironmentId);
       yield* Effect.annotateCurrentSpan({
         "connection.remote_token_cache": "miss",
       });

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -124,7 +124,7 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
   const releaseCount = yield* Ref.make(0);
   const wakeups = yield* SubscriptionRef.make<{
     readonly sequence: number;
-    readonly reason: "application-active" | "credentials-changed";
+    readonly reason: ConnectionWakeups.ConnectionWakeup;
   }>({
     sequence: 0,
     reason: "application-active",
@@ -198,7 +198,7 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
     sessionCount,
     releaseCount,
     setNetworkStatus: (status: NetworkStatus) => SubscriptionRef.set(networkStatus, status),
-    wake: (reason: "application-active" | "credentials-changed") =>
+    wake: (reason: ConnectionWakeups.ConnectionWakeup) =>
       SubscriptionRef.update(wakeups, (event) => ({
         sequence: event.sequence + 1,
         reason,
@@ -677,6 +677,32 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
+  it.effect("immediately replaces a mobile session after a long background resume", () =>
+    Effect.gen(function* () {
+      const probeCount = yield* Ref.make(0);
+      const harness = yield* makeHarness({
+        probe: () => Ref.update(probeCount, (count) => count + 1),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* harness.wake("application-active-reconnect");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+
+      expect(yield* Ref.get(probeCount)).toBe(0);
+      expect(yield* Ref.get(harness.sessionCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }),
+  );
+
   it.effect("reconnects when the foreground liveness probe fails", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({
@@ -701,7 +727,7 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("times out a stalled foreground liveness probe and reconnects", () =>
+  it.effect("quickly times out a stalled mobile foreground liveness probe", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({
         probe: (attempt) => (attempt === 1 ? Effect.never : Effect.void),
@@ -711,8 +737,8 @@ describe("EnvironmentSupervisor", () => {
       }).pipe(Effect.provide(harness.dependencies));
 
       yield* awaitState(supervisor.state, (state) => state.phase === "connected");
-      yield* harness.wake("application-active");
-      yield* TestClock.adjust("15 seconds");
+      yield* harness.wake("application-active-probe");
+      yield* TestClock.adjust("3 seconds");
       yield* awaitState(
         supervisor.state,
         (state) => state.phase === "backoff" && state.lastFailure?.reason === "timeout",

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -652,6 +652,45 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
+  it.effect("restarts the retry ladder when mobile returns to the foreground", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.closeLatestSession();
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      yield* TestClock.adjust("1 second");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+      yield* harness.closeLatestSession();
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 2,
+      );
+
+      yield* harness.wake("application-active-reconnect");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 3 && state.attempt === 1,
+      );
+      yield* harness.closeLatestSession();
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+
+      expect(yield* Ref.get(harness.sessionCount)).toBe(3);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
   it.effect("probes the active session without reconnecting on application activation", () =>
     Effect.gen(function* () {
       const probeCount = yield* Ref.make(0);

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -691,6 +691,62 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
+  it.effect("restarts the retry ladder when a long resume replaces a connected session", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.closeLatestSession();
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      yield* TestClock.adjust("1 second");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2 && state.attempt === 2,
+      );
+
+      yield* harness.wake("application-active-reconnect");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 3 && state.attempt === 1,
+      );
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("restarts the retry ladder when a long resume interrupts connection setup", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        prepare: (attempt) => (attempt === 2 ? Effect.never : Effect.succeed(PREPARED_CONNECTION)),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.closeLatestSession();
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      yield* TestClock.adjust("1 second");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connecting" && state.attempt === 2,
+      );
+
+      yield* harness.wake("application-active-reconnect");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2 && state.attempt === 1,
+      );
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
   it.effect("probes the active session without reconnecting on application activation", () =>
     Effect.gen(function* () {
       const probeCount = yield* Ref.make(0);

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -703,6 +703,32 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
+  it.effect("replaces a mobile session when a long resume interrupts an active probe", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        probe: (attempt) => (attempt === 1 ? Effect.never : Effect.void),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* harness.wake("application-active-probe");
+      yield* Effect.yieldNow;
+      yield* harness.wake("application-active-reconnect");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+
+      expect(yield* Ref.get(harness.sessionCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }),
+  );
+
   it.effect("reconnects when the foreground liveness probe fails", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -311,6 +311,38 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
+  it.effect("resets retries when activation arrives before the network returns", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.closeLatestSession();
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      yield* harness.setNetworkStatus("offline");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "offline" && state.attempt === 2,
+      );
+
+      yield* harness.wake("application-active-reconnect");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "offline" && state.attempt === 1,
+      );
+      yield* harness.setNetworkStatus("online");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2 && state.attempt === 1,
+      );
+    }),
+  );
+
   it.effect("retries forever with exponential backoff capped at sixteen seconds", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({
@@ -498,6 +530,38 @@ describe("EnvironmentSupervisor", () => {
       yield* supervisor.retryNow;
       yield* awaitState(supervisor.state, (state) => state.phase === "connected");
       expect(yield* Ref.get(harness.prepareCount)).toBe(2);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("resets retries when activation wakes a blocked connection", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        prepare: (attempt) =>
+          attempt === 1
+            ? Effect.fail(transient())
+            : attempt === 2
+              ? Effect.fail(blocked())
+              : Effect.succeed(PREPARED_CONNECTION),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      yield* TestClock.adjust("1 second");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "blocked" && state.attempt === 2,
+      );
+
+      yield* harness.wake("application-active-reconnect");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.attempt === 1,
+      );
     }).pipe(Effect.provide(TestClock.layer())),
   );
 

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -64,6 +64,7 @@ type AttemptOutcome =
       readonly _tag: "Interrupted";
       readonly established: boolean;
       readonly stable: boolean;
+      readonly resetRetry: boolean;
     }
   | {
       readonly _tag: "Failure";
@@ -83,7 +84,7 @@ type EstablishmentEvent =
         TracedAttemptFailure
       >;
     }
-  | { readonly _tag: "Interrupted" }
+  | { readonly _tag: "Interrupted"; readonly resetRetry: boolean }
   | { readonly _tag: "TimedOut" };
 
 function exitUnlessInterrupted<A, E, R>(
@@ -169,7 +170,7 @@ function failureFromExit<A>(
   stable: boolean,
 ): AttemptOutcome {
   if (Exit.isSuccess(exit) || Cause.hasInterruptsOnly(exit.cause)) {
-    return { _tag: "Interrupted", established, stable };
+    return { _tag: "Interrupted", established, stable, resetRetry: false };
   }
   const typedFailure = exit.cause.reasons.find(Cause.isFailReason);
   if (typedFailure) {
@@ -366,21 +367,21 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
       switch (next._tag) {
         case "DisconnectRequested":
         case "RetryRequested":
-          return;
+          return false;
         case "NetworkChanged":
           if (next.network === "offline") {
-            return;
+            return false;
           }
           break;
         case "ConnectRequested":
           break;
         case "Wakeup":
           if (next.reason === "application-active-reconnect") {
-            return;
+            return true;
           }
           if (next.reason === "credentials-changed" && target._tag === "RelayConnectionTarget") {
             yield* logManagedRelayAccountChange;
-            return;
+            return false;
           }
           break;
       }
@@ -395,22 +396,22 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
       switch (next._tag) {
         case "DisconnectRequested":
         case "RetryRequested":
-          return;
+          return false;
         case "NetworkChanged":
           if (next.network === "offline") {
-            return;
+            return false;
           }
           break;
         case "Wakeup":
           if (next.reason === "credentials-changed" && target._tag === "RelayConnectionTarget") {
             yield* logManagedRelayAccountChange;
-            return;
+            return false;
           }
           if (next.reason === "application-active-reconnect") {
             // Mobile operating systems commonly suspend sockets without
             // delivering a close event. A long background resume deliberately
             // replaces that lease and starts a fresh attempt without backoff.
-            return;
+            return true;
           }
           if (next.reason === "application-active" || next.reason === "application-active-probe") {
             const probe = yield* lease.session.probe.pipe(
@@ -446,21 +447,24 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
                 case "DisconnectRequested":
                 case "RetryRequested":
                   yield* Fiber.interrupt(probe);
-                  return;
+                  return false;
                 case "NetworkChanged":
                   if (probeEvent.signal.network === "offline") {
                     yield* Fiber.interrupt(probe);
-                    return;
+                    return false;
                   }
                   break;
                 case "Wakeup":
+                  if (probeEvent.signal.reason === "application-active-reconnect") {
+                    yield* Fiber.interrupt(probe);
+                    return true;
+                  }
                   if (
-                    probeEvent.signal.reason === "application-active-reconnect" ||
-                    (probeEvent.signal.reason === "credentials-changed" &&
-                      target._tag === "RelayConnectionTarget")
+                    probeEvent.signal.reason === "credentials-changed" &&
+                    target._tag === "RelayConnectionTarget"
                   ) {
                     yield* Fiber.interrupt(probe);
-                    return;
+                    return false;
                   }
                   break;
                 case "ConnectRequested":
@@ -493,7 +497,14 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
           }),
         ),
       ),
-      waitForEstablishmentInterrupt().pipe(Effect.as<EstablishmentEvent>({ _tag: "Interrupted" })),
+      waitForEstablishmentInterrupt().pipe(
+        Effect.map(
+          (resetRetry): EstablishmentEvent => ({
+            _tag: "Interrupted",
+            resetRetry,
+          }),
+        ),
+      ),
       Effect.sleep(CONNECTION_ESTABLISHMENT_TIMEOUT).pipe(
         Effect.as<EstablishmentEvent>({ _tag: "TimedOut" }),
       ),
@@ -504,6 +515,7 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
         _tag: "Interrupted",
         established: false,
         stable: false,
+        resetRetry: establishment.resetRetry,
       } satisfies AttemptOutcome;
     }
     if (establishment._tag === "TimedOut") {
@@ -546,6 +558,7 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
         _tag: "Interrupted",
         established: false,
         stable: false,
+        resetRetry: false,
       } satisfies AttemptOutcome;
     }
 
@@ -582,6 +595,14 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
       ),
     ).pipe(exitUnlessInterrupted);
     const connectedForMs = (yield* Clock.currentTimeMillis) - connectedAt;
+    if (Exit.isSuccess(connectedExit)) {
+      return {
+        _tag: "Interrupted",
+        established: true,
+        stable: connectedForMs >= BACKOFF_RESET_AFTER_MS,
+        resetRetry: connectedExit.value,
+      } satisfies AttemptOutcome;
+    }
     return failureFromExit(target, connectedExit, true, connectedForMs >= BACKOFF_RESET_AFTER_MS);
   }, Effect.ensuring(clearLease));
 
@@ -645,6 +666,10 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
         }
       }
       if (outcome._tag === "Interrupted") {
+        if (outcome.resetRetry) {
+          failureCount = 0;
+          pendingRetry = Option.none();
+        }
         continue;
       }
 

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -587,17 +587,18 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
 
   const waitForRetrySignal = Effect.fnUntraced(function* (delayMs: number) {
     return yield* Effect.raceFirst(
-      Effect.sleep(delayMs),
+      Effect.sleep(delayMs).pipe(Effect.as(false)),
       Effect.gen(function* () {
         for (;;) {
           const next = yield* Queue.take(signals);
           switch (next._tag) {
+            case "Wakeup":
+              return ConnectionWakeups.isApplicationActiveWakeup(next.reason);
             case "ConnectRequested":
             case "DisconnectRequested":
             case "RetryRequested":
             case "NetworkChanged":
-            case "Wakeup":
-              return;
+              return false;
           }
         }
       }),
@@ -685,7 +686,11 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
         lastFailure: error,
         retryAt: (yield* Clock.currentTimeMillis) + delayMs,
       });
-      yield* waitForRetrySignal(delayMs);
+      const applicationActivated = yield* waitForRetrySignal(delayMs);
+      if (applicationActivated) {
+        failureCount = 0;
+        pendingRetry = Option.none();
+      }
     }
   });
 

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -32,6 +32,7 @@ import * as ConnectionWakeups from "./wakeups.ts";
 const RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 16_000] as const;
 const CONNECTION_ESTABLISHMENT_TIMEOUT = "15 seconds";
 const CONNECTION_PROBE_TIMEOUT = "15 seconds";
+const MOBILE_CONNECTION_PROBE_TIMEOUT = "3 seconds";
 const BACKOFF_RESET_AFTER_MS = 30_000;
 
 interface SupervisorIntent {
@@ -374,6 +375,9 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
         case "ConnectRequested":
           break;
         case "Wakeup":
+          if (next.reason === "application-active-reconnect") {
+            return;
+          }
           if (next.reason === "credentials-changed" && target._tag === "RelayConnectionTarget") {
             yield* logManagedRelayAccountChange;
             return;
@@ -402,10 +406,19 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
             yield* logManagedRelayAccountChange;
             return;
           }
-          if (next.reason === "application-active") {
+          if (next.reason === "application-active-reconnect") {
+            // Mobile operating systems commonly suspend sockets without
+            // delivering a close event. A long background resume deliberately
+            // replaces that lease and starts a fresh attempt without backoff.
+            return;
+          }
+          if (next.reason === "application-active" || next.reason === "application-active-probe") {
             const probe = yield* lease.session.probe.pipe(
               Effect.timeoutOrElse({
-                duration: CONNECTION_PROBE_TIMEOUT,
+                duration:
+                  next.reason === "application-active-probe"
+                    ? MOBILE_CONNECTION_PROBE_TIMEOUT
+                    : CONNECTION_PROBE_TIMEOUT,
                 orElse: () =>
                   Effect.fail(
                     new ConnectionTransientError({

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -453,8 +453,17 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
                     return;
                   }
                   break;
-                case "ConnectRequested":
                 case "Wakeup":
+                  if (
+                    probeEvent.signal.reason === "application-active-reconnect" ||
+                    (probeEvent.signal.reason === "credentials-changed" &&
+                      target._tag === "RelayConnectionTarget")
+                  ) {
+                    yield* Fiber.interrupt(probe);
+                    return;
+                  }
+                  break;
+                case "ConnectRequested":
                   break;
               }
             }

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -626,20 +626,27 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
     );
   });
 
-  const waitForSignal = Queue.take(signals);
+  const waitForSignal = Queue.take(signals).pipe(
+    Effect.map(
+      (next) => next._tag === "Wakeup" && ConnectionWakeups.isApplicationActiveWakeup(next.reason),
+    ),
+  );
 
   const run = Effect.fnUntraced(function* () {
     let failureCount = 0;
     let generation = 0;
     let latestFailure: ConnectionAttemptError | null = null;
     let pendingRetry = Option.none<PendingRetryTrace>();
+    const resetRetryLadder = () => {
+      failureCount = 0;
+      pendingRetry = Option.none();
+    };
 
     for (;;) {
       const currentIntent = yield* Ref.get(intent);
       if (!currentIntent.desired) {
-        failureCount = 0;
+        resetRetryLadder();
         latestFailure = null;
-        pendingRetry = Option.none();
         yield* clearLease;
         yield* setState(availableState(currentIntent, generation));
         yield* waitForSignal;
@@ -648,7 +655,10 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
       if (currentIntent.network === "offline") {
         yield* clearLease;
         yield* setState(offlineState(currentIntent, generation, failureCount + 1, latestFailure));
-        yield* waitForSignal;
+        const applicationActivated = yield* waitForSignal;
+        if (applicationActivated) {
+          resetRetryLadder();
+        }
         continue;
       }
 
@@ -660,15 +670,13 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
       if (outcome.established) {
         generation = nextGeneration;
         if (outcome.stable) {
-          failureCount = 0;
+          resetRetryLadder();
           latestFailure = null;
-          pendingRetry = Option.none();
         }
       }
       if (outcome._tag === "Interrupted") {
         if (outcome.resetRetry) {
-          failureCount = 0;
-          pendingRetry = Option.none();
+          resetRetryLadder();
         }
         continue;
       }
@@ -688,7 +696,10 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
           lastFailure: error,
           retryAt: null,
         });
-        yield* waitForSignal;
+        const applicationActivated = yield* waitForSignal;
+        if (applicationActivated) {
+          resetRetryLadder();
+        }
         continue;
       }
 
@@ -713,8 +724,7 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
       });
       const applicationActivated = yield* waitForRetrySignal(delayMs);
       if (applicationActivated) {
-        failureCount = 0;
-        pendingRetry = Option.none();
+        resetRetryLadder();
       }
     }
   });

--- a/packages/client-runtime/src/connection/wakeups.ts
+++ b/packages/client-runtime/src/connection/wakeups.ts
@@ -8,6 +8,18 @@ export type ConnectionWakeup =
   | "application-active-reconnect"
   | "credentials-changed";
 
+export function isApplicationActiveWakeup(reason: ConnectionWakeup): boolean {
+  return (
+    reason === "application-active" ||
+    reason === "application-active-probe" ||
+    reason === "application-active-reconnect"
+  );
+}
+
+export function shouldResubscribeAfterWakeup(reason: ConnectionWakeup): boolean {
+  return reason === "application-active" || reason === "application-active-probe";
+}
+
 export class ConnectionWakeups extends Context.Service<
   ConnectionWakeups,
   {

--- a/packages/client-runtime/src/connection/wakeups.ts
+++ b/packages/client-runtime/src/connection/wakeups.ts
@@ -2,7 +2,11 @@ import * as Context from "effect/Context";
 import * as Layer from "effect/Layer";
 import type * as Stream from "effect/Stream";
 
-export type ConnectionWakeup = "application-active" | "credentials-changed";
+export type ConnectionWakeup =
+  | "application-active"
+  | "application-active-probe"
+  | "application-active-reconnect"
+  | "credentials-changed";
 
 export class ConnectionWakeups extends Context.Service<
   ConnectionWakeups,

--- a/packages/client-runtime/src/state/shell-sync.test.ts
+++ b/packages/client-runtime/src/state/shell-sync.test.ts
@@ -329,6 +329,14 @@ describe("environment shell synchronization", () => {
 
       expect(yield* Ref.get(loaderCalls)).toBe(2);
       expect(yield* Ref.get(subscriptionCount)).toBe(2);
+
+      yield* Queue.offer(wakeups, "application-active-probe");
+      yield* Queue.offer(wakeups, "application-active-reconnect");
+      for (let attempt = 0; attempt < 10; attempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      expect(yield* Ref.get(loaderCalls)).toBe(2);
+      expect(yield* Ref.get(subscriptionCount)).toBe(2);
     }),
   );
 });

--- a/packages/client-runtime/src/state/shell-sync.test.ts
+++ b/packages/client-runtime/src/state/shell-sync.test.ts
@@ -331,12 +331,19 @@ describe("environment shell synchronization", () => {
       expect(yield* Ref.get(subscriptionCount)).toBe(2);
 
       yield* Queue.offer(wakeups, "application-active-probe");
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if ((yield* Ref.get(subscriptionCount)) >= 3) break;
+        yield* Effect.yieldNow;
+      }
+      expect(yield* Ref.get(loaderCalls)).toBe(3);
+      expect(yield* Ref.get(subscriptionCount)).toBe(3);
+
       yield* Queue.offer(wakeups, "application-active-reconnect");
       for (let attempt = 0; attempt < 10; attempt += 1) {
         yield* Effect.yieldNow;
       }
-      expect(yield* Ref.get(loaderCalls)).toBe(2);
-      expect(yield* Ref.get(subscriptionCount)).toBe(2);
+      expect(yield* Ref.get(loaderCalls)).toBe(3);
+      expect(yield* Ref.get(subscriptionCount)).toBe(3);
     }),
   );
 });

--- a/packages/client-runtime/src/state/shell.ts
+++ b/packages/client-runtime/src/state/shell.ts
@@ -172,7 +172,7 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
   const foregroundResubscriptions = Option.match(wakeups, {
     onNone: () => Stream.never,
     onSome: (service) =>
-      service.changes.pipe(Stream.filter((reason) => reason === "application-active")),
+      service.changes.pipe(Stream.filter(ConnectionWakeups.shouldResubscribeAfterWakeup)),
   });
 
   yield* setSynchronizing;

--- a/packages/client-runtime/src/state/threads-sync.test.ts
+++ b/packages/client-runtime/src/state/threads-sync.test.ts
@@ -696,6 +696,13 @@ describe("EnvironmentThreads", () => {
         (value) => value.status === "live" && Option.isSome(value.data),
       );
       expect(Option.getOrThrow(live.data).title).toBe("Latest title");
+
+      yield* Queue.offer(harness.wakeups, "application-active-probe");
+      yield* Queue.offer(harness.wakeups, "application-active-reconnect");
+      for (let attempt = 0; attempt < 10; attempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(2);
     }),
   );
 });

--- a/packages/client-runtime/src/state/threads-sync.test.ts
+++ b/packages/client-runtime/src/state/threads-sync.test.ts
@@ -698,11 +698,17 @@ describe("EnvironmentThreads", () => {
       expect(Option.getOrThrow(live.data).title).toBe("Latest title");
 
       yield* Queue.offer(harness.wakeups, "application-active-probe");
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if ((yield* Ref.get(harness.subscriptionCount)) >= 3) break;
+        yield* Effect.yieldNow;
+      }
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(3);
+
       yield* Queue.offer(harness.wakeups, "application-active-reconnect");
       for (let attempt = 0; attempt < 10; attempt += 1) {
         yield* Effect.yieldNow;
       }
-      expect(yield* Ref.get(harness.subscriptionCount)).toBe(2);
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(3);
     }),
   );
 });

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -236,7 +236,7 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
   const foregroundResubscriptions = Option.match(wakeups, {
     onNone: () => Stream.never,
     onSome: (service) =>
-      service.changes.pipe(Stream.filter((reason) => reason === "application-active")),
+      service.changes.pipe(Stream.filter(ConnectionWakeups.shouldResubscribeAfterWakeup)),
   });
 
   yield* setSynchronizing;


### PR DESCRIPTION
Returning to T3 Code Mobile after using another app could leave every suspended environment waiting on a socket probe and retry backoff, making multi-environment reconnects feel sequential.

This change gives mobile resume an explicit fast path:

- brief interruptions immediately probe existing sessions and refresh shell/thread subscriptions
- meaningful background suspensions replace stale session leases so environments reconnect in parallel
- foreground activation interrupts any in-flight probe or retry delay and resets the retry ladder
- a reconnect request received during an active probe is retained and honored after the probe finishes

The branch is rebased onto current `main`, including #4882. That PR improves mobile action/feed responsiveness but does not overlap the connection runtime. After comparing #4885, this PR adopts its useful retry-backoff reset while keeping the existing in-memory token catalog and relay synchronization model; migrating persisted tokens or widening the relay critical section would add failure surface without improving the normal foreground path.

### Verification

- 58 focused client-runtime/mobile tests
- `@t3tools/client-runtime` typecheck
- `@t3tools/mobile` typecheck
- targeted client-runtime lint
- iOS Simulator: two connected environments plus five offline environments, backgrounded for 11 seconds, then resumed from the app icon; connected environments stayed available while only the offline environments retried

![iOS resume verification](https://files.tslop.org/2026/07/t3-mobile-reconnect-resume-preview-596005ce.gif)

[Watch the full verification clip](https://files.tslop.org/2026/07/t3-mobile-reconnect-resume-proof-db12b079.mp4) (the middle background interval is accelerated).

Made with GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconnect mobile environments immediately on resume after long background suspension
> - Adds `mobileApplicationActiveWakeup` in [app-state-wakeups.ts](https://github.com/pingdotgg/t3code/pull/4878/files#diff-ff2420db2cd80096bff37ca39ec2b1cddd496b15839120982515212e64e42d51) to classify resume events as either `application-active-probe` (short interruption, <10s) or `application-active-reconnect` (long suspension, ≥10s).
> - On `application-active-reconnect`, the connection supervisor resets the retry backoff ladder and immediately replaces the session rather than probing the existing one.
> - On `application-active-probe`, the supervisor runs a liveness probe with a 3s timeout (vs 15s normally); shell and thread state resubscribe on probe but not on reconnect.
> - Bearer descriptor caching (10s TTL) and a 3s DPoP socket ticket timeout are added to the authorization service to reduce reconnect latency.
> - Behavioral Change: `application-active` wakeup is split into two distinct kinds; any code relying on `application-active` alone will not receive mobile resume events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e279787.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core connection supervisor behavior, mobile wakeup semantics, and remote auth caching/timeouts; broad test coverage but affects reconnect and token paths for all mobile environments.
> 
> **Overview**
> Mobile resume no longer treats every foreground return like a single **application-active** probe. **Short** background gaps emit **`application-active-probe`** (3s health check, shell/thread resubscribe). **≥10s** in background emits **`application-active-reconnect`**, which **replaces the session immediately** and **resets the retry ladder** instead of waiting on probes or backoff.
> 
> The connection **supervisor** honors **`application-active-reconnect`** during setup, while connected, and during an in-flight probe (probe is interrupted). Foreground activation also **resets backoff** when offline, blocked, or waiting to retry.
> 
> **Remote authorization** caches validated bearer descriptors for 10s (fewer descriptor fetches; fresh websocket tickets each connect). Cached DPoP endpoint use now uses a **3s** websocket-ticket timeout and **refreshes after the first transient socket failure** (replacing a two-failure threshold).
> 
> **Shell and thread sync** only resubscribe on probe-style wakeups, not on reconnect (new session already drives sync).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27978741cbcf507fc96cc0fe909da8210b6420c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->