### PR TITLE
fix(server): restore PR detection without HOME

### DIFF
--- a/apps/server/src/os-jank.test.ts
+++ b/apps/server/src/os-jank.test.ts
@@ -1,27 +1,40 @@
-import { assert, it } from "@effect/vitest";
+import * as NodeOS from "node:os";
+import { assert, it } from "vite-plus/test";
 
 import { hydratePosixHome } from "./os-jank.ts";
 
-it("hydrates HOME for minimal service environments", () => {
+it("hydrates HOME for minimal service environments from the user account", () => {
   const env: NodeJS.ProcessEnv = {};
 
-  hydratePosixHome(env, "/home/service-user");
+  hydratePosixHome(env);
 
-  assert.equal(env.HOME, "/home/service-user");
+  assert.equal(env.HOME, NodeOS.userInfo().homedir);
 });
 
-it("hydrates a blank HOME value", () => {
+it("hydrates HOME independently of a blank process HOME", () => {
+  const originalHome = process.env.HOME;
   const env: NodeJS.ProcessEnv = { HOME: " " };
 
-  hydratePosixHome(env, "/home/service-user");
+  try {
+    process.env.HOME = " ";
+    hydratePosixHome(env);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+  }
 
-  assert.equal(env.HOME, "/home/service-user");
+  assert.equal(env.HOME, NodeOS.userInfo().homedir);
 });
 
 it("preserves an explicitly configured HOME", () => {
   const env: NodeJS.ProcessEnv = { HOME: "/custom/home" };
 
-  hydratePosixHome(env, "/home/service-user");
+  hydratePosixHome(env, () => {
+    throw new Error("HOME lookup should not run");
+  });
 
   assert.equal(env.HOME, "/custom/home");
 });

--- a/apps/server/src/os-jank.test.ts
+++ b/apps/server/src/os-jank.test.ts
@@ -1,0 +1,27 @@
+import { assert, it } from "@effect/vitest";
+
+import { hydratePosixHome } from "./os-jank.ts";
+
+it("hydrates HOME for minimal service environments", () => {
+  const env: NodeJS.ProcessEnv = {};
+
+  hydratePosixHome(env, "/home/service-user");
+
+  assert.equal(env.HOME, "/home/service-user");
+});
+
+it("hydrates a blank HOME value", () => {
+  const env: NodeJS.ProcessEnv = { HOME: " " };
+
+  hydratePosixHome(env, "/home/service-user");
+
+  assert.equal(env.HOME, "/home/service-user");
+});
+
+it("preserves an explicitly configured HOME", () => {
+  const env: NodeJS.ProcessEnv = { HOME: "/custom/home" };
+
+  hydratePosixHome(env, "/home/service-user");
+
+  assert.equal(env.HOME, "/custom/home");
+});

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -36,6 +36,12 @@ function hydratePosixPath(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): vo
   }
 }
 
+export function hydratePosixHome(env: NodeJS.ProcessEnv, homeDir = NodeOS.homedir()): void {
+  if ((env.HOME?.trim() ?? "").length === 0 && homeDir.length > 0) {
+    env.HOME = homeDir;
+  }
+}
+
 export const fixPath = Effect.fn("fixPath")(function* (): Effect.fn.Return<
   void,
   never,
@@ -63,10 +69,13 @@ export const fixPath = Effect.fn("fixPath")(function* (): Effect.fn.Return<
 
   if (platform !== "darwin" && platform !== "linux") return;
 
-  yield* Effect.sync(() => hydratePosixPath(env, platform)).pipe(
+  yield* Effect.sync(() => {
+    hydratePosixHome(env);
+    hydratePosixPath(env, platform);
+  }).pipe(
     Effect.catchDefect((defect) =>
       Effect.sync(() => {
-        logPathHydrationWarning("Failed to hydrate PATH from the user environment.", defect);
+        logPathHydrationWarning("Failed to hydrate the user environment.", defect);
       }),
     ),
   );

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -36,8 +36,14 @@ function hydratePosixPath(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): vo
   }
 }
 
-export function hydratePosixHome(env: NodeJS.ProcessEnv, homeDir = NodeOS.homedir()): void {
-  if ((env.HOME?.trim() ?? "").length === 0 && homeDir.length > 0) {
+export function hydratePosixHome(
+  env: NodeJS.ProcessEnv,
+  resolveHomeDir = () => NodeOS.userInfo().homedir,
+): void {
+  if ((env.HOME?.trim() ?? "").length > 0) return;
+
+  const homeDir = resolveHomeDir();
+  if (homeDir.length > 0) {
     env.HOME = homeDir;
   }
 }
@@ -69,13 +75,17 @@ export const fixPath = Effect.fn("fixPath")(function* (): Effect.fn.Return<
 
   if (platform !== "darwin" && platform !== "linux") return;
 
-  yield* Effect.sync(() => {
-    hydratePosixHome(env);
-    hydratePosixPath(env, platform);
-  }).pipe(
+  yield* Effect.sync(() => hydratePosixHome(env)).pipe(
     Effect.catchDefect((defect) =>
       Effect.sync(() => {
-        logPathHydrationWarning("Failed to hydrate the user environment.", defect);
+        logPathHydrationWarning("Failed to hydrate HOME from the user account.", defect);
+      }),
+    ),
+  );
+  yield* Effect.sync(() => hydratePosixPath(env, platform)).pipe(
+    Effect.catchDefect((defect) =>
+      Effect.sync(() => {
+        logPathHydrationWarning("Failed to hydrate PATH from the user environment.", defect);
       }),
     ),
   );


### PR DESCRIPTION
## Problem

T3 servers launched by service managers without `HOME` cannot let `gh` locate its existing credentials. Git status then silently omits pull request metadata, which leaves PR numbers blank for threads in worktrees and remote clients.

## Fix

Hydrate a missing or blank POSIX `HOME` from `os.homedir()` during server startup before hydrating `PATH`, while preserving any explicitly configured value. Add focused coverage for missing, blank, and explicit `HOME` values.

## Impact

PR numbers and statuses resolve across worktrees for web, desktop, and mobile clients connected to the updated server.

## Validation

- Commit-time formatting passed for both changed files.
- `vp run --filter t3 typecheck` passed (existing Effect suggestions only).
- `git diff --check upstream/main...HEAD` passed.
- A standalone server startup with `HOME` unset used the real `gh` binary and returned PR `#4844`.
- A separate tracked worktree displayed PR `#4844` in the thread footer and sidebar.
- T3's **Checkout pull request → Worktree** flow displayed PR `#4981` in the sidebar, footer, and **View PR** action.
- `vp test run apps/server/src/os-jank.test.ts` is blocked before collection by the existing `Vitest failed to find current suite` runner failure, which reproduces on unchanged tests.

## image
<img width="1287" height="797" alt="image" src="https://github.com/user-attachments/assets/1571bb4c-ab9d-4598-a7ac-b2c1f9e9fe78" />

Created with GPT-5.6-Sol in the T3 Code Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore PR detection by hydrating HOME on POSIX when unset or blank
> - Adds `hydratePosixHome` in [`os-jank.ts`](https://github.com/pingdotgg/t3code/pull/4985/files#diff-01387cb8f0521a1e152ae377c15805f328384e404ccf93da7a82c02d30cf694c) that sets `env.HOME` from `NodeOS.userInfo().homedir` when `HOME` is missing or blank.
> - Updates the `fixPath` generator to call `hydratePosixHome` before `hydratePosixPath` on POSIX, wrapping failures with `Effect.catchDefect` to log a warning rather than crash.
> - Behavioral Change: `process.env.HOME` will now be populated on POSIX systems where it was previously unset, which fixes PR detection flows that depend on a valid home directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 643f981.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only env repair on POSIX with early return when HOME is already set; failures are logged and do not block server startup.
> 
> **Overview**
> **Restores PR metadata when the server runs without `HOME`** (e.g. service managers) by hydrating `env.HOME` from the user account before existing PATH hydration on darwin/linux.
> 
> Adds `hydratePosixHome`, which fills missing or whitespace-only `HOME` via `os.userInfo().homedir` and leaves an explicit value untouched. `fixPath` invokes it ahead of `hydratePosixPath`, with the same defect logging pattern as PATH failures. Unit tests cover empty env, blank `HOME`, and preserved custom `HOME`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643f981636c9dc367ed0778f175d67a9d180c1a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->