### PR TITLE
fix(web): allow removing stale Connect environments

### DIFF
--- a/apps/web/src/cloud/linkEnvironment.test.ts
+++ b/apps/web/src/cloud/linkEnvironment.test.ts
@@ -33,6 +33,7 @@ import {
   readPrimaryCloudLinkState,
   type CloudLinkTarget,
   unlinkPrimaryEnvironmentFromCloud,
+  unlinkRelayEnvironmentFromCloud,
   updatePrimaryCloudPreferences,
 } from "./linkEnvironment";
 
@@ -434,6 +435,26 @@ describe("web cloud link environment client", () => {
       expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
         `/v1/client/environment-links/${TARGET.environmentId}`,
       );
+    }),
+  );
+
+  it.effect("unlinks an inaccessible environment directly through the relay", () =>
+    Effect.gen(function* () {
+      const fetchMock = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      yield* withServices(
+        unlinkRelayEnvironmentFromCloud({
+          environmentId: EnvironmentId.make("stale-environment"),
+          clerkToken: "clerk-token",
+        }),
+      );
+
+      expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+        "/v1/client/environment-links/stale-environment",
+      );
+      expect(fetchMock.mock.calls[0]?.[1]?.method).toBe("DELETE");
+      expect(fetchMock.mock.calls[0]?.[1]?.headers.authorization).toBe("Bearer clerk-token");
     }),
   );
 });

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -385,6 +385,17 @@ export function unlinkPrimaryEnvironmentFromCloud(input: {
   }).pipe(Effect.provide(primaryEnvironmentHttpLayer));
 }
 
+export function unlinkRelayEnvironmentFromCloud(input: {
+  readonly environmentId: EnvironmentId;
+  readonly clerkToken: string;
+}): Effect.Effect<void, CloudEnvironmentLinkError, ManagedRelay.ManagedRelayClient> {
+  return ManagedRelay.ManagedRelayClient.pipe(
+    Effect.flatMap((client) => client.unlinkEnvironment(input)),
+    Effect.mapError(decodedRelayClientError("Could not unlink the T3 Connect environment.")),
+    Effect.asVoid,
+  );
+}
+
 // "publish_only" links the environment to the relay for agent-activity
 // publishing alone: no managed tunnel is provisioned, so it can be toggled
 // independently of T3 Connect while clients reach the environment out of band.

--- a/apps/web/src/cloud/linkEnvironmentAtoms.ts
+++ b/apps/web/src/cloud/linkEnvironmentAtoms.ts
@@ -2,6 +2,7 @@ import {
   createAtomCommandScheduler,
   createRuntimeCommand,
 } from "@t3tools/client-runtime/state/runtime";
