### PR TITLE
feat(desktop): Add a Linux .deb to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,6 +608,7 @@ jobs:
             "release/*.dmg" \
             "release/*.zip" \
             "release/*.AppImage" \
+            "release/*.deb" \
             "release/*.exe" \
             "release/*.blockmap" \
             "release/*.yml"; do
@@ -836,6 +837,7 @@ jobs:
             release-assets/*.dmg
             release-assets/*.zip
             release-assets/*.AppImage
+            release-assets/*.deb
             release-assets/*.exe
             release-assets/*.blockmap
             release-assets/*.yml
@@ -856,6 +858,7 @@ jobs:
             release-assets/*.dmg
             release-assets/*.zip
             release-assets/*.AppImage
+            release-assets/*.deb
             release-assets/*.exe
             release-assets/*.blockmap
             release-assets/*.yml

--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -56,6 +56,10 @@ import { ANDROID_PLAY_STORE_URL, IOS_APP_STORE_URL } from "../lib/site";
           <span class="card-arch">x86_64</span>
           <span class="card-format">AppImage</span>
         </a>
+        <a class="download-card" data-asset="amd64.deb" href={RELEASES_URL}>
+          <span class="card-arch">Debian, Ubuntu (x86_64)</span>
+          <span class="card-format">.deb</span>
+        </a>
       </div>
     </section>
 

--- a/docs/internals/scripts.md
+++ b/docs/internals/scripts.md
@@ -67,7 +67,7 @@ authenticated.
 - `vp run dist:desktop:dmg`: Builds a shareable macOS `.dmg` into `./release`. Architecture defaults
   to the host, so this produces an arm64 DMG on Apple Silicon. Use `dist:desktop:dmg:arm64` or
   `dist:desktop:dmg:x64`, or pass `--arch <arm64|x64|universal>`, to force one.
-- `vp run dist:desktop:linux`: Builds a Linux AppImage into `./release`.
+- `vp run dist:desktop:linux`: Builds a Linux AppImage and `.deb` into `./release`.
 - `vp run dist:desktop:win`: Builds a Windows NSIS installer into `./release`. `:arm64` and `:x64`
   variants exist.
 

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -16,7 +16,7 @@ This document covers the unified release workflow for stable and nightly desktop
 - Builds four artifacts in parallel for both channels:
   - macOS `arm64` DMG
   - macOS `x64` DMG
-  - Linux `x64` AppImage
+  - Linux `x64` AppImage plus a `.deb` package built from the same job
   - Windows `x64` NSIS installer
 - Publishes one GitHub Release with all produced files.
   - Stable tags with a suffix after `X.Y.Z` (for example `1.2.3-alpha.1`) are published as GitHub prereleases.
@@ -205,6 +205,7 @@ guidance when those environments are available.
   - otherwise `GITHUB_REPOSITORY` from GitHub Actions.
 - Required release assets for updater:
   - platform installers (`.exe`, `.dmg`, `.AppImage`, plus macOS `.zip` for Squirrel.Mac update payloads)
+  - the Linux `.deb` ships in the same release but is a manual-install package; in-app updates on Linux stay AppImage-only, so `.deb` users upgrade with `dpkg`/`apt`
   - channel metadata: `latest*.yml` for stable releases, `nightly*.yml` for nightly releases
   - `*.blockmap` files (used for differential downloads)
 - macOS metadata note:

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -16,11 +16,13 @@ import {
   DESKTOP_ELECTRON_LANGUAGES,
   DESKTOP_FILE_EXCLUSIONS,
   DESKTOP_EXTRA_RESOURCES,
+  DESKTOP_LINUX_MAINTAINER,
   InvalidMacPasskeyRpDomainError,
   InvalidMacPasskeyPublishableKeyError,
   InvalidMockUpdateServerPortError,
   UnsupportedDesktopBuildArchitectureError,
   isMacPasskeySigningConfigurationError,
+  LINUX_APPIMAGE_COMPANION_TARGETS,
   LinuxIconResizeError,
   MacPasskeySigningConfigurationResolutionError,
   MissingMacPasskeyProvisioningProfileError,
@@ -353,6 +355,41 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         assert.deepStrictEqual(config.electronLanguages, DESKTOP_ELECTRON_LANGUAGES);
         assert.deepStrictEqual(config.files, DESKTOP_FILE_EXCLUSIONS);
       }
+    }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
+  );
+
+  it.effect("packages a companion .deb alongside the Linux AppImage", () =>
+    Effect.gen(function* () {
+      const appImage = yield* createBuildConfig(
+        "linux",
+        "AppImage",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+      const debOnly = yield* createBuildConfig(
+        "linux",
+        "deb",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+
+      assert.deepStrictEqual((appImage.linux as { target: ReadonlyArray<string> }).target, [
+        "AppImage",
+        ...LINUX_APPIMAGE_COMPANION_TARGETS,
+      ]);
+      assert.deepStrictEqual((debOnly.linux as { target: ReadonlyArray<string> }).target, ["deb"]);
+
+      // fpm refuses to build a .deb without a maintainer address.
+      for (const config of [appImage, debOnly]) {
+        assert.equal((config.linux as { maintainer: string }).maintainer, DESKTOP_LINUX_MAINTAINER);
+      }
+      assert.match(DESKTOP_LINUX_MAINTAINER, /^.+ <[^@\s]+@[^@\s]+>$/u);
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
   );
 

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -36,6 +36,11 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 const LINUX_ICON_SIZES = [16, 22, 24, 32, 48, 64, 128, 256, 512] as const;
 const DESKTOP_APP_ID = "com.t3tools.t3code";
+export const DESKTOP_HOMEPAGE_URL = "https://github.com/pingdotgg/t3code";
+// Debian control files need an RFC 822 maintainer address. Reuses the project
+// identity the server already commits checkpoints under (see GitVcsDriver), so
+// the contact survives team changes.
+export const DESKTOP_LINUX_MAINTAINER = "T3 Tools <t3code@users.noreply.github.com>";
 const APPLE_TEAM_ID_PATTERN = /^[A-Z0-9]{10}$/u;
 
 const BuildPlatform = Schema.Literals(["mac", "linux", "win"]);
@@ -617,6 +622,7 @@ interface StagePackageJson {
   readonly packageManager: string;
   readonly description: string;
   readonly author: string;
+  readonly homepage: string;
   readonly main: string;
   readonly build: Record<string, unknown>;
   readonly dependencies: Record<string, unknown>;
@@ -627,6 +633,9 @@ interface StagePackageJson {
 
 export const STAGE_INSTALL_ARGS = ["install", "--prod"] as const;
 export const DESKTOP_ELECTRON_LANGUAGES = ["en-US"] as const;
+// Extra Linux packages built alongside the AppImage. electron-builder produces
+// them from the same staged app, so the release only pays the packaging cost.
+export const LINUX_APPIMAGE_COMPANION_TARGETS = ["deb"] as const;
 export const DESKTOP_FILE_EXCLUSIONS = [
   // T3 Code always passes the user's installed Claude executable to the SDK,
   // so the SDK's optional platform packages (each a ~200MB bundled executable)
@@ -1585,7 +1594,11 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
 
   if (platform === "linux") {
     buildConfig.linux = {
-      target: [target],
+      // The AppImage stays the download that self-updates in place; a companion
+      // .deb from the same build serves users who install through dpkg/apt and
+      // upgrade there instead.
+      target: target === "AppImage" ? [target, ...LINUX_APPIMAGE_COMPANION_TARGETS] : [target],
+      maintainer: DESKTOP_LINUX_MAINTAINER,
       executableName: "t3code",
       icon: "icons",
       category: "Development",
@@ -1911,6 +1924,9 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     packageManager: rootPackageJson.packageManager,
     description: "T3 Code desktop build",
     author: "T3 Tools",
+    // The .deb control file requires a project URL, and electron-builder only
+    // reads it from the packaged app's metadata (never from the build config).
+    homepage: DESKTOP_HOMEPAGE_URL,
     main: "apps/desktop/dist-electron/main.cjs",
     build: yield* createBuildConfig(
       options.platform,


### PR DESCRIPTION
## What Changed

Linux releases now publish a .deb alongside the AppImage, built from the same electron-builder run by adding deb to the Linux target list (plus the homepage and maintainer metadata the Debian control file requires) and including *.deb in the workflow's collect and publish steps.

Made with gpt-5.6-sol

## Why

The AppImage was the only Linux artifact, so anyone who installs through a package manager had no supported path — no desktop entry, no /usr/bin entry, and no dpkg/apt upgrades — and since the .deb reuses the already-staged app, the release gains it without a second build

## UI Changes

None

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Linux packaging metadata, release asset globbing, marketing download links, and tests; no auth, server, or updater behavior changes beyond documenting AppImage-only updates.
> 
> **Overview**
> Linux desktop packaging now produces a **companion `.deb`** from the same electron-builder run as the AppImage by extending the Linux target list with `deb`, and setting **`linux.maintainer`** plus staged **`homepage`** metadata required for Debian control files.
> 
> The **release workflow** collects and publishes `*.deb` with the other desktop assets. The **marketing download page** adds a Debian/Ubuntu `.deb` card, and internal docs describe the new artifact.
> 
> **In-app auto-updates on Linux remain AppImage-only**; `.deb` installs are manual via `dpkg`/`apt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a81713aa69919ea1c177536ad8a4d1bd89edfa6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Linux .deb package to desktop releases
> - Updates [`build-desktop-artifact.ts`](https://github.com/pingdotgg/t3code/pull/4900/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) to build a `deb` target alongside the `AppImage` on Linux, setting `DESKTOP_LINUX_MAINTAINER` and `homepage` metadata required for Debian control files.
> - Updates the release workflow to stage and upload `*.deb` files to GitHub Releases alongside existing artifacts.
> - Adds a Debian/Ubuntu download card to the marketing downloads page pointing to the new `.deb` artifact.
> - Behavioral Change: Linux AppImage builds now also produce a `.deb`; the `.deb` is manual-install only — in-app updates on Linux remain AppImage-only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a81713a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->