### PR TITLE
feat(provider): add GitHub Copilot as a first-class provider

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,8 @@
     "@effect/platform-node-shared": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
     "@ff-labs/fff-node": "0.9.4",
+    "@github/copilot": "^1.0.75",
+    "@github/copilot-sdk": "^1.0.8",
     "@opencode-ai/sdk": "^1.3.15",
     "@pierre/diffs": "catalog:",
     "effect": "catalog:",

--- a/apps/server/src/provider/Drivers/CopilotDriver.ts
+++ b/apps/server/src/provider/Drivers/CopilotDriver.ts
@@ -1,0 +1,161 @@
+/**
+ * CopilotDriver — GitHub Copilot provider driver.
+ *
+ * Bundles the per-instance Copilot adapter, snapshot, and text generation.
+ * Unlike the CLI-wrapping drivers, Copilot is driven through
+ * `@github/copilot-sdk`, so there is no version probe to run: the CLI binary
+ * ships as a dependency of this app and is updated with it. Maintenance is
+ * therefore advertised as manual-only against the `@github/copilot` package.
+ *
+ * @module provider/Drivers/CopilotDriver
+ */
+import { CopilotSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { HttpClient } from "effect/unstable/http";
+
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { makeCopilotTextGeneration } from "../../textGeneration/CopilotTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeCopilotAdapter } from "../Layers/CopilotAdapter.ts";
+import {
+  buildInitialCopilotProviderSnapshot,
+  checkCopilotProviderStatus,
+  enrichCopilotSnapshot,
+} from "../Layers/CopilotProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+
+const decodeCopilotSettings = Schema.decodeSync(CopilotSettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("copilot");
+const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: "@github/copilot",
+  }),
+);
+
+export type CopilotDriverEnv =
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const CopilotDriver: ProviderDriver<CopilotSettings, CopilotDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "GitHub Copilot",
+    supportsMultipleInstances: true,
+  },
+  configSchema: CopilotSettings,
+  defaultConfig: (): CopilotSettings => decodeCopilotSettings({}),
+  create: ({ instanceId, displayName, accentColor, enabled, config }) =>
+    Effect.gen(function* () {
+      const httpClient = yield* HttpClient.HttpClient;
+      const serverSettings = yield* ServerSettingsService;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies CopilotSettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: process.env,
+      });
+
+      const adapter = yield* makeCopilotAdapter(effectiveConfig, {
+        instanceId,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+      });
+      const textGeneration = makeCopilotTextGeneration(effectiveConfig);
+
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CopilotSettings>>({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialCopilotProviderSnapshot(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider: checkCopilotProviderStatus(effectiveConfig).pipe(Effect.map(stampIdentity)),
+        enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichCopilotSnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+            publishSnapshot,
+            httpClient,
+          }),
+        refreshInterval: SNAPSHOT_REFRESH_INTERVAL,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build GitHub Copilot snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/CopilotAdapter.ts
+++ b/apps/server/src/provider/Layers/CopilotAdapter.ts
@@ -1,0 +1,1633 @@
+/**
+ * GitHub Copilot provider adapter.
+ *
+ * Drives the Copilot CLI through `@github/copilot-sdk`, which speaks JSON-RPC
+ * to a `copilot` child process. The SDK is push-based (`session.on(handler)`),
+ * so the adapter's job is a translation layer in three directions:
+ *
+ *   1. `SessionEvent` → `ProviderRuntimeEvent` (`mapSessionEvent`).
+ *   2. Copilot's callback-style permission / user-input requests → T3 Code's
+ *      request/response events, by parking the promise resolver in a map keyed
+ *      by a synthetic request id (`createInteractionHandlers`).
+ *   3. T3 Code's turn ids → Copilot's, which it mints itself only once the
+ *      assistant starts working (see `./copilotTurnTracking.ts`).
+ *
+ * Model and reasoning-effort changes go through `session.setModel`, which
+ * preserves conversation history and takes effect from the next message —
+ * hence `sessionModelSwitch: "in-session"`.
+ *
+ * @module provider/Layers/CopilotAdapter
+ */
+import {
+  type CopilotSettings,
+  EventId,
+  type ModelSelection,
+  type ProviderApprovalDecision,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ProviderItemId,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderTurnStartResult,
+  type ProviderUserInputAnswers,
+  RuntimeItemId,
+  RuntimeRequestId,
+  RuntimeTaskId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import {
+  CopilotClient,
+  type CopilotClientOptions,
+  type MCPServerConfig,
+  type PermissionRequest,
+  type PermissionRequestResult,
+  type SessionEvent,
+} from "@github/copilot-sdk";
+import * as NodeCrypto from "node:crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as PubSub from "effect/PubSub";
+import * as Stream from "effect/Stream";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { type CopilotAdapterShape } from "../Services/CopilotAdapter.ts";
+import { type EventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import { makeCopilotClientOptions } from "./CopilotProvider.ts";
+import { loadCopilotMcpServers } from "./copilotMcpServers.ts";
+import {
+  assistantUsageFields,
+  beginCopilotTurn,
+  clearTurnTracking,
+  completionTurnRefs,
+  isCopilotTurnTerminalEvent,
+  markTurnAwaitingCompletion,
+  recordTurnUsage,
+  type CopilotTurnTrackingState,
+} from "./copilotTurnTracking.ts";
+import type {
+  ProviderThreadSnapshot,
+  ProviderThreadTurnSnapshot,
+} from "../Services/ProviderAdapter.ts";
+
+const PROVIDER = ProviderDriverKind.make("copilot");
+const USER_INPUT_QUESTION_ID = "answer";
+const USER_INPUT_QUESTION_HEADER = "Question";
+/** Option descriptor id published by `CopilotProvider`'s effort select. */
+const EFFORT_OPTION_ID = "effort";
+
+type CopilotReasoningEffort = "low" | "medium" | "high" | "xhigh";
+
+export interface CopilotAdapterOptions {
+  readonly instanceId?: ProviderInstanceId;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  /** Test seam: substitute a fake Copilot client. */
+  readonly clientFactory?: (options: CopilotClientOptions) => CopilotClientHandle;
+}
+
+interface PendingApprovalRequest {
+  readonly requestType:
+    | "command_execution_approval"
+    | "file_change_approval"
+    | "file_read_approval"
+    | "dynamic_tool_call"
+    | "unknown";
+  readonly turnId: TurnId | undefined;
+  readonly resolve: (result: PermissionRequestResult) => void;
+}
+
+interface CopilotUserInputRequest {
+  readonly question: string;
+  readonly choices?: ReadonlyArray<string>;
+  readonly allowFreeform?: boolean;
+}
+
+interface CopilotUserInputResponse {
+  readonly answer: string;
+  readonly wasFreeform: boolean;
+}
+
+interface PendingUserInputRequest {
+  readonly request: CopilotUserInputRequest;
+  readonly turnId: TurnId | undefined;
+  readonly resolve: (result: CopilotUserInputResponse) => void;
+}
+
+interface CopilotSessionConfiguration {
+  readonly model: string | undefined;
+  readonly reasoningEffort: CopilotReasoningEffort | undefined;
+}
+
+interface ActiveCopilotSession extends CopilotTurnTrackingState {
+  readonly client: CopilotClientHandle;
+  session: CopilotSessionHandle;
+  readonly threadId: ThreadId;
+  readonly createdAt: string;
+  readonly runtimeMode: ProviderSession["runtimeMode"];
+  cwd: string | undefined;
+  configDir: string | undefined;
+  mcpServers: Record<string, MCPServerConfig> | undefined;
+  model: string | undefined;
+  reasoningEffort: CopilotReasoningEffort | undefined;
+  interactionMode: "default" | "plan" | undefined;
+  updatedAt: string;
+  lastError: string | undefined;
+  toolTitlesByCallId: Map<string, string>;
+  pendingApprovalResolvers: Map<string, PendingApprovalRequest>;
+  pendingUserInputResolvers: Map<string, PendingUserInputRequest>;
+  unsubscribe: () => void;
+}
+
+/**
+ * The adapter talks to the SDK through these two aliases rather than the
+ * concrete classes. Deriving them from `CopilotClient` (instead of hand-rolling
+ * structural interfaces) means a real client always satisfies them, while
+ * tests can still substitute a stand-in via `clientFactory`.
+ */
+export type CopilotSessionHandle = Awaited<ReturnType<CopilotClient["createSession"]>>;
+
+export type CopilotClientHandle = Pick<
+  CopilotClient,
+  "start" | "listModels" | "createSession" | "resumeSession" | "stop"
+>;
+
+/** Wall-clock ISO stamp usable from the SDK's synchronous event callbacks. */
+const nowIso = (): string => DateTime.formatIso(DateTime.nowUnsafe());
+
+function toMessage(cause: unknown, fallback: string): string {
+  if (cause instanceof Error && cause.message.length > 0) {
+    return cause.message;
+  }
+  return fallback;
+}
+
+function makeEventId(prefix: string) {
+  return EventId.make(`${prefix}-${NodeCrypto.randomUUID()}`);
+}
+
+function toTurnId(value: string | undefined): TurnId | undefined {
+  if (!value || value.trim().length === 0) return undefined;
+  return TurnId.make(value);
+}
+
+function toRuntimeItemId(value: string | undefined) {
+  if (!value || value.trim().length === 0) return undefined;
+  return RuntimeItemId.make(value);
+}
+
+function toProviderItemId(value: string | undefined) {
+  if (!value || value.trim().length === 0) return undefined;
+  return ProviderItemId.make(value);
+}
+
+function toRuntimeRequestId(value: string | undefined) {
+  if (!value || value.trim().length === 0) return undefined;
+  return RuntimeRequestId.make(value);
+}
+
+function toRuntimeTaskId(value: string | undefined) {
+  if (!value || value.trim().length === 0) return undefined;
+  return RuntimeTaskId.make(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function trimToUndefined(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function toNonNegativeInt(value: number | undefined) {
+  return value === undefined || !Number.isFinite(value)
+    ? undefined
+    : Math.max(0, Math.floor(value));
+}
+
+function toPositiveInt(value: number | undefined) {
+  const normalized = toNonNegativeInt(value);
+  return normalized && normalized > 0 ? normalized : undefined;
+}
+
+function mapSessionUsageInfo(usage: Extract<SessionEvent, { type: "session.usage_info" }>["data"]) {
+  const currentTokens = toNonNegativeInt(usage.currentTokens);
+  return {
+    usedTokens: currentTokens ?? 0,
+    ...(currentTokens !== undefined ? { totalProcessedTokens: currentTokens } : {}),
+    ...(toPositiveInt(usage.tokenLimit) ? { maxTokens: toPositiveInt(usage.tokenLimit) } : {}),
+  };
+}
+
+function mapAssistantUsage(usage: Extract<SessionEvent, { type: "assistant.usage" }>["data"]) {
+  const inputTokens = toNonNegativeInt(usage.inputTokens);
+  const outputTokens = toNonNegativeInt(usage.outputTokens);
+  const cachedInputTokens = toNonNegativeInt(usage.cacheReadTokens);
+  const durationMs = toNonNegativeInt(usage.duration);
+  const usedTokens = (inputTokens ?? 0) + (outputTokens ?? 0) + (cachedInputTokens ?? 0);
+  return {
+    usedTokens,
+    totalProcessedTokens: usedTokens,
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(usedTokens > 0 ? { lastUsedTokens: usedTokens } : {}),
+    ...(inputTokens !== undefined ? { lastInputTokens: inputTokens } : {}),
+    ...(cachedInputTokens !== undefined ? { lastCachedInputTokens: cachedInputTokens } : {}),
+    ...(outputTokens !== undefined ? { lastOutputTokens: outputTokens } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+  };
+}
+
+export function isCopilotReasoningEffortValue(value: unknown): value is CopilotReasoningEffort {
+  return value === "low" || value === "medium" || value === "high" || value === "xhigh";
+}
+
+/**
+ * Read the effort the user picked in the model picker.
+ *
+ * Copilot only accepts its own four-level ladder, so anything else (a Claude
+ * `ultrathink`, a Codex `minimal`) is dropped rather than forwarded — passing
+ * an unknown level makes the SDK reject session creation outright.
+ */
+export function copilotReasoningEffortFromSelection(
+  modelSelection: ModelSelection | undefined,
+): CopilotReasoningEffort | undefined {
+  if (!modelSelection) return undefined;
+  const value = getModelSelectionStringOptionValue(modelSelection, EFFORT_OPTION_ID);
+  return isCopilotReasoningEffortValue(value) ? value : undefined;
+}
+
+export function extractResumeSessionId(resumeCursor: unknown): string | undefined {
+  if (typeof resumeCursor === "string" && resumeCursor.trim().length > 0) {
+    return resumeCursor.trim();
+  }
+  return normalizeString(asRecord(resumeCursor)?.sessionId);
+}
+
+function toCopilotSessionMode(interactionMode: "default" | "plan"): "interactive" | "plan" {
+  return interactionMode === "plan" ? "plan" : "interactive";
+}
+
+function toInteractionMode(mode: string): "default" | "plan" {
+  return mode === "plan" ? "plan" : "default";
+}
+
+function approvalDecisionToPermissionResult(
+  decision: ProviderApprovalDecision,
+): PermissionRequestResult {
+  switch (decision) {
+    case "accept":
+    case "acceptForSession":
+      return { kind: "approved" };
+    case "decline":
+    case "cancel":
+    default:
+      return { kind: "denied-interactively-by-user" };
+  }
+}
+
+function requestTypeFromPermissionRequest(request: PermissionRequest) {
+  switch (request.kind) {
+    case "shell":
+      return "command_execution_approval" as const;
+    case "write":
+      return "file_change_approval" as const;
+    case "read":
+      return "file_read_approval" as const;
+    case "mcp":
+    case "custom-tool":
+      return "dynamic_tool_call" as const;
+    default:
+      return "unknown" as const;
+  }
+}
+
+function requestDetailFromPermissionRequest(request: PermissionRequest): string | undefined {
+  switch (request.kind) {
+    case "shell":
+      return trimToUndefined(String(request.fullCommandText ?? ""));
+    case "write":
+      return trimToUndefined(String(request.fileName ?? request.intention ?? ""));
+    case "read":
+      return trimToUndefined(String(request.path ?? request.intention ?? ""));
+    case "mcp":
+      return trimToUndefined(String(request.toolTitle ?? request.toolName ?? ""));
+    case "url":
+      return trimToUndefined(String(request.url ?? request.intention ?? ""));
+    case "custom-tool":
+      return trimToUndefined(String(request.toolName ?? request.toolDescription ?? ""));
+    default:
+      return undefined;
+  }
+}
+
+function itemTypeFromToolEvent(event: Extract<SessionEvent, { type: "tool.execution_start" }>) {
+  return event.data.mcpToolName ? "mcp_tool_call" : "dynamic_tool_call";
+}
+
+function toolDetailFromEvent(data: {
+  readonly toolName?: string;
+  readonly mcpToolName?: string;
+  readonly mcpServerName?: string;
+}) {
+  return trimToUndefined(
+    [data.mcpServerName, data.mcpToolName ?? data.toolName].filter(Boolean).join(" / "),
+  );
+}
+
+function resolveUserInputAnswer(
+  pending: PendingUserInputRequest,
+  answers: ProviderUserInputAnswers,
+): CopilotUserInputResponse {
+  const direct = answers[USER_INPUT_QUESTION_ID];
+  const candidate =
+    typeof direct === "string"
+      ? direct
+      : Object.values(answers).find((value): value is string => typeof value === "string");
+  const answer = trimToUndefined(candidate) ?? "";
+  return {
+    answer,
+    wasFreeform: !pending.request.choices?.includes(answer),
+  };
+}
+
+export function makeCopilotAdapter(
+  copilotSettings: CopilotSettings,
+  options?: CopilotAdapterOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("copilot");
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const nativeEventLogger = options?.nativeEventLogger;
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+    const sessions = new Map<ThreadId, ActiveCopilotSession>();
+    // The SDK calls us back on plain promises, outside any fiber. Capturing
+    // the context lets those callbacks run Effects (queue offers, logging)
+    // without re-entering the runtime from scratch each time.
+    const services = yield* Effect.context<never>();
+    const runPromise = Effect.runPromiseWith(services);
+
+    const emitRuntimeEvents = (events: ReadonlyArray<ProviderRuntimeEvent>) =>
+      runPromise(
+        Effect.forEach(events, (event) => PubSub.publish(runtimeEventPubSub, event), {
+          discard: true,
+        }),
+      ).catch(() => undefined);
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const writeNativeEvent = (threadId: ThreadId, event: SessionEvent) => {
+      if (!nativeEventLogger) return Promise.resolve();
+      return runPromise(nativeEventLogger.write(event, threadId)).catch(() => undefined);
+    };
+
+    const withRefs = (input: {
+      readonly threadId: ThreadId;
+      readonly eventId: EventId;
+      readonly createdAt: string;
+      readonly turnId: TurnId | undefined;
+      readonly providerTurnId?: TurnId | undefined;
+      readonly itemId: string | undefined;
+      readonly requestId: string | undefined;
+      readonly rawMethod: string | undefined;
+      readonly rawPayload: unknown;
+    }): Omit<ProviderRuntimeEvent, "type" | "payload"> => {
+      const providerTurnId = input.providerTurnId ?? input.turnId;
+      const providerItemId = toProviderItemId(input.itemId);
+      const providerRequestId = trimToUndefined(input.requestId);
+      return {
+        eventId: input.eventId,
+        provider: PROVIDER,
+        providerInstanceId: boundInstanceId,
+        threadId: input.threadId,
+        createdAt: input.createdAt,
+        ...(input.turnId ? { turnId: input.turnId } : {}),
+        ...(input.itemId ? { itemId: toRuntimeItemId(input.itemId) } : {}),
+        ...(input.requestId ? { requestId: toRuntimeRequestId(input.requestId) } : {}),
+        ...(providerTurnId || providerItemId || providerRequestId
+          ? {
+              providerRefs: {
+                ...(providerTurnId ? { providerTurnId } : {}),
+                ...(providerItemId ? { providerItemId } : {}),
+                ...(providerRequestId ? { providerRequestId } : {}),
+              },
+            }
+          : {}),
+        raw: {
+          source: input.rawMethod ? "copilot.sdk.session-event" : "copilot.sdk.synthetic",
+          ...(input.rawMethod ? { method: input.rawMethod } : {}),
+          payload: input.rawPayload,
+        },
+      };
+    };
+
+    const makeSyntheticEvent = (
+      threadId: ThreadId,
+      type: ProviderRuntimeEvent["type"],
+      payload: ProviderRuntimeEvent["payload"],
+      extra?: {
+        readonly turnId?: TurnId | undefined;
+        readonly itemId?: string | undefined;
+        readonly requestId?: string | undefined;
+      },
+    ): ProviderRuntimeEvent =>
+      ({
+        ...withRefs({
+          threadId,
+          eventId: makeEventId("copilot-synthetic"),
+          createdAt: nowIso(),
+          turnId: extra?.turnId,
+          itemId: extra?.itemId,
+          requestId: extra?.requestId,
+          rawMethod: undefined,
+          rawPayload: payload,
+        }),
+        type,
+        payload,
+      }) as ProviderRuntimeEvent;
+
+    const currentSyntheticTurnId = (record: ActiveCopilotSession) =>
+      completionTurnRefs(record).turnId ?? record.currentTurnId;
+
+    const syncInteractionMode = (
+      record: ActiveCopilotSession,
+      interactionMode: "default" | "plan",
+    ) => {
+      if (record.interactionMode === interactionMode) {
+        return Effect.void;
+      }
+      return Effect.tryPromise({
+        try: async () => {
+          await record.session.rpc.mode.set({ mode: toCopilotSessionMode(interactionMode) });
+          record.interactionMode = interactionMode;
+        },
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.mode.set",
+            detail: toMessage(cause, "Failed to switch GitHub Copilot interaction mode."),
+            cause,
+          }),
+      });
+    };
+
+    const emitLatestProposedPlan = (record: ActiveCopilotSession) =>
+      Effect.tryPromise({
+        try: () => record.session.rpc.plan.read(),
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.plan.read",
+            detail: toMessage(cause, "Failed to read the GitHub Copilot plan."),
+            cause,
+          }),
+      }).pipe(
+        Effect.flatMap((plan) => {
+          const planMarkdown = trimToUndefined(plan.content ?? undefined);
+          if (!plan.exists || !planMarkdown) {
+            return Effect.void;
+          }
+          return offerRuntimeEvent(
+            makeSyntheticEvent(
+              record.threadId,
+              "turn.proposed.completed",
+              { planMarkdown },
+              { turnId: currentSyntheticTurnId(record) },
+            ),
+          );
+        }),
+      );
+
+    const mapSessionEvent = (
+      record: ActiveCopilotSession,
+      event: SessionEvent,
+    ): ReadonlyArray<ProviderRuntimeEvent> => {
+      const currentTurnId = record.currentTurnId;
+      const base = (input?: {
+        readonly turnId?: TurnId | undefined;
+        readonly providerTurnId?: TurnId | undefined;
+        readonly itemId?: string | undefined;
+        readonly requestId?: string | undefined;
+      }) =>
+        withRefs({
+          threadId: record.threadId,
+          eventId: EventId.make(event.id),
+          createdAt: event.timestamp,
+          // Always report the orchestration turn id T3 Code handed out; the
+          // provider's own id rides along in `providerRefs`.
+          turnId: currentTurnId ?? input?.providerTurnId ?? input?.turnId,
+          providerTurnId: input?.providerTurnId ?? input?.turnId,
+          itemId: input?.itemId,
+          requestId: input?.requestId,
+          rawMethod: event.type,
+          rawPayload: event,
+        });
+
+      switch (event.type) {
+        case "session.start":
+        case "session.resume":
+          return [
+            {
+              ...base(),
+              type: "session.started",
+              payload: {
+                message:
+                  event.type === "session.resume"
+                    ? "Resumed GitHub Copilot session"
+                    : "Started GitHub Copilot session",
+                resume: event.data,
+              },
+            },
+            {
+              ...base(),
+              type: "thread.started",
+              payload: {
+                providerThreadId:
+                  event.type === "session.start" ? event.data.sessionId : record.session.sessionId,
+              },
+            },
+          ];
+        case "session.info":
+        case "session.warning":
+          return [
+            {
+              ...base(),
+              type: "runtime.warning",
+              payload: { message: event.data.message, detail: event.data },
+            },
+          ];
+        case "session.error":
+          return [
+            {
+              ...base(),
+              type: "runtime.error",
+              payload: {
+                message: event.data.message,
+                class: "provider_error",
+                detail: event.data,
+              },
+            },
+            {
+              ...base(),
+              type: "session.state.changed",
+              payload: { state: "error", reason: "session.error", detail: event.data },
+            },
+          ];
+        case "session.idle": {
+          const idleCompletionRefs = completionTurnRefs(record);
+          const idleCompletionEvents: ProviderRuntimeEvent[] =
+            idleCompletionRefs.turnId || idleCompletionRefs.providerTurnId
+              ? [
+                  {
+                    ...base(idleCompletionRefs),
+                    type: "turn.completed",
+                    payload: {
+                      state: "completed",
+                      ...assistantUsageFields(record.pendingTurnUsage),
+                    },
+                  } satisfies ProviderRuntimeEvent,
+                ]
+              : [];
+          return [
+            ...idleCompletionEvents,
+            {
+              ...base(),
+              type: "session.state.changed",
+              payload: { state: "ready", reason: "session.idle" },
+            },
+            {
+              ...base(),
+              type: "thread.state.changed",
+              payload: { state: "idle", detail: event.data },
+            },
+          ];
+        }
+        case "session.title_changed":
+          return [
+            {
+              ...base(),
+              type: "thread.metadata.updated",
+              payload: { name: event.data.title, metadata: event.data },
+            },
+          ];
+        case "session.model_change":
+          return [
+            {
+              ...base(),
+              type: "model.rerouted",
+              payload: {
+                fromModel: event.data.previousModel ?? "unknown",
+                toModel: event.data.newModel,
+                reason: "session.model_change",
+              },
+            },
+          ];
+        case "session.plan_changed":
+          return [
+            {
+              ...base(),
+              type: "turn.plan.updated",
+              payload: { explanation: `Plan ${event.data.operation}d`, plan: [] },
+            },
+          ];
+        case "session.workspace_file_changed":
+          return [
+            {
+              ...base(),
+              type: "files.persisted",
+              payload: {
+                files: [{ filename: event.data.path, fileId: event.data.path }],
+              },
+            },
+          ];
+        case "session.context_changed":
+          return [
+            {
+              ...base(),
+              type: "thread.metadata.updated",
+              payload: { metadata: event.data },
+            },
+          ];
+        case "session.usage_info":
+          return [
+            {
+              ...base(),
+              type: "thread.token-usage.updated",
+              payload: { usage: mapSessionUsageInfo(event.data) },
+            },
+          ];
+        case "session.task_complete":
+          return [
+            {
+              ...base(),
+              type: "task.completed",
+              payload: {
+                taskId: toRuntimeTaskId(record.threadId) ?? RuntimeTaskId.make(record.threadId),
+                status: "completed",
+                ...(trimToUndefined(event.data.summary) ? { summary: event.data.summary } : {}),
+              },
+            },
+          ];
+        case "assistant.turn_start":
+          return [
+            {
+              ...base({ providerTurnId: toTurnId(event.data.turnId) }),
+              type: "turn.started",
+              payload: record.model ? { model: record.model } : {},
+            },
+            {
+              ...base({ providerTurnId: toTurnId(event.data.turnId) }),
+              type: "session.state.changed",
+              payload: { state: "running", reason: "assistant.turn_start" },
+            },
+          ];
+        case "assistant.reasoning":
+          return [
+            {
+              ...base({ itemId: event.data.reasoningId }),
+              type: "item.completed",
+              payload: {
+                itemType: "reasoning",
+                status: "completed",
+                title: "Reasoning",
+                detail: trimToUndefined(event.data.content),
+                data: event.data,
+              },
+            },
+          ];
+        case "assistant.reasoning_delta":
+          return [
+            {
+              ...base({ itemId: event.data.reasoningId }),
+              type: "content.delta",
+              payload: { streamKind: "reasoning_text", delta: event.data.deltaContent },
+            },
+          ];
+        case "assistant.message":
+          return [
+            {
+              ...base({ itemId: event.data.messageId }),
+              type: "item.completed",
+              payload: {
+                itemType: "assistant_message",
+                status: "completed",
+                title: "Assistant message",
+                detail: trimToUndefined(event.data.content),
+                data: event.data,
+              },
+            },
+          ];
+        case "assistant.message_delta":
+          return [
+            {
+              ...base({ itemId: event.data.messageId }),
+              type: "content.delta",
+              payload: { streamKind: "assistant_text", delta: event.data.deltaContent },
+            },
+          ];
+        case "assistant.turn_end":
+          // Deliberately silent: the terminal `turn.completed` is emitted at
+          // `session.idle`, once trailing usage has landed.
+          return [];
+        case "assistant.usage": {
+          const completionRefs = completionTurnRefs(record);
+          const completionBase =
+            completionRefs.turnId || completionRefs.providerTurnId ? base(completionRefs) : base();
+          return [
+            {
+              ...completionBase,
+              type: "thread.token-usage.updated",
+              payload: { usage: mapAssistantUsage(event.data) },
+            },
+          ];
+        }
+        case "abort": {
+          const abortedTurnRefs = completionTurnRefs(record);
+          const abortedBase =
+            abortedTurnRefs.turnId || abortedTurnRefs.providerTurnId
+              ? base(abortedTurnRefs)
+              : base();
+          return [
+            {
+              ...abortedBase,
+              type: "turn.aborted",
+              payload: { reason: event.data.reason },
+            },
+          ];
+        }
+        case "tool.execution_start":
+          return [
+            {
+              ...base({ itemId: event.data.toolCallId }),
+              type: "item.started",
+              payload: {
+                itemType: itemTypeFromToolEvent(event),
+                status: "inProgress",
+                title: event.data.toolName ?? "Tool call",
+                ...(toolDetailFromEvent(event.data)
+                  ? { detail: toolDetailFromEvent(event.data) }
+                  : {}),
+                data: event.data,
+              },
+            },
+          ];
+        case "tool.execution_progress":
+          return [
+            {
+              ...base({ itemId: event.data.toolCallId }),
+              type: "tool.progress",
+              payload: {
+                toolUseId: event.data.toolCallId,
+                summary: event.data.progressMessage,
+              },
+            },
+          ];
+        case "tool.execution_partial_result":
+          return [
+            {
+              ...base({ itemId: event.data.toolCallId }),
+              type: "tool.progress",
+              payload: {
+                toolUseId: event.data.toolCallId,
+                summary: event.data.partialOutput,
+              },
+            },
+          ];
+        case "tool.execution_complete": {
+          const summary = trimToUndefined(event.data.result?.content);
+          return [
+            {
+              ...base({ itemId: event.data.toolCallId }),
+              type: "item.completed",
+              payload: {
+                itemType: event.data.result?.contents?.some(
+                  (content: { type?: string }) => content.type === "terminal",
+                )
+                  ? "command_execution"
+                  : "dynamic_tool_call",
+                status: event.data.success ? "completed" : "failed",
+                title: record.toolTitlesByCallId.get(event.data.toolCallId) ?? "Tool call",
+                ...(summary ? { detail: summary } : {}),
+                data: event.data,
+              },
+            },
+            ...(summary
+              ? [
+                  {
+                    ...base({ itemId: event.data.toolCallId }),
+                    type: "tool.summary" as const,
+                    payload: {
+                      summary,
+                      precedingToolUseIds: [event.data.toolCallId],
+                    },
+                  },
+                ]
+              : []),
+          ];
+        }
+        case "skill.invoked":
+          return [
+            {
+              ...base(),
+              type: "task.progress",
+              payload: {
+                taskId: toRuntimeTaskId(event.data.name) ?? RuntimeTaskId.make(event.data.name),
+                description: `Invoked skill ${event.data.name}`,
+              },
+            },
+          ];
+        case "subagent.started":
+          return [
+            {
+              ...base(),
+              type: "task.started",
+              payload: {
+                taskId:
+                  toRuntimeTaskId(event.data.toolCallId) ??
+                  RuntimeTaskId.make(event.data.toolCallId),
+                description: trimToUndefined(event.data.agentDescription),
+                taskType: "subagent",
+              },
+            },
+          ];
+        case "subagent.completed":
+          return [
+            {
+              ...base(),
+              type: "task.completed",
+              payload: {
+                taskId:
+                  toRuntimeTaskId(event.data.toolCallId) ??
+                  RuntimeTaskId.make(event.data.toolCallId),
+                status: "completed",
+                ...(trimToUndefined(event.data.agentDisplayName)
+                  ? { summary: event.data.agentDisplayName }
+                  : {}),
+              },
+            },
+          ];
+        case "subagent.failed":
+          return [
+            {
+              ...base(),
+              type: "task.completed",
+              payload: {
+                taskId:
+                  toRuntimeTaskId(event.data.toolCallId) ??
+                  RuntimeTaskId.make(event.data.toolCallId),
+                status: "failed",
+                ...(trimToUndefined(event.data.error) ? { summary: event.data.error } : {}),
+              },
+            },
+          ];
+        default:
+          return [];
+      }
+    };
+
+    const handleSessionEvent = (record: ActiveCopilotSession, event: SessionEvent) => {
+      record.updatedAt = event.timestamp;
+      if (event.type === "assistant.turn_start") {
+        beginCopilotTurn(record, TurnId.make(event.data.turnId));
+      }
+      if (event.type === "assistant.usage") {
+        recordTurnUsage(record, event.data);
+      }
+      if (event.type === "session.error") {
+        record.lastError = event.data.message;
+      }
+      if (event.type === "session.model_change") {
+        record.model = event.data.newModel;
+      }
+      if (event.type === "session.mode_changed") {
+        record.interactionMode = toInteractionMode(event.data.newMode);
+      }
+      if (event.type === "tool.execution_start") {
+        const toolName = trimToUndefined(event.data.toolName);
+        if (toolName) {
+          record.toolTitlesByCallId.set(event.data.toolCallId, toolName);
+        }
+      }
+
+      void writeNativeEvent(record.threadId, event);
+      const runtimeEvents = mapSessionEvent(record, event);
+      if (runtimeEvents.length > 0) {
+        void emitRuntimeEvents(runtimeEvents);
+      }
+      if (event.type === "session.plan_changed" && event.data.operation !== "delete") {
+        void runPromise(emitLatestProposedPlan(record)).catch((cause) => {
+          void emitRuntimeEvents([
+            makeSyntheticEvent(
+              record.threadId,
+              "runtime.warning",
+              {
+                message: "Failed to read GitHub Copilot plan.",
+                detail: toMessage(cause, "Failed to read GitHub Copilot plan."),
+              },
+              { turnId: currentSyntheticTurnId(record) },
+            ),
+          ]);
+        });
+      }
+      if (event.type === "tool.execution_complete") {
+        record.toolTitlesByCallId.delete(event.data.toolCallId);
+      }
+      if (event.type === "assistant.turn_end") {
+        markTurnAwaitingCompletion(record);
+      }
+      if (event.type === "abort" || event.type === "session.idle") {
+        clearTurnTracking(record);
+      }
+    };
+
+    const createInteractionHandlers = (
+      threadId: ThreadId,
+      getCurrentTurnId: () => TurnId | undefined,
+      getRuntimeMode: () => ProviderSession["runtimeMode"],
+      pendingApprovalResolvers: Map<string, PendingApprovalRequest>,
+      pendingUserInputResolvers: Map<string, PendingUserInputRequest>,
+    ) => {
+      const onPermissionRequest = (request: PermissionRequest) =>
+        getRuntimeMode() === "full-access"
+          ? Promise.resolve<PermissionRequestResult>({ kind: "approved" })
+          : new Promise<PermissionRequestResult>((resolve) => {
+              const requestId = `copilot-approval-${NodeCrypto.randomUUID()}`;
+              const turnId = getCurrentTurnId();
+              const requestType = requestTypeFromPermissionRequest(request);
+              const detail = requestDetailFromPermissionRequest(request);
+              pendingApprovalResolvers.set(requestId, { requestType, turnId, resolve });
+              void emitRuntimeEvents([
+                makeSyntheticEvent(
+                  threadId,
+                  "request.opened",
+                  {
+                    requestType,
+                    ...(detail ? { detail } : {}),
+                    args: request,
+                  },
+                  { requestId, turnId },
+                ),
+              ]);
+            });
+
+      const onUserInputRequest = (request: CopilotUserInputRequest) =>
+        new Promise<CopilotUserInputResponse>((resolve) => {
+          const requestId = `copilot-user-input-${NodeCrypto.randomUUID()}`;
+          const turnId = getCurrentTurnId();
+          pendingUserInputResolvers.set(requestId, { request, turnId, resolve });
+          void emitRuntimeEvents([
+            makeSyntheticEvent(
+              threadId,
+              "user-input.requested",
+              {
+                questions: [
+                  {
+                    id: USER_INPUT_QUESTION_ID,
+                    header: USER_INPUT_QUESTION_HEADER,
+                    question: request.question,
+                    options: (request.choices ?? []).map((choice: string) => ({
+                      label: choice,
+                      description: choice,
+                    })),
+                  },
+                ],
+              },
+              { requestId, turnId },
+            ),
+          ]);
+        });
+
+      return { onPermissionRequest, onUserInputRequest };
+    };
+
+    /**
+     * Fail fast on a model/effort combination Copilot would reject.
+     *
+     * Without this the SDK surfaces the rejection mid-turn as an opaque
+     * session error, long after the user pressed send.
+     */
+    const validateSessionConfiguration = (input: {
+      readonly client: CopilotClientHandle;
+      readonly threadId: ThreadId;
+      readonly model: string | undefined;
+      readonly reasoningEffort: CopilotReasoningEffort | undefined;
+    }) =>
+      Effect.gen(function* () {
+        if (!input.model && !input.reasoningEffort) {
+          return;
+        }
+
+        yield* Effect.tryPromise({
+          try: () => input.client.start(),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+              detail: toMessage(cause, "Failed to start GitHub Copilot client."),
+              cause,
+            }),
+        });
+
+        const models = yield* Effect.tryPromise({
+          try: () => input.client.listModels(),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+              detail: toMessage(cause, "Failed to load GitHub Copilot model metadata."),
+              cause,
+            }),
+        });
+        const supportedModels = new Map(models.map((model) => [model.id, model]));
+        const selectedModel = input.model ? supportedModels.get(input.model) : undefined;
+
+        if (input.model && !selectedModel) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "session.model",
+            issue: `GitHub Copilot model '${input.model}' is not available on this account.`,
+          });
+        }
+
+        if (!input.reasoningEffort) {
+          return;
+        }
+
+        if (!selectedModel) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "session.reasoningEffort",
+            issue:
+              "GitHub Copilot reasoning effort requires an explicit supported model selection.",
+          });
+        }
+
+        const supportedReasoningEfforts = selectedModel.supportedReasoningEfforts ?? [];
+        if (supportedReasoningEfforts.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "session.reasoningEffort",
+            issue: `GitHub Copilot model '${selectedModel.id}' does not support reasoning effort configuration.`,
+          });
+        }
+
+        if (!supportedReasoningEfforts.includes(input.reasoningEffort)) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "session.reasoningEffort",
+            issue: `GitHub Copilot model '${selectedModel.id}' does not support reasoning effort '${input.reasoningEffort}'.`,
+          });
+        }
+      });
+
+    /**
+     * Apply a new model and/or reasoning effort to a live session.
+     *
+     * `setModel` keeps the conversation, the session id, and our event
+     * subscription intact — it only takes effect from the next message — so a
+     * mid-thread model switch costs nothing and needs no re-subscription.
+     *
+     * There is no way to clear a previously-set effort back to the model's
+     * default, so an `undefined` effort simply leaves the last value in place
+     * on the SDK side; `record.reasoningEffort` still tracks our intent.
+     */
+    const reconfigureSession = (
+      record: ActiveCopilotSession,
+      input: {
+        readonly model: string | undefined;
+        readonly reasoningEffort: CopilotReasoningEffort | undefined;
+      },
+    ) => {
+      const targetModel = input.model ?? record.model;
+      if (!targetModel) {
+        // Nothing to switch to — the session keeps Copilot's default model.
+        return Effect.sync(() => {
+          record.reasoningEffort = input.reasoningEffort;
+        });
+      }
+      return Effect.tryPromise({
+        try: async () => {
+          await record.session.setModel(
+            targetModel,
+            input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {},
+          );
+          record.model = targetModel;
+          record.reasoningEffort = input.reasoningEffort;
+          record.updatedAt = nowIso();
+        },
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.setModel",
+            detail: toMessage(cause, "Failed to reconfigure GitHub Copilot session."),
+            cause,
+          }),
+      });
+    };
+
+    const getSessionRecord = (threadId: ThreadId) => {
+      const record = sessions.get(threadId);
+      if (!record) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(record);
+    };
+
+    const stopRecord = async (record: ActiveCopilotSession) => {
+      record.unsubscribe();
+      try {
+        await record.session.disconnect();
+      } catch {
+        // Best effort: the CLI may already be gone.
+      }
+      try {
+        await record.client.stop();
+      } catch {
+        // Best effort.
+      }
+      // Never leave the SDK awaiting a promise we will no longer resolve —
+      // that would wedge the child process on shutdown.
+      for (const pending of record.pendingApprovalResolvers.values()) {
+        pending.resolve({ kind: "denied-interactively-by-user" });
+      }
+      for (const pending of record.pendingUserInputResolvers.values()) {
+        pending.resolve({ answer: "", wasFreeform: true });
+      }
+      record.pendingApprovalResolvers.clear();
+      record.pendingUserInputResolvers.clear();
+      sessions.delete(record.threadId);
+    };
+
+    const toProviderSession = (
+      record: ActiveCopilotSession,
+      status: ProviderSession["status"],
+    ): ProviderSession => ({
+      provider: PROVIDER,
+      providerInstanceId: boundInstanceId,
+      status,
+      runtimeMode: record.runtimeMode,
+      ...(record.cwd ? { cwd: record.cwd } : {}),
+      ...(record.model ? { model: record.model } : {}),
+      threadId: record.threadId,
+      resumeCursor: record.session.sessionId,
+      ...(record.currentTurnId ? { activeTurnId: record.currentTurnId } : {}),
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+      ...(record.lastError ? { lastError: record.lastError } : {}),
+    });
+
+    const startSession: CopilotAdapterShape["startSession"] = (input) =>
+      Effect.gen(function* () {
+        if (input.provider !== undefined && input.provider !== PROVIDER) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: `Expected provider '${PROVIDER}', received '${input.provider}'.`,
+          });
+        }
+
+        const existing = sessions.get(input.threadId);
+        if (existing) {
+          return toProviderSession(existing, "ready");
+        }
+
+        const requestedModelSelection =
+          input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+        const sessionConfiguration: CopilotSessionConfiguration = {
+          model: requestedModelSelection?.model,
+          reasoningEffort: copilotReasoningEffortFromSelection(requestedModelSelection),
+        };
+
+        const configDir = trimToUndefined(copilotSettings.homePath);
+        const mcpServers = yield* Effect.tryPromise({
+          try: () => loadCopilotMcpServers(configDir),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+              detail: toMessage(cause, "Failed to load GitHub Copilot MCP configuration."),
+              cause,
+            }),
+        });
+        const resumeSessionId = extractResumeSessionId(input.resumeCursor);
+        const clientOptions = yield* makeCopilotClientOptions(
+          copilotSettings,
+          input.cwd ? { cwd: input.cwd } : {},
+        );
+        const client = options?.clientFactory?.(clientOptions) ?? new CopilotClient(clientOptions);
+        const pendingApprovalResolvers = new Map<string, PendingApprovalRequest>();
+        const pendingUserInputResolvers = new Map<string, PendingUserInputRequest>();
+        // Handlers can fire before `createSession` resolves, so they read the
+        // record through a mutable binding rather than capturing it.
+        let sessionRecord: ActiveCopilotSession | undefined;
+        const handlers = createInteractionHandlers(
+          input.threadId,
+          () => sessionRecord?.currentTurnId,
+          () => sessionRecord?.runtimeMode ?? input.runtimeMode,
+          pendingApprovalResolvers,
+          pendingUserInputResolvers,
+        );
+
+        yield* validateSessionConfiguration({
+          client,
+          threadId: input.threadId,
+          ...sessionConfiguration,
+        });
+
+        const session = yield* Effect.tryPromise({
+          try: async () => {
+            const config = {
+              ...handlers,
+              ...(sessionConfiguration.model ? { model: sessionConfiguration.model } : {}),
+              ...(sessionConfiguration.reasoningEffort
+                ? { reasoningEffort: sessionConfiguration.reasoningEffort }
+                : {}),
+              ...(input.cwd ? { workingDirectory: input.cwd } : {}),
+              ...(configDir ? { configDir } : {}),
+              ...(mcpServers ? { mcpServers } : {}),
+              streaming: true,
+            };
+            return resumeSessionId
+              ? client.resumeSession(resumeSessionId, config)
+              : client.createSession(config);
+          },
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+              detail: toMessage(cause, "Failed to start GitHub Copilot session."),
+              cause,
+            }),
+        });
+
+        const startedAt = nowIso();
+        const record: ActiveCopilotSession = {
+          client,
+          session,
+          threadId: input.threadId,
+          createdAt: startedAt,
+          runtimeMode: input.runtimeMode,
+          cwd: input.cwd,
+          configDir,
+          mcpServers,
+          model: sessionConfiguration.model,
+          reasoningEffort: sessionConfiguration.reasoningEffort,
+          interactionMode: undefined,
+          updatedAt: startedAt,
+          lastError: undefined,
+          currentTurnId: undefined,
+          currentProviderTurnId: undefined,
+          pendingCompletionTurnId: undefined,
+          pendingCompletionProviderTurnId: undefined,
+          pendingTurnIds: [],
+          pendingTurnUsage: undefined,
+          toolTitlesByCallId: new Map(),
+          pendingApprovalResolvers,
+          pendingUserInputResolvers,
+          unsubscribe: () => undefined,
+        };
+        record.unsubscribe = session.on((event) => {
+          handleSessionEvent(record, event);
+        });
+        sessionRecord = record;
+        sessions.set(input.threadId, record);
+
+        yield* Effect.forEach(
+          [
+            makeSyntheticEvent(input.threadId, "session.started", {
+              message: resumeSessionId
+                ? "Resumed GitHub Copilot session"
+                : "Started GitHub Copilot session",
+              resume: { sessionId: session.sessionId },
+            }),
+            makeSyntheticEvent(input.threadId, "session.configured", {
+              config: {
+                ...(input.cwd ? { cwd: input.cwd } : {}),
+                ...(sessionConfiguration.model ? { model: sessionConfiguration.model } : {}),
+                ...(sessionConfiguration.reasoningEffort
+                  ? { reasoningEffort: sessionConfiguration.reasoningEffort }
+                  : {}),
+                ...(configDir ? { configDir } : {}),
+                streaming: true,
+              },
+            }),
+            makeSyntheticEvent(input.threadId, "thread.started", {
+              providerThreadId: session.sessionId,
+            }),
+            makeSyntheticEvent(input.threadId, "session.state.changed", {
+              state: "ready",
+              reason: "session.started",
+            }),
+          ],
+          offerRuntimeEvent,
+          { discard: true },
+        );
+
+        return toProviderSession(record, "ready");
+      });
+
+    const sendTurn: CopilotAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(input.threadId);
+        const requestedModelSelection =
+          input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+        const explicitReasoningEffort =
+          copilotReasoningEffortFromSelection(requestedModelSelection);
+        const nextModel = requestedModelSelection?.model ?? record.model;
+        // Switching models drops a stale effort rather than carrying it over:
+        // the new model may not support the old level at all.
+        const nextReasoningEffort =
+          explicitReasoningEffort !== undefined
+            ? explicitReasoningEffort
+            : requestedModelSelection?.model !== undefined &&
+                requestedModelSelection.model !== record.model
+              ? undefined
+              : record.reasoningEffort;
+
+        const attachments: Array<{ type: "file"; path: string; displayName: string }> = [];
+        for (const attachment of input.attachments ?? []) {
+          const attachmentPath = resolveAttachmentPath({
+            attachmentsDir: serverConfig.attachmentsDir,
+            attachment,
+          });
+          if (!attachmentPath) {
+            return yield* new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session.send",
+              detail: `Invalid attachment id '${attachment.id}'.`,
+            });
+          }
+          attachments.push({
+            type: "file",
+            path: attachmentPath,
+            displayName: attachment.name,
+          });
+        }
+
+        yield* validateSessionConfiguration({
+          client: record.client,
+          threadId: input.threadId,
+          model: nextModel,
+          reasoningEffort: nextReasoningEffort,
+        });
+
+        if (nextModel !== record.model || nextReasoningEffort !== record.reasoningEffort) {
+          yield* reconfigureSession(record, {
+            model: nextModel,
+            reasoningEffort: nextReasoningEffort,
+          });
+        }
+
+        const interactionMode = input.interactionMode ?? record.interactionMode ?? "default";
+        yield* syncInteractionMode(record, interactionMode);
+
+        const turnId = TurnId.make(`copilot-turn-${NodeCrypto.randomUUID()}`);
+        record.pendingTurnIds.push(turnId);
+        record.currentTurnId = turnId;
+        record.currentProviderTurnId = undefined;
+
+        yield* Effect.tryPromise({
+          try: () =>
+            record.session.send({
+              prompt: input.input ?? "",
+              ...(attachments.length > 0 ? { attachments } : {}),
+              mode: "immediate",
+            }),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session.send",
+              detail: toMessage(cause, "Failed to send GitHub Copilot turn."),
+              cause,
+            }),
+        }).pipe(
+          Effect.tapError(() =>
+            Effect.sync(() => {
+              // Roll back the optimistic turn bookkeeping so a failed send
+              // does not leave a phantom turn queued forever.
+              record.pendingTurnIds = record.pendingTurnIds.filter(
+                (candidate) => candidate !== turnId,
+              );
+              if (record.currentTurnId === turnId) {
+                record.currentTurnId = undefined;
+              }
+            }),
+          ),
+        );
+
+        record.updatedAt = nowIso();
+
+        return {
+          threadId: input.threadId,
+          turnId,
+          resumeCursor: record.session.sessionId,
+        } satisfies ProviderTurnStartResult;
+      });
+
+    const interruptTurn: CopilotAdapterShape["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        yield* Effect.tryPromise({
+          try: () => record.session.abort(),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session.abort",
+              detail: toMessage(cause, "Failed to interrupt GitHub Copilot turn."),
+              cause,
+            }),
+        });
+      });
+
+    const respondToRequest: CopilotAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        const pending = record.pendingApprovalResolvers.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.permission.respond",
+            detail: `Unknown pending GitHub Copilot approval request '${requestId}'.`,
+          });
+        }
+        record.pendingApprovalResolvers.delete(requestId);
+        const resolution = approvalDecisionToPermissionResult(decision);
+        pending.resolve(resolution);
+        yield* offerRuntimeEvent(
+          makeSyntheticEvent(
+            threadId,
+            "request.resolved",
+            { requestType: pending.requestType, decision, resolution },
+            { requestId, turnId: pending.turnId },
+          ),
+        );
+      });
+
+    const respondToUserInput: CopilotAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      answers,
+    ) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        const pending = record.pendingUserInputResolvers.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.userInput.respond",
+            detail: `Unknown pending GitHub Copilot user-input request '${requestId}'.`,
+          });
+        }
+        record.pendingUserInputResolvers.delete(requestId);
+        pending.resolve(resolveUserInputAnswer(pending, answers));
+        yield* offerRuntimeEvent(
+          makeSyntheticEvent(
+            threadId,
+            "user-input.resolved",
+            { answers },
+            { requestId, turnId: pending.turnId },
+          ),
+        );
+      });
+
+    const stopSession: CopilotAdapterShape["stopSession"] = (threadId) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        yield* Effect.tryPromise({
+          try: () => stopRecord(record),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId,
+              detail: toMessage(cause, "Failed to stop GitHub Copilot session."),
+              cause,
+            }),
+        });
+      });
+
+    const listSessions: CopilotAdapterShape["listSessions"] = () =>
+      Effect.sync(() =>
+        Array.from(sessions.values()).map((record) =>
+          toProviderSession(record, record.currentTurnId ? "running" : "ready"),
+        ),
+      );
+
+    const hasSession: CopilotAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => sessions.has(threadId));
+
+    const readThread: CopilotAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        return yield* Effect.tryPromise({
+          try: async () => mapHistoryToTurns(threadId, await record.session.getEvents()),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session.getEvents",
+              detail: toMessage(cause, "Failed to read GitHub Copilot thread history."),
+              cause,
+            }),
+        });
+      });
+
+    const rollbackThread: CopilotAdapterShape["rollbackThread"] = () =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "thread.rollback",
+          detail:
+            "The GitHub Copilot SDK does not expose a conversation rollback API for existing sessions.",
+        }),
+      );
+
+    const stopAll: CopilotAdapterShape["stopAll"] = () =>
+      Effect.tryPromise({
+        try: async () => {
+          await Promise.all(Array.from(sessions.values()).map((record) => stopRecord(record)));
+        },
+        catch: (cause) =>
+          new ProviderAdapterProcessError({
+            provider: PROVIDER,
+            threadId: ThreadId.make("_all"),
+            detail: toMessage(cause, "Failed to stop GitHub Copilot sessions."),
+            cause,
+          }),
+      });
+
+    return {
+      provider: PROVIDER,
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      readThread,
+      rollbackThread,
+      stopAll,
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+    } satisfies CopilotAdapterShape;
+  });
+}
+
+/**
+ * Slice a flat Copilot event log into turns.
+ *
+ * Events before the first `assistant.turn_start` (session bootstrap, restored
+ * user messages) belong to no turn and are dropped — `readThread` is only
+ * asked for assistant turns.
+ */
+export function mapHistoryToTurns(
+  threadId: ThreadId,
+  events: ReadonlyArray<SessionEvent>,
+): ProviderThreadSnapshot {
+  const turns: Array<{ id: TurnId; items: Array<unknown> }> = [];
+  let current: { id: TurnId; items: Array<unknown> } | undefined;
+
+  for (const event of events) {
+    if (event.type === "assistant.turn_start") {
+      current = { id: TurnId.make(event.data.turnId), items: [event] };
+      turns.push(current);
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    current.items.push(event);
+    if (isCopilotTurnTerminalEvent(event)) {
+      current = undefined;
+    }
+  }
+
+  return {
+    threadId,
+    turns: turns.map((turn): ProviderThreadTurnSnapshot => ({ id: turn.id, items: turn.items })),
+  };
+}

--- a/apps/server/src/provider/Layers/CopilotProvider.test.ts
+++ b/apps/server/src/provider/Layers/CopilotProvider.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import { CopilotSettings } from "@t3tools/contracts";
+import type { ModelInfo } from "@github/copilot-sdk";
+
+import {
+  buildCopilotEffortDescriptors,
+  buildInitialCopilotProviderSnapshot,
+  copilotAuthStatusFromMessage,
+  copilotModelFromInfo,
+  copilotModelsFromInfos,
+} from "./CopilotProvider.ts";
+
+const decodeCopilotSettings = Schema.decodeSync(CopilotSettings);
+
+const modelInfo = (overrides: Partial<ModelInfo> & Pick<ModelInfo, "id" | "name">): ModelInfo =>
+  ({
+    capabilities: {
+      supports: { vision: false, reasoningEffort: false },
+      limits: { max_context_window_tokens: 128_000 },
+    },
+    ...overrides,
+  }) as ModelInfo;
+
+describe("buildInitialCopilotProviderSnapshot", () => {
+  it.effect("returns a disabled snapshot when settings.enabled is false", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialCopilotProviderSnapshot(
+        decodeCopilotSettings({ enabled: false }),
+      );
+      expect(snapshot.enabled).toBe(false);
+      expect(snapshot.status).toBe("disabled");
+      expect(snapshot.installed).toBe(false);
+      expect(snapshot.message).toContain("disabled");
+    }),
+  );
+
+  it.effect("seeds the picker with the fallback catalog before the first probe", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialCopilotProviderSnapshot(decodeCopilotSettings({}));
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.status).toBe("warning");
+      expect(snapshot.message).toContain("Checking GitHub Copilot");
+      expect(snapshot.models.length).toBeGreaterThan(0);
+      // The user's headline ask: every catalog entry advertises its limit.
+      for (const model of snapshot.models) {
+        expect(model.maxContextWindowTokens).toBeGreaterThan(0);
+      }
+    }),
+  );
+
+  it.effect("appends user-configured custom models", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialCopilotProviderSnapshot(
+        decodeCopilotSettings({ customModels: ["some-private-preview"] }),
+      );
+      const custom = snapshot.models.find((model) => model.slug === "some-private-preview");
+      expect(custom?.isCustom).toBe(true);
+    }),
+  );
+});
+
+describe("copilotModelFromInfo", () => {
+  it("carries the context window and billing multiplier through", () => {
+    const model = copilotModelFromInfo(
+      modelInfo({
+        id: "claude-sonnet-4.6",
+        name: "Claude Sonnet 4.6",
+        billing: { multiplier: 1 },
+        capabilities: {
+          supports: { vision: true, reasoningEffort: false },
+          limits: { max_context_window_tokens: 144_000 },
+        },
+      }),
+    );
+
+    expect(model.slug).toBe("claude-sonnet-4.6");
+    expect(model.maxContextWindowTokens).toBe(144_000);
+    expect(model.billingMultiplier).toBe(1);
+    expect(model.capabilities?.optionDescriptors).toEqual([]);
+  });
+
+  it("keeps a zero multiplier — 'included in plan' is meaningful, not missing", () => {
+    const model = copilotModelFromInfo(
+      modelInfo({ id: "gpt-5-mini", name: "GPT-5 mini", billing: { multiplier: 0 } }),
+    );
+    expect(model.billingMultiplier).toBe(0);
+  });
+
+  it("omits the context window when the provider reports a non-positive limit", () => {
+    const model = copilotModelFromInfo(
+      modelInfo({
+        id: "weird",
+        name: "Weird",
+        capabilities: {
+          supports: { vision: false, reasoningEffort: false },
+          limits: { max_context_window_tokens: 0 },
+        },
+      }),
+    );
+    expect(model.maxContextWindowTokens).toBeUndefined();
+  });
+
+  it("exposes only the reasoning efforts the model advertises", () => {
+    const model = copilotModelFromInfo(
+      modelInfo({
+        id: "gpt-5.1-codex",
+        name: "GPT-5.1 Codex",
+        supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+        defaultReasoningEffort: "medium",
+      }),
+    );
+
+    const descriptor = model.capabilities?.optionDescriptors?.[0];
+    expect(descriptor?.id).toBe("effort");
+    expect(descriptor?.type).toBe("select");
+    if (descriptor?.type !== "select") throw new Error("expected a select descriptor");
+    expect(descriptor.options.map((option) => option.id)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(descriptor.options.find((option) => option.isDefault)?.id).toBe("medium");
+  });
+});
+
+describe("buildCopilotEffortDescriptors", () => {
+  it("returns no descriptor when the model supports no efforts", () => {
+    expect(buildCopilotEffortDescriptors({ supportedEfforts: [] })).toEqual([]);
+  });
+
+  it("falls back to 'high' when the provider names no default", () => {
+    const [descriptor] = buildCopilotEffortDescriptors({
+      supportedEfforts: ["low", "high", "xhigh"],
+    });
+    if (descriptor?.type !== "select") throw new Error("expected a select descriptor");
+    expect(descriptor.options.find((option) => option.isDefault)?.id).toBe("high");
+  });
+
+  it("falls back to the strongest level when 'high' is unsupported", () => {
+    const [descriptor] = buildCopilotEffortDescriptors({ supportedEfforts: ["low", "medium"] });
+    if (descriptor?.type !== "select") throw new Error("expected a select descriptor");
+    expect(descriptor.options.find((option) => option.isDefault)?.id).toBe("medium");
+  });
+
+  it("ignores efforts Copilot does not define", () => {
+    const [descriptor] = buildCopilotEffortDescriptors({
+      supportedEfforts: ["low", "ultrathink", "max"],
+    });
+    if (descriptor?.type !== "select") throw new Error("expected a select descriptor");
+    expect(descriptor.options.map((option) => option.id)).toEqual(["low"]);
+  });
+});
+
+describe("copilotModelsFromInfos", () => {
+  it("drops policy-disabled models the account cannot select", () => {
+    const models = copilotModelsFromInfos([
+      modelInfo({ id: "allowed", name: "Allowed" }),
+      modelInfo({
+        id: "blocked",
+        name: "Blocked",
+        policy: { state: "disabled", terms: "" },
+      }),
+    ]);
+    expect(models.map((model) => model.slug)).toEqual(["allowed"]);
+  });
+
+  it("keeps unconfigured-policy models, which are still selectable", () => {
+    const models = copilotModelsFromInfos([
+      modelInfo({ id: "pending", name: "Pending", policy: { state: "unconfigured", terms: "" } }),
+    ]);
+    expect(models.map((model) => model.slug)).toEqual(["pending"]);
+  });
+});
+
+describe("copilotAuthStatusFromMessage", () => {
+  it.each([
+    "Not authenticated with GitHub",
+    "login required",
+    "Please sign in to continue",
+    "request failed with status 401",
+    // Observed verbatim from the CLI for an account with no Copilot seat.
+    'Request models.list failed with message: 403 "unauthorized: not authorized to use this Copilot feature"',
+  ])("classifies %j as unauthenticated", (message) => {
+    expect(copilotAuthStatusFromMessage(message).status).toBe("unauthenticated");
+  });
+
+  it("leaves unrelated failures unknown", () => {
+    expect(copilotAuthStatusFromMessage("ENOENT: spawn copilot").status).toBe("unknown");
+  });
+});

--- a/apps/server/src/provider/Layers/CopilotProvider.ts
+++ b/apps/server/src/provider/Layers/CopilotProvider.ts
@@ -1,0 +1,512 @@
+/**
+ * GitHub Copilot provider snapshot — availability probe and model catalog.
+ *
+ * Model discovery goes through `CopilotClient.listModels()`, which returns the
+ * models the *signed-in account's subscription* actually grants, along with
+ * the two things the picker cares about:
+ *
+ *   - `supportedReasoningEfforts` → an `effort` select descriptor, so the
+ *     effort control only offers levels the model really accepts (Copilot
+ *     rejects a session configured with an unsupported effort).
+ *   - `capabilities.limits.max_context_window_tokens` → `maxContextWindowTokens`,
+ *     rendered next to the model name. Copilot's context window is a fixed
+ *     per-model limit, not a user-selectable variant, so it is presentational
+ *     rather than a `contextWindow` option descriptor.
+ *
+ * `COPILOT_BUILT_IN_MODELS` is only a fallback for when the CLI cannot be
+ * reached (not installed, not signed in, offline). A successful probe always
+ * replaces it wholesale with live data.
+ *
+ * @module provider/Layers/CopilotProvider
+ */
+import {
+  type CopilotSettings,
+  type ModelCapabilities,
+  type ServerProvider,
+  type ServerProviderAuth,
+  type ServerProviderModel,
+  type ServerProviderState,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { CopilotClient, type CopilotClientOptions, type ModelInfo } from "@github/copilot-sdk";
+import { causeErrorTag } from "@t3tools/shared/observability";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import { HttpClient } from "effect/unstable/http";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+import {
+  buildSelectOptionDescriptor,
+  buildServerProvider,
+  providerModelsFromSettings,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+import { normalizeCopilotCliPathOverride, resolveBundledCopilotCliPath } from "./copilotCliPath.ts";
+
+const COPILOT_PRESENTATION = {
+  displayName: "GitHub Copilot",
+  badgeLabel: "Early Access",
+  // The Copilot CLI has a first-class plan mode we forward via `mode.set`.
+  showInteractionModeToggle: true,
+  // Sessions are reconfigured in place (see `CopilotAdapter.reconfigureSession`),
+  // so switching model mid-thread does not require a new thread.
+  requiresNewThreadForModelChange: false,
+} as const;
+
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({ optionDescriptors: [] });
+
+/** Copilot's reasoning ladder, ordered weakest → strongest. */
+const REASONING_EFFORT_ORDER = ["low", "medium", "high", "xhigh"] as const;
+type CopilotReasoningEffort = (typeof REASONING_EFFORT_ORDER)[number];
+
+const REASONING_EFFORT_LABELS: Record<CopilotReasoningEffort, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+};
+
+/** Copilot's model probe spawns the CLI; give it room on a cold start. */
+const MODEL_DISCOVERY_TIMEOUT_MS = 20_000;
+
+/**
+ * The SDK throws untyped `Error`s. Wrapping them keeps the probe's failure
+ * channel tagged, and preserves the human-readable text we sniff for auth
+ * state in {@link copilotAuthStatusFromMessage}.
+ */
+class CopilotProbeError extends Schema.TaggedErrorClass<CopilotProbeError>()("CopilotProbeError", {
+  detail: Schema.String,
+  cause: Schema.optional(Schema.Defect()),
+}) {
+  override get message(): string {
+    return this.detail;
+  }
+}
+
+export function isCopilotReasoningEffort(value: unknown): value is CopilotReasoningEffort {
+  return (
+    typeof value === "string" && (REASONING_EFFORT_ORDER as ReadonlyArray<string>).includes(value)
+  );
+}
+
+/**
+ * Build the `effort` descriptor from the levels a model advertises.
+ *
+ * `defaultEffort` comes from Copilot's own `defaultReasoningEffort` when
+ * present; otherwise we prefer `high`, then the strongest supported level, so
+ * the picker always has a marked default.
+ */
+export function buildCopilotEffortDescriptors(input: {
+  readonly supportedEfforts: ReadonlyArray<string>;
+  readonly defaultEffort?: string | undefined;
+}) {
+  const supported = REASONING_EFFORT_ORDER.filter((effort) =>
+    input.supportedEfforts.includes(effort),
+  );
+  if (supported.length === 0) {
+    return [];
+  }
+
+  const preferred = isCopilotReasoningEffort(input.defaultEffort) ? input.defaultEffort : undefined;
+  const defaultEffort =
+    preferred && supported.includes(preferred)
+      ? preferred
+      : supported.includes("high")
+        ? "high"
+        : supported[supported.length - 1];
+
+  return [
+    buildSelectOptionDescriptor({
+      id: "effort",
+      label: "Reasoning",
+      description: "Reasoning effort passed to the Copilot session.",
+      options: supported.map((effort) => ({
+        value: effort,
+        label: REASONING_EFFORT_LABELS[effort],
+        ...(effort === defaultEffort ? { isDefault: true as const } : {}),
+      })),
+    }),
+  ];
+}
+
+function capabilitiesForEfforts(input: {
+  readonly supportedEfforts: ReadonlyArray<string>;
+  readonly defaultEffort?: string | undefined;
+}): ModelCapabilities {
+  return createModelCapabilities({
+    optionDescriptors: buildCopilotEffortDescriptors(input),
+  });
+}
+
+function staticModel(input: {
+  readonly slug: string;
+  readonly name: string;
+  readonly maxContextWindowTokens: number;
+  readonly billingMultiplier: number;
+  readonly efforts?: ReadonlyArray<CopilotReasoningEffort>;
+}): ServerProviderModel {
+  return {
+    slug: input.slug,
+    name: input.name,
+    isCustom: false,
+    maxContextWindowTokens: input.maxContextWindowTokens,
+    billingMultiplier: input.billingMultiplier,
+    capabilities: input.efforts
+      ? capabilitiesForEfforts({ supportedEfforts: input.efforts })
+      : EMPTY_CAPABILITIES,
+  };
+}
+
+/**
+ * Offline fallback catalog of Copilot subscription models.
+ *
+ * These figures mirror what the Copilot API reports for a paid plan at the
+ * time of writing; they exist so the picker is not empty before the first
+ * successful probe. Every field here is replaced by live `listModels()` data
+ * as soon as the CLI answers, so treat them as a seed, not a source of truth.
+ */
+export const COPILOT_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+  staticModel({
+    slug: "claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
+    maxContextWindowTokens: 144_000,
+    billingMultiplier: 1,
+  }),
+  staticModel({
+    slug: "claude-opus-4.7",
+    name: "Claude Opus 4.7",
+    maxContextWindowTokens: 144_000,
+    billingMultiplier: 10,
+  }),
+  staticModel({
+    slug: "claude-haiku-4.5",
+    name: "Claude Haiku 4.5",
+    maxContextWindowTokens: 144_000,
+    billingMultiplier: 0.33,
+  }),
+  staticModel({
+    slug: "gpt-5.1-codex",
+    name: "GPT-5.1 Codex",
+    maxContextWindowTokens: 128_000,
+    billingMultiplier: 1,
+    efforts: ["low", "medium", "high", "xhigh"],
+  }),
+  staticModel({
+    slug: "gpt-5-mini",
+    name: "GPT-5 mini",
+    maxContextWindowTokens: 128_000,
+    billingMultiplier: 0,
+    efforts: ["low", "medium", "high"],
+  }),
+  staticModel({
+    slug: "gemini-3.1-pro",
+    name: "Gemini 3.1 Pro",
+    maxContextWindowTokens: 128_000,
+    billingMultiplier: 1,
+  }),
+];
+
+function trimToUndefined(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function toMessage(cause: unknown, fallback: string): string {
+  if (cause instanceof Error && cause.message.length > 0) {
+    return cause.message;
+  }
+  return fallback;
+}
+
+function toPositiveInt(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : undefined;
+}
+
+export const makeCopilotClientOptions = Effect.fn("makeCopilotClientOptions")(function* (
+  settings: CopilotSettings,
+  overrides?: { readonly cwd?: string | undefined },
+): Effect.fn.Return<CopilotClientOptions, never, never> {
+  const platform = yield* HostProcessPlatform;
+  const arch = yield* HostProcessArchitecture;
+  const cliPath =
+    normalizeCopilotCliPathOverride(settings.binaryPath) ??
+    resolveBundledCopilotCliPath({ platform, arch });
+  return {
+    ...(cliPath ? { cliPath } : {}),
+    ...(overrides?.cwd ? { cwd: overrides.cwd } : {}),
+    logLevel: "error",
+  };
+});
+
+/** Translate one live `ModelInfo` into a picker entry. */
+export function copilotModelFromInfo(model: ModelInfo): ServerProviderModel {
+  const contextWindow = toPositiveInt(model.capabilities?.limits?.max_context_window_tokens);
+  const multiplier = model.billing?.multiplier;
+  const supportedEfforts = model.supportedReasoningEfforts ?? [];
+
+  return {
+    slug: model.id,
+    name: trimToUndefined(model.name) ?? model.id,
+    isCustom: false,
+    ...(contextWindow !== undefined ? { maxContextWindowTokens: contextWindow } : {}),
+    ...(typeof multiplier === "number" && Number.isFinite(multiplier) && multiplier >= 0
+      ? { billingMultiplier: multiplier }
+      : {}),
+    capabilities: capabilitiesForEfforts({
+      supportedEfforts,
+      ...(model.defaultReasoningEffort ? { defaultEffort: model.defaultReasoningEffort } : {}),
+    }),
+  };
+}
+
+/**
+ * Drop models the account cannot actually use. Copilot returns
+ * policy-gated models (org admin has not enabled them) in the same list as
+ * usable ones; selecting those fails at session start with an opaque error.
+ */
+function isSelectableModel(model: ModelInfo): boolean {
+  return model.policy === undefined || model.policy.state !== "disabled";
+}
+
+export function copilotModelsFromInfos(
+  models: ReadonlyArray<ModelInfo>,
+): ReadonlyArray<ServerProviderModel> {
+  return models
+    .filter(isSelectableModel)
+    .map(copilotModelFromInfo)
+    .toSorted((left, right) => left.name.localeCompare(right.name));
+}
+
+function fallbackModels(settings: CopilotSettings): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(
+    COPILOT_BUILT_IN_MODELS,
+    settings.customModels ?? [],
+    EMPTY_CAPABILITIES,
+  );
+}
+
+function resolveRuntimeModels(
+  models: ReadonlyArray<ModelInfo>,
+  settings: CopilotSettings,
+): ReadonlyArray<ServerProviderModel> {
+  const runtimeModels = copilotModelsFromInfos(models);
+  return providerModelsFromSettings(
+    runtimeModels.length > 0 ? runtimeModels : COPILOT_BUILT_IN_MODELS,
+    settings.customModels ?? [],
+    EMPTY_CAPABILITIES,
+  );
+}
+
+/**
+ * The SDK surfaces auth failures as ordinary `Error`s with human text, so
+ * sniffing the message is the only signal available for distinguishing
+ * "not signed in" from "CLI is broken".
+ */
+export function copilotAuthStatusFromMessage(message: string): Pick<ServerProviderAuth, "status"> {
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("not authenticated") ||
+    normalized.includes("unauthenticated") ||
+    normalized.includes("unauthorized") ||
+    normalized.includes("login required") ||
+    normalized.includes("not logged in") ||
+    normalized.includes("sign in") ||
+    normalized.includes("sign-in") ||
+    normalized.includes("authentication required") ||
+    normalized.includes("401") ||
+    // An account without a Copilot entitlement fails `models.list` with
+    // `403 unauthorized: not authorized to use this Copilot feature` —
+    // actionable in exactly the same way as a missing login.
+    normalized.includes("403")
+  ) {
+    return { status: "unauthenticated" };
+  }
+  return { status: "unknown" };
+}
+
+function isInstalledFromMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    !normalized.includes("enoent") &&
+    !normalized.includes("not found") &&
+    !normalized.includes("spawn")
+  );
+}
+
+function statusFromMessage(message: string): Exclude<ServerProviderState, "disabled"> {
+  return copilotAuthStatusFromMessage(message).status === "unauthenticated" ? "error" : "warning";
+}
+
+export function buildInitialCopilotProviderSnapshot(
+  settings: CopilotSettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = fallbackModels(settings);
+
+    if (!settings.enabled) {
+      return buildServerProvider({
+        presentation: COPILOT_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "GitHub Copilot is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: COPILOT_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking GitHub Copilot availability…",
+      },
+    });
+  });
+}
+
+export const checkCopilotProviderStatus = Effect.fn("checkCopilotProviderStatus")(function* (
+  settings: CopilotSettings,
+): Effect.fn.Return<ServerProviderDraft, never, never> {
+  const checkedAt = DateTime.formatIso(yield* DateTime.now);
+
+  if (!settings.enabled) {
+    return buildServerProvider({
+      presentation: COPILOT_PRESENTATION,
+      enabled: false,
+      checkedAt,
+      models: fallbackModels(settings),
+      probe: {
+        installed: false,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "GitHub Copilot is disabled in T3 Code settings.",
+      },
+    });
+  }
+
+  const client = new CopilotClient(yield* makeCopilotClientOptions(settings));
+  const probe = yield* Effect.tryPromise({
+    try: async () => {
+      await client.start();
+      return { models: await client.listModels() };
+    },
+    catch: (cause) =>
+      new CopilotProbeError({
+        detail: toMessage(cause, "Failed to start GitHub Copilot."),
+        cause,
+      }),
+  }).pipe(
+    // `client.stop()` must run whether the probe succeeded, failed, or timed
+    // out — otherwise every refresh leaks a CLI child process.
+    Effect.ensuring(Effect.promise(() => client.stop().catch(() => []))),
+    Effect.timeoutOption(MODEL_DISCOVERY_TIMEOUT_MS),
+    Effect.result,
+  );
+
+  if (Result.isSuccess(probe) && Option.isSome(probe.success)) {
+    return buildServerProvider({
+      presentation: COPILOT_PRESENTATION,
+      enabled: settings.enabled,
+      checkedAt,
+      models: resolveRuntimeModels(probe.success.value.models, settings),
+      probe: {
+        installed: true,
+        version: null,
+        status: "ready",
+        auth: {
+          status: "authenticated",
+          type: "github",
+          label: "GitHub Copilot",
+        },
+      },
+    });
+  }
+
+  if (Result.isSuccess(probe)) {
+    yield* Effect.logWarning(
+      `GitHub Copilot model discovery timed out after ${MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+    );
+    return buildServerProvider({
+      presentation: COPILOT_PRESENTATION,
+      enabled: settings.enabled,
+      checkedAt,
+      models: fallbackModels(settings),
+      probe: {
+        installed: true,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: `GitHub Copilot CLI did not respond within ${MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+      },
+    });
+  }
+
+  const message = probe.failure.detail;
+  const auth = copilotAuthStatusFromMessage(message);
+  yield* Effect.logWarning("GitHub Copilot health check failed.", {
+    errorTag: probe.failure._tag,
+  });
+
+  return buildServerProvider({
+    presentation: COPILOT_PRESENTATION,
+    enabled: settings.enabled,
+    checkedAt,
+    models: fallbackModels(settings),
+    probe: {
+      installed: isInstalledFromMessage(message),
+      version: null,
+      status: statusFromMessage(message),
+      auth,
+      message:
+        auth.status === "unauthenticated"
+          ? "GitHub Copilot is not signed in, or this account has no Copilot subscription. Run `copilot` in a terminal, sign in with `/login`, then refresh."
+          : message,
+    },
+  });
+});
+
+export const enrichCopilotSnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly enableProviderUpdateChecks?: boolean;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void> => {
+  const { snapshot, publishSnapshot } = input;
+
+  return enrichProviderSnapshotWithVersionAdvisory(snapshot, input.maintenanceCapabilities, {
+    enableProviderUpdateChecks: input.enableProviderUpdateChecks,
+  }).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("GitHub Copilot version advisory enrichment failed", {
+        errorTag: causeErrorTag(cause),
+      }),
+    ),
+    Effect.asVoid,
+  );
+};

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -10,7 +10,7 @@
  *
  *  2. **Many drivers, one registry** — the "all drivers slice" describe
  *     block below configures one instance of every shipped driver
