### PR TITLE
feat(mobile): home bottom toolbar as expo-glass-effect GlassContainer

### DIFF
--- a/apps/mobile/src/features/home/HomeGlassSearchToolbar.tsx
+++ b/apps/mobile/src/features/home/HomeGlassSearchToolbar.tsx
@@ -1,0 +1,210 @@
+import type { MenuAction } from "@react-native-menu/menu";
+import { GlassContainer, GlassView } from "expo-glass-effect";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Pressable, TextInput, useColorScheme, type ViewStyle } from "react-native";
+import { View } from "react-native";
+import { KeyboardStickyView } from "react-native-keyboard-controller";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { AndroidAnchoredMenu } from "../../components/AndroidAnchoredMenu";
+import { SymbolView, type AppSymbolName } from "../../components/AppSymbol";
+import { useThemeColor } from "../../lib/useThemeColor";
+import { useHardwareKeyboardCommand } from "../keyboard/hardwareKeyboardCommands";
+import type { HomeListFilterMenu } from "./home-list-filter-menu";
+
+/* Metrics mirror the native mail-search toolbar this replaces (patched
+   react-native-screens): 48pt capsule bar, 48pt round side buttons, 8pt gaps,
+   560pt max content width inside 18pt insets, resting 4pt above the safe
+   area, and a Title3-sized (20pt) search field. */
+const TOOLBAR_HEIGHT = 48;
+const TOOLBAR_RADIUS = TOOLBAR_HEIGHT / 2;
+const BUTTON_SIZE = TOOLBAR_HEIGHT;
+const ELEMENT_GAP = 8;
+const CONTENT_MAX_WIDTH = 560;
+const HORIZONTAL_INSET = 18;
+const BOTTOM_SPACING = 4;
+
+/* Below the resting 8pt gap so the elements read as separate pills at rest,
+   while UIGlassContainerEffect can still merge and morph them the moment
+   they animate closer together. */
+const GLASS_MERGE_SPACING = 4;
+
+const CIRCLE_BUTTON_STYLE: ViewStyle = {
+  alignItems: "center",
+  borderRadius: TOOLBAR_RADIUS,
+  height: BUTTON_SIZE,
+  justifyContent: "center",
+  overflow: "hidden",
+  width: BUTTON_SIZE,
+};
+
+const FILL_CENTER_STYLE: ViewStyle = {
+  alignItems: "center",
+  height: "100%",
+  justifyContent: "center",
+  width: "100%",
+};
+
+/** Flattens the shared filter-menu model into MenuView actions plus an
+    id → onPress lookup, so the same menu drives this JS toolbar and the
+    native header elsewhere. */
+function useFilterMenuActions(menu: HomeListFilterMenu) {
+  return useMemo(() => {
+    const handlers = new Map<string, () => void>();
+    const actions: MenuAction[] = menu.items.map((item, itemIndex) => {
+      if (item.type === "submenu") {
+        return {
+          id: `submenu:${itemIndex}`,
+          title: item.title,
+          subactions: item.items.map((action, actionIndex) => {
+            const id = `action:${itemIndex}:${actionIndex}`;
+            handlers.set(id, action.onPress);
+            return {
+              id,
+              title: action.title,
+              subtitle: action.subtitle,
+              state: action.state === "on" ? ("on" as const) : undefined,
+            };
+          }),
+        };
+      }
+      const id = `action:${itemIndex}`;
+      handlers.set(id, item.onPress);
+      return {
+        id,
+        title: item.title,
+        subtitle: item.subtitle,
+        state: item.state === "on" ? ("on" as const) : undefined,
+      };
+    });
+    return { actions, handlers };
+  }, [menu]);
+}
+
+/**
+ * JS bottom search toolbar for liquid-glass iOS: filter button, search
+ * field, and compose button as sibling GlassViews inside one GlassContainer
+ * (UIGlassContainerEffect), so the three glass elements share one container
+ * and can merge / morph together — the previous native toolbar drew them as
+ * three unrelated glass surfaces. Each glass view keeps the same shape,
+ * size, and regular glass style it had natively.
+ */
+export function HomeGlassSearchToolbar(props: {
+  readonly searchQuery: string;
+  readonly filterMenu: HomeListFilterMenu;
+  readonly filterIcon: AppSymbolName;
+  readonly onSearchQueryChange: (query: string) => void;
+  readonly onStartNewTask: () => void;
+}) {
+  const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme() === "dark" ? "dark" : "light";
+  const foregroundColor = useThemeColor("--color-foreground");
+  const iconColor = useThemeColor("--color-icon");
+  const mutedColor = useThemeColor("--color-foreground-muted");
+  const searchInputRef = useRef<TextInput>(null);
+  const [searchFocused, setSearchFocused] = useState(false);
+  const { actions: filterActions, handlers: filterHandlers } = useFilterMenuActions(
+    props.filterMenu,
+  );
+
+  const focusSearch = useCallback(() => {
+    searchInputRef.current?.focus();
+    return searchInputRef.current !== null;
+  }, []);
+  useHardwareKeyboardCommand("focusSearch", focusSearch);
+
+  return (
+    <KeyboardStickyView
+      pointerEvents="box-none"
+      style={{ position: "absolute", bottom: 0, left: 0, right: 0 }}
+      offset={{ closed: 0, opened: 0 }}
+    >
+      <View
+        pointerEvents="box-none"
+        style={{
+          alignSelf: "center",
+          maxWidth: CONTENT_MAX_WIDTH + HORIZONTAL_INSET * 2,
+          paddingBottom: searchFocused ? ELEMENT_GAP : insets.bottom + BOTTOM_SPACING,
+          paddingHorizontal: HORIZONTAL_INSET,
+          width: "100%",
+        }}
+      >
+        <GlassContainer
+          pointerEvents="box-none"
+          spacing={GLASS_MERGE_SPACING}
+          style={{ alignItems: "center", flexDirection: "row", gap: ELEMENT_GAP }}
+        >
+          <GlassView colorScheme={colorScheme} isInteractive style={CIRCLE_BUTTON_STYLE}>
+            {/* JS anchored menu (the same one ControlPillMenu renders on
+                Android) instead of a native UIMenu: presenting a UIMenu from
+                a view in this overlay leaves UIKit's responder chain in a
+                broken state on iOS 26 — the menu opens invisibly behind a
+                phantom system keyboard. The portal-rendered JS menu skips
+                UIKit menu presentation entirely. */}
+            <AndroidAnchoredMenu
+              actions={filterActions}
+              style={FILL_CENTER_STYLE}
+              onPressAction={({ nativeEvent }) => {
+                filterHandlers.get(nativeEvent.event)?.();
+              }}
+            >
+              {(open) => (
+                <Pressable
+                  accessibilityLabel="Filter and sort threads"
+                  accessibilityRole="button"
+                  onPress={open}
+                  style={FILL_CENTER_STYLE}
+                >
+                  <SymbolView name={props.filterIcon} size={17} tintColor={iconColor} />
+                </Pressable>
+              )}
+            </AndroidAnchoredMenu>
+          </GlassView>
+
+          <GlassView
+            colorScheme={colorScheme}
+            isInteractive
+            style={{
+              alignItems: "center",
+              borderRadius: TOOLBAR_RADIUS,
+              flex: 1,
+              flexDirection: "row",
+              gap: ELEMENT_GAP,
+              height: TOOLBAR_HEIGHT,
+              overflow: "hidden",
+              paddingHorizontal: 14,
+            }}
+          >
+            <SymbolView name="magnifyingglass" size={17} tintColor={mutedColor} />
+            <TextInput
+              ref={searchInputRef}
+              accessibilityLabel="Search threads"
+              autoCapitalize="none"
+              autoCorrect={false}
+              clearButtonMode="while-editing"
+              onBlur={() => setSearchFocused(false)}
+              onChangeText={props.onSearchQueryChange}
+              onFocus={() => setSearchFocused(true)}
+              placeholder="Search"
+              placeholderTextColor={mutedColor}
+              returnKeyType="search"
+              style={{ color: foregroundColor, flex: 1, fontSize: 20, paddingVertical: 0 }}
+              value={props.searchQuery}
+            />
+          </GlassView>
+
+          <GlassView colorScheme={colorScheme} isInteractive style={CIRCLE_BUTTON_STYLE}>
+            <Pressable
+              accessibilityLabel="New task"
+              accessibilityRole="button"
+              onPress={props.onStartNewTask}
+              style={FILL_CENTER_STYLE}
+            >
+              <SymbolView name="square.and.pencil" size={17} tintColor={iconColor} />
+            </Pressable>
+          </GlassView>
+        </GlassContainer>
+      </View>
+    </KeyboardStickyView>
+  );
+}

