### PR TITLE
feat(marketing): add mobile app download links

### DIFF
--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -3,7 +3,7 @@ import Layout from "../layouts/Layout.astro";
 import { RELEASES_URL } from "../lib/releases";
 ---
 
-<Layout title="Download — T3 Code" description="Download T3 Code for macOS, Windows, or Linux.">
+<Layout title="Download — T3 Code" description="Download T3 Code for macOS, Windows, Linux, iOS, or Android.">
   <div class="download-page">
   <h1 class="heading">Download T3 Code</h1>
   <p class="subheading">
@@ -57,6 +57,34 @@ import { RELEASES_URL } from "../lib/releases";
         </a>
       </div>
     </section>
+
+    <!-- Mobile -->
+    <section class="platform-section">
+      <div class="platform-header">
+        <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M17 2H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zm0 17H7V5h10v14z"/></svg>
+        <h2 class="platform-name">Mobile</h2>
+      </div>
+      <div class="download-cards">
+        <a
+          class="download-card"
+          href="https://apps.apple.com/pl/app/t3-code-remote-claude-more/id6787819824"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span class="card-arch">iPhone and iPad</span>
+          <span class="card-format">Download on the App Store</span>
+        </a>
+        <a
+          class="download-card"
+          href="https://play.google.com/store/apps/details?id=com.t3tools.t3code"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span class="card-arch">Android</span>
+          <span class="card-format">Get it on Google Play</span>
+        </a>
+      </div>
+    </section>
   </div>
 
   <p class="releases-link">
@@ -73,7 +101,7 @@ import { RELEASES_URL } from "../lib/releases";
 
   async function init() {
     const versionLabel = document.getElementById("version-label");
-    const cards = document.querySelectorAll<HTMLAnchorElement>(".download-card");
+    const cards = document.querySelectorAll<HTMLAnchorElement>(".download-card[data-asset]");
 
     try {
       const release = await fetchLatestRelease();

--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -67,7 +67,7 @@ import { RELEASES_URL } from "../lib/releases";
       <div class="download-cards">
         <a
           class="download-card"
-          href="https://apps.apple.com/pl/app/t3-code-remote-claude-more/id6787819824"
+          href="https://apps.apple.com/app/t3-code-remote-claude-more/id6787819824"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
## What Changed

- Added a Mobile section to the T3 Code download page with direct links for iPhone/iPad and Android.
- Updated the page description to include iOS and Android.
- Limited GitHub release hydration to installer cards so release-fetch failures cannot replace the mobile store URLs.

## Why

The shared `https://t3.codes/download` URL only exposed desktop installers, which meant mobile users still needed separate platform-specific links. This keeps one canonical download URL useful across desktop and mobile while preserving the existing page structure and styling.

## UI Changes

### Before

![Download page before, showing desktop platforms only](https://ampcode.com/user-content/artifacts/db53dc1183898342e95a80ba36c32b50d357f248e96492ae1e3cfc349b7747bd-file.png)

### After

![Download page after, showing App Store and Google Play cards](https://ampcode.com/user-content/artifacts/ea1644e9392c54dfd68606177c442b927cc021cb60423926e452cba12868fb0d-file.png)

## Validation

- `git diff --check`
- Confirmed both store URLs return HTTP 200.
- Used `agent-browser` at 1440×1100 to verify the new section matches the existing card layout with no clipping, overlap, or alignment regression.
- Marketing typecheck was not run because dependency installation stopped when the local machine ran out of disk space (`ENOSPC`). No lockfile changes were produced.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] Video is not applicable because this change adds no animation or interaction behavior

Model: GPT-5; Harness: Amp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-only UI and link changes with a small selector fix to isolate release hydration from static mobile URLs.
> 
> **Overview**
> The marketing **download** page now lists **iOS** and **Android** alongside desktop platforms so one canonical URL covers mobile and desktop.
> 
> A new **Mobile** section adds App Store and Google Play cards (static external links, same card layout as installers). Page metadata description is updated to mention iOS and Android.
> 
> Client-side GitHub release hydration now targets only `.download-card[data-asset]` instead of every `.download-card`, so failed or fallback release logic cannot overwrite the mobile store URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35cea2188237cb2602cc36e104c4b30d7abcd24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mobile app download links to the marketing download page
> - Adds a new Mobile section to [download.astro](https://github.com/pingdotgg/t3code/pull/4886/files#diff-9ac8ff1be0976fe42db086d1efaff539e58c29a5da4e782816188ed3cd0c8926) with cards linking to the iOS App Store and Google Play, both opening in a new tab.
> - Updates the page meta description to mention iOS and Android.
> - Narrows the download card JS query to only select anchors with a `data-asset` attribute, excluding the new mobile links from any asset-related processing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c35cea2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->