### PR TITLE
fix(source-control): explain clone failures

### DIFF
--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -195,6 +195,68 @@ it.effect("clones a looked-up repository into the requested destination", () =>
   }).pipe(Effect.provide(NodeServices.layer)),
 );
 
+it.effect("returns actionable, transport-safe clone failures", () => {
+  const cases = [
+    {
+      stderr: "Host key verification failed.\nfatal: Could not read from remote repository.\n",
+      expected:
+        "SSH could not verify the source control host. Add its host key to known_hosts and try again.",
+    },
+    {
+      stderr: "git@example.com: Permission denied (publickey).\n",
+      expected:
+        "SSH authentication failed. Add an SSH key to your source control account and try again.",
+    },
+    {
+      stderr:
+        "fatal: could not read Username for 'https://example.com': terminal prompts disabled\n",
+      expected:
+        "HTTPS authentication failed. Configure Git credentials for the source control host and try again.",
+    },
+    {
+      stderr: "ssh: Could not resolve hostname example.com: nodename nor servname provided\n",
+      expected:
+        "The source control host could not be resolved. Check your network or VPN connection and try again.",
+    },
+  ] as const;
+
+  return Effect.forEach(cases, ({ stderr, expected }) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const parent = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-source-control-clone-failure-",
+      });
+      const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+      const error = yield* Effect.flip(
+        service.cloneRepository({
+          remoteUrl: CLONE_URLS.sshUrl,
+          destinationPath: `${parent}/t3code`,
+        }),
+      );
+
+      assert.strictEqual(error.operation, "cloneRepository");
+      assert.strictEqual(error.provider, "github");
+      assert.strictEqual(error.detail, expected);
+      assert.instanceOf(error.cause, GitCommandError);
+      assert.strictEqual(error.cause.detail, expected);
+      assert.strictEqual(error.cause.stderrLength, stderr.length);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          git: {
+            execute: () =>
+              Effect.succeed({
+                ...processOutput(),
+                exitCode: ChildProcessSpawner.ExitCode(128),
+                stderr,
+              }),
+          },
+        }),
+      ),
+    ),
+  ).pipe(Effect.scoped, Effect.provide(NodeServices.layer));
+});
+
 it.effect("preserves destination probe failures instead of treating them as missing paths", () => {
   const fileSystemCause = PlatformError.systemError({
     _tag: "PermissionDenied",

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -214,7 +214,8 @@ it.effect("returns actionable, transport-safe clone failures", () => {
         "HTTPS authentication failed. Configure Git credentials for the source control host and try again.",
     },
     {
-      stderr: "ssh: Could not resolve hostname example.com: nodename nor servname provided\n",
+      stderr:
+        "ssh: Could not resolve hostname example.com: nodename nor servname provided\nfatal: Could not read from remote repository.\n",
       expected:
         "The source control host could not be resolved. Check your network or VPN connection and try again.",
     },

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -219,6 +219,11 @@ it.effect("returns actionable, transport-safe clone failures", () => {
       expected:
         "The source control host could not be resolved. Check your network or VPN connection and try again.",
     },
+    {
+      stderr: "fatal: an unrecognized clone failure\n",
+      expected:
+        "Git could not clone the repository. Verify that the remote works in a terminal and try again.",
+    },
   ] as const;
 
   return Effect.forEach(cases, ({ stderr, expected }) =>

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -26,7 +26,7 @@ import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 const isSourceControlRepositoryError = Schema.is(SourceControlRepositoryError);
 
-function cloneFailureDetail(stderr: string, remoteUrl: string): string {
+function cloneFailureDetail(stderr: string): string {
   if (/host key verification failed/iu.test(stderr)) {
     return "SSH could not verify the source control host. Add its host key to known_hosts and try again.";
   }
@@ -50,8 +50,7 @@ function cloneFailureDetail(stderr: string, remoteUrl: string): string {
     return "The repository could not be read. Check that it exists and that your Git credentials have access.";
   }
 
-  const transport = /^(?:ssh:\/\/|[^@/\s]+@[^:/\s]+:)/u.test(remoteUrl) ? "SSH" : "HTTPS";
-  return `Git could not clone the repository over ${transport}. Verify that this Git transport works in a terminal and try again.`;
+  return "Git could not clone the repository. Verify that the remote works in a terminal and try again.";
 }
 
 export class SourceControlRepositoryService extends Context.Service<
@@ -246,7 +245,7 @@ export const make = Effect.gen(function* () {
     });
 
     if (cloneResult.exitCode !== 0) {
-      const detail = cloneFailureDetail(cloneResult.stderr, remoteUrl);
+      const detail = cloneFailureDetail(cloneResult.stderr);
       return yield* new SourceControlRepositoryError({
         operation: "cloneRepository",
         provider,

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -7,6 +7,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
 import {
+  GitCommandError,
   SourceControlRepositoryError,
   type SourceControlCloneRepositoryInput,
   type SourceControlCloneRepositoryResult,
@@ -18,11 +19,40 @@ import {
   type SourceControlRepositoryInfo,
   type SourceControlRepositoryLookupInput,
 } from "@t3tools/contracts";
+import { detectSourceControlProviderFromRemoteUrl } from "@t3tools/shared/sourceControl";
 
 import { ServerConfig } from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 const isSourceControlRepositoryError = Schema.is(SourceControlRepositoryError);
+
+function cloneFailureDetail(stderr: string, remoteUrl: string): string {
+  if (/host key verification failed/iu.test(stderr)) {
+    return "SSH could not verify the source control host. Add its host key to known_hosts and try again.";
+  }
+  if (/permission denied \(publickey(?:,[^)]+)?\)/iu.test(stderr)) {
+    return "SSH authentication failed. Add an SSH key to your source control account and try again.";
+  }
+  if (
+    /authentication failed|http basic: access denied|could not read username|terminal prompts disabled/iu.test(
+      stderr,
+    )
+  ) {
+    return "HTTPS authentication failed. Configure Git credentials for the source control host and try again.";
+  }
+  if (/repository not found|could not read from remote repository/iu.test(stderr)) {
+    return "The repository could not be read. Check that it exists and that your Git credentials have access.";
+  }
+  if (/could not resolve (?:host|hostname)/iu.test(stderr)) {
+    return "The source control host could not be resolved. Check your network or VPN connection and try again.";
+  }
+  if (/connection (?:timed out|refused)|failed to connect/iu.test(stderr)) {
+    return "Git could not connect to the source control host. Check your network or VPN connection and try again.";
+  }
+
+  const transport = /^(?:ssh:\/\/|[^@/\s]+@[^:/\s]+:)/u.test(remoteUrl) ? "SSH" : "HTTPS";
+  return `Git could not clone the repository over ${transport}. Verify that this Git transport works in a terminal and try again.`;
+}
 
 export class SourceControlRepositoryService extends Context.Service<
   SourceControlRepositoryService,
@@ -183,7 +213,10 @@ export const make = Effect.gen(function* () {
     const preparedDestination = yield* prepareDestination(input.destinationPath);
     let repository: SourceControlRepositoryInfo | null = null;
     let remoteUrl = input.remoteUrl?.trim() ?? null;
-    let provider: SourceControlProviderKind = input.provider ?? "unknown";
+    let provider: SourceControlProviderKind =
+      input.provider ??
+      (remoteUrl ? detectSourceControlProviderFromRemoteUrl(remoteUrl)?.kind : null) ??
+      "unknown";
 
     if (input.provider && input.repository) {
       repository = yield* lookupRepository({
@@ -203,13 +236,33 @@ export const make = Effect.gen(function* () {
       });
     }
 
-    yield* git.execute({
+    const cloneResult = yield* git.execute({
       operation: "SourceControlRepositoryService.cloneRepository",
       cwd: preparedDestination.parentPath,
       args: ["clone", remoteUrl, preparedDestination.directoryName],
+      allowNonZeroExit: true,
       timeoutMs: 120_000,
       maxOutputBytes: 256 * 1024,
     });
+
+    if (cloneResult.exitCode !== 0) {
+      const detail = cloneFailureDetail(cloneResult.stderr, remoteUrl);
+      return yield* new SourceControlRepositoryError({
+        operation: "cloneRepository",
+        provider,
+        detail,
+        cause: new GitCommandError({
+          operation: "SourceControlRepositoryService.cloneRepository",
+          command: "git",
+          cwd: preparedDestination.parentPath,
+          argumentCount: 3,
+          exitCode: cloneResult.exitCode,
+          stdoutLength: cloneResult.stdout.length,
+          stderrLength: cloneResult.stderr.length,
+          detail,
+        }),
+      });
+    }
 
     return {
       cwd: preparedDestination.destinationPath,

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -40,14 +40,14 @@ function cloneFailureDetail(stderr: string, remoteUrl: string): string {
   ) {
     return "HTTPS authentication failed. Configure Git credentials for the source control host and try again.";
   }
-  if (/repository not found|could not read from remote repository/iu.test(stderr)) {
-    return "The repository could not be read. Check that it exists and that your Git credentials have access.";
-  }
   if (/could not resolve (?:host|hostname)/iu.test(stderr)) {
     return "The source control host could not be resolved. Check your network or VPN connection and try again.";
   }
   if (/connection (?:timed out|refused)|failed to connect/iu.test(stderr)) {
     return "Git could not connect to the source control host. Check your network or VPN connection and try again.";
+  }
+  if (/repository not found|could not read from remote repository/iu.test(stderr)) {
+    return "The repository could not be read. Check that it exists and that your Git credentials have access.";
   }
 
   const transport = /^(?:ssh:\/\/|[^@/\s]+@[^:/\s]+:)/u.test(remoteUrl) ? "SSH" : "HTTPS";


### PR DESCRIPTION
Source-control clones currently collapse Git transport failures into a generic operation error. This leaves users unable to distinguish SSH host trust, SSH key authentication, HTTPS credentials, repository access, DNS, and network failures. Raw clone URLs also report the provider as unknown even when the host identifies GitHub, GitLab, Bitbucket, or Azure DevOps.

Keep cloning in the shared Git driver rather than delegating to provider CLIs. Both glab repo clone and gh repo clone ultimately invoke Git, while Bitbucket has no equivalent official CLI path; provider-specific cloning would split one operation across inconsistent implementations without fixing Git transport setup.

The clone service now captures nonzero Git results locally, maps common stderr signatures to actionable transport-safe messages, preserves structured Git failure metadata without sending raw stderr over RPC, and infers the provider from raw remote URLs. This applies uniformly to GitHub, GitLab, Bitbucket, Azure DevOps, self-hosted instances, and generic Git URLs.

Verification:
- focused SourceControlRepositoryService tests: 8 passed
- targeted server typecheck: passed
- targeted lint and formatting: passed

Generated with GPT-5.6 using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes clone error handling and user-facing transport/auth messaging without altering credential storage, but misclassified stderr patterns could mislead users during setup failures.
> 
> **Overview**
> **Clone failures now return clear, transport-safe errors** instead of a generic Git failure. `cloneRepository` runs `git clone` with `allowNonZeroExit`, then maps common `stderr` patterns (SSH host trust, publickey auth, HTTPS credentials, DNS, connectivity, repo access) to actionable messages via `cloneFailureDetail`. Raw stderr is not exposed over RPC; failures surface as `SourceControlRepositoryError` with a nested `GitCommandError` (exit code and lengths only).
> 
> When only a **remote URL** is supplied, the provider is inferred with `detectSourceControlProviderFromRemoteUrl` so errors can name GitHub/GitLab/etc. instead of `unknown`.
> 
> Tests cover the main stderr cases and assert `operation`, `provider`, `detail`, and structured `cause` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb093be95d1276443ce2a09fc707dd2051a629d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `cloneRepository` to return actionable error details on Git clone failures
> - Adds `cloneFailureDetail` in [`SourceControlRepositoryService.ts`](https://github.com/pingdotgg/t3code/pull/5005/files#diff-ee6247891e4a01ae6615258135b417c8454fe770eae597f3591b677b32c7aa0b) that maps common Git clone stderr patterns (SSH key issues, auth failures, DNS errors, timeouts, repo not found) to human-readable messages.
> - `cloneRepository` now captures the Git exit code via `allowNonZeroExit: true` and wraps non-zero exits in a `SourceControlRepositoryError` with a `GitCommandError` cause, replacing raw error propagation.
> - Provider is now inferred from `remoteUrl` via `detectSourceControlProviderFromRemoteUrl` when not explicitly supplied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cb093b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->