### PR TITLE
perf(server): cache default branch name and origin existence across status refreshes

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -171,6 +171,33 @@ it.effect("invalidates origin remote cache when a driver mutation adds origin", 
   }).pipe(Effect.provide(TestLayer)),
 );
 
+it.effect("re-reads origin remote status after cache TTL expiry and bypassed invalidation", () =>
+  Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.GitVcsDriver;
+    const cwd = yield* makeTmpDir();
+    const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+    yield* initRepoWithCommit(cwd);
+    yield* git(remote, ["init", "--bare"]);
+
+    // First call caches hasOriginRemote = false (5-min TTL)
+    assert.equal((yield* driver.statusDetailsLocal(cwd)).hasOriginRemote, false);
+
+    // Add origin via raw git (bypasses invalidation hook)
+    yield* git(cwd, ["remote", "add", "origin", remote]);
+
+    // Cache still has the stale false (TTL not yet expired)
+    const stillCached = yield* driver.statusDetailsLocal(cwd);
+    assert.equal(stillCached.hasOriginRemote, false);
+
+    // Advance past the 5-minute TTL so the cache entry expires
+    yield* TestClock.adjust("6 minutes");
+
+    // After expiry, the next call re-executes and picks up the remote
+    const afterExpiry = yield* driver.statusDetailsLocal(cwd);
+    assert.equal(afterExpiry.hasOriginRemote, true);
+  }).pipe(Effect.provide(TestLayer)),
+);
+
 it.effect("coalesces concurrent ref pages into one repository snapshot", () =>
   Effect.scoped(
     Effect.gen(function* () {

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -153,6 +153,25 @@ it.effect("uses stable diagnostics for every parsed non-repository command", () 
   }).pipe(Effect.provide(layer));
 });
 
+it.effect(
+  "returns consistent default branch and origin remote across repeated local status calls",
+  () =>
+    Effect.gen(function* () {
+      const driver = yield* GitVcsDriver.GitVcsDriver;
+      const cwd = yield* makeTmpDir();
+      const { initialBranch } = yield* initRepoWithCommit(cwd);
+
+      const a = yield* driver.statusDetailsLocal(cwd);
+      const b = yield* driver.statusDetailsLocal(cwd);
+
+      assert.equal(a.isRepo, true);
+      assert.equal(a.branch, initialBranch);
+      assert.equal(a.isDefaultBranch, b.isDefaultBranch);
+      assert.equal(a.hasOriginRemote, b.hasOriginRemote);
+      assert.equal(a.hasWorkingTreeChanges, false);
+    }).pipe(Effect.provide(TestLayer)),
+);
+
 it.effect("coalesces concurrent ref pages into one repository snapshot", () =>
   Effect.scoped(
     Effect.gen(function* () {

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -153,23 +153,22 @@ it.effect("uses stable diagnostics for every parsed non-repository command", () 
   }).pipe(Effect.provide(layer));
 });
 
-it.effect(
-  "returns consistent default branch and origin remote across repeated local status calls",
-  () =>
-    Effect.gen(function* () {
-      const driver = yield* GitVcsDriver.GitVcsDriver;
-      const cwd = yield* makeTmpDir();
-      const { initialBranch } = yield* initRepoWithCommit(cwd);
+it.effect("invalidates origin remote cache when a driver mutation adds origin", () =>
+  Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.GitVcsDriver;
+    const cwd = yield* makeTmpDir();
+    const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+    yield* initRepoWithCommit(cwd);
+    yield* git(remote, ["init", "--bare"]);
 
-      const a = yield* driver.statusDetailsLocal(cwd);
-      const b = yield* driver.statusDetailsLocal(cwd);
+    const before = yield* driver.statusDetailsLocal(cwd);
+    assert.equal(before.hasOriginRemote, false);
 
-      assert.equal(a.isRepo, true);
-      assert.equal(a.branch, initialBranch);
-      assert.equal(a.isDefaultBranch, b.isDefaultBranch);
-      assert.equal(a.hasOriginRemote, b.hasOriginRemote);
-      assert.equal(a.hasWorkingTreeChanges, false);
-    }).pipe(Effect.provide(TestLayer)),
+    yield* driver.ensureRemote({ cwd, preferredName: "origin", url: remote });
+
+    const after = yield* driver.statusDetailsLocal(cwd);
+    assert.equal(after.hasOriginRemote, true);
+  }).pipe(Effect.provide(TestLayer)),
 );
 
 it.effect("coalesces concurrent ref pages into one repository snapshot", () =>

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1122,19 +1122,16 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   };
 
   const defaultBranchCache = yield* Cache.makeWith(
-    (cwd: string) => resolveDefaultBranchName(cwd, "origin").pipe(Effect.orElseSucceed(() => null)),
+    (cwd: string) => resolveDefaultBranchName(cwd, "origin"),
     {
       capacity: 2_048,
       timeToLive: () => STATUS_DEFAULT_BRANCH_CACHE_TTL,
     },
   );
-  const originExistsCache = yield* Cache.makeWith(
-    (cwd: string) => originRemoteExists(cwd).pipe(Effect.orElseSucceed(() => false)),
-    {
-      capacity: 2_048,
-      timeToLive: () => STATUS_ORIGIN_EXISTS_CACHE_TTL,
-    },
-  );
+  const originExistsCache = yield* Cache.makeWith((cwd: string) => originRemoteExists(cwd), {
+    capacity: 2_048,
+    timeToLive: () => STATUS_ORIGIN_EXISTS_CACHE_TTL,
+  });
   const invalidateStatusStaticCaches = (cwd: string) =>
     Effect.gen(function* () {
       const cacheKey = normalizeRepositoryPathsCacheKey(cwd);
@@ -1598,8 +1595,8 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             );
           }),
         ),
