### PR TITLE
feat(web): add file downloads to the Files panel

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -182,6 +182,41 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
+  it.effect("issues attachment URLs for arbitrary workspace files", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-download-workspace-",
+      });
+      const archivePath = path.join(root, "artifacts", "build.t3-bundle");
+      yield* fileSystem.makeDirectory(path.dirname(archivePath), { recursive: true });
+      yield* fileSystem.writeFile(archivePath, new Uint8Array([0, 1, 2, 3]));
+      const canonicalArchivePath = yield* fileSystem.realPath(archivePath);
+
+      const result = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: archivePath,
+          disposition: "attachment",
+        },
+        workspaceRoot: root,
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      expect(yield* resolveAsset(token, "build.t3-bundle")).toEqual({
+        kind: "file",
+        path: canonicalArchivePath,
+        disposition: "attachment",
+      });
+      expect(yield* resolveAsset(token, "other.t3-bundle")).toBeNull();
+      expect(yield* resolveAsset(token, "../build.t3-bundle")).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.effect("issues exact attachment capabilities by attachment id", () =>
     Effect.gen(function* () {
       const config = yield* ServerConfig.ServerConfig;

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -69,6 +69,7 @@ const AssetClaimsSchema = Schema.Union([
     kind: Schema.Literal("workspace-file-exact"),
     workspaceRoot: Schema.String,
     relativePath: Schema.String,
+    disposition: Schema.optionalKey(Schema.Literal("attachment")),
     expiresAt: Schema.Number,
   }),
   Schema.Struct({
@@ -91,7 +92,11 @@ const AssetClaimsJson = Schema.fromJsonString(AssetClaimsSchema);
 const decodeAssetClaims = Schema.decodeUnknownOption(AssetClaimsJson);
 const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
-export type ResolvedAsset = { readonly kind: "file"; readonly path: string };
+export type ResolvedAsset = {
+  readonly kind: "file";
+  readonly path: string;
+  readonly disposition?: "attachment";
+};
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
@@ -203,7 +208,10 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
               }),
           ),
         );
-      if (!isWorkspacePreviewEntryPath(resolved.relativePath)) {
+      if (
+        input.resource.disposition !== "attachment" &&
+        !isWorkspacePreviewEntryPath(resolved.relativePath)
+      ) {
         return yield* new AssetPreviewTypeValidationError({
           resource: input.resource,
         });
@@ -234,21 +242,26 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
             }),
         ),
       );
-      claims = isWorkspaceImagePreviewPath(resolved.relativePath)
-        ? {
-            version: 1,
-            kind: "workspace-file-exact",
-            workspaceRoot: canonicalWorkspaceRoot,
-            relativePath: resolved.relativePath,
-            expiresAt,
-          }
-        : {
-            version: 1,
-            kind: "workspace-file",
-            workspaceRoot: canonicalWorkspaceRoot,
-            baseRelativePath: path.dirname(resolved.relativePath),
-            expiresAt,
-          };
+      claims =
+        input.resource.disposition === "attachment" ||
+        isWorkspaceImagePreviewPath(resolved.relativePath)
+          ? {
+              version: 1,
+              kind: "workspace-file-exact",
+              workspaceRoot: canonicalWorkspaceRoot,
+              relativePath: resolved.relativePath,
+              ...(input.resource.disposition === "attachment"
+                ? { disposition: "attachment" as const }
+                : {}),
+              expiresAt,
+            }
+          : {
+              version: 1,
+              kind: "workspace-file",
+              workspaceRoot: canonicalWorkspaceRoot,
+              baseRelativePath: path.dirname(resolved.relativePath),
+              expiresAt,
+            };
       fileName = path.basename(resolved.relativePath);
       break;
     }
@@ -407,7 +420,11 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
       relativePath: claims.relativePath,
     });
     return exactWorkspaceFile
-      ? ({ kind: "file", path: exactWorkspaceFile } satisfies ResolvedAsset)
+      ? ({
+          kind: "file",
+          path: exactWorkspaceFile,
+          ...(claims.disposition === "attachment" ? { disposition: "attachment" as const } : {}),
+        } satisfies ResolvedAsset)
       : null;
   }
   const segments = decodedPath.split(/[\\/]/);

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -1,7 +1,17 @@
 import { expect, it } from "@effect/vitest";
 import { describe } from "vite-plus/test";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import { isLoopbackHostname, resolveAssetCacheControl, resolveDevRedirectUrl } from "./http.ts";
