### PR TITLE
fix(cursor): implement the latest refined plan

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeFS from "node:fs";
+import * as NodeURL from "node:url";
 
 import * as Effect from "effect/Effect";
 
@@ -18,6 +19,7 @@ const emitInterleavedAssistantToolCalls =
   process.env.T3_ACP_EMIT_INTERLEAVED_ASSISTANT_TOOL_CALLS === "1";
 const emitGenericToolPlaceholders = process.env.T3_ACP_EMIT_GENERIC_TOOL_PLACEHOLDERS === "1";
 const emitAskQuestion = process.env.T3_ACP_EMIT_ASK_QUESTION === "1";
+const emitCreatePlan = process.env.T3_ACP_EMIT_CREATE_PLAN === "1";
 const emitXAiAskUserQuestion = process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION === "1";
 const emitXAiPromptCompleteThenHang = process.env.T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG === "1";
 const emitForeignSessionUpdates = process.env.T3_ACP_EMIT_FOREIGN_SESSION_UPDATES === "1";
@@ -55,6 +57,7 @@ let currentContext = "272k";
 let currentFast = false;
 let promptCount = 0;
 let overlappingFirstPromptId: string | undefined;
+let proposedPlanUri: string | undefined;
 const cancelledSessions = new Set<string>();
 
 function promptIdFromRequestMeta(
@@ -463,6 +466,47 @@ const program = Effect.gen(function* () {
 
       if (failPrompt) {
         return yield* AcpError.AcpRequestError.internalError("Mock prompt failure");
+      }
+
+      if (emitCreatePlan && promptCount === 1) {
+        const response = yield* agent.client.extRequest("cursor/create_plan", {
+          toolCallId: "create-plan-tool-call-1",
+          name: "Mock plan",
+          overview: "Verify plan refinements",
+          plan: "# Mock plan\n\n- initial step",
+          todos: [{ id: "step-1", content: "Initial step", status: "pending" }],
+          isProject: false,
+        });
+        const outcome =
+          typeof response === "object" && response !== null && "outcome" in response
+            ? response.outcome
+            : undefined;
+        if (
+          typeof outcome !== "object" ||
+          outcome === null ||
+          !("outcome" in outcome) ||
+          outcome.outcome !== "accepted" ||
+          !("planUri" in outcome) ||
+          typeof outcome.planUri !== "string"
+        ) {
+          throw new Error(
+            "Expected cursor/create_plan to return an accepted outcome with planUri.",
+          );
+        }
+        proposedPlanUri = outcome.planUri;
+        return { stopReason: "end_turn" };
+      }
+
+      if (emitCreatePlan && promptCount === 2) {
+        if (!proposedPlanUri) {
+          throw new Error("Expected the first create-plan prompt to capture planUri.");
+        }
+        NodeFS.writeFileSync(
+          NodeURL.fileURLToPath(proposedPlanUri),
+          "# Mock plan\n\n- refined step\n",
+          "utf8",
+        );
+        return { stopReason: "end_turn" };
       }
 
       if (emitStaleXAiPromptCompleteBeforeSecondHang && promptCount === 1) {

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -509,6 +509,18 @@ const program = Effect.gen(function* () {
         return { stopReason: "end_turn" };
       }
 
+      if (emitCreatePlan && promptCount === 3) {
+        yield* agent.client.extRequest("cursor/create_plan", {
+          toolCallId: "create-plan-tool-call-2",
+          name: "Mock plan",
+          overview: "Re-propose the refined plan",
+          plan: "# Mock plan\n\n- refined step",
+          todos: [{ id: "step-1", content: "Refined step", status: "pending" }],
+          isProject: false,
+        });
+        return { stopReason: "end_turn" };
+      }
+
       if (emitStaleXAiPromptCompleteBeforeSecondHang && promptCount === 1) {
         return {
           stopReason: "end_turn",

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -267,7 +267,7 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
             event.threadId === threadId &&
             (event.type === "turn.proposed.completed" || event.type === "turn.completed"),
         ),
-        Stream.take(4),
+        Stream.take(6),
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -292,6 +292,12 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         attachments: [],
         interactionMode: "plan",
       });
+      const reproposedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "propose the same refined plan again",
+        attachments: [],
+        interactionMode: "plan",
+      });
 
       const planEvents = Array.from(yield* Fiber.join(planEventsFiber));
       const proposedPlans = planEvents.filter(
@@ -299,14 +305,23 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
           event.type === "turn.proposed.completed",
       );
 
-      assert.equal(proposedPlans.length, 2);
+      assert.equal(proposedPlans.length, 3);
       assert.equal(proposedPlans[0]?.turnId, initialTurn.turnId);
       assert.equal(proposedPlans[0]?.payload.planMarkdown, "# Mock plan\n\n- initial step");
       assert.equal(proposedPlans[1]?.turnId, refinedTurn.turnId);
       assert.equal(proposedPlans[1]?.payload.planMarkdown, "# Mock plan\n\n- refined step");
+      assert.equal(proposedPlans[2]?.turnId, reproposedTurn.turnId);
+      assert.equal(proposedPlans[2]?.payload.planMarkdown, "# Mock plan\n\n- refined step");
       assert.deepStrictEqual(
         planEvents.map((event) => event.type),
-        ["turn.proposed.completed", "turn.completed", "turn.proposed.completed", "turn.completed"],
+        [
+          "turn.proposed.completed",
+          "turn.completed",
+          "turn.proposed.completed",
+          "turn.completed",
+          "turn.proposed.completed",
+          "turn.completed",
+        ],
       );
 
       yield* adapter.stopSession(threadId);

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -250,6 +250,69 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
     }),
   );
 
