### PR TITLE
perf(orchestration): per-thread shell deltas, visit throttling, event compaction

### DIFF
--- a/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
+++ b/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
@@ -265,49 +265,140 @@ it.layer(TestLayer)("orchestration V2 foundation persistence", (it) => {
     }),
   );
 
-  it.effect("compacts superseded thread.visited events, keeping the newest per thread", () =>
+  it.effect("compacts superseded state events, imported v1 events, and legacy receipts", () =>
     Effect.gen(function* () {
       const eventSink = yield* EventSinkV2;
       const maintenance = yield* ProjectionMaintenanceV2;
       const sql = yield* SqlClient.SqlClient;
       const now = yield* DateTime.now;
-      const threadId = ThreadId.make("thread:foundation-compact-visits");
+      const nowIso = DateTime.formatIso(now);
+      const threadId = ThreadId.make("thread:foundation-compact");
       const thread = makeThread(threadId, now);
-      const visitedEvent = (suffix: string): OrchestrationV2DomainEvent => ({
-        id: EventId.make(`event:foundation-compact-visits:${suffix}`),
-        type: "thread.visited",
+      const messageId = MessageId.make("message:foundation-compact");
+      const threadStateEvent = (
+        suffix: string,
+        type: "thread.visited" | "thread.metadata-updated",
+      ): OrchestrationV2DomainEvent => ({
+        id: EventId.make(`event:foundation-compact:${suffix}`),
+        type,
         threadId,
         providerInstanceId,
         occurredAt: now,
         payload: { ...thread, lastVisitedAt: now },
       });
+      const messageEvent = (suffix: string, text: string): OrchestrationV2DomainEvent => ({
+        id: EventId.make(`event:foundation-compact:${suffix}`),
+        type: "message.updated",
+        threadId,
+        occurredAt: now,
+        payload: {
+          createdBy: "user",
+          creationSource: "web",
+          id: messageId,
+          threadId,
+          runId: null,
+          nodeId: null,
+          role: "user",
+          text,
+          attachments: [],
+          streaming: false,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
 
       yield* eventSink.write({
         events: [
-          threadCreatedEvent({ id: "event:foundation-compact-visits:create", thread, now }),
-          visitedEvent("first"),
-          visitedEvent("second"),
-          visitedEvent("third"),
+          threadCreatedEvent({ id: "event:foundation-compact:create", thread, now }),
+          threadStateEvent("meta", "thread.metadata-updated"),
+          threadStateEvent("visit-1", "thread.visited"),
+          threadStateEvent("visit-2", "thread.visited"),
+          messageEvent("message-1", "streaming"),
+          messageEvent("message-2", "final"),
         ],
       });
 
-      const summary = yield* maintenance.compactReadStateEvents;
-      assert.isAtLeast(summary.deletedEventCount, 2);
+      // A fully imported legacy thread: its v1 events and pre-migration
+      // receipts are dead weight; a still-pending import keeps its rows.
+      const importedV1ThreadId = "thread:foundation-compact-v1-imported";
+      const pendingV1ThreadId = "thread:foundation-compact-v1-pending";
+      const insertV1Event = (threadIdValue: string, version: number) => sql`
+        INSERT INTO orchestration_events (
+          event_id, aggregate_kind, stream_id, stream_version, event_type,
+          occurred_at, actor_kind, payload_json, metadata_json, application_event_version
+        )
+        VALUES (
+          ${`event:v1:${threadIdValue}:${version}`}, 'thread', ${threadIdValue}, ${version},
+          'thread.message-appended', ${nowIso}, 'user', '{}', '{}', 1
+        )
+      `;
+      yield* insertV1Event(importedV1ThreadId, 1);
+      yield* insertV1Event(importedV1ThreadId, 2);
+      yield* insertV1Event(pendingV1ThreadId, 1);
+      yield* sql`
+        INSERT INTO orchestration_v2_legacy_imports (
+          thread_id, source_updated_at, shell_imported_at, transcript_imported_at,
+          imported_message_count, last_error
+        )
+        VALUES
+          (${importedV1ThreadId}, ${nowIso}, ${nowIso}, ${nowIso}, 2, NULL),
+          (${pendingV1ThreadId}, ${nowIso}, ${nowIso}, NULL, 0, NULL)
+        ON CONFLICT(thread_id) DO NOTHING
+      `;
+      yield* sql`
+        INSERT INTO orchestration_command_receipts (
+          command_id, aggregate_kind, aggregate_id, accepted_at, result_sequence, status, command_type
+        )
+        VALUES
+          ('command:foundation-compact:legacy', 'thread', ${importedV1ThreadId}, ${nowIso}, 1, 'accepted', 'legacy'),
+          ('command:foundation-compact:pending', 'thread', ${pendingV1ThreadId}, ${nowIso}, 1, 'accepted', 'legacy')
+        ON CONFLICT(command_id) DO NOTHING
+      `;
+
+      const summary = yield* maintenance.compactEventStore;
+      // meta + visit-1 (superseded thread state), message-1, and the two
+      // imported v1 events.
+      assert.isAtLeast(summary.deletedEventCount, 5);
+      assert.isAtLeast(summary.deletedReceiptCount, 1);
 
       const remaining = yield* sql<{ readonly event_id: string }>`
         SELECT event_id
         FROM orchestration_events
         WHERE aggregate_kind = 'thread'
           AND stream_id = ${threadId}
-          AND event_type = 'thread.visited'
         ORDER BY sequence ASC
       `;
       assert.deepEqual(
         remaining.map((row) => row.event_id),
-        ["event:foundation-compact-visits:third"],
+        [
+          "event:foundation-compact:create",
+          "event:foundation-compact:visit-2",
+          "event:foundation-compact:message-2",
+        ],
       );
 
-      // Replay across the deletion gap must still produce a valid projection.
+      const remainingV1 = yield* sql<{ readonly stream_id: string }>`
+        SELECT stream_id
+        FROM orchestration_events
+        WHERE application_event_version = 1
+          AND stream_id IN (${importedV1ThreadId}, ${pendingV1ThreadId})
+      `;
+      assert.deepEqual(
+        remainingV1.map((row) => row.stream_id),
+        [pendingV1ThreadId],
+      );
+
+      const remainingReceipts = yield* sql<{ readonly command_id: string }>`
+        SELECT command_id
+        FROM orchestration_command_receipts
+        WHERE command_id IN ('command:foundation-compact:legacy', 'command:foundation-compact:pending')
+      `;
+      assert.deepEqual(
+        remainingReceipts.map((row) => row.command_id),
+        ["command:foundation-compact:pending"],
+      );
+
+      // Replay across the deletion gaps must still produce a valid projection.
       assert.isTrue((yield* maintenance.verify).valid);
       assert.isTrue((yield* maintenance.rebuild).valid);
     }),

--- a/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
+++ b/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
@@ -265,6 +265,54 @@ it.layer(TestLayer)("orchestration V2 foundation persistence", (it) => {
     }),
   );
 
+  it.effect("compacts superseded thread.visited events, keeping the newest per thread", () =>
+    Effect.gen(function* () {
+      const eventSink = yield* EventSinkV2;
+      const maintenance = yield* ProjectionMaintenanceV2;
+      const sql = yield* SqlClient.SqlClient;
+      const now = yield* DateTime.now;
+      const threadId = ThreadId.make("thread:foundation-compact-visits");
+      const thread = makeThread(threadId, now);
+      const visitedEvent = (suffix: string): OrchestrationV2DomainEvent => ({
+        id: EventId.make(`event:foundation-compact-visits:${suffix}`),
+        type: "thread.visited",
+        threadId,
+        providerInstanceId,
+        occurredAt: now,
+        payload: { ...thread, lastVisitedAt: now },
+      });
+
+      yield* eventSink.write({
+        events: [
+          threadCreatedEvent({ id: "event:foundation-compact-visits:create", thread, now }),
+          visitedEvent("first"),
+          visitedEvent("second"),
+          visitedEvent("third"),
+        ],
+      });
+
+      const summary = yield* maintenance.compactReadStateEvents;
+      assert.isAtLeast(summary.deletedEventCount, 2);
+
+      const remaining = yield* sql<{ readonly event_id: string }>`
+        SELECT event_id
+        FROM orchestration_events
+        WHERE aggregate_kind = 'thread'
+          AND stream_id = ${threadId}
+          AND event_type = 'thread.visited'
+        ORDER BY sequence ASC
+      `;
+      assert.deepEqual(
+        remaining.map((row) => row.event_id),
+        ["event:foundation-compact-visits:third"],
+      );
+
+      // Replay across the deletion gap must still produce a valid projection.
+      assert.isTrue((yield* maintenance.verify).valid);
+      assert.isTrue((yield* maintenance.rebuild).valid);
+    }),
+  );
+
   it.effect("verifies and rebuilds projections with cross-thread subagent relations", () =>
     Effect.gen(function* () {
       const eventSink = yield* EventSinkV2;

--- a/apps/server/src/orchestration-v2/LegacyV1ThreadImporter.ts
+++ b/apps/server/src/orchestration-v2/LegacyV1ThreadImporter.ts
@@ -488,6 +488,13 @@ const make = Effect.gen(function* () {
     ),
   );
 
+  // Threads whose transcript import this process has already confirmed.
+  // `transcript_imported_at` is never reset to NULL, so a positive answer
+  // stays valid for the process lifetime; ensureTranscript runs on most
+  // thread reads and command dispatches, so skipping the lock + lookup here
+  // keeps that path off the database entirely after first confirmation.
+  const confirmedTranscriptThreadIds = new Set<ThreadId>();
+
   const ensureTranscriptBase = (threadId: ThreadId) =>
     transcriptImports.withLock(
       threadId,
@@ -500,6 +507,9 @@ const make = Effect.gen(function* () {
         `;
         const imported = imports[0];
         if (imported === undefined || imported.transcript_imported_at !== null) {
+          if (imported !== undefined) {
+            confirmedTranscriptThreadIds.add(threadId);
+          }
           return { importedThreadCount: 0, importedMessageCount: 0 };
         }
         const messages = yield* listMessages(threadId);
@@ -546,6 +556,7 @@ const make = Effect.gen(function* () {
             last_error = NULL
           WHERE thread_id = ${threadId}
         `;
+        confirmedTranscriptThreadIds.add(threadId);
         return {
           importedThreadCount: 1,
           importedMessageCount: missing.length,
@@ -554,16 +565,18 @@ const make = Effect.gen(function* () {
     );
 
   const ensureTranscript = (threadId: ThreadId) =>
-    ensureTranscriptBase(threadId).pipe(
-      Effect.mapError(
-        (cause) =>
-          new LegacyV1ThreadImportError({
-            operation: "hydrate transcript for",
-            threadId,
-            cause,
-          }),
-      ),
-    );
+    confirmedTranscriptThreadIds.has(threadId)
+      ? Effect.succeed({ importedThreadCount: 0, importedMessageCount: 0 })
+      : ensureTranscriptBase(threadId).pipe(
+          Effect.mapError(
+            (cause) =>
+              new LegacyV1ThreadImportError({
+                operation: "hydrate transcript for",
+                threadId,
+                cause,
+              }),
+          ),
+        );
 
   const importPendingTranscripts = Effect.gen(function* () {
     const rows = yield* sql<LegacyImportRow>`

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -15,6 +15,7 @@ import {
   type OrchestrationV2ProviderTurn,
   type OrchestrationV2Run,
   type OrchestrationV2RunAttempt,
+  type OrchestrationV2ThreadShell,
   type OrchestrationV2ThreadShellSnapshot,
   type OrchestrationV2StoredEvent,
   type OrchestrationV2Subagent,
@@ -160,6 +161,9 @@ export interface OrchestratorV2Shape {
     OrchestrationV2ThreadShellSnapshot,
     OrchestratorV2Error
   >;
+  readonly getThreadShell: (
+    threadId: ThreadId,
+  ) => Effect.Effect<OrchestrationV2ThreadShell | null, OrchestratorV2Error>;
   readonly getThreadEventSequence: (
     threadId: ThreadId,
   ) => Effect.Effect<number, OrchestratorV2Error>;
@@ -5999,6 +6003,10 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
             }),
         ),
       ),
+    getThreadShell: (threadId) =>
+      projectionStore
+        .getThreadShell(threadId)
+        .pipe(Effect.mapError((cause) => new OrchestratorProjectionError({ threadId, cause }))),
     getThreadEventSequence: (threadId) =>
       eventSink
         .latestSequence({ threadId })
@@ -6085,6 +6093,13 @@ export const layerUnavailable: Layer.Layer<OrchestratorV2> = Layer.succeed(
       Effect.fail(
         new OrchestratorProjectionError({
           threadId: ThreadId.make("thread:shell"),
+          cause: "Orchestration V2 live runtime is not configured.",
+        }),
+      ),
+    getThreadShell: (threadId) =>
+      Effect.fail(
+        new OrchestratorProjectionError({
+          threadId,
           cause: "Orchestration V2 live runtime is not configured.",
         }),
       ),

--- a/apps/server/src/orchestration-v2/ProjectionMaintenance.ts
+++ b/apps/server/src/orchestration-v2/ProjectionMaintenance.ts
@@ -34,6 +34,10 @@ export class ProjectionMaintenanceError extends Schema.TaggedErrorClass<Projecti
 export interface ProjectionMaintenanceV2Shape {
   readonly verify: Effect.Effect<ProjectionVerificationV2, ProjectionMaintenanceError>;
   readonly rebuild: Effect.Effect<ProjectionVerificationV2, ProjectionMaintenanceError>;
+  readonly compactReadStateEvents: Effect.Effect<
+    { readonly deletedEventCount: number },
+    ProjectionMaintenanceError
+  >;
 }
 
 export class ProjectionMaintenanceV2 extends Context.Service<
@@ -210,9 +214,37 @@ export const layer: Layer.Layer<
           Effect.mapError((cause) => new ProjectionMaintenanceError({ operation, cause })),
         );
 
+    /**
+     * thread.visited events carry the full thread payload, so only the newest
+     * one per thread can influence a replay or an afterSequence catch-up; the
+     * rest are dead weight. Visits fire on every activity bump while a thread
+     * is open, so without compaction they dominate the event store.
+     */
+    const compactReadStateEvents = sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
+          DELETE FROM orchestration_events
+          WHERE application_event_version = 2
+            AND aggregate_kind = 'thread'
+            AND event_type = 'thread.visited'
+            AND sequence NOT IN (
+              SELECT MAX(sequence)
+              FROM orchestration_events
+              WHERE application_event_version = 2
+                AND aggregate_kind = 'thread'
+                AND event_type = 'thread.visited'
+              GROUP BY stream_id
+            )
+        `;
+        const rows = yield* sql<{ readonly deleted: number }>`SELECT changes() AS deleted`;
+        return { deletedEventCount: rows[0]?.deleted ?? 0 };
+      }),
+    );
+
     return ProjectionMaintenanceV2.of({
       verify: mapError("verify")(verify),
       rebuild: mapError("rebuild")(rebuild),
+      compactReadStateEvents: mapError("compact read-state events")(compactReadStateEvents),
     });
   }),
 );

--- a/apps/server/src/orchestration-v2/ProjectionMaintenance.ts
+++ b/apps/server/src/orchestration-v2/ProjectionMaintenance.ts
@@ -34,8 +34,12 @@ export class ProjectionMaintenanceError extends Schema.TaggedErrorClass<Projecti
 export interface ProjectionMaintenanceV2Shape {
   readonly verify: Effect.Effect<ProjectionVerificationV2, ProjectionMaintenanceError>;
   readonly rebuild: Effect.Effect<ProjectionVerificationV2, ProjectionMaintenanceError>;
-  readonly compactReadStateEvents: Effect.Effect<
-    { readonly deletedEventCount: number },
+  readonly compactEventStore: Effect.Effect<
+    {
+      readonly deletedEventCount: number;
+      readonly deletedReceiptCount: number;
+      readonly reclaimableBytes: number;
+    },
     ProjectionMaintenanceError
   >;
 }
@@ -214,37 +218,171 @@ export const layer: Layer.Layer<
           Effect.mapError((cause) => new ProjectionMaintenanceError({ operation, cause })),
         );
 
-    /**
-     * thread.visited events carry the full thread payload, so only the newest
-     * one per thread can influence a replay or an afterSequence catch-up; the
-     * rest are dead weight. Visits fire on every activity bump while a thread
-     * is open, so without compaction they dominate the event store.
-     */
-    const compactReadStateEvents = sql.withTransaction(
+    // Thread-state events whose payload is the complete thread: only the
+    // newest per thread can influence a replay or an afterSequence catch-up.
+    // thread.created stays out — verify derives the expected thread set from
+    // it, and it anchors replay ordering.
+    const SUPERSEDABLE_THREAD_EVENT_TYPES = [
+      "thread.archived",
+      "thread.unarchived",
+      "thread.deleted",
+      "thread.settled",
+      "thread.unsettled",
+      "thread.snoozed",
+      "thread.unsnoozed",
+      "thread.metadata-updated",
+      "thread.runtime-mode-updated",
+      "thread.interaction-mode-updated",
+      "thread.model-selection-updated",
+      "thread.provider-switched",
+      "thread.visited",
+      "thread.marked-unread",
+    ];
+
+    const chunksOf = <A>(items: ReadonlyArray<A>, size: number): Array<ReadonlyArray<A>> => {
+      const out: Array<ReadonlyArray<A>> = [];
+      for (let index = 0; index < items.length; index += size) {
+        out.push(items.slice(index, index + size));
+      }
+      return out;
+    };
+
+    // The sqlite driver is synchronous: one statement over millions of rows
+    // would pin the event loop for its whole duration. Small auto-committed
+    // batches with a yield between them keep the server responsive and bound
+    // WAL growth; each batch is independently durable, so a crash mid-way
+    // just leaves less garbage for the next run.
+    const COMPACTION_DELETE_BATCH_SIZE = 2_000;
+    const deleteRowsBatched = (input: {
+      readonly table: "orchestration_events" | "orchestration_command_receipts";
+      readonly keys: ReadonlyArray<number | string>;
+    }) =>
       Effect.gen(function* () {
-        yield* sql`
-          DELETE FROM orchestration_events
-          WHERE application_event_version = 2
-            AND aggregate_kind = 'thread'
-            AND event_type = 'thread.visited'
-            AND sequence NOT IN (
-              SELECT MAX(sequence)
-              FROM orchestration_events
-              WHERE application_event_version = 2
-                AND aggregate_kind = 'thread'
-                AND event_type = 'thread.visited'
-              GROUP BY stream_id
-            )
-        `;
-        const rows = yield* sql<{ readonly deleted: number }>`SELECT changes() AS deleted`;
-        return { deletedEventCount: rows[0]?.deleted ?? 0 };
-      }),
-    );
+        let deleted = 0;
+        for (const batch of chunksOf(input.keys, COMPACTION_DELETE_BATCH_SIZE)) {
+          if (input.table === "orchestration_events") {
+            yield* sql`DELETE FROM orchestration_events WHERE sequence IN ${sql.in(batch)}`;
+          } else {
+            yield* sql`DELETE FROM orchestration_command_receipts WHERE command_id IN ${sql.in(batch)}`;
+          }
+          deleted += batch.length;
+          yield* Effect.yieldNow;
+        }
+        return deleted;
+      });
+
+    /**
+     * Full event-store compaction. Projections are the working state (startup
+     * verifies rather than replays), so events only serve afterSequence
+     * catch-up and disaster-recovery rebuild — and for full-payload "state of
+     * the entity" events, anything but the newest per entity is dead weight
+     * in both. Three passes:
+     *
+     * 1. Superseded thread-state events (visits alone accumulate at multiple
+     *    per minute while a thread is open).
+     * 2. Superseded message.updated / node.updated events per entity id —
+     *    streaming rewrites the same message many times. turn-item.updated is
+     *    deliberately NOT compacted: rebuild derives turn_item_positions from
+     *    those events with first-write-wins semantics, so keep-latest would
+     *    change replay outcomes for reordered items.
+     * 3. Legacy v1 thread events and their pre-migration command receipts for
+     *    threads whose v2 import completed — the v1 store is only read to
+     *    import from, and imports never re-run once transcript_imported_at is
+     *    set.
+     *
+     * VACUUM is deliberately not run here: on the synchronous driver it would
+     * block every query for minutes on a multi-GB file. The reclaimable page
+     * count is reported so the caller can surface a hint instead; freed pages
+     * are reused, so the file stops growing either way.
+     */
+    const compactEventStore = Effect.gen(function* () {
+      const supersededThreadStateRows = yield* sql<{ readonly sequence: number }>`
+        SELECT sequence
+        FROM orchestration_events
+        WHERE application_event_version = 2
+          AND aggregate_kind = 'thread'
+          AND event_type IN ${sql.in(SUPERSEDABLE_THREAD_EVENT_TYPES)}
+          AND sequence NOT IN (
+            SELECT MAX(sequence)
+            FROM orchestration_events
+            WHERE application_event_version = 2
+              AND aggregate_kind = 'thread'
+              AND event_type IN ${sql.in(SUPERSEDABLE_THREAD_EVENT_TYPES)}
+            GROUP BY stream_id
+          )
+      `;
+
+      const supersededEntityRows = (eventType: "message.updated" | "node.updated") => sql<{
+        readonly sequence: number;
+      }>`
+        SELECT sequence
+        FROM orchestration_events
+        WHERE application_event_version = 2
+          AND event_type = ${eventType}
+          AND sequence NOT IN (
+            SELECT MAX(sequence)
+            FROM orchestration_events
+            WHERE application_event_version = 2
+              AND event_type = ${eventType}
+            GROUP BY stream_id, json_extract(payload_json, '$.id')
+          )
+      `;
+      const supersededMessageRows = yield* supersededEntityRows("message.updated");
+      const supersededNodeRows = yield* supersededEntityRows("node.updated");
+
+      const importedLegacyEventRows = yield* sql<{ readonly sequence: number }>`
+        SELECT sequence
+        FROM orchestration_events
+        WHERE application_event_version = 1
+          AND aggregate_kind = 'thread'
+          AND stream_id IN (
+            SELECT thread_id
+            FROM orchestration_v2_legacy_imports
+            WHERE transcript_imported_at IS NOT NULL
+          )
+      `;
+
+      const deletedEventCount = yield* deleteRowsBatched({
+        table: "orchestration_events",
+        keys: [
+          ...supersededThreadStateRows,
+          ...supersededMessageRows,
+          ...supersededNodeRows,
+          ...importedLegacyEventRows,
+        ].map((row) => row.sequence),
+      });
+
+      // Receipts written before the command_type column existed default to
+      // 'legacy'; for fully imported v1 threads they guard idempotency of
+      // commands that can no longer be re-sent.
+      const legacyReceiptRows = yield* sql<{ readonly command_id: string }>`
+        SELECT command_id
+        FROM orchestration_command_receipts
+        WHERE command_type = 'legacy'
+          AND aggregate_kind = 'thread'
+          AND aggregate_id IN (
+            SELECT thread_id
+            FROM orchestration_v2_legacy_imports
+            WHERE transcript_imported_at IS NOT NULL
+          )
+      `;
+      const deletedReceiptCount = yield* deleteRowsBatched({
+        table: "orchestration_command_receipts",
+        keys: legacyReceiptRows.map((row) => row.command_id),
+      });
+
+      const freelistRows = yield* sql<{ readonly freelist_count: number }>`PRAGMA freelist_count`;
+      const pageSizeRows = yield* sql<{ readonly page_size: number }>`PRAGMA page_size`;
+      const reclaimableBytes =
+        (freelistRows[0]?.freelist_count ?? 0) * (pageSizeRows[0]?.page_size ?? 0);
+
+      return { deletedEventCount, deletedReceiptCount, reclaimableBytes };
+    });
 
     return ProjectionMaintenanceV2.of({
       verify: mapError("verify")(verify),
       rebuild: mapError("rebuild")(rebuild),
-      compactReadStateEvents: mapError("compact read-state events")(compactReadStateEvents),
+      compactEventStore: mapError("compact event store")(compactEventStore),
     });
   }),
 );

--- a/apps/server/src/orchestration-v2/ProjectionStore.ts
+++ b/apps/server/src/orchestration-v2/ProjectionStore.ts
@@ -104,6 +104,9 @@ export interface ProjectionStoreV2Shape {
     OrchestrationV2ThreadShellSnapshot,
     ProjectionStoreV2Error
   >;
+  readonly getThreadShell: (
+    threadId: ThreadId,
+  ) => Effect.Effect<OrchestrationV2ThreadShell | null, ProjectionStoreV2Error>;
   readonly getThreadProjection: (
     threadId: ThreadId,
   ) => Effect.Effect<OrchestrationV2ThreadProjection, ProjectionStoreV2Error>;
@@ -395,6 +398,7 @@ type PayloadRow = {
 type ShellThreadRow = {
   readonly thread_id: string;
   readonly payload_json: string;
+  readonly forked_from_run_source_thread_id: string | null;
   readonly latest_run_id: string | null;
   readonly latest_run_status: string | null;
   readonly latest_run_requested_at: string | null;
@@ -2100,15 +2104,16 @@ export const layer: Layer.Layer<ProjectionStoreV2, never, SqlClient.SqlClient> =
           ),
         );
 
-    const getShellSnapshot: ProjectionStoreV2Shape["getShellSnapshot"] = () =>
-      sql
-        .withTransaction(
-          Effect.gen(function* () {
-            const [threadRows, runRows, itemCountRows, sequenceRows] = yield* Effect.all([
-              sql<ShellThreadRow>`
+    const selectShellThreadRows = (threadId?: ThreadId) =>
+      sql<ShellThreadRow>`
             SELECT
               t.thread_id,
               t.payload_json,
+              CASE
+                WHEN json_extract(t.payload_json, '$.forkedFrom.type') = 'run'
+                  THEN json_extract(t.payload_json, '$.forkedFrom.threadId')
+                ELSE NULL
+              END AS forked_from_run_source_thread_id,
               (
                 SELECT r.run_id
                 FROM orchestration_v2_projection_runs r
@@ -2207,19 +2212,118 @@ export const layer: Layer.Layer<ProjectionStoreV2, never, SqlClient.SqlClient> =
                   AND i.run_id IS NULL
               ) AS runless_item_count
             FROM orchestration_v2_projection_threads t
-            WHERE t.deleted_at IS NULL
+            WHERE t.deleted_at IS NULL${threadId === undefined ? sql`` : sql` AND t.thread_id = ${threadId}`}
             ORDER BY t.updated_at ASC, t.thread_id ASC
-          `,
-              sql<ShellRunRow>`
+          `;
+
+    const selectShellRunRows = (threadIds?: ReadonlyArray<ThreadId>) =>
+      threadIds === undefined
+        ? sql<ShellRunRow>`
             SELECT thread_id, run_id, ordinal
             FROM orchestration_v2_projection_runs
-          `,
-              sql<ShellRunItemCountRow>`
+          `
+        : sql<ShellRunRow>`
+            SELECT thread_id, run_id, ordinal
+            FROM orchestration_v2_projection_runs
+            WHERE thread_id IN ${sql.in(threadIds)}
+          `;
+
+    const selectShellRunItemCounts = (threadIds?: ReadonlyArray<ThreadId>) =>
+      threadIds === undefined
+        ? sql<ShellRunItemCountRow>`
             SELECT thread_id, run_id, COUNT(*) AS item_count
             FROM orchestration_v2_projection_turn_items
             WHERE run_id IS NOT NULL
             GROUP BY thread_id, run_id
-          `,
+          `
+        : sql<ShellRunItemCountRow>`
+            SELECT thread_id, run_id, COUNT(*) AS item_count
+            FROM orchestration_v2_projection_turn_items
+            WHERE run_id IS NOT NULL
+              AND thread_id IN ${sql.in(threadIds)}
+            GROUP BY thread_id, run_id
+          `;
+
+    const runMapsByThreadId = (input: {
+      readonly runRows: ReadonlyArray<ShellRunRow>;
+      readonly itemCountRows: ReadonlyArray<ShellRunItemCountRow>;
+    }) => {
+      const runOrdinalsByThreadId = new Map<ThreadId, Map<RunId, number>>();
+      for (const row of input.runRows) {
+        const threadId = ThreadId.make(row.thread_id);
+        const runId = RunId.make(row.run_id);
+        const existing = runOrdinalsByThreadId.get(threadId) ?? new Map<RunId, number>();
+        existing.set(runId, row.ordinal);
+        runOrdinalsByThreadId.set(threadId, existing);
+      }
+      const itemCountsByThreadId = new Map<ThreadId, Map<RunId, number>>();
+      for (const row of input.itemCountRows) {
+        const threadId = ThreadId.make(row.thread_id);
+        const runId = RunId.make(row.run_id);
+        const existing = itemCountsByThreadId.get(threadId) ?? new Map<RunId, number>();
+        existing.set(runId, row.item_count);
+        itemCountsByThreadId.set(threadId, existing);
+      }
+      return { runOrdinalsByThreadId, itemCountsByThreadId };
+    };
+
+    const shellThreadStateFromRow = (input: {
+      readonly row: ShellThreadRow;
+      readonly runOrdinalsByThreadId: ReadonlyMap<ThreadId, Map<RunId, number>>;
+      readonly itemCountsByThreadId: ReadonlyMap<ThreadId, Map<RunId, number>>;
+    }) =>
+      Effect.gen(function* () {
+        const { row, runOrdinalsByThreadId, itemCountsByThreadId } = input;
+        const thread = yield* decodeThreadPayload(row.payload_json);
+        const pendingRuntimeRequest =
+          row.pending_request_payload_json === null
+            ? null
+            : yield* decodeRuntimeRequestPayload(row.pending_request_payload_json);
+        const latestVisibleMessage =
+          row.latest_message_payload_json === null
+            ? null
+            : yield* decodeMessagePayload(row.latest_message_payload_json);
+        return {
+          thread,
+          latestRunId: row.latest_run_id === null ? null : RunId.make(row.latest_run_id),
+          latestRunStatus: shellStatusFromStoredRunStatus(row.latest_run_status),
+          latestRunRequestedAt:
+            row.latest_run_requested_at === null
+              ? null
+              : DateTime.makeUnsafe(row.latest_run_requested_at),
+          latestRunStartedAt:
+            row.latest_run_started_at === null
+              ? null
+              : DateTime.makeUnsafe(row.latest_run_started_at),
+          latestRunCompletedAt:
+            row.latest_run_completed_at === null
+              ? null
+              : DateTime.makeUnsafe(row.latest_run_completed_at),
+          activeRunId: row.active_run_id === null ? null : RunId.make(row.active_run_id),
+          lastError: row.last_error,
+          pendingRuntimeRequest,
+          latestVisibleMessage,
+          latestUserMessageAt:
+            row.latest_user_message_at === null
+              ? null
+              : DateTime.makeUnsafe(row.latest_user_message_at),
+          hasActionableProposedPlan: row.has_actionable_proposed_plan === 1,
+          itemCount: row.item_count,
+          runlessItemCount: row.runless_item_count,
+          updatedAt: thread.updatedAt,
+          runOrdinalById: runOrdinalsByThreadId.get(ThreadId.make(row.thread_id)) ?? new Map(),
+          itemCountByRunId: itemCountsByThreadId.get(ThreadId.make(row.thread_id)) ?? new Map(),
+        } satisfies ShellThreadState;
+      });
+
+    const getShellSnapshot: ProjectionStoreV2Shape["getShellSnapshot"] = () =>
+      sql
+        .withTransaction(
+          Effect.gen(function* () {
+            const [threadRows, runRows, itemCountRows, sequenceRows] = yield* Effect.all([
+              selectShellThreadRows(),
+              selectShellRunRows(),
+              selectShellRunItemCounts(),
               sql<{ readonly snapshot_sequence: number | null }>`
             SELECT MAX(sequence) AS snapshot_sequence
             FROM orchestration_events
@@ -2228,69 +2332,13 @@ export const layer: Layer.Layer<ProjectionStoreV2, never, SqlClient.SqlClient> =
           `,
             ]);
 
-            const runOrdinalsByThreadId = new Map<ThreadId, Map<RunId, number>>();
-            for (const row of runRows) {
-              const threadId = ThreadId.make(row.thread_id);
-              const runId = RunId.make(row.run_id);
-              const existing = runOrdinalsByThreadId.get(threadId) ?? new Map<RunId, number>();
-              existing.set(runId, row.ordinal);
-              runOrdinalsByThreadId.set(threadId, existing);
-            }
-
-            const itemCountsByThreadId = new Map<ThreadId, Map<RunId, number>>();
-            for (const row of itemCountRows) {
-              const threadId = ThreadId.make(row.thread_id);
-              const runId = RunId.make(row.run_id);
-              const existing = itemCountsByThreadId.get(threadId) ?? new Map<RunId, number>();
-              existing.set(runId, row.item_count);
-              itemCountsByThreadId.set(threadId, existing);
-            }
+            const { runOrdinalsByThreadId, itemCountsByThreadId } = runMapsByThreadId({
+              runRows,
+              itemCountRows,
+            });
 
             const states = yield* Effect.forEach(threadRows, (row) =>
-              Effect.gen(function* () {
-                const thread = yield* decodeThreadPayload(row.payload_json);
-                const pendingRuntimeRequest =
-                  row.pending_request_payload_json === null
-                    ? null
-                    : yield* decodeRuntimeRequestPayload(row.pending_request_payload_json);
-                const latestVisibleMessage =
-                  row.latest_message_payload_json === null
-                    ? null
-                    : yield* decodeMessagePayload(row.latest_message_payload_json);
-                return {
-                  thread,
-                  latestRunId: row.latest_run_id === null ? null : RunId.make(row.latest_run_id),
-                  latestRunStatus: shellStatusFromStoredRunStatus(row.latest_run_status),
-                  latestRunRequestedAt:
-                    row.latest_run_requested_at === null
-                      ? null
-                      : DateTime.makeUnsafe(row.latest_run_requested_at),
-                  latestRunStartedAt:
-                    row.latest_run_started_at === null
-                      ? null
-                      : DateTime.makeUnsafe(row.latest_run_started_at),
-                  latestRunCompletedAt:
-                    row.latest_run_completed_at === null
-                      ? null
-                      : DateTime.makeUnsafe(row.latest_run_completed_at),
-                  activeRunId: row.active_run_id === null ? null : RunId.make(row.active_run_id),
-                  lastError: row.last_error,
-                  pendingRuntimeRequest,
-                  latestVisibleMessage,
-                  latestUserMessageAt:
-                    row.latest_user_message_at === null
-                      ? null
-                      : DateTime.makeUnsafe(row.latest_user_message_at),
-                  hasActionableProposedPlan: row.has_actionable_proposed_plan === 1,
-                  itemCount: row.item_count,
-                  runlessItemCount: row.runless_item_count,
-                  updatedAt: thread.updatedAt,
-                  runOrdinalById:
-                    runOrdinalsByThreadId.get(ThreadId.make(row.thread_id)) ?? new Map(),
-                  itemCountByRunId:
-                    itemCountsByThreadId.get(ThreadId.make(row.thread_id)) ?? new Map(),
-                } satisfies ShellThreadState;
-              }),
+              shellThreadStateFromRow({ row, runOrdinalsByThreadId, itemCountsByThreadId }),
             );
             const statesByThreadId = new Map(states.map((state) => [state.thread.id, state]));
 
@@ -2322,9 +2370,64 @@ export const layer: Layer.Layer<ProjectionStoreV2, never, SqlClient.SqlClient> =
           ),
         );
 
+    // Per-thread shell for the live shell streams: reads only the target thread
+    // plus its fork-source chain instead of materializing every thread. Returns
+    // null when the thread is deleted or unknown.
+    const getThreadShell: ProjectionStoreV2Shape["getThreadShell"] = (threadId) =>
+      sql
+        .withTransaction(
+          Effect.gen(function* () {
+            const rowsByThreadId = new Map<ThreadId, ShellThreadRow>();
+            const pending: Array<ThreadId> = [threadId];
+            while (pending.length > 0) {
+              const nextId = pending.pop();
+              if (nextId === undefined || rowsByThreadId.has(nextId)) {
+                continue;
+              }
+              const rows = yield* selectShellThreadRows(nextId);
+              const row = rows[0];
+              if (row === undefined) {
+                continue;
+              }
+              rowsByThreadId.set(nextId, row);
+              if (row.forked_from_run_source_thread_id !== null) {
+                pending.push(ThreadId.make(row.forked_from_run_source_thread_id));
+              }
+            }
+            if (!rowsByThreadId.has(threadId)) {
+              return null;
+            }
+
+            const threadIds = [...rowsByThreadId.keys()];
+            const [runRows, itemCountRows] = yield* Effect.all([
+              selectShellRunRows(threadIds),
+              selectShellRunItemCounts(threadIds),
+            ]);
+            const { runOrdinalsByThreadId, itemCountsByThreadId } = runMapsByThreadId({
+              runRows,
+              itemCountRows,
+            });
+
+            const states = yield* Effect.forEach([...rowsByThreadId.values()], (row) =>
+              shellThreadStateFromRow({ row, runOrdinalsByThreadId, itemCountsByThreadId }),
+            );
+            const statesByThreadId = new Map(states.map((state) => [state.thread.id, state]));
+            const state = statesByThreadId.get(threadId);
+            if (state === undefined) {
+              return null;
+            }
+            return shellFromState({
+              state,
+              visibleItemCount: visibleItemCountForShell({ threadId, statesByThreadId }),
+            });
+          }),
+        )
+        .pipe(Effect.mapError((cause) => new ProjectionStoreReadError({ threadId, cause })));
+
     return {
       apply,
       getShellSnapshot,
+      getThreadShell,
       getThreadProjection,
       getThreadSnapshot,
     } satisfies ProjectionStoreV2Shape;
@@ -2376,6 +2479,17 @@ export const layerMemory: Layer.Layer<ProjectionStoreV2> = Layer.effect(
             threads: visible.filter((thread) => thread.archivedAt === null),
             archivedThreads: visible.filter((thread) => thread.archivedAt !== null),
           };
+        }),
+      getThreadShell: (threadId) =>
+        Effect.gen(function* () {
+          const existing = (yield* Ref.get(replayState)).projections;
+          if (!existing.has(threadId)) {
+            return null;
+          }
+          const shell = yield* service
+            .getThreadProjection(threadId)
+            .pipe(Effect.map(threadShellFromProjection));
+          return shell.deletedAt === null ? shell : null;
         }),
       getThreadProjection: (threadId) =>
         Effect.gen(function* () {

--- a/apps/server/src/orchestration-v2/ProviderEventIngestor.test.ts
+++ b/apps/server/src/orchestration-v2/ProviderEventIngestor.test.ts
@@ -301,10 +301,9 @@ layer("ProviderEventIngestorV2", (it) => {
         maxAttempts: 3,
         retryDelayMs: 2_000,
       });
-      assert.equal(
-        DateTime.toEpochMillis(errorItem.startedAt),
-        DateTime.toEpochMillis(retryStartedAt),
-      );
+      const errorStartedAt = errorItem.startedAt;
+      assert.ok(errorStartedAt);
+      assert.equal(DateTime.toEpochMillis(errorStartedAt), DateTime.toEpochMillis(retryStartedAt));
       assert.equal(errorItem.providerThreadId, providerThreadId);
       assert.equal(errorItem.providerTurnId, providerTurnId);
     }),

--- a/apps/server/src/orchestration-v2/ProviderTurnControlService.test.ts
+++ b/apps/server/src/orchestration-v2/ProviderTurnControlService.test.ts
@@ -215,6 +215,7 @@ it.effect(
         ProjectionStoreV2.of({
           apply: () => Effect.void,
           getShellSnapshot: () => Effect.die("unused getShellSnapshot"),
+          getThreadShell: () => Effect.die("unused getThreadShell"),
           getThreadProjection: () => Ref.get(projection),
           getThreadSnapshot: () => Effect.die("unused getThreadSnapshot"),
         }),

--- a/apps/server/src/orchestration-v2/ShellStream.test.ts
+++ b/apps/server/src/orchestration-v2/ShellStream.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "@effect/vitest";
-import type { ApplicationStoredEvent, OrchestrationV2ShellSnapshot } from "@t3tools/contracts";
+import type {
+  ApplicationStoredEvent,
+  OrchestrationV2ShellSnapshot,
+  OrchestrationV2StoredEvent,
+  OrchestrationV2ThreadShell,
+} from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 
 import {
+  archivedShellStreamItemFromThreadShell,
   coalesceShellApplicationEvents,
+  coalesceStoredThreadEvents,
   composeShellStreamWithEnrichment,
   shellStreamItemFromEnrichmentRefresh,
+  shellStreamItemFromThreadShell,
   shellStreamItemsFromInitialSnapshot,
 } from "./ShellStream.ts";
 
@@ -44,6 +52,129 @@ describe("coalesceShellApplicationEvents", () => {
         project(6, "project-a"),
       ]).map((event) => event.sequence),
     ).toEqual([4, 5, 6]);
+  });
+});
+
+function storedThreadEvent(
+  sequence: number,
+  threadId: string,
+  event: Record<string, unknown> = {},
+): OrchestrationV2StoredEvent {
+  return { sequence, event: { threadId, ...event } } as OrchestrationV2StoredEvent;
+}
+
+function shellFixture(overrides: Partial<OrchestrationV2ThreadShell>): OrchestrationV2ThreadShell {
+  return { id: "thread-a", archivedAt: null, ...overrides } as OrchestrationV2ThreadShell;
+}
+
+describe("coalesceStoredThreadEvents", () => {
+  it("keeps the newest stored event per thread and preserves sequence order", () => {
+    expect(
+      coalesceStoredThreadEvents([
+        storedThreadEvent(2, "thread-a"),
+        storedThreadEvent(3, "thread-b"),
+        storedThreadEvent(5, "thread-a"),
+      ]).map((stored) => stored.sequence),
+    ).toEqual([3, 5]);
+  });
+});
+
+describe("shellStreamItemFromThreadShell", () => {
+  it("emits an active thread update when the shell is not archived", () => {
+    const shell = shellFixture({ archivedAt: null });
+    expect(
+      shellStreamItemFromThreadShell({ stored: storedThreadEvent(4, "thread-a"), shell }),
+    ).toEqual({
+      kind: "thread.updated",
+      sequence: 4,
+      location: "active",
+      thread: shell,
+    });
+  });
+
+  it("emits an archive update when the shell is archived", () => {
+    const shell = shellFixture({ archivedAt: "2026-07-30T00:00:00.000Z" as never });
+    expect(
+      shellStreamItemFromThreadShell({ stored: storedThreadEvent(4, "thread-a"), shell }),
+    ).toEqual({
+      kind: "thread.updated",
+      sequence: 4,
+      location: "archive",
+      thread: shell,
+    });
+  });
+
+  it("emits a removal from the archive when an archived thread is deleted", () => {
+    expect(
+      shellStreamItemFromThreadShell({
+        stored: storedThreadEvent(6, "thread-a", {
+          type: "thread.deleted",
+          payload: { archivedAt: "2026-07-30T00:00:00.000Z" },
+        }),
+        shell: null,
+      }),
+    ).toEqual({
+      kind: "thread.removed",
+      sequence: 6,
+      location: "archive",
+      threadId: "thread-a",
+    });
+  });
+
+  it("emits a removal from the active list for other missing shells", () => {
+    expect(
+      shellStreamItemFromThreadShell({
+        stored: storedThreadEvent(6, "thread-a", {
+          type: "thread.deleted",
+          payload: { archivedAt: null },
+        }),
+        shell: null,
+      }),
+    ).toEqual({
+      kind: "thread.removed",
+      sequence: 6,
+      location: "active",
+      threadId: "thread-a",
+    });
+  });
+});
+
+describe("archivedShellStreamItemFromThreadShell", () => {
+  it("emits an update for an archived shell", () => {
+    const shell = shellFixture({ archivedAt: "2026-07-30T00:00:00.000Z" as never });
+    expect(
+      archivedShellStreamItemFromThreadShell({ stored: storedThreadEvent(4, "thread-a"), shell }),
+    ).toEqual({ kind: "thread.updated", sequence: 4, thread: shell });
+  });
+
+  it("ignores active threads that never touched the archive", () => {
+    expect(
+      archivedShellStreamItemFromThreadShell({
+        stored: storedThreadEvent(4, "thread-a", { type: "thread.settled" }),
+        shell: shellFixture({ archivedAt: null }),
+      }),
+    ).toBeNull();
+  });
+
+  it("emits a removal when a thread leaves the archive", () => {
+    expect(
+      archivedShellStreamItemFromThreadShell({
+        stored: storedThreadEvent(4, "thread-a", { type: "thread.unarchived" }),
+        shell: shellFixture({ archivedAt: null }),
+      }),
+    ).toEqual({ kind: "thread.removed", sequence: 4, threadId: "thread-a" });
+  });
+
+  it("emits a removal when an archived thread is deleted", () => {
+    expect(
+      archivedShellStreamItemFromThreadShell({
+        stored: storedThreadEvent(4, "thread-a", {
+          type: "thread.deleted",
+          payload: { archivedAt: "2026-07-30T00:00:00.000Z" },
+        }),
+        shell: null,
+      }),
+    ).toEqual({ kind: "thread.removed", sequence: 4, threadId: "thread-a" });
   });
 });
 

--- a/apps/server/src/orchestration-v2/ShellStream.ts
+++ b/apps/server/src/orchestration-v2/ShellStream.ts
@@ -2,7 +2,7 @@ import type {
   ApplicationStoredEvent,
   OrchestrationV2ArchivedShellStreamItem,
   OrchestrationV2ShellSnapshot,
-  OrchestrationV2ThreadShellSnapshot,
+  OrchestrationV2ThreadShell,
   OrchestrationV2ShellStreamItem,
   OrchestrationV2StoredEvent,
 } from "@t3tools/contracts";
@@ -77,30 +77,33 @@ export function shellStreamItemsFromInitialSnapshot(input: {
   ];
 }
 
-/** Converts a committed event and its resulting shell snapshot into one delta. */
-export function shellStreamItemFromSnapshot(input: {
-  readonly stored: OrchestrationV2StoredEvent;
-  readonly snapshot: OrchestrationV2ThreadShellSnapshot;
-}): Exclude<OrchestrationV2ShellStreamItem, { readonly kind: "snapshot" }> {
-  const active = input.snapshot.threads.find((thread) => thread.id === input.stored.event.threadId);
-  if (active !== undefined) {
-    return {
-      kind: "thread.updated",
-      sequence: input.stored.sequence,
-      location: "active",
-      thread: active,
-    };
+/** Keep only the newest stored event per thread within a coalescing window. */
+export function coalesceStoredThreadEvents(
+  events: ReadonlyArray<OrchestrationV2StoredEvent>,
+): ReadonlyArray<OrchestrationV2StoredEvent> {
+  const latestByThreadId = new Map<string, OrchestrationV2StoredEvent>();
+  for (const stored of events) {
+    latestByThreadId.set(stored.event.threadId, stored);
   }
-
-  const archived = input.snapshot.archivedThreads.find(
-    (thread) => thread.id === input.stored.event.threadId,
+  return Array.from(latestByThreadId.values()).sort(
+    (left, right) => left.sequence - right.sequence,
   );
-  if (archived !== undefined) {
+}
+
+/**
+ * Converts a committed event and the affected thread's current shell into one
+ * delta. `shell` is null when the thread is deleted or unknown.
+ */
+export function shellStreamItemFromThreadShell(input: {
+  readonly stored: OrchestrationV2StoredEvent;
+  readonly shell: OrchestrationV2ThreadShell | null;
+}): Exclude<OrchestrationV2ShellStreamItem, { readonly kind: "snapshot" }> {
+  if (input.shell !== null) {
     return {
       kind: "thread.updated",
       sequence: input.stored.sequence,
-      location: "archive",
-      thread: archived,
+      location: input.shell.archivedAt === null ? "active" : "archive",
+      thread: input.shell,
     };
   }
 
@@ -116,18 +119,15 @@ export function shellStreamItemFromSnapshot(input: {
 }
 
 /** Converts a committed event into an archive-only delta when it changes archive membership. */
-export function archivedShellStreamItemFromSnapshot(input: {
+export function archivedShellStreamItemFromThreadShell(input: {
   readonly stored: OrchestrationV2StoredEvent;
-  readonly snapshot: OrchestrationV2ThreadShellSnapshot;
+  readonly shell: OrchestrationV2ThreadShell | null;
 }): Exclude<OrchestrationV2ArchivedShellStreamItem, { readonly kind: "snapshot" }> | null {
-  const archived = input.snapshot.archivedThreads.find(
-    (thread) => thread.id === input.stored.event.threadId,
-  );
-  if (archived !== undefined) {
+  if (input.shell !== null && input.shell.archivedAt !== null) {
     return {
       kind: "thread.updated",
       sequence: input.stored.sequence,
-      thread: archived,
+      thread: input.shell,
     };
   }
   if (

--- a/apps/server/src/orchestration-v2/ThreadManagementService.test.ts
+++ b/apps/server/src/orchestration-v2/ThreadManagementService.test.ts
@@ -107,6 +107,25 @@ it("identifies every existing thread that must be hydrated before dispatch", () 
     }),
   ).toEqual([targetThreadId]);
 
+  // Read-state commands skip transcript hydration entirely: they fire on
+  // every activity bump while a thread is open and never touch messages.
+  expect(
+    existingThreadIdsForCommand({
+      type: "thread.visit",
+      commandId: CommandId.make("command:thread-management:visit"),
+      threadId: targetThreadId,
+      visitedAt: "2026-07-30T00:00:00.000Z",
+    }),
+  ).toEqual([]);
+
+  expect(
+    existingThreadIdsForCommand({
+      type: "thread.mark-unread",
+      commandId: CommandId.make("command:thread-management:mark-unread"),
+      threadId: targetThreadId,
+    }),
+  ).toEqual([]);
+
   expect(
     existingThreadIdsForCommand({
       type: "thread.fork",

--- a/apps/server/src/orchestration-v2/ThreadManagementService.ts
+++ b/apps/server/src/orchestration-v2/ThreadManagementService.ts
@@ -65,6 +65,13 @@ export function existingThreadIdsForCommand(
   switch (command.type) {
     case "thread.create":
       return [];
+    // Read-state commands only rewrite the thread payload's visited/unread
+    // watermark; they never touch messages, so they do not need the imported
+    // v1 transcript hydrated first. Visits fire on every thread-activity bump
+    // while a thread is open, so keeping them off the import path matters.
+    case "thread.visit":
+    case "thread.mark-unread":
+      return [];
     case "thread.fork":
       return [command.sourceThreadId];
     case "thread.merge_back":
@@ -273,6 +280,7 @@ export interface ThreadManagementServiceShape {
     OrchestrationV2ThreadShellSnapshot,
     OrchestratorV2Error
   >;
+  readonly getThreadShell: OrchestratorV2["Service"]["getThreadShell"];
   readonly listProjectThreads: (input: {
     readonly projectId: ProjectId;
     readonly includeSubagents: boolean;
@@ -631,6 +639,7 @@ const make = Effect.gen(function* () {
     getThreadSnapshot,
     getProjectThread,
     getShellSnapshot: orchestrator.getShellSnapshot,
+    getThreadShell: orchestrator.getThreadShell,
     listProjectThreads,
     sendToThread,
     waitForThread,

--- a/apps/server/src/orchestration-v2/ThreadManagementService.ts
+++ b/apps/server/src/orchestration-v2/ThreadManagementService.ts
@@ -113,7 +113,8 @@ export interface ThreadManagementSendResult {
   readonly projection: OrchestrationV2ThreadProjection;
   readonly message: OrchestrationV2ConversationMessage;
   readonly run: OrchestrationV2Run;
-  readonly turnItem: Extract<OrchestrationV2TurnItem, { readonly type: "user_message" }>;
+  /** Null for queued sends: the user turn item materializes when the queued turn starts. */
+  readonly turnItem: Extract<OrchestrationV2TurnItem, { readonly type: "user_message" }> | null;
   readonly delivery: "started" | "queued" | "steered" | "restarted";
 }
 
@@ -513,23 +514,32 @@ const make = Effect.gen(function* () {
         message?.runId === null || message?.runId === undefined
           ? undefined
           : projection.runs.find((candidate) => candidate.id === message.runId);
-      const turnItem = projection.turnItems.find(
-        (
-          candidate,
-        ): candidate is Extract<OrchestrationV2TurnItem, { readonly type: "user_message" }> =>
-          candidate.type === "user_message" && candidate.messageId === input.messageId,
-      );
-      if (message === undefined || run === undefined || turnItem === undefined) {
+      const turnItem =
+        projection.turnItems.find(
+          (
+            candidate,
+          ): candidate is Extract<OrchestrationV2TurnItem, { readonly type: "user_message" }> =>
+            candidate.type === "user_message" && candidate.messageId === input.messageId,
+        ) ?? null;
+      // A queued message's user turn item is deliberately not emitted at
+      // dispatch time — it materializes when the queued turn actually starts,
+      // so it can map onto the provider turn. Every other dispatch mode still
+      // produces its turn item transactionally with the run.
+      if (
+        message === undefined ||
+        run === undefined ||
+        (turnItem === null && run.status !== "queued")
+      ) {
         return yield* new ThreadManagementDurableRunProjectionError({
           threadId: input.threadId,
           messageId: input.messageId,
         });
       }
       const delivery: ThreadManagementSendResult["delivery"] =
-        turnItem.inputIntent === "turn_start"
-          ? "started"
-          : turnItem.inputIntent === "queued_turn"
-            ? "queued"
+        turnItem === null || turnItem.inputIntent === "queued_turn"
+          ? "queued"
+          : turnItem.inputIntent === "turn_start"
+            ? "started"
             : input.mode === "restart"
               ? "restarted"
               : "steered";

--- a/apps/server/src/orchestration-v2/runtimeLayer.test.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.test.ts
@@ -46,7 +46,7 @@ import { EventSinkV2 } from "./EventSink.ts";
 import { ProjectionMaintenanceV2 } from "./ProjectionMaintenance.ts";
 import type { ProviderAdapterV2Shape } from "./ProviderAdapter.ts";
 import { OrchestrationV2EventSinkLayerLive, OrchestrationV2LayerLive } from "./runtimeLayer.ts";
-import { shellStreamItemFromSnapshot } from "./ShellStream.ts";
+import { shellStreamItemFromThreadShell } from "./ShellStream.ts";
 import { CodexProviderCapabilitiesV2 } from "./Adapters/CodexAdapterV2.ts";
 import { ThreadManagementService } from "./ThreadManagementService.ts";
 
@@ -655,9 +655,9 @@ it.layer(TestLayer)("OrchestrationV2LayerLive lifecycle", (it) => {
         threadId,
       );
       assert.deepEqual(
-        shellStreamItemFromSnapshot({
+        shellStreamItemFromThreadShell({
           stored: archive.storedEvents[0]!,
-          snapshot: archivedShell,
+          shell: yield* orchestrator.getThreadShell(threadId),
         }),
         {
           kind: "thread.updated",
@@ -682,7 +682,10 @@ it.layer(TestLayer)("OrchestrationV2LayerLive lifecycle", (it) => {
         threadId,
       );
       assert.deepEqual(
-        shellStreamItemFromSnapshot({ stored: remove.storedEvents[0]!, snapshot: deletedShell }),
+        shellStreamItemFromThreadShell({
+          stored: remove.storedEvents[0]!,
+          shell: yield* orchestrator.getThreadShell(threadId),
+        }),
         {
           kind: "thread.removed",
           sequence: remove.sequence,

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -524,15 +524,27 @@ export const make = Effect.gen(function* () {
         : importPendingTranscripts
     ).pipe(Effect.forkScoped);
 
-    // Off the startup path: the first run after an upgrade can delete a large
-    // backlog of superseded visited events, and nothing at boot depends on it.
-    yield* projectionMaintenance.compactReadStateEvents.pipe(
+    // Off the startup path: the first run after an upgrade deletes the whole
+    // superseded-event and legacy-v1 backlog (potentially millions of rows,
+    // paced in small batches), and nothing at boot depends on it.
+    yield* projectionMaintenance.compactEventStore.pipe(
       Effect.tap((summary) =>
-        summary.deletedEventCount === 0
+        summary.deletedEventCount === 0 && summary.deletedReceiptCount === 0
           ? Effect.void
-          : Effect.logInfo("Compacted superseded read-state events", summary),
+          : Effect.logInfo("Compacted orchestration event store", summary),
       ),
-      Effect.catch((cause) => Effect.logWarning("Unable to compact read-state events", { cause })),
+      Effect.tap((summary) =>
+        // Freed pages are reused, so the file stops growing regardless; only
+        // an offline VACUUM shrinks it, which is not safe to run on the
+        // synchronous sqlite connection while serving.
+        summary.reclaimableBytes >= 512 * 1024 * 1024
+          ? Effect.logInfo(
+              "state.sqlite has substantial reclaimable free space; an offline VACUUM would shrink the file",
+              { reclaimableBytes: summary.reclaimableBytes },
+            )
+          : Effect.void,
+      ),
+      Effect.catch((cause) => Effect.logWarning("Unable to compact the event store", { cause })),
       Effect.forkScoped,
     );
 

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -524,6 +524,18 @@ export const make = Effect.gen(function* () {
         : importPendingTranscripts
     ).pipe(Effect.forkScoped);
 
+    // Off the startup path: the first run after an upgrade can delete a large
+    // backlog of superseded visited events, and nothing at boot depends on it.
+    yield* projectionMaintenance.compactReadStateEvents.pipe(
+      Effect.tap((summary) =>
+        summary.deletedEventCount === 0
+          ? Effect.void
+          : Effect.logInfo("Compacted superseded read-state events", summary),
+      ),
+      Effect.catch((cause) => Effect.logWarning("Unable to compact read-state events", { cause })),
+      Effect.forkScoped,
+    );
+
     yield* Effect.logDebug("startup phase: publishing welcome event", {
       environmentId: environment.environmentId,
       cwd: welcomeBase.cwd,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -71,11 +71,12 @@ import * as ThreadManagementService from "./orchestration-v2/ThreadManagementSer
 import * as ThreadLaunchService from "./orchestration-v2/ThreadLaunchService.ts";
 import * as ScheduledTasks from "./scheduledTasks/ScheduledTaskService.ts";
 import {
-  archivedShellStreamItemFromSnapshot,
+  archivedShellStreamItemFromThreadShell,
   coalesceShellApplicationEvents,
+  coalesceStoredThreadEvents,
   composeShellStreamWithEnrichment,
   shellStreamItemFromEnrichmentRefresh,
-  shellStreamItemFromSnapshot,
+  shellStreamItemFromThreadShell,
   shellStreamItemsFromInitialSnapshot,
 } from "./orchestration-v2/ShellStream.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
@@ -747,25 +748,23 @@ const makeWsRpcLayer = (
             });
           });
 
+          // Coalescing makes each per-thread shell read represent every event
+          // for that thread in the current window; reading only the affected
+          // threads keeps the cost of a busy stream independent of how many
+          // threads exist overall.
           const projectShellItems = Effect.fn("ws.orchestrationV2.projectShellItems")(function* (
             events: ReadonlyArray<ApplicationStoredEvent>,
           ) {
-            const survivors = coalesceShellApplicationEvents(events);
-            const needsThreadSnapshot = survivors.some((stored) => !("aggregateKind" in stored));
-            const threadSnapshot = needsThreadSnapshot
-              ? yield* threadManagement.getShellSnapshot().pipe(Effect.map(Option.some))
-              : Option.none();
             return yield* Effect.forEach(
-              survivors,
+              coalesceShellApplicationEvents(events),
               (stored) =>
-                "aggregateKind" in stored
-                  ? projectItem(stored)
-                  : Effect.succeed(
-                      shellStreamItemFromSnapshot({
-                        stored,
-                        snapshot: Option.getOrThrow(threadSnapshot),
-                      }),
-                    ),
+                Effect.gen(function* () {
+                  if ("aggregateKind" in stored) {
+                    return yield* projectItem(stored);
+                  }
+                  const shell = yield* threadManagement.getThreadShell(stored.event.threadId);
+                  return shellStreamItemFromThreadShell({ stored, shell });
+                }),
               { concurrency: 8 },
             );
           });
@@ -920,20 +919,22 @@ const makeWsRpcLayer = (
         const live = threadManagement
           .streamStoredEventsFrom({ afterSequence: snapshot.snapshotSequence })
           .pipe(
-            Stream.mapEffect((stored) =>
-              threadManagement.getShellSnapshot().pipe(
-                Effect.map((nextSnapshot) =>
-                  archivedShellStreamItemFromSnapshot({ stored, snapshot: nextSnapshot }),
-                ),
-                Effect.mapError(
-                  (cause) =>
-                    new OrchestrationV2GetShellSnapshotError({
-                      message: "Failed while streaming archived threads",
-                      cause,
-                    }),
-                ),
+            Stream.groupedWithin(512, Duration.millis(50)),
+            Stream.mapEffect((events) =>
+              Effect.forEach(
+                coalesceStoredThreadEvents(Array.from(events)),
+                (stored) =>
+                  threadManagement
+                    .getThreadShell(stored.event.threadId)
+                    .pipe(
+                      Effect.map((shell) =>
+                        archivedShellStreamItemFromThreadShell({ stored, shell }),
+                      ),
+                    ),
+                { concurrency: 8 },
               ),
             ),
+            Stream.flatMap(Stream.fromIterable),
             Stream.filterMap((item) => (item === null ? Result.failVoid : Result.succeed(item))),
             Stream.mapError(
               (cause) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -332,6 +332,11 @@ import { useAssetUrls } from "../assets/assetUrls";
 const IMAGE_ONLY_BOOTSTRAP_PROMPT =
   "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
 const EMPTY_PROVIDERS: ServerProvider[] = [];
+// During an active turn the thread's updatedAt advances several times per
+// second, and every server-side visit is a full command dispatch plus a
+// broadcast to all shell subscribers. One watermark per interval is plenty for
+// cross-device read state; the local watermark below stays instant.
+const VISIT_DISPATCH_THROTTLE_MS = 10_000;
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
 const EMPTY_PROJECTION_RUNS: OrchestrationV2ThreadProjection["runs"] = [];
 const EMPTY_ATTACHMENT_IDS: string[] = [];
@@ -1243,6 +1248,7 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const visitThreadMutation = useAtomCommand(threadEnvironment.visit, { reportFailure: false });
   const lastDispatchedVisitRef = useRef<string | null>(null);
+  const lastVisitDispatchAtRef = useRef(0);
   const settings = useEnvironmentSettings(environmentId);
   // New-thread defaults live in the primary environment's settings.json (the
   // settings UI never writes to remote environments), so read them from the
@@ -1920,26 +1926,52 @@ function ChatViewContent(props: ChatViewProps) {
     if (!serverThread?.id) return;
     const threadUpdatedAt = Date.parse(serverThread.updatedAt);
     if (Number.isNaN(threadUpdatedAt)) return;
+
+    if (serverThread.lastVisitedAt !== undefined) {
+      // Server-tracked visited state: record the watermark server-side so it
+      // syncs across every device connected to the environment. Decide from
+      // the server watermark alone — the local watermark is written eagerly
+      // below and must not suppress the server sync.
+      const serverVisitedAt =
+        serverThread.lastVisitedAt === null ? NaN : Date.parse(serverThread.lastVisitedAt);
+      if (Number.isNaN(serverVisitedAt) || serverVisitedAt < threadUpdatedAt) {
+        // The local watermark keeps the open thread reading as visited while
+        // the throttled server dispatch is still pending.
+        markThreadVisited(
+          scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
+          serverThread.updatedAt,
+        );
+        // Dedupe per watermark — the effect re-runs before the command's echo
+        // lands — and throttle to one dispatch per interval; each rerun swaps
+        // the pending timer so the trailing dispatch carries the newest
+        // watermark.
+        const dispatchKey = `${routeThreadKey}:${serverThread.updatedAt}`;
+        if (lastDispatchedVisitRef.current === dispatchKey) return;
+        const dispatch = () => {
+          lastDispatchedVisitRef.current = dispatchKey;
+          lastVisitDispatchAtRef.current = Date.now();
+          void visitThreadMutation({
+            environmentId: serverThread.environmentId,
+            input: { threadId: serverThread.id, visitedAt: serverThread.updatedAt },
+          });
+        };
+        const elapsed = Date.now() - lastVisitDispatchAtRef.current;
+        if (elapsed >= VISIT_DISPATCH_THROTTLE_MS) {
+          dispatch();
+          return;
+        }
+        const timer = setTimeout(dispatch, VISIT_DISPATCH_THROTTLE_MS - elapsed);
+        return () => clearTimeout(timer);
+      }
+      return;
+    }
+
     const effectiveLastVisitedAt = resolveThreadLastVisitedAt(
       serverThread.lastVisitedAt,
       activeThreadLocalLastVisitedAt,
     );
     const lastVisitedAt = effectiveLastVisitedAt ? Date.parse(effectiveLastVisitedAt) : NaN;
     if (!Number.isNaN(lastVisitedAt) && lastVisitedAt >= threadUpdatedAt) return;
-
-    if (serverThread.lastVisitedAt !== undefined) {
-      // Server-tracked visited state: record the watermark server-side so it
-      // syncs across every device connected to the environment. Dedupe per
-      // watermark — the effect re-runs before the command's echo lands.
-      const dispatchKey = `${routeThreadKey}:${serverThread.updatedAt}`;
-      if (lastDispatchedVisitRef.current === dispatchKey) return;
-      lastDispatchedVisitRef.current = dispatchKey;
-      void visitThreadMutation({
-        environmentId: serverThread.environmentId,
-        input: { threadId: serverThread.id, visitedAt: serverThread.updatedAt },
-      });
-      return;
-    }
 
     markThreadVisited(
       scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -334,8 +334,9 @@ const IMAGE_ONLY_BOOTSTRAP_PROMPT =
 const EMPTY_PROVIDERS: ServerProvider[] = [];
 // During an active turn the thread's updatedAt advances several times per
 // second, and every server-side visit is a full command dispatch plus a
-// broadcast to all shell subscribers. One watermark per interval is plenty for
-// cross-device read state; the local watermark below stays instant.
+// broadcast to all shell subscribers. Mid-turn bumps carry no unread signal
+// (unread flips on run completions, which bypass the throttle), so one
+// watermark per interval is plenty.
 const VISIT_DISPATCH_THROTTLE_MS = 10_000;
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
 const EMPTY_PROJECTION_RUNS: OrchestrationV2ThreadProjection["runs"] = [];
@@ -1926,52 +1927,49 @@ function ChatViewContent(props: ChatViewProps) {
     if (!serverThread?.id) return;
     const threadUpdatedAt = Date.parse(serverThread.updatedAt);
     if (Number.isNaN(threadUpdatedAt)) return;
-
-    if (serverThread.lastVisitedAt !== undefined) {
-      // Server-tracked visited state: record the watermark server-side so it
-      // syncs across every device connected to the environment. Decide from
-      // the server watermark alone — the local watermark is written eagerly
-      // below and must not suppress the server sync.
-      const serverVisitedAt =
-        serverThread.lastVisitedAt === null ? NaN : Date.parse(serverThread.lastVisitedAt);
-      if (Number.isNaN(serverVisitedAt) || serverVisitedAt < threadUpdatedAt) {
-        // The local watermark keeps the open thread reading as visited while
-        // the throttled server dispatch is still pending.
-        markThreadVisited(
-          scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
-          serverThread.updatedAt,
-        );
-        // Dedupe per watermark — the effect re-runs before the command's echo
-        // lands — and throttle to one dispatch per interval; each rerun swaps
-        // the pending timer so the trailing dispatch carries the newest
-        // watermark.
-        const dispatchKey = `${routeThreadKey}:${serverThread.updatedAt}`;
-        if (lastDispatchedVisitRef.current === dispatchKey) return;
-        const dispatch = () => {
-          lastDispatchedVisitRef.current = dispatchKey;
-          lastVisitDispatchAtRef.current = Date.now();
-          void visitThreadMutation({
-            environmentId: serverThread.environmentId,
-            input: { threadId: serverThread.id, visitedAt: serverThread.updatedAt },
-          });
-        };
-        const elapsed = Date.now() - lastVisitDispatchAtRef.current;
-        if (elapsed >= VISIT_DISPATCH_THROTTLE_MS) {
-          dispatch();
-          return;
-        }
-        const timer = setTimeout(dispatch, VISIT_DISPATCH_THROTTLE_MS - elapsed);
-        return () => clearTimeout(timer);
-      }
-      return;
-    }
-
     const effectiveLastVisitedAt = resolveThreadLastVisitedAt(
       serverThread.lastVisitedAt,
       activeThreadLocalLastVisitedAt,
     );
     const lastVisitedAt = effectiveLastVisitedAt ? Date.parse(effectiveLastVisitedAt) : NaN;
     if (!Number.isNaN(lastVisitedAt) && lastVisitedAt >= threadUpdatedAt) return;
+
+    if (serverThread.lastVisitedAt !== undefined) {
+      // Server-tracked visited state: record the watermark server-side so it
+      // syncs across every device connected to the environment. Dedupe per
+      // watermark — the effect re-runs before the command's echo lands. The
+      // dedupe also keeps a mark-unread on the open thread sticky: the rewind
+      // leaves updatedAt untouched, so the already-dispatched key skips a
+      // fresh visit until new activity lands or the thread is reopened.
+      const dispatchKey = `${routeThreadKey}:${serverThread.updatedAt}`;
+      if (lastDispatchedVisitRef.current === dispatchKey) return;
+      const dispatch = () => {
+        lastDispatchedVisitRef.current = dispatchKey;
+        lastVisitDispatchAtRef.current = Date.now();
+        void visitThreadMutation({
+          environmentId: serverThread.environmentId,
+          input: { threadId: serverThread.id, visitedAt: serverThread.updatedAt },
+        });
+      };
+      // Unread prominence only flips on run completions (hasUnseenCompletion),
+      // so an unseen completion publishes immediately; mid-turn activity bumps
+      // — several per second while a turn streams — ride a trailing throttle,
+      // each rerun swapping the timer so the trailing dispatch carries the
+      // newest watermark.
+      const latestRunCompletedAtMs = serverThread.latestRun?.completedAt
+        ? Date.parse(serverThread.latestRun.completedAt)
+        : NaN;
+      const hasUnseenCompletion =
+        !Number.isNaN(latestRunCompletedAtMs) &&
+        (Number.isNaN(lastVisitedAt) || latestRunCompletedAtMs > lastVisitedAt);
+      const elapsed = Date.now() - lastVisitDispatchAtRef.current;
+      if (hasUnseenCompletion || elapsed >= VISIT_DISPATCH_THROTTLE_MS) {
+        dispatch();
+        return;
+      }
+      const timer = setTimeout(dispatch, VISIT_DISPATCH_THROTTLE_MS - elapsed);
+      return () => clearTimeout(timer);
+    }
 
     markThreadVisited(
       scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
@@ -1984,6 +1982,7 @@ function ChatViewContent(props: ChatViewProps) {
     serverThread?.environmentId,
     serverThread?.id,
     serverThread?.lastVisitedAt,
+    serverThread?.latestRun?.completedAt,
     serverThread?.updatedAt,
     visitThreadMutation,
   ]);

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -27,6 +27,7 @@ import {
   shouldClearThreadSelectionOnMouseDown,
   sortLogicalProjectsForSidebar,
   sortSidebarV2ProjectGroups,
+  resolveThreadLastVisitedAt,
   sortSettledThreadsForSidebarV2,
   sortThreadsForSidebarV2,
   sortScopedProjectsForSidebar,
@@ -1549,5 +1550,41 @@ describe("sortSidebarV2ProjectGroups", () => {
         (project) => project.projectKey,
       ),
     ).toEqual(["logical-newer", "logical-older"]);
+  });
+});
+
+describe("resolveThreadLastVisitedAt", () => {
+  it("uses the local watermark when the server does not track visits", () => {
+    expect(resolveThreadLastVisitedAt(undefined, "2026-07-30T10:00:00.000Z")).toBe(
+      "2026-07-30T10:00:00.000Z",
+    );
+    expect(resolveThreadLastVisitedAt(undefined, undefined)).toBeUndefined();
+  });
+
+  it("keeps an explicit server-side unread regardless of the local watermark", () => {
+    expect(resolveThreadLastVisitedAt(null, "2026-07-30T10:00:00.000Z")).toBeUndefined();
+  });
+
+  it("prefers the newer of server and local watermarks", () => {
+    // The local watermark is written eagerly while the server dispatch is
+    // throttled, so it may run ahead of the server echo.
+    expect(resolveThreadLastVisitedAt("2026-07-30T10:00:00.000Z", "2026-07-30T10:00:05.000Z")).toBe(
+      "2026-07-30T10:00:05.000Z",
+    );
+    expect(resolveThreadLastVisitedAt("2026-07-30T10:00:05.000Z", "2026-07-30T10:00:00.000Z")).toBe(
+      "2026-07-30T10:00:05.000Z",
+    );
+    expect(resolveThreadLastVisitedAt("2026-07-30T10:00:00.000Z", undefined)).toBe(
+      "2026-07-30T10:00:00.000Z",
+    );
+  });
+
+  it("falls back to the parseable side when a watermark is malformed", () => {
+    expect(resolveThreadLastVisitedAt("not-a-date", "2026-07-30T10:00:00.000Z")).toBe(
+      "2026-07-30T10:00:00.000Z",
+    );
+    expect(resolveThreadLastVisitedAt("2026-07-30T10:00:00.000Z", "not-a-date")).toBe(
+      "2026-07-30T10:00:00.000Z",
+    );
   });
 });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1561,30 +1561,18 @@ describe("resolveThreadLastVisitedAt", () => {
     expect(resolveThreadLastVisitedAt(undefined, undefined)).toBeUndefined();
   });
 
-  it("keeps an explicit server-side unread regardless of the local watermark", () => {
-    expect(resolveThreadLastVisitedAt(null, "2026-07-30T10:00:00.000Z")).toBeUndefined();
-  });
-
-  it("prefers the newer of server and local watermarks", () => {
-    // The local watermark is written eagerly while the server dispatch is
-    // throttled, so it may run ahead of the server echo.
+  it("keeps the server watermark authoritative when visited tracking exists", () => {
+    // A rewound server value (mark-unread) must win even over a newer local
+    // watermark left behind by earlier viewing on this device.
     expect(resolveThreadLastVisitedAt("2026-07-30T10:00:00.000Z", "2026-07-30T10:00:05.000Z")).toBe(
-      "2026-07-30T10:00:05.000Z",
-    );
-    expect(resolveThreadLastVisitedAt("2026-07-30T10:00:05.000Z", "2026-07-30T10:00:00.000Z")).toBe(
-      "2026-07-30T10:00:05.000Z",
+      "2026-07-30T10:00:00.000Z",
     );
     expect(resolveThreadLastVisitedAt("2026-07-30T10:00:00.000Z", undefined)).toBe(
       "2026-07-30T10:00:00.000Z",
     );
   });
 
-  it("falls back to the parseable side when a watermark is malformed", () => {
-    expect(resolveThreadLastVisitedAt("not-a-date", "2026-07-30T10:00:00.000Z")).toBe(
-      "2026-07-30T10:00:00.000Z",
-    );
-    expect(resolveThreadLastVisitedAt("2026-07-30T10:00:00.000Z", "not-a-date")).toBe(
-      "2026-07-30T10:00:00.000Z",
-    );
+  it("treats an explicit server-side null as never visited", () => {
+    expect(resolveThreadLastVisitedAt(null, "2026-07-30T10:00:00.000Z")).toBeUndefined();
   });
 });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -260,7 +260,17 @@ export function resolveThreadLastVisitedAt(
   localLastVisitedAt: string | undefined,
 ): string | undefined {
   if (serverLastVisitedAt === undefined) return localLastVisitedAt;
-  return serverLastVisitedAt ?? undefined;
+  // Explicitly marked unread: a stale local watermark must not mask it.
+  if (serverLastVisitedAt === null) return undefined;
+  // The server value is authoritative but its dispatch is throttled while a
+  // thread is open; the eagerly-written local watermark keeps the open thread
+  // reading as visited until the trailing dispatch echoes back.
+  if (localLastVisitedAt === undefined) return serverLastVisitedAt;
+  const serverMs = Date.parse(serverLastVisitedAt);
+  const localMs = Date.parse(localLastVisitedAt);
+  if (Number.isNaN(localMs)) return serverLastVisitedAt;
+  if (Number.isNaN(serverMs)) return localLastVisitedAt;
+  return localMs > serverMs ? localLastVisitedAt : serverLastVisitedAt;
 }
 
 export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -259,18 +259,11 @@ export function resolveThreadLastVisitedAt(
   serverLastVisitedAt: string | null | undefined,
   localLastVisitedAt: string | undefined,
 ): string | undefined {
+  // When the server tracks visits it is authoritative — including explicit
+  // rewinds from mark-unread, which a newer browser-local watermark must not
+  // mask. The local value only carries servers without visited tracking.
   if (serverLastVisitedAt === undefined) return localLastVisitedAt;
-  // Explicitly marked unread: a stale local watermark must not mask it.
-  if (serverLastVisitedAt === null) return undefined;
-  // The server value is authoritative but its dispatch is throttled while a
-  // thread is open; the eagerly-written local watermark keeps the open thread
-  // reading as visited until the trailing dispatch echoes back.
-  if (localLastVisitedAt === undefined) return serverLastVisitedAt;
-  const serverMs = Date.parse(serverLastVisitedAt);
-  const localMs = Date.parse(localLastVisitedAt);
-  if (Number.isNaN(localMs)) return serverLastVisitedAt;
-  if (Number.isNaN(serverMs)) return localLastVisitedAt;
-  return localMs > serverMs ? localLastVisitedAt : serverLastVisitedAt;
+  return serverLastVisitedAt ?? undefined;
 }
 
 export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {


### PR DESCRIPTION
## Problem

Live profiling of the Alpha build on this branch (native `sample`, V8 CPU profile via the inspector, and `server.trace.ndjson` span aggregation) showed the server pinning a full core with a sustained ~4.5 MB/s write stream. Per 88.7s trace window:

- **`thread.visit` command storm**: ~2.4 dispatches/sec while a turn is active — `ChatView` re-dispatched a visit on every thread `updatedAt` bump. 2,572 of the last 2,590 command receipts were visits; **100,626 `thread.visited` events (106 MB) accumulated in the event store in about a day** — the #1 v2 event type.
- **`ws.orchestrationV2.projectShellItems`: 221 × 196 ms avg ≈ 50% of a core.** Every stored event batch ran a full `getShellSnapshot()`: a 12-correlated-subquery SELECT over all ~1,000 threads plus an Effect-Schema decode of every thread + latest-message payload — to then extract a single thread's delta. The archived-shell subscription did this **per event with no batching window**.
- Every dispatch (including visits) also ran `ensureLegacyTranscript` (~80 ms avg → ~20% of a core during the storm).

The v1 shell stream on `main` already avoids all of this by refetching only the affected aggregate per coalesced event; the v2 rewrite regressed it.

## Changes

**Server**
- `ProjectionStore.getThreadShell(threadId)`: materializes one thread's shell (plus its fork-source chain for `visibleItemCount`) instead of every thread. `getShellSnapshot` now shares the same query/decoder helpers, so the two paths cannot drift.
- `ws.ts`: both the live and archived shell subscriptions map each coalesced event to a per-thread shell read (restoring main's v1 design); the archived stream gains the 512/50 ms coalescing window it was missing. The wire protocol already spoke per-thread deltas — no contract or client changes.
- `ThreadManagementService`: `thread.visit` / `thread.mark-unread` skip legacy-transcript hydration (they only rewrite the read-state watermark). `LegacyV1ThreadImporter` memoizes threads whose transcript import is already confirmed (`transcript_imported_at` is never reset).
- `ProjectionMaintenance.compactEventStore`: full event-store compaction, forked after startup. Projections are the working state (startup verifies, never replays), so events only serve `afterSequence` catch-up and disaster-recovery rebuild — for full-payload state events, everything but the newest per entity is dead weight in both. Passes: superseded thread-state events (visit/unread/archive/settle/snooze/metadata/…, keeping the newest per thread plus `thread.created`, which `verify` anchors on); superseded `message.updated`/`node.updated` per entity id (`turn-item.updated` deliberately untouched — rebuild derives `turn_item_positions` from it with first-write-wins semantics); and legacy v1 thread events plus pre-migration command receipts for threads whose v2 import completed. Deletes run in paced 2k-row batches with yields so the synchronous sqlite driver never pins the event loop. `VACUUM` is not auto-run (it would block the connection for minutes); reclaimable free-page bytes are reported and startup logs a hint. Dry-run against the real 8.2 GB `state.sqlite`: ~2.1M rows pruned — 113k superseded thread-state events, 1.02M v1 events (~3 GB), 1.01M legacy receipts (~400 MB with indexes). Covered by a test asserting per-pass retention and that `verify`/`rebuild` stay valid across the deletion gaps.

**Web**
- `ChatView`: server-side visit dispatch is throttled to one per 10 s with a trailing timer (the trailing dispatch carries the newest watermark). Unread prominence only flips on run completions (`hasUnseenCompletion`), so an unseen completion bypasses the throttle and publishes immediately — only mid-turn activity bumps, which carry no unread signal, are throttled. `resolveThreadLastVisitedAt` stays server-authoritative (a mark-unread rewind cannot be masked by a stale browser-local watermark), and the per-watermark dispatch dedupe keeps a mark-unread on the open thread sticky until new activity lands.

## Expected effect

During an active turn with a thread open: shell work per event drops from O(all threads) (~196 ms) to O(1 thread), visit commands drop from ~2.4/s to ≤0.1/s, and the event store stops accumulating ~100k read-state events/day. Idle-with-open-thread sessions should dispatch zero commands.

## Testing

- `apps/server`: typecheck clean (except the pre-existing `ProviderEventIngestor.test.ts` DateTime error at the base commit, deliberately not absorbed here — it has a pending fix in a separate working tree). Orchestration-v2 test files (43 tests) and `FoundationPersistence` (23 tests, incl. new compaction test) pass; `runtimeLayer` lifecycle test now asserts `getThreadShell` parity with the full snapshot end-to-end.
- `apps/web`: typecheck clean; full suite (1,679 tests) passes, incl. new `resolveThreadLastVisitedAt` cases.

## Inherited base-branch breaks fixed here

The base branch's CI was already red; this PR absorbs the small fixes so its own CI can go green:
- `sendToThread` now tolerates the missing user turn item for queued sends — the base branch intentionally stopped emitting it at dispatch time (it materializes when the queued turn starts), but `sendToThread` still demanded it, failing the `ThreadLaunchService` queued-follow-up test.
- `ProviderEventIngestor.test` narrows the nullable retry `startedAt` before `DateTime.toEpochMillis` (the typecheck break).

Still failing **on the base branch** (pre-existing, out of scope here): the 5 `queued_turn/*` replay fixtures (`await_thread_idle` leaves run 1 `waiting` / run 2 `queued` — the in-flight queued-turn promotion work; fails at least as far back as the merge-main commit `33e9559b92`) and the flaky `OrchestratorMcpToolkit` cross-provider delegation test (fails identically at the base tip).

## Deliberately out of scope (follow-ups)

- Pruning the v1 *projection* tables (`projection_thread_activities` ≈ 2.9 GB) — the v1 event rows are handled by `compactEventStore` above, but the v1 projection tables may still serve legacy protocol paths and the importer needs them until the last threads finish importing.
- A `VACUUM` story to shrink the file on disk (needs to run offline or via `VACUUM INTO` + swap; not safe on the live synchronous connection).
- The VCS remote-status broadcaster (git fetch every ~10 s) and terminal subprocess polling — pre-existing on main, not regressions from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live shell projection reads, event-store deletion for thread.visited, and cross-device read-state semantics; compaction is guarded by verify/rebuild tests but first-run backlog deletion is still a one-time data mutation.
> 
> **Overview**
> Cuts orchestration v2 shell-stream and **thread.visit** load by computing WebSocket deltas from **per-thread** shells instead of reloading every thread on each stored event, throttling client visit commands, and pruning redundant **thread.visited** rows.
> 
> **Server — shell streaming:** Adds `getThreadShell` on the projection store (target thread plus fork-source chain for `visibleItemCount`) and wires live and archived shell subscriptions in `ws.ts` to coalesce events per thread and map them through `shellStreamItemFromThreadShell` / `archivedShellStreamItemFromThreadShell` (archived stream now uses the same batching window as the live stream).
> 
> **Server — visits and imports:** `thread.visit` and `thread.mark-unread` no longer require legacy transcript hydration before dispatch; confirmed transcript imports are memoized in-process to skip repeated DB work on hot read paths.
> 
> **Server — compaction:** `ProjectionMaintenance.compactReadStateEvents` deletes superseded `thread.visited` events (keeps the newest per thread); forked after startup with logging on failure.
> 
> **Web:** `ChatView` throttles server visit dispatches to about one per 10s (trailing timer for mid-turn bumps) but dispatches immediately when there is an unseen run completion. `resolveThreadLastVisitedAt` treats server-tracked watermarks as authoritative (including explicit `null` from mark-unread) so local state does not mask rewinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9952f0a19e52af0369abc9c6ab07c3cbf4f07ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-thread shell deltas, visit throttling, and event store compaction to orchestration
> - Adds `getThreadShell` to the projection store, orchestrator, and thread management service, enabling per-thread shell retrieval instead of full snapshot reads for WebSocket shell stream updates in [ws.ts](https://github.com/pingdotgg/t3code/pull/4971/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125).
> - Implements `compactEventStore` in [ProjectionMaintenance.ts](https://github.com/pingdotgg/t3code/pull/4971/files#diff-7e0d55f70bf0471cce1186448783fcb0a58acd2187eee6ba4dd8ef5203045fe5), which deletes superseded thread-state, message/node update, and imported legacy v1 events in batched transactions; runs in the background at server startup.
> - Adds `coalesceStoredThreadEvents` in [ShellStream.ts](https://github.com/pingdotgg/t3code/pull/4971/files#diff-2c11c165faa07a08dd49ca3a5f68da788e77fb6aa69b120a2820905fed08d218) to deduplicate per-thread events within a batch before shell conversion.
> - Throttles `thread.visit` command dispatch in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4971/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to at most once per 10s during active turns, with an immediate dispatch on completion.
> - Skips transcript hydration for `thread.visit` and `thread.mark-unread` commands in [ThreadManagementService.ts](https://github.com/pingdotgg/t3code/pull/4971/files#diff-4bc3c30459f73120ea1eb6d76f809275562c4e368223865f071a79e530aadb7b).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c43eec4. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

