### PR TITLE
fix(web): treat server update restart as expected

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -207,6 +207,7 @@ import {
   primaryServerSettingsAtom,
   serverEnvironment,
 } from "../state/server";
+import { clearPendingServerUpdate, usePendingServerUpdate } from "../state/serverUpdate";
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
@@ -1879,21 +1880,43 @@ function ChatViewContent(props: ChatViewProps) {
   const versionMismatchEnvironmentId =
     versionMismatch && activeThread ? activeThread.environmentId : null;
   const versionMismatchSelfUpdate = resolveServerSelfUpdateCapability(serverConfig);
+  const pendingServerUpdate = usePendingServerUpdate(activeThread?.environmentId ?? null);
+  useEffect(() => {
+    if (
+      pendingServerUpdate &&
+      activeThread &&
+      activeEnvironmentConnectionPhase === "connected" &&
+      serverConfig !== null &&
+      versionMismatch === null
+    ) {
+      clearPendingServerUpdate(activeThread.environmentId, pendingServerUpdate.attempt);
+    }
+  }, [
+    activeEnvironmentConnectionPhase,
+    activeThread,
+    pendingServerUpdate,
+    serverConfig,
+    versionMismatch,
+  ]);
   const systemComposerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const items: ComposerBannerStackItem[] = [];
     if (activeEnvironmentUnavailableState) {
       const connection = activeEnvironmentUnavailableState.connection;
       const isReconnecting =
         connection.phase === "connecting" || connection.phase === "reconnecting";
+      const isUpdatingServer = pendingServerUpdate !== null;
       items.push({
         id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
         variant: connection.phase === "error" ? "error" : "warning",
         icon: <WifiOffIcon />,
-        title: `${activeEnvironmentUnavailableState.label}: ${connectionStatusTitle(connection)}`,
-        description:
-          connection.error ??
-          "Reconnect this environment before sending messages or running actions.",
-        actions: (
+        title: isUpdatingServer
+          ? `${activeEnvironmentUnavailableState.label}: Updating server...`
+          : `${activeEnvironmentUnavailableState.label}: ${connectionStatusTitle(connection)}`,
+        description: isUpdatingServer
+          ? "The server is restarting and will reconnect automatically."
+          : (connection.error ??
+            "Reconnect this environment before sending messages or running actions."),
+        actions: isUpdatingServer ? undefined : (
           <>
             <Button
               size="xs"
@@ -1958,6 +1981,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeEnvironmentUnavailableState,
     handleReconnectActiveEnvironment,
     navigate,
+    pendingServerUpdate,
     setDismissedVersionMismatchKey,
     showVersionMismatchBanner,
     versionMismatch,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -207,7 +207,7 @@ import {
   primaryServerSettingsAtom,
   serverEnvironment,
 } from "../state/server";
-import { clearPendingServerUpdate, usePendingServerUpdate } from "../state/serverUpdate";
+import { usePendingServerUpdate } from "../state/serverUpdate";
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
@@ -1881,23 +1881,6 @@ function ChatViewContent(props: ChatViewProps) {
     versionMismatch && activeThread ? activeThread.environmentId : null;
   const versionMismatchSelfUpdate = resolveServerSelfUpdateCapability(serverConfig);
   const pendingServerUpdate = usePendingServerUpdate(activeThread?.environmentId ?? null);
-  useEffect(() => {
-    if (
-      pendingServerUpdate &&
-      activeThread &&
-      activeEnvironmentConnectionPhase === "connected" &&
-      serverConfig !== null &&
-      versionMismatch === null
-    ) {
-      clearPendingServerUpdate(activeThread.environmentId, pendingServerUpdate.attempt);
-    }
-  }, [
-    activeEnvironmentConnectionPhase,
-    activeThread,
-    pendingServerUpdate,
-    serverConfig,
-    versionMismatch,
-  ]);
   const systemComposerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const items: ComposerBannerStackItem[] = [];
     if (activeEnvironmentUnavailableState) {

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -5,6 +5,9 @@ import { AsyncResult } from "effect/unstable/reactivity";
 import type { EnvironmentId } from "@t3tools/contracts";
 
 const testState = vi.hoisted(() => ({
+  beginPendingServerUpdate: vi.fn(() => 1),
+  clearPendingServerUpdate: vi.fn(),
+  markPendingServerUpdateRestartAccepted: vi.fn(),
   updateServer: vi.fn(),
   toast: vi.fn(),
 }));
@@ -72,6 +75,12 @@ vi.mock("~/hooks/useCopyToClipboard", () => ({
 vi.mock("~/state/server", () => ({
   serverEnvironment: { updateServer: Symbol("updateServer") },
 }));
+vi.mock("~/state/serverUpdate", () => ({
+  beginPendingServerUpdate: testState.beginPendingServerUpdate,
+  clearPendingServerUpdate: testState.clearPendingServerUpdate,
+  markPendingServerUpdateRestartAccepted: testState.markPendingServerUpdateRestartAccepted,
+  SERVER_UPDATE_PENDING_EXPIRY_MS: 12 * 60_000,
+}));
 vi.mock("~/state/use-atom-command", () => ({
   useAtomCommand: () => testState.updateServer,
 }));
@@ -116,6 +125,9 @@ describe("ServerUpdateAction", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     hooks.reset();
+    testState.beginPendingServerUpdate.mockClear();
+    testState.clearPendingServerUpdate.mockReset();
+    testState.markPendingServerUpdateRestartAccepted.mockReset();
     testState.updateServer.mockReset();
     testState.toast.mockReset();
   });
@@ -194,5 +206,17 @@ describe("ServerUpdateAction", () => {
     expect(testState.toast).not.toHaveBeenCalledWith(
       expect.objectContaining({ title: "Server update failed" }),
     );
+    expect(testState.clearPendingServerUpdate).not.toHaveBeenCalled();
+  });
+
+  it("clears the expected-restart state when the update fails", async () => {
+    testState.updateServer.mockResolvedValue(
+      AsyncResult.failure(Cause.fail(new Error("install failed"))),
+    );
+
+    renderAction().props.onClick?.();
+    await flushPromises();
+
+    expect(testState.clearPendingServerUpdate).toHaveBeenCalledWith("env-test", 1);
   });
 });

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -5,9 +5,16 @@ import { AsyncResult } from "effect/unstable/reactivity";
 import type { EnvironmentId } from "@t3tools/contracts";
 
 const testState = vi.hoisted(() => ({
-  beginPendingServerUpdate: vi.fn(() => 1),
+  beginPendingServerUpdate: vi.fn(),
   clearPendingServerUpdate: vi.fn(),
+  markPendingServerUpdateInterrupted: vi.fn(),
   markPendingServerUpdateRestartAccepted: vi.fn(),
+  nextUpdateAttempt: 0,
+  pendingUpdate: null as {
+    readonly attempt: number;
+    readonly phase: "requesting" | "restarting" | "interrupted";
+    readonly targetVersion: string;
+  } | null,
   updateServer: vi.fn(),
   toast: vi.fn(),
 }));
@@ -87,8 +94,10 @@ vi.mock("~/state/server", () => ({
 vi.mock("~/state/serverUpdate", () => ({
   beginPendingServerUpdate: testState.beginPendingServerUpdate,
   clearPendingServerUpdate: testState.clearPendingServerUpdate,
+  markPendingServerUpdateInterrupted: testState.markPendingServerUpdateInterrupted,
   markPendingServerUpdateRestartAccepted: testState.markPendingServerUpdateRestartAccepted,
   SERVER_UPDATE_PENDING_EXPIRY_MS: 12 * 60_000,
+  usePendingServerUpdate: () => testState.pendingUpdate,
 }));
 vi.mock("~/state/use-atom-command", () => ({
   useAtomCommand: () => testState.updateServer,
@@ -134,9 +143,35 @@ describe("ServerUpdateAction", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     hooks.reset();
-    testState.beginPendingServerUpdate.mockClear();
-    testState.clearPendingServerUpdate.mockReset();
-    testState.markPendingServerUpdateRestartAccepted.mockReset();
+    testState.nextUpdateAttempt = 0;
+    testState.pendingUpdate = null;
+    testState.beginPendingServerUpdate.mockReset().mockImplementation((_, targetVersion) => {
+      if (testState.pendingUpdate?.phase !== "interrupted" && testState.pendingUpdate !== null) {
+        return null;
+      }
+      const attempt = ++testState.nextUpdateAttempt;
+      testState.pendingUpdate = { attempt, phase: "requesting", targetVersion };
+      return attempt;
+    });
+    testState.clearPendingServerUpdate.mockReset().mockImplementation((_, attempt) => {
+      if (testState.pendingUpdate?.attempt === attempt) {
+        testState.pendingUpdate = null;
+      }
+    });
+    testState.markPendingServerUpdateInterrupted.mockReset().mockImplementation((_, attempt) => {
+      const pendingUpdate = testState.pendingUpdate;
+      if (pendingUpdate !== null && pendingUpdate.attempt === attempt) {
+        testState.pendingUpdate = { ...pendingUpdate, phase: "interrupted" };
+      }
+    });
+    testState.markPendingServerUpdateRestartAccepted
+      .mockReset()
+      .mockImplementation((_, attempt) => {
+        const pendingUpdate = testState.pendingUpdate;
+        if (pendingUpdate !== null && pendingUpdate.attempt === attempt) {
+          testState.pendingUpdate = { ...pendingUpdate, phase: "restarting" };
+        }
+      });
     testState.updateServer.mockReset();
     testState.toast.mockReset();
   });
@@ -216,6 +251,7 @@ describe("ServerUpdateAction", () => {
       expect.objectContaining({ title: "Server update failed" }),
     );
     expect(testState.clearPendingServerUpdate).not.toHaveBeenCalled();
+    expect(testState.markPendingServerUpdateInterrupted).toHaveBeenCalledWith("env-test", 1);
   });
 
   it("clears the expected-restart state when the update fails", async () => {
@@ -258,5 +294,18 @@ describe("ServerUpdateAction", () => {
 
     expect(testState.markPendingServerUpdateRestartAccepted).toHaveBeenCalledWith("env-test", 1);
     expect(testState.toast).not.toHaveBeenCalled();
+  });
+
+  it("keeps the action disabled after remount while the shared request is in flight", async () => {
+    testState.updateServer.mockReturnValue(new Promise(() => {}));
+
+    renderAction().props.onClick?.();
+    await flushPromises();
+    hooks.unmount();
+    hooks.reset();
+
+    expect(renderAction().props.disabled).toBe(true);
+    renderAction().props.onClick?.();
+    expect(testState.updateServer).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -15,6 +15,7 @@ const testState = vi.hoisted(() => ({
 const hooks = vi.hoisted(() => {
   let cursor = 0;
   let slots: unknown[] = [];
+  let effectCleanups: Array<(() => void) | undefined> = [];
   const nextIndex = () => cursor++;
 
   return {
@@ -24,9 +25,17 @@ const hooks = vi.hoisted(() => {
     reset() {
       cursor = 0;
       slots = [];
+      effectCleanups = [];
     },
-    useEffect() {
-      nextIndex();
+    unmount() {
+      for (const cleanup of effectCleanups) cleanup?.();
+      effectCleanups = [];
+    },
+    useEffect(effect: () => void | (() => void)) {
+      const index = nextIndex();
+      if (index >= effectCleanups.length) {
+        effectCleanups[index] = effect() ?? undefined;
+      }
     },
     useMemoCache(size: number): unknown[] {
       const index = nextIndex();
@@ -218,5 +227,36 @@ describe("ServerUpdateAction", () => {
     await flushPromises();
 
     expect(testState.clearPendingServerUpdate).toHaveBeenCalledWith("env-test", 1);
+  });
+
+  it("clears the expected-restart state when the update fails after unmount", async () => {
+    const update = deferred<ReturnType<typeof AsyncResult.failure>>();
+    testState.updateServer.mockReturnValue(update.promise);
+
+    renderAction().props.onClick?.();
+    hooks.unmount();
+    update.resolve(AsyncResult.failure(Cause.fail(new Error("install failed"))));
+    await flushPromises();
+
+    expect(testState.clearPendingServerUpdate).toHaveBeenCalledWith("env-test", 1);
+    expect(testState.toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Server update failed" }),
+    );
+  });
+
+  it("refreshes the expected-restart deadline without showing a toast after unmount", async () => {
+    const update =
+      deferred<
+        ReturnType<typeof AsyncResult.success<{ targetVersion: string; method: "boot-service" }>>
+      >();
+    testState.updateServer.mockReturnValue(update.promise);
+
+    renderAction().props.onClick?.();
+    hooks.unmount();
+    update.resolve(AsyncResult.success({ targetVersion: "0.0.29", method: "boot-service" }));
+    await flushPromises();
+
+    expect(testState.markPendingServerUpdateRestartAccepted).toHaveBeenCalledWith("env-test", 1);
+    expect(testState.toast).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import type { EnvironmentId, ServerSelfUpdateCapability } from "@t3tools/contracts";
 import {
   isAtomCommandInterrupted,
@@ -10,8 +10,10 @@ import { serverEnvironment } from "~/state/server";
 import {
   beginPendingServerUpdate,
   clearPendingServerUpdate,
+  markPendingServerUpdateInterrupted,
   markPendingServerUpdateRestartAccepted,
   SERVER_UPDATE_PENDING_EXPIRY_MS,
+  usePendingServerUpdate,
 } from "~/state/serverUpdate";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { manualServerUpdateCommand } from "~/versionSkew";
@@ -45,8 +47,7 @@ export function ServerUpdateAction({
   const updateServer = useAtomCommand(serverEnvironment.updateServer, {
     reportFailure: false,
   });
-  const [pending, setPending] = useState(false);
-  const inFlightRef = useRef(false);
+  const pendingUpdate = usePendingServerUpdate(environmentId);
   const attemptRef = useRef(0);
   const expiryRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { copyToClipboard } = useCopyToClipboard<{ command: string }>({
@@ -74,30 +75,23 @@ export function ServerUpdateAction({
         expiryRef.current = null;
       }
       attemptRef.current += 1;
-      inFlightRef.current = false;
     },
     [],
   );
 
   const handleUpdate = () => {
-    // Synchronous re-entry guard: setPending is async, so a rapid
-    // double-click would otherwise dispatch two updates.
-    if (inFlightRef.current) {
-      return;
-    }
-    inFlightRef.current = true;
+    const updateStateAttempt = beginPendingServerUpdate(environmentId, targetVersion);
+    if (updateStateAttempt === null) return;
+
     const attempt = attemptRef.current + 1;
     attemptRef.current = attempt;
-    const updateStateAttempt = beginPendingServerUpdate(environmentId, targetVersion);
     const ownsAttempt = () => attemptRef.current === attempt;
-    setPending(true);
     const armExpiry = () => {
       const expiry = setTimeout(() => {
         if (!ownsAttempt()) return;
         expiryRef.current = null;
+        clearPendingServerUpdate(environmentId, updateStateAttempt);
         attemptRef.current += 1;
-        inFlightRef.current = false;
-        setPending(false);
         toastManager.add({
           type: "error",
           title: "Server update timed out",
@@ -130,6 +124,7 @@ export function ServerUpdateAction({
           // Release the action quietly; version sync will remove it when a
           // successful replacement reconnects.
           if (isAtomCommandInterrupted(result)) {
+            markPendingServerUpdateInterrupted(environmentId, updateStateAttempt);
             return;
           }
           clearPendingServerUpdate(environmentId, updateStateAttempt);
@@ -170,8 +165,6 @@ export function ServerUpdateAction({
         expiryRef.current = null;
         clearTimeout(expiry);
         attemptRef.current += 1;
-        inFlightRef.current = false;
-        setPending(false);
       });
   };
 
@@ -192,7 +185,7 @@ export function ServerUpdateAction({
     );
   }
 
-  return pending ? (
+  return pendingUpdate !== null && pendingUpdate.phase !== "interrupted" ? (
     <Button size="xs" disabled>
       <Spinner className="size-3.5" />
       Updating...

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -7,6 +7,12 @@ import {
 
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { serverEnvironment } from "~/state/server";
+import {
+  beginPendingServerUpdate,
+  clearPendingServerUpdate,
+  markPendingServerUpdateRestartAccepted,
+  SERVER_UPDATE_PENDING_EXPIRY_MS,
+} from "~/state/serverUpdate";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { manualServerUpdateCommand } from "~/versionSkew";
 import { Button } from "./ui/button";
@@ -18,8 +24,6 @@ import { toastManager } from "./ui/toast";
  * spinner a bit beyond that so a dead transport never strands a disabled
  * button, while a legitimately slow install is never cut off.
  */
-const UPDATE_PENDING_EXPIRY_MS = 12 * 60_000;
-
 function updateFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Server update failed.";
 }
@@ -89,6 +93,7 @@ export function ServerUpdateAction({
     inFlightRef.current = true;
     const attempt = attemptRef.current + 1;
     attemptRef.current = attempt;
+    const updateStateAttempt = beginPendingServerUpdate(environmentId, targetVersion);
     const ownsAttempt = () => attemptRef.current === attempt;
     setPending(true);
     const armExpiry = () => {
@@ -103,7 +108,7 @@ export function ServerUpdateAction({
           title: "Server update timed out",
           description: "The update may still be running on the server — check again in a minute.",
         });
-      }, UPDATE_PENDING_EXPIRY_MS);
+      }, SERVER_UPDATE_PENDING_EXPIRY_MS);
       expiryRef.current = expiry;
       return expiry;
     };
@@ -111,6 +116,7 @@ export function ServerUpdateAction({
     let restartAccepted = false;
     const keepPendingForRestart = () => {
       restartAccepted = true;
+      markPendingServerUpdateRestartAccepted(environmentId, updateStateAttempt);
       if (expiryRef.current === expiry) {
         clearTimeout(expiry);
         expiry = armExpiry();
@@ -133,6 +139,7 @@ export function ServerUpdateAction({
           if (isAtomCommandInterrupted(result)) {
             return;
           }
+          clearPendingServerUpdate(environmentId, updateStateAttempt);
           toastManager.add({
             type: "error",
             title: "Server update failed",
@@ -152,6 +159,7 @@ export function ServerUpdateAction({
       })
       .catch((error: unknown) => {
         if (!ownsAttempt()) return;
+        clearPendingServerUpdate(environmentId, updateStateAttempt);
         toastManager.add({
           type: "error",
           title: "Server update failed",

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -19,11 +19,6 @@ import { Button } from "./ui/button";
 import { Spinner } from "./ui/spinner";
 import { toastManager } from "./ui/toast";
 
-/**
- * The npm install on the server side is capped at 10 minutes; expire the
- * spinner a bit beyond that so a dead transport never strands a disabled
- * button, while a legitimately slow install is never cut off.
- */
 function updateFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Server update failed.";
 }
@@ -116,7 +111,6 @@ export function ServerUpdateAction({
     let restartAccepted = false;
     const keepPendingForRestart = () => {
       restartAccepted = true;
-      markPendingServerUpdateRestartAccepted(environmentId, updateStateAttempt);
       if (expiryRef.current === expiry) {
         clearTimeout(expiry);
         expiry = armExpiry();
@@ -130,7 +124,6 @@ export function ServerUpdateAction({
         }),
       )
       .then((result) => {
-        if (!ownsAttempt()) return;
         if (result._tag === "Failure") {
           // An interrupt may be the expected boot-service disconnect, but it
           // can also be client-side cancellation before restart was accepted.
@@ -140,6 +133,7 @@ export function ServerUpdateAction({
             return;
           }
           clearPendingServerUpdate(environmentId, updateStateAttempt);
+          if (!ownsAttempt()) return;
           toastManager.add({
             type: "error",
             title: "Server update failed",
@@ -147,6 +141,8 @@ export function ServerUpdateAction({
           });
           return;
         }
+        markPendingServerUpdateRestartAccepted(environmentId, updateStateAttempt);
+        if (!ownsAttempt()) return;
         keepPendingForRestart();
         // Installation can legitimately consume most of the request window.
         // Give restart/reconnect a fresh full window after the server accepts
@@ -158,8 +154,8 @@ export function ServerUpdateAction({
         });
       })
       .catch((error: unknown) => {
-        if (!ownsAttempt()) return;
         clearPendingServerUpdate(environmentId, updateStateAttempt);
+        if (!ownsAttempt()) return;
         toastManager.add({
           type: "error",
           title: "Server update failed",

--- a/apps/web/src/components/ServerUpdateStateCoordinator.test.tsx
+++ b/apps/web/src/components/ServerUpdateStateCoordinator.test.tsx
@@ -1,0 +1,85 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => ({
+  cleanup: undefined as (() => void) | undefined,
+  clearPendingServerUpdate: vi.fn(),
+  connectionPhase: "connected" as "connected" | "reconnecting",
+  environmentId: "environment-1" as EnvironmentId,
+  reconcilePendingServerUpdates: vi.fn(),
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => {
+      testState.cleanup?.();
+      testState.cleanup = effect() ?? undefined;
+    },
+  };
+});
+vi.mock("../state/entities", () => ({
+  useServerConfigs: () => new Map(),
+}));
+vi.mock("../state/environments", () => ({
+  useEnvironments: () => ({
+    environments: [
+      {
+        environmentId: testState.environmentId,
+        connection: { phase: testState.connectionPhase },
+      },
+    ],
+  }),
+}));
+vi.mock("../state/serverUpdate", () => ({
+  clearPendingServerUpdate: testState.clearPendingServerUpdate,
+  reconcilePendingServerUpdates: testState.reconcilePendingServerUpdates,
+  usePendingServerUpdates: () =>
+    new Map([
+      [
+        testState.environmentId,
+        {
+          attempt: 1,
+          phase: "interrupted",
+          targetVersion: "0.0.29",
+        },
+      ],
+    ]),
+}));
+
+import { ServerUpdateStateCoordinator } from "./ServerUpdateStateCoordinator";
+
+describe("ServerUpdateStateCoordinator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    testState.cleanup = undefined;
+    testState.clearPendingServerUpdate.mockReset();
+    testState.connectionPhase = "connected";
+    testState.reconcilePendingServerUpdates.mockReset();
+  });
+
+  afterEach(() => {
+    testState.cleanup?.();
+    vi.useRealTimers();
+  });
+
+  it("clears an interrupted update when the environment remains connected", () => {
+    ServerUpdateStateCoordinator();
+
+    vi.advanceTimersByTime(999);
+    expect(testState.clearPendingServerUpdate).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(testState.clearPendingServerUpdate).toHaveBeenCalledWith(testState.environmentId, 1);
+  });
+
+  it("keeps the update presentation when the environment starts reconnecting", () => {
+    ServerUpdateStateCoordinator();
+    testState.connectionPhase = "reconnecting";
+    ServerUpdateStateCoordinator();
+
+    vi.advanceTimersByTime(1_000);
+    expect(testState.clearPendingServerUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ServerUpdateStateCoordinator.tsx
+++ b/apps/web/src/components/ServerUpdateStateCoordinator.tsx
@@ -1,15 +1,41 @@
 import { useEffect } from "react";
 
 import { useServerConfigs } from "../state/entities";
-import { reconcilePendingServerUpdates, usePendingServerUpdates } from "../state/serverUpdate";
+import { useEnvironments } from "../state/environments";
+import {
+  clearPendingServerUpdate,
+  reconcilePendingServerUpdates,
+  usePendingServerUpdates,
+} from "../state/serverUpdate";
+
+const INTERRUPTED_UPDATE_SETTLE_MS = 1_000;
 
 export function ServerUpdateStateCoordinator() {
   const serverConfigs = useServerConfigs();
   const pendingServerUpdates = usePendingServerUpdates();
+  const { environments } = useEnvironments();
 
   useEffect(() => {
     reconcilePendingServerUpdates(serverConfigs);
-  }, [pendingServerUpdates, serverConfigs]);
+
+    const interruptedConnectedUpdates = environments.flatMap((environment) => {
+      const update = pendingServerUpdates.get(environment.environmentId);
+      return update?.phase === "interrupted" && environment.connection.phase === "connected"
+        ? [{ environmentId: environment.environmentId, attempt: update.attempt }]
+        : [];
+    });
+    if (interruptedConnectedUpdates.length === 0) return;
+
+    // A boot-service update interrupts its RPC as the socket closes. Give the
+    // supervisor one turn to publish that disconnect before treating an
+    // interrupt on an otherwise stable connection as client cancellation.
+    const timeout = setTimeout(() => {
+      for (const update of interruptedConnectedUpdates) {
+        clearPendingServerUpdate(update.environmentId, update.attempt);
+      }
+    }, INTERRUPTED_UPDATE_SETTLE_MS);
+    return () => clearTimeout(timeout);
+  }, [environments, pendingServerUpdates, serverConfigs]);
 
   return null;
 }

--- a/apps/web/src/components/ServerUpdateStateCoordinator.tsx
+++ b/apps/web/src/components/ServerUpdateStateCoordinator.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+import { useServerConfigs } from "../state/entities";
+import { reconcilePendingServerUpdates, usePendingServerUpdates } from "../state/serverUpdate";
+
+export function ServerUpdateStateCoordinator() {
+  const serverConfigs = useServerConfigs();
+  const pendingServerUpdates = usePendingServerUpdates();
+
+  useEffect(() => {
+    reconcilePendingServerUpdates(serverConfigs);
+  }, [pendingServerUpdates, serverConfigs]);
+
+  return null;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import { ConnectOnboardingDialog } from "../components/cloud/ConnectOnboardingDi
 import { RelayClientInstallDialog } from "../components/cloud/RelayClientInstallDialog";
 import { SshPasswordPromptDialog } from "../components/desktop/SshPasswordPromptDialog";
 import { ProviderUpdateLaunchNotification } from "../components/ProviderUpdateLaunchNotification";
+import { ServerUpdateStateCoordinator } from "../components/ServerUpdateStateCoordinator";
 import { SlowRpcRequestToastCoordinator } from "../components/SlowRpcRequestToastCoordinator";
 import { Button } from "../components/ui/button";
 import {
@@ -133,6 +134,7 @@ function RootRouteView() {
         <ConnectOnboardingDialog />
         <SshPasswordPromptDialog />
         <SlowRpcRequestToastCoordinator />
+        <ServerUpdateStateCoordinator />
         <HostedStaticEnvironmentBootstrap />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
         {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}

--- a/apps/web/src/rpc/requestLatencyState.test.ts
+++ b/apps/web/src/rpc/requestLatencyState.test.ts
@@ -52,7 +52,14 @@ describe("requestLatencyState", () => {
   });
 
   it("ignores the long-lived preview automation connection", () => {
-    trackRpcRequestSent("1", WS_METHODS.previewAutomationConnect);
+    trackRpcRequestSent("1", `${WS_METHODS.previewAutomationConnect} · environment-1`);
+    vi.advanceTimersByTime(SLOW_RPC_ACK_THRESHOLD_MS * 2);
+
+    expect(getSlowRpcAckRequests()).toEqual([]);
+  });
+
+  it("ignores server updates because their install phase is intentionally long-running", () => {
+    trackRpcRequestSent("1", `${WS_METHODS.serverUpdateServer} · environment-1`);
     vi.advanceTimersByTime(SLOW_RPC_ACK_THRESHOLD_MS * 2);
 
     expect(getSlowRpcAckRequests()).toEqual([]);

--- a/apps/web/src/rpc/requestLatencyState.ts
+++ b/apps/web/src/rpc/requestLatencyState.ts
@@ -22,7 +22,10 @@ interface PendingRpcAckRequest {
 }
 
 const pendingRpcAckRequests = new Map<string, PendingRpcAckRequest>();
-const untrackedRpcAckTags = new Set<string>([WS_METHODS.previewAutomationConnect]);
+const untrackedRpcAckTags = new Set<string>([
+  WS_METHODS.previewAutomationConnect,
+  WS_METHODS.serverUpdateServer,
+]);
 
 const slowRpcAckRequestsAtom = Atom.make<ReadonlyArray<SlowRpcAckRequest>>([]).pipe(
   Atom.keepAlive,
@@ -38,7 +41,11 @@ function getSlowRpcAckRequestsValue(): ReadonlyArray<SlowRpcAckRequest> {
 }
 
 function shouldTrackRpcAck(tag: string): boolean {
-  return !tag.includes("subscribe") && !untrackedRpcAckTags.has(tag);
+  if (tag.includes("subscribe")) return false;
+  for (const untrackedTag of untrackedRpcAckTags) {
+    if (tag === untrackedTag || tag.startsWith(`${untrackedTag} · `)) return false;
+  }
+  return true;
 }
 
 export function getSlowRpcAckRequests(): ReadonlyArray<SlowRpcAckRequest> {

--- a/apps/web/src/state/serverUpdate.test.ts
+++ b/apps/web/src/state/serverUpdate.test.ts
@@ -1,0 +1,57 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  beginPendingServerUpdate,
+  clearPendingServerUpdate,
+  getPendingServerUpdateForTests,
+  markPendingServerUpdateRestartAccepted,
+  resetPendingServerUpdatesForTests,
+  SERVER_UPDATE_PENDING_EXPIRY_MS,
+} from "./serverUpdate";
+
+const environmentId = "environment-1" as EnvironmentId;
+
+describe("serverUpdate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetPendingServerUpdatesForTests();
+  });
+
+  afterEach(() => {
+    resetPendingServerUpdatesForTests();
+    vi.useRealTimers();
+  });
+
+  it("keeps the latest update pending until its safety deadline", () => {
+    const attempt = beginPendingServerUpdate(environmentId, "0.0.29");
+
+    expect(getPendingServerUpdateForTests(environmentId)).toEqual({
+      attempt,
+      targetVersion: "0.0.29",
+    });
+
+    vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS);
+    expect(getPendingServerUpdateForTests(environmentId)).toBeNull();
+  });
+
+  it("starts a fresh deadline after restart is accepted", () => {
+    const attempt = beginPendingServerUpdate(environmentId, "0.0.29");
+    vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS - 1);
+
+    markPendingServerUpdateRestartAccepted(environmentId, attempt);
+    vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS - 1);
+    expect(getPendingServerUpdateForTests(environmentId)).not.toBeNull();
+
+    vi.advanceTimersByTime(1);
+    expect(getPendingServerUpdateForTests(environmentId)).toBeNull();
+  });
+
+  it("does not let an older attempt clear a newer retry", () => {
+    const firstAttempt = beginPendingServerUpdate(environmentId, "0.0.29");
+    const retryAttempt = beginPendingServerUpdate(environmentId, "0.0.29");
+
+    clearPendingServerUpdate(environmentId, firstAttempt);
+    expect(getPendingServerUpdateForTests(environmentId)?.attempt).toBe(retryAttempt);
+  });
+});

--- a/apps/web/src/state/serverUpdate.test.ts
+++ b/apps/web/src/state/serverUpdate.test.ts
@@ -50,6 +50,18 @@ describe("serverUpdate", () => {
     expect(getPendingServerUpdateForTests(environmentId)).toBeNull();
   });
 
+  it("starts a fresh reconnect deadline after the update request is interrupted", () => {
+    const attempt = beginPendingServerUpdate(environmentId, "0.0.29");
+    vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS - 1);
+
+    markPendingServerUpdateInterrupted(environmentId, attempt!);
+    vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS - 1);
+    expect(getPendingServerUpdateForTests(environmentId)).not.toBeNull();
+
+    vi.advanceTimersByTime(1);
+    expect(getPendingServerUpdateForTests(environmentId)).toBeNull();
+  });
+
   it("does not let an older attempt clear a newer retry", () => {
     const firstAttempt = beginPendingServerUpdate(environmentId, "0.0.29");
     expect(firstAttempt).not.toBeNull();

--- a/apps/web/src/state/serverUpdate.test.ts
+++ b/apps/web/src/state/serverUpdate.test.ts
@@ -5,7 +5,9 @@ import {
   beginPendingServerUpdate,
   clearPendingServerUpdate,
   getPendingServerUpdateForTests,
+  markPendingServerUpdateInterrupted,
   markPendingServerUpdateRestartAccepted,
+  reconcilePendingServerUpdates,
   resetPendingServerUpdatesForTests,
   SERVER_UPDATE_PENDING_EXPIRY_MS,
 } from "./serverUpdate";
@@ -28,6 +30,7 @@ describe("serverUpdate", () => {
 
     expect(getPendingServerUpdateForTests(environmentId)).toEqual({
       attempt,
+      phase: "requesting",
       targetVersion: "0.0.29",
     });
 
@@ -39,7 +42,7 @@ describe("serverUpdate", () => {
     const attempt = beginPendingServerUpdate(environmentId, "0.0.29");
     vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS - 1);
 
-    markPendingServerUpdateRestartAccepted(environmentId, attempt);
+    markPendingServerUpdateRestartAccepted(environmentId, attempt!);
     vi.advanceTimersByTime(SERVER_UPDATE_PENDING_EXPIRY_MS - 1);
     expect(getPendingServerUpdateForTests(environmentId)).not.toBeNull();
 
@@ -49,9 +52,44 @@ describe("serverUpdate", () => {
 
   it("does not let an older attempt clear a newer retry", () => {
     const firstAttempt = beginPendingServerUpdate(environmentId, "0.0.29");
+    expect(firstAttempt).not.toBeNull();
+    markPendingServerUpdateInterrupted(environmentId, firstAttempt!);
     const retryAttempt = beginPendingServerUpdate(environmentId, "0.0.29");
 
-    clearPendingServerUpdate(environmentId, firstAttempt);
+    clearPendingServerUpdate(environmentId, firstAttempt!);
     expect(getPendingServerUpdateForTests(environmentId)?.attempt).toBe(retryAttempt);
+  });
+
+  it("rejects a second request while the shared update is active", () => {
+    const attempt = beginPendingServerUpdate(environmentId, "0.0.29");
+
+    expect(beginPendingServerUpdate(environmentId, "0.0.29")).toBeNull();
+    markPendingServerUpdateRestartAccepted(environmentId, attempt!);
+    expect(beginPendingServerUpdate(environmentId, "0.0.29")).toBeNull();
+  });
+
+  it("allows retry after an interrupted request", () => {
+    const attempt = beginPendingServerUpdate(environmentId, "0.0.29");
+    markPendingServerUpdateInterrupted(environmentId, attempt!);
+
+    const retryAttempt = beginPendingServerUpdate(environmentId, "0.0.29");
+    expect(retryAttempt).not.toBeNull();
+    expect(retryAttempt).not.toBe(attempt);
+  });
+
+  it("clears completed updates from every environment config", () => {
+    const otherEnvironmentId = "environment-2" as EnvironmentId;
+    beginPendingServerUpdate(environmentId, "0.0.29");
+    beginPendingServerUpdate(otherEnvironmentId, "0.0.30");
+
+    reconcilePendingServerUpdates(
+      new Map([
+        [environmentId, { environment: { serverVersion: "0.0.29" } }],
+        [otherEnvironmentId, { environment: { serverVersion: "0.0.28" } }],
+      ]),
+    );
+
+    expect(getPendingServerUpdateForTests(environmentId)).toBeNull();
+    expect(getPendingServerUpdateForTests(otherEnvironmentId)).not.toBeNull();
   });
 });

--- a/apps/web/src/state/serverUpdate.ts
+++ b/apps/web/src/state/serverUpdate.ts
@@ -1,0 +1,89 @@
+import { useAtomValue } from "@effect/atom-react";
+import type { EnvironmentId } from "@t3tools/contracts";
+import { Atom } from "effect/unstable/reactivity";
+
+import { appAtomRegistry } from "../rpc/atomRegistry";
+
+export const SERVER_UPDATE_PENDING_EXPIRY_MS = 12 * 60_000;
+
+export interface PendingServerUpdate {
+  readonly attempt: number;
+  readonly targetVersion: string;
+}
+
+const pendingServerUpdatesAtom = Atom.make<
+  Readonly<Record<string, PendingServerUpdate | undefined>>
+>({}).pipe(Atom.keepAlive, Atom.withLabel("server-update:pending"));
+
+const expiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+let nextAttempt = 0;
+
+function clearExpiryTimer(environmentId: EnvironmentId): void {
+  const timer = expiryTimers.get(environmentId);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  expiryTimers.delete(environmentId);
+}
+
+function armExpiry(environmentId: EnvironmentId, attempt: number): void {
+  clearExpiryTimer(environmentId);
+  expiryTimers.set(
+    environmentId,
+    setTimeout(() => {
+      clearPendingServerUpdate(environmentId, attempt);
+    }, SERVER_UPDATE_PENDING_EXPIRY_MS),
+  );
+}
+
+export function beginPendingServerUpdate(
+  environmentId: EnvironmentId,
+  targetVersion: string,
+): number {
+  const attempt = ++nextAttempt;
+  appAtomRegistry.set(pendingServerUpdatesAtom, {
+    ...appAtomRegistry.get(pendingServerUpdatesAtom),
+    [environmentId]: { attempt, targetVersion },
+  });
+  armExpiry(environmentId, attempt);
+  return attempt;
+}
+
+export function markPendingServerUpdateRestartAccepted(
+  environmentId: EnvironmentId,
+  attempt: number,
+): void {
+  if (appAtomRegistry.get(pendingServerUpdatesAtom)[environmentId]?.attempt !== attempt) return;
+  armExpiry(environmentId, attempt);
+}
+
+export function clearPendingServerUpdate(environmentId: EnvironmentId, attempt: number): void {
+  const updates = appAtomRegistry.get(pendingServerUpdatesAtom);
+  if (updates[environmentId]?.attempt !== attempt) return;
+
+  clearExpiryTimer(environmentId);
+  const next = { ...updates };
+  delete next[environmentId];
+  appAtomRegistry.set(pendingServerUpdatesAtom, next);
+}
+
+export function usePendingServerUpdate(
+  environmentId: EnvironmentId | null,
+): PendingServerUpdate | null {
+  const updates = useAtomValue(pendingServerUpdatesAtom);
+  return environmentId === null ? null : (updates[environmentId] ?? null);
+}
+
+export function getPendingServerUpdateForTests(
+  environmentId: EnvironmentId,
+): PendingServerUpdate | null {
+  return appAtomRegistry.get(pendingServerUpdatesAtom)[environmentId] ?? null;
+}
+
+export function resetPendingServerUpdatesForTests(): void {
+  for (const timer of expiryTimers.values()) {
+    clearTimeout(timer);
+  }
+  expiryTimers.clear();
+  nextAttempt = 0;
+  appAtomRegistry.set(pendingServerUpdatesAtom, {});
+}

--- a/apps/web/src/state/serverUpdate.ts
+++ b/apps/web/src/state/serverUpdate.ts
@@ -81,6 +81,7 @@ export function markPendingServerUpdateInterrupted(
   const next = new Map(updates);
   next.set(environmentId, { ...current, phase: "interrupted" });
   appAtomRegistry.set(pendingServerUpdatesAtom, next);
+  armExpiry(environmentId, attempt);
 }
 
 export function clearPendingServerUpdate(environmentId: EnvironmentId, attempt: number): void {

--- a/apps/web/src/state/serverUpdate.ts
+++ b/apps/web/src/state/serverUpdate.ts
@@ -13,12 +13,13 @@ export const SERVER_UPDATE_PENDING_EXPIRY_MS = 12 * 60_000;
 
 export interface PendingServerUpdate {
   readonly attempt: number;
+  readonly phase: "requesting" | "restarting" | "interrupted";
   readonly targetVersion: string;
 }
 
-const pendingServerUpdatesAtom = Atom.make<
-  Readonly<Record<string, PendingServerUpdate | undefined>>
->({}).pipe(Atom.keepAlive, Atom.withLabel("server-update:pending"));
+const pendingServerUpdatesAtom = Atom.make<ReadonlyMap<EnvironmentId, PendingServerUpdate>>(
+  new Map(),
+).pipe(Atom.keepAlive, Atom.withLabel("server-update:pending"));
 
 const expiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 let nextAttempt = 0;
@@ -43,12 +44,14 @@ function armExpiry(environmentId: EnvironmentId, attempt: number): void {
 export function beginPendingServerUpdate(
   environmentId: EnvironmentId,
   targetVersion: string,
-): number {
+): number | null {
+  const current = appAtomRegistry.get(pendingServerUpdatesAtom).get(environmentId);
+  if (current && current.phase !== "interrupted") return null;
+
   const attempt = ++nextAttempt;
-  appAtomRegistry.set(pendingServerUpdatesAtom, {
-    ...appAtomRegistry.get(pendingServerUpdatesAtom),
-    [environmentId]: { attempt, targetVersion },
-  });
+  const updates = new Map(appAtomRegistry.get(pendingServerUpdatesAtom));
+  updates.set(environmentId, { attempt, phase: "requesting", targetVersion });
+  appAtomRegistry.set(pendingServerUpdatesAtom, updates);
   armExpiry(environmentId, attempt);
   return attempt;
 }
@@ -57,31 +60,68 @@ export function markPendingServerUpdateRestartAccepted(
   environmentId: EnvironmentId,
   attempt: number,
 ): void {
-  if (appAtomRegistry.get(pendingServerUpdatesAtom)[environmentId]?.attempt !== attempt) return;
+  const updates = appAtomRegistry.get(pendingServerUpdatesAtom);
+  const current = updates.get(environmentId);
+  if (current?.attempt !== attempt) return;
+
+  const next = new Map(updates);
+  next.set(environmentId, { ...current, phase: "restarting" });
+  appAtomRegistry.set(pendingServerUpdatesAtom, next);
   armExpiry(environmentId, attempt);
+}
+
+export function markPendingServerUpdateInterrupted(
+  environmentId: EnvironmentId,
+  attempt: number,
+): void {
+  const updates = appAtomRegistry.get(pendingServerUpdatesAtom);
+  const current = updates.get(environmentId);
+  if (current?.attempt !== attempt) return;
+
+  const next = new Map(updates);
+  next.set(environmentId, { ...current, phase: "interrupted" });
+  appAtomRegistry.set(pendingServerUpdatesAtom, next);
 }
 
 export function clearPendingServerUpdate(environmentId: EnvironmentId, attempt: number): void {
   const updates = appAtomRegistry.get(pendingServerUpdatesAtom);
-  if (updates[environmentId]?.attempt !== attempt) return;
+  if (updates.get(environmentId)?.attempt !== attempt) return;
 
   clearExpiryTimer(environmentId);
-  const next = { ...updates };
-  delete next[environmentId];
+  const next = new Map(updates);
+  next.delete(environmentId);
   appAtomRegistry.set(pendingServerUpdatesAtom, next);
+}
+
+export function reconcilePendingServerUpdates(
+  serverConfigs: ReadonlyMap<
+    EnvironmentId,
+    { readonly environment: { readonly serverVersion: string } }
+  >,
+): void {
+  for (const [environmentId, update] of appAtomRegistry.get(pendingServerUpdatesAtom)) {
+    const serverVersion = serverConfigs.get(environmentId)?.environment.serverVersion.trim();
+    if (serverVersion && serverVersion === update.targetVersion.trim()) {
+      clearPendingServerUpdate(environmentId, update.attempt);
+    }
+  }
 }
 
 export function usePendingServerUpdate(
   environmentId: EnvironmentId | null,
 ): PendingServerUpdate | null {
   const updates = useAtomValue(pendingServerUpdatesAtom);
-  return environmentId === null ? null : (updates[environmentId] ?? null);
+  return environmentId === null ? null : (updates.get(environmentId) ?? null);
+}
+
+export function usePendingServerUpdates(): ReadonlyMap<EnvironmentId, PendingServerUpdate> {
+  return useAtomValue(pendingServerUpdatesAtom);
 }
 
 export function getPendingServerUpdateForTests(
   environmentId: EnvironmentId,
 ): PendingServerUpdate | null {
-  return appAtomRegistry.get(pendingServerUpdatesAtom)[environmentId] ?? null;
+  return appAtomRegistry.get(pendingServerUpdatesAtom).get(environmentId) ?? null;
 }
 
 export function resetPendingServerUpdatesForTests(): void {
@@ -90,5 +130,5 @@ export function resetPendingServerUpdatesForTests(): void {
   }
   expiryTimers.clear();
   nextAttempt = 0;
-  appAtomRegistry.set(pendingServerUpdatesAtom, {});
+  appAtomRegistry.set(pendingServerUpdatesAtom, new Map());
 }

--- a/apps/web/src/state/serverUpdate.ts
+++ b/apps/web/src/state/serverUpdate.ts
@@ -4,6 +4,11 @@ import { Atom } from "effect/unstable/reactivity";
 
 import { appAtomRegistry } from "../rpc/atomRegistry";
 
+/**
+ * The npm install on the server side is capped at 10 minutes; expire the
+ * pending state a bit beyond that so a dead transport never leaves the client
+ * presenting an update indefinitely.
+ */
 export const SERVER_UPDATE_PENDING_EXPIRY_MS = 12 * 60_000;
 
 export interface PendingServerUpdate {

--- a/docs/user/server-updates.md
+++ b/docs/user/server-updates.md
@@ -45,6 +45,9 @@ commands.
 Keep the web or desktop app open while the server restarts. When it reconnects with the matching
 version, the warning and update action disappear.
 
+While an update-triggered restart is in progress, T3 Code identifies it as an update and reconnects
+automatically instead of reporting the expected disconnect as a connection failure.
+
 If the client reports a timeout, the server may still be finishing the update. Wait a minute, then
 reconnect or open **Settings** → **Connections** again. If the warning remains:
 


### PR DESCRIPTION
## What changed

- exclude the intentionally long-running `server.updateServer` RPC from the generic slow-request warning
- track pending server updates per environment with the existing 12-minute safety deadline
- present an update-triggered disconnect as “Updating server…” while retaining the normal connection supervisor and retry behavior
- clear the expected-restart state on a real update failure, successful version sync, or timeout
- document the reconnect behavior

## Why

Remote self-updates normally take longer than the generic 15-second RPC warning threshold and intentionally restart the connected server. The generic latency and connection presentation paths therefore reported two false alarms during the expected flow: a slow-request toast and “Failed to connect. Reconnecting…”.

## User impact

Users now see a single accurate update/restart state while the remote server installs, restarts, and reconnects. Unrelated disconnects and genuine update failures keep their existing error behavior.

## Validation

- `vp test run --passWithNoTests --project unit src/components/ServerUpdateStateCoordinator.test.tsx src/components/ServerUpdateAction.test.tsx src/state/serverUpdate.test.ts src/rpc/requestLatencyState.test.ts` (22 tests)
- `vp run --filter @t3tools/web typecheck`
- targeted `vp lint --report-unused-disable-directives`
- targeted `vp fmt --check`

Browser verification and screenshots are not included yet because this is a draft PR.

## Related issue

Closes #3598

Implemented with Codex (GPT-5.6) in the T3 Code Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat server update restarts as expected reconnects instead of connection failures
> - Adds shared pending server update state in [`serverUpdate.ts`](https://github.com/pingdotgg/t3code/pull/4937/files#diff-38969a1fd532f58a68c572035416f9933e591070dcf1fc9cfffec2bf494423cb) with lifecycle functions (`beginPendingServerUpdate`, `markPendingServerUpdateInterrupted`, `markPendingServerUpdateRestartAccepted`, `clearPendingServerUpdate`) and automatic expiry.
> - While a server update is pending, the environment-unavailable banner in [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/4937/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) shows 'Updating server...' with an auto-reconnect message instead of reconnect action buttons.
> - [`ServerUpdateAction.tsx`](https://github.com/pingdotgg/t3code/pull/4937/files#diff-c763cea5fd019df67ff03a8c988bc9ea2af55b7f10b5fa6fe8557bd1f92471a3) now uses shared pending state to suppress duplicate in-flight requests and keep the button disabled across unmount/remount.
> - [`ServerUpdateStateCoordinator.tsx`](https://github.com/pingdotgg/t3code/pull/4937/files#diff-0a10455de08312612b6b257a58328bdcec6faac7446915c134e87884229986db) runs globally to clear interrupted update state after a 1s settle period once the environment reconnects.
> - `serverUpdateServer` RPCs are excluded from slow-ack latency tracking in [`requestLatencyState.ts`](https://github.com/pingdotgg/t3code/pull/4937/files#diff-084b89e2becd47f287bdcaaf7d1ac9de731014c0b96d196afd4d1f54814eb085).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 182e3ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and client-side state around server updates and RPC latency presentation; no auth, data, or server protocol changes beyond excluding one RPC from slow-ack tracking.
> 
> **Overview**
> During remote self-updates, the client no longer surfaces false alarms from the generic slow-RPC toast or “failed to connect” banner while the server is installing and restarting.
> 
> **Shared pending-update state** (`serverUpdate.ts`) tracks updates per environment with phases (`requesting`, `restarting`, `interrupted`), attempt sequencing, a 12-minute safety expiry, and clearing when server config matches the target version. `ServerUpdateAction` uses this instead of local `pending` state so the update button stays disabled across remounts and duplicate clicks are blocked.
> 
> **`ServerUpdateStateCoordinator`** (mounted in `__root.tsx`) reconciles pending state against server configs and, after a 1s settle window, clears interrupted updates when the environment is still connected (distinguishing expected boot disconnect from user cancellation).
> 
> **`ChatView`** shows “Updating server…” and hides reconnect actions when a pending update exists for the active environment.
> 
> **`requestLatencyState`** excludes `server.updateServer` (including tagged variants) from slow-ack tracking, matching the intentionally long install phase.
> 
> User docs note that update-triggered restarts reconnect automatically instead of being reported as connection failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182e3ef318fd73060cf7c6d59a8d9910000eafa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->