### PR TITLE
feat: persistent custom model display labels for all providers

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -796,6 +796,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     BUILT_IN_MODELS,
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+    claudeSettings.customModelLabels ?? {},
   );
 
   if (!claudeSettings.enabled) {
@@ -886,6 +887,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     getBuiltInClaudeModelsForVersion(parsedVersion),
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+    claudeSettings.customModelLabels ?? {},
   );
   const versionUpgradeMessage = supportsClaudeOpus5(parsedVersion)
     ? undefined
@@ -959,6 +961,7 @@ export const makePendingClaudeProvider = (
       BUILT_IN_MODELS,
       claudeSettings.customModels,
       DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+      claudeSettings.customModelLabels ?? {},
     );
 
     if (!claudeSettings.enabled) {

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,18 @@
-import { assert, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as CodexErrors from "effect-codex-app-server/errors";
+import { CodexSettings } from "@t3tools/contracts";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  checkCodexProviderStatus,
+  makePendingCodexProvider,
+  mapCodexModelCapabilities,
+} from "./CodexProvider.ts";
+
+const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({
@@ -143,4 +155,59 @@ it("ignores custom models that shadow a preferred slug", () => {
   ]);
 
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.4");
+});
+
+describe("Codex custom model labels", () => {
+  it.effect("applies customModelLabels on the pending/disabled snapshot path", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* makePendingCodexProvider(
+        decodeCodexSettings({
+          enabled: false,
+          customModels: ["gpt-custom-ultra"],
+          customModelLabels: { "gpt-custom-ultra": "Ultra Preview" },
+        }),
+      );
+
+      expect(snapshot.models).toContainEqual({
+        slug: "gpt-custom-ultra",
+        name: "Ultra Preview",
+        isCustom: true,
+        capabilities: null,
+      });
+    }),
+  );
+});
+
+it.layer(NodeServices.layer)("checkCodexProviderStatus custom model labels", (it) => {
+  it.effect("forwards customModelLabels into the probe and keeps them on error fallbacks", () =>
+    Effect.gen(function* () {
+      let forwardedLabels: Readonly<Record<string, string>> | undefined;
+      const snapshot = yield* checkCodexProviderStatus(
+        decodeCodexSettings({
+          enabled: true,
+          binaryPath: "codex",
+          customModels: ["gpt-custom-ultra"],
+          customModelLabels: { "gpt-custom-ultra": "Ultra Preview" },
+        }),
+        (input) => {
+          forwardedLabels = input.customModelLabels;
+          return Effect.fail(
+            new CodexErrors.CodexAppServerSpawnError({
+              command: "codex app-server",
+              cause: new Error("spawn failed"),
+            }),
+          );
+        },
+      );
+
+      expect(forwardedLabels).toEqual({ "gpt-custom-ultra": "Ultra Preview" });
+      expect(snapshot.models).toContainEqual({
+        slug: "gpt-custom-ultra",
+        name: "Ultra Preview",
+        isCustom: true,
+        capabilities: null,
+      });
+      expect(snapshot.status).toBe("error");
+    }),
+  );
 });

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -413,6 +413,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
 
 const emptyCodexModelsFromSettings = (codexSettings: CodexSettings): ServerProvider["models"] => {
   const models = new Set<string>();
+  const labels = codexSettings.customModelLabels ?? {};
   for (const model of codexSettings.customModels) {
     const trimmed = model.trim();
     if (trimmed.length > 0) {
@@ -421,7 +422,7 @@ const emptyCodexModelsFromSettings = (codexSettings: CodexSettings): ServerProvi
   }
   return Array.from(models, (model) => ({
     slug: model,
-    name: model,
+    name: getCustomModelLabel(labels, model) ?? model,
     isCustom: true,
     capabilities: null,
   }));
@@ -504,6 +505,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     readonly launchArgs?: string;
     readonly cwd: string;
     readonly customModels: ReadonlyArray<string>;
+    readonly customModelLabels?: Readonly<Record<string, string>>;
     readonly environment?: NodeJS.ProcessEnv;
   }) => Effect.Effect<
     CodexAppServerProviderSnapshot,
@@ -543,6 +545,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     launchArgs: resolveCodexLaunchArgs(codexSettings.launchArgs, resolvedEnvironment),
     cwd: process.cwd(),
     customModels: codexSettings.customModels,
+    customModelLabels: codexSettings.customModelLabels ?? {},
     environment: resolvedEnvironment,
   }).pipe(
     Effect.scoped,

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -405,7 +405,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     account: accountResponse,
     version,
     models: applyPreferredCodexDefaultModel(
-      appendCustomCodexModels(models, input.customModels ?? []),
+      appendCustomCodexModels(models, input.customModels ?? [], input.customModelLabels ?? {}),
     ),
     skills: parseCodexSkillsListResponse(skillsResponse, input.cwd),
   } satisfies CodexAppServerProviderSnapshot;

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -24,7 +24,7 @@ import type {
 } from "@t3tools/contracts";
 import { PREFERRED_DEFAULT_CODEX_MODELS, ServerSettingsError } from "@t3tools/contracts";
 
