### PR TITLE
fix(server): brew upgrade the installed formula, not the configured one

### DIFF
--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -451,6 +451,94 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  it("upgrades the Homebrew package the binary actually came from, not the configured formula", () => {
+    expect(
+      packageToolUpdate.resolve({
+        binaryPath: "/usr/local/Caskroom/package-tool@latest/1.2.3/package-tool",
+        env: {
+          PATH: "",
+        },
+      }),
+    ).toEqual({
+      provider: driver("packageTool"),
+      packageName: "@example/package-tool",
+      update: {
+        command: "brew upgrade package-tool@latest",
+
+        executable: "brew",
+
+        args: ["upgrade", "package-tool@latest"],
+
+        lockKey: "homebrew",
+      },
+    });
+  });
+
+  it("keeps the tap prefix when swapping in the installed Homebrew package name", () => {
+    expect(
+      scopedPackageToolUpdate.resolve({
+        binaryPath: "/opt/homebrew/Cellar/scoped-package-tool@2/2.0.1/bin/scoped-package-tool",
+        env: {
+          PATH: "",
+        },
+      }),
+    ).toEqual({
+      provider: driver("scopedPackageTool"),
+      packageName: "@example/scoped-package-tool",
+      update: {
+        command: "brew upgrade example/tap/scoped-package-tool@2",
+
+        executable: "brew",
+
+        args: ["upgrade", "example/tap/scoped-package-tool@2"],
+
+        lockKey: "homebrew",
+      },
+    });
+  });
+
+  it.effect("derives the installed Homebrew package name through the Homebrew bin symlink", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-homebrew-cask-capabilities");
+      const binDir = NodePath.join(tempDir, "usr", "local", "bin");
+      const caskroomDir = NodePath.join(
+        tempDir,
+        "usr",
+        "local",
+        "Caskroom",
+        "package-tool@latest",
+        "1.2.3",
+      );
+      NodeFS.mkdirSync(binDir, { recursive: true });
+      NodeFS.mkdirSync(caskroomDir, { recursive: true });
+      const caskBinaryPath = NodePath.join(caskroomDir, "package-tool");
+      NodeFS.writeFileSync(caskBinaryPath, "#!/bin/sh\n");
+      NodeFS.chmodSync(caskBinaryPath, 0o755);
+      NodeFS.symlinkSync(caskBinaryPath, NodePath.join(binDir, "package-tool"));
+
+      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(packageToolUpdate, {
+        binaryPath: "package-tool",
+        env: {
+          PATH: binDir,
+        },
+      }).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
+
+      expect(capabilities).toEqual({
+        provider: driver("packageTool"),
+        packageName: "@example/package-tool",
+        update: {
+          command: "brew upgrade package-tool@latest",
+
+          executable: "brew",
+
+          args: ["upgrade", "package-tool@latest"],
+
+          lockKey: "homebrew",
+        },
+      });
+    }),
+  );
+
   it.effect("keeps npm updates for binaries symlinked into npm's global node_modules tree", () =>
     Effect.gen(function* () {
       const tempDir = yield* makeTempDir("t3-npm-capabilities");

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -178,8 +178,25 @@ function makeVitePlusGlobalProviderMaintenanceCapabilities(
   });
 }
 
+// Homebrew ships versioned siblings of the same tool (`claude-code` and
+// `claude-code@latest`) as separate packages, so the configured formula name is
+// only a fallback: the package the user actually installed is whatever the
+// Cellar/Caskroom path segment says it is.
+function resolveHomebrewPackageName(
+  configuredFormula: string,
+  installedPackageName: string | null,
+): string {
+  if (!installedPackageName) {
+    return configuredFormula;
+  }
+  const segments = configuredFormula.split("/");
+  // Keep any tap prefix (`example/tap/tool`) and swap only the package name.
+  return [...segments.slice(0, -1), installedPackageName].join("/");
+}
+
 function makeHomebrewProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
+  installedPackageName: string | null,
 ): ProviderMaintenanceCapabilities {
   if (!definition.homebrewFormula) {
     return makeManualOnlyProviderMaintenanceCapabilities({
@@ -188,11 +205,12 @@ function makeHomebrewProviderMaintenanceCapabilities(
     });
   }
 
+  const formula = resolveHomebrewPackageName(definition.homebrewFormula, installedPackageName);
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
     packageName: definition.npmPackageName,
     updateExecutable: "brew",
-    updateArgs: ["upgrade", definition.homebrewFormula],
+    updateArgs: ["upgrade", formula],
     updateLockKey: "homebrew",
   });
 }
