### PR TITLE
fix(shared): lenient JSON parser deletes commas inside string values

### DIFF
--- a/packages/shared/src/schemaJson.test.ts
+++ b/packages/shared/src/schemaJson.test.ts
@@ -57,6 +57,15 @@ Done.`),
     expect(() => decodeLenientJson('{ "enabled": true,, }')).toThrow();
   });
 
+  it("preserves commas before brackets inside string values", () => {
+    // A comma inside a string value that happens to precede `}`/`]` must not
+    // be stripped as if it were a trailing comma.
+    expect(decodeLenientJson('{"note":"a,]"}')).toEqual({ note: "a,]" });
+    expect(decodeLenientJson('{"list":["x,}"]}')).toEqual({ list: ["x,}"] });
+    // Genuine trailing commas are still removed.
+    expect(decodeLenientJson('{"values":[1, 2,],}')).toEqual({ values: [1, 2] });
+  });
+
   it("formats schema failures with paths without exposing invalid values", () => {
     const decodeCredential = decodeJsonResult(Schema.Struct({ token: Schema.Number }));
     const decoded = decodeCredential('{"token":"credential=secret-value"}');

--- a/packages/shared/src/schemaJson.ts
+++ b/packages/shared/src/schemaJson.ts
@@ -190,8 +190,14 @@ const parseLenientJsonGetter = SchemaGetter.onSome((input: string) => {
     (match, stringLiteral: string | undefined) => (stringLiteral ? match : ""),
   );
 
-  // Strip trailing commas before `}` or `]`.
-  stripped = stripped.replace(/,(\s*[}\]])/g, "$1");
+  // Strip trailing commas before `}` or `]`. The alternation preserves quoted
+  // strings so a comma inside a string value (e.g. `{"note":"a,]"}`) is not
+  // mistaken for a trailing comma and removed.
+  stripped = stripped.replace(
+    /("(?:[^"\\]|\\.)*")|,(\s*[}\]])/g,
+    (match, stringLiteral: string | undefined, bracket: string | undefined) =>
+      stringLiteral ? match : (bracket ?? ""),
+  );
 
   return decodeJsonString(stripped).pipe(
     Effect.map(Option.some),


### PR DESCRIPTION
## What Changed

Made the trailing-comma pass in `parseLenientJsonGetter` (`packages/shared/src/schemaJson.ts`) string-aware, so commas inside string values are no longer stripped. Added a test.

## Why

The two comment-stripping passes just above use a string-aware alternation that leaves quoted string literals untouched. The trailing-comma pass did not:

```ts
stripped = stripped.replace(/,(\s*[}\]])/g, "$1");
```

So any string value containing a comma immediately before `}` or `]` had that comma silently deleted:

- `{"note":"a,]"}` → decoded to `{ note: "a]" }`
- `{"list":["x,}"]}` → decoded to `{ list: ["x}"] }`

The result is still valid JSON, so it parses to a **wrong value with no error** — the worst kind of silent corruption. This path parses real config: `t3.json` (via `fromLenientJson` / `T3ProjectFileFromJson`) and `ServerSettingsJson`.

The fix reuses the exact string-aware alternation pattern already established in this function, so genuine trailing commas are still collapsed (`[1, 2,]` → `[1, 2]`) while commas inside strings survive. Verified against the real module before/after.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Corrects config parsing used for project and server settings JSON; wrong values could have been accepted before, so behavior change is intentional but affects real config decode paths.
> 
> **Overview**
> Fixes **silent corruption** in `parseLenientJsonGetter` when trailing-comma cleanup ran on the whole input without respecting quoted strings. Commas inside values like `a,]` or `x,}` were removed and still parsed as valid JSON with wrong data.
> 
> The trailing-comma pass now uses the same **string-aware alternation** as the comment-stripping steps: quoted literals are kept intact, real trailing commas before `}`/`]` are still stripped. A regression test covers string edge cases and confirms `[1, 2,]` still normalizes to `[1, 2]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db304b2f8ec5058b30574cdc43ccc1f251e3a1bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix lenient JSON parser incorrectly deleting commas inside string values
> The trailing-comma stripping regex in `parseLenientJsonGetter` in [schemaJson.ts](https://github.com/pingdotgg/t3code/pull/5025/files#diff-d79129a7d12059ea757ac16209eb5470e9f1a538e909adadefe5cf684b995a88) was matching commas inside quoted strings when they appeared immediately before a closing `}` or `]`. The regex is reworked to use an alternation that skips over quoted string literals and only removes commas outside of strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db304b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->