### PR TITLE
feat(shared): support shorthand (major-only) versions in the semver helpers

### DIFF
--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { compareSemverVersions, normalizeSemverVersion, satisfiesSemverRange } from "./semver.ts";
+import {
+  compareSemverVersions,
+  normalizeSemverVersion,
+  parseSemver,
+  satisfiesSemverRange,
+} from "./semver.ts";
 
 describe("semver helpers", () => {
   it("matches supported range groups", () => {
@@ -16,6 +21,25 @@ describe("semver helpers", () => {
 
   it("normalizes versions with a missing patch segment", () => {
     expect(normalizeSemverVersion("2.1")).toBe("2.1.0");
+  });
+
+  it("normalizes and parses shorthand major-only versions", () => {
+    expect(normalizeSemverVersion("20")).toBe("20.0.0");
+    expect(normalizeSemverVersion("v18")).toBe("v18.0.0");
+    expect(normalizeSemverVersion("20-rc.1")).toBe("20.0.0-rc.1");
+    expect(parseSemver("20")).toEqual({ major: 20, minor: 0, patch: 0, prerelease: [] });
+  });
+
+  it("compares shorthand versions numerically instead of lexically", () => {
+    // Regression: "20" vs "9" previously fell back to string comparison, which
+    // ordered "20" before "9" ("2" < "9").
+    expect(compareSemverVersions("20", "9")).toBeGreaterThan(0);
+    expect(compareSemverVersions("18", "18.0.0")).toBe(0);
+  });
+
+  it("still rejects non-numeric shorthand and keeps empty input empty", () => {
+    expect(parseSemver("abc")).toBeNull();
+    expect(normalizeSemverVersion("")).toBe("");
   });
 
   it("compares prerelease versions before stable versions", () => {

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -17,7 +17,12 @@ export function normalizeSemverVersion(version: string): string {
     }
   }
 
-  if (segments.length === 2) {
+  // Pad shorthand versions ("20" or "20.1") up to three segments so major-only
+  // and minor-only inputs parse and compare numerically. This matches
+  // satisfiesSemverRange, which already treats a missing minor/patch as 0. The
+  // length > 0 guard keeps empty/garbage input empty (parseSemver still
+  // rejects it), and inputs with more than three segments are left untouched.
+  while (segments.length > 0 && segments.length < 3) {
     segments.push("0");
   }
 


### PR DESCRIPTION
## What Changed

`normalizeSemverVersion` (`packages/shared/src/semver.ts`) now pads any 1- or 2-segment version up to three segments, so major-only (`"20"`) and minor-only (`"20.1"`) inputs parse and compare numerically. Added tests.

## Why

The helper already padded two-segment versions (`"2.1"` → `"2.1.0"`) but left a bare major (`"20"`) untouched, so:

- `parseSemver("20")` returned `null`, and
- `compareSemverVersions("20", "9")` fell back to lexical string comparison and returned a **negative** number — i.e. it ordered `20` before `9` (`"2" < "9"`).

Meanwhile the sibling `satisfiesSemverRange` in the same module already accepts shorthand versions (its regex defaults a missing minor/patch to `0`). So the helpers disagreed on what a valid version is. This makes them consistent.

Only numeric segments become valid — `parseSemver("abc")` still returns `null`, empty input stays empty, and inputs with more than three segments are untouched. The cross-package consumers (`compareSemverVersions` in the provider version gates) all pass full `x.y.z` today, so existing behavior is unchanged; they simply become robust to a shorthand report.

Verified before/after against the real module: `normalize("20") → "20.0.0"`, `parseSemver("20") → {20,0,0}`, `compareSemverVersions("20","9") > 0`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shared semver helper change only; full `x.y.z` inputs behave as before, with safer handling if providers report shorthand versions in existing version gates.
> 
> **Overview**
> **`normalizeSemverVersion`** now pads 1- and 2-segment inputs (e.g. `"20"`, `"20.1"`) to three segments with trailing `0`s, replacing the previous behavior that only padded two-segment versions.
> 
> That aligns **`parseSemver`** and **`compareSemverVersions`** with **`satisfiesSemverRange`**, which already treats missing minor/patch as zero. Major-only strings now parse (e.g. `"20"` → `20.0.0`) and compare numerically—fixing the regression where `"20"` vs `"9"` used lexical fallback and ordered 20 before 9. Empty input stays empty; non-numeric shorthand still fails parse; versions with more than three segments are unchanged.
> 
> Tests cover normalization (including `v` prefix and prerelease), comparison, and rejection of garbage input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e72e93a0e29e16ea63c00dd589f3b9b985570ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support shorthand major-only versions in `normalizeSemverVersion`
> Updates `normalizeSemverVersion` in [semver.ts](https://github.com/pingdotgg/t3code/pull/5027/files#diff-509b00c0da909c9a18e64a8659c9e208b0a7b423de4e59f76e73abd7215f4c15) to pad any version with fewer than three segments up to `major.minor.patch` by appending `.0` as needed. For example, `'20'` becomes `'20.0.0'` and `'20.1'` becomes `'20.1.0'`. Empty or unparseable inputs are left unmodified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e72e93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->