### PR TITLE
fix(server): put ~/.local/bin on the boot service PATH so providers resolve

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -108,6 +108,7 @@ it("renders a systemd unit with absolute paths and append-mode logging", () => {
       "[Service]",
       "Type=simple",
       "WorkingDirectory=%h",
+      "Environment=PATH=%h/.local/bin:%h/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin",
       "Environment=T3CODE_HOME=/home/theo/.t3",
       "Environment=T3_BOOT_SERVICE_UNIT=t3code.service",
       "ExecStart=/usr/local/bin/node /home/theo/.t3/runtime/versions/0.0.27/node_modules/t3/dist/bin.mjs serve",
@@ -137,6 +138,8 @@ it("quotes systemd values containing spaces and escapes percent specifiers", () 
   });
   assert.include(unit, 'ExecStart="/home/me/my tools/node" "/home/me/T3 Data/bin.mjs" serve');
   assert.include(unit, 'Environment=T3CODE_HOME="/home/me/T3 Data"');
+  // ~/.local/bin is prepended so user-scoped provider CLIs resolve.
+  assert.include(unit, "Environment=PATH=%h/.local/bin:%h/bin:");
   // append: paths take the rest of the line literally (spaces are fine,
   // quoting is not), but % still goes through specifier expansion.
   assert.include(unit, "StandardOutput=append:/home/me/100%%logs/boot.log");

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -100,6 +100,15 @@ export function renderBootServiceUnit(plan: BootServicePlan): string {
     "[Service]",
     "Type=simple",
     "WorkingDirectory=%h",
+    // A systemd user unit inherits the user manager's minimal PATH, which does
+    // NOT include ~/.local/bin — the directory Ubuntu's ~/.profile prepends and
+    // where user-scoped provider CLIs (claude, codex) land on a headless
+    // install. Without this, `t3 serve` finds every provider by hand from a
+    // login shell but the service starts with zero providers. Prepend the
+    // user-local bins to the standard system PATH; %h expands to the home dir
+    // (like WorkingDirectory), and absent entries (e.g. /snap/bin on non-Debian
+    // distros) are simply skipped during lookup.
+    "Environment=PATH=%h/.local/bin:%h/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin",
     `Environment=T3CODE_HOME=${quoteSystemdValue(plan.baseDir)}`,
     `Environment=${BOOT_SERVICE_UNIT_ENV}=${BOOT_SERVICE_UNIT_FILE}`,
     `ExecStart=${quoteSystemdValue(plan.nodePath)} ${quoteSystemdValue(plan.t3EntryPath)} serve`,


### PR DESCRIPTION
## What Changed

The generated systemd user unit (`renderBootServiceUnit`) now sets an explicit `Environment=PATH=` that prepends `~/.local/bin` and `~/bin` (via the `%h` specifier) to the standard system directories.

File: `apps/server/src/cloud/bootService.ts`, plus the byte-for-byte render test.

## Why

Closes #4913.

The unit set no `PATH`, so `t3code.service` inherited the systemd user manager's minimal environment, which does not include `~/.local/bin` — exactly where user-scoped provider CLIs (`claude`, `codex`) land on a headless install. Ubuntu's `~/.profile` prepends `~/.local/bin`, but that only runs for **login** shells and a systemd user unit never sources it. The result: a server that listens, pairs and authenticates but exposes **zero providers**, so no thread can run. It is also confusing to diagnose, because `t3 serve` run by hand over an SSH login shell finds every provider while the service cannot.

`%h` expands to the home dir (the same specifier the unit already uses for `WorkingDirectory`), and directories absent on a given distro are simply skipped during lookup. `renderBootServiceUnit` stays pure and deterministic, so `status` still flags an older unit as out-of-date and offers a repair that rewrites it with the PATH.

Verified: `bootService.test.ts` passes (render test updated byte-for-byte); `apps/server` typecheck is clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to generated systemd unit environment and test expectations; no auth, data, or runtime logic changes beyond PATH for CLI discovery.
> 
> **Overview**
> The generated **systemd user unit** for `t3code.service` now sets an explicit `Environment=PATH=` that prepends `%h/.local/bin` and `%h/bin` ahead of the usual system directories, matching what login shells get from `~/.profile` on typical Ubuntu headless installs.
> 
> **Why it matters:** without this, `t3 serve` under the user manager inherited a minimal PATH and could not find user-scoped provider CLIs (e.g. `claude`, `codex`) in `~/.local/bin`, so the service listened and paired but exposed **zero providers**—while the same command over SSH looked fine.
> 
> `renderBootServiceUnit` stays deterministic, so **status** still compares the installed unit byte-for-byte; units written before this change are reported **out of date** and repair/install rewrites them with the new PATH. Tests assert the full rendered unit and PATH prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bba10621ae5f5dd2131fd7314e3ffd8f92830196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `~/.local/bin` to PATH in generated systemd boot service unit
> The `BootService.renderBootServiceUnit` function now injects an `Environment=PATH=` line into the `[Service]` section, prepending `%h/.local/bin` and `%h/bin` before standard system directories. This ensures user-installed binaries (e.g. provider CLIs) are resolvable when the boot service starts. Behavioral Change: the boot service process now runs with an explicit PATH instead of inheriting the default systemd user environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized bba1062. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->