### PR TITLE
fix(server): keep older clients connected after keybinding additions

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -9,6 +9,7 @@ import {
   AuthEnvironmentBootstrapTokenType,
   AuthTokenExchangeGrantType,
   CommandId,
+  CURRENT_KEYBINDING_COMMAND_SET_VERSION,
   DEFAULT_SERVER_SETTINGS,
   EnvironmentId,
   EventId,
@@ -27,6 +28,7 @@ import {
   ProviderInstanceId,
   ResolvedKeybindingRule,
   ThreadId,
+  WS_KEYBINDING_COMMAND_SET_QUERY_PARAM,
   WS_METHODS,
   WsRpcGroup,
   EditorId,
@@ -4318,6 +4320,143 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
       assert.deepEqual(response.issues, []);
       assert.deepEqual(response.keybindings, [resolved]);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("projects keybinding commands for each websocket client version", () =>
+    Effect.gen(function* () {
+      const currentCommands = [
+        "terminal.toggle",
+        "filePicker.toggle",
+        "projectSearch.toggle",
+        "script.format.run",
+      ] satisfies Array<ResolvedKeybindingRule["command"]>;
+      const shortcut = {
+        key: "k",
+        metaKey: false,
+        ctrlKey: true,
+        shiftKey: false,
+        altKey: false,
+        modKey: true,
+      };
+      const keybindings = currentCommands.map((command) => ({
+        command,
+        shortcut,
+      })) satisfies ReadonlyArray<ResolvedKeybindingRule>;
+      const issues = [
+        {
+          kind: "keybindings.invalid-entry",
+          message: "Preserved issue",
+          index: 4,
+        },
+      ] as const;
+      const changeEvent = { keybindings, issues };
+
+      yield* buildAppUnderTest({
+        layers: {
+          keybindings: {
+            loadConfigState: Effect.succeed({ keybindings, issues }),
+            streamChanges: Stream.succeed(changeEvent),
+            upsertKeybindingRule: () => Effect.succeed(keybindings),
+            removeKeybindingRule: () => Effect.succeed(keybindings),
+          },
+        },
+      });
+
+      const unnegotiatedUrl = yield* getWsServerUrl("/ws");
+      const oldClientUrl = new URL(unnegotiatedUrl);
+      oldClientUrl.searchParams.set(WS_KEYBINDING_COMMAND_SET_QUERY_PARAM, "0");
+      const currentClientUrl = new URL(unnegotiatedUrl);
+      currentClientUrl.searchParams.set(
+        WS_KEYBINDING_COMMAND_SET_QUERY_PARAM,
+        CURRENT_KEYBINDING_COMMAND_SET_VERSION,
+      );
+      const legacyCommands = ["terminal.toggle", "script.format.run"];
+      const commands = (rules: ReadonlyArray<ResolvedKeybindingRule>) =>
+        rules.map(({ command }) => command);
+      const mutationRule: KeybindingRule = {
+        command: "terminal.toggle",
+        key: "ctrl+t",
+      };
+
+      const unnegotiatedConfig = yield* Effect.scoped(
+        withWsRpcClient(unnegotiatedUrl, (client) => client[WS_METHODS.serverGetConfig]({})),
+      );
+      const oldClientConfig = yield* Effect.scoped(
+        withWsRpcClient(oldClientUrl.toString(), (client) =>
+          client[WS_METHODS.serverGetConfig]({}),
+        ),
+      );
+      const currentClientConfig = yield* Effect.scoped(
+        withWsRpcClient(currentClientUrl.toString(), (client) =>
+          client[WS_METHODS.serverGetConfig]({}),
+        ),
+      );
+      const unnegotiatedEvents = yield* Effect.scoped(
+        withWsRpcClient(unnegotiatedUrl, (client) =>
+          client[WS_METHODS.subscribeServerConfig]({}).pipe(Stream.take(2), Stream.runCollect),
+        ),
+      );
+      const currentClientEvents = yield* Effect.scoped(
+        withWsRpcClient(currentClientUrl.toString(), (client) =>
+          client[WS_METHODS.subscribeServerConfig]({}).pipe(Stream.take(2), Stream.runCollect),
+        ),
+      );
+      const unnegotiatedUpsert = yield* Effect.scoped(
+        withWsRpcClient(unnegotiatedUrl, (client) =>
+          client[WS_METHODS.serverUpsertKeybinding](mutationRule),
+        ),
+      );
+      const currentClientUpsert = yield* Effect.scoped(
+        withWsRpcClient(currentClientUrl.toString(), (client) =>
+          client[WS_METHODS.serverUpsertKeybinding](mutationRule),
+        ),
+      );
+      const unnegotiatedRemove = yield* Effect.scoped(
+        withWsRpcClient(unnegotiatedUrl, (client) =>
+          client[WS_METHODS.serverRemoveKeybinding](mutationRule),
+        ),
+      );
+      const currentClientRemove = yield* Effect.scoped(
+        withWsRpcClient(currentClientUrl.toString(), (client) =>
+          client[WS_METHODS.serverRemoveKeybinding](mutationRule),
+        ),
+      );
+
+      assert.deepEqual(commands(unnegotiatedConfig.keybindings), legacyCommands);
+      assert.deepEqual(commands(oldClientConfig.keybindings), legacyCommands);
+      assert.deepEqual(commands(currentClientConfig.keybindings), currentCommands);
+      assert.deepEqual(unnegotiatedConfig.issues, issues);
+      assert.deepEqual(currentClientConfig.issues, issues);
+
+      const [unnegotiatedSnapshot, unnegotiatedUpdate] = Array.from(unnegotiatedEvents);
+      assert.equal(unnegotiatedSnapshot?.type, "snapshot");
+      assert.equal(unnegotiatedUpdate?.type, "keybindingsUpdated");
+      if (unnegotiatedSnapshot?.type === "snapshot") {
+        assert.deepEqual(commands(unnegotiatedSnapshot.config.keybindings), legacyCommands);
+        assert.deepEqual(unnegotiatedSnapshot.config.issues, issues);
+      }
+      if (unnegotiatedUpdate?.type === "keybindingsUpdated") {
+        assert.deepEqual(commands(unnegotiatedUpdate.payload.keybindings), legacyCommands);
+        assert.deepEqual(unnegotiatedUpdate.payload.issues, issues);
+      }
+
+      const [currentSnapshot, currentUpdate] = Array.from(currentClientEvents);
+      assert.equal(currentSnapshot?.type, "snapshot");
+      assert.equal(currentUpdate?.type, "keybindingsUpdated");
+      if (currentSnapshot?.type === "snapshot") {
+        assert.deepEqual(commands(currentSnapshot.config.keybindings), currentCommands);
+        assert.deepEqual(currentSnapshot.config.issues, issues);
+      }
+      if (currentUpdate?.type === "keybindingsUpdated") {
+        assert.deepEqual(commands(currentUpdate.payload.keybindings), currentCommands);
+        assert.deepEqual(currentUpdate.payload.issues, issues);
+      }
+
+      assert.deepEqual(commands(unnegotiatedUpsert.keybindings), legacyCommands);
+      assert.deepEqual(commands(currentClientUpsert.keybindings), currentCommands);
+      assert.deepEqual(commands(unnegotiatedRemove.keybindings), legacyCommands);
+      assert.deepEqual(commands(currentClientRemove.keybindings), currentCommands);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4369,7 +4369,12 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       const currentClientUrl = new URL(unnegotiatedUrl);
       currentClientUrl.searchParams.set(
         WS_KEYBINDING_COMMAND_SET_QUERY_PARAM,
-        CURRENT_KEYBINDING_COMMAND_SET_VERSION,
+        String(CURRENT_KEYBINDING_COMMAND_SET_VERSION),
+      );
+      const futureClientUrl = new URL(unnegotiatedUrl);
+      futureClientUrl.searchParams.set(
+        WS_KEYBINDING_COMMAND_SET_QUERY_PARAM,
+        String(CURRENT_KEYBINDING_COMMAND_SET_VERSION + 1),
       );
       const legacyCommands = ["terminal.toggle", "script.format.run"];
       const commands = (rules: ReadonlyArray<ResolvedKeybindingRule>) =>
@@ -4389,6 +4394,11 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       );
       const currentClientConfig = yield* Effect.scoped(
         withWsRpcClient(currentClientUrl.toString(), (client) =>
+          client[WS_METHODS.serverGetConfig]({}),
+        ),
+      );
+      const futureClientConfig = yield* Effect.scoped(
+        withWsRpcClient(futureClientUrl.toString(), (client) =>
           client[WS_METHODS.serverGetConfig]({}),
         ),
       );
@@ -4426,6 +4436,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.deepEqual(commands(unnegotiatedConfig.keybindings), legacyCommands);
       assert.deepEqual(commands(oldClientConfig.keybindings), legacyCommands);
       assert.deepEqual(commands(currentClientConfig.keybindings), currentCommands);
+      assert.deepEqual(commands(futureClientConfig.keybindings), currentCommands);
       assert.deepEqual(unnegotiatedConfig.issues, issues);
       assert.deepEqual(currentClientConfig.issues, issues);
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -138,6 +138,11 @@ const projectKeybindingsForClient = (
         ({ command }) => command !== "filePicker.toggle" && command !== "projectSearch.toggle",
       );
 
+const supportsCurrentKeybindingCommandSet = (url: URL) => {
+  const version = Number(url.searchParams.get(WS_KEYBINDING_COMMAND_SET_QUERY_PARAM));
+  return Number.isSafeInteger(version) && version >= CURRENT_KEYBINDING_COMMAND_SET_VERSION;
+};
+
 export const resolveAvailableEditorsForConfig = <A, E, R>(
   discovery: Effect.Effect<ReadonlyArray<A>, E, R>,
 ) =>
@@ -2129,9 +2134,7 @@ export const websocketRpcRouteLayer = Layer.unwrap(
         const request = yield* HttpServerRequest.HttpServerRequest;
         const requestUrl = HttpServerRequest.toURL(request);
         const supportsCurrentKeybindingCommands =
-          Option.isSome(requestUrl) &&
-          requestUrl.value.searchParams.get(WS_KEYBINDING_COMMAND_SET_QUERY_PARAM) ===
-            CURRENT_KEYBINDING_COMMAND_SET_VERSION;
+          Option.isSome(requestUrl) && supportsCurrentKeybindingCommandSet(requestUrl.value);
         const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
         const sessions = yield* SessionStore.SessionStore;
         const session = yield* serverAuth.authenticateWebSocketUpgrade(request).pipe(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -16,6 +16,7 @@ import {
   type AuthEnvironmentScope,
   AuthSessionId,
   CommandId,
+  CURRENT_KEYBINDING_COMMAND_SET_VERSION,
   type DiscoveredLocalServerList,
   EventId,
   type OrchestrationCommand,
@@ -41,6 +42,7 @@ import {
   ProjectSearchEntriesError,
   ProjectWriteFileError,
   RelayClientInstallFailedError,
+  type ResolvedKeybindingRule,
   type RelayClientInstallProgressEvent,
   type ServerSelfUpdateError,
   type ServerSelfUpdateProgressEvent,
@@ -55,6 +57,7 @@ import {
   type TerminalError,
   type TerminalEvent,
   type TerminalMetadataStreamEvent,
+  WS_KEYBINDING_COMMAND_SET_QUERY_PARAM,
   WS_METHODS,
   WsRpcGroup,
 } from "@t3tools/contracts";
@@ -124,6 +127,16 @@ const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchComma
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const EDITOR_DISCOVERY_TIMEOUT = Duration.seconds(5);
+
+const projectKeybindingsForClient = (
+  keybindings: ReadonlyArray<ResolvedKeybindingRule>,
+  supportsCurrentKeybindingCommands: boolean,
+) =>
+  supportsCurrentKeybindingCommands
+    ? keybindings
+    : keybindings.filter(
+        ({ command }) => command !== "filePicker.toggle" && command !== "projectSearch.toggle",
+      );
 
 export const resolveAvailableEditorsForConfig = <A, E, R>(
   discovery: Effect.Effect<ReadonlyArray<A>, E, R>,
@@ -341,6 +354,7 @@ function toAuthAccessStreamEvent(
 const makeWsRpcLayer = (
   currentSession: EnvironmentAuth.AuthenticatedSession,
   previewAutomationBroker: PreviewAutomationBroker.PreviewAutomationBroker["Service"],
+  supportsCurrentKeybindingCommands: boolean,
 ) =>
   WsRpcGroup.toLayer(
     Effect.gen(function* () {
@@ -983,7 +997,10 @@ const makeWsRpcLayer = (
           auth,
           cwd: config.cwd,
           keybindingsConfigPath: config.keybindingsConfigPath,
-          keybindings: keybindingsConfig.keybindings,
+          keybindings: projectKeybindingsForClient(
+            keybindingsConfig.keybindings,
+            supportsCurrentKeybindingCommands,
+          ),
           issues: keybindingsConfig.issues,
           providers,
           availableEditors: yield* resolveAvailableEditorsForConfig(
@@ -1414,7 +1431,13 @@ const makeWsRpcLayer = (
             WS_METHODS.serverUpsertKeybinding,
             Effect.gen(function* () {
               const keybindingsConfig = yield* keybindings.upsertKeybindingRule(rule);
-              return { keybindings: keybindingsConfig, issues: [] };
+              return {
+                keybindings: projectKeybindingsForClient(
+                  keybindingsConfig,
+                  supportsCurrentKeybindingCommands,
+                ),
+                issues: [],
+              };
             }),
             { "rpc.aggregate": "server" },
           ),
@@ -1423,7 +1446,13 @@ const makeWsRpcLayer = (
             WS_METHODS.serverRemoveKeybinding,
             Effect.gen(function* () {
               const keybindingsConfig = yield* keybindings.removeKeybindingRule(rule);
-              return { keybindings: keybindingsConfig, issues: [] };
+              return {
+                keybindings: projectKeybindingsForClient(
+                  keybindingsConfig,
+                  supportsCurrentKeybindingCommands,
+                ),
+                issues: [],
+              };
             }),
             { "rpc.aggregate": "server" },
           ),
@@ -1973,7 +2002,10 @@ const makeWsRpcLayer = (
                   version: 1 as const,
                   type: "keybindingsUpdated" as const,
                   payload: {
-                    keybindings: event.keybindings,
+                    keybindings: projectKeybindingsForClient(
+                      event.keybindings,
+                      supportsCurrentKeybindingCommands,
+                    ),
                     issues: event.issues,
                   },
                 })),
@@ -2095,6 +2127,11 @@ export const websocketRpcRouteLayer = Layer.unwrap(
       "/ws",
       Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest;
+        const requestUrl = HttpServerRequest.toURL(request);
+        const supportsCurrentKeybindingCommands =
+          Option.isSome(requestUrl) &&
+          requestUrl.value.searchParams.get(WS_KEYBINDING_COMMAND_SET_QUERY_PARAM) ===
+            CURRENT_KEYBINDING_COMMAND_SET_VERSION;
         const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
         const sessions = yield* SessionStore.SessionStore;
         const session = yield* serverAuth.authenticateWebSocketUpgrade(request).pipe(
@@ -2109,7 +2146,11 @@ export const websocketRpcRouteLayer = Layer.unwrap(
           disableTracing: true,
         }).pipe(
           Effect.provide(
-            makeWsRpcLayer(session, previewAutomationBroker).pipe(
+            makeWsRpcLayer(
+              session,
+              previewAutomationBroker,
+              supportsCurrentKeybindingCommands,
+            ).pipe(
               Layer.provideMerge(RpcSerialization.layerJson),
               Layer.provide(ProviderMaintenanceRunner.layer),
               Layer.provide(Layer.succeed(ServerSelfUpdate.ServerSelfUpdate, serverSelfUpdate)),

--- a/packages/client-runtime/src/rpc/session.test.ts
+++ b/packages/client-runtime/src/rpc/session.test.ts
@@ -227,7 +227,7 @@ describe("RpcSessionFactory", () => {
       const socketUrl = new URL(socket.url);
       expect(socketUrl.searchParams.get("wsTicket")).toBe("test");
       expect(socketUrl.searchParams.get(WS_KEYBINDING_COMMAND_SET_QUERY_PARAM)).toBe(
-        CURRENT_KEYBINDING_COMMAND_SET_VERSION,
+        String(CURRENT_KEYBINDING_COMMAND_SET_VERSION),
       );
       socket.open();
       yield* completeInitialConfig(socket);

--- a/packages/client-runtime/src/rpc/session.test.ts
+++ b/packages/client-runtime/src/rpc/session.test.ts
@@ -1,8 +1,10 @@
 import {
+  CURRENT_KEYBINDING_COMMAND_SET_VERSION,
   DEFAULT_SERVER_SETTINGS,
   EnvironmentId,
   ServerConfig,
   type ServerConfig as ServerConfigType,
+  WS_KEYBINDING_COMMAND_SET_QUERY_PARAM,
   WS_METHODS,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
@@ -222,7 +224,11 @@ describe("RpcSessionFactory", () => {
       const readyFiber = yield* Effect.forkChild(session.ready);
       const socket = yield* awaitSocket(sockets);
 
-      expect(socket.url).toBe(PREPARED.socketUrl);
+      const socketUrl = new URL(socket.url);
+      expect(socketUrl.searchParams.get("wsTicket")).toBe("test");
+      expect(socketUrl.searchParams.get(WS_KEYBINDING_COMMAND_SET_QUERY_PARAM)).toBe(
+        CURRENT_KEYBINDING_COMMAND_SET_VERSION,
+      );
       socket.open();
       yield* completeInitialConfig(socket);
       yield* Fiber.join(readyFiber);

--- a/packages/client-runtime/src/rpc/session.ts
+++ b/packages/client-runtime/src/rpc/session.ts
@@ -100,7 +100,7 @@ export const make = Effect.gen(function* () {
     const socketUrl = new URL(connection.socketUrl);
     socketUrl.searchParams.set(
       WS_KEYBINDING_COMMAND_SET_QUERY_PARAM,
-      CURRENT_KEYBINDING_COMMAND_SET_VERSION,
+      String(CURRENT_KEYBINDING_COMMAND_SET_VERSION),
     );
     const socketLayer = Socket.layerWebSocket(socketUrl.toString(), {
       openTimeout: SOCKET_OPEN_TIMEOUT,

--- a/packages/client-runtime/src/rpc/session.ts
+++ b/packages/client-runtime/src/rpc/session.ts
@@ -1,4 +1,9 @@
-import { type ServerConfig, WS_METHODS } from "@t3tools/contracts";
+import {
+  CURRENT_KEYBINDING_COMMAND_SET_VERSION,
+  type ServerConfig,
+  WS_KEYBINDING_COMMAND_SET_QUERY_PARAM,
+  WS_METHODS,
+} from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -92,7 +97,12 @@ export const make = Effect.gen(function* () {
         Effect.asVoid,
       ),
     });
-    const socketLayer = Socket.layerWebSocket(connection.socketUrl, {
+    const socketUrl = new URL(connection.socketUrl);
+    socketUrl.searchParams.set(
+      WS_KEYBINDING_COMMAND_SET_QUERY_PARAM,
+      CURRENT_KEYBINDING_COMMAND_SET_VERSION,
+    );
+    const socketLayer = Socket.layerWebSocket(socketUrl.toString(), {
       openTimeout: SOCKET_OPEN_TIMEOUT,
     }).pipe(Layer.provide(Layer.succeed(Socket.WebSocketConstructor, webSocketConstructor)));
     const protocolLayer = Layer.effect(

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -165,7 +165,7 @@ import { VcsError } from "./vcs.ts";
 /** WebSocket capability for keybinding commands added after v0.0.31.
     Absence means the client needs the legacy-safe keybinding projection. */
 export const WS_KEYBINDING_COMMAND_SET_QUERY_PARAM = "keybindingCommandSet";
-export const CURRENT_KEYBINDING_COMMAND_SET_VERSION = "1";
+export const CURRENT_KEYBINDING_COMMAND_SET_VERSION = 1;
 
 export const WS_METHODS = {
   // Project registry methods

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -162,6 +162,11 @@ import {
 } from "./sourceControl.ts";
 import { VcsError } from "./vcs.ts";
 
+/** WebSocket capability for keybinding commands added after v0.0.31.
+    Absence means the client needs the legacy-safe keybinding projection. */
+export const WS_KEYBINDING_COMMAND_SET_QUERY_PARAM = "keybindingCommandSet";
+export const CURRENT_KEYBINDING_COMMAND_SET_VERSION = "1";
+
 export const WS_METHODS = {
   // Project registry methods
   projectsList: "projects.list",


### PR DESCRIPTION
## What Changed

- Negotiate the supported keybinding command set once per WebSocket connection.
- Keep `filePicker.toggle` and `projectSearch.toggle` out of config and mutation responses for clients that predate the negotiation.
- Preserve the full keybinding list for current web, desktop, and mobile clients.
- Cover initial config, streamed config updates, and keybinding upsert/remove responses.

## Why

Nightly `0.0.32-nightly.20260730.957` began returning two new default keybinding commands. The `0.0.31` client validates those commands against a closed schema while establishing its connection, so it rejects the initial server config and never reaches the connected state.

Current clients now advertise support through the WebSocket URL. Older clients omit the capability and receive a legacy-safe wire projection without changing the persisted or in-memory keybinding configuration. Older servers ignore the additional query parameter.

## Verification

- `vp test run packages/client-runtime/src/rpc/session.test.ts apps/server/src/server.test.ts` — 121 tests passed
- `vp run --filter @t3tools/contracts --filter @t3tools/client-runtime --filter t3 typecheck`
- targeted lint and formatting checks for all changed files
- `git diff --check origin/main...HEAD`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I added regression coverage

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wire compatibility logic on the hot WebSocket path; mistakes could hide keybindings from current clients or still break legacy connects, but scope is limited to response projection with strong test coverage.
> 
> **Overview**
> Adds **WebSocket keybinding command-set negotiation** so nightly servers can expose `filePicker.toggle` and `projectSearch.toggle` without breaking **0.0.31** clients that validate keybindings against a smaller schema during connect.
> 
> **Contracts** define `WS_KEYBINDING_COMMAND_SET_QUERY_PARAM` and `CURRENT_KEYBINDING_COMMAND_SET_VERSION`. **Client runtime** appends that query param when opening the WebSocket. **Server** reads it on `/ws` upgrade and, for connections without a current version, **filters** those two commands from keybinding payloads on `serverGetConfig`, upsert/remove responses, and `subscribeServerConfig` streams—without changing persisted config.
> 
> Regression tests cover unnegotiated, legacy (`0`), current, and future client versions across config, streams, and mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8785f3d86347ca1255c89ec5c3c6c33a7979bc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter keybinding commands for older clients after new keybinding additions
> - Adds `WS_KEYBINDING_COMMAND_SET_QUERY_PARAM` and `CURRENT_KEYBINDING_COMMAND_SET_VERSION` (1) to [rpc.ts](https://github.com/pingdotgg/t3code/pull/5018/files#diff-64c16995299d1af309c72e94a298ffcb5c2ee5c65774cf0c73bf997358e9c266) as a versioning mechanism for keybinding command sets.
> - Clients advertise support by appending `keybindingCommandSet=<version>` to the WebSocket URL in [session.ts](https://github.com/pingdotgg/t3code/pull/5018/files#diff-413697619cef4e7d7df113ee882be2fee715333d107a67398e84e7a90a036f0b).
> - The server in [ws.ts](https://github.com/pingdotgg/t3code/pull/5018/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) inspects this query param and, for clients not advertising the current version, strips `filePicker.toggle` and `projectSearch.toggle` from keybindings in `serverGetConfig`, `serverUpsertKeybinding`, `serverRemoveKeybinding`, and `subscribeServerConfig` responses.
> - Behavioral Change: older or unversioned clients now receive a filtered keybinding set that omits the two new commands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8785f3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->