### PR TITLE
fix(mobile): keep the composer from covering the last message on thread open

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -82,6 +82,8 @@ export const COMPOSER_COLLAPSED_CHROME = 60;
  */
 export const COMPOSER_EXPANDED_CHROME = 174;
 
+export const COMPOSER_PENDING_CARD_MIN_CHROME = 160;
+
 export interface ThreadComposerProps {
   readonly draftMessage: string;
   readonly draftAttachments: ReadonlyArray<DraftComposerImageAttachment>;

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -16,7 +16,12 @@ import type {
 } from "@t3tools/contracts";
 import * as Haptics from "expo-haptics";
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Platform, View, type GestureResponderEvent } from "react-native";
+import {
+  Platform,
+  View,
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+} from "react-native";
 import { KeyboardController, KeyboardStickyView } from "react-native-keyboard-controller";
 import Animated, { FadeInDown, FadeOut } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -37,6 +42,7 @@ import { PendingUserInputCard } from "./PendingUserInputCard";
 import {
   COMPOSER_COLLAPSED_CHROME,
   COMPOSER_EXPANDED_CHROME,
+  COMPOSER_PENDING_CARD_MIN_CHROME,
   ThreadComposer,
 } from "./ThreadComposer";
 import { ThreadFeed } from "./ThreadFeed";
@@ -180,7 +186,13 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const selectedThreadKeyRef = useRef(selectedThreadKey);
   const lastScrolledAnchorMessageIdRef = useRef<MessageId | null>(null);
   const [composerExpanded, setComposerExpanded] = useState(false);
+  const composerExpandedRef = useRef(false);
+  const handleComposerExpandedChange = useCallback((expanded: boolean) => {
+    composerExpandedRef.current = expanded;
+    setComposerExpanded(expanded);
+  }, []);
   const [anchorMessageId, setAnchorMessageId] = useState<MessageId | null>(null);
+  const [composerMeasuredHeight, setComposerMeasuredHeight] = useState<number | null>(null);
   const composerBottomInset = composerExpanded ? 0 : Math.max(insets.bottom, 12);
   const contentPresentationKind = props.contentPresentation.kind;
   // The raw sync status enters "synchronizing" on every full fetch, cached or
@@ -201,7 +213,11 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   })();
   const selectedThreadFeed = props.selectedThreadFeed;
   const composerChrome = composerExpanded ? COMPOSER_EXPANDED_CHROME : COMPOSER_COLLAPSED_CHROME;
-  const composerOverlapHeight = composerChrome + composerBottomInset;
+  const composerExtraChrome =
+    ((props.activePendingApproval === null ? 0 : 1) +
+      (props.activePendingUserInput === null ? 0 : 1)) *
+    COMPOSER_PENDING_CARD_MIN_CHROME;
+  const composerOverlapHeight = composerChrome + composerExtraChrome + composerBottomInset;
   const estimatedOverlayHeight = composerOverlapHeight;
   // The overlay's measured height includes the home-indicator inset (the
   // composer pads it), but contentInsetAdjustmentBehavior="automatic" makes
@@ -217,6 +233,16 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
     composerOverlayRef,
     Math.max(0, estimatedOverlayHeight - nativeInsetOvercount),
     -nativeInsetOvercount,
+  );
+  const handleComposerOverlayLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      onComposerLayout(event);
+      // expanded = keyboard transition, which manages its own inset
+      if (!composerExpandedRef.current) {
+        setComposerMeasuredHeight(event.nativeEvent.layout.height);
+      }
+    },
+    [onComposerLayout],
   );
   const { freeze, scrollMessageToEnd } = useKeyboardScrollToEnd({ listRef });
   const showContent = props.showContent ?? true;
@@ -240,6 +266,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
     setAnchorMessageId(null);
     lastScrolledAnchorMessageIdRef.current = null;
     freeze.set(false);
