### PR TITLE
fix(mobile): keep working timer moving across clock skew

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -103,7 +103,11 @@ import {
 import { useMarkdownCodeHighlight } from "./markdownCodeHighlightState";
 import { useAssetUrl } from "../../state/assets";
 import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
-import { formatWorkingTimelineDuration } from "../../lib/workingTimelineDuration";
+import {
+  formatWorkingTimelineDuration,
+  resolveWorkingTimelineObservation,
+  type WorkingTimelineObservation,
+} from "../../lib/workingTimelineDuration";
 
 const MESSAGE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
@@ -836,13 +840,19 @@ function renderFeedEntry(
     readonly reviewCommentColors: ReviewCommentColors;
     readonly reviewCommentBubbleWidth: number;
     readonly userBubbleMaxWidth: number;
+    readonly workingTimelineObservation: WorkingTimelineObservation | null;
   },
 ) {
   const entry = info.item;
   const { markdownStyles, iconSubtleColor, userBubbleColor } = props;
 
   if (entry.type === "working") {
-    return <WorkingTimelineRow key={entry.createdAt} startedAt={entry.createdAt} />;
+    if (props.workingTimelineObservation?.startedAt !== entry.createdAt) {
+      return null;
+    }
+    return (
+      <WorkingTimelineRow key={entry.createdAt} observation={props.workingTimelineObservation} />
+    );
   }
 
   if (entry.type === "turn-fold") {
@@ -1022,9 +1032,10 @@ function renderFeedEntry(
   );
 }
 
-const WorkingTimelineRow = memo(function WorkingTimelineRow(props: { readonly startedAt: string }) {
-  const [observedAtMs] = useState(() => Date.now());
-  const [nowMs, setNowMs] = useState(observedAtMs);
+const WorkingTimelineRow = memo(function WorkingTimelineRow(props: {
+  readonly observation: WorkingTimelineObservation;
+}) {
+  const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
     const intervalId = setInterval(() => {
@@ -1033,7 +1044,11 @@ const WorkingTimelineRow = memo(function WorkingTimelineRow(props: { readonly st
     return () => clearInterval(intervalId);
   }, []);
 
-  const durationLabel = formatWorkingTimelineDuration(props.startedAt, observedAtMs, nowMs);
+  const durationLabel = formatWorkingTimelineDuration(
+    props.observation.startedAt,
+    props.observation.observedAtMs,
+    nowMs,
+  );
 
   return (
     <View className="mb-4 flex-row items-center gap-2 px-1.5 py-1">
@@ -1501,6 +1516,13 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     }
     return ids;
   }, [expandedWorkGroups]);
+  const workingTimelineObservationRef = useRef<WorkingTimelineObservation | null>(null);
+  const workingTimelineObservation = resolveWorkingTimelineObservation(
+    workingTimelineObservationRef.current,
+    props.activeWorkStartedAt,
+    Date.now(),
+  );
+  workingTimelineObservationRef.current = workingTimelineObservation;
   const presentedFeed = useMemo(
     () =>
       deriveThreadFeedPresentation(
@@ -1749,6 +1771,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
         reviewCommentColors,
         reviewCommentBubbleWidth,
         userBubbleMaxWidth,
+        workingTimelineObservation,
         skills: props.skills,
       }),
     [
@@ -1762,6 +1785,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       reviewCommentColors,
       reviewCommentBubbleWidth,
       userBubbleMaxWidth,
+      workingTimelineObservation,
       onCopyWorkRow,
       onMarkdownLinkPress,
       onPressImage,

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -3,7 +3,6 @@ import { KeyboardAwareLegendList } from "@legendapp/list/keyboard";
 import { type LegendListRef } from "@legendapp/list/react-native";
 import type { EnvironmentId, MessageId, ThreadId, TurnId } from "@t3tools/contracts";
 import { CHAT_LIST_ANCHOR_OFFSET, resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
-import { formatElapsed } from "@t3tools/shared/orchestrationTiming";
 import { SymbolView } from "../../components/AppSymbol";
 import { HeaderHeightContext } from "@react-navigation/elements";
 import { useNavigation } from "@react-navigation/native";
@@ -104,6 +103,7 @@ import {
 import { useMarkdownCodeHighlight } from "./markdownCodeHighlightState";
 import { useAssetUrl } from "../../state/assets";
 import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
+import { formatWorkingTimelineDuration } from "../../lib/workingTimelineDuration";
 
 const MESSAGE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
@@ -842,7 +842,7 @@ function renderFeedEntry(
   const { markdownStyles, iconSubtleColor, userBubbleColor } = props;
 
   if (entry.type === "working") {
-    return <WorkingTimelineRow startedAt={entry.createdAt} />;
+    return <WorkingTimelineRow key={entry.createdAt} startedAt={entry.createdAt} />;
   }
 
   if (entry.type === "turn-fold") {
@@ -1023,16 +1023,17 @@ function renderFeedEntry(
 }
 
 const WorkingTimelineRow = memo(function WorkingTimelineRow(props: { readonly startedAt: string }) {
-  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [observedAtMs] = useState(() => Date.now());
+  const [nowMs, setNowMs] = useState(observedAtMs);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
       setNowMs(Date.now());
     }, 1_000);
     return () => clearInterval(intervalId);
-  }, [props.startedAt]);
+  }, []);
 
-  const durationLabel = formatElapsed(props.startedAt, new Date(nowMs).toISOString()) ?? "0s";
+  const durationLabel = formatWorkingTimelineDuration(props.startedAt, observedAtMs, nowMs);
 
   return (
     <View className="mb-4 flex-row items-center gap-2 px-1.5 py-1">

--- a/apps/mobile/src/lib/workingTimelineDuration.test.ts
+++ b/apps/mobile/src/lib/workingTimelineDuration.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { formatWorkingTimelineDuration } from "./workingTimelineDuration";
+import {
+  formatWorkingTimelineDuration,
+  resolveWorkingTimelineObservation,
+} from "./workingTimelineDuration";
 
 describe("formatWorkingTimelineDuration", () => {
   it("preserves elapsed time for a server timestamp in the past", () => {
@@ -38,6 +41,42 @@ describe("formatWorkingTimelineDuration", () => {
         secondObservedAtMs + 3_000,
       ),
     ).toBe("3.0s");
+  });
+
+  it("preserves a work session observation when its row remounts", () => {
+    const firstObservedAtMs = Date.parse("2026-07-31T12:00:00.000Z");
+    const serverStartedAt = "2026-07-31T12:00:53.000Z";
+    const initialObservation = resolveWorkingTimelineObservation(
+      null,
+      serverStartedAt,
+      firstObservedAtMs,
+    );
+
+    const observationAfterRemount = resolveWorkingTimelineObservation(
+      initialObservation,
+      serverStartedAt,
+      firstObservedAtMs + 10_000,
+    );
+
+    expect(observationAfterRemount).toBe(initialObservation);
+    expect(
+      formatWorkingTimelineDuration(
+        serverStartedAt,
+        observationAfterRemount?.observedAtMs ?? Number.NaN,
+        firstObservedAtMs + 12_000,
+      ),
+    ).toBe("12s");
+
+    expect(
+      resolveWorkingTimelineObservation(
+        observationAfterRemount,
+        "2026-07-31T12:01:23.000Z",
+        firstObservedAtMs + 30_000,
+      ),
+    ).toEqual({
+      startedAt: "2026-07-31T12:01:23.000Z",
+      observedAtMs: firstObservedAtMs + 30_000,
+    });
   });
 
   it("keeps the existing fallback for an invalid server timestamp", () => {

--- a/apps/mobile/src/lib/workingTimelineDuration.test.ts
+++ b/apps/mobile/src/lib/workingTimelineDuration.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatWorkingTimelineDuration } from "./workingTimelineDuration";
+
+describe("formatWorkingTimelineDuration", () => {
+  it("preserves elapsed time for a server timestamp in the past", () => {
+    const observedAtMs = Date.parse("2026-07-31T12:00:10.000Z");
+
+    expect(
+      formatWorkingTimelineDuration("2026-07-31T12:00:00.000Z", observedAtMs, observedAtMs + 5_000),
+    ).toBe("15s");
+  });
+
+  it("advances from when a future server timestamp is first observed", () => {
+    const observedAtMs = Date.parse("2026-07-31T12:00:00.000Z");
+    const serverStartedAt = "2026-07-31T12:00:53.000Z";
+
+    expect(formatWorkingTimelineDuration(serverStartedAt, observedAtMs, observedAtMs + 5_000)).toBe(
+      "5.0s",
+    );
+  });
+
+  it("anchors a new work session to its own observation time", () => {
+    const firstObservedAtMs = Date.parse("2026-07-31T12:00:00.000Z");
+    const secondObservedAtMs = firstObservedAtMs + 30_000;
+
+    expect(
+      formatWorkingTimelineDuration(
+        "2026-07-31T12:00:53.000Z",
+        firstObservedAtMs,
+        firstObservedAtMs + 5_000,
+      ),
+    ).toBe("5.0s");
+    expect(
+      formatWorkingTimelineDuration(
+        "2026-07-31T12:01:23.000Z",
+        secondObservedAtMs,
+        secondObservedAtMs + 3_000,
+      ),
+    ).toBe("3.0s");
+  });
+
+  it("keeps the existing fallback for an invalid server timestamp", () => {
+    const observedAtMs = Date.parse("2026-07-31T12:00:00.000Z");
+
+    expect(formatWorkingTimelineDuration("invalid", observedAtMs, observedAtMs + 5_000)).toBe("0s");
+  });
+});

--- a/apps/mobile/src/lib/workingTimelineDuration.ts
+++ b/apps/mobile/src/lib/workingTimelineDuration.ts
@@ -1,0 +1,18 @@
+import { formatElapsed } from "@t3tools/shared/orchestrationTiming";
+
+export function formatWorkingTimelineDuration(
+  startedAt: string,
+  observedAtMs: number,
+  nowMs: number,
+): string {
+  const parsedStartedAtMs = Date.parse(startedAt);
+  if (!Number.isFinite(parsedStartedAtMs)) {
+    return "0s";
+  }
+  const effectiveStartedAtMs = Math.min(parsedStartedAtMs, observedAtMs);
+
+  return (
+    formatElapsed(new Date(effectiveStartedAtMs).toISOString(), new Date(nowMs).toISOString()) ??
+    "0s"
+  );
+}

--- a/apps/mobile/src/lib/workingTimelineDuration.ts
+++ b/apps/mobile/src/lib/workingTimelineDuration.ts
@@ -1,5 +1,24 @@
 import { formatElapsed } from "@t3tools/shared/orchestrationTiming";
 
+export type WorkingTimelineObservation = {
+  readonly startedAt: string;
+  readonly observedAtMs: number;
+};
+
+export function resolveWorkingTimelineObservation(
+  current: WorkingTimelineObservation | null,
+  startedAt: string | null,
+  nowMs: number,
+): WorkingTimelineObservation | null {
+  if (startedAt === null) {
+    return null;
+  }
+  if (current?.startedAt === startedAt) {
+    return current;
+  }
+  return { startedAt, observedAtMs: nowMs };
+}
+
 export function formatWorkingTimelineDuration(
   startedAt: string,
   observedAtMs: number,


### PR DESCRIPTION
## What Changed

- Anchor a future working start timestamp to when it is first observed on the mobile device.
- Continue advancing the mobile working timer from that local anchor.
- Preserve the existing behavior for valid past timestamps and invalid timestamps.
- Add regression coverage for normal timestamps, future timestamps, new work sessions, and invalid input.

## Why

The working timer compares a server-provided `startedAt` timestamp with the mobile device clock.

When the server/laptop clock is ahead of the phone clock, the start timestamp appears to be in the future. The elapsed-time formatter rejects that negative duration, causing the mobile UI to remain at `Working for 0s` until the phone clock catches up.

This was reproduced on a physical Android device with approximately 53 seconds of clock skew. Anchoring only future timestamps to their first local observation allows the timer to advance immediately without changing normal elapsed-time behavior.

## UI Changes

### Before

<!-- Upload t3-code-working-timer-before.png and Before.mp4 here. -->

https://github.com/user-attachments/assets/f8b7d4a7-97b9-44c1-9bf7-2030f184e065


The working timer remains at `0s`.

<img width="386" height="850" alt="t3-code-working-timer-before" src="https://github.com/user-attachments/assets/5ac6d00e-b8a8-4e11-abd0-a571188c65f1" />

### After

<!-- Upload t3-code-working-timer-after.png and After.mp4 here. -->

https://github.com/user-attachments/assets/074c4328-5a6e-41ef-a1e9-85faac04016c

<img width="386" height="850" alt="t3-code-working-timer-after" src="https://github.com/user-attachments/assets/89b90fc3-0932-4c34-b809-08167e444323" />





The working timer begins advancing immediately despite the same clock skew.

## Testing

- `cd apps/mobile && pnpm test` — 585 tests passed
- `cd apps/mobile && pnpm typecheck`
- Targeted lint and formatting checks
- Verified before and after on a physical Android device with approximately 53 seconds of clock skew

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix working timer display to handle clock skew on mobile thread feed
> - Introduces `resolveWorkingTimelineObservation` and `formatWorkingTimelineDuration` in [`workingTimelineDuration.ts`](https://github.com/pingdotgg/t3code/pull/5044/files#diff-4cce5e4ff1c7e2341d599ff081fdbb02261f3d44da7d48d7dacac89b795d0954) to anchor the timer to the first observed time when the server-provided `startedAt` is in the future.
> - `WorkingTimelineRow` now receives a `WorkingTimelineObservation` object instead of a raw `startedAt` string, and its interval no longer restarts when `startedAt` changes.
> - `ThreadFeed` persists the observation across renders via a ref, preventing duration resets and remount artifacts when `activeWorkStartedAt` changes.
> - A working row only renders when a current observation exists and its `startedAt` matches the feed entry, avoiding stale or mismatched rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6d4df0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile UI timing logic with unit tests; no auth, networking, or shared contract changes beyond display formatting.
> 
> **Overview**
> Fixes the mobile thread **“Working for …”** timer when the server’s `startedAt` is ahead of the device clock (negative elapsed time previously stuck the label at **0s**).
> 
> Adds **`workingTimelineDuration`**: **`resolveWorkingTimelineObservation`** records the first local observation per work session (kept in a ref so list remounts don’t reset the anchor), and **`formatWorkingTimelineDuration`** uses `min(serverStart, observedAtMs)` before calling shared **`formatElapsed`**. Past server timestamps and invalid values behave as before.
> 
> **`ThreadFeed`** passes a stable observation into **`WorkingTimelineRow`**, hides the working row when observation doesn’t match the feed entry, and runs the 1s tick interval with stable deps so the timer doesn’t restart on every `startedAt` update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d4df0989f258d5f5538223b0e87966014aea22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

