### PR TITLE
docs: link iOS and Android app store downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # T3 Code
 
-T3 Code is an "agent harness control surface". It enables control of the agents on your machine with a best-in-class mobile app, [web app](https://app.t3.codes) and [Electron-based desktop app](https://t3.codes).
+T3 Code is an "agent harness control surface". It enables control of the agents on your machine with a best-in-class mobile app ([iOS](https://apps.apple.com/us/app/t3-code-remote-claude-more/id6787819824), [Android](https://play.google.com/store/apps/details?id=com.t3tools.t3code)), [web app](https://app.t3.codes) and [Electron-based desktop app](https://t3.codes).
 
 Works with your subscriptions on Claude Code, Codex, Cursor, Grok Build, and OpenCode. If they're set up on your computer, T3 Code can control them.
 

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -1,5 +1,10 @@
 ---
-import { GITHUB_REPOSITORY_URL, MARKETING_STATS } from "../lib/site";
+import {
+  ANDROID_PLAY_STORE_URL,
+  GITHUB_REPOSITORY_URL,
+  IOS_APP_STORE_URL,
+  MARKETING_STATS,
+} from "../lib/site";
 
 interface Props {
   title?: string;
@@ -69,6 +74,8 @@ const {
             <a href={GITHUB_REPOSITORY_URL} target="_blank" rel="noopener noreferrer">GitHub</a>
             <a href="https://discord.gg/jn4EGJjrvv" target="_blank" rel="noopener noreferrer">Discord</a>
             <a href="/download">Download</a>
+            <a href={IOS_APP_STORE_URL} target="_blank" rel="noopener noreferrer">iOS app</a>
+            <a href={ANDROID_PLAY_STORE_URL} target="_blank" rel="noopener noreferrer">Android app</a>
             <a href="/terms-of-service">Terms</a>
             <a href="/privacy-policy">Privacy</a>
             <a href="/security-policy">Security</a>

--- a/apps/marketing/src/lib/site.ts
+++ b/apps/marketing/src/lib/site.ts
@@ -1,5 +1,11 @@
 export const GITHUB_REPOSITORY_URL = "https://github.com/pingdotgg/t3code";
 
+export const IOS_APP_STORE_URL =
+  "https://apps.apple.com/us/app/t3-code-remote-claude-more/id6787819824";
+
+export const ANDROID_PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=com.t3tools.t3code";
+
 export const MARKETING_STATS = {
   githubStars: "14k+",
   users: "100,000",

--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import { RELEASES_URL } from "../lib/releases";
+import { ANDROID_PLAY_STORE_URL, IOS_APP_STORE_URL } from "../lib/site";
 ---
 
 <Layout title="Download — T3 Code" description="Download T3 Code for macOS, Windows, or Linux.">
@@ -57,6 +58,24 @@ import { RELEASES_URL } from "../lib/releases";
         </a>
       </div>
     </section>
+
+    <!-- Mobile -->
+    <section class="platform-section">
+      <div class="platform-header">
+        <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="7" y="2" width="10" height="20" rx="2.5"/><path d="M11 18.5h2"/></svg>
+        <h2 class="platform-name">Mobile</h2>
+      </div>
+      <div class="download-cards">
+        <a class="download-card" href={IOS_APP_STORE_URL} target="_blank" rel="noopener noreferrer">
+          <span class="card-arch">iPhone &amp; iPad</span>
+          <span class="card-format">App Store</span>
+        </a>
+        <a class="download-card" href={ANDROID_PLAY_STORE_URL} target="_blank" rel="noopener noreferrer">
+          <span class="card-arch">Android</span>
+          <span class="card-format">Google Play</span>
+        </a>
+      </div>
+    </section>
   </div>
 
   <p class="releases-link">
@@ -73,7 +92,8 @@ import { RELEASES_URL } from "../lib/releases";
 
   async function init() {
     const versionLabel = document.getElementById("version-label");
-    const cards = document.querySelectorAll<HTMLAnchorElement>(".download-card");
+    // Only release-asset cards; mobile store cards have no data-asset and keep their href.
+    const cards = document.querySelectorAll<HTMLAnchorElement>(".download-card[data-asset]");
 
     try {
       const release = await fetchLatestRelease();

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -1,6 +1,11 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import { GITHUB_REPOSITORY_URL, MARKETING_STATS } from "../lib/site";
+import {
+  ANDROID_PLAY_STORE_URL,
+  GITHUB_REPOSITORY_URL,
+  IOS_APP_STORE_URL,
+  MARKETING_STATS,
+} from "../lib/site";
 import { tweets } from "../lib/tweets";
 
 const desktopEndorsementRows = [
@@ -66,6 +71,12 @@ const mobileEndorsementRows = [
           <span>Steal our code (legally)</span>
           <svg class="hero-source-arrow" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17L17 7M8 7h9v9"/></svg>
         </a>
+        <p class="hero-mobile-line">
+          Also on your phone:
+          <a href={IOS_APP_STORE_URL} target="_blank" rel="noopener noreferrer">iOS</a>
+          <span aria-hidden="true">·</span>
+          <a href={ANDROID_PLAY_STORE_URL} target="_blank" rel="noopener noreferrer">Android</a>
+        </p>
       </div>
 
       <div class="hero-preview">
@@ -576,6 +587,28 @@ const mobileEndorsementRows = [
   .hero-source-link:hover .hero-source-arrow {
     transform: translate(2px, -2px);
     opacity: 1;
+  }
+
+  .hero-mobile-line {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--fg-dim);
+    font-size: 13px;
+    letter-spacing: -0.005em;
+  }
+
+  .hero-mobile-line a {
+    color: var(--fg-muted);
+    text-decoration: underline;
+    text-decoration-color: rgba(161, 161, 170, 0.4);
+    text-underline-offset: 3px;
+    transition: color 0.18s ease, text-decoration-color 0.18s ease;
+  }
+
+  .hero-mobile-line a:hover {
+    color: var(--fg);
+    text-decoration-color: var(--fg);
   }
 
   /* Download button icons (platform-aware) */


### PR DESCRIPTION
The mobile apps are live on both stores but nothing linked to them: the README, marketing site, and download page only covered desktop.

Now:

- **README**: the intro line links the mobile app to the App Store and Google Play.
- **Marketing hero**: a quiet "Also on your phone: iOS · Android" line under the download actions.
- **/download**: a Mobile platform section (iPhone & iPad / Android cards) matching the existing macOS/Windows/Linux sections. The release-asset script now only rewrites `data-asset` cards so store links are untouched.
- **Footer**: "iOS app" / "Android app" links on every marketing page.

Store URLs live in `lib/site.ts` alongside the other site constants.

---
Changes made by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketing-only changes (external store URLs and UI copy); no application logic, auth, or data handling.
> 
> **Overview**
> Adds **public links to the live iOS and Android apps** wherever users discover downloads, using shared URLs in `lib/site.ts`.
> 
> The **README** intro now links the mobile app to the App Store and Google Play alongside web and desktop. On the **marketing site**, the hero includes an “Also on your phone: iOS · Android” line; the **footer** adds iOS/Android app links on every page; and **`/download`** adds a Mobile section with App Store and Google Play cards like the desktop platforms.
> 
> The download page **release script** only updates cards with `data-asset`, so store links are not overwritten when GitHub release URLs are applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 850541bc4f0e2de25223c3aa85225626d4d73e53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add iOS App Store and Google Play Store links to the marketing site and README
> - Adds `IOS_APP_STORE_URL` and `ANDROID_PLAY_STORE_URL` constants to [site.ts](https://github.com/pingdotgg/t3code/pull/4902/files#diff-248474d7225337d6d1604123700c6b123b4c6935e65af658c7429d0cf1061510) and uses them across the marketing site.
> - The [download page](https://github.com/pingdotgg/t3code/pull/4902/files#diff-9ac8ff1be0976fe42db086d1efaff539e58c29a5da4e782816188ed3cd0c8926) gains a new Mobile section with store download cards; the release-fetch script is updated to target only cards with a `data-asset` attribute, skipping the new mobile cards.
> - The [homepage hero](https://github.com/pingdotgg/t3code/pull/4902/files#diff-44a2946e1eacc7096aee1ba8a172800aa7d94150585e21ff8486d94f4776677a) and [footer](https://github.com/pingdotgg/t3code/pull/4902/files#diff-cd40546c5d1667e6a791b4befdf6583020a7cfd7a6bbe78583471acd1618eaba) display inline links to both app stores.
> - [README.md](https://github.com/pingdotgg/t3code/pull/4902/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) replaces the plain mobile app mention with direct store links.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 850541b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->