+    setComposerMeasuredHeight(null);
   }, [freeze, selectedThreadKey]);
 
   useEffect(() => {
@@ -364,6 +391,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
             freeze={freeze}
             anchorMessageId={anchorMessageId}
             contentInsetEndAdjustment={contentInsetEndAdjustment}
+            composerMeasuredHeight={composerMeasuredHeight}
             contentTopInset={0}
             contentBottomInset={estimatedOverlayHeight}
             contentMaxWidth={contentMaxWidth}
@@ -386,7 +414,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
           {/* No paddingTop here: the overlay's measured height becomes the
               list's bottom inset, so any padding above the pill/composer
               pushes the resting content floor up by the same amount. */}
-          <View ref={composerOverlayRef} onLayout={onComposerLayout} className="w-full">
+          <View ref={composerOverlayRef} onLayout={handleComposerOverlayLayout} className="w-full">
             <View className="w-full self-center" style={{ maxWidth: contentMaxWidth }}>
               {props.activePendingApproval || props.activePendingUserInput ? (
                 <Animated.View
@@ -443,7 +471,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
               onUpdateModelSelection={props.onUpdateThreadModelSelection}
               onUpdateRuntimeMode={props.onUpdateThreadRuntimeMode}
               onUpdateInteractionMode={props.onUpdateThreadInteractionMode}
-              onExpandedChange={setComposerExpanded}
+              onExpandedChange={handleComposerExpandedChange}
             />
           </View>
         </KeyboardStickyView>

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -157,6 +157,7 @@ export interface ThreadFeedProps {
   readonly freeze: SharedValue<boolean>;
   readonly anchorMessageId: MessageId | null;
   readonly contentInsetEndAdjustment: SharedValue<number>;
+  readonly composerMeasuredHeight?: number | null;
   readonly contentTopInset?: number;
   readonly contentBottomInset?: number;
   readonly contentMaxWidth?: number;
@@ -1438,6 +1439,10 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
   // only region where layout shifts should animate. Starts true because the
   // list opens pinned to the end.
   const nearListEnd = useSharedValue(true);
+  const userDraggedSinceMountRef = useRef(false);
+  const handleScrollBeginDrag = useCallback(() => {
+    userDraggedSinceMountRef.current = true;
+  }, []);
 
   const handleScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -1526,12 +1531,29 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
   // composer-height short of the end. Layout effect: it must land before the
   // list's first positioning tick or the one-shot initial scroll misses it.
   const listMountKey = `${props.threadId}:${props.feed.length === 0 ? "empty" : "filled"}`;
+  const lastReprimedMountKeyRef = useRef<string | null>(null);
   useLayoutEffect(() => {
     const bottom = props.contentInsetEndAdjustment.value;
-    if (bottom > 0) {
-      props.listRef.current?.reportContentInset({ bottom });
+    const isInitialMountForKey = lastReprimedMountKeyRef.current !== listMountKey;
+    lastReprimedMountKeyRef.current = listMountKey;
+    if (isInitialMountForKey) {
+      nearListEnd.value = true;
+      userDraggedSinceMountRef.current = false;
     }
-  }, [listMountKey, props.contentInsetEndAdjustment, props.listRef]);
+    if (bottom <= 0) {
+      return;
+    }
+    props.listRef.current?.reportContentInset({ bottom });
+    if (!isInitialMountForKey && nearListEnd.value && !userDraggedSinceMountRef.current) {
+      props.listRef.current?.scrollToEnd({ animated: true });
+    }
+  }, [
+    listMountKey,
+    props.composerMeasuredHeight,
+    props.contentInsetEndAdjustment,
+    props.listRef,
+    nearListEnd,
+  ]);
 
   const anchoredEndSpace = useMemo(
     () =>
@@ -1891,6 +1913,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             alignItemsAtEnd
             initialScrollAtEnd
             onScroll={handleScroll}
+            onScrollBeginDrag={handleScrollBeginDrag}
             scrollEventThrottle={16}
             ListHeaderComponent={
               usesNativeAutomaticInsets ? null : <View style={{ height: topContentInset }} />


### PR DESCRIPTION
## What changed

Opening a remote thread could leave the last message pinned underneath the chat input bar, with no way to scroll down to it.

## Why it happens

The feed's bottom inset is derived from an **asynchronous measurement** of the floating composer (`onComposerLayout` → `contentInsetEndAdjustment`), not from layout flow — the composer is an absolutely-positioned overlay, so the list has to reserve space for it explicitly.

Meanwhile `ThreadFeed` remounts its list **synchronously** the moment messages arrive (the `empty`→`filled` `listMountKey`) and primes the fresh instance from whatever that shared value currently holds.

The composer's real height is data-dependent too. The `"Loading messages..."` / `"Syncing messages..."` pill and the pending approval / user-input cards appear on that *same* transition, animated over 220ms. So the composer's true height lands a frame or more after the list has already finished its initial end-positioning against a stale, too-small inset — and nothing re-scrolls afterwards.

On top of the timing race, the status pill was rendered **outside layout flow** (`absolute bottom-full` inside the composer), so the overlay's `onLayout` measurement never included it at all — the reserved inset was structurally wrong whenever the pill was visible, not just transiently.

## The fix

Three parts — the measurement, the correction, and the estimate each needed work:

- **Make the measurement truthful.** The status pill now renders in normal layout flow inside the measured composer overlay (next to the pending approval/user-input cards, which already lived there), instead of absolutely positioned inside `ThreadComposer`. The overlay's `onLayout` height therefore genuinely includes everything the feed must reserve space for, and "the real measurement wins" is actually correct. This also collapses the duplicated `composerConnectionStatus` computation (screen-side estimate vs composer-side render) into one call, and drops the composer props that only existed to feed the pill.

- **Correct once the real height is known.** The composer's measured height is mirrored into plain React state (the reanimated shared value can't trigger effects) and threaded to `ThreadFeed`, which distinguishes the initial prime for a fresh list from a later correction. When the height changes post-mount it re-reports the inset and re-pins to the end if the user is still near it.

- **Over-reserve during the pre-measurement frames.** The seed estimate adds conservative chrome for the status pill and pending cards whenever they're knowable synchronously from props, so the brief window before the first `onLayout` errs tall rather than short. These constants are now only first-frame seeds (the standard estimated-size pattern) — correctness no longer depends on them, since the real measurement includes the pill and cards and always overrides.

Also tightens the `bottom > 0` guard, which previously let a zero-inset mount count as primed and skip the corrective path entirely.

## Notes

No visual change when things go right — the pill sits a few px higher (it now clears the composer's top padding), otherwise this only affects the failure case. Addresses the high-severity finding from Cursor Bugbot and Macroscope that the absolutely-positioned pill was excluded from the measured height.

## Verification

- `tsc --noEmit` clean
- `vp lint` clean on changed files
- Full mobile suite green (580 tests)

Branched off current `main`; the patch applies cleanly on top of #4882.

## Related issues

No open issue tracks this exact mobile bug, so nothing is auto-closed. Related but **not** closed by this PR: #4619 — the web `ChatView` has the same architecture (composer overlay measurement feeding LegendList's `contentInsetEndAdjustment`) and shows the mirror-image transient symptom (over-inset blank space at the end of long threads, self-correcting later). Its "stale composer measurement" investigation lead matches the race fixed here; the web side likely wants the same late-measurement correction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat list inset priming and auto scroll-to-end behavior on inset updates; wrong guards could surprise users who scrolled up, but changes are scoped to near-bottom, no-drag cases.
> 
> **Overview**
> Fixes mobile thread open where the **last message could sit under the floating composer** because the feed’s bottom inset was seeded from estimates and async `onLayout` while `ThreadFeed` remounts when messages arrive.
> 
> **`ThreadDetailScreen`** adds **`COMPOSER_PENDING_CARD_MIN_CHROME`** to the overlap estimate when pending approval or user-input cards are active, tracks **collapsed composer overlay height** from layout (skipping updates while the composer is keyboard-expanded), and passes **`composerMeasuredHeight`** into the feed.
> 
> **`ThreadFeed`** reprimes LegendList’s bottom inset on mount and when that measured height changes: initial mount for a `listMountKey` only reports the inset; later updates **scroll to end** if the user is still near the bottom and hasn’t dragged since mount. **`onScrollBeginDrag`** sets that drag guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a62ad93975820212d48543c4796c730f178479d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread composer covering the last message on thread open
> - Computes a `composerExtraChrome` value in [ThreadDetailScreen.tsx](https://github.com/pingdotgg/t3code/pull/4999/files#diff-4a36307d6c720c14cd36832a71a74b980215a01d29282c4f03d82889219d2fae) that adds `COMPOSER_PENDING_CARD_MIN_CHROME` (160px) per visible pending card (approval or user input) to the bottom overlap/inset.
> - Captures the composer overlay's measured height when not expanded and passes it to [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/4999/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245) so the feed knows how much space the composer occupies.
> - Auto-scrolls to the end of the feed when the content inset changes (e.g. composer height changes), provided the user was near the end and has not manually dragged since mount.
> - Tracks composer expansion via a ref in addition to state so layout measurement is suppressed during keyboard transitions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a62ad9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