-        Cache.get(defaultBranchCache, statusCacheKey),
-        Cache.get(originExistsCache, statusCacheKey),
+        Cache.get(defaultBranchCache, statusCacheKey).pipe(Effect.orElseSucceed(() => null)),
+        Cache.get(originExistsCache, statusCacheKey).pipe(Effect.orElseSucceed(() => false)),
       ],
       { concurrency: "unbounded" },
     );

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1122,19 +1122,55 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   };
 
   const defaultBranchCache = yield* Cache.makeWith(
-    (cwd: string) => resolveDefaultBranchName(cwd, "origin"),
+    (gitCommonDir: string) =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fetchCwd =
+          path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
+        return yield* executeGit(
+          "GitVcsDriver.statusDetails.defaultBranch",
+          fetchCwd,
+          ["--git-dir", gitCommonDir, "symbolic-ref", "refs/remotes/origin/HEAD"],
+          { allowNonZeroExit: true },
+        ).pipe(
+          Effect.map((result) => {
+            if (result.exitCode !== 0) return null;
+            return parseDefaultBranchFromRemoteHeadRef(result.stdout, "origin");
+          }),
+        );
+      }),
     {
       capacity: 2_048,
       timeToLive: () => STATUS_DEFAULT_BRANCH_CACHE_TTL,
     },
   );
-  const originExistsCache = yield* Cache.makeWith((cwd: string) => originRemoteExists(cwd), {
-    capacity: 2_048,
-    timeToLive: () => STATUS_ORIGIN_EXISTS_CACHE_TTL,
-  });
+  const originExistsCache = yield* Cache.makeWith(
+    (gitCommonDir: string) =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fetchCwd =
+          path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
+        return yield* executeGit(
+          "GitVcsDriver.statusDetails.originExists",
+          fetchCwd,
+          ["--git-dir", gitCommonDir, "remote", "get-url", "origin"],
+          { allowNonZeroExit: true },
+        ).pipe(Effect.map((result) => result.exitCode === 0));
+      }),
+    {
+      capacity: 2_048,
+      timeToLive: () => STATUS_ORIGIN_EXISTS_CACHE_TTL,
+    },
+  );
   const invalidateStatusStaticCaches = (cwd: string) =>
     Effect.gen(function* () {
-      const cacheKey = normalizeRepositoryPathsCacheKey(cwd);
+      const repositoryPaths = yield* resolveRepositoryPaths(cwd).pipe(
+        Effect.catchTags({
+          GitCommandError: (error) =>
+            isMissingGitCwdError(error) ? Effect.succeed(null) : Effect.fail(error),
+        }),
+      );
+      const cacheKey = repositoryPaths?.gitCommonDir ?? cwd;
       yield* Cache.invalidate(defaultBranchCache, cacheKey);
       yield* Cache.invalidate(originExistsCache, cacheKey);
     });
