### PR TITLE
fix(mobile): stop shared content errors in Personal Team builds

### DIFF
--- a/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
+++ b/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
@@ -15,6 +15,7 @@ import {
   type IncomingShareDestination,
   type IncomingShareDraft,
 } from "./incoming-share-model";
+import { createIncomingSharePayloadReader } from "./incoming-share-native";
 import { IncomingShareInbox } from "./incoming-share-inbox";
 import {
   loadIncomingShareDrafts,
@@ -47,6 +48,11 @@ function receiveSharingEnabled(): boolean {
   }
   return Constants.expoConfig?.extra?.iosPersonalTeamBuild !== true;
 }
+
+const getIncomingSharePayloads = createIncomingSharePayloadReader({
+  platform: Platform.OS,
+  readPayloads: getSharedPayloads,
+});
 
 async function resolvedPayloadsForImages(): Promise<ReadonlyArray<ResolvedSharePayload>> {
   try {
@@ -121,7 +127,7 @@ const incomingShareInbox = new IncomingShareInbox({
   loadDrafts: loadIncomingShareDrafts,
   writeDraft: writeIncomingShareDraft,
   removeDraft: removeIncomingShareDraft,
-  getPayloads: getSharedPayloads,
+  getPayloads: getIncomingSharePayloads,
   clearPayloads: clearSharedPayloads,
   buildDraft: async ({ payloads, id, createdAt }) => {
     const cleanupUris = new Set<string>();

--- a/apps/mobile/src/features/sharing/incoming-share-native.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-native.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import type { SharePayload } from "expo-sharing";
+
+import { createIncomingSharePayloadReader } from "./incoming-share-native";
+
+const PAYLOAD: SharePayload = {
+  shareType: "text",
+  mimeType: "text/plain",
+  value: "Fix this",
+};
+
+describe("createIncomingSharePayloadReader", () => {
+  it("treats a missing iOS App Group as an unavailable inbox", () => {
+    const readPayloads = vi.fn((): ReadonlyArray<SharePayload> => {
+      throw Object.assign(new Error("Expo-sharing has failed to fetch the app group id"), {
+        code: "ERR_FAILED_TO_RESOLVE_APP_GROUP_ID",
+      });
+    });
+    const read = createIncomingSharePayloadReader({ platform: "ios", readPayloads });
+
+    expect(read()).toEqual([]);
+    expect(read()).toEqual([]);
+    expect(readPayloads).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns native payloads when receiving is available", () => {
+    const read = createIncomingSharePayloadReader({
+      platform: "ios",
+      readPayloads: () => [PAYLOAD],
+    });
+
+    expect(read()).toEqual([PAYLOAD]);
+  });
+
+  it("preserves other native errors", () => {
+    const error = new Error("native failure");
+    const read = createIncomingSharePayloadReader({
+      platform: "ios",
+      readPayloads: () => {
+        throw error;
+      },
+    });
+
+    expect(read).toThrow(error);
+  });
+});

--- a/apps/mobile/src/features/sharing/incoming-share-native.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-native.ts
@@ -1,0 +1,37 @@
+import type { SharePayload } from "expo-sharing";
+
+const IOS_APP_GROUP_UNAVAILABLE_ERROR_CODE = "ERR_FAILED_TO_RESOLVE_APP_GROUP_ID";
+
+function errorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return null;
+  }
+  return typeof error.code === "string" ? error.code : null;
+}
+
+/**
+ * Normalizes the native "share into" capability to an empty inbox. Personal
+ * Team builds cannot include the App Group that expo-sharing reads from.
+ */
+export function createIncomingSharePayloadReader(input: {
+  readonly platform: string;
+  readonly readPayloads: () => ReadonlyArray<SharePayload>;
+}): () => ReadonlyArray<SharePayload> {
+  let isUnavailable = false;
+
+  return () => {
+    if (isUnavailable) {
+      return [];
+    }
+
+    try {
+      return input.readPayloads();
+    } catch (error) {
+      if (input.platform === "ios" && errorCode(error) === IOS_APP_GROUP_UNAVAILABLE_ERROR_CODE) {
+        isUnavailable = true;
+        return [];
+      }
+      throw error;
+    }
+  };
+}


### PR DESCRIPTION
Personal Team iOS builds intentionally omit App Groups, but the active Expo manifest could still report incoming sharing as enabled. That made every foreground refresh call expo-sharing without an App Group ID and show a repeated import error.

Treat Expo's missing-App-Group error as an unavailable incoming-share inbox and cache that binary capability. Other native sharing failures continue to surface.

Tests: focused sharing tests, mobile typecheck, targeted lint, and formatting.

Generated by GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sharing ingestion change with tests; no auth, data, or payment impact.
> 
> **Overview**
> Personal Team iOS builds omit App Groups, but incoming sharing could still be treated as enabled, so **foreground refreshes repeatedly called expo-sharing** and surfaced import errors.
> 
> A new **`createIncomingSharePayloadReader`** wrapper treats expo-sharing’s **`ERR_FAILED_TO_RESOLVE_APP_GROUP_ID`** on iOS as an unavailable inbox (empty payloads) and **caches that state** so later reads don’t hit native code again. **`IncomingShareProvider`** wires this reader into **`IncomingShareInbox`** instead of calling **`getSharedPayloads`** directly. Other native failures still throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11d3753322e4b8cdcc11b902b00f4f31f92143f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix shared content errors in Personal Team builds by handling missing iOS App Group
> - Adds `createIncomingSharePayloadReader` in [incoming-share-native.ts](https://github.com/pingdotgg/t3code/pull/4943/files#diff-9621dd3fd8572be78d353ec70daf149f55c0daf1967df5b98e60606d09182698) to wrap native payload reads with error handling specific to iOS Personal Team builds.
> - When the iOS App Group is unavailable (`ERR_FAILED_TO_RESOLVE_APP_GROUP_ID`), the reader treats it as an empty inbox and memoizes the unavailable state to skip future native reads.
> - All other errors continue to propagate normally; non-iOS platforms pass through unchanged.
> - Behavioral Change: `IncomingShareInbox.getPayloads` now returns `[]` instead of throwing when the iOS App Group is missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a11d375.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->