### PR TITLE
perf(mobile): sends respond instantly, thread opens stop freezing

### DIFF
--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -284,6 +284,15 @@ function workspacePathFromState(state: NavigationState): string {
   return path.startsWith("/") ? path : `/${path}`;
 }
 
+// The drain hook subscribes to the outbox, all thread shells, projects, and
+// connection statuses. Hosting it in a null-rendering leaf keeps those
+// updates from re-rendering RootStackLayout (and with it every screen) on
+// each enqueue, shell change, or reconnect.
+function ThreadOutboxDrainWorker() {
+  useThreadOutboxDrain();
+  return null;
+}
+
 function RootStackLayout(props: {
   readonly children: React.ReactNode;
   readonly state: NavigationState;
@@ -292,7 +301,6 @@ function RootStackLayout(props: {
   const { pendingShare } = useIncomingShare();
   const sharePresentationRef = useRef(EMPTY_INCOMING_SHARE_PRESENTATION_STATE);
   useAgentNotificationNavigation();
-  useThreadOutboxDrain();
   // Presents the T3 Connect onboarding sheet after an in-session sign-in.
   useConnectOnboardingNavigation();
   // Launcher app shortcuts: routes shortcut taps and tracks opened threads.
@@ -320,6 +328,7 @@ function RootStackLayout(props: {
 
   return (
     <HardwareKeyboardCommandProvider pathname={pathname}>
+      <ThreadOutboxDrainWorker />
       <ShowcaseCaptureCoordinator pathname={pathname} />
       <ClerkSettingsSheetDetentProvider initiallyExpanded={false}>
         <AdaptiveWorkspaceLayout pathname={workspacePathname}>

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -665,6 +665,26 @@ export function HomeScreen(props: HomeScreenProps) {
   );
   const v2KeyExtractor = useCallback((item: ThreadListV2ListItem) => item.key, []);
 
+  // FlatList treats a changed extraData identity as "re-render every visible
+  // row", so an inline object literal would invalidate all rows on every
+  // HomeScreen render.
+  const v2ExtraData = useMemo(
+    () => ({
+      projectByKey,
+      projectCwdByKey,
+      projectTitleByProjectKey: v2ProjectTitleByProjectKey,
+      serverConfigs,
+      savedConnectionsById: props.savedConnectionsById,
+    }),
+    [
+      projectByKey,
+      projectCwdByKey,
+      props.savedConnectionsById,
+      serverConfigs,
+      v2ProjectTitleByProjectKey,
+    ],
+  );
+
   const extraData = useMemo(
     () => ({ savedConnectionsById: props.savedConnectionsById, projectCwdByKey }),
     [props.savedConnectionsById, projectCwdByKey],
@@ -900,13 +920,7 @@ export function HomeScreen(props: HomeScreenProps) {
             data={threadListV2Items}
             renderItem={renderV2Item}
             keyExtractor={v2KeyExtractor}
-            extraData={{
-              projectByKey,
-              projectCwdByKey,
-              projectTitleByProjectKey: v2ProjectTitleByProjectKey,
-              serverConfigs,
-              savedConnectionsById: props.savedConnectionsById,
-            }}
+            extraData={v2ExtraData}
             ListHeaderComponent={v2ListHeader}
             ListFooterComponent={
               threadListV2Layout.hiddenSettledCount > 0 ? (

--- a/apps/mobile/src/features/shortcuts/useAppShortcuts.ts
+++ b/apps/mobile/src/features/shortcuts/useAppShortcuts.ts
@@ -54,7 +54,14 @@ function useShortcutNavigation(): void {
 }
 
 function useRecentThreadShortcutSync(state: NavigationState): void {
-  const threadRef = useMemo(() => activeThreadRef(state), [state]);
+  // Launcher shortcuts are Android-only. A null ref on iOS keeps this hook
+  // (mounted in the root stack layout) from subscribing the root to the
+  // active thread's shell, which would re-render every screen on each
+  // title/status/session change.
+  const threadRef = useMemo(
+    () => (Platform.OS === "android" ? activeThreadRef(state) : null),
+    [state],
+  );
   const threadShell = useThreadShell(threadRef);
   // null until the persisted list loads; recording waits on it so the first
   // thread opened after a cold start cannot clobber older entries.

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -946,7 +946,11 @@ export function NewTaskDraftScreen(props: {
   const promptEditor = (
     <ComposerEditor
       ref={promptInputRef}
-      autoFocus={!isAndroid}
+      // Native autoFocus fires becomeFirstResponder in didMoveToWindow, which
+      // forces the iOS keyboard bring-up during the formSheet present
+      // animation and stalls it. The runAfterInteractions effect above focuses
+      // the editor once the transition settles instead.
+      autoFocus={false}
       editable={!isIncomingShareTransferPending}
       multiline
       scrollEnabled={isExpanded}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -518,14 +518,16 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     const threadKey = scopedThreadKey(props.environmentId, props.selectedThread.id);
     if (inFlightThreadIdsRef.current.has(threadKey)) return;
     inFlightThreadIdsRef.current.add(threadKey);
-    // Sending a prompt starts agent work: arm the lock-screen card now, while
-    // the app is foregrounded and the activity token can be registered.
-    armAgentAwarenessLiveActivityForLocalWork({
-      threadTitle: props.selectedThread.title,
-      projectTitle: props.environmentLabel ?? "T3 Code",
-    });
     try {
       await onSendMessage();
+      // Sending a prompt starts agent work: arm the lock-screen card while the
+      // app is foregrounded and the activity token can be registered. Armed
+      // after the send so its preference read and native Activity start don't
+      // contend with the queued-message feedback on the tap frame.
+      armAgentAwarenessLiveActivityForLocalWork({
+        threadTitle: props.selectedThread.title,
+        projectTitle: props.environmentLabel ?? "T3 Code",
+      });
     } finally {
       inFlightThreadIdsRef.current.delete(threadKey);
     }

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -957,6 +957,11 @@ function isEmptyMessage(entry: RawThreadFeedEntry): boolean {
 
 function groupAdjacentActivities(entries: ReadonlyArray<RawThreadFeedEntry>): ThreadFeedEntry[] {
   const grouped: ThreadFeedEntry[] = [];
+  // Mutable backing array for the trailing group so appending an activity is
+  // O(1) instead of re-copying the group (which made this loop quadratic on
+  // long tool runs). The array is only mutated while it is the trailing group.
+  let openGroupActivities: ThreadFeedActivity[] | null = null;
+  let openGroupTurnId: TurnId | null = null;
 
   for (const entry of entries) {
     // Skip empty messages so they don't break activity grouping.
@@ -966,24 +971,23 @@ function groupAdjacentActivities(entries: ReadonlyArray<RawThreadFeedEntry>): Th
 
     if (entry.type !== "activity") {
       grouped.push(entry);
+      openGroupActivities = null;
       continue;
     }
 
-    const previous = grouped.at(-1);
-    if (previous?.type === "activity-group" && previous.turnId === entry.turnId) {
-      grouped[grouped.length - 1] = {
-        ...previous,
-        activities: [...previous.activities, entry.activity],
-      };
+    if (openGroupActivities !== null && openGroupTurnId === entry.turnId) {
+      openGroupActivities.push(entry.activity);
       continue;
     }
 
+    openGroupActivities = [entry.activity];
+    openGroupTurnId = entry.turnId;
     grouped.push({
       type: "activity-group",
       id: entry.id,
       createdAt: entry.createdAt,
       turnId: entry.turnId,
-      activities: [entry.activity],
+      activities: openGroupActivities,
     });
   }
 
@@ -1225,13 +1229,24 @@ function appendPresentedFeedEntry(
   });
 }
 
-export function derivePendingApprovals(
+/**
+ * Sorts activities into lifecycle order. `derivePendingApprovals` and
+ * `derivePendingUserInputs` both expect this ordering; sorting once and
+ * passing the result to both avoids re-sorting the full activity history
+ * per derivation.
+ */
+export function sortThreadActivities(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ReadonlyArray<OrchestrationThreadActivity> {
+  return Arr.sort(activities, activityOrder);
+}
+
+export function derivePendingApprovals(
+  sortedActivities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingApproval[] {
   const openByRequestId = new Map<ApprovalRequestId, PendingApproval>();
-  const ordered = Arr.sort(activities, activityOrder);
 
-  for (const activity of ordered) {
+  for (const activity of sortedActivities) {
     const payload =
       activity.payload && typeof activity.payload === "object"
         ? (activity.payload as Record<string, unknown>)
@@ -1273,12 +1288,11 @@ export function derivePendingApprovals(
 }
 
 export function derivePendingUserInputs(
-  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  sortedActivities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingUserInput[] {
   const openByRequestId = new Map<ApprovalRequestId, PendingUserInput>();
-  const ordered = Arr.sort(activities, activityOrder);
 
-  for (const activity of ordered) {
+  for (const activity of sortedActivities) {
     const payload =
       activity.payload && typeof activity.payload === "object"
         ? (activity.payload as Record<string, unknown>)

--- a/apps/mobile/src/state/thread-outbox-manager.ts
+++ b/apps/mobile/src/state/thread-outbox-manager.ts
@@ -88,11 +88,22 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
     return loadPromise;
   };
 
-  const enqueue = (message: QueuedThreadMessage): Promise<void> =>
-    serialize(async () => {
+  // The queued atom drives the composer's immediate "queued" feedback, so it
+  // is published synchronously; the durable write happens behind it and rolls
+  // the message back out if it fails (durability only matters for crash
+  // recovery, not for the in-session queue).
+  const enqueue = (message: QueuedThreadMessage): Promise<void> => {
+    setMessages([
+      ...currentMessages().filter((candidate) => candidate.messageId !== message.messageId),
+      message,
+    ]);
+    return serialize(async () => {
       try {
         await options.storage.write(message);
       } catch (cause) {
+        setMessages(
+          currentMessages().filter((candidate) => candidate.messageId !== message.messageId),
+        );
         throw new ThreadOutboxManagerError({
           operation: "enqueue",
           environmentId: message.environmentId,
@@ -101,11 +112,8 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
           cause,
         });
       }
-      setMessages([
-        ...currentMessages().filter((candidate) => candidate.messageId !== message.messageId),
-        message,
-      ]);
     });
+  };
 
   // Rewrites an already-queued message. A no-op when the message has been
   // removed in the meantime (e.g. deleted or delivered), so a trailing editor

--- a/apps/mobile/src/state/thread-outbox-manager.ts
+++ b/apps/mobile/src/state/thread-outbox-manager.ts
@@ -101,9 +101,10 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
       try {
         await options.storage.write(message);
       } catch (cause) {
-        setMessages(
-          currentMessages().filter((candidate) => candidate.messageId !== message.messageId),
-        );
+        // Roll back by reference, not messageId: a retry enqueue with the same
+        // id may have optimistically replaced this attempt while the write was
+        // in flight, and its entry must survive this attempt's failure.
+        setMessages(currentMessages().filter((candidate) => candidate !== message));
         throw new ThreadOutboxManagerError({
           operation: "enqueue",
           environmentId: message.environmentId,
@@ -114,6 +115,13 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
       }
     });
   };
+
+  // Resolves once all pending mutations (including any in-flight enqueue
+  // write) have settled, reporting whether the message is still queued. The
+  // drain awaits this before dispatching so a message whose durable write
+  // later fails can never have been delivered first.
+  const confirmQueued = (message: QueuedThreadMessage): Promise<boolean> =>
+    serialize(async () => currentMessages().some((candidate) => candidate === message));
 
   // Rewrites an already-queued message. A no-op when the message has been
   // removed in the meantime (e.g. deleted or delivered), so a trailing editor
@@ -212,6 +220,7 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
     serialize,
     load,
     enqueue,
+    confirmQueued,
     update,
     remove,
     clearEnvironment,

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -357,6 +357,48 @@ describe("thread outbox", () => {
     registry.dispose();
   });
 
+  it("keeps a same-id retry queued when the first attempt's write fails", async () => {
+    const registry = AtomRegistry.make();
+    let failNextWrite = true;
+    let releaseFirstWrite!: () => void;
+    const firstWriteBlocked = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    const manager = createThreadOutboxManager({
+      registry,
+      storage: {
+        load: async () => [],
+        write: async () => {
+          if (failNextWrite) {
+            failNextWrite = false;
+            await firstWriteBlocked;
+            throw new Error("disk full");
+          }
+        },
+        remove: async () => undefined,
+      },
+    });
+    const message = queuedMessage({
+      messageId: "message-1",
+      createdAt: "2026-06-08T10:00:01.000Z",
+    });
+    const retried = { ...message, text: "retried" };
+
+    const first = manager.enqueue(message);
+    const second = manager.enqueue(retried);
+    releaseFirstWrite();
+    await expect(first).rejects.toBeInstanceOf(ThreadOutboxManagerError);
+    await second;
+
+    // The failed first attempt must not roll back the retry that replaced it.
+    expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
+      "environment-1:thread-1": [retried],
+    });
+    await expect(manager.confirmQueued(retried)).resolves.toBe(true);
+    await expect(manager.confirmQueued(message)).resolves.toBe(false);
+    registry.dispose();
+  });
+
   it("replaces an existing message when an enqueue retry uses the same id", async () => {
     const registry = AtomRegistry.make();
     const manager = createThreadOutboxManager({

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -294,6 +294,69 @@ describe("thread outbox", () => {
     registry.dispose();
   });
 
+  it("publishes an enqueued message before the durable write resolves", async () => {
+    const registry = AtomRegistry.make();
+    let releaseWrite!: () => void;
+    const writeBlocked = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    const manager = createThreadOutboxManager({
+      registry,
+      storage: {
+        load: async () => [],
+        write: async () => writeBlocked,
+        remove: async () => undefined,
+      },
+    });
+    const message = queuedMessage({
+      messageId: "message-1",
+      createdAt: "2026-06-08T10:00:01.000Z",
+    });
+
+    const enqueueing = manager.enqueue(message);
+    expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
+      "environment-1:thread-1": [message],
+    });
+
+    releaseWrite();
+    await enqueueing;
+    expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
+      "environment-1:thread-1": [message],
+    });
+    registry.dispose();
+  });
+
+  it("rolls an enqueued message back out when the durable write fails", async () => {
+    const registry = AtomRegistry.make();
+    const writeCause = new Error("disk full");
+    const manager = createThreadOutboxManager({
+      registry,
+      storage: {
+        load: async () => [],
+        write: async () => {
+          throw writeCause;
+        },
+        remove: async () => undefined,
+      },
+    });
+    const message = queuedMessage({
+      messageId: "message-1",
+      createdAt: "2026-06-08T10:00:01.000Z",
+    });
+
+    await expect(manager.enqueue(message)).rejects.toEqual(
+      new ThreadOutboxManagerError({
+        operation: "enqueue",
+        environmentId: message.environmentId,
+        threadId: message.threadId,
+        messageId: message.messageId,
+        cause: writeCause,
+      }),
+    );
+    expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({});
+    registry.dispose();
+  });
+
   it("replaces an existing message when an enqueue retry uses the same id", async () => {
     const registry = AtomRegistry.make();
     const manager = createThreadOutboxManager({

--- a/apps/mobile/src/state/thread-outbox.ts
+++ b/apps/mobile/src/state/thread-outbox.ts
@@ -20,6 +20,11 @@ export function enqueueThreadOutboxMessage(message: QueuedThreadMessage): Promis
   return threadOutboxManager.enqueue(message);
 }
 
+/** Waits for pending writes to settle; false if the message was rolled back. */
+export function confirmThreadOutboxMessageQueued(message: QueuedThreadMessage): Promise<boolean> {
+  return threadOutboxManager.confirmQueued(message);
+}
+
 /** Rewrite a queued message; no-op (false) if it was removed in the meantime. */
 export function updateThreadOutboxMessage(message: QueuedThreadMessage): Promise<boolean> {
   return threadOutboxManager.update(message);

--- a/apps/mobile/src/state/use-selected-thread-requests.ts
+++ b/apps/mobile/src/state/use-selected-thread-requests.ts
@@ -11,6 +11,7 @@ import {
   derivePendingApprovals,
   derivePendingUserInputs,
   setPendingUserInputCustomAnswer,
+  sortThreadActivities,
   type PendingUserInputDraftAnswer,
 } from "../lib/threadActivity";
 import { appAtomRegistry } from "./atom-registry";
@@ -70,14 +71,19 @@ export function useSelectedThreadRequests() {
     null,
   );
 
-  const activePendingApprovals = useMemo(
-    () => (selectedThread ? derivePendingApprovals(selectedThread.activities) : []),
+  // Sort once; both derivations expect the same lifecycle ordering.
+  const sortedActivities = useMemo(
+    () => (selectedThread ? sortThreadActivities(selectedThread.activities) : []),
     [selectedThread],
+  );
+  const activePendingApprovals = useMemo(
+    () => derivePendingApprovals(sortedActivities),
+    [sortedActivities],
   );
   const activePendingApproval = activePendingApprovals[0] ?? null;
   const activePendingUserInputs = useMemo(
-    () => (selectedThread ? derivePendingUserInputs(selectedThread.activities) : []),
-    [selectedThread],
+    () => derivePendingUserInputs(sortedActivities),
+    [sortedActivities],
   );
   const activePendingUserInput = activePendingUserInputs[0] ?? null;
   const activePendingUserInputDrafts =

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -168,7 +168,12 @@ export function useThreadComposerState() {
     });
     clearComposerDraftContent(threadKey);
     enqueuePromise.catch((error: unknown) => {
-      void mergeComposerDraftContent(threadKey, { text, attachments });
+      // Restore text via merge (idempotent) but attachments via the uncapped
+      // append: the merge path slots existing attachments first and truncates
+      // at the send limit, which would silently drop this message's images if
+      // the user attached new ones while the write was in flight.
+      void mergeComposerDraftContent(threadKey, { text, attachments: [] });
+      appendComposerDraftAttachments(threadKey, attachments);
       setPendingConnectionError(
         error instanceof Error ? error.message : "Failed to save the queued message.",
       );

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -30,6 +30,7 @@ import {
   composerDraftsAtom,
   ensureComposerDraftsLoaded,
   getComposerDraftSnapshot,
+  mergeComposerDraftContent,
   removeComposerDraftAttachment,
   setComposerDraftText,
   updateComposerDraftSettings,
@@ -148,27 +149,31 @@ export function useThreadComposerState() {
 
     const metadata = makeQueuedMessageMetadata();
     const messageId = MessageId.make(metadata.messageId);
-    try {
-      await enqueueThreadOutboxMessage({
-        environmentId: selectedThreadShell.environmentId,
-        threadId: selectedThreadShell.id,
-        messageId,
-        commandId: CommandId.make(metadata.commandId),
-        text,
-        attachments,
-        modelSelection: draft.modelSelection ?? thread.modelSelection,
-        runtimeMode: draft.runtimeMode ?? thread.runtimeMode,
-        interactionMode: draft.interactionMode ?? thread.interactionMode,
-        createdAt: metadata.createdAt,
-      });
-      clearComposerDraftContent(threadKey);
-      return messageId;
-    } catch (error) {
+    // Enqueue publishes the queued atom synchronously (the durable write
+    // happens behind it), so clearing the draft here gives send feedback on
+    // the tap frame instead of after file I/O. If the write fails the message
+    // is rolled out of the queue and the content is merged back into the
+    // draft, preserving anything typed since.
+    const enqueuePromise = enqueueThreadOutboxMessage({
+      environmentId: selectedThreadShell.environmentId,
+      threadId: selectedThreadShell.id,
+      messageId,
+      commandId: CommandId.make(metadata.commandId),
+      text,
+      attachments,
+      modelSelection: draft.modelSelection ?? thread.modelSelection,
+      runtimeMode: draft.runtimeMode ?? thread.runtimeMode,
+      interactionMode: draft.interactionMode ?? thread.interactionMode,
+      createdAt: metadata.createdAt,
+    });
+    clearComposerDraftContent(threadKey);
+    enqueuePromise.catch((error: unknown) => {
+      void mergeComposerDraftContent(threadKey, { text, attachments });
       setPendingConnectionError(
         error instanceof Error ? error.message : "Failed to save the queued message.",
       );
-      return null;
-    }
+    });
+    return messageId;
   }, [selectedThreadDetail, selectedThreadShell]);
 
   const onChangeDraftMessage = useCallback(

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -21,7 +21,11 @@ import { toUploadChatImageAttachments } from "../lib/composerImages";
 import { randomHex } from "../lib/uuid";
 import { appAtomRegistry } from "./atom-registry";
 import { useProjects, useThreadShells } from "./entities";
-import { ensureThreadOutboxLoaded, removeThreadOutboxMessage } from "./thread-outbox";
+import {
+  confirmThreadOutboxMessageQueued,
+  ensureThreadOutboxLoaded,
+  removeThreadOutboxMessage,
+} from "./thread-outbox";
 import {
   isQueuedThreadCreationSendable,
   modelSelectionsEqual,
@@ -349,8 +353,15 @@ export function useThreadOutboxDrain(): void {
             return false;
           },
         );
-      const delivery =
-        deliveryAction === "remove"
+      // Enqueues publish optimistically before their durable write settles.
+      // Confirm the write landed (and the message wasn't rolled back) before
+      // sending, so a failed write can never chase an already-delivered turn.
+      const delivery = confirmThreadOutboxMessageQueued(nextQueuedMessage).then((queued) => {
+        if (!queued) {
+          // Rolled back by a failed write; nothing to deliver or retry.
+          return true;
+        }
+        return deliveryAction === "remove"
           ? removeQueuedMessage("[thread-outbox] failed to remove message for a missing thread")
           : creation !== undefined
             ? creationProjectCwd !== null
@@ -359,6 +370,7 @@ export function useThreadOutboxDrain(): void {
             : thread !== undefined
               ? sendQueuedMessage(nextQueuedMessage, thread)
               : Promise.resolve(false);
+      });
       void delivery
         .then((sent) => {
           if (sent) {

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -37,7 +37,7 @@ import {
   type QueuedThreadMessage,
   type ThreadOutboxCommandStage,
 } from "./thread-outbox-model";
-import { threadEnvironment } from "./threads";
+import { environmentThreadShells, threadEnvironment } from "./threads";
 import { useAtomCommand } from "./use-atom-command";
 import {
   editingQueuedMessageIdsAtom,
@@ -359,6 +359,23 @@ export function useThreadOutboxDrain(): void {
       const delivery = confirmThreadOutboxMessageQueued(nextQueuedMessage).then((queued) => {
         if (!queued) {
           // Rolled back by a failed write; nothing to deliver or retry.
+          return true;
+        }
+        // The guards evaluated before the confirmation await are stale by now:
+        // the thread may have gone busy, or the user may have opened this
+        // message in the editor. Re-read both and defer to the next drain pass
+        // (returning true skips the failure/backoff path) rather than sending
+        // a payload the user is editing or racing an active turn.
+        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]) {
+          return true;
+        }
+        const freshThread = findThread(
+          appAtomRegistry.get(environmentThreadShells.threadShellsAtom),
+          nextQueuedMessage,
+        );
+        const freshThreadBusy =
+          freshThread?.session?.status === "running" || freshThread?.session?.status === "starting";
+        if (deliveryAction === "send" && creation === undefined && freshThreadBusy) {
           return true;
         }
         return deliveryAction === "remove"


### PR DESCRIPTION
On iOS, sending a message did nothing for 3+ seconds before showing "queued", opening a thread locked the app for ~1s before the transition, and starting a new thread froze before the composer appeared. A multi-agent investigation traced each symptom; this PR takes the highest-impact fixes that were safe to make small.

**Send: feedback on the tap frame.** The "queued" state waited on a durable JSON file write (with attachments inlined as base64) before anything changed on screen, and the draft only cleared after that resolved. The outbox atom now publishes synchronously with the write happening behind it (rolled back on failure, content restored to the draft), and the lock-screen Live Activity arms after the send instead of before. Sending now clears the composer and shows "queued" immediately; the file write and relay round trip happen behind that feedback.

**Thread open: linear feed derivation.** `groupAdjacentActivities` copied the accumulated group array per activity — O(k²) on long tool runs. It now appends into a mutable trailing group. Isolated benchmark: 2,000 activities in one turn drops 1.47ms → 0.009ms per pass (~160x); at 5,000 activities ~1.8ms → 0.03ms. This runs on every thread open *and* every streaming update, and pending approvals/user inputs re-sorted the full activity array twice more per update — now sorted once and shared.

**New thread: keyboard no longer races the sheet.** The native composer's `autoFocus` fired `becomeFirstResponder` the moment the view attached, forcing iOS keyboard bring-up (300ms+ cold) during the formSheet present animation. The existing `InteractionManager`-deferred focus takes over, so the sheet animates immediately and the keyboard rises after it settles.

**Re-render hygiene.** The v2 home thread list passed a fresh `extraData` object literal every render, forcing all visible FlatList rows to re-render on any HomeScreen render — now memoized. `useThreadOutboxDrain` (subscribed to all threads, projects, connections, and the outbox) ran directly in the root navigation layout, re-rendering every screen on each enqueue/shell/connection change — now hosted in a null-rendering leaf. The Android-only shortcuts hook also subscribed the iOS root to the active thread shell — now gated.

**Estimated impact** (release builds; ranked by user-visible effect):
- Send: perceived latency drops from 3+ seconds to instantaneous queued feedback (the transport round trip still runs, but behind visible state).
- Thread open: eliminates the quadratic + duplicate-sort share of the pre-transition freeze (up to ~2ms per pass per 2k activities, × N re-runs during catch-up replay) and stops whole-list row re-renders on the way out; the remaining mount cost (markdown expansion, schema decode) is follow-up work.
- New thread: removes the main-thread keyboard stall from the present animation, which was the dominant visible beat.
- Streaming/idle: outbox and shell updates no longer re-render the root tree, cutting steady-state render fan-out during active turns.

Deeper follow-ups identified but out of scope here: client-side event-stream batching, using the existing granular thread-detail slice atoms, skipping re-decode of warm snapshots, dropping the drain's redundant pre-flight settings RPCs, and file-referenced (not base64) attachments.

Written by Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Optimistic outbox + confirm-before-drain changes message delivery ordering and failure recovery; incorrect rollback or stale guard logic could drop or duplicate sends, though new tests cover write failure and same-id retry cases.
> 
> **Overview**
> Makes **send** feel immediate and cuts main-thread work and root re-renders that were freezing **thread open** and **new task** flows.
> 
> **Thread outbox:** Queued messages update the in-memory atom **before** the durable write finishes; the composer clears on the tap frame. Failed writes roll back the queue entry and **merge** text back into the draft (attachments via uncapped append). The drain calls **`confirmThreadOutboxMessageQueued`** and re-checks edit/busy state after that await so rolled-back or stale messages are never delivered.
> 
> **Re-render isolation:** `useThreadOutboxDrain` moves into a null **`ThreadOutboxDrainWorker`** so outbox/shell/connection churn does not re-render `RootStackLayout`. On iOS, launcher shortcut sync no longer subscribes to the active thread shell. Home v2 **`FlatList` `extraData`** is memoized.
> 
> **Feed derivation:** `groupAdjacentActivities` appends into a mutable trailing group (avoids quadratic copies). **`sortThreadActivities`** runs once and feeds both pending-approval and pending-user-input derivations.
> 
> **UX timing:** New-task composer **`autoFocus`** is off on iOS; focus stays deferred until after the sheet animation. Live Activity arms **after** `onSendMessage` completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d87beb6d8962711d1a550956bf87846d7fa842d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make mobile send respond instantly and stop thread opens from freezing
> - Queued messages in [thread-outbox-manager.ts](https://github.com/pingdotgg/t3code/pull/4882/files#diff-8761ed0ec0414d025a4ec6d247ce9b47563b6c741fc707dbf506e9671fdd3045) are now published to state synchronously before the durable write, so the draft clears immediately on send; failed writes roll back the message and restore the draft with an error.
> - [use-thread-outbox-drain.ts](https://github.com/pingdotgg/t3code/pull/4882/files#diff-c6afd8ca1f9412d0350ad44712f269fd37ea380215bf974fa2fcead4352da5a3) uses the new `confirmQueued` API to verify the durable write succeeded before dispatching, preventing dispatch of rolled-back or stale messages.
> - `ThreadOutboxDrainWorker` in [Stack.tsx](https://github.com/pingdotgg/t3code/pull/4882/files#diff-6c445d1d9bb762a38688d21c21790ec36c9a0b882fd17c04888c694ba76736ab) isolates outbox drain subscriptions to a leaf component, preventing outbox state updates from re-rendering `RootStackLayout`.
> - `ComposerEditor` in [NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/4882/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2) defers auto-focus until after the iOS sheet presentation animation completes.
> - `FlatList.extraData` in [HomeScreen.tsx](https://github.com/pingdotgg/t3code/pull/4882/files#diff-b6e075b3065ae370669290cbaa8476a852399968002468571cd914d06a32fd40) is memoized to avoid unnecessary row re-renders, and `useRecentThreadShortcutSync` in [useAppShortcuts.ts](https://github.com/pingdotgg/t3code/pull/4882/files#diff-a586a7f153cd4e62d48218a7c37e9ef382630064d622fc09a77e56761bba915b) skips active thread subscription on iOS.
> - Behavioral Change: `onSendMessage` now resolves immediately with the new `messageId` without waiting for the durable write; callers previously relying on post-send resolution timing may see different behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d87beb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->