### PR TITLE
fix(connect): suggest a serve command that matches how you ran connect

### DIFF
--- a/apps/server/src/cli/connect.ts
+++ b/apps/server/src/cli/connect.ts
@@ -46,6 +46,7 @@ import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
 import * as ExternalLauncher from "../process/externalLauncher.ts";
 import { readPersistedServerRuntimeState } from "../serverRuntimeState.ts";
 import { projectLocationFlags, resolveCliAuthConfig } from "./config.ts";
+import { resolveCliCommand } from "./invocation.ts";
 import {
   bootServiceLayer,
   offerServiceDuringOnboarding,
@@ -526,10 +527,11 @@ const connectLinkCommand = Command.make("link", {
         yield* Console.log("T3 Connect\n");
         const linked = yield* linkEnvironmentForConnect(flags);
         if (linked) {
+          const serveCommand = yield* resolveCliCommand("serve");
           yield* Console.log(
             flags.publishOnly
               ? `✓ Authorized${connectedAs(linked.identity)}\n\nNext\n  Start T3 to publish agent activity (no managed tunnel).`
-              : `✓ Authorized${connectedAs(linked.identity)}\n\nNext\n  Start the server with \`t3 serve\` to make this machine reachable.`,
+              : `✓ Authorized${connectedAs(linked.identity)}\n\nNext\n  Start the server with \`${serveCommand}\` to make this machine reachable.`,
           );
         }
       }),
@@ -691,10 +693,15 @@ export const connectCommand = Command.make("connect", {
         // Connect itself already succeeded; a boot-service failure must not
         // fail the command, just tell the user what happened and move on.
         const background = yield* recoverServiceOnboardingOffer(offerServiceDuringOnboarding);
+        if (background) {
+          yield* Console.log(
+            "\n✓ Background service ready\n\nT3 Code will stay reachable after you log out.",
+          );
+          return;
+        }
+        const serveCommand = yield* resolveCliCommand("serve");
         yield* Console.log(
-          background
-            ? "\n✓ Background service ready\n\nT3 Code will stay reachable after you log out."
-            : "\nNext\n  Start the server with `t3 serve` to make this machine reachable.",
+          `\nNext\n  Start the server with \`${serveCommand}\` to make this machine reachable.`,
         );
       }),
     ),

--- a/apps/server/src/cli/invocation.test.ts
+++ b/apps/server/src/cli/invocation.test.ts
@@ -1,0 +1,62 @@
+import { assert, it } from "@effect/vitest";
+
+import { detectCliRunner, formatCliCommand, suggestedPackageSpec } from "./invocation.ts";
+
+it("detects package runners from their cache entry paths", () => {
+  assert.equal(detectCliRunner("/home/theo/.npm/_npx/abc123/node_modules/t3/dist/bin.mjs"), "npx");
+  assert.equal(
+    detectCliRunner(
+      "C:\\Users\\theo\\AppData\\Local\\npm-cache\\_npx\\abc\\node_modules\\t3\\dist\\bin.mjs",
+    ),
+    "npx",
+  );
+  assert.equal(
+    detectCliRunner("/home/theo/.cache/pnpm/dlx/abc/node_modules/t3/dist/bin.mjs"),
+    "pnpm dlx",
+  );
+  assert.equal(
+    detectCliRunner("/home/theo/.local/share/pnpm/.pnpm/dlx/abc/node_modules/t3/dist/bin.mjs"),
+    "pnpm dlx",
+  );
+  assert.equal(detectCliRunner("/home/theo/.bun/install/cache/t3@0.0.31/dist/bin.mjs"), "bunx");
+  assert.equal(detectCliRunner("/tmp/bunx-1000-t3@latest/node_modules/t3/dist/bin.mjs"), "bunx");
+});
+
+it("treats stable installs as direct invocations", () => {
+  assert.isNull(detectCliRunner("/usr/local/lib/node_modules/t3/dist/bin.mjs"));
+  assert.isNull(detectCliRunner("/home/theo/Code/work/t3code/apps/server/dist/bin.mjs"));
+  assert.isNull(detectCliRunner("/home/theo/.t3/runtime/0.0.31/node_modules/t3/dist/bin.mjs"));
+  assert.isNull(detectCliRunner(""));
+});
+
+it("re-suggests the nightly channel only for nightly builds", () => {
+  assert.equal(suggestedPackageSpec("0.0.31-nightly.20260729"), "t3@nightly");
+  assert.equal(suggestedPackageSpec("0.0.31"), "t3");
+});
+
+it("formats serve suggestions to match the launching command", () => {
+  assert.equal(
+    formatCliCommand({
+      subcommand: "serve",
+      entryPath: "/home/theo/.npm/_npx/abc/node_modules/t3/dist/bin.mjs",
+      version: "0.0.31-nightly.20260729",
+    }),
+    "npx t3@nightly serve",
+  );
+  assert.equal(
+    formatCliCommand({
+      subcommand: "serve",
+      entryPath: "/tmp/bunx-1000-t3@latest/node_modules/t3/dist/bin.mjs",
+      version: "0.0.31",
+    }),
+    "bunx t3 serve",
+  );
+  assert.equal(
+    formatCliCommand({
+      subcommand: "serve",
+      entryPath: "/usr/local/lib/node_modules/t3/dist/bin.mjs",
+      version: "0.0.31-nightly.20260729",
+    }),
+    "t3 serve",
+  );
+});

