### PR TITLE
fix(web): fill fast mode icon

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -476,7 +476,13 @@ export const TraitsPicker = memo(function TraitsPicker({
   });
   const fastModeIcon = showFastModeIcon ? (
     <>
-      <ComposerControlIcon icon={ZapIcon} className="text-foreground/80 opacity-100" />
+      <ComposerControlIcon
+        icon={ZapIcon}
+        className={cn(
+          "fill-current opacity-80",
+          provider === "claudeAgent" ? "text-[#d97757]" : "text-foreground",
+        )}
+      />
       <span className="sr-only">Fast mode on</span>
     </>
   ) : null;


### PR DESCRIPTION
before
<img width="286" height="53" alt="image" src="https://github.com/user-attachments/assets/744bd204-9ef8-4b69-971e-24a36d0aa700" />
after
<img width="726" height="120" alt="image" src="https://github.com/user-attachments/assets/aa31d2a9-cd2c-4af3-acf4-39ca8257d29c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component Tailwind class change for icon styling with no logic or data impact.
> 
> **Overview**
> Updates the traits picker **fast mode** bolt so it renders as a filled icon instead of outline-only.
> 
> `ComposerControlIcon` for `ZapIcon` now uses `fill-current` and `opacity-80`, replacing the previous `text-foreground/80 opacity-100` treatment. When the provider is **Claude Agent**, the bolt uses the brand accent `text-[#d97757]`; other providers keep `text-foreground`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a968a6df732337b9a1dcf50a753d5bbc48e7532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fill fast mode icon with provider-specific color in `TraitsPicker`
> Updates the fast mode icon in [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/5004/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45) to use `fill-current` and conditionally apply an orange tint (`#d97757`) when the provider is `claudeAgent`, falling back to `text-foreground` otherwise. Opacity is also reduced from 100 to 80.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a968a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->