### PR TITLE
fix(web): settle button now works on hover, not just right-click

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -932,9 +932,12 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                   the hidden state out of flow lets the project label reclaim
                   space without either state overlapping it. */}
               <span className="group/v2-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
+                {/* pointer-events-none: while hovered this label is absolute
+                    + opacity-0, which paints it ABOVE the in-flow settle/snooze
+                    buttons; without it the invisible label eats their clicks. */}
                 <span
                   className={cn(
-                    "self-center justify-self-end tabular-nums text-muted-foreground/65 transition-opacity group-focus-within/v2-status-slot:absolute group-focus-within/v2-status-slot:right-0 group-hover/v2-row:absolute group-hover/v2-row:right-0 group-hover/v2-row:opacity-0",
+                    "pointer-events-none self-center justify-self-end tabular-nums text-muted-foreground/65 transition-opacity group-focus-within/v2-status-slot:absolute group-focus-within/v2-status-slot:right-0 group-hover/v2-row:absolute group-hover/v2-row:right-0 group-hover/v2-row:opacity-0",
                     snoozeMenuOpen && "absolute right-0 opacity-0",
                   )}
                 >


### PR DESCRIPTION
Hovering a thread card in sidebar v2 shows a Settle button that didn't respond to clicks — the only way to settle was the right-click context menu.

Cause: #4789 changed the status label ("Woke", "Done", time, etc.) to go \`absolute\` + \`opacity-0\` on hover so the settle/snooze actions could take its place without truncating. Being absolutely positioned, the invisible label painted *above* the buttons and swallowed their clicks. The context menu path never went through those buttons, which is why it still worked.

Fix: \`pointer-events-none\` on the status label, so clicks pass through to the buttons beneath. One line plus a comment explaining the constraint.

Verified with typecheck and the web unit suite (1665 passing).

Change made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class on a sidebar status label; no auth, data, or API changes.
> 
> **Overview**
> Fixes **Settle** (and snooze) on sidebar v2 **card** rows: hover shows the action buttons, but clicks did nothing while the context menu still worked.
> 
> On hover, the status/time label is taken out of flow with `absolute` and `opacity-0` so settle/snooze can use that slot. That invisible label still stacked above the buttons and captured pointer events. The fix adds **`pointer-events-none`** on that label so clicks reach the buttons underneath, with a short comment documenting the stacking constraint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6898f03852c74dfa7eeb482b9e3bf07dbbe2bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix settle/snooze buttons in sidebar to respond to hover clicks
> The invisible status label in `SidebarV2Row` was absolutely positioned over the settle/snooze buttons, intercepting pointer events and blocking clicks on hover. Adding `pointer-events-none` to the label span in [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4905/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) lets pointer events pass through to the underlying controls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6898f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->