### PR TITLE
fix(connect): reboots no longer strand the relay link, 403s now say why

### DIFF
--- a/apps/mobile/src/features/cloud/linkEnvironment.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.ts
@@ -134,7 +134,14 @@ function relayProtectedErrorMessage(error: RelayProtectedErrorType): string {
     case "RelayEnvironmentLinkProofInvalidError":
       return `Relay rejected the environment link proof (${error.reason}).`;
     case "RelayEnvironmentConnectNotAuthorizedError":
-      return "Relay rejected the environment connection request.";
+      // "Not authorized" covers non-auth causes too; surface the reason so a
+      // missing link doesn't read as a credential problem.
+      if (error.reason === "environment_link_not_found") {
+        return "Relay has no active link for this environment. The environment server may not have re-established its link yet.";
+      }
+      return error.reason
+        ? `Relay rejected the environment connection request (${error.reason}).`
+        : "Relay rejected the environment connection request.";
     case "RelayEnvironmentEndpointUnavailableError":
       return `Relay could not reach the environment endpoint (${error.reason}).`;
     case "RelayEnvironmentEndpointTimedOutError":

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -540,12 +540,15 @@ export const makeServerLayer = Layer.unwrap(
             // On reboot this races NIC/DNS bring-up, so back off exponentially
             // (capped at 30s) instead of burning all retries in a second.
             // Bounded overall so a permanently broken setup still surfaces the
-            // warning below. Bad-request/unauthorized are deterministic local
-            // failures that no amount of retrying converges.
+            // warning below. Bad-request/unauthorized/conflict are
+            // deterministic failures (malformed origin, not linked yet, linked
+            // to a different cloud account) that no amount of retrying
+            // converges.
             Effect.retry({
               while: (error) =>
                 error._tag !== "EnvironmentHttpBadRequestError" &&
-                error._tag !== "EnvironmentHttpUnauthorizedError",
+                error._tag !== "EnvironmentHttpUnauthorizedError" &&
+                error._tag !== "EnvironmentHttpConflictError",
               schedule: Schedule.exponential("1 second").pipe(
                 Schedule.modifyDelay(({ duration }) =>
                   Effect.succeed(Duration.min(duration, Duration.seconds(30))),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,6 +1,8 @@
 import { EnvironmentHttpApi } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schedule from "effect/Schedule";
 import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
 import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 
@@ -535,7 +537,22 @@ export const makeServerLayer = Layer.unwrap(
         yield* Effect.forkScoped(
           Effect.sleep("250 millis").pipe(
             Effect.andThen(reconcileDesiredCloudLink(`http://127.0.0.1:${address.port}`)),
-            Effect.retry({ times: 4 }),
+            // On reboot this races NIC/DNS bring-up, so back off exponentially
+            // (capped at 30s) instead of burning all retries in a second.
+            // Bounded overall so a permanently broken setup still surfaces the
+            // warning below. Bad-request/unauthorized are deterministic local
+            // failures that no amount of retrying converges.
+            Effect.retry({
+              while: (error) =>
+                error._tag !== "EnvironmentHttpBadRequestError" &&
+                error._tag !== "EnvironmentHttpUnauthorizedError",
+              schedule: Schedule.exponential("1 second").pipe(
+                Schedule.modifyDelay(({ duration }) =>
+                  Effect.succeed(Duration.min(duration, Duration.seconds(30))),
+                ),
+                Schedule.upTo({ duration: "10 minutes" }),
+              ),
+            }),
             Effect.tap(() => Effect.logInfo("T3 Connect desired link reconciled on startup")),
             Effect.catch((cause) =>
               Effect.logWarning("Failed to reconcile T3 Connect desired link on startup", {

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -145,7 +145,14 @@ function relayProtectedErrorMessage(error: RelayProtectedErrorType): string {
     case "RelayEnvironmentLinkProofInvalidError":
       return `Relay rejected the environment link proof (${error.reason}).`;
     case "RelayEnvironmentConnectNotAuthorizedError":
-      return "Relay rejected the environment connection request.";
+      // "Not authorized" covers non-auth causes too; surface the reason so a
+      // missing link doesn't read as a credential problem.
+      if (error.reason === "environment_link_not_found") {
+        return "Relay has no active link for this environment. The environment server may not have re-established its link yet.";
+      }
+      return error.reason
+        ? `Relay rejected the environment connection request (${error.reason}).`
+        : "Relay rejected the environment connection request.";
     case "RelayEnvironmentEndpointUnavailableError":
       return `Relay could not reach the environment endpoint (${error.reason}).`;
     case "RelayEnvironmentEndpointTimedOutError":

--- a/infra/relay/src/environments/EnvironmentConnector.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.ts
@@ -45,14 +45,8 @@ import * as ManagedEndpointAllocations from "./ManagedEndpointAllocations.ts";
 import * as RelayConfiguration from "../Config.ts";
 import { isManagedEndpointHostname } from "../deploymentConfig.ts";
 
-// The reason set is part of the public relay contract so clients can render
-// specific diagnostics (e.g. "your server never linked" vs. a real auth issue).
-export const EnvironmentConnectNotAuthorizedReason = RelayEnvironmentConnectNotAuthorizedReason;
-export type EnvironmentConnectNotAuthorizedReason =
-  typeof EnvironmentConnectNotAuthorizedReason.Type;
-
 function environmentConnectNotAuthorizedReasonMessage(
-  reason: EnvironmentConnectNotAuthorizedReason,
+  reason: RelayEnvironmentConnectNotAuthorizedReason,
 ): string {
   switch (reason) {
     case "client_proof_key_thumbprint_missing":
@@ -79,7 +73,7 @@ export class EnvironmentConnectNotAuthorized extends Schema.TaggedErrorClass<Env
   {
     environmentId: Schema.String,
     operation: Schema.Literals(["connect", "status"]),
-    reason: EnvironmentConnectNotAuthorizedReason,
+    reason: RelayEnvironmentConnectNotAuthorizedReason,
   },
 ) {
   override get message(): string {

--- a/infra/relay/src/environments/EnvironmentConnector.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.ts
@@ -13,6 +13,7 @@ import {
   RelayEnvironmentMintResponse,
   RelayEnvironmentMintResponseProofPayload,
   RelayCloudMintCredentialProofPayload,
+  RelayEnvironmentConnectNotAuthorizedReason,
   type RelayEnvironmentConnectResponse,
   type RelayEnvironmentStatusResponse,
 } from "@t3tools/contracts/relay";
@@ -44,16 +45,9 @@ import * as ManagedEndpointAllocations from "./ManagedEndpointAllocations.ts";
 import * as RelayConfiguration from "../Config.ts";
 import { isManagedEndpointHostname } from "../deploymentConfig.ts";
 
-export const EnvironmentConnectNotAuthorizedReason = Schema.Literals([
-  "client_proof_key_thumbprint_missing",
-  "environment_link_not_found",
-  "endpoint_provider_not_managed",
-  "managed_endpoint_allocation_not_found",
-  "managed_endpoint_base_domain_not_configured",
-  "managed_endpoint_allocation_not_ready",
-  "managed_endpoint_hostname_invalid",
-  "managed_endpoint_mismatch",
-]);
+// The reason set is part of the public relay contract so clients can render
+// specific diagnostics (e.g. "your server never linked" vs. a real auth issue).
+export const EnvironmentConnectNotAuthorizedReason = RelayEnvironmentConnectNotAuthorizedReason;
 export type EnvironmentConnectNotAuthorizedReason =
   typeof EnvironmentConnectNotAuthorizedReason.Type;
 

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -778,9 +778,10 @@ export const dpopClientApi = HttpApiBuilder.group(
           },
           mapRelayCommonApiErrors("invalid_dpop"),
           mapErrorTags({
-            EnvironmentConnectNotAuthorized: (_error, traceId) =>
+            EnvironmentConnectNotAuthorized: (error, traceId) =>
               new RelayEnvironmentConnectNotAuthorizedError({
                 code: "environment_connect_not_authorized",
+                reason: error.reason,
                 traceId,
               }),
             EnvironmentMintRequestFailed: (_error, traceId) =>
@@ -820,9 +821,10 @@ export const dpopClientApi = HttpApiBuilder.group(
           },
           mapRelayCommonApiErrors("invalid_dpop"),
           mapErrorTags({
-            EnvironmentConnectNotAuthorized: (_error, traceId) =>
+            EnvironmentConnectNotAuthorized: (error, traceId) =>
               new RelayEnvironmentConnectNotAuthorizedError({
                 code: "environment_connect_not_authorized",
+                reason: error.reason,
                 traceId,
               }),
             EnvironmentMintRequestFailed: (_error, traceId) =>

--- a/packages/contracts/src/relay.ts
+++ b/packages/contracts/src/relay.ts
@@ -371,16 +371,34 @@ export class RelayEnvironmentLinkProofInvalidError extends Schema.TaggedErrorCla
   }
 }
 
+export const RelayEnvironmentConnectNotAuthorizedReason = Schema.Literals([
+  "client_proof_key_thumbprint_missing",
+  "environment_link_not_found",
+  "endpoint_provider_not_managed",
+  "managed_endpoint_allocation_not_found",
+  "managed_endpoint_base_domain_not_configured",
+  "managed_endpoint_allocation_not_ready",
+  "managed_endpoint_hostname_invalid",
+  "managed_endpoint_mismatch",
+]);
+export type RelayEnvironmentConnectNotAuthorizedReason =
+  typeof RelayEnvironmentConnectNotAuthorizedReason.Type;
+
 export class RelayEnvironmentConnectNotAuthorizedError extends Schema.TaggedErrorClass<RelayEnvironmentConnectNotAuthorizedError>()(
   "RelayEnvironmentConnectNotAuthorizedError",
   {
     code: Schema.Literal("environment_connect_not_authorized"),
+    // Optional so responses from relays deployed before the reason was
+    // threaded through still decode.
+    reason: Schema.optional(RelayEnvironmentConnectNotAuthorizedReason),
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 403 },
 ) {
   override get message(): string {
-    return "Relay environment connection is not authorized";
+    return this.reason
+      ? `Relay environment connection is not authorized: ${this.reason}`
+      : "Relay environment connection is not authorized";
   }
 }
 


### PR DESCRIPTION
## Problem

Two independent bugs made a reboot look like "T3 Connect is broken" with no useful signal:

1. On boot, systemd can start the server before the network is usable. Startup link reconciliation retried with `Effect.retry({ times: 4 })` and **no delay**, so all retries burned in ~1 second while the NIC was still coming up, then gave up permanently. The server ran fine locally but no environment link existed at the relay.
2. Every connect attempt then failed with the generic 403 "Relay environment connection is not authorized". The relay internally knows 8 distinct not-authorized reasons (including `environment_link_not_found`), but dropped the reason before it reached the client, so "your server never linked" read as a credential problem.

## Solution

- Startup reconcile now retries on an exponential schedule (1s base, capped at 30s, bounded at 10 minutes overall) and skips retrying deterministic local failures (bad request / not linked yet). A boot-time network race now converges instead of giving up.
- `RelayEnvironmentConnectNotAuthorizedError` carries an optional `reason` field threaded from the relay's internal reason set. Optional keeps old-relay responses decoding, and old clients ignore the extra field, so it deploys compatibly in either order. Web and mobile now render `environment_link_not_found` as "Relay has no active link for this environment" instead of an auth-sounding 403, and show the raw reason for the rest.
- The relay's internal reason schema is now re-exported from the shared contract so the two lists can't drift.

Typecheck, lint, build, and the relay/contracts/client-runtime/server test suites all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Fable 5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches startup cloud link reconciliation and relay/client error contracts; backward-compatible optional `reason`, but wrong retry bounds could delay or hide permanent link failures.
> 
> **Overview**
> Fixes two reboot/connect failure modes: the environment server giving up on relay link reconciliation too quickly after boot, and clients seeing a generic auth-style 403 when the relay knows a specific cause.
> 
> **Startup link reconcile** (`server.ts`): Replaces four immediate retries with exponential backoff (1s base, 30s cap per delay) over up to ~10 minutes. Retries stop on deterministic local errors (`EnvironmentHttpBadRequestError`, `EnvironmentHttpUnauthorizedError`, `EnvironmentHttpConflictError`) so malformed origins or “not linked yet” don’t spin forever.
> 
> **403 semantics**: Adds shared `RelayEnvironmentConnectNotAuthorizedReason` in contracts and an optional `reason` on `RelayEnvironmentConnectNotAuthorizedError`. The relay API forwards the connector’s reason; relay code uses the shared schema instead of a duplicate list. Web and mobile map `environment_link_not_found` to a clear “no active link / server may not have re-established yet” message and include other reasons in the error text when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b9b2eafcfcc8dfd5f002057cde600eb0723e2d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix relay link stranding on reboot and include 403 reason in connect errors
> - Replaces the fixed 4-retry startup reconciliation in [server.ts](https://github.com/pingdotgg/t3code/pull/4988/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) with exponential backoff (1s base, 30s max delay, 10-minute cap), so server reboots no longer exhaust retries immediately and strand the relay link.
> - Skips retries for deterministic 4xx errors (`BadRequest`, `Unauthorized`, `Conflict`) to avoid pointless loops.
> - Adds `RelayEnvironmentConnectNotAuthorizedReason` to [relay.ts contracts](https://github.com/pingdotgg/t3code/pull/4988/files#diff-cb107044ca7f6b82daab8e559dd6407c25ff0c6fdb488cc9e1b58ebd31ed8310) and threads the reason through the relay API and both client `relayProtectedErrorMessage` functions, so 403 responses now surface the specific reason in user-visible messages.
> - Special-cases `environment_link_not_found` in error messages to clarify it is not a credential issue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b9b2ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->