@@ -1537,7 +1573,13 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       });
     }
 
-    const statusCacheKey = normalizeRepositoryPathsCacheKey(cwd);
+    const repositoryPaths = yield* resolveRepositoryPaths(cwd).pipe(
+      Effect.catchTags({
+        GitCommandError: (error) =>
+          isMissingGitCwdError(error) ? Effect.succeed(null) : Effect.fail(error),
+      }),
+    );
+    const statusCacheKey = repositoryPaths?.gitCommonDir ?? normalizeRepositoryPathsCacheKey(cwd);
     const [numstatStdout, defaultBranch, hasPrimaryRemote] = yield* Effect.all(
       [
         executeGitWithStableDiagnostics(

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1141,7 +1141,10 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       }),
     {
       capacity: 2_048,
-      timeToLive: () => STATUS_DEFAULT_BRANCH_CACHE_TTL,
+      timeToLive: Exit.match({
+        onSuccess: () => STATUS_DEFAULT_BRANCH_CACHE_TTL,
+        onFailure: () => Duration.zero,
+      }),
     },
   );
   const originExistsCache = yield* Cache.makeWith(
@@ -1159,7 +1162,10 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       }),
     {
       capacity: 2_048,
-      timeToLive: () => STATUS_ORIGIN_EXISTS_CACHE_TTL,
+      timeToLive: Exit.match({
+        onSuccess: () => STATUS_ORIGIN_EXISTS_CACHE_TTL,
+        onFailure: () => Duration.zero,
+      }),
     },
   );
   const invalidateStatusStaticCaches = (cwd: string) =>

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1165,12 +1165,9 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   const invalidateStatusStaticCaches = (cwd: string) =>
     Effect.gen(function* () {
       const repositoryPaths = yield* resolveRepositoryPaths(cwd).pipe(
-        Effect.catchTags({
-          GitCommandError: (error) =>
-            isMissingGitCwdError(error) ? Effect.succeed(null) : Effect.fail(error),
-        }),
+        Effect.catchTags({ GitCommandError: () => Effect.succeed(null) }),
       );
-      const cacheKey = repositoryPaths?.gitCommonDir ?? cwd;
+      const cacheKey = repositoryPaths?.gitCommonDir ?? normalizeRepositoryPathsCacheKey(cwd);
       yield* Cache.invalidate(defaultBranchCache, cacheKey);
       yield* Cache.invalidate(originExistsCache, cacheKey);
     });
@@ -1574,12 +1571,9 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     }
 
     const repositoryPaths = yield* resolveRepositoryPaths(cwd).pipe(
-      Effect.catchTags({
-        GitCommandError: (error) =>
-          isMissingGitCwdError(error) ? Effect.succeed(null) : Effect.fail(error),
-      }),
+      Effect.catchTags({ GitCommandError: () => Effect.succeed(null) }),
     );
-    const statusCacheKey = repositoryPaths?.gitCommonDir ?? normalizeRepositoryPathsCacheKey(cwd);
+    const statusCacheKey = repositoryPaths?.gitCommonDir;
     const [numstatStdout, defaultBranch, hasPrimaryRemote] = yield* Effect.all(
       [
         executeGitWithStableDiagnostics(
@@ -1637,8 +1631,12 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             );
           }),
         ),