--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -13,10 +13,8 @@ import { useThemeColor } from "../../lib/useThemeColor";
 import { useThreadListV2Enabled } from "../threads/use-thread-list-v2-enabled";
 import { useHardwareKeyboardCommand } from "../keyboard/hardwareKeyboardCommands";
 import { withNativeGlassHeaderItem } from "../layout/native-glass-header-items";
-import {
-  createNativeMailSearchToolbarItem,
-  NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED,
-} from "../layout/native-mail-search-toolbar";
+import { NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED } from "../layout/native-mail-search-toolbar";
+import { HomeGlassSearchToolbar } from "./HomeGlassSearchToolbar";
 import type { HomeProjectSortOrder } from "./homeThreadList";
 import {
   buildHomeListFilterMenu,
@@ -30,6 +28,40 @@ import {
 } from "./home-list-options";
 
 export type HomeHeaderEnvironment = HomeListFilterMenuEnvironment;
+
+/**
+ * Floating glass bottom bar (filter / search / compose) for liquid-glass
+ * iOS. Rendered by HomeRouteScreen AFTER HomeScreen — the anchor views must
+ * sit above the list in real UIKit z-order (not lifted via zIndex from an
+ * earlier sibling), otherwise the filter UIMenu presents invisibly.
+ */
+export function HomeBottomSearchToolbar(props: HomeHeaderProps) {
+  const threadListV2Enabled = useThreadListV2Enabled();
+  if (Platform.OS !== "ios" || !NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED) {
+    return null;
+  }
+  const hasCustomListOptions = threadListV2Enabled
+    ? props.selectedEnvironmentId !== null || props.selectedProjectKey !== null
+    : hasCustomHomeListOptions(props);
+  const filterMenu = buildHomeListFilterMenu({
+    ...props,
+    listOrganization: !threadListV2Enabled,
+  });
+
+  return (
+    <HomeGlassSearchToolbar
+      searchQuery={props.searchQuery}
+      filterMenu={filterMenu}
+      filterIcon={
+        hasCustomListOptions
+          ? "line.3.horizontal.decrease.circle.fill"
+          : "line.3.horizontal.decrease"
+      }
+      onSearchQueryChange={props.onSearchQueryChange}
+      onStartNewTask={props.onStartNewTask}
+    />
+  );
+}
 
 export function HomeHeader(props: {
   readonly environments: ReadonlyArray<HomeHeaderEnvironment>;
@@ -326,23 +358,10 @@ function IosHomeHeader(props: HomeHeaderProps) {
           // The keys below are set per-branch (not `undefined`) so a later
           // reapply cannot clobber options owned by NativeHeaderToolbar.
           ...(NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED
-            ? {
-                unstable_headerToolbarItems: () => [
-                  createNativeMailSearchToolbarItem({
-                    composeButtonId: "home-new-task",
-                    composeSystemImageName: "square.and.pencil",
-                    filterMenu,
-                    filterButtonId: "home-filter",
-                    filterSystemImageName: hasCustomListOptions
-                      ? "line.3.horizontal.decrease.circle.fill"
-                      : "line.3.horizontal.decrease",
-                    onComposePress: props.onStartNewTask,
-                    onSearchTextChange: props.onSearchQueryChange,
-                    placeholder: "Search",
-                    searchTextChangeId: "home-search-text",
-                  }),
-                ],
-              }
+            ? // Liquid-glass iOS: the bottom bar is the JS
+              // HomeGlassSearchToolbar rendered below, so no native toolbar
+              // items are sent.
+              {}
             : {
                 // Pre-Liquid-Glass iOS: standard pull-down search in the nav
                 // bar; create + sort live in the plain bottom toolbar below.

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -14,7 +14,7 @@ import { WorkspaceSidebarToolbar } from "../layout/workspace-sidebar-toolbar";
 import { checkForAppUpdateOnLaunch } from "../updates/app-updates";
 import { AndroidHomeFabLayout } from "./AndroidHomeFab";
 import { HomeScreen } from "./HomeScreen";
-import { HomeHeader } from "./HomeHeader";
+import { HomeBottomSearchToolbar, HomeHeader } from "./HomeHeader";
 import { useHomeListOptions } from "./home-list-options";
 import { buildHomeProjectScopes } from "./homeThreadList";
 import { usePendingTaskListActions } from "./usePendingTaskListActions";
@@ -184,6 +184,25 @@ export function HomeRouteScreen() {
           selectedProjectKey={selectedProjectKey}
           threads={threads}
           threadSortOrder={listOptions.threadSortOrder}
+        />
+
+        {/* Must mount after HomeScreen: the glass toolbar overlays the list
+            and its filter menu needs real UIKit z-order (see HomeHeader). */}
+        <HomeBottomSearchToolbar
+          environments={environments}
+          projects={projectFilterOptions}
+          searchQuery={searchQuery}
+          selectedEnvironmentId={selectedEnvironmentId}
+          selectedProjectKey={selectedProjectKey}
+          projectSortOrder={listOptions.projectSortOrder}
+          threadSortOrder={listOptions.threadSortOrder}
+          onEnvironmentChange={setSelectedEnvironmentId}
+          onProjectChange={setSelectedProjectKey}
+          onOpenSettings={() => navigation.navigate("SettingsSheet", { screen: "Settings" })}
+          onProjectSortOrderChange={setProjectSortOrder}
+          onSearchQueryChange={setSearchQuery}
+          onStartNewTask={() => navigation.navigate("NewTaskSheet", { screen: "NewTask" })}
+          onThreadSortOrderChange={setThreadSortOrder}
         />
       </>
     </AndroidHomeFabLayout>


### PR DESCRIPTION
## Summary

Replaces the native mail-search bottom toolbar on the home screen (liquid-glass iOS) with a JS bar built from **expo-glass-effect**. The filter button, search field, and compose button are now sibling `GlassView`s inside one `GlassContainer` (`UIGlassContainerEffect`), so the three glass elements share a container and can merge / morph together. Each glass view keeps the same shape, size, and regular glass style it had natively (48pt capsule, 48pt round side buttons, 8pt gaps, 560pt max width).

Pre-Liquid-Glass iOS (standard bottom toolbar) and Android are unchanged. The Archived Threads and Thread Files screens still use the native mail toolbar — they can move to a shared component in a follow-up.

## Changes

- New `HomeGlassSearchToolbar`: `GlassContainer` + three `GlassView`s, riding the keyboard via `KeyboardStickyView`. Container `spacing` sits just below the resting gap, so the pills read as separate at rest but morph when they animate closer.
- `HomeHeader` no longer sends the `mailSearchToolbar` native item on liquid-glass iOS. A new `HomeBottomSearchToolbar` export builds the shared filter menu and renders the glass bar. It must mount **after** `HomeScreen` (real UIKit z-order), so `HomeRouteScreen` renders it last.
- The filter menu uses the portal-rendered JS anchored menu (the one `ControlPillMenu` already uses on Android) instead of a native `UIMenu` — see the bug below.
- Hardware ⌘F/⌘K focus-search now focuses the JS search field on the glass path.

## Pre-existing bug this fixes

On iOS 26.5, presenting the filter `UIMenu` from the bottom toolbar opens the menu invisibly behind a phantom system keyboard. This reproduces **on main with the untouched native toolbar** (screenshot below). The JS anchored menu skips UIKit menu presentation entirely, so the filter menu now opens correctly.

## Screenshots

| Before (native toolbar) | After (GlassContainer) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/SchroederNathan/t3code/assets/glass-toolbar-pr/before-rest.png" width="320"> | <img src="https://raw.githubusercontent.com/SchroederNathan/t3code/assets/glass-toolbar-pr/after-rest.png" width="320"> |

| Before: filter menu on main (invisible menu, phantom keyboard) | After: filter menu (JS anchored menu) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/SchroederNathan/t3code/assets/glass-toolbar-pr/before-menu-bug.png" width="320"> | <img src="https://raw.githubusercontent.com/SchroederNathan/t3code/assets/glass-toolbar-pr/after-menu.png" width="320"> |

| After: search focused, bar rides the keyboard |
| --- |
| <img src="https://raw.githubusercontent.com/SchroederNathan/t3code/assets/glass-toolbar-pr/after-keyboard.png" width="320"> |

## Testing

- Verified on the iPhone 17 Pro Max simulator (iOS 26.5, dev client rebuilt from this branch's deps): search focus + typing + clear button, keyboard ride and return-to-rest, filter menu with submenu drill-in and checkmarks, compose button navigation.
- `tsc --noEmit` and `vp lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Home search/filter/compose on liquid-glass iOS now depends on JS overlay layout, glass effects, and anchored menus instead of the native toolbar; regressions would affect a primary navigation surface but scope is limited to that iOS variant.
> 
> **Overview**
> On **liquid-glass iOS**, the home screen’s native mail-search bottom toolbar is replaced with a JS **`HomeGlassSearchToolbar`**: filter, search, and compose as sibling **`GlassView`s** inside one **`GlassContainer`** so the pills can merge/morph, with **`KeyboardStickyView`** for keyboard tracking and the same 48pt layout as the native bar.
> 
> **`HomeHeader`** stops sending **`unstable_headerToolbarItems`** / **`createNativeMailSearchToolbarItem`** on that path and adds **`HomeBottomSearchToolbar`**, which builds the shared filter menu and renders the glass bar. **`HomeRouteScreen`** mounts it **after** **`HomeScreen`** so overlay z-order keeps the filter UI usable.
> 
> The filter control uses the portal **`AndroidAnchoredMenu`** instead of a native **`UIMenu`** to avoid an iOS 26 bug (invisible menu + phantom keyboard). Hardware focus-search is wired to the JS **`TextInput`** on the glass path. Pre-liquid-glass iOS and Android are unchanged; other screens still use the native mail toolbar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee68fac0f684867127d4f907112d1f6c451f8caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace native iOS home toolbar items with a glass-effect bottom search toolbar
> - Adds [`HomeGlassSearchToolbar`](https://github.com/pingdotgg/t3code/pull/5039/files#diff-7a0d8b3c522b821f6c1970e9126bc8945f5925dd0fe82418f4aa205513dd3b47), a new iOS bottom toolbar using `GlassContainer`/`GlassView` that renders a filter menu button, a central search input, and a compose button with liquid-glass merging behavior.
> - Adds a `useFilterMenuActions` hook that flattens the `HomeListFilterMenu` into action objects and an id→handler map for use with `AndroidAnchoredMenu`.
> - Adds [`HomeBottomSearchToolbar`](https://github.com/pingdotgg/t3code/pull/5039/files#diff-1ba9649b1bf1262669a23a80f40994038467f6ae019d2ce77f1bbc7e0f65e198) to wire filter/search/compose props and renders the glass toolbar on iOS when `NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED`.
> - Mounts `HomeBottomSearchToolbar` in [`HomeRouteScreen`](https://github.com/pingdotgg/t3code/pull/5039/files#diff-c2d4821e3a79b2c54784238ebdee5378f310422e4a79169b0bc6fc95081dacf5) after `HomeScreen` for correct UIKit z-ordering.
> - Behavioral Change: on iOS with `NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED`, the native header toolbar items (search/filter/compose) are no longer injected; they are replaced by the JS-rendered bottom bar.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ee68fac. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->