### PR TITLE
fix(mobile): support dragged images in the composer

### DIFF
--- a/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
+++ b/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
@@ -141,7 +141,7 @@ private final class ComposerTextView: UITextView {
     replace(textRange, withText: "")
   }
 
-  private func loadImages(from providers: [NSItemProvider]) {
+  func loadImages(from providers: [NSItemProvider]) {
     let group = DispatchGroup()
     let lock = NSLock()
     var images = [UIImage?](repeating: nil, count: providers.count)
@@ -282,7 +282,7 @@ private final class ComposerTextView: UITextView {
   }
 }
 
-public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
+public final class T3ComposerEditorView: ExpoView, UITextViewDelegate, UITextDropDelegate {
   private let textView = ComposerTextView()
   private let placeholderLabel = UILabel()
   private var value = ""
@@ -326,6 +326,7 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
 
     clipsToBounds = false
     textView.delegate = self
+    textView.textDropDelegate = self
     textView.backgroundColor = .clear
     textView.textContainerInset = .zero
     textView.textContainer.lineFragmentPadding = 0
@@ -498,6 +499,38 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
   ) -> Bool {
     restoreBaseTypingAttributes()
     return true
+  }
+
+  public func textDroppableView(
+    _ textDroppableView: UIView & UITextDroppable,
+    proposalForDrop drop: UITextDropRequest
+  ) -> UITextDropProposal {
+    let hasImages = drop.dropSession.items.contains {
+      $0.itemProvider.canLoadObject(ofClass: UIImage.self)
+    }
+    guard hasImages else {
+      return drop.suggestedProposal
+    }
+
+    // The composer owns image drops so UIKit does not insert NSTextAttachments
+    // that the controlled plain-text value cannot represent.
+    let proposal = UITextDropProposal(operation: .copy)
+    proposal.dropAction = .insert
+    proposal.dropPerformer = .delegate
+    return proposal
+  }
+
+  public func textDroppableView(
+    _ textDroppableView: UIView & UITextDroppable,
+    willPerformDrop drop: UITextDropRequest
+  ) {
+    let imageProviders = drop.dropSession.items
+      .map(\.itemProvider)
+      .filter { $0.canLoadObject(ofClass: UIImage.self) }
+    guard !imageProviders.isEmpty else {
+      return
+    }
+    textView.loadImages(from: imageProviders)
   }
 
   public func textViewDidBeginEditing(_ textView: UITextView) {

--- a/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
+++ b/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
@@ -505,11 +505,7 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate, UITextDro
     _ textDroppableView: UIView & UITextDroppable,
     proposalForDrop drop: UITextDropRequest
   ) -> UITextDropProposal {
-    let items = drop.dropSession.items
-    let containsOnlyImages = !items.isEmpty && items.allSatisfy {
-      $0.itemProvider.canLoadObject(ofClass: UIImage.self)
-    }
-    guard containsOnlyImages else {
+    guard droppedImageProviders(in: drop) != nil else {
       return drop.suggestedProposal
     }
 
@@ -525,13 +521,19 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate, UITextDro
     _ textDroppableView: UIView & UITextDroppable,
     willPerformDrop drop: UITextDropRequest
   ) {
-    let imageProviders = drop.dropSession.items
-      .map(\.itemProvider)
-      .filter { $0.canLoadObject(ofClass: UIImage.self) }
-    guard !imageProviders.isEmpty else {
+    guard let imageProviders = droppedImageProviders(in: drop) else {
       return
     }
     textView.loadImages(from: imageProviders)
+  }
+
+  private func droppedImageProviders(in drop: UITextDropRequest) -> [NSItemProvider]? {
+    let providers = drop.dropSession.items.map(\.itemProvider)
+    guard !providers.isEmpty,
+          providers.allSatisfy({ $0.canLoadObject(ofClass: UIImage.self) }) else {
+      return nil
+    }
+    return providers
   }
 
   public func textViewDidBeginEditing(_ textView: UITextView) {

--- a/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
+++ b/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
@@ -505,10 +505,11 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate, UITextDro
     _ textDroppableView: UIView & UITextDroppable,
     proposalForDrop drop: UITextDropRequest
   ) -> UITextDropProposal {
-    let hasImages = drop.dropSession.items.contains {
+    let items = drop.dropSession.items
+    let containsOnlyImages = !items.isEmpty && items.allSatisfy {
       $0.itemProvider.canLoadObject(ofClass: UIImage.self)
     }
-    guard hasImages else {
+    guard containsOnlyImages else {
       return drop.suggestedProposal
     }
 


### PR DESCRIPTION
Dragging an image over the iOS composer did not add it to the draft. UIKit could only attempt to insert it as rich text, which the controlled composer cannot represent.

The iOS editor now claims image drops through `UITextDropDelegate` and forwards their item providers through the existing image attachment path. Non-image drops keep UIKit’s suggested behavior.

Tests:
- `vp test run apps/mobile/src/lib/composerImages.test.ts`
- `vp run --filter @t3tools/mobile typecheck`

Built by gpt-5.6-sol with the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to iOS composer drag handling and reuses the existing paste image pipeline; no auth, data model, or cross-platform behavior changes beyond fixing image drops.
> 
> **Overview**
> **iOS composer** now handles **dragged images** the same way as paste, so drafts can pick up images from drag-and-drop instead of UIKit trying to insert rich-text attachments the controlled value cannot represent.
> 
> `T3ComposerEditorView` adopts **`UITextDropDelegate`** and sets **`textView.textDropDelegate`**. For drops whose session items are all image providers, **`proposalForDrop`** returns a copy/insert/**delegate** proposal so UIKit does not insert `NSTextAttachment` into the text view. **`willPerformDrop`** forwards those providers to **`ComposerTextView.loadImages`**, which writes temp PNGs and fires **`onComposerPasteImages`**—unchanged from the paste path. **`loadImages`** is no longer `private` so the drop delegate can call it. Mixed or non-image drops still use UIKit’s suggested proposal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85134f5c28013ec6f74d3aebe18c8aa07d50cf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support dragged images in the mobile composer
> Adds `UITextDropDelegate` conformance to `T3ComposerEditorView` in [T3ComposerEditorView.swift](https://github.com/pingdotgg/t3code/pull/4953/files#diff-bf020ce11861c51d7a3be2ccf67632f77afe80ff4ecf76a17884c5b040c21749) so image drops into the text composer are handled natively on iOS.
>
> - When all dropped items are images, the view returns a `.copy`/`.delegate` drop proposal and loads them via `textView.loadImages(from:)` instead of letting UIKit insert attachments.
> - Non-image drops fall back to UIKit's suggested proposal.
> - `ComposerTextView.loadImages` access level is widened from `private` to `internal` to allow this call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d85134f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->