-        Cache.get(defaultBranchCache, statusCacheKey).pipe(Effect.orElseSucceed(() => null)),
-        Cache.get(originExistsCache, statusCacheKey).pipe(Effect.orElseSucceed(() => false)),
+        statusCacheKey
+          ? Cache.get(defaultBranchCache, statusCacheKey).pipe(Effect.orElseSucceed(() => null))
+          : resolveDefaultBranchName(cwd, "origin").pipe(Effect.orElseSucceed(() => null)),
+        statusCacheKey
+          ? Cache.get(originExistsCache, statusCacheKey).pipe(Effect.orElseSucceed(() => false))
+          : originRemoteExists(cwd).pipe(Effect.orElseSucceed(() => false)),
       ],
       { concurrency: "unbounded" },
     );

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -61,6 +61,8 @@ const LIST_REFS_SNAPSHOT_CACHE_CAPACITY = 64;
 const LIST_REFS_SNAPSHOT_CACHE_TTL = Duration.minutes(2);
 const LIST_REFS_REFRESH_COALESCE_TTL = Duration.seconds(5);
 const LIST_REFS_REFRESH_FAILURE_COOLDOWN = Duration.seconds(30);
+const STATUS_DEFAULT_BRANCH_CACHE_TTL = Duration.minutes(5);
+const STATUS_ORIGIN_EXISTS_CACHE_TTL = Duration.minutes(5);
 const STATUS_UPSTREAM_REFRESH_ENV = Object.freeze({
   GCM_INTERACTIVE: "never",
   GIT_ASKPASS: "",
@@ -1119,6 +1121,26 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     return Cache.get(refresh ? repositoryPathsRefreshCache : repositoryPathsCache, cacheKey);
   };
 
+  const defaultBranchCache = yield* Cache.makeWith(
+    (cwd: string) => resolveDefaultBranchName(cwd, "origin").pipe(Effect.orElseSucceed(() => null)),
+    {
+      capacity: 2_048,
+      timeToLive: () => STATUS_DEFAULT_BRANCH_CACHE_TTL,
+    },
+  );
+  const originExistsCache = yield* Cache.makeWith(
+    (cwd: string) => originRemoteExists(cwd).pipe(Effect.orElseSucceed(() => false)),
+    {
+      capacity: 2_048,
+      timeToLive: () => STATUS_ORIGIN_EXISTS_CACHE_TTL,
+    },
+  );
+  const invalidateStatusStaticCaches = (cwd: string) =>
+    Effect.gen(function* () {
+      yield* Cache.invalidate(defaultBranchCache, cwd);
+      yield* Cache.invalidate(originExistsCache, cwd);
+    });
+
   const resolveGitCommonDir = Effect.fn("resolveGitCommonDir")(function* (cwd: string) {
     const repositoryPaths = yield* resolveRepositoryPaths(cwd);
     if (repositoryPaths !== null) {
@@ -1517,7 +1539,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       });
     }
 
-    const [numstatStdout, defaultRefResult, hasPrimaryRemote] = yield* Effect.all(
+    const [numstatStdout, defaultBranch, hasPrimaryRemote] = yield* Effect.all(
       [
         executeGitWithStableDiagnostics(
           "GitVcsDriver.statusDetails.numstat",
@@ -1574,21 +1596,12 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             );
           }),
         ),
-        executeGit(
-          "GitVcsDriver.statusDetails.defaultRef",
-          cwd,
-          ["symbolic-ref", "refs/remotes/origin/HEAD"],
-          { allowNonZeroExit: true },
-        ),
-        originRemoteExists(cwd).pipe(Effect.orElseSucceed(() => false)),
+        Cache.get(defaultBranchCache, cwd),
+        Cache.get(originExistsCache, cwd),
       ],
       { concurrency: "unbounded" },
     );
     const statusStdout = statusResult.stdout;
-    const defaultBranch =
-      defaultRefResult.exitCode === 0
-        ? defaultRefResult.stdout.trim().replace(/^refs\/remotes\/origin\//, "")
-        : null;
 
     let refName: string | null = null;
     let upstreamRef: string | null = null;
@@ -2809,7 +2822,14 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     cwd: string,
     effect: Effect.Effect<A, E>,
   ): Effect.Effect<A, E> =>
