### PR TITLE
fix(web): show Codex fast mode as a bolt

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.test.ts
+++ b/apps/web/src/components/chat/TraitsPicker.test.ts
@@ -64,7 +64,7 @@ describe("buildTraitsTriggerDisplay", () => {
       "serviceTier",
       [
         { id: "default", label: "Standard", isDefault: true },
-        { id: "fast", label: "Fast" },
+        { id: "priority", label: "Fast" },
       ],
       "default",
     );
@@ -73,7 +73,7 @@ describe("buildTraitsTriggerDisplay", () => {
       label: "High",
       showFastModeIcon: false,
     });
-    expect(display([EFFORT, { ...serviceTier, currentValue: "fast" }])).toEqual({
+    expect(display([EFFORT, { ...serviceTier, currentValue: "priority" }])).toEqual({
       label: "High",
       showFastModeIcon: true,
     });

--- a/apps/web/src/components/chat/TraitsPicker.test.ts
+++ b/apps/web/src/components/chat/TraitsPicker.test.ts
@@ -35,39 +35,48 @@ const CONTEXT_WINDOW = selectDescriptor(
 
 const CODEX = ProviderDriverKind.make("codex");
 
-function display(descriptors: ReadonlyArray<ProviderOptionDescriptor>, fastModeEnabled: boolean) {
+function display(descriptors: ReadonlyArray<ProviderOptionDescriptor>) {
   return buildTraitsTriggerDisplay({
     provider: CODEX,
     descriptors,
     primarySelectDescriptorId: "reasoningEffort",
     ultrathinkPromptControlled: false,
-    fastModeEnabled,
   });
 }
 
 describe("buildTraitsTriggerDisplay", () => {
   it("omits fast mode from the label entirely when it is off", () => {
-    expect(display([EFFORT, fastModeDescriptor(false), CONTEXT_WINDOW], false)).toEqual({
+    expect(display([EFFORT, fastModeDescriptor(false), CONTEXT_WINDOW])).toEqual({
       label: "High · 1M",
       showFastModeIcon: false,
     });
   });
 
   it("shows the bolt instead of a text label when fast mode is on", () => {
-    expect(display([EFFORT, fastModeDescriptor(true), CONTEXT_WINDOW], true)).toEqual({
+    expect(display([EFFORT, fastModeDescriptor(true), CONTEXT_WINDOW])).toEqual({
       label: "High · 1M",
       showFastModeIcon: true,
     });
   });
 
-  it("omits Codex's default Standard tier beside reasoning", () => {
+  it("renders Codex's Standard and Fast service tiers as fast mode", () => {
     const serviceTier = selectDescriptor(
       "serviceTier",
-      [{ id: "default", label: "Standard", isDefault: true }],
+      [
+        { id: "default", label: "Standard", isDefault: true },
+        { id: "fast", label: "Fast" },
+      ],
       "default",
     );
 
-    expect(display([EFFORT, serviceTier], false).label).toBe("High");
+    expect(display([EFFORT, serviceTier])).toEqual({
+      label: "High",
+      showFastModeIcon: false,
+    });
+    expect(display([EFFORT, { ...serviceTier, currentValue: "fast" }])).toEqual({
+      label: "High",
+      showFastModeIcon: true,
+    });
   });
 
   it("keeps non-fastMode booleans as text labels", () => {
@@ -77,18 +86,18 @@ describe("buildTraitsTriggerDisplay", () => {
       type: "boolean",
       currentValue: true,
     };
-    expect(display([EFFORT, thinking], false)).toEqual({
+    expect(display([EFFORT, thinking])).toEqual({
       label: "High · Thinking On",
       showFastModeIcon: false,
     });
   });
 
   it("falls back to a text label when fast mode is the only trait", () => {
-    expect(display([fastModeDescriptor(true)], true)).toEqual({
+    expect(display([fastModeDescriptor(true)])).toEqual({
       label: "Fast",
       showFastModeIcon: false,
     });
-    expect(display([fastModeDescriptor(false)], false)).toEqual({
+    expect(display([fastModeDescriptor(false)])).toEqual({
       label: "Normal",
       showFastModeIcon: false,
     });
@@ -107,7 +116,7 @@ describe("buildTraitsTriggerDisplay", () => {
         { id: "high", label: "High" },
       ],
     };
-    expect(display([unresolved], false)).toEqual({ label: "", showFastModeIcon: false });
+    expect(display([unresolved])).toEqual({ label: "", showFastModeIcon: false });
   });
 
   it("still renders the prompt-controlled ultrathink label alongside the bolt", () => {
@@ -117,7 +126,6 @@ describe("buildTraitsTriggerDisplay", () => {
         descriptors: [EFFORT, fastModeDescriptor(true)],
         primarySelectDescriptorId: "reasoningEffort",
         ultrathinkPromptControlled: true,
-        fastModeEnabled: true,
       }),
     ).toEqual({ label: "Ultrathink", showFastModeIcon: true });
   });

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -134,8 +134,6 @@ function getSelectedTraits(
       : getDescriptorStringValue(primarySelectDescriptor)) ?? null;
   const thinkingEnabled =
     typeof thinkingDescriptor?.currentValue === "boolean" ? thinkingDescriptor.currentValue : null;
-  const fastModeEnabled =
-    typeof fastModeDescriptor?.currentValue === "boolean" ? fastModeDescriptor.currentValue : false;
   const contextWindow = getDescriptorStringValue(contextWindowDescriptor);
   const selectedAgent = getDescriptorStringValue(agentDescriptor);
   const selectedAgentLabel = agentDescriptor
@@ -154,7 +152,6 @@ function getSelectedTraits(
     thinkingDescriptor,
     effort,
     thinkingEnabled,
-    fastModeEnabled,
     contextWindow,
     ultrathinkPromptControlled,
     ultrathinkInBodyText,
@@ -392,24 +389,26 @@ export function buildTraitsTriggerDisplay(input: {
   descriptors: ReadonlyArray<ProviderOptionDescriptor>;
   primarySelectDescriptorId: string | null;
   ultrathinkPromptControlled: boolean;
-  fastModeEnabled: boolean;
 }): { label: string; showFastModeIcon: boolean } {
   let hasFastMode = false;
+  let fastModeEnabled = false;
   const labels: Array<string> = [];
   for (const descriptor of input.descriptors) {
     if (descriptor.id === "fastMode" && descriptor.type === "boolean") {
       hasFastMode = true;
+      fastModeEnabled = descriptor.currentValue === true;
       continue;
     }
     if (
       input.provider === "codex" &&
       descriptor.id === "serviceTier" &&
       descriptor.type === "select" &&
-      input.descriptors.some(({ id }) => id === "reasoningEffort")
+      descriptor.options.some(({ id }) => id === "fast")
     ) {
       const currentValue = getProviderOptionCurrentValue(descriptor);
-      const currentOption = descriptor.options.find((option) => option.id === currentValue);
-      if (currentOption?.id === "default" && currentOption.isDefault === true) {
+      if (currentValue === "default" || currentValue === "fast") {
+        hasFastMode = true;
+        fastModeEnabled = currentValue === "fast";
         continue;
       }
     }
@@ -428,9 +427,9 @@ export function buildTraitsTriggerDisplay(input: {
   // off an empty label list alone would also catch descriptors that resolved to
   // no label at all, printing a bogus "Normal" for a model without fast mode.
   if (labels.length === 0 && hasFastMode) {
-    return { label: input.fastModeEnabled ? "Fast" : "Normal", showFastModeIcon: false };
+    return { label: fastModeEnabled ? "Fast" : "Normal", showFastModeIcon: false };
   }
-  return { label: labels.join(" · "), showFastModeIcon: input.fastModeEnabled };
+  return { label: labels.join(" · "), showFastModeIcon: fastModeEnabled };
 }
 
 export const TraitsPicker = memo(function TraitsPicker({
@@ -447,7 +446,7 @@ export const TraitsPicker = memo(function TraitsPicker({
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled, fastModeEnabled } =
+  const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled } =
     getTraitsSectionVisibility({
       provider,
       models,
@@ -474,7 +473,6 @@ export const TraitsPicker = memo(function TraitsPicker({
     descriptors,
     primarySelectDescriptorId: primarySelectDescriptor?.id ?? null,
     ultrathinkPromptControlled,
-    fastModeEnabled,
   });
   const fastModeIcon = showFastModeIcon ? (
     <>

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -402,13 +402,13 @@ export function buildTraitsTriggerDisplay(input: {
     if (
       input.provider === "codex" &&
       descriptor.id === "serviceTier" &&
-      descriptor.type === "select" &&
-      descriptor.options.some(({ id }) => id === "fast")
+      descriptor.type === "select"
     ) {
       const currentValue = getProviderOptionCurrentValue(descriptor);
-      if (currentValue === "default" || currentValue === "fast") {
+      const fastTier = descriptor.options.find(({ label }) => label === "Fast");
+      if (fastTier && (currentValue === "default" || currentValue === fastTier.id)) {
         hasFastMode = true;
-        fastModeEnabled = currentValue === "fast";
+        fastModeEnabled = currentValue === fastTier.id;
         continue;
       }
     }


### PR DESCRIPTION
Codex fast mode still appeared as Standard/Fast text because Codex exposes it as a service tier instead of the boolean fast-mode option used by other providers.

Treat Codex’s Standard/Fast service tiers as the same presentation state: hide Standard and show the existing lightning bolt when Fast is selected. Other service tiers keep their text labels.

Tests:
- `vp test run apps/web/src/components/chat/TraitsPicker.test.ts`
- `vp run @t3tools/web#typecheck`
- `vp lint apps/web/src/components/chat/TraitsPicker.tsx apps/web/src/components/chat/TraitsPicker.test.ts`

Made by GPT-5.6-Sol with the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to traits trigger labeling for Codex; no auth, data, or API behavior changes.
> 
> **Overview**
> Codex **fast mode** no longer shows as **Standard/Fast** text on the traits trigger. **`buildTraitsTriggerDisplay`** now treats Codex’s **`serviceTier`** select (when it includes a **Fast** option) like the boolean **`fastMode`** trait: **Standard**/`default` stays silent with no bolt, and **Fast** shows the existing lightning bolt beside other trait labels.
> 
> **Fast mode on/off** is derived inside **`buildTraitsTriggerDisplay`** from descriptors instead of a separate **`fastModeEnabled`** argument, and **`getSelectedTraits`** no longer exposes **`fastModeEnabled`** to **`TraitsPicker`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37b862ea3f992676b2e8d16528cf47362259b35c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show bolt icon for Codex 'Fast' service tier in `buildTraitsTriggerDisplay`
> Moves fast-mode detection logic from the call site into `buildTraitsTriggerDisplay` in [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/4947/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45). For Codex, selecting the 'Fast' service tier now shows the bolt icon; 'Standard' (default) does not, though both tiers suppress the label as fast-mode traits. The `fastModeEnabled` property is removed from `getSelectedTraits` and is no longer passed explicitly to `buildTraitsTriggerDisplay`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37b862e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->