### PR TITLE
fix(web): server updates no longer look like warnings

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1889,13 +1889,19 @@ function ChatViewContent(props: ChatViewProps) {
       unavailableConnection !== null &&
       (unavailableConnection.phase === "connecting" ||
         unavailableConnection.phase === "reconnecting");
-    // Reconnecting to a version-skewed server usually means the server is
-    // restarting mid-update (e.g. a refresh wiped the in-memory update
-    // state). Fold the reconnect and version banners into one calm line
-    // instead of stacking "Failed to connect" on "versions differ".
+    // Reconnecting to a version-skewed server with no update in flight
+    // usually means the server is restarting mid-update and a refresh wiped
+    // the in-memory update state. Fold the reconnect and version banners
+    // into one calm line instead of stacking "Failed to connect" on
+    // "versions differ". A failed update never folds: its error and retry
+    // action must stay visible.
     const reconnectingThroughVersionSkew =
-      !updateRunning && environmentReconnecting && versionMismatch !== null;
-    if (activeEnvironmentUnavailableState && unavailableConnection && !updateRunning) {
+      serverUpdateState.status === "idle" && environmentReconnecting && versionMismatch !== null;
+    // While an update runs, transient connect blips are expected (the server
+    // restarts) and the update banner already shows progress. Hard failure
+    // phases still surface so the Reconnect action stays reachable.
+    const suppressUnavailableBanner = updateRunning && environmentReconnecting;
+    if (activeEnvironmentUnavailableState && unavailableConnection && !suppressUnavailableBanner) {
       if (reconnectingThroughVersionSkew) {
         items.push({
           id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
@@ -1906,7 +1912,7 @@ function ChatViewContent(props: ChatViewProps) {
               aria-hidden="true"
             />
           ),
-          title: `Reconnecting to ${activeEnvironmentUnavailableState.label}`,
+          title: `${unavailableConnection.phase === "connecting" ? "Connecting" : "Reconnecting"} to ${activeEnvironmentUnavailableState.label}`,
           description: "It may be finishing an update. One moment.",
         });
       } else {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1883,46 +1883,69 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const systemComposerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const items: ComposerBannerStackItem[] = [];
-    const resumingServerUpdate =
-      serverUpdateState.status === "running" && serverUpdateState.stage === "resuming";
-    if (activeEnvironmentUnavailableState && !resumingServerUpdate) {
-      const connection = activeEnvironmentUnavailableState.connection;
-      const isReconnecting =
-        connection.phase === "connecting" || connection.phase === "reconnecting";
-      items.push({
-        id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
-        variant: connection.phase === "error" ? "error" : "warning",
-        icon: <WifiOffIcon />,
-        title: `${activeEnvironmentUnavailableState.label}: ${connectionStatusTitle(connection)}`,
-        description:
-          connection.error ??
-          "Reconnect this environment before sending messages or running actions.",
-        actions: (
-          <>
-            <Button
-              size="xs"
-              disabled={isReconnecting}
-              onClick={() =>
-                void handleReconnectActiveEnvironment(
-                  activeEnvironmentUnavailableState.environmentId,
-                )
-              }
-            >
-              {isReconnecting ? "Reconnecting..." : "Reconnect"}
-            </Button>
-            <Button
-              size="xs"
-              variant="outline"
-              onClick={() => void navigate({ to: "/settings/connections" })}
-            >
-              Connections
-            </Button>
-          </>
-        ),
-      });
+    const updateRunning = serverUpdateState.status === "running";
+    const unavailableConnection = activeEnvironmentUnavailableState?.connection ?? null;
+    const environmentReconnecting =
+      unavailableConnection !== null &&
+      (unavailableConnection.phase === "connecting" ||
+        unavailableConnection.phase === "reconnecting");
+    // Reconnecting to a version-skewed server usually means the server is
+    // restarting mid-update (e.g. a refresh wiped the in-memory update
+    // state). Fold the reconnect and version banners into one calm line
+    // instead of stacking "Failed to connect" on "versions differ".
+    const reconnectingThroughVersionSkew =
+      !updateRunning && environmentReconnecting && versionMismatch !== null;
+    if (activeEnvironmentUnavailableState && unavailableConnection && !updateRunning) {
+      if (reconnectingThroughVersionSkew) {
+        items.push({
+          id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
+          variant: "default",
+          icon: (
+            <span
+              className="size-1.5 animate-status-pulse rounded-full bg-foreground"
+              aria-hidden="true"
+            />
+          ),
+          title: `Reconnecting to ${activeEnvironmentUnavailableState.label}`,
+          description: "It may be finishing an update. One moment.",
+        });
+      } else {
+        items.push({
+          id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
+          variant: unavailableConnection.phase === "error" ? "error" : "warning",
+          icon: <WifiOffIcon />,
+          title: `${activeEnvironmentUnavailableState.label}: ${connectionStatusTitle(unavailableConnection)}`,
+          description:
+            unavailableConnection.error ??
+            "Reconnect this environment before sending messages or running actions.",
+          actions: (
+            <>
+              <Button
+                size="xs"
+                disabled={environmentReconnecting}
+                onClick={() =>
+                  void handleReconnectActiveEnvironment(
+                    activeEnvironmentUnavailableState.environmentId,
+                  )
+                }
+              >
+                {environmentReconnecting ? "Reconnecting..." : "Reconnect"}
+              </Button>
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={() => void navigate({ to: "/settings/connections" })}
+              >
+                Connections
+              </Button>
+            </>
+          ),
+        });
+      }
     }
     if (
       serverUpdateEnvironmentId &&
+      !reconnectingThroughVersionSkew &&
       (serverUpdateState.status !== "idle" ||
         (showVersionMismatchBanner && versionMismatch && versionMismatchDismissKey))
     ) {
@@ -1930,8 +1953,15 @@ function ChatViewContent(props: ChatViewProps) {
       const updateFailed = serverUpdateState.status === "failed";
       items.push({
         id: `server-version:${serverUpdateEnvironmentId}`,
-        variant: updateFailed ? "error" : "warning",
-        icon: <TriangleAlertIcon />,
+        variant: updateFailed ? "error" : updateInProgress ? "default" : "warning",
+        icon: updateInProgress ? (
+          <span
+            className="size-1.5 animate-status-pulse rounded-full bg-foreground"
+            aria-hidden="true"
+          />
+        ) : (
+          <TriangleAlertIcon />
+        ),
         title:
           updateInProgress || updateFailed
             ? `${updateFailed ? "Could not update" : "Updating"} ${versionMismatchServerLabel}`
@@ -1940,7 +1970,6 @@ function ChatViewContent(props: ChatViewProps) {
           updateInProgress || updateFailed ? (
             <ServerUpdateProgress
               fromVersion={serverUpdateState.fromVersion}
-              serverLabel={versionMismatchServerLabel}
               state={serverUpdateState}
             />
           ) : versionMismatch ? (

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -101,11 +101,10 @@ describe("ServerUpdateAction", () => {
 });
 
 describe("ServerUpdateProgress", () => {
-  it("renders the chosen horizontal step rail without an animated spinner", () => {
+  it("renders the monochrome step rail with only the active step highlighted", () => {
     const markup = renderToStaticMarkup(
       <ServerUpdateProgress
         fromVersion="0.0.30"
-        serverLabel="bb-1"
         state={{
           status: "running",
           stage: "resuming",
@@ -119,8 +118,12 @@ describe("ServerUpdateProgress", () => {
     expect(markup).toContain("0.0.31");
     expect(markup).toContain("Download");
     expect(markup).toContain("Install");
-    expect(markup).toContain("Resume");
-    expect(markup).toContain("Waiting for bb-1 to accept commands.");
+    expect(markup).toContain("Resuming");
+    // The wait state is monochrome and calm: no success/warning colors, no
+    // status sentence, one duty-cycled pulse on the active step.
+    expect(markup).not.toContain("text-success");
+    expect(markup).not.toContain("text-primary");
+    expect(markup).toContain("animate-status-pulse");
     expect(markup).not.toContain("animate-spin");
   });
 
@@ -128,7 +131,6 @@ describe("ServerUpdateProgress", () => {
     const markup = renderToStaticMarkup(
       <ServerUpdateProgress
         fromVersion="0.0.30"
-        serverLabel="bb-1"
         state={{
           status: "failed",
           stage: "installing",
@@ -141,5 +143,6 @@ describe("ServerUpdateProgress", () => {
 
     expect(markup).toContain('role="alert"');
     expect(markup).toContain("The package could not be verified.");
+    expect(markup).not.toContain("animate-status-pulse");
   });
 });

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -15,9 +15,9 @@ import { Button } from "./ui/button";
 import { toastManager } from "./ui/toast";
 
 const UPDATE_STEPS = [
-  { stage: "downloading", label: "Download" },
-  { stage: "installing", label: "Install" },
-  { stage: "resuming", label: "Resume" },
+  { stage: "downloading", label: "Download", activeLabel: "Downloading" },
+  { stage: "installing", label: "Install", activeLabel: "Installing" },
+  { stage: "resuming", label: "Resume", activeLabel: "Resuming" },
 ] as const;
 const pendingUpdateEnvironmentIds = new Set<EnvironmentId>();
 
@@ -25,37 +25,24 @@ function updateFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Server update failed.";
 }
 
-function updateStatusCopy(
-  state: Exclude<ServerUpdateState, { status: "idle" }>,
-  serverLabel: string,
-): string {
-  if (state.status === "failed") {
-    return state.message;
-  }
-  switch (state.stage) {
-    case "downloading":
-      return "Downloading the matching server version.";
-    case "installing":
-      return `Installing and verifying t3@${state.targetVersion}.`;
-    case "resuming":
-      return `Waiting for ${serverLabel} to accept commands.`;
-  }
-}
-
+/**
+ * Monochrome step rail for an in-flight server update. The update is a
+ * wait, not a warning: done steps recede to gray, the active step is the
+ * only bright element and pulses. Failure keeps the rail but surfaces the
+ * error below it.
+ */
 export function ServerUpdateProgress({
   fromVersion,
-  serverLabel,
   state,
 }: {
   readonly fromVersion: string;
-  readonly serverLabel: string;
   readonly state: Exclude<ServerUpdateState, { status: "idle" }>;
 }) {
   const currentIndex = UPDATE_STEPS.findIndex(({ stage }) => stage === state.stage);
 
   return (
     <div className="mt-1 min-w-0 space-y-2.5">
-      <p className="text-xs text-muted-foreground">
+      <p className="text-xs text-muted-foreground/70">
         {fromVersion} <span aria-hidden="true">→</span> {state.targetVersion}
       </p>
       <ol className="flex min-w-0 items-center" aria-label="Server update progress">
@@ -63,6 +50,7 @@ export function ServerUpdateProgress({
           const complete = index < currentIndex;
           const current = index === currentIndex;
           const failed = current && state.status === "failed";
+          const running = current && state.status === "running";
           return (
             <li
               key={step.stage}
@@ -70,36 +58,40 @@ export function ServerUpdateProgress({
                 "flex min-w-0 items-center text-xs font-medium",
                 index < UPDATE_STEPS.length - 1 ? "flex-1" : null,
                 complete
-                  ? "text-success"
+                  ? "text-muted-foreground"
                   : failed
                     ? "text-destructive"
-                    : current
-                      ? "text-primary"
-                      : "text-muted-foreground/60",
+                    : running
+                      ? "animate-status-pulse text-foreground"
+                      : "text-muted-foreground/50",
               )}
-              aria-current={current && state.status === "running" ? "step" : undefined}
+              aria-current={running ? "step" : undefined}
             >
-              <span
-                className={cn(
-                  "grid size-4 shrink-0 place-items-center rounded-full border",
-                  complete
-                    ? "border-success bg-success text-success-foreground"
-                    : failed
-                      ? "border-destructive bg-destructive text-destructive-foreground"
-                      : current
-                        ? "border-primary bg-primary text-primary-foreground"
-                        : "border-muted-foreground/35",
-                )}
-                aria-hidden="true"
-              >
-                {complete ? <CheckIcon className="size-3" strokeWidth={3} /> : null}
-              </span>
-              <span className="ml-1.5 truncate">{step.label}</span>
+              {complete ? (
+                <CheckIcon
+                  className="size-3.5 shrink-0 opacity-70"
+                  strokeWidth={2.5}
+                  aria-hidden="true"
+                />
+              ) : (
+                <span
+                  className={cn(
+                    "size-1.5 shrink-0 rounded-full",
+                    failed
+                      ? "bg-destructive"
+                      : running
+                        ? "bg-foreground"
+                        : "border border-muted-foreground/40",
+                  )}
+                  aria-hidden="true"
+                />
+              )}
+              <span className="ml-1.5 truncate">{running ? step.activeLabel : step.label}</span>
               {index < UPDATE_STEPS.length - 1 ? (
                 <span
                   className={cn(
                     "mx-2 h-px min-w-3 flex-1",
-                    complete ? "bg-success/60" : "bg-border",
+                    complete ? "bg-muted-foreground/40" : "bg-border",
                   )}
                   aria-hidden="true"
                 />
@@ -108,15 +100,11 @@ export function ServerUpdateProgress({
           );
         })}
       </ol>
-      <p
-        className={cn(
-          "text-xs",
-          state.status === "failed" ? "text-destructive" : "text-muted-foreground",
-        )}
-        role={state.status === "failed" ? "alert" : "status"}
-      >
-        {updateStatusCopy(state, serverLabel)}
-      </p>
+      {state.status === "failed" ? (
+        <p className="text-xs text-destructive" role="alert">
+          {state.message}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -24,7 +24,7 @@ const exitTransitionStyle = {
 
 export interface ComposerBannerStackItem {
   readonly id: string;
-  readonly variant: "error" | "info" | "success" | "warning";
+  readonly variant: "default" | "error" | "info" | "success" | "warning";
   readonly icon: ReactNode;
   readonly title: ReactNode;
   readonly description?: ReactNode;

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1434,7 +1434,6 @@ function SavedBackendListRow({
             <div className="max-w-md">
               <ServerUpdateProgress
                 fromVersion={serverUpdateState.fromVersion}
-                serverLabel={`${environment.label} server`}
                 state={serverUpdateState}
               />
             </div>
@@ -3011,7 +3010,6 @@ export function ConnectionsSettings() {
                   primaryServerUpdateState.status !== "idle" ? (
                     <ServerUpdateProgress
                       fromVersion={primaryServerUpdateState.fromVersion}
-                      serverLabel={primaryEnvironment?.label ?? "this server"}
                       state={primaryServerUpdateState}
                     />
                   ) : primaryVersionMismatch ? (


### PR DESCRIPTION
Updating a server showed an amber warning banner with a triangle icon and a green/blue stepper, which made a routine "one moment please" delay feel like something was wrong. Worse, refreshing mid-update stacked two alarming banners: "Client and server versions differ" (with a dead Update button) on top of "Failed to connect. Reconnecting...".

The update banner is now calm and monochrome. Done steps recede to gray, the active step is the only bright element and pulses with the existing duty-cycled animation, and the redundant status sentence is gone. Failures still get full error treatment.

Reconnecting to a version-skewed server (the refresh case, or the reconnect blip during resume) now collapses both banners into a single quiet "Reconnecting - it may be finishing an update" line. The version-mismatch banner with its Update action only returns if the server comes back still on the old version.

Written by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to composer banners and update progress presentation; no auth, data, or server logic changes.
> 
> **Overview**
> **In-progress server updates and version-skew reconnects** now use calm **default** composer banners (pulsing dot) instead of warning triangles and amber styling, so routine waits don’t read as errors.
> 
> **Banner stacking** is reduced: when reconnecting during version skew with no failed update, unavailable and version-mismatch banners merge into one quiet “Connecting/Reconnecting… it may be finishing an update” line; the version banner with **Update** only returns if the server is still skewed after reconnect. During an active update, transient reconnect blips hide the unavailable banner unless the connection is in a hard error phase.
> 
> **`ServerUpdateProgress`** is a monochrome step rail—muted checks for done steps, pulsing dot on the active step with labels like “Resuming”, no per-stage status line except on failure; **`serverLabel`** is removed from the component and all call sites. **`ComposerBannerStackItem`** adds a **`default`** variant for these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11e4ebc7e7836a92415297ffa1b68a9dc40dc23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix server update banners to use neutral styling instead of warning appearance
> - The server update progress rail in [ServerUpdateAction.tsx](https://github.com/pingdotgg/t3code/pull/4992/files#diff-c763cea5fd019df67ff03a8c988bc9ea2af55b7f10b5fa6fe8557bd1f92471a3) is now monochrome: completed steps show a faint check, the active step pulses, and no status sentence is shown while running (only errors surface an alert).
> - Transient 'environment unavailable' warnings are suppressed in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4992/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) when a server update is running and the environment is reconnecting.
> - Version-skew reconnects without an active update now show a single calm 'Connecting/Reconnecting' banner (`variant: 'default'`) instead of an error/warning banner.
> - `ServerUpdateProgress` no longer accepts or displays a `serverLabel` prop; call sites in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/4992/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) are updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d11e4eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->