### PR TITLE
fix(web): keep thread branch metadata consistent

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -229,7 +229,11 @@ import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
-import { resolveEffectiveEnvMode, resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
+import {
+  resolveBranchToolbarValue,
+  resolveEffectiveEnvMode,
+  resolveLocalCheckoutBranchMismatch,
+} from "./BranchToolbar.logic";
 import {
   getProviderStatusBannerKey,
   ProviderStatusBanner,
@@ -4749,6 +4753,12 @@ function ChatViewContent(props: ChatViewProps) {
 
     let turnStartSucceeded = false;
     if (failure === null && turnAttachmentsResult._tag === "Success") {
+      const branchForCreate = resolveBranchToolbarValue({
+        envMode: sendEnvMode,
+        activeWorktreePath: activeThread.worktreePath,
+        activeThreadBranch,
+        currentGitBranch: gitStatusQuery.data?.refName ?? null,
+      });
       const bootstrap =
         isLocalDraftThread || baseBranchForWorktree
           ? {
@@ -4760,7 +4770,7 @@ function ChatViewContent(props: ChatViewProps) {
                       modelSelection: threadCreateModelSelection,
                       runtimeMode,
                       interactionMode,
-                      branch: activeThreadBranch,
+                      branch: branchForCreate,
                       worktreePath: activeThread.worktreePath,
                       createdAt: activeThread.createdAt,
                     },

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -14,6 +14,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
+  resolveSidebarBranchLabel,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveSidebarV2Status,
@@ -45,6 +46,16 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("resolveSidebarBranchLabel", () => {
+  it("hides the default branch", () => {
+    expect(resolveSidebarBranchLabel("trunk", true)).toBeNull();
+  });
+
+  it("shows a custom branch", () => {
+    expect(resolveSidebarBranchLabel("feature/demo", false)).toBe("feature/demo");
+  });
+});
 
 describe("shouldNavigateAfterProjectRemoval", () => {
   const projectThreads = [{ environmentId: "environment-local", id: "thread-1" }];

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -140,6 +140,13 @@ export function resolveSidebarStageBadgeLabel(input: {
   return resolveServerBackedAppStageLabel(input);
 }
 
+export function resolveSidebarBranchLabel(
+  branch: string | null,
+  isDefaultBranch: boolean,
+): string | null {
+  return branch && !isDefaultBranch ? branch : null;
+}
+
 export function createThreadJumpHintVisibilityController(input: {
   delayMs: number;
   onVisibilityChange: (visible: boolean) => void;

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -112,6 +112,7 @@ import {
   orderItemsByPreferredIds,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
+  resolveSidebarBranchLabel,
   resolveSidebarV2Status,
   resolveWorkingStartedAt,
   shouldNavigateAfterProjectRemoval,
@@ -496,6 +497,22 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
         })
       : null,
   );
+  const branchRefs = useEnvironmentQuery(
+    thread.branch !== null && gitCwd !== null
+      ? vcsEnvironment.listRefs({
+          environmentId: thread.environmentId,
+          input: { cwd: gitCwd, query: thread.branch, limit: 10 },
+        })
+      : null,
+  );
+  const matchingBranchRef = branchRefs.data?.refs.find((refName) => refName.name === thread.branch);
+  const isDefaultBranch =
+    matchingBranchRef?.isDefault === true ||
+    (gitStatus.data?.isDefaultRef === true && gitStatus.data.refName === thread.branch);
+  const branchLabel =
+    branchRefs.isPending && branchRefs.data === null
+      ? null
+      : resolveSidebarBranchLabel(thread.branch, isDefaultBranch);
   const branchMismatch = resolveLocalCheckoutBranchMismatch({
     effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
     activeWorktreePath: thread.worktreePath,
@@ -947,8 +964,8 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
             </div>
             <div className="mt-1 flex min-w-0">{title}</div>
             <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/75">
-              {thread.branch ? (
-                <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
+              {branchLabel ? (
+                <span className="min-w-0 flex-1 truncate whitespace-nowrap">{branchLabel}</span>
               ) : (
                 <span className="flex-1" />
               )}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -511,10 +511,13 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   const isDefaultBranch =
     defaultBranchRef?.name === thread.branch ||
     (gitStatus.data?.isDefaultRef === true && gitStatus.data.refName === thread.branch);
-  const branchLabel =
-    branchRefs.isPending && branchRefs.data === null
-      ? null
-      : resolveSidebarBranchLabel(thread.branch, isDefaultBranch);
+  const isDefaultBranchPending =
+    thread.worktreePath === null
+      ? branchRefs.isPending && branchRefs.data === null
+      : gitStatus.isPending && gitStatus.data === null;
+  const branchLabel = isDefaultBranchPending
+    ? null
+    : resolveSidebarBranchLabel(thread.branch, isDefaultBranch);
   const branchMismatch = resolveLocalCheckoutBranchMismatch({
     effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
     activeWorktreePath: thread.worktreePath,

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -497,17 +497,19 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
         })
       : null,
   );
+  // Keep this project-scoped so local threads share one cached refs query instead of
+  // launching a separate Git command group for every branch-backed row.
   const branchRefs = useEnvironmentQuery(
-    thread.branch !== null && gitCwd !== null
+    thread.branch !== null && thread.worktreePath === null && gitCwd !== null
       ? vcsEnvironment.listRefs({
           environmentId: thread.environmentId,
-          input: { cwd: gitCwd, query: thread.branch, limit: 10 },
+          input: { cwd: gitCwd, limit: 2 },
         })
       : null,
   );
-  const matchingBranchRef = branchRefs.data?.refs.find((refName) => refName.name === thread.branch);
+  const defaultBranchRef = branchRefs.data?.refs.find((refName) => refName.isDefault);
   const isDefaultBranch =
-    matchingBranchRef?.isDefault === true ||
+    defaultBranchRef?.name === thread.branch ||
     (gitStatus.data?.isDefaultRef === true && gitStatus.data.refName === thread.branch);
   const branchLabel =
     branchRefs.isPending && branchRefs.data === null


### PR DESCRIPTION
<!-- fix(web): keep thread branch metadata consistent -->

## What Changed

- save the checked-out branch when creating a thread without touching the branch picker
- consistently omit the default branch from sidebar rows while keeping custom branches visible

## Why

The branch picker displayed the current branch without persisting it. This made equivalent threads look different depending on whether the default branch had been explicitly reselected.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<details>
<summary>Show AI summary</summary>

New draft-thread bootstraps now derive their persisted branch with `resolveBranchToolbarValue`, using the live checkout from Git status while preserving explicit new-worktree base selections. Sidebar V2 resolves the persisted branch through `listRefs`, so default-branch rows keep their existing branch-free presentation whether or not the dropdown was touched. The tooltip continues to render the persisted branch directly.

Focused verification passed: web typecheck, formatting, lint, `BranchToolbar.logic.test.ts`, and `Sidebar.logic.test.ts`.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only branch display and draft bootstrap metadata; no auth or server contract changes. Extra `listRefs` queries per local branch-backed row are bounded and project-scoped via query caching.
> 
> **Overview**
> Aligns **persisted thread branch** with what the branch toolbar shows, and **sidebar branch labels** with the rule that default branches stay hidden.
> 
> **Chat bootstrap** — Draft thread creation no longer always saves `activeThreadBranch`. It now uses `resolveBranchToolbarValue` (env mode, worktree path, thread branch, live Git ref) so a untouched picker still records the checked-out branch.
> 
> **Sidebar V2** — Card rows use `resolveSidebarBranchLabel` instead of always showing `thread.branch`. Local (non-worktree) threads load `listRefs` (cached per project, `limit: 2`) to detect the default branch; worktrees rely on `gitStatus.isDefaultRef`. The label stays blank while that resolution is pending.
> 
> **Sidebar.logic** — Adds `resolveSidebarBranchLabel` with unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d80ade58ff8d5f7526e416928dbefc62ea58fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread branch metadata consistency in sidebar and new thread creation
> - Sidebar rows now hide the branch label when the thread's branch matches the default branch, using a new `resolveSidebarBranchLabel` helper in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/4926/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a). The label is also suppressed until the default branch is determined.
> - New thread creation in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4926/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) now uses `resolveBranchToolbarValue` to resolve the branch instead of reading `activeThreadBranch` directly, aligning the created thread's branch with what the toolbar shows.
> - Behavioral Change: `listRefs` may now be called in sidebar rows to determine the default branch when a thread has a branch but no worktree path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d80ade.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->