+import type { EnvironmentId } from "@t3tools/contracts";
 
 import { connectionAtomRuntime } from "../connection/runtime";
 import {
@@ -9,6 +10,7 @@ import {
   type CloudLinkMode,
   type CloudLinkTarget,
   unlinkPrimaryEnvironmentFromCloud,
+  unlinkRelayEnvironmentFromCloud,
   updatePrimaryCloudPreferences,
 } from "./linkEnvironment";
 
@@ -35,6 +37,17 @@ export const unlinkPrimaryEnvironment = createRuntimeCommand(connectionAtomRunti
   concurrency: cloudLinkConcurrency,
   execute: (input: { readonly target: CloudLinkTarget; readonly clerkToken: string | null }) =>
     unlinkPrimaryEnvironmentFromCloud(input),
+});
+
+export const unlinkRelayEnvironment = createRuntimeCommand(connectionAtomRuntime, {
+  label: "web:cloud:unlink-relay-environment",
+  scheduler: cloudLinkScheduler,
+  concurrency: {
+    mode: "serial",
+    key: (input: { readonly environmentId: EnvironmentId }) => input.environmentId,
+  },
+  execute: (input: { readonly environmentId: EnvironmentId; readonly clerkToken: string }) =>
+    unlinkRelayEnvironmentFromCloud(input),
 });
 
 export const updatePrimaryEnvironmentPreferences = createRuntimeCommand(connectionAtomRuntime, {

--- a/apps/web/src/components/cloud/CloudEnvironmentConnectList.tsx
+++ b/apps/web/src/components/cloud/CloudEnvironmentConnectList.tsx
@@ -6,6 +6,7 @@ import {
 } from "@t3tools/client-runtime/connection";
 import {
   isAtomCommandInterrupted,
+  settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import type { EnvironmentId } from "@t3tools/contracts";
@@ -14,6 +15,8 @@ import * as Option from "effect/Option";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 
 import { environmentCatalog } from "~/connection/catalog";
+import { readManagedRelayClerkToken } from "~/cloud/managedAuth";
+import { unlinkRelayEnvironment } from "~/cloud/linkEnvironmentAtoms";
 import { cn } from "~/lib/utils";
 import { relayEnvironmentDiscovery } from "~/state/relay";
 import { useRelayEnvironmentDiscovery } from "~/state/environments";
@@ -21,6 +24,15 @@ import { useAtomCommand } from "~/state/use-atom-command";
 import { ConnectionStatusDot } from "../ConnectionStatusDot";
 import { ITEM_ROW_CLASSNAME, ITEM_ROW_INNER_CLASSNAME } from "../settings/itemRows";
 import { Button } from "../ui/button";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "../ui/alert-dialog";
 import { Skeleton } from "../ui/skeleton";
 import { toastManager } from "../ui/toast";
 import { presentSavedCloudEnvironmentConnection } from "./cloudEnvironmentConnectionPresentation";
@@ -69,6 +81,9 @@ export function CloudEnvironmentConnectRows({
   const refreshRelayEnvironments = useAtomCommand(relayEnvironmentDiscovery.refresh, {
     reportFailure: false,
   });
+  const unlinkEnvironment = useAtomCommand(unlinkRelayEnvironment, {
+    reportFailure: false,
+  });
   const connectRelayEnvironment = useCallback(
     (environment: RelayClientEnvironmentRecord) =>
       registerEnvironment(
@@ -84,6 +99,8 @@ export function CloudEnvironmentConnectRows({
   const [connectingEnvironmentId, setConnectingEnvironmentId] = useState<EnvironmentId | null>(
     null,
   );
+  const [removingEnvironmentId, setRemovingEnvironmentId] = useState<EnvironmentId | null>(null);
+  const [pendingRemoval, setPendingRemoval] = useState<RelayClientEnvironmentRecord | null>(null);
   const savedById = new Map(
     savedEnvironments.map((environment) => [environment.environmentId, environment]),
   );
@@ -115,6 +132,60 @@ export function CloudEnvironmentConnectRows({
     toastManager.add({
       type: "error",
       title: "Could not connect environment",
+      description: message,
+      data: traceId
+        ? {
+            secondaryActionProps: {
+              children: "Copy trace ID",
+              onClick: () => void navigator.clipboard?.writeText(traceId),
+            },
+          }
+        : undefined,
+    });
+  };
+
+  const removeEnvironment = async () => {
+    if (!pendingRemoval) return;
+    const environment = pendingRemoval;
+    setRemovingEnvironmentId(environment.environmentId);
+    const tokenResult = await settlePromise(readManagedRelayClerkToken);
+    if (tokenResult._tag === "Failure" || !tokenResult.value) {
+      const cause =
+        tokenResult._tag === "Failure"
+          ? squashAtomCommandFailure(tokenResult)
+          : new Error("Sign in to T3 Connect before removing an environment.");
+      reportRemovalFailure(cause);
+      setRemovingEnvironmentId(null);
+      return;
+    }
+    const result = await unlinkEnvironment({
+      environmentId: environment.environmentId,
+      clerkToken: tokenResult.value,
+    });
+    setRemovingEnvironmentId(null);
+    if (result._tag === "Success") {
+      setPendingRemoval(null);
+      await refreshRelayEnvironments();
+      toastManager.add({
+        type: "success",
+        title: "Environment removed",
+        description: `${environment.label} is no longer linked to T3 Connect.`,
+      });
+      return;
+    }
+    if (!isAtomCommandInterrupted(result)) {
+      reportRemovalFailure(squashAtomCommandFailure(result));
+    }
+  };
+
+  const reportRemovalFailure = (cause: unknown) => {
+    const message =
+      cause instanceof Error ? cause.message : "Could not remove the T3 Connect environment.";
+    const traceId = findErrorTraceId(cause);
+    console.error("[t3-connect] Could not remove environment", { message, traceId, cause });
+    toastManager.add({
+      type: "error",
+      title: "Could not remove environment",
       description: message,
       data: traceId
         ? {
@@ -171,90 +242,142 @@ export function CloudEnvironmentConnectRows({
     return empty;
   }
 
-  return visibleEnvironments.map(({ environment, availability, error }) => {
-    const savedEnvironment = savedById.get(environment.environmentId);
-    const savedConnection = savedEnvironment
-      ? presentSavedCloudEnvironmentConnection(savedEnvironment.connection)
-      : null;
-    const dotClassName = savedConnection
-      ? savedConnection.tone === "connected"
-        ? "bg-success"
-        : savedConnection.tone === "connecting"
-          ? "bg-warning"
-          : savedConnection.tone === "error"
-            ? "bg-destructive"
-            : "bg-muted-foreground/35"
-      : availability === "online"
-        ? "bg-success"
-        : availability === "error"
-          ? "bg-destructive"
-          : availability === "checking"
-            ? "bg-warning"
-            : "bg-muted-foreground/35";
-    const statusText = savedConnection
-      ? savedConnection.statusText
-      : availability === "online"
-        ? "Available · Relay online"
-        : availability === "offline"
-          ? "Available · Relay offline"
-          : availability === "checking"
-            ? "Available · Checking relay status…"
-            : (Option.getOrNull(error)?.message ?? "Available · Relay status unavailable");
-    return (
-      <div key={environment.environmentId} className={ITEM_ROW_CLASSNAME}>
-        <div className={ITEM_ROW_INNER_CLASSNAME}>
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <ConnectionStatusDot
-                dotClassName={dotClassName}
-                pingClassName={
-                  savedConnection?.tone === "connecting" ||
-                  (savedConnection === null && availability === "checking")
-                    ? "bg-warning/60 duration-2000"
-                    : null
-                }
-                tooltipText={
-                  savedConnection
-                    ? savedConnection.statusText
-                    : availability === "online"
-                      ? "Relay online"
-                      : availability === "offline"
-                        ? "Relay offline"
-                        : availability === "checking"
-                          ? "Checking relay status"
-                          : (Option.getOrNull(error)?.message ?? "Relay status unavailable")
-                }
-              />
-              <p className="truncate text-sm font-medium">{environment.label}</p>
-            </div>
-            <p
-              className={cn(
-                "mt-1 truncate text-xs",
-                savedConnection?.tone === "error" ||
-                  (savedConnection?.tone === "connecting" && savedEnvironment?.connection.error) ||
-                  (savedConnection === null && availability === "error")
-                  ? "text-destructive"
-                  : "text-muted-foreground",
+  return (
+    <>
+      {visibleEnvironments.map(({ environment, availability, error }) => {
+        const savedEnvironment = savedById.get(environment.environmentId);
+        const savedConnection = savedEnvironment
+          ? presentSavedCloudEnvironmentConnection(savedEnvironment.connection)
+          : null;
+        const dotClassName = savedConnection
+          ? savedConnection.tone === "connected"
+            ? "bg-success"
+            : savedConnection.tone === "connecting"
+              ? "bg-warning"
+              : savedConnection.tone === "error"
+                ? "bg-destructive"
+                : "bg-muted-foreground/35"
+          : availability === "online"
+            ? "bg-success"
+            : availability === "error"
+              ? "bg-destructive"
+              : availability === "checking"
+                ? "bg-warning"
+                : "bg-muted-foreground/35";
+        const statusText = savedConnection
+          ? savedConnection.statusText
+          : availability === "online"
+            ? "Available · Relay online"
+            : availability === "offline"
+              ? "Available · Relay offline"
+              : availability === "checking"
+                ? "Available · Checking relay status…"
+                : (Option.getOrNull(error)?.message ?? "Available · Relay status unavailable");
+        return (
+          <div key={environment.environmentId} className={ITEM_ROW_CLASSNAME}>
+            <div className={ITEM_ROW_INNER_CLASSNAME}>
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <ConnectionStatusDot
+                    dotClassName={dotClassName}
+                    pingClassName={
+                      savedConnection?.tone === "connecting" ||
+                      (savedConnection === null && availability === "checking")
+                        ? "bg-warning/60 duration-2000"
+                        : null
+                    }
+                    tooltipText={
+                      savedConnection
+                        ? savedConnection.statusText
+                        : availability === "online"
+                          ? "Relay online"
+                          : availability === "offline"
+                            ? "Relay offline"
+                            : availability === "checking"
+                              ? "Checking relay status"
+                              : (Option.getOrNull(error)?.message ?? "Relay status unavailable")
+                    }
+                  />
+                  <p className="truncate text-sm font-medium">{environment.label}</p>
+                </div>
+                <p
+                  className={cn(
+                    "mt-1 truncate text-xs",
+                    savedConnection?.tone === "error" ||
+                      (savedConnection?.tone === "connecting" &&
+                        savedEnvironment?.connection.error) ||
+                      (savedConnection === null && availability === "error")
+                      ? "text-destructive"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {statusText}
+                </p>
+              </div>
+              {savedConnection ? (
+                <Button size="sm" variant="outline" disabled>
+                  {savedConnection.buttonLabel}
+                </Button>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="destructive-outline"
+                    disabled={connectingEnvironmentId !== null || removingEnvironmentId !== null}
+                    onClick={() => setPendingRemoval(environment)}
+                  >
+                    Remove
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={connectingEnvironmentId !== null || removingEnvironmentId !== null}
+                    onClick={() => void connectEnvironment(environment)}
+                  >
+                    {connectingEnvironmentId === environment.environmentId
+                      ? "Connecting…"
+                      : "Connect"}
+                  </Button>
+                </div>
               )}
-            >
-              {statusText}
-            </p>
+            </div>
           </div>
-          {savedConnection ? (
-            <Button size="sm" variant="outline" disabled>
-              {savedConnection.buttonLabel}
-            </Button>
-          ) : (
-            <Button
-              size="sm"
-              disabled={connectingEnvironmentId !== null}
-              onClick={() => void connectEnvironment(environment)}
+        );
+      })}
+      <AlertDialog
+        open={pendingRemoval !== null}
+        onOpenChange={(open) => {
+          if (!open && removingEnvironmentId === null) setPendingRemoval(null);
+        }}
+      >
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove T3 Connect environment?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingRemoval ? (
+                <>
+                  <span className="font-medium text-foreground">{pendingRemoval.label}</span> (
+                  <code>{pendingRemoval.environmentId}</code>) will be unlinked from your account.
+                  You will need access to that environment to link it again.
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose
+              render={<Button variant="outline" disabled={removingEnvironmentId !== null} />}
             >
-              {connectingEnvironmentId === environment.environmentId ? "Connecting…" : "Connect"}
+              Cancel
+            </AlertDialogClose>
+            <Button
+              variant="destructive"
+              disabled={removingEnvironmentId !== null}
+              onClick={() => void removeEnvironment()}
+            >
+              {removingEnvironmentId !== null ? "Removing…" : "Remove environment"}
             </Button>
-          )}
-        </div>
-      </div>
-    );
-  });
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </>
+  );
 }


### PR DESCRIPTION
## Problem

T3 Connect environments discovered through the relay only offered **Connect**. If the original machine was lost or rebuilt, users could not unlink its stale relay record because `t3 connect unlink` always targets the machine running the command.

## Fix

- add a **Remove** action to relay-discovered environment rows
- require destructive confirmation that identifies the environment by label and ID
- call the existing authenticated relay `unlinkEnvironment` operation
- refresh discovery and report success or trace-aware failure
- cover the direct relay unlink request with a focused test

This stays web-only; desktop inherits the web surface. It does not add a new relay contract or expand the CLI.

Fixes #4965.

## Validation

- `vp test run src/cloud/linkEnvironment.test.ts --project unit --passWithNoTests` — 10 tests passed
- `pnpm typecheck` in `apps/web`
- targeted `vp lint` for the four changed files
- `pnpm build` in `apps/web`

## UI evidence

### Before — existing connected environment

![Before: existing connected environment](https://raw.githubusercontent.com/soestin/t3code/pr-assets/4968/pr-assets/4968/before.png)

### After — stale environment can be removed

![After: stale environment row with Remove action](https://raw.githubusercontent.com/soestin/t3code/pr-assets/4968/pr-assets/4968/after.png)

### Confirmation

![Confirmation dialog identifies the environment before unlinking](https://raw.githubusercontent.com/soestin/t3code/pr-assets/4968/pr-assets/4968/confirmation.png)

Generated with GPT-5.6-sol through the T3 Code Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Remove button to Connect environment list to unlink stale relay environments
> - Adds `unlinkRelayEnvironmentFromCloud` in [linkEnvironment.ts](https://github.com/pingdotgg/t3code/pull/4968/files#diff-4779753c4f4f62d3a9b8e590c438d2420171ed7338960fa78f2f0b849b66dc55) that calls the relay client's `unlinkEnvironment` method via a DELETE request to `/v1/client/environment-links/:environmentId`.
> - Adds an `unlinkRelayEnvironment` atom command in [linkEnvironmentAtoms.ts](https://github.com/pingdotgg/t3code/pull/4968/files#diff-74966d5ed6fc73425fd9ec2b48532bca3f38f28a2640a63f8d3c925df72b8854) that serializes execution per `environmentId`.
> - Updates [CloudEnvironmentConnectList.tsx](https://github.com/pingdotgg/t3code/pull/4968/files#diff-18f369a6fd1384b0ae3c2fafe9e8415f7fbe2977bb50cd533d98c0a81772299b) to show a destructive 'Remove' button per row; clicking it opens a confirmation dialog, then calls the unlink command, refreshes the list, and shows a success or error toast.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 902a37c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes account-linked environment records via the relay API with destructive UI; scope is web-only and reuses existing unlink contracts rather than new auth paths.
> 
> **Overview**
> Users can **unlink stale T3 Connect environments** from relay discovery when the original machine is gone—without running unlink on that host.
> 
> Relay-discovered rows that are not already saved now show **Remove** next to **Connect**. Remove opens a confirmation dialog (label + environment ID), then calls the existing authenticated relay **`unlinkEnvironment`** path via new `unlinkRelayEnvironmentFromCloud` and the `unlinkRelayEnvironment` atom command. On success the list refreshes and a toast confirms; failures surface trace-aware errors. Saved/connected rows still only show the disabled connection state—no Remove there.
> 
> A unit test asserts the direct relay DELETE to `/v1/client/environment-links/:id` with the Clerk bearer token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 902a37c54dda6af7f809ad554fd0df2e9ad868cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->