### PR TITLE
fix(server): pass the explicit user to loginctl enable-linger (fixes WSL2 service install)

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -12,6 +12,7 @@ import {
   HostProcessArguments,
   HostProcessExecutablePath,
   HostProcessPlatform,
+  HostProcessUserName,
 } from "@t3tools/shared/hostProcess";
 
 import { reconcileService } from "../cli/service.ts";
@@ -60,10 +61,11 @@ const makeHost = (entry: string): BootService.BootServiceHost => ({
   cliEntryPath: entry,
 });
 
-const provideHostRefs = (home: string, platform: NodeJS.Platform = "linux") =>
+const provideHostRefs = (home: string, platform: NodeJS.Platform = "linux", userName = "t3user") =>
   Effect.provide(
     Layer.mergeAll(
       Layer.succeed(HostProcessPlatform, platform),
+      Layer.succeed(HostProcessUserName, userName),
       ConfigProvider.layer(ConfigProvider.fromEnv({ env: { HOME: home } })),
     ),
   );
@@ -222,7 +224,10 @@ it.layer(NodeServices.layer)("BootService", (it) => {
           // restart (not enable --now) so repairing a stale unit replaces a
           // running process instead of leaving the old one until reboot.
           "systemctl --user restart t3code.service",
-          "loginctl enable-linger",
+          // The user is passed explicitly (resolved from the effective uid),
+          // because the bare form resolves the caller through a logind session
+          // that does not exist under WSL2.
+          "loginctl enable-linger t3user",
         ],
       );
 
@@ -243,6 +248,32 @@ it.layer(NodeServices.layer)("BootService", (it) => {
       assert.isFalse(statusAfter.installed);
       const removedAgain = yield* service.uninstall;
       assert.isFalse(removedAgain);
+    }),
+  );
+
+  it.effect("enables linger for the resolved user so it works without a logind session", () =>
+    Effect.gen(function* () {
+      const { dirs } = yield* makeTestContext();
+      const commands: Array<RecordedCommand> = [];
+      const service = yield* BootService.make({
+        baseDir: dirs.baseDir,
+        logsDir: dirs.logsDir,
+        cliVersion: "0.0.27",
+        host: makeHost(dirs.stableEntry),
+      }).pipe(
+        Effect.provide(makeRecordingRunnerLayer(commands)),
+        provideHostRefs(dirs.home, "linux", "caesar"),
+      );
+
+      yield* service.install;
+
+      // The username must be forwarded verbatim — the bare `loginctl
+      // enable-linger` needs a logind session (absent under WSL2), so the
+      // explicit form is what makes install succeed there.
+      assert.deepEqual(
+        commands.filter(({ command }) => command === "loginctl"),
+        [{ command: "loginctl", args: ["enable-linger", "caesar"] }],
+      );
     }),
   );
 

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -13,6 +13,7 @@ import {
   HostProcessArguments,
   HostProcessExecutablePath,
   HostProcessPlatform,
+  HostProcessUserName,
 } from "@t3tools/shared/hostProcess";
 
 import * as ProcessRunner from "../processRunner.ts";
@@ -197,6 +198,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
     cliEntryPath: hostArguments[1] ?? "",
   };
   const platform = yield* HostProcessPlatform;
+  const userName = yield* HostProcessUserName;
   const homeDir = yield* Config.string("HOME").pipe(Config.withDefault(""));
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -340,10 +342,13 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
         BOOT_SERVICE_UNIT_FILE,
       ]);
       // Linger keeps the user manager (and this service) running without an
-      // open session — the whole point on a box reached over SSH. No
-      // username argument: loginctl defaults to the calling user, which is
-      // always right, while $USER can be stale (su without -l) or unset.
-      yield* runStep("enabling lingering for this user", "loginctl", ["enable-linger"]);
+      // open session — the whole point on a box reached over SSH. Pass the
+      // user explicitly (resolved from the effective uid, so it is never the
+      // stale-or-unset $USER): the bare `loginctl enable-linger` resolves the
+      // caller through their logind *session*, which does not exist under
+      // WSL2 (no XDG_SESSION_ID), so the no-arg form fails there while the
+      // explicit user works everywhere.
+      yield* runStep("enabling lingering for this user", "loginctl", ["enable-linger", userName]);
     }).pipe(Effect.tapError(() => rollbackFailedInstall(previousUnit)));
 
     return plan;