-    effect.pipe(Effect.ensuring(invalidateListRefsSnapshot(cwd).pipe(Effect.ignore)));
+    effect.pipe(
+      Effect.ensuring(
+        Effect.all([
+          invalidateListRefsSnapshot(cwd).pipe(Effect.ignore),
+          invalidateStatusStaticCaches(cwd).pipe(Effect.ignore),
+        ]),
+      ),
+    );
   const initRepoWithListRefsInvalidation: GitVcsDriver.GitVcsDriver["Service"]["initRepo"] = (
     input,
   ) =>

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1137,8 +1137,9 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   );
   const invalidateStatusStaticCaches = (cwd: string) =>
     Effect.gen(function* () {
-      yield* Cache.invalidate(defaultBranchCache, cwd);
-      yield* Cache.invalidate(originExistsCache, cwd);
+      const cacheKey = normalizeRepositoryPathsCacheKey(cwd);
+      yield* Cache.invalidate(defaultBranchCache, cacheKey);
+      yield* Cache.invalidate(originExistsCache, cacheKey);
     });
 
   const resolveGitCommonDir = Effect.fn("resolveGitCommonDir")(function* (cwd: string) {
@@ -1539,6 +1540,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       });
     }
 
+    const statusCacheKey = normalizeRepositoryPathsCacheKey(cwd);
     const [numstatStdout, defaultBranch, hasPrimaryRemote] = yield* Effect.all(
       [
         executeGitWithStableDiagnostics(
@@ -1596,8 +1598,8 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             );
           }),
         ),
-        Cache.get(defaultBranchCache, cwd),
-        Cache.get(originExistsCache, cwd),
+        Cache.get(defaultBranchCache, statusCacheKey),
+        Cache.get(originExistsCache, statusCacheKey),
       ],
       { concurrency: "unbounded" },
     );


### PR DESCRIPTION
## What Changed

Every status refresh was spawning four git subprocesses, even though two of them (checking the default branch name and whether the "origin" remote exists) return the same answer most of the times. This change caches those two lookups for 5 minutes so they only run once.

The cache is automatically cleared whenever you commit, push, pull, switch branches, or do any other git operation that could change the result.

## Why

On every status refresh we were running `git status`, `git diff`, `git symbolic-ref`, and `git remote get-url`. The last two are just reading things that don't change during normal work. Cutting them out drops the process count from 4 to 2 per refresh in steady state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Server-side git driver caching only; invalidation is tied to existing mutation hooks and TTL expiry limits stale reads.
> 
> **Overview**
> Adds **5-minute caches** in `GitVcsDriverCore` for two lookups that were previously run on every local status refresh: origin’s default branch (`symbolic-ref refs/remotes/origin/HEAD`) and whether the `origin` remote exists (`remote get-url origin`). `readStatusDetailsLocal` now reads these via caches keyed by `gitCommonDir`, so steady-state refreshes drop from four git subprocesses to two (`status` + `diff --numstat`).
> 
> Cache entries are cleared through `invalidateStatusStaticCaches`, wired into the same `withListRefsInvalidation` path used for driver mutations (commit, push, pull, `ensureRemote`, branch/worktree changes, etc.). Tests cover invalidation after `ensureRemote` and TTL-based refresh when origin is added outside the driver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff8cada4d75a753078b2b875227b6921edfcaa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache default branch name and origin remote existence for 5 minutes in `GitVcsDriverCore`
> - `statusDetailsLocal` now caches the result of `symbolic-ref refs/remotes/origin/HEAD` and `remote get-url origin` in two separate caches keyed by `gitCommonDir`, each with a 5-minute TTL.
> - Driver mutation paths that use `withListRefsInvalidation` also invalidate these new caches so status calls immediately reflect changes (e.g. after `ensureRemote`).
> - When `gitCommonDir` is not available, the existing inline resolution logic is used as a fallback.
> - Behavioral Change: origin remote existence and default branch name are now stale for up to 5 minutes if changed outside the driver (e.g. direct git commands).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ff8cad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->