### PR TITLE
fix(mobile): enable agent activity publishing with Live Activities

### DIFF
--- a/apps/mobile/src/features/agent-awareness/capabilities.ts
+++ b/apps/mobile/src/features/agent-awareness/capabilities.ts
@@ -1,5 +1,6 @@
 import Constants from "expo-constants";
+import { Platform } from "react-native";
 
 export function supportsAgentAwarenessPush() {
-  return Constants.expoConfig?.extra?.iosPersonalTeamBuild !== true;
+  return Platform.OS === "ios" && Constants.expoConfig?.extra?.iosPersonalTeamBuild !== true;
 }

--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, vi } from "vite-plus/test";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import { Platform } from "react-native";
 import { EnvironmentId } from "@t3tools/contracts";
 import { RelayMobileClientId } from "@t3tools/contracts/relay";
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
@@ -189,6 +190,7 @@ function listedEnvironment(environmentId: string) {
 describe("mobile cloud link environment client", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    Object.defineProperty(Platform, "OS", { value: "ios", configurable: true });
     createProofMock.mockClear();
     loadPreferences.mockClear();
   });
@@ -855,6 +857,40 @@ describe("mobile cloud link environment client", () => {
       const preferencesRequest = fetchMock.mock.calls.at(-1)?.[1];
       expect(new Headers(preferencesRequest?.headers).get("authorization")).toBe(
         "Bearer local-bearer",
+      );
+    }),
+  );
+
+  it.effect("does not enable environment activity publishing on Android", () =>
+    Effect.gen(function* () {
+      Object.defineProperty(Platform, "OS", { value: "android", configurable: true });
+      const fetchMock = vi.fn((url: string | URL) => {
+        if (String(url).endsWith("/v1/client/environment-link-challenges")) {
+          return Promise.resolve(Response.json(validLinkChallengeResponse()));
+        }
+        if (String(url).endsWith("/api/connect/link-proof")) {
+          return Promise.resolve(Response.json(validLinkProof()));
+        }
+        if (String(url).endsWith("/v1/client/environment-links")) {
+          return Promise.resolve(Response.json(validLinkResponse()));
+        }
+        return Promise.resolve(
+          Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),
+        );
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      yield* withCloudServices(
+        linkEnvironmentToCloudWithPreference({
+          clerkToken: "clerk-token",
+          connection: savedConnection,
+          liveActivitiesEnabled: true,
+        }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(fetchMock.mock.calls.map(([url]) => String(url))).not.toContain(
+        "https://desktop.example.test/api/connect/preferences",
       );
     }),
   );

--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -148,6 +148,17 @@ function validLinkChallengeResponse() {
   };
 }
 
+function validCloudLinkState() {
+  return {
+    linked: true,
+    cloudUserId: "user_123",
+    relayUrl: "https://relay.example.test",
+    relayIssuer: "https://relay.example.test",
+    managedTunnelActive: true,
+    publishAgentActivity: true,
+  };
+}
+
 function requestBodyText(body: BodyInit | null | undefined): string {
   return body instanceof Uint8Array ? new TextDecoder().decode(body) : String(body ?? "");
 }
@@ -789,10 +800,14 @@ describe("mobile cloud link environment client", () => {
         cloudUserId: "user_123",
         environmentCredential: "environment-credential",
       });
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(fetchMock.mock.calls.map(([url]) => String(url))).not.toContain(
+        "https://desktop.example.test/api/connect/preferences",
+      );
     }),
   );
 