- *     (`codex`, `claudeAgent`, `cursor`, `grok`, `opencode`) in a single
+ *     (`codex`, `claudeAgent`, `cursor`, `grok`, `copilot`, `opencode`) in a single
  *     `ProviderInstanceConfigMap` and asserts the registry boots them all
  *     without cross-contamination. This proves the driver SPI is uniform
  *     across every provider — any driver plugs into the registry through
@@ -27,6 +27,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   type ClaudeSettings,
   type CodexSettings,
+  type CopilotSettings,
   type CursorSettings,
   type GrokSettings,
   type OpenCodeSettings,
@@ -43,6 +44,7 @@ import { ServerSettingsService } from "../../serverSettings.ts";
 import { ClaudeDriver } from "../Drivers/ClaudeDriver.ts";
 import { CodexDriver } from "../Drivers/CodexDriver.ts";
 import { CursorDriver } from "../Drivers/CursorDriver.ts";
+import { CopilotDriver } from "../Drivers/CopilotDriver.ts";
 import { GrokDriver } from "../Drivers/GrokDriver.ts";
 import { OpenCodeDriver } from "../Drivers/OpenCodeDriver.ts";
 import { OpenCodeRuntimeLive } from "../opencodeRuntime.ts";
@@ -86,6 +88,14 @@ const makeCursorConfig = (overrides: Partial<CursorSettings>): CursorSettings =>
 const makeGrokConfig = (overrides: Partial<GrokSettings>): GrokSettings => ({
   enabled: false,
   binaryPath: "grok",
+  customModels: [],
+  ...overrides,
+});
+
+const makeCopilotConfig = (overrides: Partial<CopilotSettings>): CopilotSettings => ({
+  enabled: false,
+  binaryPath: "copilot",
+  homePath: "",
   customModels: [],
   ...overrides,
 });
