### PR TITLE
fix(connect): reject malformed connect fragments before authorizing

### DIFF
--- a/apps/server/src/cloud/CliTokenManager.test.ts
+++ b/apps/server/src/cloud/CliTokenManager.test.ts
@@ -1,4 +1,7 @@
-import { readConnectAuthorizeRequest } from "@t3tools/shared/connectAuth";
+import {
+  type ConnectAuthorizeRequest,
+  readConnectAuthorizeRequest,
+} from "@t3tools/shared/connectAuth";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -28,6 +31,16 @@ interface RecordedTokenRequest {
   readonly url: string;
   readonly params: URLSearchParams;
 }
+
+// The hosted page rejects anything that is not the exact shape the CLI prints,
+// so these tests also assert that the printed URL survives that check.
+const expectAuthorizeRequest = (authorizeUrl: string): ConnectAuthorizeRequest => {
+  const parsed = readConnectAuthorizeRequest(new URL(authorizeUrl));
+  if (!parsed.ok) {
+    throw new Error(`Expected a valid connect authorize request, got "${parsed.problem}".`);
+  }
+  return parsed.request;
+};
 
 // A JWT whose payload claims { email: "theo@example.test" } (signature is not
 // verified — the CLI only reads the claim to display the connected account).
@@ -168,9 +181,8 @@ it.layer(NodeServices.layer)("CliTokenManager.outOfBandOAuthLogin", (it) => {
         ({ authorizeUrl, validate }: OutOfBandOAuthPromptInput) =>
           Effect.gen(function* () {
             seenAuthorizeUrl = authorizeUrl;
-            const request = readConnectAuthorizeRequest(new URL(authorizeUrl));
-            assert.isNotNull(request);
-            return yield* validate(`clerk-code-123.${request!.state}`).pipe(
+            const request = expectAuthorizeRequest(authorizeUrl);
+            return yield* validate(`clerk-code-123.${request.state}`).pipe(
               Effect.mapError((message) => new PromptRejectedError({ message })),
             );
           }),
@@ -179,9 +191,9 @@ it.layer(NodeServices.layer)("CliTokenManager.outOfBandOAuthLogin", (it) => {
       const authorizeUrl = new URL(seenAuthorizeUrl);
       assert.equal(authorizeUrl.origin, "https://hosted.example.test");
       assert.equal(authorizeUrl.pathname, "/connect");
-      const request = readConnectAuthorizeRequest(authorizeUrl);
-      assert.isNotNull(request);
-      assert.match(request!.state, /^[A-Za-z0-9_-]{22}$/);
+      const request = expectAuthorizeRequest(seenAuthorizeUrl);
+      assert.match(request.state, /^[A-Za-z0-9_-]{22}$/);
+      assert.match(request.challenge, /^[A-Za-z0-9_-]{43}$/);
 
       assert.equal(token.accessToken, "access-token-1");
       assert.equal(token.refreshToken, "refresh-token-1");
@@ -204,7 +216,7 @@ it.layer(NodeServices.layer)("CliTokenManager.outOfBandOAuthLogin", (it) => {
       assert.isNotNull(verifier);
       const crypto = yield* Crypto.Crypto;
       const digest = yield* crypto.digest("SHA-256", new TextEncoder().encode(verifier!));
-      assert.equal(Encoding.encodeBase64Url(digest), request!.challenge);
+      assert.equal(Encoding.encodeBase64Url(digest), request.challenge);
     }),
   );
 
@@ -234,11 +246,8 @@ it.layer(NodeServices.layer)("CliTokenManager.outOfBandOAuthLogin", (it) => {
       const malformedIdToken = `header.${Encoding.encodeBase64Url("not-json")}.signature`;
 
       const { identity } = yield* CliTokenManager.outOfBandOAuthLogin(
-        ({ authorizeUrl }: OutOfBandOAuthPromptInput) => {
-          const request = readConnectAuthorizeRequest(new URL(authorizeUrl));
-          assert.isNotNull(request);
-          return Effect.succeed(`clerk-code-123.${request!.state}`);
-        },
+        ({ authorizeUrl }: OutOfBandOAuthPromptInput) =>
+          Effect.succeed(`clerk-code-123.${expectAuthorizeRequest(authorizeUrl).state}`),
       ).pipe(
         Effect.provide(makeTokenEndpointLayer(requests, { idToken: malformedIdToken })),
         provideTestEnv,

--- a/apps/web/src/components/cloud/ConnectCliAuthSurface.test.tsx
+++ b/apps/web/src/components/cloud/ConnectCliAuthSurface.test.tsx
@@ -1,0 +1,173 @@
+import type { Dispatch, ReactElement, SetStateAction } from "react";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const STATE = "q7mK9xV2pL4nR8sT6wYzAQ";
+const CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+const AUTHORIZE_URL = "https://clerk.example.test/oauth/authorize?state=q7mK9xV2pL4nR8sT6wYzAQ";
+
+const testState = vi.hoisted(() => ({
+  isSignedIn: false,
+  openSignIn: vi.fn(),
+  assign: vi.fn(),
+  rememberState: vi.fn(),
+  buildAuthorizeUrl: vi.fn(() => AUTHORIZE_URL),
+}));
+
+// The component tree is inspected directly, so hooks are faked rather than
+// driven by a renderer. Effects run inline: the point of these tests is what
+// the surface does before it hands off to Clerk.
+const hooks = vi.hoisted(() => {
+  let cursor = 0;
+  let slots: unknown[] = [];
+  const nextIndex = () => cursor++;
+
+  return {
+    beginRender() {
+      cursor = 0;
+      slots = [];
+    },
+    useEffect(effect: () => void | (() => void)) {
+      nextIndex();
+      effect();
+    },
+    useRef<T>(initialValue: T): { current: T } {
+      const index = nextIndex();
+      if (!slots[index]) {
+        slots[index] = { current: initialValue };
+      }
+      return slots[index] as { current: T };
+    },
+    useState<T>(initialValue: T | (() => T)): [T, Dispatch<SetStateAction<T>>] {
+      const index = nextIndex();
+      if (index >= slots.length) {
+        slots[index] =
+          typeof initialValue === "function" ? (initialValue as () => T)() : initialValue;
+      }
+      return [slots[index] as T, vi.fn()];
+    },
+  };
+});
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useEffect: hooks.useEffect,
+    useRef: hooks.useRef,
+    useState: hooks.useState,
+  };
+});
+
+vi.mock("@clerk/react", () => ({
+  useAuth: () => ({ isLoaded: true, isSignedIn: testState.isSignedIn }),
+  useClerk: () => ({ openSignIn: testState.openSignIn }),
+  useUser: () => ({ user: null }),
+}));
+
+vi.mock("../../cloud/connectCliAuth", () => ({
+  buildConnectCliClerkAuthorizeUrl: testState.buildAuthorizeUrl,
+  rememberConnectCliAuthState: testState.rememberState,
+  readConnectCliAuthState: () => null,
+  readConnectCliCallbackResult: () => null,
+}));
+
+import { ConnectCliAuthorizeSurface } from "./ConnectCliAuthSurface";
+
+interface SurfaceMessage {
+  readonly title: string;
+  readonly description: string;
+}
+
+function findMessage(node: unknown): SurfaceMessage | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findMessage(child);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (typeof node !== "object" || node === null || !("props" in node)) {
+    return null;
+  }
+  const props = (node as { readonly props: Record<string, unknown> }).props;
+  if (typeof props.title === "string" && typeof props.description === "string") {
+    return { title: props.title, description: props.description };
+  }
+  return findMessage(props.children);
+}
+
+function renderAuthorizeSurface(href: string): SurfaceMessage {
+  vi.stubGlobal("window", {
+    location: { href, assign: testState.assign },
+    sessionStorage: { getItem: () => null, setItem: () => {} },
+  });
+  hooks.beginRender();
+  const message = findMessage(ConnectCliAuthorizeSurface() as ReactElement);
+  if (!message) {
+    throw new Error("The connect surface rendered without a message.");
+  }
+  return message;
+}
+
+const connectUrl = (state: string, challenge: string) =>
+  `https://app.t3.codes/connect#state=${state}&challenge=${challenge}`;
+
+describe("ConnectCliAuthorizeSurface", () => {
+  beforeEach(() => {
+    testState.isSignedIn = false;
+    testState.openSignIn.mockClear();
+    testState.assign.mockClear();
+    testState.rememberState.mockClear();
+  });
+
+  it("refuses a corrupted connect URL before starting the browser flow", () => {
+    // A pane border picked up while copying a URL that wrapped in a narrow
+    // terminal: the CLI never prints a non-base64url character.
+    const message = renderAuthorizeSurface(
+      connectUrl(`${STATE.slice(0, 10)}%E2%94%82${STATE.slice(11)}`, CHALLENGE),
+    );
+
+    expect(message.title).toBe("This connect link is incomplete or corrupted");
+    expect(message.description).toContain("Copy the whole URL again");
+    expect(testState.openSignIn).not.toHaveBeenCalled();
+    expect(testState.rememberState).not.toHaveBeenCalled();
+    expect(testState.assign).not.toHaveBeenCalled();
+  });
+
+  it("refuses a truncated connect URL before starting the browser flow", () => {
+    const message = renderAuthorizeSurface(connectUrl(STATE, CHALLENGE.slice(0, 30)));
+
+    expect(message.title).toBe("This connect link is incomplete or corrupted");
+    expect(testState.openSignIn).not.toHaveBeenCalled();
+    expect(testState.assign).not.toHaveBeenCalled();
+  });
+
+  it("still reports a connect URL that carries no request at all", () => {
+    const message = renderAuthorizeSurface("https://app.t3.codes/connect");
+
+    expect(message.title).toBe("This connect link is incomplete");
+    expect(testState.openSignIn).not.toHaveBeenCalled();
+  });
+
+  it("opens sign-in for a well-formed request from a signed-out browser", () => {
+    const message = renderAuthorizeSurface(connectUrl(STATE, CHALLENGE));
+
+    expect(message.title).toBe("Connecting your terminal");
+    expect(testState.openSignIn).toHaveBeenCalledTimes(1);
+    expect(testState.assign).not.toHaveBeenCalled();
+  });
+
+  it("forwards a well-formed request to Clerk once signed in", () => {
+    testState.isSignedIn = true;
+
+    renderAuthorizeSurface(connectUrl(STATE, CHALLENGE));
+
+    expect(testState.buildAuthorizeUrl).toHaveBeenCalledWith({
+      state: STATE,
+      challenge: CHALLENGE,
+    });
+    expect(testState.rememberState).toHaveBeenCalledWith(STATE);
+    expect(testState.assign).toHaveBeenCalledWith(AUTHORIZE_URL);
+    expect(testState.openSignIn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
+++ b/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
@@ -1,5 +1,9 @@
 import { useAuth, useClerk, useUser } from "@clerk/react";
-import { encodeConnectAuthCode, readConnectAuthorizeRequest } from "@t3tools/shared/connectAuth";
+import {
+  type ConnectAuthorizeRequestProblem,
+  encodeConnectAuthCode,
+  readConnectAuthorizeRequest,
+} from "@t3tools/shared/connectAuth";
 import { useEffect, useRef, useState } from "react";
 
 import {
@@ -36,12 +40,23 @@ function ConnectCliAuthMessage({
   );
 }
 
-const invalidLinkMessage = {
-  eyebrow: "Authorization request",
-  title: "This connect link is incomplete",
-  description:
-    "The link is missing its authorization request. Re-run `t3 connect` in your terminal and open the freshly printed URL.",
-} as const;
+const invalidLinkMessages = {
+  missing: {
+    eyebrow: "Authorization request",
+    title: "This connect link is incomplete",
+    description:
+      "The link is missing its authorization request. Re-run `t3 connect` in your terminal and open the freshly printed URL.",
+  },
+  malformed: {
+    eyebrow: "Authorization request",
+    title: "This connect link is incomplete or corrupted",
+    description:
+      "The authorization request in this URL is not the one `t3 connect` printed, so part of it was lost or extra characters were copied with it. This happens when the URL wraps across terminal lines. Copy the whole URL again — re-run `t3 connect` if it has scrolled away — and open the freshly printed URL.",
+  },
+} as const satisfies Record<
+  ConnectAuthorizeRequestProblem,
+  { readonly eyebrow: string; readonly title: string; readonly description: string }
+>;
 
 /**
  * /connect: the URL the CLI prints for both flows. Waits for a Clerk session,
@@ -50,7 +65,8 @@ const invalidLinkMessage = {
  * straight to the waiting CLI, and the hosted callback page otherwise.
  */
 export function ConnectCliAuthorizeSurface() {
-  const [request] = useState(() => readConnectAuthorizeRequest(new URL(window.location.href)));
+  const [parsed] = useState(() => readConnectAuthorizeRequest(new URL(window.location.href)));
+  const request = parsed.ok ? parsed.request : null;
   const clerk = useClerk();
   const { isLoaded, isSignedIn } = useAuth();
   const signInOpened = useRef(false);
@@ -76,10 +92,10 @@ export function ConnectCliAuthorizeSurface() {
     window.location.assign(authorizeUrl);
   }, [clerk, isLoaded, isSignedIn, request]);
 
-  if (!request) {
+  if (!parsed.ok) {
     return (
       <AuthSurfaceShell>
-        <ConnectCliAuthMessage {...invalidLinkMessage} />
+        <ConnectCliAuthMessage {...invalidLinkMessages[parsed.problem]} />
       </AuthSurfaceShell>
     );
   }

--- a/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
+++ b/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
@@ -1,5 +1,9 @@
 import { useAuth, useClerk, useUser } from "@clerk/react";
-import { encodeConnectAuthCode, readConnectAuthorizeRequest } from "@t3tools/shared/connectAuth";
+import {
+  type ConnectAuthorizeRequestProblem,
+  encodeConnectAuthCode,
+  readConnectAuthorizeRequest,
+} from "@t3tools/shared/connectAuth";
 import { useEffect, useRef, useState } from "react";
 
 import {
@@ -36,19 +40,31 @@ function ConnectCliAuthMessage({
   );
 }
 
-const invalidLinkMessage = {
-  eyebrow: "Authorization request",
-  title: "This connect link is incomplete",
-  description:
-    "The link is missing its authorization request. Re-run `t3 connect` in your terminal and open the freshly printed URL.",
-} as const;
+const invalidLinkMessages = {
+  missing: {
+    eyebrow: "Authorization request",
+    title: "This connect link is incomplete",
+    description:
+      "The link is missing its authorization request. Re-run `t3 connect` in your terminal and open the freshly printed URL.",
+  },
+  malformed: {
+    eyebrow: "Authorization request",
+    title: "This connect link is incomplete or corrupted",
+    description:
+      "The authorization request in this URL is not the one `t3 connect` printed, so part of it was lost or extra characters were copied with it. This happens when the URL wraps across terminal lines. Copy the whole URL again — re-run `t3 connect` if it has scrolled away — and open the freshly printed URL.",
+  },
+} as const satisfies Record<
+  ConnectAuthorizeRequestProblem,
+  { readonly eyebrow: string; readonly title: string; readonly description: string }
+>;
 
 /**
  * /connect: the URL a headless CLI prints. Waits for a Clerk session, then
  * forwards the CLI's PKCE request to Clerk's authorize endpoint.
  */
 export function ConnectCliAuthorizeSurface() {
-  const [request] = useState(() => readConnectAuthorizeRequest(new URL(window.location.href)));
+  const [parsed] = useState(() => readConnectAuthorizeRequest(new URL(window.location.href)));
+  const request = parsed.ok ? parsed.request : null;
   const clerk = useClerk();
   const { isLoaded, isSignedIn } = useAuth();
   const signInOpened = useRef(false);
@@ -74,10 +90,10 @@ export function ConnectCliAuthorizeSurface() {
     window.location.assign(authorizeUrl);
   }, [clerk, isLoaded, isSignedIn, request]);
 
-  if (!request) {
+  if (!parsed.ok) {
     return (
       <AuthSurfaceShell>
-        <ConnectCliAuthMessage {...invalidLinkMessage} />
+        <ConnectCliAuthMessage {...invalidLinkMessages[parsed.problem]} />
       </AuthSurfaceShell>
     );
   }

--- a/packages/shared/src/connectAuth.test.ts
+++ b/packages/shared/src/connectAuth.test.ts
@@ -10,12 +10,17 @@ import {
   readConnectAuthorizeRequest,
 } from "./connectAuth.ts";
 
+// The shapes the CLI prints: base64url over 16 random bytes and over a
+// SHA-256 digest.
+const STATE = "q7mK9xV2pL4nR8sT6wYzAQ";
+const CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
 describe("connectAuth", () => {
   it("round-trips state and challenge through the authorize URL fragment", () => {
     const url = buildConnectAuthorizeRequestUrl({
       hostedAppUrl: "https://app.t3.codes",
-      state: "q7mK9xV2pL4nR8sT6wYzAQ",
-      challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      state: STATE,
+      challenge: CHALLENGE,
     });
     const parsed = new URL(url);
 
@@ -23,33 +28,89 @@ describe("connectAuth", () => {
     expect(parsed.pathname).toBe("/connect");
     expect(parsed.search).toBe("");
     expect(readConnectAuthorizeRequest(parsed)).toEqual({
-      state: "q7mK9xV2pL4nR8sT6wYzAQ",
-      challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      ok: true,
+      request: { state: STATE, challenge: CHALLENGE },
     });
   });
 
-  it("rejects authorize requests missing state or challenge", () => {
-    expect(readConnectAuthorizeRequest(new URL("https://app.t3.codes/connect"))).toBeNull();
+  it("reports authorize requests missing state or challenge", () => {
+    expect(readConnectAuthorizeRequest(new URL("https://app.t3.codes/connect"))).toEqual({
+      ok: false,
+      problem: "missing",
+    });
     expect(
-      readConnectAuthorizeRequest(new URL("https://app.t3.codes/connect#state=abc")),
-    ).toBeNull();
+      readConnectAuthorizeRequest(new URL(`https://app.t3.codes/connect#state=${STATE}`)),
+    ).toEqual({ ok: false, problem: "missing" });
     expect(
-      readConnectAuthorizeRequest(new URL("https://app.t3.codes/connect#challenge=abc")),
-    ).toBeNull();
+      readConnectAuthorizeRequest(new URL(`https://app.t3.codes/connect#challenge=${CHALLENGE}`)),
+    ).toEqual({ ok: false, problem: "missing" });
+  });
+
+  it("reports authorize requests whose values are not the shape the CLI prints", () => {
+    const authorizeUrl = (state: string, challenge: string) =>
+      new URL(
+        buildConnectAuthorizeRequestUrl({
+          hostedAppUrl: "https://app.t3.codes",
+          state,
+          challenge,
+        }),
+      );
+
+    // A character the copied URL picked up from a wrapped terminal line.
+    expect(
+      readConnectAuthorizeRequest(
+        authorizeUrl(`${STATE.slice(0, 10)}│${STATE.slice(11)}`, CHALLENGE),
+      ),
+    ).toEqual({
+      ok: false,
+      problem: "malformed",
+    });
+    expect(
+      readConnectAuthorizeRequest(
+        authorizeUrl(STATE, `${CHALLENGE.slice(0, 20)} ${CHALLENGE.slice(21)}`),
+      ),
+    ).toEqual({ ok: false, problem: "malformed" });
+    // Truncated by a line break that was not copied along.
+    expect(readConnectAuthorizeRequest(authorizeUrl(STATE.slice(0, 18), CHALLENGE))).toEqual({
+      ok: false,
+      problem: "malformed",
+    });
+    expect(readConnectAuthorizeRequest(authorizeUrl(STATE, CHALLENGE.slice(0, 30)))).toEqual({
+      ok: false,
+      problem: "malformed",
+    });
+    // Base64 padding and standard-alphabet characters are not base64url.
+    expect(readConnectAuthorizeRequest(authorizeUrl(`${STATE.slice(0, 20)}==`, CHALLENGE))).toEqual(
+      {
+        ok: false,
+        problem: "malformed",
+      },
+    );
+    expect(readConnectAuthorizeRequest(authorizeUrl(STATE, `${CHALLENGE.slice(0, 42)}+`))).toEqual({
+      ok: false,
+      problem: "malformed",
+    });
+  });
+
+  it("accepts values padded with whitespace while copying", () => {
+    expect(
+      readConnectAuthorizeRequest(
+        new URL(`https://app.t3.codes/connect#state=+${STATE}+&challenge=${CHALLENGE}`),
+      ),
+    ).toEqual({ ok: true, request: { state: STATE, challenge: CHALLENGE } });
   });
 
   it("round-trips the loopback port through the authorize URL fragment", () => {
     const url = buildConnectAuthorizeRequestUrl({
       hostedAppUrl: "https://app.t3.codes",
-      state: "state-1",
-      challenge: "challenge-1",
+      state: STATE,
+      challenge: CHALLENGE,
       loopbackPort: 34338,
     });
 
     expect(readConnectAuthorizeRequest(new URL(url))).toEqual({
-      state: "state-1",
-      challenge: "challenge-1",
-      loopbackPort: 34338,
+      ok: true,
+      request: { state: STATE, challenge: CHALLENGE, loopbackPort: 34338 },
     });
     expect(connectLoopbackRedirectUri(34338)).toBe("http://127.0.0.1:34338/callback");
   });
@@ -57,9 +118,12 @@ describe("connectAuth", () => {
   it("rejects authorize requests whose loopback port is corrupted", () => {
     for (const port of ["", "abc", "-1", "0", "65536", "34338x", "34 38"]) {
       const url = new URL(
-        `https://app.t3.codes/connect#state=state-1&challenge=challenge-1&port=${encodeURIComponent(port)}`,
+        `https://app.t3.codes/connect#state=${STATE}&challenge=${CHALLENGE}&port=${encodeURIComponent(port)}`,
       );
-      expect(readConnectAuthorizeRequest(url), port).toBeNull();
+      expect(readConnectAuthorizeRequest(url), port).toEqual({
+        ok: false,
+        problem: "malformed",
+      });
     }
   });
 

--- a/packages/shared/src/connectAuth.test.ts
+++ b/packages/shared/src/connectAuth.test.ts
@@ -9,12 +9,17 @@ import {
   readConnectAuthorizeRequest,
 } from "./connectAuth.ts";
 
+// The shapes the CLI prints: base64url over 16 random bytes and over a
+// SHA-256 digest.
+const STATE = "q7mK9xV2pL4nR8sT6wYzAQ";
+const CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
 describe("connectAuth", () => {
   it("round-trips state and challenge through the authorize URL fragment", () => {
     const url = buildConnectAuthorizeRequestUrl({
       hostedAppUrl: "https://app.t3.codes",
-      state: "q7mK9xV2pL4nR8sT6wYzAQ",
-      challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      state: STATE,
+      challenge: CHALLENGE,
     });
     const parsed = new URL(url);
 
@@ -22,19 +27,76 @@ describe("connectAuth", () => {
     expect(parsed.pathname).toBe("/connect");
     expect(parsed.search).toBe("");
     expect(readConnectAuthorizeRequest(parsed)).toEqual({
-      state: "q7mK9xV2pL4nR8sT6wYzAQ",
-      challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      ok: true,
+      request: { state: STATE, challenge: CHALLENGE },
     });
   });
 
-  it("rejects authorize requests missing state or challenge", () => {
-    expect(readConnectAuthorizeRequest(new URL("https://app.t3.codes/connect"))).toBeNull();
+  it("reports authorize requests missing state or challenge", () => {
+    expect(readConnectAuthorizeRequest(new URL("https://app.t3.codes/connect"))).toEqual({
+      ok: false,
+      problem: "missing",
+    });
     expect(
-      readConnectAuthorizeRequest(new URL("https://app.t3.codes/connect#state=abc")),
-    ).toBeNull();
+      readConnectAuthorizeRequest(new URL(`https://app.t3.codes/connect#state=${STATE}`)),
+    ).toEqual({ ok: false, problem: "missing" });
     expect(
-      readConnectAuthorizeRequest(new URL("https://app.t3.codes/connect#challenge=abc")),
-    ).toBeNull();
+      readConnectAuthorizeRequest(new URL(`https://app.t3.codes/connect#challenge=${CHALLENGE}`)),
+    ).toEqual({ ok: false, problem: "missing" });
+  });
+
+  it("reports authorize requests whose values are not the shape the CLI prints", () => {
+    const authorizeUrl = (state: string, challenge: string) =>
+      new URL(
+        buildConnectAuthorizeRequestUrl({
+          hostedAppUrl: "https://app.t3.codes",
+          state,
+          challenge,
+        }),
+      );
+
+    // A character the copied URL picked up from a wrapped terminal line.
+    expect(
+      readConnectAuthorizeRequest(
+        authorizeUrl(`${STATE.slice(0, 10)}│${STATE.slice(11)}`, CHALLENGE),
+      ),
+    ).toEqual({
+      ok: false,
+      problem: "malformed",
+    });
+    expect(
+      readConnectAuthorizeRequest(
+        authorizeUrl(STATE, `${CHALLENGE.slice(0, 20)} ${CHALLENGE.slice(21)}`),
+      ),
+    ).toEqual({ ok: false, problem: "malformed" });
+    // Truncated by a line break that was not copied along.
+    expect(readConnectAuthorizeRequest(authorizeUrl(STATE.slice(0, 18), CHALLENGE))).toEqual({
+      ok: false,
+      problem: "malformed",
+    });
+    expect(readConnectAuthorizeRequest(authorizeUrl(STATE, CHALLENGE.slice(0, 30)))).toEqual({
+      ok: false,
+      problem: "malformed",
+    });
+    // Base64 padding and standard-alphabet characters are not base64url.
+    expect(readConnectAuthorizeRequest(authorizeUrl(`${STATE.slice(0, 20)}==`, CHALLENGE))).toEqual(
+      {
+        ok: false,
+        problem: "malformed",
+      },
+    );
+    expect(readConnectAuthorizeRequest(authorizeUrl(STATE, `${CHALLENGE.slice(0, 42)}+`))).toEqual({
+      ok: false,
+      problem: "malformed",
+    });
+  });
+
+  it("accepts values padded with whitespace while copying", () => {
+    expect(
+      readConnectAuthorizeRequest(
+        new URL(`https://app.t3.codes/connect#state=+${STATE}+&challenge=${CHALLENGE}`),
+      ),
+    ).toEqual({ ok: true, request: { state: STATE, challenge: CHALLENGE } });
   });
 
   it("builds a PKCE authorize URL against the Clerk endpoint", () => {

--- a/packages/shared/src/connectAuth.ts
+++ b/packages/shared/src/connectAuth.ts
@@ -34,6 +34,31 @@ export interface ConnectAuthorizeRequest {
 }
 
 /**
+ * `state` is base64url over 16 random bytes and the PKCE `challenge` is
+ * base64url over a SHA-256 digest, so both have a fixed length and alphabet.
+ * Keep these in sync with the CLI's request generation.
+ */
+const CONNECT_AUTH_STATE_LENGTH = 22;
+const CONNECT_AUTH_CHALLENGE_LENGTH = 43;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function isBase64Url(value: string, length: number): boolean {
+  return value.length === length && BASE64URL_PATTERN.test(value);
+}
+
+/**
+ * `missing` means the fragment carries no request at all; `malformed` means it
+ * carries one that the CLI could not have printed — the shape a connect URL
+ * takes when it is truncated or picks up stray characters while being copied
+ * out of a wrapped terminal line.
+ */
+export type ConnectAuthorizeRequestProblem = "missing" | "malformed";
+
+export type ConnectAuthorizeRequestResult =
+  | { readonly ok: true; readonly request: ConnectAuthorizeRequest }
+  | { readonly ok: false; readonly problem: ConnectAuthorizeRequestProblem };
+
+/**
  * The URL the CLI prints for the user to open in a browser. `state` and
  * `code_challenge` ride the fragment so they never reach the hosted app's
  * server or CDN logs; neither is a secret.
@@ -62,25 +87,36 @@ export function buildConnectAuthorizeRequestUrl(input: {
   return url.toString();
 }
 
-export function readConnectAuthorizeRequest(url: URL): ConnectAuthorizeRequest | null {
+/**
+ * Checks the fragment against the shape the CLI prints before any of it is
+ * used, so a corrupted copy of the URL is reported here rather than after a
+ * full browser authorization that the waiting CLI would reject anyway.
+ */
+export function readConnectAuthorizeRequest(url: URL): ConnectAuthorizeRequestResult {
   const params = readHashParams(url);
   const state = params.get(CONNECT_AUTH_STATE_PARAM)?.trim() ?? "";
   const challenge = params.get(CONNECT_AUTH_CHALLENGE_PARAM)?.trim() ?? "";
   if (!state || !challenge) {
-    return null;
+    return { ok: false, problem: "missing" };
+  }
+  if (
+    !isBase64Url(state, CONNECT_AUTH_STATE_LENGTH) ||
+    !isBase64Url(challenge, CONNECT_AUTH_CHALLENGE_LENGTH)
+  ) {
+    return { ok: false, problem: "malformed" };
   }
   const port = params.get(CONNECT_AUTH_PORT_PARAM);
   if (port === null) {
-    return { state, challenge };
+    return { ok: true, request: { state, challenge } };
   }
   // A present-but-invalid port means the link was corrupted; reject the whole
   // request rather than silently downgrading a loopback flow to the
   // out-of-band one, which would strand the waiting CLI.
   const loopbackPort = parseLoopbackPort(port.trim());
   if (loopbackPort === null) {
-    return null;
+    return { ok: false, problem: "malformed" };
   }
-  return { state, challenge, loopbackPort };
+  return { ok: true, request: { state, challenge, loopbackPort } };
 }
 
 function parseLoopbackPort(value: string): number | null {

--- a/packages/shared/src/connectAuth.ts
+++ b/packages/shared/src/connectAuth.ts
@@ -26,6 +26,31 @@ export interface ConnectAuthorizeRequest {
 }
 
 /**
+ * `state` is base64url over 16 random bytes and the PKCE `challenge` is
+ * base64url over a SHA-256 digest, so both have a fixed length and alphabet.
+ * Keep these in sync with the CLI's request generation.
+ */
+const CONNECT_AUTH_STATE_LENGTH = 22;
+const CONNECT_AUTH_CHALLENGE_LENGTH = 43;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function isBase64Url(value: string, length: number): boolean {
+  return value.length === length && BASE64URL_PATTERN.test(value);
+}
+
+/**
+ * `missing` means the fragment carries no request at all; `malformed` means it
+ * carries one that the CLI could not have printed — the shape a connect URL
+ * takes when it is truncated or picks up stray characters while being copied
+ * out of a wrapped terminal line.
+ */
+export type ConnectAuthorizeRequestProblem = "missing" | "malformed";
+
+export type ConnectAuthorizeRequestResult =
+  | { readonly ok: true; readonly request: ConnectAuthorizeRequest }
+  | { readonly ok: false; readonly problem: ConnectAuthorizeRequestProblem };
+
+/**
  * The URL a headless CLI prints for the user to open on a machine with a
  * browser. `state` and `code_challenge` ride the fragment so they never reach
  * the hosted app's server or CDN logs; neither is a secret.
@@ -43,14 +68,25 @@ export function buildConnectAuthorizeRequestUrl(input: {
   return url.toString();
 }
 
-export function readConnectAuthorizeRequest(url: URL): ConnectAuthorizeRequest | null {
+/**
+ * Checks the fragment against the shape the CLI prints before any of it is
+ * used, so a corrupted copy of the URL is reported here rather than after a
+ * full browser authorization that the waiting CLI would reject anyway.
+ */
+export function readConnectAuthorizeRequest(url: URL): ConnectAuthorizeRequestResult {
   const params = readHashParams(url);
   const state = params.get(CONNECT_AUTH_STATE_PARAM)?.trim() ?? "";
   const challenge = params.get(CONNECT_AUTH_CHALLENGE_PARAM)?.trim() ?? "";
   if (!state || !challenge) {
-    return null;
+    return { ok: false, problem: "missing" };
   }
-  return { state, challenge };
+  if (
+    !isBase64Url(state, CONNECT_AUTH_STATE_LENGTH) ||
+    !isBase64Url(challenge, CONNECT_AUTH_CHALLENGE_LENGTH)
+  ) {
+    return { ok: false, problem: "malformed" };
+  }
+  return { ok: true, request: { state, challenge } };
 }
 
 export function connectCallbackUrl(hostedAppUrl: string): string {


### PR DESCRIPTION
Closes #4934.

## Problem

The hosted `/connect` page accepted any non-empty `state` and `challenge` from the URL fragment. When a connect URL printed by `t3 connect` wraps in a narrow terminal, copying it can drop characters or pull in multiplexer pane borders — and the page happily opened sign-in, completed the Clerk authorization, and displayed a code. The mismatch surfaced only afterwards, when the waiting CLI rejected the pasted code:

```
That code belongs to a different connect request. Open the URL above and try again.
```

The CLI fails closed, so nothing is bypassed, but the user pays for a full browser round trip and gets a message that points nowhere near the real cause.

## Fix

Both values have a known shape — `state` is base64url over 16 random bytes (22 chars) and the PKCE `challenge` is base64url over a SHA-256 digest (43 chars). `readConnectAuthorizeRequest` now validates that shape and distinguishes two cases:

- `missing` — the fragment carries no request (unchanged wording).
- `malformed` — it carries one the CLI could not have printed. The page now says the link is incomplete or corrupted, explains that this happens when the URL wraps across terminal lines, and asks for a fresh copy.

Nothing is stored and neither sign-in nor the Clerk redirect starts for a malformed request. Leading/trailing whitespace is still trimmed, so a slightly sloppy selection keeps working.

## Testing

- `packages/shared/src/connectAuth.test.ts` — corrupted, truncated, base64-padded (`==`) and standard-alphabet (`+`) fragments, plus the whitespace-tolerance case.
- `apps/web/src/components/cloud/ConnectCliAuthSurface.test.tsx` (new) — drives the surface with a `│` inserted into `state` and with a truncated `challenge`, asserting the corrupted message renders and `openSignIn` / `rememberConnectCliAuthState` / `location.assign` are never called; the signed-out and signed-in paths are covered too.
- `apps/server/src/cloud/CliTokenManager.test.ts` — updated to the new return type through a helper that also asserts the URL the CLI prints passes the hosted page's check, so the constants cannot drift from request generation.
- Verified end-to-end in headless Chromium against the real surface (Clerk stubbed at the module boundary): with the fix, a corrupted fragment stops on the page and no authorize request is made; on `main`, the same URL is forwarded to `/oauth/authorize` with `state=q7mK9xV2pL│nR8sT6wYzAQ`.

Full `shared`, `web` and `server` suites, typecheck and lint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tightens input validation on the connect authorize entry point without changing token exchange; fail-closed behavior reduces mistaken full OAuth round trips.
> 
> **Overview**
> **`readConnectAuthorizeRequest`** now returns a discriminated result (`ok` + request, or `problem: 'missing' | 'malformed'`) instead of `null`, and enforces the CLI’s fixed **base64url** shapes (22-char `state`, 43-char PKCE `challenge`), with invalid loopback ports classified as **malformed**.
> 
> The hosted **`ConnectCliAuthorizeSurface`** uses that result to **stop before Clerk**: corrupted or truncated connect URLs get a dedicated “incomplete or corrupted” message (terminal wrap / bad copy), while **sign-in**, state storage, and redirect never run. Valid URLs behave as before; leading/trailing whitespace on fragment values is still trimmed.
> 
> Tests cover the parser edge cases, the surface’s gated behavior, and server OAuth tests that assert CLI-printed URLs pass the same validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3886d770f57a0f8c8e27ca1ceb4285729b9fc43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject malformed connect fragments before authorizing in the connect auth flow
> - `readConnectAuthorizeRequest` in [`connectAuth.ts`](https://github.com/pingdotgg/t3code/pull/4946/files#diff-6265a91c3adb728990b798816e64251a8350390e2b8e5753577fbe7a66883415) now returns a discriminated union `{ ok, request } | { ok: false, problem }` instead of `ConnectAuthorizeRequest | null`, where `problem` is `'missing'` or `'malformed'`.
> - Validation enforces exact base64url lengths (state: 22 chars, challenge: 43 chars), alphabet correctness, and trims whitespace; invalid loopback ports also return `malformed`.
> - The `/connect` surface in [`ConnectCliAuthSurface.tsx`](https://github.com/pingdotgg/t3code/pull/4946/files#diff-4d2edee788842fd8bde98fe5bae1e43d591e62e8b9ab9351fb37abb8b4c9acff) now shows problem-specific error messages for missing vs. malformed requests, and only proceeds to sign-in or redirect when parsing succeeds.
> - Behavioral Change: callers previously checking for `null` must now handle the discriminated union; corrupted or truncated connect URLs are rejected before any auth flow begins.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3886d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->