### PR TITLE
fix(web): stop the transcript scrolling itself on every streamed chunk

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -166,7 +166,8 @@ import {
 import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
 import { getProviderModelCapabilities, resolveSelectableProvider } from "../providerModels";
 import { NO_PROVIDER_MODEL_SELECTION } from "../providerInstances";
-import { useClientSettings, useEnvironmentSettings } from "../hooks/useSettings";
+import { getClientSettings, useClientSettings, useEnvironmentSettings } from "../hooks/useSettings";
+import { prefersReducedMotion } from "../reducedMotion";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
@@ -307,6 +308,12 @@ import {
 } from "../versionSkew";
 import { useAssetUrls } from "../assets/assetUrls";
 
+// How long after live-follow takes the scroll position we still treat a
+// not-at-end report as that scroll settling rather than the reader moving. Only
+// consulted when follow-output is off; while it is on, live-follow owns the
+// position for as long as it holds it.
+const LIVE_FOLLOW_SETTLE_MS = 500;
+
 const IMAGE_ONLY_BOOTSTRAP_PROMPT =
   "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
@@ -333,9 +340,7 @@ function useDraftHeroLayoutTransition(isDraftHeroState: boolean) {
     const transitionGroup = transitionGroupRef.current;
     const nextComposerRect = composerAnchorRef.current?.getBoundingClientRect() ?? null;
     const stateChanged = previousStateRef.current !== isDraftHeroState;
-    const prefersReducedMotion =
-      typeof window !== "undefined" &&
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    const reducedMotion = prefersReducedMotion(getClientSettings().reduceMotion);
     const mobileComposerTransitionActive =
       typeof document !== "undefined" &&
       document.documentElement.dataset.mobileComposerRouteTransition === "true";
@@ -346,7 +351,7 @@ function useDraftHeroLayoutTransition(isDraftHeroState: boolean) {
     const previousComposerRect = previousComposerRectRef.current;
     if (
       stateChanged &&
-      !prefersReducedMotion &&
+      !reducedMotion &&
       !mobileComposerTransitionActive &&
       transitionGroup &&
       previousComposerRect &&
@@ -3435,6 +3440,21 @@ function ChatViewContent(props: ChatViewProps) {
   const showScrollDebouncer = useRef(
     new Debouncer(() => setShowScrollToBottom(true), { wait: 150 }),
   );
+  const chatAutoScroll = useClientSettings((settings) => settings.chatAutoScroll);
+  const reduceMotionSetting = useClientSettings((settings) => settings.reduceMotion);
+  const timelineReduceMotion = prefersReducedMotion(reduceMotionSetting);
+  // The scroll callbacks below are deliberately stable (empty dependency lists,
+  // refs only) so changing a setting never re-creates them mid-stream; these
+  // mirrors are what let those callbacks read the current values.
+  const chatAutoScrollRef = useRef(chatAutoScroll);
+  // When live-follow last took ownership of the scroll position, used to tell a
+  // settling programmatic scroll apart from the reader falling behind.
+  const liveFollowSyncedAtRef = useRef(0);
+  const timelineReduceMotionRef = useRef(timelineReduceMotion);
+  useEffect(() => {
+    chatAutoScrollRef.current = chatAutoScroll;
+    timelineReduceMotionRef.current = timelineReduceMotion;
+  }, [chatAutoScroll, timelineReduceMotion]);
   const timelineScrollModeRef = useRef<TimelineScrollMode>("following-end");
   const pendingTimelineAnchorRef = useRef<MessageId | null>(null);
   const positionedTimelineAnchorRef = useRef<MessageId | null>(null);
@@ -3523,6 +3543,7 @@ function ChatViewContent(props: ChatViewProps) {
     isAtEndRef.current = true;
     timelineScrollModeRef.current = "following-end";
     liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
+    liveFollowSyncedAtRef.current = performance.now();
     pendingTimelineAnchorRef.current = null;
     activeTimelineAnchorIndexRef.current = null;
     showScrollDebouncer.current.cancel();
@@ -3603,7 +3624,7 @@ function ChatViewContent(props: ChatViewProps) {
         scrollNode.addEventListener("scrollend", finishAnimatedPositioning, { once: true });
         void list.scrollToIndex({
           index: anchorIndex,
-          animated: true,
+          animated: !timelineReduceMotionRef.current,
           viewPosition: 0,
           viewOffset: CHAT_LIST_ANCHOR_OFFSET,
         });
@@ -3654,8 +3675,18 @@ function ChatViewContent(props: ChatViewProps) {
   }, []);
 
   const onIsAtEndChange = useCallback((isAtEnd: boolean) => {
+    // Leaving the live edge without a user gesture means a programmatic scroll
+    // is still settling, not that the reader navigated away, so the pill stays
+    // hidden. While live-follow is on it owns the position indefinitely. With it
+    // off, only the window right after a thread switch or a send is settling —
+    // LegendList reports not-at-end while `initialScrollAtEnd` lands — and once
+    // that passes, falling behind is exactly when the pill has to appear.
+    const settling =
+      chatAutoScrollRef.current ||
+      performance.now() - liveFollowSyncedAtRef.current < LIVE_FOLLOW_SETTLE_MS;
     if (
       !isAtEnd &&
+      settling &&
       liveFollowUserScrollGenerationRef.current === anchorUserScrollGenerationRef.current
     ) {
       showScrollDebouncer.current.cancel();
@@ -3667,6 +3698,7 @@ function ChatViewContent(props: ChatViewProps) {
     if (isAtEnd) {
       timelineScrollModeRef.current = "following-end";
       liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
+      liveFollowSyncedAtRef.current = performance.now();
       showScrollDebouncer.current.cancel();
       setShowScrollToBottom(false);
     } else {
@@ -3676,8 +3708,16 @@ function ChatViewContent(props: ChatViewProps) {
     }
   }, []);
 
+  // Live-follow. This runs on every timeline change, i.e. once per streamed
+  // chunk, so it is the scrolling a reader actually feels. With the setting off
+  // the transcript holds still and the scroll-to-end pill takes over; the
+  // one-time anchor positioning after a send is unaffected because that lives in
+  // onTimelineAnchorReady.
   useEffect(() => {
     if (!activeThread?.id) {
+      return;
+    }
+    if (!chatAutoScroll) {
       return;
     }
     if (liveFollowUserScrollGenerationRef.current !== anchorUserScrollGenerationRef.current) {
@@ -3737,6 +3777,7 @@ function ChatViewContent(props: ChatViewProps) {
     };
   }, [
     activeThread?.id,
+    chatAutoScroll,
     timelineEntries,
     getActiveTimelineTurnMetrics,
     timelineRealContentOverflowsViewport,
@@ -3747,6 +3788,7 @@ function ChatViewContent(props: ChatViewProps) {
     isAtEndRef.current = true;
     timelineScrollModeRef.current = "following-end";
     liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
+    liveFollowSyncedAtRef.current = performance.now();
     pendingTimelineAnchorRef.current = null;
     positionedTimelineAnchorRef.current = null;
     settledTimelineAnchorRef.current = null;
@@ -4665,6 +4707,7 @@ function ChatViewContent(props: ChatViewProps) {
     isAtEndRef.current = true;
     timelineScrollModeRef.current = "anchoring-new-turn";
     liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
+    liveFollowSyncedAtRef.current = performance.now();
     pendingTimelineAnchorRef.current = messageIdForSend;
     activeTimelineAnchorIndexRef.current = null;
     showScrollDebouncer.current.cancel();
@@ -5108,6 +5151,7 @@ function ChatViewContent(props: ChatViewProps) {
       isAtEndRef.current = true;
       timelineScrollModeRef.current = "anchoring-new-turn";
       liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
+      liveFollowSyncedAtRef.current = performance.now();
       pendingTimelineAnchorRef.current = messageIdForSend;
       activeTimelineAnchorIndexRef.current = null;
       showScrollDebouncer.current.cancel();
@@ -5758,6 +5802,8 @@ function ChatViewContent(props: ChatViewProps) {
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
                 hideEmptyPlaceholder={isDraftHeroState || threadDetailLoading}
                 topFadeEnabled={!hasTimelineTopBanner}
+                autoScrollEnabled={chatAutoScroll}
+                reduceMotion={timelineReduceMotion}
               />
 
               {/* scroll to end pill — shown when user has scrolled away from the live edge */}
@@ -5770,7 +5816,7 @@ function ChatViewContent(props: ChatViewProps) {
                     type="button"
                     aria-label="Scroll to end"
                     title="Scroll to end"
-                    onClick={() => scrollToEnd(true)}
+                    onClick={() => scrollToEnd(!timelineReduceMotion)}
                     className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
                   >
                     <ChevronDownIcon className="size-3.5" />

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -414,14 +414,27 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain("Show full message");
-    expect(markup).toContain('data-maintain-scroll-at-end="enabled"');
-    expect(markup).toContain('data-maintain-scroll-at-end-animated="false"');
-    expect(markup).toContain('data-maintain-scroll-at-end-data-change="true"');
-    expect(markup).toContain('data-maintain-scroll-at-end-item-layout="true"');
-    expect(markup).toContain('data-maintain-scroll-at-end-layout="true"');
     expect(markup).toContain('data-user-message-collapsed="true"');
     expect(markup).toContain('data-user-message-fade="true"');
     expect(markup).toContain('data-user-message-footer="true"');
+  });
+
+  it("only lets the list re-pin itself to the end when auto-scroll is on", () => {
+    const timelineEntries = [buildUserTimelineEntry("Short prompt.")];
+
+    const following = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={timelineEntries} autoScrollEnabled />,
+    );
+    expect(following).toContain('data-maintain-scroll-at-end="enabled"');
+    expect(following).toContain('data-maintain-scroll-at-end-animated="false"');
+    expect(following).toContain('data-maintain-scroll-at-end-data-change="true"');
+    expect(following).toContain('data-maintain-scroll-at-end-item-layout="true"');
+    expect(following).toContain('data-maintain-scroll-at-end-layout="true"');
+
+    const still = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={timelineEntries} />,
+    );
+    expect(still).not.toContain('data-maintain-scroll-at-end="enabled"');
   });
 
   it("does not render collapse controls for short user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -184,6 +184,10 @@ interface MessagesTimelineProps {
   onManualNavigation: () => void;
   hideEmptyPlaceholder?: boolean;
   topFadeEnabled?: boolean;
+  /** Whether the list may re-pin itself to the end as rows arrive or resize. */
+  autoScrollEnabled?: boolean;
+  /** Turns the minimap jump into an instant scroll instead of an animated one. */
+  reduceMotion?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +223,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   onManualNavigation,
   hideEmptyPlaceholder = false,
   topFadeEnabled = false,
+  autoScrollEnabled = false,
+  reduceMotion = false,
 }: MessagesTimelineProps) {
   const [expandedTurnIds, setExpandedTurnIds] = useState<ReadonlySet<TurnId>>(new Set());
   const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
@@ -495,7 +501,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             {...(anchoredEndSpace ? { anchoredEndSpace } : {})}
             contentInsetEndAdjustment={contentInsetEndAdjustment}
             maintainScrollAtEnd={
-              anchoredEndSpace
+              anchoredEndSpace || !autoScrollEnabled
                 ? false
                 : {
                     animated: false,
@@ -528,7 +534,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
               onManualNavigation();
               void listRef.current?.scrollToIndex({
                 index: item.rowIndex,
-                animated: true,
+                animated: !reduceMotion,
                 viewOffset: 24,
               });
             }}
@@ -694,7 +700,7 @@ function TimelineMinimap({
   return (
     <div
       className={cn(
-        "group/minimap pointer-events-none absolute top-0 left-0 z-40 hidden w-18 [@media(pointer:fine)]:block",
+        "group/minimap pointer-events-none absolute top-0 start-0 z-40 hidden w-18 [@media(pointer:fine)]:block",
         hasPersistentGutter
           ? "opacity-100"
           : "opacity-0 transition-opacity duration-150 hover:opacity-100 focus-within:opacity-100",
@@ -707,7 +713,7 @@ function TimelineMinimap({
         <button
           aria-label={`Jump to message: ${activeItem?.userText ?? "User message"}`}
           className={cn(
-            "absolute top-1/2 left-3 -translate-y-1/2 cursor-pointer bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
+            "absolute top-1/2 start-3 -translate-y-1/2 cursor-pointer bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
             // The strip is width-capped to the side gutter so it never overlays
             // the centered content column; with no usable gutter it goes inert.
             hitStripWidth > 0 ? "pointer-events-auto" : "pointer-events-none",
@@ -759,7 +765,7 @@ function TimelineMinimap({
           }}
           type="button"
         >
-          <div className="absolute top-0 left-3 h-full w-px bg-border/15" />
+          <div className="absolute top-0 start-3 h-full w-px bg-border/15" />
           {items.map((item, index) => {
             const top = `${resolveTimelineMinimapTopPercent(index, items.length)}%`;
             const activeDistance =
@@ -768,7 +774,7 @@ function TimelineMinimap({
               <span
                 aria-hidden="true"
                 className={cn(
-                  "pointer-events-none absolute left-0 h-0.5 -translate-y-1/2 rounded-full bg-muted-foreground/35 transition-[background-color,width] duration-150 data-[in-view=true]:bg-foreground/90",
+                  "pointer-events-none absolute start-0 h-0.5 -translate-y-1/2 rounded-full bg-muted-foreground/35 transition-[background-color,width] duration-150 data-[in-view=true]:bg-foreground/90",
                   activeDistance === 0
                     ? "w-6 bg-muted-foreground/75"
                     : activeDistance === 1
@@ -793,7 +799,7 @@ function TimelineMinimap({
           })}
           {activeItem ? (
             <span
-              className="pointer-events-auto absolute left-8 w-80 cursor-text select-text"
+              className="pointer-events-auto absolute start-8 w-80 cursor-text select-text"
               data-minimap-preview
               onMouseMove={(event) => event.stopPropagation()}
               style={{
@@ -801,7 +807,7 @@ function TimelineMinimap({
                 transform: `translateY(${activeTooltipTranslate})`,
               }}
             >
-              <span className="dropdown-glass block rounded-xl p-3 text-left text-popover-foreground shadow-xl shadow-black/25">
+              <span className="dropdown-glass block rounded-xl p-3 text-start text-popover-foreground shadow-xl shadow-black/25">
                 <span className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium leading-5">
                   {activeItem.userText ?? "User message"}
                 </span>
@@ -1093,7 +1099,7 @@ function ProposedPlanTimelineRow({
 
 function WorkingTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "working" }> }) {
   return (
-    <div className="py-0.5 pl-1.5">
+    <div className="py-0.5 ps-1.5">
       <div className="flex items-center gap-2 pt-1 text-[11px] text-muted-foreground/70 tabular-nums">
         <span className="inline-flex items-center gap-[3px]">
           <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse" />
@@ -1204,7 +1210,7 @@ function WorkGroupToggleTimelineRow({
   return (
     <button
       type="button"
-      className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[12px] leading-5 transition-colors duration-150 hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
+      className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-0.5 py-0.5 text-start text-[12px] leading-5 transition-colors duration-150 hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
       aria-expanded={row.expanded}
       onClick={(event) => {
         const anchorElement =
@@ -1353,7 +1359,7 @@ function UserMessagePreviewAnnotationCard(props: {
       {props.image?.previewUrl ? (
         <button
           type="button"
-          className="size-14 shrink-0 cursor-zoom-in overflow-hidden border-r border-border/70 bg-muted"
+          className="size-14 shrink-0 cursor-zoom-in overflow-hidden border-e border-border/70 bg-muted"
           aria-label={`Preview ${props.image.name}`}
           onClick={() => {
             if (!props.image) return;
@@ -1465,13 +1471,13 @@ const CollapsibleUserMessageBody = memo(function CollapsibleUserMessageBody(prop
               aria-expanded={expanded}
               data-scroll-anchor-ignore
               onClick={() => setExpanded((value) => !value)}
-              className="-ml-1 h-6 rounded-md px-1.5 text-xs text-muted-foreground/72 hover:bg-muted/55 hover:text-foreground/85"
+              className="-ms-1 h-6 rounded-md px-1.5 text-xs text-muted-foreground/72 hover:bg-muted/55 hover:text-foreground/85"
             >
               {expanded ? "Show less" : "Show full message"}
             </Button>
           ) : null}
           {props.footer ? (
-            <div className="ml-auto flex items-center gap-2">{props.footer}</div>
+            <div className="ms-auto flex items-center gap-2">{props.footer}</div>
           ) : null}
         </div>
       ) : null}
@@ -2071,7 +2077,8 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
-          <pre className="max-h-64 cursor-text overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground select-text">
+          {/* Tool output is command output, not prose: keep it left-to-right. */}
+          <pre className="force-ltr max-h-64 cursor-text overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground select-text">
             {expandedBody}
           </pre>
         </div>

--- a/apps/web/src/components/chat/draftHeroTransition.ts
+++ b/apps/web/src/components/chat/draftHeroTransition.ts
@@ -1,3 +1,6 @@
+import { prefersReducedMotion } from "~/reducedMotion";
+import { getClientSettings } from "~/hooks/useSettings";
+
 export const DRAFT_HERO_TRANSITION_ANIMATION_ID = "t3-draft-hero-transition";
 export const DRAFT_HERO_TRANSITION_DURATION_MS = 180;
 export const DRAFT_HERO_TRANSITION_EASING = "cubic-bezier(0.4, 0, 0.2, 1)";
@@ -47,9 +50,8 @@ export async function runMobileComposerTransition(
 
   const transitionDocument = document as ComposerViewTransitionDocument;
   const mobileViewport = window.matchMedia?.("(max-width: 639px)").matches ?? false;
-  const prefersReducedMotion =
-    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-  if (!mobileViewport || prefersReducedMotion || !transitionDocument.startViewTransition) {
+  const reducedMotion = prefersReducedMotion(getClientSettings().reduceMotion);
+  if (!mobileViewport || reducedMotion || !transitionDocument.startViewTransition) {
     await update();
     return;
   }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -569,6 +569,10 @@ export function useSettingsRestore(onRestored?: () => void) {
   const changedSettingLabels = useMemo(
     () => [
       ...(theme !== "system" ? ["Theme"] : []),
+      ...(settings.chatAutoScroll !== DEFAULT_UNIFIED_SETTINGS.chatAutoScroll
+        ? ["Follow agent output"]
+        : []),
+      ...(settings.reduceMotion !== DEFAULT_UNIFIED_SETTINGS.reduceMotion ? ["Reduce motion"] : []),
       ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? ["Glass opacity"] : []),
       ...(settings.environmentIdentificationMode !==
       DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode
@@ -621,6 +625,8 @@ export function useSettingsRestore(onRestored?: () => void) {
       isTextGenerationModelDirty,
       isBackgroundActivityDirty,
       settings.autoOpenPlanSidebar,
+      settings.chatAutoScroll,
+      settings.reduceMotion,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
@@ -651,6 +657,8 @@ export function useSettingsRestore(onRestored?: () => void) {
 
     setTheme("system");
     updateSettings({
+      chatAutoScroll: DEFAULT_UNIFIED_SETTINGS.chatAutoScroll,
+      reduceMotion: DEFAULT_UNIFIED_SETTINGS.reduceMotion,
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
@@ -994,6 +1002,50 @@ export function AppearanceSettingsPanel() {
                 ))}
               </SelectPopup>
             </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Follow agent output"
+          description="Scroll the transcript automatically while an agent streams. Off keeps the view still; the scroll-to-end button jumps when you want it."
+          resetAction={
+            settings.chatAutoScroll !== DEFAULT_UNIFIED_SETTINGS.chatAutoScroll ? (
+              <SettingResetButton
+                label="follow agent output"
+                onClick={() =>
+                  updateSettings({ chatAutoScroll: DEFAULT_UNIFIED_SETTINGS.chatAutoScroll })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.chatAutoScroll}
+              onCheckedChange={(checked) => updateSettings({ chatAutoScroll: Boolean(checked) })}
+              aria-label="Follow agent output while it streams"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Reduce motion"
+          description="Stop looping indicator animations and make every scroll instant instead of animated."
+          resetAction={
+            settings.reduceMotion !== DEFAULT_UNIFIED_SETTINGS.reduceMotion ? (
+              <SettingResetButton
+                label="reduce motion"
+                onClick={() =>
+                  updateSettings({ reduceMotion: DEFAULT_UNIFIED_SETTINGS.reduceMotion })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.reduceMotion}
+              onCheckedChange={(checked) => updateSettings({ reduceMotion: Boolean(checked) })}
+              aria-label="Reduce motion"
+            />
           }
         />
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1496,6 +1496,49 @@ label:has(> select#reasoning-effort) select {
   }
 }
 
+/* Calm mode. `data-reduce-motion` is set from the Reduce motion setting; the
+   media query covers users who asked the OS instead. Continuously repainting
+   indicators are the target: they are the only motion on screen while an agent
+   works, and on a high-refresh display they never stop. Static styling is left
+   alone so nothing disappears — only the looping repaints stop. Spinners keep
+   spinning: a frozen spinner reads as a hung app, which is worse than the
+   motion it would remove. */
+@media (prefers-reduced-motion: reduce) {
+  .ultrathink-frame::before,
+  .ultrathink-chroma,
+  .ultrathink-pill,
+  .ultrathink-word,
+  [class*="animate-status-pulse"],
+  [class*="animate-status-ping"],
+  [class*="animate-sidebar-working-text"],
+  [class*="animate-skeleton"],
+  [class*="animate-pulse"],
+  [class*="animation:bounce"] {
+    animation: none !important;
+  }
+}
+
+html[data-reduce-motion="true"] .ultrathink-frame::before,
+html[data-reduce-motion="true"] .ultrathink-chroma,
+html[data-reduce-motion="true"] .ultrathink-pill,
+html[data-reduce-motion="true"] .ultrathink-word,
+html[data-reduce-motion="true"] [class*="animate-status-pulse"],
+html[data-reduce-motion="true"] [class*="animate-status-ping"],
+html[data-reduce-motion="true"] [class*="animate-sidebar-working-text"],
+html[data-reduce-motion="true"] [class*="animate-skeleton"],
+html[data-reduce-motion="true"] [class*="animate-pulse"],
+html[data-reduce-motion="true"] [class*="animation:bounce"] {
+  animation: none !important;
+}
+
+/* The composer morph is driven from JS, which reads the same setting; this only
+   covers the route-level transition the browser owns. */
+html[data-reduce-motion="true"]::view-transition-group(*),
+html[data-reduce-motion="true"]::view-transition-old(*),
+html[data-reduce-motion="true"]::view-transition-new(*) {
+  animation: none;
+}
+
 @keyframes provider-update-pill-countdown {
   from {
     transform: scaleX(1);

--- a/apps/web/src/reducedMotion.ts
+++ b/apps/web/src/reducedMotion.ts
@@ -1,0 +1,24 @@
+/**
+ * The reduced-motion decision, in one place so the CSS attribute, the scroll
+ * helpers, and the composer transition cannot disagree.
+ *
+ * The setting forces it on; the OS preference can also ask for it. Nothing here
+ * turns it off — asking for less motion in either place wins.
+ */
+export function prefersReducedMotion(reduceMotionSetting: boolean): boolean {
+  if (reduceMotionSetting) return true;
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true
+  );
+}
+
+/** Mirrors the setting onto `<html>` so the stylesheet can react to it. */
+export function syncReducedMotionAttribute(reduceMotionSetting: boolean): void {
+  if (typeof document === "undefined") return;
+  if (reduceMotionSetting) {
+    document.documentElement.dataset.reduceMotion = "true";
+  } else {
+    delete document.documentElement.dataset.reduceMotion;
+  }
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -28,6 +28,7 @@ import {
 } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { useClientSettings } from "../hooks/useSettings";
+import { syncReducedMotionAttribute } from "../reducedMotion";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKeyFromPath,
@@ -144,10 +145,15 @@ function RootRouteView() {
 
 function GlassAppearanceSync() {
   const glassOpacity = useClientSettings((settings) => settings.glassOpacity);
+  const reduceMotion = useClientSettings((settings) => settings.reduceMotion);
 
   useEffect(() => {
     document.documentElement.style.setProperty("--glass-opacity", `${glassOpacity}%`);
   }, [glassOpacity]);
+
+  useEffect(() => {
+    syncReducedMotionAttribute(reduceMotion);
+  }, [reduceMotion]);
 
   return null;
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
   - [Remote access](./user/remote-access.md)
   - [Keeping T3 Code in sync](./user/server-updates.md)
   - [Keybindings](./user/keybindings.md)
+  - [Follow agent output and Reduce motion](./user/reduced-motion.md)
 - [T3 Connect](./cloud/t3-connect-clerk.md)
 - [Integrations](./integrations/source-control-providers.md)
 - [Mobile](./mobile/app.md)

--- a/docs/user/reduced-motion.md
+++ b/docs/user/reduced-motion.md
@@ -1,0 +1,34 @@
+# Follow agent output and Reduce motion
+
+Two per-device settings in **Settings → Appearance**, both aimed at how much the
+UI moves while an agent works.
+
+## Follow agent output
+
+Off by default. When on, the transcript scrolls itself to stay at the live edge
+while an agent streams. That fires once per streamed chunk, which is the
+continuous scrolling that makes long sessions tiring to read.
+
+With it off:
+
+- the transcript holds still while output streams in
+- sending a message still positions the new turn once, so you are not left
+  looking at old messages
+- the scroll-to-end button appears whenever you are away from the live edge, so
+  jumping to the end stays one click away
+
+## Reduce motion
+
+Forces the reduced-motion path on even when the OS does not ask for it:
+
+- scrolls become instant instead of animated — the new-turn jump, the
+  scroll-to-end button, and the minimap
+- looping indicator animations stop (status pulse, skeleton shimmer, the working
+  indicator, the ultrathink gradients)
+- the composer morph and the mobile route view-transition are skipped
+
+Spinners keep spinning. A frozen spinner reads as a hung app, which is worse
+than the motion it would remove.
+
+`prefers-reduced-motion: reduce` from the OS still applies on its own, whatever
+this setting says.

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -64,6 +64,10 @@ export const DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE: EnvironmentIdentificationM
 
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  // Whether the transcript follows streaming output. Off by default: the
+  // per-chunk scrolling is the most-reported source of eye strain, and the
+  // scroll-to-end pill is always there for a deliberate jump.
+  chatAutoScroll: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   dismissedProviderUpdateNotificationKeys: Schema.Array(TrimmedNonEmptyString).pipe(
@@ -101,6 +105,9 @@ export const ClientSettingsSchema = Schema.Struct({
       modelOrder: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
     }),
   ).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  // Forces the reduced-motion path on regardless of the OS setting: instant
+  // scrolls instead of animated ones, and no looping indicator animations.
+  reduceMotion: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
   ),
@@ -675,6 +682,7 @@ export type ServerSettingsPatch = typeof ServerSettingsPatch.Type;
 
 export const ClientSettingsPatch = Schema.Struct({
   autoOpenPlanSidebar: Schema.optionalKey(Schema.Boolean),
+  chatAutoScroll: Schema.optionalKey(Schema.Boolean),
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
@@ -701,6 +709,7 @@ export const ClientSettingsPatch = Schema.Struct({
       }),
     ),
   ),
+  reduceMotion: Schema.optionalKey(Schema.Boolean),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(


### PR DESCRIPTION
The chat transcript follows the live edge while an agent streams, which fires a scroll once per chunk. Over a long session that continuous movement is tiring to read, and there is no way to turn it off.

## How it's fixed

Two per-device client settings in **Settings → Appearance**:

- **`chatAutoScroll`** gates live-follow, defaulting to **off**. The transcript holds still while output streams; the send-time anchor still positions the new turn once, so you are not left looking at old messages; and the scroll-to-end pill becomes the way back to the edge.
- **`reduceMotion`** forces the reduced-motion path on regardless of the OS preference — scrolls become instant instead of animated, and the looping indicator animations stop (status pulse, skeleton shimmer, working indicator, ultrathink gradients).

Two details worth review attention:

The pill's visibility guard needed the setting too. It treats "left the live edge" as the list settling rather than the reader navigating — which is only true while something is actually following. Without that, turning follow off hid the pill exactly when it became the only way back.

Spinners are deliberately left spinning under reduce-motion. A frozen spinner reads as a hung app, which is worse than the motion it removes.

## Verification

`tsgo --noEmit`, `vp test run --project unit` (1666 tests), `vp lint`, and `vp build` all pass on this branch against current `main`. `MessagesTimeline.test.tsx` gains a case asserting the list only re-pins to the end when the setting is on.

## Screenshots

The new rows in Settings → Appearance:

![Appearance settings](https://raw.githubusercontent.com/AsimNet/t3code/pr-media/media/04-textsize-before-100.png)

This change is behavioural rather than visual — the difference is motion during streaming, which a still image can't show. Happy to record a short clip if that's wanted before review.

---

Written by Claude Opus 4.5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-off live-follow changes behavior for all users during streaming, and scroll-mode/pill logic in ChatView is easy to regress; changes are UI-only with no auth or data impact.
> 
> **Overview**
> **Behavior change:** streaming transcripts no longer auto-follow the live edge by default. A new **`chatAutoScroll`** client setting (default **off**) gates per-chunk live-follow in `ChatView` and LegendList **`maintainScrollAtEnd`** in `MessagesTimeline`. Send-time turn anchoring still runs once; the scroll-to-end pill is shown when the reader is behind the edge, with settling guards updated so the pill is not suppressed when follow is off.
> 
> Adds **`reduceMotion`** (default off) plus a shared **`prefersReducedMotion`** helper and **`data-reduce-motion`** on `<html>` so scroll jumps (anchor, pill, minimap), draft-hero / mobile composer transitions, and looping status animations respect the setting or OS **`prefers-reduced-motion`** (spinners stay animated).
> 
> **Settings → Appearance** exposes both toggles, restore-defaults, and user docs. Chat timeline tests assert list re-pin only when auto-scroll is enabled. Minor RTL-oriented class swaps (`ps`/`ms`/`start`, **`force-ltr`** on tool output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c376c94a79a2ae9db95933993bad6991a89fe54a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop transcript auto-scrolling on every streamed chunk with a new "Follow agent output" setting
> - Adds `chatAutoScroll` and `reduceMotion` boolean client settings (both defaulting to `false`) in [`settings.ts`](https://github.com/pingdotgg/t3code/pull/4884/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c); when `chatAutoScroll` is off the message list no longer re-pins to the end during streaming.
> - Introduces a settle window (`LIVE_FOLLOW_SETTLE_MS`) in [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/4884/files#diff-90b4b4dee89df040fe8cb45b1788c1d5876bd5092229a414007b0359c2142f4f) to suppress the scroll-to-end pill from flashing during thread switches and post-send transitions.
> - Adds a `prefersReducedMotion` utility in [`reducedMotion.ts`](https://github.com/pingdotgg/t3code/pull/4884/files#diff-bddb06905dd8bf21efd91f023404a94a184e596c77f490872f52a1abd3814607) that checks both the new setting and the OS `prefers-reduced-motion` media query; mirrors the result to `html[data-reduce-motion]` for CSS.
> - CSS in [`index.css`](https://github.com/pingdotgg/t3code/pull/4884/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) disables continuous animations (pulses, shimmers, view transitions) when reduced motion is active.
> - Exposes both settings as toggles in the Appearance settings panel in [`SettingsPanels.tsx`](https://github.com/pingdotgg/t3code/pull/4884/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18).
> - Behavioral Change: existing users default to `chatAutoScroll: false`, meaning auto-follow of streaming output is **off by default** for all users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c376c94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->