### PR TITLE
feat(release): publish a Linux .deb alongside the AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -573,6 +573,37 @@ jobs:
 
           vp run dist:desktop:artifact "${args[@]}"
 
+      - name: Build Linux deb package
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          # electron-builder writes update metadata for every fpm target, so the
+          # deb build would overwrite the AppImage updater manifest. Linux
+          # auto-update only supports the AppImage, so stash the manifest and put
+          # it back once the deb is packaged.
+          manifest_backup="$RUNNER_TEMP/linux-update-manifest"
+          mkdir -p "$manifest_backup"
+          for manifest in release/*-linux*.yml; do
+            cp "$manifest" "$manifest_backup/"
+          done
+
+          # --skip-build reuses the app compiled by the previous step; this only
+          # reruns packaging.
+          vp run dist:desktop:artifact \
+            --platform linux \
+            --target deb \
+            --arch "${{ matrix.arch }}" \
+            --build-version "${{ needs.preflight.outputs.version }}" \
+            --skip-build \
+            --verbose
+
+          for manifest in "$manifest_backup"/*.yml; do
+            cp "$manifest" release/
+          done
+
       - name: Collect release assets
         shell: bash
         run: |
@@ -584,6 +615,7 @@ jobs:
             "release/*.dmg" \
             "release/*.zip" \
             "release/*.AppImage" \
+            "release/*.deb" \
             "release/*.exe" \
             "release/*.blockmap" \
             "release/*.yml"; do
@@ -804,6 +836,7 @@ jobs:
             release-assets/*.dmg
             release-assets/*.zip
             release-assets/*.AppImage
+            release-assets/*.deb
             release-assets/*.exe
             release-assets/*.blockmap
             release-assets/*.yml
@@ -824,6 +857,7 @@ jobs:
             release-assets/*.dmg
             release-assets/*.zip
             release-assets/*.AppImage
+            release-assets/*.deb
             release-assets/*.exe
             release-assets/*.blockmap
             release-assets/*.yml

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -11,10 +11,10 @@ This document covers the unified release workflow for stable and nightly desktop
   - manual `workflow_dispatch` for either channel
 - Runs quality gates first: lint, typecheck, test.
 - Reads the shared production T3 Connect relay URL and Clerk client configuration before packaging clients.
-- Builds four artifacts in parallel for both channels:
+- Builds four platform bundles in parallel for both channels:
   - macOS `arm64` DMG
   - macOS `x64` DMG
-  - Linux `x64` AppImage
+  - Linux `x64` AppImage, plus a `.deb` repackaged from the same build
   - Windows `x64` NSIS installer
 - Publishes one GitHub Release with all produced files.
   - Stable tags with a suffix after `X.Y.Z` (for example `1.2.3-alpha.1`) are published as GitHub prereleases.
@@ -194,6 +194,12 @@ guidance when those environments are available.
   - platform installers (`.exe`, `.dmg`, `.AppImage`, plus macOS `.zip` for Squirrel.Mac update payloads)
   - channel metadata: `latest*.yml` for stable releases, `nightly*.yml` for nightly releases
   - `*.blockmap` files (used for differential downloads)
+- Linux packaging note:
+  - The `.deb` is published for installation only; `DesktopUpdates` disables in-app
+    updates unless the app is running from the AppImage.
+  - `electron-builder` rewrites `latest-linux.yml` for every fpm target, so the
+    workflow restores the AppImage manifest after building the `.deb`. Without
+    that, the updater would advertise a `.deb` the app refuses to install.
 - macOS metadata note:
   - `electron-updater` reads `latest-mac.yml` on stable and `nightly-mac.yml` on nightly, for both Intel and Apple Silicon.
   - The workflow merges the per-arch mac manifests into one channel-specific mac manifest before publishing the GitHub Release.

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -18,6 +18,7 @@
 - `vp run dist:desktop:dmg` — Builds a shareable macOS `.dmg` into `./release`.
 - `vp run dist:desktop:dmg:x64` — Builds an Intel macOS `.dmg`.
 - `vp run dist:desktop:linux` — Builds a Linux AppImage into `./release`.
+- `vp run dist:desktop:linux:deb` — Builds a Linux `.deb` into `./release`.
 - `vp run dist:desktop:win` — Builds a Windows NSIS installer into `./release`.
 
 ## Desktop `.dmg` packaging notes

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dist:desktop:dmg:arm64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch arm64",
     "dist:desktop:dmg:x64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch x64",
     "dist:desktop:linux": "node scripts/build-desktop-artifact.ts --platform linux --target AppImage --arch x64",
+    "dist:desktop:linux:deb": "node scripts/build-desktop-artifact.ts --platform linux --target deb --arch x64",
     "dist:desktop:win": "node scripts/build-desktop-artifact.ts --platform win --target nsis",
     "dist:desktop:win:arm64": "node scripts/build-desktop-artifact.ts --platform win --target nsis --arch arm64",
     "dist:desktop:win:x64": "node scripts/build-desktop-artifact.ts --platform win --target nsis --arch x64",

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -356,6 +356,29 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
   );
 
+  it.effect("supplies the package maintainer that fpm-backed Linux targets require", () =>
+    Effect.gen(function* () {
+      const linux = yield* createBuildConfig(
+        "linux",
+        "deb",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+      const linuxConfig = linux.linux as {
+        readonly target: ReadonlyArray<string>;
+        readonly maintainer?: string;
+      };
+
+      assert.deepStrictEqual(linuxConfig.target, ["deb"]);
+      // electron-builder's FpmTarget aborts the build unless it can resolve a
+      // `Name <email>` maintainer, so this is what keeps deb/rpm buildable.
+      assert.match(linuxConfig.maintainer ?? "", /^.+ <[^@\s]+@[^@\s]+>$/u);
+    }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
+  );
+
   it.effect("preserves both Linux icon resize failures with structural context", () => {
     const commands: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];
 

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -36,6 +36,11 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 const LINUX_ICON_SIZES = [16, 22, 24, 32, 48, 64, 128, 256, 512] as const;
 const DESKTOP_APP_ID = "com.t3tools.t3code";
+// fpm-backed Linux targets (deb, rpm) refuse to build without a project URL and
+// a `Name <email>` maintainer; AppImage never asked for either. The maintainer
+// string becomes both the deb Maintainer and Vendor fields.
+const DESKTOP_HOMEPAGE = "https://t3.codes";
+const DESKTOP_LINUX_MAINTAINER = "pingdotgg <support@t3.codes>";
 const APPLE_TEAM_ID_PATTERN = /^[A-Z0-9]{10}$/u;
 
 const BuildPlatform = Schema.Literals(["mac", "linux", "win"]);
@@ -617,6 +622,7 @@ interface StagePackageJson {
   readonly packageManager: string;
   readonly description: string;
   readonly author: string;
+  readonly homepage: string;
   readonly main: string;
   readonly build: Record<string, unknown>;
   readonly dependencies: Record<string, unknown>;
@@ -1589,6 +1595,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       executableName: "t3code",
       icon: "icons",
       category: "Development",
+      maintainer: DESKTOP_LINUX_MAINTAINER,
       desktop: {
         entry: {
           StartupWMClass: "t3code",
@@ -1911,6 +1918,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     packageManager: rootPackageJson.packageManager,
     description: "T3 Code desktop build",
     author: "T3 Tools",
+    homepage: DESKTOP_HOMEPAGE,
     main: "apps/desktop/dist-electron/main.cjs",
     build: yield* createBuildConfig(
       options.platform,


### PR DESCRIPTION
## Problem

Linux is the only platform where T3 Code ships a single artifact. The AppImage works, but installing it leaves users without a desktop entry, an icon, dependency resolution, or any package manager integration unless they wire all of it up by hand. `.deb` covers the large majority of Linux desktop users and costs one extra packaging pass over an app we have already compiled.

## What changed

**Made `--target deb` actually work.** `scripts/build-desktop-artifact.ts` already forwarded `--target` straight through to electron-builder, so `deb` looked supported. It was not: fpm aborts unless it can resolve a project homepage and a `Name <email>` maintainer, and the generated config set neither, because AppImage never needed them.

```
⨯ Please specify project homepage, see https://www.electron.build/configuration#metadata
  Please specify author 'email' in the application package.json
  It is required to set Linux .deb package maintainer.
```

Two fields fix it — `homepage` on the staged `package.json` and `linux.maintainer`, which becomes both the deb `Maintainer` and `Vendor`.

**Release workflow builds and publishes it.** A platform-gated step reruns packaging with `--skip-build`, reusing the app the AppImage step already compiled, then `.deb` is added to the collect and publish globs. This deliberately avoids a second Linux matrix leg, which would have duplicated a ~25 minute compile and collided on the `desktop-linux-x64` and `resource-monitor-linux-x64` artifact names.

**Guarded the updater manifest.** `FpmTarget` sets `isWriteUpdateInfo: true`, exactly like `AppImageTarget`, so the deb build overwrites `latest-linux.yml`. `DesktopUpdates.ts` refuses to install any Linux update unless the app is running from an AppImage, so an unguarded version of this change would publish a manifest pointing at a `.deb` the app rejects and silently break auto-update for every existing AppImage user. The workflow stashes the manifest and restores it after packaging.

Also adds `vp run dist:desktop:linux:deb` for local parity with `dist:desktop:linux`, and documents the artifact plus the update caveat.

## Verification

Built end-to-end on Ubuntu 24.04 at v0.0.31:

```
Package: t3code          Architecture: amd64
Version: 0.0.31          Maintainer: pingdotgg <support@t3.codes>
Homepage: https://t3.codes
Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6,
         xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0
```

- All 9 hicolor icon sizes present; packaged icon is pixel-identical to `assets/prod/black-universal-1024.png`.
- Valid desktop entry with `StartupWMClass=t3code`; postinst registers `/usr/bin/t3code` and handles `chrome-sandbox` permissions.
- Every declared dependency resolves on 24.04 (`libgtk-3-0` and `libatspi2.0-0` via the `t64` packages that `Provide` them).
- New regression test fails if `linux.maintainer` is removed, so the build break cannot silently return.
- `vp test run scripts/build-desktop-artifact.test.ts` (31 passed), `scripts` typecheck, lint, and `fmt:check` all clean.
- Workflow shell logic simulated in isolation under `set -euo pipefail`, including the case where no manifest exists.

## Notes for reviewers

**The maintainer address needs your call.** The repo has no packaging contact anywhere, so `support@t3.codes` is a placeholder derived from the site. It gets baked permanently into every published package — please replace it if there is a real address.

**In-app updates are intentionally not enabled for deb.** The `.deb` ships both `app-update.yml` and electron-builder's `package-type` marker, so `electron-updater` would select `DebUpdater`, but T3's own Linux gate blocks it first and deb users will see "Automatic updates on Linux require running the AppImage build." Turning that on means accepting a `pkexec dpkg -i` prompt per update and pointing the feed at the deb, which is a separate decision I did not make here. Most distro-packaged apps leave updates to the package manager.

**Scope.** `.snap` was built and verified alongside this but is deliberately excluded: it needs a Snap Store account, credentials, and manual review for classic confinement, which is a product decision rather than a packaging one. Happy to open it separately if wanted.

Per `CONTRIBUTING.md` I recognise this may not be something you want right now — close it freely if so.

Generated with claude-opus-5 running in opencode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release workflow changes affect Linux updater metadata and published assets; incorrect manifest handling could break AppImage auto-update, though the backup/restore step mitigates that. Maintainer email is baked into every deb package.
> 
> **Overview**
> Adds a **Linux `.deb`** to release artifacts so Debian/Ubuntu users can install via the package manager, while **in-app auto-update stays AppImage-only**.
> 
> The desktop packager now supplies **homepage** and **`linux.maintainer`** (fpm requirements for `deb`) on the staged `package.json` and Linux build config, plus a **`dist:desktop:linux:deb`** script and a regression test so deb builds cannot break silently.
> 
> The **release workflow** runs a second Linux packaging pass with `--skip-build` after the AppImage step, **backs up and restores** `*-linux*.yml` updater manifests (deb packaging would overwrite them with `.deb` metadata the app refuses to install), and includes `.deb` in collect/publish globs. Docs note the deb vs AppImage update behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a37813e526d223c617a8cd1cf225b5691a603076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish a Linux .deb package alongside the AppImage in release builds
> - Adds a new build step in [release.yml](.github/workflows/release.yml) that runs `dist:desktop:artifact` with `--target deb` after the AppImage is built, stashing and restoring the AppImage update manifest so it isn't overwritten by the `.deb` build.
> - Adds `maintainer` and `homepage` metadata to the Linux build config in [build-desktop-artifact.ts](scripts/build-desktop-artifact.ts), which are required by electron-builder's fpm-backed targets like `.deb`.
> - Adds a `dist:desktop:linux:deb` npm script in `package.json` for local builds.
> - Behavioral Change: in-app updates are disabled when running from the `.deb` package; only the AppImage supports update delivery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a37813e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->