### PR TITLE
fix(mobile): keep threads visibly working while background subagents run

### DIFF
--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -26,6 +26,7 @@ import { HardwareKeyboardCommandProvider } from "./features/keyboard/HardwareKey
 import { ReviewCommentComposerSheet } from "./features/review/ReviewCommentComposerSheet";
 import { ReviewSheet } from "./features/review/ReviewSheet";
 import { ThreadTerminalRouteScreen } from "./features/terminal/ThreadTerminalRouteScreen";
+import { BackgroundAgentsSheet } from "./features/threads/BackgroundAgentsSheet";
 import { GitBranchesSheet } from "./features/threads/git/GitBranchesSheet";
 import { GitCommitSheet } from "./features/threads/git/GitCommitSheet";
 import { GitConfirmSheet } from "./features/threads/git/GitConfirmSheet";
@@ -437,6 +438,15 @@ export const RootStack = createNativeStackNavigator({
       screen: ThreadFileScreen,
       linking: `${THREAD_LINKING_PREFIX}/files/:path*`,
       options: SOLID_HEADER_OPTIONS,
+    }),
+    BackgroundAgents: createNativeStackScreen({
+      screen: BackgroundAgentsSheet,
+      linking: `${THREAD_LINKING_PREFIX}/agents`,
+      options: {
+        presentation: "formSheet",
+        sheetAllowedDetents: [0.5, 0.9],
+        sheetGrabberVisible: true,
+      },
     }),
     GitOverview: createNativeStackScreen({
       screen: GitOverviewSheet,

--- a/apps/mobile/src/features/threads/BackgroundAgentsSheet.tsx
+++ b/apps/mobile/src/features/threads/BackgroundAgentsSheet.tsx
@@ -1,0 +1,230 @@
+import type { StaticScreenProps } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
+import {
+  deriveBackgroundTasks,
+  type BackgroundTask,
+} from "@t3tools/client-runtime/state/background-tasks";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { useMemo } from "react";
+import { ActivityIndicator, Platform, ScrollView, View } from "react-native";
+import { Screen, ScreenStack, ScreenStackHeaderConfig } from "react-native-screens";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { AndroidSheetHeader } from "../../components/AndroidScreenHeader";
+import { AppText as Text } from "../../components/AppText";
+import { SymbolView, type AppSymbolName } from "../../components/AppSymbol";
+import { nativeHeaderScrollEdgeEffects } from "../../native/StackHeader";
+import { relativeTime } from "../../lib/time";
+import { useThemeColor } from "../../lib/useThemeColor";
+import { useThreadDetail } from "../../state/use-thread-detail";
+import { elapsedLabel, useLiveElapsedClock } from "./thread-swarm-rail";
+
+const HEADER_SCROLL_EDGE_EFFECTS = nativeHeaderScrollEdgeEffects(Platform.OS, Platform.Version);
+
+const MONO_FONT = Platform.select({
+  ios: "Menlo",
+  android: "monospace",
+  default: "monospace",
+});
+
+const SHEET_TITLE = "Background agents";
+
+type BackgroundAgentsSheetProps = StaticScreenProps<{
+  readonly environmentId: string;
+  readonly threadId: string;
+}>;
+
+function settledGlyph(status: BackgroundTask["status"]): AppSymbolName {
+  if (status === "failed") return "exclamationmark.triangle";
+  if (status === "stopped") return "xmark";
+  return "checkmark";
+}
+
+function RunningTaskRow(props: {
+  readonly task: BackgroundTask;
+  readonly nowMs: number;
+  readonly accentColor: string;
+}) {
+  const duration = elapsedLabel(props.task.startedAt, props.nowMs);
+
+  return (
+    <View
+      accessible
+      accessibilityLabel={`${props.task.name}, running for ${duration}${
+        props.task.latestProgress === null ? "" : `. ${props.task.latestProgress}`
+      }`}
+      className="flex-row items-center gap-3 px-1 py-3"
+    >
+      <ActivityIndicator size="small" color={props.accentColor} />
+      <View className="min-w-0 flex-1 gap-0.5">
+        <Text className="text-foreground text-base font-t3-bold" numberOfLines={1}>
+          {props.task.name}
+        </Text>
+        {props.task.latestProgress !== null ? (
+          <Text
+            className="text-xs leading-snug"
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            style={{ color: props.accentColor, fontFamily: MONO_FONT, opacity: 0.75 }}
+          >
+            {props.task.latestProgress}
+          </Text>
+        ) : null}
+      </View>
+      <Text
+        className="text-foreground-muted text-xs tabular-nums"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        {duration}
+      </Text>
+    </View>
+  );
+}
+
+function SettledTaskRow(props: { readonly task: BackgroundTask }) {
+  const iconSubtleColor = useThemeColor("--color-icon-subtle");
+  const settledLabel =
+    props.task.settledAt === null ? null : `settled ${relativeTime(props.task.settledAt)} ago`;
+
+  return (
+    <View
+      accessible
+      accessibilityLabel={`${props.task.name}, ${props.task.status}${
+        settledLabel === null ? "" : `, ${settledLabel}`
+      }`}
+      className="flex-row items-center gap-3 px-1 py-3 opacity-[0.55]"
+    >
+      <View className="bg-subtle h-7 w-7 items-center justify-center rounded-full">
+        <SymbolView
+          name={settledGlyph(props.task.status)}
+          size={13}
+          tintColor={iconSubtleColor}
+          type="monochrome"
+          weight="semibold"
+        />
+      </View>
+      <Text className="text-foreground min-w-0 flex-1 text-base font-t3-medium" numberOfLines={1}>
+        {props.task.name}
+      </Text>
+      {settledLabel !== null ? (
+        <Text className="text-foreground-muted text-xs">{settledLabel}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+export function BackgroundAgentsSheet(props: BackgroundAgentsSheetProps) {
+  const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
+  const environmentId = EnvironmentId.make(props.route.params.environmentId);
+  const threadId = ThreadId.make(props.route.params.threadId);
+
+  const foregroundColor = String(useThemeColor("--color-foreground"));
+  const sheetColor = String(useThemeColor("--color-sheet"));
+  const accentColor = String(useThemeColor("--color-user-bubble"));
+
+  // The sheet reads the thread projection itself rather than taking a
+  // snapshot through route params: tasks start and settle while it is open.
+  const thread = Option.getOrNull(useThreadDetail({ environmentId, threadId }).data);
+  const tasks = useMemo(
+    () => deriveBackgroundTasks(thread?.activities ?? [], thread?.session ?? null),
+    [thread],
+  );
+
+  const nowMs = useLiveElapsedClock(tasks.running.length > 0);
+  const runningCaption = `${tasks.running.length} running`;
+
+  const content = (
+    <ScrollView
+      className="flex-1 bg-screen"
+      contentInsetAdjustmentBehavior={Platform.OS === "ios" ? "automatic" : "never"}
+      showsVerticalScrollIndicator={false}
+      contentInset={{ bottom: Math.max(insets.bottom, 18) + 18 }}
+      contentContainerStyle={{ paddingHorizontal: 20, paddingTop: 8, gap: 14 }}
+    >
+      <Text className="text-foreground-muted text-2xs font-t3-bold tracking-[0.9px] uppercase">
+        {runningCaption}
+      </Text>
+
+      {tasks.running.length === 0 && tasks.settled.length === 0 ? (
+        <View className="rounded-[22px] border border-border bg-card px-4 py-5">
+          <Text className="text-foreground-muted text-sm leading-snug">
+            No background agents on this thread.
+          </Text>
+        </View>
+      ) : null}
+
+      {tasks.running.length > 0 ? (
+        <View className="overflow-hidden rounded-[22px] border border-border bg-card px-4 py-1">
+          {tasks.running.map((task, index) => (
+            <View key={task.taskId}>
+              {index > 0 ? <View className="h-px bg-border" /> : null}
+              <RunningTaskRow task={task} nowMs={nowMs} accentColor={accentColor} />
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {tasks.settled.length > 0 ? (
+        <View className="gap-2">
+          <Text className="text-foreground-muted text-2xs font-t3-bold tracking-[0.9px] uppercase">
+            Finished
+          </Text>
+          <View className="overflow-hidden rounded-[22px] border border-border bg-card px-4 py-1">
+            {tasks.settled.map((task, index) => (
+              <View key={task.taskId}>
+                {index > 0 ? <View className="h-px bg-border" /> : null}
+                <SettledTaskRow task={task} />
+              </View>
+            ))}
+          </View>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+
+  if (Platform.OS === "ios") {
+    // A screen presented as formSheet never renders a stack header, so — like
+    // the git sheets — the header comes from a nested native stack INSIDE it.
+    return (
+      <View collapsable={false} className="flex-1 bg-sheet">
+        <ScreenStack style={{ flex: 1 }}>
+          <Screen
+            activityState={2}
+            enabled
+            isNativeStack
+            screenId="thread-background-agents-sheet-native"
+            scrollEdgeEffects={HEADER_SCROLL_EDGE_EFFECTS}
+            style={{ backgroundColor: sheetColor, flex: 1 }}
+          >
+            {content}
+            <ScreenStackHeaderConfig
+              backgroundColor="rgba(0,0,0,0)"
+              color={foregroundColor}
+              hideBackButton
+              hideShadow={false}
+              navigationItemStyle="editor"
+              title={SHEET_TITLE}
+              titleColor={foregroundColor}
+              titleFontSize={18}
+              titleFontWeight="800"
+              translucent
+            />
+          </Screen>
+        </ScreenStack>
+      </View>
+    );
+  }
+
+  return (
+    <View collapsable={false} className="flex-1 bg-sheet">
+      <AndroidSheetHeader
+        title={SHEET_TITLE}
+        subtitle={runningCaption}
+        onBack={() => navigation.goBack()}
+      />
+      {content}
+    </View>
+  );
+}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -1,3 +1,4 @@
+import type { BackgroundTaskState } from "@t3tools/client-runtime/state/background-tasks";
 import { type EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import type { EnvironmentThreadStatus } from "@t3tools/client-runtime/state/threads";
 import { useKeyboardChatComposerInset, useKeyboardScrollToEnd } from "@legendapp/list/keyboard";
@@ -41,6 +42,7 @@ import {
 } from "./ThreadComposer";
 import { ThreadFeed } from "./ThreadFeed";
 import type { ThreadContentPresentation } from "./threadContentPresentation";
+import { SWARM_RAIL_CHROME, ThreadSwarmRail } from "./thread-swarm-rail";
 
 export interface ThreadDetailScreenProps {
   readonly selectedThread: OrchestrationThreadShell;
@@ -50,6 +52,9 @@ export interface ThreadDetailScreenProps {
   readonly environmentLabel: string | null;
   readonly selectedThreadFeed: ReadonlyArray<ThreadFeedEntry>;
   readonly activeWorkStartedAt: string | null;
+  /** Provider subagents for this thread; drives the swarm rail above the composer. */
+  readonly backgroundTasks: BackgroundTaskState;
+  readonly onOpenBackgroundAgents: () => void;
   readonly activePendingApproval: PendingApproval | null;
   readonly respondingApprovalId: ApprovalRequestId | null;
   readonly activePendingUserInput: PendingUserInput | null;
@@ -201,8 +206,12 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   })();
   const selectedThreadFeed = props.selectedThreadFeed;
   const composerChrome = composerExpanded ? COMPOSER_EXPANDED_CHROME : COMPOSER_COLLAPSED_CHROME;
+  const showSwarmRail = props.backgroundTasks.running.length > 0;
   const composerOverlapHeight = composerChrome + composerBottomInset;
-  const estimatedOverlayHeight = composerOverlapHeight;
+  // The rail is part of the measured overlay, so its block height has to enter
+  // the estimate too — otherwise the feed floor sits a rail short until the
+  // next layout pass lands.
+  const estimatedOverlayHeight = composerOverlapHeight + (showSwarmRail ? SWARM_RAIL_CHROME : 0);
   // The overlay's measured height includes the home-indicator inset (the
   // composer pads it), but contentInsetAdjustmentBehavior="automatic" makes
   // UIKit add the safe-area bottom to the content inset AGAIN — leaving a
@@ -413,6 +422,14 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                     />
                   ) : null}
                 </Animated.View>
+              ) : null}
+
+              {showSwarmRail ? (
+                <ThreadSwarmRail
+                  runningCount={props.backgroundTasks.running.length}
+                  startedAt={props.backgroundTasks.startedAt}
+                  onPress={props.onOpenBackgroundAgents}
+                />
               ) : null}
             </View>
 

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -479,6 +479,16 @@ function ThreadRouteContent(
     });
   }, [interruptThreadTurn, selectedThread]);
 
+  const handleOpenBackgroundAgents = useCallback(() => {
+    if (!selectedThread) {
+      return;
+    }
+    navigation.navigate("BackgroundAgents", {
+      environmentId: String(selectedThread.environmentId),
+      threadId: String(selectedThread.id),
+    });
+  }, [navigation, selectedThread]);
+
   const handleOpenTerminal = useCallback(
     (nextTerminalId?: string | null) => {
       terminalDebugLog("terminal-menu:open-existing", {
@@ -756,6 +766,8 @@ function ThreadRouteContent(
           environmentLabel={selectedEnvironmentConnection?.environmentLabel ?? null}
           selectedThreadFeed={composer.selectedThreadFeed}
           activeWorkStartedAt={composer.activeWorkStartedAt}
+          backgroundTasks={composer.backgroundTasks}
+          onOpenBackgroundAgents={handleOpenBackgroundAgents}
           activePendingApproval={requests.activePendingApproval}
           respondingApprovalId={requests.respondingApprovalId}
           activePendingUserInput={requests.activePendingUserInput}

--- a/apps/mobile/src/features/threads/thread-swarm-rail.tsx
+++ b/apps/mobile/src/features/threads/thread-swarm-rail.tsx
@@ -1,0 +1,133 @@
+import { formatElapsed } from "@t3tools/shared/orchestrationTiming";
+import * as Haptics from "expo-haptics";
+import { useCallback, useEffect, useState } from "react";
+import { ActivityIndicator, Platform, Pressable, useColorScheme, View } from "react-native";
+import Animated, { FadeInDown, FadeOut } from "react-native-reanimated";
+
+import { AppText as Text } from "../../components/AppText";
+import { SymbolView } from "../../components/AppSymbol";
+import { useThemeColor } from "../../lib/useThemeColor";
+import { ComposerSurface } from "./ThreadComposer";
+
+/**
+ * Height of the rail pill. Deliberately slimmer and squarer-per-height than
+ * the 52px composer pill (radius 19 against 999) so it never reads as a
+ * second input sitting above the real one.
+ */
+const SWARM_RAIL_HEIGHT = 38;
+
+/**
+ * Height the rail block adds above the composer (pill + its bottom padding).
+ * Exported so the parent can fold it into the feed's estimated bottom inset
+ * before the overlay re-measures.
+ */
+export const SWARM_RAIL_CHROME = SWARM_RAIL_HEIGHT + 8;
+
+const MONO_FONT = Platform.select({
+  ios: "Menlo",
+  android: "monospace",
+  default: "monospace",
+});
+
+/**
+ * 1s clock for live elapsed labels, parked while `enabled` is false so an
+ * idle rail or a sheet with nothing running holds no timer.
+ */
+export function useLiveElapsedClock(enabled: boolean): number {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!enabled) return;
+    setNowMs(Date.now());
+    const intervalId = setInterval(() => {
+      setNowMs(Date.now());
+    }, 1_000);
+    return () => clearInterval(intervalId);
+  }, [enabled]);
+
+  return nowMs;
+}
+
+export function elapsedLabel(startedAt: string, nowMs: number): string {
+  return formatElapsed(startedAt, new Date(nowMs).toISOString()) ?? "0s";
+}
+
+export function backgroundAgentsLabel(runningCount: number): string {
+  return runningCount === 1 ? "1 subagent working" : `${runningCount} subagents working`;
+}
+
+/**
+ * Full-width rail docked directly above the composer while provider
+ * background tasks (subagents) are still running — the thread's own turn can
+ * settle long before its children do, and without this the screen reads as
+ * idle (#4962). Tapping opens the Background agents sheet.
+ */
+export function ThreadSwarmRail(props: {
+  readonly runningCount: number;
+  readonly startedAt: string | null;
+  readonly onPress: () => void;
+}) {
+  const isDarkMode = useColorScheme() === "dark";
+  const accentColor = useThemeColor("--color-user-bubble");
+  const iconColor = useThemeColor("--color-icon");
+  const nowMs = useLiveElapsedClock(props.startedAt !== null);
+  const label = backgroundAgentsLabel(props.runningCount);
+  const durationLabel = props.startedAt === null ? null : elapsedLabel(props.startedAt, nowMs);
+
+  const handlePress = useCallback(() => {
+    void Haptics.selectionAsync();
+    props.onPress();
+  }, [props.onPress]);
+
+  return (
+    <Animated.View
+      className="px-4 pb-2"
+      entering={FadeInDown.duration(220)}
+      exiting={FadeOut.duration(140)}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={
+          durationLabel === null ? label : `${label}, ${durationLabel}. Open background agents.`
+        }
+        onPress={handlePress}
+      >
+        <ComposerSurface
+          isDarkMode={isDarkMode}
+          style={{
+            height: SWARM_RAIL_HEIGHT,
+            borderRadius: SWARM_RAIL_HEIGHT / 2,
+            overflow: "hidden",
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 9,
+            paddingLeft: 14,
+            paddingRight: 6,
+          }}
+        >
+          <ActivityIndicator size="small" color={accentColor} />
+          <Text className="min-w-0 flex-1 text-sm font-t3-medium" numberOfLines={1}>
+            {label}
+          </Text>
+          {durationLabel !== null ? (
+            <Text
+              className="text-foreground-muted text-xs tabular-nums"
+              style={{ fontFamily: MONO_FONT }}
+            >
+              {durationLabel}
+            </Text>
+          ) : null}
+          <View className="bg-subtle h-[26px] w-[26px] items-center justify-center rounded-full">
+            <SymbolView
+              name="chevron.up"
+              size={13}
+              tintColor={iconColor}
+              type="monochrome"
+              weight="semibold"
+            />
+          </View>
+        </ComposerSurface>
+      </Pressable>
+    </Animated.View>
+  );
+}

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -50,6 +50,21 @@ function makeThread(
 
 const NOW = "2026-06-02T00:00:00.000Z";
 
+type ThreadSession = NonNullable<EnvironmentThreadShell["session"]>;
+
+function makeSession(status: ThreadSession["status"]): ThreadSession {
+  return {
+    threadId: ThreadId.make("t"),
+    status,
+    providerName: "Codex",
+    providerInstanceId: ProviderInstanceId.make("codex"),
+    runtimeMode: "full-access",
+    activeTurnId: null,
+    lastError: null,
+    updatedAt: NOW,
+  };
+}
+
 describe("resolveThreadListV2Enabled", () => {
   it("defaults on when the device has never chosen", () => {
     expect(resolveThreadListV2Enabled({ preference: undefined, preferencesLoaded: true })).toBe(
@@ -75,16 +90,7 @@ describe("resolveThreadListV2Status", () => {
       id: ThreadId.make("t"),
       title: "t",
       hasPendingApprovals: true,
-      session: {
-        threadId: ThreadId.make("t"),
-        status: "running",
-        providerName: "Codex",
-        providerInstanceId: ProviderInstanceId.make("codex"),
-        runtimeMode: "full-access",
-        activeTurnId: null,
-        lastError: null,
-        updatedAt: NOW,
-      },
+      session: makeSession("running"),
     });
     expect(resolveThreadListV2Status(thread)).toBe("approval");
   });
@@ -93,6 +99,56 @@ describe("resolveThreadListV2Status", () => {
     expect(resolveThreadListV2Status(makeThread({ id: ThreadId.make("t"), title: "t" }))).toBe(
       "ready",
     );
+  });
+
+  it("stays working while subagents run past the parent turn", () => {
+    const thread = makeThread({
+      id: ThreadId.make("t"),
+      title: "t",
+      outstandingBackgroundTaskCount: 2,
+      session: makeSession("ready"),
+    });
+    expect(resolveThreadListV2Status(thread)).toBe("working");
+  });
+
+  it("resolves ready once the outstanding count drains to zero", () => {
+    const thread = makeThread({
+      id: ThreadId.make("t"),
+      title: "t",
+      outstandingBackgroundTaskCount: 0,
+      session: makeSession("ready"),
+    });
+    expect(resolveThreadListV2Status(thread)).toBe("ready");
+  });
+
+  it("keeps approval ahead of background work", () => {
+    const thread = makeThread({
+      id: ThreadId.make("t"),
+      title: "t",
+      hasPendingApprovals: true,
+      outstandingBackgroundTaskCount: 3,
+      session: makeSession("ready"),
+    });
+    expect(resolveThreadListV2Status(thread)).toBe("approval");
+  });
+
+  it("keeps a failed session ahead of background work", () => {
+    const thread = makeThread({
+      id: ThreadId.make("t"),
+      title: "t",
+      outstandingBackgroundTaskCount: 1,
+      session: makeSession("error"),
+    });
+    expect(resolveThreadListV2Status(thread)).toBe("failed");
+  });
+
+  it("reads a legacy server's missing count as no background work", () => {
+    const thread = makeThread({
+      id: ThreadId.make("t"),
+      title: "t",
+      session: makeSession("ready"),
+    });
+    expect(resolveThreadListV2Status(thread)).toBe("ready");
   });
 });
 

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -42,7 +42,10 @@ export function resolveThreadListV2Enabled(input: {
 }
 
 export function resolveThreadListV2Status(
-  thread: Pick<EnvironmentThreadShell, "hasPendingApprovals" | "hasPendingUserInput" | "session">,
+  thread: Pick<
+    EnvironmentThreadShell,
+    "hasPendingApprovals" | "hasPendingUserInput" | "outstandingBackgroundTaskCount" | "session"
+  >,
 ): ThreadListV2Status {
   if (thread.hasPendingApprovals) {
     return "approval";
@@ -55,6 +58,12 @@ export function resolveThreadListV2Status(
   }
   if (thread.session?.status === "error") {
     return "failed";
+  }
+  // The parent turn can settle while its subagents keep going; the row stays
+  // Working until they finish rather than resolving to ready (#4962). Servers
+  // that predate the aggregate send no count, which reads as "none".
+  if ((thread.outstandingBackgroundTaskCount ?? 0) > 0) {
+    return "working";
   }
   return "ready";
 }

--- a/apps/mobile/src/features/threads/threadPresentation.test.ts
+++ b/apps/mobile/src/features/threads/threadPresentation.test.ts
@@ -1,0 +1,75 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveThreadStatus } from "./threadPresentation";
+
+const NOW = "2026-06-02T00:00:00.000Z";
+const threadId = ThreadId.make("thread-1");
+
+type ThreadSession = NonNullable<EnvironmentThreadShell["session"]>;
+
+function makeSession(status: ThreadSession["status"]): ThreadSession {
+  return {
+    threadId,
+    status,
+    providerName: "Codex",
+    providerInstanceId: ProviderInstanceId.make("codex"),
+    runtimeMode: "full-access",
+    activeTurnId: null,
+    lastError: null,
+    updatedAt: NOW,
+  };
+}
+
+function makeThread(input: Partial<EnvironmentThreadShell> = {}): EnvironmentThreadShell {
+  return {
+    id: threadId,
+    title: "Thread",
+    environmentId: EnvironmentId.make("environment-1"),
+    projectId: ProjectId.make("project-1"),
+    modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    session: makeSession("ready"),
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...input,
+  };
+}
+
+describe("resolveThreadStatus", () => {
+  it("keeps the working presentation while subagents run past the parent turn", () => {
+    expect(resolveThreadStatus(makeThread({ outstandingBackgroundTaskCount: 2 }))).toMatchObject({
+      kind: "working",
+      label: "Working",
+      pulse: true,
+    });
+  });
+
+  it("falls quiet once the outstanding count drains to zero", () => {
+    expect(resolveThreadStatus(makeThread({ outstandingBackgroundTaskCount: 0 }))).toBeNull();
+  });
+
+  it("reads a legacy server's missing count as no background work", () => {
+    expect(resolveThreadStatus(makeThread())).toBeNull();
+  });
+
+  it("keeps an errored session ahead of background work", () => {
+    expect(
+      resolveThreadStatus(
+        makeThread({ outstandingBackgroundTaskCount: 1, session: makeSession("error") }),
+      ),
+    ).toMatchObject({ kind: "error" });
+  });
+});

--- a/apps/mobile/src/features/threads/threadPresentation.ts
+++ b/apps/mobile/src/features/threads/threadPresentation.ts
@@ -109,6 +109,21 @@ export function resolveThreadStatus(
     };
   }
 
+  // Subagents outlive the parent turn: keep the Working presentation (and its
+  // pulse) while background tasks are outstanding instead of letting the row
+  // fall quiet (#4962). Legacy servers send no count, which reads as "none".
+  if ((thread.outstandingBackgroundTaskCount ?? 0) > 0) {
+    return {
+      kind: "working",
+      label: "Working",
+      pillClassName: "bg-sky-500/12 dark:bg-sky-500/16",
+      textClassName: "text-sky-700 dark:text-sky-300",
+      iconColor: "#0a84ff",
+      iconBackground: "rgba(10,132,255,0.22)",
+      pulse: true,
+    };
+  }
+
   const hasPlanReadyPrompt =
     thread.interactionMode === "plan" &&
     isLatestTurnSettled(thread.latestTurn, thread.session) &&

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -10,6 +10,7 @@ import {
   type RuntimeMode,
   type ThreadId,
 } from "@t3tools/contracts";
+import { deriveBackgroundTasks } from "@t3tools/client-runtime/state/background-tasks";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import { deriveActiveWorkStartedAt } from "@t3tools/shared/orchestrationTiming";
 
@@ -128,6 +129,18 @@ export function useThreadComposerState() {
       null,
     );
   }, [selectedThreadDetail, selectedThreadSessionActivity, selectedThreadShell]);
+
+  // Provider subagents outlive the parent turn: the fold reads "Worked for …"
+  // while children are still running, so the swarm rail needs its own signal
+  // rather than the turn/session timing above (#4962).
+  const backgroundTasks = useMemo(
+    () =>
+      deriveBackgroundTasks(
+        selectedThreadDetail?.activities ?? [],
+        selectedThreadDetail?.session ?? null,
+      ),
+    [selectedThreadDetail],
+  );
 
   const activeThreadBusy =
     !!selectedThread &&
@@ -303,6 +316,7 @@ export function useThreadComposerState() {
     selectedThreadFeed,
     selectedThreadQueueCount,
     activeWorkStartedAt,
+    backgroundTasks,
     draftMessage,
     draftAttachments,
     modelSelection,

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2775,3 +2775,281 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
     }),
   );
 });
+
+/**
+ * Harness for the #4962 outstanding-background-task scenarios: seeds a project
+ * and thread, then drives session and task lifecycle events through the
+ * pipeline. Every id derives from `suffix`, so scenarios stay isolated inside
+ * the layer's shared in-memory database.
+ */
+const makeBackgroundTaskHarness = Effect.fn("makeBackgroundTaskHarness")(function* (
+  suffix: string,
+) {
+  const eventStore = yield* OrchestrationEventStore;
+  const projectionPipeline = yield* OrchestrationProjectionPipeline;
+  const sql = yield* SqlClient.SqlClient;
+
+  const projectId = ProjectId.make(`project-${suffix}`);
+  const threadId = ThreadId.make(`thread-${suffix}`);
+  let tick = 0;
+  const nextAt = () => {
+    tick += 1;
+    return `2026-07-01T00:00:${String(tick).padStart(2, "0")}.000Z`;
+  };
+
+  const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+    eventStore
+      .append(event)
+      .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+  const projectCreatedAt = nextAt();
+  yield* appendAndProject({
+    type: "project.created",
+    eventId: EventId.make(`evt-${suffix}-project`),
+    aggregateKind: "project",
+    aggregateId: projectId,
+    occurredAt: projectCreatedAt,
+    commandId: CommandId.make(`cmd-${suffix}-project`),
+    causationEventId: null,
+    correlationId: CorrelationId.make(`cmd-${suffix}-project`),
+    metadata: {},
+    payload: {
+      projectId,
+      title: `Project ${suffix}`,
+      workspaceRoot: `/tmp/project-${suffix}`,
+      defaultModelSelection: null,
+      scripts: [],
+      createdAt: projectCreatedAt,
+      updatedAt: projectCreatedAt,
+    },
+  });
+
+  const threadCreatedAt = nextAt();
+  yield* appendAndProject({
+    type: "thread.created",
+    eventId: EventId.make(`evt-${suffix}-thread`),
+    aggregateKind: "thread",
+    aggregateId: threadId,
+    occurredAt: threadCreatedAt,
+    commandId: CommandId.make(`cmd-${suffix}-thread`),
+    causationEventId: null,
+    correlationId: CorrelationId.make(`cmd-${suffix}-thread`),
+    metadata: {},
+    payload: {
+      threadId,
+      projectId,
+      title: `Thread ${suffix}`,
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+        model: "claude-opus-4-6",
+      },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      branch: null,
+      worktreePath: null,
+      createdAt: threadCreatedAt,
+      updatedAt: threadCreatedAt,
+    },
+  });
+
+  let sessionRevision = 0;
+  const setSessionStatus = (
+    status: "starting" | "running" | "ready" | "idle" | "interrupted" | "stopped" | "error",
+  ) => {
+    sessionRevision += 1;
+    const occurredAt = nextAt();
+    return appendAndProject({
+      type: "thread.session-set",
+      eventId: EventId.make(`evt-${suffix}-session-${sessionRevision}`),
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      occurredAt,
+      commandId: CommandId.make(`cmd-${suffix}-session-${sessionRevision}`),
+      causationEventId: null,
+      correlationId: CorrelationId.make(`cmd-${suffix}-session-${sessionRevision}`),
+      metadata: {},
+      payload: {
+        threadId,
+        session: {
+          threadId,
+          status,
+          providerName: "claude",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: occurredAt,
+        },
+      },
+    });
+  };
+
+  let activityRevision = 0;
+  const appendTaskActivity = (kind: string, payload: Record<string, unknown>) => {
+    activityRevision += 1;
+    const createdAt = nextAt();
+    return appendAndProject({
+      type: "thread.activity-appended",
+      eventId: EventId.make(`evt-${suffix}-activity-${activityRevision}`),
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      occurredAt: createdAt,
+      commandId: CommandId.make(`cmd-${suffix}-activity-${activityRevision}`),
+      causationEventId: null,
+      correlationId: CorrelationId.make(`cmd-${suffix}-activity-${activityRevision}`),
+      metadata: {},
+      payload: {
+        threadId,
+        activity: {
+          id: EventId.make(`activity-${suffix}-${activityRevision}`),
+          tone: "info",
+          kind,
+          summary: kind,
+          payload,
+          turnId: null,
+          createdAt,
+        },
+      },
+    }).pipe(Effect.as(createdAt));
+  };
+
+  const readOutstanding = () =>
+    sql<{
+      readonly count: number;
+      readonly startedAt: string | null;
+    }>`
+      SELECT
+        outstanding_background_task_count AS "count",
+        outstanding_background_task_started_at AS "startedAt"
+      FROM projection_threads
+      WHERE thread_id = ${threadId}
+    `;
+
+  return {
+    setSessionStatus,
+    startTask: (taskId: string) => appendTaskActivity("task.started", { taskId }),
+    progressTask: (taskId: string, detail: string) =>
+      appendTaskActivity("task.progress", { taskId, detail }),
+    completeTask: (taskId: string, status: "completed" | "failed" | "stopped") =>
+      appendTaskActivity("task.completed", { taskId, status }),
+    readOutstanding,
+  };
+});
+
+it.layer(makeProjectionPipelinePrefixedTestLayer("t3-projection-background-tasks-test-"))(
+  "OrchestrationProjectionPipeline background tasks",
+  (it) => {
+    it.effect("counts a child task started under a running parent turn", () =>
+      Effect.gen(function* () {
+        const harness = yield* makeBackgroundTaskHarness("bg-running");
+        yield* harness.setSessionStatus("running");
+        const startedAt = yield* harness.startTask("task-1");
+
+        assert.deepEqual(yield* harness.readOutstanding(), [{ count: 1, startedAt }]);
+      }),
+    );
+
+    it.effect("keeps counting a child task after the parent turn completes", () =>
+      Effect.gen(function* () {
+        // The core #4962 regression: the parent session settles back to ready
+        // while its subagent is still working, and the thread must not read
+        // as idle.
+        const harness = yield* makeBackgroundTaskHarness("bg-outlives-turn");
+        yield* harness.setSessionStatus("running");
+        const startedAt = yield* harness.startTask("task-1");
+        yield* harness.setSessionStatus("ready");
+
+        assert.deepEqual(yield* harness.readOutstanding(), [{ count: 1, startedAt }]);
+      }),
+    );
+
+    it.effect("keeps a progressing child task counted with its original start", () =>
+      Effect.gen(function* () {
+        const harness = yield* makeBackgroundTaskHarness("bg-progress");
+        yield* harness.setSessionStatus("ready");
+        const startedAt = yield* harness.startTask("task-1");
+        yield* harness.progressTask("task-1", "Reading files");
+
+        assert.deepEqual(yield* harness.readOutstanding(), [{ count: 1, startedAt }]);
+
+        // Progress implies running, so it opens a task we never saw start.
+        const progressOnly = yield* makeBackgroundTaskHarness("bg-progress-only");
+        yield* progressOnly.setSessionStatus("ready");
+        const progressedAt = yield* progressOnly.progressTask("task-2", "Grepping");
+
+        assert.deepEqual(yield* progressOnly.readOutstanding(), [
+          { count: 1, startedAt: progressedAt },
+        ]);
+      }),
+    );
+
+    it.effect("clears the count on every terminal task status", () =>
+      Effect.gen(function* () {
+        for (const status of ["completed", "failed", "stopped"] as const) {
+          const harness = yield* makeBackgroundTaskHarness(`bg-terminal-${status}`);
+          yield* harness.setSessionStatus("ready");
+          yield* harness.startTask("task-1");
+          yield* harness.completeTask("task-1", status);
+
+          assert.deepEqual(yield* harness.readOutstanding(), [{ count: 0, startedAt: null }]);
+        }
+      }),
+    );
+
+    it.effect("clears only after the last of several tasks settles", () =>
+      Effect.gen(function* () {
+        const harness = yield* makeBackgroundTaskHarness("bg-two-tasks");
+        yield* harness.setSessionStatus("running");
+        const firstStartedAt = yield* harness.startTask("task-1");
+        const secondStartedAt = yield* harness.startTask("task-2");
+
+        assert.deepEqual(yield* harness.readOutstanding(), [
+          { count: 2, startedAt: firstStartedAt },
+        ]);
+
+        // The oldest OPEN task drives the aggregate elapsed label.
+        yield* harness.completeTask("task-1", "completed");
+        assert.deepEqual(yield* harness.readOutstanding(), [
+          { count: 1, startedAt: secondStartedAt },
+        ]);
+
+        yield* harness.completeTask("task-2", "stopped");
+        assert.deepEqual(yield* harness.readOutstanding(), [{ count: 0, startedAt: null }]);
+      }),
+    );
+
+    it.effect("does not drift on duplicate, stale, or unknown task events", () =>
+      Effect.gen(function* () {
+        const harness = yield* makeBackgroundTaskHarness("bg-noise");
+        yield* harness.setSessionStatus("running");
+        const startedAt = yield* harness.startTask("task-1");
+
+        // A duplicate start and a terminal event for a task we never saw
+        // start are both no-ops.
+        yield* harness.startTask("task-1");
+        yield* harness.completeTask("task-unknown", "completed");
+        assert.deepEqual(yield* harness.readOutstanding(), [{ count: 1, startedAt }]);
+
+        // Settled wins: neither a repeated completion nor a late start reopens.
+        yield* harness.completeTask("task-1", "completed");
+        yield* harness.completeTask("task-1", "failed");
+        yield* harness.startTask("task-1");
+        assert.deepEqual(yield* harness.readOutstanding(), [{ count: 0, startedAt: null }]);
+      }),
+    );
+
+    it.effect("forces the count to zero when the provider process dies", () =>
+      Effect.gen(function* () {
+        // A crashed or stopped adapter takes its children with it — without
+        // the session gate the thread would be Working forever.
+        for (const status of ["stopped", "error"] as const) {
+          const harness = yield* makeBackgroundTaskHarness(`bg-dead-${status}`);
+          yield* harness.setSessionStatus("running");
+          yield* harness.startTask("task-1");
+          yield* harness.setSessionStatus(status);
+
+          assert.deepEqual(yield* harness.readOutstanding(), [{ count: 0, startedAt: null }]);
+        }
+      }),
+    );
+  },
+);

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -176,6 +176,89 @@ function derivePendingUserInputCountFromActivities(
   return openRequestIds.size;
 }
 
+/**
+ * Session states under which a provider's background tasks (subagents) can
+ * still be alive. Anything else (stopped, interrupted, error, idle, or no
+ * session at all) means the provider process is gone and its children with
+ * it — counting tasks past that point would strand a permanent Working state.
+ *
+ * Mirrors TASK_BEARING_SESSION_STATUSES in the client-side twin at
+ * packages/client-runtime/src/state/backgroundTasks.ts; keep the two in sync.
+ */
+const TASK_BEARING_SESSION_STATUSES: ReadonlySet<OrchestrationSessionStatus> = new Set([
+  "starting",
+  "running",
+  "ready",
+]);
+
+interface OutstandingBackgroundTasks {
+  readonly count: number;
+  /** Start of the oldest still-outstanding task, or null when none are. */
+  readonly startedAt: string | null;
+}
+
+/**
+ * Replays task.started/task.progress/task.completed into the set of provider
+ * background tasks still running for a thread. Duplicate lifecycle events are
+ * idempotent, a completed for a task we never saw start is stale noise, and a
+ * started/progress arriving after its task settled stays settled — so repeated
+ * or out-of-order events cannot strand a thread as permanently working (#4962).
+ */
+function deriveOutstandingBackgroundTasks(
+  activities: ReadonlyArray<ProjectionThreadActivity>,
+): OutstandingBackgroundTasks {
+  // Insertion-ordered, so the first surviving entry is the oldest open task.
+  const openStartedAt = new Map<string, string>();
+  const settledTaskIds = new Set<string>();
+  const ordered = [...activities].toSorted((left, right) =>
+    left.sequence !== undefined && right.sequence !== undefined && left.sequence !== right.sequence
+      ? left.sequence - right.sequence
+      : left.createdAt.localeCompare(right.createdAt) ||
+        left.activityId.localeCompare(right.activityId),
+  );
+
+  for (const activity of ordered) {
+    if (
+      activity.kind !== "task.started" &&
+      activity.kind !== "task.progress" &&
+      activity.kind !== "task.completed"
+    ) {
+      continue;
+    }
+    const payload =
+      typeof activity.payload === "object" && activity.payload !== null
+        ? (activity.payload as Record<string, unknown>)
+        : null;
+    const taskId =
+      typeof payload?.taskId === "string" && payload.taskId.trim().length > 0
+        ? payload.taskId
+        : null;
+    if (taskId === null) {
+      continue;
+    }
+
+    if (activity.kind === "task.completed") {
+      // Every terminal status (completed/failed/stopped) clears the task.
+      if (!openStartedAt.has(taskId)) {
+        continue;
+      }
+      openStartedAt.delete(taskId);
+      settledTaskIds.add(taskId);
+      continue;
+    }
+
+    // Progress implies running, so it opens an unseen task. Settled wins: a
+    // late or duplicated started/progress never reopens one.
+    if (settledTaskIds.has(taskId) || openStartedAt.has(taskId)) {
+      continue;
+    }
+    openStartedAt.set(taskId, activity.createdAt);
+  }
+
+  const [oldestOpenStartedAt] = openStartedAt.values();
+  return { count: openStartedAt.size, startedAt: oldestOpenStartedAt ?? null };
+}
+
 function deriveHasActionableProposedPlan(input: {
   readonly latestTurnId: string | null;
   readonly proposedPlans: ReadonlyArray<ProjectionThreadProposedPlan>;
@@ -554,11 +637,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         return;
       }
 
-      const [messages, proposedPlans, activities, pendingApprovals] = yield* Effect.all([
+      const [messages, proposedPlans, activities, pendingApprovals, session] = yield* Effect.all([
         projectionThreadMessageRepository.listByThreadId({ threadId }),
         projectionThreadProposedPlanRepository.listByThreadId({ threadId }),
         projectionThreadActivityRepository.listByThreadId({ threadId }),
         projectionPendingApprovalRepository.listByThreadId({ threadId }),
+        projectionThreadSessionRepository.getByThreadId({ threadId }),
       ]);
 
       let latestUserMessageAt: string | null = null;
@@ -579,6 +663,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         latestTurnId: existingRow.value.latestTurnId,
         proposedPlans,
       });
+      // No live provider process means no live children, whatever the
+      // timeline still shows as open.
+      const outstandingBackgroundTasks =
+        Option.isSome(session) && TASK_BEARING_SESSION_STATUSES.has(session.value.status)
+          ? deriveOutstandingBackgroundTasks(activities)
+          : { count: 0, startedAt: null };
 
       yield* projectionThreadRepository.upsert({
         ...existingRow.value,
@@ -586,6 +676,8 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         pendingApprovalCount,
         pendingUserInputCount,
         hasActionableProposedPlan: hasActionableProposedPlan ? 1 : 0,
+        outstandingBackgroundTaskCount: outstandingBackgroundTasks.count,
+        outstandingBackgroundTaskStartedAt: outstandingBackgroundTasks.startedAt,
       });
     });
 
@@ -617,6 +709,8 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             pendingApprovalCount: 0,
             pendingUserInputCount: 0,
             hasActionableProposedPlan: 0,
+            outstandingBackgroundTaskCount: 0,
+            outstandingBackgroundTaskStartedAt: null,
             deletedAt: null,
           });
           return;

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -210,12 +210,18 @@ function deriveOutstandingBackgroundTasks(
   // Insertion-ordered, so the first surviving entry is the oldest open task.
   const openStartedAt = new Map<string, string>();
   const settledTaskIds = new Set<string>();
-  const ordered = [...activities].toSorted((left, right) =>
-    left.sequence !== undefined && right.sequence !== undefined && left.sequence !== right.sequence
-      ? left.sequence - right.sequence
-      : left.createdAt.localeCompare(right.createdAt) ||
-        left.activityId.localeCompare(right.activityId),
-  );
+  // Total order: unsequenced (pre-sequence) rows sort first as a group, so
+  // mixing them with sequenced rows cannot produce a non-transitive
+  // comparison and an arbitrary replay order.
+  const ordered = [...activities].toSorted((left, right) => {
+    const leftSequence = left.sequence ?? Number.NEGATIVE_INFINITY;
+    const rightSequence = right.sequence ?? Number.NEGATIVE_INFINITY;
+    if (leftSequence !== rightSequence) return leftSequence < rightSequence ? -1 : 1;
+    return (
+      left.createdAt.localeCompare(right.createdAt) ||
+      left.activityId.localeCompare(right.activityId)
+    );
+  });
 
   for (const activity of ordered) {
     if (
@@ -255,8 +261,16 @@ function deriveOutstandingBackgroundTasks(
     openStartedAt.set(taskId, activity.createdAt);
   }
 
-  const [oldestOpenStartedAt] = openStartedAt.values();
-  return { count: openStartedAt.size, startedAt: oldestOpenStartedAt ?? null };
+  // Min-scan rather than first-inserted: replay order follows sequence, which
+  // can disagree with createdAt under clock skew, and the elapsed label must
+  // count from the genuinely oldest open task.
+  let oldestOpenStartedAt: string | null = null;
+  for (const startedAt of openStartedAt.values()) {
+    if (oldestOpenStartedAt === null || startedAt < oldestOpenStartedAt) {
+      oldestOpenStartedAt = startedAt;
+    }
+  }
+  return { count: openStartedAt.size, startedAt: oldestOpenStartedAt };
 }
 
 function deriveHasActionableProposedPlan(input: {

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -441,6 +441,8 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           hasPendingApprovals: true,
           hasPendingUserInput: false,
           hasActionableProposedPlan: false,
+          outstandingBackgroundTaskCount: 0,
+          outstandingBackgroundTaskStartedAt: null,
         },
       ]);
 

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -390,6 +390,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
+          outstanding_background_task_count AS "outstandingBackgroundTaskCount",
+          outstanding_background_task_started_at AS "outstandingBackgroundTaskStartedAt",
           deleted_at AS "deletedAt"
         FROM projection_threads
         ORDER BY created_at ASC, thread_id ASC
@@ -424,6 +426,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
+          outstanding_background_task_count AS "outstandingBackgroundTaskCount",
+          outstanding_background_task_started_at AS "outstandingBackgroundTaskStartedAt",
           deleted_at AS "deletedAt"
         FROM projection_threads
         WHERE deleted_at IS NULL
@@ -460,6 +464,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
+          outstanding_background_task_count AS "outstandingBackgroundTaskCount",
+          outstanding_background_task_started_at AS "outstandingBackgroundTaskStartedAt",
           deleted_at AS "deletedAt"
         FROM projection_threads
         WHERE deleted_at IS NULL
@@ -896,6 +902,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
+          outstanding_background_task_count AS "outstandingBackgroundTaskCount",
+          outstanding_background_task_started_at AS "outstandingBackgroundTaskStartedAt",
           deleted_at AS "deletedAt"
         FROM projection_threads
         WHERE thread_id = ${threadId}
@@ -1671,6 +1679,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                       hasPendingApprovals: row.pendingApprovalCount > 0,
                       hasPendingUserInput: row.pendingUserInputCount > 0,
                       hasActionableProposedPlan: row.hasActionableProposedPlan > 0,
+                      outstandingBackgroundTaskCount: row.outstandingBackgroundTaskCount,
+                      outstandingBackgroundTaskStartedAt: row.outstandingBackgroundTaskStartedAt,
                     } satisfies OrchestrationThreadShell)
                   : Result.failVoid,
               ),
