### PR TITLE
fix(shared): formatDuration renders "60s" instead of "1m" at the sub-minute boundary

### DIFF
--- a/packages/shared/src/orchestrationTiming.test.ts
+++ b/packages/shared/src/orchestrationTiming.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatDuration } from "./orchestrationTiming.ts";
+
+describe("formatDuration", () => {
+  it("formats sub-second and second durations", () => {
+    expect(formatDuration(0)).toBe("1ms");
+    expect(formatDuration(250)).toBe("250ms");
+    expect(formatDuration(1_500)).toBe("1.5s");
+    expect(formatDuration(12_000)).toBe("12s");
+  });
+
+  it("rolls a sub-minute duration up to 1m instead of 60s", () => {
+    // Math.round(59_500 / 1_000) === 60, which must render as "1m", not "60s",
+    // matching the >= 60_000 branch (formatDuration(60_000) === "1m").
+    expect(formatDuration(59_499)).toBe("59s");
+    expect(formatDuration(59_500)).toBe("1m");
+    expect(formatDuration(60_000)).toBe("1m");
+  });
+
+  it("formats minute durations", () => {
+    expect(formatDuration(90_000)).toBe("1m 30s");
+    expect(formatDuration(120_000)).toBe("2m");
+  });
+
+  it("guards against invalid input", () => {
+    expect(formatDuration(-1)).toBe("0ms");
+    expect(formatDuration(Number.NaN)).toBe("0ms");
+  });
+});

--- a/packages/shared/src/orchestrationTiming.ts
+++ b/packages/shared/src/orchestrationTiming.ts
@@ -13,7 +13,12 @@ export function formatDuration(durationMs: number): string {
   if (!Number.isFinite(durationMs) || durationMs < 0) return "0ms";
   if (durationMs < 1_000) return `${Math.max(1, Math.round(durationMs))}ms`;
   if (durationMs < 10_000) return `${(durationMs / 1_000).toFixed(1)}s`;
-  if (durationMs < 60_000) return `${Math.round(durationMs / 1_000)}s`;
+  if (durationMs < 60_000) {
+    // Rounding can land on 60 (e.g. 59_500ms); roll that up to "1m" instead of
+    // rendering "60s", matching the seconds === 60 guard in the branch below.
+    const seconds = Math.round(durationMs / 1_000);
+    return seconds === 60 ? "1m" : `${seconds}s`;
+  }
   const minutes = Math.floor(durationMs / 60_000);
   const seconds = Math.round((durationMs % 60_000) / 1_000);
   if (seconds === 0) return `${minutes}m`;


### PR DESCRIPTION
## What Changed

`formatDuration` (`packages/shared/src/orchestrationTiming.ts`) now rolls a sub-minute duration that rounds to 60 seconds up to `"1m"`, instead of printing `"60s"`. Added a test file covering the boundary and surrounding formats.

## Why

The sub-minute branch used `${Math.round(durationMs / 1_000)}s`, so any value in `[59_500, 60_000)` rounds to 60 and renders `"60s"`. The `>= 60_000` branch already guards exactly this rollover:

```ts
if (seconds === 60) return `${minutes + 1}m`;
```

…so the two branches disagreed: `formatDuration(59_500)` → `"60s"` while `formatDuration(60_000)` → `"1m"`. This is user-visible via thread duration display (`apps/mobile/src/lib/threadActivity.ts`).

Verified before/after against the real module: `59_499 → "59s"`, `59_500 → "1m"`, `60_000 → "1m"`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes (text formatting only; covered by a new unit test)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only duration formatting in shared code; no auth, data, or API behavior changes.
> 
> **Overview**
> **`formatDuration`** in `orchestrationTiming.ts` now treats sub-minute durations that round to 60 seconds (e.g. **59_500ms**) as **`"1m"`** instead of **`"60s"`**, matching the rollover logic already used for **`>= 60_000ms`**.
> 
> A new **`orchestrationTiming.test.ts`** covers ms/s formats, the **59.5s** boundary, minute strings, and invalid inputs (**`NaN`**, negatives).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d3146943d0b2f955249fc4000837aacadd7adac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `formatDuration` rendering '60s' instead of '1m' at the sub-minute boundary
> Durations that round to exactly 60 seconds (e.g. 59,500ms) were displayed as '60s' instead of '1m'. The fix adds a check in [orchestrationTiming.ts](https://github.com/pingdotgg/t3code/pull/5026/files#diff-4629df268b463d9cbffdfd7c6d6dc59bcc05274d118484510e868c6d276e365b) that returns '1m' when the rounded seconds value equals 60. New tests in [orchestrationTiming.test.ts](https://github.com/pingdotgg/t3code/pull/5026/files#diff-3427b78d344f13d3634f29dcecc7d1ebb26107d167e79a24176410d3a2bdd7bd) cover this boundary along with sub-second, minute, and invalid-input cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d31469.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->