### PR TITLE
fix(server): let archived-only projects delete without force

### DIFF
--- a/apps/server/src/orchestration/decider.delete.test.ts
+++ b/apps/server/src/orchestration/decider.delete.test.ts
@@ -102,6 +102,44 @@ const seedReadModel = Effect.gen(function* () {
   });
 });
 
+const seedReadModelWithOnlyArchivedThread = Effect.gen(function* () {
+  const readModel = yield* seedReadModel;
+  const withoutSecondThread = yield* projectEvent(readModel, {
+    sequence: 4,
+    eventId: asEventId("evt-thread-delete-2"),
+    aggregateKind: "thread",
+    aggregateId: asThreadId("thread-delete-2"),
+    type: "thread.deleted",
+    occurredAt: "2026-01-01T00:01:00.000Z",
+    commandId: asCommandId("cmd-thread-delete-2"),
+    causationEventId: null,
+    correlationId: asCommandId("cmd-thread-delete-2"),
+    metadata: {},
+    payload: {
+      threadId: asThreadId("thread-delete-2"),
+      deletedAt: "2026-01-01T00:01:00.000Z",
+    },
+  });
+
+  return yield* projectEvent(withoutSecondThread, {
+    sequence: 5,
+    eventId: asEventId("evt-thread-archive-1"),
+    aggregateKind: "thread",
+    aggregateId: asThreadId("thread-delete-1"),
+    type: "thread.archived",
+    occurredAt: "2026-01-01T00:02:00.000Z",
+    commandId: asCommandId("cmd-thread-archive-1"),
+    causationEventId: null,
+    correlationId: asCommandId("cmd-thread-archive-1"),
+    metadata: {},
+    payload: {
+      threadId: asThreadId("thread-delete-1"),
+      archivedAt: "2026-01-01T00:02:00.000Z",
+      updatedAt: "2026-01-01T00:02:00.000Z",
+    },
+  });
+});
+
 type PlannedEvent = Omit<OrchestrationEvent, "sequence">;
 
 function normalizeDeleteEvent(event: PlannedEvent | ReadonlyArray<PlannedEvent>) {
@@ -151,6 +189,27 @@ it.layer(NodeServices.layer)("decider deletion flows", (it) => {
         }),
       );
       expect(error.message).toContain("cannot be deleted without force=true");
+    }),
+  );
+
+  it.effect("deletes a project whose only threads are archived without force", () =>
+    Effect.gen(function* () {
+      const readModel = yield* seedReadModelWithOnlyArchivedThread;
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "project.delete",
+          commandId: asCommandId("cmd-project-delete-archived-only"),
+          projectId: asProjectId("project-delete"),
+        },
+        readModel,
+      });
+      const events = Array.isArray(result) ? result : [result];
+
+      expect(events.map((event) => event.type)).toEqual(["thread.deleted", "project.deleted"]);
+      const threadDeleted = events[0];
+      expect(threadDeleted?.type === "thread.deleted" && threadDeleted.payload.threadId).toBe(
+        asThreadId("thread-delete-1"),
+      );
     }),
   );
 

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -299,20 +299,24 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         projectId: command.projectId,
       });
-      const activeThreads = listThreadsByProjectId(readModel, command.projectId).filter(
+      const liveThreads = listThreadsByProjectId(readModel, command.projectId).filter(
         (thread) => thread.deletedAt === null,
       );
-      if (activeThreads.length > 0 && command.force !== true) {
+      // Archived threads are excluded from client project views, so they must
+      // not block a plain delete; they still cascade below so no thread row
+      // outlives its project.
+      const visibleThreads = liveThreads.filter((thread) => thread.archivedAt === null);
+      if (visibleThreads.length > 0 && command.force !== true) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
           detail: `Project '${command.projectId}' is not empty and cannot be deleted without force=true.`,
         });
       }
-      if (activeThreads.length > 0) {
+      if (liveThreads.length > 0) {
         return yield* decideCommandSequence({
           readModel,
           commands: [
-            ...activeThreads.map(
+            ...liveThreads.map(
               (thread): Extract<OrchestrationCommand, { type: "thread.delete" }> => ({
                 type: "thread.delete",
                 commandId: command.commandId,


### PR DESCRIPTION
## What changed

`project.delete` in `apps/server/src/orchestration/decider.ts` now requires `force=true` only when the project has non-archived live threads. Archived threads no longer block deletion, but they are still included in the synthesized `thread.delete` cascade so no thread row outlives its project.

Added a regression test: a project whose only thread is archived deletes without `force` and emits `[thread.deleted, project.deleted]`.

## Why it should exist

Fixes #4632. The delete invariant counts every thread with `deletedAt === null`, but the client shell snapshot deliberately excludes archived threads (`listActiveThreadRows` filters `archived_at IS NULL`, and `thread.archived` deltas evict them from the store). So the sidebar sees an empty project, sends a plain delete without `force`, and the server rejects it with the raw invariant text — the user has no way out of the loop from the UI.

Gating the invariant on user-visible threads makes the server's definition of "empty" match what the client (and user) can actually see. Cascading over archived threads too is deliberate: `project.deleted` does not cascade in the projection, so skipping them would leave invisible, undeletable rows that the Archive panel silently drops (it groups archived threads by non-deleted projects).

No UI change.

## Testing

- `vitest run src/orchestration` in `apps/server`: 18 files, 203 tests pass
- typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration delete invariants and cascade behavior for archived threads; scope is limited to project deletion logic with a targeted regression test.
> 
> **Overview**
> **`project.delete`** now treats a project as empty for the `force` check only when it has no **non-archived** live threads. Archived threads no longer block a plain delete, aligning server “empty” with what clients show in project views (`archived_at IS NULL` filters).
> 
> Deletion still cascades **`thread.delete`** over every live thread (including archived ones) before **`project.deleted`**, so archived rows are not left behind when the project goes away.
> 
> Adds a regression test: a project whose only remaining thread is archived deletes without `force` and emits `thread.deleted` then `project.deleted`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0d80d489943e1a1edaff2f15fcc03177b92c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `project.delete` without force when only archived threads exist
> Previously, a non-forced `project.delete` was blocked whenever any non-deleted threads existed, including archived ones. Now, only visible (non-deleted, non-archived) threads block plain deletes.
>
> - In [decider.ts](https://github.com/pingdotgg/t3code/pull/5037/files#diff-6f7345ef9257e77e02acccced5be5251aa0f108aa0620614c5c80cc072949dc6), the invariant check now uses `visibleThreads` (non-deleted, non-archived) instead of all live threads.
> - Archived threads are still cleaned up: `liveThreads` (non-deleted) drives the cascade of `thread.delete` events before `project.deleted`.
> - Behavioral Change: projects with only archived threads now delete without requiring the `force` flag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd0d80d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->