### PR TITLE
fix(mobile): prevent crash on sign out in settings

### DIFF
--- a/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from "@clerk/expo";
 import { AuthView, UserProfileView } from "@clerk/expo/native";
 import { StackActions, useNavigation } from "@react-navigation/native";
-import { useCallback, useLayoutEffect } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { View } from "react-native";
 
 import { hasCloudPublicConfig } from "../cloud/publicConfig";
@@ -25,11 +25,21 @@ function ConfiguredSettingsAuthRouteScreen() {
     () => navigation.dispatch(StackActions.popTo("SettingsContent")),
     [navigation],
   );
+  const hasBeenSignedIn = useRef(isSignedIn);
+  if (isSignedIn) {
+    hasBeenSignedIn.current = true;
+  }
+
+  useEffect(() => {
+    if (hasBeenSignedIn.current && isLoaded && isSignedIn === false) {
+      navigation.dispatch(StackActions.popTo("SettingsContent"));
+    }
+  }, [isLoaded, isSignedIn, navigation]);
 
   return (
     <View collapsable={false} className="flex-1 overflow-hidden bg-sheet">
       {isLoaded ? (
-        isSignedIn ? (
+        hasBeenSignedIn.current ? (
           <UserProfileView isDismissible={false} onHostBack={handleHostBack} />
         ) : (
           <AuthView isDismissible={false} onHostBack={handleHostBack} />

--- a/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
@@ -29,14 +29,14 @@ function ConfiguredSettingsAuthRouteScreen() {
   }
 
   useEffect(() => {
-    if (hasBeenSignedIn.current && !isSignedIn) {
+    if (hasBeenSignedIn.current && isLoaded && isSignedIn === false) {
       if (navigation.canGoBack()) {
         navigation.goBack();
       } else {
         navigation.dispatch(StackActions.replace("Settings"));
       }
     }
-  }, [isSignedIn, navigation]);
+  }, [isLoaded, isSignedIn, navigation]);
 
   return (
     <>

--- a/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
@@ -23,10 +23,6 @@ function ConfiguredSettingsAuthRouteScreen() {
   const { isLoaded, isSignedIn } = useAuth({ treatPendingAsSignedOut: false });
   const navigation = useNavigation();
 
-  // Clerk's UserProfileView crashes on Android if it's abruptly replaced by AuthView
-  // while its internal sign-out dialog is closing. To prevent this, once this screen
-  // renders UserProfileView, it never switches back to AuthView. Instead, we detect
-  // the sign-out and pop the screen.
   const hasBeenSignedIn = useRef(isSignedIn);
   if (isSignedIn) {
     hasBeenSignedIn.current = true;

--- a/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
@@ -2,7 +2,7 @@ import { useAuth } from "@clerk/expo";
 import { AuthView, UserProfileView } from "@clerk/expo/native";
 import { StackActions, useNavigation } from "@react-navigation/native";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { View } from "react-native";
 
 import { hasCloudPublicConfig } from "../cloud/publicConfig";
@@ -21,13 +21,31 @@ export function SettingsAuthRouteScreen() {
 
 function ConfiguredSettingsAuthRouteScreen() {
   const { isLoaded, isSignedIn } = useAuth({ treatPendingAsSignedOut: false });
+  const navigation = useNavigation();
+
+  // Clerk's UserProfileView crashes on Android if it's abruptly replaced by AuthView
+  // while its internal sign-out dialog is closing. To prevent this, once this screen
+  // renders UserProfileView, it never switches back to AuthView. Instead, we detect
+  // the sign-out and pop the screen.
+  const hasBeenSignedIn = useRef(isSignedIn);
+  if (isSignedIn) {
+    hasBeenSignedIn.current = true;
+  }
+
+  useEffect(() => {
+    if (hasBeenSignedIn.current && !isSignedIn) {
+      if (navigation.canGoBack()) {
+        navigation.goBack();
+      }
+    }
+  }, [isSignedIn, navigation]);
 
   return (
     <>
       <NativeStackScreenOptions options={{ title: isSignedIn ? "Account" : "Sign in" }} />
       <View collapsable={false} className="flex-1 overflow-hidden bg-sheet">
         {isLoaded ? (
-          isSignedIn ? (
+          hasBeenSignedIn.current ? (
             <UserProfileView isDismissible={false} />
           ) : (
             <AuthView isDismissible={false} />

--- a/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsAuthRouteScreen.tsx
@@ -32,6 +32,8 @@ function ConfiguredSettingsAuthRouteScreen() {
     if (hasBeenSignedIn.current && !isSignedIn) {
       if (navigation.canGoBack()) {
         navigation.goBack();
+      } else {
+        navigation.dispatch(StackActions.replace("Settings"));
       }
     }
   }, [isSignedIn, navigation]);


### PR DESCRIPTION
Fixes pingdotgg/t3code#4888

Pressing "Sign out of this device" in the Android app crashed the app. This happened because the auth state instantly changed to signed out, causing the native `UserProfileView` to unmount and get replaced by `AuthView` while the internal sign-out dialog was still active and closing.

This updates `SettingsAuthRouteScreen` to "lock" the view to `UserProfileView` once the user is signed in. When a sign-out event happens, instead of swapping the view (which crashes Android), the screen gracefully detects the sign-out and closes itself, returning the user to the main Settings screen.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix crash on sign out in settings by navigating back to `SettingsContent`
> When a user signs out while the settings auth screen is loaded, the screen now dispatches a `popTo("SettingsContent")` navigation instead of abruptly switching views, preventing a crash.
>
> - A `hasBeenSignedIn` ref tracks whether the user was ever signed in during the screen session, so `UserProfileView` continues rendering until the navigation completes.
> - A `useEffect` watches for the transition from signed-in to signed-out and triggers the back navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed21298.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow navigation/auth UI change in one settings screen with no backend or data-handling impact.
> 
> **Overview**
> Fixes an **Android crash** when signing out from Settings: Clerk flips to signed-out immediately, which used to **swap `UserProfileView` for `AuthView`** while the native sign-out dialog was still closing.
> 
> `ConfiguredSettingsAuthRouteScreen` now keeps a **`hasBeenSignedIn` ref** so the profile view stays mounted once the user has signed in, instead of keying the branch on live `isSignedIn`. A **`useEffect`** watches `isLoaded` and `isSignedIn`; after a prior sign-in, it **`popTo("SettingsContent")`** when auth becomes signed out, so the screen exits cleanly instead of remounting auth chrome on the same route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed21298278ec276805abaa5fc4b72db57188f695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->