### PR TITLE
fix(mobile): use system medium/large detents for form sheets

### DIFF
--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -131,12 +131,13 @@ const LEGAL_DOCUMENT_HEADER_OPTIONS: AppScreenOptions = {
   presentation: "fullScreenModal",
 };
 
-// UIKit's own `.medium()` and `.large()` detents, so a sheet opens and expands to the
-// heights the running iOS version considers right. The negative values are sentinels
-// our react-native-screens patch understands (SHEET_SYSTEM_DETENT_* in
-// patches/react-native-screens@4.25.2.patch); Android has no system detents, so it
-// gets the fractions those two approximate.
-const SYSTEM_MEDIUM_LARGE_DETENTS = Platform.OS === "ios" ? [-3, -2] : [0.5, 1.0];
+// UIKit's own `.medium()` and `.large()` detents, so sheets sit at the heights the
+// running iOS version considers right. The negative values are sentinels our
+// react-native-screens patch understands (SHEET_SYSTEM_DETENT_* in
+// patches/react-native-screens@4.25.2.patch). Android has no system detents and throws
+// on anything outside 0..1, so it keeps the fractions these sheets used before.
+const SYSTEM_MEDIUM_LARGE_DETENTS = Platform.OS === "ios" ? [-3, -2] : [0.55, 0.92];
+const SYSTEM_LARGE_DETENTS = Platform.OS === "ios" ? [-2] : [0.92];
 
 const SettingsSheetStack = createNativeStackNavigator({
   initialRouteName: "Settings",

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -416,7 +416,7 @@ export const RootStack = createNativeStackNavigator({
         // Android cannot host the keyboard-driven comment composer inside a
         // formSheet; use a full-screen modal there instead.
         presentation: Platform.OS === "android" ? "fullScreenModal" : "formSheet",
-        sheetAllowedDetents: Platform.OS === "android" ? undefined : [0.55, 0.92],
+        sheetAllowedDetents: Platform.OS === "android" ? undefined : SYSTEM_MEDIUM_LARGE_DETENTS,
         sheetGrabberVisible: Platform.OS !== "android",
       },
     }),
@@ -442,7 +442,7 @@ export const RootStack = createNativeStackNavigator({
       linking: `${THREAD_LINKING_PREFIX}/git`,
       options: {
         presentation: "formSheet",
-        sheetAllowedDetents: [0.55, 0.92],
+        sheetAllowedDetents: SYSTEM_MEDIUM_LARGE_DETENTS,
         sheetGrabberVisible: true,
       },
     }),
@@ -451,7 +451,7 @@ export const RootStack = createNativeStackNavigator({
       linking: `${THREAD_LINKING_PREFIX}/git/commit`,
       options: {
         presentation: "formSheet",
-        sheetAllowedDetents: [0.55, 0.92],
+        sheetAllowedDetents: SYSTEM_MEDIUM_LARGE_DETENTS,
         sheetGrabberVisible: true,
       },
     }),
@@ -460,7 +460,7 @@ export const RootStack = createNativeStackNavigator({
       linking: `${THREAD_LINKING_PREFIX}/git/branches`,
       options: {
         presentation: "formSheet",
-        sheetAllowedDetents: [0.55, 0.92],
+        sheetAllowedDetents: SYSTEM_MEDIUM_LARGE_DETENTS,
         sheetGrabberVisible: true,
       },
     }),
@@ -508,7 +508,7 @@ export const RootStack = createNativeStackNavigator({
         title: "Set up T3 Connect",
         gestureEnabled: true,
         presentation: "formSheet",
-        sheetAllowedDetents: [0.6, 0.95],
+        sheetAllowedDetents: SYSTEM_MEDIUM_LARGE_DETENTS,
         sheetGrabberVisible: true,
       },
     }),
@@ -553,7 +553,7 @@ export const RootStack = createNativeStackNavigator({
           ? { presentation: "card" as const }
           : {
               presentation: "formSheet" as const,
-              sheetAllowedDetents: [0.92],
+              sheetAllowedDetents: SYSTEM_LARGE_DETENTS,
               sheetGrabberVisible: true,
             }),
       },

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -131,6 +131,13 @@ const LEGAL_DOCUMENT_HEADER_OPTIONS: AppScreenOptions = {
   presentation: "fullScreenModal",
 };
 
