### PR TITLE
fix(client): show hours and days in working durations

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -3,7 +3,7 @@ import { KeyboardAwareLegendList } from "@legendapp/list/keyboard";
 import { type LegendListRef } from "@legendapp/list/react-native";
 import type { EnvironmentId, MessageId, ThreadId, TurnId } from "@t3tools/contracts";
 import { CHAT_LIST_ANCHOR_OFFSET, resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
-import { formatElapsed } from "@t3tools/shared/orchestrationTiming";
+import { formatWorkingDuration } from "@t3tools/shared/orchestrationTiming";
 import { SymbolView } from "../../components/AppSymbol";
 import { HeaderHeightContext } from "@react-navigation/elements";
 import { useNavigation } from "@react-navigation/native";
@@ -1032,7 +1032,7 @@ const WorkingTimelineRow = memo(function WorkingTimelineRow(props: { readonly st
     return () => clearInterval(intervalId);
   }, [props.startedAt]);
 
-  const durationLabel = formatElapsed(props.startedAt, new Date(nowMs).toISOString()) ?? "0s";
+  const durationLabel = formatWorkingDuration(nowMs - Date.parse(props.startedAt));
 
   return (
     <View className="mb-4 flex-row items-center gap-2 px-1.5 py-1">

--- a/apps/mobile/src/state/use-vcs-action-state.ts
+++ b/apps/mobile/src/state/use-vcs-action-state.ts
@@ -1,5 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
 import { type VcsActionState, type VcsActionTarget } from "@t3tools/client-runtime/state/vcs";
+import { formatCompactWorkingDuration } from "@t3tools/shared/orchestrationTiming";
 import { Atom } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -67,11 +68,11 @@ const EMPTY_PROGRESS: GitActionProgress = {
   description: null,
 };
 
-function formatElapsedSeconds(ms: number | null): string | null {
+function formatElapsedDescription(ms: number | null): string | null {
   if (ms === null) return null;
-  const elapsed = Math.max(0, Math.floor((Date.now() - ms) / 1000));
-  if (elapsed < 2) return null;
-  return `Running for ${elapsed}s`;
+  const elapsedMs = Date.now() - ms;
+  if (elapsedMs < 2_000) return null;
+  return `Running for ${formatCompactWorkingDuration(elapsedMs)}`;
 }
 
 export function useGitActionProgress(target: VcsActionTarget): GitActionProgress {
@@ -105,7 +106,7 @@ export function useGitActionProgress(target: VcsActionTarget): GitActionProgress
   if (actionState.isRunning) {
     const description =
       actionState.lastOutputLine ??
-      formatElapsedSeconds(actionState.hookStartedAtMs ?? actionState.phaseStartedAtMs);
+      formatElapsedDescription(actionState.hookStartedAtMs ?? actionState.phaseStartedAtMs);
     return {
       phase: "running",
       label: actionState.currentLabel,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1,5 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
 import { type ScopedThreadRef } from "@t3tools/contracts";
+import { formatCompactWorkingDuration } from "@t3tools/shared/orchestrationTiming";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -241,13 +242,7 @@ function formatElapsedDescription(startedAtMs: number | null): string | undefine
   if (startedAtMs === null) {
     return undefined;
   }
-  const elapsedSeconds = Math.max(0, Math.floor((Date.now() - startedAtMs) / 1000));
-  if (elapsedSeconds < 60) {
-    return `Running for ${elapsedSeconds}s`;
-  }
-  const minutes = Math.floor(elapsedSeconds / 60);
-  const seconds = elapsedSeconds % 60;
-  return `Running for ${minutes}m ${seconds}s`;
+  return `Running for ${formatCompactWorkingDuration(Date.now() - startedAtMs)}`;
 }
 
 function resolveProgressDescription(progress: ActiveGitActionProgress): string | undefined {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -20,7 +20,6 @@ import {
   resolveSidebarV2Status,
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
-  formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
   sortLogicalProjectsForSidebar,
@@ -835,20 +834,6 @@ describe("resolveWorkingStartedAt", () => {
 
   it("returns null with neither a running turn nor a session", () => {
     expect(resolveWorkingStartedAt({ latestTurn: null, session: null })).toBeNull();
-  });
-});
-
-describe("formatWorkingDurationLabel", () => {
-  it("formats seconds, minutes, and hours", () => {
-    expect(formatWorkingDurationLabel(0)).toBe("0s");
-    expect(formatWorkingDurationLabel(42_000)).toBe("42s");
-    expect(formatWorkingDurationLabel(5 * 60_000)).toBe("5m");
-    expect(formatWorkingDurationLabel(90 * 60_000)).toBe("1h 30m");
-  });
-
-  it("clamps negative and non-finite elapsed values to zero", () => {
-    expect(formatWorkingDurationLabel(-5_000)).toBe("0s");
-    expect(formatWorkingDurationLabel(Number.NaN)).toBe("0s");
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -549,14 +549,6 @@ export function resolveWorkingStartedAt(
   return firstValidTimestamp(thread.session?.updatedAt);
 }
 
-export function formatWorkingDurationLabel(elapsedMs: number): string {
-  const seconds = Number.isFinite(elapsedMs) ? Math.max(0, Math.floor(elapsedMs / 1000)) : 0;
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
-}
-
 export function resolveThreadStatusPill(input: {
   thread: ThreadStatusInput;
 }): ThreadStatusPill | null {

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -104,10 +104,10 @@ import {
 } from "../threadRoutes";
 import { formatRelativeTimeLabel, parseTimestampDate } from "../timestampFormat";
 import type { SidebarThreadSummary } from "../types";
+import { formatCompactWorkingDuration } from "@t3tools/shared/orchestrationTiming";
 import { cn } from "~/lib/utils";
 import {
   buildBulkTitleRegenerationContextMenuItem,
-  formatWorkingDurationLabel,
   firstValidTimestampMs,
   hasUnseenCompletion,
   isTrailingDoubleClick,
@@ -220,7 +220,7 @@ function WorkingDuration(props: { startedAt: string | null }) {
   if (Number.isNaN(startedMs)) return null;
   return (
     <span className="font-mono tabular-nums">
-      {formatWorkingDurationLabel(Date.now() - startedMs)}
+      {formatCompactWorkingDuration(Date.now() - startedMs)}
     </span>
   );
 }

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -7,6 +7,7 @@ import {
 } from "@t3tools/contracts";
 import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import { resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
+import { formatWorkingDuration } from "@t3tools/shared/orchestrationTiming";
 import {
   createContext,
   Fragment,
@@ -1729,24 +1730,11 @@ function formatWorkingTimer(startIso: string, endIso: string): string | null {
     return null;
   }
 
-  const elapsedSeconds = Math.max(0, Math.floor((endedAtMs - startedAtMs) / 1000));
-  if (elapsedSeconds < 60) {
-    return `${elapsedSeconds}s`;
-  }
-
-  const hours = Math.floor(elapsedSeconds / 3600);
-  const minutes = Math.floor((elapsedSeconds % 3600) / 60);
-  const seconds = elapsedSeconds % 60;
-
-  if (hours > 0) {
-    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-  }
-
-  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  return formatWorkingDuration(endedAtMs - startedAtMs);
 }
 
 function formatWorkingTimerNow(startIso: string): string {
-  return formatWorkingTimer(startIso, new Date().toISOString()) ?? "0s";
+  return formatWorkingTimer(startIso, new Date().toISOString()) ?? "1s";
 }
 
 type WorkEntryIconName =

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -271,6 +271,18 @@ export function formatDuration(durationMs: number): string {
     return tenths >= 10 ? "10s" : `${tenths.toFixed(1)}s`;
   }
   if (durationMs < 60_000) return `${Math.round(durationMs / 1_000)}s`;
+
+  if (durationMs >= 86_400_000) {
+    const days = Math.floor(durationMs / 86_400_000);
+    const hours = Math.floor((durationMs % 86_400_000) / 3_600_000);
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (durationMs >= 3_600_000) {
+    const hours = Math.floor(durationMs / 3_600_000);
+    const minutes = Math.floor((durationMs % 3_600_000) / 60_000);
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+
   const minutes = Math.floor(durationMs / 60_000);
   const seconds = Math.round((durationMs % 60_000) / 1_000);
   if (seconds === 0) return `${minutes}m`;

--- a/packages/shared/src/orchestrationTiming.test.ts
+++ b/packages/shared/src/orchestrationTiming.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  formatCompactWorkingDuration,
+  formatDuration,
+  formatElapsed,
+  formatWorkingDuration,
+} from "./orchestrationTiming.js";
+
+describe("formatWorkingDuration", () => {
+  it("shows whole seconds for the first minute", () => {
+    expect(formatWorkingDuration(Number.NaN)).toBe("1s");
+    expect(formatWorkingDuration(-1)).toBe("1s");
+    expect(formatWorkingDuration(0)).toBe("1s");
+    expect(formatWorkingDuration(999)).toBe("1s");
+    expect(formatWorkingDuration(1_000)).toBe("1s");
+    expect(formatWorkingDuration(1_999)).toBe("1s");
+    expect(formatWorkingDuration(2_000)).toBe("2s");
+    expect(formatWorkingDuration(9_999)).toBe("9s");
+    expect(formatWorkingDuration(10_000)).toBe("10s");
+    expect(formatWorkingDuration(10_999)).toBe("10s");
+    expect(formatWorkingDuration(11_000)).toBe("11s");
+    expect(formatWorkingDuration(59_999)).toBe("59s");
+  });
+
+  it("shows minutes with remaining seconds for the first hour", () => {
+    expect(formatWorkingDuration(60_000)).toBe("1m");
+    expect(formatWorkingDuration(119_999)).toBe("1m 59s");
+    expect(formatWorkingDuration(11 * 60_000 + 30_000)).toBe("11m 30s");
+    expect(formatWorkingDuration(5 * 60_000)).toBe("5m");
+    expect(formatWorkingDuration(59 * 60_000)).toBe("59m");
+  });
+
+  it("shows hours with remaining minutes", () => {
+    expect(formatWorkingDuration(60 * 60_000)).toBe("1h");
+    expect(formatWorkingDuration(61 * 60_000)).toBe("1h 1m");
+    expect(formatWorkingDuration(23 * 60 * 60_000 + 59 * 60_000)).toBe("23h 59m");
+  });
+
+  it("shows days with remaining hours", () => {
+    expect(formatWorkingDuration(24 * 60 * 60_000)).toBe("1d");
+    expect(formatWorkingDuration(25 * 60 * 60_000)).toBe("1d 1h");
+    expect(formatWorkingDuration(3 * 24 * 60 * 60_000 + 4 * 60 * 60_000)).toBe("3d 4h");
+  });
+});
+
+describe("formatCompactWorkingDuration", () => {
+  it("keeps seconds alone and truncates sub-hour durations to whole minutes", () => {
+    expect(formatCompactWorkingDuration(999)).toBe("1s");
+    expect(formatCompactWorkingDuration(59_999)).toBe("59s");
+    expect(formatCompactWorkingDuration(60_000)).toBe("1m");
+    expect(formatCompactWorkingDuration(11 * 60_000 + 30_000)).toBe("11m");
+    expect(formatCompactWorkingDuration(59 * 60_000 + 59_000)).toBe("59m");
+  });
+
+  it("matches the chat formatter at hour and day precision", () => {
+    expect(formatCompactWorkingDuration(61 * 60_000)).toBe("1h 1m");
+    expect(formatCompactWorkingDuration(25 * 60 * 60_000)).toBe("1d 1h");
+  });
+});
+
+describe("formatDuration", () => {
+  it("preserves the existing sub-minute precision", () => {
+    expect(formatDuration(0)).toBe("1ms");
+    expect(formatDuration(750)).toBe("750ms");
+    expect(formatDuration(1_500)).toBe("1.5s");
+    expect(formatDuration(9_950)).toBe("9.9s");
+    expect(formatDuration(9_999)).toBe("10.0s");
+    expect(formatDuration(42_000)).toBe("42s");
+  });
+
+  it("keeps sub-hour durations in minutes and seconds", () => {
+    expect(formatDuration(135_000)).toBe("2m 15s");
+    expect(formatDuration(3_599_000)).toBe("59m 59s");
+  });
+
+  it("rolls long durations up into hours", () => {
+    expect(formatDuration(3_600_000)).toBe("1h");
+    expect(formatDuration(8_138_000)).toBe("2h 15m");
+    expect(formatDuration(86_399_000)).toBe("23h 59m");
+  });
+
+  it("rolls multi-day durations up into days", () => {
+    expect(formatDuration(86_400_000)).toBe("1d");
+    expect(formatDuration(93_600_000)).toBe("1d 2h");
+    expect(formatDuration(273_600_000)).toBe("3d 4h");
+  });
+
+  it("formats an elapsed multi-day turn through the shared mobile path", () => {
+    expect(formatElapsed("2026-07-28T23:45:00.000Z", "2026-07-30T01:45:00.000Z")).toBe("1d 2h");
+  });
+});

--- a/packages/shared/src/orchestrationTiming.ts
+++ b/packages/shared/src/orchestrationTiming.ts
@@ -9,11 +9,57 @@ type SessionActivityState = {
   readonly activeTurnId?: string | null;
 };
 
+export function formatWorkingDuration(durationMs: number): string {
+  return formatWorkingDurationWithMinutePrecision(durationMs, true);
+}
+
+export function formatCompactWorkingDuration(durationMs: number): string {
+  return formatWorkingDurationWithMinutePrecision(durationMs, false);
+}
+
+function formatWorkingDurationWithMinutePrecision(
+  durationMs: number,
+  includeRemainingSeconds: boolean,
+): string {
+  const seconds = Number.isFinite(durationMs) ? Math.max(1, Math.floor(durationMs / 1_000)) : 1;
+  if (seconds < 60) return `${seconds}s`;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    const remainingSeconds = seconds % 60;
+    return includeRemainingSeconds && remainingSeconds > 0
+      ? `${minutes}m ${remainingSeconds}s`
+      : `${minutes}m`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    const remainingMinutes = minutes % 60;
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+  }
+
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
+}
+
 export function formatDuration(durationMs: number): string {
   if (!Number.isFinite(durationMs) || durationMs < 0) return "0ms";
   if (durationMs < 1_000) return `${Math.max(1, Math.round(durationMs))}ms`;
   if (durationMs < 10_000) return `${(durationMs / 1_000).toFixed(1)}s`;
   if (durationMs < 60_000) return `${Math.round(durationMs / 1_000)}s`;
+
+  if (durationMs >= 86_400_000) {
+    const days = Math.floor(durationMs / 86_400_000);
+    const hours = Math.floor((durationMs % 86_400_000) / 3_600_000);
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (durationMs >= 3_600_000) {
+    const hours = Math.floor(durationMs / 3_600_000);
+    const minutes = Math.floor((durationMs % 3_600_000) / 60_000);
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+
   const minutes = Math.floor(durationMs / 60_000);
   const seconds = Math.round((durationMs % 60_000) / 1_000);
   if (seconds === 0) return `${minutes}m`;


### PR DESCRIPTION
Live elapsed labels used different precision and rollover rules across chat, the sidebar, and repository actions. Long-running work could remain in total minutes or hours, while some surfaces displayed milliseconds or `0s`.

This consolidates live elapsed formatting in the shared client package with two intentional presentation policies:

- Chat on web, desktop, iOS, and Android shows `1s`, `11m 30s`, `1h 1m`, and `1d 1h`.
- Sidebar and live repository actions show `1s`, `11m`, `1h 1m`, and `1d 1h`.

Both policies floor elapsed time to completed units and clamp the first visible value to `1s`. Completed `Worked for` durations retain their existing short-duration precision while gaining the same hour and day rollovers. Provider adapters remain unchanged because Codex, Claude, Cursor, Grok, and OpenCode all reach these common client renderers after normalization.

## UI Changes

The screenshots use isolated synthetic thread data and contain no account, workspace, path, credential, or pairing information.

### Before

![Before — the timer continues past 24 hours](https://raw.githubusercontent.com/andreivcodes/t3code/8ac4d9b699c2ac547a0919e40e8c17eebc488301/working-duration-before.png)

### After

![After — the timer rolls up into days and hours](https://raw.githubusercontent.com/andreivcodes/t3code/8ac4d9b699c2ac547a0919e40e8c17eebc488301/working-duration-after.png)

### Native Android

![Native Android — the chat timer uses days and hours](https://raw.githubusercontent.com/andreivcodes/t3code/cb3c7c6c5389d75c86b86b832ecd4c16505ad86d/working-duration-native-after.png)

## Validation

- `vp test run packages/shared/src/orchestrationTiming.test.ts` — 11 passed
- `vp test run apps/web/src/components/chat/MessagesTimeline.logic.test.ts` — 28 passed
- `vp test run apps/web/src/components/Sidebar.logic.test.ts` — 79 passed
- `vp test run apps/mobile/src/lib/threadActivity.test.ts` — 9 passed
- Shared, web, and mobile typechecks
- Targeted lint and formatting checks for all 10 changed files
- Native Android debug build on an API 36 x86_64 emulator
- Native assertions for `Working for 14m 12s` and `Working for 1d 1h`

Made with GPT-5.6-sol in T3 Code via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only duration labeling with shared helpers and tests; no auth, data, or orchestration logic changes.
> 
> **Overview**
> Live “working” and “running” timers no longer stick at large minute counts or disagree across surfaces. **Shared** `formatWorkingDuration` and `formatCompactWorkingDuration` in `orchestrationTiming` centralize rollover through **days** (`1d 1h`), with elapsed time floored to completed units and the first visible value clamped to **1s** (replacing `0s` in several live paths).
> 
> **Chat** (web `MessagesTimeline`, mobile `ThreadFeed`) uses the full formatter (`11m 30s`). **Sidebar** (`SidebarV2`) and **git action progress** (web `GitActionsControl`, mobile `use-vcs-action-state`) use the compact variant (sub-hour durations truncate to whole minutes). Completed **Worked for** durations via `formatDuration` / `formatElapsed` gain the same hour and day rollovers while keeping existing sub-minute precision.
> 
> Local duplicate formatters are removed from `Sidebar.logic` (and its tests). New unit coverage lives in `orchestrationTiming.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d1e8503b2f3e34a812dae271fc35dcf9df9ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show hours and days in working duration timers across web and mobile
> - Adds `formatWorkingDuration` and `formatCompactWorkingDuration` to [`orchestrationTiming.ts`](https://github.com/pingdotgg/t3code/pull/4906/files#diff-4629df268b463d9cbffdfd7c6d6dc59bcc05274d118484510e868c6d276e365b), replacing multiple bespoke duration formatters with a single shared implementation that supports seconds, minutes, hours, and days.
> - Updates `WorkingDuration` in [`SidebarV2.tsx`](https://github.com/pingdotgg/t3code/pull/4906/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c), `formatWorkingTimer` in [`MessagesTimeline.tsx`](https://github.com/pingdotgg/t3code/pull/4906/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588), `WorkingTimelineRow` in [`ThreadFeed.tsx`](https://github.com/pingdotgg/t3code/pull/4906/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245), and progress descriptions in [`GitActionsControl.tsx`](https://github.com/pingdotgg/t3code/pull/4906/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) and [`use-vcs-action-state.ts`](https://github.com/pingdotgg/t3code/pull/4906/files#diff-08545df4d3c90b80dd3c44a18c8d8c15af947268732eb24153a2bb26db93d4b2) to use the shared formatters.
> - Removes the now-redundant `formatWorkingDurationLabel` from [`Sidebar.logic.ts`](https://github.com/pingdotgg/t3code/pull/4906/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) and its test suite.
> - Behavioral Change: the minimum displayed duration changes from `0s` to `1s`; progress descriptions in the mobile VCS action hook now only appear after 2 seconds of elapsed time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 448f7e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->