### PR TITLE
fix(web): treat server update restart as expected

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -207,6 +207,7 @@ import {
   primaryServerSettingsAtom,
   serverEnvironment,
 } from "../state/server";
+import { clearPendingServerUpdate, usePendingServerUpdate } from "../state/serverUpdate";
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
@@ -1879,21 +1880,43 @@ function ChatViewContent(props: ChatViewProps) {
   const versionMismatchEnvironmentId =
     versionMismatch && activeThread ? activeThread.environmentId : null;
   const versionMismatchSelfUpdate = resolveServerSelfUpdateCapability(serverConfig);
+  const pendingServerUpdate = usePendingServerUpdate(activeThread?.environmentId ?? null);
+  useEffect(() => {
+    if (
+      pendingServerUpdate &&
+      activeThread &&
+      activeEnvironmentConnectionPhase === "connected" &&
+      serverConfig !== null &&
+      versionMismatch === null
+    ) {
+      clearPendingServerUpdate(activeThread.environmentId, pendingServerUpdate.attempt);
+    }
+  }, [
+    activeEnvironmentConnectionPhase,
+    activeThread,
+    pendingServerUpdate,
+    serverConfig,
+    versionMismatch,
+  ]);
   const systemComposerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const items: ComposerBannerStackItem[] = [];
     if (activeEnvironmentUnavailableState) {
       const connection = activeEnvironmentUnavailableState.connection;
       const isReconnecting =
         connection.phase === "connecting" || connection.phase === "reconnecting";
+      const isUpdatingServer = pendingServerUpdate !== null;
       items.push({
         id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
         variant: connection.phase === "error" ? "error" : "warning",
         icon: <WifiOffIcon />,
-        title: `${activeEnvironmentUnavailableState.label}: ${connectionStatusTitle(connection)}`,
-        description:
-          connection.error ??
-          "Reconnect this environment before sending messages or running actions.",
-        actions: (
+        title: isUpdatingServer
+          ? `${activeEnvironmentUnavailableState.label}: Updating server...`
+          : `${activeEnvironmentUnavailableState.label}: ${connectionStatusTitle(connection)}`,
+        description: isUpdatingServer
+          ? "The server is restarting and will reconnect automatically."
+          : (connection.error ??
+            "Reconnect this environment before sending messages or running actions."),
+        actions: isUpdatingServer ? undefined : (
           <>
             <Button
               size="xs"
@@ -1958,6 +1981,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeEnvironmentUnavailableState,
     handleReconnectActiveEnvironment,
     navigate,
+    pendingServerUpdate,
     setDismissedVersionMismatchKey,
     showVersionMismatchBanner,
     versionMismatch,

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -5,6 +5,9 @@ import { AsyncResult } from "effect/unstable/reactivity";
 import type { EnvironmentId } from "@t3tools/contracts";
 
 const testState = vi.hoisted(() => ({
+  beginPendingServerUpdate: vi.fn(() => 1),
+  clearPendingServerUpdate: vi.fn(),
+  markPendingServerUpdateRestartAccepted: vi.fn(),
   updateServer: vi.fn(),
   toast: vi.fn(),
 }));
@@ -72,6 +75,12 @@ vi.mock("~/hooks/useCopyToClipboard", () => ({
 vi.mock("~/state/server", () => ({
   serverEnvironment: { updateServer: Symbol("updateServer") },
 }));
+vi.mock("~/state/serverUpdate", () => ({
+  beginPendingServerUpdate: testState.beginPendingServerUpdate,
+  clearPendingServerUpdate: testState.clearPendingServerUpdate,
+  markPendingServerUpdateRestartAccepted: testState.markPendingServerUpdateRestartAccepted,
+  SERVER_UPDATE_PENDING_EXPIRY_MS: 12 * 60_000,
+}));
 vi.mock("~/state/use-atom-command", () => ({
   useAtomCommand: () => testState.updateServer,
 }));
@@ -116,6 +125,9 @@ describe("ServerUpdateAction", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     hooks.reset();
+    testState.beginPendingServerUpdate.mockClear();
+    testState.clearPendingServerUpdate.mockReset();
+    testState.markPendingServerUpdateRestartAccepted.mockReset();
     testState.updateServer.mockReset();
     testState.toast.mockReset();
   });
@@ -194,5 +206,17 @@ describe("ServerUpdateAction", () => {
     expect(testState.toast).not.toHaveBeenCalledWith(
       expect.objectContaining({ title: "Server update failed" }),
     );
+    expect(testState.clearPendingServerUpdate).not.toHaveBeenCalled();
+  });
+
+  it("clears the expected-restart state when the update fails", async () => {
+    testState.updateServer.mockResolvedValue(
+      AsyncResult.failure(Cause.fail(new Error("install failed"))),
+    );
+
+    renderAction().props.onClick?.();
+    await flushPromises();
+
+    expect(testState.clearPendingServerUpdate).toHaveBeenCalledWith("env-test", 1);
   });
 });

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -7,6 +7,12 @@ import {
 
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { serverEnvironment } from "~/state/server";
+import {
+  beginPendingServerUpdate,
+  clearPendingServerUpdate,
+  markPendingServerUpdateRestartAccepted,
+  SERVER_UPDATE_PENDING_EXPIRY_MS,
+} from "~/state/serverUpdate";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { manualServerUpdateCommand } from "~/versionSkew";
 import { Button } from "./ui/button";
@@ -18,8 +24,6 @@ import { toastManager } from "./ui/toast";
  * spinner a bit beyond that so a dead transport never strands a disabled
  * button, while a legitimately slow install is never cut off.
  */
-const UPDATE_PENDING_EXPIRY_MS = 12 * 60_000;
-
 function updateFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Server update failed.";
 }
@@ -89,6 +93,7 @@ export function ServerUpdateAction({
     inFlightRef.current = true;
     const attempt = attemptRef.current + 1;
     attemptRef.current = attempt;
+    const updateStateAttempt = beginPendingServerUpdate(environmentId, targetVersion);
     const ownsAttempt = () => attemptRef.current === attempt;
     setPending(true);
     const armExpiry = () => {
@@ -103,7 +108,7 @@ export function ServerUpdateAction({
           title: "Server update timed out",
           description: "The update may still be running on the server — check again in a minute.",
         });
-      }, UPDATE_PENDING_EXPIRY_MS);
+      }, SERVER_UPDATE_PENDING_EXPIRY_MS);
       expiryRef.current = expiry;
       return expiry;
     };
@@ -111,6 +116,7 @@ export function ServerUpdateAction({
     let restartAccepted = false;
     const keepPendingForRestart = () => {
       restartAccepted = true;
+      markPendingServerUpdateRestartAccepted(environmentId, updateStateAttempt);
       if (expiryRef.current === expiry) {
         clearTimeout(expiry);
         expiry = armExpiry();
@@ -133,6 +139,7 @@ export function ServerUpdateAction({
           if (isAtomCommandInterrupted(result)) {
             return;
           }
+          clearPendingServerUpdate(environmentId, updateStateAttempt);
           toastManager.add({
             type: "error",
             title: "Server update failed",
@@ -152,6 +159,7 @@ export function ServerUpdateAction({
       })
       .catch((error: unknown) => {
         if (!ownsAttempt()) return;
+        clearPendingServerUpdate(environmentId, updateStateAttempt);
         toastManager.add({
           type: "error",
           title: "Server update failed",

--- a/apps/web/src/rpc/requestLatencyState.test.ts
+++ b/apps/web/src/rpc/requestLatencyState.test.ts
@@ -52,7 +52,14 @@ describe("requestLatencyState", () => {
   });
 
   it("ignores the long-lived preview automation connection", () => {
-    trackRpcRequestSent("1", WS_METHODS.previewAutomationConnect);
+    trackRpcRequestSent("1", `${WS_METHODS.previewAutomationConnect} · environment-1`);
+    vi.advanceTimersByTime(SLOW_RPC_ACK_THRESHOLD_MS * 2);
+
+    expect(getSlowRpcAckRequests()).toEqual([]);
+  });
+
+  it("ignores server updates because their install phase is intentionally long-running", () => {
+    trackRpcRequestSent("1", `${WS_METHODS.serverUpdateServer} · environment-1`);
     vi.advanceTimersByTime(SLOW_RPC_ACK_THRESHOLD_MS * 2);
 
     expect(getSlowRpcAckRequests()).toEqual([]);

--- a/apps/web/src/rpc/requestLatencyState.ts
+++ b/apps/web/src/rpc/requestLatencyState.ts
@@ -22,7 +22,10 @@ interface PendingRpcAckRequest {
 }
 
 const pendingRpcAckRequests = new Map<string, PendingRpcAckRequest>();
-const untrackedRpcAckTags = new Set<string>([WS_METHODS.previewAutomationConnect]);
+const untrackedRpcAckTags = new Set<string>([
+  WS_METHODS.previewAutomationConnect,
+  WS_METHODS.serverUpdateServer,
+]);
 
 const slowRpcAckRequestsAtom = Atom.make<ReadonlyArray<SlowRpcAckRequest>>([]).pipe(
   Atom.keepAlive,
@@ -38,7 +41,11 @@ function getSlowRpcAckRequestsValue(): ReadonlyArray<SlowRpcAckRequest> {
 }
 
 function shouldTrackRpcAck(tag: string): boolean {
-  return !tag.includes("subscribe") && !untrackedRpcAckTags.has(tag);
+  if (tag.includes("subscribe")) return false;
+  for (const untrackedTag of untrackedRpcAckTags) {
+    if (tag === untrackedTag || tag.startsWith(`${untrackedTag} · `)) return false;
+  }
+  return true;
 }
 
 export function getSlowRpcAckRequests(): ReadonlyArray<SlowRpcAckRequest> {

--- a/apps/web/src/state/serverUpdate.test.ts
+++ b/apps/web/src/state/serverUpdate.test.ts
@@ -1,0 +1,57 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  beginPendingServerUpdate,
+  clearPendingServerUpdate,
+  getPendingServerUpdateForTests,
+  markPendingServerUpdateRestartAccepted,
+  resetPendingServerUpdatesForTests,
+  SERVER_UPDATE_PENDING_EXPIRY_MS,
+} from "./serverUpdate";
+
+const environmentId = "environment-1" as EnvironmentId;
+
+describe("serverUpdate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetPendingServerUpdatesForTests();
+  });
+
+  afterEach(() => {
+    resetPendingServerUpdatesForTests();
+    vi.useRealTimers();
+  });
+
+  it("keeps the latest update pending until its safety deadline", () => {
+    const attempt = beginPendingServerUpdate(environmentId, "0.0.29");
+
+    expect(getPendingServerUpdateForTests(environmentId)).toEqual({
+      attempt,
+      targetVersion: "0.0.29",
+    });
+
+    vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS);
+    expect(getPendingServerUpdateForTests(environmentId)).toBeNull();
+  });
+
+  it("starts a fresh deadline after restart is accepted", () => {
+    const attempt = beginPendingServerUpdate(environmentId, "0.0.29");
+    vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS - 1);
+
+    markPendingServerUpdateRestartAccepted(environmentId, attempt);
+    vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS - 1);
+    expect(getPendingServerUpdateForTests(environmentId)).not.toBeNull();
+
+    vi.advanceTimersByTime(1);
+    expect(getPendingServerUpdateForTests(environmentId)).toBeNull();
+  });
+
+  it("does not let an older attempt clear a newer retry", () => {
+    const firstAttempt = beginPendingServerUpdate(environmentId, "0.0.29");
+    const retryAttempt = beginPendingServerUpdate(environmentId, "0.0.29");
+
+    clearPendingServerUpdate(environmentId, firstAttempt);
+    expect(getPendingServerUpdateForTests(environmentId)?.attempt).toBe(retryAttempt);
+  });
+});

--- a/apps/web/src/state/serverUpdate.ts
+++ b/apps/web/src/state/serverUpdate.ts
@@ -1,0 +1,89 @@
+import { useAtomValue } from "@effect/atom-react";
+import type { EnvironmentId } from "@t3tools/contracts";
+import { Atom } from "effect/unstable/reactivity";
+
+import { appAtomRegistry } from "../rpc/atomRegistry";
+
+export const SERVER_UPDATE_PENDING_EXPIRY_MS = 12 * 60_000;
+
+export interface PendingServerUpdate {
+  readonly attempt: number;
+  readonly targetVersion: string;
+}
+
+const pendingServerUpdatesAtom = Atom.make<
+  Readonly<Record<string, PendingServerUpdate | undefined>>
+>({}).pipe(Atom.keepAlive, Atom.withLabel("server-update:pending"));
+
+const expiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+let nextAttempt = 0;
+
+function clearExpiryTimer(environmentId: EnvironmentId): void {
+  const timer = expiryTimers.get(environmentId);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  expiryTimers.delete(environmentId);
+}
+
+function armExpiry(environmentId: EnvironmentId, attempt: number): void {
+  clearExpiryTimer(environmentId);
+  expiryTimers.set(
+    environmentId,
+    setTimeout(() => {
+      clearPendingServerUpdate(environmentId, attempt);
+    }, SERVER_UPDATE_PENDING_EXPIRY_MS),
+  );
+}
+
+export function beginPendingServerUpdate(
+  environmentId: EnvironmentId,
+  targetVersion: string,
+): number {
+  const attempt = ++nextAttempt;
+  appAtomRegistry.set(pendingServerUpdatesAtom, {
+    ...appAtomRegistry.get(pendingServerUpdatesAtom),
+    [environmentId]: { attempt, targetVersion },
+  });
+  armExpiry(environmentId, attempt);
+  return attempt;
+}
+
+export function markPendingServerUpdateRestartAccepted(
+  environmentId: EnvironmentId,
+  attempt: number,
+): void {
+  if (appAtomRegistry.get(pendingServerUpdatesAtom)[environmentId]?.attempt !== attempt) return;
+  armExpiry(environmentId, attempt);
+}
+
+export function clearPendingServerUpdate(environmentId: EnvironmentId, attempt: number): void {
+  const updates = appAtomRegistry.get(pendingServerUpdatesAtom);
+  if (updates[environmentId]?.attempt !== attempt) return;
+
+  clearExpiryTimer(environmentId);
+  const next = { ...updates };
+  delete next[environmentId];
+  appAtomRegistry.set(pendingServerUpdatesAtom, next);
+}
+
+export function usePendingServerUpdate(
+  environmentId: EnvironmentId | null,
+): PendingServerUpdate | null {
+  const updates = useAtomValue(pendingServerUpdatesAtom);
+  return environmentId === null ? null : (updates[environmentId] ?? null);
+}
+
+export function getPendingServerUpdateForTests(
+  environmentId: EnvironmentId,
+): PendingServerUpdate | null {
+  return appAtomRegistry.get(pendingServerUpdatesAtom)[environmentId] ?? null;
+}
+
+export function resetPendingServerUpdatesForTests(): void {
+  for (const timer of expiryTimers.values()) {
+    clearTimeout(timer);
+  }
+  expiryTimers.clear();
+  nextAttempt = 0;
+  appAtomRegistry.set(pendingServerUpdatesAtom, {});
+}

--- a/docs/user/server-updates.md
+++ b/docs/user/server-updates.md
@@ -45,6 +45,9 @@ commands.
 Keep the web or desktop app open while the server restarts. When it reconnects with the matching
 version, the warning and update action disappear.
 
+While an update-triggered restart is in progress, T3 Code identifies it as an update and reconnects
+automatically instead of reporting the expected disconnect as a connection failure.
+
 If the client reports a timeout, the server may still be finishing the update. Wait a minute, then
 reconnect or open **Settings** → **Connections** again. If the warning remains:
 


### PR DESCRIPTION
## What changed

- exclude the intentionally long-running `server.updateServer` RPC from the generic slow-request warning
- track pending server updates per environment with the existing 12-minute safety deadline
- present an update-triggered disconnect as “Updating server…” while retaining the normal connection supervisor and retry behavior
- clear the expected-restart state on a real update failure, successful version sync, or timeout
- document the reconnect behavior

## Why

Remote self-updates normally take longer than the generic 15-second RPC warning threshold and intentionally restart the connected server. The generic latency and connection presentation paths therefore reported two false alarms during the expected flow: a slow-request toast and “Failed to connect. Reconnecting…”.

## User impact

Users now see a single accurate update/restart state while the remote server installs, restarts, and reconnects. Unrelated disconnects and genuine update failures keep their existing error behavior.

## Validation

- `vp test run --passWithNoTests --project unit src/rpc/requestLatencyState.test.ts src/state/serverUpdate.test.ts src/components/ServerUpdateAction.test.tsx` (13 tests)
- `vp run --filter @t3tools/web typecheck`
- targeted `vp lint --report-unused-disable-directives`
- targeted `vp fmt --check`

Browser verification and screenshots are not included yet because this is a draft PR.

Implemented with Codex (GPT-5.6) in the T3 Code Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat server update restarts as expected disconnects in the chat view
> - Adds pending server update state per environment in [`state/serverUpdate.ts`](https://github.com/pingdotgg/t3code/pull/4936/files#diff-38969a1fd532f58a68c572035416f9933e591070dcf1fc9cfffec2bf494423cb) with attempt-aware clearing and safety expiry timers.
> - The chat view now shows an 'Updating server...' banner during a restart and suppresses reconnect actions until the server reconnects without a version mismatch.
> - `serverUpdateServer` and `previewAutomationConnect` RPCs (including environment-suffixed variants) are excluded from slow ack tracking in [`requestLatencyState.ts`](https://github.com/pingdotgg/t3code/pull/4936/files#diff-084b89e2becd47f287bdcaaf7d1ac9de731014c0b96d196afd4d1f54814eb085).
> - `ServerUpdateAction` now records, extends, and clears pending update state across the update lifecycle using the shared `SERVER_UPDATE_PENDING_EXPIRY_MS` constant.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b47eff9. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->