### PR TITLE
feat(server): add headless Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:24-bookworm-slim AS t3-install
+
+ARG T3_VERSION=latest
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    g++ \
+    make \
+    python3 \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install \
+    --no-audit \
+    --no-fund \
+    --omit=dev \
+    --prefix /opt/t3 \
+    "t3@${T3_VERSION}"
+
+FROM node:24-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    git \
+    openssh-client \
+    tini \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /data /workspace \
+  && chown node:node /data /workspace \
+  && git config --system --add safe.directory /workspace
+
+COPY --from=t3-install --chown=node:node /opt/t3 /opt/t3
+
+ENV PATH="/opt/t3/node_modules/.bin:${PATH}" \
+  T3CODE_HOME=/data
+
+USER node
+WORKDIR /workspace
+
+EXPOSE 3773
+VOLUME ["/data", "/workspace"]
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["t3", "serve", "--auto-bootstrap-project-from-cwd", "--host", "0.0.0.0", "--port", "3773", "/workspace"]

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -557,7 +557,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
     }),
   );
 
-  it.effect("forces noBrowser and disables auto-bootstrap for headless startup presentation", () =>
+  it.effect("defaults auto-bootstrap off for headless startup but allows an explicit opt-in", () =>
     Effect.gen(function* () {
       const { join } = yield* Path.Path;
       const baseDir = join(NodeOS.tmpdir(), "t3-cli-config-headless-base");
@@ -589,7 +589,6 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
               ConfigProvider.fromEnv({
                 env: {
                   T3CODE_NO_BROWSER: "false",
-                  T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD: "true",
                 },
               }),
             ),
@@ -617,6 +616,43 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
       });
+
+      const optedIn = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.some(baseDir),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.some(true),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+        {
+          startupPresentation: "headless",
+        },
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: {
+                  T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD: "false",
+                },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(optedIn.autoBootstrapProjectFromCwd).toBe(true);
+      expect(optedIn.noBrowser).toBe(true);
     }),
   );
 });

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -212,7 +212,6 @@ export const resolveServerConfig = (
   cliLogLevel: Option.Option<LogLevel.LogLevel>,
   options?: {
     readonly startupPresentation?: ServerConfig.StartupPresentation;
-    readonly forceAutoBootstrapProjectFromCwd?: boolean;
   },
 ) =>
   Effect.gen(function* () {
@@ -308,10 +307,9 @@ export const resolveServerConfig = (
     const resourceMonitorPath = bootstrap?.resourceMonitorPath;
     const autoBootstrapProjectFromCwd = Option.getOrElse(
       resolveOptionPrecedence(
-        Option.fromUndefinedOr(options?.forceAutoBootstrapProjectFromCwd),
-        isHeadlessStartup ? Option.some(false) : Option.none(),
         normalizedFlags.autoBootstrapProjectFromCwd,
         Option.fromUndefinedOr(env.autoBootstrapProjectFromCwd),
+        isHeadlessStartup ? Option.some(false) : Option.none(),
       ),
       () => mode === "web",
     );

--- a/apps/server/src/cli/server.ts
+++ b/apps/server/src/cli/server.ts
@@ -9,7 +9,6 @@ export const runServerCommand = (
   flags: CliServerFlags,
   options?: {
     readonly startupPresentation?: StartupPresentation;
-    readonly forceAutoBootstrapProjectFromCwd?: boolean;
   },
 ) =>
   Effect.gen(function* () {
@@ -27,10 +26,5 @@ export const serveCommand = Command.make("serve", { ...sharedServerCommandFlags 
   Command.withDescription(
     "Run the T3 Code server without opening a browser and print headless pairing details.",
   ),
-  Command.withHandler((flags) =>
-    runServerCommand(flags, {
-      startupPresentation: "headless",
-      forceAutoBootstrapProjectFromCwd: false,
-    }),
-  ),
+  Command.withHandler((flags) => runServerCommand(flags, { startupPresentation: "headless" })),
 );

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -106,6 +106,36 @@ From there, connect from another device in either of these ways:
 
 Use `t3 serve --help` for the full flag reference. It supports the same general startup options as the normal server command, including an optional `cwd` argument.
 
+#### Docker
+
+The repository includes a multi-stage Dockerfile that installs the published T3 server during the
+image build. The default package version is `latest`; pass an exact version for reproducible builds
+and reliable Docker cache invalidation when upgrading:
+
+```bash
+docker build --build-arg T3_VERSION=0.0.33 -t t3-code-server:0.0.33 .
+```
+
+Run the server with persistent T3 data and a project mounted as the container workspace:
+
+```bash
+docker run --rm -it \
+  --name t3-code-server \
+  -p 3773:3773 \
+  -v t3-code-data:/data \
+  -v "$PWD:/workspace" \
+  t3-code-server:0.0.33
+```
+
+The image contains T3 Code, Git, and the SSH client. Provider CLIs and their credentials are not
+included. Install the provider you use in a derived image and make its credentials available to the
+container's `node` user. The container registers `/workspace` as a project on first startup and
+trusts that exact path for Git operations, including bind mounts owned by a different host user.
+
+The server runs as UID/GID `1000:1000`. On native Linux hosts, make sure that user can write to the
+bind-mounted workspace. Git can read the trusted repository regardless of its owner, but agents
+still need normal filesystem permissions to edit its files.
+
 For hosted web pairing over Tailscale HTTPS, opt in to Tailscale Serve:
 
 ```bash


### PR DESCRIPTION
## Problem

Running the published T3 server in a fresh container requires downloading the package and compiling native dependencies at startup. Keeping that compiler toolchain in the runtime image also makes a headless deployment larger and less predictable.

## Solution

- Add a multi-stage Dockerfile that installs an exact published T3 package during the image build.
- Keep compilers in the builder stage and run the server as the non-root node user behind tini.
- Include CA certificates for Git HTTPS and trust the intentionally mounted `/workspace` path.
- Let explicit headless auto-bootstrap configuration override the headless default, and use it to register the Docker workspace on startup.
- Persist T3 state and the workspace through dedicated volumes.
- Document build, run, persistence, provider CLI, and host filesystem permission requirements.

## Impact

Users can build a repeatable headless T3 server image that starts without an npm download and opens with the mounted workspace ready as a project. Provider CLIs and credentials remain an explicit deployment choice rather than being baked into the base image.

## Validation

- `vp test run apps/server/src/cli/config.test.ts`
- `vp test run apps/server/src/serverRuntimeStartup.test.ts`
- `vp run t3#typecheck`
- `vp lint apps/server/src/cli/config.ts apps/server/src/cli/server.ts apps/server/src/cli/config.test.ts`
- `vp fmt --check apps/server/src/cli/config.ts apps/server/src/cli/server.ts apps/server/src/cli/config.test.ts docs/user/remote-access.md`
- `docker build --check --build-arg T3_VERSION=0.0.33 .`
- `docker build --build-arg T3_VERSION=0.0.33 --tag t3-pr4911-review:local .`
- Confirmed Git HTTPS access and Git status against a root-owned mounted repository while the container runs as UID 1000.

Built with GPT-5.6 using the Codex harness in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add headless Docker image for the T3 server
> - Adds a multi-stage [Dockerfile](https://github.com/pingdotgg/t3code/pull/4911/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557) that installs the published T3 server via npm, with Git, SSH client, and tini in the runtime image. Exposes port 3773 and declares volumes for `/data` and `/workspace`.
> - Adds a Docker section to [remote-access.md](https://github.com/pingdotgg/t3code/pull/4911/files#diff-e6cd63b1b8b5df551539c3cbb1790b40f70baa2a5ed146d56f1c7044d7adcb8a) covering build/run examples, credential setup, and UID/GID considerations for bind mounts.
> - Fixes `autoBootstrapProjectFromCwd` precedence in headless mode: flags and environment variables can now opt in to auto-bootstrap rather than being hard-disabled by the `t3 serve` command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebc1486.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and CLI precedence changes with tests; no auth or data-model changes; Docker runs as non-root with documented volume/permission caveats.
> 
> **Overview**
> Adds a **multi-stage Dockerfile** that installs the published `t3` npm package at build time (`T3_VERSION` build arg, default `latest`), keeps build tooling out of the runtime image, and runs **`t3 serve`** as the non-root `node` user on `0.0.0.0:3773` with **`--auto-bootstrap-project-from-cwd`**, `/data` and `/workspace` volumes, Git/SSH, and `tini`.
> 
> **Headless CLI behavior** no longer hard-disables auto-bootstrap via `forceAutoBootstrapProjectFromCwd`. `t3 serve` still defaults auto-bootstrap off in headless mode, but an explicit flag or env can opt in—matching what the Docker image needs to register the mounted workspace on first start.
> 
> Documents **build/run**, persistence, UID `1000:1000`, and provider CLI expectations in the remote-access guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc14867fcb4c04f00ef34d97911d200ddac8ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->