### PR TITLE
fix(mobile): remove unnecessary photo library permission

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -275,11 +275,12 @@ const config: ExpoConfig = {
       "expo-camera",
       {
         cameraPermission: "Allow T3 Code to access your camera so you can scan pairing QR codes.",
+        microphonePermission: false,
         barcodeScannerEnabled: true,
         recordAudioAndroid: false,
       },
     ],
-    ["expo-image-picker", { photosPermission: false }],
+    ["expo-image-picker", { photosPermission: false, microphonePermission: false }],
     [
       "expo-splash-screen",
       {

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -279,6 +279,7 @@ const config: ExpoConfig = {
         recordAudioAndroid: false,
       },
     ],
+    ["expo-image-picker", { photosPermission: false }],
     [
       "expo-splash-screen",
       {

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -65,14 +65,6 @@ export async function pickComposerImages(input: { readonly existingCount: number
     };
   }
 
-  const permission = await imagePicker.requestMediaLibraryPermissionsAsync();
-  if (!permission.granted) {
-    return {
-      images: [],
-      error: "Allow photo library access to attach images.",
-    };
-  }
-
   const result = await imagePicker.launchImageLibraryAsync({
     mediaTypes: ["images"],
     allowsMultipleSelection: true,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Remove unnecessary permission requests for photo library and microphone access

## Why

These permissions are not needed, and it is better to not prompt users for unneeded permissions. The photo picker uses the native privacy-preserving picker and the QR code scanner does not need microphone permissions

## UI Changes

This doesn't exactly prove it, but here's a screen recording of a simulator opening the photo picker for the first time (note there is no permission request)

https://github.com/user-attachments/assets/c5627f4a-318f-4550-892e-2ddf1b1fb6ee

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Permission and picker-flow changes only; no auth or data-handling logic. Users need a new native build for manifest/plugin changes to apply.
> 
> **Overview**
> Stops asking users for **photo library** and **microphone** access when those capabilities aren’t needed for composer attachments and QR scanning.
> 
> **Native config (`app.config.ts`):** `expo-camera` now sets `microphonePermission: false` (with `recordAudioAndroid: false` unchanged). **`expo-image-picker`** is registered with `photosPermission: false` and `microphonePermission: false` so prebuild doesn’t declare those permissions.
> 
> **Composer flow (`composerImages.ts`):** Removes the upfront `requestMediaLibraryPermissionsAsync()` gate before `launchImageLibraryAsync`, relying on the system privacy-preserving photo picker instead of a library-access prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb267a26b432b7a8f8e32eeabfabdafc2e319cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unnecessary photo library permission request in mobile image picker
> - Removes the explicit media library permission pre-check and early return from `pickComposerImages` in [composerImages.ts](https://github.com/pingdotgg/t3code/pull/4929/files#diff-8723c2d87dbdbb196075db6f79088889d3a7f72c0b472d71bc669adc4b533e51), delegating permission handling to the image picker itself.
> - Disables microphone and photo library permission prompts in [app.config.ts](https://github.com/pingdotgg/t3code/pull/4929/files#diff-290065ad5da22af2aa0a274a6657359bd050ba8ad4e36b97765dac7c98f90bab) for the `expo-camera` and `expo-image-picker` plugins, so these permissions are no longer included in the iOS/Android manifests.
> - Behavioral Change: iOS/Android apps will no longer request photo library or microphone permissions via these plugins; apps relying on those prompts will need an alternative permission strategy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb267a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->