--- a/packages/shared/src/hostProcess.ts
+++ b/packages/shared/src/hostProcess.ts
@@ -51,4 +51,16 @@ export const HostProcessArguments = Context.Reference<ReadonlyArray<string>>(
   },
 );
 
+/**
+ * The calling user's account name, resolved from the effective uid rather than
+ * `$USER`. `$USER` can be stale (`su` without `-l`) or unset, while
+ * `os.userInfo()` reads the passwd database by uid and is always the real user.
+ */
+export const HostProcessUserName = Context.Reference<string>(
+  "@t3tools/shared/hostProcess/HostProcessUserName",
+  {
+    defaultValue: () => NodeOS.userInfo().username,
+  },
+);
+
 export const isHostWindows = Effect.map(HostProcessPlatform, (platform) => platform === "win32");


### PR DESCRIPTION
## What Changed

`t3 service install` now runs `loginctl enable-linger <user>` with the user resolved from the effective uid (`os.userInfo()`, exposed as a new `HostProcessUserName` reference), instead of the bare `loginctl enable-linger`.

Files: `apps/server/src/cloud/bootService.ts`, `packages/shared/src/hostProcess.ts`, plus tests.

## Why

Closes #4894.

The bare `loginctl enable-linger` resolves the caller through their **logind session**. Under WSL2 a normal shell has no `XDG_SESSION_ID`, so logind cannot resolve a session and the step exits non-zero — install then rolls back and the service is never set up, even when lingering is already enabled for that user.

The existing comment justified the no-arg form by wanting to avoid a stale-or-unset `$USER`. Resolving the username from the effective uid keeps that intent (it is never `$USER`) while dropping the session dependency, so `loginctl enable-linger <user>` succeeds on WSL2 **and** on ordinary systemd Linux. This is the standard way to enable-linger for a specific user and does not depend on an active session.

Verified: `bootService.test.ts` passes, including a new test asserting the resolved user is forwarded verbatim; `apps/server` typecheck is clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Linux boot-service install linger invocation and a shared host-process username ref; no auth, data, or API surface changes.
> 
> **Overview**
> **Fixes `t3 service install` failing on WSL2** when the linger step runs `loginctl enable-linger` with no arguments. That form needs a logind session; WSL2 shells often lack `XDG_SESSION_ID`, so the step fails and install rolls back.
> 
> Install now runs **`loginctl enable-linger <user>`**, with the username from a new **`HostProcessUserName`** reference in `@t3tools/shared/hostProcess` (default `os.userInfo().username` from the effective uid, not `$USER`). **`bootService`** reads that ref and passes it into the linger command.
> 
> Tests expect the explicit user in the install command list and add a case that the resolved name is forwarded verbatim (e.g. `caesar`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e132e70799b187089ba5b707fbc95a3566d048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `loginctl enable-linger` to pass an explicit username for WSL2 service install
> - Adds `HostProcessUserName` to [hostProcess.ts](https://github.com/pingdotgg/t3code/pull/5012/files#diff-bfd8aa15bef02a4e3e39ffafc1b2868e593c03d10852d3d3490c5456149a099b), a `Context.Reference<string>` that resolves the current user's account name from the system passwd database (via `os.userInfo().username`) rather than the `$USER` env var.
> - Updates `bootService.ts` to pass the resolved username explicitly to `loginctl enable-linger <user>`, fixing a failure in WSL2 where the no-argument form fails without an active logind session.
> - Behavioral Change: `loginctl enable-linger` is now always called with an explicit username argument instead of relying on the session-derived default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3e132e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->