### PR TITLE
fix(desktop): resolve claude executable on windows

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -242,6 +242,17 @@ const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
   [
     "$ErrorActionPreference = 'Stop'",
     ...names.flatMap((name) => {
+      if (name.toUpperCase() === "PATH") {
+        return [
+          `Write-Output '${startMarker(name)}'`,
+          `$machineValue = [Environment]::GetEnvironmentVariable('${name}', 'Machine')`,
+          `$userValue = [Environment]::GetEnvironmentVariable('${name}', 'User')`,
+          `$processValue = [Environment]::GetEnvironmentVariable('${name}')`,
+          `$merged = ($machineValue, $userValue, $processValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
+          "if ($null -ne $merged -and $merged.Length -gt 0) { Write-Output $merged }",
+          `Write-Output '${endMarker(name)}'`,
+        ];
+      }
       return [
         `Write-Output '${startMarker(name)}'`,
         `$value = [Environment]::GetEnvironmentVariable('${name}')`,

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -248,7 +248,7 @@ const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
           `$machineValue = [Environment]::GetEnvironmentVariable('${name}', 'Machine')`,
           `$userValue = [Environment]::GetEnvironmentVariable('${name}', 'User')`,
           `$processValue = [Environment]::GetEnvironmentVariable('${name}')`,
-          `$merged = ($machineValue, $userValue, $processValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
+          `$merged = ($processValue, $userValue, $machineValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
           "if ($null -ne $merged -and $merged.Length -gt 0) { Write-Output $merged }",
           `Write-Output '${endMarker(name)}'`,
         ];

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -248,7 +248,7 @@ const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
           `$machineValue = [Environment]::GetEnvironmentVariable('${name}', 'Machine')`,
           `$userValue = [Environment]::GetEnvironmentVariable('${name}', 'User')`,
           `$processValue = [Environment]::GetEnvironmentVariable('${name}')`,
-          `$merged = ($processValue, $userValue, $machineValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
+          `$merged = ($processValue, $machineValue, $userValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
           "if ($null -ne $merged -and $merged.Length -gt 0) { Write-Output $merged }",
           `Write-Output '${endMarker(name)}'`,
         ];

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -199,7 +199,7 @@ const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
           `$machineValue = [Environment]::GetEnvironmentVariable('${name}', 'Machine')`,
           `$userValue = [Environment]::GetEnvironmentVariable('${name}', 'User')`,
           `$processValue = [Environment]::GetEnvironmentVariable('${name}')`,
-          `$merged = ($processValue, $userValue, $machineValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
+          `$merged = ($processValue, $machineValue, $userValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
           "if ($null -ne $merged -and $merged.Length -gt 0) { Write-Output $merged }",
           `Write-Output '${endMarker(name)}'`,
         ];

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -158,7 +158,7 @@ const knownWindowsCliDirs = (env: NodeJS.ProcessEnv): ReadonlyArray<string> => [
   ...trimNonEmpty(env.USERPROFILE).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}\\.bun\\bin`, `${value}\\scoop\\shims`],
+      onSome: (value) => [`${value}\\.bun\\bin`, `${value}\\scoop\\shims`, `${value}\\.local\\bin`],
     }),
   ),
 ];
@@ -193,6 +193,17 @@ const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
   [
     "$ErrorActionPreference = 'Stop'",
     ...names.flatMap((name) => {
+      if (name.toUpperCase() === "PATH") {
+        return [
+          `Write-Output '${startMarker(name)}'`,
+          `$machineValue = [Environment]::GetEnvironmentVariable('${name}', 'Machine')`,
+          `$userValue = [Environment]::GetEnvironmentVariable('${name}', 'User')`,
+          `$processValue = [Environment]::GetEnvironmentVariable('${name}')`,
+          `$merged = ($machineValue, $userValue, $processValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
+          "if ($null -ne $merged -and $merged.Length -gt 0) { Write-Output $merged }",
+          `Write-Output '${endMarker(name)}'`,
+        ];
+      }
       return [
         `Write-Output '${startMarker(name)}'`,
         `$value = [Environment]::GetEnvironmentVariable('${name}')`,

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -199,7 +199,7 @@ const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
           `$machineValue = [Environment]::GetEnvironmentVariable('${name}', 'Machine')`,
           `$userValue = [Environment]::GetEnvironmentVariable('${name}', 'User')`,
           `$processValue = [Environment]::GetEnvironmentVariable('${name}')`,
-          `$merged = ($machineValue, $userValue, $processValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
+          `$merged = ($processValue, $userValue, $machineValue | Where-Object { $null -ne $_ -and $_.Length -gt 0 }) -join ';'`,
           "if ($null -ne $merged -and $merged.Length -gt 0) { Write-Output $merged }",
           `Write-Output '${endMarker(name)}'`,
         ];


### PR DESCRIPTION
Fixes pingdotgg/t3code#4846

On Windows, T3 Code would report Claude as missing if it was installed in the user's persistent PATH but the process inherited a stale PATH.

This fixes the desktop environment resolver to explicitly read and merge the `Machine`, `User`, and `Process` environment variables for `PATH` on Windows, and adds `%USERPROFILE%\.local\bin` to the known CLI directories fallback.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows-only desktop startup PATH probing; improves CLI discovery without touching auth, data, or network paths.
> 
> **Overview**
> Fixes false “Claude not found” on Windows when Claude lives on the **User** or **Machine** PATH but the Electron process inherited a stale **Process** PATH.
> 
> **`captureWindowsEnvironmentCommand`** now treats `PATH` specially: the PowerShell probe reads **Machine**, **User**, and **Process** values via `[Environment]::GetEnvironmentVariable`, concatenates non-empty segments, and emits that merged string between the existing markers. Other env vars still use the single-scope lookup unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5a2c95f6e9c946f50d50f330dc8b55a7fa04d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude executable resolution on Windows by merging Machine, User, and Process PATH scopes
> The `captureWindowsEnvironmentCommand` util in [DesktopShellEnvironment.ts](https://github.com/pingdotgg/t3code/pull/4896/files#diff-ed26aa44c93ddc9fedab8bc7cf7aa64c7b0b8fc0e22a3960d5c02c30c940dabd) previously captured only the process-scoped PATH, which could miss entries added by installers to the Machine or User scopes. PATH is now resolved by fetching all three scopes separately, filtering out null/empty entries, and joining them with `;`. Behavioral Change: the captured PATH value will now be broader than the process-scoped value alone, which may surface executables not previously visible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c5a2c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->