### PR TITLE
fix(mobile): iOS long-press opens the row menu without opening the thread

### DIFF
--- a/apps/mobile/src/components/ControlPill.tsx
+++ b/apps/mobile/src/components/ControlPill.tsx
@@ -14,6 +14,7 @@ import { cn } from "../lib/cn";
 import { AndroidAnchoredMenu } from "./AndroidAnchoredMenu";
 import { SymbolView } from "./AppSymbol";
 import { AppText as Text } from "./AppText";
+import { longPressMenuChildProps } from "./longPressMenuChildProps";
 
 export function ControlPill(props: {
   readonly icon?: ComponentProps<typeof SymbolView>["name"];
@@ -132,10 +133,23 @@ export function ControlPillMenu(
     );
   }
 
-  const { className: _className, ...menuProps } = props;
+  const { className: _className, children, ...menuProps } = props;
+  // The patched context-menu interaction lives inside the React Native view
+  // tree, so RN never cancels the touch it is tracking: without an onLongPress
+  // the wrapped child fires onPress when the finger lifts and acts behind the
+  // open menu. Pressability skips onPress once a long press has fired, so the
+  // child gets one (see longPressMenuChildProps). The child is expected to be a
+  // Pressable; any other child silently ignores the injected props.
+  const child =
+    props.shouldOpenOnLongPress && isValidElement(children)
+      ? cloneElement(
+          children as ReactElement<typeof longPressMenuChildProps>,
+          longPressMenuChildProps,
+        )
+      : children;
   return (
     <MenuView {...menuProps} themeVariant={isDarkMode ? "dark" : "light"}>
-      {menuProps.children}
+      {child}
     </MenuView>
   );
 }

--- a/apps/mobile/src/components/longPressMenuChildProps.test.ts
+++ b/apps/mobile/src/components/longPressMenuChildProps.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { IOS_MENU_LONG_PRESS_DELAY_MS, longPressMenuChildProps } from "./longPressMenuChildProps";
+
+describe("longPressMenuChildProps", () => {
+  it("gives the child an onLongPress so its tap is cancelled by the long press", () => {
+    expect(typeof longPressMenuChildProps.onLongPress).toBe("function");
+    expect(() => longPressMenuChildProps.onLongPress()).not.toThrow();
+  });
+
+  it("fires the injected long press before UIKit commits the context menu", () => {
+    // 500ms is UIKit's context-menu threshold and React Native's default
+    // long-press total, so this has to be shorter or the tap is still live
+    // when the menu appears.
+    expect(IOS_MENU_LONG_PRESS_DELAY_MS).toBeLessThan(500);
+  });
+});

--- a/apps/mobile/src/components/longPressMenuChildProps.ts
+++ b/apps/mobile/src/components/longPressMenuChildProps.ts
@@ -1,0 +1,18 @@
+/** Shorter than UIKit's ~500ms context-menu threshold (and than React Native's
+    own 500ms default) so the long press is registered before the menu is
+    committed. */
+export const IOS_MENU_LONG_PRESS_DELAY_MS = 400;
+
+/**
+ * Props a long-press menu injects into the child it wraps on iOS, replacing
+ * whatever the child had (the menu owns the long press, as it does on Android).
+ * React Native only drops a Pressable's onPress after a long press when that
+ * Pressable has an onLongPress at all, so it gets a no-op: enough to keep the
+ * tap from firing when the finger lifts off an open context menu. No haptic
+ * here, UIKit plays the context-menu one itself. One frozen object, so cloning
+ * a child never changes prop identity between renders.
+ */
+export const longPressMenuChildProps = Object.freeze({
+  onLongPress: () => undefined,
+  delayLongPress: IOS_MENU_LONG_PRESS_DELAY_MS,
+});

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -668,9 +668,12 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
         // patched @react-native-menu, see
         // patches/@react-native-menu__menu@2.0.0.patch — in long-press mode the
         // interaction is hosted by the component view and the underlying
-        // UIButton passes touches through, so row taps keep working). Android:
-        // ControlPillMenu injects onLongPress into the row and anchors the
-        // token-styled dropdown to it; taps and swipes are untouched.
+        // UIButton passes touches through, so row taps keep working). Because
+        // that interaction lives inside the RN view tree, RN never cancels the
+        // touch, so ControlPillMenu also injects a long-press handler into the
+        // row on iOS and Pressability drops the tap once the menu gesture
+        // fires. Android: the same injection opens the token-styled dropdown
+        // anchored to the row. Taps and swipes are untouched on both.
         <ControlPillMenu
           actions={THREAD_ROW_MENU_ACTIONS}
           onPressAction={handleMenuAction}


### PR DESCRIPTION
Fixes #4938

## Problem