@@ -263,6 +281,15 @@ function isHomebrewCommandPath(commandPath: string): boolean {
   );
 }
 
+function extractHomebrewPackageName(commandPath: string): string | null {
+  const segments = normalizeCommandPath(commandPath).split("/");
+  const rootIndex = segments.findIndex((segment) => segment === "cellar" || segment === "caskroom");
+  if (rootIndex < 0) {
+    return null;
+  }
+  return nonEmptyString(segments[rootIndex + 1]);
+}
+
 export function resolvePackageManagedProviderMaintenance(
   definition: PackageManagedProviderMaintenanceDefinition,
   options?: ProviderMaintenanceCapabilityResolutionOptions,
@@ -304,7 +331,10 @@ export function resolvePackageManagedProviderMaintenance(
       return makeNpmGlobalProviderMaintenanceCapabilities(definition);
     }
     if (commandPaths.some(isHomebrewCommandPath)) {
-      return makeHomebrewProviderMaintenanceCapabilities(definition);
+      return makeHomebrewProviderMaintenanceCapabilities(
+        definition,
+        commandPaths.map(extractHomebrewPackageName).find((name) => name !== null) ?? null,
+      );
     }
   }
 


### PR DESCRIPTION
## What Changed
- derive the Homebrew package name from the binary's Cellar/Caskroom path so versioned siblings (e.g. `tool@latest`) upgrade the package that is actually installed
- keep any tap prefix from the configured formula when swapping in the installed package name
- fall back to the configured formula when no Homebrew path segment is found

## Why
Would not automatically update otherwis.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Homebrew upgrade command selection in provider maintenance, with fallback to the previous formula name and added test coverage.
> 
> **Overview**
> **Homebrew provider updates** now target the package name taken from the binary’s **Cellar/Caskroom** path (e.g. `package-tool@latest`), instead of always using the configured formula (e.g. `package-tool`). That fixes one-click upgrades when Homebrew ships versioned siblings as separate packages.
> 
> Tap-prefixed formulas still keep their tap segment; only the final package segment is replaced with the installed name. If no Cellar/Caskroom segment is found, behavior falls back to the configured formula.
> 
> Tests cover direct Caskroom/Cellar paths, tap prefixes, and resolution through a `bin` symlink to Caskroom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d4decdf9036636d0ba6a14d736d49b1de2cde4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `brew upgrade` to target the installed formula, not the configured one
> - When a binary is installed via Homebrew, the `brew upgrade` command was using the configured formula name rather than the actual installed package (e.g. from Cellar/Caskroom paths).
> - Adds `extractHomebrewPackageName` in [providerMaintenance.ts](https://github.com/pingdotgg/t3code/pull/4910/files#diff-e29fae218a488cafd27faaeea37f0b7c1dccd03ba4a994975736ddf89e3bde14) to detect the real package name from the binary's resolved path by looking for `cellar` or `caskroom` segments.
> - Adds `resolveHomebrewPackageName` to replace only the package name segment of the configured formula, preserving any tap prefix (e.g. `org/tap/package-tool@2` → `org/tap/scoped-package-tool@2`).
> - Behavioral Change: `brew upgrade` arguments now use the installed package name derived from the binary path when available, rather than always using the configured formula.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84d4dec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->