--- a/apps/server/src/cli/invocation.test.ts
+++ b/apps/server/src/cli/invocation.test.ts
@@ -18,8 +18,20 @@ it("detects package runners from their cache entry paths", () => {
     detectCliRunner("/home/theo/.local/share/pnpm/.pnpm/dlx/abc/node_modules/t3/dist/bin.mjs"),
     "pnpm dlx",
   );
+  assert.equal(
+    detectCliRunner(
+      "C:\\Users\\theo\\AppData\\Local\\pnpm-cache\\dlx\\abc\\node_modules\\t3\\dist\\bin.mjs",
+    ),
+    "pnpm dlx",
+  );
   assert.equal(detectCliRunner("/home/theo/.bun/install/cache/t3@0.0.31/dist/bin.mjs"), "bunx");
   assert.equal(detectCliRunner("/tmp/bunx-1000-t3@latest/node_modules/t3/dist/bin.mjs"), "bunx");
+  assert.equal(
+    detectCliRunner(
+      "C:\\Users\\theo\\AppData\\Local\\Temp\\bunx-0-t3@latest\\node_modules\\t3\\dist\\bin.mjs",
+    ),
+    "bunx",
+  );
 });
 
 it("treats stable installs as direct invocations", () => {

--- a/apps/server/src/cli/invocation.ts
+++ b/apps/server/src/cli/invocation.ts
@@ -1,0 +1,73 @@
+import * as Effect from "effect/Effect";
+
+import { HostProcessArguments } from "@t3tools/shared/hostProcess";
+
+import packageJson from "../../package.json" with { type: "json" };
+
+export type CliRunner = "npx" | "pnpm dlx" | "bunx";
+
+/**
+ * How the CLI was launched, judged by where its entry script lives. Each
+ * package runner executes out of a distinctive cache/temp layout:
+ *
+ *   npx      ~/.npm/_npx/<hash>/node_modules/...
+ *   pnpm dlx ~/.cache/pnpm/dlx/... or $PNPM_HOME/.pnpm/dlx/...
+ *   bunx     ~/.bun/install/cache/... or $TMPDIR/bunx-<uid>-<spec>/...
+ *
+ * Global installs and repo checkouts match none of these and return null.
+ * Detection is best-effort; callers must fail closed to a plain `t3` command.
+ */
+export function detectCliRunner(entryPath: string): CliRunner | null {
+  if (entryPath.includes("/_npx/") || entryPath.includes("\\_npx\\")) {
+    return "npx";
+  }
+  if (entryPath.includes("/pnpm/dlx/") || entryPath.includes("/.pnpm/dlx/")) {
+    return "pnpm dlx";
+  }
+  if (
+    entryPath.includes("/.bun/install/cache/") ||
+    entryPath.includes("/bunx-") ||
+    entryPath.includes("\\bunx-")
+  ) {
+    return "bunx";
+  }
+  return null;
+}
+
+/**
+ * The `t3` package spec to suggest. The literal spec the user typed (e.g.
+ * `t3@nightly`) is resolved away before our process starts, so re-derive it
+ * from the running version: nightly builds re-suggest the nightly channel,
+ * anything else suggests the bare package.
+ */
+export function suggestedPackageSpec(version: string): string {
+  return version.includes("-nightly.") ? "t3@nightly" : "t3";
+}
+
+/**
+ * Render a `t3 <subcommand>` suggestion that matches how this process was
+ * launched, so copy/pasting it actually works: `npx t3 connect` suggests
+ * `npx t3 serve`, a global install suggests `t3 serve`, and a nightly build
+ * keeps the `@nightly` tag.
+ */
+export function formatCliCommand(input: {
+  readonly subcommand: string;
+  readonly entryPath: string;
+  readonly version: string;
+}): string {
+  const runner = detectCliRunner(input.entryPath);
+  if (runner === null) {
+    return `t3 ${input.subcommand}`;
+  }
+  return `${runner} ${suggestedPackageSpec(input.version)} ${input.subcommand}`;
+}
+
+/** `formatCliCommand` against this process's real entry path and version. */
+export const resolveCliCommand = (subcommand: string) =>
+  Effect.map(HostProcessArguments, (processArguments) =>
+    formatCliCommand({
+      subcommand,
+      entryPath: processArguments[1] ?? "",
+      version: packageJson.version,
+    }),
+  );

--- a/apps/server/src/cli/invocation.ts
+++ b/apps/server/src/cli/invocation.ts
@@ -11,24 +11,26 @@ export type CliRunner = "npx" | "pnpm dlx" | "bunx";
  * package runner executes out of a distinctive cache/temp layout:
  *
  *   npx      ~/.npm/_npx/<hash>/node_modules/...
- *   pnpm dlx ~/.cache/pnpm/dlx/... or $PNPM_HOME/.pnpm/dlx/...
+ *   pnpm dlx ~/.cache/pnpm/dlx/..., $PNPM_HOME/.pnpm/dlx/...,
+ *            or %LOCALAPPDATA%/pnpm-cache/dlx/... on Windows
  *   bunx     ~/.bun/install/cache/... or $TMPDIR/bunx-<uid>-<spec>/...
  *
  * Global installs and repo checkouts match none of these and return null.
  * Detection is best-effort; callers must fail closed to a plain `t3` command.
  */
 export function detectCliRunner(entryPath: string): CliRunner | null {
-  if (entryPath.includes("/_npx/") || entryPath.includes("\\_npx\\")) {
+  const path = entryPath.replaceAll("\\", "/");
+  if (path.includes("/_npx/")) {
     return "npx";
   }
-  if (entryPath.includes("/pnpm/dlx/") || entryPath.includes("/.pnpm/dlx/")) {
+  if (
+    path.includes("/pnpm/dlx/") ||
+    path.includes("/.pnpm/dlx/") ||
+    path.includes("/pnpm-cache/dlx/")
+  ) {
     return "pnpm dlx";
   }
-  if (
-    entryPath.includes("/.bun/install/cache/") ||
-    entryPath.includes("/bunx-") ||
-    entryPath.includes("\\bunx-")
-  ) {
+  if (path.includes("/.bun/install/cache/") || path.includes("/bunx-")) {
     return "bunx";
   }
   return null;


### PR DESCRIPTION
## Problem

`npx t3@nightly connect` ends with:

> Next
>   Start the server with `t3 serve` to make this machine reachable.

Copy/pasting that fails on any machine without a global `t3` install — which is exactly the machine that just ran connect through npx. Same story for `bunx` and `pnpm dlx`.

## Solution

Detect how the CLI was launched from its entry path (npx / pnpm dlx / bunx caches each have a distinctive layout) and re-derive the channel from the running version, then render the suggestion to match:

- `npx t3@nightly connect` → ``Start the server with `npx t3@nightly serve` ``
- `bunx t3 connect` → ``Start the server with `bunx t3 serve` ``
- `t3 connect` (global install / repo checkout) → ``Start the server with `t3 serve` ``

Detection is best-effort and fails closed to plain `t3 serve`. The suggestion is only shown when the user did not opt into the background service — that path keeps its existing "Background service ready" copy. Applies to both `t3 connect` and `t3 connect link`.

---

Change made by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI messaging and small pure helpers with unit tests; no auth, networking, or persistence changes.
> 
> **Overview**
> **Connect** success copy no longer hardcodes `t3 serve`. It now suggests a **copy-pasteable** command that mirrors how the user launched the CLI (`npx`, `pnpm dlx`, `bunx`, or plain `t3`), including **`t3@nightly`** when the running build is nightly.
> 
> New **`invocation.ts`** helpers infer the package runner from the process entry path, derive the package spec from `package.json` version, and **`resolveCliCommand`** wires that into Effect via host process args. **`connect link`** and the main connect flow use it; the background-service success path still shows the existing message and returns early without a serve hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f87e8731f24816be234df735a6b2a2beeadaf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `connect` CLI to suggest a serve command matching the actual invocation context
> - Adds `resolveCliCommand` in [`invocation.ts`](https://github.com/pingdotgg/t3code/pull/4897/files#diff-f66315c334f5c48011ca39453770f9f79309c92830faf9f19f96bf162b7ae089), an Effect-based helper that detects the package runner (npx, pnpm dlx, bunx) and build channel (nightly vs stable) from the process entry path and formats a matching CLI suggestion.
> - Updates `connectLinkCommand` and `connectCommand` in [`connect.ts`](https://github.com/pingdotgg/t3code/pull/4897/files#diff-369ea07c1ac5b161aaf3838766eade272006cee25413a596386e01aa6d2b9aa0) to use `resolveCliCommand` instead of the hardcoded string `'t3 serve'` in their success/next-step messages.
> - Adds unit tests in [`invocation.test.ts`](https://github.com/pingdotgg/t3code/pull/4897/files#diff-5c632f9b08c44463a303eccd3c135130d6171594a4f8e5e700c40d82c405f2bf) covering runner detection, package spec selection, and command formatting across runners and versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43f87e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->