### PR TITLE
fix(connect): reject malformed state/PKCE challenge on the /connect page

### DIFF
--- a/packages/shared/src/connectAuth.test.ts
+++ b/packages/shared/src/connectAuth.test.ts
@@ -37,6 +37,63 @@ describe("connectAuth", () => {
     ).toBeNull();
   });
 
+  it("rejects malformed state or challenge before starting the browser flow", () => {
+    const state = "q7mK9xV2pL4nR8sT6wYzAQ";
+    const challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+    // A stray space (e.g. from a URL that wrapped in a narrow terminal).
+    expect(
+      readConnectAuthorizeRequest(
+        new URL(
+          buildConnectAuthorizeRequestUrl({
+            hostedAppUrl: "https://app.t3.codes",
+            state: "q7mK9xV2pL4nR8sT6w Yz",
+            challenge,
+          }),
+        ),
+      ),
+    ).toBeNull();
+
+    // A non-base64url character pasted from a multiplexer pane border.
+    expect(
+      readConnectAuthorizeRequest(
+        new URL(
+          buildConnectAuthorizeRequestUrl({
+            hostedAppUrl: "https://app.t3.codes",
+            state,
+            challenge: `E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw│cM`,
+          }),
+        ),
+      ),
+    ).toBeNull();
+
+    // Wrong length (truncated challenge) even though every character is valid.
+    expect(
+      readConnectAuthorizeRequest(
+        new URL(
+          buildConnectAuthorizeRequestUrl({
+            hostedAppUrl: "https://app.t3.codes",
+            state,
+            challenge: challenge.slice(0, 42),
+          }),
+        ),
+      ),
+    ).toBeNull();
+
+    // The well-formed pair still round-trips.
+    expect(
+      readConnectAuthorizeRequest(
+        new URL(
+          buildConnectAuthorizeRequestUrl({
+            hostedAppUrl: "https://app.t3.codes",
+            state,
+            challenge,
+          }),
+        ),
+      ),
+    ).toEqual({ state, challenge });
+  });
+
   it("builds a PKCE authorize URL against the Clerk endpoint", () => {
     const url = new URL(
       buildConnectClerkAuthorizeUrl({

--- a/packages/shared/src/connectAuth.ts
+++ b/packages/shared/src/connectAuth.ts
@@ -4,6 +4,20 @@ const CONNECT_AUTH_STATE_PARAM = "state";
 const CONNECT_AUTH_CHALLENGE_PARAM = "challenge";
 const CONNECT_AUTH_CODE_SEPARATOR = ".";
 
+/**
+ * The CLI generates both values with `encodeBase64Url`, so they have known
+ * lengths: `state` is base64url(16 random bytes) and the PKCE `challenge` is
+ * base64url(SHA-256 digest = 32 bytes). Base64url has no padding, so 16 bytes
+ * encode to 22 characters and 32 bytes to 43.
+ */
+const CONNECT_AUTH_STATE_LENGTH = 22;
+const CONNECT_AUTH_CHALLENGE_LENGTH = 43;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function isBase64UrlOfLength(value: string, length: number): boolean {
+  return value.length === length && BASE64URL_PATTERN.test(value);
+}
+
 const CONNECT_AUTHORIZE_PATH = "/connect";
 const CONNECT_CALLBACK_PATH = "/connect/callback";
 
@@ -47,7 +61,16 @@ export function readConnectAuthorizeRequest(url: URL): ConnectAuthorizeRequest |
   const params = readHashParams(url);
   const state = params.get(CONNECT_AUTH_STATE_PARAM)?.trim() ?? "";
   const challenge = params.get(CONNECT_AUTH_CHALLENGE_PARAM)?.trim() ?? "";
-  if (!state || !challenge) {
+  // Reject anything that is not a well-formed T3-generated value. A connect
+  // URL that wraps in a narrow terminal can pick up stray characters (spaces,
+  // multiplexer pane borders) during native text selection; validating the
+  // known base64url shape here fails such requests before the browser flow
+  // instead of after, so the /connect page can tell the user to re-copy the
+  // freshly printed URL.
+  if (
+    !isBase64UrlOfLength(state, CONNECT_AUTH_STATE_LENGTH) ||
+    !isBase64UrlOfLength(challenge, CONNECT_AUTH_CHALLENGE_LENGTH)
+  ) {
     return null;
   }
   return { state, challenge };


### PR DESCRIPTION
## What Changed

`readConnectAuthorizeRequest` (in `packages/shared`, used by the `/connect` page and the CLI token exchange) now validates that the `state` and `challenge` fragment values have the exact base64url shape the CLI generates, instead of only checking that they are non-empty. Anything malformed returns `null`.

- `state` = `encodeBase64Url(16 bytes)` → 22 base64url chars
- PKCE `challenge` = `encodeBase64Url(SHA-256 digest)` → 43 base64url chars

Added unit tests for a stray space, a non-base64url character (`│`), a wrong-length value, and that the well-formed pair still round-trips.

## Why

Closes #4934.

The headless flow prints a `/connect#state=...&challenge=...` URL. When that URL wraps in a narrow terminal (tmux/screen pane borders, native text selection), a stray character can be pasted into the fragment. The old check accepted it, the full browser authorization flow ran, and the resulting code was only rejected at the very end by the waiting CLI with *"That code belongs to a different connect request"* — a message that never hints at URL corruption, long after the point where it could have been caught.

Both values have a known, generated shape, so the page can fail closed up front. The existing `/connect` surface already renders a *"this connect link is incomplete — re-run `t3 connect` and open the freshly printed URL"* message whenever the parsed request is `null`, so malformed URLs now get that actionable guidance before the browser flow rather than a confusing failure after it. No behavior change for well-formed URLs (verified: the full `packages/shared` suite and `CliTokenManager.test.ts`, which feed real generated values through the validator, still pass).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes (the existing null-request message is reused)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change in shared connect auth parsing; well-formed CLI URLs are unchanged and malformed inputs fail earlier with clearer UX.
> 
> **Overview**
> **`readConnectAuthorizeRequest`** now rejects `state` and `challenge` unless they match the CLI’s fixed base64url shape (22 chars for state, 43 for the PKCE challenge), not merely non-empty after trim.
> 
> Corrupted connect URLs—spaces from terminal wrapping, invalid characters from pane borders, truncated values—return **`null`** immediately so the `/connect` page can show the existing “re-run `t3 connect`” guidance instead of running the full browser OAuth flow and failing later in the CLI.
> 
> Tests cover stray spaces, non-base64url characters, wrong length, and confirm well-formed URLs still round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a723ffd89f51a9841f789b367ff374b46156c4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject malformed state/PKCE challenge values in `readConnectAuthorizeRequest`
> Adds strict validation to `readConnectAuthorizeRequest` in [connectAuth.ts](https://github.com/pingdotgg/t3code/pull/5010/files#diff-6265a91c3adb728990b798816e64251a8350390e2b8e5753577fbe7a66883415) so that non-empty but malformed `state` or `challenge` values are rejected. Previously, only falsy values triggered a null return; now both fields must be valid base64url strings of exact expected lengths (22 and 43 characters respectively). A `BASE64URL_PATTERN` regex and an `isBase64UrlOfLength` helper enforce this.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a723ffd. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->