### PR TITLE
[codex] feat(web): show git progress in the commit button

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -8,6 +8,7 @@ import {
   resolveAutoFeatureBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveGitActionProgressPresentation,
+  resolveGitActionResultToastTiming,
   resolveLiveThreadBranchUpdate,
   resolveQuickAction,
   resolveThreadBranchUpdate,
@@ -108,6 +109,19 @@ describe("git action progress presentation", () => {
     assert.equal(formatGitActionElapsed(10_000, 9_000), "0s");
     assert.equal(formatGitActionElapsed(10_000, 14_900), "4s");
     assert.equal(formatGitActionElapsed(10_000, 75_000), "1m 5s");
+  });
+});
+
+describe("git action result toast timing", () => {
+  it("keeps errors sticky and dismisses successes after visible time", () => {
+    assert.deepEqual(resolveGitActionResultToastTiming("error"), {
+      timeout: 0,
+      dismissAfterVisibleMs: null,
+    });
+    assert.deepEqual(resolveGitActionResultToastTiming("success"), {
+      timeout: 0,
+      dismissAfterVisibleMs: 10_000,
+    });
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -3,9 +3,11 @@ import { assert, describe, it } from "vite-plus/test";
 import {
   buildGitActionProgressStages,
   buildMenuItems,
+  formatGitActionElapsed,
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
   resolveDefaultBranchActionDialogCopy,
+  resolveGitActionProgressPresentation,
   resolveLiveThreadBranchUpdate,
   resolveQuickAction,
   resolveThreadBranchUpdate,
@@ -31,6 +33,65 @@ function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
     ...overrides,
   };
 }
+
+describe("git action progress presentation", () => {
+  it("keeps the phase on the first row and hook output on the second", () => {
+    assert.deepEqual(
+      resolveGitActionProgressPresentation({
+        isRunning: true,
+        operation: "run_change_request",
+        currentLabel: "Running pre-commit...",
+        lastOutputLine: "Checking formatting and lint rules",
+        phaseStartedAtMs: 1_000,
+        hookStartedAtMs: 2_000,
+      }),
+      {
+        status: "Running pre-commit...",
+        output: "Checking formatting and lint rules",
+        startedAtMs: 2_000,
+      },
+    );
+  });
+
+  it("omits empty output and supplies a brief startup label", () => {
+    assert.deepEqual(
+      resolveGitActionProgressPresentation({
+        isRunning: true,
+        operation: "run_change_request",
+        currentLabel: "Running source control action",
+        lastOutputLine: "  ",
+        phaseStartedAtMs: 1_000,
+        hookStartedAtMs: null,
+      }),
+      {
+        status: "Starting source control action...",
+        output: null,
+        startedAtMs: 1_000,
+      },
+    );
+  });
+
+  it("does not present unrelated or completed actions", () => {
+    const input = {
+      isRunning: true,
+      operation: "pull",
+      currentLabel: "Pulling...",
+      lastOutputLine: null,
+      phaseStartedAtMs: 1_000,
+      hookStartedAtMs: null,
+    };
+
+    assert.isNull(resolveGitActionProgressPresentation(input));
+    assert.isNull(resolveGitActionProgressPresentation({ ...input, isRunning: false }));
+  });
+
+  it("formats compact elapsed time without allowing negative values", () => {
+    assert.isNull(formatGitActionElapsed(null, 10_000));
+    assert.equal(formatGitActionElapsed(10_000, 9_000), "0s");
+    assert.equal(formatGitActionElapsed(10_000, 14_900), "4s");
+    assert.equal(formatGitActionElapsed(10_000, 75_000), "1m 5s");
+  });
+});
 
 describe("when: ref is clean and has an open PR", () => {
   it("resolveQuickAction opens the existing PR", () => {

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -71,11 +71,29 @@ describe("git action progress presentation", () => {
     );
   });
 
+  it("presents pull progress inline without a second row", () => {
+    assert.deepEqual(
+      resolveGitActionProgressPresentation({
+        isRunning: true,
+        operation: "pull",
+        currentLabel: "Pulling latest changes...",
+        lastOutputLine: null,
+        phaseStartedAtMs: 1_000,
+        hookStartedAtMs: null,
+      }),
+      {
+        status: "Pulling latest changes...",
+        output: null,
+        startedAtMs: 1_000,
+      },
+    );
+  });
+
   it("does not present unrelated or completed actions", () => {
     const input = {
       isRunning: true,
-      operation: "pull",
-      currentLabel: "Pulling...",
+      operation: "publish_repository",
+      currentLabel: "Publishing repository",
       lastOutputLine: null,
       phaseStartedAtMs: 1_000,
       hookStartedAtMs: null,

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -65,19 +65,27 @@ export function resolveGitActionProgressPresentation(input: {
   readonly phaseStartedAtMs: number | null;
   readonly hookStartedAtMs: number | null;
 }): GitActionProgressPresentation | null {
-  if (!input.isRunning || input.operation !== "run_change_request") {
+  if (
+    !input.isRunning ||
+    (input.operation !== "run_change_request" && input.operation !== "pull")
+  ) {
     return null;
   }
 
   const currentLabel = input.currentLabel?.trim();
   const output = input.lastOutputLine?.trim();
+  const isPull = input.operation === "pull";
   return {
     status:
-      !currentLabel || currentLabel === "Running source control action"
-        ? "Starting source control action..."
-        : currentLabel,
-    output: output ? output : null,
-    startedAtMs: input.hookStartedAtMs ?? input.phaseStartedAtMs,
+      currentLabel && currentLabel !== "Running source control action"
+        ? currentLabel
+        : isPull
+          ? "Pulling latest changes..."
+          : "Starting source control action...",
+    output: !isPull && output ? output : null,
+    startedAtMs: isPull
+      ? input.phaseStartedAtMs
+      : (input.hookStartedAtMs ?? input.phaseStartedAtMs),
   };
 }
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -43,11 +43,27 @@ export interface GitActionProgressPresentation {
   readonly startedAtMs: number | null;
 }
 
+export interface GitActionResultToastTiming {
+  readonly timeout: 0;
+  readonly dismissAfterVisibleMs: number | null;
+}
+
 export type DefaultBranchConfirmableAction =
   | "push"
   | "create_pr"
   | "commit_push"
   | "commit_push_pr";
+
+const GIT_ACTION_SUCCESS_TOAST_VISIBLE_MS = 10_000;
+
+export function resolveGitActionResultToastTiming(
+  type: "error" | "success",
+): GitActionResultToastTiming {
+  return {
+    timeout: 0,
+    dismissAfterVisibleMs: type === "success" ? GIT_ACTION_SUCCESS_TOAST_VISIBLE_MS : null,
+  };
+}
 
 function resolveChangeRequestTerminology(
   gitStatus: VcsStatusResult | null,

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -37,6 +37,12 @@ export interface DefaultBranchActionDialogCopy {
   continueLabel: string;
 }
 
+export interface GitActionProgressPresentation {
+  readonly status: string;
+  readonly output: string | null;
+  readonly startedAtMs: number | null;
+}
+
 export type DefaultBranchConfirmableAction =
   | "push"
   | "create_pr"
@@ -49,6 +55,45 @@ function resolveChangeRequestTerminology(
   return gitStatus?.sourceControlProvider
     ? getChangeRequestTerminology(gitStatus.sourceControlProvider)
     : DEFAULT_CHANGE_REQUEST_TERMINOLOGY;
+}
+
+export function resolveGitActionProgressPresentation(input: {
+  readonly isRunning: boolean;
+  readonly operation: string | null;
+  readonly currentLabel: string | null;
+  readonly lastOutputLine: string | null;
+  readonly phaseStartedAtMs: number | null;
+  readonly hookStartedAtMs: number | null;
+}): GitActionProgressPresentation | null {
+  if (!input.isRunning || input.operation !== "run_change_request") {
+    return null;
+  }
+
+  const currentLabel = input.currentLabel?.trim();
+  const output = input.lastOutputLine?.trim();
+  return {
+    status:
+      !currentLabel || currentLabel === "Running source control action"
+        ? "Starting source control action..."
+        : currentLabel,
+    output: output ? output : null,
+    startedAtMs: input.hookStartedAtMs ?? input.phaseStartedAtMs,
+  };
+}
+
+export function formatGitActionElapsed(startedAtMs: number | null, nowMs: number): string | null {
+  if (startedAtMs === null) {
+    return null;
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000));
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds}s`;
+  }
+
+  const minutes = Math.floor(elapsedSeconds / 60);
+  const seconds = elapsedSeconds % 60;
+  return `${minutes}m ${seconds}s`;
 }
 
 export function buildGitActionProgressStages(input: {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -46,6 +46,7 @@ import {
   requiresDefaultBranchConfirmation,
   resolveDefaultBranchActionDialogCopy,
   resolveGitActionProgressPresentation,
+  resolveGitActionResultToastTiming,
   resolveLiveThreadBranchUpdate,
   resolveThreadBranchMetadataPatch,
   resolveQuickAction,
@@ -1317,11 +1318,13 @@ export default function GitActionsControl({
         }
 
         const error = squashAtomCommandFailure(result);
+        const errorToastTiming = resolveGitActionResultToastTiming("error");
         toastManager.add(
           stackedThreadToast({
             type: "error",
             title: "Action failed",
             description: error instanceof Error ? error.message : "An error occurred.",
+            timeout: errorToastTiming.timeout,
             ...(scopedToastData !== undefined ? { data: scopedToastData } : {}),
           }),
         );
@@ -1364,9 +1367,12 @@ export default function GitActionsControl({
         };
       }
 
+      const successToastTiming = resolveGitActionResultToastTiming("success");
       const successToastData = {
         ...scopedToastData,
-        dismissAfterVisibleMs: 10_000,
+        ...(successToastTiming.dismissAfterVisibleMs !== null
+          ? { dismissAfterVisibleMs: successToastTiming.dismissAfterVisibleMs }
+          : {}),
       };
 
       if (toastActionProps) {
@@ -1375,7 +1381,7 @@ export default function GitActionsControl({
             type: "success",
             title: actionResult.toast.title,
             description: actionResult.toast.description,
-            timeout: 0,
+            timeout: successToastTiming.timeout,
             actionProps: toastActionProps,
             data: successToastData,
           }),
@@ -1385,7 +1391,7 @@ export default function GitActionsControl({
           type: "success",
           title: actionResult.toast.title,
           description: actionResult.toast.description,
-          timeout: 0,
+          timeout: successToastTiming.timeout,
           data: successToastData,
         });
       }

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -5,7 +5,6 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import type {
-  GitActionProgressEvent,
   GitRunStackedActionResult,
   GitStackedAction,
   SourceControlCloneProtocol,
@@ -37,14 +36,16 @@ import { RadioGroup } from "~/components/ui/radio-group";
 import { Spinner } from "~/components/ui/spinner";
 import { cn } from "~/lib/utils";
 import {
-  buildGitActionProgressStages,
   buildMenuItems,
+  formatGitActionElapsed,
+  type GitActionProgressPresentation,
   type GitActionIconName,
   type GitActionMenuItem,
   type GitQuickAction,
   type DefaultBranchConfirmableAction,
   requiresDefaultBranchConfirmation,
   resolveDefaultBranchActionDialogCopy,
+  resolveGitActionProgressPresentation,
   resolveLiveThreadBranchUpdate,
   resolveThreadBranchMetadataPatch,
   resolveQuickAction,
@@ -68,7 +69,7 @@ import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Textarea } from "~/components/ui/textarea";
-import { stackedThreadToast, toastManager, type ThreadToastData } from "~/components/ui/toast";
+import { stackedThreadToast, toastManager } from "~/components/ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useOpenInPreferredEditor } from "~/editorPreferences";
 import {
@@ -84,7 +85,7 @@ import { serverEnvironment } from "~/state/server";
 import { sourceControlEnvironment } from "~/state/sourceControl";
 import { threadEnvironment } from "~/state/threads";
 import { useAtomCommand } from "~/state/use-atom-command";
-import { vcsEnvironment } from "~/state/vcs";
+import { vcsActionManager, vcsEnvironment } from "~/state/vcs";
 import { randomUUID } from "~/lib/utils";
 import { resolvePathLinkTarget } from "~/terminal-links";
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
@@ -126,18 +127,6 @@ type PublishProviderKind = Extract<
 
 type GitActionToastId = ReturnType<typeof toastManager.add>;
 
-interface ActiveGitActionProgress {
-  toastId: GitActionToastId;
-  toastData: ThreadToastData | undefined;
-  actionId: string;
-  title: string;
-  phaseStartedAtMs: number | null;
-  hookStartedAtMs: number | null;
-  hookName: string | null;
-  lastOutputLine: string | null;
-  currentPhaseLabel: string | null;
-}
-
 interface RunGitActionWithToastInput {
   action: GitStackedAction;
   commitMessage?: string;
@@ -145,7 +134,6 @@ interface RunGitActionWithToastInput {
   skipDefaultBranchPrompt?: boolean;
   statusOverride?: VcsStatusResult | null;
   featureBranch?: boolean;
-  progressToastId?: GitActionToastId;
   filePaths?: string[];
 }
 
@@ -248,26 +236,6 @@ function getPublishProviderReadiness(input: {
     };
   }
   return { ready: true, hint: null };
-}
-
-function formatElapsedDescription(startedAtMs: number | null): string | undefined {
-  if (startedAtMs === null) {
-    return undefined;
-  }
-  const elapsedSeconds = Math.max(0, Math.floor((Date.now() - startedAtMs) / 1000));
-  if (elapsedSeconds < 60) {
-    return `Running for ${elapsedSeconds}s`;
-  }
-  const minutes = Math.floor(elapsedSeconds / 60);
-  const seconds = elapsedSeconds % 60;
-  return `Running for ${minutes}m ${seconds}s`;
-}
-
-function resolveProgressDescription(progress: ActiveGitActionProgress): string | undefined {
-  if (progress.lastOutputLine) {
-    return progress.lastOutputLine;
-  }
-  return formatElapsedDescription(progress.hookStartedAtMs ?? progress.phaseStartedAtMs);
 }
 
 function getMenuActionDisabledReason({
@@ -377,6 +345,59 @@ function GitQuickActionIcon({
   }
   if (quickAction.label === "Commit") return <GitCommitIcon className={iconClassName} />;
   return <InfoIcon className={iconClassName} />;
+}
+
+function GitActionProgressButtonContent({ progress }: { progress: GitActionProgressPresentation }) {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (progress.startedAtMs === null) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      setNowMs(Date.now());
+    }, 1_000);
+    return () => window.clearInterval(intervalId);
+  }, [progress.startedAtMs]);
+
+  const elapsed = formatGitActionElapsed(progress.startedAtMs, nowMs);
+  const hasOutput = progress.output !== null;
+
+  return (
+    <div
+      aria-atomic="false"
+      aria-live="polite"
+      className="grid min-w-0 flex-1 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-2.5 gap-y-0.5"
+      role="status"
+    >
+      <Spinner
+        aria-hidden="true"
+        className="row-start-1 -mx-0.5 size-4 shrink-0 text-muted-foreground"
+      />
+      <p className="row-start-1 min-w-0 truncate text-left">{progress.status}</p>
+      {elapsed ? (
+        <p className="row-start-1 text-[11px] font-normal tabular-nums text-muted-foreground">
+          {elapsed}
+        </p>
+      ) : null}
+      <div
+        className={cn(
+          "col-span-2 col-start-2 grid min-w-0 transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none",
+          hasOutput ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+        )}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <p
+            className="truncate text-left text-[11px] font-normal text-muted-foreground"
+            title={progress.output ?? undefined}
+          >
+            {progress.output}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 interface PublishRepositoryDialogProps {
@@ -1022,26 +1043,12 @@ export default function GitActionsControl({
   const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
   const [pendingDefaultBranchAction, setPendingDefaultBranchAction] =
     useState<PendingDefaultBranchAction | null>(null);
-  const activeGitActionProgressRef = useRef<ActiveGitActionProgress | null>(null);
   const sourceControlScope = useMemo(
     () => ({ environmentId: activeEnvironmentId, cwd: gitCwd }),
     [activeEnvironmentId, gitCwd],
   );
+  const vcsActionState = useAtomValue(vcsActionManager.stateAtom(sourceControlScope));
   let runGitActionWithToast: (input: RunGitActionWithToastInput) => Promise<void>;
-
-  const updateActiveProgressToast = useCallback(() => {
-    const progress = activeGitActionProgressRef.current;
-    if (!progress) {
-      return;
-    }
-    toastManager.update(progress.toastId, {
-      type: "loading",
-      title: progress.title,
-      description: resolveProgressDescription(progress),
-      timeout: 0,
-      data: progress.toastData,
-    });
-  }, []);
 
   const persistThreadBranchSync = useCallback(
     (branch: string | null) => {
@@ -1175,6 +1182,7 @@ export default function GitActionsControl({
   const quickActionDisabledReason = quickAction.disabled
     ? (quickAction.hint ?? "This action is currently unavailable.")
     : null;
+  const gitActionProgress = resolveGitActionProgressPresentation(vcsActionState);
   const pendingDefaultBranchActionCopy = pendingDefaultBranchAction
     ? resolveDefaultBranchActionDialogCopy({
         action: pendingDefaultBranchAction.action,
@@ -1183,19 +1191,6 @@ export default function GitActionsControl({
         terminology: changeRequestTerminology,
       })
     : null;
-
-  useEffect(() => {
-    const interval = window.setInterval(() => {
-      if (!activeGitActionProgressRef.current) {
-        return;
-      }
-      updateActiveProgressToast();
-    }, 1000);
-
-    return () => {
-      window.clearInterval(interval);
-    };
-  }, [updateActiveProgressToast]);
 
   useEffect(() => {
     if (gitCwd === null) {
@@ -1270,7 +1265,6 @@ export default function GitActionsControl({
       skipDefaultBranchPrompt = false,
       statusOverride,
       featureBranch = false,
-      progressToastId,
       filePaths,
     }: RunGitActionWithToastInput) => {
       const actionStatus = statusOverride ?? gitStatusForActions;
@@ -1306,105 +1300,8 @@ export default function GitActionsControl({
       }
       onConfirmed?.();
 
-      const progressStages = buildGitActionProgressStages({
-        action,
-        hasCustomCommitMessage: !!commitMessage?.trim(),
-        hasWorkingTreeChanges: !!actionStatus?.hasWorkingTreeChanges,
-        featureBranch,
-        terminology: changeRequestTerminology,
-        shouldPushBeforePr:
-          action === "create_pr" &&
-          (!actionStatus?.hasUpstream || (actionStatus?.aheadCount ?? 0) > 0),
-      });
       const scopedToastData = threadToastData ? { ...threadToastData } : undefined;
       const actionId = randomUUID();
-      const resolvedProgressToastId =
-        progressToastId ??
-        toastManager.add({
-          type: "loading",
-          title: progressStages[0] ?? "Running git action...",
-          description: "Waiting for Git...",
-          timeout: 0,
-          data: scopedToastData,
-        });
-
-      activeGitActionProgressRef.current = {
-        toastId: resolvedProgressToastId,
-        toastData: scopedToastData,
-        actionId,
-        title: progressStages[0] ?? "Running git action...",
-        phaseStartedAtMs: null,
-        hookStartedAtMs: null,
-        hookName: null,
-        lastOutputLine: null,
-        currentPhaseLabel: progressStages[0] ?? "Running git action...",
-      };
-
-      if (progressToastId) {
-        toastManager.update(progressToastId, {
-          type: "loading",
-          title: progressStages[0] ?? "Running git action...",
-          description: "Waiting for Git...",
-          timeout: 0,
-          data: scopedToastData,
-        });
-      }
-
-      const applyProgressEvent = (event: GitActionProgressEvent) => {
-        const progress = activeGitActionProgressRef.current;
-        if (!progress) {
-          return;
-        }
-        if (gitCwd && event.cwd !== gitCwd) {
-          return;
-        }
-        if (progress.actionId !== event.actionId) {
-          return;
-        }
-
-        const now = Date.now();
-        switch (event.kind) {
-          case "action_started":
-            progress.phaseStartedAtMs = now;
-            progress.hookStartedAtMs = null;
-            progress.hookName = null;
-            progress.lastOutputLine = null;
-            break;
-          case "phase_started":
-            progress.title = event.label;
-            progress.currentPhaseLabel = event.label;
-            progress.phaseStartedAtMs = now;
-            progress.hookStartedAtMs = null;
-            progress.hookName = null;
-            progress.lastOutputLine = null;
-            break;
-          case "hook_started":
-            progress.title = `Running ${event.hookName}...`;
-            progress.hookName = event.hookName;
-            progress.hookStartedAtMs = now;
-            progress.lastOutputLine = null;
-            break;
-          case "hook_output":
-            progress.lastOutputLine = event.text;
-            break;
-          case "hook_finished":
-            progress.title = progress.currentPhaseLabel ?? "Committing...";
-            progress.hookName = null;
-            progress.hookStartedAtMs = null;
-            progress.lastOutputLine = null;
-            break;
-          case "action_finished":
-            // Let the resolved mutation update the toast so we keep the
-            // elapsed description visible until the final success state renders.
-            return;
-          case "action_failed":
-            // Let the settled mutation publish the error toast to avoid a
-            // transient intermediate state before the final failure message.
-            return;
-        }
-
-        updateActiveProgressToast();
-      };
 
       const result = await runImmediateGitAction.run({
         actionId,
@@ -1412,19 +1309,15 @@ export default function GitActionsControl({
         ...(commitMessage ? { commitMessage } : {}),
         ...(featureBranch ? { featureBranch } : {}),
         ...(filePaths ? { filePaths } : {}),
-        onProgress: applyProgressEvent,
       });
 
-      activeGitActionProgressRef.current = null;
       if (result._tag === "Failure") {
         if (isAtomCommandInterrupted(result)) {
-          toastManager.close(resolvedProgressToastId);
           return;
         }
 
         const error = squashAtomCommandFailure(result);
-        toastManager.update(
-          resolvedProgressToastId,
+        toastManager.add(
           stackedThreadToast({
             type: "error",
             title: "Action failed",
@@ -1437,8 +1330,11 @@ export default function GitActionsControl({
 
       const actionResult = result.value;
       syncThreadBranchAfterGitAction(actionResult);
+      let resultToastId: GitActionToastId | null = null;
       const closeResultToast = () => {
-        toastManager.close(resolvedProgressToastId);
+        if (resultToastId !== null) {
+          toastManager.close(resultToastId);
+        }
       };
 
       const toastCta = actionResult.toast.cta;
@@ -1474,8 +1370,7 @@ export default function GitActionsControl({
       };
 
       if (toastActionProps) {
-        toastManager.update(
-          resolvedProgressToastId,
+        resultToastId = toastManager.add(
           stackedThreadToast({
             type: "success",
             title: actionResult.toast.title,
@@ -1486,7 +1381,7 @@ export default function GitActionsControl({
           }),
         );
       } else {
-        toastManager.update(resolvedProgressToastId, {
+        resultToastId = toastManager.add({
           type: "success",
           title: actionResult.toast.title,
           description: actionResult.toast.description,
@@ -1708,9 +1603,32 @@ export default function GitActionsControl({
           role="group"
           aria-label="Git actions"
           {...(isPanel ? { ref: panelAnchorRef } : {})}
-          className={cn("shrink-0", isPanel && THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS)}
+          className={cn(
+            "shrink-0",
+            isPanel && THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS,
+            isPanel && gitActionProgress && "bg-black/[0.035] dark:bg-white/[0.055]",
+          )}
         >
-          {quickActionDisabledReason ? (
+          {gitActionProgress ? (
+            <Button
+              aria-label={
+                gitActionProgress.output
+                  ? `${gitActionProgress.status} ${gitActionProgress.output}`
+                  : gitActionProgress.status
+              }
+              className={cn(
+                isPanel
+                  ? THREAD_DETAILS_PANEL_SPLIT_PRIMARY_CLASS
+                  : "h-auto min-h-7 max-w-72 py-1 sm:h-auto sm:min-h-6",
+                isPanel && "h-auto min-h-9 py-1 disabled:opacity-100 sm:h-auto sm:min-h-9",
+              )}
+              disabled
+              size="xs"
+              variant={isPanel ? "ghost" : "outline"}
+            >
+              <GitActionProgressButtonContent progress={gitActionProgress} />
+            </Button>
+          ) : quickActionDisabledReason ? (
             <Popover>
               <PopoverTrigger
                 openOnHover
@@ -1785,7 +1703,10 @@ export default function GitActionsControl({
                   aria-label="Git action options"
                   size={isPanel ? "sm" : "icon-xs"}
                   variant={isPanel ? "ghost" : "outline"}
-                  className={isPanel ? THREAD_DETAILS_PANEL_SPLIT_SECONDARY_CLASS : undefined}
+                  className={cn(
+                    isPanel && THREAD_DETAILS_PANEL_SPLIT_SECONDARY_CLASS,
+                    isPanel && gitActionProgress && "h-auto self-stretch sm:h-auto",
+                  )}
                 />
               }
               disabled={isGitActionRunning}

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1453,26 +1453,20 @@ export default function GitActionsControl({
       return;
     }
     if (quickAction.kind === "run_pull") {
-      const toastId = toastManager.add({
-        type: "loading",
-        title: "Pulling...",
-        timeout: 0,
-        data: threadToastData,
-      });
       void (async () => {
         const result = await pullAction.run();
         if (result._tag === "Failure") {
           if (isAtomCommandInterrupted(result)) {
-            toastManager.close(toastId);
             return;
           }
           const error = squashAtomCommandFailure(result);
-          toastManager.update(
-            toastId,
+          const errorToastTiming = resolveGitActionResultToastTiming("error");
+          toastManager.add(
             stackedThreadToast({
               type: "error",
               title: "Pull failed",
               description: error instanceof Error ? error.message : "An error occurred.",
+              timeout: errorToastTiming.timeout,
               ...(threadToastData !== undefined ? { data: threadToastData } : {}),
             }),
           );
@@ -1480,14 +1474,21 @@ export default function GitActionsControl({
         }
 
         const pullResult = result.value;
-        toastManager.update(toastId, {
+        const successToastTiming = resolveGitActionResultToastTiming("success");
+        toastManager.add({
           type: "success",
           title: pullResult.status === "pulled" ? "Pulled" : "Already up to date",
           description:
             pullResult.status === "pulled"
               ? `Updated ${pullResult.refName} from ${pullResult.upstreamRef ?? "upstream"}`
               : `${pullResult.refName} is already synchronized.`,
-          data: threadToastData,
+          timeout: successToastTiming.timeout,
+          data: {
+            ...threadToastData,
+            ...(successToastTiming.dismissAfterVisibleMs !== null
+              ? { dismissAfterVisibleMs: successToastTiming.dismissAfterVisibleMs }
+              : {}),
+          },
         });
       })();
       return;

--- a/apps/web/src/state/sourceControlActions.ts
+++ b/apps/web/src/state/sourceControlActions.ts
@@ -191,7 +191,7 @@ export function useVcsPullAction(scope: SourceControlActionScope) {
   }, [pull, scope]);
   return useAction({
     kind: "pull",
-    label: "Pulling latest changes",
+    label: "Pulling latest changes...",
     scope,
     action,
     onSuccess: status.refresh,

--- a/packages/client-runtime/src/state/vcsAction.test.ts
+++ b/packages/client-runtime/src/state/vcsAction.test.ts
@@ -203,7 +203,7 @@ describe("vcsActionState", () => {
     });
   });
 
-  it("clears running presentation state once the action finishes", () => {
+  it("keeps running presentation state until the finished action settles", () => {
     const initial = beginVcsActionState({
       operation: "run_change_request",
       label: "Running source control action",
@@ -232,18 +232,18 @@ describe("vcsActionState", () => {
     );
 
     expect(finished).toMatchObject({
-      isRunning: false,
+      isRunning: true,
       operation: "run_change_request",
       actionId,
       action,
-      currentLabel: null,
-      currentPhaseLabel: null,
+      currentLabel: "Pushing...",
+      currentPhaseLabel: "Pushing...",
       lastOutputLine: null,
       error: null,
     });
   });
 
-  it("retains a terminal action error for presentation", () => {
+  it("keeps running presentation state and retains a terminal action error until settle", () => {
     const initial = beginVcsActionState({
       operation: "run_change_request",
       label: "Running source control action",
@@ -262,7 +262,7 @@ describe("vcsActionState", () => {
     );
 
     expect(failed).toMatchObject({
-      isRunning: false,
+      isRunning: true,
       operation: "run_change_request",
       actionId,
       action,
@@ -659,6 +659,7 @@ describe("vcsActionState", () => {
         );
 
         expect(AsyncResult.isSuccess(successfulResult)).toBe(true);
+        expect(registry.get(manager.stateAtom(targetKey))).toEqual(EMPTY_VCS_ACTION_STATE);
         expect(registry.get(state).revision).toBe(1);
         expect(removed).toEqual([`${environmentId}:*`]);
 
@@ -670,6 +671,12 @@ describe("vcsActionState", () => {
         );
 
         expect(AsyncResult.isFailure(failedResult)).toBe(true);
+        expect(registry.get(manager.stateAtom(targetKey))).toMatchObject({
+          isRunning: false,
+          operation: "run_change_request",
+          actionId: failedActionId,
+          error: "Source control action 'commit_push' failed during push.",
+        });
         expect(registry.get(state).revision).toBe(2);
         expect(removed).toEqual([`${environmentId}:*`, `${environmentId}:*`]);
       }),

--- a/packages/client-runtime/src/state/vcsAction.test.ts
+++ b/packages/client-runtime/src/state/vcsAction.test.ts
@@ -583,11 +583,16 @@ describe("vcsActionState", () => {
         const targetKey = { environmentId, cwd };
         const successfulActionId = "invalidate-success";
         const failedActionId = "invalidate-failure";
+        const interruptedActionId = "invalidate-interrupted";
         const successfulTransportActionId = createVcsActionTransportId(
           targetKey,
           successfulActionId,
         );
         const failedTransportActionId = createVcsActionTransportId(targetKey, failedActionId);
+        const interruptedTransportActionId = createVcsActionTransportId(
+          targetKey,
+          interruptedActionId,
+        );
         const client = {
           [WS_METHODS.gitRunStackedAction]: (input: { readonly actionId: string }) =>
             input.actionId === successfulTransportActionId
@@ -600,16 +605,18 @@ describe("vcsActionState", () => {
                     result,
                   }),
                 )
-              : Stream.make(
-                  progress({
-                    kind: "action_failed",
-                    actionId: failedTransportActionId,
-                    cwd,
-                    action,
-                    phase: "push",
-                    message: "push failed after creating the branch",
-                  }),
-                ),
+              : input.actionId === interruptedTransportActionId
+                ? Stream.fromEffect(Effect.interrupt)
+                : Stream.make(
+                    progress({
+                      kind: "action_failed",
+                      actionId: failedTransportActionId,
+                      cwd,
+                      action,
+                      phase: "push",
+                      message: "push failed after creating the branch",
+                    }),
+                  ),
         } as unknown as WsRpcProtocolClient;
         const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
           target,
@@ -679,6 +686,21 @@ describe("vcsActionState", () => {
         });
         expect(registry.get(state).revision).toBe(2);
         expect(removed).toEqual([`${environmentId}:*`, `${environmentId}:*`]);
+
+        const interruptedResult = yield* Effect.promise(() =>
+          manager.runStackedAction(targetKey).run(registry, {
+            actionId: interruptedActionId,
+            action,
+          }),
+        );
+
+        expect(AsyncResult.isFailure(interruptedResult)).toBe(true);
+        if (AsyncResult.isFailure(interruptedResult)) {
+          expect(Cause.hasInterruptsOnly(interruptedResult.cause)).toBe(true);
+        }
+        expect(registry.get(manager.stateAtom(targetKey))).toEqual(EMPTY_VCS_ACTION_STATE);
+        expect(registry.get(state).revision).toBe(3);
+        expect(removed).toEqual([`${environmentId}:*`, `${environmentId}:*`, `${environmentId}:*`]);
       }),
     ),
   );

--- a/packages/client-runtime/src/state/vcsAction.ts
+++ b/packages/client-runtime/src/state/vcsAction.ts
@@ -388,14 +388,17 @@ export function applyVcsActionProgressEvent(
       };
     case "action_finished":
       return {
-        ...EMPTY_VCS_ACTION_STATE,
+        ...current,
+        isRunning: true,
         actionId: event.actionId,
         action: event.action,
         operation: "run_change_request",
+        error: null,
       };
     case "action_failed":
       return {
-        ...EMPTY_VCS_ACTION_STATE,
+        ...current,
+        isRunning: true,
         actionId: event.actionId,
         action: event.action,
         operation: "run_change_request",
@@ -492,6 +495,14 @@ export function createVcsActionManager<R, E>(
           },
         ).pipe(
           Effect.ensuring(invalidateCachedVcsRefs(registry, target)),
+          Effect.tap(() =>
+            Effect.sync(() => {
+              const current = registry.get(stateAtom);
+              if (current.actionId === input.actionId) {
+                registry.set(stateAtom, EMPTY_VCS_ACTION_STATE);
+              }
+            }),
+          ),
           Effect.tapError((error) =>
             Effect.sync(() => {
               const current = registry.get(stateAtom);

--- a/packages/client-runtime/src/state/vcsAction.ts
+++ b/packages/client-runtime/src/state/vcsAction.ts
@@ -467,6 +467,12 @@ export function createVcsActionManager<R, E>(
           ...(input.featureBranch ? { featureBranch: true } : {}),
           ...(input.filePaths?.length ? { filePaths: [...input.filePaths] } : {}),
         };
+        const clearOwnedState = Effect.sync(() => {
+          const current = registry.get(stateAtom);
+          if (current.actionId === input.actionId) {
+            registry.set(stateAtom, EMPTY_VCS_ACTION_STATE);
+          }
+        });
         return consumeVcsActionProgress(
           runStreamInEnvironment(
             target.environmentId,
@@ -495,14 +501,7 @@ export function createVcsActionManager<R, E>(
           },
         ).pipe(
           Effect.ensuring(invalidateCachedVcsRefs(registry, target)),
-          Effect.tap(() =>
-            Effect.sync(() => {
-              const current = registry.get(stateAtom);
-              if (current.actionId === input.actionId) {
-                registry.set(stateAtom, EMPTY_VCS_ACTION_STATE);
-              }
-            }),
-          ),
+          Effect.tap(() => clearOwnedState),
           Effect.tapError((error) =>
             Effect.sync(() => {
               const current = registry.get(stateAtom);
@@ -514,6 +513,7 @@ export function createVcsActionManager<R, E>(
               }
             }),
           ),
+          Effect.onInterrupt(() => clearOwnedState),
         );
       },
     });


### PR DESCRIPTION
## Problem

Git commit progress currently appears in a floating loading toast even though the wider commit action button has enough room to communicate the same state in context. The toast obscures the right context panel, duplicates the active action, and makes multi-line pre-commit feedback feel detached from the action producing it.

The VCS action manager already projects the current phase label, elapsed timing source, and latest hook output line, so this presentation did not need a new contract or backend event.

## Fix

- subscribe the commit action button directly to the scoped VCS action state
- expand the active button into two rows:
  - top: the current status (`Generating commit message`, `Running pre-commit hooks`, `Committing`, and related phases) plus elapsed time
  - bottom: the latest pre-commit/hook output line, truncated with the full value available via the native tooltip
- animate the second row and button height while respecting reduced-motion preferences
- remove the in-progress commit toast while retaining success and failure toasts
- add focused presentation tests for active, startup, unrelated, completed, and elapsed-time states

This applies to the shared web UI used by web and desktop. Mobile does not render this right context panel.


https://github.com/user-attachments/assets/477d3205-0661-447b-98fd-72b10b45b387



## Validation

- `vp test run src/components/GitActionsControl.logic.test.ts --project unit` — 66 passed
- `vp run typecheck` in `apps/web` — passed
- targeted `vp fmt --check` — passed
- `vp lint --report-unused-disable-directives` — passed with pre-existing warnings outside the changed files
- `npx -y react-doctor@latest . --verbose --scope changed --base t3code/codex-turn-mapping` — no actionable diagnostics
- `git diff --check` — passed

Visual browser verification was not run because no browser session was authorized for this task.

Built with GPT-5 Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show live git action progress in the commit button
> - Replaces transient loading toasts with inline progress in the commit button: a spinner, status label, elapsed time, and collapsible hook output line are rendered directly in the button while a VCS action is running.
> - Adds `resolveGitActionProgressPresentation` in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/4963/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) to map running VCS action state to a display model, and `formatGitActionElapsed` to format durations as `Xs` or `Ym Zs`.
> - Result toasts are now only shown after completion: errors are sticky, successes auto-dismiss after 10s via `resolveGitActionResultToastTiming`.
> - The quick pull action no longer shows a loading toast; it reports only final success or error.
> - Behavioral Change: `action_finished`/`action_failed` progress events no longer immediately clear running state in [vcsAction.ts](https://github.com/pingdotgg/t3code/pull/4963/files#diff-9d82c1bc86fd3b8f1a9707d02b8e59da5adafee765000496e43fcedb95b0e305); state is cleared only after the command settles, so the button stays in progress mode until the full result is known.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe647d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and presentation-layer changes with focused logic tests; runtime behavior shifts are limited to progress visibility timing and toast patterns, not git execution or auth.
> 
> **Overview**
> **Git commit/pull progress** moves from a floating loading toast into the **disabled primary git action button**: spinner, phase label, live elapsed time, and (for change-request flows) a second truncated hook/output line with full text on hover.
> 
> New helpers in `GitActionsControl.logic` (`resolveGitActionProgressPresentation`, `formatGitActionElapsed`, `resolveGitActionResultToastTiming`) drive that UI and standardize result toasts—**success** auto-dismisses after 10s; **errors** stay until dismissed. Pull quick-action no longer uses an in-progress loading toast.
> 
> **VCS action state** in `vcsAction.ts` keeps `isRunning` true through `action_finished` / `action_failed` so the inline button stays visible until the command settles; state is cleared on success, interrupt, or via `failVcsActionState` on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe647d00b3dc95e2fbb2dd2164bfd3fa89a789cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->