@@ -1810,6 +1820,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   hasPendingApprovals: row.pendingApprovalCount > 0,
                   hasPendingUserInput: row.pendingUserInputCount > 0,
                   hasActionableProposedPlan: row.hasActionableProposedPlan > 0,
+                  outstandingBackgroundTaskCount: row.outstandingBackgroundTaskCount,
+                  outstandingBackgroundTaskStartedAt: row.outstandingBackgroundTaskStartedAt,
                 }),
               ),
               updatedAt: updatedAt ?? "1970-01-01T00:00:00.000Z",
@@ -2081,6 +2093,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         hasPendingApprovals: threadRow.value.pendingApprovalCount > 0,
         hasPendingUserInput: threadRow.value.pendingUserInputCount > 0,
         hasActionableProposedPlan: threadRow.value.hasActionableProposedPlan > 0,
+        outstandingBackgroundTaskCount: threadRow.value.outstandingBackgroundTaskCount,
+        outstandingBackgroundTaskStartedAt: threadRow.value.outstandingBackgroundTaskStartedAt,
       } satisfies OrchestrationThreadShell);
     });
 

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -99,6 +99,8 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         pendingApprovalCount: 0,
         pendingUserInputCount: 0,
         hasActionableProposedPlan: 0,
+        outstandingBackgroundTaskCount: 0,
+        outstandingBackgroundTaskStartedAt: null,
         deletedAt: null,
       });
 