@@ -258,12 +268,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       const claudeId = ProviderInstanceId.make("claude_default");
       const cursorId = ProviderInstanceId.make("cursor_default");
       const grokId = ProviderInstanceId.make("grok_default");
+      const copilotId = ProviderInstanceId.make("copilot_default");
       const openCodeId = ProviderInstanceId.make("opencode_default");
 
       const codexDriverKind = ProviderDriverKind.make("codex");
       const claudeDriverKind = ProviderDriverKind.make("claudeAgent");
       const cursorDriverKind = ProviderDriverKind.make("cursor");
       const grokDriverKind = ProviderDriverKind.make("grok");
+      const copilotDriverKind = ProviderDriverKind.make("copilot");
       const openCodeDriverKind = ProviderDriverKind.make("opencode");
 
       const configMap: ProviderInstanceConfigMap = {
@@ -294,6 +306,12 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
           enabled: false,
           config: makeGrokConfig({}),
         },
+        [copilotId]: {
+          driver: copilotDriverKind,
+          displayName: "GitHub Copilot",
+          enabled: false,
+          config: makeCopilotConfig({}),
+        },
         [openCodeId]: {
           driver: openCodeDriverKind,
           displayName: "OpenCode",
@@ -303,7 +321,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       };
 
       const { registry } = yield* makeProviderInstanceRegistry({
-        drivers: [CodexDriver, ClaudeDriver, CursorDriver, GrokDriver, OpenCodeDriver],
+        drivers: [
+          CodexDriver,
+          ClaudeDriver,
+          CursorDriver,
+          GrokDriver,
+          CopilotDriver,
+          OpenCodeDriver,
+        ],
         configMap,
       });
 