+// UIKit's own `.medium()` and `.large()` detents, so a sheet opens and expands to the
+// heights the running iOS version considers right. The negative values are sentinels
+// our react-native-screens patch understands (SHEET_SYSTEM_DETENT_* in
+// patches/react-native-screens@4.25.2.patch); Android has no system detents, so it
+// gets the fractions those two approximate.
+const SYSTEM_MEDIUM_LARGE_DETENTS = Platform.OS === "ios" ? [-3, -2] : [0.5, 1.0];
+
 const SettingsSheetStack = createNativeStackNavigator({
   initialRouteName: "Settings",
   screenOptions: {
@@ -477,7 +484,7 @@ export const RootStack = createNativeStackNavigator({
           ? { presentation: "card" as const }
           : {
               presentation: "formSheet" as const,
-              sheetAllowedDetents: [0.7, 0.92],
+              sheetAllowedDetents: SYSTEM_MEDIUM_LARGE_DETENTS,
               sheetGrabberVisible: true,
             }),
       },

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -131,11 +131,8 @@ const LEGAL_DOCUMENT_HEADER_OPTIONS: AppScreenOptions = {
   presentation: "fullScreenModal",
 };
 
-// UIKit's own `.medium()` and `.large()` detents, so sheets sit at the heights the
-// running iOS version considers right. The negative values are sentinels our
-// react-native-screens patch understands (SHEET_SYSTEM_DETENT_* in
-// patches/react-native-screens@4.25.2.patch). Android has no system detents and throws
-// on anything outside 0..1, so it keeps the fractions these sheets used before.
+// Negative values ask for UIKit's own `.medium()`/`.large()` detents, via
+// patches/react-native-screens@4.25.2.patch; Android has none, so it keeps fractions.
 const SYSTEM_MEDIUM_LARGE_DETENTS = Platform.OS === "ios" ? [-3, -2] : [0.55, 0.92];
 const SYSTEM_LARGE_DETENTS = Platform.OS === "ios" ? [-2] : [0.92];
 

--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -113,6 +113,118 @@ index 0eb1f09dee82edd99e3e614938233db5cdeaebfe..73298f10807520970f625e166d7f5dd1
  
  #if !TARGET_OS_TV || __TV_OS_VERSION_MAX_ALLOWED >= 170000
    if (@available(tvOS 17.0, *)) {
+diff --git a/ios/RNSScreen.mm b/ios/RNSScreen.mm
+index 69d4d9a..2c17b0b 100644
+--- a/ios/RNSScreen.mm
++++ b/ios/RNSScreen.mm
+@@ -36,6 +36,12 @@
+ namespace react = facebook::react;
+ 
+ constexpr NSInteger SHEET_FIT_TO_CONTENTS = -1;
++// Entries in `sheetAllowedDetents` that ask for a UIKit-defined detent instead of a
++// fraction of the available height, so a sheet can adopt whatever `.medium()` and
++// `.large()` mean on the running iOS version. Ordered ascending by resulting height
++// to keep arrays that use them sorted, as the JS side asserts.
++constexpr NSInteger SHEET_SYSTEM_DETENT_MEDIUM = -3;
++constexpr NSInteger SHEET_SYSTEM_DETENT_LARGE = -2;
+ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
+ 
+ struct ContentWrapperBox {
+@@ -897,12 +903,50 @@ - (void)setLargestUndimmedDetentForSheet:(UISheetPresentationController *)sheet
+   }
+ }
+ 
++/**
++ * Identifier of the UIKit-defined detent an entry of `sheetAllowedDetents` asks for,
++ * or nil when the entry is an ordinary height fraction. See SHEET_SYSTEM_DETENT_*.
++ */
++- (UISheetPresentationControllerDetentIdentifier)systemDetentIdentifierForAllowedDetent:(NSNumber *)allowedDetent
++{
++  switch (allowedDetent.intValue) {
++    case SHEET_SYSTEM_DETENT_MEDIUM:
++      return UISheetPresentationControllerDetentIdentifierMedium;
++    case SHEET_SYSTEM_DETENT_LARGE:
++      return UISheetPresentationControllerDetentIdentifierLarge;
++    default:
++      return nil;
++  }
++}
++
++/// Position in `sheetAllowedDetents` of the entry that asked for the given system detent.
++- (NSInteger)indexOfAllowedDetentWithSystemIdentifier:(UISheetPresentationControllerDetentIdentifier)identifier
++{
++  if (identifier == nil) {
++    return NSNotFound;
++  }
++  for (NSUInteger index = 0; index < _sheetAllowedDetents.count; index++) {
++    UISheetPresentationControllerDetentIdentifier candidate =
++        [self systemDetentIdentifierForAllowedDetent:_sheetAllowedDetents[index]];
++    if (candidate != nil && [candidate isEqualToString:identifier]) {
++      return index;
++    }
++  }
++  return NSNotFound;
++}
++
+ - (NSInteger)detentIndexFromDetentIdentifier:(UISheetPresentationControllerDetentIdentifier)identifier
+ {
+   // We first check if we are running on iOS 16+ as the API is different
+ #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+   if (_sheetAllowedDetents.count > 0) {
+-    // We should be running on custom detents in this case, thus identifier should be a stringified number.
++    // System detents keep their own identifier rather than a stringified index, so we
++    // resolve those back to the position they were requested from.
++    NSInteger systemDetentIndex = [self indexOfAllowedDetentWithSystemIdentifier:identifier];
++    if (systemDetentIndex != NSNotFound) {
++      return systemDetentIndex;
++    }
++    // Otherwise we are running on custom detents, thus identifier should be a stringified number.
+     return identifier.integerValue;
+   } else
+ #endif // iOS 16 check
+@@ -1052,8 +1096,14 @@ - (void)updateFormSheetPresentationStyle
+         [self setLargestUndimmedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
+       }
+     } else {
+-      // We're on iOS 16+ & have custom detents.
+-      [self setLargestUndimmedDetentForSheet:sheet to:[NSNumber numberWithInt:ludIndex].stringValue animate:YES];
++      // We're on iOS 16+ & have custom detents. Detents that came in as a system detent
++      // request answer to UIKit's identifier instead of their index.
++      UISheetPresentationControllerDetentIdentifier systemIdent = (NSUInteger)ludIndex < _sheetAllowedDetents.count
++          ? [self systemDetentIdentifierForAllowedDetent:_sheetAllowedDetents[ludIndex]]
++          : nil;
++      [self setLargestUndimmedDetentForSheet:sheet
++                                          to:systemIdent ?: [NSNumber numberWithInt:ludIndex].stringValue
++                                     animate:YES];
+     }
+   } else {
+     RCTLogError(@"[RNScreens] Value of sheetLargestUndimmedDetent prop must be >= -1");
+@@ -1069,7 +1119,8 @@ - (void)updateFormSheetPresentationStyle
+ /**
+  * Creates array of detent objects based on provided `values` & `resolver`. Since we need to name the detents to be able
+  * to later refer to them, this method names the detents by stringifying their indices, e.g. detent on index 2 will be
+- * named "2".
++ * named "2". Values asking for a system detent are passed through to UIKit untouched, keeping
++ * their own identifier; `resolver` is not consulted for those.
+  */
+ - (NSArray<UISheetPresentationControllerDetent *> *)
+     detentsFromValues:(NSArray<NSNumber *> *)values
+@@ -1079,6 +1130,15 @@ - (void)updateFormSheetPresentationStyle
+   NSMutableArray<UISheetPresentationControllerDetent *> *customDetents =
+       [NSMutableArray arrayWithCapacity:values.count];
+   [values enumerateObjectsUsingBlock:^(NSNumber *value, NSUInteger index, BOOL *stop) {
++    UISheetPresentationControllerDetentIdentifier systemIdent =
++        [self systemDetentIdentifierForAllowedDetent:value];
++    if (systemIdent != nil) {
++      [customDetents
++          addObject:[systemIdent isEqualToString:UISheetPresentationControllerDetentIdentifierLarge]
++              ? UISheetPresentationControllerDetent.largeDetent
++              : UISheetPresentationControllerDetent.mediumDetent];
++      return;
++    }
+     UISheetPresentationControllerDetentIdentifier ident = [[NSNumber numberWithUnsignedInteger:index] stringValue];
+     [customDetents addObject:[UISheetPresentationControllerDetent
+                                  customDetentWithIdentifier:ident
 diff --git a/ios/RNSScreenStackHeaderConfig.h b/ios/RNSScreenStackHeaderConfig.h
 index 919b984edc9f91ee9ac26faf257d8a721e26457c..5bb0cd6736ed6bc51db57e2a9326f758f22c51d8 100644
 --- a/ios/RNSScreenStackHeaderConfig.h

--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -114,30 +114,24 @@ index 0eb1f09dee82edd99e3e614938233db5cdeaebfe..73298f10807520970f625e166d7f5dd1
  #if !TARGET_OS_TV || __TV_OS_VERSION_MAX_ALLOWED >= 170000
    if (@available(tvOS 17.0, *)) {
 diff --git a/ios/RNSScreen.mm b/ios/RNSScreen.mm
-index 69d4d9a..2c17b0b 100644
+index 69d4d9a..6a90e3d 100644
 --- a/ios/RNSScreen.mm
 +++ b/ios/RNSScreen.mm
-@@ -36,6 +36,12 @@
+@@ -36,6 +36,10 @@
  namespace react = facebook::react;
  
  constexpr NSInteger SHEET_FIT_TO_CONTENTS = -1;
-+// Entries in `sheetAllowedDetents` that ask for a UIKit-defined detent instead of a
-+// fraction of the available height, so a sheet can adopt whatever `.medium()` and
-+// `.large()` mean on the running iOS version. Ordered ascending by resulting height
-+// to keep arrays that use them sorted, as the JS side asserts.
++// Sentinel `sheetAllowedDetents` entries requesting a UIKit-defined detent. Ascending by
++// resulting height, so arrays using them stay sorted as the JS side asserts.
 +constexpr NSInteger SHEET_SYSTEM_DETENT_MEDIUM = -3;
 +constexpr NSInteger SHEET_SYSTEM_DETENT_LARGE = -2;
  constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
  
  struct ContentWrapperBox {
-@@ -897,12 +903,50 @@ - (void)setLargestUndimmedDetentForSheet:(UISheetPresentationController *)sheet
+@@ -897,11 +901,42 @@ - (void)setLargestUndimmedDetentForSheet:(UISheetPresentationController *)sheet
    }
  }
  
-+/**
-+ * Identifier of the UIKit-defined detent an entry of `sheetAllowedDetents` asks for,
-+ * or nil when the entry is an ordinary height fraction. See SHEET_SYSTEM_DETENT_*.
-+ */
 +- (UISheetPresentationControllerDetentIdentifier)systemDetentIdentifierForAllowedDetent:(NSNumber *)allowedDetent
 +{
 +  switch (allowedDetent.intValue) {
@@ -150,7 +144,6 @@ index 69d4d9a..2c17b0b 100644
 +  }
 +}
 +
-+/// Position in `sheetAllowedDetents` of the entry that asked for the given system detent.
 +- (NSInteger)indexOfAllowedDetentWithSystemIdentifier:(UISheetPresentationControllerDetentIdentifier)identifier
 +{
 +  if (identifier == nil) {
@@ -171,25 +164,18 @@ index 69d4d9a..2c17b0b 100644
    // We first check if we are running on iOS 16+ as the API is different
  #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
    if (_sheetAllowedDetents.count > 0) {
--    // We should be running on custom detents in this case, thus identifier should be a stringified number.
-+    // System detents keep their own identifier rather than a stringified index, so we
-+    // resolve those back to the position they were requested from.
 +    NSInteger systemDetentIndex = [self indexOfAllowedDetentWithSystemIdentifier:identifier];
 +    if (systemDetentIndex != NSNotFound) {
 +      return systemDetentIndex;
 +    }
-+    // Otherwise we are running on custom detents, thus identifier should be a stringified number.
+     // We should be running on custom detents in this case, thus identifier should be a stringified number.
      return identifier.integerValue;
    } else
- #endif // iOS 16 check
-@@ -1052,8 +1096,14 @@ - (void)updateFormSheetPresentationStyle
-         [self setLargestUndimmedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
+@@ -1053,7 +1088,12 @@ - (void)updateFormSheetPresentationStyle
        }
      } else {
--      // We're on iOS 16+ & have custom detents.
+       // We're on iOS 16+ & have custom detents.
 -      [self setLargestUndimmedDetentForSheet:sheet to:[NSNumber numberWithInt:ludIndex].stringValue animate:YES];
-+      // We're on iOS 16+ & have custom detents. Detents that came in as a system detent
-+      // request answer to UIKit's identifier instead of their index.
 +      UISheetPresentationControllerDetentIdentifier systemIdent = (NSUInteger)ludIndex < _sheetAllowedDetents.count
 +          ? [self systemDetentIdentifierForAllowedDetent:_sheetAllowedDetents[ludIndex]]
 +          : nil;
@@ -199,17 +185,16 @@ index 69d4d9a..2c17b0b 100644
      }
    } else {
      RCTLogError(@"[RNScreens] Value of sheetLargestUndimmedDetent prop must be >= -1");
-@@ -1069,7 +1119,8 @@ - (void)updateFormSheetPresentationStyle
+@@ -1069,7 +1109,7 @@ - (void)updateFormSheetPresentationStyle
  /**
   * Creates array of detent objects based on provided `values` & `resolver`. Since we need to name the detents to be able
   * to later refer to them, this method names the detents by stringifying their indices, e.g. detent on index 2 will be
 - * named "2".
-+ * named "2". Values asking for a system detent are passed through to UIKit untouched, keeping
-+ * their own identifier; `resolver` is not consulted for those.
++ * named "2". Entries requesting a system detent keep UIKit's own identifier instead.
   */
  - (NSArray<UISheetPresentationControllerDetent *> *)
      detentsFromValues:(NSArray<NSNumber *> *)values
-@@ -1079,6 +1130,15 @@ - (void)updateFormSheetPresentationStyle
+@@ -1079,6 +1119,15 @@ - (void)updateFormSheetPresentationStyle
    NSMutableArray<UISheetPresentationControllerDetent *> *customDetents =
        [NSMutableArray arrayWithCapacity:values.count];
    [values enumerateObjectsUsingBlock:^(NSNumber *value, NSUInteger index, BOOL *stop) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ patchedDependencies:
   react-native-gesture-handler@2.31.2: 808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3
   react-native-keyboard-controller@1.21.13: 20be72c84d74253acdcfefbc6defe36dc396944f1a44cab2bdd0e3cd572ae008
   react-native-nitro-modules@0.35.9: 825622aae63a8fb5b904f3c77908a0e216261d727ea171709f2c0b6088422675
-  react-native-screens@4.25.2: e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca
+  react-native-screens@4.25.2: c3c804498c378e03b39127c5f91c65f99ada902249c4065d3575c1253db4e08b
 
 importers:
 
@@ -234,7 +234,7 @@ importers:
         version: 7.3.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@react-navigation/native-stack':
         specifier: 7.17.6
-        version: 7.17.6(patch_hash=c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273)(f33ec00a567bb85eb7231a9f93abbf93)
+        version: 7.17.6(patch_hash=c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273)(19074db86e22203db2ad43f1aa004c26)
       '@shikijs/core':
         specifier: 4.2.0
         version: 4.2.0
@@ -399,7 +399,7 @@ importers:
         version: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-screens:
         specifier: 4.25.2
-        version: 4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 4.25.2(patch_hash=c3c804498c378e03b39127c5f91c65f99ada902249c4065d3575c1253db4e08b)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-shiki-engine:
         specifier: ^0.3.12
         version: 0.3.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -12244,7 +12244,7 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.11(a1cb0cd1ed6935827665f5f4dfea10c8)
+      expo-router: 56.2.11(f3cb31edca1e50ef686ca8399082bdb8)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12320,7 +12320,7 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.11(5f6f17c0753424303b0255c82e5ab0d3)
+      expo-router: 56.2.11(06a5e5e34fffdce30ab0253968ca7c5e)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12660,7 +12660,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-router: 56.2.11(a1cb0cd1ed6935827665f5f4dfea10c8)
+      expo-router: 56.2.11(f3cb31edca1e50ef686ca8399082bdb8)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -12675,7 +12675,7 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      expo-router: 56.2.11(5f6f17c0753424303b0255c82e5ab0d3)
+      expo-router: 56.2.11(06a5e5e34fffdce30ab0253968ca7c5e)
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
@@ -14264,7 +14264,7 @@ snapshots:
     optionalDependencies:
       '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
 
-  '@react-navigation/native-stack@7.17.6(patch_hash=c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273)(f33ec00a567bb85eb7231a9f93abbf93)':
+  '@react-navigation/native-stack@7.17.6(patch_hash=c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273)(19074db86e22203db2ad43f1aa004c26)':
     dependencies:
       '@react-navigation/elements': 2.9.26(c6a2ad0e2c930f8e3896e77c3ba11bc4)
       '@react-navigation/native': 7.3.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -14272,7 +14272,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-screens: 4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-screens: 4.25.2(patch_hash=c3c804498c378e03b39127c5f91c65f99ada902249c4065d3575c1253db4e08b)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
@@ -17013,7 +17013,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-router@56.2.11(5f6f17c0753424303b0255c82e5ab0d3):
+  expo-router@56.2.11(06a5e5e34fffdce30ab0253968ca7c5e):
     dependencies:
       '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
@@ -17044,7 +17044,7 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       react-native-drawer-layout: 4.2.4(de9b2f2dc96a3557fdc0df187a8417ee)
       react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-screens: 4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-screens: 4.25.2(patch_hash=c3c804498c378e03b39127c5f91c65f99ada902249c4065d3575c1253db4e08b)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
@@ -17064,7 +17064,7 @@ snapshots:
       - supports-color
     optional: true
 
-  expo-router@56.2.11(a1cb0cd1ed6935827665f5f4dfea10c8):
+  expo-router@56.2.11(f3cb31edca1e50ef686ca8399082bdb8):
     dependencies:
       '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -17095,7 +17095,7 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-drawer-layout: 4.2.4(05364bd849de538917a7364cc7dee3f5)
       react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-screens: 4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-screens: 4.25.2(patch_hash=c3c804498c378e03b39127c5f91c65f99ada902249c4065d3575c1253db4e08b)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
@@ -19912,14 +19912,14 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optional: true
 
-  react-native-screens@4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-screens@4.25.2(patch_hash=c3c804498c378e03b39127c5f91c65f99ada902249c4065d3575c1253db4e08b)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-freeze: 1.0.4(react@19.2.3)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
 
-  react-native-screens@4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-screens@4.25.2(patch_hash=c3c804498c378e03b39127c5f91c65f99ada902249c4065d3575c1253db4e08b)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-freeze: 1.0.4(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ patchedDependencies:
   react-native-gesture-handler@2.31.2: 808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3
   react-native-keyboard-controller@1.21.13: 20be72c84d74253acdcfefbc6defe36dc396944f1a44cab2bdd0e3cd572ae008
   react-native-nitro-modules@0.35.9: 825622aae63a8fb5b904f3c77908a0e216261d727ea171709f2c0b6088422675
-  react-native-screens@4.25.2: 47a07b0849ebf1ae454be3cb9fde7700c763584afa403d381e11e06e36187de8
+  react-native-screens@4.25.2: e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca
 
 importers:
 
@@ -234,7 +234,7 @@ importers:
         version: 7.3.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@react-navigation/native-stack':
         specifier: 7.17.6
-        version: 7.17.6(patch_hash=c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273)(a49e8e72dc3ef754b9d26038db8e6d3f)
+        version: 7.17.6(patch_hash=c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273)(f33ec00a567bb85eb7231a9f93abbf93)
       '@shikijs/core':
         specifier: 4.2.0
         version: 4.2.0
@@ -399,7 +399,7 @@ importers:
         version: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-screens:
         specifier: 4.25.2
-        version: 4.25.2(patch_hash=47a07b0849ebf1ae454be3cb9fde7700c763584afa403d381e11e06e36187de8)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-shiki-engine:
         specifier: ^0.3.12
         version: 0.3.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -12244,7 +12244,7 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.11(014c98b83770a9a763d36edd2815d6d7)
+      expo-router: 56.2.11(a1cb0cd1ed6935827665f5f4dfea10c8)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12320,7 +12320,7 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.11(e081a134f3c85dd26e314f8c96e5476f)
+      expo-router: 56.2.11(5f6f17c0753424303b0255c82e5ab0d3)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12660,7 +12660,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-router: 56.2.11(014c98b83770a9a763d36edd2815d6d7)
+      expo-router: 56.2.11(a1cb0cd1ed6935827665f5f4dfea10c8)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -12675,7 +12675,7 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      expo-router: 56.2.11(e081a134f3c85dd26e314f8c96e5476f)
+      expo-router: 56.2.11(5f6f17c0753424303b0255c82e5ab0d3)
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
@@ -14264,7 +14264,7 @@ snapshots:
     optionalDependencies:
       '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
 
-  '@react-navigation/native-stack@7.17.6(patch_hash=c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273)(a49e8e72dc3ef754b9d26038db8e6d3f)':
+  '@react-navigation/native-stack@7.17.6(patch_hash=c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273)(f33ec00a567bb85eb7231a9f93abbf93)':
     dependencies:
       '@react-navigation/elements': 2.9.26(c6a2ad0e2c930f8e3896e77c3ba11bc4)
       '@react-navigation/native': 7.3.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -14272,7 +14272,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-screens: 4.25.2(patch_hash=47a07b0849ebf1ae454be3cb9fde7700c763584afa403d381e11e06e36187de8)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-screens: 4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
@@ -17013,58 +17013,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-router@56.2.11(014c98b83770a9a763d36edd2815d6d7):
-    dependencies:
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      '@expo/schema-utils': 56.0.1
-      '@expo/ui': 56.0.18(3cdc0dde9f93166d952f1e1bd0cb25c0)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.16)(react@19.2.3)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      client-only: 0.0.1
-      color: 4.2.3
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
-      expo-constants: 56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
-      expo-glass-effect: 56.0.4(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-linking: 56.0.14(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-server: 56.0.5
-      expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      fast-deep-equal: 3.1.3
-      invariant: 2.2.4
-      nanoid: 3.3.12
-      query-string: 7.1.3
-      react: 19.2.3
-      react-fast-compare: 3.2.2
-      react-is: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-      react-native-drawer-layout: 4.2.4(05364bd849de538917a7364cc7dee3f5)
-      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-screens: 4.25.2(patch_hash=47a07b0849ebf1ae454be3cb9fde7700c763584afa403d381e11e06e36187de8)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      server-only: 0.0.1
-      sf-symbols-typescript: 2.2.0
-      shallowequal: 1.1.0
-      standard-navigation: 0.0.5
-      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    optionalDependencies:
-      react-dom: 19.2.3(react@19.2.3)
-      react-native-gesture-handler: 2.31.2(patch_hash=808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@testing-library/dom'
-      - '@types/react'
-      - '@types/react-dom'
-      - expo-font
-      - react-native-worklets
-      - supports-color
-    optional: true
-
-  expo-router@56.2.11(e081a134f3c85dd26e314f8c96e5476f):
+  expo-router@56.2.11(5f6f17c0753424303b0255c82e5ab0d3):
     dependencies:
       '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
@@ -17095,7 +17044,7 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       react-native-drawer-layout: 4.2.4(de9b2f2dc96a3557fdc0df187a8417ee)
       react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-screens: 4.25.2(patch_hash=47a07b0849ebf1ae454be3cb9fde7700c763584afa403d381e11e06e36187de8)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-screens: 4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
@@ -17105,6 +17054,57 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       react-native-gesture-handler: 2.31.2(patch_hash=808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@testing-library/dom'
+      - '@types/react'
+      - '@types/react-dom'
+      - expo-font
+      - react-native-worklets
+      - supports-color
+    optional: true
+
+  expo-router@56.2.11(a1cb0cd1ed6935827665f5f4dfea10c8):
+    dependencies:
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/schema-utils': 56.0.1
+      '@expo/ui': 56.0.18(3cdc0dde9f93166d952f1e1bd0cb25c0)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.16)(react@19.2.3)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      client-only: 0.0.1
+      color: 4.2.3
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
+      expo-constants: 56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-glass-effect: 56.0.4(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-linking: 56.0.14(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-server: 56.0.5
+      expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.12
+      query-string: 7.1.3
+      react: 19.2.3
+      react-fast-compare: 3.2.2
+      react-is: 19.2.7
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native-drawer-layout: 4.2.4(05364bd849de538917a7364cc7dee3f5)
+      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-screens: 4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      standard-navigation: 0.0.5
+      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.3)
+      react-native-gesture-handler: 2.31.2(patch_hash=808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@testing-library/dom'
@@ -19912,14 +19912,14 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optional: true
 
-  react-native-screens@4.25.2(patch_hash=47a07b0849ebf1ae454be3cb9fde7700c763584afa403d381e11e06e36187de8)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-screens@4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-freeze: 1.0.4(react@19.2.3)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
 
-  react-native-screens@4.25.2(patch_hash=47a07b0849ebf1ae454be3cb9fde7700c763584afa403d381e11e06e36187de8)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-screens@4.25.2(patch_hash=e68cb7f6c77490443fd68602d1a8efc471493fef118c122eabf7623795d1bfca)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-freeze: 1.0.4(react@19.2.6)


### PR DESCRIPTION
## What Changed

Added an option to use native medium and large detents on iOS sheets, and applied that to many existing sheets.

## Why

The existing sheets had hard-coded detent heights which looked a bit off to me personally. The small height looked too tall and the tall height looked too short, leading to a very small difference between the two heights. Letting iOS handle the detent heights makes the sheets feel more native and consistent across other apps on any given iOS version.

## UI Changes

Screenshots of the settings screen on iOS 26

| Before | After |
| --- | --- |
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-29 at 23 48 46" src="https://github.com/user-attachments/assets/2121e61b-38ee-4bbf-b173-499ed8804bc2" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-29 at 23 44 38" src="https://github.com/user-attachments/assets/bd6feb03-62e9-48b8-9e5f-62d974106496" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-29 at 23 48 50" src="https://github.com/user-attachments/assets/e0281b9b-f2ef-48ef-877d-1f9ed949b489" />  | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-29 at 23 44 43" src="https://github.com/user-attachments/assets/7c76dbc7-2324-4108-92f0-1fdce4cc1135" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native sheet presentation on iOS across many routes via a patched dependency; behavior is UI-focused but detent/undimming bugs could affect sheet gestures and layout.
> 
> **Overview**
> iOS form sheets that used fixed fractional `sheetAllowedDetents` (e.g. `0.55` / `0.92`) now use **UIKit’s system medium and large detents** on iOS via sentinel values `[-3, -2]` and `[-2]`, wired through shared constants in `Stack.tsx`. Android keeps the same fraction-based detents.
> 
> The **`react-native-screens` patch** is extended so `-3` and `-2` map to `UISheetPresentationControllerDetent.mediumDetent` / `.largeDetent`, with detent indexing and largest-undimmed handling updated for those system identifiers. `pnpm-lock.yaml` updates the patch hash for `react-native-screens@4.25.2`.
> 
> **Scope:** Settings, git overview/commit/branches, review comment composer, connect onboarding, and new-task sheet adopt the new constants. **Git confirm**, **Connections**, and **ConnectionsNew** still use custom fractional detents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07c35a15d368830a434fcbc8d03adaac334d4f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use UIKit system medium/large detents for iOS form sheets
> - Adds `SYSTEM_MEDIUM_LARGE_DETENTS` and `SYSTEM_LARGE_DETENTS` constants in [Stack.tsx](https://github.com/pingdotgg/t3code/pull/4914/files#diff-6c445d1d9bb762a38688d21c21790ec36c9a0b882fd17c04888c694ba76736ab) that use negative sentinel values (`-3`, `-2`) on iOS to request UIKit's built-in detents, with fractional fallbacks on Android.
> - Patches [react-native-screens](https://github.com/pingdotgg/t3code/pull/4914/files#diff-4a3fdb0138c1f4fc1d7c17e43532abae9c0f109ba7b7f5dbf6ebbefc136c6c33) to recognize these sentinels in `detentsFromValues`, emitting `UISheetPresentationControllerDetent.mediumDetent`/`.largeDetent` instead of custom fractional detents.
> - Updates `detentIndexFromDetentIdentifier` to correctly map UIKit detent identifiers back to indices, fixing misidentification of system detents as numeric strings.
> - Applies the new constants to all major form sheets: ThreadReviewComment, GitOverview, GitCommit, GitBranches, Settings, ConnectOnboarding, and NewTask.
> - Behavioral Change: iOS sheets now conform to UIKit's system-defined detent sizing rather than app-specified fractional heights; Android behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 07c35a1. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->