### PR TITLE
fix(mobile): default bare IP pairing to HTTP

### DIFF
--- a/.agents/skills/test-t3-mobile/SKILL.md
+++ b/.agents/skills/test-t3-mobile/SKILL.md
@@ -66,7 +66,7 @@ Use these client origins:
 - Android Emulator: `http://10.0.2.2:<server-port>`
 - Physical device: bind the backend to `0.0.0.0` and use the host's reachable LAN origin
 
-Always enter the complete `http://` origin; the mobile host field otherwise assumes HTTPS. When testing web and mobile together, run `vp run dev --home-dir <base-dir> --host 127.0.0.1` instead and do not launch a second backend over the same base directory.
+Enter the complete `http://` origin to make the test transport explicit. Bare IP addresses default to HTTP, while bare hostnames default to HTTPS. When testing web and mobile together, run `vp run dev --home-dir <base-dir> --host 127.0.0.1` instead and do not launch a second backend over the same base directory.
 
 ## Start or reuse Metro safely
 

--- a/apps/mobile/src/features/connection/pairing.test.ts
+++ b/apps/mobile/src/features/connection/pairing.test.ts
@@ -1,10 +1,31 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  buildPairingUrl,
   extractPairingUrlFromQrPayload,
   PairingQrPayloadEmptyError,
   parsePairingUrl,
 } from "./pairing";
+
+describe("buildPairingUrl", () => {
+  it("uses HTTP for a schemeless IP address", () => {
+    expect(buildPairingUrl("192.168.1.100:3773", "pairing-token")).toBe(
+      "http://192.168.1.100:3773/#token=pairing-token",
+    );
+  });
+
+  it("keeps HTTPS as the default for a schemeless hostname", () => {
+    expect(buildPairingUrl("remote.example.com", "pairing-token")).toBe(
+      "https://remote.example.com/#token=pairing-token",
+    );
+  });
+
+  it("preserves an explicit scheme for an IP address", () => {
+    expect(buildPairingUrl("https://192.168.1.100:3773", "pairing-token")).toBe(
+      "https://192.168.1.100:3773/#token=pairing-token",
+    );
+  });
+});
 
 describe("extractPairingUrlFromQrPayload", () => {
   it("trims raw pairing urls from qr payloads", () => {

--- a/apps/mobile/src/features/connection/pairing.ts
+++ b/apps/mobile/src/features/connection/pairing.ts
@@ -3,6 +3,21 @@ import * as Schema from "effect/Schema";
 
 const MOBILE_PAIRING_URL_PARAM = "pairingUrl";
 
+function isIpLiteral(host: string): boolean {
+  try {
+    const hostname = new URL(`http://${host}`).hostname.replace(/^\[|\]$/g, "");
+    if (hostname.includes(":")) return true;
+
+    const octets = hostname.split(".");
+    return (
+      octets.length === 4 &&
+      octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export class PairingQrPayloadEmptyError extends Schema.TaggedErrorClass<PairingQrPayloadEmptyError>()(
   "PairingQrPayloadEmptyError",
   {},
@@ -19,7 +34,7 @@ export function buildPairingUrl(host: string, code: string): string {
   if (!c) return h;
 
   try {
-    const url = new URL(h.includes("://") ? h : `https://${h}`);
+    const url = new URL(h.includes("://") ? h : `${isIpLiteral(h) ? "http" : "https"}://${h}`);
     url.hash = new URLSearchParams([["token", c]]).toString();
     return url.toString();
   } catch {

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -38,6 +38,8 @@ available. You can set another endpoint as the default from the expanded endpoin
 
 If the copied link points directly at `http://192.168.x.y:3773`, open it from a client that can reach that LAN address. If it points at `https://app.t3.codes/pair?...`, the hosted web app will save the environment and connect directly to the backend URL in the link.
 
+In the mobile app's **Add Environment** form, a numeric IP address without a scheme uses HTTP. Include `https://` explicitly when the backend is served over HTTPS.
+
 ### Tailscale Endpoints
 
 When the desktop app can detect Tailscale, it adds Tailnet endpoints to the reachable endpoint list.


### PR DESCRIPTION
## Problem

The mobile **Add Environment** form treated every schemeless host as HTTPS. Entering the LAN IP and port advertised by a desktop server therefore tried `https://<lan-ip>` even though direct LAN endpoints use HTTP, causing manual pairing to fail while the QR-code flow worked.

Closes #4893.

## What Changed

- default schemeless IP literals to HTTP in the mobile pairing URL builder
- keep schemeless hostnames on HTTPS and preserve every explicit scheme
- add focused regression coverage for all three cases
- document the mobile LAN behavior in the user guide and mobile test runbook

## User Impact

Users can paste a LAN IP and port into the mobile form without adding `http://` manually. Secure endpoints remain opt-in through an explicit `https://` scheme.

## UI Changes

No visual changes. This only changes the URL used when the user submits a bare numeric IP address.

## Validation

- `pnpm exec vp test run apps/mobile/src/features/connection/pairing.test.ts` — 7 passed
- `pnpm exec vp run --filter @t3tools/mobile typecheck`
- targeted lint and formatting checks for the four changed files
- `git diff --check upstream/main...HEAD`

An integrated simulator pass was not available on this host because neither Xcode/Simulator nor the Android SDK/emulator is installed.

Model: GPT-5.6 Sol | Harness: Codex desktop app


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default bare IP addresses to HTTP in mobile `buildPairingUrl`
> - `buildPairingUrl` in [pairing.ts](https://github.com/pingdotgg/t3code/pull/4990/files#diff-f8dd0ceabf9233f24f8dbef1bcfa23856b70a5d29687d58548a1e1d6366a65e3) now uses HTTP for schemeless IP addresses (IPv4 and IPv6) and HTTPS for schemeless hostnames; explicit schemes are always preserved.
> - A new `isIpLiteral` helper parses the host to distinguish IP literals from hostnames.
> - Docs and skill guidance updated to clarify that bare IPs use HTTP and bare hostnames use HTTPS in the mobile Add Environment form.
> - Behavioral Change: previously all schemeless hosts defaulted to HTTPS; bare IPs now default to HTTP.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afc00fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit afc00fb393c5db55b759aa4199d9ca2f9c7c3184. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->