@@ -313,9 +338,9 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       expect(unavailable).toEqual([]);
 
       const instances = yield* registry.listInstances;
-      expect(instances).toHaveLength(5);
+      expect(instances).toHaveLength(6);
       expect(instances.map((instance) => instance.instanceId).toSorted()).toEqual(
-        [codexId, claudeId, cursorId, grokId, openCodeId].toSorted(),
+        [codexId, claudeId, cursorId, grokId, copilotId, openCodeId].toSorted(),
       );
 
       // Instance lookup by id resolves each instance to its own bundle —
@@ -325,16 +350,19 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       const claude = yield* registry.getInstance(claudeId);
       const cursor = yield* registry.getInstance(cursorId);
       const grok = yield* registry.getInstance(grokId);
+      const copilot = yield* registry.getInstance(copilotId);
       const openCode = yield* registry.getInstance(openCodeId);
       expect(codex?.driverKind).toBe(codexDriverKind);
       expect(claude?.driverKind).toBe(claudeDriverKind);
       expect(cursor?.driverKind).toBe(cursorDriverKind);
       expect(grok?.driverKind).toBe(grokDriverKind);
+      expect(copilot?.driverKind).toBe(copilotDriverKind);
       expect(openCode?.driverKind).toBe(openCodeDriverKind);
       expect(codex?.displayName).toBe("Codex");
       expect(claude?.displayName).toBe("Claude");
       expect(cursor?.displayName).toBe("Cursor");
       expect(grok?.displayName).toBe("Grok");
