### PR TITLE
fix(desktop): register Linux deep-link protocol

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -528,6 +528,23 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
   );
 
+  it.effect("registers the renderer protocol in Linux desktop builds", () =>
+    Effect.gen(function* () {
+      const config = yield* createBuildConfig(
+        "linux",
+        "AppImage",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+
+      const linux = config.linux as Record<string, unknown>;
+      assert.deepStrictEqual(linux.protocols, [{ name: "T3 Code", schemes: ["t3code"] }]);
+    }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
+  );
+
   it.effect("keeps executable resource editing enabled for unsigned Windows builds", () =>
     Effect.gen(function* () {
       const config = yield* createBuildConfig(

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1589,6 +1589,12 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       executableName: "t3code",
       icon: "icons",
       category: "Development",
+      protocols: [
+        {
+          name: "T3 Code",
+          schemes: ["t3code"],
+        },
+      ],
       desktop: {
         entry: {
           StartupWMClass: "t3code",


### PR DESCRIPTION
Linux AppImage desktop entries do not declare the `t3code://` scheme, so desktop OAuth callbacks can end at a "No Apps Available" chooser even after the AppImage has been integrated.

Declare the production renderer scheme in the electron-builder Linux protocol configuration. electron-builder then emits `MimeType=x-scheme-handler/t3code;` in `t3code.desktop`, allowing the startup `setAsDefaultProtocolClient` call and desktop integration tools to associate callbacks with T3 Code. A focused build-config test covers the declaration.

Tests:
- `pnpm exec vp test run scripts/build-desktop-artifact.test.ts`
- `pnpm exec vp fmt --check scripts/build-desktop-artifact.ts scripts/build-desktop-artifact.test.ts`
- `pnpm exec vp lint --report-unused-disable-directives scripts/build-desktop-artifact.ts scripts/build-desktop-artifact.test.ts`
- `pnpm exec vp run --filter ./scripts typecheck`

Model: GPT-5.6-sol
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to Linux desktop metadata with a matching unit test; no runtime auth or server logic changes.
> 
> **Overview**
> Linux AppImage desktop entries previously lacked a declared `t3code://` handler, so OAuth and other deep-link callbacks could land in a generic “No Apps Available” chooser instead of T3 Code.
> 
> **`createBuildConfig`** now adds `linux.protocols` with the production `t3code` scheme (aligned with macOS packaging, without `t3code-dev` on Linux). electron-builder should emit `MimeType=x-scheme-handler/t3code;` on `t3code.desktop`, so desktop integration and startup `setAsDefaultProtocolClient` can associate callbacks with the app.
> 
> A test asserts Linux AppImage build config includes the same protocol declaration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11fd98948868f99fb811159a31e2bb520216dc0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register `t3code` deep-link protocol in Linux desktop builds
> Adds `linux.protocols` with `{ name: 'T3 Code', schemes: ['t3code'] }` to the Linux branch of `createBuildConfig` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/5014/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d). This was already present for other platforms but was missing for Linux. A corresponding test asserts the protocol entry is included in Linux AppImage configurations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11fd989.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->