### PR TITLE
fix(orchestration): thread visits no longer create activity loops

### DIFF
--- a/apps/server/src/orchestration-v2/ProjectionStore.test.ts
+++ b/apps/server/src/orchestration-v2/ProjectionStore.test.ts
@@ -84,6 +84,75 @@ it("includes imported runless history when selecting fork context through a run"
 });
 
 it.layer(TestLayer)("ProjectionStoreV2", (it) => {
+  it.effect("does not treat visited or marked-unread state as thread activity", () =>
+    Effect.gen(function* () {
+      const projectionStore = yield* ProjectionStoreV2;
+      const createdAt = yield* DateTime.now;
+      const visitedOccurredAt = DateTime.add(createdAt, { seconds: 1 });
+      const markedUnreadOccurredAt = DateTime.add(createdAt, { seconds: 2 });
+      const threadId = ThreadId.make("thread:projection-read-state");
+      const projectId = ProjectId.make("project:projection-read-state");
+      const thread = {
+        createdBy: "user" as const,
+        creationSource: "web" as const,
+        id: threadId,
+        projectId,
+        title: "Projection read state",
+        providerInstanceId,
+        modelSelection,
+        runtimeMode: "full-access" as const,
+        interactionMode: "default" as const,
+        branch: null,
+        worktreePath: null,
+        activeProviderThreadId: null,
+        lineage: {
+          parentThreadId: null,
+          relationshipToParent: null,
+          rootThreadId: threadId,
+        },
+        forkedFrom: null,
+        createdAt,
+        updatedAt: createdAt,
+        archivedAt: null,
+        settledOverride: null,
+        settledAt: null,
+        lastVisitedAt: null,
+        deletedAt: null,
+      };
+
+      yield* projectionStore.apply({
+        id: EventId.make("event:projection-read-state:created"),
+        type: "thread.created",
+        threadId,
+        occurredAt: createdAt,
+        payload: thread,
+      });
+      yield* projectionStore.apply({
+        id: EventId.make("event:projection-read-state:visited"),
+        type: "thread.visited",
+        threadId,
+        occurredAt: visitedOccurredAt,
+        payload: { ...thread, lastVisitedAt: createdAt },
+      });
+
+      const visited = yield* projectionStore.getThreadProjection(threadId);
+      assert.deepEqual(visited.thread.lastVisitedAt, createdAt);
+      assert.deepEqual(visited.thread.updatedAt, createdAt);
+
+      yield* projectionStore.apply({
+        id: EventId.make("event:projection-read-state:marked-unread"),
+        type: "thread.marked-unread",
+        threadId,
+        occurredAt: markedUnreadOccurredAt,
+        payload: thread,
+      });
+
+      const markedUnread = yield* projectionStore.getThreadProjection(threadId);
+      assert.isNull(markedUnread.thread.lastVisitedAt);
+      assert.deepEqual(markedUnread.thread.updatedAt, createdAt);
+    }),
+  );
+
   it.effect("only exposes interruptible runs through the shell activeRunId", () =>
     Effect.gen(function* () {
       const projectionStore = yield* ProjectionStoreV2;

--- a/apps/server/src/orchestration-v2/ProjectionStore.ts
+++ b/apps/server/src/orchestration-v2/ProjectionStore.ts
@@ -1812,6 +1812,8 @@ export const layer: Layer.Layer<ProjectionStoreV2, never, SqlClient.SqlClient> =
           event.type !== "thread.unsettled" &&
           event.type !== "thread.snoozed" &&
           event.type !== "thread.unsnoozed" &&
+          event.type !== "thread.visited" &&
+          event.type !== "thread.marked-unread" &&
           event.type !== "thread.metadata-updated" &&
           event.type !== "thread.runtime-mode-updated" &&
           event.type !== "thread.interaction-mode-updated" &&

--- a/apps/server/src/orchestration-v2/runtimeLayer.test.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.test.ts
@@ -19,6 +19,7 @@ import * as DateTime from "effect/DateTime";
 import * as Layer from "effect/Layer";
 import * as Queue from "effect/Queue";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
@@ -1335,6 +1336,7 @@ it.layer(SharedApplicationDataPlaneTestLayer)("visited projection", (it) => {
       assert.isNull(created.thread.lastVisitedAt);
       const createdUpdatedAt = created.thread.updatedAt;
 
+      yield* TestClock.adjust("1 second");
       yield* orchestrator.dispatch({
         type: "thread.visit",
         commandId: CommandId.make("runtime-layer-visited-thread-visit"),


### PR DESCRIPTION
## What Changed

- Exclude `thread.visited` and `thread.marked-unread` from the projection store's generic `updatedAt` bump.
- Add persistent projection coverage proving read-state events update `lastVisitedAt` without changing thread activity.
- Advance the Effect test clock in the existing visit integration test so distinct event timestamps cannot mask this regression.

The functional fix is two production lines. The remaining changes are focused regression coverage.

## Why

Web and mobile record a visit whenever `lastVisitedAt` is older than `updatedAt`.

The orchestrator correctly preserves `updatedAt` for read-state commands. However, after applying the event payload, the projection store's generic post-processing replaced `updatedAt` with the event's later `occurredAt`.

That created a durable feedback loop:

1. The client observes `lastVisitedAt < updatedAt`.
2. The client dispatches `thread.visit` using the current `updatedAt` as its visited watermark.
3. The orchestrator emits `thread.visited` while correctly preserving the thread's `updatedAt`.
4. The projection store overwrites `updatedAt` with the event's later `occurredAt`.
5. The client receives another projection where `lastVisitedAt < updatedAt` and dispatches another visit.

Because every visit created a new activity timestamp, the thread could never converge to a fully visited state.

`thread.marked-unread` had the same projection omission. Besides potentially participating in the loop, this could prevent mark-unread from remaining stable while a thread was open.

## Observed Impact

PR #4971 measured the visit storm at approximately:

- 2.4 `thread.visit` commands per second
- 2,572 visits among the last 2,590 command receipts
- 100,626 `thread.visited` events consuming 106 MB in roughly one day

An independent local reproduction accumulated approximately 12,000 visit events and 17.7 MB for one open thread. Two other open threads accumulated approximately 6,000 visits each, confirming that the behavior is systemic rather than thread-specific.

The 10-second web throttle from #4971 reduces the rate to at most 0.1 visits per second, but it does not eliminate the feedback condition. A continuously open thread could still generate up to 8,640 unnecessary events per day. Mobile also remains unthrottled.

Per-thread shell reads and startup compaction from #4971 reduce processing cost and clean accumulated events, but neither prevents new visit events from being generated.

## Expected Behavior

After this change:

- A visit updates `lastVisitedAt` without changing `updatedAt`.
- The client converges after one visit and sends no additional visit commands until real thread activity advances `updatedAt`.
- Mark-unread can remain stable until real activity occurs or the thread is reopened.
- The server-side correction applies equally to web and mobile clients.
- Existing throttling and compaction remain useful as defense-in-depth.

## Validation

- Focused projector and integration regressions:

  ```text
  vp test run apps/server/src/orchestration-v2/ProjectionStore.test.ts apps/server/src/orchestration-v2/runtimeLayer.test.ts -t 'does not treat visited or marked-unread state as thread activity|visited projection'
  ```

  Result: 2 test files passed, 2 focused tests passed.

- Server typecheck:

  ```text
  vp run --filter t3 typecheck
  ```

- Targeted formatting and lint checks for the three changed files.
- `git diff --check`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable because there are no UI changes
- [x] A video is not applicable because there are no animation or interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `thread.visited` and `thread.marked-unread` events to no longer trigger activity loops in orchestration
> In [ProjectionStore.ts](https://github.com/pingdotgg/t3code/pull/5038/files#diff-591ac0894aba4bb3699a5694cc3336eb039e9ccd0806148a4699482750f22034), `thread.visited` and `thread.marked-unread` events were falling through to the `payload_json` lookup/update branch in `apply()`, causing unintended activity loops. These event types are now excluded from that branch, matching the pattern used for other explicitly handled event types. A new test confirms that `updatedAt` is not affected by visit or mark-unread events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b174277.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core orchestration projection persistence for all threads; behavior change is intentional and narrowly scoped to read-state events, with regression tests.
> 
> **Overview**
> Fixes a **feedback loop** where clients kept dispatching `thread.visit` because projected `updatedAt` advanced on every visit even when the orchestrator preserved activity timestamps.
> 
> **Production change:** In `ProjectionStore.apply()`, `thread.visited` and `thread.marked-unread` are excluded from the generic post-processing that overwrites thread `updatedAt` with `event.occurredAt`. Read-state events now only update `lastVisitedAt` (and mark-unread clears it) without treating the thread as newly active—aligned with existing in-memory `applyToProjection` behavior.
> 
> **Tests:** A projection-store regression proves visit and mark-unread do not move `updatedAt`; the visited integration test advances `TestClock` so distinct event times cannot mask the bug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b174277a087a72cae70e5b3c5afb1331de6a51c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->