@@ -161,6 +163,8 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         pendingApprovalCount: 0,
         pendingUserInputCount: 0,
         hasActionableProposedPlan: 0,
+        outstandingBackgroundTaskCount: 0,
+        outstandingBackgroundTaskStartedAt: null,
         deletedAt: null,
       });
 

--- a/apps/server/src/persistence/Layers/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreads.ts
@@ -53,6 +53,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           pending_approval_count,
           pending_user_input_count,
           has_actionable_proposed_plan,
+          outstanding_background_task_count,
+          outstanding_background_task_started_at,
           deleted_at
         )
         VALUES (
@@ -78,6 +80,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           ${row.pendingApprovalCount},
           ${row.pendingUserInputCount},
           ${row.hasActionableProposedPlan},
+          ${row.outstandingBackgroundTaskCount},
+          ${row.outstandingBackgroundTaskStartedAt},
           ${row.deletedAt}
         )
         ON CONFLICT (thread_id)
@@ -103,6 +107,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           pending_approval_count = excluded.pending_approval_count,
           pending_user_input_count = excluded.pending_user_input_count,
           has_actionable_proposed_plan = excluded.has_actionable_proposed_plan,
+          outstanding_background_task_count = excluded.outstanding_background_task_count,
+          outstanding_background_task_started_at = excluded.outstanding_background_task_started_at,
           deleted_at = excluded.deleted_at
       `,
   });
@@ -135,6 +141,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
+          outstanding_background_task_count AS "outstandingBackgroundTaskCount",
+          outstanding_background_task_started_at AS "outstandingBackgroundTaskStartedAt",
           deleted_at AS "deletedAt"
         FROM projection_threads
         WHERE thread_id = ${threadId}
@@ -169,6 +177,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
+          outstanding_background_task_count AS "outstandingBackgroundTaskCount",
+          outstanding_background_task_started_at AS "outstandingBackgroundTaskStartedAt",
           deleted_at AS "deletedAt"
         FROM projection_threads
         WHERE project_id = ${projectId}

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -48,6 +48,7 @@ import Migration0032 from "./Migrations/032_AuthPairingProofKeyThumbprint.ts";
 import Migration0033 from "./Migrations/033_ProjectionThreadsSettled.ts";
 import Migration0034 from "./Migrations/034_ProjectionThreadsSnoozed.ts";
 import Migration0035 from "./Migrations/035_ProjectionThreadTitleRegeneration.ts";
+import Migration0036 from "./Migrations/036_ProjectionThreadsOutstandingBackgroundTasks.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -95,6 +96,7 @@ export const migrationEntries = [
   [33, "ProjectionThreadsSettled", Migration0033],
   [34, "ProjectionThreadsSnoozed", Migration0034],
   [35, "ProjectionThreadTitleRegeneration", Migration0035],
+  [36, "ProjectionThreadsOutstandingBackgroundTasks", Migration0036],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/036_ProjectionThreadsOutstandingBackgroundTasks.test.ts
+++ b/apps/server/src/persistence/Migrations/036_ProjectionThreadsOutstandingBackgroundTasks.test.ts
@@ -1,0 +1,222 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("036_ProjectionThreadsOutstandingBackgroundTasks", (it) => {
+  it.effect("backfills outstanding background tasks behind the session gate", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 35 });
+
+      const insertThread = (threadId: string) =>
+        sql`
+          INSERT INTO projection_threads (
+            thread_id,
+            project_id,
+            title,
+            model_selection_json,
+            runtime_mode,
+            interaction_mode,
+            branch,
+            worktree_path,
+            latest_turn_id,
+            created_at,
+            updated_at,
+            archived_at,
+            latest_user_message_at,
+            pending_approval_count,
+            pending_user_input_count,
+            has_actionable_proposed_plan,
+            deleted_at
+          )
+          VALUES (
+            ${threadId},
+            'project-1',
+            ${threadId},
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            '2026-07-01T00:00:00.000Z',
+            '2026-07-01T00:00:00.000Z',
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            NULL
+          )
+        `;
+
+      const insertSession = (threadId: string, status: string) =>
+        sql`
+          INSERT INTO projection_thread_sessions (
+            thread_id,
+            status,
+            provider_name,
+            provider_session_id,
+            provider_thread_id,
+            runtime_mode,
+            active_turn_id,
+            last_error,
+            updated_at
+          )
+          VALUES (
+            ${threadId},
+            ${status},
+            'claude',
+            NULL,
+            NULL,
+            'full-access',
+            NULL,
+            NULL,
+            '2026-07-01T00:01:00.000Z'
+          )
+        `;
+
+      const insertActivity = (input: {
+        readonly activityId: string;
+        readonly threadId: string;
+        readonly kind: string;
+        readonly payload: string;
+        readonly createdAt: string;
+      }) =>
+        sql`
+          INSERT INTO projection_thread_activities (
+            activity_id,
+            thread_id,
+            turn_id,
+            tone,
+            kind,
+            summary,
+            payload_json,
+            sequence,
+            created_at
+          )
+          VALUES (
+            ${input.activityId},
+            ${input.threadId},
+            NULL,
+            'info',
+            ${input.kind},
+            ${input.kind},
+            ${input.payload},
+            NULL,
+            ${input.createdAt}
+          )
+        `;
+
+      // Live session, two tasks started and the first one finished.
+      yield* insertThread("thread-live");
+      yield* insertSession("thread-live", "ready");
+      yield* insertActivity({
+        activityId: "activity-live-1",
+        threadId: "thread-live",
+        kind: "task.started",
+        payload: '{"taskId":"task-1","taskType":"explore"}',
+        createdAt: "2026-07-01T00:02:00.000Z",
+      });
+      yield* insertActivity({
+        activityId: "activity-live-2",
+        threadId: "thread-live",
+        kind: "task.started",
+        payload: '{"taskId":"task-2","taskType":"explore"}',
+        createdAt: "2026-07-01T00:03:00.000Z",
+      });
+      yield* insertActivity({
+        activityId: "activity-live-3",
+        threadId: "thread-live",
+        kind: "task.completed",
+        payload: '{"taskId":"task-1","status":"completed"}',
+        createdAt: "2026-07-01T00:04:00.000Z",
+      });
+
+      // Same timeline, but the provider process is gone: its children went
+      // with it, so the thread must stay at zero.
+      yield* insertThread("thread-dead");
+      yield* insertSession("thread-dead", "stopped");
+      yield* insertActivity({
+        activityId: "activity-dead-1",
+        threadId: "thread-dead",
+        kind: "task.started",
+        payload: '{"taskId":"task-3"}',
+        createdAt: "2026-07-01T00:02:00.000Z",
+      });
+
+      // Live session, every task settled.
+      yield* insertThread("thread-settled");
+      yield* insertSession("thread-settled", "running");
+      yield* insertActivity({
+        activityId: "activity-settled-1",
+        threadId: "thread-settled",
+        kind: "task.progress",
+        payload: '{"taskId":"task-4","detail":"Reading"}',
+        createdAt: "2026-07-01T00:02:00.000Z",
+      });
+      yield* insertActivity({
+        activityId: "activity-settled-2",
+        threadId: "thread-settled",
+        kind: "task.completed",
+        payload: '{"taskId":"task-4","status":"stopped"}',
+        createdAt: "2026-07-01T00:03:00.000Z",
+      });
+
+      // No session row at all: nothing for children to run under.
+      yield* insertThread("thread-sessionless");
+      yield* insertActivity({
+        activityId: "activity-sessionless-1",
+        threadId: "thread-sessionless",
+        kind: "task.started",
+        payload: '{"taskId":"task-5"}',
+        createdAt: "2026-07-01T00:02:00.000Z",
+      });
+
+      yield* runMigrations({ toMigrationInclusive: 36 });
+
+      const rows = yield* sql<{
+        readonly threadId: string;
+        readonly outstandingBackgroundTaskCount: number;
+        readonly outstandingBackgroundTaskStartedAt: string | null;
+      }>`
+        SELECT
+          thread_id AS "threadId",
+          outstanding_background_task_count AS "outstandingBackgroundTaskCount",
+          outstanding_background_task_started_at AS "outstandingBackgroundTaskStartedAt"
+        FROM projection_threads
+        ORDER BY thread_id ASC
+      `;
+
+      assert.deepStrictEqual(rows, [
+        {
+          threadId: "thread-dead",
+          outstandingBackgroundTaskCount: 0,
+          outstandingBackgroundTaskStartedAt: null,
+        },
+        {
+          threadId: "thread-live",
+          outstandingBackgroundTaskCount: 1,
+          outstandingBackgroundTaskStartedAt: "2026-07-01T00:03:00.000Z",
+        },
+        {
+          threadId: "thread-sessionless",
+          outstandingBackgroundTaskCount: 0,
+          outstandingBackgroundTaskStartedAt: null,
+        },
+        {
+          threadId: "thread-settled",
+          outstandingBackgroundTaskCount: 0,
+          outstandingBackgroundTaskStartedAt: null,
+        },
+      ]);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/036_ProjectionThreadsOutstandingBackgroundTasks.test.ts
+++ b/apps/server/src/persistence/Migrations/036_ProjectionThreadsOutstandingBackgroundTasks.test.ts
@@ -180,6 +180,73 @@ layer("036_ProjectionThreadsOutstandingBackgroundTasks", (it) => {
         createdAt: "2026-07-01T00:02:00.000Z",
       });
 
+      // Malformed ids never count: empty, whitespace-only, and non-string
+      // taskIds match the live derivation's rejects, not the Working state.
+      yield* insertThread("thread-malformed");
+      yield* insertSession("thread-malformed", "ready");
+      yield* insertActivity({
+        activityId: "activity-malformed-1",
+        threadId: "thread-malformed",
+        kind: "task.started",
+        payload: '{"taskId":""}',
+        createdAt: "2026-07-01T00:02:00.000Z",
+      });
+      yield* insertActivity({
+        activityId: "activity-malformed-2",
+        threadId: "thread-malformed",
+        kind: "task.started",
+        payload: '{"taskId":"   "}',
+        createdAt: "2026-07-01T00:03:00.000Z",
+      });
+      yield* insertActivity({
+        activityId: "activity-malformed-3",
+        threadId: "thread-malformed",
+        kind: "task.progress",
+        payload: '{"taskId":7,"detail":"numeric id"}',
+        createdAt: "2026-07-01T00:04:00.000Z",
+      });
+
+      // A stale completed BEFORE the task's first start does not settle it
+      // (the live replay ignores a completed for a task it has not seen), and
+      // a progress row after a real completed does not reopen it.
+      yield* insertThread("thread-out-of-order");
+      yield* insertSession("thread-out-of-order", "ready");
+      yield* insertActivity({
+        activityId: "activity-ooo-1",
+        threadId: "thread-out-of-order",
+        kind: "task.completed",
+        payload: '{"taskId":"task-6","status":"completed"}',
+        createdAt: "2026-07-01T00:02:00.000Z",
+      });
+      yield* insertActivity({
+        activityId: "activity-ooo-2",
+        threadId: "thread-out-of-order",
+        kind: "task.started",
+        payload: '{"taskId":"task-6"}',
+        createdAt: "2026-07-01T00:03:00.000Z",
+      });
+      yield* insertActivity({
+        activityId: "activity-ooo-3",
+        threadId: "thread-out-of-order",
+        kind: "task.started",
+        payload: '{"taskId":"task-7"}',
+        createdAt: "2026-07-01T00:04:00.000Z",
+      });
+      yield* insertActivity({
+        activityId: "activity-ooo-4",
+        threadId: "thread-out-of-order",
+        kind: "task.completed",
+        payload: '{"taskId":"task-7","status":"completed"}',
+        createdAt: "2026-07-01T00:05:00.000Z",
+      });
+      yield* insertActivity({
+        activityId: "activity-ooo-5",
+        threadId: "thread-out-of-order",
+        kind: "task.progress",
+        payload: '{"taskId":"task-7","detail":"late echo"}',
+        createdAt: "2026-07-01T00:06:00.000Z",
+      });
+
       yield* runMigrations({ toMigrationInclusive: 36 });
 
       const rows = yield* sql<{
@@ -203,6 +270,18 @@ layer("036_ProjectionThreadsOutstandingBackgroundTasks", (it) => {
         },
         {
           threadId: "thread-live",
+          outstandingBackgroundTaskCount: 1,
+          outstandingBackgroundTaskStartedAt: "2026-07-01T00:03:00.000Z",
+        },
+        {
+          threadId: "thread-malformed",
+          outstandingBackgroundTaskCount: 0,
+          outstandingBackgroundTaskStartedAt: null,
+        },
+        {
+          // task-6: stale completed precedes its start, so it stays open;
+          // task-7: settled, and the late progress echo does not reopen it.
+          threadId: "thread-out-of-order",
           outstandingBackgroundTaskCount: 1,
           outstandingBackgroundTaskStartedAt: "2026-07-01T00:03:00.000Z",
         },

--- a/apps/server/src/persistence/Migrations/036_ProjectionThreadsOutstandingBackgroundTasks.ts
+++ b/apps/server/src/persistence/Migrations/036_ProjectionThreadsOutstandingBackgroundTasks.ts
@@ -21,11 +21,14 @@ export default Effect.gen(function* () {
     `;
   }
 
