### PR TITLE
docs: seed worktrees with a copy of real userdata instead of banning it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ We need to be on the same page with terminology. When communicating, use this la
 ## The three ways to hurt yourself
 
 1. **Killing by pattern.** Never `pkill -f`, `pgrep | kill`, or `kill` a PID you found by matching a name, path, or worktree string. Your own agent process has this worktree's path in its argv, and this machine runs several other dev servers at once. Kill only a PID you captured at spawn, or the owner of your port from `ss -H -ltnp` after confirming `/proc/<pid>/cwd` is your worktree.
-2. **Touching the live install.** `~/.t3/userdata` is the developer's real T3 Code database, in use while you work. Read-only inspection is fine. Never start a server against it, never open it read-write, never clean it up.
+2. **Writing to the live install.** `~/.t3/userdata` is the developer's real T3 Code database, in use while you work. Reading it and copying from it are fine, and a good way to get real test data (see Test data). Never start a server against it, never open it read-write, never clean it up.
 3. **Baking in origins.** Never set `VITE_HTTP_URL` or `VITE_WS_URL` for dev. Dev is single-origin and Vite proxies `/api`, `/ws`, `/oauth`, and `/.well-known`. Setting them bakes localhost into the bundle and silently breaks every remote browser.
 
 ## Hit every surface
@@ -85,10 +85,19 @@ The most common defect in this repo is a change that works on the path you teste
 
 ## Test data
 
-An empty database is a bad test. Seed your worktree's `.t3` instead of pointing at live state:
+An empty database is a bad test. Seed your worktree's `.t3` with a copy of real data instead of pointing at live state:
 
-- Copy from `~/.t3/dev`, never from `~/.t3/userdata`.
-- Copy `state.sqlite` together with its `-wal` and `-shm` siblings, and only while no server has the source open. A live copy is a corrupt copy.
+- Copy from `~/.t3/userdata` (the developer's real data, the most realistic test set) or `~/.t3/dev`. Worktree state lives at `<worktree>/.t3/userdata`.
+- Snapshot the database with `VACUUM INTO`, which is safe even while a server has the source open and yields one consistent file:
+
+  ```bash
+  mkdir -p .t3/userdata
+  rm -f .t3/userdata/state.sqlite*  # VACUUM INTO refuses to overwrite
+  bun -e "new (require('bun:sqlite').Database)(process.env.HOME + '/.t3/userdata/state.sqlite', { readonly: true }).run(\"VACUUM INTO '.t3/userdata/state.sqlite'\")"
+  ```
+
+  A plain `cp` is only safe when no server has the source open, and must bring the `-wal` and `-shm` siblings along. A live file copy is a corrupt copy.
+
 - Bring `secrets` and `settings.json` only if the flow under test needs them.
 - Copy in, never symlink. Data flows one way: into your sandbox, never back out.
 


### PR DESCRIPTION
AGENTS.md told agents to never touch `~/.t3/userdata`, so worktree testing happened against empty or stale `~/.t3/dev` data. An empty database is a bad test.

The rule is now "never write to it": reading and copying from the live install are explicitly fine, and the Test data section recommends snapshotting the real database into the worktree's `.t3/userdata` with `VACUUM INTO` (safe against a live source, verified against the running install on this box). The plain-`cp` caveats about `-wal`/`-shm` siblings and open servers remain for the offline path.

Written by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor agent rules; no runtime or security behavior in the product changes.
> 
> **Overview**
> Updates **AGENTS.md** so agents treat `~/.t3/userdata` as **read/copy OK, write forbidden**, instead of broadly “don’t touch the live install.” Rule 2 now points readers to **Test data** for using real data safely.
> 
> The **Test data** section recommends seeding the worktree’s `.t3/userdata` from **`~/.t3/userdata`** (preferred) or `~/.t3/dev`, and adds a **`VACUUM INTO`** one-liner to snapshot SQLite while the live server still has the source open. The older “copy only from `~/.t3/dev`, never userdata” guidance is removed; **`cp`** still requires closed sources and `-wal`/`-shm` siblings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28852a40b35047bc166add9f0e60dac5083d5695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed worktree test data with copies of real userdata instead of banning it
> Updates [AGENTS.md](https://github.com/pingdotgg/t3code/pull/4949/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to replace the blanket prohibition on using real user data in worktrees with a recommended workflow for copying it safely.
>
> - Clarifies that reading and copying from `~/.t3/userdata` is allowed; only writing to the live install (starting a server against it, opening it read-write, or running cleanup) is prohibited.
> - Adds a step-by-step snapshot procedure using `sqlite VACUUM INTO` via `bun` to produce a consistent `state.sqlite` while the source database may still be open.
> - Notes that plain `cp` is only safe when no server has the source open, must include `-wal` and `-shm`, and that live file copies will be corrupt.
> - Clarifies that secrets/`settings.json` can optionally be copied in, and that symlinks must never be used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28852a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->