+      expect(copilot?.displayName).toBe("GitHub Copilot");
       expect(openCode?.displayName).toBe("OpenCode");
 
       // Every instance owns its own set of closures — no sharing across
@@ -347,6 +375,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         claude!.adapter,
         cursor!.adapter,
         grok!.adapter,
+        copilot!.adapter,
         openCode!.adapter,
       ];
       expect(new Set(adapters).size).toBe(adapters.length);
@@ -355,6 +384,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         claude!.textGeneration,
         cursor!.textGeneration,
         grok!.textGeneration,
+        copilot!.textGeneration,
         openCode!.textGeneration,
       ];
       expect(new Set(textGenerations).size).toBe(textGenerations.length);
@@ -363,6 +393,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         claude!.snapshot,
         cursor!.snapshot,
         grok!.snapshot,
+        copilot!.snapshot,
         openCode!.snapshot,
       ];
       expect(new Set(snapshots).size).toBe(snapshots.length);

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1167,9 +1167,10 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               }
 
               assert.deepStrictEqual(cachedProvider?.models, [authoritativeProvider.models[0]!]);
-              assert.deepStrictEqual((yield* registry.getProviders)[0]?.models, [
-                authoritativeProvider.models[0]!,
-              ]);
+              const openCodeProvider = (yield* registry.getProviders).find(
+                (provider) => provider.instanceId === openCodeInstanceId,
+              );
+              assert.deepStrictEqual(openCodeProvider?.models, [authoritativeProvider.models[0]!]);
             }).pipe(Effect.provide(runtimeServices));
           }),
       );
@@ -1761,6 +1762,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               assert.deepStrictEqual(providers.map((provider) => provider.instanceId).toSorted(), [
                 "claudeAgent",
                 "codex",
+                "copilot",
                 "cursor",
                 "grok",
                 "opencode",

--- a/apps/server/src/provider/Layers/copilotCliPath.test.ts
+++ b/apps/server/src/provider/Layers/copilotCliPath.test.ts
@@ -1,0 +1,136 @@
+// @effect-diagnostics nodeBuiltinImport:off - builds expected paths with the
+// same separator rules as the code under test.
+import { describe, expect, it } from "@effect/vitest";
+import * as NodePath from "node:path";
+
+import {
+  getBundledCopilotPlatformPackages,
+  normalizeCopilotCliPathOverride,
+  resolveBundledCopilotCliPathFrom,
+} from "./copilotCliPath.ts";
+
+describe("normalizeCopilotCliPathOverride", () => {
+  it.each([undefined, null, "", "   "])("treats %j as no override", (value) => {
+    expect(normalizeCopilotCliPathOverride(value)).toBeUndefined();
+  });
+
+  it.each(["copilot", "copilot.exe", "COPILOT.CMD", "copilot.bat"])(
+    "treats the bare command %j as no override so the bundled binary wins",
+    (value) => {
+      expect(normalizeCopilotCliPathOverride(value)).toBeUndefined();
+    },
+  );
+
+  it.each(["/usr/local/bin/copilot", "C:\\tools\\copilot.exe", "./copilot"])(
+    "keeps a real path like %j",
+    (value) => {
+      expect(normalizeCopilotCliPathOverride(value)).toBe(value);
+    },
+  );
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeCopilotCliPathOverride("  /opt/copilot  ")).toBe("/opt/copilot");
+  });
+});
+
+describe("getBundledCopilotPlatformPackages", () => {
+  it.each([
+    ["darwin", "arm64", "copilot-darwin-arm64"],
+    ["darwin", "x64", "copilot-darwin-x64"],
+    ["linux", "arm64", "copilot-linux-arm64"],
+    ["linux", "x64", "copilot-linux-x64"],
+    ["win32", "arm64", "copilot-win32-arm64"],
+    ["win32", "x64", "copilot-win32-x64"],
+  ])("maps %s/%s to %s", (platform, arch, expected) => {
+    expect(getBundledCopilotPlatformPackages(platform, arch)).toEqual([expected]);
+  });
+
+  it("returns nothing for a platform GitHub does not ship", () => {
+    expect(getBundledCopilotPlatformPackages("aix", "ppc64")).toEqual([]);
+  });
+});
+
+describe("resolveBundledCopilotCliPathFrom", () => {
+  // Five levels up from the Layers dir is the workspace root, matching how
+  // this module sits in the built output.
+  const currentDir = NodePath.join("/app", "apps", "server", "src", "provider", "Layers");
+  const workspaceNodeModules = NodePath.join("/app", "node_modules");
+  const baseInput = { currentDir, platform: "linux", arch: "x64" } as const;
+
+  it("returns undefined when nothing exists and the SDK cannot be located", () => {
+    expect(resolveBundledCopilotCliPathFrom({ ...baseInput, exists: () => false })).toBeUndefined();
+  });
+
+  it("prefers the unpacked binary inside a packaged desktop app", () => {
+    const resourcesPath = NodePath.join("/Applications", "T3.app", "Contents", "Resources");
+    const expected = NodePath.join(
+      resourcesPath,
+      "app.asar.unpacked/node_modules",
+      "@github",
+      "copilot-linux-x64",
+      "copilot",
+    );
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        ...baseInput,
+        resourcesPath,
+        exists: (candidate) => candidate === expected,
+      }),
+    ).toBe(expected);
+  });
+
+  it("prefers the real binary over the npm loader shim", () => {
+    const binary = NodePath.join(workspaceNodeModules, "@github", "copilot-linux-x64", "copilot");
+    const loader = NodePath.join(workspaceNodeModules, "@github", "copilot", "npm-loader.js");
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        ...baseInput,
+        exists: (candidate) => candidate === binary || candidate === loader,
+      }),
+    ).toBe(binary);
+  });
+
+  it("falls back to the npm loader when no platform binary is present", () => {
+    const loader = NodePath.join(workspaceNodeModules, "@github", "copilot", "npm-loader.js");
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        ...baseInput,
+        exists: (candidate) => candidate === loader,
+      }),
+    ).toBe(loader);
+  });
+
+  it("finds the platform package next to the SDK in a pnpm store", () => {
+    // require.resolve("@github/copilot-sdk") lands on the package's dist entry;
+    // the platform package is a sibling of the SDK inside the @github scope.
+    const scopeDir = NodePath.join("/store", "node_modules", "@github");
+    const sdkEntrypoint = NodePath.join(scopeDir, "copilot-sdk", "dist", "index.js");
+    const expected = NodePath.join(scopeDir, "copilot-linux-x64", "copilot");
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        ...baseInput,
+        sdkEntrypoint,
+        exists: (candidate) => candidate === expected,
+      }),
+    ).toBe(expected);
+  });
+
+  it("uses the requested platform, not the host's", () => {
+    const expected = NodePath.join(
+      workspaceNodeModules,
+      "@github",
+      "copilot-win32-x64",
+      "copilot.exe",
+    );
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        ...baseInput,
+        platform: "win32",
+        exists: (candidate) => candidate === expected,
+      }),
+    ).toBe(expected);
+  });
+});

