### PR TITLE
fix(claude): make "Always allow for session" stick, and only for the session

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2882,6 +2882,118 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("acceptForSession returns session-scoped permission updates", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "approval-required",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "approve this for the session",
+        attachments: [],
+      });
+      yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+      const createInput = harness.getLastCreateQueryInput();
+      const canUseTool = createInput?.options.canUseTool;
+      assert.equal(typeof canUseTool, "function");
+      if (!canUseTool) {
+        return;
+      }
+
+      const respondToNextRequest = Effect.gen(function* () {
+        const requested = yield* Stream.runHead(adapter.streamEvents);
+        assert.equal(requested._tag, "Some");
+        if (requested._tag !== "Some" || requested.value.type !== "request.opened") {
+          return;
+        }
+        const runtimeRequestId = requested.value.requestId;
+        assert.equal(typeof runtimeRequestId, "string");
+        if (runtimeRequestId === undefined) {
+          return;
+        }
+        yield* adapter.respondToRequest(
+          session.threadId,
+          ApprovalRequestId.make(runtimeRequestId),
+          "acceptForSession",
+        );
+        yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+      });
+
+      // MCP tools frequently arrive with no usable suggestion (Claude Code
+      // sends an empty array); the decision must still stick for the session.
+      const mcpPermissionPromise = canUseTool(
+        "mcp__linear__create_issue",
+        { title: "hello" },
+        {
+          signal: new AbortController().signal,
+          suggestions: [],
+          toolUseID: "tool-use-mcp-1",
+        },
+      );
+      yield* respondToNextRequest;
+      const mcpPermission = (yield* Effect.promise(() => mcpPermissionPromise)) as PermissionResult;
+      assert.equal(mcpPermission.behavior, "allow");
+      if (mcpPermission.behavior !== "allow") {
+        return;
+      }
+      assert.deepEqual(mcpPermission.updatedPermissions, [
+        {
+          type: "addRules",
+          rules: [{ toolName: "mcp__linear__create_issue" }],
+          behavior: "allow",
+          destination: "session",
+        },
+      ]);
+
+      // Received suggestions are reused but rescoped to the session —
+      // echoing "localSettings" would persist a session-only choice to disk.
+      const bashPermissionPromise = canUseTool(
+        "Bash",
+        { command: "git status" },
+        {
+          signal: new AbortController().signal,
+          suggestions: [
+            {
+              type: "addRules",
+              rules: [{ toolName: "Bash", ruleContent: "git status" }],
+              behavior: "allow",
+              destination: "localSettings",
+            },
+          ],
+          toolUseID: "tool-use-bash-1",
+        },
+      );
+      yield* respondToNextRequest;
+      const bashPermission = (yield* Effect.promise(
+        () => bashPermissionPromise,
+      )) as PermissionResult;
+      assert.equal(bashPermission.behavior, "allow");
+      if (bashPermission.behavior !== "allow") {
+        return;
+      }
+      assert.deepEqual(bashPermission.updatedPermissions, [
+        {
+          type: "addRules",
+          rules: [{ toolName: "Bash", ruleContent: "git status" }],
+          behavior: "allow",
+          destination: "session",
+        },
+      ]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("classifies Agent tools and read-only Claude tools correctly for approvals", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -155,6 +155,37 @@ interface PendingApproval {
   readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
 }
 
+/**
+ * Permission updates applied for an "Always allow this session" decision.
+ *
+ * Claude Code's suggestions are reused when present but rescoped to
+ * `destination: "session"` — echoing them verbatim would persist the
+ * session-only choice as a permanent rule (suggestions typically target
+ * `localSettings`, i.e. `.claude/settings.local.json`). When Claude Code
+ * offers no suggestion — common for MCP tools — fall back to a whole-tool
+ * session allow rule so the decision still sticks for the session instead of
+ * silently degrading into a one-shot accept.
+ */
+function toSessionPermissionUpdates(
+  toolName: string,
+  suggestions: ReadonlyArray<PermissionUpdate> | undefined,
+): Array<PermissionUpdate> {
+  const sessionScoped = (suggestions ?? []).map(
+    (suggestion): PermissionUpdate => ({ ...suggestion, destination: "session" }),
+  );
+  if (sessionScoped.length > 0) {
+    return sessionScoped;
+  }
+  return [
+    {
+      type: "addRules",
+      rules: [{ toolName }],
+      behavior: "allow",
+      destination: "session",
+    },
+  ];
+}
+
 interface PendingUserInput {
   readonly questions: ReadonlyArray<UserInputQuestion>;
   readonly answers: Deferred.Deferred<ProviderUserInputAnswers>;
@@ -3465,9 +3496,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           return {
             behavior: "allow",
             updatedInput: toolInput,
-            ...(decision === "acceptForSession" && pendingApproval.suggestions
+            ...(decision === "acceptForSession"
               ? {
-                  updatedPermissions: [...pendingApproval.suggestions],
+                  updatedPermissions: toSessionPermissionUpdates(
+                    toolName,
+                    pendingApproval.suggestions,
+                  ),
                 }
               : {}),
           } satisfies PermissionResult;


### PR DESCRIPTION
## What changed

For the Claude provider, an `acceptForSession` decision in `canUseToolEffect` no longer echoes Claude Code's permission `suggestions` verbatim. A small normalizer (`toSessionPermissionUpdates`) now:

1. rescopes any received suggestions to `destination: "session"`, and
2. synthesizes a whole-tool session allow rule (`{ type: "addRules", rules: [{ toolName }], behavior: "allow", destination: "session" }`) when Claude Code offered no suggestions at all.

## Why it should exist

Fixes #4512. T3 keeps no session-permission state of its own for Claude — "Always allow this session" worked only if Claude Code happened to attach usable suggestions to the prompt. That breaks in both directions:

- **MCP tools re-prompt forever.** Claude Code sends empty or absent `suggestions` for MCP tools in several cases (tools flagged `requiresUserInteraction`, server-configured ask levels, ask-rule matches). The echo then produced no `updatedPermissions`, so `acceptForSession` silently degraded into a one-shot `accept` and the same tool prompted again on the next call — the exact behavior reported in #4512. Built-in tools always carry suggestions, which is why only MCP tools were affected. (The old guard also treated `suggestions: []` as truthy, echoing an empty no-op array.)
- **"This session" was persisted to disk.** When suggestions were present they carried `destination: "localSettings"`, so echoing them made Claude Code write a permanent allow rule into the workspace's `.claude/settings.local.json` — a session-scoped consent becoming durable state without the user asking for it.

The synthesized rule uses the fully qualified tool name (e.g. `mcp__server__tool`), which is the exact rule shape Claude Code's own matcher generates, so subsequent calls match natively. Other providers are unaffected (they map `acceptForSession` to their agent's native always-allow option).

No UI change.

## Testing

- New test drives two `acceptForSession` round-trips through `canUseTool`: an MCP tool with empty suggestions (asserts the synthesized session rule) and a Bash call with a `localSettings` suggestion (asserts it is rescoped to `session`, preserving `ruleContent`)
- `ClaudeAdapter.test.ts`: 63 tests pass; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude approval/permission handling in `canUseTool`, which affects tool execution consent and what rules Claude Code stores; scope is limited to the Claude adapter and is covered by new tests.
> 
> **Overview**
> Fixes Claude **"Always allow for session"** so it actually applies session-only rules instead of echoing Claude Code's permission suggestions verbatim.
> 
> `canUseTool` now routes `acceptForSession` through **`toSessionPermissionUpdates`**, which rescopes any SDK suggestions to `destination: "session"` (avoiding writes to `localSettings` / `.claude/settings.local.json`) and, when suggestions are missing or empty—typical for MCP tools—synthesizes a whole-tool session allow rule so the choice persists for the session rather than behaving like a one-shot accept.
> 
> A new test covers MCP tools with empty suggestions and Bash with `localSettings` suggestions, asserting the returned `updatedPermissions` shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e624533da7058719b18772b5c824609f91c07b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 'Always allow for session' to scope permission updates to the current session only
> - In `ClaudeAdapter`, the `acceptForSession` decision now calls a new `toSessionPermissionUpdates` helper instead of spreading `pendingApproval.suggestions` directly.
> - `toSessionPermissionUpdates` forces `destination: 'session'` on all suggestions, and when no suggestions exist (e.g. MCP tools), returns a fallback `addRules` allow entry scoped to the session.
> - Previously, session-accept could either use wrong destination scoping from suggestions or produce no permission update at all for suggestion-less tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48e6245.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->