### PR TITLE
fix(mobile): remove redundant, frozen spinner from file browser

### DIFF
--- a/apps/mobile/src/features/files/FileTreeBrowser.tsx
+++ b/apps/mobile/src/features/files/FileTreeBrowser.tsx
@@ -108,6 +108,7 @@ const FileTreeRow = memo(function FileTreeRow(props: {
 export function FileTreeBrowser(props: {
   readonly entries: ReadonlyArray<ProjectEntry>;
   readonly error: string | null;
+  readonly isInitialLoad: boolean;
   readonly isPending: boolean;
   readonly searchQuery: string;
   readonly selectedPath: string | null;
@@ -256,16 +257,17 @@ export function FileTreeBrowser(props: {
       updateCellsBatchingPeriod={16}
       windowSize={5}
       contentContainerStyle={{ paddingTop: 8, paddingBottom: 8 }}
+      // Refreshing at mount leaves iOS with a frozen indicator; initial load uses the empty state.
       refreshControl={
         <RefreshControl
-          refreshing={props.isPending && props.entries.length > 0}
+          refreshing={props.isPending && !props.isInitialLoad}
           onRefresh={props.onRefresh}
         />
       }
       renderItem={renderItem}
       ListEmptyComponent={
         <View className="px-4 py-5">
-          {props.isPending ? (
+          {props.isPending && props.isInitialLoad ? (
             <ActivityIndicator size="small" />
           ) : (
             <>

--- a/apps/mobile/src/features/files/FileTreeBrowser.tsx
+++ b/apps/mobile/src/features/files/FileTreeBrowser.tsx
@@ -256,7 +256,12 @@ export function FileTreeBrowser(props: {
       updateCellsBatchingPeriod={16}
       windowSize={5}
       contentContainerStyle={{ paddingTop: 8, paddingBottom: 8 }}
-      refreshControl={<RefreshControl refreshing={props.isPending} onRefresh={props.onRefresh} />}
+      refreshControl={
+        <RefreshControl
+          refreshing={props.isPending && props.entries.length > 0}
+          onRefresh={props.onRefresh}
+        />
+      }
       renderItem={renderItem}
       ListEmptyComponent={
         <View className="px-4 py-5">

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -444,6 +444,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
       <FileTreeBrowser
         entries={entriesData?.entries ?? []}
         error={entriesQuery.error}
+        isInitialLoad={entriesData === null}
         isPending={entriesQuery.isPending}
         searchQuery={searchQuery}
         selectedPath={null}

--- a/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
+++ b/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
@@ -72,6 +72,7 @@ export function ThreadFileNavigatorPane(props: {
     <FileTreeBrowser
       entries={entriesData?.entries ?? []}
       error={entriesQuery.error}
+      isInitialLoad={entriesData === null}
       isPending={entriesQuery.isPending}
       searchQuery={searchQuery}
       selectedPath={props.selectedPath}


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Hide the refresh control from first appearance of file browser
- I can confirm that pull-to-refresh still works after the initial load

## Why

There were two spinners that would appear while loading the file browser for the first time, and the top one (the refresh control) would not animate. The hiding of it removes the extra, frozen spinner.

## UI Changes

### Before

https://github.com/user-attachments/assets/c9dd9bdd-8578-4bb8-8cf5-084ea16f308a

### After

https://github.com/user-attachments/assets/be5ed9dc-1d70-4353-9603-82bce8ac6207

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading-state logic in the file tree; no auth, data, or API changes.
> 
> **Overview**
> Fixes **duplicate loading spinners** on first open of the mobile file tree: the pull-to-refresh `RefreshControl` used to show a **frozen** indicator on iOS while the list was still empty.
> 
> `FileTreeBrowser` now takes **`isInitialLoad`** (from callers when `entriesData === null`). On initial load, the empty state shows a single **`ActivityIndicator`**; the refresh control’s **`refreshing`** flag is only set when pending **and** not on that first load. Pull-to-refresh after data has loaded is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 613644feb16a4295fd7bde305799a2406f04bb8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove frozen pull-to-refresh spinner from file browser initial load
> Adds an `isInitialLoad` prop to [FileTreeBrowser](https://github.com/pingdotgg/t3code/pull/4954/files#diff-8353fd7ee22cd906a02c3d0415f8ad40f8a91cd9cdfc919491f52e63499db6c4), set to `true` when `entriesData` is null. During initial load, the `RefreshControl` spinner is suppressed and a inline `ActivityIndicator` is shown in the empty list instead. Callers [ThreadFilesRouteScreen](https://github.com/pingdotgg/t3code/pull/4954/files#diff-9d701f672b12c7184cdf9b51e0e5b5417c35e688fe894ee38e91017bf15aea6a) and [ThreadFileNavigatorPane](https://github.com/pingdotgg/t3code/pull/4954/files#diff-5c60d47be8b47d98c17ff476fc2bd41a9d1cdda24c7a0dda7fba4732add69b72) pass the new prop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 613644f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->