### PR TITLE
switch propvider mid conversation

### DIFF
--- a/apps/mobile/src/components/ControlPill.tsx
+++ b/apps/mobile/src/components/ControlPill.tsx
@@ -87,12 +87,17 @@ export function ControlPill(props: {
 // AppCompat popup can't be themed past its stock animation, metrics, and
 // submenu chrome.
 export function ControlPillMenu(
-  props: Omit<ComponentProps<typeof MenuView>, "children" | "themeVariant"> & {
+  props: Omit<ComponentProps<typeof MenuView>, "children" | "disabled" | "themeVariant"> & {
     readonly children: ReactNode;
     readonly className?: string;
+    readonly disabled?: boolean;
   },
 ) {
   const isDarkMode = useColorScheme() === "dark";
+
+  if (props.disabled) {
+    return props.children;
+  }
 
   if (Platform.OS === "android") {
     // Long-press menus keep their child interactive: the child element gets
@@ -132,7 +137,7 @@ export function ControlPillMenu(
     );
   }
 
-  const { className: _className, ...menuProps } = props;
+  const { className: _className, disabled: _disabled, ...menuProps } = props;
   return (
     <MenuView {...menuProps} themeVariant={isDarkMode ? "dark" : "light"}>
       {menuProps.children}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -869,10 +869,12 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                 />
                 <ControlPillMenu
                   actions={modelMenuActions}
+                  disabled={showStopAction || props.activeThreadBusy}
                   onPressAction={({ nativeEvent }) => handleModelMenuAction(nativeEvent.event)}
                 >
                   <ComposerToolbarTrigger
                     accessibilityLabel="Model"
+                    disabled={showStopAction || props.activeThreadBusy}
                     iconNode={
                       <ProviderIcon provider={currentModelOption?.providerDriver} size={16} />
                     }

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2178,7 +2178,7 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.runtimeMode).toBe("full-access");
   });
 
-  it("rejects provider changes after a thread is already bound to a session provider", async () => {
+  it("hands an active thread to another provider and can switch back", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -2223,34 +2223,83 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(async () => {
-      const readModel = await harness.readModel();
-      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-      return (
-        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
-        false
-      );
-    });
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
 
-    expect(harness.startSession.mock.calls.length).toBe(1);
-    expect(harness.sendTurn.mock.calls.length).toBe(1);
-    expect(harness.stopSession.mock.calls.length).toBe(0);
-
-    const readModel = await harness.readModel();
-    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-    expect(thread?.session?.threadId).toBe("thread-1");
-    expect(thread?.session?.providerName).toBe("codex");
-    expect(thread?.session?.runtimeMode).toBe("approval-required");
-    expect(
-      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
-    ).toMatchObject({
-      payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
+    expect(harness.stopSession).toHaveBeenCalledTimes(1);
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      provider: ProviderDriverKind.make("claudeAgent"),
+      providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+        model: "claude-opus-4-6",
       },
     });
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
+    expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({
+      input: expect.stringContaining("[T3 CODE PROVIDER HANDOFF]"),
+    });
+    expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({
+      input: expect.stringContaining("second"),
+    });
+
+    let readModel = await harness.readModel();
+    let thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.providerName).toBe("claudeAgent");
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.session.switched"),
+    ).toMatchObject({
+      summary: "Switched from Codex to Claude",
+      payload: {
+        from: {
+          driver: "codex",
+          instanceId: "codex",
+        },
+        to: {
+          driver: "claudeAgent",
+          instanceId: "claudeAgent",
+        },
+      },
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-provider-switch-3"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-provider-switch-3"),
+          role: "user",
+          text: "third",
+          attachments: [],
+        },
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 3);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 3);
+    expect(harness.stopSession).toHaveBeenCalledTimes(2);
+    expect(harness.startSession.mock.calls[2]?.[1]).not.toHaveProperty("resumeCursor");
+    expect(harness.sendTurn.mock.calls[2]?.[0]).toMatchObject({
+      input: expect.stringContaining("Continue this thread from claudeAgent"),
+    });
+
+    readModel = await harness.readModel();
+    thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.providerName).toBe("codex");
+    expect(
+      thread?.activities.filter((activity) => activity.kind === "provider.session.switched"),
+    ).toHaveLength(2);
   });
 