-  it.effect("uses an explicit Live Activity preference when persisted state is unavailable", () =>
+  it.effect("enables environment activity publishing for explicit Live Activities", () =>
     Effect.gen(function* () {
       loadPreferences.mockReturnValueOnce(Effect.die("persisted preferences must not be read"));
       const bodies: Array<Record<string, unknown>> = [];
@@ -809,6 +824,9 @@ describe("mobile cloud link environment client", () => {
         }
         if (String(url).endsWith("/v1/client/environment-links")) {
           return Promise.resolve(Response.json(validLinkResponse()));
+        }
+        if (String(url).endsWith("/api/connect/preferences")) {
+          return Promise.resolve(Response.json(validCloudLinkState()));
         }
         return Promise.resolve(
           Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),
@@ -828,6 +846,16 @@ describe("mobile cloud link environment client", () => {
         expect.objectContaining({ liveActivitiesEnabled: true }),
         expect.objectContaining({ liveActivitiesEnabled: true }),
       ]);
+      expect(bodies.at(-1)).toEqual({ publishAgentActivity: true });
+      expect(fetchMock).toHaveBeenCalledTimes(5);
+      expect(fetchMock.mock.calls.slice(-2).map(([url]) => String(url))).toEqual([
+        "https://desktop.example.test/api/connect/relay-config",
+        "https://desktop.example.test/api/connect/preferences",
+      ]);
+      const preferencesRequest = fetchMock.mock.calls.at(-1)?.[1];
+      expect(new Headers(preferencesRequest?.headers).get("authorization")).toBe(
+        "Bearer local-bearer",
+      );
     }),
   );
 

--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -164,6 +164,25 @@ function requestBodyText(body: BodyInit | null | undefined): string {
   return body instanceof Uint8Array ? new TextDecoder().decode(body) : String(body ?? "");
 }
 
+function successfulEnvironmentLinkResponse(url: string | URL) {
+  const requestUrl = String(url);
+  if (requestUrl.endsWith("/v1/client/environment-link-challenges")) {
+    return Promise.resolve(Response.json(validLinkChallengeResponse()));
+  }
+  if (requestUrl.endsWith("/api/connect/link-proof")) {
+    return Promise.resolve(Response.json(validLinkProof()));
+  }
+  if (requestUrl.endsWith("/v1/client/environment-links")) {
+    return Promise.resolve(Response.json(validLinkResponse()));
+  }
+  if (requestUrl.endsWith("/api/connect/preferences")) {
+    return Promise.resolve(Response.json(validCloudLinkState()));
+  }
+  return Promise.resolve(
+    Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),
+  );
+}
+
 function validDpopAccessTokenResponse(scope = "environment:status environment:connect") {
   return {
     access_token: "relay-dpop-token",
@@ -759,18 +778,7 @@ describe("mobile cloud link environment client", () => {
           // @effect-diagnostics-next-line preferSchemaOverJson:off
           bodies.push(JSON.parse(requestBodyText(init.body)));
         }
-        if (String(url).endsWith("/v1/client/environment-link-challenges")) {
-          return Promise.resolve(Response.json(validLinkChallengeResponse()));
-        }
-        if (String(url).endsWith("/api/connect/link-proof")) {
-          return Promise.resolve(Response.json(validLinkProof()));
-        }
-        if (String(url).endsWith("/v1/client/environment-links")) {
-          return Promise.resolve(Response.json(validLinkResponse()));
-        }
-        return Promise.resolve(
-          Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),
-        );
+        return successfulEnvironmentLinkResponse(url);
       });
       vi.stubGlobal("fetch", fetchMock);
 
@@ -818,21 +826,7 @@ describe("mobile cloud link environment client", () => {
           // @effect-diagnostics-next-line preferSchemaOverJson:off
           bodies.push(JSON.parse(requestBodyText(init.body)) as Record<string, unknown>);
         }
-        if (String(url).endsWith("/v1/client/environment-link-challenges")) {
-          return Promise.resolve(Response.json(validLinkChallengeResponse()));
-        }
-        if (String(url).endsWith("/api/connect/link-proof")) {
-          return Promise.resolve(Response.json(validLinkProof()));
-        }
-        if (String(url).endsWith("/v1/client/environment-links")) {
-          return Promise.resolve(Response.json(validLinkResponse()));
-        }
-        if (String(url).endsWith("/api/connect/preferences")) {
-          return Promise.resolve(Response.json(validCloudLinkState()));
-        }
-        return Promise.resolve(
-          Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),
-        );
+        return successfulEnvironmentLinkResponse(url);
       });
       vi.stubGlobal("fetch", fetchMock);
 
