### PR TITLE
style(web): make scroll-to-end pill translucent

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5829,7 +5829,7 @@ function ChatViewContent(props: ChatViewProps) {
                     aria-label="Scroll to end"
                     title="Scroll to end"
                     onClick={() => scrollToEnd(true)}
-                    className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
+                    className="chat-composer-glass pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
                   >
                     <ChevronDownIcon className="size-3.5" />
                     Scroll to end


### PR DESCRIPTION
## Summary

The “Scroll to end” pill used an opaque `bg-card` surface, bypassing the shared glass treatment. This swaps it to the existing `chat-composer-glass` class so the pill gains translucency and follows the glass opacity setting without adding new CSS.

## Validation

- `vp lint apps/web/src/components/ChatView.tsx`
- `vp run --filter @t3tools/web typecheck`

Implemented with GPT-5.6 Sol in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make scroll-to-end pill in chat view translucent
> Replaces the `bg-card` class with `chat-composer-glass` on the scroll-to-end button in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/5036/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), giving it a translucent appearance consistent with the composer style.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a84c2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single class swap on a UI control with no logic, data, or security impact.
> 
> **Overview**
> The **Scroll to end** pill above the chat composer no longer uses an opaque `bg-card` fill. It now applies the shared **`chat-composer-glass`** class so it matches the composer’s translucent glass look and respects the same glass opacity setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a84c2cf62be2658dacf8d701c83b19fdc4b613b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->