### PR TITLE
feat(mobile): add a refresh-all button to the environments screen

### DIFF
--- a/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
@@ -58,6 +58,16 @@ export function SettingsEnvironmentsRouteScreen() {
   const handleToggle = useCallback((environmentId: EnvironmentId) => {
     setExpandedId((prev) => (prev === environmentId ? null : environmentId));
   }, []);
+  // Retries every environment at once. This is not a placebo refresh: the
+  // underlying command is `retryNow`, which short-circuits the reconnect
+  // backoff, so it is the one way to escape a long backoff delay without
+  // waiting it out.
+  const handleRefreshAll = useCallback(() => {
+    for (const environment of connectedEnvironments) {
+      onReconnectEnvironment(environment.environmentId);
+    }
+  }, [connectedEnvironments, onReconnectEnvironment]);
+  const canRefreshAll = connectedEnvironments.length > 0;
   const handleUpdateEnvironment = useCallback(
     (
       environmentId: EnvironmentId,
@@ -94,7 +104,15 @@ export function SettingsEnvironmentsRouteScreen() {
           <AndroidScreenHeader
             title="Environments"
             onBack={() => navigation.goBack()}
+            // Rendered in array order, left to right — the reverse of the iOS
+            // toolbar below. Same result on screen: (refresh, add).
             actions={[
+              {
+                accessibilityLabel: "Refresh all environments",
+                disabled: !canRefreshAll,
+                icon: "arrow.clockwise",
+                onPress: handleRefreshAll,
+              },
               {
                 accessibilityLabel: "Add environment",
                 icon: "plus",
@@ -105,12 +123,23 @@ export function SettingsEnvironmentsRouteScreen() {
           />
         </>
       ) : (
+        // UIKit orders right-side bar items from the right edge inward, so
+        // this reads right-to-left on screen: add stays outermost, refresh
+        // sits inside it. Visually: (refresh, add).
         <NativeHeaderToolbar placement="right">
           <NativeHeaderToolbar.Button
             icon="plus"
             onPress={() =>
               navigation.navigate("SettingsSheet", { screen: "SettingsEnvironmentNew" })
             }
+            separateBackground
+            tintColor={headerIconColor}
+          />
+          <NativeHeaderToolbar.Button
+            accessibilityLabel="Refresh all environments"
+            disabled={!canRefreshAll}
+            icon="arrow.clockwise"
+            onPress={handleRefreshAll}
             separateBackground
             tintColor={headerIconColor}
           />


### PR DESCRIPTION
## What changed

Adds an `arrow.clockwise` button to the Environments settings header, next to the existing add-environment button, that retries every registered environment at once.

## Why it earns its place

This is **not a placebo refresh**. `onReconnectEnvironment` bottoms out in `environmentCatalog.retryNow`, which short-circuits the reconnect backoff — so it is the one way to escape a long backoff delay without waiting it out. That is exactly the moment a user is staring at a stale list wanting to do *something* about it.

It also pairs with the workspace status indicator, which already navigates to this screen: the status reports that something is wrong, and this is the remedy sitting where the user lands.

## Details

- Disabled when no environments are registered, so it can never be a dead tap.
- Wired into both header styles — `NativeHeaderToolbar` on iOS, `AndroidScreenHeader` actions on Android.
- Retries *every* environment, including already-connected ones. Harmless (it just re-establishes) and matches the plain reading of "refresh all". Easy to narrow to only disconnected/backing-off environments if reviewers prefer.

## Verification

- `tsc --noEmit` clean
- Mobile suite green

No screenshots: this adds one standard header icon button in the existing toolbar and changes nothing else visually.

Kept separate from the status-bar fix so the two stay independently reviewable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only addition reusing existing reconnect plumbing; no new auth or data paths, with harmless duplicate retries for already-connected environments.
> 
> **Overview**
> Adds a **refresh all** header action on the Environments settings screen so users can trigger reconnect for every registered environment in one tap.
> 
> `handleRefreshAll` loops `connectedEnvironments` and calls `onReconnectEnvironment` for each id (backed by `retryNow`, so it can skip long reconnect backoff). The `arrow.clockwise` control is **disabled** when there are no environments. The same action is wired on **Android** (`AndroidScreenHeader` actions) and **iOS** (`NativeHeaderToolbar.Button`), with ordering comments so both platforms show refresh beside the existing add button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e4504b2c93ef0192a90834e09b87f69d628272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a refresh-all button to the environments settings screen
> Adds a "Refresh all environments" toolbar button to [SettingsEnvironmentsRouteScreen](https://github.com/pingdotgg/t3code/pull/5022/files#diff-bc1c0645060b1c7d7535cfb71f0b9dfacc30fd67a338c67c4f8715cc57055045) that calls `onReconnectEnvironment` for every connected environment. The button is disabled when no environments are connected. On Android it appears before the add button; on iOS it appears after (due to UIKit ordering).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89e4504.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->