-  it("rejects cross-driver provider changes after the existing thread session has stopped", async () => {
+  it("hands a stopped thread to another provider without a native resume cursor", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -2294,25 +2343,23 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(async () => {
-      const readModel = await harness.readModel();
-      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-      return (
-        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
-        false
-      );
-    });
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
 
-    expect(harness.startSession.mock.calls.length).toBe(0);
-    expect(harness.sendTurn.mock.calls.length).toBe(0);
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      provider: ProviderDriverKind.make("claudeAgent"),
+      providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+    });
+    expect(harness.startSession.mock.calls[0]?.[1]).not.toHaveProperty("resumeCursor");
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      input: expect.stringContaining("[T3 CODE PROVIDER HANDOFF]"),
+    });
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(
-      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
+      thread?.activities.find((activity) => activity.kind === "provider.session.switched"),
     ).toMatchObject({
-      payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
-      },
+      summary: "Switched from Codex to Claude",
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -4,6 +4,7 @@ import {
   EventId,
   type ModelSelection,
   type OrchestrationEvent,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -44,8 +45,23 @@ import {
 } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
+import { buildProviderHandoff, PROVIDER_HANDOFF_MAX_CHARS } from "../ProviderHandoff.ts";
+
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
+
+function providerDisplayName(provider: ProviderDriverKind): string {
+  switch (provider) {
+    case "claudeAgent":
+      return "Claude";
+    case "codex":
+      return "Codex";
+    case "opencode":
+      return "OpenCode";
+    default:
+      return provider.charAt(0).toUpperCase() + provider.slice(1);
+  }
+}
 
 type ProviderIntentEvent = Extract<
   OrchestrationEvent,
@@ -312,6 +328,44 @@ const make = Effect.gen(function* () {
       ),
     );
 
+  const appendProviderTransitionActivity = (input: {
+    readonly threadId: ThreadId;
+    readonly from: {
+      readonly driver: ProviderDriverKind;
+      readonly instanceId: ModelSelection["instanceId"];
+    };
+    readonly to: {
+      readonly driver: ProviderDriverKind;
+      readonly instanceId: ModelSelection["instanceId"];
+    };
+    readonly createdAt: string;
+  }) =>
+    Effect.all({
+      commandId: serverCommandId("provider-transition-activity"),
+      eventId: serverEventId(),
+    }).pipe(
+      Effect.flatMap(({ commandId, eventId }) =>
+        orchestrationEngine.dispatch({
+          type: "thread.activity.append",
+          commandId,
+          threadId: input.threadId,
+          activity: {
+            id: eventId,
+            tone: "info",
+            kind: "provider.session.switched",
+            summary: `Switched from ${providerDisplayName(input.from.driver)} to ${providerDisplayName(input.to.driver)}`,
+            payload: {
+              from: input.from,
+              to: input.to,
+            },
+            turnId: null,
+            createdAt: input.createdAt,
+          },
+          createdAt: input.createdAt,
+        }),
+      ),
+    );
+
   const formatFailureDetail = (cause: Cause.Cause<unknown>): string => {
     const failReason = cause.reasons.find(Cause.isFailReason);
     const providerError = isProviderAdapterRequestError(failReason?.error)
@@ -450,12 +504,18 @@ const make = Effect.gen(function* () {
       });
     }
     const currentInstanceId =
-      activeThreadSession !== null &&
-      activeSession !== undefined &&
-      activeSession.providerInstanceId !== undefined
-        ? activeSession.providerInstanceId
-        : thread.modelSelection.instanceId;
-    const desiredModelSelection = requestedModelSelection ?? thread.modelSelection;
+      activeSession?.providerInstanceId ??
+      thread.session?.providerInstanceId ??
+      thread.modelSelection.instanceId;
+    const desiredModelSelection =
+      requestedModelSelection ??
+      (options?.pendingTurnStart !== true && activeSession?.providerInstanceId !== undefined
+        ? {
+            ...thread.modelSelection,
+            instanceId: activeSession.providerInstanceId,
+            ...(activeSession.model !== undefined ? { model: activeSession.model } : {}),
+          }
+        : thread.modelSelection);
     const desiredInstanceId = desiredModelSelection.instanceId;
     const currentInfo = yield* providerService.getInstanceInfo(currentInstanceId).pipe(
       Effect.mapError(
@@ -492,6 +552,19 @@ const make = Effect.gen(function* () {
       });
     }
     const preferredProvider: ProviderDriverKind = desiredDriverKind;
+    const providerChanged = currentInfo.driverKind !== desiredInfo.driverKind;
+    if (
+      providerChanged &&
+      (activeThreadSession?.status === "running" ||
+        activeSession?.status === "running" ||
+        activeSession?.status === "connecting")
+    ) {
+      return yield* new ProviderAdapterRequestError({
+        provider: preferredProvider,
+        method: "thread.turn.start",
+        detail: `Thread '${threadId}' can switch providers after the current turn settles or is interrupted.`,
+      });
+    }
     if (options?.pendingTurnStart === true && thread.session?.status !== "running") {
       yield* setThreadSession({
         threadId,
@@ -508,7 +581,7 @@ const make = Effect.gen(function* () {
         createdAt,
       });
     }
-    if (thread.session !== null) {
+    if (thread.session !== null && !providerChanged) {
       yield* rejectStartedThreadModelChangeIfRequired({
         threadId,
         currentModelSelection:
@@ -525,15 +598,9 @@ const make = Effect.gen(function* () {
     if (
       thread.session !== null &&
       requestedModelSelection !== undefined &&
-      requestedModelSelection.instanceId !== currentInstanceId
+      requestedModelSelection.instanceId !== currentInstanceId &&
+      !providerChanged
     ) {
-      if (currentInfo.driverKind !== desiredInfo.driverKind) {
-        return yield* new ProviderAdapterRequestError({
-          provider: preferredProvider,
-          method: "thread.turn.start",
-          detail: `Thread '${threadId}' is bound to driver '${currentInfo.driverKind}' and cannot switch to '${desiredInfo.driverKind}'.`,
-        });
-      }
       if (
         currentInfo.continuationIdentity.continuationKey !==
         desiredInfo.continuationIdentity.continuationKey
@@ -621,12 +688,16 @@ const make = Effect.gen(function* () {
         !shouldRestartForModelChange &&
         !shouldRestartForModelSelectionChange
       ) {
-        return existingSessionThreadId;
+        return {
+          threadId: existingSessionThreadId,
+          transition: null,
+        };
       }
 
-      const resumeCursor = shouldRestartForModelChange
-        ? undefined
-        : (activeSession?.resumeCursor ?? undefined);
+      const resumeCursor =
+        shouldRestartForModelChange || providerChanged
+          ? undefined
+          : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
         threadId,
         existingSessionThreadId,
@@ -644,8 +715,12 @@ const make = Effect.gen(function* () {
         instanceChanged,
         shouldRestartForModelChange,
         shouldRestartForModelSelectionChange,
+        providerChanged,
         hasResumeCursor: resumeCursor !== undefined,
       });
+      if (providerChanged) {
+        yield* providerService.stopSession({ threadId });
+      }
       const restartedSession = yield* startProviderSession(
         resumeCursor !== undefined ? { resumeCursor } : undefined,
       );
@@ -658,16 +733,46 @@ const make = Effect.gen(function* () {
         cwd: restartedSession.cwd,
       });
       yield* bindSessionToThread(restartedSession);
-      return restartedSession.threadId;
+      return {
+        threadId: restartedSession.threadId,
+        transition: providerChanged
+          ? {
+              from: {
+                driver: currentInfo.driverKind,
+                instanceId: currentInstanceId,
+              },
+              to: {
+                driver: desiredInfo.driverKind,
+                instanceId: desiredInstanceId,
+              },
+            }
+          : null,
+      };
     }
 
     const startedSession = yield* startProviderSession(undefined);
     yield* bindSessionToThread(startedSession);
-    return startedSession.threadId;
+    return {
+      threadId: startedSession.threadId,
+      transition:
+        thread.session !== null && providerChanged
+          ? {
+              from: {
+                driver: currentInfo.driverKind,
+                instanceId: currentInstanceId,
+              },
+              to: {
+                driver: desiredInfo.driverKind,
+                instanceId: desiredInstanceId,
+              },
+            }
+          : null,
+    };
   });
 
   const buildSendTurnRequestForThread = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
+    readonly messageId: string;
     readonly messageText: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
     readonly modelSelection?: ModelSelection;
@@ -680,7 +785,7 @@ const make = Effect.gen(function* () {
         new Error(`Thread '${input.threadId}' was not found in read model.`),
       );
     }
-    yield* ensureSessionForThread(input.threadId, input.createdAt, {
+    const ensuredSession = yield* ensureSessionForThread(input.threadId, input.createdAt, {
       ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
       pendingTurnStart: true,
     });
@@ -688,6 +793,30 @@ const make = Effect.gen(function* () {
       threadModelSelections.set(input.threadId, input.modelSelection);
     }
     const normalizedInput = toNonEmptyProviderInput(input.messageText);
+    let providerInput = normalizedInput;
+    if (ensuredSession.transition !== null) {
+      const availableHandoffChars = Math.max(
+        0,
+        PROVIDER_SEND_TURN_MAX_INPUT_CHARS - (normalizedInput?.length ?? 0) - 2,
+      );
+      const handoff = buildProviderHandoff({
+        from: ensuredSession.transition.from,
+        to: ensuredSession.transition.to,
+        messages: thread.messages,
+        activities: thread.activities,
+        currentMessageId: input.messageId,
+        branch: thread.branch,
+        workspacePath: thread.worktreePath,
+        maxChars: Math.min(PROVIDER_HANDOFF_MAX_CHARS, availableHandoffChars),
+      });
+      providerInput = [handoff, normalizedInput].filter(Boolean).join("\n\n");
+      yield* appendProviderTransitionActivity({
+        threadId: input.threadId,
+        from: ensuredSession.transition.from,
+        to: ensuredSession.transition.to,
+        createdAt: input.createdAt,
+      });
+    }
     const normalizedAttachments = input.attachments ?? [];
     const activeSession = yield* providerService
       .listSessions()
@@ -719,7 +848,7 @@ const make = Effect.gen(function* () {
 
     return {
       threadId: input.threadId,
-      ...(normalizedInput ? { input: normalizedInput } : {}),
+      ...(providerInput ? { input: providerInput } : {}),
       ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
       ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
       ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
@@ -1091,6 +1220,7 @@ const make = Effect.gen(function* () {
 
     const sendTurnRequest = yield* buildSendTurnRequestForThread({
       threadId: event.payload.threadId,
+      messageId: event.payload.messageId,
       messageText: message.text,
       ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
       ...(event.payload.modelSelection !== undefined

--- a/apps/server/src/orchestration/ProviderHandoff.test.ts
+++ b/apps/server/src/orchestration/ProviderHandoff.test.ts
@@ -1,0 +1,87 @@
+import {
+  EventId,
+  MessageId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type OrchestrationMessage,
+  type OrchestrationThreadActivity,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildProviderHandoff, PROVIDER_HANDOFF_MAX_CHARS } from "./ProviderHandoff.ts";
+
+const message = (
+  id: string,
+  role: OrchestrationMessage["role"],
+  text: string,
+): OrchestrationMessage => ({
+  id: MessageId.make(id),
+  role,
+  text,
+  turnId: null,
+  streaming: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+});
+
+const activity = (id: string, summary: string): OrchestrationThreadActivity => ({
+  id: EventId.make(id),
+  tone: "info",
+  kind: "test.activity",
+  summary,
+  payload: { detail: summary },
+  turnId: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+});
+
+describe("buildProviderHandoff", () => {
+  it("carries the original goal, recent context, workspace, and activities", () => {
+    const handoff = buildProviderHandoff({
+      from: {
+        driver: ProviderDriverKind.make("claudeAgent"),
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+      },
+      to: {
+        driver: ProviderDriverKind.make("codex"),
+        instanceId: ProviderInstanceId.make("codex"),
+      },
+      messages: [
+        message("message-1", "user", "Implement provider switching"),
+        message("message-2", "assistant", "The server currently locks the provider."),
+        message("message-3", "user", "Use a compact handoff."),
+      ],
+      activities: [activity("activity-1", "Changed two files")],
+      currentMessageId: "message-3",
+      branch: "feature/provider-handoff",
+      workspacePath: "/repo/worktree",
+    });
+
+    expect(handoff).toContain("Continue this thread from claudeAgent");
+    expect(handoff).toContain("Original goal:\nImplement provider switching");
+    expect(handoff).toContain("Assistant: The server currently locks the provider.");
+    expect(handoff).not.toContain("User: Use a compact handoff.");
+    expect(handoff).toContain("Branch: feature/provider-handoff");
+    expect(handoff).toContain("Changed two files");
+  });
+
+  it("stays within the requested and global character budgets", () => {
+    const handoff = buildProviderHandoff({
+      from: {
+        driver: ProviderDriverKind.make("claudeAgent"),
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+      },
+      to: {
+        driver: ProviderDriverKind.make("codex"),
+        instanceId: ProviderInstanceId.make("codex"),
+      },
+      messages: [message("message-1", "user", "x".repeat(PROVIDER_HANDOFF_MAX_CHARS * 2))],
+      activities: [],
+      currentMessageId: "message-current",
+      branch: null,
+      workspacePath: null,
+      maxChars: 1_000,
+    });
+
+    expect(handoff.length).toBeLessThanOrEqual(1_000);
+  });
+});

--- a/apps/server/src/orchestration/ProviderHandoff.ts
+++ b/apps/server/src/orchestration/ProviderHandoff.ts
@@ -1,0 +1,114 @@
+import type {
+  OrchestrationMessage,
+  OrchestrationThreadActivity,
+  ProviderDriverKind,
+  ProviderInstanceId,
+} from "@t3tools/contracts";
+
+export const PROVIDER_HANDOFF_MAX_CHARS = 24_000;
+
+type ProviderHandoffInput = {
+  readonly from: {
+    readonly driver: ProviderDriverKind;
+    readonly instanceId: ProviderInstanceId;
+  };
+  readonly to: {
+    readonly driver: ProviderDriverKind;
+    readonly instanceId: ProviderInstanceId;
+  };
+  readonly messages: ReadonlyArray<OrchestrationMessage>;
+  readonly activities: ReadonlyArray<OrchestrationThreadActivity>;
+  readonly currentMessageId: string;
+  readonly branch: string | null;
+  readonly workspacePath: string | null;
+  readonly maxChars?: number;
+};
+
+function clip(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  if (maxChars <= 1) return value.slice(0, maxChars);
+  return `${value.slice(0, maxChars - 1)}…`;
+}
+
+function appendWithinBudget(sections: Array<string>, section: string, maxChars: number): boolean {
+  const separatorLength = sections.length === 0 ? 0 : 2;
+  const currentLength = sections.reduce((total, value) => total + value.length, 0);
+  if (currentLength + separatorLength + section.length > maxChars) {
+    return false;
+  }
+  sections.push(section);
+  return true;
+}
+
+export function buildProviderHandoff(input: ProviderHandoffInput): string {
+  const maxChars = Math.max(
+    0,
+    Math.min(input.maxChars ?? PROVIDER_HANDOFF_MAX_CHARS, PROVIDER_HANDOFF_MAX_CHARS),
+  );
+  if (maxChars === 0) return "";
+
+  const priorMessages = input.messages.filter((message) => message.id !== input.currentMessageId);
+  const firstUserMessage = priorMessages.find((message) => message.role === "user");
+  const header = [
+    "[T3 CODE PROVIDER HANDOFF]",
+    `Continue this thread from ${input.from.driver} (${input.from.instanceId}) in ${input.to.driver} (${input.to.instanceId}).`,
+    "Use the canonical thread context below to preserve the task, decisions, and completed work.",
+    "The user's current request follows after this handoff.",
+  ].join("\n");
+  const sections = [clip(header, maxChars)];
+
+  if (firstUserMessage?.text.trim()) {
+    appendWithinBudget(
+      sections,
+      `Original goal:\n${clip(firstUserMessage.text.trim(), 3_000)}`,
+      maxChars,
+    );
+  }
+
+  const workspaceLines = [
+    `Branch: ${input.branch ?? "(none)"}`,
+    `Workspace: ${input.workspacePath ?? "(project root)"}`,
+  ];
+  appendWithinBudget(sections, `Current workspace:\n${workspaceLines.join("\n")}`, maxChars);
+
+  const recentMessageLines: Array<string> = [];
+  for (const message of priorMessages.slice().reverse()) {
+    const text = message.text.trim();
+    if (!text || message.id === firstUserMessage?.id) continue;
+    const label =
+      message.role === "assistant" ? "Assistant" : message.role === "user" ? "User" : "System";
+    const line = `${label}: ${clip(text, 2_000)}`;
+    const candidate = [line, ...recentMessageLines].join("\n\n");
+    const section = `Recent conversation:\n${candidate}`;
+    const projected = [...sections, section].join("\n\n");
+    if (projected.length > maxChars) break;
+    recentMessageLines.unshift(line);
+    if (recentMessageLines.length >= 12) break;
+  }
+  if (recentMessageLines.length > 0) {
+    appendWithinBudget(
+      sections,
+      `Recent conversation:\n${recentMessageLines.join("\n\n")}`,
+      maxChars,
+    );
+  }
+
+  const activityLines: Array<string> = [];
+  for (const activity of input.activities.slice(-12).reverse()) {
+    const line = `- [${activity.kind}] ${activity.summary}`;
+    const candidate = [line, ...activityLines].join("\n");
+    const section = `Recent operational state:\n${candidate}`;
+    const projected = [...sections, section].join("\n\n");
+    if (projected.length > maxChars) break;
+    activityLines.unshift(line);
+  }
+  if (activityLines.length > 0) {
+    appendWithinBudget(
+      sections,
+      `Recent operational state:\n${activityLines.join("\n")}`,
+      maxChars,
+    );
+  }
+
+  return clip(sections.join("\n\n"), maxChars);
+}

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,9 +1,7 @@
 import {
   type EnvironmentId,
-  isProviderDriverKind,
   ProjectId,
   type ModelSelection,
-  type ProviderDriverKind,
   type ServerProvider,
   type ScopedProjectRef,
   type ScopedThreadRef,
@@ -355,41 +353,6 @@ export function threadHasStarted(thread: Thread | null | undefined): boolean {
   return Boolean(
     thread && (thread.latestTurn !== null || thread.messages.length > 0 || thread.session !== null),
   );
-}
-
-// `threadProvider` is the open branded driver kind carried by the session.
-// Unknown driver kinds degrade to `null` (i.e. "unlocked"), which is the safe
-// rollback / fork behavior — the routing layer is the right place to surface
-// "driver not installed" errors, not the lock state.
-//
-// `selectedProvider` takes the same open-string shape because the composer
-// now tracks the picker selection as a `ProviderInstanceId` (e.g.
-// `codex_personal`). Custom instance ids that don't directly match a
-// registered driver resolve to `null` here, which matches the existing
-// "unknown driver -> unlocked" semantics. Callers that want the lock to track
-// a custom instance's underlying driver kind should resolve the instance id
-// upstream and pass the correlated kind.
-export function deriveLockedProvider(input: {
-  thread: Thread | null | undefined;
-  selectedProvider: string | null;
-  threadProvider: string | null;
-}): ProviderDriverKind | null {
-  if (!threadHasStarted(input.thread)) {
-    return null;
-  }
-  const sessionProvider = input.thread?.session?.providerName ?? null;
-  if (sessionProvider && isProviderDriverKind(sessionProvider)) {
-    return sessionProvider;
-  }
-  const narrowedThreadProvider =
-    input.threadProvider && isProviderDriverKind(input.threadProvider)
-      ? input.threadProvider
-      : null;
-  const narrowedSelectedProvider =
-    input.selectedProvider && isProviderDriverKind(input.selectedProvider)
-      ? input.selectedProvider
-      : null;
-  return narrowedThreadProvider ?? narrowedSelectedProvider ?? null;
 }
 
 export function getStartedThreadModelChangeBlockReason(input: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -267,7 +267,6 @@ import {
   type LocalDispatchSnapshot,
   PullRequestDialogState,
   cloneComposerImageForRetry,
-  deriveLockedProvider,
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
@@ -1848,11 +1847,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeThread?.modelSelection.instanceId ??
     activeProject?.defaultModelSelection?.instanceId ??
     null;
-  const lockedProvider = deriveLockedProvider({
-    thread: activeThread,
-    selectedProvider: selectedProviderByThreadId,
-    threadProvider,
-  });
+  const lockedProvider = null;
   // Once a thread selects an environment, never substitute the primary
   // environment's config while the selected environment is still loading.
   const serverConfig = activeThread

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3138,6 +3138,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 ) : (
                   <ProviderModelPicker
                     compact={isComposerFooterCompact}
+                    disabled={phase === "connecting" || phase === "running"}
                     activeInstanceId={selectedInstanceId}
                     model={selectedModelForPickerWithCustomFallback}
                     lockedProvider={lockedProvider}

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
   - [Remote access](./user/remote-access.md)
   - [Keeping T3 Code in sync](./user/server-updates.md)
   - [Keybindings](./user/keybindings.md)
+  - [Switching providers in a thread](./user/switching-providers.md)
 - [T3 Connect](./cloud/t3-connect-clerk.md)
 - [Integrations](./integrations/source-control-providers.md)
 - [Mobile](./mobile/app.md)

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -13,7 +13,8 @@ Methods mirror the `NativeApi` interface defined in `@t3tools/contracts`:
 - `providers.respondToRequest`, `providers.stopSession`
 - `shell.openInEditor`, `server.getConfig`
 
-Codex is the only implemented provider. `claudeCode` is reserved in contracts/UI.
+Provider instances are open routing identities backed by drivers such as Codex, Claude, Cursor, Grok,
+and OpenCode.
 
 ## Client transport
 
@@ -28,3 +29,18 @@ Provider runtime events flow through queue-based workers:
 3. **CheckpointReactor** — captures git checkpoints on turn start/complete, publishes runtime receipts
 
 All three use `DrainableWorker` internally and expose `drain()` for deterministic test synchronization.
+
+## Cross-provider handoffs
+
+The T3 thread is the durable conversation; a provider session is a replaceable execution epoch.
+When a settled thread selects an instance backed by another driver, `ProviderCommandReactor`:
+
+1. derives a bounded handoff from canonical messages, activities, and workspace metadata;
+2. stops the active provider session;
+3. starts the target provider without the previous provider's resume cursor;
+4. appends a `provider.session.switched` activity; and
+5. sends the handoff together with the new user message.
+
+`ProviderService` continues to expose one active runtime binding per thread. This keeps routing stable
+for local, relay, tunnel, and multi-device clients while allowing the execution provider to change at
+a turn boundary.

--- a/docs/user/switching-providers.md
+++ b/docs/user/switching-providers.md
@@ -1,0 +1,33 @@
+# Switching providers in a thread
+
+T3 Code can continue a settled thread with another configured provider. For example, a thread that
+started in Claude can send its next message through Codex/GPT without changing the thread or its
+workspace.
+
+## Switch providers
+
+1. Wait for the current turn to finish, or interrupt it.
+2. Open the model picker in the composer.
+3. Choose a model from another provider.
+4. Send the next message.
+
+T3 Code starts a fresh native session for the selected provider and gives it a compact handoff built
+from the thread history and workspace state. The handoff is not shown as a user message. The timeline
+records the transition, such as **Switched from Claude to Codex**.
+
+You can switch back through the same model picker after the new provider's turn settles.
+
+## What carries over
+
+The receiving provider gets the original goal, recent conversation, recent operational activity,
+branch, and workspace path. T3 Code keeps this context bounded so long threads do not replay every
+provider-specific tool event.
+
+The provider's native session identifier does not carry over. Claude and Codex use different resume
+formats, so each transition starts a fresh native session inside the same durable T3 Code thread.
+
+## Availability
+
+Only enabled and available provider instances appear in the picker. A provider change is unavailable
+while a turn is starting or running. Providers that require a new thread for model changes keep that
+restriction.


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core turn/session orchestration (session stop/restart, handoff injection, resume cursor omission) and provider routing at turn boundaries—mistakes could break continuity or send oversized prompts.
> 
> **Overview**
> **Enables switching the execution provider on a settled thread** instead of rejecting cross-driver changes. On a turn boundary, the server stops the active session, starts the target provider **without** the previous resume cursor, prepends a bounded **`[T3 CODE PROVIDER HANDOFF]`** block (goal, recent messages, activities, workspace) to the user message, and records **`provider.session.switched`** on the timeline. Switching is **blocked** while a turn is starting or running.
> 
> **Clients** stop locking the model picker to the thread’s original driver (`deriveLockedProvider` removed; web `lockedProvider` is always `null`). The model picker is **disabled** during connecting/running (web and mobile `ControlPillMenu` / composer triggers).
> 
> **Docs** add user and architecture notes on cross-provider handoffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d9a01e13a7b4a59c1f7c9302da445595bee9f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow switching AI providers mid-conversation at turn boundaries
> - Adds cross-provider handoff logic in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/5034/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d): stops the current session, clears the resume cursor, starts the new provider, and prepends a compact handoff summary (original goal, recent context, activities) to the next turn's input.
> - Adds [ProviderHandoff.ts](https://github.com/pingdotgg/t3code/pull/5034/files#diff-a8b2f74e6cdc24dd14e88df6b299ddd7807761e31ccd4c0950b58c6c8edebc95), a new module that builds the bounded handoff string with budget-aware section clipping.
> - Removes the `deriveLockedProvider` lock in the web `ChatView`, and disables the model/provider picker in both web and mobile while a turn is connecting or running.
> - Adds user and architecture docs covering handoff behavior and constraints.
> - Risk: provider switches are rejected (error) if the session is already running or connecting; switching clears the resume cursor so the new provider starts without prior session state.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6d9a01e. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->