### PR TITLE
fix(server): keep installed editors visible when discovery times out

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -1,16 +1,25 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
-import { SpawnExecutableResolution } from "@t3tools/shared/shell";
+import {
+  CommandAvailability,
+  type CommandAvailabilityChecker,
+  isCommandAvailable,
+  SpawnExecutableResolution,
+} from "@t3tools/shared/shell";
 import * as ExternalLauncher from "./externalLauncher.ts";
 
 function makeMockDetachedHandle(onUnref: () => void = () => undefined) {
@@ -36,6 +45,7 @@ const testLayer = (input: {
   readonly platform: NodeJS.Platform;
   readonly env?: Record<string, string>;
   readonly resolveExecutable?: (command: string) => string | undefined;
+  readonly commandAvailability?: CommandAvailabilityChecker;
   readonly onSpawn?: (command: ChildProcess.StandardCommand) => void;
   readonly onUnref?: () => void;
 }) => {
@@ -60,6 +70,7 @@ const testLayer = (input: {
       SpawnExecutableResolution,
       (command) => input.resolveExecutable?.(command) ?? command,
     ),
+    Layer.succeed(CommandAvailability, input.commandAvailability ?? isCommandAvailable),
     ConfigProvider.layer(ConfigProvider.fromEnv({ env: input.env ?? {} })),
   );
 };
@@ -138,7 +149,7 @@ it.effect("discovers editors through the service API", () =>
     yield* fileSystem.writeFileString(path.join(binDir, "code.CMD"), "@echo off\r\n");
     yield* fileSystem.writeFileString(path.join(binDir, "explorer.CMD"), "@echo off\r\n");
 
-    const editors = yield* Effect.gen(function* () {
+    const discovery = yield* Effect.gen(function* () {
       const launcher = yield* ExternalLauncher.ExternalLauncher;
       return yield* launcher.resolveAvailableEditors();
     }).pipe(
@@ -150,10 +161,183 @@ it.effect("discovers editors through the service API", () =>
       ),
     );
 
-    assert.equal(editors.includes("vscode"), true);
-    assert.equal(editors.includes("file-manager"), true);
+    assert.equal(discovery.complete, true);
+    assert.equal(discovery.editors.includes("vscode"), true);
+    assert.equal(discovery.editors.includes("file-manager"), true);
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
+
+it.effect("keeps responsive editors when other discovery probes time out", () => {
+  const discoveryTimeout = Duration.seconds(3);
+
+  return Effect.gen(function* () {
+    const launcher = yield* ExternalLauncher.ExternalLauncher;
+    const discoveryFiber = yield* launcher.resolveAvailableEditors().pipe(Effect.forkScoped);
+
+    yield* Effect.yieldNow;
+    yield* TestClock.adjust(discoveryTimeout);
+
+    const discovery = yield* Fiber.join(discoveryFiber);
+    assert.deepEqual(discovery, {
+      editors: ["vscode", "file-manager"],
+      complete: false,
+    });
+  }).pipe(
+    Effect.scoped,
+    Effect.provide(
+      Layer.merge(
+        TestClock.layer(),
+        testLayer({
+          platform: "linux",
+          env: { PATH: "/bin" },
+          commandAvailability: (command) =>
+            command === "code" || command === "xdg-open" ? Effect.succeed(true) : Effect.never,
+        }),
+      ),
+    ),
+  );
+});
+
+it.effect("preserves the last complete editor list when a cached refresh is incomplete", () => {
+  const discoveryTimeout = Duration.seconds(3);
+  let incomplete = false;
+  let codeChecks = 0;
+
+  return Effect.gen(function* () {
+    const launcher = yield* ExternalLauncher.ExternalLauncher;
+    const [initialDiscovery, concurrentDiscovery] = yield* Effect.all(
+      [launcher.resolveAvailableEditors(), launcher.resolveAvailableEditors()],
+      { concurrency: "unbounded" },
+    );
+    assert.deepEqual(initialDiscovery, {
+      editors: ["vscode", "file-manager"],
+      complete: true,
+    });
+    assert.deepEqual(concurrentDiscovery, initialDiscovery);
+    assert.equal(codeChecks, 1);
+
+    const cachedDiscovery = yield* launcher.resolveAvailableEditors();
+    assert.deepEqual(cachedDiscovery, initialDiscovery);
+    assert.equal(codeChecks, 1);
+
+    incomplete = true;
+    yield* TestClock.adjust(Duration.minutes(1));
+
+    const refreshFiber = yield* launcher.resolveAvailableEditors().pipe(Effect.forkScoped);
+    yield* Effect.yieldNow;
+    yield* TestClock.adjust(discoveryTimeout);
+
+    const refreshedDiscovery = yield* Fiber.join(refreshFiber);
+    assert.deepEqual(refreshedDiscovery, {
+      editors: initialDiscovery.editors,
+      complete: false,
+    });
+    assert.equal(codeChecks, 2);
+  }).pipe(
+    Effect.scoped,
+    Effect.provide(
+      Layer.merge(
+        TestClock.layer(),
+        testLayer({
+          platform: "linux",
+          env: { PATH: "/bin" },
+          commandAvailability: (command) => {
+            if (command === "code") {
+              codeChecks += 1;
+            }
+            if (command === "code" || command === "xdg-open") {
+              return Effect.succeed(true);
+            }
+            return incomplete ? Effect.never : Effect.succeed(false);
+          },
+        }),
+      ),
+    ),
+  );
+});
+
+it.effect("does not cache an incomplete first discovery", () => {
+  const discoveryTimeout = Duration.seconds(3);
+  let stalled = true;
+  let codeChecks = 0;
+
+  return Effect.gen(function* () {
+    const launcher = yield* ExternalLauncher.ExternalLauncher;
+    const initialFiber = yield* launcher.resolveAvailableEditors().pipe(Effect.forkScoped);
+
+    yield* Effect.yieldNow;
+    yield* TestClock.adjust(discoveryTimeout);
+
+    assert.deepEqual(yield* Fiber.join(initialFiber), {
+      editors: [],
+      complete: false,
+    });
+
+    stalled = false;
+    const retryDiscovery = yield* launcher.resolveAvailableEditors();
+    assert.deepEqual(retryDiscovery, {
+      editors: ["vscode", "file-manager"],
+      complete: true,
+    });
+    assert.equal(codeChecks, 2);
+  }).pipe(
+    Effect.scoped,
+    Effect.provide(
+      Layer.merge(
+        TestClock.layer(),
+        testLayer({
+          platform: "linux",
+          env: { PATH: "/bin" },
+          commandAvailability: (command) => {
+            if (command === "code") {
+              codeChecks += 1;
+            }
+            return stalled
+              ? Effect.never
+              : Effect.succeed(command === "code" || command === "xdg-open");
+          },
+        }),
+      ),
+    ),
+  );
+});
+
+it.effect("allows editor discovery to retry after a shared lookup defects", () => {
+  let shouldDefect = true;
+  let codeChecks = 0;
+
+  return Effect.gen(function* () {
+    const launcher = yield* ExternalLauncher.ExternalLauncher;
+    const failedDiscovery = yield* launcher.resolveAvailableEditors().pipe(Effect.exit);
+
+    assert.equal(Exit.isFailure(failedDiscovery), true);
+
+    shouldDefect = false;
+    const retryDiscovery = yield* launcher.resolveAvailableEditors();
+
+    assert.deepEqual(retryDiscovery, {
+      editors: ["vscode", "file-manager"],
+      complete: true,
+    });
+    assert.equal(codeChecks, 2);
+  }).pipe(
+    Effect.provide(
+      testLayer({
+        platform: "linux",
+        env: { PATH: "/bin" },
+        commandAvailability: (command) => {
+          if (command === "code") {
+            codeChecks += 1;
+            if (shouldDefect) {
+              return Effect.die("discovery defect");
+            }
+          }
+          return Effect.succeed(command === "code" || command === "xdg-open");
+        },
+      }),
+    ),
+  );
+});
 
 it.effect("rejects unknown editors through the service API", () =>
   Effect.gen(function* () {

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -18,15 +18,23 @@ import {
   type LaunchEditorInput,
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
-import { isCommandAvailable, resolveSpawnCommand } from "@t3tools/shared/shell";
+import {
+  discoverAvailableCommands,
+  isCommandAvailable,
+  resolveSpawnCommand,
+} from "@t3tools/shared/shell";
+import * as Cache from "effect/Cache";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
@@ -63,6 +71,11 @@ interface TargetPathAndPosition {
   readonly column: Option.Option<string>;
 }
 
+export interface EditorDiscoveryResult {
+  readonly editors: ReadonlyArray<EditorId>;
+  readonly complete: boolean;
+}
+
 const TARGET_WITH_POSITION_PATTERN = /^(.*?):(\d+)(?::(\d+))?$/;
 const POWERSHELL_ARGUMENTS_PREFIX = [
   "-NoProfile",
@@ -78,6 +91,10 @@ const DETACHED_IGNORE_STDIO_OPTIONS = {
   stdout: "ignore",
   stderr: "ignore",
 } as const satisfies ChildProcess.CommandOptions;
+
+const EDITOR_DISCOVERY_TIMEOUT = Duration.seconds(3);
+const EDITOR_DISCOVERY_CACHE_TTL = Duration.minutes(1);
+const EDITOR_DISCOVERY_CACHE_KEY = "available-editors" as const;
 
 const compactEnv = (input: Record<string, Option.Option<string>>): NodeJS.ProcessEnv =>
   Object.fromEntries(
@@ -263,26 +280,32 @@ function buildBrowserLaunch(
 const buildAvailableEditors = Effect.fn("externalLauncher.buildAvailableEditors")(function* (
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
-): Effect.fn.Return<ReadonlyArray<EditorId>, never, FileSystem.FileSystem | Path.Path> {
-  const available: EditorId[] = [];
+): Effect.fn.Return<EditorDiscoveryResult, never, FileSystem.FileSystem | Path.Path> {
+  const fileManagerCommand = fileManagerCommandForPlatform(platform);
+  const discovery = yield* discoverAvailableCommands(
+    [...EDITORS.flatMap((editor) => editor.commands ?? []), fileManagerCommand],
+    {
+      env,
+      timeout: EDITOR_DISCOVERY_TIMEOUT,
+    },
+  );
 
-  for (const editor of EDITORS) {
-    if (editor.commands === null) {
-      const command = fileManagerCommandForPlatform(platform);
-      if (yield* isCommandAvailable(command, { env })) {
-        available.push(editor.id);
-      }
-      continue;
-    }
-
-    const command = yield* resolveAvailableCommand(editor.commands, env);
-    if (Option.isSome(command)) {
-      available.push(editor.id);
-    }
-  }
-
-  return available;
+  return {
+    editors: EDITORS.flatMap((editor) => {
+      const editorCommands = editor.commands ?? [fileManagerCommand];
+      return editorCommands.some((command) => discovery.available.has(command)) ? [editor.id] : [];
+    }),
+    complete: discovery.complete,
+  };
 });
+
+function mergeEditorLists(
+  current: ReadonlyArray<EditorId>,
+  previous: ReadonlyArray<EditorId>,
+): ReadonlyArray<EditorId> {
+  const available = new Set([...current, ...previous]);
+  return EDITORS.flatMap((editor) => (available.has(editor.id) ? [editor.id] : []));
+}
 
 const resolveBrowserLaunch = Effect.fn("externalLauncher.resolveBrowserLaunch")(function* (
   target: string,
@@ -304,7 +327,7 @@ const resolveAvailableEditors = Effect.fn("externalLauncher.resolveAvailableEdit
 export class ExternalLauncher extends Context.Service<
   ExternalLauncher,
   {
-    readonly resolveAvailableEditors: () => Effect.Effect<ReadonlyArray<EditorId>>;
+    readonly resolveAvailableEditors: () => Effect.Effect<EditorDiscoveryResult>;
     /** Launch a URL target in the default browser. */
     readonly launchBrowser: (target: string) => Effect.Effect<void, ExternalLauncherError>;
     /**
@@ -430,10 +453,11 @@ const launchEditorProcess = Effect.fn("externalLauncher.launchEditorProcess")(fu
   );
 });
 
-export const make = Effect.gen(function* () {
+export const make = Effect.fn("externalLauncher.make")(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const lastKnownEditors = yield* Ref.make<ReadonlyArray<EditorId>>([]);
 
   const provideCommandResolutionServices = <A, E, R>(
     effect: Effect.Effect<A, E, R | FileSystem.FileSystem | Path.Path>,
@@ -443,8 +467,28 @@ export const make = Effect.gen(function* () {
       Effect.provideService(Path.Path, path),
     );
 
+  const discoverAndRememberEditors = Effect.fn("externalLauncher.discoverAndRememberEditors")(
+    function* () {
+      const discovery = yield* provideCommandResolutionServices(resolveAvailableEditors());
+      const editors = discovery.complete
+        ? discovery.editors
+        : mergeEditorLists(discovery.editors, yield* Ref.get(lastKnownEditors));
+
+      yield* Ref.set(lastKnownEditors, editors);
+      return { editors, complete: discovery.complete };
+    },
+  );
+
+  const discoveryCache = yield* Cache.makeWith(() => discoverAndRememberEditors(), {
+    capacity: 1,
+    timeToLive: Exit.match({
+      onSuccess: ({ complete }) => (complete ? EDITOR_DISCOVERY_CACHE_TTL : Duration.zero),
+      onFailure: () => Duration.zero,
+    }),
+  });
+
   return ExternalLauncher.of({
-    resolveAvailableEditors: () => provideCommandResolutionServices(resolveAvailableEditors()),
+    resolveAvailableEditors: () => Cache.get(discoveryCache, EDITOR_DISCOVERY_CACHE_KEY),
     launchBrowser: (target) =>
       launchBrowser(target).pipe(
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
@@ -460,4 +504,4 @@ export const make = Effect.gen(function* () {
   });
 });
 
-export const layer = Layer.effect(ExternalLauncher, make);
+export const layer = Layer.effect(ExternalLauncher, make());

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -593,7 +593,11 @@ const buildAppUnderTest = (options?: {
       ),
       Layer.provide(
         Layer.mock(ExternalLauncher.ExternalLauncher)({
-          resolveAvailableEditors: () => Effect.succeed([]),
+          resolveAvailableEditors: () =>
+            Effect.succeed({
+              editors: [],
+              complete: true,
+            }),
           ...options?.layers?.externalLauncher,
         }),
       ),
@@ -3947,8 +3951,39 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
       assert.equal(response.environment.environmentId, testEnvironmentDescriptor.environmentId);
       assert.equal(response.auth.policy, "desktop-managed-local");
+      assert.equal(response.availableEditorsComplete, true);
       assert.equal(response.shellResumeCompletionMarker, true);
       assert.equal(response.threadResumeCompletionMarker, true);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("preserves incomplete editor discovery in server config", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest({
+        layers: {
+          externalLauncher: {
+            resolveAvailableEditors: () =>
+              Effect.succeed({
+                editors: [],
+                complete: false,
+              }),
+          },
+        },
+      });
+
+      const { cookie } = yield* bootstrapBrowserSession();
+      assert.isDefined(cookie);
+
+      const wsUrl = appendSessionCookieToWsUrl(
+        yield* getWsServerUrl("/ws", { authenticated: false }),
+        cookie?.split(";")[0] ?? "",
+      );
+      const response = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) => client[WS_METHODS.serverGetConfig]({})),
+      );
+
+      assert.deepEqual(response.availableEditors, []);
+      assert.equal(response.availableEditorsComplete, false);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
@@ -3963,9 +3998,12 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
       yield* TestClock.adjust(Duration.seconds(5));
 
-      const availableEditors = yield* Fiber.join(responseFiber);
+      const editorDiscovery = yield* Fiber.join(responseFiber);
       yield* Deferred.await(discoveryInterrupted);
-      assert.deepEqual(availableEditors, []);
+      assert.deepEqual(editorDiscovery, {
+        editors: [],
+        complete: false,
+      });
     }),
   );
 
@@ -4522,6 +4560,77 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         payload: { keybindings: [], issues: [] },
       });
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("retries incomplete editor discovery without clobbering live config updates", () =>
+    Effect.gen(function* () {
+      const retryStarted = yield* Deferred.make<void>();
+      const settingsUpdateDelivered = yield* Deferred.make<void>();
+      const updatedSettings = {
+        ...DEFAULT_SERVER_SETTINGS,
+        enableAssistantStreaming: true,
+      };
+      let discoveryCalls = 0;
+      yield* buildAppUnderTest({
+        layers: {
+          externalLauncher: {
+            resolveAvailableEditors: () =>
+              Effect.gen(function* () {
+                discoveryCalls += 1;
+                if (discoveryCalls === 1) {
+                  return {
+                    editors: [],
+                    complete: false,
+                  };
+                }
+                yield* Deferred.succeed(retryStarted, undefined);
+                yield* Deferred.await(settingsUpdateDelivered);
+                return {
+                  editors: [EditorId.make("vscode")],
+                  complete: true,
+                };
+              }),
+          },
+          serverSettings: {
+            streamChanges: Stream.concat(
+              Stream.fromEffect(Deferred.await(retryStarted)).pipe(Stream.drain),
+              Stream.concat(
+                Stream.succeed(updatedSettings),
+                Stream.fromEffect(Deferred.succeed(settingsUpdateDelivered, undefined)).pipe(
+                  Stream.drain,
+                ),
+              ),
+            ),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const events = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[WS_METHODS.subscribeServerConfig]({}).pipe(Stream.take(3), Stream.runCollect),
+        ),
+      );
+
+      const [initial, settingsUpdated, refreshed] = Array.from(events);
+      assert.equal(initial?.type, "snapshot");
+      if (initial?.type === "snapshot") {
+        assert.deepEqual(initial.config.availableEditors, []);
+        assert.equal(initial.config.availableEditorsComplete, false);
+      }
+      assert.deepEqual(settingsUpdated, {
+        version: 1,
+        type: "settingsUpdated",
+        payload: { settings: updatedSettings },
+      });
+      assert.equal(refreshed?.type, "snapshot");
+      if (refreshed?.type === "snapshot") {
+        assert.deepEqual(refreshed.config.availableEditors, [EditorId.make("vscode")]);
+        assert.equal(refreshed.config.availableEditorsComplete, true);
+        assert.deepEqual(refreshed.config.settings, updatedSettings);
+      }
+      assert.equal(discoveryCalls, 2);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 
   it.effect("routes websocket resource telemetry through the subscription", () =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -44,6 +44,8 @@ import {
   type RelayClientInstallProgressEvent,
   type ServerSelfUpdateError,
   type ServerSelfUpdateProgressEvent,
+  type ServerConfig as ServerConfigValue,
+  type ServerConfigStreamEvent,
   type FilesystemBrowseFailure,
   FilesystemBrowseError,
   AssetWorkspaceContextNotFoundError,
@@ -125,14 +127,73 @@ const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchComma
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const EDITOR_DISCOVERY_TIMEOUT = Duration.seconds(5);
+const EDITOR_DISCOVERY_RETRY_DELAY = Duration.seconds(1);
 
-export const resolveAvailableEditorsForConfig = <A, E, R>(
-  discovery: Effect.Effect<ReadonlyArray<A>, E, R>,
+export const resolveAvailableEditorsForConfig = <E, R>(
+  discovery: Effect.Effect<ExternalLauncher.EditorDiscoveryResult, E, R>,
 ) =>
   discovery.pipe(
     Effect.timeoutOption(EDITOR_DISCOVERY_TIMEOUT),
-    Effect.map(Option.getOrElse(() => [])),
+    Effect.map(
+      Option.getOrElse(
+        (): ExternalLauncher.EditorDiscoveryResult => ({
+          editors: [],
+          complete: false,
+        }),
+      ),
+    ),
   );
+
+type ServerConfigIncrementalEvent = Exclude<ServerConfigStreamEvent, { readonly type: "snapshot" }>;
+
+interface EditorDiscoveryRetryEvent {
+  readonly type: "editorDiscoveryRetried";
+  readonly discovery: ExternalLauncher.EditorDiscoveryResult;
+}
+
+function projectServerConfigLiveEvent(
+  config: ServerConfigValue,
+  event: ServerConfigIncrementalEvent | EditorDiscoveryRetryEvent,
+): readonly [ServerConfigValue, ReadonlyArray<ServerConfigStreamEvent>] {
+  let next: ServerConfigValue;
+  switch (event.type) {
+    case "editorDiscoveryRetried":
+      next = {
+        ...config,
+        availableEditors: event.discovery.editors,
+        availableEditorsComplete: event.discovery.complete,
+      };
+      break;
+    case "keybindingsUpdated":
+      next = {
+        ...config,
+        keybindings: event.payload.keybindings,
+        issues: event.payload.issues,
+      };
+      break;
+    case "providerStatuses":
+      next = {
+        ...config,
+        providers: event.payload.providers,
+      };
+      break;
+    case "settingsUpdated":
+      next = {
+        ...config,
+        settings: event.payload.settings,
+      };
+      break;
+  }
+  const output: ServerConfigStreamEvent =
+    event.type === "editorDiscoveryRetried"
+      ? {
+          version: 1,
+          type: "snapshot",
+          config: next,
+        }
+      : event;
+  return [next, [output]];
+}
 
 function unexpectedCompatibilityError(error: never): never {
   throw new Error(`Unhandled compatibility error: ${String(error)}`);
@@ -985,6 +1046,9 @@ const makeWsRpcLayer = (
         );
         const environment = yield* serverEnvironment.getDescriptor;
         const auth = yield* serverAuth.getDescriptor();
+        const editorDiscovery = yield* resolveAvailableEditorsForConfig(
+          externalLauncher.resolveAvailableEditors(),
+        );
 
         return {
           environment,
@@ -994,9 +1058,8 @@ const makeWsRpcLayer = (
           keybindings: keybindingsConfig.keybindings,
           issues: keybindingsConfig.issues,
           providers,
-          availableEditors: yield* resolveAvailableEditorsForConfig(
-            externalLauncher.resolveAvailableEditors(),
-          ),
+          availableEditors: editorDiscovery.editors,
+          availableEditorsComplete: editorDiscovery.complete,
           observability: {
             logsDirectoryPath: config.logsDir,
             localTracingEnabled: true,
@@ -2031,16 +2094,33 @@ const makeWsRpcLayer = (
                 .refresh()
                 .pipe(Effect.ignoreCause({ log: true }), Effect.forkScoped);
 
+              const initialConfig = yield* loadServerConfig;
+              const editorDiscoveryRetry =
+                initialConfig.availableEditorsComplete === false
+                  ? Stream.fromEffect(
+                      Effect.sleep(EDITOR_DISCOVERY_RETRY_DELAY).pipe(
+                        Effect.andThen(
+                          resolveAvailableEditorsForConfig(
+                            externalLauncher.resolveAvailableEditors(),
+                          ),
+                        ),
+                        Effect.map((discovery) => ({
+                          type: "editorDiscoveryRetried" as const,
+                          discovery,
+                        })),
+                      ),
+                    )
+                  : Stream.empty;
               const liveUpdates = Stream.merge(
-                keybindingsUpdates,
-                Stream.merge(providerStatuses, settingsUpdates),
-              );
+                editorDiscoveryRetry,
+                Stream.merge(keybindingsUpdates, Stream.merge(providerStatuses, settingsUpdates)),
+              ).pipe(Stream.mapAccum(() => initialConfig, projectServerConfigLiveEvent));
 
               return Stream.concat(
                 Stream.make({
                   version: 1 as const,
                   type: "snapshot" as const,
-                  config: yield* loadServerConfig,
+                  config: initialConfig,
                 }),
                 liveUpdates,
               );

--- a/apps/web/src/components/chat/OpenInPicker.test.ts
+++ b/apps/web/src/components/chat/OpenInPicker.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveEmptyEditorMessage } from "./OpenInPicker";
+
+describe("resolveEmptyEditorMessage", () => {
+  it("does not report incomplete discovery as no installed editors", () => {
+    expect(resolveEmptyEditorMessage(false)).toBe("Couldn’t check for installed editors");
+  });
+
+  it("treats missing discovery metadata from older servers as unknown", () => {
+    expect(resolveEmptyEditorMessage(undefined)).toBe("Couldn’t check for installed editors");
+  });
+
+  it("reports no installed editors after complete empty discovery", () => {
+    expect(resolveEmptyEditorMessage(true)).toBe("No installed editors found");
+  });
+});

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -1,3 +1,4 @@
+import { useAtomValue } from "@effect/atom-react";
 import { EditorId, type EnvironmentId, type ResolvedKeybindingsConfig } from "@t3tools/contracts";
 import { memo, useCallback, useEffect, useMemo } from "react";
 import { isOpenFavoriteEditorShortcut, shortcutLabelForCommand } from "../../keybindings";
@@ -32,6 +33,7 @@ import {
   WebStormIcon,
 } from "../JetBrainsIcons";
 import { cn, isMacPlatform, isWindowsPlatform } from "~/lib/utils";
+import { serverEnvironment } from "~/state/server";
 import { shellEnvironment } from "~/state/shell";
 import { useAtomCommand } from "~/state/use-atom-command";
 
@@ -183,6 +185,12 @@ function getOpenInIconClass(kind: OpenInOption["kind"]) {
   return cn(kind === "brand" ? "text-foreground opacity-100" : "text-muted-foreground");
 }
 
+export function resolveEmptyEditorMessage(discoveryComplete: boolean | undefined): string {
+  return discoveryComplete === true
+    ? "No installed editors found"
+    : "Couldn’t check for installed editors";
+}
+
 export const OpenInPicker = memo(function OpenInPicker({
   environmentId,
   keybindings,
@@ -198,6 +206,7 @@ export const OpenInPicker = memo(function OpenInPicker({
   compact?: boolean;
   enableShortcut?: boolean;
 }) {
+  const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
   const openInEditorMutation = useAtomCommand(shellEnvironment.openInEditor, "open in editor");
   const [preferredEditor, setPreferredEditor] = usePreferredEditor(availableEditors);
   const options = useMemo(
@@ -296,7 +305,11 @@ export const OpenInPicker = memo(function OpenInPicker({
           <ChevronDownIcon aria-hidden="true" className="size-4" />
         </MenuTrigger>
         <MenuPopup align="end">
-          {options.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
+          {options.length === 0 && (
+            <MenuItem disabled>
+              {resolveEmptyEditorMessage(serverConfig?.availableEditorsComplete)}
+            </MenuItem>
+          )}
           {options.map(({ label, Icon, value, kind }) => (
             <MenuItem key={value} onClick={() => openInEditor(value)}>
               <Icon aria-hidden="true" className={getOpenInIconClass(kind)} />

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -428,6 +428,7 @@ export const ServerConfig = Schema.Struct({
   // Editor ids grow over time; drop ones this build does not know rather than
   // failing the whole config decode.
   availableEditors: ForwardCompatibleArray(EditorId),
+  availableEditorsComplete: Schema.optionalKey(Schema.Boolean),
   observability: ServerObservability,
   settings: ServerSettings,
   /** Whether shell subscriptions can emit an opt-in catch-up completion marker. */

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -1,13 +1,21 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as TestClock from "effect/testing/TestClock";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   extractPathFromShellOutput,
   CommandAvailability,
   type CommandAvailabilityChecker,
+  discoverAvailableCommands,
   isCommandAvailable,
   listLoginShellCandidates,
   mergePathEntries,
@@ -350,6 +358,239 @@ effectIt.layer(NodeServices.layer)("isCommandAvailable", (it) => {
           env: { PATH: "", PATHEXT: ".COM;.EXE;.BAT;.CMD" },
         }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
       ).toBe(false);
+    }),
+  );
+});
+
+effectIt.layer(NodeServices.layer)("discoverAvailableCommands", (it) => {
+  it.effect("uses the provided host environment for Windows discovery", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-commands-" });
+
+      yield* fileSystem.writeFileString(path.join(binDir, "code.CMD"), "@echo off\r\n");
+
+      const discovery = yield* discoverAvailableCommands(["code"], {
+        timeout: Duration.seconds(3),
+      }).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(HostProcessEnvironment, {
+          PATH: binDir,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        }),
+      );
+
+      expect(discovery.complete).toBe(true);
+      expect(Array.from(discovery.available)).toEqual(["code"]);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("keeps Windows command aliases that resolve to the same executable", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-commands-" });
+
+      yield* fileSystem.writeFileString(path.join(binDir, "foo.CMD"), "@echo off\r\n");
+
+      const discovery = yield* discoverAvailableCommands(["foo", "foo.cmd"], {
+        env: {
+          PATH: binDir,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        },
+        timeout: Duration.seconds(3),
+      }).pipe(Effect.provideService(HostProcessPlatform, "win32"));
+
+      expect(discovery.complete).toBe(true);
+      expect(Array.from(discovery.available)).toEqual(["foo", "foo.cmd"]);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("keeps validated Windows matches when another PATH entry times out", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-commands-" });
+      const stalledPath = path.join(binDir, "stalled");
+      const responsiveMatchValidated = yield* Deferred.make<void>();
+
+      yield* fileSystem.writeFileString(path.join(binDir, "code.CMD"), "@echo off\r\n");
+      yield* fileSystem.makeDirectory(path.join(binDir, "fake.CMD"));
+
+      const testFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        readDirectory: (directory, options) =>
+          directory === stalledPath ? Effect.never : fileSystem.readDirectory(directory, options),
+        stat: (entry) =>
+          fileSystem
+            .stat(entry)
+            .pipe(
+              Effect.tap(() =>
+                entry === path.join(binDir, "code.CMD")
+                  ? Deferred.succeed(responsiveMatchValidated, undefined)
+                  : Effect.void,
+              ),
+            ),
+      });
+
+      const discoveryFiber = yield* discoverAvailableCommands(["code", "fake"], {
+        env: {
+          PATH: `${binDir};${stalledPath}`,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        },
+        timeout: Duration.seconds(3),
+      }).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(FileSystem.FileSystem, testFileSystem),
+        Effect.forkScoped,
+      );
+
+      yield* Deferred.await(responsiveMatchValidated);
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust(Duration.seconds(3));
+
+      const discovery = yield* Fiber.join(discoveryFiber);
+      expect(discovery.complete).toBe(false);
+      expect(Array.from(discovery.available)).toEqual(["code"]);
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("bounds concurrent Windows PATH directory reads", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const firstBatchStarted = yield* Deferred.make<void>();
+      let startedReads = 0;
+
+      const testFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        readDirectory: () =>
+          Effect.sync(() => {
+            startedReads += 1;
+            return startedReads === 8;
+          }).pipe(
+            Effect.flatMap((batchStarted) =>
+              batchStarted ? Deferred.succeed(firstBatchStarted, undefined) : Effect.void,
+            ),
+            Effect.andThen(Effect.never),
+          ),
+      });
+
+      const discoveryFiber = yield* discoverAvailableCommands(["code"], {
+        env: {
+          PATH: Array.from({ length: 20 }, (_, index) => `C:\\slow-${index}`).join(";"),
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        },
+        timeout: Duration.seconds(3),
+      }).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(FileSystem.FileSystem, testFileSystem),
+        Effect.forkScoped,
+      );
+
+      yield* Deferred.await(firstBatchStarted);
+      yield* TestClock.adjust(Duration.seconds(3));
+
+      const discovery = yield* Fiber.join(discoveryFiber);
+      expect(discovery.complete).toBe(false);
+      expect(startedReads).toBe(8);
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("bounds concurrent portable command probes", () =>
+    Effect.gen(function* () {
+      const firstBatchStarted = yield* Deferred.make<void>();
+      let startedProbes = 0;
+
+      const discoveryFiber = yield* discoverAvailableCommands(
+        Array.from({ length: 40 }, (_, index) => `command-${index}`),
+        {
+          env: { PATH: "/bin" },
+          timeout: Duration.seconds(3),
+        },
+      ).pipe(
+        Effect.provideService(HostProcessPlatform, "linux"),
+        Effect.provideService(CommandAvailability, () =>
+          Effect.sync(() => {
+            startedProbes += 1;
+            return startedProbes === 32;
+          }).pipe(
+            Effect.flatMap((batchStarted) =>
+              batchStarted ? Deferred.succeed(firstBatchStarted, undefined) : Effect.void,
+            ),
+            Effect.andThen(Effect.never),
+          ),
+        ),
+        Effect.forkScoped,
+      );
+
+      yield* Deferred.await(firstBatchStarted);
+      yield* TestClock.adjust(Duration.seconds(3));
+
+      const discovery = yield* Fiber.join(discoveryFiber);
+      expect(discovery.complete).toBe(false);
+      expect(startedProbes).toBe(32);
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("marks non-NotFound Windows filesystem failures as incomplete", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const options = {
+        env: {
+          PATH: "C:\\bin",
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        },
+        timeout: Duration.seconds(3),
+      } as const;
+      const missingError = PlatformError.systemError({
+        _tag: "NotFound",
+        module: "FileSystem",
+        method: "readDirectory",
+        pathOrDescriptor: "C:\\bin",
+      });
+      const permissionDenied = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "readDirectory",
+        pathOrDescriptor: "C:\\bin",
+      });
+
+      const missingPath = yield* discoverAvailableCommands(["code"], options).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(
+          FileSystem.FileSystem,
+          FileSystem.FileSystem.of({
+            ...fileSystem,
+            readDirectory: () => Effect.fail(missingError),
+          }),
+        ),
+      );
+      const deniedPath = yield* discoverAvailableCommands(["code"], options).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(
+          FileSystem.FileSystem,
+          FileSystem.FileSystem.of({
+            ...fileSystem,
+            readDirectory: () => Effect.fail(permissionDenied),
+          }),
+        ),
+      );
+      const deniedStat = yield* discoverAvailableCommands(["code"], options).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(
+          FileSystem.FileSystem,
+          FileSystem.FileSystem.of({
+            ...fileSystem,
+            readDirectory: () => Effect.succeed(["code.CMD"]),
+            stat: () => Effect.fail(permissionDenied),
+          }),
+        ),
+      );
+
+      expect(missingPath.complete).toBe(true);
+      expect(deniedPath.complete).toBe(false);
+      expect(deniedStat.complete).toBe(false);
     }),
   );
 });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -4,9 +4,12 @@ import * as NodePath from "node:path";
 import * as NodeChildProcess from "node:child_process";
 import * as NodeFS from "node:fs";
 import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
 
 import { HostProcessEnvironment, HostProcessPlatform } from "./hostProcess.ts";
 import * as Context from "effect/Context";
@@ -43,12 +46,23 @@ export type CommandAvailabilityChecker = (
   options?: CommandAvailabilityOptions,
 ) => Effect.Effect<boolean, never, FileSystem.FileSystem | Path.Path>;
 
+export interface CommandDiscoveryOptions extends CommandAvailabilityOptions {
+  readonly timeout: Duration.Input;
+}
+
+export interface CommandDiscoveryResult {
+  readonly available: ReadonlySet<string>;
+  readonly complete: boolean;
+}
+
 export class CommandResolutionError extends Data.TaggedError("CommandResolutionError")<{
   readonly command: string;
   readonly reason: "not-found";
 }> {}
 
 const WINDOWS_SHELL_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
+const COMMAND_DISCOVERY_CONCURRENCY = 8;
+const PORTABLE_COMMAND_DISCOVERY_CONCURRENCY = 32;
 
 /**
  * Escapes a single argument for `cmd.exe` shell mode (`spawn(..., { shell: true })`
@@ -606,6 +620,149 @@ export const isCommandAvailable = Effect.fn("shell.isCommandAvailable")(function
     Effect.as(true),
     Effect.catchTag("CommandResolutionError", () => Effect.succeed(false)),
   );
+});
+
+const discoverWindowsPathEntry = Effect.fn("shell.discoverWindowsPathEntry")(function* (
+  pathEntry: string,
+  commandsByExecutableName: ReadonlyMap<string, ReadonlySet<string>>,
+  availableRef: Ref.Ref<ReadonlySet<string>>,
+): Effect.fn.Return<boolean, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const directory = yield* fileSystem.readDirectory(pathEntry).pipe(
+    Effect.map((entries) => ({ entries, complete: true })),
+    Effect.catch((error) =>
+      Effect.succeed({
+        entries: [] as ReadonlyArray<string>,
+        complete: error.reason._tag === "NotFound",
+      }),
+    ),
+  );
+
+  let complete = directory.complete;
+  for (const entry of directory.entries) {
+    const commands = commandsByExecutableName.get(entry.toLowerCase());
+    if (commands === undefined) {
+      continue;
+    }
+
+    const stat = yield* fileSystem.stat(path.join(pathEntry, entry)).pipe(
+      Effect.map(Option.some),
+      Effect.catch((error) => {
+        if (error.reason._tag !== "NotFound") {
+          complete = false;
+        }
+        return Effect.succeed(Option.none());
+      }),
+    );
+    if (Option.isNone(stat)) {
+      continue;
+    }
+    if (stat.value.type !== "File") {
+      continue;
+    }
+
+    yield* Ref.update(availableRef, (available) => {
+      const updated = new Set(available);
+      for (const command of commands) {
+        updated.add(command);
+      }
+      return updated;
+    });
+  }
+
+  return complete;
+});
+
+const discoverAvailableWindowsCommands = Effect.fn("shell.discoverAvailableWindowsCommands")(
+  function* (
+    commands: ReadonlyArray<string>,
+    env: NodeJS.ProcessEnv,
+    availableRef: Ref.Ref<ReadonlySet<string>>,
+  ): Effect.fn.Return<boolean, never, FileSystem.FileSystem | Path.Path> {
+    const path = yield* Path.Path;
+    const windowsPathExtensions = resolveWindowsPathExtensions(env);
+    const commandsByExecutableName = new Map<string, Set<string>>();
+
+    for (const command of commands) {
+      for (const candidate of resolveCommandCandidates(
+        command,
+        "win32",
+        windowsPathExtensions,
+        path.extname,
+      )) {
+        const executableName = candidate.toLowerCase();
+        const aliases = commandsByExecutableName.get(executableName);
+        if (aliases === undefined) {
+          commandsByExecutableName.set(executableName, new Set([command]));
+        } else {
+          aliases.add(command);
+        }
+      }
+    }
+
+    const results = yield* Effect.forEach(
+      resolvePathEnvironmentVariable(env)
+        .split(pathDelimiterForPlatform("win32"))
+        .map((entry) => stripWrappingQuotes(entry.trim()))
+        .filter((entry) => entry.length > 0),
+      (pathEntry) => discoverWindowsPathEntry(pathEntry, commandsByExecutableName, availableRef),
+      { concurrency: COMMAND_DISCOVERY_CONCURRENCY },
+    );
+
+    return results.every((complete) => complete);
+  },
+);
+
+const discoverAvailablePortableCommands = Effect.fn("shell.discoverAvailablePortableCommands")(
+  function* (
+    commands: ReadonlyArray<string>,
+    env: NodeJS.ProcessEnv | undefined,
+    availableRef: Ref.Ref<ReadonlySet<string>>,
+  ): Effect.fn.Return<boolean, never, FileSystem.FileSystem | Path.Path> {
+    const commandAvailable = yield* CommandAvailability;
+    yield* Effect.forEach(
+      commands,
+      (command) =>
+        commandAvailable(command, env === undefined ? {} : { env }).pipe(
+          Effect.tap((available) =>
+            available
+              ? Ref.update(availableRef, (current) => new Set(current).add(command))
+              : Effect.void,
+          ),
+        ),
+      { concurrency: PORTABLE_COMMAND_DISCOVERY_CONCURRENCY },
+    );
+    return true;
+  },
+);
+
+export const discoverAvailableCommands = Effect.fn("shell.discoverAvailableCommands")(function* (
+  commands: ReadonlyArray<string>,
+  options: CommandDiscoveryOptions,
+): Effect.fn.Return<CommandDiscoveryResult, never, FileSystem.FileSystem | Path.Path> {
+  const platform = yield* HostProcessPlatform;
+  const uniqueCommands = Array.from(new Set(commands));
+  const availableRef = yield* Ref.make<ReadonlySet<string>>(new Set());
+
+  const scan =
+    platform === "win32"
+      ? discoverAvailableWindowsCommands(
+          uniqueCommands,
+          options.env ?? (yield* HostProcessEnvironment),
+          availableRef,
+        )
+      : discoverAvailablePortableCommands(uniqueCommands, options.env, availableRef);
+
+  const complete = yield* scan.pipe(
+    Effect.timeoutOption(options.timeout),
+    Effect.map(Option.getOrElse(() => false)),
+  );
+
+  return {
+    available: yield* Ref.get(availableRef),
+    complete,
+  };
 });
 
 export function resolveKnownWindowsCliDirs(env: NodeJS.ProcessEnv): ReadonlyArray<string> {


### PR DESCRIPTION
## What Changed

- made Windows editor discovery bounded and concurrent while preserving partial successes
- retained last-known editors when a discovery attempt is incomplete
- added an optional completion signal and one retry through the existing config snapshot stream
- added focused shell, launcher, server, and picker coverage

## Why

Editor discovery could exceed the server config timeout and discard editors already found, causing clients to incorrectly show “No installed editors found.”

The optional completion field and existing snapshot event keep this compatible across mixed client/server versions.

Fixes #4697.

Related approaches: #4739 and #4435. Complementary command-probe performance work: #4778.

## UI Changes

Before: 
<img width="313" height="114" alt="image" src="https://github.com/user-attachments/assets/fa4ab8b2-b71e-43b1-b978-55272c3c2725" />

After:
<img width="177" height="98" alt="image" src="https://github.com/user-attachments/assets/a926e468-face-464d-be52-b85e8082753d" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] No animation or interaction changes require a video

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches server config streaming and cross-platform command discovery with new timeout/partial-result semantics; behavior is well tested but affects what clients show for editor availability.
> 
> **Overview**
> Editor discovery no longer collapses to an empty list when probes time out or stall. **`discoverAvailableCommands`** in shared shell code runs bounded, concurrent PATH checks and returns **`{ available, complete }`**. **`ExternalLauncher.resolveAvailableEditors`** now returns **`{ editors, complete }`**, merges partial results with the last known complete list, and only caches successful complete discoveries.
> 
> **`ServerConfig`** adds optional **`availableEditorsComplete`**. The websocket config stream keeps that flag on snapshots, schedules a **1s retry** when the initial load is incomplete, and folds retries into live updates without clobbering settings/keybinding events. **`OpenInPicker`** shows **“Couldn’t check for installed editors”** when discovery is incomplete or unknown, instead of **“No installed editors found”**.
> 
> Coverage spans shell discovery, launcher caching/retry behavior, server config subscription, and the picker empty state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d5e41df8b40d7dd5d44429f43aa71fa4185dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep installed editors visible in server config when editor discovery times out
> - Adds `EditorDiscoveryResult` (with `editors` and `complete` fields) to replace the plain editor array returned by `resolveAvailableEditors` in [externalLauncher.ts](https://github.com/pingdotgg/t3code/pull/4956/files#diff-157ca66b5181820e0a628ef443d244577cda2329dd1d88fe5f2aff441da05e56).
> - Introduces `discoverAvailableCommands` in [shell.ts](https://github.com/pingdotgg/t3code/pull/4956/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce): a platform-aware, timeout-bounded bulk command scanner that returns partial results with a `complete` flag instead of failing on timeout.
> - Caches complete discoveries for 1 minute; incomplete or failed discoveries are not cached, and the last known complete editor list is preserved on incomplete refreshes.
> - On incomplete discovery, `subscribeServerConfig` in [ws.ts](https://github.com/pingdotgg/t3code/pull/4956/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) schedules a retry after 1s and emits a refreshed `ServerConfig` snapshot, propagating `availableEditorsComplete` to clients.
> - The `OpenInPicker` UI in [OpenInPicker.tsx](https://github.com/pingdotgg/t3code/pull/4956/files#diff-e2a98d212ae98eb3ec0902f11d6e8f0daeb2b1729c80a65a8792371f7605e802) now shows "Couldn't check for installed editors" when discovery is incomplete, versus "No installed editors found" when it is complete.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64d5e41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->