### PR TITLE
fix(mobile): stale Connecting live activity is retired on a bound

### DIFF
--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -11,7 +11,8 @@ import * as Layer from "effect/Layer";
 import { FetchHttpClient } from "effect/unstable/http";
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
 
-import type { EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import type { RelayAgentActivitySnapshotResponse } from "@t3tools/contracts/relay";
 import { verifyDpopProof } from "@t3tools/shared/dpop";
 import type { SavedRemoteConnection } from "../../lib/connection";
 import { cryptoLayer } from "../cloud/dpop";
@@ -20,14 +21,17 @@ import {
   clearAgentAwarenessRegistrationRecord,
   loadAgentAwarenessRegistrationRecord,
   loadOrCreateAgentAwarenessDeviceId,
+  loadPreferences,
   saveAgentAwarenessRegistrationRecord,
 } from "../../persistence/imperative";
 import { makeRelayDeviceRegistrationRequest, resolveApsEnvironment } from "./registrationPayload";
 import {
   AgentAwarenessOperationError,
   __resetAgentAwarenessRemoteRegistrationForTest,
+  armAgentAwarenessLiveActivityForLocalWork,
   getAgentAwarenessRegistrationStatus,
   mergeAgentAwarenessRegistrationPreferences,
+  reconcileLocallyArmedLiveActivity,
   refreshActiveLiveActivityRemoteRegistration,
   refreshAgentAwarenessRegistration,
   normalizeAgentAwarenessRelayBaseUrl,
@@ -43,6 +47,7 @@ import * as Notifications from "expo-notifications";
 const secureStore = vi.hoisted(() => new Map<string, string>());
 const widgetMocks = vi.hoisted(() => ({
   getInstances: vi.fn(() => []),
+  start: vi.fn(),
 }));
 const backgroundRuntime = vi.hoisted(() => ({
   pending: [] as Array<{
@@ -77,6 +82,7 @@ vi.mock("expo-widgets", () => ({
 vi.mock("../../widgets/AgentActivity", () => ({
   default: {
     getInstances: widgetMocks.getInstances,
+    start: widgetMocks.start,
   },
 }));
 
@@ -187,6 +193,57 @@ const relayTestLayer = managedRelayClientLayer("https://relay.example.test").pip
   Layer.provide(Layer.mergeAll(FetchHttpClient.layer, cryptoLayer)),
 );
 
+// `FetchHttpClient.Fetch` caches globalThis.fetch the first time its default is
+// read, so the module-level layer above answers every later test with the first
+// test's stub. Tests that care about a specific response body build their own
+// layer with the fetch handed in explicitly.
+const relayLayerWithFetch = (fetchFn: typeof fetch) =>
+  managedRelayClientLayer("https://relay.example.test").pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch, fetchFn))),
+        cryptoLayer,
+      ),
+    ),
+  );
+
+function relayFetchAnsweringSnapshotWith(snapshotResponse: () => Response): typeof fetch {
+  return vi.fn((request: RequestInfo | URL) => {
+    const url = request instanceof Request ? request.url : String(request);
+    if (url.endsWith("/v1/client/dpop-token")) {
+      return Promise.resolve(
+        Response.json({
+          access_token: "relay-dpop-token",
+          issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+          token_type: "DPoP",
+          expires_in: 300,
+          scope: "mobile:registration",
+        }),
+      );
+    }
+    if (url.endsWith("/v1/mobile/agent-activity")) {
+      return Promise.resolve(snapshotResponse());
+    }
+    return Promise.resolve(Response.json({ ok: true }));
+  }) as unknown as typeof fetch;
+}
+
+function relayFetchServingSnapshot(snapshot: RelayAgentActivitySnapshotResponse): typeof fetch {
+  return relayFetchAnsweringSnapshotWith(() => Response.json(snapshot));
+}
+
+function relayFetchFailingSnapshot(): typeof fetch {
+  return relayFetchAnsweringSnapshotWith(() => new Response("relay unavailable", { status: 503 }));
+}
+
+function localLiveActivity(end: (mode: string) => Promise<void>) {
+  return {
+    getPushToken: vi.fn(() => Promise.resolve("activity-token")),
+    addPushTokenListener: vi.fn(),
+    end,
+  };
+}
+
 const runBackgroundOperations = Effect.fn("TestRemoteRegistration.runBackgroundOperations")(
   function* () {
     let idlePasses = 0;
@@ -211,8 +268,20 @@ const runBackgroundOperations = Effect.fn("TestRemoteRegistration.runBackgroundO
   },
 );
 
+// Drains the queue with fake timers still installed: the drain itself only needs
+// microtasks, so the reconcile deadlines a test is driving stay under its
+// control (and any deadline the drained operation arms is observable).
+async function drainBackgroundOperationsWith(
+  relayLayer: ReturnType<typeof relayLayerWithFetch>,
+): Promise<void> {
+  const drained = Effect.runPromise(runBackgroundOperations().pipe(Effect.provide(relayLayer)));
+  await vi.advanceTimersByTimeAsync(0);
+  await drained;
+}
+
 describe("makeRelayDeviceRegistrationRequest", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.stubGlobal("__DEV__", false);
     secureStore.clear();
@@ -225,8 +294,15 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     vi.mocked(loadAgentAwarenessRegistrationRecord).mockClear();
     vi.mocked(clearAgentAwarenessRegistrationRecord).mockClear();
     vi.mocked(loadOrCreateAgentAwarenessDeviceId).mockResolvedValue("device-1");
+    vi.mocked(loadPreferences).mockResolvedValue({ liveActivitiesEnabled: false });
     widgetMocks.getInstances.mockReset();
     widgetMocks.getInstances.mockReturnValue([]);
+    widgetMocks.start.mockReset();
+    widgetMocks.start.mockReturnValue({
+      getPushToken: vi.fn(() => Promise.resolve("activity-token")),
+      addPushTokenListener: vi.fn(),
+      end: vi.fn(() => Promise.resolve()),
+    } as never);
   });
 
   it("preserves disabled Live Activity preferences in relay registrations", () => {
@@ -856,4 +932,226 @@ describe("makeRelayDeviceRegistrationRequest", () => {
       }).pipe(Effect.provide(relayTestLayer));
     },
   );
+
+  it.effect(
+    "ends a locally armed placeholder when the relay has nothing to repaint it with",
+    () => {
+      const end = vi.fn(() => Promise.resolve());
+      widgetMocks.getInstances.mockReturnValue([localLiveActivity(end)] as never);
+      Constants.expoConfig!.extra = {
+        relay: {
+          url: "https://relay.example.test/",
+        },
+      };
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+      return Effect.gen(function* () {
+        yield* reconcileLocallyArmedLiveActivity();
+
+        expect(end).toHaveBeenCalledWith("immediate");
+      }).pipe(Effect.provide(relayLayerWithFetch(relayFetchServingSnapshot({ aggregate: null }))));
+    },
+  );
+
+  it.effect("keeps a locally armed placeholder while the relay still has activity to show", () => {
+    const end = vi.fn(() => Promise.resolve());
+    widgetMocks.getInstances.mockReturnValue([localLiveActivity(end)] as never);
+    Constants.expoConfig!.extra = {
+      relay: {
+        url: "https://relay.example.test/",
+      },
+    };
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+    return Effect.gen(function* () {
+      yield* reconcileLocallyArmedLiveActivity();
+
+      expect(end).not.toHaveBeenCalled();
+    }).pipe(
+      Effect.provide(
+        relayLayerWithFetch(
+          relayFetchServingSnapshot({
+            aggregate: {
+              title: "T3 Code",
+              subtitle: "Agent work in progress",
+              activeCount: 1,
+              updatedAt: "2026-05-25T13:07:00.000Z",
+              activities: [
+                {
+                  environmentId: "env-1" as EnvironmentId,
+                  threadId: "thread-1" as ThreadId,
+                  projectTitle: "Project",
+                  threadTitle: "Thread",
+                  modelTitle: "gpt-5.4",
+                  phase: "running",
+                  status: "Working",
+                  updatedAt: "2026-05-25T13:07:00.000Z",
+                  deepLink: "/threads/env-1/thread-1",
+                },
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+  });
+
+  it.effect("keeps a locally armed placeholder when the relay snapshot cannot be read", () => {
+    // A failed snapshot read says nothing about what the relay would push —
+    // APNs delivery does not depend on it — so the card must survive.
+    const end = vi.fn(() => Promise.resolve());
+    widgetMocks.getInstances.mockReturnValue([localLiveActivity(end)] as never);
+    Constants.expoConfig!.extra = {
+      relay: {
+        url: "https://relay.example.test/",
+      },
+    };
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+    return Effect.gen(function* () {
+      yield* reconcileLocallyArmedLiveActivity();
+
+      expect(end).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(relayLayerWithFetch(relayFetchFailingSnapshot())));
+  });
+
+  it.effect("keeps a locally armed placeholder after the relay token provider is released", () => {
+    const end = vi.fn(() => Promise.resolve());
+    widgetMocks.getInstances.mockReturnValue([localLiveActivity(end)] as never);
+    Constants.expoConfig!.extra = {
+      relay: {
+        url: "https://relay.example.test/",
+      },
+    };
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+    releaseAgentAwarenessRelayTokenProvider();
+
+    return Effect.gen(function* () {
+      yield* reconcileLocallyArmedLiveActivity();
+
+      expect(end).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(relayLayerWithFetch(relayFetchServingSnapshot({ aggregate: null }))));
+  });
+
+  it("ends the local placeholder when the bounded reconcile fires", async () => {
+    vi.useFakeTimers();
+    Constants.expoConfig!.extra = {
+      relay: {
+        url: "https://relay.example.test/",
+      },
+    };
+    vi.mocked(loadPreferences).mockResolvedValue({ liveActivitiesEnabled: true });
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+    armAgentAwarenessLiveActivityForLocalWork({
+      threadTitle: "Fix the stale placeholder",
+      projectTitle: "T3 Code",
+    });
+    // Let the preference read settle so the card is armed.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(widgetMocks.start).toHaveBeenCalledTimes(1);
+    expect(widgetMocks.start.mock.calls[0]?.[0]).toMatchObject({
+      activities: [
+        {
+          threadTitle: "Fix the stale placeholder",
+          projectTitle: "T3 Code",
+          phase: "starting",
+          status: "Connecting",
+        },
+      ],
+    });
+
+    // The armed card is what the reconcile finds a window later.
+    const end = vi.fn(() => Promise.resolve());
+    widgetMocks.getInstances.mockReturnValue([localLiveActivity(end)] as never);
+    backgroundRuntime.pending.length = 0;
+    await vi.advanceTimersByTimeAsync(60_000);
+    vi.useRealTimers();
+
+    await Effect.runPromise(
+      runBackgroundOperations().pipe(
+        Effect.provide(relayLayerWithFetch(relayFetchServingSnapshot({ aggregate: null }))),
+      ),
+    );
+
+    expect(end).toHaveBeenCalledWith("immediate");
+  });
+
+  it("gives every armed placeholder the full reconcile window", async () => {
+    vi.useFakeTimers();
+    Constants.expoConfig!.extra = {
+      relay: {
+        url: "https://relay.example.test/",
+      },
+    };
+    vi.mocked(loadPreferences).mockResolvedValue({ liveActivitiesEnabled: true });
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+    armAgentAwarenessLiveActivityForLocalWork({
+      threadTitle: "First turn",
+      projectTitle: "T3 Code",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(59_000);
+
+    // The relay ended the first card, and the next send arms a fresh one that
+    // must not inherit the previous card's remaining second.
+    armAgentAwarenessLiveActivityForLocalWork({
+      threadTitle: "Second turn",
+      projectTitle: "T3 Code",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const end = vi.fn(() => Promise.resolve());
+    widgetMocks.getInstances.mockReturnValue([localLiveActivity(end)] as never);
+    backgroundRuntime.pending.length = 0;
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(backgroundRuntime.pending).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(59_000);
+    await drainBackgroundOperationsWith(
+      relayLayerWithFetch(relayFetchServingSnapshot({ aggregate: null })),
+    );
+
+    expect(end).toHaveBeenCalledWith("immediate");
+    vi.useRealTimers();
+  });
+
+  it("looks once more, then stops, while the relay snapshot stays unreadable", async () => {
+    const unreadableRelay = relayLayerWithFetch(relayFetchFailingSnapshot());
+    vi.useFakeTimers();
+    Constants.expoConfig!.extra = {
+      relay: {
+        url: "https://relay.example.test/",
+      },
+    };
+    vi.mocked(loadPreferences).mockResolvedValue({ liveActivitiesEnabled: true });
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+    armAgentAwarenessLiveActivityForLocalWork({
+      threadTitle: "Fix the stale placeholder",
+      projectTitle: "T3 Code",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const end = vi.fn(() => Promise.resolve());
+    widgetMocks.getInstances.mockReturnValue([localLiveActivity(end)] as never);
+    backgroundRuntime.pending.length = 0;
+
+    // First look: the read fails, so the card survives and one more look is armed.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(backgroundRuntime.pending).toHaveLength(1);
+    await drainBackgroundOperationsWith(unreadableRelay);
+
+    // Second look a window later, still unreadable — and that is the last one,
+    // so a durably unreachable relay cannot keep the timer alive forever.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(backgroundRuntime.pending).toHaveLength(1);
+    await drainBackgroundOperationsWith(unreadableRelay);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(backgroundRuntime.pending).toHaveLength(0);
+    expect(end).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
 });

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -35,6 +35,16 @@ import { supportsAgentAwarenessPush } from "./capabilities";
 import { makeRelayDeviceRegistrationRequest, resolveApsEnvironment } from "./registrationPayload";
 
 const REMOTE_ACTIVITY_REGISTRATION_RETRY_MS = 15_000;
+// How long a locally armed placeholder may sit at "Connecting" before the app
+// checks whether the relay owns the card at all. An environment with
+// agent-activity publishing disabled never publishes, so the registration
+// replay that normally repaints the placeholder has nothing to send and the
+// relay's end-on-empty stays held off by the grace window every foreground
+// re-registration renews. The app cannot read an activity's current props, so
+// it asks the relay what the card should show instead. Retried once, because a
+// single failed read says nothing about what the relay would push.
+const LOCALLY_ARMED_RECONCILE_MS = 60_000;
+const LOCALLY_ARMED_RECONCILE_ATTEMPTS = 2;
 
 const AgentAwarenessOperation = Schema.Literals([
   "read-notification-permissions",
@@ -110,6 +120,7 @@ export function subscribeAgentAwarenessRegistrationStatus(listener: () => void):
   };
 }
 let activeLiveActivityRegistrationRetry: ReturnType<typeof setTimeout> | null = null;
+let locallyArmedReconcile: ReturnType<typeof setTimeout> | null = null;
 let relayTokenProvider: (() => Promise<string | null>) | null = null;
 let relayTokenProviderIdentity: string | null = null;
 let deviceRegistrationGeneration = 0;
@@ -192,6 +203,10 @@ export function setAgentAwarenessRelayTokenProvider(
       clearTimeout(activeLiveActivityRegistrationRetry);
       activeLiveActivityRegistrationRetry = null;
     }
+    if (locallyArmedReconcile) {
+      clearTimeout(locallyArmedReconcile);
+      locallyArmedReconcile = null;
+    }
     // Without a signed-in user the relay can no longer update or end these
     // activities, so they would sit orphaned on the lock screen.
     endLocalLiveActivities("live activity cleanup after cloud sign-out failed");
@@ -236,6 +251,10 @@ export function releaseAgentAwarenessRelayTokenProvider(): void {
   if (activeLiveActivityRegistrationRetry) {
     clearTimeout(activeLiveActivityRegistrationRetry);
     activeLiveActivityRegistrationRetry = null;
+  }
+  if (locallyArmedReconcile) {
+    clearTimeout(locallyArmedReconcile);
+    locallyArmedReconcile = null;
   }
 }
 
@@ -452,7 +471,9 @@ function unregisterDeviceWithRelay(input: {
 // phone, while the app is still foregrounded and the fresh activity's token
 // can be registered immediately. The seeded row is a best-effort placeholder;
 // the relay's registration replay repaints it with the authoritative
-// aggregate within seconds. No-ops when a card is already armed.
+// aggregate within seconds, and if no authoritative content ever arrives the
+// bounded reconcile retires it (LOCALLY_ARMED_RECONCILE_MS). No-ops when a
+// card is already armed.
 export function armAgentAwarenessLiveActivityForLocalWork(input: {
   readonly threadTitle: string;
   readonly projectTitle: string;
@@ -505,9 +526,86 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
       registerLiveActivityPushToken({ activity }).pipe(Effect.asVoid),
       "live activity arming after local task start failed",
     );
+    scheduleLocallyArmedLiveActivityReconcile();
   } catch (error) {
     logRegistrationError("live activity arming failed", error);
   }
+}
+
+// Restarts the window on every arm: sends arm a card per turn, and a card armed
+// seconds before an older deadline must not inherit its remainder.
+function scheduleLocallyArmedLiveActivityReconcile(attempt = 1): void {
+  if (locallyArmedReconcile) {
+    clearTimeout(locallyArmedReconcile);
+  }
+
+  locallyArmedReconcile = setTimeout(() => {
+    locallyArmedReconcile = null;
+    runRegistrationInBackground(
+      reconcileLocallyArmedLiveActivity(attempt),
+      "locally armed live activity reconciliation failed",
+    );
+  }, LOCALLY_ARMED_RECONCILE_MS);
+}
+
+// Retires a placeholder the relay turns out not to own. Exported for the
+// bound's timer and for tests; see LOCALLY_ARMED_RECONCILE_MS for why the
+// snapshot is the only signal available here.
+export function reconcileLocallyArmedLiveActivity(
+  attempt = 1,
+): Effect.Effect<void, never, ManagedRelay.ManagedRelayClient> {
+  return Effect.gen(function* () {
+    // Without a provider the relay cannot be asked anything, and provider
+    // teardown while signed in deliberately leaves cards alone.
+    if (!canRegisterRemoteLiveActivities() || !relayTokenProvider) {
+      return;
+    }
+
+    const activities = yield* listLocalLiveActivities("locally armed live activity lookup failed");
+    if (activities.length === 0) {
+      return;
+    }
+
+    const snapshot = yield* readAgentActivitySnapshot();
+    if (!snapshot) {
+      // An unreadable snapshot says nothing about what the relay would push —
+      // APNs delivery does not depend on this request — so the card stays. One
+      // more look a window later keeps a flaky read from restoring an
+      // unbounded placeholder.
+      if (attempt < LOCALLY_ARMED_RECONCILE_ATTEMPTS) {
+        scheduleLocallyArmedLiveActivityReconcile(attempt + 1);
+      }
+      return;
+    }
+    // Any aggregate means this account's activity is being published, so the
+    // relay owns the card — including ending it. An all-done aggregate is left
+    // alone deliberately: its dismissal rides on the relay's own end push.
+    if (snapshot.aggregate) {
+      return;
+    }
+    logRegistrationDebug("locally armed live activity retired; relay has nothing to show");
+    endLocalLiveActivities("locally armed live activity cleanup failed");
+  });
+}
+
+function listLocalLiveActivities(
+  context: string,
+): Effect.Effect<ReadonlyArray<LiveActivity<AgentActivityProps>>> {
+  return Effect.try({
+    try: () => AgentActivity.getInstances(),
+    catch: (cause) =>
+      new AgentAwarenessOperationError({
+        operation: "list-active-live-activities",
+        cause,
+      }),
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.sync(() => {
+        logRegistrationError(context, error);
+        return [] as ReadonlyArray<LiveActivity<AgentActivityProps>>;
+      }),
+    ),
+  );
 }
 
 function readAgentActivitySnapshot(): Effect.Effect<
@@ -816,6 +914,10 @@ export function unregisterAllAgentAwarenessConnections(): void {
     clearTimeout(activeLiveActivityRegistrationRetry);
     activeLiveActivityRegistrationRetry = null;
   }
+  if (locallyArmedReconcile) {
+    clearTimeout(locallyArmedReconcile);
+    locallyArmedReconcile = null;
+  }
 }
 
 export function refreshAgentAwarenessRegistration(): Effect.Effect<
@@ -861,6 +963,10 @@ export function __resetAgentAwarenessRemoteRegistrationForTest(): void {
   if (activeLiveActivityRegistrationRetry) {
     clearTimeout(activeLiveActivityRegistrationRetry);
     activeLiveActivityRegistrationRetry = null;
+  }
+  if (locallyArmedReconcile) {
+    clearTimeout(locallyArmedReconcile);
+    locallyArmedReconcile = null;
   }
   relayTokenProvider = null;
   relayTokenProviderIdentity = null;
@@ -1010,21 +1116,7 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
       return;
     }
 
-    let activities = yield* Effect.try({
-      try: () => AgentActivity.getInstances(),
-      catch: (cause) =>
-        new AgentAwarenessOperationError({
-          operation: "list-active-live-activities",
-          cause,
-        }),
-    }).pipe(
-      Effect.catch((error) =>
-        Effect.sync(() => {
-          logRegistrationError("active live activity lookup failed", error);
-          return [] as ReadonlyArray<LiveActivity<AgentActivityProps>>;
-        }),
-      ),
-    );
+    let activities = yield* listLocalLiveActivities("active live activity lookup failed");
 
     // The relay tracks exactly one card per device; if concurrent arming ever
     // produced extras, end them so only one keeps receiving updates.

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -857,7 +857,8 @@ export function NewTaskDraftScreen(props: {
     // Arm the lock-screen card before the async thread creation: backgrounding
     // the app right after tapping submit would otherwise reject the foreground
     // -only Activity start. If creation fails, the token registration's replay
-    // finds no work and ends the card within seconds.
+    // normally ends the card within seconds, and the arming's bounded reconcile
+    // retires it if no authoritative update ever lands.
     armAgentAwarenessLiveActivityForLocalWork({
       threadTitle: deriveThreadTitleFromPrompt(initialMessageText),
       projectTitle: selectedProject.title,


### PR DESCRIPTION
Fixes #4950

## Problem

Starting agent work from the iOS app arms a local placeholder Live Activity ("Connecting", one active agent) and relies on the relay's registration replay to repaint it with the authoritative aggregate. When the linked environment has agent-activity publishing disabled — the default for an environment linked from mobile, since the mobile link flow never sets the publish secret — no repaint or end push can ever arrive, and the placeholder stays at Connecting indefinitely, even after the turn completes. The relay's own end-on-empty is held off by a freshly-armed grace window that every foreground token re-registration renews, so nothing ever retires the card.

## Fix

The client cannot read the environment's `publishAgentActivity` state, and expo-widgets provides no way to read a live activity's current props, so the app cannot distinguish a repainted card from a stale placeholder. Instead, arming the placeholder now also arms a one-shot 60-second reconcile in `remoteRegistration.ts`:

- On fire, it reads the relay agent-activity snapshot (`GET /v1/mobile/agent-activity`) — exactly the content the relay would push to the card.
- A successful read with a null aggregate means the relay has nothing to show: the placeholder was a lie, and the local activity is ended immediately.
- Any non-null aggregate means the relay owns the card (including its eventual dismissal via its own end push) — the card is left alone.
- An unreadable snapshot (offline, relay error) says nothing about what APNs may be delivering, so the card is kept and the check retries once on the same bound, capped at two attempts total.
- The reconcile no-ops without a relay token provider, and the pending timer is cleared on sign-out, provider release, and connection unregistration. Each new arming resets the full window so a fresh card never inherits an almost-expired deadline.

Note: the fix rests on the relay-side behavior described above (grace window renewed by re-registration suppressing end-on-empty); the client-side bound is correct regardless, but the relay-side grace renewal may deserve its own issue.

## Tests

7 new tests in `remoteRegistration.test.ts` (35 total in the file, all passing): the regression (null aggregate ends the card with `"immediate"`), populated aggregate keeps the card, unreadable snapshot (HTTP 503) keeps the card, released provider keeps the card, the end-to-end arm → timer → reconcile → end path under fake timers, re-arming resets the deadline, and the retry fires exactly once then stops. New logic was mutation-checked: reverting each behavior makes its test fail. Also ran the scoped mobile typecheck, lint, and format checks — all green. Verified via unit tests on Linux; no native iOS run was performed.

---
Implemented and reviewed with Claude Code (Fable 5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS Live Activity lifecycle and relay snapshot handling on user-visible lock-screen UI; logic is bounded and well-tested but affects foreground agent-awareness behavior.
> 
> **Overview**
> Fixes **stale "Connecting" Live Activities** when the relay never publishes agent activity (e.g. mobile-linked environments without a publish secret).
> 
> **`remoteRegistration.ts`** now schedules a **60s bounded reconcile** whenever a local placeholder is armed. After the window, the app fetches the relay agent-activity snapshot (`GET /v1/mobile/agent-activity`). A **null aggregate** means the relay has nothing to show, so local activities are ended immediately; a **non-null aggregate** leaves the card under relay control. **Failed snapshot reads** keep the card and **retry once** (two attempts total). Each new arm **resets the full 60s window**; the reconcile timer is cleared on sign-out, provider release, and unregister.
> 
> **`NewTaskDraftScreen.tsx`** comment is updated to mention this reconcile path when authoritative relay updates never arrive.
> 
> **Tests** add relay fetch helpers, seven reconcile/timer scenarios, and shared `listLocalLiveActivities` usage in refresh paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aa33c8fe3108e0b98f1c56cfd0c83b818ead547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retire stale locally-armed Live Activity placeholders on a bounded reconcile
> - Adds `reconcileLocallyArmedLiveActivity` to [remoteRegistration.ts](https://github.com/pingdotgg/t3code/pull/4980/files#diff-ac13745728627647bf60cf50ea2b1d61f0b216df0229029b70f9e6be23887f47), which ends locally-armed Live Activity placeholders immediately when the relay reports no active aggregate.
> - Schedules reconcile via `scheduleLocallyArmedLiveActivityReconcile` 60 seconds after arming (`LOCALLY_ARMED_RECONCILE_MS = 60_000`), with up to 2 attempts (`LOCALLY_ARMED_RECONCILE_ATTEMPTS`) when the snapshot is unreadable.
> - Cancels any pending reconcile timer when the relay token provider is set, released, or all connections are unregistered.
> - Adds comprehensive tests covering end, no-end, retry, and per-arm window-reset scenarios in [remoteRegistration.test.ts](https://github.com/pingdotgg/t3code/pull/4980/files#diff-37056a3258fd7e3d844421249775155234fffa3a416f15cf40573963540cdc73).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1aa33c8. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->