### PR TITLE
fix: marketing site Vercel builds no longer die after ~100 deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prepare": "effect-tsgo patch && vp config --no-agent",
+    "prepare": "node scripts/clean-tsgo-backups.mjs && effect-tsgo patch && vp config --no-agent",
     "dev": "node scripts/dev-runner.ts dev",
     "dev:share": "node scripts/dev-runner.ts dev --share",
     "dev:server": "node scripts/dev-runner.ts dev:server",

--- a/scripts/clean-tsgo-backups.mjs
+++ b/scripts/clean-tsgo-backups.mjs
@@ -1,0 +1,24 @@
+// Deletes stale tsgo backup files left behind by `effect-tsgo patch`.
+//
+// The patch command backs up the real tsgo binary to `tsgo.original`, and if
+// that name is taken it writes `tsgo.original.1`, `.2`, ... without ever
+// cleaning up. On runners that restore node_modules from a build cache
+// (Vercel), backups accumulate across deploys until patch hard-fails at 101
+// with "Too many backup files exist". Removing them is safe: from the second
+// patch onward the backup is just the previously-patched binary, and pnpm
+// restores the pristine one whenever the package is re-materialized.
+//
+// Runs as part of `prepare`, so it must only use node builtins.
+import { globSync, rmSync } from "node:fs";
+
+const backups = globSync(
+  "node_modules/.pnpm/@typescript+native-preview-*/node_modules/@typescript/native-preview-*/lib/tsgo{,.exe}.original*",
+);
+
+for (const backup of backups) {
+  rmSync(backup, { force: true });
+}
+
+if (backups.length > 0) {
+  console.log(`Removed ${backups.length} stale tsgo backup(s)`);
+}

--- a/scripts/clean-tsgo-backups.mjs
+++ b/scripts/clean-tsgo-backups.mjs
@@ -9,14 +9,14 @@
 // restores the pristine one whenever the package is re-materialized.
 //
 // Runs as part of `prepare`, so it must only use node builtins.
-import { globSync, rmSync } from "node:fs";
+import * as NodeFS from "node:fs";
 
-const backups = globSync(
+const backups = NodeFS.globSync(
   "node_modules/.pnpm/@typescript+native-preview-*/node_modules/@typescript/native-preview-*/lib/tsgo{,.exe}.original*",
 );
 
 for (const backup of backups) {
-  rmSync(backup, { force: true });
+  NodeFS.rmSync(backup, { force: true });
 }
 
 if (backups.length > 0) {


### PR DESCRIPTION
## Problem

Vercel builds of the marketing site started failing in `prepare` with:

> BackupRestoreError: Too many backup files exist (over 100). Please clean up old backups

`effect-tsgo patch` backs up the real `tsgo` binary to `tsgo.original` on every run, and if that name is taken it writes `.original.1`, `.2`, ... without ever cleaning up (confirmed the latest 0.24.3 has the same logic, so upgrading doesn't help). CI is fine because Blacksmith runners start fresh, but Vercel restores `node_modules` from build cache between deploys — so every deploy stacked one more backup until patch hard-failed at 101.

## Solution

A tiny `scripts/clean-tsgo-backups.mjs` (node builtins only) deletes stale `tsgo.original*` backups, and `prepare` now runs it before `effect-tsgo patch`. Deleting them is safe: from the second patch onward the backup is just the previously-patched binary, and pnpm restores the pristine one whenever the package is re-materialized. Verified locally by simulating the cached-rebuild loop — steady state is one backup, no accumulation.

Note: the currently-wedged Vercel project still needs one "Redeploy without build cache" to clear the existing pile; this PR keeps it from re-accumulating.

---
Change authored by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the prepare hook and a small cleanup script; no runtime app logic, auth, or data paths.
> 
> **Overview**
> Vercel marketing builds were failing in **`prepare`** once **`effect-tsgo patch`** had created more than 100 **`tsgo.original*`** backups in cached **`node_modules`**.
> 
> **`scripts/clean-tsgo-backups.mjs`** removes matching backup files under **`@typescript/native-preview`** in the pnpm store (node builtins only), and **`prepare`** now runs it **before** **`effect-tsgo patch`** so backups do not accumulate across deploys. Existing wedged projects still need one redeploy without build cache to clear the current pile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 555d37599489634b6a6452050d5449036438ef5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delete stale tsgo backup files before each build to prevent Vercel deploy failures
> Adds [clean-tsgo-backups.mjs](https://github.com/pingdotgg/t3code/pull/4975/files#diff-3033a2dddcbf47e9c725d67ef01c3a464ab6308f0018929294a755588347819b), a script that globs for tsgo backup binaries in `node_modules` and removes them with `rmSync`. The `prepare` script in [package.json](https://github.com/pingdotgg/t3code/pull/4975/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) now runs this cleanup before `effect-tsgo patch` and `vp config`, preventing the accumulation of backup files that caused builds to fail after ~100 deploys.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 555d375.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->