+  it.effect("syncs refined Cursor plan markdown before the follow-up turn completes", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-refined-plan-thread");
+
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockAgentWrapper({ T3_ACP_EMIT_CREATE_PLAN: "1" }),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+
+      const planEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.proposed.completed" || event.type === "turn.completed"),
+        ),
+        Stream.take(4),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+      });
+
+      const initialTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "create a plan",
+        attachments: [],
+        interactionMode: "plan",
+      });
+      const refinedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "refine the plan",
+        attachments: [],
+        interactionMode: "plan",
+      });
+
+      const planEvents = Array.from(yield* Fiber.join(planEventsFiber));
+      const proposedPlans = planEvents.filter(
+        (event): event is Extract<ProviderRuntimeEvent, { type: "turn.proposed.completed" }> =>
+          event.type === "turn.proposed.completed",
+      );
+
+      assert.equal(proposedPlans.length, 2);
+      assert.equal(proposedPlans[0]?.turnId, initialTurn.turnId);
+      assert.equal(proposedPlans[0]?.payload.planMarkdown, "# Mock plan\n\n- initial step");
+      assert.equal(proposedPlans[1]?.turnId, refinedTurn.turnId);
+      assert.equal(proposedPlans[1]?.payload.planMarkdown, "# Mock plan\n\n- refined step");
+      assert.deepStrictEqual(
+        planEvents.map((event) => event.type),
+        ["turn.proposed.completed", "turn.completed", "turn.proposed.completed", "turn.completed"],
+      );
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("steers a running turn instead of opening a new one on mid-turn sendTurn", () =>
     Effect.gen(function* () {
       const adapter = yield* CursorAdapter;

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -548,6 +548,7 @@ export function makeCursorAdapter(
             serverConfig.stateDir,
             "plans",
             "cursor",
+            encodeURIComponent(boundInstanceId),
             `${encodeURIComponent(input.threadId)}.md`,
           );
           const lastProposedPlanMarkdown = yield* fileSystem

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -69,6 +69,7 @@ import { applyCursorAcpModelSelection, makeCursorAcpRuntime } from "../acp/Curso
 import {
   CursorAskQuestionRequest,
   CursorCreatePlanRequest,
+  CursorCreatePlanResponse,
   CursorUpdateTodosRequest,
   extractAskQuestions,
   extractPlanMarkdown,
@@ -132,6 +133,8 @@ interface CursorSessionContext {
   readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   lastPlanFingerprint: string | undefined;
+  readonly proposedPlanFilePath: string;
+  lastProposedPlanMarkdown: string | undefined;
   activeTurnId: TurnId | undefined;
   /** Number of sendTurn prompts currently in flight or being prepared.
    * >0 means a turn is actively running, so a new sendTurn is a steer that
@@ -364,6 +367,47 @@ export function makeCursorAdapter(
     const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
       PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
 
+    const normalizeProposedPlanMarkdown = (planMarkdown: string) => planMarkdown.trim();
+
+    const emitProposedPlanCompleted = Effect.fn("CursorAdapter.emitProposedPlanCompleted")(
+      function* (ctx: CursorSessionContext, planMarkdown: string) {
+        const normalizedPlanMarkdown = normalizeProposedPlanMarkdown(planMarkdown);
+        if (
+          normalizedPlanMarkdown.length === 0 ||
+          normalizedPlanMarkdown === ctx.lastProposedPlanMarkdown
+        ) {
+          return;
+        }
+        ctx.lastProposedPlanMarkdown = normalizedPlanMarkdown;
+        yield* offerRuntimeEvent({
+          type: "turn.proposed.completed",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          turnId: ctx.activeTurnId,
+          payload: { planMarkdown: normalizedPlanMarkdown },
+        });
+      },
+    );
+
+    const syncProposedPlanFromFile = Effect.fn("CursorAdapter.syncProposedPlanFromFile")(
+      function* (ctx: CursorSessionContext) {
+        if (!(yield* fileSystem.exists(ctx.proposedPlanFilePath))) {
+          return;
+        }
+        const planMarkdown = yield* fileSystem.readFileString(ctx.proposedPlanFilePath);
+        yield* emitProposedPlanCompleted(ctx, planMarkdown);
+      },
+      (effect, ctx) =>
+        Effect.catch(effect, (cause) =>
+          Effect.logWarning("Failed to refresh Cursor proposed plan from its backing file.", {
+            cause,
+            threadId: ctx.threadId,
+            proposedPlanFilePath: ctx.proposedPlanFilePath,
+          }),
+        ),
+    );
+
     const getThreadSemaphore = (threadId: string) =>
       SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
         const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
@@ -496,6 +540,20 @@ export function makeCursorAdapter(
           }
 
           const cwd = path.resolve(input.cwd.trim());
+          const proposedPlanFilePath = path.join(
+            serverConfig.stateDir,
+            "plans",
+            "cursor",
+            `${encodeURIComponent(input.threadId)}.md`,
+          );
+          const lastProposedPlanMarkdown = yield* fileSystem
+            .readFileString(proposedPlanFilePath)
+            .pipe(
+              Effect.map(
+                (planMarkdown) => normalizeProposedPlanMarkdown(planMarkdown) || undefined,
+              ),
+              Effect.orElseSucceed(() => undefined),
+            );
           const cursorModelSelection =
             input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
           const existing = sessions.get(input.threadId);
@@ -622,20 +680,22 @@ export function makeCursorAdapter(
                     params,
                     "acp.cursor.extension",
                   );
-                  yield* offerRuntimeEvent({
-                    type: "turn.proposed.completed",
-                    ...(yield* makeEventStamp()),
-                    provider: PROVIDER,
-                    threadId: input.threadId,
-                    turnId: ctx?.activeTurnId,
-                    payload: { planMarkdown: extractPlanMarkdown(params) },
-                    raw: {
-                      source: "acp.cursor.extension",
-                      method: "cursor/create_plan",
-                      payload: params,
+                  const planMarkdown = extractPlanMarkdown(params);
+                  yield* fileSystem.makeDirectory(path.dirname(ctx.proposedPlanFilePath), {
+                    recursive: true,
+                  });
+                  yield* fileSystem.writeFileString(
+                    ctx.proposedPlanFilePath,
+                    `${planMarkdown.trimEnd()}\n`,
+                  );
+                  yield* emitProposedPlanCompleted(ctx, planMarkdown);
+                  const planUri = yield* path.toFileUrl(ctx.proposedPlanFilePath);
+                  return CursorCreatePlanResponse.make({
+                    outcome: {
+                      outcome: "accepted",
+                      planUri: planUri.href,
                     },
                   });
-                  return { accepted: true } as const;
                 }),
               ),
             );
@@ -777,6 +837,8 @@ export function makeCursorAdapter(
             pendingUserInputs,
             turns: [],
             lastPlanFingerprint: undefined,
+            proposedPlanFilePath,
+            lastProposedPlanMarkdown,
             activeTurnId: undefined,
             promptsInFlight: 0,
             stopped: false,
@@ -1031,6 +1093,7 @@ export function makeCursorAdapter(
           // superseded prompt resolving (usually cancelled) while another is
           // in flight or pending must leave the merged turn running.
           if (ctx.promptsInFlight === 1) {
+            yield* syncProposedPlanFromFile(ctx);
             yield* offerRuntimeEvent({
               type: "turn.completed",
               ...(yield* makeEventStamp()),

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -370,11 +370,15 @@ export function makeCursorAdapter(
     const normalizeProposedPlanMarkdown = (planMarkdown: string) => planMarkdown.trim();
 
     const emitProposedPlanCompleted = Effect.fn("CursorAdapter.emitProposedPlanCompleted")(
-      function* (ctx: CursorSessionContext, planMarkdown: string) {
+      function* (
+        ctx: CursorSessionContext,
+        planMarkdown: string,
+        options?: { readonly force?: boolean },
+      ) {
         const normalizedPlanMarkdown = normalizeProposedPlanMarkdown(planMarkdown);
         if (
           normalizedPlanMarkdown.length === 0 ||
-          normalizedPlanMarkdown === ctx.lastProposedPlanMarkdown
+          (!options?.force && normalizedPlanMarkdown === ctx.lastProposedPlanMarkdown)
         ) {
           return;
         }
@@ -688,7 +692,7 @@ export function makeCursorAdapter(
                     ctx.proposedPlanFilePath,
                     `${planMarkdown.trimEnd()}\n`,
                   );
-                  yield* emitProposedPlanCompleted(ctx, planMarkdown);
+                  yield* emitProposedPlanCompleted(ctx, planMarkdown, { force: true });
                   const planUri = yield* path.toFileUrl(ctx.proposedPlanFilePath);
                   return CursorCreatePlanResponse.make({
                     outcome: {

--- a/apps/server/src/provider/acp/CursorAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpExtension.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vite-plus/test";
+import * as Schema from "effect/Schema";
 
 import {
+  CursorCreatePlanResponse,
   CursorListAvailableModelsResponse,
   extractAskQuestions,
   extractPlanMarkdown,
   extractTodosAsPlan,
 } from "./CursorAcpExtension.ts";
+
+const decodeCursorCreatePlanResponse = Schema.decodeUnknownSync(CursorCreatePlanResponse);
 
 describe("CursorAcpExtension", () => {
   it("extracts ask-question prompts from the real Cursor ACP payload shape", () => {
@@ -82,6 +86,23 @@ describe("CursorAcpExtension", () => {
     });
 
     expect(planMarkdown).toBe("# Plan\n\n1. Add schemas\n2. Remove casts");
+  });
+
+  it("decodes the documented accepted create-plan response shape", () => {
+    expect(
+      decodeCursorCreatePlanResponse({
+        outcome: {
+          outcome: "accepted",
+          planUri: "file:///tmp/plan.md",
+        },
+      }),
+    ).toEqual({
+      outcome: {
+        outcome: "accepted",
+        planUri: "file:///tmp/plan.md",
+      },
+    });
+    expect(() => decodeCursorCreatePlanResponse({ accepted: true })).toThrow();
   });
 
   it("projects todo updates into a plan shape and drops invalid entries", () => {

--- a/apps/server/src/provider/acp/CursorAcpExtension.ts
+++ b/apps/server/src/provider/acp/CursorAcpExtension.ts
@@ -48,6 +48,22 @@ export const CursorCreatePlanRequest = Schema.Struct({
   phases: Schema.optional(Schema.Array(CursorPlanPhase)),
 });
 
+export const CursorCreatePlanResponse = Schema.Struct({
+  outcome: Schema.Union([
+    Schema.Struct({
+      outcome: Schema.Literal("accepted"),
+      planUri: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      outcome: Schema.Literal("rejected"),
+      reason: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      outcome: Schema.Literal("cancelled"),
+    }),
+  ]),
+});
+
 export const CursorUpdateTodosRequest = Schema.Struct({
   toolCallId: Schema.String,
   todos: Schema.Array(CursorTodo),


### PR DESCRIPTION
## What Changed

- persist Cursor plan markdown behind the ACP `planUri`
- refresh changed plan markdown before a turn completes
- cover the initial-plan and refinement flow with focused adapter tests

## Why

Cursor plan refinements edit the plan file returned by `cursor/create_plan`. T3 previously returned a non-contract response without a backing file, so the Implement action could paste the initial plan after the user refined it. Returning the documented outcome and projecting the backing file keeps implementation aligned with the latest accepted plan.

## Verification

- `pnpm exec vp test run apps/server/src/provider/acp/CursorAcpExtension.test.ts apps/server/src/provider/Layers/CursorAdapter.test.ts`
- `pnpm exec vp run --filter t3 typecheck`
- targeted lint for all edited files

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable; this is a provider adapter fix
- [x] Interaction video is not applicable

Generated with GPT-5.6 Sol in Cursor.

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement three-step refined plan flow in `CursorAdapter` for ACP create-plan
> - Adds a `CursorCreatePlanResponse` schema in [CursorAcpExtension.ts](https://github.com/pingdotgg/t3code/pull/4942/files#diff-253a39f0df72941d62ebf067c20543e5f060f4ef874c813608f6bf40fe905bb0) with a discriminated `outcome` union (`accepted`, `rejected`, `cancelled`) including an optional `planUri`.
> - The `cursor/create_plan` handler in [CursorAdapter.ts](https://github.com/pingdotgg/t3code/pull/4942/files#diff-363bf2a012a813301f31ff1d94657c457c86fad16a4c210da894eb7ae2deb3fb) now persists plan markdown to a deterministic file path under `stateDir/plans/cursor/{instanceId}/{threadId}.md` and returns a `planUri` file URL to the caller.
> - Before each `turn.completed` event, `syncProposedPlanFromFile` reads the backing file and emits a `turn.proposed.completed` event, enabling refined plan markdown written during the turn to be surfaced before the turn closes.
> - The mock agent in [acp-mock-agent.ts](https://github.com/pingdotgg/t3code/pull/4942/files#diff-8a006152e281284d31dee6c6726df790c3c486b6899a0746f334a8d0663fabc7) implements the full three-prompt flow when `T3_ACP_EMIT_CREATE_PLAN=1`: propose initial plan (capture `planUri`), write refined markdown to the file, then re-propose the refined plan.
> - Deduplication in `emitProposedPlanCompleted` prevents repeated `turn.proposed.completed` events for identical plan content within a session unless forced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d646f5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->