-  // Backfill from the projected activity timeline. A task is outstanding when
-  // it was started (or observed via progress) and never completed. The
-  // WHERE clause is the session gate: a thread whose provider process is gone
-  // takes its children with it, so dead threads keep the 0/NULL default
-  // instead of resurrecting as permanently working.
+  // Backfill from the projected activity timeline, mirroring the live
+  // derivation in ProjectionPipeline: a task counts only with a well-formed
+  // string taskId, and it is settled only by a task.completed at or after the
+  // task's first opening activity — a stale completed that precedes the start
+  // does not settle it, and a progress row after a completed does not reopen
+  // it. The outer WHERE is the session gate: a thread whose provider process
+  // is gone takes its children with it, so dead threads keep the 0/NULL
+  // default instead of resurrecting as permanently working.
   yield* sql`
     UPDATE projection_threads
     SET
@@ -34,7 +37,8 @@ export default Effect.gen(function* () {
         FROM projection_thread_activities AS open_activity
         WHERE open_activity.thread_id = projection_threads.thread_id
           AND open_activity.kind IN ('task.started', 'task.progress')
-          AND json_extract(open_activity.payload_json, '$.taskId') IS NOT NULL
+          AND json_type(open_activity.payload_json, '$.taskId') = 'text'
+          AND TRIM(json_extract(open_activity.payload_json, '$.taskId')) <> ''
           AND NOT EXISTS (
             SELECT 1
             FROM projection_thread_activities AS settled_activity
@@ -42,6 +46,14 @@ export default Effect.gen(function* () {
               AND settled_activity.kind = 'task.completed'
               AND json_extract(settled_activity.payload_json, '$.taskId')
                 = json_extract(open_activity.payload_json, '$.taskId')
+              AND settled_activity.created_at >= (
+                SELECT MIN(first_open.created_at)
+                FROM projection_thread_activities AS first_open
+                WHERE first_open.thread_id = open_activity.thread_id
+                  AND first_open.kind IN ('task.started', 'task.progress')
+                  AND json_extract(first_open.payload_json, '$.taskId')
+                    = json_extract(open_activity.payload_json, '$.taskId')
+              )
           )
       ), 0),
       outstanding_background_task_started_at = (
@@ -49,7 +61,8 @@ export default Effect.gen(function* () {
         FROM projection_thread_activities AS open_activity
         WHERE open_activity.thread_id = projection_threads.thread_id
           AND open_activity.kind IN ('task.started', 'task.progress')
-          AND json_extract(open_activity.payload_json, '$.taskId') IS NOT NULL
+          AND json_type(open_activity.payload_json, '$.taskId') = 'text'
+          AND TRIM(json_extract(open_activity.payload_json, '$.taskId')) <> ''
           AND NOT EXISTS (
             SELECT 1
             FROM projection_thread_activities AS settled_activity
@@ -57,6 +70,14 @@ export default Effect.gen(function* () {
               AND settled_activity.kind = 'task.completed'
               AND json_extract(settled_activity.payload_json, '$.taskId')
                 = json_extract(open_activity.payload_json, '$.taskId')
+              AND settled_activity.created_at >= (
+                SELECT MIN(first_open.created_at)
+                FROM projection_thread_activities AS first_open
+                WHERE first_open.thread_id = open_activity.thread_id
+                  AND first_open.kind IN ('task.started', 'task.progress')
+                  AND json_extract(first_open.payload_json, '$.taskId')
+                    = json_extract(open_activity.payload_json, '$.taskId')
+              )
           )
       )
     WHERE EXISTS (

--- a/apps/server/src/persistence/Migrations/036_ProjectionThreadsOutstandingBackgroundTasks.ts
+++ b/apps/server/src/persistence/Migrations/036_ProjectionThreadsOutstandingBackgroundTasks.ts
@@ -1,0 +1,69 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_threads)
+  `;
+
+  if (!columns.some((column) => column.name === "outstanding_background_task_count")) {
+    yield* sql`
+      ALTER TABLE projection_threads
+      ADD COLUMN outstanding_background_task_count INTEGER NOT NULL DEFAULT 0
+    `;
+  }
+
+  if (!columns.some((column) => column.name === "outstanding_background_task_started_at")) {
+    yield* sql`
+      ALTER TABLE projection_threads
+      ADD COLUMN outstanding_background_task_started_at TEXT
+    `;
+  }
+
+  // Backfill from the projected activity timeline. A task is outstanding when
+  // it was started (or observed via progress) and never completed. The
+  // WHERE clause is the session gate: a thread whose provider process is gone
+  // takes its children with it, so dead threads keep the 0/NULL default
+  // instead of resurrecting as permanently working.
+  yield* sql`
+    UPDATE projection_threads
+    SET
+      outstanding_background_task_count = COALESCE((
+        SELECT COUNT(DISTINCT json_extract(open_activity.payload_json, '$.taskId'))
+        FROM projection_thread_activities AS open_activity
+        WHERE open_activity.thread_id = projection_threads.thread_id
+          AND open_activity.kind IN ('task.started', 'task.progress')
+          AND json_extract(open_activity.payload_json, '$.taskId') IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1
+            FROM projection_thread_activities AS settled_activity
+            WHERE settled_activity.thread_id = open_activity.thread_id
+              AND settled_activity.kind = 'task.completed'
+              AND json_extract(settled_activity.payload_json, '$.taskId')
+                = json_extract(open_activity.payload_json, '$.taskId')
+          )
+      ), 0),
+      outstanding_background_task_started_at = (
+        SELECT MIN(open_activity.created_at)
+        FROM projection_thread_activities AS open_activity
+        WHERE open_activity.thread_id = projection_threads.thread_id
+          AND open_activity.kind IN ('task.started', 'task.progress')
+          AND json_extract(open_activity.payload_json, '$.taskId') IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1
+            FROM projection_thread_activities AS settled_activity
+            WHERE settled_activity.thread_id = open_activity.thread_id
+              AND settled_activity.kind = 'task.completed'
+              AND json_extract(settled_activity.payload_json, '$.taskId')
+                = json_extract(open_activity.payload_json, '$.taskId')
+          )
+      )
+    WHERE EXISTS (
+      SELECT 1
+      FROM projection_thread_sessions AS session
+      WHERE session.thread_id = projection_threads.thread_id
+        AND session.status IN ('starting', 'running', 'ready')
+    )
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreads.ts
@@ -47,6 +47,11 @@ export const ProjectionThread = Schema.Struct({
   pendingApprovalCount: NonNegativeInt,
   pendingUserInputCount: NonNegativeInt,
   hasActionableProposedPlan: NonNegativeInt,
+  // Provider background tasks (subagents) still running for this thread, and
+  // the oldest outstanding one's start. Lets a thread read as working while
+  // child work outlives the parent turn (#4962).
+  outstandingBackgroundTaskCount: NonNegativeInt,
+  outstandingBackgroundTaskStartedAt: Schema.NullOr(IsoDateTime),
   deletedAt: Schema.NullOr(IsoDateTime),
 });
 export type ProjectionThread = typeof ProjectionThread.Type;

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -836,6 +836,26 @@ describe("resolveWorkingStartedAt", () => {
   it("returns null with neither a running turn nor a session", () => {
     expect(resolveWorkingStartedAt({ latestTurn: null, session: null })).toBeNull();
   });
+
+  it("counts from the oldest outstanding subagent once the parent turn settled", () => {
+    expect(
+      resolveWorkingStartedAt({
+        latestTurn: makeLatestTurn(),
+        outstandingBackgroundTaskStartedAt: "2026-03-09T10:01:00.000Z",
+        session,
+      }),
+    ).toBe("2026-03-09T10:01:00.000Z");
+  });
+
+  it("keeps the session transition when no subagent start is reported", () => {
+    expect(
+      resolveWorkingStartedAt({
+        latestTurn: makeLatestTurn(),
+        outstandingBackgroundTaskStartedAt: null,
+        session,
+      }),
+    ).toBe("2026-03-09T10:02:00.000Z");
+  });
 });
 
 describe("formatWorkingDurationLabel", () => {
@@ -899,6 +919,24 @@ describe("resolveThreadStatusPill", () => {
     expect(
       resolveThreadStatusPill({
         thread: baseThread,
+      }),
+    ).toMatchObject({ label: "Working", pulse: true });
+  });
+
+  it("stays working while subagents run past the parent turn", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          interactionMode: "default",
+          latestTurn: makeLatestTurn(),
+          outstandingBackgroundTaskCount: 2,
+          session: {
+            ...baseThread.session,
+            status: "ready",
+            activeTurnId: null,
+          },
+        },
       }),
     ).toMatchObject({ label: "Working", pulse: true });
   });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -689,6 +689,36 @@ describe("resolveSidebarV2Status", () => {
   it("defaults to ready with no session", () => {
     expect(resolveSidebarV2Status({ ...idle, session: null })).toBe("ready");
   });
+
+  it("stays working while background tasks outlive a settled session", () => {
+    expect(
+      resolveSidebarV2Status({
+        ...idle,
+        session: { ...session, status: "ready" as const },
+        outstandingBackgroundTaskCount: 2,
+      }),
+    ).toBe("working");
+  });
+
+  it("keeps failed above background-task working and ignores zero or legacy counts", () => {
+    expect(
+      resolveSidebarV2Status({
+        ...idle,
+        session: { ...session, status: "error" as const, lastError: "boom" },
+        outstandingBackgroundTaskCount: 2,
+      }),
+    ).toBe("failed");
+    expect(
+      resolveSidebarV2Status({
+        ...idle,
+        session: { ...session, status: "ready" as const },
+        outstandingBackgroundTaskCount: 0,
+      }),
+    ).toBe("ready");
+    expect(
+      resolveSidebarV2Status({ ...idle, session: { ...session, status: "ready" as const } }),
+    ).toBe("ready");
+  });
 });
 
 describe("sortThreadsForSidebarV2", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -426,7 +426,7 @@ export type SidebarV2Status = "approval" | "input" | "working" | "failed" | "rea
 
 type SidebarV2StatusInput = Pick<
   SidebarThreadSummary,
-  "hasPendingApprovals" | "hasPendingUserInput" | "session"
+  "hasPendingApprovals" | "hasPendingUserInput" | "outstandingBackgroundTaskCount" | "session"
 >;
 
 export function resolveSidebarV2Status(thread: SidebarV2StatusInput): SidebarV2Status {
@@ -441,6 +441,12 @@ export function resolveSidebarV2Status(thread: SidebarV2StatusInput): SidebarV2S
   }
   if (thread.session?.status === "error") {
     return "failed";
+  }
+  // Subagents outlive the parent turn: background tasks keep the row in
+  // motion after the session settles (#4962). Below failed so a broken
+  // session is never masked by a stale count.
+  if ((thread.outstandingBackgroundTaskCount ?? 0) > 0) {
+    return "working";
   }
   return "ready";
 }

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -142,6 +142,8 @@ type ThreadStatusInput = Pick<
   | "hasPendingUserInput"
   | "interactionMode"
   | "latestTurn"
+  | "outstandingBackgroundTaskCount"
+  | "outstandingBackgroundTaskStartedAt"
   | "session"
 > & {
   lastVisitedAt?: string | undefined;
@@ -540,13 +542,19 @@ export function sortSettledThreadsForSidebarV2<
     last transition when the turn projection lags behind. Malformed
     timestamps fall through to the next candidate, not just missing ones. */
 export function resolveWorkingStartedAt(
-  thread: Pick<SidebarThreadSummary, "latestTurn" | "session">,
+  thread: Pick<
+    SidebarThreadSummary,
+    "latestTurn" | "outstandingBackgroundTaskStartedAt" | "session"
+  >,
 ): string | null {
   const turn = thread.latestTurn;
   if (turn && turn.completedAt === null) {
     return firstValidTimestamp(turn.startedAt, turn.requestedAt, thread.session?.updatedAt);
   }
-  return firstValidTimestamp(thread.session?.updatedAt);
+  // A thread can be Working purely because its subagents are: with the turn
+  // settled, the oldest outstanding task is what the elapsed label counts
+  // from, so it keeps ticking instead of freezing at the session transition.
+  return firstValidTimestamp(thread.outstandingBackgroundTaskStartedAt, thread.session?.updatedAt);
 }
 
 export function formatWorkingDurationLabel(elapsedMs: number): string {
@@ -592,6 +600,18 @@ export function resolveThreadStatusPill(input: {
   if (thread.session?.status === "starting") {
     return {
       label: "Connecting",
+      colorClass: "text-sky-600 dark:text-sky-300/80",
+      dotClass: "bg-sky-500 dark:bg-sky-300/80",
+      pulse: true,
+    };
+  }
+
+  // Subagents outlive the parent turn, so a thread whose own session has gone
+  // quiet is still Working while background tasks are outstanding (#4962).
+  // Servers that predate the aggregate send no count, which reads as "none".
+  if ((thread.outstandingBackgroundTaskCount ?? 0) > 0) {
+    return {
+      label: "Working",
       colorClass: "text-sky-600 dark:text-sky-300/80",
       dotClass: "bg-sky-500 dark:bg-sky-300/80",
       pulse: true,

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -116,6 +116,10 @@ Controls how assistant text reaches the thread timeline. In [the contracts][1], 
 
 A point-in-time view of state. The word is used in multiple layers, including orchestration, provider, and checkpointing. See [ProjectionSnapshotQuery.ts][10], [ProviderAdapter.ts][15], and [CheckpointStore.ts][19].
 
+#### Background task
+
+A subagent a provider spawns that can outlive the foreground turn. Its lifecycle arrives as `task.started` / `task.progress` / `task.completed` runtime events in [the provider runtime contracts][25], and the outstanding set is projected onto the thread shell so clients keep showing Working while children run. See [background-agents.md](../user/background-agents.md).
+
 ### Checkpointing
 
 Checkpointing captures workspace state over time so the app can diff turns and restore earlier points. The main pieces are [CheckpointStore.ts][19], [CheckpointDiffQuery.ts][20], and [CheckpointReactor.ts][6].
@@ -179,3 +183,4 @@ The file patch and changed-file summary for one turn. It is usually computed in 
 [22]: ../../apps/server/src/checkpointing/Utils.ts
 [23]: ../../apps/server/src/checkpointing/Diffs.ts
 [24]: ./overview.md
+[25]: ../../packages/contracts/src/providerRuntime.ts

--- a/docs/user/background-agents.md
+++ b/docs/user/background-agents.md
@@ -1,0 +1,25 @@
+# Background Agents
+
+Providers can delegate work to background subagents that keep running after the
+main response settles. T3 Code keeps that work visible so a thread never looks
+finished while children are still active.
+
+## What you see
+
+- **Thread list.** A thread stays in the **Working** state while any of its
+  background tasks are running, even when the main turn has completed. The row
+  returns to ready only when the last task completes, fails, or is stopped.
+- **Open thread (mobile).** A slim rail docks above the composer showing a
+  spinner, how many subagents are working, and how long the oldest one has been
+  at it. The rail appears the moment a subagent starts and leaves when the last
+  one settles.
+- **Background agents sheet (mobile).** Tap the rail to open a sheet listing
+  each agent with its elapsed time and latest progress line. Recently settled
+  agents stay listed with their outcome.
+
+## Behavior notes
+
+- Sending another prompt while background agents run is allowed — the rail is
+  there so you know follow-up work is still changing files or running tests.
+- If the provider session stops, errors, or is interrupted, its background
+  tasks end with it and the indicator clears.

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -39,6 +39,10 @@
       "types": "./src/relay/index.ts",
       "default": "./src/relay/index.ts"
     },
+    "./state/background-tasks": {
+      "types": "./src/state/backgroundTasks.ts",
+      "default": "./src/state/backgroundTasks.ts"
+    },
     "./state/auth": {
       "types": "./src/state/auth.ts",
       "default": "./src/state/auth.ts"

--- a/packages/client-runtime/src/state/backgroundTasks.test.ts
+++ b/packages/client-runtime/src/state/backgroundTasks.test.ts
@@ -1,0 +1,214 @@
+import {
+  EventId,
+  type OrchestrationSession,
+  type OrchestrationThreadActivity,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { deriveBackgroundTasks } from "./backgroundTasks.ts";
+
+const READY: Pick<OrchestrationSession, "status"> = { status: "ready" };
+const RUNNING: Pick<OrchestrationSession, "status"> = { status: "running" };
+
+let nextSequence = 0;
+
+function activity(
+  kind: string,
+  payload: Record<string, unknown>,
+  overrides: { readonly createdAt?: string; readonly sequence?: number; readonly id?: string } = {},
+): OrchestrationThreadActivity {
+  nextSequence += 1;
+  const sequence = overrides.sequence ?? nextSequence;
+  return {
+    id: EventId.make(overrides.id ?? `activity-${sequence}`),
+    tone: "info",
+    kind,
+    summary: kind,
+    payload,
+    turnId: null,
+    sequence,
+    // Monotonic with `sequence`, so replay order matches construction order.
+    createdAt: overrides.createdAt ?? `2026-06-01T00:00:00.${String(sequence).padStart(3, "0")}Z`,
+  };
+}
+
+const started = (taskId: string, payload: Record<string, unknown> = {}) =>
+  activity("task.started", { taskId, ...payload });
+const progress = (taskId: string, payload: Record<string, unknown> = {}) =>
+  activity("task.progress", { taskId, ...payload });
+const completed = (taskId: string, status = "completed") =>
+  activity("task.completed", { taskId, status });
+
+describe("deriveBackgroundTasks", () => {
+  it("counts a child task started under a running parent turn", () => {
+    const state = deriveBackgroundTasks([started("task-1", { detail: "Audit imports" })], RUNNING);
+
+    expect(state.running).toHaveLength(1);
+    expect(state.running[0]?.name).toBe("Audit imports");
+    expect(state.startedAt).toBe(state.running[0]?.startedAt);
+    expect(state.settled).toEqual([]);
+  });
+
+  it("keeps counting a child task after the parent turn completes", () => {
+    // #4962: the parent session drops back to ready while the subagent runs.
+    const state = deriveBackgroundTasks([started("task-1")], READY);
+
+    expect(state.running).toHaveLength(1);
+    expect(state.startedAt).not.toBeNull();
+  });
+
+  it("opens a task from progress alone and leaves its start unchanged", () => {
+    const open = started("task-1");
+    const state = deriveBackgroundTasks(
+      [open, progress("task-1", { summary: "Reading files" })],
+      READY,
+    );
+
+    expect(state.running).toHaveLength(1);
+    expect(state.running[0]?.startedAt).toBe(open.createdAt);
+    expect(state.running[0]?.latestProgress).toBe("Reading files");
+
+    // Progress for a task we never saw start still counts: it implies running.
+    const progressOnly = deriveBackgroundTasks([progress("task-2", { detail: "Grepping" })], READY);
+    expect(progressOnly.running).toHaveLength(1);
+    expect(progressOnly.running[0]?.latestProgress).toBe("Grepping");
+  });
+
+  it.each(["completed", "failed", "stopped"] as const)("clears the task on %s", (status) => {
+    const state = deriveBackgroundTasks([started("task-1"), completed("task-1", status)], READY);
+
+    expect(state.running).toEqual([]);
+    expect(state.startedAt).toBeNull();
+    expect(state.settled).toHaveLength(1);
+    expect(state.settled[0]?.status).toBe(status);
+  });
+
+  it("clears only after the last of several tasks settles", () => {
+    const first = started("task-1");
+    const second = started("task-2");
+    const withBoth = deriveBackgroundTasks([first, second], READY);
+    expect(withBoth.running).toHaveLength(2);
+    expect(withBoth.startedAt).toBe(first.createdAt);
+
+    // The oldest OPEN task drives the aggregate elapsed label.
+    const afterFirst = deriveBackgroundTasks([first, second, completed("task-1")], READY);
+    expect(afterFirst.running).toHaveLength(1);
+    expect(afterFirst.startedAt).toBe(second.createdAt);
+
+    const afterBoth = deriveBackgroundTasks(
+      [first, second, completed("task-1"), completed("task-2")],
+      READY,
+    );
+    expect(afterBoth.running).toEqual([]);
+    expect(afterBoth.startedAt).toBeNull();
+    expect(afterBoth.settled).toHaveLength(2);
+  });
+
+  it("does not drift on duplicate or unknown lifecycle events", () => {
+    const first = started("task-1");
+    const duplicates = deriveBackgroundTasks(
+      [first, started("task-1", { detail: "again" }), completed("task-2")],
+      READY,
+    );
+    expect(duplicates.running).toHaveLength(1);
+    expect(duplicates.running[0]?.startedAt).toBe(first.createdAt);
+    // A terminal event for a task we never saw start is stale noise.
+    expect(duplicates.settled).toEqual([]);
+
+    const settledTwice = deriveBackgroundTasks(
+      [first, completed("task-1"), completed("task-1", "failed")],
+      READY,
+    );
+    expect(settledTwice.running).toEqual([]);
+    expect(settledTwice.settled).toHaveLength(1);
+    expect(settledTwice.settled[0]?.status).toBe("completed");
+
+    // Settled wins: a late started/progress never reopens a finished task.
+    const resurrected = deriveBackgroundTasks(
+      [first, completed("task-1"), started("task-1"), progress("task-1", { detail: "late" })],
+      READY,
+    );
+    expect(resurrected.running).toEqual([]);
+    expect(resurrected.startedAt).toBeNull();
+  });
+
+  it.each([
+    ["starting", 1],
+    ["running", 1],
+    ["ready", 1],
+    ["idle", 0],
+    ["stopped", 0],
+    ["interrupted", 0],
+    ["error", 0],
+  ] as const)("gates outstanding tasks on a %s session", (status, expected) => {
+    const state = deriveBackgroundTasks([started("task-1")], { status });
+    expect(state.running).toHaveLength(expected);
+  });
+
+  it("reports nothing without a session", () => {
+    // No session means no provider process, so no children either.
+    const state = deriveBackgroundTasks([started("task-1")], null);
+    expect(state).toEqual({ running: [], settled: [], startedAt: null });
+  });
+
+  it("names tasks by detail, then type, then a generic fallback", () => {
+    const state = deriveBackgroundTasks(
+      [
+        started("task-detail", { detail: "Audit imports", taskType: "general" }),
+        started("task-type", { taskType: "explore" }),
+        started("task-bare"),
+      ],
+      READY,
+    );
+
+    const namesById = new Map(state.running.map((task) => [task.taskId, task.name]));
+    expect(namesById.get("task-detail")).toBe("Audit imports");
+    expect(namesById.get("task-type")).toBe("explore");
+    expect(namesById.get("task-bare")).toBe("Subagent");
+  });
+
+  it("tracks the latest progress line per task", () => {
+    const open = started("task-1");
+    const first = progress("task-1", { summary: "Reading files" });
+    const last = progress("task-1", { summary: "Writing the patch" });
+    const state = deriveBackgroundTasks([open, first, last], READY);
+
+    expect(state.running[0]?.latestProgress).toBe("Writing the patch");
+    expect(state.running[0]?.latestProgressAt).toBe(last.createdAt);
+  });
+
+  it("orders settled tasks most recently settled first", () => {
+    const state = deriveBackgroundTasks(
+      [started("task-1"), started("task-2"), completed("task-1"), completed("task-2", "stopped")],
+      READY,
+    );
+
+    expect(state.settled.map((task) => task.taskId)).toEqual(["task-2", "task-1"]);
+  });
+
+  it("ignores activities that are not task lifecycle events", () => {
+    const state = deriveBackgroundTasks(
+      [
+        activity("assistant.message", { taskId: "task-1" }),
+        activity("task.started", { taskId: "   " }),
+        activity("task.started", {}),
+      ],
+      READY,
+    );
+
+    expect(state.running).toEqual([]);
+  });
+
+  it("replays out-of-order activities by sequence", () => {
+    // Server-assigned sequence outranks createdAt, so a completion delivered
+    // with an earlier wall clock still settles its task.
+    const openEvent = activity("task.started", { taskId: "task-1" }, { sequence: 10 });
+    const settleEvent = activity(
+      "task.completed",
+      { taskId: "task-1", status: "completed" },
+      { sequence: 11, createdAt: "2020-01-01T00:00:00.000Z" },
+    );
+
+    expect(deriveBackgroundTasks([settleEvent, openEvent], READY).running).toEqual([]);
+  });
+});

--- a/packages/client-runtime/src/state/backgroundTasks.test.ts
+++ b/packages/client-runtime/src/state/backgroundTasks.test.ts
@@ -211,4 +211,46 @@ describe("deriveBackgroundTasks", () => {
 
     expect(deriveBackgroundTasks([settleEvent, openEvent], READY).running).toEqual([]);
   });
+
+  it("orders unsequenced legacy activities as a group before sequenced ones", () => {
+    // A pairwise sequence-else-createdAt comparator is non-transitive on
+    // mixed collections; the total order sorts the unsequenced group first,
+    // so this legacy start is settled by the later sequenced completion even
+    // though its wall clock is newer.
+    const legacyStart: OrchestrationThreadActivity = {
+      id: EventId.make("legacy-start"),
+      tone: "info",
+      kind: "task.started",
+      summary: "task.started",
+      payload: { taskId: "task-1" },
+      turnId: null,
+      createdAt: "2026-06-01T09:00:00.000Z",
+    };
+    const sequencedSettle = activity(
+      "task.completed",
+      { taskId: "task-1", status: "completed" },
+      { sequence: 1, createdAt: "2026-06-01T08:00:00.000Z" },
+    );
+
+    const state = deriveBackgroundTasks([sequencedSettle, legacyStart], READY);
+    expect(state.running).toEqual([]);
+    expect(state.settled.map((task) => task.taskId)).toEqual(["task-1"]);
+  });
+
+  it("reports the oldest running start by timestamp, not replay order", () => {
+    const openedFirstButNewer = activity(
+      "task.started",
+      { taskId: "task-newer" },
+      { sequence: 1, createdAt: "2026-06-01T10:00:00.000Z" },
+    );
+    const openedSecondButOlder = activity(
+      "task.started",
+      { taskId: "task-older" },
+      { sequence: 2, createdAt: "2026-06-01T05:00:00.000Z" },
+    );
+
+    const state = deriveBackgroundTasks([openedFirstButNewer, openedSecondButOlder], READY);
+    expect(state.running).toHaveLength(2);
+    expect(state.startedAt).toBe("2026-06-01T05:00:00.000Z");
+  });
 });

--- a/packages/client-runtime/src/state/backgroundTasks.ts
+++ b/packages/client-runtime/src/state/backgroundTasks.ts
@@ -59,10 +59,14 @@ function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+// Total order: unsequenced (pre-sequence) rows sort first as a group, so
+// mixing them with sequenced rows cannot produce a non-transitive comparison
+// and an arbitrary replay order. Mirrors the server-side comparator in
+// ProjectionPipeline's deriveOutstandingBackgroundTasks.
 function compareActivities(a: OrchestrationThreadActivity, b: OrchestrationThreadActivity): number {
-  if (a.sequence !== undefined && b.sequence !== undefined && a.sequence !== b.sequence) {
-    return a.sequence - b.sequence;
-  }
+  const aSequence = a.sequence ?? Number.NEGATIVE_INFINITY;
+  const bSequence = b.sequence ?? Number.NEGATIVE_INFINITY;
+  if (aSequence !== bSequence) return aSequence < bSequence ? -1 : 1;
   if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
   return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
 }
@@ -150,9 +154,13 @@ export function deriveBackgroundTasks(
   }
   settled.sort((a, b) => (a.settledAt! < b.settledAt! ? 1 : a.settledAt! > b.settledAt! ? -1 : 0));
 
-  return {
-    running,
-    settled,
-    startedAt: running.length > 0 ? running[0]!.startedAt : null,
-  };
+  // Min-scan rather than first-inserted: replay order follows sequence, which
+  // can disagree with createdAt under clock skew, and the elapsed label must
+  // count from the genuinely oldest running task.
+  let startedAt: string | null = null;
+  for (const task of running) {
+    if (startedAt === null || task.startedAt < startedAt) startedAt = task.startedAt;
+  }
+
+  return { running, settled, startedAt };
 }

--- a/packages/client-runtime/src/state/backgroundTasks.ts
+++ b/packages/client-runtime/src/state/backgroundTasks.ts
@@ -1,0 +1,158 @@
+import type { OrchestrationSession, OrchestrationThreadActivity } from "@t3tools/contracts";
+
+export type BackgroundTaskStatus = "running" | "completed" | "failed" | "stopped";
+
+export interface BackgroundTask {
+  readonly taskId: string;
+  /** Human label: the task's description, falling back to its type. */
+  readonly name: string;
+  readonly startedAt: string;
+  readonly status: BackgroundTaskStatus;
+  /** Latest task.progress line, for "what is it doing right now" rows. */
+  readonly latestProgress: string | null;
+  readonly latestProgressAt: string | null;
+  readonly settledAt: string | null;
+}
+
+export interface BackgroundTaskState {
+  readonly running: ReadonlyArray<BackgroundTask>;
+  /** Settled (completed/failed/stopped) tasks, most recently settled first. */
+  readonly settled: ReadonlyArray<BackgroundTask>;
+  /** Oldest running task's start, for an aggregate elapsed label. */
+  readonly startedAt: string | null;
+}
+
+const EMPTY_STATE: BackgroundTaskState = { running: [], settled: [], startedAt: null };
+
+const FALLBACK_TASK_NAME = "Subagent";
+
+/**
+ * Session states under which a provider's background tasks can still be alive.
+ * Anything else (stopped, interrupted, error, idle, no session) means the
+ * provider process is gone, and its children with it — reporting tasks as
+ * running past that point would strand a permanent Working state.
+ *
+ * Mirrors the server-side aggregate in ProjectionPipeline's
+ * refreshThreadShellSummary; keep the two in sync.
+ */
+const TASK_BEARING_SESSION_STATUSES: ReadonlySet<OrchestrationSession["status"]> = new Set([
+  "starting",
+  "running",
+  "ready",
+]);
+
+interface MutableTask {
+  taskId: string;
+  name: string | null;
+  startedAt: string;
+  status: BackgroundTaskStatus;
+  latestProgress: string | null;
+  latestProgressAt: string | null;
+  settledAt: string | null;
+}
+
+function asRecord(payload: unknown): Record<string, unknown> | null {
+  return payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function compareActivities(a: OrchestrationThreadActivity, b: OrchestrationThreadActivity): number {
+  if (a.sequence !== undefined && b.sequence !== undefined && a.sequence !== b.sequence) {
+    return a.sequence - b.sequence;
+  }
+  if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+function toTerminalStatus(value: unknown): BackgroundTaskStatus {
+  return value === "failed" || value === "stopped" ? value : "completed";
+}
+
+/**
+ * Replays task.started/task.progress/task.completed activities into the set of
+ * provider background tasks (subagents) for a thread. Duplicate lifecycle
+ * events are idempotent, a completed for an unknown task is ignored, and a
+ * started/progress arriving after its task settled stays settled, so stale or
+ * repeated events cannot resurrect a permanent Working state (#4962).
+ */
+export function deriveBackgroundTasks(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  session: Pick<OrchestrationSession, "status"> | null,
+): BackgroundTaskState {
+  if (session === null || !TASK_BEARING_SESSION_STATUSES.has(session.status)) {
+    return EMPTY_STATE;
+  }
+
+  const tasks = new Map<string, MutableTask>();
+  const ordered = [...activities].sort(compareActivities);
+  for (const activity of ordered) {
+    if (
+      activity.kind !== "task.started" &&
+      activity.kind !== "task.progress" &&
+      activity.kind !== "task.completed"
+    ) {
+      continue;
+    }
+    const payload = asRecord(activity.payload);
+    const taskId = nonEmptyString(payload?.taskId);
+    if (!taskId) continue;
+
+    const existing = tasks.get(taskId);
+    if (activity.kind === "task.completed") {
+      // A terminal event for a task we never saw start is stale noise.
+      if (!existing) continue;
+      if (existing.settledAt !== null) continue;
+      existing.status = toTerminalStatus(payload?.status);
+      existing.settledAt = activity.createdAt;
+      continue;
+    }
+
+    // Settled wins: a late or duplicated started/progress cannot reopen a task.
+    if (existing?.settledAt) continue;
+
+    const name =
+      activity.kind === "task.started"
+        ? (nonEmptyString(payload?.detail) ?? nonEmptyString(payload?.taskType))
+        : nonEmptyString(payload?.title);
+    const progress =
+      activity.kind === "task.progress"
+        ? (nonEmptyString(payload?.summary) ?? nonEmptyString(payload?.detail))
+        : null;
+
+    if (existing) {
+      existing.name ??= name;
+      if (progress !== null) {
+        existing.latestProgress = progress;
+        existing.latestProgressAt = activity.createdAt;
+      }
+      continue;
+    }
+    tasks.set(taskId, {
+      taskId,
+      name,
+      startedAt: activity.createdAt,
+      status: "running",
+      latestProgress: progress,
+      latestProgressAt: progress === null ? null : activity.createdAt,
+      settledAt: null,
+    });
+  }
+
+  const running: BackgroundTask[] = [];
+  const settled: BackgroundTask[] = [];
+  for (const task of tasks.values()) {
+    const finished: BackgroundTask = { ...task, name: task.name ?? FALLBACK_TASK_NAME };
+    if (finished.status === "running") running.push(finished);
+    else settled.push(finished);
+  }
+  settled.sort((a, b) => (a.settledAt! < b.settledAt! ? 1 : a.settledAt! > b.settledAt! ? -1 : 0));
+
+  return {
+    running,
+    settled,
+    startedAt: running.length > 0 ? running[0]!.startedAt : null,
+  };
+}

--- a/packages/client-runtime/src/state/threadSettled.test.ts
+++ b/packages/client-runtime/src/state/threadSettled.test.ts
@@ -205,6 +205,32 @@ describe("effectiveSettled", () => {
     ).toBe(false);
   });
 
+  it("never settles a thread whose background subagents are still running", () => {
+    // #4962: the parent session already went ready and the turn is stale, but
+    // child work is outstanding — the thread is not idle.
+    const working: OrchestrationThreadShell = {
+      ...makeShell({ settledOverride: "settled", activityAt: STALE }),
+      outstandingBackgroundTaskCount: 1,
+      outstandingBackgroundTaskStartedAt: FRESH,
+    };
+    expect(
+      effectiveSettled(working, {
+        now: NOW,
+        autoSettleAfterDays: 3,
+        changeRequestState: "merged",
+      }),
+    ).toBe(false);
+    expect(canSettle(working, { now: NOW })).toBe(false);
+
+    // Once the last task settles, the override applies again.
+    expect(
+      effectiveSettled(
+        { ...working, outstandingBackgroundTaskCount: 0, outstandingBackgroundTaskStartedAt: null },
+        { now: NOW, autoSettleAfterDays: 3 },
+      ),
+    ).toBe(true);
+  });
+
   it("keeps a new turn active from queued through starting and running", () => {
     const requestedAt = "2026-04-09T12:00:00.000Z";
     const transitionNow = "2026-04-09T12:00:30.000Z";
@@ -347,6 +373,19 @@ describe("canSettle", () => {
     expect(canSettle(makeShell({ activityAt: FRESH, pending: "user-input" }), { now: NOW })).toBe(
       false,
     );
+    expect(
+      canSettle(
+        { ...makeShell({ activityAt: FRESH }), outstandingBackgroundTaskCount: 1 },
+        { now: NOW },
+      ),
+    ).toBe(false);
+    // Shells from older servers omit the field entirely.
+    expect(
+      canSettle(
+        { ...makeShell({ activityAt: FRESH }), outstandingBackgroundTaskCount: undefined },
+        { now: NOW },
+      ),
+    ).toBe(true);
   });
 
   it("blocks settling a queued turn start, only within the grace window", () => {

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -78,12 +78,20 @@ export function hasQueuedTurnStart(
 export function canSettle(
   shell: Pick<
     OrchestrationThreadShell,
-    "hasPendingApprovals" | "hasPendingUserInput" | "session" | "latestUserMessageAt" | "latestTurn"
+    | "hasPendingApprovals"
+    | "hasPendingUserInput"
+    | "session"
+    | "latestUserMessageAt"
+    | "latestTurn"
+    | "outstandingBackgroundTaskCount"
   >,
   options: { readonly now: string },
 ): boolean {
   if (shell.hasPendingApprovals || shell.hasPendingUserInput) return false;
   if (shell.session?.status === "starting" || shell.session?.status === "running") return false;
+  // Background subagents outlive the parent turn: a thread whose children are
+  // still running is working, even though the session already went ready.
+  if ((shell.outstandingBackgroundTaskCount ?? 0) > 0) return false;
   // Queued work is as blocked-on-progress as a live session: settling it
   // (or auto-settling it on a closed PR) would hide a just-requested turn.
   if (hasQueuedTurnStart(shell, options)) return false;
@@ -236,6 +244,7 @@ export function effectiveSettled(
   // Blocked work must remain visible even when a user explicitly settled it.
   if (shell.hasPendingApprovals || shell.hasPendingUserInput) return false;
   if (shell.session?.status === "starting" || shell.session?.status === "running") return false;
+  if ((shell.outstandingBackgroundTaskCount ?? 0) > 0) return false;
   if (hasQueuedTurnStart(shell, { now: options.now })) {
     // The queued-turn blocker alone is forgivable: it is clock-derived, and
     // list callers pass a coarser `now` than the settle action used. When

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -425,6 +425,59 @@ it.effect("defaults settled fields when decoding historical thread data", () =>
   }),
 );
 
+it.effect("round-trips outstanding background task fields on the thread shell", () =>
+  Effect.gen(function* () {
+    const common = {
+      id: "thread-1",
+      projectId: "project-1",
+      title: "Thread with subagents",
+      modelSelection: { provider: "codex", model: "gpt-5.4" },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      branch: null,
+      worktreePath: null,
+      latestTurn: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      archivedAt: null,
+      session: null,
+      latestUserMessageAt: null,
+      hasPendingApprovals: false,
+      hasPendingUserInput: false,
+      hasActionableProposedPlan: false,
+    };
+
+    const shell = yield* decodeOrchestrationThreadShell({
+      ...common,
+      outstandingBackgroundTaskCount: 2,
+      outstandingBackgroundTaskStartedAt: "2026-01-01T00:00:05.000Z",
+    });
+    assert.strictEqual(shell.outstandingBackgroundTaskCount, 2);
+    assert.strictEqual(shell.outstandingBackgroundTaskStartedAt, "2026-01-01T00:00:05.000Z");
+
+    // Servers with no outstanding tasks still emit the fields, with a null start.
+    const idle = yield* decodeOrchestrationThreadShell({
+      ...common,
+      outstandingBackgroundTaskCount: 0,
+      outstandingBackgroundTaskStartedAt: null,
+    });
+    assert.strictEqual(idle.outstandingBackgroundTaskCount, 0);
+    assert.strictEqual(idle.outstandingBackgroundTaskStartedAt, null);
+
+    // Payloads from older servers omit both fields entirely.
+    const legacy = yield* decodeOrchestrationThreadShell(common);
+    assert.strictEqual(legacy.outstandingBackgroundTaskCount, undefined);
+    assert.strictEqual(legacy.outstandingBackgroundTaskStartedAt, undefined);
+
+    // A negative count is not a count.
+    const invalid = yield* decodeOrchestrationThreadShell({
+      ...common,
+      outstandingBackgroundTaskCount: -1,
+    }).pipe(Effect.flip);
+    assert.ok(invalid);
+  }),
+);
+
 it.effect("decodes thread archived and unarchived events", () =>
   Effect.gen(function* () {
     const archived = yield* decodeOrchestrationEvent({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -434,6 +434,13 @@ export const OrchestrationThreadShell = Schema.Struct({
   hasPendingApprovals: Schema.Boolean,
   hasPendingUserInput: Schema.Boolean,
   hasActionableProposedPlan: Schema.Boolean,
+  // Background provider tasks (subagents) still running for this thread.
+  // Projected from task.started/task.completed activities so a list row can
+  // stay Working while child work outlives the parent turn. startedAt is the
+  // oldest outstanding task's start, for elapsed labels. Optional so payloads
+  // from older servers still decode.
+  outstandingBackgroundTaskCount: Schema.optional(NonNegativeInt),
+  outstandingBackgroundTaskStartedAt: Schema.optional(Schema.NullOr(IsoDateTime)),
 });
 export type OrchestrationThreadShell = typeof OrchestrationThreadShell.Type;
 

--- a/packages/shared/src/agentAwareness.test.ts
+++ b/packages/shared/src/agentAwareness.test.ts
@@ -29,6 +29,7 @@ function thread(
   | "updatedAt"
   | "hasPendingApprovals"
   | "hasPendingUserInput"
+  | "outstandingBackgroundTaskCount"
 > {
   return {
     id: "thread-1" as ThreadId,
@@ -39,6 +40,7 @@ function thread(
     updatedAt: NOW,
     hasPendingApprovals: false,
     hasPendingUserInput: false,
+    outstandingBackgroundTaskCount: 0,
     ...overrides,
   };
 }
@@ -152,6 +154,75 @@ describe("projectThreadAwareness", () => {
     });
 
     expect(state?.phase).toBe("completed");
+  });
+
+  it("keeps working while background subagents outlive the parent turn", () => {
+    // #4962: the parent session settles back to ready and the turn reads as
+    // completed while spawned subagents are still running.
+    const readySessionWithTasks = thread({
+      outstandingBackgroundTaskCount: 2,
+      latestTurn: {
+        turnId: "turn-1" as TurnId,
+        state: "completed",
+        requestedAt: NOW,
+        startedAt: NOW,
+        completedAt: NOW,
+        assistantMessageId: null,
+      },
+      session: {
+        threadId: "thread-1" as ThreadId,
+        status: "ready",
+        providerName: "Codex",
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: NOW,
+      },
+    });
+
+    expect(
+      projectThreadAwareness({
+        environmentId: "env-1" as EnvironmentId,
+        project,
+        thread: readySessionWithTasks,
+      }),
+    ).toMatchObject({ phase: "running", headline: "Agent is working" });
+
+    // Once the last task settles the thread reports Done again.
+    expect(
+      projectThreadAwareness({
+        environmentId: "env-1" as EnvironmentId,
+        project,
+        thread: { ...readySessionWithTasks, outstandingBackgroundTaskCount: 0 },
+      })?.phase,
+    ).toBe("completed");
+  });
+
+  it("keeps blocked and failed phases above outstanding background tasks", () => {
+    const blocked = projectThreadAwareness({
+      environmentId: "env-1" as EnvironmentId,
+      project,
+      thread: thread({ outstandingBackgroundTaskCount: 1, hasPendingUserInput: true }),
+    });
+    expect(blocked?.phase).toBe("waiting_for_input");
+
+    const failed = projectThreadAwareness({
+      environmentId: "env-1" as EnvironmentId,
+      project,
+      thread: thread({
+        outstandingBackgroundTaskCount: 1,
+        session: {
+          threadId: "thread-1" as ThreadId,
+          status: "error",
+          providerName: "Codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: "Provider process exited.",
+          updatedAt: NOW,
+        },
+      }),
+    });
+    expect(failed?.phase).toBe("failed");
   });
 
   it("projects failures with the session error detail", () => {

--- a/packages/shared/src/agentAwareness.ts
+++ b/packages/shared/src/agentAwareness.ts
@@ -40,6 +40,7 @@ export interface ProjectThreadAwarenessInput {
     | "updatedAt"
     | "hasPendingApprovals"
     | "hasPendingUserInput"
+    | "outstandingBackgroundTaskCount"
   >;
 }
 
@@ -90,6 +91,12 @@ function resolveThreadAwarenessPhase(
     return "starting";
   }
   if (thread.session?.status === "running" || thread.latestTurn?.state === "running") {
+    return "running";
+  }
+  // Background subagents outlive the parent turn: while any are still open the
+  // agent is working, even though the session already settled back to ready
+  // and the turn reads as completed (#4962).
+  if ((thread.outstandingBackgroundTaskCount ?? 0) > 0) {
     return "running";
   }
   if (thread.latestTurn?.state === "completed") {


### PR DESCRIPTION
Fixes #4962.

## Problem

Thread status is derived only from the parent session/turn, so once the foreground turn settles, mobile shows a completed-looking `Worked for …` fold and the thread list resolves to ready — while background subagents are still changing files and running tests. When a child later emits an update the thread flips back to working, producing an intermittent idle/working presentation.

## Fix

Project a session-gated aggregate of outstanding background tasks onto the thread shell, and render it on every surface:

- **Server:** `deriveOutstandingBackgroundTasks` in the projection pipeline replays `task.started` / `task.progress` / `task.completed` activities keyed by `taskId` (duplicates idempotent, unknown-task completions ignored, settled wins over late events; all three terminal statuses clear). The count is forced to 0 unless the session is `starting|running|ready`, so a dead provider can never strand a permanent Working state. New `projection_threads` columns via migration 036 with a gated backfill.
- **Contracts:** optional `outstandingBackgroundTaskCount` / `outstandingBackgroundTaskStartedAt` on `OrchestrationThreadShell` (legacy payloads still decode).
- **Mobile:** a slim swarm rail docks above the composer while subagents run — spinner, "N subagents working", live elapsed timer, chevron — and opens a new Background agents sheet listing each agent with elapsed time and latest progress line, plus recently finished agents. Thread list v1/v2 stay **Working** until the last child settles.
- **Web / shared:** sidebar Working pill + elapsed label pick up the aggregate; Live Activity phase stays `running`; settle logic treats outstanding tasks as an activity blocker.

No per-task stop buttons: no backend command exists to stop an individual task.

## Verification

- All six regression scenarios from the issue are covered twice: at the server projection layer (SQL-asserted) and in the shared client derivation (`packages/client-runtime/src/state/backgroundTasks.test.ts`), plus contract decode round-trips, migration backfill tests, and status-resolver cases on mobile and web — 517 tests green on the touched suites.
- Integrated pass on an Android emulator against a seeded environment reproducing the exact bug (parent turn settled + 2 subagents running): list row shows Working, rail + sheet render live, and both clear once the tasks settle. Before/after screenshots in the comments below.

Built by Claude Fable 5 on Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread projection, a DB migration, and settle/status semantics across mobile, web, and server; regression coverage is broad but any mismatch between server aggregate and client derivation could show wrong Working state.
> 
> **Overview**
> Fixes **#4962**: when the parent turn/session settles but provider subagents keep running, threads no longer flash idle.
> 
> **Server & contracts** add session-gated projection of outstanding background tasks (`outstandingBackgroundTaskCount` / `outstandingBackgroundTaskStartedAt` on the thread shell) by replaying `task.started` / `task.progress` / `task.completed` with idempotent ordering; migration **036** backfills existing rows. Counts drop to zero if the session is not `starting|running|ready` so dead providers cannot strand a permanent Working state.
> 
> **Shared client-runtime** introduces `deriveBackgroundTasks` (mirrored server logic) for live task lists; **settle** and **agent awareness** treat outstanding tasks like active work.
> 
> **Mobile** adds a **swarm rail** above the composer (count, elapsed time, tap to open) and a **Background agents** form sheet listing running and recently finished subagents; thread list status stays Working until the aggregate clears.
> 
> **Web** sidebar status, working elapsed labels, and pills use the same shell fields. User docs and glossary cover background agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32de0e8352e621ee615902ea8b3bb27d771e829d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show background subagent status in mobile threads while subagents run after parent turn settles
> - Adds `outstandingBackgroundTaskCount` and `outstandingBackgroundTaskStartedAt` to the `ProjectionThread` model and `OrchestrationThreadShell` contract, persisted via migration 036 and kept up-to-date by `refreshThreadShellSummary`.
> - Introduces `deriveBackgroundTasks` in `client-runtime` to replay thread activities into running/settled task state, gated by session status.
> - Updates `resolveThreadListV2Status`, `resolveThreadStatus`, `resolveSidebarV2Status`, `resolveThreadStatusPill`, and `resolveThreadAwarenessPhase` to return `'working'`/`'running'` when outstanding background tasks exist, even if the parent session is `'ready'`.
> - Adds a `ThreadSwarmRail` above the mobile composer showing a live elapsed timer while tasks run; tapping opens a new `BackgroundAgentsSheet` form sheet listing running and settled tasks with spinners, status glyphs, and relative timestamps.
> - Behavioral Change: `canSettle` and `effectiveSettled` now return false for threads with `outstandingBackgroundTaskCount > 0`; threads on legacy servers (field absent) are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32de0e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->