--- a/apps/server/src/provider/Layers/copilotCliPath.ts
+++ b/apps/server/src/provider/Layers/copilotCliPath.ts
@@ -1,0 +1,192 @@
+// @effect-diagnostics nodeBuiltinImport:off - resolves a binary path on disk
+// before any Effect runtime exists; the SDK wants a plain string.
+/**
+ * Locate the GitHub Copilot CLI binary the SDK should drive.
+ *
+ * `@github/copilot` ships the actual binary in a per-platform optional
+ * dependency (`@github/copilot-<platform>-<arch>`) plus an `npm-loader.js`
+ * shim. The SDK can find it on its own when the process runs from a normal
+ * `node_modules` tree, but the packaged desktop app runs from inside
+ * `app.asar`, where module resolution does not reach the unpacked binary.
+ * So we resolve it ourselves and hand the SDK an explicit `cliPath`.
+ *
+ * @module provider/Layers/copilotCliPath
+ */
+import * as NodeFS from "node:fs";
+import * as NodeModule from "node:module";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+const require = NodeModule.createRequire(import.meta.url);
+const CURRENT_DIR = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const GITHUB_SCOPE_DIR = "@github";
+const COPILOT_PATHLESS_COMMAND_PATTERN = /^copilot(?:\.(?:exe|cmd|bat))?$/i;
+const COPILOT_NPM_LOADER = "npm-loader.js";
+
+function dedupePaths(paths: ReadonlyArray<string | undefined>): string[] {
+  const resolved: string[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of paths) {
+    if (!candidate || seen.has(candidate)) continue;
+    seen.add(candidate);
+    resolved.push(candidate);
+  }
+
+  return resolved;
+}
+
+function resolveSdkEntrypoint(): string | undefined {
+  try {
+    return require.resolve("@github/copilot-sdk");
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveProcessResourcesPath(): string | undefined {
+  const processWithResourcesPath = process as NodeJS.Process & {
+    readonly resourcesPath?: string;
+  };
+  return processWithResourcesPath.resourcesPath;
+}
+
+/**
+ * A bare `copilot` (the settings default) means "let the SDK find it".
+ * Returning `undefined` for that case keeps the bundled-path fallback in
+ * play; only a real path counts as a deliberate override.
+ */
+export function normalizeCopilotCliPathOverride(
+  value: string | null | undefined,
+): string | undefined {
+  if (value == null) return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  if (
+    !trimmed.includes("/") &&
+    !trimmed.includes("\\") &&
+    COPILOT_PATHLESS_COMMAND_PATTERN.test(trimmed)
+  ) {
+    return undefined;
+  }
+
+  return trimmed;
+}
+
+function resolveGithubScopeDirFromSdkEntrypoint(
+  sdkEntrypoint: string | undefined,
+): string | undefined {
+  if (!sdkEntrypoint) return undefined;
+  return NodePath.join(NodePath.dirname(NodePath.dirname(sdkEntrypoint)), "..");
+}
+
+function resolveNodeModulesRoots(input: {
+  currentDir: string;
+  resourcesPath?: string;
+  sdkEntrypoint?: string;
+}): string[] {
+  const githubScopeDir = resolveGithubScopeDirFromSdkEntrypoint(input.sdkEntrypoint);
+  return dedupePaths([
+    input.resourcesPath
+      ? NodePath.join(input.resourcesPath, "app.asar.unpacked/node_modules")
+      : undefined,
+    input.resourcesPath ? NodePath.join(input.resourcesPath, "node_modules") : undefined,
+    NodePath.join(input.currentDir, "../../../node_modules"),
+    NodePath.join(input.currentDir, "../../../../../node_modules"),
+    githubScopeDir ? NodePath.join(githubScopeDir, "..") : undefined,
+  ]);
+}
+
+function getCopilotPlatformBinaryName(platform: string): string {
+  return platform === "win32" ? "copilot.exe" : "copilot";
+}
+
+export function getBundledCopilotPlatformPackages(
+  platform: string,
+  arch: string,
+): ReadonlyArray<string> {
+  if (platform === "darwin" && arch === "arm64") return ["copilot-darwin-arm64"];
+  if (platform === "darwin" && arch === "x64") return ["copilot-darwin-x64"];
+  if (platform === "linux" && arch === "arm64") return ["copilot-linux-arm64"];
+  if (platform === "linux" && arch === "x64") return ["copilot-linux-x64"];
+  if (platform === "win32" && arch === "arm64") return ["copilot-win32-arm64"];
+  if (platform === "win32" && arch === "x64") return ["copilot-win32-x64"];
+  return [];
+}
+
+/** Injectable core so the resolution order can be unit-tested per platform. */
+export function resolveBundledCopilotCliPathFrom(input: {
+  currentDir: string;
+  platform: string;
+  arch: string;
+  resourcesPath?: string;
+  sdkEntrypoint?: string;
+  exists?: (path: string) => boolean;
+}): string | undefined {
+  const { platform, arch } = input;
+  const exists = input.exists ?? NodeFS.existsSync;
+  const sdkEntrypoint = input.sdkEntrypoint;
+  const nodeModulesRoots = resolveNodeModulesRoots({
+    currentDir: input.currentDir,
+    ...(input.resourcesPath ? { resourcesPath: input.resourcesPath } : {}),
+    ...(sdkEntrypoint ? { sdkEntrypoint } : {}),
+  });
+  const binaryName = getCopilotPlatformBinaryName(platform);
+  const platformPackages = getBundledCopilotPlatformPackages(platform, arch);
+
+  // Prefer the real binary over the loader shim — spawning the shim costs an
+  // extra Node boot per session.
+  const binaryCandidates = nodeModulesRoots.flatMap((root) =>
+    platformPackages.map((packageName) =>
+      NodePath.join(root, GITHUB_SCOPE_DIR, packageName, binaryName),
+    ),
+  );
+  const npmLoaderCandidates = nodeModulesRoots.map((root) =>
+    NodePath.join(root, GITHUB_SCOPE_DIR, "copilot", COPILOT_NPM_LOADER),
+  );
+  for (const candidate of dedupePaths([...binaryCandidates, ...npmLoaderCandidates])) {
+    if (exists(candidate)) {
+      return candidate;
+    }
+  }
+
+  // pnpm's isolated store puts the platform package next to the SDK rather
+  // than under a shared `node_modules` root, so check there last.
+  const githubScopeDir = resolveGithubScopeDirFromSdkEntrypoint(sdkEntrypoint);
+  if (!githubScopeDir) {
+    return undefined;
+  }
+
+  const sdkSiblingBinaryCandidates = platformPackages.map((packageName) =>
+    NodePath.join(githubScopeDir, packageName, binaryName),
+  );
+  const sdkSiblingLoaderPath = NodePath.join(githubScopeDir, "copilot", COPILOT_NPM_LOADER);
+  for (const candidate of dedupePaths([...sdkSiblingBinaryCandidates, sdkSiblingLoaderPath])) {
+    if (exists(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Platform and arch are passed in (rather than read from the host here) so
+ * the only place that touches the real runtime is the shared
+ * `HostProcess*` references — see `makeCopilotClientOptions`.
+ */
+export function resolveBundledCopilotCliPath(host: {
+  readonly platform: string;
+  readonly arch: string;
+}): string | undefined {
+  const sdkEntrypoint = resolveSdkEntrypoint();
+  const resourcesPath = resolveProcessResourcesPath();
+  return resolveBundledCopilotCliPathFrom({
+    currentDir: CURRENT_DIR,
+    platform: host.platform,
+    arch: host.arch,
+    ...(resourcesPath ? { resourcesPath } : {}),
+    ...(sdkEntrypoint ? { sdkEntrypoint } : {}),
+  });
+}

--- a/apps/server/src/provider/Layers/copilotMcpServers.ts
+++ b/apps/server/src/provider/Layers/copilotMcpServers.ts
@@ -1,0 +1,159 @@
+// @effect-diagnostics nodeBuiltinImport:off - reads the Copilot CLI's own
+// config file from a plain promise, outside the Effect runtime.
+/**
+ * Read the Copilot CLI's own `mcp-config.json` and translate it into the
+ * shape `CopilotClient.createSession` expects.
+ *
+ * The CLI stores MCP servers outside the SDK, so a session started through
+ * the SDK gets none of the user's configured servers unless we forward them
+ * explicitly. Reading the CLI's file (rather than inventing a T3-Code-specific
+ * one) means `copilot mcp add ...` keeps working and the same servers show up
+ * in both the terminal CLI and T3 Code.
+ *
+ * @module provider/Layers/copilotMcpServers
+ */
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import type { MCPServerConfig } from "@github/copilot-sdk";
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.flatMap((item) => {
+    const normalized = asNonEmptyString(item);
+    return normalized ? [normalized] : [];
+  });
+}
+
+function asStringRecord(value: unknown): Record<string, string> | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const entries = Object.entries(record).flatMap(([key, item]) => {
+    const normalized = asNonEmptyString(item);
+    return normalized ? [[key, normalized] as const] : [];
+  });
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function asTimeout(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** An absent `tools` list means "expose everything", matching the CLI. */
+function normalizeTools(value: unknown): string[] {
+  return asStringArray(value) ?? ["*"];
+}
+
+function toMcpServerConfig(entry: unknown): MCPServerConfig | undefined {
+  const record = asRecord(entry);
+  if (!record) {
+    return undefined;
+  }
+
+  const type = asNonEmptyString(record.type);
+  const command = asNonEmptyString(record.command);
+  const args = asStringArray(record.args) ?? [];
+  const url = asNonEmptyString(record.url);
+  const tools = normalizeTools(record.tools);
+  const timeout = asTimeout(record.timeout);
+  const env = asStringRecord(record.env);
+  const cwd = asNonEmptyString(record.cwd);
+  const headers = asStringRecord(record.headers);
+
+  if (command && (type === undefined || type === "local" || type === "stdio")) {
+    return {
+      type: "local",
+      command,
+      args,
+      tools,
+      ...(env ? { env } : {}),
+      ...(cwd ? { cwd } : {}),
+      ...(timeout !== undefined ? { timeout } : {}),
+    };
+  }
+
+  if (url && (type === undefined || type === "http" || type === "sse")) {
+    return {
+      type: type === "sse" ? "sse" : "http",
+      url,
+      tools,
+      ...(headers ? { headers } : {}),
+      ...(timeout !== undefined ? { timeout } : {}),
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Directories to search, most specific first. Copilot CLI moved from
+ * `~/.copilot` to the XDG-style `~/.config/copilot`; both are still in the
+ * wild depending on install age, so we take the first file that exists.
+ */
+export function copilotConfigDirCandidates(
+  configDir: string | undefined,
+  homedir: string = NodeOS.homedir(),
+): ReadonlyArray<string> {
+  const explicit = asNonEmptyString(configDir);
+  if (explicit) {
+    return [explicit];
+  }
+  return [NodePath.join(homedir, ".config", "copilot"), NodePath.join(homedir, ".copilot")];
+}
+
+export async function loadCopilotMcpServers(
+  configDir: string | undefined,
+): Promise<Record<string, MCPServerConfig> | undefined> {
+  for (const baseDir of copilotConfigDirCandidates(configDir)) {
+    const configPath = NodePath.join(baseDir, "mcp-config.json");
+
+    let raw: string;
+    try {
+      raw = await NodeFSP.readFile(configPath, "utf-8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+
+    const parsed = asRecord(JSON.parse(raw));
+    // Accept both the `{ mcpServers: {...} }` envelope and a bare map, which
+    // older CLI versions wrote.
+    const servers = asRecord(parsed?.mcpServers) ?? parsed;
+    if (!servers) {
+      return undefined;
+    }
+
+    const normalizedEntries = Object.entries(servers).flatMap(([name, value]) => {
+      const normalized = toMcpServerConfig(value);
+      return normalized ? [[name, normalized] as const] : [];
+    });
+
+    return normalizedEntries.length > 0 ? Object.fromEntries(normalizedEntries) : undefined;
+  }
+
+  return undefined;
+}

--- a/apps/server/src/provider/Layers/copilotTurnTracking.test.ts
+++ b/apps/server/src/provider/Layers/copilotTurnTracking.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "@effect/vitest";
+import { TurnId } from "@t3tools/contracts";
+import type { SessionEvent } from "@github/copilot-sdk";
+
+import {
+  assistantUsageFields,
+  beginCopilotTurn,
+  clearTurnTracking,
+  completionTurnRefs,
+  isCopilotTurnTerminalEvent,
+  markTurnAwaitingCompletion,
+  recordTurnUsage,
+  type CopilotAssistantUsage,
+  type CopilotTurnTrackingState,
+} from "./copilotTurnTracking.ts";
+
+const makeState = (): CopilotTurnTrackingState => ({
+  currentTurnId: undefined,
+  currentProviderTurnId: undefined,
+  pendingCompletionTurnId: undefined,
+  pendingCompletionProviderTurnId: undefined,
+  pendingTurnIds: [],
+  pendingTurnUsage: undefined,
+});
+
+const usage = (overrides: Partial<CopilotAssistantUsage> = {}): CopilotAssistantUsage =>
+  ({ inputTokens: 10, outputTokens: 5, ...overrides }) as CopilotAssistantUsage;
+
+describe("beginCopilotTurn", () => {
+  it("binds Copilot's turn id to the id sendTurn already handed out", () => {
+    const state = makeState();
+    const ours = TurnId.make("copilot-turn-ours");
+    state.pendingTurnIds.push(ours);
+
+    beginCopilotTurn(state, TurnId.make("provider-1"));
+
+    expect(state.currentTurnId).toBe(ours);
+    expect(state.currentProviderTurnId).toBe(TurnId.make("provider-1"));
+    expect(state.pendingTurnIds).toEqual([]);
+  });
+
+  it("drains the queue in order across back-to-back turns", () => {
+    const state = makeState();
+    state.pendingTurnIds.push(TurnId.make("ours-1"), TurnId.make("ours-2"));
+
+    beginCopilotTurn(state, TurnId.make("provider-1"));
+    expect(state.currentTurnId).toBe(TurnId.make("ours-1"));
+
+    beginCopilotTurn(state, TurnId.make("provider-2"));
+    expect(state.currentTurnId).toBe(TurnId.make("ours-2"));
+  });
+
+  it("reuses the last known id for a turn Copilot started on its own", () => {
+    const state = makeState();
+    state.pendingTurnIds.push(TurnId.make("ours-1"));
+    beginCopilotTurn(state, TurnId.make("provider-1"));
+
+    // No matching sendTurn — e.g. Copilot compacting or exiting plan mode.
+    beginCopilotTurn(state, TurnId.make("provider-2"));
+
+    expect(state.currentTurnId).toBe(TurnId.make("ours-1"));
+    expect(state.currentProviderTurnId).toBe(TurnId.make("provider-2"));
+  });
+
+  it("falls back to the provider id when nothing was queued", () => {
+    const state = makeState();
+    beginCopilotTurn(state, TurnId.make("provider-1"));
+    expect(state.currentTurnId).toBe(TurnId.make("provider-1"));
+  });
+
+  it("clears usage carried over from the previous turn", () => {
+    const state = makeState();
+    recordTurnUsage(state, usage());
+    beginCopilotTurn(state, TurnId.make("provider-1"));
+    expect(state.pendingTurnUsage).toBeUndefined();
+  });
+});
+
+describe("completion parking", () => {
+  it("keeps the turn ids addressable between turn_end and session.idle", () => {
+    const state = makeState();
+    state.pendingTurnIds.push(TurnId.make("ours-1"));
+    beginCopilotTurn(state, TurnId.make("provider-1"));
+
+    // `assistant.turn_end` arrives before the trailing usage/idle events.
+    markTurnAwaitingCompletion(state);
+
+    expect(completionTurnRefs(state)).toEqual({
+      turnId: TurnId.make("ours-1"),
+      providerTurnId: TurnId.make("provider-1"),
+    });
+  });
+
+  it("reports no refs once the session goes idle", () => {
+    const state = makeState();
+    state.pendingTurnIds.push(TurnId.make("ours-1"));
+    beginCopilotTurn(state, TurnId.make("provider-1"));
+    markTurnAwaitingCompletion(state);
+
+    clearTurnTracking(state);
+
+    expect(completionTurnRefs(state)).toEqual({
+      turnId: undefined,
+      providerTurnId: undefined,
+    });
+  });
+});
+
+describe("assistantUsageFields", () => {
+  it("returns nothing when no usage was recorded", () => {
+    expect(assistantUsageFields(undefined)).toEqual({});
+  });
+
+  it("surfaces cost and model when Copilot reports them", () => {
+    const fields = assistantUsageFields(usage({ cost: 0.42, model: "claude-sonnet-4.6" }));
+    expect(fields.totalCostUsd).toBe(0.42);
+    expect(fields.modelUsage).toEqual({ model: "claude-sonnet-4.6" });
+  });
+
+  it("omits cost and model when absent rather than emitting zeros", () => {
+    const fields = assistantUsageFields(usage());
+    expect(fields.totalCostUsd).toBeUndefined();
+    expect(fields.modelUsage).toBeUndefined();
+    expect(fields.usage).toBeDefined();
+  });
+});
+
+describe("isCopilotTurnTerminalEvent", () => {
+  it.each(["abort", "session.idle"])("treats %s as terminal", (type) => {
+    expect(isCopilotTurnTerminalEvent({ type } as SessionEvent)).toBe(true);
+  });
+
+  it.each(["assistant.turn_end", "assistant.message", "tool.execution_complete"])(
+    "does not treat %s as terminal",
+    (type) => {
+      expect(isCopilotTurnTerminalEvent({ type } as SessionEvent)).toBe(false);
+    },
+  );
+});

--- a/apps/server/src/provider/Layers/copilotTurnTracking.ts
+++ b/apps/server/src/provider/Layers/copilotTurnTracking.ts
@@ -1,0 +1,96 @@
+/**
+ * Turn correlation for the GitHub Copilot adapter.
+ *
+ * Copilot mints its own `turnId` when the assistant starts working, but
+ * `sendTurn` has to return an orchestration turn id *before* that happens.
+ * We therefore keep both ids side by side: `currentTurnId` is the one T3 Code
+ * handed to the caller, `currentProviderTurnId` is Copilot's.
+ *
+ * The `pendingCompletion*` pair exists because `assistant.turn_end` arrives
+ * before the trailing `assistant.usage` and `session.idle` events. Clearing
+ * the current ids at `turn_end` would orphan those late events, so we park
+ * the ids until the session actually goes idle.
+ *
+ * @module provider/Layers/copilotTurnTracking
+ */
+import { TurnId } from "@t3tools/contracts";
+import type { SessionEvent } from "@github/copilot-sdk";
+
+export type CopilotAssistantUsage = Extract<SessionEvent, { type: "assistant.usage" }>["data"];
+
+export interface CopilotTurnTrackingState {
+  currentTurnId: TurnId | undefined;
+  currentProviderTurnId: TurnId | undefined;
+  pendingCompletionTurnId: TurnId | undefined;
+  pendingCompletionProviderTurnId: TurnId | undefined;
+  pendingTurnIds: Array<TurnId>;
+  pendingTurnUsage: CopilotAssistantUsage | undefined;
+}
+
+/** Ids to stamp on completion-ish events (`turn.completed`, `turn.aborted`). */
+export function completionTurnRefs(state: CopilotTurnTrackingState): {
+  readonly turnId: TurnId | undefined;
+  readonly providerTurnId: TurnId | undefined;
+} {
+  return {
+    turnId: state.pendingCompletionTurnId ?? state.currentTurnId,
+    providerTurnId: state.pendingCompletionProviderTurnId ?? state.currentProviderTurnId,
+  };
+}
+
+/**
+ * Bind Copilot's turn id to the orchestration turn id queued by `sendTurn`.
+ *
+ * `pendingTurnIds` is a queue rather than a single slot: Copilot can start a
+ * follow-up turn on its own (compaction, plan mode hand-off) without a
+ * matching `sendTurn`, and the queue drains in order so those extra turns
+ * reuse the last known id instead of desynchronising every later turn.
+ */
+export function beginCopilotTurn(state: CopilotTurnTrackingState, providerTurnId: TurnId): void {
+  state.pendingCompletionTurnId = undefined;
+  state.pendingCompletionProviderTurnId = undefined;
+  state.pendingTurnUsage = undefined;
+  state.currentProviderTurnId = providerTurnId;
+  state.currentTurnId = state.pendingTurnIds.shift() ?? state.currentTurnId ?? providerTurnId;
+}
+
+export function markTurnAwaitingCompletion(state: CopilotTurnTrackingState): void {
+  state.pendingCompletionTurnId = state.currentTurnId ?? state.pendingCompletionTurnId;
+  state.pendingCompletionProviderTurnId =
+    state.currentProviderTurnId ?? state.pendingCompletionProviderTurnId;
+}
+
+export function recordTurnUsage(
+  state: CopilotTurnTrackingState,
+  usage: CopilotAssistantUsage,
+): void {
+  state.pendingTurnUsage = usage;
+}
+
+export function clearTurnTracking(state: CopilotTurnTrackingState): void {
+  state.currentTurnId = undefined;
+  state.currentProviderTurnId = undefined;
+  state.pendingCompletionTurnId = undefined;
+  state.pendingCompletionProviderTurnId = undefined;
+  state.pendingTurnUsage = undefined;
+}
+
+export function assistantUsageFields(usage: CopilotAssistantUsage | undefined): {
+  usage?: CopilotAssistantUsage;
+  modelUsage?: { model: string };
+  totalCostUsd?: number;
+} {
+  if (!usage) {
+    return {};
+  }
+
+  return {
+    usage,
+    ...(usage.cost !== undefined ? { totalCostUsd: usage.cost } : {}),
+    ...(usage.model ? { modelUsage: { model: usage.model } } : {}),
+  };
+}
+
+export function isCopilotTurnTerminalEvent(event: SessionEvent): boolean {
+  return event.type === "abort" || event.type === "session.idle";
+}

--- a/apps/server/src/provider/Services/CopilotAdapter.ts
+++ b/apps/server/src/provider/Services/CopilotAdapter.ts
@@ -1,0 +1,16 @@
+/**
+ * CopilotAdapter — shape type for the GitHub Copilot provider adapter.
+ *
+ * The driver model ({@link ../Drivers/CopilotDriver}) bundles one adapter per
+ * instance as a captured closure, so this module only retains the shape
+ * interface as a naming anchor for the driver bundle.
+ *
+ * @module CopilotAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * CopilotAdapterShape — per-instance GitHub Copilot adapter contract.
+ */
+export interface CopilotAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -22,6 +22,7 @@
  */
 import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
+import { CopilotDriver, type CopilotDriverEnv } from "./Drivers/CopilotDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
@@ -35,6 +36,7 @@ import type { AnyProviderDriver } from "./ProviderDriver.ts";
 export type BuiltInDriversEnv =
   | ClaudeDriverEnv
   | CodexDriverEnv
+  | CopilotDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
   | OpenCodeDriverEnv;
@@ -49,5 +51,6 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   ClaudeDriver,
   CursorDriver,
   GrokDriver,
+  CopilotDriver,
   OpenCodeDriver,
 ];

--- a/apps/server/src/textGeneration/CopilotTextGeneration.ts
+++ b/apps/server/src/textGeneration/CopilotTextGeneration.ts
@@ -1,0 +1,276 @@
+/**
+ * Commit / PR / branch / title generation backed by the GitHub Copilot CLI.
+ *
+ * Each call spins up a short-lived headless Copilot session, sends one prompt,
+ * concatenates the streamed assistant text, and tears the session down. The
+ * session denies every permission request outright: these prompts only need
+ * the model to write text, so any attempt to run a command or touch a file is
+ * a prompt-injection risk from diff content, not legitimate work.
+ *
+ * @module textGeneration/CopilotTextGeneration
+ */
+import { CopilotClient } from "@github/copilot-sdk";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import { type CopilotSettings, type ModelSelection, TextGenerationError } from "@t3tools/contracts";
+import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import { makeCopilotClientOptions } from "../provider/Layers/CopilotProvider.ts";
+import * as TextGeneration from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+
+const COPILOT_TIMEOUT_MS = 180_000;
+
+const isTextGenerationError = Schema.is(TextGenerationError);
+
+type TextGenerationOperation =
+  | "generateCommitMessage"
+  | "generatePrContent"
+  | "generateBranchName"
+  | "generateThreadTitle";
+
+export function makeCopilotTextGeneration(
+  copilotSettings: CopilotSettings,
+): TextGeneration.TextGeneration["Service"] {
+  /**
+   * Run one prompt to completion and return the assistant's raw text.
+   *
+   * Copilot streams `assistant.message_delta` and then repeats the whole
+   * message in `assistant.message`, so we accumulate deltas and let the
+   * final message overwrite them — that avoids duplicated text while still
+   * producing output if only one of the two arrives.
+   */
+  const runCopilotPrompt = (input: {
+    readonly operation: TextGenerationOperation;
+    readonly cwd: string;
+    readonly prompt: string;
+    readonly model: string | undefined;
+  }): Effect.Effect<string, TextGenerationError> =>
+    Effect.flatMap(makeCopilotClientOptions(copilotSettings, { cwd: input.cwd }), (clientOptions) =>
+      Effect.tryPromise({
+        try: async () => {
+          const client = new CopilotClient(clientOptions);
+          let streamed = "";
+          let finalMessage: string | undefined;
+
+          try {
+            await client.start();
+            const session = await client.createSession({
+              ...(input.model ? { model: input.model } : {}),
+              ...(copilotSettings.homePath.trim()
+                ? { configDir: copilotSettings.homePath.trim() }
+                : {}),
+              workingDirectory: input.cwd,
+              streaming: true,
+              onPermissionRequest: async () => ({ kind: "denied-interactively-by-user" }) as const,
+            });
+
+            const unsubscribe = session.on((event) => {
+              if (event.type === "assistant.message_delta") {
+                streamed += event.data.deltaContent;
+                return;
+              }
+              if (event.type === "assistant.message") {
+                finalMessage = event.data.content;
+              }
+            });
+
+            try {
+              await session.send({ prompt: input.prompt, mode: "immediate" });
+            } finally {
+              unsubscribe();
+              await session.disconnect().catch(() => undefined);
+            }
+          } finally {
+            await client.stop().catch(() => []);
+          }
+
+          return (finalMessage ?? streamed).trim();
+        },
+        catch: (cause) =>
+          new TextGenerationError({
+            operation: input.operation,
+            detail: "GitHub Copilot text generation request failed.",
+            cause,
+          }),
+      }).pipe(
+        Effect.timeoutOption(COPILOT_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({
+                  operation: input.operation,
+                  detail: "GitHub Copilot text generation request timed out.",
+                }),
+              ),
+            onSome: (value: string) => Effect.succeed(value),
+          }),
+        ),
+      ),
+    );
+
+  const runCopilotJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+    modelSelection,
+  }: {
+    operation: TextGenerationOperation;
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+    modelSelection: ModelSelection;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      const output = yield* runCopilotPrompt({
+        operation,
+        cwd,
+        prompt,
+        model: modelSelection.model,
+      });
+
+      if (!output) {
+        return yield* new TextGenerationError({
+          operation,
+          detail: "GitHub Copilot returned empty output.",
+        });
+      }
+
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(output)).pipe(
+        Effect.catchTags({
+          SchemaError: (cause) =>
+            Effect.fail(
+              new TextGenerationError({
+                operation,
+                detail: "GitHub Copilot returned invalid structured output.",
+                cause,
+              }),
+            ),
+        }),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : new TextGenerationError({
+              operation,
+              detail: "GitHub Copilot text generation failed.",
+              cause,
+            }),
+      ),
+    );
+
+  const generateCommitMessage: TextGeneration.TextGeneration["Service"]["generateCommitMessage"] =
+    Effect.fn("CopilotTextGeneration.generateCommitMessage")(function* (input) {
+      const { prompt, outputSchema } = buildCommitMessagePrompt({
+        branch: input.branch,
+        stagedSummary: input.stagedSummary,
+        stagedPatch: input.stagedPatch,
+        includeBranch: input.includeBranch === true,
+        policy: input.policy,
+      });
+
+      const generated = yield* runCopilotJson({
+        operation: "generateCommitMessage",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        subject: sanitizeCommitSubject(generated.subject),
+        body: generated.body.trim(),
+        ...("branch" in generated && typeof generated.branch === "string"
+          ? { branch: sanitizeFeatureBranchName(generated.branch) }
+          : {}),
+      };
+    });
+
+  const generatePrContent: TextGeneration.TextGeneration["Service"]["generatePrContent"] =
+    Effect.fn("CopilotTextGeneration.generatePrContent")(function* (input) {
+      const { prompt, outputSchema } = buildPrContentPrompt({
+        baseBranch: input.baseBranch,
+        headBranch: input.headBranch,
+        commitSummary: input.commitSummary,
+        diffSummary: input.diffSummary,
+        diffPatch: input.diffPatch,
+        policy: input.policy,
+        changeRequestTemplate: input.changeRequestTemplate,
+      });
+
+      const generated = yield* runCopilotJson({
+        operation: "generatePrContent",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizePrTitle(generated.title),
+        body: generated.body.trim(),
+      };
+    });
+
+  const generateBranchName: TextGeneration.TextGeneration["Service"]["generateBranchName"] =
+    Effect.fn("CopilotTextGeneration.generateBranchName")(function* (input) {
+      const { prompt, outputSchema } = buildBranchNamePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runCopilotJson({
+        operation: "generateBranchName",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return { branch: sanitizeBranchFragment(generated.branch) };
+    });
+
+  const generateThreadTitle: TextGeneration.TextGeneration["Service"]["generateThreadTitle"] =
+    Effect.fn("CopilotTextGeneration.generateThreadTitle")(function* (input) {
+      const { prompt, outputSchema } = buildThreadTitlePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runCopilotJson({
+        operation: "generateThreadTitle",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizeThreadTitle(generated.title),
+      } satisfies TextGeneration.ThreadTitleGenerationResult;
+    });
+
+  return {
+    generateCommitMessage,
+    generatePrContent,
+    generateBranchName,
+    generateThreadTitle,
+  } satisfies TextGeneration.TextGeneration["Service"];
+}

--- a/apps/server/src/textGeneration/TextGeneration.ts
+++ b/apps/server/src/textGeneration/TextGeneration.ts
@@ -8,7 +8,13 @@ import * as ProviderInstanceRegistry from "../provider/Services/ProviderInstance
 import type { ProviderInstance } from "../provider/ProviderDriver.ts";
 import type { TextGenerationPolicy } from "./TextGenerationPolicy.ts";
 
-export type TextGenerationProvider = "codex" | "claudeAgent" | "cursor" | "grok" | "opencode";
+export type TextGenerationProvider =
+  | "codex"
+  | "claudeAgent"
+  | "cursor"
+  | "grok"
+  | "copilot"
+  | "opencode";
 
 export interface CommitMessageGenerationInput {
   cwd: string;

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -2,6 +2,8 @@ import { type ProviderDriverKind, type ProviderInstanceId } from "@t3tools/contr
 import { memo } from "react";
 import { StarIcon } from "lucide-react";
 import {
+  formatBillingMultiplier,
+  formatContextWindowTokens,
   getDisplayModelName,
   getTriggerDisplayModelLabel,
   type ModelEsque,
@@ -41,6 +43,8 @@ export const ModelListRow = memo(function ModelListRow(props: {
   const providerLabel = props.model.subProvider
     ? `${props.providerDisplayName} · ${props.model.subProvider}`
     : props.providerDisplayName;
+  const contextWindowLabel = formatContextWindowTokens(props.model.maxContextWindowTokens);
+  const billingLabel = formatBillingMultiplier(props.model.billingMultiplier);
 
   const row = (
     <ComboboxItem
@@ -75,12 +79,36 @@ export const ModelListRow = memo(function ModelListRow(props: {
             </span>
           ) : null}
         </div>
-        {props.showProvider && (
+        {(props.showProvider || contextWindowLabel || billingLabel) && (
           <div className="mt-1 flex items-center gap-1.5">
-            {ProviderIcon ? <ProviderIcon className="size-3 shrink-0" /> : null}
-            <span className="truncate text-xs font-normal leading-snug text-muted-foreground/70">
-              {providerLabel}
-            </span>
+            {props.showProvider ? (
+              <>
+                {ProviderIcon ? <ProviderIcon className="size-3 shrink-0" /> : null}
+                <span className="truncate text-xs font-normal leading-snug text-muted-foreground/70">
+                  {providerLabel}
+                </span>
+              </>
+            ) : null}
+            {contextWindowLabel ? (
+              <span
+                className="shrink-0 text-[10px] font-normal leading-snug text-muted-foreground/60"
+                title={`${props.model.maxContextWindowTokens?.toLocaleString()} token context window`}
+              >
+                {contextWindowLabel} ctx
+              </span>
+            ) : null}
+            {billingLabel ? (
+              <span
+                className="shrink-0 text-[10px] font-normal leading-snug text-muted-foreground/60"
+                title={
+                  props.model.billingMultiplier === 0
+                    ? "Included in your plan — does not consume premium requests"
+                    : `Costs ${props.model.billingMultiplier} premium requests per turn`
+                }
+              >
+                {billingLabel}
+              </span>
+            ) : null}
           </div>
         )}
       </div>

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,13 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  ClaudeAI,
+  CursorIcon,
+  GithubCopilotIcon,
+  GrokIcon,
+  Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -8,6 +16,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("copilot")]: GithubCopilotIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {
@@ -26,7 +35,47 @@ export type ModelEsque = {
   name: string;
   shortName?: string | undefined;
   subProvider?: string | undefined;
+  /** Fixed per-model context window reported by the provider, in tokens. */
+  maxContextWindowTokens?: number | undefined;
+  /** Premium-request multiplier for subscription-metered providers. */
+  billingMultiplier?: number | undefined;
 };
+
+/**
+ * Render a context window as a compact token count ("128k", "1M").
+ *
+ * Uses the powers-of-ten convention providers publish in their own docs
+ * (128000 → "128k"), not binary units, so the label matches what users see
+ * on the provider's pricing page.
+ */
+export function formatContextWindowTokens(tokens: number | undefined): string | undefined {
+  if (typeof tokens !== "number" || !Number.isFinite(tokens) || tokens <= 0) {
+    return undefined;
+  }
+  if (tokens >= 1_000_000) {
+    const millions = tokens / 1_000_000;
+    return `${Number.isInteger(millions) ? millions : millions.toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) {
+    return `${Math.round(tokens / 1_000)}k`;
+  }
+  return String(tokens);
+}
+
+/**
+ * Label for the premium-request cost of one turn. `0` is meaningful (the
+ * model is included in the base plan), so it gets its own label rather than
+ * being hidden as falsy.
+ */
+export function formatBillingMultiplier(multiplier: number | undefined): string | undefined {
+  if (typeof multiplier !== "number" || !Number.isFinite(multiplier) || multiplier < 0) {
+    return undefined;
+  }
+  if (multiplier === 0) {
+    return "Included";
+  }
+  return `${Number.isInteger(multiplier) ? multiplier : multiplier.toFixed(2)}×`;
+}
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -1,13 +1,22 @@
 import {
   ClaudeSettings,
   CodexSettings,
+  CopilotSettings,
   CursorSettings,
   GrokSettings,
   OpenCodeSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  ClaudeAI,
+  CursorIcon,
+  GithubCopilotIcon,
+  GrokIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -60,6 +69,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     icon: GrokIcon,
     badgeLabel: "Early Access",
     settingsSchema: GrokSettings,
+  },
+  {
+    value: ProviderDriverKind.make("copilot"),
+    label: "GitHub Copilot",
+    icon: GithubCopilotIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: CopilotSettings,
   },
   {
     value: ProviderDriverKind.make("opencode"),

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -51,6 +51,12 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("copilot"),
+    label: "GitHub Copilot",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
 ];
 
 export type WorkLogToolLifecycleStatus =

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -131,6 +131,7 @@ const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
 const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
+const COPILOT_DRIVER_KIND = ProviderDriverKind.make("copilot");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
@@ -151,6 +152,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CLAUDE_DRIVER_KIND]: "claude-sonnet-5",
   [CURSOR_DRIVER_KIND]: "auto",
   [GROK_DRIVER_KIND]: "grok-build",
+  [COPILOT_DRIVER_KIND]: "claude-sonnet-4.6",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
 };
 
@@ -161,6 +163,7 @@ export const DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CODEX_DRIVER_KIND]: DEFAULT_TEXT_GENERATION_MODEL,
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
+  [COPILOT_DRIVER_KIND]: "gpt-5-mini",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
 };
 
@@ -210,6 +213,25 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5-thinking": "claude-opus-4-5",
     "opus-4.5": "claude-opus-4-5",
   },
+  // Copilot exposes vendor-native slugs (`claude-sonnet-4.6`, `gemini-3.1-pro`),
+  // which collide with the dotted/dashed spellings users type from muscle
+  // memory in the other providers. Normalize the common ones so a slug copied
+  // out of the Claude or Codex picker still resolves here.
+  [COPILOT_DRIVER_KIND]: {
+    sonnet: "claude-sonnet-4.6",
+    "sonnet-4.6": "claude-sonnet-4.6",
+    "claude-sonnet-4-6": "claude-sonnet-4.6",
+    opus: "claude-opus-4.7",
+    "opus-4.7": "claude-opus-4.7",
+    "claude-opus-4-7": "claude-opus-4.7",
+    "opus-4.6": "claude-opus-4.6",
+    "claude-opus-4-6": "claude-opus-4.6",
+    haiku: "claude-haiku-4.5",
+    "haiku-4.5": "claude-haiku-4.5",
+    "claude-haiku-4-5": "claude-haiku-4.5",
+    "gemini-3.1": "gemini-3.1-pro",
+    "gpt-5.1": "gpt-5.1-codex",
+  },
   [OPENCODE_DRIVER_KIND]: {},
 };
 
@@ -220,5 +242,6 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CLAUDE_DRIVER_KIND]: "Claude",
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
+  [COPILOT_DRIVER_KIND]: "GitHub Copilot",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
 };

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -26,6 +26,8 @@ const RuntimeEventRawSource = Schema.Union([
   Schema.Literal("claude.sdk.permission"),
   Schema.Literal("codex.sdk.thread-event"),
   Schema.Literal("opencode.sdk.event"),
+  Schema.Literal("copilot.sdk.session-event"),
+  Schema.Literal("copilot.sdk.synthetic"),
   Schema.Literal("acp.jsonrpc"),
   Schema.TemplateLiteral(["acp.", Schema.String, ".extension"]),
 ]);

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -65,6 +65,24 @@ export const ServerProviderModel = Schema.Struct({
   subProvider: Schema.optional(TrimmedNonEmptyString),
   isCustom: Schema.Boolean,
   isDefault: Schema.optional(Schema.Boolean),
+  /**
+   * Total context window the provider advertises for this model, in tokens.
+   *
+   * Unlike Claude's `contextWindow` option descriptor — a *choice* the user
+   * makes between two variants of one model — this is a fixed per-model limit
+   * reported by the provider (GitHub Copilot returns it as
+   * `capabilities.limits.max_context_window_tokens`). It is presentational
+   * only: the picker renders it next to the model name so users can compare
+   * models, and nothing routes on it. Omitted when the provider does not
+   * report a limit.
+   */
+  maxContextWindowTokens: Schema.optional(PositiveInt),
+  /**
+   * Premium-request cost multiplier for subscription-metered providers.
+   * GitHub Copilot bills each turn as `multiplier` premium requests against
+   * the plan's monthly allowance (0 for models included at no extra cost).
+   */
+  billingMultiplier: Schema.optional(Schema.Number.check(Schema.isGreaterThanOrEqualTo(0))),
   capabilities: Schema.NullOr(ModelCapabilities),
 });
 export type ServerProviderModel = typeof ServerProviderModel.Type;

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -351,6 +351,43 @@ export const GrokSettings = makeProviderSettingsSchema(
 );
 export type GrokSettings = typeof GrokSettings.Type;
 
+export const CopilotSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("copilot").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description:
+          "Path to the GitHub Copilot CLI. Leave blank to use the copy bundled with T3 Code.",
+        providerSettingsForm: { placeholder: "copilot", clearWhenEmpty: "omit" },
+      }),
+    ),
+    homePath: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Copilot config directory",
+        description:
+          "Custom XDG config dir holding Copilot auth and mcp-config.json. Defaults to ~/.config/copilot.",
+        providerSettingsForm: {
+          placeholder: "~/.config/copilot",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath", "homePath"],
+  },
+);
+export type CopilotSettings = typeof CopilotSettings.Type;
+
 export const OpenCodeSettings = makeProviderSettingsSchema(
   {
     enabled: Schema.Boolean.pipe(
@@ -468,6 +505,7 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    copilot: CopilotSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
@@ -564,6 +602,13 @@ const GrokSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const CopilotSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  homePath: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 const OpenCodeSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
@@ -601,6 +646,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
+      copilot: Schema.optionalKey(CopilotSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
     }),
   ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,12 @@ importers:
       '@ff-labs/fff-node':
         specifier: 0.9.4
         version: 0.9.4(patch_hash=2b16019ce7ab61aec6478dd02f79ef468cc1d5c51e9d00764f7d2ab8167210c8)
+      '@github/copilot':
+        specifier: ^1.0.75
+        version: 1.0.75
+      '@github/copilot-sdk':
+        specifier: ^1.0.8
+        version: 1.0.8
       '@opencode-ai/sdk':
         specifier: ^1.3.15
         version: 1.15.13
@@ -2724,6 +2730,66 @@ packages:
   '@formkit/auto-animate@0.9.0':
     resolution: {integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==}
 
+  '@github/copilot-darwin-arm64@1.0.75':
+    resolution: {integrity: sha512-avt2ganQwtycGkqz9z8JpARoEz2Fzi02O+WitbB8I8iF3jfvEGpQ8k3z9oSCPAAO0rIMBeSl05xEUUV5RJwfRA==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-darwin-x64@1.0.75':
+    resolution: {integrity: sha512-eyM5cz83d9h05m6cnnG7tIHR4lSHHXUnxXeQm4rU3nGB1uwHWOa1TH9B4uAaW3zKQgkCkNgm+IlcPJ7geM0KBg==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-linux-arm64@1.0.75':
+    resolution: {integrity: sha512-PuGjPCy+z7DrD0rkcXQRBzoA8lVxD1WC6UeZxkZaIb9asueE798eqHHMV169zYiA3gsiSegIKu5J/aUeWwhpuQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+    hasBin: true
+
+  '@github/copilot-linux-x64@1.0.75':
+    resolution: {integrity: sha512-aGDtUrNyj/ubqLfXOomL4XYZR//1Cs4tDGe7r/464e3Nw4WlNxWPjBbNyOCcUPUMbPHXck6TyxjEvBwwlKCK5w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+    hasBin: true
+
+  '@github/copilot-linuxmusl-arm64@1.0.75':
+    resolution: {integrity: sha512-4cbjjR/laL+4a0VjMkzjIsprRUxiAHAefWVTppFitKiqNxfgyRuOhfSUPUA5TVxPwfyYXknsxeYSNRL8zu9YDA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+    hasBin: true
+
+  '@github/copilot-linuxmusl-x64@1.0.75':
+    resolution: {integrity: sha512-I4oFPNOULMGxWghGCG/VkiT0a62UiL4XGKSlp6X0rVD9xyoYyiLGlsBmTumrooPbzEvgKICYWIz8PCZjrZTyhA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+    hasBin: true
+
+  '@github/copilot-sdk@1.0.8':
+    resolution: {integrity: sha512-dbahVsyt2aX8qqtOOtmYNe40MnvzSvOSHYFFgoFK7gHZSTNz9QgOht8b1sCCJlcXaFAn/w+5qNc7CwWoCjpQ0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@github/copilot-win32-arm64@1.0.75':
+    resolution: {integrity: sha512-wlLDuor+Qm1H43VwZNi03QI4H9FSyZoQzE/YHpGhUay7sKA+4cDJF8ZZNGrtYkyPskfH5HCdNygUn7EEt6lRyQ==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot-win32-x64@1.0.75':
+    resolution: {integrity: sha512-TKISaaILkgcOi7ThaTnln1XoasbUIx+HKSb+pf678RvGucIfLohQyLceuq+rTykoynX54KQ0pf9TEUbMVkUNAA==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot@1.0.75':
+    resolution: {integrity: sha512-rn7ZQmhydCZ9XRdG6V78QEhXIdYlChlUvOVAtyJ6KHJGt2O9/71si7PCt84amfmg0N7IXBT2UGRYF4GQDQBt+g==}
+    hasBin: true
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -2962,6 +3028,81 @@ packages:
   '@js-temporal/polyfill@0.5.1':
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
     engines: {node: '>=12'}
+
+  '@koromix/koffi-darwin-arm64@3.1.2':
+    resolution: {integrity: sha512-32pU4pNZABIz+l9DNJl51Y+jur4vv+SF4Ip2CSF4OUg1xUyefoLpX0NttDmzGITIrneUEVSEN+dT22524ESKBw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@koromix/koffi-darwin-x64@3.1.2':
+    resolution: {integrity: sha512-S+H6LQgUoMj77BqDegwlRaxwLXDfwvSJGuceOqtH0I5V8rzKLmu/hC7NBlxOoAlvKlcV63FtdNiE2E9YSltffg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@koromix/koffi-freebsd-arm64@3.1.2':
+    resolution: {integrity: sha512-fD0ow2PBE60nw7K6xcbala6qwXxfcYeU62tduNeIPvx0KoWhU2rMKZiDNe+iI5TQb3rxYYjjP+aF2Sdm9y6EXQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-ia32@3.1.2':
+    resolution: {integrity: sha512-t8OmL+hoJGDLZDnuLjgLemSYrXX99M7Md+zJX8bMHOtiNbFtkGXn/mV21Pb1ik9JhBXjwK1r4hvBPNlqTMGrHg==}
+    cpu: [ia32]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-x64@3.1.2':
+    resolution: {integrity: sha512-axbLgiM4Y2vyDOTqlXCI8vkg9wqjwSRsmoWXSKreA5YFJwnYA6Sc4aHMz+qZgUSfFei52Qrv1RGhDyo4kHvqhA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@koromix/koffi-linux-arm64@3.1.2':
+    resolution: {integrity: sha512-f0hqAIlFcL9wlRGJ/uCfyfspqnGaASk2gLx1UAP3RBgMQl68D1e+fiHNdXa7g9d76ttmpA8/PGNAqc1X4Byy1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@koromix/koffi-linux-ia32@3.1.2':
+    resolution: {integrity: sha512-UGLPuqeOV/UArsK6oeB5yI/XjSWkFqFlBTC9rUbezBuHJhSibk1EMv7QC0cvtDMu18bo+ucqXWPzh42oT5yYlw==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@koromix/koffi-linux-loong64@3.1.2':
+    resolution: {integrity: sha512-jI0+gM2oDsJ7reOt3XPyO7lyQtZ1CT6NR2uqGQcQVM43cyXBAVYYCUxEH3LHCbgumFaZ+LueIUgbMSwb9pHBxQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@koromix/koffi-linux-riscv64@3.1.2':
+    resolution: {integrity: sha512-yB99adXBRd5T+xXG+f6nnUkC3jCI0iXvPU6RqD9Kx7aZP4Y4NNUWJ5Q4FaP9jb1XmZLY4pGBUiHt8u03Yl7NyA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@koromix/koffi-linux-x64@3.1.2':
+    resolution: {integrity: sha512-Oxvo6F3Edzy/Jm2EtbHWkJ2xRB0mXDAe63k5+USL5uiGE5xZjwEUDOBKIhv2BpCZSOAJrfoojFFogj6+ICKQhw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@koromix/koffi-openbsd-ia32@3.1.2':
+    resolution: {integrity: sha512-SSWzUhL8Ex84JTsO67+MdWZrdwgOzoOrQ0+ZbB+UsivHoAxmWLHKWZaSafNqyBZtxGY1EgtR8AIPouWE9U+Zfw==}
+    cpu: [ia32]
+    os: [openbsd]
+
+  '@koromix/koffi-openbsd-x64@3.1.2':
+    resolution: {integrity: sha512-0ZuI4St7chq3M0d3VivvKIqacZ7RhgohdR476V3HpJkaNdfIywsJIw+GBvqkQahu+4A2Rpu6yQJpWSrfk/Z+Jw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@koromix/koffi-win32-arm64@3.1.2':
+    resolution: {integrity: sha512-8Wn6phw7y53uI52+aBPAqEfZ5pj/HCjg/YtdthqSWYHy+d0MhyASKlcmuP0B5raxQnnA1Bm9LC8UO3M3RojeBw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@koromix/koffi-win32-ia32@3.1.2':
+    resolution: {integrity: sha512-FkKaPBMawgHMNnp1FwLldXMNvEa139GXkxPi9JD9xU71Kh/ZmuEYHGSD6JwZDmDr4jekVrBrr+eGZ+j6C2mkXg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@koromix/koffi-win32-x64@3.1.2':
+    resolution: {integrity: sha512-FeFC59UU1XX4J3ZaqKrsrEzczzB5qksMJo7/R45vIg8mGNVSLMVE85JRiZpjcp9i5Lbav5Vw47QvwFzBgIfvlw==}
+    cpu: [x64]
+    os: [win32]
 
   '@legendapp/list@3.2.0':
     resolution: {integrity: sha512-bN+g/oQYjFz+UAyuBN4cmYJAwdJS1TdNcZZOVlh3+VwCQUWrsg0PH46Mvm76gdZSCYMfoFanPY4dKnILcYEzeg==}
@@ -7519,6 +7660,9 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  koffi@3.1.2:
+    resolution: {integrity: sha512-wVwuE21TBl8/si6E0hPorKR2PJ2q33mEWVETANrtSp3kFM8fi2FcD/J5wmxu0T4TBcqmMQ4xKuF1X1ayFmphzw==}
+
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
 
@@ -10239,6 +10383,10 @@ packages:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
 
+  vscode-jsonrpc@8.2.1:
+    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
+    engines: {node: '>=14.0.0'}
+
   vscode-languageserver-protocol@3.17.5:
     resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
 
@@ -12798,6 +12946,50 @@ snapshots:
 
   '@formkit/auto-animate@0.9.0': {}
 
+  '@github/copilot-darwin-arm64@1.0.75':
+    optional: true
+
+  '@github/copilot-darwin-x64@1.0.75':
+    optional: true
+
+  '@github/copilot-linux-arm64@1.0.75':
+    optional: true
+
+  '@github/copilot-linux-x64@1.0.75':
+    optional: true
+
+  '@github/copilot-linuxmusl-arm64@1.0.75':
+    optional: true
+
+  '@github/copilot-linuxmusl-x64@1.0.75':
+    optional: true
+
+  '@github/copilot-sdk@1.0.8':
+    dependencies:
+      '@github/copilot': 1.0.75
+      koffi: 3.1.2
+      vscode-jsonrpc: 8.2.1
+      zod: 4.4.3
+
+  '@github/copilot-win32-arm64@1.0.75':
+    optional: true
+
+  '@github/copilot-win32-x64@1.0.75':
+    optional: true
+
+  '@github/copilot@1.0.75':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@github/copilot-darwin-arm64': 1.0.75
+      '@github/copilot-darwin-x64': 1.0.75
+      '@github/copilot-linux-arm64': 1.0.75
+      '@github/copilot-linux-x64': 1.0.75
+      '@github/copilot-linuxmusl-arm64': 1.0.75
+      '@github/copilot-linuxmusl-x64': 1.0.75
+      '@github/copilot-win32-arm64': 1.0.75
+      '@github/copilot-win32-x64': 1.0.75
+
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
@@ -12977,6 +13169,51 @@ snapshots:
   '@js-temporal/polyfill@0.5.1':
     dependencies:
       jsbi: 4.3.2
+
+  '@koromix/koffi-darwin-arm64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-darwin-x64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-freebsd-arm64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-freebsd-ia32@3.1.2':
+    optional: true
+
+  '@koromix/koffi-freebsd-x64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-linux-arm64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-linux-ia32@3.1.2':
+    optional: true
+
+  '@koromix/koffi-linux-loong64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-linux-riscv64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-linux-x64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-openbsd-ia32@3.1.2':
+    optional: true
+
+  '@koromix/koffi-openbsd-x64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-win32-arm64@3.1.2':
+    optional: true
+
+  '@koromix/koffi-win32-ia32@3.1.2':
+    optional: true
+
+  '@koromix/koffi-win32-x64@3.1.2':
+    optional: true
 
   '@legendapp/list@3.2.0(patch_hash=9203ec3db86574a31e157a265cefd8997b259cc420a0c4c61c580c80ed8cf78d)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
@@ -18155,6 +18392,24 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  koffi@3.1.2:
+    optionalDependencies:
+      '@koromix/koffi-darwin-arm64': 3.1.2
+      '@koromix/koffi-darwin-x64': 3.1.2
+      '@koromix/koffi-freebsd-arm64': 3.1.2
+      '@koromix/koffi-freebsd-ia32': 3.1.2
+      '@koromix/koffi-freebsd-x64': 3.1.2
+      '@koromix/koffi-linux-arm64': 3.1.2
+      '@koromix/koffi-linux-ia32': 3.1.2
+      '@koromix/koffi-linux-loong64': 3.1.2
+      '@koromix/koffi-linux-riscv64': 3.1.2
+      '@koromix/koffi-linux-x64': 3.1.2
+      '@koromix/koffi-openbsd-ia32': 3.1.2
+      '@koromix/koffi-openbsd-x64': 3.1.2
+      '@koromix/koffi-win32-arm64': 3.1.2
+      '@koromix/koffi-win32-ia32': 3.1.2
+      '@koromix/koffi-win32-x64': 3.1.2
+
   kubernetes-types@1.30.0: {}
 
   lan-network@0.2.1: {}
@@ -21500,6 +21755,8 @@ snapshots:
       vscode-uri: 3.1.0
 
   vscode-jsonrpc@8.2.0: {}
+
+  vscode-jsonrpc@8.2.1: {}
 
   vscode-languageserver-protocol@3.17.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,10 @@ allowBuilds:
   electron: true
   electron-winstaller: false
   esbuild: true
+  # Native FFI shim pulled in by @github/copilot-sdk. Only the SDK's
+  # in-process runtime host uses it — we drive the Copilot CLI over stdio —
+  # but its install script is what selects the prebuilt platform binary.
+  koffi: true
   msgpackr-extract: true
   msw: false
   node-pty: true


### PR DESCRIPTION
Adds a `copilot` driver that drives the GitHub Copilot CLI through `@github/copilot-sdk` (JSON-RPC over a child process), alongside the existing Codex / Claude / Cursor / Grok / OpenCode drivers.

Server:
  - `CopilotAdapter` translates the SDK's push-based `SessionEvent` stream into `ProviderRuntimeEvent`s, bridges Copilot's callback-style permission and user-input requests onto T3 Code's request/resolve events, and reconciles Copilot's own turn ids with the ones `sendTurn` hands out (`copilotTurnTracking`).
  - `CopilotProvider` probes availability and builds the model catalog from `listModels()`, so the picker only ever offers models the signed-in subscription actually grants.
  - Model/effort switches use `session.setModel`, which preserves history — so `sessionModelSwitch` is `"in-session"`.
  - Plan mode maps onto the CLI's own `mode.set`, and the user's `mcp-config.json` is forwarded so `copilot mcp add` keeps working.
  - `CopilotTextGeneration` backs commit/PR/branch/title generation with a short-lived headless session that denies every permission request.

Models expose the two things Copilot reports per model:
  - `supportedReasoningEfforts` becomes the `effort` select descriptor, so the control only offers levels the model accepts.
  - `max_context_window_tokens` and the premium-request multiplier land on new optional `ServerProviderModel` fields and render in the picker. These are fixed per-model facts, not user-selectable variants, so they are presentational rather than option descriptors.

Notes:
  - The CLI binary ships as a dependency, so there is no version probe; maintenance is manual-only against `@github/copilot`.
  - A 403 from `models.list` means "no Copilot seat" and is surfaced with the same actionable sign-in message as a missing login.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new provider surface (adapter, sessions, auth probing, child processes) alongside contracts and UI, but it follows existing driver patterns and does not alter other providers’ runtime paths.
> 
> **Overview**
> Adds **GitHub Copilot** as a new `copilot` provider driver, wired like Codex/Claude/Cursor through the shared `ProviderDriver` SPI and registered in `builtInDrivers`.
> 
> The server drives the Copilot CLI via `@github/copilot-sdk` (JSON-RPC child process). **`CopilotAdapter`** maps SDK `SessionEvent`s to `ProviderRuntimeEvent`s, bridges permission/user-input callbacks to T3’s request/resolve flow, and **`copilotTurnTracking`** aligns Copilot’s turn ids with ids returned from `sendTurn`. **`CopilotProvider`** probes auth and builds the model list from `listModels()` (with a static fallback catalog). In-session model and reasoning effort use `session.setModel`; plan mode and the user’s **`mcp-config.json`** are forwarded. **`CopilotTextGeneration`** runs short headless sessions for commit/PR/branch/title helpers with permissions denied.
> 
> New **`CopilotSettings`**, **`maxContextWindowTokens`** and **`billingMultiplier`** on `ServerProviderModel`, Copilot slug aliases and defaults in contracts, and **`copilotCliPath`** resolution for bundled/desktop binaries. The web picker shows context window and billing labels and Copilot in settings/session UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0952d05f58d76fb13bb12c35cb32dcd143205b1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub Copilot as a first-class provider with full session, model, and text generation support
> - Introduces a `CopilotDriver` that registers GitHub Copilot as a selectable provider, wiring together a `CopilotAdapter` for session/turn management and `CopilotTextGeneration` for commit messages, PR content, branch names, and thread titles.
> - `CopilotAdapter` handles the full session lifecycle: start/resume, send turns with attachments, interrupt, respond to permission and user-input requests, model/effort switching, and streaming event translation from the Copilot SDK to runtime events.
> - Adds `CopilotProvider` which probes CLI availability and authentication, discovers live models with context window and billing metadata, and falls back to a built-in model catalog on failure or timeout (20s).
> - Adds `CopilotSettings` to server config (binary path, home path, custom models) and surfaces GitHub Copilot in the web UI provider picker and settings panel with an 'Early Access' badge.
> - Model list rows now display compact context window (`128k ctx`) and billing multiplier (`Included` / `2×`) labels drawn from new `maxContextWindowTokens` and `billingMultiplier` fields on `ServerProviderModel`.
> - Adds `@github/copilot` and `@github/copilot-sdk` as server dependencies; `koffi` build scripts are allow-listed in `pnpm-workspace.yaml` for SDK prebuilt binary selection.
> - Risk: `CopilotAdapter` does not support thread rollback — calls return a hard error — and session resume depends on a cursor string that is only available after a successful first turn.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0952d05. 19 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->