### PR TITLE
fix(desktop): surface Tailscale Serve failures instead of failing silently

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -46,6 +46,7 @@ const serverExposureLayer = Layer.succeed(DesktopServerExposure.DesktopServerExp
   setMode: () => Effect.die("unexpected setMode"),
   setTailscaleServeEnabled: () => Effect.die("unexpected setTailscaleServeEnabled"),
   getAdvertisedEndpoints: Effect.succeed([]),
+  resolveTailscaleHttpsEndpoint: Effect.succeed(null),
 } satisfies DesktopServerExposure.DesktopServerExposure["Service"]);
 
 function makeEnvironmentLayer(

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -3,8 +3,10 @@ import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
@@ -16,6 +18,15 @@ import * as DesktopServerExposure from "./DesktopServerExposure.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 
 const encoder = new TextEncoder();
+
+/** What the spawner reports when the `tailscale` binary is not on PATH. */
+const tailscaleBinaryMissing = PlatformError.systemError({
+  _tag: "NotFound",
+  module: "ChildProcessSpawner",
+  method: "spawn",
+  syscall: "spawn",
+  description: "spawn tailscale ENOENT",
+});
 
 const emptyNetworkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces = {};
 const lanNetworkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces = {
@@ -58,13 +69,6 @@ function mockSpawnerLayer(statusJson = "{}") {
         }),
       ),
     ),
-  );
-}
-
-function dieOnSpawnLayer() {
-  return Layer.succeed(
-    ChildProcessSpawner.ChildProcessSpawner,
-    ChildProcessSpawner.make(() => Effect.die("unexpected tailscale spawn")),
   );
 }
 
@@ -209,7 +213,7 @@ describe("DesktopServerExposure", () => {
     ),
   );
 
-  it.effect("persists tailscale serve preferences atomically and reports no-op updates", () =>
+  it.effect("persists tailscale serve preferences atomically after a successful preflight", () =>
     withHarness(
       emptyNetworkInterfaces,
       Effect.gen(function* () {
@@ -227,11 +231,14 @@ describe("DesktopServerExposure", () => {
         assert.equal(changed.state.tailscaleServeEnabled, true);
         assert.equal(changed.state.tailscaleServePort, 8443);
 
-        const unchanged = yield* serverExposure.setTailscaleServeEnabled({
+        // Re-enabling still relaunches so the child server re-binds Serve to
+        // its listen port, even when the preference document is unchanged.
+        const reenabled = yield* serverExposure.setTailscaleServeEnabled({
           enabled: true,
           port: 8443,
         });
-        assert.equal(unchanged.requiresRelaunch, false);
+        assert.equal(reenabled.requiresRelaunch, true);
+        assert.equal(reenabled.state.tailscaleServeEnabled, true);
 
         const persisted = yield* settings.get;
         assert.equal(persisted.tailscaleServeEnabled, true);
@@ -239,6 +246,427 @@ describe("DesktopServerExposure", () => {
       }),
     ),
   );
+
+  it.effect("fails enablement with CLI guidance when Tailscale Serve is not available", () => {
+    const configureUrl = "https://login.tailscale.com/f/serve?node=nExampleNodeIdForTests";
+    const failingSpawner = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        const childProcess = command as unknown as {
+          readonly command: string;
+          readonly args: ReadonlyArray<string>;
+        };
+        const isServe = childProcess.args[0] === "serve";
+        const stderr = isServe
+          ? [
+              "Serve is not enabled on your tailnet.",
+              "To enable, visit:",
+              "",
+              `         ${configureUrl}`,
+            ].join("\n")
+          : "";
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(isServe ? 1 : 0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.make(encoder.encode(isServe ? "" : "{}")),
+            stderr: Stream.make(encoder.encode(stderr)),
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      }),
+    );
+
+    return withHarness(
+      emptyNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+
+        yield* settings.load;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        const error = yield* serverExposure
+          .setTailscaleServeEnabled({ enabled: true, port: 443 })
+          .pipe(Effect.flip);
+
+        assert.instanceOf(error, DesktopServerExposure.DesktopTailscaleServeConfigureError);
+        assert.isTrue(DesktopServerExposure.isDesktopServerExposureSetTailscaleServeError(error));
+        assert.isTrue(DesktopServerExposure.isDesktopServerExposureError(error));
+        assert.equal(error.detail, "Serve is not enabled on your tailnet.");
+        assert.equal(error.configureUrl, configureUrl);
+        assert.equal(error.cause?._tag, "TailscaleCommandExitError");
+        assert.equal(
+          error.message,
+          `Serve is not enabled on your tailnet. To enable, visit: ${configureUrl}`,
+        );
+        // The desktop error turns the label into prose for the toast; the CLI
+        // error underneath stays label-free because that one gets logged.
+        const exitCause = error.cause;
+        if (exitCause?._tag !== "TailscaleCommandExitError") {
+          throw new Error(`expected TailscaleCommandExitError, got ${String(exitCause?._tag)}`);
+        }
+        assert.equal(exitCause.stderrDiagnostic, "serve-not-enabled");
+        assert.equal(
+          exitCause.message,
+          `tailscale serve exited with code 1. To enable, visit: ${configureUrl}`,
+        );
+
+        const persisted = yield* settings.get;
+        assert.equal(persisted.tailscaleServeEnabled, false);
+      }),
+      {},
+      failingSpawner,
+    );
+  });
+
+  it.effect("reports the actionable CLI hint when the tailscale binary cannot be spawned", () => {
+    const unspawnableSpawner = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => Effect.fail(tailscaleBinaryMissing)),
+    );
+
+    return withHarness(
+      emptyNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+
+        yield* settings.load;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        const error = yield* serverExposure
+          .setTailscaleServeEnabled({ enabled: true, port: 443 })
+          .pipe(Effect.flip);
+
+        assert.instanceOf(error, DesktopServerExposure.DesktopTailscaleServeConfigureError);
+        assert.equal(error.cause?._tag, "TailscaleCommandSpawnError");
+        // Tailscale missing from PATH is the most common failure; the toast must
+        // say so instead of the generic "on port 4173" fallback.
+        assert.equal(
+          error.message,
+          "Could not run the tailscale CLI. Is Tailscale installed and on PATH?",
+        );
+
+        const persisted = yield* settings.get;
+        assert.equal(persisted.tailscaleServeEnabled, false);
+      }),
+      {},
+      unspawnableSpawner,
+    );
+  });
+
+  it.effect("tears Serve down from the main process when disabling", () => {
+    const tailscaleCommands: Array<ReadonlyArray<string>> = [];
+    const recordingSpawner = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        const childProcess = command as unknown as {
+          readonly command: string;
+          readonly args: ReadonlyArray<string>;
+        };
+        tailscaleCommands.push(childProcess.args);
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.make(encoder.encode("{}")),
+            stderr: Stream.empty,
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      }),
+    );
+
+    return withHarness(
+      emptyNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+
+        yield* settings.load;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+        yield* serverExposure.setTailscaleServeEnabled({ enabled: true, port: 8443 });
+
+        tailscaleCommands.length = 0;
+        const disabled = yield* serverExposure.setTailscaleServeEnabled({ enabled: false });
+
+        assert.equal(disabled.state.tailscaleServeEnabled, false);
+        // Disabling must not depend on the child server's acquireRelease
+        // finalizer — after a failed relaunch that child has none, and Serve
+        // would stay live on the tailnet while settings said disabled.
+        assert.deepEqual(tailscaleCommands, [["serve", "--https=8443", "off"]]);
+
+        const persisted = yield* settings.get;
+        assert.equal(persisted.tailscaleServeEnabled, false);
+      }),
+      {},
+      recordingSpawner,
+    );
+  });
+
+  it.effect("keeps Serve enabled when the main-process teardown fails", () => {
+    const unspawnableAfterEnable = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        const childProcess = command as unknown as { readonly args: ReadonlyArray<string> };
+        if (childProcess.args.at(-1) === "off") {
+          return Effect.fail(tailscaleBinaryMissing);
+        }
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.make(encoder.encode("{}")),
+            stderr: Stream.empty,
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      }),
+    );
+
+    return withHarness(
+      emptyNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+
+        yield* settings.load;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+        yield* serverExposure.setTailscaleServeEnabled({ enabled: true, port: 8443 });
+
+        const error = yield* serverExposure
+          .setTailscaleServeEnabled({ enabled: false })
+          .pipe(Effect.flip);
+
+        assert.instanceOf(error, DesktopServerExposure.DesktopTailscaleServeConfigureError);
+        assert.equal(error.enabled, false);
+        // The CLI hint must not crowd out the exposure warning: a teardown that
+        // only says "could not run the tailscale CLI" reads like a no-op, when
+        // in fact the backend may still be served over the tailnet.
+        assert.equal(
+          error.message,
+          "Could not run the tailscale CLI. Is Tailscale installed and on PATH? It may still be reachable on your tailnet.",
+        );
+
+        // Never record "disabled" for a teardown we could not perform — Serve
+        // may still be reachable on the tailnet.
+        const persisted = yield* settings.get;
+        assert.equal(persisted.tailscaleServeEnabled, true);
+      }),
+      {},
+      unspawnableAfterEnable,
+    );
+  });
+
+  it.effect("rolls the preflighted binding back when persistence dies", () => {
+    // `tapError` only sees typed failures, so a defect (and likewise an
+    // interrupt, e.g. the app quitting mid-toggle) used to skip the rollback and
+    // leave Serve live on the tailnet with settings still saying disabled.
+    const settingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
+      get: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
+      load: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
+      setMainWindowBounds: () => Effect.die("unexpected main window bounds update"),
+      setServerExposureMode: () => Effect.die("unexpected exposure mode change"),
+      setTailscaleServe: () => Effect.die("settings file vanished"),
+      setUpdateChannel: () => Effect.die("unexpected update channel change"),
+      setWslBackendEnabled: () => Effect.die("unexpected WSL backend toggle"),
+      setWslDistro: () => Effect.die("unexpected WSL distro change"),
+      setWslOnly: () => Effect.die("unexpected WSL-only toggle"),
+      applyWslWindowsFallback: Effect.die("unexpected WSL Windows fallback"),
+      applyWslWindowsFallbackInMemory: Effect.die("unexpected WSL Windows fallback"),
+    } satisfies DesktopAppSettings.DesktopAppSettings["Service"]);
+
+    const tailscaleCommands: Array<ReadonlyArray<string>> = [];
+    const recordingSpawner = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        tailscaleCommands.push((command as unknown as { args: ReadonlyArray<string> }).args);
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.make(encoder.encode("{}")),
+            stderr: Stream.empty,
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      }),
+    );
+
+    return withHarness(
+      emptyNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        tailscaleCommands.length = 0;
+        const exit = yield* serverExposure
+          .setTailscaleServeEnabled({ enabled: true, port: 8443 })
+          .pipe(Effect.exit);
+
+        assert.isTrue(Exit.isFailure(exit));
+        // Enabled, then rolled back — the tailnet must not be left exposed.
+        assert.deepEqual(tailscaleCommands, [
+          ["serve", "--bg", "--https=8443", "http://127.0.0.1:4173"],
+          ["serve", "--https=8443", "off"],
+        ]);
+      }),
+      {},
+      recordingSpawner,
+      settingsLayer,
+    );
+  });
+
+  it.effect("still disables when Serve was already unbound", () => {
+    // `tailscale serve --https=<port> off` exits 1 with "handler does not
+    // exist" when nothing is bound. The tailnet already matches what the user
+    // asked for, so this must not strand the toggle on.
+    const alreadyOffSpawner = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        const args = (command as unknown as { args: ReadonlyArray<string> }).args;
+        const isOff = args.at(-1) === "off";
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(isOff ? 1 : 0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.make(encoder.encode(isOff ? "" : "{}")),
+            stderr: Stream.make(
+              encoder.encode(
+                isOff ? "error: failed to remove web serve: handler does not exist" : "",
+              ),
+            ),
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      }),
+    );
+
+    return withHarness(
+      emptyNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+
+        yield* settings.load;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+        yield* serverExposure.setTailscaleServeEnabled({ enabled: true, port: 8443 });
+
+        const disabled = yield* serverExposure.setTailscaleServeEnabled({ enabled: false });
+
+        assert.equal(disabled.state.tailscaleServeEnabled, false);
+        const persisted = yield* settings.get;
+        assert.equal(persisted.tailscaleServeEnabled, false);
+      }),
+      {},
+      alreadyOffSpawner,
+    );
+  });
+
+  it.effect("re-enables Serve when persisting the disable fails", () => {
+    const settingsFailure = new DesktopAppSettings.DesktopSettingsWriteError({
+      operation: "replace-settings-file",
+      path: "/tmp/desktop-settings.json",
+      cause: new Error("disk exploded"),
+    });
+    const enabledSettings = {
+      ...DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS,
+      tailscaleServeEnabled: true,
+      tailscaleServePort: 8443,
+    };
+    const settingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
+      get: Effect.succeed(enabledSettings),
+      load: Effect.succeed(enabledSettings),
+      setMainWindowBounds: () => Effect.die("unexpected main window bounds update"),
+      setServerExposureMode: () => Effect.die("unexpected exposure mode change"),
+      setTailscaleServe: () => Effect.fail(settingsFailure),
+      setUpdateChannel: () => Effect.die("unexpected update channel change"),
+      setWslBackendEnabled: () => Effect.die("unexpected WSL backend toggle"),
+      setWslDistro: () => Effect.die("unexpected WSL distro change"),
+      setWslOnly: () => Effect.die("unexpected WSL-only toggle"),
+      applyWslWindowsFallback: Effect.die("unexpected WSL Windows fallback"),
+      applyWslWindowsFallbackInMemory: Effect.die("unexpected WSL Windows fallback"),
+    } satisfies DesktopAppSettings.DesktopAppSettings["Service"]);
+
+    const tailscaleCommands: Array<ReadonlyArray<string>> = [];
+    const recordingSpawner = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        tailscaleCommands.push((command as unknown as { args: ReadonlyArray<string> }).args);
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.make(encoder.encode("{}")),
+            stderr: Stream.empty,
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      }),
+    );
+
+    return withHarness(
+      emptyNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        tailscaleCommands.length = 0;
+        const error = yield* serverExposure
+          .setTailscaleServeEnabled({ enabled: false })
+          .pipe(Effect.flip);
+
+        assert.instanceOf(error, DesktopServerExposure.DesktopTailscaleServePersistenceError);
+        // Serve was torn down before the write, and the write failed — so the
+        // binding must come back, or settings would advertise an HTTPS endpoint
+        // that no longer answers.
+        assert.deepEqual(tailscaleCommands, [
+          ["serve", "--https=8443", "off"],
+          ["serve", "--bg", "--https=8443", "http://127.0.0.1:4173"],
+        ]);
+      }),
+      {},
+      recordingSpawner,
+      settingsLayer,
+    );
+  });
 
   it.effect("preserves persistence request context and the settings failure chain", () => {
     const diskFailure = new Error("disk exploded");
@@ -260,6 +688,39 @@ describe("DesktopServerExposure", () => {
       applyWslWindowsFallback: Effect.die("unexpected WSL Windows fallback"),
       applyWslWindowsFallbackInMemory: Effect.die("unexpected WSL Windows fallback"),
     } satisfies DesktopAppSettings.DesktopAppSettings["Service"]);
+
+    const tailscaleCommands: Array<{
+      readonly command: string;
+      readonly args: ReadonlyArray<string>;
+    }> = [];
+    const recordingSpawner = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        const childProcess = command as unknown as {
+          readonly command: string;
+          readonly args: ReadonlyArray<string>;
+        };
+        tailscaleCommands.push({
+          command: childProcess.command,
+          args: childProcess.args,
+        });
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.make(encoder.encode("{}")),
+            stderr: Stream.empty,
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      }),
+    );
 
     return withHarness(
       lanNetworkInterfaces,
@@ -300,9 +761,22 @@ describe("DesktopServerExposure", () => {
           "Failed to persist desktop Tailscale Serve settings (enabled: true, port: 8443).",
         );
         assert.notInclude(tailscaleError.message, diskFailure.message);
+
+        // Preflight turned Serve on; persistence failure must roll it back so we
+        // do not leave HTTPS exposure active while settings still say disabled.
+        assert.deepEqual(tailscaleCommands, [
+          {
+            command: "tailscale",
+            args: ["serve", "--bg", "--https=8443", "http://127.0.0.1:4173"],
+          },
+          {
+            command: "tailscale",
+            args: ["serve", "--https=8443", "off"],
+          },
+        ]);
       }),
       {},