-import { createModelCapabilities } from "@t3tools/shared/model";
+import { createModelCapabilities, getCustomModelLabel } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
 import {
@@ -222,6 +222,7 @@ export function applyPreferredCodexDefaultModel(
 function appendCustomCodexModels(
   models: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
+  customModelLabels: Readonly<Record<string, string>> = {},
 ): ReadonlyArray<ServerProviderModel> {
   if (customModels.length === 0) {
     return models;
@@ -238,7 +239,7 @@ function appendCustomCodexModels(
     seen.add(slug);
     customEntries.push({
       slug,
-      name: slug,
+      name: getCustomModelLabel(customModelLabels, slug) ?? slug,
       isCustom: true,
       capabilities: fallbackCapabilities,
     });
@@ -319,6 +320,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   readonly launchArgs?: string;
   readonly cwd: string;
   readonly customModels?: ReadonlyArray<string>;
+  readonly customModelLabels?: Readonly<Record<string, string>>;
   readonly environment?: NodeJS.ProcessEnv;
 }) {
   // `~` is not shell-expanded when env vars are set via `child_process.spawn`,
@@ -384,7 +386,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     return {
       account: accountResponse,
       version,
-      models: appendCustomCodexModels([], input.customModels ?? []),
+      models: appendCustomCodexModels([], input.customModels ?? [], input.customModelLabels ?? {}),
       skills: [],
     } satisfies CodexAppServerProviderSnapshot;
   }

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -572,9 +572,14 @@ export const discoverCursorModelsViaAcp = (
 ) => discoverCursorModelsViaListAvailableModels(cursorSettings, environment);
 
 export function getCursorFallbackModels(
-  cursorSettings: Pick<CursorSettings, "customModels">,
+  cursorSettings: Pick<CursorSettings, "customModels" | "customModelLabels">,
 ): ReadonlyArray<ServerProviderModel> {
-  return providerModelsFromSettings([], cursorSettings.customModels, EMPTY_CAPABILITIES);
+  return providerModelsFromSettings(
+    [],
+    cursorSettings.customModels,
+    EMPTY_CAPABILITIES,
+    cursorSettings.customModelLabels ?? {},
+  );
 }
 
 /** Timeout for `agent about` — it's slower than a simple `--version` probe. */
@@ -638,6 +643,7 @@ export function buildCursorProviderSnapshot(input: {
       input.discoveredModels ?? [],
       input.cursorSettings.customModels,
       EMPTY_CAPABILITIES,
+      input.cursorSettings.customModelLabels ?? {},
     ),
     probe: {
       installed: true,

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -34,6 +34,23 @@ describe("buildInitialGrokProviderSnapshot", () => {
       expect(snapshot.requiresNewThreadForModelChange).toBe(true);
     }),
   );
+
+  it.effect("applies customModelLabels to custom models", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialGrokProviderSnapshot(
+        decodeGrokSettings({
+          customModels: ["grok-custom"],
+          customModelLabels: { "grok-custom": "Friendly Grok" },
+        }),
+      );
+      expect(snapshot.models).toContainEqual({
+        slug: "grok-custom",
+        name: "Friendly Grok",
+        isCustom: true,
+        capabilities: expect.anything(),
+      });
+    }),
+  );
 });
 
 it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -58,7 +58,11 @@ export function buildInitialGrokProviderSnapshot(
 ): Effect.Effect<ServerProviderDraft> {
   return Effect.gen(function* () {
     const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
-    const models = grokModelsFromSettings(grokSettings.customModels);
+    const models = grokModelsFromSettings(
+      grokSettings.customModels,
+      undefined,
+      grokSettings.customModelLabels ?? {},
+    );
 
     if (!grokSettings.enabled) {
       return buildServerProvider({
@@ -173,7 +177,11 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
   ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
 > {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
-  const fallbackModels = grokModelsFromSettings(grokSettings.customModels);
+  const fallbackModels = grokModelsFromSettings(
+    grokSettings.customModels,
+    undefined,
+    grokSettings.customModelLabels ?? {},
+  );
 
   if (!grokSettings.enabled) {
     return buildServerProvider({
@@ -300,7 +308,11 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
   const discoveredModels = discoveryExit.value.value;
   const models =
     discoveredModels.length > 0
-      ? grokModelsFromSettings(grokSettings.customModels, discoveredModels)
+      ? grokModelsFromSettings(
+          grokSettings.customModels,
+          discoveredModels,
+          grokSettings.customModelLabels ?? {},
+        )
       : fallbackModels;
 
   return buildServerProvider({

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -95,8 +95,14 @@ export function buildInitialGrokProviderSnapshot(
 function grokModelsFromSettings(
   customModels: ReadonlyArray<string> | undefined,
   builtInModels: ReadonlyArray<ServerProviderModel> = GROK_BUILT_IN_MODELS,
+  customModelLabels: Readonly<Record<string, string>> = {},
 ): ReadonlyArray<ServerProviderModel> {
-  return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
+  return providerModelsFromSettings(
+    builtInModels,
+    customModels ?? [],
+    EMPTY_CAPABILITIES,
+    customModelLabels,
+  );
 }
 
 function buildGrokDiscoveredModelsFromSessionModelState(

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -215,6 +215,23 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
     }),
   );
 
+  it.effect("applies customModelLabels to custom models on the success path", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* checkOpenCodeProviderStatus(
+        makeOpenCodeSettings({
+          customModels: ["anthropic/claude-sonnet-4-6"],
+          customModelLabels: { "anthropic/claude-sonnet-4-6": "Sonnet 4.6" },
+        }),
+        process.cwd(),
+      );
+
+      const custom = snapshot.models.find((entry) => entry.slug === "anthropic/claude-sonnet-4-6");
+      NodeAssert.ok(custom);
+      NodeAssert.equal(custom.isCustom, true);
+      NodeAssert.equal(custom.name, "Sonnet 4.6");
+    }),
+  );
+
   it.effect("reports local model inventory failures without treating them as empty", () =>
     Effect.gen(function* () {
       runtimeMock.state.inventoryError = new Error("opencode models failed");

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -259,11 +259,7 @@ export const makePendingOpenCodeProvider = (
       [],
       openCodeSettings.customModels,
       DEFAULT_OPENCODE_MODEL_CAPABILITIES,
-      (
-        openCodeSettings as OpenCodeSettings & {
-          customModelLabels?: Readonly<Record<string, string>>;
-        }
-      ).customModelLabels ?? {},
+      openCodeSettings.customModelLabels ?? {},
     );
 
     if (!openCodeSettings.enabled) {
@@ -309,12 +305,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   const resolvedEnvironment = environment ?? process.env;
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const customModels = openCodeSettings.customModels;
-  const customModelLabels =
-    (
-      openCodeSettings as OpenCodeSettings & {
-        customModelLabels?: Readonly<Record<string, string>>;
-      }
-    ).customModelLabels ?? {};
+  const customModelLabels = openCodeSettings.customModelLabels ?? {};
   const isExternalServer = openCodeSettings.serverUrl.trim().length > 0;
 
   const fallback = (cause: unknown, version: string | null = null) => {
@@ -348,7 +339,12 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
       presentation: OPENCODE_PRESENTATION,
       enabled: false,
       checkedAt,
-      models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES),
+      models: providerModelsFromSettings(
+        [],
+        customModels,
+        DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+        customModelLabels,
+      ),
       probe: {
         installed: false,
         version: null,
@@ -394,7 +390,12 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
         presentation: OPENCODE_PRESENTATION,
         enabled: openCodeSettings.enabled,
         checkedAt,
-        models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES),
+        models: providerModelsFromSettings(
+          [],
+          customModels,
+          DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+          customModelLabels,
+        ),
         probe: {
           installed: true,
           version,
@@ -444,6 +445,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     flattenOpenCodeModels(inventoryExit.value),
     customModels,
     DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+    customModelLabels,
   );
   const connectedCount = inventoryExit.value.providerList.connected.length;
   return buildServerProvider({

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -259,6 +259,11 @@ export const makePendingOpenCodeProvider = (
       [],
       openCodeSettings.customModels,
       DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+      (
+        openCodeSettings as OpenCodeSettings & {
+          customModelLabels?: Readonly<Record<string, string>>;
+        }
+      ).customModelLabels ?? {},
     );
 
     if (!openCodeSettings.enabled) {
@@ -304,6 +309,12 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   const resolvedEnvironment = environment ?? process.env;
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const customModels = openCodeSettings.customModels;
+  const customModelLabels =
+    (
+      openCodeSettings as OpenCodeSettings & {
+        customModelLabels?: Readonly<Record<string, string>>;
+      }
+    ).customModelLabels ?? {};
   const isExternalServer = openCodeSettings.serverUrl.trim().length > 0;
 
   const fallback = (cause: unknown, version: string | null = null) => {
@@ -316,7 +327,12 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
       presentation: OPENCODE_PRESENTATION,
       enabled: openCodeSettings.enabled,
       checkedAt,
-      models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES),
+      models: providerModelsFromSettings(
+        [],
+        customModels,
+        DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+        customModelLabels,
+      ),
       probe: {
         installed: failure.installed,
         version,

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -84,6 +84,16 @@ describe("providerModelsFromSettings", () => {
       { slug: "other", name: "other" },
     ]);
   });
+
+  it("does not crash when a custom slug collides with Object.prototype keys", () => {
+    const capabilities = createModelCapabilities({ optionDescriptors: [] });
+    expect(
+      providerModelsFromSettings([], ["__proto__", "constructor"], capabilities, {}),
+    ).toMatchObject([
+      { slug: "__proto__", name: "__proto__", isCustom: true },
+      { slug: "constructor", name: "constructor", isCustom: true },
+    ]);
+  });
 });
 
 describe("ProviderCommandNotFoundError", () => {

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -70,6 +70,20 @@ describe("providerModelsFromSettings", () => {
     expect(models.map((model) => model.slug)).toEqual(["claude-opus-4-8", "opus"]);
     expect(models[1]?.isCustom).toBe(true);
   });
+
+  it("uses trimmed labels only for configured custom slugs", () => {
+    const capabilities = createModelCapabilities({ optionDescriptors: [] });
+    expect(
+      providerModelsFromSettings([], ["openai/gpt-5", "other"], capabilities, {
+        "openai/gpt-5": "  GPT 5  ",
+        absent: "ignored",
+        other: "   ",
+      }),
+    ).toMatchObject([
+      { slug: "openai/gpt-5", name: "GPT 5" },
+      { slug: "other", name: "other" },
+    ]);
+  });
 });
 
 describe("ProviderCommandNotFoundError", () => {

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -142,6 +142,7 @@ export function providerModelsFromSettings(
   builtInModels: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
   customModelCapabilities: ModelCapabilities,
+  customModelLabels: Readonly<Record<string, string>> = {},
 ): ReadonlyArray<ServerProviderModel> {
   const resolvedBuiltInModels = [...builtInModels];
   const seen = new Set(resolvedBuiltInModels.map((model) => model.slug));
@@ -153,9 +154,10 @@ export function providerModelsFromSettings(
       continue;
     }
     seen.add(normalized);
+    const label = customModelLabels[normalized] ?? customModelLabels[candidate];
     customEntries.push({
       slug: normalized,
-      name: normalized,
+      name: typeof label === "string" && label.trim().length > 0 ? label.trim() : normalized,
       isCustom: true,
       capabilities: customModelCapabilities,
     });

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -13,7 +13,7 @@ import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
-import { normalizeCustomModelSlug } from "@t3tools/shared/model";
+import { getCustomModelLabel, normalizeCustomModelSlug } from "@t3tools/shared/model";
 import { isWindowsCommandNotFound } from "../processRunner.ts";
 import { createProviderVersionAdvisory } from "./providerMaintenance.ts";
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
@@ -144,7 +144,15 @@ export function providerModelsFromSettings(
   customModelCapabilities: ModelCapabilities,
   customModelLabels: Readonly<Record<string, string>> = {},
 ): ReadonlyArray<ServerProviderModel> {
-  const resolvedBuiltInModels = [...builtInModels];
+  const customSlugs = new Set(customModels.map(normalizeCustomModelSlug).filter(Boolean));
+  const resolvedBuiltInModels = builtInModels.map((model) => {
+    if (!customSlugs.has(model.slug)) return model;
+    return {
+      ...model,
+      name: getCustomModelLabel(customModelLabels, model.slug) ?? model.name,
+      isCustom: true,
+    };
+  });
   const seen = new Set(resolvedBuiltInModels.map((model) => model.slug));
   const customEntries: ServerProviderModel[] = [];
 
@@ -154,7 +162,7 @@ export function providerModelsFromSettings(
       continue;
     }
     seen.add(normalized);
-    const label = customModelLabels[normalized] ?? customModelLabels[candidate];
+    const label = getCustomModelLabel(customModelLabels, normalized);
     customEntries.push({
       slug: normalized,
       name: typeof label === "string" && label.trim().length > 0 ? label.trim() : normalized,

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -33,4 +33,29 @@ describe("deriveProviderModelsForDisplay", () => {
       }).map((model) => model.slug),
     ).toEqual(["server-model", "kept-custom"]);
   });
+
+  it("applies persisted labels over live custom model names", () => {
+    const liveModels: ReadonlyArray<ServerProviderModel> = [
+      {
+        slug: "kept-custom",
+        name: "Server Name",
+        isCustom: true,
+        capabilities: null,
+      },
+    ];
+
+    expect(
+      deriveProviderModelsForDisplay({
+        liveModels,
+        customModels: ["kept-custom", "new-custom"],
+        customModelLabels: {
+          "kept-custom": "Friendly Kept",
+          "new-custom": "Friendly New",
+        },
+      }),
+    ).toMatchObject([
+      { slug: "kept-custom", name: "Friendly Kept", isCustom: true },
+      { slug: "new-custom", name: "Friendly New", isCustom: true },
+    ]);
+  });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -90,6 +90,18 @@ function readConfigStringArray(config: unknown, key: string): ReadonlyArray<stri
   return value.filter((entry): entry is string => typeof entry === "string");
 }
 
+function readConfigStringRecord(config: unknown, key: string): Readonly<Record<string, string>> {
+  if (config === null || typeof config !== "object") return {};
+  const value = (config as Record<string, unknown>)[key];
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === "string" && entry[1].trim().length > 0,
+    ),
+  );
+}
+
 /**
  * Set `key` to an arbitrary value on the opaque config blob. Unlike
  * provider settings field updates, does not drop empty-looking values — the
@@ -444,6 +456,7 @@ export function ProviderInstanceCard({
     : null;
 
   const customModels = readConfigStringArray(instance.config, "customModels");
+  const customModelLabels = readConfigStringRecord(instance.config, "customModelLabels");
   // Server-returned models may lag behind settings writes. Treat probe
   // models as the source for built-ins only; custom rows come directly
   // from the current instance config so add/remove reflects immediately.
@@ -780,6 +793,7 @@ export function ProviderInstanceCard({
                 driverKind={driverKind}
                 models={modelsForDisplay}
                 customModels={customModels}
+                customModelLabels={customModelLabels}
                 hiddenModels={hiddenModels}
                 favoriteModels={favoriteModels}
                 modelOrder={modelOrder}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -124,6 +124,7 @@ function nextConfigBlobWithValue(
 export function deriveProviderModelsForDisplay(input: {
   readonly liveModels: ReadonlyArray<ServerProviderModel> | undefined;
   readonly customModels: ReadonlyArray<string>;
+  readonly customModelLabels?: Readonly<Record<string, string>>;
 }): ReadonlyArray<ServerProviderModel> {
   const liveCustomModelsBySlug = new Map(
     Arr.filterMap(input.liveModels ?? [], (model) =>
@@ -135,7 +136,7 @@ export function deriveProviderModelsForDisplay(input: {
     (slug) =>
       liveCustomModelsBySlug.get(slug) ?? {
         slug,
-        name: slug,
+        name: input.customModelLabels?.[slug]?.trim() || slug,
         isCustom: true,
         capabilities: null,
       },
@@ -463,6 +464,7 @@ export function ProviderInstanceCard({
   const modelsForDisplay = deriveProviderModelsForDisplay({
     liveModels: liveProvider?.models,
     customModels,
+    customModelLabels,
   });
 
   const updateDisplayName = (value: string) => {
@@ -500,6 +502,12 @@ export function ProviderInstanceCard({
 
   const updateCustomModels = (next: ReadonlyArray<string>) => {
     const nextConfig = nextConfigBlobWithValue(instance.config, "customModels", [...next]);
+    const { config: _omit, ...rest } = instance;
+    onUpdate({ ...rest, config: nextConfig } as ProviderInstanceConfig);
+  };
+
+  const updateCustomModelLabels = (next: Readonly<Record<string, string>>) => {
+    const nextConfig = nextConfigBlobWithValue(instance.config, "customModelLabels", { ...next });
     const { config: _omit, ...rest } = instance;
     onUpdate({ ...rest, config: nextConfig } as ProviderInstanceConfig);
   };
@@ -798,6 +806,7 @@ export function ProviderInstanceCard({
                 favoriteModels={favoriteModels}
                 modelOrder={modelOrder}
                 onChange={updateCustomModels}
+                onLabelChange={updateCustomModelLabels}
                 onHiddenModelsChange={onHiddenModelsChange}
                 onFavoriteModelsChange={onFavoriteModelsChange}
                 onModelOrderChange={onModelOrderChange}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -22,6 +22,7 @@ import {
   type ServerProvider,
   type ServerProviderModel,
 } from "@t3tools/contracts";
+import { getCustomModelLabel } from "@t3tools/shared/model";
 
 import { cn } from "../../lib/utils";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
@@ -132,15 +133,19 @@ export function deriveProviderModelsForDisplay(input: {
     ),
   );
   const serverModels = input.liveModels?.filter((model) => !model.isCustom) ?? [];
-  const customModels = input.customModels.map(
-    (slug) =>
-      liveCustomModelsBySlug.get(slug) ?? {
-        slug,
-        name: input.customModelLabels?.[slug]?.trim() || slug,
-        isCustom: true,
-        capabilities: null,
-      },
-  );
+  const customModels = input.customModels.map((slug) => {
+    const live = liveCustomModelsBySlug.get(slug);
+    const label = getCustomModelLabel(input.customModelLabels, slug);
+    if (live) {
+      return label ? { ...live, name: label } : live;
+    }
+    return {
+      slug,
+      name: label ?? slug,
+      isCustom: true,
+      capabilities: null,
+    };
+  });
   return [...serverModels, ...customModels];
 }
 
@@ -512,6 +517,21 @@ export function ProviderInstanceCard({
     onUpdate({ ...rest, config: nextConfig } as ProviderInstanceConfig);
   };
 
+  /**
+   * Atomically update both customModels and customModelLabels from the same
+   * base config. Sequential onChange + onLabelChange clobber each other
+   * because each rebuilds from stale `instance.config`.
+   */
+  const updateCustomModelsAndLabels = (
+    nextModels: ReadonlyArray<string>,
+    nextLabels: Readonly<Record<string, string>>,
+  ) => {
+    let nextConfig = nextConfigBlobWithValue(instance.config, "customModels", [...nextModels]);
+    nextConfig = nextConfigBlobWithValue(nextConfig, "customModelLabels", { ...nextLabels });
+    const { config: _omit, ...rest } = instance;
+    onUpdate({ ...rest, config: nextConfig } as ProviderInstanceConfig);
+  };
+
   const updateEnvironment = (environment: ReadonlyArray<ProviderInstanceEnvironmentVariable>) => {
     const cleaned = environment.filter((variable) => variable.name.trim().length > 0);
     const { environment: _omit, ...rest } = instance;
@@ -807,6 +827,7 @@ export function ProviderInstanceCard({
                 modelOrder={modelOrder}
                 onChange={updateCustomModels}
                 onLabelChange={updateCustomModelLabels}
+                onModelsAndLabelsChange={updateCustomModelsAndLabels}
                 onHiddenModelsChange={onHiddenModelsChange}
                 onFavoriteModelsChange={onFavoriteModelsChange}
                 onModelOrderChange={onModelOrderChange}

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { modelRowPrimaryText, nextCustomModelLabels } from "./ProviderModelsSection";
+import {
+  areCustomModelLabelMapsEqual,
+  modelRowPrimaryText,
+  nextCustomModelLabels,
+} from "./ProviderModelsSection";
 
 describe("nextCustomModelLabels", () => {
   it("sets, updates, and clears labels without mutating the source map", () => {
@@ -21,6 +25,27 @@ describe("nextCustomModelLabels", () => {
       "model-a": "Label A",
       "model-b": "Label B",
     });
+  });
+});
+
+describe("areCustomModelLabelMapsEqual", () => {
+  it("treats equal content as equal even when object identity differs", () => {
+    const a = { "model-a": "Label A" };
+    const b = { "model-a": "Label A" };
+    expect(a).not.toBe(b);
+    expect(areCustomModelLabelMapsEqual(a, b)).toBe(true);
+  });
+
+  it("detects added, removed, and changed values", () => {
+    expect(areCustomModelLabelMapsEqual({ a: "1" }, { a: "1", b: "2" })).toBe(false);
+    expect(areCustomModelLabelMapsEqual({ a: "1", b: "2" }, { a: "1" })).toBe(false);
+    expect(areCustomModelLabelMapsEqual({ a: "1" }, { a: "2" })).toBe(false);
+  });
+
+  it("does not treat inherited prototype keys as map entries", () => {
+    const polluted = Object.create({ inherited: "nope" }) as Record<string, string>;
+    polluted.a = "1";
+    expect(areCustomModelLabelMapsEqual(polluted, { a: "1" })).toBe(true);
   });
 });
 

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { modelRowPrimaryText, nextCustomModelLabels } from "./ProviderModelsSection";
+
+describe("nextCustomModelLabels", () => {
+  it("sets, updates, and clears labels without mutating the source map", () => {
+    const base = { "model-a": "Label A" };
+    const withB = nextCustomModelLabels(base, "model-b", "Label B");
+    expect(withB).toEqual({ "model-a": "Label A", "model-b": "Label B" });
+    expect(base).toEqual({ "model-a": "Label A" });
+
+    const cleared = nextCustomModelLabels(withB, "model-a", "   ");
+    expect(cleared).toEqual({ "model-b": "Label B" });
+  });
+
+  it("composes sequential edits from the previous result (blur race)", () => {
+    let labels: Readonly<Record<string, string>> = {};
+    labels = nextCustomModelLabels(labels, "model-a", "Label A");
+    labels = nextCustomModelLabels(labels, "model-b", "Label B");
+    expect(labels).toEqual({
+      "model-a": "Label A",
+      "model-b": "Label B",
+    });
+  });
+});
+
+describe("modelRowPrimaryText", () => {
+  it("keeps the API slug visible for custom models", () => {
+    expect(
+      modelRowPrimaryText({
+        slug: "gpt-custom-ultra",
+        name: "Ultra Preview",
+        isCustom: true,
+      }),
+    ).toBe("gpt-custom-ultra");
+  });
+
+  it("uses the display name for built-in models", () => {
+    expect(
+      modelRowPrimaryText({
+        slug: "gpt-5.4",
+        name: "GPT-5.4",
+        isCustom: false,
+      }),
+    ).toBe("GPT-5.4");
+  });
+});

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -16,7 +16,7 @@ import {
   type ProviderInstanceId,
   type ServerProviderModel,
 } from "@t3tools/contracts";
-import { normalizeCustomModelSlug } from "@t3tools/shared/model";
+import { getCustomModelLabel, normalizeCustomModelSlug } from "@t3tools/shared/model";
 
 import { cn } from "../../lib/utils";
 import { sortModelsForProviderInstance } from "../../modelOrdering";
@@ -70,6 +70,14 @@ interface ProviderModelsSectionProps {
    */
   readonly onChange: (next: ReadonlyArray<string>) => void;
   readonly onLabelChange: (next: Readonly<Record<string, string>>) => void;
+  /**
+   * Atomic models+labels update. Prefer this over sequential onChange +
+   * onLabelChange so both fields are written from the same base config.
+   */
+  readonly onModelsAndLabelsChange?: (
+    nextModels: ReadonlyArray<string>,
+    nextLabels: Readonly<Record<string, string>>,
+  ) => void;
   readonly onHiddenModelsChange: (next: ReadonlyArray<string>) => void;
   readonly onFavoriteModelsChange: (next: ReadonlyArray<string>) => void;
   readonly onModelOrderChange: (next: ReadonlyArray<string>) => void;
@@ -97,6 +105,7 @@ export function ProviderModelsSection({
   modelOrder,
   onChange,
   onLabelChange,
+  onModelsAndLabelsChange,
   onHiddenModelsChange,
   onFavoriteModelsChange,
   onModelOrderChange,
@@ -154,13 +163,22 @@ export function ProviderModelsSection({
   };
 
   const handleRemove = (slug: string) => {
-    onChange(customModels.filter((model) => model !== slug));
+    const nextModels = customModels.filter((model) => model !== slug);
     onModelOrderChange(modelOrder.filter((model) => model !== slug));
     onFavoriteModelsChange(favoriteModels.filter((model) => model !== slug));
-    if (customModelLabels[slug] !== undefined) {
+
+    const hasOwnLabel = Object.prototype.hasOwnProperty.call(customModelLabels, slug);
+    if (hasOwnLabel) {
       const nextLabels = { ...customModelLabels };
       delete nextLabels[slug];
-      onLabelChange(nextLabels);
+      if (onModelsAndLabelsChange) {
+        onModelsAndLabelsChange(nextModels, nextLabels);
+      } else {
+        onChange(nextModels);
+        onLabelChange(nextLabels);
+      }
+    } else {
+      onChange(nextModels);
     }
     setError(null);
   };
@@ -244,7 +262,7 @@ export function ProviderModelsSection({
                 {model.isCustom ? (
                   <Input
                     className="h-6 min-w-0 max-w-44 text-xs"
-                    defaultValue={customModelLabels[model.slug] ?? ""}
+                    defaultValue={getCustomModelLabel(customModelLabels, model.slug) ?? ""}
                     placeholder="Display label (optional)"
                     aria-label={`Display label for ${model.slug}`}
                     onBlur={(event) => {
@@ -263,7 +281,7 @@ export function ProviderModelsSection({
                   )}
                 >
                   {model.isCustom
-                    ? customModelLabels[model.slug]?.trim() || model.name
+                    ? (getCustomModelLabel(customModelLabels, model.slug) ?? model.name)
                     : model.name}
                 </span>
                 {hasDetails ? (

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -101,6 +101,26 @@ export function nextCustomModelLabels(
 }
 
 /**
+ * Content equality for label maps. Parent often rebuilds a new object with
+ * the same entries (e.g. `Object.fromEntries` on every render); identity
+ * alone must not reset the write-through label cache.
+ */
+export function areCustomModelLabelMapsEqual(
+  a: Readonly<Record<string, string>>,
+  b: Readonly<Record<string, string>>,
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(b, key) || a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Primary row text for a model entry. Custom rows always show the API slug
  * because the optional display label is edited in a sibling input.
  */
@@ -142,8 +162,16 @@ export function ProviderModelsSection({
   const listRef = useRef<HTMLDivElement | null>(null);
   // Keep a write-through cache so sequential label blurs before the parent
   // re-renders do not clobber each other by spreading a stale prop snapshot.
+  // Only adopt the prop when its *content* changes — parents often rebuild a
+  // new object reference with identical entries, which must not wipe local
+  // edits that have not landed in parent state yet.
   const labelsRef = useRef(customModelLabels);
+  const lastPropLabelsRef = useRef(customModelLabels);
   useEffect(() => {
+    if (areCustomModelLabelMapsEqual(lastPropLabelsRef.current, customModelLabels)) {
+      return;
+    }
+    lastPropLabelsRef.current = customModelLabels;
     labelsRef.current = customModelLabels;
   }, [customModelLabels]);
   const hiddenModelSet = useMemo(() => new Set(hiddenModels), [hiddenModels]);

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -56,6 +56,7 @@ interface ProviderModelsSectionProps {
    * removed) via `onChange`.
    */
   readonly customModels: ReadonlyArray<string>;
+  readonly customModelLabels: Readonly<Record<string, string>>;
   /** Server-returned model slugs hidden from the model picker. */
   readonly hiddenModels: ReadonlyArray<string>;
   /** Model slugs favorited for this provider instance. */
@@ -89,6 +90,7 @@ export function ProviderModelsSection({
   driverKind,
   models,
   customModels,
+  customModelLabels,
   hiddenModels,
   favoriteModels,
   modelOrder,
@@ -238,7 +240,9 @@ export function ProviderModelsSection({
                     isHidden ? "text-muted-foreground line-through" : "text-foreground/90",
                   )}
                 >
-                  {model.name}
+                  {model.isCustom
+                    ? customModelLabels[model.slug]?.trim() || model.name
+                    : model.name}
                 </span>
                 {hasDetails ? (
                   <Tooltip>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -10,7 +10,7 @@ import {
   StarIcon,
   XIcon,
 } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ProviderDriverKind,
   type ProviderInstanceId,
@@ -84,6 +84,33 @@ interface ProviderModelsSectionProps {
 }
 
 /**
+ * Build the next custom-model label map for a single slug edit.
+ * Pure helper so sequential blur handlers can compose from a write-through
+ * cache instead of a stale prop snapshot.
+ */
+export function nextCustomModelLabels(
+  labels: Readonly<Record<string, string>>,
+  slug: string,
+  label: string,
+): Record<string, string> {
+  const nextLabels = { ...labels };
+  const trimmed = label.trim();
+  if (trimmed) nextLabels[slug] = trimmed;
+  else delete nextLabels[slug];
+  return nextLabels;
+}
+
+/**
+ * Primary row text for a model entry. Custom rows always show the API slug
+ * because the optional display label is edited in a sibling input.
+ */
+export function modelRowPrimaryText(
+  model: Pick<ServerProviderModel, "slug" | "name" | "isCustom">,
+): string {
+  return model.isCustom ? model.slug : model.name;
+}
+
+/**
  * Shared "Models" section rendered on both the built-in default and custom
  * provider-instance cards. Owns its own input + error local state so two
  * cards on screen don't fight over the input value.
@@ -113,6 +140,12 @@ export function ProviderModelsSection({
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
+  // Keep a write-through cache so sequential label blurs before the parent
+  // re-renders do not clobber each other by spreading a stale prop snapshot.
+  const labelsRef = useRef(customModelLabels);
+  useEffect(() => {
+    labelsRef.current = customModelLabels;
+  }, [customModelLabels]);
   const hiddenModelSet = useMemo(() => new Set(hiddenModels), [hiddenModels]);
   const favoriteModelSet = useMemo(() => new Set(favoriteModels), [favoriteModels]);
   const orderedModels = useMemo(() => {
@@ -167,10 +200,10 @@ export function ProviderModelsSection({
     onModelOrderChange(modelOrder.filter((model) => model !== slug));
     onFavoriteModelsChange(favoriteModels.filter((model) => model !== slug));
 
-    const hasOwnLabel = Object.prototype.hasOwnProperty.call(customModelLabels, slug);
+    const hasOwnLabel = Object.prototype.hasOwnProperty.call(labelsRef.current, slug);
     if (hasOwnLabel) {
-      const nextLabels = { ...customModelLabels };
-      delete nextLabels[slug];
+      const nextLabels = nextCustomModelLabels(labelsRef.current, slug, "");
+      labelsRef.current = nextLabels;
       if (onModelsAndLabelsChange) {
         onModelsAndLabelsChange(nextModels, nextLabels);
       } else {
@@ -266,10 +299,12 @@ export function ProviderModelsSection({
                     placeholder="Display label (optional)"
                     aria-label={`Display label for ${model.slug}`}
                     onBlur={(event) => {
-                      const label = event.currentTarget.value.trim();
-                      const nextLabels = { ...customModelLabels };
-                      if (label) nextLabels[model.slug] = label;
-                      else delete nextLabels[model.slug];
+                      const nextLabels = nextCustomModelLabels(
+                        labelsRef.current,
+                        model.slug,
+                        event.currentTarget.value,
+                      );
+                      labelsRef.current = nextLabels;
                       onLabelChange(nextLabels);
                     }}
                   />
@@ -280,9 +315,9 @@ export function ProviderModelsSection({
                     isHidden ? "text-muted-foreground line-through" : "text-foreground/90",
                   )}
                 >
-                  {model.isCustom
-                    ? (getCustomModelLabel(customModelLabels, model.slug) ?? model.name)
-                    : model.name}
+                  {/* Custom rows already have a label editor; keep the API slug
+                      visible so labels never hide which model they map to. */}
+                  {modelRowPrimaryText(model)}
                 </span>
                 {hasDetails ? (
                   <Tooltip>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -69,6 +69,7 @@ interface ProviderModelsSectionProps {
    * `providerInstances[id].config`).
    */
   readonly onChange: (next: ReadonlyArray<string>) => void;
+  readonly onLabelChange: (next: Readonly<Record<string, string>>) => void;
   readonly onHiddenModelsChange: (next: ReadonlyArray<string>) => void;
   readonly onFavoriteModelsChange: (next: ReadonlyArray<string>) => void;
   readonly onModelOrderChange: (next: ReadonlyArray<string>) => void;
@@ -95,6 +96,7 @@ export function ProviderModelsSection({
   favoriteModels,
   modelOrder,
   onChange,
+  onLabelChange,
   onHiddenModelsChange,
   onFavoriteModelsChange,
   onModelOrderChange,
@@ -155,6 +157,11 @@ export function ProviderModelsSection({
     onChange(customModels.filter((model) => model !== slug));
     onModelOrderChange(modelOrder.filter((model) => model !== slug));
     onFavoriteModelsChange(favoriteModels.filter((model) => model !== slug));
+    if (customModelLabels[slug] !== undefined) {
+      const nextLabels = { ...customModelLabels };
+      delete nextLabels[slug];
+      onLabelChange(nextLabels);
+    }
     setError(null);
   };
 
@@ -234,6 +241,21 @@ export function ProviderModelsSection({
               )}
             >
               <div className="flex min-w-0 items-center gap-1">
+                {model.isCustom ? (
+                  <Input
+                    className="h-6 min-w-0 max-w-44 text-xs"
+                    defaultValue={customModelLabels[model.slug] ?? ""}
+                    placeholder="Display label (optional)"
+                    aria-label={`Display label for ${model.slug}`}
+                    onBlur={(event) => {
+                      const label = event.currentTarget.value.trim();
+                      const nextLabels = { ...customModelLabels };
+                      if (label) nextLabels[model.slug] = label;
+                      else delete nextLabels[model.slug];
+                      onLabelChange(nextLabels);
+                    }}
+                  />
+                ) : null}
                 <span
                   className={cn(
                     "min-w-0 truncate text-xs",

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -302,4 +302,54 @@ describe("instance-scoped model selection", () => {
       model: "openai/gpt-5.5",
     });
   });
+
+  it("applies persisted labels to custom models already present in the snapshot", () => {
+    const providers = [
+      {
+        ...provider({
+          instanceId: "claude_openrouter",
+          models: ["claude-sonnet-4-6"],
+        }),
+        models: [
+          {
+            slug: "claude-sonnet-4-6",
+            name: "claude-sonnet-4-6",
+            isCustom: false,
+            capabilities: {},
+          },
+          {
+            slug: "openai/gpt-5.5",
+            name: "openai/gpt-5.5",
+            isCustom: true,
+            capabilities: {},
+          },
+        ],
+      },
+    ];
+    const settings: UnifiedSettings = {
+      ...settingsWithProviderInstances(),
+      providerInstances: {
+        ...settingsWithProviderInstances().providerInstances,
+        [ProviderInstanceId.make("claude_openrouter")]: {
+          driver: ProviderDriverKind.make("claudeAgent"),
+          config: {
+            customModels: ["openai/gpt-5.5"],
+            customModelLabels: { "openai/gpt-5.5": "GPT 5.5 Display" },
+          },
+        },
+      },
+    };
+    const openrouter = deriveProviderInstanceEntries(providers).find(
+      (entry) => entry.instanceId === "claude_openrouter",
+    )!;
+
+    const option = getAppModelOptionsForInstance(settings, openrouter).find(
+      (entry) => entry.slug === "openai/gpt-5.5",
+    );
+    expect(option).toMatchObject({
+      slug: "openai/gpt-5.5",
+      name: "GPT 5.5 Display",
+      isCustom: true,
+    });
+  });
 });

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -180,6 +180,43 @@ export function normalizeCustomModelSlugs(
   return normalizedModels;
 }
 
+/**
+ * Merge persisted display labels into already-present options, and append any
+ * custom slugs that are not yet in the list. Built-in slugs listed in
+ * `customModels` are treated as custom rows when a label is applied.
+ */
+function applyCustomModelLabelsToOptions(
+  options: AppModelOption[],
+  labels: Readonly<Record<string, string>>,
+  customModels: ReadonlyArray<string>,
+  builtInModelSlugs: ReadonlySet<string>,
+  seen: Set<string>,
+): void {
+  // First pass: override names for options already present (server snapshot)
+  // when the user has a persisted label for that slug.
+  for (const option of options) {
+    const label = getCustomModelLabel(labels, option.slug);
+    if (!label) continue;
+    option.name = label;
+    if (customModels.some((candidate) => normalizeCustomModelSlug(candidate) === option.slug)) {
+      option.isCustom = true;
+    }
+  }
+
+  for (const slug of normalizeCustomModelSlugs(customModels, builtInModelSlugs)) {
+    if (seen.has(slug)) {
+      continue;
+    }
+
+    seen.add(slug);
+    options.push({
+      slug,
+      name: getCustomModelLabel(labels, slug) ?? slug,
+      isCustom: true,
+    });
+  }
+}
+
 export function getAppModelOptions(
   settings: UnifiedSettings,
   providers: ReadonlyArray<ServerProvider>,
@@ -201,18 +238,7 @@ export function getAppModelOptions(
   const defaultInstanceId = defaultInstanceIdForDriver(provider);
   const customModels = readInstanceCustomModels(settings, defaultInstanceId, provider);
   const labels = readInstanceCustomModelLabels(settings, defaultInstanceId, provider);
-  for (const slug of normalizeCustomModelSlugs(customModels, builtInModelSlugs)) {
-    if (seen.has(slug)) {
-      continue;
-    }
-
-    seen.add(slug);
-    options.push({
-      slug,
-      name: getCustomModelLabel(labels, slug) ?? slug,
-      isCustom: true,
-    });
-  }
+  applyCustomModelLabelsToOptions(options, labels, customModels, builtInModelSlugs, seen);
 
   return applyInstanceModelPreferences(
     options,
@@ -245,14 +271,7 @@ export function getAppModelOptionsForInstance(
 
   const customModels = readInstanceCustomModels(settings, entry.instanceId, entry.driverKind);
   const labels = readInstanceCustomModelLabels(settings, entry.instanceId, entry.driverKind);
-  for (const slug of normalizeCustomModelSlugs(customModels, builtInModelSlugs)) {
-    if (seen.has(slug)) {
-      continue;
-    }
-
-    seen.add(slug);
-    options.push({ slug, name: getCustomModelLabel(labels, slug) ?? slug, isCustom: true });
-  }
+  applyCustomModelLabelsToOptions(options, labels, customModels, builtInModelSlugs, seen);
 
   return applyInstanceModelPreferences(
     options,

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -9,6 +9,7 @@ import {
 } from "@t3tools/contracts";
 import {
   createModelSelection,
+  getCustomModelLabel,
   normalizeCustomModelSlug,
   resolveSelectableModel,
 } from "@t3tools/shared/model";
@@ -208,7 +209,7 @@ export function getAppModelOptions(
     seen.add(slug);
     options.push({
       slug,
-      name: labels[slug]?.trim() || slug,
+      name: getCustomModelLabel(labels, slug) ?? slug,
       isCustom: true,
     });
   }
@@ -250,7 +251,7 @@ export function getAppModelOptionsForInstance(
     }
 
     seen.add(slug);
-    options.push({ slug, name: labels[slug]?.trim() || slug, isCustom: true });
+    options.push({ slug, name: getCustomModelLabel(labels, slug) ?? slug, isCustom: true });
   }
 
   return applyInstanceModelPreferences(

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -69,6 +69,41 @@ function readInstanceCustomModels(
   return legacyProviders[driverKind]?.customModels ?? [];
 }
 
+function readInstanceCustomModelLabels(
+  settings: UnifiedSettings,
+  instanceId: ProviderInstanceId,
+  driverKind: ProviderDriverKind,
+): Readonly<Record<string, string>> {
+  const instance = settings.providerInstances?.[instanceId];
+  const config = instance?.config;
+  if (config !== null && typeof config === "object") {
+    const value = (config as Record<string, unknown>).customModelLabels;
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return Object.fromEntries(
+        Object.entries(value).filter(
+          (entry): entry is [string, string] =>
+            typeof entry[0] === "string" &&
+            typeof entry[1] === "string" &&
+            entry[1].trim().length > 0,
+        ),
+      );
+    }
+  }
+  const defaultInstanceId = defaultInstanceIdForDriver(driverKind);
+  if (instanceId !== defaultInstanceId) return {};
+  const legacy = (settings.providers as Record<string, unknown>)[driverKind];
+  if (!legacy || typeof legacy !== "object") return {};
+  const labels = (legacy as Record<string, unknown>).customModelLabels;
+  return labels && typeof labels === "object" && !Array.isArray(labels)
+    ? Object.fromEntries(
+        Object.entries(labels).filter(
+          (entry): entry is [string, string] =>
+            typeof entry[1] === "string" && entry[1].trim().length > 0,
+        ),
+      )
+    : {};
+}
+
 export interface AppModelOption {
   slug: string;
   name: string;
@@ -164,6 +199,7 @@ export function getAppModelOptions(
   // see the user's authored custom models.
   const defaultInstanceId = defaultInstanceIdForDriver(provider);
   const customModels = readInstanceCustomModels(settings, defaultInstanceId, provider);
+  const labels = readInstanceCustomModelLabels(settings, defaultInstanceId, provider);
   for (const slug of normalizeCustomModelSlugs(customModels, builtInModelSlugs)) {
     if (seen.has(slug)) {
       continue;
@@ -172,7 +208,7 @@ export function getAppModelOptions(
     seen.add(slug);
     options.push({
       slug,
-      name: slug,
+      name: labels[slug]?.trim() || slug,
       isCustom: true,
     });
   }
@@ -207,13 +243,14 @@ export function getAppModelOptionsForInstance(
   );
 
   const customModels = readInstanceCustomModels(settings, entry.instanceId, entry.driverKind);
+  const labels = readInstanceCustomModelLabels(settings, entry.instanceId, entry.driverKind);
   for (const slug of normalizeCustomModelSlugs(customModels, builtInModelSlugs)) {
     if (seen.has(slug)) {
       continue;
     }
 
     seen.add(slug);
-    options.push({ slug, name: slug, isCustom: true });
+    options.push({ slug, name: labels[slug]?.trim() || slug, isCustom: true });
   }
 
   return applyInstanceModelPreferences(

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -33,6 +33,17 @@ describe("ClientSettings word wrap", () => {
   });
 });
 
+describe("Claude custom model labels", () => {
+  it("keeps labels optional for old settings and accepts the patch field", () => {
+    expect(decodeServerSettings({}).providers.claudeAgent.customModelLabels).toBeUndefined();
+    expect(
+      decodeServerSettingsPatch({
+        providers: { claudeAgent: { customModelLabels: { "claude-sonnet-4-6": "Sonnet 4.6" } } },
+      }).providers?.claudeAgent?.customModelLabels,
+    ).toEqual({ "claude-sonnet-4-6": "Sonnet 4.6" });
+  });
+});
+
 describe("ClientSettings glass opacity", () => {
   it("defaults to a readable translucent surface", () => {
     expect(decodeClientSettings({}).glassOpacity).toBe(80);

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -44,6 +44,24 @@ describe("Claude custom model labels", () => {
   });
 });
 
+describe("provider custom model labels round-trip", () => {
+  // Every provider that accepts customModelLabels on a PATCH must also keep
+  // the field on its full ServerSettings schema — otherwise the labels are
+  // stripped during normalizeServerSettings and never persist.
+  for (const provider of ["codex", "claudeAgent", "cursor", "grok", "opencode"] as const) {
+    it(`persists ${provider} labels through a full decode round-trip`, () => {
+      const decoded = decodeServerSettings({
+        providers: {
+          [provider]: { customModelLabels: { "model/a[1m]": "Display A" } },
+        },
+      } as typeof ServerSettings.Encoded);
+      expect(decoded.providers[provider].customModelLabels).toEqual({
+        "model/a[1m]": "Display A",
+      });
+    });
+  }
+});
+
 describe("ClientSettings glass opacity", () => {
   it("defaults to a readable translucent surface", () => {
     expect(decodeClientSettings({}).glassOpacity).toBe(80);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -398,6 +398,7 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
   },
   {
     order: ["binaryPath", "serverUrl", "serverPassword"],

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -241,6 +241,7 @@ export const CodexSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
   },
   {
     order: ["binaryPath", "homePath", "shadowHomePath", "launchArgs"],
@@ -321,6 +322,7 @@ export const CursorSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
   },
   {
     order: ["binaryPath", "apiEndpoint"],
@@ -345,6 +347,7 @@ export const GrokSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
   },
   {
     order: ["binaryPath"],
@@ -593,6 +596,7 @@ const CodexSettingsPatch = Schema.Struct({
   shadowHomePath: Schema.optionalKey(TrimmedString),
   launchArgs: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
 });
 
 const ClaudeSettingsPatch = Schema.Struct({
@@ -609,12 +613,14 @@ const CursorSettingsPatch = Schema.Struct({
   binaryPath: Schema.optionalKey(TrimmedString),
   apiEndpoint: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
 });
 
 const GrokSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
 });
 
 const OpenCodeSettingsPatch = Schema.Struct({
@@ -623,6 +629,7 @@ const OpenCodeSettingsPatch = Schema.Struct({
   serverUrl: Schema.optionalKey(TrimmedString),
   serverPassword: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
 });
 
 export const ServerSettingsPatch = Schema.Struct({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -274,6 +274,7 @@ export const ClaudeSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
     launchArgs: Schema.String.pipe(
       Schema.withDecodingDefault(Effect.succeed("")),
       Schema.annotateKey({
@@ -599,6 +600,7 @@ const ClaudeSettingsPatch = Schema.Struct({
   binaryPath: Schema.optionalKey(TrimmedString),
   homePath: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
   launchArgs: Schema.optionalKey(TrimmedString),
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -241,7 +241,9 @@ export const CodexSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
-    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)).pipe(
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
   },
   {
     order: ["binaryPath", "homePath", "shadowHomePath", "launchArgs"],
@@ -275,7 +277,9 @@ export const ClaudeSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
-    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)).pipe(
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
     launchArgs: Schema.String.pipe(
       Schema.withDecodingDefault(Effect.succeed("")),
       Schema.annotateKey({
@@ -322,7 +326,9 @@ export const CursorSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
-    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)).pipe(
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
   },
   {
     order: ["binaryPath", "apiEndpoint"],
@@ -347,7 +353,9 @@ export const GrokSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
-    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)).pipe(
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
   },
   {
     order: ["binaryPath"],
@@ -398,7 +406,9 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
-    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+    customModelLabels: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)).pipe(
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
   },
   {
     order: ["binaryPath", "serverUrl", "serverPassword"],

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -5,6 +5,7 @@ import {
   buildProviderOptionSelectionsFromDescriptors,
   createModelCapabilities,
   createModelSelection,
+  getCustomModelLabel,
   getModelSelectionBooleanOptionValue,
   getModelSelectionStringOptionValue,
   getProviderOptionDescriptors,
@@ -153,5 +154,14 @@ describe("model slug normalization", () => {
 
     expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-5");
     expect(normalizeCustomModelSlug(" opus ")).toBe("opus");
+  });
+});
+
+describe("getCustomModelLabel", () => {
+  it("returns trimmed own labels and ignores inherited prototype keys", () => {
+    expect(getCustomModelLabel({ "gpt-5": "  GPT 5  " }, "gpt-5")).toBe("GPT 5");
+    expect(getCustomModelLabel({ "gpt-5": "   " }, "gpt-5")).toBeNull();
+    expect(getCustomModelLabel({}, "__proto__")).toBeNull();
+    expect(getCustomModelLabel({ constructor: "nope" }, "constructor")).toBe("nope");
   });
 });

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -263,8 +263,11 @@ export function getCustomModelLabel(
   slug: string,
 ): string | null {
   const normalized = normalizeCustomModelSlug(slug);
-  if (!normalized) return null;
-  const label = labels?.[normalized];
+  if (!normalized || !labels) return null;
+  // Own-property only: bare `labels[slug]` can hit Object.prototype for
+  // hostile keys like `__proto__` / `constructor` and then crash on `.trim()`.
+  if (!Object.prototype.hasOwnProperty.call(labels, normalized)) return null;
+  const label = labels[normalized];
   return typeof label === "string" && label.trim() ? label.trim() : null;
 }
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -257,6 +257,17 @@ export function normalizeCustomModelSlug(model: string | null | undefined): stri
   return model.trim() || null;
 }
 
+/** Resolve a persisted display label using the same trimmed custom slug key. */
+export function getCustomModelLabel(
+  labels: Readonly<Record<string, string>> | null | undefined,
+  slug: string,
+): string | null {
+  const normalized = normalizeCustomModelSlug(slug);
+  if (!normalized) return null;
+  const label = labels?.[normalized];
+  return typeof label === "string" && label.trim() ? label.trim() : null;
+}
+
 export function resolveSelectableModel(
   provider: ProviderDriverKind,
   value: string | null | undefined,


### PR DESCRIPTION
## Summary

Adds generic, persistent `customModelLabels` so users can assign human-readable display names to custom models without changing the exact model slug used for API calls.

### What changed
- **Persistent labels** stored in server settings as optional `customModelLabels: Record<string, string>`
- **Exact slug preservation** — labels are display-only; the real model id/slug is unchanged for requests
- **`[1m]` context suffixes** still surface correctly when present on the model id
- **All five providers** — Codex, Claude, Cursor, Grok, and OpenCode
- **Backward compatible** — field is optional; existing settings without labels continue to work
- **OpenCode fix** — labels are included in the full `OpenCodeSettings` schema (so they survive `normalizeServerSettings` round-trips) and forwarded on every `providerModelsFromSettings` path (success, disabled, version-too-old, pending, error)

### Tests / builds
- Per-provider decode round-trip coverage for `customModelLabels` (all five providers)
- OpenCode success-path test asserting labels reach the rendered model list
- Local typecheck/tests exercised during development

### Notes
- Unrelated pre-existing warnings may still appear in the monorepo toolchain; this PR does not introduce Gateway Manager-specific logic or secrets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only metadata on existing custom-model flows; optional settings field with backward compatibility and no change to request model IDs.
> 
> **Overview**
> Adds optional **`customModelLabels`** (`slug → display name`) on provider settings and instance config so custom models can show friendly names in the UI and model picker while **API slugs stay exact**.
> 
> **Contracts & shared:** New optional field on Codex, Claude, Cursor, Grok, and OpenCode settings (full schema + patch). **`getCustomModelLabel`** resolves labels with trimmed keys and own-property checks. **`providerModelsFromSettings`** applies labels to custom entries and can mark built-in slugs as custom when listed in `customModels`.
> 
> **Server:** All provider snapshot paths forward labels into model list construction (pending, probe success/error, Codex append helpers).
> 
> **Web:** Settings cards persist labels; **`ProviderModelsSection`** adds optional label inputs per custom row (slug still shown), with atomic **`customModels` + `customModelLabels`** updates and blur-safe label caching. **`modelSelection`** merges labels into app model options for legacy and instance-scoped pickers.
> 
> Tests cover round-trip persistence, per-provider probes, prototype-key safety, and UI helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fbc77ab77a307e1cff4b065b71a008d0644bfd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add persistent custom model display labels for all providers
> - Adds `customModelLabels` (a slug→label map) to the settings schemas for Claude, Codex, Cursor, Grok, and OpenCode providers in [settings.ts](https://github.com/pingdotgg/t3code/pull/4997/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), persisting labels via existing PATCH endpoints.
> - Introduces `getCustomModelLabel` in [model.ts](https://github.com/pingdotgg/t3code/pull/4997/files#diff-6319cd97b4ed5842958c7fbc93b4ed733efa158c2b1ad15c1d54bcddea713505) as a shared util for safe label resolution, guarding against prototype collisions and empty strings.
> - Extends `providerModelsFromSettings` in [providerSnapshot.ts](https://github.com/pingdotgg/t3code/pull/4997/files#diff-62373f674410fb63637739f0efeb07b9ef79b579393ae2adf51567de0b812b26) and all per-provider status/snapshot functions to apply labels when building model lists, including fallback and error paths.
> - Updates [ProviderModelsSection.tsx](https://github.com/pingdotgg/t3code/pull/4997/files#diff-9fcf1c8de4ed79e2e714793beba3ce13ac2b99ce4d1a51781f270d7377ab90be) to render an editable label input for each custom model row and [ProviderInstanceCard.tsx](https://github.com/pingdotgg/t3code/pull/4997/files#diff-abfacda8242e42a51ed23d2b21b91d4822ff52c2dfb6650be36af9d8c82302e9) to persist labels atomically alongside custom model slug changes.
> - Updates `getAppModelOptions` and `getAppModelOptionsForInstance` in [modelSelection.ts](https://github.com/pingdotgg/t3code/pull/4997/files#diff-3bbcb619a0f4b212f9d0b396a6b561103b0630227331138956971e1e960d86f2) to apply persisted labels to model picker options.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fbc77a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->