On iOS with Thread List v2, long-pressing a thread row opened the native context menu and also navigated into the thread behind it. The repo's `@react-native-menu` patch hosts the `UIContextMenuInteraction` on the component view inside the RN view tree, and React Native's touch handler only cancels its tracked touch for recognizers outside its own tree — so the row's `Pressable` kept receiving the whole touch sequence while the menu presented. Since the row defines `onPress` but no `onLongPress`, and RN Pressability only suppresses `onPress` after a long press when an `onLongPress` handler exists, lifting the finger fired the navigation behind the menu. The Android branch of `ControlPillMenu` already injects an `onLongPress` into its child (which is why Android behaves correctly); the iOS branch passed children through untouched.

## Fix

`ControlPillMenu`'s iOS branch now mirrors Android: the wrapped child is cloned with a stable no-op `onLongPress` and `delayLongPress: 400` (below UIKit's ~500 ms context-menu commit), so Pressability cancels the tap once the long-press fires. The injected props replace any child handler, matching the Android branch's semantics. This one change in the shared wrapper fixes Thread List v2 rows, v2 pending rows, and the same latent defect in Thread List v1 rows and pending rows — every `shouldOpenOnLongPress` call site in the app. A stale comment in `thread-list-items.tsx` that encoded the old wrong assumption ("row taps keep working") was corrected. Android code path, swipe actions, scroll, and VoiceOver activation (a synthetic quick activation that never runs the long-press timer) are unaffected.

Known narrow gaps of the timer approach, declared deliberately (the deterministic alternative — suppressing via `MenuView.onOpenMenu` — adds stateful arbitration whose touch timing we could not verify in this environment): a ~400-500 ms press-and-release before the menu presents now does nothing instead of navigating; a finger drifting >10 pt during the hold cancels RN's timer while UIKit may still present, in which case the old behavior can recur; heavy JS-thread congestion could delay the 400 ms timer past release. All three fail toward pre-existing behavior and are candidates for an `onOpenMenu`-based follow-up if on-device testing shows they matter.

## Verification status

The core gesture arbitration lives in RN Pressability + UIKit and is not unit-testable in this repo (mobile tests are pure logic only). A small helper module carries the injected props with a regression test pinning the delay below UIKit's 500 ms threshold. The RN mechanism (`isPressCanceledByLongPress`, timer arithmetic, responder-termination on scroll/swipe) was verified against the vendored RN 0.85.3 source. Scoped mobile typecheck, lint, and format checks are green.

**Native iOS verification is still required and was not performed** (this change was developed and tested on Linux). Before merge, on a device/simulator with Thread List v2: long-press a thread row → menu only, no navigation behind it; short tap still navigates; same for pending rows, v1 rows, and the iPad split-view sidebar; swipe actions and scroll unaffected; menu actions fire exactly once; VoiceOver double-tap still navigates; Android smoke test (unchanged branch). A deliberate ~450 ms press-and-release and a drift-while-holding probe are worth explicit checks for the declared gaps.

---
Implemented and reviewed with Claude Code (Fable 5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared gesture handling for all long-press menus on iOS; logic is localized to ControlPillMenu but timing edge cases (press-and-release ~400–500ms, drift while holding) may still allow navigation in rare cases.
> 
> **Overview**
> Fixes iOS thread rows (and other `shouldOpenOnLongPress` menus) where lifting the finger after a long-press opened the context menu **also fired the row’s `onPress`**, navigating into the thread behind the menu.
> 
> **`ControlPillMenu` on iOS** now matches Android: when `shouldOpenOnLongPress` is set, the wrapped child is cloned with frozen **`longPressMenuChildProps`** — a no-op `onLongPress` and **`delayLongPress: 400ms`** (under UIKit’s ~500ms menu commit) so React Native Pressability cancels the tap once the long press registers.
> 
> Adds **`longPressMenuChildProps.ts`** plus a small test pinning the delay below 500ms. Updates the thread-list comment to document why iOS needs the injection alongside the patched context-menu interaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 593c6b1ac37b4ad318c3bd96c277a8b1da34fee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iOS long-press on thread list rows to open the row menu without triggering thread open
> - Adds a new [`longPressMenuChildProps`](https://github.com/pingdotgg/t3code/pull/4987/files#diff-ca7eb23da1e43c33a4bf5c29b6bffef09b30e9b6a3b365229c509a75cbc8cd45) module exporting a frozen prop bundle with a no-op `onLongPress` and a 400ms `delayLongPress` constant.
> - In [`ControlPillMenu`](https://github.com/pingdotgg/t3code/pull/4987/files#diff-399d916fedf786f62149bf81f4839236f5389657a810489f04807d53fde21a4f), the iOS path now clones its child with these props when `shouldOpenOnLongPress` is true, causing `Pressability` to cancel the tap when the long-press gesture fires.
> - Android behavior is unchanged; only the iOS/`MenuView` branch is affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 593c6b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->