+
+describe("asset response caching", () => {
+  it("does not cache attachment downloads", () => {
+    expect(resolveAssetCacheControl("attachment")).toBe("private, no-store");
+  });
+
+  it("keeps preview assets cacheable", () => {
+    expect(resolveAssetCacheControl(undefined)).toBe("private, max-age=3600");
+  });
+});
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -27,7 +27,7 @@ import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 import { OtlpTracer } from "effect/unstable/observability";
 
 import * as ServerConfig from "./config.ts";
-import { ASSET_ROUTE_PREFIX, resolveAsset } from "./assets/AssetAccess.ts";
+import { ASSET_ROUTE_PREFIX, resolveAsset, type ResolvedAsset } from "./assets/AssetAccess.ts";
 import * as BrowserTraceCollector from "./observability/BrowserTraceCollector.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import * as HttpResponseCompression from "./httpCompression/HttpResponseCompression.ts";
@@ -45,6 +45,10 @@ const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 const DESKTOP_RENDERER_ORIGINS = ["t3code://app", "t3code-dev://app"];
 const GZIP_MIN_BYTES = 1024;
+
+export function resolveAssetCacheControl(disposition: ResolvedAsset["disposition"]) {
+  return disposition === "attachment" ? "private, no-store" : "private, max-age=3600";
+}
 
 function acceptsGzip(value: string | undefined): boolean {
   if (!value) return false;
@@ -273,7 +277,7 @@ export const assetRouteLayer = HttpRouter.add(
     return yield* HttpServerResponse.file(asset.path, {
       status: 200,
       headers: {
-        "Cache-Control": "private, max-age=3600",
+        "Cache-Control": resolveAssetCacheControl(asset.disposition),
         ...(asset.disposition === "attachment" ? { "Content-Disposition": "attachment" } : {}),
         "X-Content-Type-Options": "nosniff",
       },

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -274,6 +274,7 @@ export const assetRouteLayer = HttpRouter.add(
       status: 200,
       headers: {
         "Cache-Control": "private, max-age=3600",
+        ...(asset.disposition === "attachment" ? { "Content-Disposition": "attachment" } : {}),
         "X-Content-Type-Options": "nosniff",
       },
     }).pipe(

--- a/apps/web/src/browser/downloadWorkspaceFile.test.ts
+++ b/apps/web/src/browser/downloadWorkspaceFile.test.ts
@@ -1,16 +1,50 @@
 import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { downloadWorkspaceFile } from "./downloadWorkspaceFile";
+import { downloadWorkspaceFile, startBrowserDownload } from "./downloadWorkspaceFile";
 
 const threadRef = {
   environmentId: EnvironmentId.make("environment-1"),
   threadId: ThreadId.make("thread-1"),
 };
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("downloadWorkspaceFile", () => {
+  it("keeps fallback navigation out of the current app", () => {
+    const anchor = {
+      click: vi.fn(),
+      download: "",
+      hidden: false,
+      href: "",
+      rel: "",
+      remove: vi.fn(),
+      target: "",
+    };
+    const appendChild = vi.fn();
+    vi.stubGlobal("document", {
+      body: { appendChild },
+      createElement: vi.fn(() => anchor),
+    });
+
+    startBrowserDownload("https://environment.example/api/assets/token/build.zip", "build.zip");
+
+    expect(anchor).toMatchObject({
+      download: "build.zip",
+      hidden: true,
+      href: "https://environment.example/api/assets/token/build.zip",
+      rel: "noopener",
+      target: "_blank",
+    });
+    expect(appendChild).toHaveBeenCalledWith(anchor);
+    expect(anchor.click).toHaveBeenCalledOnce();
+    expect(anchor.remove).toHaveBeenCalledOnce();
+  });
+
   it("requests an attachment URL and starts the browser download", async () => {
     const createAssetUrl = vi.fn().mockResolvedValue(
       AsyncResult.success({

--- a/apps/web/src/browser/downloadWorkspaceFile.test.ts
+++ b/apps/web/src/browser/downloadWorkspaceFile.test.ts
@@ -1,0 +1,64 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { downloadWorkspaceFile } from "./downloadWorkspaceFile";
+
+const threadRef = {
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: ThreadId.make("thread-1"),
+};
+
+describe("downloadWorkspaceFile", () => {
+  it("requests an attachment URL and starts the browser download", async () => {
+    const createAssetUrl = vi.fn().mockResolvedValue(
+      AsyncResult.success({
+        relativeUrl: "/api/assets/token/build.zip",
+        expiresAt: Date.now() + 1_000,
+      }),
+    );
+    const startDownload = vi.fn();
+
+    const result = await downloadWorkspaceFile({
+      threadRef,
+      filePath: "/workspace/artifacts/build.zip",
+      httpBaseUrl: "https://environment.example/base/",
+      createAssetUrl,
+      startDownload,
+    });
+
+    expect(result._tag).toBe("Success");
+    expect(createAssetUrl).toHaveBeenCalledWith({
+      environmentId: threadRef.environmentId,
+      input: {
+        resource: {
+          _tag: "workspace-file",
+          threadId: threadRef.threadId,
+          path: "/workspace/artifacts/build.zip",
+          disposition: "attachment",
+        },
+      },
+    });
+    expect(startDownload).toHaveBeenCalledWith(
+      "https://environment.example/api/assets/token/build.zip",
+      "build.zip",
+    );
+  });
+
+  it("does not start a download when the asset request fails", async () => {
+    const failure = Cause.fail(new Error("asset unavailable"));
+    const startDownload = vi.fn();
+
+    const result = await downloadWorkspaceFile({
+      threadRef,
+      filePath: "artifact.bin",
+      httpBaseUrl: "https://environment.example/",
+      createAssetUrl: vi.fn().mockResolvedValue(AsyncResult.failure(failure)),
+      startDownload,
+    });
+
+    expect(result).toEqual(AsyncResult.failure(failure));
+    expect(startDownload).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/browser/downloadWorkspaceFile.ts
+++ b/apps/web/src/browser/downloadWorkspaceFile.ts
@@ -19,6 +19,8 @@ export function startBrowserDownload(url: string, fileName: string): void {
   const anchor = document.createElement("a");
   anchor.href = url;
   anchor.download = fileName;
+  anchor.target = "_blank";
+  anchor.rel = "noopener";
   anchor.hidden = true;
   document.body.appendChild(anchor);
   anchor.click();

--- a/apps/web/src/browser/downloadWorkspaceFile.ts
+++ b/apps/web/src/browser/downloadWorkspaceFile.ts
@@ -1,0 +1,66 @@
+import type {
+  AssetCreateUrlResult,
+  AssetResource,
+  EnvironmentId,
+  ScopedThreadRef,
+} from "@t3tools/contracts";
+import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+
+import { resolveAssetUrl } from "~/assets/assetUrls";
+
+function fileNameFromPath(path: string): string {
+  const segments = path.split(/[\\/]/);
+  return segments.findLast(Boolean) ?? "download";
+}
+
+export function startBrowserDownload(url: string, fileName: string): void {
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.hidden = true;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+export async function downloadWorkspaceFile<E>(input: {
+  readonly threadRef: ScopedThreadRef;
+  readonly filePath: string;
+  readonly httpBaseUrl: string;
+  readonly createAssetUrl: (input: {
+    readonly environmentId: EnvironmentId;
+    readonly input: { readonly resource: AssetResource };
+  }) => Promise<AtomCommandResult<AssetCreateUrlResult, E>>;
+  readonly startDownload?: (url: string, fileName: string) => void;
+}): Promise<AtomCommandResult<void, E>> {
+  const result = await input.createAssetUrl({
+    environmentId: input.threadRef.environmentId,
+    input: {
+      resource: {
+        _tag: "workspace-file",
+        threadId: input.threadRef.threadId,
+        path: input.filePath,
+        disposition: "attachment",
+      },
+    },
+  });
+  if (result._tag === "Failure") {
+    return AsyncResult.failure(result.cause);
+  }
+
+  const url = resolveAssetUrl(input.httpBaseUrl, result.value.relativeUrl);
+  if (url === null) {
+    return AsyncResult.failure(
+      Cause.die(new Error("The environment returned an invalid asset URL.")),
+    );
+  }
+
+  try {
+    (input.startDownload ?? startBrowserDownload)(url, fileNameFromPath(input.filePath));
+    return AsyncResult.success(undefined);
+  } catch (cause) {
+    return AsyncResult.failure(Cause.die(cause));
+  }
+}

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -20,6 +20,7 @@ import { readLocalApi } from "~/localApi";
 import { T3_PIERRE_ICONS } from "~/pierre-icons";
 
 import { createFileTreeDragMentionController } from "./fileTreeDragMention";
+import { buildFileBrowserContextMenuItems } from "./fileBrowserContextMenu";
 import { useProjectEntriesQuery } from "./projectFilesQueryState";
 
 interface FileBrowserPanelProps {
@@ -27,6 +28,7 @@ interface FileBrowserPanelProps {
   cwd: string;
   projectName: string;
   onOpenFile: (relativePath: string) => void;
+  onDownloadFile: (relativePath: string) => void;
 }
 
 const TREE_UNSAFE_CSS = `
@@ -99,6 +101,7 @@ export default function FileBrowserPanel({
   cwd,
   projectName,
   onOpenFile,
+  onDownloadFile,
 }: FileBrowserPanelProps) {
   const { resolvedTheme } = useTheme();
   const composerRef = useComposerHandleContext();
@@ -143,12 +146,13 @@ export default function FileBrowserPanel({
       : { x: anchorRect.left, y: anchorRect.bottom };
     try {
       const clicked = await api.contextMenu.show(
-        [
-          { id: "copy-mention", label: "Copy mention" },
-          { id: "add-to-chat", label: "Add to chat" },
-        ],
+        buildFileBrowserContextMenuItems(entryKindsRef.current.get(relativePath)),
         position,
       );
+      if (clicked === "download") {
+        onDownloadFile(relativePath);
+        return;
+      }
       if (clicked === "copy-mention") {
         try {
           await writeTextToClipboard(mention);

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -17,6 +17,7 @@ import * as Schema from "effect/Schema";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { isBrowserPreviewFile, openFileInPreview } from "~/browser/openFileInPreview";
+import { downloadWorkspaceFile } from "~/browser/downloadWorkspaceFile";
 import { useAssetUrlState } from "~/assets/assetUrls";
 import ChatMarkdown from "~/components/ChatMarkdown";
 import { OpenInPicker } from "~/components/chat/OpenInPicker";
@@ -754,6 +755,40 @@ export default function FilePreviewPanel({
     })();
   }, [absolutePath, createAssetUrl, environmentHttpBaseUrl, openPreview, threadRef]);
 
+  const handleDownloadFile = useCallback(
+    (downloadRelativePath: string) => {
+      const downloadPath = resolvePathLinkTarget(downloadRelativePath, cwd);
+      if (!environmentHttpBaseUrl) {
+        toastManager.add({
+          type: "error",
+          title: "Unable to download file",
+          description: "The environment is not connected.",
+        });
+        return;
+      }
+      void (async () => {
+        const result = await downloadWorkspaceFile({
+          threadRef,
+          filePath: downloadPath,
+          httpBaseUrl: environmentHttpBaseUrl,
+          createAssetUrl,
+        });
+        if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
+          return;
+        }
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Unable to download file",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      })();
+    },
+    [createAssetUrl, cwd, environmentHttpBaseUrl, threadRef],
+  );
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
       {relativePath ? (
@@ -964,6 +999,7 @@ export default function FilePreviewPanel({
               cwd={cwd}
               projectName={projectName}
               onOpenFile={onOpenFile}
+              onDownloadFile={handleDownloadFile}
             />
           </aside>
         ) : null}

--- a/apps/web/src/components/files/fileBrowserContextMenu.test.ts
+++ b/apps/web/src/components/files/fileBrowserContextMenu.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildFileBrowserContextMenuItems } from "./fileBrowserContextMenu";
+
+describe("buildFileBrowserContextMenuItems", () => {
+  it("offers downloads for files", () => {
+    expect(buildFileBrowserContextMenuItems("file")).toContainEqual({
+      id: "download",
+      label: "Download",
+    });
+  });
+
+  it("does not offer downloads for directories", () => {
+    expect(buildFileBrowserContextMenuItems("directory").map((item) => item.id)).not.toContain(
+      "download",
+    );
+  });
+});

--- a/apps/web/src/components/files/fileBrowserContextMenu.ts
+++ b/apps/web/src/components/files/fileBrowserContextMenu.ts
@@ -1,0 +1,13 @@
+import type { ContextMenuItem, ProjectEntry } from "@t3tools/contracts";
+
+export type FileBrowserContextMenuAction = "download" | "copy-mention" | "add-to-chat";
+
+export function buildFileBrowserContextMenuItems(
+  kind: ProjectEntry["kind"] | undefined,
+): readonly ContextMenuItem<FileBrowserContextMenuAction>[] {
+  return [
+    ...(kind === "file" ? [{ id: "download" as const, label: "Download" }] : []),
+    { id: "copy-mention", label: "Copy mention" },
+    { id: "add-to-chat", label: "Add to chat" },
+  ];
+}

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -8,6 +8,7 @@ export const AssetResource = Schema.Union([
   Schema.TaggedStruct("workspace-file", {
     threadId: ThreadId,
     path: TrimmedNonEmptyString.check(Schema.isMaxLength(ASSET_PATH_MAX_LENGTH)),
+    disposition: Schema.optionalKey(Schema.Literal("attachment")),
   }),
   Schema.TaggedStruct("attachment", {
     attachmentId: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),


### PR DESCRIPTION
## What Changed

Added a **Download** action to the right-click menu for files in the right-side Files panel.

Downloads use a signed attachment URL from the connected environment, preserving the original file contents and supporting binary and large files. The action works with both local and remote environments and is not shown for folders.

## Why

The Files panel allowed users to open files, copy mentions, and add files to chat, but it did not provide a way to download them.

Using the existing signed asset endpoint keeps the implementation remote-ready and avoids the limitations of the text-preview API, which rejects binary files and truncates large files.

## UI Changes

### Before

<img width="548" height="329" alt="before" src="https://github.com/user-attachments/assets/816de66e-202c-4e62-a741-4a9d19eb5453" />

### After

<img width="548" height="326" alt="after" src="https://github.com/user-attachments/assets/646d408b-0457-475b-9971-b024f338f457" />

### Interaction

https://github.com/user-attachments/assets/1e9d7eed-2c98-45d6-a4f9-a7fb384c2deb

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the signed asset endpoint to arbitrary workspace files when disposition is attachment, which is intentional but increases the sensitivity of correct path scoping and token validation on the existing asset security boundary.
> 
> **Overview**
> Adds **Download** to the Files panel context menu for file entries (not folders). Downloads go through the existing signed asset API instead of the text-preview path, so binary and large files keep full contents.
> 
> The `workspace-file` asset resource now accepts optional **`disposition: "attachment`**. Issuing skips preview-only type checks for attachments, uses exact workspace-file claims with disposition encoded in the token, and resolution returns that disposition. Asset HTTP responses set **`Content-Disposition: attachment`** and **`Cache-Control: private, no-store`** for downloads while preview assets stay cacheable.
> 
> The web layer adds **`downloadWorkspaceFile`** (requests the attachment URL, triggers download via a hidden anchor with `target="_blank"`) and wires it from **`FilePreviewPanel`** into **`FileBrowserPanel`** via **`buildFileBrowserContextMenuItems`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a4f7780edc65815d554d8c49f30fe3004911997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file download support to the Files panel
> - Adds a Download context menu item for files in the file browser, wired through `FileBrowserPanel` via a new `onDownloadFile` prop and built by a new `buildFileBrowserContextMenuItems` helper.
> - Implements `downloadWorkspaceFile` in [downloadWorkspaceFile.ts](https://github.com/pingdotgg/t3code/pull/4966/files#diff-85ec2c4a47be6014f116150446a586ef9744ca4c9f91e25b469d61b2c578cb1c), which requests a workspace-file asset URL with `disposition: "attachment"` and triggers a browser download via a hidden anchor element.
> - Extends the asset pipeline in `AssetAccess` and the contracts schema to support `disposition: "attachment"` on workspace-file claims, encoding it in the signed token and returning it in the resolved asset.
> - Sets `Content-Disposition: attachment` and `Cache-Control: private, no-store` response headers for attachment assets in the HTTP asset route handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a4f778.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->