### PR TITLE
fix(mobile): local-checkout threads record their branch so PR badges show

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -584,11 +584,17 @@ export function NewTaskDraftScreen(props: {
     flow.environments.find(
       (environment) => environment.environmentId === flow.selectedEnvironmentId,
     )?.environmentLabel ?? "Environment";
-  const currentBranchName =
+  const availableCurrentBranchName =
     flow.availableBranches.find((branch) => branch.current)?.name ??
     flow.availableBranches.find((branch) => branch.isDefault)?.name ??
     null;
-  const selectedBranchName = flow.selectedBranchName ?? currentBranchName;
+  const selectedBranchName = resolveProjectThreadCreationBranch({
+    workspaceMode: flow.workspaceMode,
+    selectedBranch:
+      flow.selectedBranchName ??
+      (flow.workspaceMode === "worktree" ? availableCurrentBranchName : null),
+    currentCheckoutBranch: flow.currentCheckoutBranchName,
+  });
   const selectedBranchLabel = resolveNewTaskBranchLabel({
     branchName: selectedBranchName,
     startFromOrigin: flow.startFromOrigin,

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -56,6 +56,7 @@ import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/re
 import { enqueueThreadOutboxMessage, removeThreadOutboxMessage } from "../../state/thread-outbox";
 import { useRemoteConnectionStatus } from "../../state/use-remote-environment-registry";
 import { useNewTaskFlow } from "./new-task-flow-provider";
+import { resolveProjectThreadCreationBranch } from "./projectThreadCreationValidation";
 import { useCreateProjectThread } from "./use-project-actions";
 import { resolveDraftProjectSelection } from "./new-task-project-selection";
 import {
@@ -713,11 +714,16 @@ export function NewTaskDraftScreen(props: {
       threadTitle: deriveThreadTitleFromPrompt(initialMessageText),
       projectTitle: selectedProject.title,
     });
+    const creationBranch = resolveProjectThreadCreationBranch({
+      workspaceMode,
+      selectedBranch: selectedBranchName,
+      currentCheckoutBranch: flow.currentCheckoutBranchName,
+    });
     const result = await createProjectThread({
       project: selectedProject,
       modelSelection,
       envMode: workspaceMode,
-      branch: selectedBranchName,
+      branch: creationBranch,
       worktreePath: workspaceMode === "worktree" ? null : selectedWorktreePath,
       startFromOrigin,
       runtimeMode,

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -48,6 +48,7 @@ import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/re
 import { enqueueThreadOutboxMessage, removeThreadOutboxMessage } from "../../state/thread-outbox";
 import { useRemoteConnectionStatus } from "../../state/use-remote-environment-registry";
 import { branchBadgeLabel, useNewTaskFlow } from "./new-task-flow-provider";
+import { resolveProjectThreadCreationBranch } from "./projectThreadCreationValidation";
 import { useCreateProjectThread } from "./use-project-actions";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
 
@@ -862,11 +863,16 @@ export function NewTaskDraftScreen(props: {
       threadTitle: deriveThreadTitleFromPrompt(initialMessageText),
       projectTitle: selectedProject.title,
     });
+    const creationBranch = resolveProjectThreadCreationBranch({
+      workspaceMode,
+      selectedBranch: selectedBranchName,
+      currentCheckoutBranch: flow.currentCheckoutBranchName,
+    });
     const result = await createProjectThread({
       project: selectedProject,
       modelSelection,
       envMode: workspaceMode,
-      branch: selectedBranchName,
+      branch: creationBranch,
       worktreePath: workspaceMode === "worktree" ? null : selectedWorktreePath,
       startFromOrigin,
       runtimeMode,

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -52,6 +52,7 @@ import {
   useComposerDraft,
 } from "../../state/use-composer-drafts";
 import { useDebouncedValue, usePaginatedBranches } from "../../state/queries";
+import { vcsEnvironment } from "../../state/vcs";
 import {
   flattenQueuedThreadMessages,
   threadOutboxManager,
@@ -139,6 +140,7 @@ type NewTaskFlowContextValue = {
   readonly branchesFetchingNextPage: boolean;
   readonly hasMoreBranches: boolean;
   readonly availableBranches: ReadonlyArray<VcsRef>;
+  readonly currentCheckoutBranchName: string | null;
   readonly runtimeMode: RuntimeMode;
   readonly interactionMode: ProviderInteractionMode;
   readonly planModeEnabled: boolean;
@@ -553,6 +555,22 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       ),
     [allBranchRefs],
   );
+  // The ref actually checked out in the project root, serialized onto new
+  // local threads. It comes from the live status stream rather than listRefs'
+  // `current` flag, which is served from a cache that can lag an out-of-band
+  // `git switch` by minutes — and from the same value the PR badge compares
+  // against. Detached HEAD and non-repository projects report no ref, so this
+  // stays null instead of fabricating a branch. The status family is
+  // deduplicated per (environmentId, cwd) with the thread rows.
+  const projectGitStatus = useEnvironmentQuery(
+    branchTarget.environmentId !== null && branchTarget.cwd !== null
+      ? vcsEnvironment.status({
+          environmentId: branchTarget.environmentId,
+          input: { cwd: branchTarget.cwd },
+        })
+      : null,
+  );
+  const currentCheckoutBranchName = projectGitStatus.data?.refName ?? null;
 
   const filteredBranches = useMemo(() => {
     const query = branchQuery.trim().toLowerCase();
@@ -859,6 +877,10 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
           ...(projectTitle !== undefined ? { projectTitle } : {}),
           ...(projectCwd !== undefined ? { projectCwd } : {}),
           workspaceMode: mode,
+          // Only an explicit picker choice, never the current checkout: a
+          // queued local task drains days later against whatever is checked
+          // out then, so recording a queue-time guess would pin a stale label
+          // to a thread that ran somewhere else.
           branch: workspaceSelection?.branch ?? null,
           worktreePath: mode === "worktree" ? null : (workspaceSelection?.worktreePath ?? null),
           // The draft only carries the flag when the user touched it; fall
@@ -996,6 +1018,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       branchesFetchingNextPage,
       hasMoreBranches,
       availableBranches,
+      currentCheckoutBranchName,
       runtimeMode,
       interactionMode,
       planModeEnabled,
@@ -1043,6 +1066,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       branchesFetchingNextPage,
       buildPendingTaskMessage,
       cancelEditingPendingTask,
+      currentCheckoutBranchName,
       editingPendingTask,
       environments,
       expandedProvider,

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -37,7 +37,9 @@ import {
   updateComposerDraftSettings,
   useComposerDraft,
 } from "../../state/use-composer-drafts";
+import { useEnvironmentQuery } from "../../state/query";
 import { useBranches } from "../../state/queries";
+import { vcsEnvironment } from "../../state/vcs";
 import {
   flattenQueuedThreadMessages,
   threadOutboxManager,
@@ -124,6 +126,7 @@ type NewTaskFlowContextValue = {
   readonly branchQuery: string;
   readonly branchesLoading: boolean;
   readonly availableBranches: ReadonlyArray<VcsRef>;
+  readonly currentCheckoutBranchName: string | null;
   readonly runtimeMode: RuntimeMode;
   readonly interactionMode: ProviderInteractionMode;
   readonly expandedProvider: string | null;
@@ -494,6 +497,22 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       ),
     [allBranchRefs],
   );
+  // The ref actually checked out in the project root, serialized onto new
+  // local threads. It comes from the live status stream rather than listRefs'
+  // `current` flag, which is served from a cache that can lag an out-of-band
+  // `git switch` by minutes — and from the same value the PR badge compares
+  // against. Detached HEAD and non-repository projects report no ref, so this
+  // stays null instead of fabricating a branch. The status family is
+  // deduplicated per (environmentId, cwd) with the thread rows.
+  const projectGitStatus = useEnvironmentQuery(
+    branchTarget.environmentId !== null && branchTarget.cwd !== null
+      ? vcsEnvironment.status({
+          environmentId: branchTarget.environmentId,
+          input: { cwd: branchTarget.cwd },
+        })
+      : null,
+  );
+  const currentCheckoutBranchName = projectGitStatus.data?.refName ?? null;
 
   const filteredBranches = useMemo(() => {
     const query = branchQuery.trim().toLowerCase();
@@ -707,6 +726,10 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
           ...(projectTitle !== undefined ? { projectTitle } : {}),
           ...(projectCwd !== undefined ? { projectCwd } : {}),
           workspaceMode: mode,
+          // Only an explicit picker choice, never the current checkout: a
+          // queued local task drains days later against whatever is checked
+          // out then, so recording a queue-time guess would pin a stale label
+          // to a thread that ran somewhere else.
           branch: workspaceSelection?.branch ?? null,
           worktreePath: mode === "worktree" ? null : (workspaceSelection?.worktreePath ?? null),
           // The draft only carries the flag when the user touched it; fall
@@ -837,6 +860,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       branchQuery,
       branchesLoading,
       availableBranches,
+      currentCheckoutBranchName,
       runtimeMode,
       interactionMode,
       expandedProvider,
@@ -880,6 +904,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       branchesLoading,
       buildPendingTaskMessage,
       cancelEditingPendingTask,
+      currentCheckoutBranchName,
       editingPendingTask,
       environments,
       expandedProvider,

--- a/apps/mobile/src/features/threads/projectThreadCreationValidation.test.ts
+++ b/apps/mobile/src/features/threads/projectThreadCreationValidation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveProjectThreadCreationBranch } from "./projectThreadCreationValidation";
+
+describe("resolveProjectThreadCreationBranch", () => {
+  it("records the current checkout for an untouched local draft", () => {
+    expect(
+      resolveProjectThreadCreationBranch({
+        workspaceMode: "local",
+        selectedBranch: null,
+        currentCheckoutBranch: "feature/x",
+      }),
+    ).toBe("feature/x");
+  });
+
+  it("prefers an explicit picker choice over the current checkout", () => {
+    expect(
+      resolveProjectThreadCreationBranch({
+        workspaceMode: "local",
+        selectedBranch: "main",
+        currentCheckoutBranch: "feature/x",
+      }),
+    ).toBe("main");
+  });
+
+  it("stays null when no ref is checked out (detached HEAD, non-repository, status not loaded)", () => {
+    expect(
+      resolveProjectThreadCreationBranch({
+        workspaceMode: "local",
+        selectedBranch: null,
+        currentCheckoutBranch: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("never borrows the current checkout for a worktree draft", () => {
+    expect(
+      resolveProjectThreadCreationBranch({
+        workspaceMode: "worktree",
+        selectedBranch: null,
+        currentCheckoutBranch: "feature/x",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps the explicit base branch for a worktree draft", () => {
+    expect(
+      resolveProjectThreadCreationBranch({
+        workspaceMode: "worktree",
+        selectedBranch: "main",
+        currentCheckoutBranch: "feature/x",
+      }),
+    ).toBe("main");
+  });
+});

--- a/apps/mobile/src/features/threads/projectThreadCreationValidation.test.ts
+++ b/apps/mobile/src/features/threads/projectThreadCreationValidation.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { resolveProjectThreadCreationBranch } from "./projectThreadCreationValidation";
 
 describe("resolveProjectThreadCreationBranch", () => {
-  it("records the current checkout for an untouched local draft", () => {
+  it("uses the live checkout for an untouched local draft label and recorded branch", () => {
     expect(
       resolveProjectThreadCreationBranch({
         workspaceMode: "local",

--- a/apps/mobile/src/features/threads/projectThreadCreationValidation.ts
+++ b/apps/mobile/src/features/threads/projectThreadCreationValidation.ts
@@ -32,6 +32,26 @@ export const ProjectThreadCreationValidationError = Schema.Union([
 ]);
 export type ProjectThreadCreationValidationError = typeof ProjectThreadCreationValidationError.Type;
 
+/**
+ * Branch recorded on a thread created from the new-task composer. An explicit
+ * picker choice always wins. An untouched current-checkout draft records the
+ * ref that is actually checked out, so the thread's PR badge and branch label
+ * match the live git status instead of staying blank. A detached HEAD, a
+ * non-repository project, or a status that has not arrived stays null rather
+ * than fabricating a branch. Only the online creation path resolves a
+ * checkout; a queued task cannot know the checkout it will drain against.
+ */
+export function resolveProjectThreadCreationBranch(input: {
+  readonly workspaceMode: "local" | "worktree";
+  readonly selectedBranch: string | null;
+  readonly currentCheckoutBranch: string | null;
+}): string | null {
+  if (input.selectedBranch !== null) {
+    return input.selectedBranch;
+  }
+  return input.workspaceMode === "local" ? input.currentCheckoutBranch : null;
+}
+
 export function validateProjectThreadCreation(input: {
   readonly environmentId: EnvironmentId;
   readonly projectId: ProjectId;


### PR DESCRIPTION
Fixes #4951

## Problem

Creating a thread from the mobile composer with the untouched current-checkout default persisted `branch: null`: the local workspace mode never writes a `workspaceSelection` into the draft, and the automatic branch selection effect only runs for worktree mode. `useThreadPr` refuses to subscribe when `thread.branch === null` and matches on exact equality with the live `status.refName`, so an open PR for the work was never surfaced on the thread row — while threads with explicit branch metadata showed their badge fine.

## Fix

Online creation now resolves the branch through a small pure helper, `resolveProjectThreadCreationBranch`: an explicit picker choice always wins; an untouched local-checkout draft records the live checkout ref; worktree mode is unchanged. The current checkout comes from the project's `vcsEnvironment.status` stream (`refName`) — the exact value the PR matcher compares against, parsed fresh per publish — not from the ref list, whose `current` flag is served from a server-side cache with a 10-minute TTL. The subscription is deduped per `(environmentId, cwd)` with the ones thread rows already open and lives only while the composer sheet is mounted.

No branch is ever fabricated: a detached HEAD, a non-repository project, or a status that has not arrived yet all resolve to `null`, i.e. exactly the pre-fix behavior. Nothing is written back into the draft's `workspaceSelection`, so the untouched default stays distinguishable from an explicit choice.

Scope note: queued/offline tasks still record only explicit choices. A queued local task drains against whatever is checked out at drain time, so recording a queue-time guess would pin a stale branch to a thread that ran somewhere else; that trade is commented at the call site.

Visible side effects: mobile-created local threads now show a branch label on their rows and become eligible for web's informational local-checkout mismatch banner, the same treatment web gives its own local threads (web self-heals the branch on next send). Composer sessions open one deduped status subscription per project cwd.

## Tests

New `projectThreadCreationValidation.test.ts` with 5 cases: the regression (untouched local default records the checkout), explicit selection wins (local and worktree), no checked-out ref stays null, and worktree mode never borrows the checkout. Each behavior was mutation-checked (reverting it fails exactly its test). Scoped mobile typecheck, lint, and format checks are green, plus adjacent suites (thread-outbox, threadListV2, use-thread-pr — 45 tests). Verified via unit tests on Linux; no native iOS run was performed.

---
Implemented and reviewed with Claude Code (Fable 5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile composer/thread-creation logic with a pure helper and deduped existing VCS status queries; no auth or server changes.
> 
> **Overview**
> Fixes **#4951** by persisting a branch on mobile threads created from the default local-checkout composer, so **PR badges** and row branch labels can match live git status.
> 
> Adds **`resolveProjectThreadCreationBranch`**: explicit picker choice wins; otherwise **local** mode uses the live checkout ref from **`vcsEnvironment.status`** (`refName`), not the branch list’s cached `current` flag. **Worktree** mode and **detached / missing status** still resolve to `null`. **`NewTaskFlowProvider`** exposes **`currentCheckoutBranchName`** while the composer is open; **`NewTaskDraftScreen`** uses the helper for the displayed branch label and the **`createProjectThread`** payload.
> 
> **Queued/offline** tasks are unchanged: only explicit `workspaceSelection.branch` is stored, with a comment that a queue-time checkout guess would go stale at drain time. Five unit tests cover the resolver matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff916b0beca8fbc4323607c2af37336d95966fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record live checkout branch on local-checkout threads so PR badges display
> - Adds `resolveProjectThreadCreationBranch` in [projectThreadCreationValidation.ts](https://github.com/pingdotgg/t3code/pull/4986/files#diff-38690cf67687d3b29ae5abcfdd3fd017dc5f60cdde0cc1f420fce74b88c84afb) to determine which branch to record: uses the explicit picker selection if provided, falls back to the live checked-out branch for local workspace mode, and returns `null` for worktree mode without an explicit selection.
> - Exposes `currentCheckoutBranchName` from live VCS status in [new-task-flow-provider.tsx](https://github.com/pingdotgg/t3code/pull/4986/files#diff-70cedfb5c403f777ceda2ca120dd7f822b033acf06053841f85a63b7d0cd3192) by issuing a `vcsEnvironment` status query for the selected environment/cwd.
> - Updates [NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/4986/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2) to pass the resolved branch to `createProjectThread`, so threads created without an explicit branch selection still record the current checkout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff916b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Screenshots (Android emulator, synthetic data)

Verified end-to-end on a Linux-hosted Android emulator against a disposable local T3 environment with a synthetic git repo checked out on `feature/checkout-demo`. Threads created on pre-fix code persisted an empty `branch`; the thread created with this fix live recorded `feature/checkout-demo` (confirmed in `projection_threads`), and the row shows the branch label. iOS behavior is the same shared React Native code path.

| Before (pre-fix code) | After (fix active) |
|---|---|
| ![before: rows show no branch](https://raw.githubusercontent.com/Zeus-Deus/t3code/assets-4951-demo/before-no-branch-on-rows.png) | ![after: new thread row shows feature/checkout-demo](https://raw.githubusercontent.com/Zeus-Deus/t3code/assets-4951-demo/after-branch-label-recorded.png) |