-      undefined,
+      recordingSpawner,
       settingsLayer,
     );
   });
@@ -333,17 +807,45 @@ describe("DesktopServerExposure", () => {
         // mode stays at default "local-only", tailscaleServeEnabled stays false.
 
         const endpoints = yield* serverExposure.getAdvertisedEndpoints;
-        // Only the loopback endpoint; no tailscale spawn means the dieOnSpawnLayer
-        // would have crashed the test if the gate was missing.
+        // Only the loopback endpoint; no tailscale spawn means dieOnSpawn would
+        // crash if the passive gate were missing.
         assert.deepEqual(
           endpoints.map((endpoint) => endpoint.httpBaseUrl),
           ["http://127.0.0.1:4173/"],
         );
       }),
       {},
-      dieOnSpawnLayer(),
+      Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() => Effect.die("unexpected tailscale spawn")),
+      ),
     ),
   );
+
+  it.effect("resolves Tailscale HTTPS on demand while remaining local-only", () => {
+    const statusJson = `{"Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.90.1.2"]}}`;
+    return withHarness(
+      lanNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        const passive = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          passive.map((endpoint) => endpoint.httpBaseUrl),
+          ["http://127.0.0.1:4173/"],
+        );
+
+        const endpoint = yield* serverExposure.resolveTailscaleHttpsEndpoint;
+        assert.isNotNull(endpoint);
+        assert.equal(endpoint?.httpBaseUrl, "https://desktop.tail.ts.net/");
+        assert.equal(endpoint?.status, "unavailable");
+        assert.equal(endpoint?.label, "Tailscale HTTPS");
+      }),
+      {},
+      mockSpawnerLayer(statusJson),
+    );
+  });
 
   it.effect("uses ConfigProvider desktop exposure overrides", () =>
     withHarness(

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -9,10 +9,20 @@ import {
   type DesktopServerExposureMode,
   type DesktopServerExposureState,
 } from "@t3tools/contracts";
-import { readTailscaleStatus } from "@t3tools/tailscale";
+import {
+  DEFAULT_TAILSCALE_SERVE_PORT,
+  describeTailscaleStderrDiagnostic,
+  disableTailscaleServe,
+  ensureTailscaleServe,
+  formatTailscaleServeUserMessage,
+  readTailscaleStatus,
+  TailscaleCommandError,
+  type TailscaleStderrDiagnostic,
+} from "@t3tools/tailscale";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
@@ -203,6 +213,18 @@ const resolveDesktopCoreAdvertisedEndpoints = (
   return endpoints;
 };
 
+/**
+ * Reason text for a `tailscale` exit failure, or undefined when the CLI said
+ * nothing we recognize. Callers fall back to their own wording rather than
+ * echoing the exit code at the user.
+ */
+function describeTailscaleServeExitCause(cause: {
+  readonly stderrDiagnostic?: TailscaleStderrDiagnostic | undefined;
+}): string | undefined {
+  if (cause.stderrDiagnostic === undefined) return undefined;
+  return describeTailscaleStderrDiagnostic(cause.stderrDiagnostic) ?? undefined;
+}
+
 export class DesktopServerExposureNoNetworkAddressError extends Schema.TaggedErrorClass<DesktopServerExposureNoNetworkAddressError>()(
   "DesktopServerExposureNoNetworkAddressError",
   {
@@ -239,6 +261,54 @@ export class DesktopTailscaleServePersistenceError extends Schema.TaggedErrorCla
   }
 }
 
+export class DesktopTailscaleServeConfigureError extends Schema.TaggedErrorClass<DesktopTailscaleServeConfigureError>()(
+  "DesktopTailscaleServeConfigureError",
+  {
+    enabled: Schema.Boolean,
+    port: Schema.NullOr(Schema.Number),
+    localPort: Schema.Number,
+    /**
+     * Safe CLI summary extracted from known `tailscale serve` patterns.
+     * Never raw stderr; optional when this is a pure validation failure.
+     */
+    detail: Schema.optionalKey(Schema.String),
+    /** Admin URL from the CLI (`login.tailscale.com/f/serve...`) when present. */
+    configureUrl: Schema.NullOr(Schema.String),
+    /** Immediate CLI failure when configuration was attempted; absent for validation-only errors. */
+    cause: Schema.optionalKey(TailscaleCommandError),
+  },
+) {
+  override get message(): string {
+    // Derive only from structural attributes — never cause.message.
+    if (this.localPort <= 0 && this.cause === undefined) {
+      return "Local backend is not ready yet. Try again in a moment.";
+    }
+    const parts: string[] = [];
+    if (this.detail !== undefined) {
+      parts.push(this.detail);
+    } else if (this.enabled) {
+      parts.push(
+        `Failed to configure Tailscale Serve for the local backend on port ${this.localPort}.`,
+      );
+    } else {
+      parts.push(
+        `Failed to turn off Tailscale Serve on port ${this.port ?? DEFAULT_TAILSCALE_SERVE_PORT}.`,
+      );
+    }
+    if (!this.enabled) {
+      // Append regardless of `detail`: whatever the CLI failed on, the point the
+      // user must not miss is that the backend may still be exposed. A teardown
+      // failure that only says "could not run the tailscale CLI" reads like a
+      // no-op, which is exactly the silent-exposure case this error exists for.
+      parts.push("It may still be reachable on your tailnet.");
+    }
+    if (this.configureUrl !== null) {
+      parts.push(`To enable, visit: ${this.configureUrl}`);
+    }
+    return parts.join(" ");
+  }
+}
+
 export const DesktopServerExposureSetModeError = Schema.Union([
   DesktopServerExposureNoNetworkAddressError,
   DesktopServerExposureModePersistenceError,
@@ -246,10 +316,21 @@ export const DesktopServerExposureSetModeError = Schema.Union([
 export type DesktopServerExposureSetModeError = typeof DesktopServerExposureSetModeError.Type;
 export const isDesktopServerExposureSetModeError = Schema.is(DesktopServerExposureSetModeError);
 
+export const DesktopServerExposureSetTailscaleServeError = Schema.Union([
+  DesktopTailscaleServePersistenceError,
+  DesktopTailscaleServeConfigureError,
+]);
+export type DesktopServerExposureSetTailscaleServeError =
+  typeof DesktopServerExposureSetTailscaleServeError.Type;
+export const isDesktopServerExposureSetTailscaleServeError = Schema.is(
+  DesktopServerExposureSetTailscaleServeError,
+);
+
 export const DesktopServerExposureError = Schema.Union([
   DesktopServerExposureNoNetworkAddressError,
   DesktopServerExposureModePersistenceError,
   DesktopTailscaleServePersistenceError,
+  DesktopTailscaleServeConfigureError,
 ]);
 export type DesktopServerExposureError = typeof DesktopServerExposureError.Type;
 export const isDesktopServerExposureError = Schema.is(DesktopServerExposureError);
@@ -281,8 +362,15 @@ export class DesktopServerExposure extends Context.Service<
     readonly setTailscaleServeEnabled: (input: {
       readonly enabled: boolean;
       readonly port?: number;
-    }) => Effect.Effect<DesktopServerExposureChange, DesktopTailscaleServePersistenceError>;
+    }) => Effect.Effect<DesktopServerExposureChange, DesktopServerExposureSetTailscaleServeError>;
     readonly getAdvertisedEndpoints: Effect.Effect<readonly AdvertisedEndpoint[]>;
+    /**
+     * User-initiated MagicDNS resolve for the Tailscale HTTPS setup flow.
+     * Spawns `tailscale status` (cached). Unlike getAdvertisedEndpoints, this
+     * runs even when network access is local-only and Serve is still off so
+     * Settings can offer the toggle without probing on every panel mount.
+     */
+    readonly resolveTailscaleHttpsEndpoint: Effect.Effect<AdvertisedEndpoint | null>;
   }
 >()("@t3tools/desktop/backend/DesktopServerExposure") {}
 
@@ -415,14 +503,15 @@ export const make = Effect.gen(function* () {
   // Cache the `tailscale status` spawn for the TTL. On macOS, the Mac App
   // Store Tailscale CLI lives inside Tailscale's sandbox container, so each
   // spawn re-triggers the "Other apps" TCC prompt.
-  const cachedReadMagicDnsName = yield* Effect.cachedWithTTL(
-    readTailscaleStatus.pipe(
-      Effect.map((status) => status.magicDnsName),
-      Effect.orElseSucceed(() => null),
-      Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
-    ),
-    TAILSCALE_STATUS_CACHE_TTL,
-  );
+  const [cachedReadMagicDnsName, invalidateCachedMagicDnsName] =
+    yield* Effect.cachedInvalidateWithTTL(
+      readTailscaleStatus.pipe(
+        Effect.map((status) => status.magicDnsName),
+        Effect.orElseSucceed(() => null),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+      ),
+      TAILSCALE_STATUS_CACHE_TTL,
+    );
 
   const readNetworkInterfaces = networkInterfaces.read;
 
@@ -492,6 +581,118 @@ export const make = Effect.gen(function* () {
         enabled: input.enabled,
         ...(input.port === undefined ? {} : { port: input.port }),
       });
+
+      // Preflight Serve configuration before persisting so Enable can fail loudly
+      // with the same CLI guidance (including the admin setup URL) instead of a
+      // silent restart that leaves the toggle unchecked. If settings write fails
+      // after Serve is already active, roll Serve back so we do not leave
+      // unintended network exposure with UI/settings still showing disabled.
+      let preflightedServePort: number | null = null;
+      let revertEnableBinding: { readonly servePort: number; readonly localPort: number } | null =
+        null;
+      if (input.enabled) {
+        const current = yield* Ref.get(stateRef);
+        const servePort = input.port ?? current.tailscaleServePort;
+        const localPort = current.port;
+        if (localPort <= 0) {
+          return yield* new DesktopTailscaleServeConfigureError({
+            enabled: true,
+            port: servePort,
+            localPort,
+            configureUrl: null,
+          });
+        }
+
+        yield* ensureTailscaleServe({
+          localPort,
+          servePort,
+          localHost: "127.0.0.1",
+        }).pipe(
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+          Effect.mapError((cause) => {
+            // Lift only safe structural diagnostics from the CLI error; keep the
+            // full TailscaleCommandError as cause for the error chain/stack.
+            // Exit errors already carry a vetted `detail`; spawn/timeout/output
+            // errors have none, and the generic "port N" fallback hides the most
+            // common failure (Tailscale not installed or not on PATH), so use the
+            // shared user-facing copy for those.
+            const exitDetail =
+              cause._tag === "TailscaleCommandExitError"
+                ? describeTailscaleServeExitCause(cause)
+                : formatTailscaleServeUserMessage(cause);
+            const configureUrl =
+              cause._tag === "TailscaleCommandExitError" ? (cause.configureUrl ?? null) : null;
+            return new DesktopTailscaleServeConfigureError({
+              enabled: true,
+              port: servePort,
+              localPort,
+              ...(exitDetail === undefined ? {} : { detail: exitDetail }),
+              configureUrl,
+              cause,
+            });
+          }),
+        );
+        // Only roll back a binding this preflight actually created. When Serve
+        // was already enabled on the same port, `tailscale serve --bg` is a
+        // no-op and disabling it on a persistence failure would tear down a
+        // working HTTPS endpoint that settings still record as enabled.
+        preflightedServePort =
+          current.tailscaleServeEnabled && current.tailscaleServePort === servePort
+            ? null
+            : servePort;
+      } else {
+        // Tear Serve down here rather than leaving it to the child server's
+        // acquireRelease finalizer. That finalizer only exists when the *current*
+        // child booted with Serve enabled, so after a failed relaunch (which
+        // `lifecycle.relaunch` logs and swallows) disabling would persist
+        // `enabled: false` while `tailscale serve --https=<port>` stayed live on
+        // the tailnet. Fail loudly instead of reporting a teardown we did not do.
+        const current = yield* Ref.get(stateRef);
+        let removedBinding = false;
+        if (current.tailscaleServeEnabled) {
+          const servePort = current.tailscaleServePort;
+          removedBinding = yield* disableTailscaleServe({ servePort }).pipe(
+            Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+            Effect.as(true),
+            // `serve off` on a port with nothing bound exits non-zero with
+            // "handler does not exist". The tailnet is already in the state the
+            // user asked for, so treating that as a failure would strand the
+            // toggle on and warn about an exposure that does not exist — and it
+            // would bite hardest in the very case this eager teardown exists
+            // for, where settings say enabled but no child ever bound Serve.
+            Effect.catchTags({
+              TailscaleCommandExitError: (cause) =>
+                cause.stderrDiagnostic === "no-existing-handler"
+                  ? Effect.succeed(false)
+                  : Effect.fail(cause),
+            }),
+            Effect.mapError((cause) => {
+              const exitDetail =
+                cause._tag === "TailscaleCommandExitError"
+                  ? describeTailscaleServeExitCause(cause)
+                  : formatTailscaleServeUserMessage(cause);
+              return new DesktopTailscaleServeConfigureError({
+                enabled: false,
+                port: servePort,
+                localPort: current.port,
+                ...(exitDetail === undefined ? {} : { detail: exitDetail }),
+                configureUrl: null,
+                cause,
+              });
+            }),
+          );
+          // Mirror the enable path's rollback. Serve is already down; if the
+          // settings write now fails, both stateRef and the persisted document
+          // still say enabled, so without this the UI would advertise an HTTPS
+          // endpoint that no longer answers. Only when we actually removed a
+          // binding, though — re-creating one that was never there would expose
+          // the backend rather than restore it.
+          if (removedBinding && current.port > 0) {
+            revertEnableBinding = { servePort, localPort: current.port };
+          }
+        }
+      }
+
       const result = yield* desktopSettings
         .setTailscaleServe({
           enabled: input.enabled,
@@ -506,6 +707,33 @@ export const make = Effect.gen(function* () {
                 cause,
               }),
           ),
+          // Put the tailnet back the way the still-unchanged settings describe
+          // it. `onExit` rather than `tapError`: the tailnet has already been
+          // changed by this point, so an interrupt (app quitting mid-toggle) or
+          // a defect must undo it too — `tapError` sees only typed failures, and
+          // skipping the rollback on those exits is exactly the silent-exposure
+          // case this whole path exists to prevent. Best-effort, since the
+          // original persistence failure is what the caller needs to see.
+          Effect.onExit((exit) => {
+            if (Exit.isSuccess(exit)) return Effect.void;
+            if (preflightedServePort !== null) {
+              return disableTailscaleServe({ servePort: preflightedServePort }).pipe(
+                Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+                Effect.ignore,
+              );
+            }
+            if (revertEnableBinding !== null) {
+              return ensureTailscaleServe({
+                localPort: revertEnableBinding.localPort,
+                servePort: revertEnableBinding.servePort,
+                localHost: "127.0.0.1",
+              }).pipe(
+                Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+                Effect.ignore,
+              );
+            }
+            return Effect.void;
+          }),
         );
 
       const nextState = yield* Ref.updateAndGet(stateRef, (current) => ({
@@ -516,39 +744,65 @@ export const make = Effect.gen(function* () {
 
       return {
         state: toContractState(nextState),
-        requiresRelaunch: result.changed,
+        // Always relaunch after a successful enable preflight so the child
+        // server re-binds Serve to its current listen port (which may change).
+        requiresRelaunch: result.changed || input.enabled,
       };
+    },
+  );
+
+  const resolveTailscaleEndpoints = Effect.fn("desktop.serverExposure.resolveTailscaleEndpoints")(
+    function* (input: { readonly state: RuntimeState }) {
+      const currentNetworkInterfaces = yield* readNetworkInterfaces;
+      return yield* resolveTailscaleAdvertisedEndpoints({
+        port: input.state.port,
+        serveEnabled: input.state.tailscaleServeEnabled,
+        servePort: input.state.tailscaleServePort,
+        networkInterfaces: currentNetworkInterfaces,
+        readMagicDnsName: cachedReadMagicDnsName,
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+        Effect.provideService(HttpClient.HttpClient, httpClient),
+      );
     },
   );
 
   const getAdvertisedEndpoints = Effect.gen(function* () {
     const state = yield* Ref.get(stateRef);
-    const currentNetworkInterfaces = yield* readNetworkInterfaces;
     const coreEndpoints = resolveDesktopCoreAdvertisedEndpoints({
       port: state.port,
       exposure: toResolvedExposure(state),
       customHttpsEndpointUrls: config.desktopHttpsEndpointUrls,
     });
 
-    // Don't spawn the Tailscale CLI when the user hasn't opted into any
-    // network exposure. The spawn itself triggers a macOS "Other apps"
-    // TCC prompt on Mac App Store Tailscale builds.
+    // Don't spawn the Tailscale CLI on every Connections panel mount when the
+    // user hasn't opted into network exposure or Serve yet. MAS Tailscale's
+    // CLI lives in a sandbox, so each spawn re-fires the "Other apps" TCC
+    // prompt (#2745). Tailscale HTTPS setup uses resolveTailscaleHttpsEndpoint
+    // on explicit user interaction instead (Serve is independent of LAN bind).
     if (state.mode !== "network-accessible" && !state.tailscaleServeEnabled) {
       return coreEndpoints;
     }
 
-    const tailscaleEndpoints = yield* resolveTailscaleAdvertisedEndpoints({
-      port: state.port,
-      serveEnabled: state.tailscaleServeEnabled,
-      servePort: state.tailscaleServePort,
-      networkInterfaces: currentNetworkInterfaces,
-      readMagicDnsName: cachedReadMagicDnsName,
-    }).pipe(
-      Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
-      Effect.provideService(HttpClient.HttpClient, httpClient),
-    );
+    const tailscaleEndpoints = yield* resolveTailscaleEndpoints({ state });
     return [...coreEndpoints, ...tailscaleEndpoints];
   }).pipe(Effect.withSpan("desktop.serverExposure.getAdvertisedEndpoints"));
+
+  const resolveTailscaleHttpsEndpoint = Effect.gen(function* () {
+    const state = yield* Ref.get(stateRef);
+    // This resolve is explicitly user-initiated ("turn on Tailscale HTTPS"), and
+    // the failure toast tells the user to start Tailscale and retry. Serving a
+    // stale cached miss for the rest of the TTL would make that retry fail for
+    // no reason, so force a fresh `tailscale status` here.
+    yield* invalidateCachedMagicDnsName;
+    const tailscaleEndpoints = yield* resolveTailscaleEndpoints({ state });
+    return (
+      tailscaleEndpoints.find(
+        (endpoint) =>
+          endpoint.provider.id === "tailscale" && endpoint.httpBaseUrl.startsWith("https:"),
+      ) ?? null
+    );
+  }).pipe(Effect.withSpan("desktop.serverExposure.resolveTailscaleHttpsEndpoint"));
 
   return DesktopServerExposure.of({
     getState,
@@ -557,6 +811,7 @@ export const make = Effect.gen(function* () {
     setMode,
     setTailscaleServeEnabled,
     getAdvertisedEndpoints,
+    resolveTailscaleHttpsEndpoint,
   });
 });
 

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -10,6 +10,7 @@ import {
 import {
   getAdvertisedEndpoints,
   getServerExposureState,
+  resolveTailscaleHttpsEndpoint,
   setServerExposureMode,
   setTailscaleServeEnabled,
 } from "./methods/serverExposure.ts";
@@ -72,6 +73,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handle(setServerExposureMode);
   yield* ipc.handle(setTailscaleServeEnabled);
   yield* ipc.handle(getAdvertisedEndpoints);
+  yield* ipc.handle(resolveTailscaleHttpsEndpoint);
 
   yield* ipc.handle(getWslState);
   yield* ipc.handle(setWslBackendEnabled);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -34,6 +34,7 @@ export const GET_SERVER_EXPOSURE_STATE_CHANNEL = "desktop:get-server-exposure-st
 export const SET_SERVER_EXPOSURE_MODE_CHANNEL = "desktop:set-server-exposure-mode";
 export const SET_TAILSCALE_SERVE_ENABLED_CHANNEL = "desktop:set-tailscale-serve-enabled";
 export const GET_ADVERTISED_ENDPOINTS_CHANNEL = "desktop:get-advertised-endpoints";
+export const RESOLVE_TAILSCALE_HTTPS_ENDPOINT_CHANNEL = "desktop:resolve-tailscale-https-endpoint";
 export const GET_WSL_STATE_CHANNEL = "desktop:get-wsl-state";
 export const SET_WSL_BACKEND_ENABLED_CHANNEL = "desktop:set-wsl-backend-enabled";
 export const SET_WSL_DISTRO_CHANNEL = "desktop:set-wsl-distro";

--- a/apps/desktop/src/ipc/methods/serverExposure.ts
+++ b/apps/desktop/src/ipc/methods/serverExposure.ts
@@ -13,7 +13,10 @@ import * as DesktopIpc from "../DesktopIpc.ts";
 
 const SetTailscaleServeEnabledInput = Schema.Struct({
   enabled: Schema.Boolean,
-  port: Schema.optionalKey(Schema.Number),
+  // Reject out-of-range ports at the boundary. Settings persistence silently
+  // normalizes anything invalid to 443, so a bare Schema.Number would let the
+  // CLI bind one port while settings recorded another.
+  port: Schema.optionalKey(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65_535 }))),
 });
 
 export const getServerExposureState = DesktopIpc.makeIpcMethod({
@@ -65,5 +68,15 @@ export const getAdvertisedEndpoints = DesktopIpc.makeIpcMethod({
   handler: Effect.fn("desktop.ipc.serverExposure.getAdvertisedEndpoints")(function* () {
     const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
     return yield* serverExposure.getAdvertisedEndpoints;
+  }),
+});
+
+export const resolveTailscaleHttpsEndpoint = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.RESOLVE_TAILSCALE_HTTPS_ENDPOINT_CHANNEL,
+  payload: Schema.Void,
+  result: Schema.NullOr(AdvertisedEndpoint),
+  handler: Effect.fn("desktop.ipc.serverExposure.resolveTailscaleHttpsEndpoint")(function* () {
+    const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+    return yield* serverExposure.resolveTailscaleHttpsEndpoint;
   }),
 });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -91,6 +91,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   setTailscaleServeEnabled: (input) =>
     ipcRenderer.invoke(IpcChannels.SET_TAILSCALE_SERVE_ENABLED_CHANNEL, input),
   getAdvertisedEndpoints: () => ipcRenderer.invoke(IpcChannels.GET_ADVERTISED_ENDPOINTS_CHANNEL),
+  resolveTailscaleHttpsEndpoint: () =>
+    ipcRenderer.invoke(IpcChannels.RESOLVE_TAILSCALE_HTTPS_ENDPOINT_CHANNEL),
   getWslState: () => ipcRenderer.invoke(IpcChannels.GET_WSL_STATE_CHANNEL),
   setWslBackendEnabled: (enabled) =>
     ipcRenderer.invoke(IpcChannels.SET_WSL_BACKEND_ENABLED_CHANNEL, enabled),

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -144,6 +144,7 @@ const desktopServerExposureLayer = Layer.succeed(DesktopServerExposure.DesktopSe
   setMode: () => Effect.die("unexpected setMode"),
   setTailscaleServeEnabled: () => Effect.die("unexpected setTailscaleServeEnabled"),
   getAdvertisedEndpoints: Effect.die("unexpected getAdvertisedEndpoints"),
+  resolveTailscaleHttpsEndpoint: Effect.die("unexpected resolveTailscaleHttpsEndpoint"),
 } satisfies DesktopServerExposure.DesktopServerExposure["Service"]);
 
 const electronMenuLayer = Layer.succeed(ElectronMenu.ElectronMenu, {

--- a/apps/desktop/src/wsl/DesktopWslBackend.test.ts
+++ b/apps/desktop/src/wsl/DesktopWslBackend.test.ts
@@ -63,6 +63,7 @@ const serverExposureLayer = Layer.succeed(DesktopServerExposure.DesktopServerExp
   setMode: () => Effect.die("unexpected setMode"),
   setTailscaleServeEnabled: () => Effect.die("unexpected setTailscaleServeEnabled"),
   getAdvertisedEndpoints: Effect.succeed([]),
+  resolveTailscaleHttpsEndpoint: Effect.succeed(null),
 } satisfies DesktopServerExposure.DesktopServerExposure["Service"]);
 
 const backendConfigurationLayer = Layer.succeed(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -106,7 +106,11 @@ import {
 import { orchestrationHttpApiLayer } from "./orchestration/http.ts";
 import * as NetService from "@t3tools/shared/Net";
 import * as RelayClient from "@t3tools/shared/relayClient";
-import { disableTailscaleServe, ensureTailscaleServe } from "@t3tools/tailscale";
+import {
+  disableTailscaleServe,
+  ensureTailscaleServe,
+  formatTailscaleServeUserMessage,
+} from "@t3tools/tailscale";
 
 // Effect's default preemptive shutdown waits 20s before finalizing request scopes.
 // T3's primary transport is long-lived WebSocket RPC, whose Effect scope finalizer
@@ -480,6 +484,7 @@ export const makeServerLayer = Layer.unwrap(
                 Effect.catch((cause) =>
                   Effect.logWarning("Failed to configure Tailscale Serve", {
                     cause,
+                    message: formatTailscaleServeUserMessage(cause),
                     localPort,
                     servePort: config.tailscaleServePort,
                   }).pipe(Effect.as(null)),

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -40,7 +40,11 @@ import * as Option from "effect/Option";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { cn } from "../../lib/utils";
 import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestampFormat";
-import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
+import {
+  isShareableOrigin,
+  resolveDesktopPairingUrl,
+  resolveHostedPairingUrl,
+} from "./pairingUrls";
 import { applyWslEnableSelection } from "./ConnectionsSettings.logic";
 import {
   SettingsPageContainer,
@@ -71,6 +75,7 @@ import {
   AlertDialogPopup,
   AlertDialogTitle,
 } from "../ui/alert-dialog";
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "../ui/alert";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { QRCodeSvg } from "../ui/qr-code";
 import { Spinner } from "../ui/spinner";
@@ -137,6 +142,43 @@ import { CloudEnvironmentConnectRows } from "../cloud/CloudEnvironmentConnectLis
 import { ITEM_ROW_CLASSNAME, ITEM_ROW_INNER_CLASSNAME } from "./itemRows";
 
 const DEFAULT_TAILSCALE_SERVE_PORT = 443;
+
+/** Matches the admin URL Tailscale CLI prints when Serve is disabled on the tailnet. */
+const TAILSCALE_SERVE_CONFIGURE_URL_PATTERN =
+  /https:\/\/login\.tailscale\.com\/f\/serve\?[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=%-]+/i;
+
+const TAILSCALE_SERVE_CONFIGURE_URL_BASE = "https://login.tailscale.com/f/serve";
+const TAILSCALE_NODE_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Mirrors `extractTailscaleServeConfigureUrl` in `@t3tools/tailscale`, which
+ * cannot be imported here — it is a Node-only package.
+ *
+ * Rebuilds the URL from constants instead of returning the match: this one is
+ * parsed out of a message rendered in the UI and handed to `openExternal`, so
+ * the query has to be an allowlist rather than whatever the text carried.
+ */
+function extractTailscaleServeConfigureUrl(text: string): string | null {
+  const match = text.match(TAILSCALE_SERVE_CONFIGURE_URL_PATTERN);
+  if (!match?.[0] || match[0].length > 500) {
+    return null;
+  }
+  try {
+    const parsed = new URL(match[0]);
+    if (parsed.protocol !== "https:") return null;
+    if (parsed.hostname !== "login.tailscale.com") return null;
+    if (!parsed.pathname.startsWith("/f/serve")) return null;
+
+    const sanitized = new URL(TAILSCALE_SERVE_CONFIGURE_URL_BASE);
+    const node = parsed.searchParams.get("node");
+    if (node !== null && TAILSCALE_NODE_ID_PATTERN.test(node)) {
+      sanitized.searchParams.set("node", node);
+    }
+    return sanitized.toString();
+  } catch {
+    return null;
+  }
+}
 const EMPTY_ADVERTISED_ENDPOINTS: ReadonlyArray<AdvertisedEndpoint> = [];
 const EMPTY_DISCOVERED_SSH_HOSTS: ReadonlyArray<DesktopDiscoveredSshHost> = [];
 
@@ -373,6 +415,62 @@ function formatDesktopSshConnectionError(error: unknown): string {
   return withoutTaggedErrorPrefix.trim() || fallback;
 }
 
+const IPC_INVOKE_ERROR_PREFIX_PATTERN = /^Error invoking remote method '[^']*':\s*/u;
+const TAGGED_ERROR_PREFIX_PATTERN = /^[A-Z][A-Za-z0-9]*Error:\s*/u;
+
+/**
+ * Electron rejects `ipcRenderer.invoke` with `Error invoking remote method
+ * '<channel>': <TaggedError>: <message>`. Strip that machinery so the toast
+ * shows the CLI guidance (and setup URL) the main process derived.
+ */
+function formatDesktopTailscaleServeError(error: unknown, fallback: string): string {
+  if (!(error instanceof Error)) return fallback;
+  let message = error.message.replace(IPC_INVOKE_ERROR_PREFIX_PATTERN, "").trim();
+  while (TAGGED_ERROR_PREFIX_PATTERN.test(message)) {
+    message = message.replace(TAGGED_ERROR_PREFIX_PATTERN, "").trim();
+  }
+  return message || fallback;
+}
+
+/**
+ * Inline failure for the Tailscale HTTPS dialogs. Both dialogs stay open when
+ * the CLI call fails, so the reason has to be visible inside them — a toast
+ * behind a modal is easy to miss, and the admin setup link is the actual fix.
+ */
+function TailscaleServeErrorAlert({
+  message,
+  title,
+  onOpenConfigureUrl,
+}: {
+  readonly message: string;
+  readonly title: string;
+  readonly onOpenConfigureUrl: (configureUrl: string) => void;
+}) {
+  const configureUrl = extractTailscaleServeConfigureUrl(message);
+  // Keep the URL in the message. The CLI phrases this as "... To enable,
+  // visit: <url>", so dropping the URL leaves a dangling colon; `wrap-anywhere`
+  // lets it break inside the dialog's narrow column instead. The button is a
+  // shortcut, not a replacement — the text stays selectable and copyable.
+  return (
+    <Alert variant="error">
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription className="wrap-anywhere">{message}</AlertDescription>
+      {configureUrl ? (
+        <AlertAction>
+          <Button
+            variant="outline"
+            onClick={() => {
+              onOpenConfigureUrl(configureUrl);
+            }}
+          >
+            Open setup
+          </Button>
+        </AlertAction>
+      ) : null}
+    </Alert>
+  );
+}
+
 const ENDPOINT_ROW_CLASSNAME = "rounded-xl px-3 py-2.5 sm:px-4";
 
 type AccessSectionPresentation = "current" | "endpoint-rail";
@@ -569,9 +667,9 @@ const PairingLinkListRow = memo(function PairingLinkListRow({
     endpointPairingUrl ??
     (endpointUrl != null && endpointUrl !== ""
       ? (hostedPairingUrl ?? resolveDesktopPairingUrl(endpointUrl, pairingLink.credential))
-      : isLoopbackHostname(window.location.hostname)
-        ? null
-        : currentOriginPairingUrl);
+      : isShareableOrigin(window.location)
+        ? currentOriginPairingUrl
+        : null);
   const revealValue = shareablePairingUrl ?? pairingLink.credential;
   const isShareableHostedAppPairingUrl =
     shareablePairingUrl !== null && isHostedAppPairingUrl(shareablePairingUrl);
@@ -1775,6 +1873,12 @@ export function ConnectionsSettings() {
   const [desktopServerExposureMutationError, setDesktopServerExposureMutationError] = useState<
     string | null
   >(null);
+  // Kept separate from the network-access error above: these two settings are
+  // independent, and a Tailscale failure reported under "Network access" points
+  // the user at the wrong control.
+  const [tailscaleServeMutationError, setTailscaleServeMutationError] = useState<string | null>(
+    null,
+  );
   const [desktopAccessManagementMutationError, setDesktopAccessManagementMutationError] = useState<
     string | null
   >(null);
@@ -1968,11 +2072,41 @@ export function ConnectionsSettings() {
     void handleDesktopServerExposureChange(checked);
   }, [handleDesktopServerExposureChange, pendingDesktopServerExposureMode]);
 
+  const openTailscaleServeConfigureUrl = useCallback(
+    (configureUrl: string) => {
+      // In a plain browser this is the only way out.
+      if (!desktopBridge) {
+        window.open(configureUrl, "_blank", "noopener,noreferrer");
+        return;
+      }
+      // openExternal resolves `false` instead of rejecting when the shell
+      // refuses the URL, so branch on the result. `window.open` is not a usable
+      // fallback here: the main window's setWindowOpenHandler routes it back
+      // into the same openExternal and denies the popup, so a failure would be
+      // a silent no-op. Say so instead — the URL is in the message above, and
+      // the alert text is selectable.
+      void desktopBridge
+        .openExternal(configureUrl)
+        .catch(() => false)
+        .then((opened) => {
+          if (opened) return;
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not open the Tailscale setup page",
+              description: `Copy this link into your browser: ${configureUrl}`,
+            }),
+          );
+        });
+    },
+    [desktopBridge],
+  );
+
   const handleConfirmTailscaleServeSetup = useCallback(async () => {
     if (!desktopBridge) return;
     if (!isTailscaleServePortValid) return;
     setIsUpdatingTailscaleServe(true);
-    setDesktopServerExposureMutationError(null);
+    setTailscaleServeMutationError(null);
     try {
       await desktopBridge.setTailscaleServeEnabled({
         enabled: true,
@@ -1981,26 +2115,48 @@ export function ConnectionsSettings() {
       refreshDesktopNetworkAccessState();
       setPendingTailscaleServeEndpoint(null);
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Failed to configure Tailscale HTTPS.";
-      setDesktopServerExposureMutationError(message);
+      const message = formatDesktopTailscaleServeError(
+        error,
+        "Failed to configure Tailscale HTTPS.",
+      );
+      setTailscaleServeMutationError(message);
+      const configureUrl = extractTailscaleServeConfigureUrl(message);
       toastManager.add(
         stackedThreadToast({
           type: "error",
           title: "Could not set up Tailscale HTTPS",
           description: message,
+          actionVariant: "outline",
+          ...(configureUrl
+            ? {
+                actionProps: {
+                  children: "Open setup",
+                  onClick: () => {
+                    openTailscaleServeConfigureUrl(configureUrl);
+                  },
+                },
+              }
+            : {}),
         }),
       );
     } finally {
       setIsUpdatingTailscaleServe(false);
     }
-  }, [desktopBridge, isTailscaleServePortValid, parsedTailscaleServePort]);
+  }, [
+    desktopBridge,
+    isTailscaleServePortValid,
+    openTailscaleServeConfigureUrl,
+    parsedTailscaleServePort,
+  ]);
 
   const handleStartTailscaleServeSetup = useCallback(
     (endpoint: AdvertisedEndpoint) => {
       setTailscaleServePortInput(
         String(desktopServerExposureState?.tailscaleServePort ?? DEFAULT_TAILSCALE_SERVE_PORT),
       );
+      // The dialog surfaces this inline, so a failure from a previous attempt
+      // must not be sitting there when it reopens.
+      setTailscaleServeMutationError(null);
       setPendingTailscaleServeEndpoint(endpoint);
     },
     [desktopServerExposureState?.tailscaleServePort],
@@ -2009,7 +2165,7 @@ export function ConnectionsSettings() {
   const handleConfirmTailscaleServeDisable = useCallback(async () => {
     if (!desktopBridge) return;
     setIsUpdatingTailscaleServe(true);
-    setDesktopServerExposureMutationError(null);
+    setTailscaleServeMutationError(null);
     try {
       await desktopBridge.setTailscaleServeEnabled({
         enabled: false,
@@ -2018,8 +2174,8 @@ export function ConnectionsSettings() {
       refreshDesktopNetworkAccessState();
       setDisableTailscaleServeDialogOpen(false);
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to disable Tailscale HTTPS.";
-      setDesktopServerExposureMutationError(message);
+      const message = formatDesktopTailscaleServeError(error, "Failed to disable Tailscale HTTPS.");
+      setTailscaleServeMutationError(message);
       toastManager.add(
         stackedThreadToast({
           type: "error",
@@ -2032,9 +2188,18 @@ export function ConnectionsSettings() {
     }
   }, [desktopBridge, desktopServerExposureState?.tailscaleServePort]);
 
-  const handleStartTailscaleServeDisable = useCallback((_endpoint: AdvertisedEndpoint) => {
+  const openTailscaleServeDisableDialog = useCallback(() => {
+    // The dialog surfaces this inline; clear any previous attempt's failure.
+    setTailscaleServeMutationError(null);
     setDisableTailscaleServeDialogOpen(true);
   }, []);
+
+  const handleStartTailscaleServeDisable = useCallback(
+    (_endpoint: AdvertisedEndpoint) => {
+      openTailscaleServeDisableDialog();
+    },
+    [openTailscaleServeDisableDialog],
+  );
 
   const handleRevokeDesktopPairingLink = useCallback(async (id: string) => {
     setRevokingDesktopPairingLinkId(id);
@@ -2295,6 +2460,57 @@ export function ConnectionsSettings() {
     () => desktopAdvertisedEndpoints.find(isTailscaleHttpsEndpoint) ?? null,
     [desktopAdvertisedEndpoints],
   );
+
+  const handleEnableTailscaleHttps = useCallback(async () => {
+    if (!desktopBridge) return;
+    if (tailscaleHttpsEndpoint) {
+      handleStartTailscaleServeSetup(tailscaleHttpsEndpoint);
+      return;
+    }
+
+    // MagicDNS is resolved only on explicit opt-in so local-only Connections
+    // mounts do not spawn `tailscale status` (macOS MAS TCC; #2745).
+    setIsUpdatingTailscaleServe(true);
+    setTailscaleServeMutationError(null);
+    try {
+      const endpoint = await desktopBridge.resolveTailscaleHttpsEndpoint();
+      if (!endpoint) {
+        const message =
+          "Tailscale is not running or has no MagicDNS name. Start Tailscale and try again.";
+        setTailscaleServeMutationError(message);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not set up Tailscale HTTPS",
+            description: message,
+          }),
+        );
+        return;
+      }
+      handleStartTailscaleServeSetup(endpoint);
+      refreshDesktopNetworkAccessState();
+    } catch (error) {
+      const message = formatDesktopTailscaleServeError(
+        error,
+        "Failed to resolve Tailscale HTTPS endpoint.",
+      );
+      setTailscaleServeMutationError(message);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not set up Tailscale HTTPS",
+          description: message,
+        }),
+      );
+    } finally {
+      setIsUpdatingTailscaleServe(false);
+    }
+  }, [
+    desktopBridge,
+    handleStartTailscaleServeSetup,
+    refreshDesktopNetworkAccessState,
+    tailscaleHttpsEndpoint,
+  ]);
   const visibleDesktopNetworkAdvertisedEndpoints = useMemo(
     () =>
       isLocalBackendNetworkAccessible
@@ -2309,8 +2525,16 @@ export function ConnectionsSettings() {
         : visibleDesktopNetworkAdvertisedEndpoints,
     [tailscaleHttpsEndpoint, visibleDesktopNetworkAdvertisedEndpoints],
   );
+  // Persisted Serve counts as reachable on its own. Until this branch, Serve
+  // implied network-accessible mode, so the first operand covered it and the
+  // probe was only ever a tiebreaker. Now that Serve stands alone without LAN,
+  // an unfinished cert or a momentary tailnet blip is enough to make `status`
+  // miss — and "Authorized clients" would vanish while the toggle above it
+  // correctly reads on. Same reason the switch tracks the setting, not the probe.
   const isLocalBackendRemotelyReachable =
-    isLocalBackendNetworkAccessible || tailscaleHttpsEndpoint?.status === "available";
+    isLocalBackendNetworkAccessible ||
+    (desktopServerExposureState?.tailscaleServeEnabled ?? false) ||
+    tailscaleHttpsEndpoint?.status === "available";
   const defaultDesktopNetworkAdvertisedEndpoint = useMemo(
     () =>
       selectPairingEndpoint(visibleDesktopNetworkAdvertisedEndpoints, defaultAdvertisedEndpointKey),
@@ -2866,28 +3090,56 @@ export function ConnectionsSettings() {
   const renderTailscaleRow = () => (
     <SettingsRow
       title="Tailscale HTTPS"
+      status={
+        tailscaleServeMutationError ? (
+          // The CLI message can carry a long admin URL; wrap it rather than
+          // letting it run past the row.
+          <span className="block wrap-anywhere text-destructive">
+            {tailscaleServeMutationError}
+          </span>
+        ) : null
+      }
       description={
         tailscaleHttpsEndpoint
           ? tailscaleHttpsEndpoint.status === "available"
             ? tailscaleHttpsEndpoint.httpBaseUrl
             : "Use Tailscale Serve to expose this backend through a MagicDNS HTTPS URL."
-          : "Start Tailscale to set up HTTPS access through MagicDNS."
+          : "Use Tailscale Serve to expose this backend through a MagicDNS HTTPS URL. Independent of LAN network access."
       }
       control={
-        tailscaleHttpsEndpoint ? (
+        // Enabling resolves MagicDNS over the tailscale CLI before any dialog
+        // opens, so the dimmed switch alone leaves that wait unexplained.
+        <div className="inline-flex items-center gap-2">
+          {isUpdatingTailscaleServe ? (
+            <Spinner
+              aria-label="Updating Tailscale HTTPS"
+              className="size-3.5 text-muted-foreground"
+            />
+          ) : null}
           <Switch
-            checked={tailscaleHttpsEndpoint.status === "available"}
-            disabled={isUpdatingTailscaleServe}
+            // Reflect the persisted setting, not endpoint reachability. `status`
+            // comes from an HTTP probe of the MagicDNS URL, so a provisioning
+            // cert or a momentary tailnet blip would render this off while
+            // `tailscale serve` is live — and turning it off would be
+            // unreachable, since that path is behind the on state.
+            checked={desktopServerExposureState?.tailscaleServeEnabled ?? false}
+            // Hold the switch until the state it reflects has loaded, matching
+            // the network access toggle above. Unresolved state renders as off,
+            // so an already-enabled Serve would look disabled — and clicking
+            // would enable against `DEFAULT_TAILSCALE_SERVE_PORT` rather than
+            // the persisted port, instead of opening the disable dialog.
+            disabled={!desktopServerExposureState || isUpdatingTailscaleServe}
             onCheckedChange={(checked) => {
               if (checked) {
-                handleStartTailscaleServeSetup(tailscaleHttpsEndpoint);
+                void handleEnableTailscaleHttps();
                 return;
               }
-              handleStartTailscaleServeDisable(tailscaleHttpsEndpoint);
+              // Disable confirmation does not require a resolved MagicDNS endpoint.
+              openTailscaleServeDisableDialog();
             }}
             aria-label="Enable Tailscale HTTPS"
           />
-        ) : null
+        </div>
       }
     />
   );
@@ -3214,6 +3466,13 @@ export function ConnectionsSettings() {
                   T3 Code will restart the local backend without Tailscale Serve.
                 </AlertDialogDescription>
               </AlertDialogHeader>
+              {tailscaleServeMutationError ? (
+                <TailscaleServeErrorAlert
+                  message={tailscaleServeMutationError}
+                  onOpenConfigureUrl={openTailscaleServeConfigureUrl}
+                  title="Could not disable Tailscale HTTPS"
+                />
+              ) : null}
               <AlertDialogFooter>
                 <AlertDialogClose
                   disabled={isUpdatingTailscaleServe}
@@ -3280,6 +3539,13 @@ export function ConnectionsSettings() {
                     {pendingTailscaleServeBaseUrl ?? "Pending MagicDNS endpoint"}
                   </p>
                 </div>
+                {tailscaleServeMutationError ? (
+                  <TailscaleServeErrorAlert
+                    message={tailscaleServeMutationError}
+                    onOpenConfigureUrl={openTailscaleServeConfigureUrl}
+                    title="Could not enable Tailscale HTTPS"
+                  />
+                ) : null}
               </DialogPanel>
               <DialogFooter>
                 <DialogClose

--- a/apps/web/src/components/settings/pairingUrls.test.ts
+++ b/apps/web/src/components/settings/pairingUrls.test.ts
@@ -1,10 +1,28 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
+import {
+  isShareableOrigin,
+  resolveDesktopPairingUrl,
+  resolveHostedPairingUrl,
+} from "./pairingUrls";
 
 describe("settings pairing URL helpers", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+  });
+
+  it("treats only reachable web origins as shareable", () => {
+    expect(isShareableOrigin({ protocol: "https:", hostname: "app.example.com" })).toBe(true);
+    expect(isShareableOrigin({ protocol: "http:", hostname: "192.168.1.44" })).toBe(true);
+
+    // The packaged desktop app loads from `t3code-dev://app/`. Its hostname is
+    // not a loopback name, so a loopback-only check would call this shareable
+    // and offer copy/QR for a URL no other device can open.
+    expect(isShareableOrigin({ protocol: "t3code-dev:", hostname: "app" })).toBe(false);
+    expect(isShareableOrigin({ protocol: "file:", hostname: "" })).toBe(false);
+
+    expect(isShareableOrigin({ protocol: "http:", hostname: "localhost" })).toBe(false);
+    expect(isShareableOrigin({ protocol: "http:", hostname: "127.0.0.1" })).toBe(false);
   });
 
   it("uses direct backend pairing URLs for HTTP endpoints", () => {

--- a/apps/web/src/components/settings/pairingUrls.ts
+++ b/apps/web/src/components/settings/pairingUrls.ts
@@ -1,5 +1,25 @@
+import { isLoopbackHostname } from "../../environments/primary/target";
 import { buildHostedPairingUrl } from "../../hostedPairing";
 import { setPairingTokenOnUrl } from "../../pairingUrl";
+
+/**
+ * Whether an origin is one another device could actually open, and so worth
+ * offering as a pairing URL instead of the pairing code.
+ *
+ * Loopback is the obvious no. The packaged desktop app is the non-obvious one:
+ * it loads from a custom scheme (`t3code-dev://app/`), whose hostname is `app`,
+ * which is not a loopback name — so testing only for loopback would call it
+ * shareable and hand out a copy/QR link that resolves nowhere off this machine.
+ */
+export function isShareableOrigin(input: {
+  readonly protocol: string;
+  readonly hostname: string;
+}): boolean {
+  if (input.protocol !== "http:" && input.protocol !== "https:") {
+    return false;
+  }
+  return !isLoopbackHostname(input.hostname);
+}
 
 export function resolveDesktopPairingUrl(endpointUrl: string, credential: string): string {
   const url = new URL(endpointUrl);

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -995,6 +995,8 @@ export interface DesktopBridge {
     readonly port?: number;
   }) => Promise<DesktopServerExposureState>;
   getAdvertisedEndpoints: () => Promise<readonly AdvertisedEndpoint[]>;
+  /** User-initiated MagicDNS resolve for Tailscale HTTPS setup (may spawn CLI once). */
+  resolveTailscaleHttpsEndpoint: () => Promise<AdvertisedEndpoint | null>;
   getWslState: () => Promise<DesktopWslState>;
   setWslBackendEnabled: (enabled: boolean) => Promise<DesktopWslState>;
   setWslDistro: (distro: string | null) => Promise<DesktopWslState>;

--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -13,6 +13,10 @@ import {
   buildTailscaleHttpsBaseUrl,
   disableTailscaleServe,
   ensureTailscaleServe,
+  extractTailscaleServeConfigureUrl,
+  describeTailscaleStderrDiagnostic,
+  stderrDiagnosticOf,
+  formatTailscaleServeUserMessage,
   isTailscaleIpv4Address,
   parseTailscaleMagicDnsName,
   parseTailscaleStatus,
@@ -315,8 +319,105 @@ describe("tailscale", () => {
       // key cannot reach a log through it either.
       assert.equal(error.stderrDiagnostic, "permission-denied");
       assertCarriesNoSecret(error, "tskey-auth-secret-token-value");
+      // The URL channel is opt-in on a validated pattern, so an unrelated
+      // failure leaves it unset rather than carrying anything from stderr.
+      assert.equal(error.configureUrl, undefined);
     });
   });
+
+  it.effect("surfaces Tailscale Serve-not-enabled diagnostics without raw stderr", () => {
+    const configureUrl = "https://login.tailscale.com/f/serve?node=nExampleNodeIdForTests";
+    const stderr = [
+      "Serve is not enabled on your tailnet.",
+      "To enable, visit:",
+      "",
+      `         ${configureUrl}`,
+      "",
+      "tskey-auth-secret-token-value",
+    ].join("\n");
+    const layer = mockSpawnerLayer(() => ({
+      code: 1,
+      stderr,
+    }));
+
+    return Effect.gen(function* () {
+      const error = yield* ensureTailscaleServe({ localPort: 13773, servePort: 443 }).pipe(
+        Effect.flip,
+        Effect.provide(layer),
+      );
+
+      assert.instanceOf(error, TailscaleCommandExitError);
+      assert.equal(error.stderrDiagnostic, "serve-not-enabled");
+      assert.equal(error.configureUrl, configureUrl);
+      // The shared message stays label-free (it is logged); the prose lives at
+      // the UI edge. The validated admin URL rides along because it is the one
+      // actionable thing in the failure.
+      assert.equal(
+        error.message,
+        `tailscale serve exited with code 1. To enable, visit: ${configureUrl}`,
+      );
+      assert.equal(
+        describeTailscaleStderrDiagnostic("serve-not-enabled"),
+        "Serve is not enabled on your tailnet.",
+      );
+      assert.equal(formatTailscaleServeUserMessage(error), error.message);
+      assert.notInclude(error.message, "tskey-auth-secret-token-value");
+      assert.notProperty(error, "stderr");
+    });
+  });
+
+  it.effect("extracts only Tailscale Serve configure URLs from CLI text", () =>
+    Effect.sync(() => {
+      const configureUrl = "https://login.tailscale.com/f/serve?node=abc123";
+      assert.equal(extractTailscaleServeConfigureUrl(`visit ${configureUrl} please`), configureUrl);
+      assert.equal(
+        extractTailscaleServeConfigureUrl("https://evil.example/f/serve?node=abc123"),
+        null,
+      );
+
+      // The matched text runs to the end of the URL token, so a plausible
+      // origin and path are not enough: everything after `?` would otherwise be
+      // stderr riding into a logged error message. Only a node ID survives.
+      assert.equal(
+        extractTailscaleServeConfigureUrl(
+          "https://login.tailscale.com/f/serve?node=abc123&authkey=tskey-secret-value",
+        ),
+        configureUrl,
+      );
+      assert.equal(
+        extractTailscaleServeConfigureUrl("https://login.tailscale.com/f/serve?authkey=tskey-x"),
+        "https://login.tailscale.com/f/serve",
+      );
+      // A "node" that is not shaped like a stable ID is not one; drop it rather
+      // than pass it through.
+      assert.equal(
+        extractTailscaleServeConfigureUrl(
+          "https://login.tailscale.com/f/serve?node=tskey-secret%20leaked",
+        ),
+        "https://login.tailscale.com/f/serve",
+      );
+      // Serve-specific failures get their own labels, so the desktop toast can
+      // name the reason without any text being lifted out of stderr.
+      assert.equal(
+        stderrDiagnosticOf(
+          "Serve is not enabled on your tailnet.\nTo enable, visit:\n\n  " + configureUrl,
+        ),
+        "serve-not-enabled",
+      );
+      assert.equal(
+        describeTailscaleStderrDiagnostic("serve-not-enabled"),
+        "Serve is not enabled on your tailnet.",
+      );
+      assert.equal(
+        stderrDiagnosticOf(
+          "500 Internal Server Error: your Tailscale account does not support getting TLS certs",
+        ),
+        "no-https-certs",
+      );
+      // An unrecognized failure stays unnamed rather than guessing.
+      assert.equal(describeTailscaleStderrDiagnostic("unknown"), null);
+    }),
+  );
 
   it.effect("disables tailscale serve through the process spawner service", () => {
     const commands: {

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -32,6 +32,8 @@ export const TailscaleStderrDiagnostic = Schema.Literals([
   "no-existing-handler",
   "not-logged-in",
   "permission-denied",
+  "serve-not-enabled",
+  "no-https-certs",
   "unknown",
 ]);
 export type TailscaleStderrDiagnostic = typeof TailscaleStderrDiagnostic.Type;
@@ -44,6 +46,8 @@ const STDERR_DIAGNOSTIC_PATTERNS: ReadonlyArray<
   [/handler does not exist/i, "no-existing-handler"],
   [/not logged in|logged out|needs? login/i, "not-logged-in"],
   [/permission denied|access denied|must be root|operation not permitted/i, "permission-denied"],
+  [/serve is not enabled on your tailnet/i, "serve-not-enabled"],
+  [/does not support getting TLS certs/i, "no-https-certs"],
 ];
 
 /** Classifies stderr into a safe label, dropping the text itself. */
@@ -91,11 +95,119 @@ export class TailscaleCommandExitError extends Schema.TaggedErrorClass<Tailscale
     // set below. Callers that need to recognize a specific failure (e.g.
     // `serve off` on a port with no mapping) match on the label.
     stderrDiagnostic: Schema.optional(TailscaleStderrDiagnostic),
+    /**
+     * Admin URL the CLI prints when the tailnet blocks Serve/HTTPS.
+     *
+     * Exempt from the label-only rule above because it is not lifted text.
+     * {@link extractTailscaleServeConfigureUrl} does not return what it matched
+     * — it rebuilds the URL from a literal origin and path, keeping only an
+     * allowlisted `node` parameter of known shape — so no part of it can carry
+     * stderr contents. Without it there is no way to point the user at the one
+     * page that fixes the failure.
+     */
+    configureUrl: Schema.optionalKey(Schema.String),
   },
 ) {
   override get message(): string {
-    return `tailscale ${this.subcommand} exited with code ${this.exitCode}.`;
+    return formatTailscaleCommandExitMessage({
+      subcommand: this.subcommand,
+      exitCode: this.exitCode,
+      stderrDiagnostic: this.stderrDiagnostic,
+      configureUrl: this.configureUrl,
+    });
   }
+}
+
+/** Admin console URL Tailscale prints when Serve/HTTPS is not enabled for the tailnet. */
+const TAILSCALE_SERVE_CONFIGURE_URL_PATTERN =
+  /https:\/\/login\.tailscale\.com\/f\/serve\?[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=%-]+/i;
+
+/** Canonical origin and path this helper is willing to emit. */
+const TAILSCALE_SERVE_CONFIGURE_URL_BASE = "https://login.tailscale.com/f/serve";
+
+/**
+ * Stable node ID shape, used to vet the one query parameter we keep.
+ *
+ * Tailscale's stable IDs are short and alphanumeric (`nExampleNodeId`); a value
+ * that does not look like one is not a node ID, so dropping it costs nothing.
+ */
+const TAILSCALE_NODE_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Extract a Tailscale Serve enablement URL from CLI text.
+ * Only accepts `https://login.tailscale.com/f/serve...` URLs.
+ *
+ * Returns a URL *rebuilt* from constants rather than the matched text. Checking
+ * the parsed origin and path is not enough on its own: the match runs to the
+ * end of the URL token, so the query would arrive verbatim from stderr — and
+ * this value reaches `TailscaleCommandExitError.message`, which is logged. That
+ * is exactly the leak `stderrDiagnostic` exists to prevent, so the query is
+ * rebuilt from an allowlist instead of being trusted. The CLI emits `?node=` to
+ * preselect the node in the admin console; anything else is dropped, at worst
+ * costing that preselection while still landing on the page that fixes the
+ * failure.
+ */
+export function extractTailscaleServeConfigureUrl(text: string): string | null {
+  const match = text.match(TAILSCALE_SERVE_CONFIGURE_URL_PATTERN);
+  if (!match?.[0] || match[0].length > 500) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(match[0]);
+    if (parsed.protocol !== "https:") return null;
+    if (parsed.hostname !== "login.tailscale.com") return null;
+    if (!parsed.pathname.startsWith("/f/serve")) return null;
+
+    const sanitized = new URL(TAILSCALE_SERVE_CONFIGURE_URL_BASE);
+    const node = parsed.searchParams.get("node");
+    if (node !== null && TAILSCALE_NODE_ID_PATTERN.test(node)) {
+      sanitized.searchParams.set("node", node);
+    }
+    return sanitized.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Prose for a classified diagnostic.
+ *
+ * The label is the safe thing to log; this turns it into something worth
+ * showing a user. `unknown` deliberately has no prose — inventing one would
+ * imply we recognized a failure we did not.
+ */
+export function describeTailscaleStderrDiagnostic(
+  diagnostic: TailscaleStderrDiagnostic,
+): string | null {
+  switch (diagnostic) {
+    case "no-existing-handler":
+      return "No matching Tailscale Serve handler exists.";
+    case "not-logged-in":
+      return "Tailscale is not logged in.";
+    case "permission-denied":
+      return "Tailscale denied permission for this command.";
+    case "serve-not-enabled":
+      return "Serve is not enabled on your tailnet.";
+    case "no-https-certs":
+      return "This Tailscale account does not support getting TLS certificates required for HTTPS Serve.";
+    case "unknown":
+      return null;
+  }
+}
+
+export function formatTailscaleCommandExitMessage(input: {
+  readonly subcommand: "status" | "serve";
+  readonly exitCode: number;
+  readonly stderrDiagnostic?: TailscaleStderrDiagnostic | undefined;
+  readonly configureUrl?: string | undefined;
+}): string {
+  // Stays generic on purpose: this message is logged, and #4556 keeps logs to
+  // the label alone. Prose for the label belongs at the UI edge, via
+  // describeTailscaleStderrDiagnostic. The admin URL is appended because it is
+  // validated rather than lifted, and it is the one actionable thing here.
+  const base = `tailscale ${input.subcommand} exited with code ${input.exitCode}.`;
+  return input.configureUrl ? `${base} To enable, visit: ${input.configureUrl}` : base;
 }
 
 export class TailscaleCommandTimeoutError extends Schema.TaggedErrorClass<TailscaleCommandTimeoutError>()(
@@ -118,6 +230,20 @@ export const TailscaleCommandError = Schema.Union([
   TailscaleCommandTimeoutError,
 ]);
 export type TailscaleCommandError = typeof TailscaleCommandError.Type;
+
+/** User-facing message for any Tailscale CLI failure while configuring Serve. */
+export function formatTailscaleServeUserMessage(error: TailscaleCommandError): string {
+  switch (error._tag) {
+    case "TailscaleCommandSpawnError":
+      return "Could not run the tailscale CLI. Is Tailscale installed and on PATH?";
+    case "TailscaleCommandOutputError":
+      return "Could not read output from the tailscale CLI.";
+    case "TailscaleCommandTimeoutError":
+      return "The tailscale CLI timed out while configuring Serve.";
+    case "TailscaleCommandExitError":
+      return error.message;
+  }
+}
 
 export class TailscaleStatusParseError extends Schema.TaggedErrorClass<TailscaleStatusParseError>()(
   "TailscaleStatusParseError",
@@ -311,13 +437,14 @@ const runTailscaleCommand = (
         Effect.mapError((cause) => new TailscaleCommandOutputError({ ...commandContext, cause })),
       );
       if (exitCode !== 0) {
+        const stderrDiagnostic = stderrDiagnosticOf(stderr);
+        const configureUrl = extractTailscaleServeConfigureUrl(stderr);
         return yield* new TailscaleCommandExitError({
           ...commandContext,
           exitCode,
           stderrLength: stderr.length,
-          ...(stderrDiagnosticOf(stderr) !== undefined
-            ? { stderrDiagnostic: stderrDiagnosticOf(stderr) }
-            : {}),
+          ...(stderrDiagnostic === undefined ? {} : { stderrDiagnostic }),
+          ...(configureUrl === null ? {} : { configureUrl }),
         });
       }
     }).pipe(

--- a/scripts/lib/dev-share.ts
+++ b/scripts/lib/dev-share.ts
@@ -34,6 +34,8 @@ const DIAGNOSTIC_EXPLANATIONS: Record<TailscaleStderrDiagnostic, string | undefi
   "no-existing-handler": "no mapping existed for that port",
   "not-logged-in": "this machine is not logged into a tailnet — run `tailscale up`",
   "permission-denied": "permission denied — `tailscale serve` may need elevated privileges",
+  "serve-not-enabled": "serve is not enabled for this tailnet — enable it in the admin console",
+  "no-https-certs": "this tailnet cannot issue the TLS certificates HTTPS serve requires",
   unknown: undefined,
 };
 


### PR DESCRIPTION
Closes #2830.

## What Changed

Enabling Tailscale HTTPS from desktop settings now reports failure instead of silently doing nothing.

`tailscale serve` was configured by the child backend on boot. When the tailnet refused it, the failure landed in a log line the user never sees — the app restarted and the toggle simply stayed off. Enabling now preflights `tailscale serve` in the main process **before** persisting, so it can fail with the CLI's own guidance and the `login.tailscale.com/f/serve` admin link. The failure surfaces three ways: a toast, an inline alert inside the setup dialog (which stays open so you can retry), and a status line on the Tailscale HTTPS row. The setup URL is shown in full and is selectable, with an **Open setup** button as a shortcut.

Related fixes in the same path:

- **Disable tears Serve down from the main process.** It previously relied on the child server's `acquireRelease` finalizer, which only exists if *that* child booted with Serve enabled. After a failed relaunch it doesn't, so toggling off persisted `enabled: false` while `tailscale serve --https=<port>` stayed live on the tailnet. A teardown that fails now refuses to record itself as done, and says the backend may still be reachable.
- **`serve off` against an already-unbound port counts as success.** The real CLI exits non-zero with "handler does not exist"; the tailnet is already in the state the user asked for, and treating it as failure would strand the toggle on and warn about an exposure that does not exist — biting hardest in exactly the case the eager teardown exists for.
- **The switch reflects the persisted setting, not endpoint reachability.** `status` came from an HTTP probe of the MagicDNS URL, so a provisioning cert or a brief tailnet blip rendered the switch off while Serve was live — and since disabling sits behind the on state, there was then no way to turn it off. The same reasoning applies to the Authorized clients section, which was gated on the same probe.
- **The toggle renders without LAN network access.** Serve only proxies to loopback, so it never depended on network-accessible mode; it was hidden anyway. MagicDNS is still resolved only on explicit opt-in, preserving the #2745 macOS TCC gate.
- Failed CLI spawns report *"Could not run the tailscale CLI. Is Tailscale installed and on PATH?"* rather than a generic port message — the most common failure, previously the least explained.
- A persistence failure no longer tears down a pre-existing working binding; rollback covers interrupt and defect rather than only typed failure; and the MagicDNS cache is invalidated on user-initiated resolve, so "start Tailscale and try again" isn't defeated by a stale 60s miss.

## Why

The bug this fixes is *silence*, not the underlying tailnet refusal. A user with Serve disabled on their tailnet flips the toggle, the app restarts, and the toggle is off again with no message — nothing distinguishes "your tailnet blocks this" from "the app is broken." #2830 describes exactly that: the screen hangs or the app restarts "with seemingly no effect," and "no visible errors were seen. (This is the key issue)."

Two design notes for review:

- **Preflight before persisting.** Writing settings first and letting the child fail on boot is what produced the silent failure; the CLI call has to happen where a user-visible error can still be raised. Rollback exists because the ordering can now leave Serve live if the settings write fails afterwards.
- **Only a label, never CLI text, crosses the error boundary.** `tailscale` prints auth keys and node names to stderr, and these errors are logged, so failures are classified into a closed set of labels and the prose lives at the UI edge. The one exception is the admin URL, and it is rebuilt from a literal origin and path keeping only an allowlisted `node` parameter — validating the parsed host and path alone would let `?authkey=tskey-…` ride through into a logged message.

## UI Changes

Affects the **Tailscale HTTPS** row in Settings → Connections:

- The switch is always rendered (previously hidden without a resolved endpoint) and is held disabled until exposure state loads, with a spinner beside it while the CLI call is in flight.
- On failure, an inline alert appears inside the setup dialog — which no longer closes — containing the CLI's guidance, the full selectable admin URL, and an **Open setup** action; plus a destructive-colored status line under the row title, and a toast.

> [!NOTE]
> Screenshots are being attached separately — I can't upload images through the API. The behaviour above was verified against a live tailnet; see Testing.

## Testing

Unit tests cover the new behaviour: eager teardown asserts the exact `serve --https=<port> off` invocation, a failed teardown keeps `enabled: true` and carries the exposure warning, the missing-binary case produces the PATH hint, `no-existing-handler` is tolerated, and the configure URL drops non-allowlisted query parameters.

Verified end-to-end by driving the built desktop app against a live tailnet:

- **Tailscale absent from PATH** (a PATH farm without the binary) → toast, toggle stays off.
- **Tailnet refuses Serve** (a shim refusing `serve`) → dialog stays open with the inline alert, full URL, and Open setup; error anchored to the Tailscale HTTPS row rather than the LAN row.
- **Happy path** → enable put `https://<magicdns> → proxy http://127.0.0.1:<port>` in `tailscale serve status`, the endpoint returned HTTP 200, and the app came back with the toggle on; disable returned `No serve config` with the endpoint unreachable and the toggle off.
- `openExternal` confirmed to resolve `true`/`false` rather than reject, which is why the previous `.catch()` fallback was dead code.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — attaching separately, see UI Changes
- [ ] I included a video for animation/interaction changes — attaching separately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes ordering of Tailscale Serve vs persisted settings and main-process network exposure teardown/rollback; mistakes could leave the tailnet exposed or block legitimate disable. Touches auth-adjacent exposure and sanitized CLI error boundaries.
> 
> **Overview**
> Fixes **silent Tailscale HTTPS toggles** (#2830) by **preflighting `tailscale serve` in the desktop main process before persisting**, so enable/disable can fail with actionable errors (CLI diagnostics, sanitized `login.tailscale.com/f/serve` link) instead of restarting with the switch still off.
> 
> **Exposure lifecycle:** disable now runs **`serve off` in the main process** (not only the child finalizer); failed teardown does not persist `enabled: false`; **`no-existing-handler`** on `serve off` is treated as success; **rollback** on failed settings writes (including interrupt/defect via `onExit`) reverses preflight enable or re-binds after a failed disable.
> 
> **UI / IPC:** new **`resolveTailscaleHttpsEndpoint`** (on-demand `tailscale status`, cache invalidated on user action); Connections **Tailscale HTTPS** switch follows **persisted settings**, works without LAN network access, shows spinner/errors inline and in dialogs; **`isShareableOrigin`** stops offering pairing URLs for custom schemes like `t3code-dev://`.
> 
> **`@t3tools/tailscale`:** classified stderr labels (`serve-not-enabled`, `no-https-certs`), safe configure URL extraction, and shared user-facing CLI messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3317caa84db6b3fc1b6d6484429f41bdffcac0c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface Tailscale Serve failures with actionable errors and rollback in desktop server exposure
> - `setTailscaleServeEnabled` now preflights `tailscale serve` before persisting settings, maps CLI failures (exit errors, spawn errors) to a structured `DesktopTailscaleServeConfigureError` with a user-safe message and optional admin `configureUrl`.
> - On persistence failure, best-effort rollback reverts the CLI state (disables if enable preflighted, re-enables if disable succeeded) to keep exposure in sync with settings.
> - A new `resolveTailscaleHttpsEndpoint` method and IPC channel (`desktop:resolve-tailscale-https-endpoint`) allows the renderer to request a fresh MagicDNS resolution on demand.
> - The Connections Settings UI surfaces inline error alerts with an optional 'Open setup' button linking to the Tailscale admin page, and the Tailscale switch now reflects the persisted `tailscaleServeEnabled` flag.
> - Two new stderr diagnostics (`serve-not-enabled`, `no-https-certs`) are classified in `@t3tools/tailscale`, and `TailscaleCommandExitError` now carries a sanitized `configureUrl` when present in CLI output.
> - Behavioral Change: enabling Tailscale Serve always sets `requiresRelaunch=true`, even when settings are unchanged, so the child process re-binds Serve.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3317caa. 11 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->