### PR TITLE
fix(web): show server update progress through reconnect

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -32,6 +32,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverRefreshProviders]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateProvider]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServer]: AuthOrchestrationOperateScope,
+  [WS_METHODS.serverUpdateServerWithProgress]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpsertKeybinding]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverRemoveKeybinding]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverGetSettings]: AuthOrchestrationReadScope,

--- a/apps/server/src/cloud/selfUpdate.test.ts
+++ b/apps/server/src/cloud/selfUpdate.test.ts
@@ -26,6 +26,33 @@ import * as SelfUpdate from "./selfUpdate.ts";
 
 const NODE_PATH = "/usr/local/bin/node";
 
+const eventuallyFileString = Effect.fn("test.eventuallyFileString")(function* (
+  filePath: string,
+  expected: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  for (let iteration = 0; iteration < 1_000; iteration += 1) {
+    const contents = yield* fs.readFileString(filePath);
+    if (contents === expected) {
+      return;
+    }
+    // The rollback performs real filesystem I/O on a detached fiber, which
+    // advancing TestClock does not await.
+    yield* Effect.yieldNow;
+  }
+  return yield* Effect.die(new Error(`Expected file contents were not observed at ${filePath}.`));
+});
+
+const eventuallyTrue = Effect.fn("test.eventuallyTrue")(function* (predicate: () => boolean) {
+  for (let iteration = 0; iteration < 1_000; iteration += 1) {
+    if (predicate()) {
+      return;
+    }
+    yield* Effect.yieldNow;
+  }
+  return yield* Effect.die(new Error("Expected condition was not observed."));
+});
+
 interface RecordedCommand {
   readonly command: string;
   readonly args: ReadonlyArray<string>;
@@ -457,8 +484,12 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
   it.effect("installs, preflights, and respawns a foreground server", () =>
     Effect.gen(function* () {
       const context = yield* makeContext();
-      const result = yield* context.service.update({ targetVersion: "0.0.29" });
+      const progress: Array<string> = [];
+      const result = yield* context.service.update({ targetVersion: "0.0.29" }, (stage) =>
+        Effect.sync(() => progress.push(stage)),
+      );
       assert.deepEqual(result, { targetVersion: "0.0.29", method: "respawn" });
+      assert.deepEqual(progress, ["downloading", "installing"]);
       assert.lengthOf(context.spawns, 1);
 
       const concurrentError = yield* context.service
@@ -506,10 +537,12 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
       assert.include(unit, `ExecStart=${NODE_PATH} ${pinnedEntry} serve`);
       assert.deepEqual(
         context.commands.map((entry) => entry.command),
-        ["npm", NODE_PATH, "systemctl", "systemctl"],
+        ["npm", NODE_PATH, "systemctl"],
       );
       assert.deepEqual(context.commands[2]?.args, ["--user", "daemon-reload"]);
 
+      // Restart waits until after the update acknowledgement can flush.
+      yield* TestClock.adjust(Duration.seconds(10));
       assert.deepEqual(context.commands[3], {
         command: "systemctl",
         args: ["--user", "restart", "t3code.service"],
@@ -542,9 +575,11 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
       );
       const previousUnit = yield* context.fs.readFileString(unitPath);
 
-      const first = yield* context.service.update({ targetVersion: "0.0.29" }).pipe(Effect.flip);
-      assert.include(first.reason, "Restarting the systemd boot service failed");
-      assert.equal(yield* context.fs.readFileString(unitPath), previousUnit);
+      const first = yield* context.service.update({ targetVersion: "0.0.29" });
+      assert.deepEqual(first, { targetVersion: "0.0.29", method: "boot-service" });
+      yield* TestClock.adjust(Duration.seconds(10));
+      yield* eventuallyFileString(unitPath, previousUnit);
+      yield* eventuallyTrue(() => context.commands.at(-1)?.args[1] === "daemon-reload");
       assert.deepEqual(
         context.commands.slice(-2).map((entry) => entry.args),
         [

--- a/apps/server/src/cloud/selfUpdate.ts
+++ b/apps/server/src/cloud/selfUpdate.ts
@@ -6,6 +6,7 @@ import {
   ServerSelfUpdateError,
   type ServerSelfUpdateCapability,
   type ServerSelfUpdateInput,
+  type ServerSelfUpdateProgressStage,
   type ServerSelfUpdateResult,
 } from "@t3tools/contracts";
 import {
@@ -147,6 +148,7 @@ export class ServerSelfUpdate extends Context.Service<
   {
     readonly update: (
       input: ServerSelfUpdateInput,
+      reportProgress?: (stage: ServerSelfUpdateProgressStage) => Effect.Effect<void, never, never>,
     ) => Effect.Effect<ServerSelfUpdateResult, ServerSelfUpdateError>;
   }
 >()("t3/cloud/selfUpdate/ServerSelfUpdate") {}
@@ -227,7 +229,7 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
 
   const update: ServerSelfUpdate["Service"]["update"] = Effect.fn(
     "cloud.server_self_update.update",
-  )(function* (input) {
+  )(function* (input, reportProgress = () => Effect.void) {
     if (capability === "desktop-managed") {
       return yield* failWith(
         "This server is managed by the T3 Code desktop app on its machine; update the desktop app to update it.",
@@ -250,6 +252,7 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
     }
 
     return yield* Effect.gen(function* () {
+      yield* reportProgress("downloading");
       const runtimePaths = yield* ensurePinnedRuntimeInstalled({
         baseDir: serverConfig.baseDir,
         version: targetVersion,
@@ -260,6 +263,7 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
         Effect.mapError((error) => failWith("Could not install the requested t3 version.", error)),
       );
 
+      yield* reportProgress("installing");
       // A broken artifact (failed native build, incompatible node) must be
       // caught while the current server is still alive to report it.
       const preflight = yield* runner
@@ -349,38 +353,45 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
         yield* Effect.logInfo("Server self-update installed; restarting boot service.", {
           targetVersion,
         });
-        // A successful systemd restart stops this process, so the RPC is
-        // interrupted and the reconnecting client observes the new version.
-        // A rejected restart returns while the old process is still alive;
-        // restore the previous unit and report that failure through the RPC.
-        yield* Effect.gen(function* () {
-          const restart = yield* runner
-            .run({
-              command: "systemctl",
-              args: ["--user", "restart", BOOT_SERVICE_UNIT_FILE],
-            })
-            .pipe(
-              Effect.mapError((cause) =>
-                failWith("Could not restart the systemd boot service.", cause),
+        // Restart after the acknowledgement has had time to cross any relay
+        // hop. If systemd rejects the handoff, restore the previous unit while
+        // this process is still alive and log the failure for diagnostics.
+        yield* scheduleRestart(
+          Effect.gen(function* () {
+            const restart = yield* runner
+              .run({
+                command: "systemctl",
+                args: ["--user", "restart", BOOT_SERVICE_UNIT_FILE],
+              })
+              .pipe(
+                Effect.mapError((cause) =>
+                  failWith("Could not restart the systemd boot service.", cause),
+                ),
+              );
+            if (restart.code !== 0) {
+              return yield* failWith(
+                `Restarting the systemd boot service failed (exit code ${String(restart.code)}).`,
+              );
+            }
+          }).pipe(
+            Effect.catch((restartError) =>
+              writeUnitAtomically(unitPath, previousUnit).pipe(
+                Effect.andThen(reloadSystemd()),
+                Effect.mapError((rollbackError) =>
+                  failWith("Could not restore the previous systemd unit.", {
+                    restartError,
+                    rollbackError,
+                  }),
+                ),
+                Effect.andThen(Effect.fail(restartError)),
               ),
-            );
-          if (restart.code !== 0) {
-            return yield* failWith(
-              `Restarting the systemd boot service failed (exit code ${String(restart.code)}).`,
-            );
-          }
-        }).pipe(
-          Effect.catch((restartError) =>
-            writeUnitAtomically(unitPath, previousUnit).pipe(
-              Effect.andThen(reloadSystemd()),
-              Effect.mapError((rollbackError) =>
-                failWith("Could not restore the previous systemd unit.", {
-                  restartError,
-                  rollbackError,
-                }),
-              ),
-              Effect.andThen(Effect.fail(restartError)),
             ),
+            Effect.catch((error) =>
+              Effect.logError("Server self-update could not restart the boot service.").pipe(
+                Effect.annotateLogs({ targetVersion, error: error.reason }),
+              ),
+            ),
+            Effect.ensuring(Ref.set(inFlight, false)),
           ),
         );
       } else {

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -143,6 +143,9 @@ export const make = Effect.gen(function* () {
       threadSettlement: true,
       threadSnooze: true,
       ...(serverSelfUpdate === null ? {} : { serverSelfUpdate }),
+      ...(serverSelfUpdate === "boot-service" || serverSelfUpdate === "respawn"
+        ? { serverSelfUpdateProgress: true }
+        : {}),
     },
   };
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -40,6 +40,8 @@ import {
   ProjectWriteFileError,
   RelayClientInstallFailedError,
   type RelayClientInstallProgressEvent,
+  type ServerSelfUpdateError,
+  type ServerSelfUpdateProgressEvent,
   type FilesystemBrowseFailure,
   FilesystemBrowseError,
   AssetWorkspaceContextNotFoundError,
@@ -1364,6 +1366,31 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.serverUpdateServer, serverSelfUpdate.update(input), {
             "rpc.aggregate": "server",
           }),
+        [WS_METHODS.serverUpdateServerWithProgress]: (input) =>
+          observeRpcStream(
+            WS_METHODS.serverUpdateServerWithProgress,
+            Stream.callback<ServerSelfUpdateProgressEvent, ServerSelfUpdateError>((queue) =>
+              serverSelfUpdate
+                .update(input, (stage) =>
+                  Queue.offer(queue, {
+                    type: "progress",
+                    stage,
+                  }).pipe(Effect.asVoid),
+                )
+                .pipe(
+                  Effect.flatMap((result) =>
+                    Queue.offer(queue, {
+                      type: "complete",
+                      result,
+                    }),
+                  ),
+                  Effect.catchTag("ServerSelfUpdateError", (error) => Queue.fail(queue, error)),
+                  Effect.andThen(Queue.end(queue)),
+                  Effect.forkScoped,
+                ),
+            ),
+            { "rpc.aggregate": "server" },
+          ),
         [WS_METHODS.serverUpsertKeybinding]: (rule) =>
           observeRpcEffect(
             WS_METHODS.serverUpsertKeybinding,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1384,7 +1384,9 @@ const makeWsRpcLayer = (
                       result,
                     }),
                   ),
-                  Effect.catchTag("ServerSelfUpdateError", (error) => Queue.fail(queue, error)),
+                  Effect.catchTags({
+                    ServerSelfUpdateError: (error) => Queue.fail(queue, error),
+                  }),
                   Effect.andThen(Queue.end(queue)),
                   Effect.forkScoped,
                 ),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -296,7 +296,7 @@ import {
   AlertDialogTitle,
 } from "./ui/alert-dialog";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
-import { ServerUpdateAction } from "./ServerUpdateAction";
+import { ServerUpdateAction, ServerUpdateProgress } from "./ServerUpdateAction";
 import {
   buildVersionMismatchDismissalKey,
   dismissVersionMismatch,
@@ -1879,9 +1879,14 @@ function ChatViewContent(props: ChatViewProps) {
   const versionMismatchEnvironmentId =
     versionMismatch && activeThread ? activeThread.environmentId : null;
   const versionMismatchSelfUpdate = resolveServerSelfUpdateCapability(serverConfig);
+  const serverUpdateState = useAtomValue(
+    serverEnvironment.updateStateAtom(versionMismatchEnvironmentId),
+  );
   const systemComposerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const items: ComposerBannerStackItem[] = [];
-    if (activeEnvironmentUnavailableState) {
+    const resumingServerUpdate =
+      serverUpdateState.status === "running" && serverUpdateState.stage === "resuming";
+    if (activeEnvironmentUnavailableState && !resumingServerUpdate) {
       const connection = activeEnvironmentUnavailableState.connection;
       const isReconnecting =
         connection.phase === "connecting" || connection.phase === "reconnecting";
@@ -1918,39 +1923,56 @@ function ChatViewContent(props: ChatViewProps) {
       });
     }
     if (
-      showVersionMismatchBanner &&
+      (showVersionMismatchBanner || serverUpdateState.status !== "idle") &&
       versionMismatch &&
       versionMismatchDismissKey &&
       versionMismatchEnvironmentId
     ) {
+      const updateInProgress = serverUpdateState.status === "running";
+      const updateFailed = serverUpdateState.status === "failed";
       items.push({
         id: `version-mismatch:${versionMismatchDismissKey}`,
-        variant: "warning",
+        variant: updateFailed ? "error" : "warning",
         icon: <TriangleAlertIcon />,
-        title: "Client and server versions differ",
-        description: (
-          <>
-            Client {versionMismatch.clientVersion} is connected to {versionMismatchServerLabel}{" "}
-            {versionMismatch.serverVersion}.{" "}
-            {serverUpdateGuidance(versionMismatchSelfUpdate, versionMismatchServerLabel)}
-          </>
-        ),
+        title:
+          updateInProgress || updateFailed
+            ? `${updateFailed ? "Could not update" : "Updating"} ${versionMismatchServerLabel}`
+            : "Client and server versions differ",
+        description:
+          updateInProgress || updateFailed ? (
+            <ServerUpdateProgress
+              fromVersion={versionMismatch.serverVersion}
+              serverLabel={versionMismatchServerLabel}
+              state={serverUpdateState}
+            />
+          ) : (
+            <>
+              Client {versionMismatch.clientVersion} is connected to {versionMismatchServerLabel}{" "}
+              {versionMismatch.serverVersion}.{" "}
+              {serverUpdateGuidance(versionMismatchSelfUpdate, versionMismatchServerLabel)}
+            </>
+          ),
         // The desktop-managed guidance is already the description; the action
         // slot would only repeat it.
         actions:
-          versionMismatchSelfUpdate === "desktop-managed" ? undefined : (
+          updateInProgress || versionMismatchSelfUpdate === "desktop-managed" ? undefined : (
             <ServerUpdateAction
               environmentId={versionMismatchEnvironmentId}
               serverLabel={versionMismatchServerLabel}
               selfUpdate={versionMismatchSelfUpdate}
               targetVersion={versionMismatch.clientVersion}
+              {...(updateFailed ? { label: "Retry update" } : {})}
             />
           ),
-        dismissLabel: "Dismiss version mismatch warning",
-        onDismiss: () => {
-          dismissVersionMismatch(versionMismatchDismissKey);
-          setDismissedVersionMismatchKey(versionMismatchDismissKey);
-        },
+        ...(updateInProgress || updateFailed
+          ? {}
+          : {
+              dismissLabel: "Dismiss version mismatch warning",
+              onDismiss: () => {
+                dismissVersionMismatch(versionMismatchDismissKey);
+                setDismissedVersionMismatchKey(versionMismatchDismissKey);
+              },
+            }),
       });
     }
     return items;
@@ -1960,6 +1982,7 @@ function ChatViewContent(props: ChatViewProps) {
     navigate,
     setDismissedVersionMismatchKey,
     showVersionMismatchBanner,
+    serverUpdateState,
     versionMismatch,
     versionMismatchDismissKey,
     versionMismatchEnvironmentId,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1876,11 +1876,10 @@ function ChatViewContent(props: ChatViewProps) {
     hasMultipleRegisteredEnvironments && activeThread
       ? `${environmentById.get(activeThread.environmentId)?.label ?? serverConfig?.environment.label ?? activeThread.environmentId} server`
       : "server";
-  const versionMismatchEnvironmentId =
-    versionMismatch && activeThread ? activeThread.environmentId : null;
+  const serverUpdateEnvironmentId = activeThread?.environmentId ?? null;
   const versionMismatchSelfUpdate = resolveServerSelfUpdateCapability(serverConfig);
   const serverUpdateState = useAtomValue(
-    serverEnvironment.updateStateAtom(versionMismatchEnvironmentId),
+    serverEnvironment.updateStateAtom(serverUpdateEnvironmentId),
   );
   const systemComposerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const items: ComposerBannerStackItem[] = [];
@@ -1923,15 +1922,14 @@ function ChatViewContent(props: ChatViewProps) {
       });
     }
     if (
-      (showVersionMismatchBanner || serverUpdateState.status !== "idle") &&
-      versionMismatch &&
-      versionMismatchDismissKey &&
-      versionMismatchEnvironmentId
+      serverUpdateEnvironmentId &&
+      (serverUpdateState.status !== "idle" ||
+        (showVersionMismatchBanner && versionMismatch && versionMismatchDismissKey))
     ) {
       const updateInProgress = serverUpdateState.status === "running";
       const updateFailed = serverUpdateState.status === "failed";
       items.push({
-        id: `version-mismatch:${versionMismatchDismissKey}`,
+        id: `server-version:${serverUpdateEnvironmentId}`,
         variant: updateFailed ? "error" : "warning",
         icon: <TriangleAlertIcon />,
         title:
@@ -1941,30 +1939,32 @@ function ChatViewContent(props: ChatViewProps) {
         description:
           updateInProgress || updateFailed ? (
             <ServerUpdateProgress
-              fromVersion={versionMismatch.serverVersion}
+              fromVersion={serverUpdateState.fromVersion}
               serverLabel={versionMismatchServerLabel}
               state={serverUpdateState}
             />
-          ) : (
+          ) : versionMismatch ? (
             <>
               Client {versionMismatch.clientVersion} is connected to {versionMismatchServerLabel}{" "}
               {versionMismatch.serverVersion}.{" "}
               {serverUpdateGuidance(versionMismatchSelfUpdate, versionMismatchServerLabel)}
             </>
-          ),
+          ) : null,
         // The desktop-managed guidance is already the description; the action
         // slot would only repeat it.
         actions:
-          updateInProgress || versionMismatchSelfUpdate === "desktop-managed" ? undefined : (
+          updateInProgress ||
+          !versionMismatch ||
+          versionMismatchSelfUpdate === "desktop-managed" ? undefined : (
             <ServerUpdateAction
-              environmentId={versionMismatchEnvironmentId}
+              environmentId={serverUpdateEnvironmentId}
               serverLabel={versionMismatchServerLabel}
               selfUpdate={versionMismatchSelfUpdate}
               targetVersion={versionMismatch.clientVersion}
               {...(updateFailed ? { label: "Retry update" } : {})}
             />
           ),
-        ...(updateInProgress || updateFailed
+        ...(updateInProgress || updateFailed || !versionMismatchDismissKey
           ? {}
           : {
               dismissLabel: "Dismiss version mismatch warning",
@@ -1985,7 +1985,7 @@ function ChatViewContent(props: ChatViewProps) {
     serverUpdateState,
     versionMismatch,
     versionMismatchDismissKey,
-    versionMismatchEnvironmentId,
+    serverUpdateEnvironmentId,
     versionMismatchSelfUpdate,
     versionMismatchServerLabel,
   ]);

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -1,71 +1,15 @@
-import type { Dispatch, ReactElement, SetStateAction } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { EnvironmentId } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
-import type { EnvironmentId } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({
   updateServer: vi.fn(),
   toast: vi.fn(),
 }));
 
-const hooks = vi.hoisted(() => {
-  let cursor = 0;
-  let slots: unknown[] = [];
-  const nextIndex = () => cursor++;
-
-  return {
-    beginRender() {
-      cursor = 0;
-    },
-    reset() {
-      cursor = 0;
-      slots = [];
-    },
-    useEffect() {
-      nextIndex();
-    },
-    useMemoCache(size: number): unknown[] {
-      const index = nextIndex();
-      if (!slots[index]) {
-        slots[index] = Array.from({ length: size }, () => Symbol.for("react.memo_cache_sentinel"));
-      }
-      return slots[index] as unknown[];
-    },
-    useRef<T>(initialValue: T): { current: T } {
-      const index = nextIndex();
-      if (!slots[index]) {
-        slots[index] = { current: initialValue };
-      }
-      return slots[index] as { current: T };
-    },
-    useState<T>(initialValue: T | (() => T)): [T, Dispatch<SetStateAction<T>>] {
-      const index = nextIndex();
-      if (index >= slots.length) {
-        slots[index] =
-          typeof initialValue === "function" ? (initialValue as () => T)() : initialValue;
-      }
-      const setValue: Dispatch<SetStateAction<T>> = (nextValue) => {
-        const previous = slots[index] as T;
-        slots[index] =
-          typeof nextValue === "function" ? (nextValue as (value: T) => T)(previous) : nextValue;
-      };
-      return [slots[index] as T, setValue];
-    },
-  };
-});
-
-vi.mock("react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react")>();
-  return {
-    ...actual,
-    useEffect: hooks.useEffect,
-    useRef: hooks.useRef,
-    useState: hooks.useState,
-  };
-});
-
-vi.mock("react/compiler-runtime", () => ({ c: hooks.useMemoCache }));
 vi.mock("~/hooks/useCopyToClipboard", () => ({
   useCopyToClipboard: () => ({ copyToClipboard: vi.fn() }),
 }));
@@ -79,120 +23,95 @@ vi.mock("./ui/toast", () => ({
   toastManager: { add: testState.toast },
 }));
 
-import { ServerUpdateAction } from "./ServerUpdateAction";
+import { ServerUpdateAction, ServerUpdateProgress } from "./ServerUpdateAction";
 
 type ActionElement = ReactElement<{
-  readonly disabled?: boolean;
   readonly onClick?: () => void;
 }>;
 
 function renderAction(): ActionElement {
-  hooks.beginRender();
   return ServerUpdateAction({
     environmentId: "env-test" as EnvironmentId,
     serverLabel: "Test server",
     selfUpdate: "boot-service",
-    targetVersion: "0.0.29",
+    targetVersion: "0.0.31",
   }) as ActionElement;
 }
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((complete) => {
-    resolve = complete;
-  });
-  return { promise, resolve };
-}
-
 async function flushPromises(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
 }
 
 describe("ServerUpdateAction", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
-    hooks.reset();
     testState.updateServer.mockReset();
     testState.toast.mockReset();
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("starts a fresh reconnect timeout after a long install succeeds", async () => {
-    const update =
-      deferred<
-        ReturnType<typeof AsyncResult.success<{ targetVersion: string; method: "boot-service" }>>
-      >();
-    testState.updateServer.mockReturnValue(update.promise);
-
-    renderAction().props.onClick?.();
-    expect(renderAction().props.disabled).toBe(true);
-
-    await vi.advanceTimersByTimeAsync(11 * 60_000);
-    update.resolve(
-      AsyncResult.success({
-        targetVersion: "0.0.29",
-        method: "boot-service",
-      }),
-    );
-    await flushPromises();
-
-    // The click-based deadline would have fired by now. Success gets a fresh
-    // twelve-minute reconnect window, so the action remains disabled.
-    await vi.advanceTimersByTimeAsync(2 * 60_000);
-    expect(renderAction().props.disabled).toBe(true);
-    expect(testState.toast).not.toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Server update timed out" }),
+  it("reports success only after the shared update flow reconnects", async () => {
+    testState.updateServer.mockResolvedValue(
+      AsyncResult.success({ targetVersion: "0.0.31", method: "boot-service" as const }),
     );
 
-    await vi.advanceTimersByTimeAsync(10 * 60_000);
-    expect(renderAction().props.disabled).not.toBe(true);
-    expect(testState.toast).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Server update timed out" }),
-    );
-  });
-
-  it("does not let an expired request clear a newer retry", async () => {
-    const first = deferred<ReturnType<typeof AsyncResult.failure>>();
-    const retry =
-      deferred<
-        ReturnType<typeof AsyncResult.success<{ targetVersion: string; method: "boot-service" }>>
-      >();
-    testState.updateServer.mockReturnValueOnce(first.promise).mockReturnValueOnce(retry.promise);
-
     renderAction().props.onClick?.();
-    await vi.advanceTimersByTimeAsync(12 * 60_000);
-    expect(renderAction().props.disabled).not.toBe(true);
-
-    renderAction().props.onClick?.();
-    expect(renderAction().props.disabled).toBe(true);
-
-    first.resolve(AsyncResult.failure(Cause.fail(new Error("first request failed late"))));
     await flushPromises();
 
-    expect(renderAction().props.disabled).toBe(true);
-    expect(testState.updateServer).toHaveBeenCalledTimes(2);
-
-    retry.resolve(AsyncResult.success({ targetVersion: "0.0.29", method: "boot-service" }));
-    await flushPromises();
-    expect(renderAction().props.disabled).toBe(true);
+    expect(testState.updateServer).toHaveBeenCalledWith({
+      environmentId: "env-test",
+      input: { targetVersion: "0.0.31" },
+    });
+    expect(testState.toast).toHaveBeenCalledWith({
+      type: "success",
+      title: "Test server updated",
+      description: "Reconnected on t3@0.0.31.",
+    });
   });
 
-  it("quietly releases the action when a restart RPC is interrupted", async () => {
+  it("quietly releases the action when the operation is interrupted", async () => {
     testState.updateServer.mockResolvedValue(AsyncResult.failure(Cause.interrupt()));
 
     renderAction().props.onClick?.();
     await flushPromises();
 
-    expect(renderAction().props.disabled).not.toBe(true);
-    expect(testState.toast).not.toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Server update failed" }),
+    expect(testState.toast).not.toHaveBeenCalled();
+  });
+});
+
+describe("ServerUpdateProgress", () => {
+  it("renders the chosen horizontal step rail without an animated spinner", () => {
+    const markup = renderToStaticMarkup(
+      <ServerUpdateProgress
+        fromVersion="0.0.30"
+        serverLabel="bb-1"
+        state={{ status: "running", stage: "resuming", targetVersion: "0.0.31" }}
+      />,
     );
+
+    expect(markup).toContain("0.0.30");
+    expect(markup).toContain("0.0.31");
+    expect(markup).toContain("Download");
+    expect(markup).toContain("Install");
+    expect(markup).toContain("Resume");
+    expect(markup).toContain("Waiting for bb-1 to accept commands.");
+    expect(markup).not.toContain("animate-spin");
+  });
+
+  it("keeps the failed stage visible with its retryable error", () => {
+    const markup = renderToStaticMarkup(
+      <ServerUpdateProgress
+        fromVersion="0.0.30"
+        serverLabel="bb-1"
+        state={{
+          status: "failed",
+          stage: "installing",
+          targetVersion: "0.0.31",
+          message: "The package could not be verified.",
+        }}
+      />,
+    );
+
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("The package could not be verified.");
   });
 });

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -106,7 +106,12 @@ describe("ServerUpdateProgress", () => {
       <ServerUpdateProgress
         fromVersion="0.0.30"
         serverLabel="bb-1"
-        state={{ status: "running", stage: "resuming", targetVersion: "0.0.31" }}
+        state={{
+          status: "running",
+          stage: "resuming",
+          fromVersion: "0.0.30",
+          targetVersion: "0.0.31",
+        }}
       />,
     );
 
@@ -127,6 +132,7 @@ describe("ServerUpdateProgress", () => {
         state={{
           status: "failed",
           stage: "installing",
+          fromVersion: "0.0.30",
           targetVersion: "0.0.31",
           message: "The package could not be verified.",
         }}

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -68,6 +68,28 @@ describe("ServerUpdateAction", () => {
     });
   });
 
+  it("reports one result when the update action is double-clicked", async () => {
+    let finishUpdate: (() => void) | undefined;
+    testState.updateServer.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishUpdate = () =>
+            resolve(
+              AsyncResult.success({ targetVersion: "0.0.31", method: "boot-service" as const }),
+            );
+        }),
+    );
+
+    const action = renderAction();
+    action.props.onClick?.();
+    action.props.onClick?.();
+
+    expect(testState.updateServer).toHaveBeenCalledTimes(1);
+    finishUpdate?.();
+    await flushPromises();
+    expect(testState.toast).toHaveBeenCalledTimes(1);
+  });
+
   it("quietly releases the action when the operation is interrupted", async () => {
     testState.updateServer.mockResolvedValue(AsyncResult.failure(Cause.interrupt()));
 

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -1,55 +1,146 @@
-import { useEffect, useRef, useState } from "react";
 import type { EnvironmentId, ServerSelfUpdateCapability } from "@t3tools/contracts";
+import type { ServerUpdateState } from "@t3tools/client-runtime/state/server";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { CheckIcon } from "lucide-react";
 
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { cn } from "~/lib/utils";
 import { serverEnvironment } from "~/state/server";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { manualServerUpdateCommand } from "~/versionSkew";
 import { Button } from "./ui/button";
-import { Spinner } from "./ui/spinner";
 import { toastManager } from "./ui/toast";
 
-/**
- * The npm install on the server side is capped at 10 minutes; expire the
- * spinner a bit beyond that so a dead transport never strands a disabled
- * button, while a legitimately slow install is never cut off.
- */
-const UPDATE_PENDING_EXPIRY_MS = 12 * 60_000;
+const UPDATE_STEPS = [
+  { stage: "downloading", label: "Download" },
+  { stage: "installing", label: "Install" },
+  { stage: "resuming", label: "Resume" },
+] as const;
 
 function updateFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Server update failed.";
 }
 
+function updateStatusCopy(
+  state: Exclude<ServerUpdateState, { status: "idle" }>,
+  serverLabel: string,
+): string {
+  if (state.status === "failed") {
+    return state.message;
+  }
+  switch (state.stage) {
+    case "downloading":
+      return "Downloading the matching server version.";
+    case "installing":
+      return `Installing and verifying t3@${state.targetVersion}.`;
+    case "resuming":
+      return `Waiting for ${serverLabel} to accept commands.`;
+  }
+}
+
+export function ServerUpdateProgress({
+  fromVersion,
+  serverLabel,
+  state,
+}: {
+  readonly fromVersion: string;
+  readonly serverLabel: string;
+  readonly state: Exclude<ServerUpdateState, { status: "idle" }>;
+}) {
+  const currentIndex = UPDATE_STEPS.findIndex(({ stage }) => stage === state.stage);
+
+  return (
+    <div className="mt-1 min-w-0 space-y-2.5">
+      <p className="text-xs text-muted-foreground">
+        {fromVersion} <span aria-hidden="true">→</span> {state.targetVersion}
+      </p>
+      <ol className="flex min-w-0 items-center" aria-label="Server update progress">
+        {UPDATE_STEPS.map((step, index) => {
+          const complete = index < currentIndex;
+          const current = index === currentIndex;
+          const failed = current && state.status === "failed";
+          return (
+            <li
+              key={step.stage}
+              className={cn(
+                "flex min-w-0 items-center text-xs font-medium",
+                index < UPDATE_STEPS.length - 1 ? "flex-1" : null,
+                complete
+                  ? "text-success"
+                  : failed
+                    ? "text-destructive"
+                    : current
+                      ? "text-primary"
+                      : "text-muted-foreground/60",
+              )}
+              aria-current={current && state.status === "running" ? "step" : undefined}
+            >
+              <span
+                className={cn(
+                  "grid size-4 shrink-0 place-items-center rounded-full border",
+                  complete
+                    ? "border-success bg-success text-success-foreground"
+                    : failed
+                      ? "border-destructive bg-destructive text-destructive-foreground"
+                      : current
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-muted-foreground/35",
+                )}
+                aria-hidden="true"
+              >
+                {complete ? <CheckIcon className="size-3" strokeWidth={3} /> : null}
+              </span>
+              <span className="ml-1.5 truncate">{step.label}</span>
+              {index < UPDATE_STEPS.length - 1 ? (
+                <span
+                  className={cn(
+                    "mx-2 h-px min-w-3 flex-1",
+                    complete ? "bg-success/60" : "bg-border",
+                  )}
+                  aria-hidden="true"
+                />
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+      <p
+        className={cn(
+          "text-xs",
+          state.status === "failed" ? "text-destructive" : "text-muted-foreground",
+        )}
+        role={state.status === "failed" ? "alert" : "status"}
+      >
+        {updateStatusCopy(state, serverLabel)}
+      </p>
+    </div>
+  );
+}
+
 /**
- * The call-to-action for a version-skewed server, matched to the update path
- * it advertises: a one-click install-and-restart for servers that can update
- * themselves, an update-the-desktop-app hint for desktop-managed backends
- * (running `npx t3` there would start a second server, not update this one),
- * and copying the manual relaunch command for everything else — so the skew
- * warning always offers a way out.
+ * Offers the update path advertised by a version-skewed server. Self-updates
+ * delegate their full lifecycle to client-runtime so this component can
+ * unmount during reconnect without losing operation state.
  */
 export function ServerUpdateAction({
   environmentId,
   serverLabel,
   selfUpdate,
   targetVersion,
+  label = "Update server",
 }: {
   readonly environmentId: EnvironmentId;
   readonly serverLabel: string;
   readonly selfUpdate: ServerSelfUpdateCapability | null;
   readonly targetVersion: string;
+  readonly label?: string;
 }) {
   const updateServer = useAtomCommand(serverEnvironment.updateServer, {
     reportFailure: false,
   });
-  const [pending, setPending] = useState(false);
-  const inFlightRef = useRef(false);
-  const attemptRef = useRef(0);
-  const expiryRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { copyToClipboard } = useCopyToClipboard<{ command: string }>({
     target: "update command",
     onCopy: ({ command }) => {
@@ -68,107 +159,27 @@ export function ServerUpdateAction({
     },
   });
 
-  useEffect(
-    () => () => {
-      if (expiryRef.current !== null) {
-        clearTimeout(expiryRef.current);
-        expiryRef.current = null;
+  const handleUpdate = async () => {
+    const result = await updateServer({
+      environmentId,
+      input: { targetVersion },
+    });
+    if (result._tag === "Failure") {
+      if (isAtomCommandInterrupted(result)) {
+        return;
       }
-      attemptRef.current += 1;
-      inFlightRef.current = false;
-    },
-    [],
-  );
-
-  const handleUpdate = () => {
-    // Synchronous re-entry guard: setPending is async, so a rapid
-    // double-click would otherwise dispatch two updates.
-    if (inFlightRef.current) {
+      toastManager.add({
+        type: "error",
+        title: "Server update failed",
+        description: updateFailureMessage(squashAtomCommandFailure(result)),
+      });
       return;
     }
-    inFlightRef.current = true;
-    const attempt = attemptRef.current + 1;
-    attemptRef.current = attempt;
-    const ownsAttempt = () => attemptRef.current === attempt;
-    setPending(true);
-    const armExpiry = () => {
-      const expiry = setTimeout(() => {
-        if (!ownsAttempt()) return;
-        expiryRef.current = null;
-        attemptRef.current += 1;
-        inFlightRef.current = false;
-        setPending(false);
-        toastManager.add({
-          type: "error",
-          title: "Server update timed out",
-          description: "The update may still be running on the server — check again in a minute.",
-        });
-      }, UPDATE_PENDING_EXPIRY_MS);
-      expiryRef.current = expiry;
-      return expiry;
-    };
-    let expiry = armExpiry();
-    let restartAccepted = false;
-    const keepPendingForRestart = () => {
-      restartAccepted = true;
-      if (expiryRef.current === expiry) {
-        clearTimeout(expiry);
-        expiry = armExpiry();
-      }
-    };
-    void Promise.resolve()
-      .then(() =>
-        updateServer({
-          environmentId,
-          input: { targetVersion },
-        }),
-      )
-      .then((result) => {
-        if (!ownsAttempt()) return;
-        if (result._tag === "Failure") {
-          // An interrupt may be the expected boot-service disconnect, but it
-          // can also be client-side cancellation before restart was accepted.
-          // Release the action quietly; version sync will remove it when a
-          // successful replacement reconnects.
-          if (isAtomCommandInterrupted(result)) {
-            return;
-          }
-          toastManager.add({
-            type: "error",
-            title: "Server update failed",
-            description: updateFailureMessage(squashAtomCommandFailure(result)),
-          });
-          return;
-        }
-        keepPendingForRestart();
-        // Installation can legitimately consume most of the request window.
-        // Give restart/reconnect a fresh full window after the server accepts
-        // the handoff instead of expiring based on the original click time.
-        toastManager.add({
-          type: "success",
-          title: `Updating ${serverLabel}`,
-          description: `t3@${result.value.targetVersion} is installed — the server is restarting and will reconnect shortly.`,
-        });
-      })
-      .catch((error: unknown) => {
-        if (!ownsAttempt()) return;
-        toastManager.add({
-          type: "error",
-          title: "Server update failed",
-          description: updateFailureMessage(error),
-        });
-      })
-      .finally(() => {
-        // A successful RPC only acknowledges that restart is scheduled. Keep
-        // the action disabled until version sync unmounts it, or until the
-        // safety expiry reports that reconnection never arrived.
-        if (restartAccepted || !ownsAttempt() || expiryRef.current !== expiry) return;
-        expiryRef.current = null;
-        clearTimeout(expiry);
-        attemptRef.current += 1;
-        inFlightRef.current = false;
-        setPending(false);
-      });
+    toastManager.add({
+      type: "success",
+      title: `${serverLabel} updated`,
+      description: `Reconnected on t3@${result.value.targetVersion}.`,
+    });
   };
 
   if (selfUpdate === "desktop-managed") {
@@ -188,14 +199,9 @@ export function ServerUpdateAction({
     );
   }
 
-  return pending ? (
-    <Button size="xs" disabled>
-      <Spinner className="size-3.5" />
-      Updating...
-    </Button>
-  ) : (
+  return (
     <Button size="xs" onClick={() => void handleUpdate()}>
-      Update server
+      {label}
     </Button>
   );
 }

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -19,6 +19,7 @@ const UPDATE_STEPS = [
   { stage: "installing", label: "Install" },
   { stage: "resuming", label: "Resume" },
 ] as const;
+const pendingUpdateEnvironmentIds = new Set<EnvironmentId>();
 
 function updateFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Server update failed.";
@@ -160,26 +161,34 @@ export function ServerUpdateAction({
   });
 
   const handleUpdate = async () => {
-    const result = await updateServer({
-      environmentId,
-      input: { targetVersion },
-    });
-    if (result._tag === "Failure") {
-      if (isAtomCommandInterrupted(result)) {
+    if (pendingUpdateEnvironmentIds.has(environmentId)) {
+      return;
+    }
+    pendingUpdateEnvironmentIds.add(environmentId);
+    try {
+      const result = await updateServer({
+        environmentId,
+        input: { targetVersion },
+      });
+      if (result._tag === "Failure") {
+        if (isAtomCommandInterrupted(result)) {
+          return;
+        }
+        toastManager.add({
+          type: "error",
+          title: "Server update failed",
+          description: updateFailureMessage(squashAtomCommandFailure(result)),
+        });
         return;
       }
       toastManager.add({
-        type: "error",
-        title: "Server update failed",
-        description: updateFailureMessage(squashAtomCommandFailure(result)),
+        type: "success",
+        title: `${serverLabel} updated`,
+        description: `Reconnected on t3@${result.value.targetVersion}.`,
       });
-      return;
+    } finally {
+      pendingUpdateEnvironmentIds.delete(environmentId);
     }
-    toastManager.add({
-      type: "success",
-      title: `${serverLabel} updated`,
-      description: `Reconnected on t3@${result.value.targetVersion}.`,
-    });
   };
 
   if (selfUpdate === "desktop-managed") {

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -7,6 +7,7 @@ import {
   TerminalIcon,
   TriangleAlertIcon,
 } from "lucide-react";
+import { useAtomValue } from "@effect/atom-react";
 import { type ReactNode, memo, useCallback, useMemo, useState } from "react";
 import {
   AuthAccessReadScope,
@@ -131,8 +132,9 @@ import {
   usePrimaryEnvironment,
 } from "~/state/environments";
 import { useAtomCommand } from "../../state/use-atom-command";
+import { serverEnvironment } from "~/state/server";
 import { ConnectionStatusDot } from "../ConnectionStatusDot";
-import { ServerUpdateAction } from "../ServerUpdateAction";
+import { ServerUpdateAction, ServerUpdateProgress } from "../ServerUpdateAction";
 import { CloudEnvironmentConnectRows } from "../cloud/CloudEnvironmentConnectList";
 import { ITEM_ROW_CLASSNAME, ITEM_ROW_INNER_CLASSNAME } from "./itemRows";
 
@@ -1389,6 +1391,9 @@ function SavedBackendListRow({
     [copyTraceIdToClipboard],
   );
   const versionMismatch = resolveServerConfigVersionMismatch(environment.serverConfig);
+  const serverUpdateState = useAtomValue(serverEnvironment.updateStateAtom(environmentId));
+  const resumingServerUpdate =
+    serverUpdateState.status === "running" && serverUpdateState.stage === "resuming";
   const sshTarget =
     environment.entry.target._tag === "SshConnectionTarget" &&
     Option.isSome(environment.entry.profile) &&
@@ -1425,14 +1430,22 @@ function SavedBackendListRow({
           {metadataBits.length > 0 ? (
             <p className="text-xs text-muted-foreground">{metadataBits.join(" · ")}</p>
           ) : null}
-          {versionMismatch ? (
+          {versionMismatch && serverUpdateState.status !== "idle" ? (
+            <div className="max-w-md">
+              <ServerUpdateProgress
+                fromVersion={versionMismatch.serverVersion}
+                serverLabel={`${environment.label} server`}
+                state={serverUpdateState}
+              />
+            </div>
+          ) : versionMismatch ? (
             <p className="flex items-center gap-1 text-warning text-xs">
               <TriangleAlertIcon className="size-3.5 shrink-0" />
               Version drift: client {versionMismatch.clientVersion}, server{" "}
               {versionMismatch.serverVersion}.
             </p>
           ) : null}
-          {environment.connection.error ? (
+          {environment.connection.error && !resumingServerUpdate ? (
             <p className="flex min-w-0 items-center gap-2 text-destructive text-xs">
               <span className="truncate">{connectionStatusText(environment.connection)}</span>
               {errorTraceId ? (
@@ -1448,12 +1461,14 @@ function SavedBackendListRow({
           ) : null}
         </div>
         <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
-          {versionMismatch ? (
+          {versionMismatch &&
+          (serverUpdateState.status === "idle" || serverUpdateState.status === "failed") ? (
             <ServerUpdateAction
               environmentId={environmentId}
               serverLabel={`${environment.label} server`}
               selfUpdate={resolveServerSelfUpdateCapability(environment.serverConfig)}
               targetVersion={versionMismatch.clientVersion}
+              label={serverUpdateState.status === "failed" ? "Retry update" : undefined}
             />
           ) : null}
           {isWslEnvironment ? (
@@ -1834,6 +1849,9 @@ export function ConnectionsSettings() {
   >(null);
   const primaryServerConfig = primaryEnvironment?.serverConfig ?? null;
   const primaryVersionMismatch = resolveServerConfigVersionMismatch(primaryServerConfig);
+  const primaryServerUpdateState = useAtomValue(
+    serverEnvironment.updateStateAtom(primaryEnvironmentId),
+  );
   const [isAdvertisedEndpointListExpanded, setIsAdvertisedEndpointListExpanded] = useState(false);
   const defaultAdvertisedEndpointKey = useUiStateStore(
     (state) => state.defaultAdvertisedEndpointKey,
@@ -2982,22 +3000,39 @@ export function ConnectionsSettings() {
           <SettingsSection title="This environment">
             {primaryVersionMismatch ? (
               <SettingsRow
-                title="Version drift"
+                title={
+                  primaryServerUpdateState.status === "failed"
+                    ? "Update failed"
+                    : primaryServerUpdateState.status === "running"
+                      ? "Updating server"
+                      : "Version drift"
+                }
                 description={
-                  <span className="flex items-center gap-1 text-warning">
-                    <TriangleAlertIcon className="size-3.5 shrink-0" />
-                    Client {primaryVersionMismatch.clientVersion}, server{" "}
-                    {primaryVersionMismatch.serverVersion}. Sync them if RPC calls or reconnects
-                    fail.
-                  </span>
+                  primaryServerUpdateState.status === "idle" ? (
+                    <span className="flex items-center gap-1 text-warning">
+                      <TriangleAlertIcon className="size-3.5 shrink-0" />
+                      Client {primaryVersionMismatch.clientVersion}, server{" "}
+                      {primaryVersionMismatch.serverVersion}. Sync them if RPC calls or reconnects
+                      fail.
+                    </span>
+                  ) : (
+                    <ServerUpdateProgress
+                      fromVersion={primaryVersionMismatch.serverVersion}
+                      serverLabel={primaryEnvironment?.label ?? "this server"}
+                      state={primaryServerUpdateState}
+                    />
+                  )
                 }
                 control={
-                  primaryEnvironmentId !== null ? (
+                  primaryEnvironmentId !== null && primaryServerUpdateState.status !== "running" ? (
                     <ServerUpdateAction
                       environmentId={primaryEnvironmentId}
                       serverLabel={primaryEnvironment?.label ?? "this server"}
                       selfUpdate={resolveServerSelfUpdateCapability(primaryServerConfig)}
                       targetVersion={primaryVersionMismatch.clientVersion}
+                      {...(primaryServerUpdateState.status === "failed"
+                        ? { label: "Retry update" }
+                        : {})}
                     />
                   ) : undefined
                 }

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1468,7 +1468,7 @@ function SavedBackendListRow({
               serverLabel={`${environment.label} server`}
               selfUpdate={resolveServerSelfUpdateCapability(environment.serverConfig)}
               targetVersion={versionMismatch.clientVersion}
-              label={serverUpdateState.status === "failed" ? "Retry update" : undefined}
+              label={serverUpdateState.status === "failed" ? "Retry update" : "Update server"}
             />
           ) : null}
           {isWslEnvironment ? (

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1430,10 +1430,10 @@ function SavedBackendListRow({
           {metadataBits.length > 0 ? (
             <p className="text-xs text-muted-foreground">{metadataBits.join(" · ")}</p>
           ) : null}
-          {versionMismatch && serverUpdateState.status !== "idle" ? (
+          {serverUpdateState.status !== "idle" ? (
             <div className="max-w-md">
               <ServerUpdateProgress
-                fromVersion={versionMismatch.serverVersion}
+                fromVersion={serverUpdateState.fromVersion}
                 serverLabel={`${environment.label} server`}
                 state={serverUpdateState}
               />
@@ -2998,7 +2998,7 @@ export function ConnectionsSettings() {
       {canManageLocalBackend ? (
         <>
           <SettingsSection title="This environment">
-            {primaryVersionMismatch ? (
+            {primaryVersionMismatch || primaryServerUpdateState.status !== "idle" ? (
               <SettingsRow
                 title={
                   primaryServerUpdateState.status === "failed"
@@ -3008,23 +3008,25 @@ export function ConnectionsSettings() {
                       : "Version drift"
                 }
                 description={
-                  primaryServerUpdateState.status === "idle" ? (
+                  primaryServerUpdateState.status !== "idle" ? (
+                    <ServerUpdateProgress
+                      fromVersion={primaryServerUpdateState.fromVersion}
+                      serverLabel={primaryEnvironment?.label ?? "this server"}
+                      state={primaryServerUpdateState}
+                    />
+                  ) : primaryVersionMismatch ? (
                     <span className="flex items-center gap-1 text-warning">
                       <TriangleAlertIcon className="size-3.5 shrink-0" />
                       Client {primaryVersionMismatch.clientVersion}, server{" "}
                       {primaryVersionMismatch.serverVersion}. Sync them if RPC calls or reconnects
                       fail.
                     </span>
-                  ) : (
-                    <ServerUpdateProgress
-                      fromVersion={primaryVersionMismatch.serverVersion}
-                      serverLabel={primaryEnvironment?.label ?? "this server"}
-                      state={primaryServerUpdateState}
-                    />
-                  )
+                  ) : null
                 }
                 control={
-                  primaryEnvironmentId !== null && primaryServerUpdateState.status !== "running" ? (
+                  primaryVersionMismatch &&
+                  primaryEnvironmentId !== null &&
+                  primaryServerUpdateState.status !== "running" ? (
                     <ServerUpdateAction
                       environmentId={primaryEnvironmentId}
                       serverLabel={primaryEnvironment?.label ?? "this server"}

--- a/docs/architecture/server-updates.md
+++ b/docs/architecture/server-updates.md
@@ -13,8 +13,9 @@ The feature has three boundaries:
 ## Detection and Presentation
 
 `ExecutionEnvironmentDescriptor` includes the server version and an optional
-`capabilities.serverSelfUpdate` value. The client compares that version with `APP_VERSION` after
-loading server config.
+`capabilities.serverSelfUpdate` value. Progress-capable servers also advertise
+`capabilities.serverSelfUpdateProgress`. The client compares the server version with `APP_VERSION`
+after loading server config.
 
 The optional capability is intentionally backward compatible. An older server does not know about
 the field, so a missing value means the client must offer a manual relaunch instead of sending an
@@ -27,6 +28,10 @@ The shared `ServerUpdateAction` is rendered in both user-facing version-drift su
 
 Both surfaces target the client's exact version. When the reconnected server reports that version,
 the mismatch and action disappear.
+
+The operation state lives in `packages/client-runtime`, keyed by environment. Both web surfaces read
+the same `downloading`, `installing`, or `resuming` state, so route changes do not own or cancel the
+operation.
 
 ## Capability Selection
 
@@ -51,20 +56,25 @@ flowchart TD
     A[Client detects different versions] --> B{Advertised update path}
     B -->|desktop-managed| C[Update desktop app on server machine]
     B -->|missing| D[Copy exact manual relaunch command]
-    B -->|boot-service or respawn| E[server.updateServer]
-    E --> F[Install exact t3 version in pinned runtime]
-    F --> G[Run version preflight]
-    G -->|fails| H[Remove failed runtime and keep current server]
-    G -->|passes| I{Handoff method}
-    I -->|boot-service| J[Rewrite and restart T3 systemd unit]
-    I -->|respawn| K[Start delayed replacement and exit current process]
-    J --> L[Client reconnects]
-    K --> L
+    B -->|boot-service or respawn| E{Progress capability}
+    E -->|present| F[server.updateServerWithProgress]
+    E -->|missing| G[server.updateServer fallback]
+    F --> H[Download exact t3 version]
+    G --> H
+    H --> I[Install and run version preflight]
+    I -->|fails| J[Remove failed runtime and keep current server]
+    I -->|passes| K{Handoff method}
+    K -->|boot-service| L[Rewrite and restart T3 systemd unit]
+    K -->|respawn| M[Start delayed replacement and exit current process]
+    L --> N[Reconnect with fresh backoff]
+    M --> N
+    N --> O[Replacement publishes ready at target version]
 ```
 
-`server.updateServer` requires the environment's `orchestration:operate` authorization scope. Its
+Both update RPCs require the environment's `orchestration:operate` authorization scope. Their
 payload accepts only an exact npm version, including an exact prerelease version; dist-tags such as
-`latest` and `nightly` are rejected.
+`latest` and `nightly` are rejected. The unary `server.updateServer` method remains available so a
+new client can still repair skew with an older server.
 
 The update service permits one update at a time. It installs `t3@<version>` under
 `<baseDir>/runtime/versions/<version>` and writes an install-complete sentinel only after npm exits
@@ -89,20 +99,20 @@ authorization; it does not uninstall the host service.
 ## Process Handoff
 
 For `boot-service`, the server atomically rewrites the T3-managed user unit to point at the verified
-runtime, reloads systemd, and restarts the unit. Reload and restart failures restore the previous
-unit before returning an error.
+runtime and reloads systemd. It acknowledges the handoff, then restarts the unit after the same
+short grace period used by foreground respawn. A rejected deferred restart restores the previous
+unit and is logged by the still-running process.
 
 For `respawn`, the server starts a detached, delayed replacement that replays the original CLI
 arguments. It then acknowledges the request and schedules the current process to exit. The delays
 give the acknowledgement time to cross direct or relayed connections before the socket closes.
 
-There is no separate progress stream. The update request remains pending while npm installs and the
-client shows a disabled update action. A restart can interrupt the request normally; the connection
-runtime keeps the environment registered and reconnects through its usual retry path. After an
-acknowledged foreground handoff, the UI keeps the action pending until version sync removes it or a
-safety timeout releases it. If a boot-service restart closes the connection before acknowledgement,
-the UI releases the interrupted action without reporting a false update failure and lets reconnect
-and the next version check determine the result.
+Progress-capable servers emit `downloading` before installing the pinned runtime and `installing`
+before preflight and handoff. A terminal stream event acknowledges that restart is scheduled. The
+client then enters `resuming`, waits for the replacement lifecycle stream to publish `ready` with
+the target version, and only then completes the operation. It watches for the intentional
+disconnect's first backoff state and requests one fresh retry, which clears historical backoff debt
+without adding a separate reconnect loop.
 
 ## Release Invariant
 

--- a/docs/user/server-updates.md
+++ b/docs/user/server-updates.md
@@ -31,6 +31,11 @@ The update does not remove saved threads, settings, or project files.
 The available action depends on how that server was started. T3 Code does not update connected
 servers silently in the background.
 
+After selecting **Update server**, the warning becomes a three-step progress rail:
+**Download**, **Install**, and **Resume**. The same progress appears in the conversation and in
+Connections, so navigating between them does not lose the update. A failed step remains visible
+with its error and an option to retry.
+
 If the server uses the T3 Code background service, you can also update it directly on the host:
 
 ```sh
@@ -42,11 +47,11 @@ commands.
 
 ## After the Update
 
-Keep the web or desktop app open while the server restarts. When it reconnects with the matching
-version, the warning and update action disappear.
+Keep the web or desktop app open while the server restarts. The update completes only after the
+replacement server reports the requested version and is ready to accept commands. The warning and
+progress rail then disappear.
 
-If the client reports a timeout, the server may still be finishing the update. Wait a minute, then
-reconnect or open **Settings** → **Connections** again. If the warning remains:
+If a step fails:
 
 1. Retry the offered action once.
 2. Make sure you updated the machine named in the warning, not only the device you are using.

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -481,6 +481,43 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
+  it.effect("explicit retry starts a fresh backoff sequence", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        prepare: () => Effect.fail(transient()),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      yield* TestClock.adjust("1 second");
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 2,
+      );
+
+      yield* supervisor.retryNow;
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      expect(yield* Ref.get(harness.prepareCount)).toBe(3);
+
+      yield* TestClock.adjust("999 millis");
+      expect(yield* Ref.get(harness.prepareCount)).toBe(3);
+      yield* TestClock.adjust("1 milli");
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 2,
+      );
+      expect(yield* Ref.get(harness.prepareCount)).toBe(4);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
   it.effect("keeps blocked failures idle until an external signal requests another attempt", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -229,6 +229,7 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
   };
   const intent = yield* Ref.make(initialIntent);
   const signals = yield* Queue.unbounded<SupervisorSignal>();
+  const resetRetryState = yield* Ref.make(false);
   const state = yield* SubscriptionRef.make<SupervisorConnectionState>(
     !initialIntent.desired
       ? availableState(initialIntent, 0)
@@ -591,6 +592,11 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
     let pendingRetry = Option.none<PendingRetryTrace>();
 
     for (;;) {
+      if (yield* Ref.getAndSet(resetRetryState, false)) {
+        failureCount = 0;
+        latestFailure = null;
+        pendingRetry = Option.none();
+      }
       const currentIntent = yield* Ref.get(intent);
       if (!currentIntent.desired) {
         failureCount = 0;
@@ -701,7 +707,8 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
     Effect.withSpan("EnvironmentSupervisor.disconnect"),
   );
 
-  const retryNow = signal({ _tag: "RetryRequested" }).pipe(
+  const retryNow = Ref.set(resetRetryState, true).pipe(
+    Effect.andThen(signal({ _tag: "RetryRequested" })),
     Effect.withSpan("EnvironmentSupervisor.retryNow"),
   );
 

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -56,6 +56,7 @@ export type EnvironmentSubscriptionRpcTag =
 
 export type EnvironmentStreamCommandRpcTag =
   | typeof WS_METHODS.cloudInstallRelayClient
+  | typeof WS_METHODS.serverUpdateServerWithProgress
   | typeof WS_METHODS.gitRunStackedAction;
 
 export type EnvironmentStreamRpcTag =
@@ -80,7 +81,7 @@ export class EnvironmentRpcSubscriptionObserver extends Context.Reference<{
   }),
 }) {}
 
-const isRpcClientError = Schema.is(RpcClientError.RpcClientError);
+export const isRpcClientError = Schema.is(RpcClientError.RpcClientError);
 
 export type EnvironmentRpcInput<TTag extends EnvironmentRpcTag> = Parameters<RpcMethod<TTag>>[0];
 

--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -13,6 +13,7 @@ import {
   environmentRpcKey,
   createAtomCommandScheduler,
   createRuntimeCommand,
+  scheduleAtomCommandEffect,
   executeAtomCommand,
   executeAtomQuery,
   isAtomCommandInterrupted,
@@ -398,6 +399,54 @@ describe("runtime command runner", () => {
     expect(events).toEqual(["first:start", "first:end", "second:start"]);
     registry.dispose();
   });
+
+  it.effect("releases a shared scheduler lane before the outer command finishes", () =>
+    Effect.gen(function* () {
+      const handoffStarted = Latch.makeUnsafe();
+      const handoffComplete = Latch.makeUnsafe();
+      const resumeComplete = Latch.makeUnsafe();
+      const runtime = Atom.runtime(Layer.empty);
+      const scheduler = createAtomCommandScheduler();
+      const concurrency = { mode: "serial" as const, key: () => "shared" };
+      const updateCommand = createRuntimeCommand(runtime, {
+        label: "test.update",
+        execute: (_input: void, registry) =>
+          scheduleAtomCommandEffect(
+            registry,
+            scheduler,
+            concurrency,
+            undefined,
+            Effect.sync(() => handoffStarted.openUnsafe()).pipe(
+              Effect.andThen(handoffComplete.await),
+            ),
+          ).pipe(Effect.andThen(resumeComplete.await)),
+      });
+      const configCommand = createRuntimeCommand(runtime, {
+        label: "test.config",
+        scheduler,
+        concurrency,
+        execute: () => Effect.succeed("configured"),
+      });
+      const registry = AtomRegistry.make();
+
+      const update = updateCommand.run(registry, undefined);
+      yield* handoffStarted.await;
+      const config = configCommand.run(registry, undefined);
+      handoffComplete.openUnsafe();
+
+      expect(yield* Effect.promise(() => config)).toMatchObject({
+        _tag: "Success",
+        value: "configured",
+        waiting: false,
+      });
+      resumeComplete.openUnsafe();
+      expect(yield* Effect.promise(() => update)).toMatchObject({
+        _tag: "Success",
+        waiting: false,
+      });
+      registry.dispose();
+    }),
+  );
 
   it("deduplicates single-flight commands by key", async () => {
     const latch = Latch.makeUnsafe();

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -253,6 +253,28 @@ export function createAtomCommandScheduler(): AtomCommandScheduler {
   };
 }
 
+/** Runs one effect inside an existing command scheduler lane. */
+export function scheduleAtomCommandEffect<W, A, E, R>(
+  registry: AtomRegistry.AtomRegistry,
+  scheduler: AtomCommandScheduler,
+  concurrency: AtomCommandConcurrency<W>,
+  input: W,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  return Effect.gen(function* () {
+    const context = yield* Effect.context<R>();
+    const result = yield* Effect.promise((signal) =>
+      scheduler.schedule<W, A, E>(registry, concurrency, input, async () => {
+        const exit = await Effect.runPromiseExitWith(context)(effect, { signal });
+        return Exit.isSuccess(exit)
+          ? AsyncResult.success(exit.value)
+          : AsyncResult.failure(exit.cause);
+      }),
+    );
+    return result._tag === "Success" ? result.value : yield* Effect.failCause(result.cause);
+  });
+}
+
 export async function runAtomCommand<W, A, E>(
   registry: AtomRegistry.AtomRegistry,
   command: AtomCommand<W, A, E>,

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -211,9 +211,16 @@ describe("server state projection", () => {
   });
 
   it("prefers an active session config over cache until a live event arrives", () => {
-    const cached = { ...CONFIG, settings: { source: "cache" } } as unknown as ServerConfig;
-    const initial = { ...CONFIG, settings: { source: "session" } } as unknown as ServerConfig;
-    const live = { ...CONFIG, settings: { source: "live" } } as unknown as ServerConfig;
+    const config = (source: string, serverVersion: string) =>
+      ({
+        ...CONFIG,
+        environment: { serverVersion },
+        settings: { source },
+      }) as unknown as ServerConfig;
+    const cached = config("cache", "0.0.29");
+    const staleLive = config("stale-live", "0.0.29");
+    const initial = config("session", "0.0.30");
+    const live = config("live", "0.0.30");
 
     expect(
       resolveServerConfigValue(
@@ -221,6 +228,16 @@ describe("server state projection", () => {
           config: cached,
           latestEvent: snapshotEvent(cached),
           source: "cache",
+        },
+        initial,
+      ),
+    ).toBe(initial);
+    expect(
+      resolveServerConfigValue(
+        {
+          config: staleLive,
+          latestEvent: snapshotEvent(staleLive),
+          source: "live",
         },
         initial,
       ),

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -29,6 +29,7 @@ import {
   isLegacyUpdateHandoffLoss,
   projectServerWelcome,
   resolveServerConfigValue,
+  resolveServerUpdateProgressResult,
   serverUpdateStateForProgressEvent,
 } from "./server.ts";
 
@@ -81,6 +82,29 @@ describe("server state projection", () => {
       ),
     ).toBe(true);
     expect(isLegacyUpdateHandoffLoss(Cause.fail(new Error("Install failed.")))).toBe(false);
+  });
+
+  it("resumes after the progress stream disconnects following completion", () => {
+    const result = {
+      targetVersion: "0.0.31",
+      method: "respawn" as const,
+    };
+    const disconnect = new RpcClientError.RpcClientError({
+      reason: new RpcClientError.RpcClientDefect({
+        message: "socket closed",
+        cause: new Error("socket closed"),
+      }),
+    });
+
+    expect(
+      Effect.runSync(
+        resolveServerUpdateProgressResult(
+          result.targetVersion,
+          Option.some(result),
+          Effect.runSyncExit(Effect.fail(disconnect)),
+        ),
+      ),
+    ).toEqual(result);
   });
 
   it("projects streamed update milestones into the shared operation state", () => {

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -14,6 +14,7 @@ import * as Queue from "effect/Queue";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import { RpcClientError } from "effect/unstable/rpc";
+import * as Socket from "effect/unstable/socket/Socket";
 
 import {
   AVAILABLE_CONNECTION_STATE,
@@ -32,6 +33,7 @@ import {
   resolveServerConfigValue,
   resolveServerUpdateProgressResult,
   serverUpdateStateForProgressEvent,
+  serverUpdateStateForServerVersion,
 } from "./server.ts";
 
 const CONFIG = {
@@ -74,14 +76,23 @@ describe("server state projection", () => {
       isLegacyUpdateHandoffLoss(
         Cause.fail(
           new RpcClientError.RpcClientError({
-            reason: new RpcClientError.RpcClientDefect({
-              message: "socket closed",
-              cause: new Error("socket closed"),
-            }),
+            reason: new Socket.SocketCloseError({ code: 1006 }),
           }),
         ),
       ),
     ).toBe(true);
+    expect(
+      isLegacyUpdateHandoffLoss(
+        Cause.fail(
+          new RpcClientError.RpcClientError({
+            reason: new RpcClientError.RpcClientDefect({
+              message: "incompatible protocol",
+              cause: new Error("invalid response"),
+            }),
+          }),
+        ),
+      ),
+    ).toBe(false);
     expect(isLegacyUpdateHandoffLoss(Cause.fail(new Error("Install failed.")))).toBe(false);
   });
 
@@ -91,10 +102,7 @@ describe("server state projection", () => {
       method: "respawn" as const,
     };
     const disconnect = new RpcClientError.RpcClientError({
-      reason: new RpcClientError.RpcClientDefect({
-        message: "socket closed",
-        cause: new Error("socket closed"),
-      }),
+      reason: new Socket.SocketCloseError({ code: 1006 }),
     });
 
     return Effect.gen(function* () {
@@ -109,25 +117,41 @@ describe("server state projection", () => {
 
   it("projects streamed update milestones into the shared operation state", () => {
     expect(
-      serverUpdateStateForProgressEvent("0.0.31", {
+      serverUpdateStateForProgressEvent("0.0.30", "0.0.31", {
         type: "progress",
         stage: "installing",
       }),
     ).toEqual({
       status: "running",
       stage: "installing",
+      fromVersion: "0.0.30",
       targetVersion: "0.0.31",
     });
     expect(
-      serverUpdateStateForProgressEvent("0.0.31", {
+      serverUpdateStateForProgressEvent("0.0.30", "0.0.31", {
         type: "complete",
         result: { targetVersion: "0.0.31", method: "respawn" },
       }),
     ).toEqual({
       status: "running",
       stage: "resuming",
+      fromVersion: "0.0.30",
       targetVersion: "0.0.31",
     });
+  });
+
+  it("hides update state after the server version changes outside the operation", () => {
+    const failed = {
+      status: "failed" as const,
+      stage: "installing" as const,
+      fromVersion: "0.0.30",
+      targetVersion: "0.0.31",
+      message: "Install failed.",
+    };
+
+    expect(serverUpdateStateForServerVersion(failed, "0.0.30")).toBe(failed);
+    expect(serverUpdateStateForServerVersion(failed, null)).toBe(failed);
+    expect(serverUpdateStateForServerVersion(failed, "0.0.31")).toEqual({ status: "idle" });
   });
 
   it("applies every config category to the projected snapshot", () => {

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -85,6 +85,18 @@ describe("server state projection", () => {
       isLegacyUpdateHandoffLoss(
         Cause.fail(
           new RpcClientError.RpcClientError({
+            reason: new Socket.SocketOpenError({
+              kind: "Unknown",
+              cause: new Error("connection refused"),
+            }),
+          }),
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      isLegacyUpdateHandoffLoss(
+        Cause.fail(
+          new RpcClientError.RpcClientError({
             reason: new RpcClientError.RpcClientDefect({
               message: "incompatible protocol",
               cause: new Error("invalid response"),

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -6,11 +6,13 @@ import {
   WS_METHODS,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
+import { RpcClientError } from "effect/unstable/rpc";
 
 import {
   AVAILABLE_CONNECTION_STATE,
@@ -24,8 +26,10 @@ import type { RpcSession } from "../rpc/session.ts";
 import {
   applyServerConfigProjection,
   makeEnvironmentServerConfigState,
+  isLegacyUpdateHandoffLoss,
   projectServerWelcome,
   resolveServerConfigValue,
+  serverUpdateStateForProgressEvent,
 } from "./server.ts";
 
 const CONFIG = {
@@ -62,6 +66,46 @@ function session(client: WsRpcProtocolClient): RpcSession {
 }
 
 describe("server state projection", () => {
+  it("only treats a legacy transport interruption as an unacknowledged handoff", () => {
+    expect(isLegacyUpdateHandoffLoss(Cause.interrupt(1))).toBe(true);
+    expect(
+      isLegacyUpdateHandoffLoss(
+        Cause.fail(
+          new RpcClientError.RpcClientError({
+            reason: new RpcClientError.RpcClientDefect({
+              message: "socket closed",
+              cause: new Error("socket closed"),
+            }),
+          }),
+        ),
+      ),
+    ).toBe(true);
+    expect(isLegacyUpdateHandoffLoss(Cause.fail(new Error("Install failed.")))).toBe(false);
+  });
+
+  it("projects streamed update milestones into the shared operation state", () => {
+    expect(
+      serverUpdateStateForProgressEvent("0.0.31", {
+        type: "progress",
+        stage: "installing",
+      }),
+    ).toEqual({
+      status: "running",
+      stage: "installing",
+      targetVersion: "0.0.31",
+    });
+    expect(
+      serverUpdateStateForProgressEvent("0.0.31", {
+        type: "complete",
+        result: { targetVersion: "0.0.31", method: "respawn" },
+      }),
+    ).toEqual({
+      status: "running",
+      stage: "resuming",
+      targetVersion: "0.0.31",
+    });
+  });
+
   it("applies every config category to the projected snapshot", () => {
     const snapshot = applyServerConfigProjection(Option.none(), {
       version: 1,

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -8,6 +8,7 @@ import {
 import { describe, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Stream from "effect/Stream";
@@ -84,7 +85,7 @@ describe("server state projection", () => {
     expect(isLegacyUpdateHandoffLoss(Cause.fail(new Error("Install failed.")))).toBe(false);
   });
 
-  it("resumes after the progress stream disconnects following completion", () => {
+  it.effect("resumes after the progress stream disconnects following completion", () => {
     const result = {
       targetVersion: "0.0.31",
       method: "respawn" as const,
@@ -96,15 +97,14 @@ describe("server state projection", () => {
       }),
     });
 
-    expect(
-      Effect.runSync(
-        resolveServerUpdateProgressResult(
-          result.targetVersion,
-          Option.some(result),
-          Effect.runSyncExit(Effect.fail(disconnect)),
-        ),
-      ),
-    ).toEqual(result);
+    return Effect.gen(function* () {
+      const resumed = yield* resolveServerUpdateProgressResult(
+        result.targetVersion,
+        Option.some(result),
+        Exit.fail(disconnect),
+      );
+      expect(resumed).toEqual(result);
+    });
   });
 
   it("projects streamed update milestones into the shared operation state", () => {

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -152,7 +152,13 @@ describe("server state projection", () => {
     });
   });
 
-  it("hides update state after the server version changes outside the operation", () => {
+  it("keeps active update state and hides stale failures after a version change", () => {
+    const running = {
+      status: "running" as const,
+      stage: "resuming" as const,
+      fromVersion: "0.0.30",
+      targetVersion: "0.0.31",
+    };
     const failed = {
       status: "failed" as const,
       stage: "installing" as const,
@@ -161,6 +167,7 @@ describe("server state projection", () => {
       message: "Install failed.",
     };
 
+    expect(serverUpdateStateForServerVersion(running, "0.0.31")).toBe(running);
     expect(serverUpdateStateForServerVersion(failed, "0.0.30")).toBe(failed);
     expect(serverUpdateStateForServerVersion(failed, null)).toBe(failed);
     expect(serverUpdateStateForServerVersion(failed, "0.0.31")).toEqual({ status: "idle" });

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -129,7 +129,6 @@ function isRpcSocketError(error: unknown): boolean {
   switch (error.reason._tag) {
     case "SocketReadError":
     case "SocketWriteError":
-    case "SocketOpenError":
     case "SocketCloseError":
       return true;
     default:

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -365,7 +365,13 @@ export function resolveServerConfigValue(
   projection: ServerConfigProjection | null,
   initialConfig: ServerConfig | null,
 ): ServerConfig | null {
-  if (projection?.source === "live") return projection.config;
+  if (
+    projection?.source === "live" &&
+    (initialConfig === null ||
+      projection.config.environment.serverVersion === initialConfig.environment.serverVersion)
+  ) {
+    return projection.config;
+  }
   return initialConfig ?? projection?.config ?? null;
 }
 

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -119,6 +119,23 @@ export function isLegacyUpdateHandoffLoss(cause: Cause.Cause<unknown>): boolean 
   );
 }
 
+export function resolveServerUpdateProgressResult<E>(
+  targetVersion: string,
+  terminal: Option.Option<ServerSelfUpdateResult>,
+  streamExit: Exit.Exit<void, E>,
+): Effect.Effect<ServerSelfUpdateResult, E | ServerUpdateProgressIncompleteError> {
+  if (
+    Option.isSome(terminal) &&
+    (Exit.isSuccess(streamExit) || isLegacyUpdateHandoffLoss(streamExit.cause))
+  ) {
+    return Effect.succeed(terminal.value);
+  }
+  if (Exit.isFailure(streamExit)) {
+    return Effect.failCause(streamExit.cause);
+  }
+  return Effect.fail(new ServerUpdateProgressIncompleteError({ targetVersion }));
+}
+
 export interface ServerConfigProjection {
   readonly config: ServerConfig;
   readonly latestEvent: ServerConfigStreamEvent;
@@ -398,7 +415,7 @@ export function createServerEnvironmentAtoms<R, E>(
               const terminal = yield* Ref.make<Option.Option<ServerSelfUpdateResult>>(
                 Option.none(),
               );
-              yield* environmentRegistry
+              const streamExit = yield* environmentRegistry
                 .runStream(
                   target.environmentId,
                   runStream(WS_METHODS.serverUpdateServerWithProgress, target.input),
@@ -419,15 +436,12 @@ export function createServerEnvironmentAtoms<R, E>(
                       ),
                     ),
                   ),
+                  Effect.exit,
                 );
-              return yield* Ref.get(terminal).pipe(
-                Effect.flatMap(
-                  Option.match({
-                    onNone: () =>
-                      Effect.fail(new ServerUpdateProgressIncompleteError({ targetVersion })),
-                    onSome: Effect.succeed,
-                  }),
-                ),
+              return yield* resolveServerUpdateProgressResult(
+                targetVersion,
+                yield* Ref.get(terminal),
+                streamExit,
               );
             })
           : yield* Effect.gen(function* () {

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -26,6 +26,7 @@ import {
   createEnvironmentRpcQueryAtomFamily,
   createEnvironmentRpcSubscriptionAtomFamily,
   createRuntimeCommand,
+  scheduleAtomCommandEffect,
 } from "./runtime.ts";
 import { EnvironmentRegistry } from "../connection/registry.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
@@ -374,6 +375,8 @@ export function createServerEnvironmentAtoms<R, E>(
   },
 ) {
   const configScheduler = createAtomCommandScheduler();
+  // Updates stay serial end-to-end, but only their handoff phase occupies the config lane.
+  const updateScheduler = createAtomCommandScheduler();
   const configConcurrency = {
     mode: "serial" as const,
     key: ({ environmentId }: { readonly environmentId: string }) => environmentId,
@@ -425,87 +428,97 @@ export function createServerEnvironmentAtoms<R, E>(
     unknown
   >(runtime, {
     label: "environment-data:server:update-server",
-    scheduler: configScheduler,
+    scheduler: updateScheduler,
     concurrency: configConcurrency,
     execute: (target, atomRegistry) => {
       const stateAtom = serverUpdateStateAtom(target.environmentId);
       const targetVersion = target.input.targetVersion;
-      const currentConfig = atomRegistry.get(configValueAtom(target.environmentId));
-      const fromVersion = currentConfig?.environment.serverVersion ?? targetVersion;
+      let fromVersion = targetVersion;
       let currentStage: ServerUpdateStage = "downloading";
-      atomRegistry.set(stateAtom, {
-        status: "running",
-        stage: currentStage,
-        fromVersion,
-        targetVersion,
-      });
 
       return Effect.gen(function* () {
         const environmentRegistry = yield* EnvironmentRegistry;
-        const supportsProgress =
-          currentConfig?.environment.capabilities.serverSelfUpdateProgress === true;
-
-        const result: ServerSelfUpdateResult = supportsProgress
-          ? yield* Effect.gen(function* () {
-              const terminal = yield* Ref.make<Option.Option<ServerSelfUpdateResult>>(
-                Option.none(),
-              );
-              const streamExit = yield* environmentRegistry
-                .runStream(
-                  target.environmentId,
-                  runStream(WS_METHODS.serverUpdateServerWithProgress, target.input),
-                )
-                .pipe(
-                  Stream.runForEach((event) =>
-                    Effect.sync(() => {
-                      currentStage = event.type === "complete" ? "resuming" : event.stage;
-                      atomRegistry.set(
-                        stateAtom,
-                        serverUpdateStateForProgressEvent(fromVersion, targetVersion, event),
-                      );
-                    }).pipe(
-                      Effect.andThen(
-                        event.type === "complete"
-                          ? Ref.set(terminal, Option.some(event.result))
-                          : Effect.void,
-                      ),
-                    ),
-                  ),
-                  Effect.exit,
-                );
-              return yield* resolveServerUpdateProgressResult(
-                targetVersion,
-                yield* Ref.get(terminal),
-                streamExit,
-              );
-            })
-          : yield* Effect.gen(function* () {
-              const selfUpdateMethod = currentConfig?.environment.capabilities.serverSelfUpdate;
-              const exit = yield* environmentRegistry
-                .run(target.environmentId, request(WS_METHODS.serverUpdateServer, target.input))
-                .pipe(Effect.exit);
-              if (Exit.isSuccess(exit)) {
-                return exit.value;
-              }
-              if (
-                (selfUpdateMethod === "boot-service" || selfUpdateMethod === "respawn") &&
-                isLegacyUpdateHandoffLoss(exit.cause)
-              ) {
-                // Older servers can tear down the transport before their
-                // unary acknowledgement arrives. Treat only that transport
-                // loss as a handoff, then prove it by waiting for target ready.
-                return { targetVersion, method: selfUpdateMethod };
-              }
-              return yield* Effect.failCause(exit.cause);
+        const result = yield* scheduleAtomCommandEffect(
+          atomRegistry,
+          configScheduler,
+          configConcurrency,
+          target,
+          Effect.gen(function* () {
+            const currentConfig = atomRegistry.get(configValueAtom(target.environmentId));
+            fromVersion = currentConfig?.environment.serverVersion ?? targetVersion;
+            atomRegistry.set(stateAtom, {
+              status: "running",
+              stage: currentStage,
+              fromVersion,
+              targetVersion,
             });
 
-        currentStage = "resuming";
-        atomRegistry.set(stateAtom, {
-          status: "running",
-          stage: currentStage,
-          fromVersion,
-          targetVersion,
-        });
+            const supportsProgress =
+              currentConfig?.environment.capabilities.serverSelfUpdateProgress === true;
+            const updateResult: ServerSelfUpdateResult = supportsProgress
+              ? yield* Effect.gen(function* () {
+                  const terminal = yield* Ref.make<Option.Option<ServerSelfUpdateResult>>(
+                    Option.none(),
+                  );
+                  const streamExit = yield* environmentRegistry
+                    .runStream(
+                      target.environmentId,
+                      runStream(WS_METHODS.serverUpdateServerWithProgress, target.input),
+                    )
+                    .pipe(
+                      Stream.runForEach((event) =>
+                        Effect.sync(() => {
+                          currentStage = event.type === "complete" ? "resuming" : event.stage;
+                          atomRegistry.set(
+                            stateAtom,
+                            serverUpdateStateForProgressEvent(fromVersion, targetVersion, event),
+                          );
+                        }).pipe(
+                          Effect.andThen(
+                            event.type === "complete"
+                              ? Ref.set(terminal, Option.some(event.result))
+                              : Effect.void,
+                          ),
+                        ),
+                      ),
+                      Effect.exit,
+                    );
+                  return yield* resolveServerUpdateProgressResult(
+                    targetVersion,
+                    yield* Ref.get(terminal),
+                    streamExit,
+                  );
+                })
+              : yield* Effect.gen(function* () {
+                  const selfUpdateMethod = currentConfig?.environment.capabilities.serverSelfUpdate;
+                  const exit = yield* environmentRegistry
+                    .run(target.environmentId, request(WS_METHODS.serverUpdateServer, target.input))
+                    .pipe(Effect.exit);
+                  if (Exit.isSuccess(exit)) {
+                    return exit.value;
+                  }
+                  if (
+                    (selfUpdateMethod === "boot-service" || selfUpdateMethod === "respawn") &&
+                    isLegacyUpdateHandoffLoss(exit.cause)
+                  ) {
+                    // Older servers can tear down the transport before their
+                    // unary acknowledgement arrives. Treat only that transport
+                    // loss as a handoff, then prove it by waiting for target ready.
+                    return { targetVersion, method: selfUpdateMethod };
+                  }
+                  return yield* Effect.failCause(exit.cause);
+                });
+
+            currentStage = "resuming";
+            atomRegistry.set(stateAtom, {
+              status: "running",
+              stage: currentStage,
+              fromVersion,
+              targetVersion,
+            });
+            return updateResult;
+          }),
+        );
 
         // The update restart is intentional. As soon as the supervisor sees
         // that first failed connection, discard any prior backoff debt and

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -47,11 +47,13 @@ export type ServerUpdateState =
   | {
       readonly status: "running";
       readonly stage: ServerUpdateStage;
+      readonly fromVersion: string;
       readonly targetVersion: string;
     }
   | {
       readonly status: "failed";
       readonly stage: ServerUpdateStage;
+      readonly fromVersion: string;
       readonly targetVersion: string;
       readonly message: string;
     };
@@ -95,18 +97,44 @@ export class ServerUpdateProgressIncompleteError extends Schema.TaggedErrorClass
 }
 
 export function serverUpdateStateForProgressEvent(
+  fromVersion: string,
   targetVersion: string,
   event: ServerSelfUpdateProgressEvent,
 ): Extract<ServerUpdateState, { status: "running" }> {
   return {
     status: "running",
     stage: event.type === "complete" ? "resuming" : event.stage,
+    fromVersion,
     targetVersion,
   };
 }
 
+export function serverUpdateStateForServerVersion(
+  state: ServerUpdateState,
+  serverVersion: string | null,
+): ServerUpdateState {
+  return state.status === "idle" || serverVersion === null || state.fromVersion === serverVersion
+    ? state
+    : IDLE_SERVER_UPDATE_STATE;
+}
+
 function serverUpdateFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Server update failed.";
+}
+
+function isRpcSocketError(error: unknown): boolean {
+  if (!isRpcClientError(error)) {
+    return false;
+  }
+  switch (error.reason._tag) {
+    case "SocketReadError":
+    case "SocketWriteError":
+    case "SocketOpenError":
+    case "SocketCloseError":
+      return true;
+    default:
+      return false;
+  }
 }
 
 export function isLegacyUpdateHandoffLoss(cause: Cause.Cause<unknown>): boolean {
@@ -115,7 +143,7 @@ export function isLegacyUpdateHandoffLoss(cause: Cause.Cause<unknown>): boolean 
   }
   return (
     cause.reasons.length > 0 &&
-    cause.reasons.every((reason) => Cause.isFailReason(reason) && isRpcClientError(reason.error))
+    cause.reasons.every((reason) => Cause.isFailReason(reason) && isRpcSocketError(reason.error))
   );
 }
 
@@ -380,8 +408,16 @@ export function createServerEnvironmentAtoms<R, E>(
       );
     }).pipe(Atom.withLabel(`environment-data:server:config:${environmentId}`));
   });
+  const updateStateValueAtom = Atom.family((environmentId: EnvironmentId) =>
+    Atom.make((get) =>
+      serverUpdateStateForServerVersion(
+        get(serverUpdateStateAtom(environmentId)),
+        get(configValueAtom(environmentId))?.environment.serverVersion ?? null,
+      ),
+    ).pipe(Atom.withLabel(`environment-data:server:update-state-value:${environmentId}`)),
+  );
   const updateStateAtom = (environmentId: EnvironmentId | null) =>
-    environmentId === null ? EMPTY_SERVER_UPDATE_STATE_ATOM : serverUpdateStateAtom(environmentId);
+    environmentId === null ? EMPTY_SERVER_UPDATE_STATE_ATOM : updateStateValueAtom(environmentId);
   const updateServer = createRuntimeCommand<
     EnvironmentRegistry | EnvironmentCacheStore | R,
     E,
@@ -390,25 +426,25 @@ export function createServerEnvironmentAtoms<R, E>(
     unknown
   >(runtime, {
     label: "environment-data:server:update-server",
-    concurrency: {
-      mode: "singleFlight",
-      key: ({ environmentId }) => environmentId,
-    },
+    scheduler: configScheduler,
+    concurrency: configConcurrency,
     execute: (target, atomRegistry) => {
-      const stateAtom = updateStateAtom(target.environmentId);
+      const stateAtom = serverUpdateStateAtom(target.environmentId);
       const targetVersion = target.input.targetVersion;
+      const currentConfig = atomRegistry.get(configValueAtom(target.environmentId));
+      const fromVersion = currentConfig?.environment.serverVersion ?? targetVersion;
       let currentStage: ServerUpdateStage = "downloading";
       atomRegistry.set(stateAtom, {
         status: "running",
         stage: currentStage,
+        fromVersion,
         targetVersion,
       });
 
       return Effect.gen(function* () {
         const environmentRegistry = yield* EnvironmentRegistry;
         const supportsProgress =
-          atomRegistry.get(configValueAtom(target.environmentId))?.environment.capabilities
-            .serverSelfUpdateProgress === true;
+          currentConfig?.environment.capabilities.serverSelfUpdateProgress === true;
 
         const result: ServerSelfUpdateResult = supportsProgress
           ? yield* Effect.gen(function* () {
@@ -426,7 +462,7 @@ export function createServerEnvironmentAtoms<R, E>(
                       currentStage = event.type === "complete" ? "resuming" : event.stage;
                       atomRegistry.set(
                         stateAtom,
-                        serverUpdateStateForProgressEvent(targetVersion, event),
+                        serverUpdateStateForProgressEvent(fromVersion, targetVersion, event),
                       );
                     }).pipe(
                       Effect.andThen(
@@ -445,8 +481,7 @@ export function createServerEnvironmentAtoms<R, E>(
               );
             })
           : yield* Effect.gen(function* () {
-              const selfUpdateMethod = atomRegistry.get(configValueAtom(target.environmentId))
-                ?.environment.capabilities.serverSelfUpdate;
+              const selfUpdateMethod = currentConfig?.environment.capabilities.serverSelfUpdate;
               const exit = yield* environmentRegistry
                 .run(target.environmentId, request(WS_METHODS.serverUpdateServer, target.input))
                 .pipe(Effect.exit);
@@ -469,6 +504,7 @@ export function createServerEnvironmentAtoms<R, E>(
         atomRegistry.set(stateAtom, {
           status: "running",
           stage: currentStage,
+          fromVersion,
           targetVersion,
         });
 
@@ -518,6 +554,7 @@ export function createServerEnvironmentAtoms<R, E>(
             atomRegistry.set(stateAtom, {
               status: "failed",
               stage: currentStage,
+              fromVersion,
               targetVersion,
               message: serverUpdateFailureMessage(Cause.squash(exit.cause)),
             });

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -3,13 +3,19 @@ import {
   type ServerConfig,
   type ServerConfigStreamEvent,
   type ServerLifecycleWelcomePayload,
+  type ServerSelfUpdateProgressEvent,
+  type ServerSelfUpdateResult,
   WS_METHODS,
 } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
@@ -19,13 +25,99 @@ import {
   createEnvironmentRpcCommand,
   createEnvironmentRpcQueryAtomFamily,
   createEnvironmentRpcSubscriptionAtomFamily,
+  createRuntimeCommand,
 } from "./runtime.ts";
-import type { EnvironmentRegistry } from "../connection/registry.ts";
+import { EnvironmentRegistry } from "../connection/registry.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
 import { safeErrorLogAttributes } from "../errors/safeLog.ts";
 import { EnvironmentCacheStore } from "../platform/persistence.ts";
-import { subscribe, type EnvironmentRpcInput } from "../rpc/client.ts";
+import {
+  isRpcClientError,
+  request,
+  runStream,
+  subscribe,
+  type EnvironmentRpcInput,
+} from "../rpc/client.ts";
 import { followStreamInEnvironment } from "./runtime.ts";
+
+export type ServerUpdateStage = "downloading" | "installing" | "resuming";
+
+export type ServerUpdateState =
+  | { readonly status: "idle" }
+  | {
+      readonly status: "running";
+      readonly stage: ServerUpdateStage;
+      readonly targetVersion: string;
+    }
+  | {
+      readonly status: "failed";
+      readonly stage: ServerUpdateStage;
+      readonly targetVersion: string;
+      readonly message: string;
+    };
+
+export interface ServerUpdateTarget {
+  readonly environmentId: EnvironmentId;
+  readonly input: EnvironmentRpcInput<typeof WS_METHODS.serverUpdateServer>;
+}
+
+const IDLE_SERVER_UPDATE_STATE: ServerUpdateState = { status: "idle" };
+const EMPTY_SERVER_UPDATE_STATE_ATOM = Atom.make<ServerUpdateState>(IDLE_SERVER_UPDATE_STATE).pipe(
+  Atom.withLabel("environment-data:server:update-state:empty"),
+);
+const serverUpdateStateAtom = Atom.family((environmentId: EnvironmentId) =>
+  Atom.make<ServerUpdateState>(IDLE_SERVER_UPDATE_STATE).pipe(
+    Atom.withLabel(`environment-data:server:update-state:${environmentId}`),
+  ),
+);
+
+export class ServerUpdateResumeTimeoutError extends Schema.TaggedErrorClass<ServerUpdateResumeTimeoutError>()(
+  "ServerUpdateResumeTimeoutError",
+  {
+    environmentId: Schema.String,
+    targetVersion: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `The server did not resume on t3@${this.targetVersion}.`;
+  }
+}
+
+export class ServerUpdateProgressIncompleteError extends Schema.TaggedErrorClass<ServerUpdateProgressIncompleteError>()(
+  "ServerUpdateProgressIncompleteError",
+  {
+    targetVersion: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `The t3@${this.targetVersion} update ended before the server accepted the restart.`;
+  }
+}
+
+export function serverUpdateStateForProgressEvent(
+  targetVersion: string,
+  event: ServerSelfUpdateProgressEvent,
+): Extract<ServerUpdateState, { status: "running" }> {
+  return {
+    status: "running",
+    stage: event.type === "complete" ? "resuming" : event.stage,
+    targetVersion,
+  };
+}
+
+function serverUpdateFailureMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Server update failed.";
+}
+
+export function isLegacyUpdateHandoffLoss(cause: Cause.Cause<unknown>): boolean {
+  if (Cause.hasInterruptsOnly(cause)) {
+    return true;
+  }
+  return (
+    cause.reasons.length > 0 &&
+    cause.reasons.every((reason) => Cause.isFailReason(reason) && isRpcClientError(reason.error))
+  );
+}
 
 export interface ServerConfigProjection {
   readonly config: ServerConfig;
@@ -271,6 +363,148 @@ export function createServerEnvironmentAtoms<R, E>(
       );
     }).pipe(Atom.withLabel(`environment-data:server:config:${environmentId}`));
   });
+  const updateStateAtom = (environmentId: EnvironmentId | null) =>
+    environmentId === null ? EMPTY_SERVER_UPDATE_STATE_ATOM : serverUpdateStateAtom(environmentId);
+  const updateServer = createRuntimeCommand<
+    EnvironmentRegistry | EnvironmentCacheStore | R,
+    E,
+    ServerUpdateTarget,
+    ServerSelfUpdateResult,
+    unknown
+  >(runtime, {
+    label: "environment-data:server:update-server",
+    concurrency: {
+      mode: "singleFlight",
+      key: ({ environmentId }) => environmentId,
+    },
+    execute: (target, atomRegistry) => {
+      const stateAtom = updateStateAtom(target.environmentId);
+      const targetVersion = target.input.targetVersion;
+      let currentStage: ServerUpdateStage = "downloading";
+      atomRegistry.set(stateAtom, {
+        status: "running",
+        stage: currentStage,
+        targetVersion,
+      });
+
+      return Effect.gen(function* () {
+        const environmentRegistry = yield* EnvironmentRegistry;
+        const supportsProgress =
+          atomRegistry.get(configValueAtom(target.environmentId))?.environment.capabilities
+            .serverSelfUpdateProgress === true;
+
+        const result: ServerSelfUpdateResult = supportsProgress
+          ? yield* Effect.gen(function* () {
+              const terminal = yield* Ref.make<Option.Option<ServerSelfUpdateResult>>(
+                Option.none(),
+              );
+              yield* environmentRegistry
+                .runStream(
+                  target.environmentId,
+                  runStream(WS_METHODS.serverUpdateServerWithProgress, target.input),
+                )
+                .pipe(
+                  Stream.runForEach((event) =>
+                    Effect.sync(() => {
+                      currentStage = event.type === "complete" ? "resuming" : event.stage;
+                      atomRegistry.set(
+                        stateAtom,
+                        serverUpdateStateForProgressEvent(targetVersion, event),
+                      );
+                    }).pipe(
+                      Effect.andThen(
+                        event.type === "complete"
+                          ? Ref.set(terminal, Option.some(event.result))
+                          : Effect.void,
+                      ),
+                    ),
+                  ),
+                );
+              return yield* Ref.get(terminal).pipe(
+                Effect.flatMap(
+                  Option.match({
+                    onNone: () =>
+                      Effect.fail(new ServerUpdateProgressIncompleteError({ targetVersion })),
+                    onSome: Effect.succeed,
+                  }),
+                ),
+              );
+            })
+          : yield* Effect.gen(function* () {
+              const selfUpdateMethod = atomRegistry.get(configValueAtom(target.environmentId))
+                ?.environment.capabilities.serverSelfUpdate;
+              const exit = yield* environmentRegistry
+                .run(target.environmentId, request(WS_METHODS.serverUpdateServer, target.input))
+                .pipe(Effect.exit);
+              if (Exit.isSuccess(exit)) {
+                return exit.value;
+              }
+              if (
+                (selfUpdateMethod === "boot-service" || selfUpdateMethod === "respawn") &&
+                isLegacyUpdateHandoffLoss(exit.cause)
+              ) {
+                // Older servers can tear down the transport before their
+                // unary acknowledgement arrives. Treat only that transport
+                // loss as a handoff, then prove it by waiting for target ready.
+                return { targetVersion, method: selfUpdateMethod };
+              }
+              return yield* Effect.failCause(exit.cause);
+            });
+
+        currentStage = "resuming";
+        atomRegistry.set(stateAtom, {
+          status: "running",
+          stage: currentStage,
+          targetVersion,
+        });
+
+        // The update restart is intentional. As soon as the supervisor sees
+        // that first failed connection, discard any prior backoff debt and
+        // retry immediately instead of carrying an old 16-second delay.
+        yield* environmentRegistry.stateChanges(target.environmentId).pipe(
+          Stream.filter((state) => state.phase === "backoff"),
+          Stream.take(1),
+          Stream.runDrain,
+          Effect.andThen(environmentRegistry.retryNow(target.environmentId)),
+          Effect.timeoutOption(Duration.seconds(30)),
+          Effect.ignore,
+          Effect.forkChild,
+        );
+
+        const resumed = yield* environmentRegistry
+          .followStream(target.environmentId, subscribe(WS_METHODS.subscribeServerLifecycle, {}))
+          .pipe(
+            Stream.filter(
+              (event) =>
+                event.type === "ready" && event.payload.environment.serverVersion === targetVersion,
+            ),
+            Stream.runHead,
+            Effect.timeoutOption(Duration.seconds(120)),
+            Effect.map(Option.flatten),
+          );
+        if (Option.isNone(resumed)) {
+          return yield* new ServerUpdateResumeTimeoutError({
+            environmentId: target.environmentId,
+            targetVersion,
+          });
+        }
+
+        atomRegistry.set(stateAtom, IDLE_SERVER_UPDATE_STATE);
+        return result;
+      }).pipe(
+        Effect.tapError((error) =>
+          Effect.sync(() => {
+            atomRegistry.set(stateAtom, {
+              status: "failed",
+              stage: currentStage,
+              targetVersion,
+              message: serverUpdateFailureMessage(error),
+            });
+          }),
+        ),
+      );
+    },
+  });
   const settingsValueAtom = Atom.family((environmentId: EnvironmentId) =>
     Atom.make((get) => get(configValueAtom(environmentId))?.settings ?? null).pipe(
       Atom.withLabel(`environment-data:server:settings:${environmentId}`),
@@ -284,6 +518,7 @@ export function createServerEnvironmentAtoms<R, E>(
 
   return {
     configValueAtom,
+    updateStateAtom,
     settingsValueAtom,
     providersValueAtom,
     traceDiagnostics: createEnvironmentRpcQueryAtomFamily(runtime, {
@@ -331,12 +566,7 @@ export function createServerEnvironmentAtoms<R, E>(
       scheduler: configScheduler,
       concurrency: configConcurrency,
     }),
-    updateServer: createEnvironmentRpcCommand(runtime, {
-      label: "environment-data:server:update-server",
-      tag: WS_METHODS.serverUpdateServer,
-      scheduler: configScheduler,
-      concurrency: configConcurrency,
-    }),
+    updateServer,
     upsertKeybinding: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:server:upsert-keybinding",
       tag: WS_METHODS.serverUpsertKeybinding,

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -114,7 +114,10 @@ export function serverUpdateStateForServerVersion(
   state: ServerUpdateState,
   serverVersion: string | null,
 ): ServerUpdateState {
-  return state.status === "idle" || serverVersion === null || state.fromVersion === serverVersion
+  return state.status === "idle" ||
+    state.status === "running" ||
+    serverVersion === null ||
+    state.fromVersion === serverVersion
     ? state
     : IDLE_SERVER_UPDATE_STATE;
 }

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -506,13 +506,20 @@ export function createServerEnvironmentAtoms<R, E>(
         atomRegistry.set(stateAtom, IDLE_SERVER_UPDATE_STATE);
         return result;
       }).pipe(
-        Effect.tapError((error) =>
+        Effect.onExit((exit) =>
           Effect.sync(() => {
+            if (Exit.isSuccess(exit)) {
+              return;
+            }
+            if (Cause.hasInterruptsOnly(exit.cause)) {
+              atomRegistry.set(stateAtom, IDLE_SERVER_UPDATE_STATE);
+              return;
+            }
             atomRegistry.set(stateAtom, {
               status: "failed",
               stage: currentStage,
               targetVersion,
-              message: serverUpdateFailureMessage(error),
+              message: serverUpdateFailureMessage(Cause.squash(exit.cause)),
             });
           }),
         ),

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -442,8 +442,16 @@ export function createServerEnvironmentAtoms<R, E>(
     execute: (target, atomRegistry) => {
       const stateAtom = serverUpdateStateAtom(target.environmentId);
       const targetVersion = target.input.targetVersion;
-      let fromVersion = targetVersion;
+      let fromVersion =
+        atomRegistry.get(configValueAtom(target.environmentId))?.environment.serverVersion ??
+        targetVersion;
       let currentStage: ServerUpdateStage = "downloading";
+      atomRegistry.set(stateAtom, {
+        status: "running",
+        stage: currentStage,
+        fromVersion,
+        targetVersion,
+      });
 
       return Effect.gen(function* () {
         const environmentRegistry = yield* EnvironmentRegistry;

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -51,6 +51,9 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
       servers that must be relaunched manually (dev checkouts, Windows
       foreground runs, pre-update servers). */
   serverSelfUpdate: Schema.optionalKey(ServerSelfUpdateCapability),
+  /** Server can stream self-update progress before acknowledging the
+      restart. Clients fall back to server.updateServer when absent. */
+  serverSelfUpdateProgress: Schema.optionalKey(Schema.Boolean),
 });
 export type ExecutionEnvironmentCapabilities = typeof ExecutionEnvironmentCapabilities.Type;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -127,6 +127,7 @@ import {
   ServerProviderUpdatedPayload,
   ServerSelfUpdateError,
   ServerSelfUpdateInput,
+  ServerSelfUpdateProgressEvent,
   ServerSelfUpdateResult,
   ServerTraceDiagnosticsResult,
   ServerProcessDiagnosticsResult,
@@ -218,6 +219,7 @@ export const WS_METHODS = {
   serverRefreshProviders: "server.refreshProviders",
   serverUpdateProvider: "server.updateProvider",
   serverUpdateServer: "server.updateServer",
+  serverUpdateServerWithProgress: "server.updateServerWithProgress",
   serverUpsertKeybinding: "server.upsertKeybinding",
   serverRemoveKeybinding: "server.removeKeybinding",
   serverGetSettings: "server.getSettings",
@@ -304,6 +306,16 @@ export const WsServerUpdateServerRpc = Rpc.make(WS_METHODS.serverUpdateServer, {
   success: ServerSelfUpdateResult,
   error: Schema.Union([ServerSelfUpdateError, EnvironmentAuthorizationError]),
 });
+
+export const WsServerUpdateServerWithProgressRpc = Rpc.make(
+  WS_METHODS.serverUpdateServerWithProgress,
+  {
+    payload: ServerSelfUpdateInput,
+    success: ServerSelfUpdateProgressEvent,
+    error: Schema.Union([ServerSelfUpdateError, EnvironmentAuthorizationError]),
+    stream: true,
+  },
+);
 
 export const WsServerGetSettingsRpc = Rpc.make(WS_METHODS.serverGetSettings, {
   payload: Schema.Struct({}),
@@ -759,6 +771,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerRefreshProvidersRpc,
   WsServerUpdateProviderRpc,
   WsServerUpdateServerRpc,
+  WsServerUpdateServerWithProgressRpc,
   WsServerUpsertKeybindingRpc,
   WsServerRemoveKeybindingRpc,
   WsServerGetSettingsRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -592,6 +592,21 @@ export const ServerSelfUpdateResult = Schema.Struct({
 });
 export type ServerSelfUpdateResult = typeof ServerSelfUpdateResult.Type;
 
+export const ServerSelfUpdateProgressStage = Schema.Literals(["downloading", "installing"]);
+export type ServerSelfUpdateProgressStage = typeof ServerSelfUpdateProgressStage.Type;
+
+export const ServerSelfUpdateProgressEvent = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("progress"),
+    stage: ServerSelfUpdateProgressStage,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("complete"),
+    result: ServerSelfUpdateResult,
+  }),
+]);
+export type ServerSelfUpdateProgressEvent = typeof ServerSelfUpdateProgressEvent.Type;
+
 export class ServerSelfUpdateError extends Schema.TaggedErrorClass<ServerSelfUpdateError>()(
   "ServerSelfUpdateError",
   {


### PR DESCRIPTION
The server update action currently becomes a blind pending request, while the expected restart can surface as a generic connection failure. Users cannot tell whether T3 is downloading, installing, or trying to reconnect.

This adds a typed progress stream and one environment-scoped update state machine that follows the operation through Download, Install, and Resume. Resume completes only after the replacement server reports the requested version and is ready for commands. Older servers retain the unary update fallback, and the intentional reconnect gets a fresh retry instead of inherited backoff.

The shared progress rail appears in both the chat warning and Connections. Failed stages remain visible with a retry action. The desktop surface inherits the web implementation; mobile has no existing server-update entry point.

Visual direction: https://f2ltacrf9xro.postplan.dev

Testing:
- contracts, client-runtime, and server typechecks
- focused authorization, self-update, environment, reconnect, update-state, version-skew, and UI tests
- targeted lint and formatting
- web typecheck is currently blocked on current main by unrelated `FilePreviewPanel` errors against `@pierre/diffs/react`; the focused web tests pass

Authored by GPT-5.6 Codex in the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration RPC auth, self-update handoff timing, and connection supervisor retry semantics; boot-service deferred restart changes when failures are visible vs RPC success.
> 
> **Overview**
> Adds **Download → Install → Resume** visibility for server self-updates instead of a blind pending button, with one shared per-environment state machine in `client-runtime` so chat and Connections stay in sync across navigation.
> 
> **Server & contracts:** New streaming RPC `serverUpdateServerWithProgress` emits `downloading` / `installing` and a terminal `complete`; capability `serverSelfUpdateProgress` is advertised when supported. Unary `serverUpdateServer` remains for older servers. Self-update accepts optional `reportProgress`; boot-service handoff **defers systemd restart** after acknowledgement (like respawn), restores the previous unit on failed restart, and logs instead of failing the RPC when restart cannot complete.
> 
> **Client-runtime:** `updateServer` drives streamed or legacy unary paths, treats transport loss after handoff as success when appropriate, enters **Resume** until lifecycle `ready` at the target version, triggers **one fresh reconnect** (supervisor `retryNow` resets backoff), and clears or surfaces failed stage state for retry.
> 
> **Web UI:** `ServerUpdateProgress` step rail in `ChatView` and Connections; version-mismatch banner merges with live update state; `ServerUpdateAction` delegates lifecycle to shared atoms and drops local spinner/timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16c2f252d04c1aa05d1c8def8128b5b85064911a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show server update progress through reconnect in conversation and connections views
> - Adds a new `serverUpdateServerWithProgress` WebSocket RPC that streams `downloading`, `installing`, and `resuming` progress stages before acknowledging restart; older servers fall back to the existing unary RPC.
> - Introduces `ServerUpdateState` atoms in [`packages/client-runtime/src/state/server.ts`](https://github.com/pingdotgg/t3code/pull/4903/files#diff-e89d2e49b487037c2e7108610cb27c1e8ad8800a8f2e66427f7e783a4fc1d428) to track update lifecycle (idle/running/failed) with stage, fromVersion, and targetVersion across the client.
> - Renders a three-step progress rail (Download → Install → Resume) in [`ChatView`](https://github.com/pingdotgg/t3code/pull/4903/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [`ConnectionsSettings`](https://github.com/pingdotgg/t3code/pull/4903/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9); suppresses environment-unavailable banners during the resuming stage.
> - The update command serializes only its handoff on the config scheduler lane, resets supervisor backoff via `retryNow`, and waits up to 120 seconds for the server to report the target version as ready.
> - For the `boot-service` path, the server acknowledges immediately and defers the systemd restart; if the restart fails it restores the previous unit file and reloads systemd without surfacing the error to the caller.
> - Behavioral Change: `resolveServerConfigValue` no longer always prefers the live projection — it holds the session config until the live snapshot's `serverVersion` matches the current server version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16c2f25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->