@@ -864,20 +858,7 @@ describe("mobile cloud link environment client", () => {
   it.effect("does not enable environment activity publishing on Android", () =>
     Effect.gen(function* () {
       Object.defineProperty(Platform, "OS", { value: "android", configurable: true });
-      const fetchMock = vi.fn((url: string | URL) => {
-        if (String(url).endsWith("/v1/client/environment-link-challenges")) {
-          return Promise.resolve(Response.json(validLinkChallengeResponse()));
-        }
-        if (String(url).endsWith("/api/connect/link-proof")) {
-          return Promise.resolve(Response.json(validLinkProof()));
-        }
-        if (String(url).endsWith("/v1/client/environment-links")) {
-          return Promise.resolve(Response.json(validLinkResponse()));
-        }
-        return Promise.resolve(
-          Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),
-        );
-      });
+      const fetchMock = vi.fn(successfulEnvironmentLinkResponse);
       vi.stubGlobal("fetch", fetchMock);
 
       yield* withCloudServices(

--- a/apps/mobile/src/features/cloud/linkEnvironment.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.ts
@@ -32,6 +32,7 @@ import { authClientMetadata } from "../../lib/authClientMetadata";
 import type { SavedRemoteConnection } from "../../lib/connection";
 import * as MobilePreferences from "../../persistence/mobile-preferences";
 import * as MobileStorage from "../../persistence/mobile-storage";
+import { supportsAgentAwarenessPush } from "../agent-awareness/capabilities";
 import { resolveCloudPublicConfig } from "./publicConfig";
 
 const RELAY_STATUS_AND_CONNECT_SCOPES = [
@@ -359,7 +360,7 @@ export function linkEnvironmentToCloudWithPreference(
         Effect.mapError(cloudEnvironmentLinkError("Could not configure environment relay access.")),
       );
 
-    if (liveActivitiesEnabled) {
+    if (liveActivitiesEnabled && supportsAgentAwarenessPush()) {
       yield* environmentClient.connect
         .preferences({
           headers: { authorization: `Bearer ${localBearerToken}` },

--- a/apps/mobile/src/features/cloud/linkEnvironment.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.ts
@@ -358,6 +358,19 @@ export function linkEnvironmentToCloudWithPreference(
       .pipe(
         Effect.mapError(cloudEnvironmentLinkError("Could not configure environment relay access.")),
       );
+
+    if (liveActivitiesEnabled) {
+      yield* environmentClient.connect
+        .preferences({
+          headers: { authorization: `Bearer ${localBearerToken}` },
+          payload: { publishAgentActivity: true },
+        })
+        .pipe(
+          Effect.mapError(
+            cloudEnvironmentLinkError("Could not enable environment agent activity publishing."),
+          ),
+        );
+    }
   });
 }
 


### PR DESCRIPTION
Enabling Live Activity Updates links the phone and environment through T3 Connect, but the mobile linker never enables agent activity publishing on the environment. The setting can therefore look enabled while the server emits no activity updates.

After relay configuration succeeds, the mobile linker now enables `publishAgentActivity` through the environment's existing authenticated preferences endpoint. This only happens on supported iOS builds when Live Activities are enabled, so Android cannot accidentally enable an unusable publisher and disabling Live Activities does not overwrite an independently managed publishing preference.

The focused tests cover the enabled request, bearer authentication, request ordering, and the disabled and unsupported-platform no-op paths.

## Validation

- `vp test run apps/mobile/src/features/cloud/linkEnvironment.test.ts` — 22 passed
- mobile TypeScript typecheck
- targeted lint and format checks
- autoreview — clean, no accepted/actionable findings

App-level iOS QA was not available because the current host is Linux without an iOS simulator; no Android SDK/emulator is installed either.

Implemented by GPT-5.6 Sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a post-link environment API call during cloud linking using the local bearer token; behavior is gated to iOS + Live Activities but failures surface as link errors.
> 
> **Overview**
> Fixes a gap where **Live Activities** could look enabled after T3 Connect linking, but the environment never turned on **agent activity publishing**, so no activity updates were emitted.
> 
> After relay configuration succeeds during cloud environment linking, the mobile linker now calls the environment’s authenticated **preferences** endpoint with `publishAgentActivity: true` when Live Activities are enabled. **`supportsAgentAwarenessPush`** is tightened to **iOS only** (`Platform.OS === "ios"`), so Android skips that call even if Live Activities is passed as enabled.
> 
> When Live Activities stay disabled, linking behavior is unchanged—no preferences request—and tests cover iOS success (ordering, bearer auth, payload), disabled Live Activities, and Android no-op paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ebc6b122cb09dcb23ea9069d4351493e5283744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable agent activity publishing via Live Activities on iOS when linking a cloud environment
> - When linking a cloud environment with `liveActivitiesEnabled: true`, [linkEnvironment.ts](https://github.com/pingdotgg/t3code/pull/4998/files#diff-14699cfea77b0136e19c830618d4732f12baf0fadf700dee05707865269277e1) now issues an authenticated `POST` to the preferences endpoint with `{ publishAgentActivity: true }`.
> - `supportsAgentAwarenessPush` in [capabilities.ts](https://github.com/pingdotgg/t3code/pull/4998/files#diff-3c6247af989b8207ba9606467e5c9e7461ef0f09f423a9f54d62a46cf1170c79) now gates on `Platform.OS === 'ios'`, so the preferences call is skipped entirely on Android.
> - Behavioral Change: non-iOS platforms no longer call the preferences endpoint during environment linking, even if `liveActivitiesEnabled` is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ebc6b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->