### PR TITLE
feat(mobile): make settled threads collapsible

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -44,6 +44,7 @@ import {
 import {
   ThreadListV2PendingRow,
   ThreadListV2Row,
+  ThreadListV2SettledShelfHeader,
   ThreadListV2SnoozedShelfHeader,
 } from "../threads/thread-list-v2-items";
 import {
@@ -534,6 +535,8 @@ export function HomeScreen(props: HomeScreenProps) {
   );
   const [snoozedShelfExpanded, setSnoozedShelfExpanded] = useState(false);
   const toggleSnoozedShelf = useCallback(() => setSnoozedShelfExpanded((value) => !value), []);
+  const [settledShelfExpanded, setSettledShelfExpanded] = useState(true);
+  const toggleSettledShelf = useCallback(() => setSettledShelfExpanded((value) => !value), []);
   // now is quantized to the minute and ticks so the inactivity auto-settle
   // boundary is actually crossed while the app stays open (mirrors web);
   // without a clock dependency the partition memoizes a frozen "now".
@@ -579,6 +582,8 @@ export function HomeScreen(props: HomeScreenProps) {
         hiddenSettledCount: 0,
         snoozedCount: 0,
         snoozedShelfHeaderIndex: null,
+        settledCount: 0,
+        settledShelfHeaderIndex: null,
         nextSnoozeWakeAt: null,
       };
     // Settled threads are live shells; archived threads keep their original
@@ -596,6 +601,7 @@ export function HomeScreen(props: HomeScreenProps) {
       now: `${nowMinute}:00.000Z`,
       snoozeNow: new Date().toISOString(),
       snoozedShelfExpanded,
+      settledShelfExpanded,
       selectedThreadKey: null,
     });
   }, [
@@ -603,6 +609,7 @@ export function HomeScreen(props: HomeScreenProps) {
     nowMinute,
     snoozeWakeTick,
     snoozedShelfExpanded,
+    settledShelfExpanded,
     settledVisibleCount,
     settlementEnvironmentIds,
     snoozeEnvironmentIds,
@@ -655,9 +662,12 @@ export function HomeScreen(props: HomeScreenProps) {
         snoozedCount: threadListV2Layout.snoozedCount,
         snoozedShelfExpanded,
         snoozedShelfHeaderIndex: threadListV2Layout.snoozedShelfHeaderIndex,
+        settledCount: threadListV2Layout.settledCount,
+        settledShelfExpanded,
+        settledShelfHeaderIndex: threadListV2Layout.settledShelfHeaderIndex,
         snoozeLabelNow: `${nowMinute}:00.000Z`,
       }),
-    [snoozedShelfExpanded, threadListV2Layout, v2PendingTasks],
+    [settledShelfExpanded, snoozedShelfExpanded, threadListV2Layout, v2PendingTasks],
   );
 
   const renderV2Item = useCallback(
@@ -693,12 +703,20 @@ export function HomeScreen(props: HomeScreenProps) {
           />
         );
       }
+      if (item.type === "v2-settled-shelf") {
+        return (
+          <ThreadListV2SettledShelfHeader
+            count={item.count}
+            expanded={item.expanded}
+            onToggle={toggleSettledShelf}
+          />
+        );
+      }
       const thread = item.item.thread;
       return (
         <ThreadListV2Row
           thread={thread}
           variant={item.item.variant}
-          showSettledDivider={item.item.showSettledDivider}
           snoozed={item.item.snoozed}
           snoozePresetMinute={nowMinute}
           snoozeWakeLabelText={item.snoozeWakeLabelText}
@@ -767,6 +785,7 @@ export function HomeScreen(props: HomeScreenProps) {
       settlementEnvironmentIds,
       snoozeEnvironmentIds,
       threadSearchMatchByKey,
+      toggleSettledShelf,
       toggleSnoozedShelf,
       v2ProjectTitleByProjectKey,
       props.searchQuery,
@@ -1036,7 +1055,7 @@ export function HomeScreen(props: HomeScreenProps) {
             extraData={v2ExtraData}
             ListHeaderComponent={v2ListHeader}
             ListFooterComponent={
-              threadListV2Layout.hiddenSettledCount > 0 ? (
+              settledShelfExpanded && threadListV2Layout.hiddenSettledCount > 0 ? (
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel={`Show ${Math.min(threadListV2Layout.hiddenSettledCount, THREAD_LIST_V2_SETTLED_PAGE_COUNT)} more settled threads`}

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -70,6 +70,7 @@ import {
 import {
   ThreadListV2PendingRow,
   ThreadListV2Row,
+  ThreadListV2SettledShelfHeader,
   ThreadListV2SnoozedShelfHeader,
 } from "./thread-list-v2-items";
 import {
@@ -440,6 +441,8 @@ function ThreadNavigationSidebarPane(
   );
   const [snoozedShelfExpanded, setSnoozedShelfExpanded] = useState(false);
   const toggleSnoozedShelf = useCallback(() => setSnoozedShelfExpanded((value) => !value), []);
+  const [settledShelfExpanded, setSettledShelfExpanded] = useState(true);
+  const toggleSettledShelf = useCallback(() => setSettledShelfExpanded((value) => !value), []);
   // now ticks per minute so the inactivity auto-settle boundary is actually
   // crossed while the pane stays open; without a clock dependency the
   // partition memoizes a frozen "now".
@@ -485,6 +488,8 @@ function ThreadNavigationSidebarPane(
         hiddenSettledCount: 0,
         snoozedCount: 0,
         snoozedShelfHeaderIndex: null,
+        settledCount: 0,
+        settledShelfHeaderIndex: null,
         nextSnoozeWakeAt: null,
       };
     return buildThreadListV2Items({
@@ -500,6 +505,7 @@ function ThreadNavigationSidebarPane(
       now: `${nowMinute}:00.000Z`,
       snoozeNow: new Date().toISOString(),
       snoozedShelfExpanded,
+      settledShelfExpanded,
       selectedThreadKey: props.selectedThreadKey ?? null,
     });
   }, [
@@ -507,6 +513,7 @@ function ThreadNavigationSidebarPane(
     nowMinute,
     snoozeWakeTick,
     snoozedShelfExpanded,
+    settledShelfExpanded,
     props.selectedThreadKey,
     options.selectedEnvironmentId,
     props.searchQuery,
@@ -557,9 +564,12 @@ function ThreadNavigationSidebarPane(
       snoozedCount: threadListV2Layout.snoozedCount,
       snoozedShelfExpanded,
       snoozedShelfHeaderIndex: threadListV2Layout.snoozedShelfHeaderIndex,
+      settledCount: threadListV2Layout.settledCount,
+      settledShelfExpanded,
+      settledShelfHeaderIndex: threadListV2Layout.settledShelfHeaderIndex,
       snoozeLabelNow: `${nowMinute}:00.000Z`,
     });
-    if (threadListV2Layout.hiddenSettledCount > 0) {
+    if (settledShelfExpanded && threadListV2Layout.hiddenSettledCount > 0) {
       items.push({
         type: "v2-show-more",
         key: "v2-show-more",
@@ -574,6 +584,7 @@ function ThreadNavigationSidebarPane(
     pendingTasks,
     props.searchQuery,
     selectedProjectRefs,
+    settledShelfExpanded,
     snoozedShelfExpanded,
     threadListV2Enabled,
     threadListV2Layout,
@@ -780,7 +791,6 @@ function ThreadNavigationSidebarPane(
           previous.key === item.key &&
           previous.item.thread === item.item.thread &&
           previous.item.variant === item.item.variant &&
-          previous.item.showSettledDivider === item.item.showSettledDivider &&
           previous.item.snoozed === item.item.snoozed &&
           previous.snoozeWakeLabelText === item.snoozeWakeLabelText
         );
@@ -797,15 +807,20 @@ function ThreadNavigationSidebarPane(
       if (previous.type === "v2-snoozed-shelf" && item.type === "v2-snoozed-shelf") {
         return previous.count === item.count && previous.expanded === item.expanded;
       }
+      if (previous.type === "v2-settled-shelf" && item.type === "v2-settled-shelf") {
+        return previous.count === item.count && previous.expanded === item.expanded;
+      }
       if (
         previous.type === "v2-thread" ||
         previous.type === "v2-show-more" ||
         previous.type === "v2-pending" ||
         previous.type === "v2-snoozed-shelf" ||
+        previous.type === "v2-settled-shelf" ||
         item.type === "v2-thread" ||
         item.type === "v2-show-more" ||
         item.type === "v2-pending" ||
-        item.type === "v2-snoozed-shelf"
+        item.type === "v2-snoozed-shelf" ||
+        item.type === "v2-settled-shelf"
       ) {
         return false;
       }
@@ -863,7 +878,6 @@ function ThreadNavigationSidebarPane(
             <ThreadListV2Row
               thread={thread}
               variant={item.item.variant}
-              showSettledDivider={item.item.showSettledDivider}
               snoozed={item.item.snoozed}
               snoozePresetMinute={nowMinute}
               snoozeWakeLabelText={item.snoozeWakeLabelText}
@@ -918,6 +932,15 @@ function ThreadNavigationSidebarPane(
               count={item.count}
               expanded={item.expanded}
               onToggle={toggleSnoozedShelf}
+              pane="sidebar"
+            />
+          );
+        case "v2-settled-shelf":
+          return (
+            <ThreadListV2SettledShelfHeader
+              count={item.count}
+              expanded={item.expanded}
+              onToggle={toggleSettledShelf}
               pane="sidebar"
             />
           );
@@ -1039,6 +1062,7 @@ function ThreadNavigationSidebarPane(
       snoozeEnvironmentIds,
       snoozeThread,
       nowMinute,
+      toggleSettledShelf,
       toggleSnoozedShelf,
       unsettleThread,
       unsnoozeThread,

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -149,6 +149,42 @@ export const ThreadListV2SnoozedShelfHeader = memo(function ThreadListV2SnoozedS
   );
 });
 
+export const ThreadListV2SettledShelfHeader = memo(function ThreadListV2SettledShelfHeader(props: {
+  readonly count: number;
+  readonly expanded: boolean;
+  readonly onToggle: () => void;
+  readonly pane?: "screen" | "sidebar";
+}) {
+  const mutedColor = useThemeColor("--color-foreground-muted");
+  return (
+    <Pressable
+      accessibilityHint={
+        props.expanded ? "Collapses the settled threads." : "Expands the settled threads."
+      }
+      accessibilityLabel={props.count === 1 ? "1 settled thread" : `${props.count} settled threads`}
+      accessibilityRole="button"
+      accessibilityState={{ expanded: props.expanded }}
+      className={cn(
+        "mb-1.5 mt-4 flex-row items-center gap-2.5",
+        props.pane === "sidebar" ? "px-3" : "px-5",
+      )}
+      onPress={props.onToggle}
+      style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+    >
+      <Text className="text-xs font-t3-medium text-foreground-tertiary">
+        {props.expanded ? "Settled" : `Settled (${props.count})`}
+      </Text>
+      <View className="h-px flex-1 bg-border" />
+      <SymbolView
+        name={props.expanded ? "chevron.up" : "chevron.down"}
+        size={10}
+        tintColor={mutedColor}
+        type="monochrome"
+      />
+    </Pressable>
+  );
+});
+
 const PENDING_TASK_MENU_ACTIONS: MenuAction[] = [
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
@@ -267,7 +303,6 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
 export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   readonly thread: EnvironmentThreadShell;
   readonly variant: "card" | "slim";
-  readonly showSettledDivider: boolean;
   /** Snoozed-shelf row: shows its wake time and offers Wake. */
   readonly snoozed?: boolean;
   /** Preformatted against the parent minute tick so this memoized row's
@@ -739,9 +774,6 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
 
   return (
     <>
-      {props.showSettledDivider ? (
-        <ThreadListV2SectionDivider label="Settled" pane={props.pane} />
-      ) : null}
       <ThreadSwipeable
         backgroundColor={sidebarPane ? drawerColor : screenColor}
         compactActions={variant === "slim"}

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -425,8 +425,8 @@ describe("buildThreadListV2Items", () => {
     expect(layout.snoozedCount).toBe(0);
   });
 
-  it("partitions settled threads into a slim tail with one divider", () => {
-    const { items } = buildThreadListV2Items({
+  it("partitions settled threads into a slim shelf", () => {
+    const layout = buildThreadListV2Items({
       threads: [
         makeThread({ id: ThreadId.make("active"), title: "Active" }),
         makeThread({
@@ -447,13 +447,64 @@ describe("buildThreadListV2Items", () => {
       now: NOW,
     });
 
-    expect(items.map((item) => [item.thread.id, item.variant])).toEqual([
+    expect(layout.items.map((item) => [item.thread.id, item.variant])).toEqual([
       ["active", "card"],
       ["settled", "slim"],
       ["settled-2", "slim"],
     ]);
-    expect(items.map((item) => item.showSettledDivider)).toEqual([false, true, false]);
-    expect(items.map((item) => item.isLast)).toEqual([false, false, true]);
+    expect(layout.items.map((item) => item.isLast)).toEqual([false, false, true]);
+    expect(layout.settledCount).toBe(2);
+    expect(layout.settledShelfHeaderIndex).toBe(1);
+  });
+
+  it("collapses settled threads to a counted shelf header", () => {
+    const layout = buildThreadListV2Items({
+      threads: [
+        makeThread({ id: ThreadId.make("active"), title: "Active" }),
+        makeThread({
+          id: ThreadId.make("settled"),
+          title: "Settled",
+          settledOverride: "settled",
+          settledAt: NOW,
+        }),
+      ],
+      environmentId: null,
+      searchQuery: "",
+      now: NOW,
+      settledShelfExpanded: false,
+    });
+
+    expect(layout.items.map((item) => item.thread.id)).toEqual(["active"]);
+    expect(layout.settledCount).toBe(1);
+    expect(layout.settledShelfHeaderIndex).toBe(1);
+  });
+
+  it("keeps the selected settled thread visible when its shelf is collapsed", () => {
+    const layout = buildThreadListV2Items({
+      threads: [
+        makeThread({
+          id: ThreadId.make("selected"),
+          title: "Selected",
+          settledOverride: "settled",
+          settledAt: NOW,
+        }),
+        makeThread({
+          id: ThreadId.make("other"),
+          title: "Other",
+          settledOverride: "settled",
+          settledAt: NOW,
+        }),
+      ],
+      environmentId: null,
+      searchQuery: "",
+      now: NOW,
+      settledShelfExpanded: false,
+      selectedThreadKey: `${environmentId}:selected`,
+    });
+
+    expect(layout.items.map((item) => item.thread.id)).toEqual(["selected"]);
+    expect(layout.settledCount).toBe(2);
+    expect(layout.settledShelfHeaderIndex).toBe(0);
   });
 
   it("keeps cards in creation order while settled sorts by recency", () => {
@@ -658,6 +709,8 @@ describe("buildThreadListV2ListItems", () => {
     const items = buildThreadListV2ListItems({
       items: layout.items,
       pendingTasks: [makePendingTask("queued-1"), makePendingTask("queued-2")],
+      settledCount: layout.settledCount,
+      settledShelfHeaderIndex: layout.settledShelfHeaderIndex,
     });
 
     expect(
@@ -666,9 +719,11 @@ describe("buildThreadListV2ListItems", () => {
           ? item.pendingTask.title
           : item.type === "v2-thread"
             ? item.item.thread.id
-            : "snoozed-shelf",
+            : item.type === "v2-snoozed-shelf"
+              ? "snoozed-shelf"
+              : "settled-shelf",
       ),
-    ).toEqual(["active", "queued-1", "queued-2", "settled"]);
+    ).toEqual(["active", "queued-1", "queued-2", "settled-shelf", "settled"]);
     // Only the leading queued row labels the section, exactly like Settled.
     expect(
       items.filter((item) => item.type === "v2-pending" && item.showPendingDivider),
@@ -690,11 +745,17 @@ describe("buildThreadListV2ListItems", () => {
     expect(items.map((item) => item.type)).toEqual(["v2-thread", "v2-pending"]);
   });
 
-  it("leaves the thread order untouched when nothing is queued", () => {
-    const items = buildThreadListV2ListItems({ items: layout.items, pendingTasks: [] });
+  it("keeps the settled shelf between active and settled rows when nothing is queued", () => {
+    const items = buildThreadListV2ListItems({
+      items: layout.items,
+      pendingTasks: [],
+      settledCount: layout.settledCount,
+      settledShelfHeaderIndex: layout.settledShelfHeaderIndex,
+    });
 
     expect(items.map((item) => item.key)).toEqual([
       `v2-thread:${environmentId}:active`,
+      "v2-settled-shelf",
       `v2-thread:${environmentId}:settled`,
     ]);
   });
@@ -726,12 +787,15 @@ describe("buildThreadListV2ListItems", () => {
       snoozedCount: snoozedLayout.snoozedCount,
       snoozedShelfExpanded: false,
       snoozedShelfHeaderIndex: snoozedLayout.snoozedShelfHeaderIndex,
+      settledCount: snoozedLayout.settledCount,
+      settledShelfHeaderIndex: snoozedLayout.settledShelfHeaderIndex,
     });
 
     expect(items.map((item) => item.type)).toEqual([
       "v2-thread",
       "v2-pending",
       "v2-snoozed-shelf",
+      "v2-settled-shelf",
       "v2-thread",
     ]);
   });

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -178,8 +178,6 @@ export function sortThreadsForListV2<T extends { readonly id: string; readonly c
 export interface ThreadListV2Item {
   readonly thread: EnvironmentThreadShell;
   readonly variant: "card" | "slim";
-  /** First settled row after the card block draws the SETTLED divider. */
-  readonly showSettledDivider: boolean;
   /** Snoozed-shelf row: shows the wake countdown and offers Wake. */
   readonly snoozed: boolean;
   readonly isLast: boolean;
@@ -194,6 +192,10 @@ export interface ThreadListV2Layout {
   /** Index in `items` where the Snoozed shelf header belongs. The header is
       still rendered when the shelf is collapsed and no snoozed rows exist. */
   readonly snoozedShelfHeaderIndex: number | null;
+  /** Total settled threads in scope, including rows hidden by collapse/paging. */
+  readonly settledCount: number;
+  /** Index in `items` where the Settled shelf header belongs. */
+  readonly settledShelfHeaderIndex: number | null;
   /** Soonest wake time among snoozed threads, or null. Callers arm
       a timeout at this boundary so the list re-partitions the moment a
       snooze expires instead of on the next minute tick. */
@@ -223,10 +225,18 @@ export interface ThreadListV2SnoozedShelfListItem {
   readonly expanded: boolean;
 }
 
+export interface ThreadListV2SettledShelfListItem {
+  readonly type: "v2-settled-shelf";
+  readonly key: "v2-settled-shelf";
+  readonly count: number;
+  readonly expanded: boolean;
+}
+
 export type ThreadListV2ListItem =
   | ThreadListV2ThreadListItem
   | ThreadListV2PendingListItem
-  | ThreadListV2SnoozedShelfListItem;
+  | ThreadListV2SnoozedShelfListItem
+  | ThreadListV2SettledShelfListItem;
 
 /**
  * Builds the shared mobile order: active → pending → snoozed shelf → settled.
@@ -239,6 +249,9 @@ export function buildThreadListV2ListItems(input: {
   readonly snoozedCount?: number;
   readonly snoozedShelfExpanded?: boolean;
   readonly snoozedShelfHeaderIndex?: number | null;
+  readonly settledCount?: number;
+  readonly settledShelfExpanded?: boolean;
+  readonly settledShelfHeaderIndex?: number | null;
   readonly snoozeLabelNow?: string;
 }): ThreadListV2ListItem[] {
   const threadItems = input.items.map(
@@ -262,27 +275,30 @@ export function buildThreadListV2ListItems(input: {
   );
   const snoozedCount = input.snoozedCount ?? 0;
   const snoozedShelfHeaderIndex = input.snoozedShelfHeaderIndex ?? null;
+  const settledCount = input.settledCount ?? 0;
+  const settledShelfHeaderIndex = input.settledShelfHeaderIndex ?? null;
+  const activeEnd = snoozedShelfHeaderIndex ?? settledShelfHeaderIndex ?? threadItems.length;
+  const snoozedEnd = settledShelfHeaderIndex ?? threadItems.length;
+  const result: ThreadListV2ListItem[] = [...threadItems.slice(0, activeEnd), ...pendingItems];
   if (snoozedShelfHeaderIndex !== null && snoozedCount > 0) {
-    return [
-      ...threadItems.slice(0, snoozedShelfHeaderIndex),
-      ...pendingItems,
-      {
-        type: "v2-snoozed-shelf",
-        key: "v2-snoozed-shelf",
-        count: snoozedCount,
-        expanded: input.snoozedShelfExpanded === true,
-      },
-      ...threadItems.slice(snoozedShelfHeaderIndex),
-    ];
+    result.push({
+      type: "v2-snoozed-shelf",
+      key: "v2-snoozed-shelf",
+      count: snoozedCount,
+      expanded: input.snoozedShelfExpanded === true,
+    });
+    result.push(...threadItems.slice(snoozedShelfHeaderIndex, snoozedEnd));
   }
-  if (pendingItems.length === 0) return threadItems;
-
-  const settledStart = threadItems.findIndex(
-    (entry) => entry.type === "v2-thread" && entry.item.showSettledDivider,
-  );
-  return settledStart === -1
-    ? [...threadItems, ...pendingItems]
-    : [...threadItems.slice(0, settledStart), ...pendingItems, ...threadItems.slice(settledStart)];
+  if (settledShelfHeaderIndex !== null && settledCount > 0) {
+    result.push({
+      type: "v2-settled-shelf",
+      key: "v2-settled-shelf",
+      count: settledCount,
+      expanded: input.settledShelfExpanded !== false,
+    });
+    result.push(...threadItems.slice(settledShelfHeaderIndex));
+  }
+  return result;
 }
 
 /**
@@ -321,6 +337,8 @@ export function buildThreadListV2Items(input: {
   readonly snoozeNow?: string;
   /** Expands the snoozed shelf into rows. Collapsed is the default. */
   readonly snoozedShelfExpanded?: boolean;
+  /** Expands the settled shelf into rows. Expanded is the default. */
+  readonly settledShelfExpanded?: boolean;
   /** The selected thread remains visible on an otherwise collapsed shelf so
       a split-view detail can never lose its navigation row. */
   readonly selectedThreadKey?: string | null;
@@ -402,15 +420,24 @@ export function buildThreadListV2Items(input: {
       firstValidTimestampMs(left.latestUserMessageAt, left.updatedAt),
   );
   const settledLimit = input.settledLimit ?? Number.POSITIVE_INFINITY;
-  const visibleSettled =
+  const pagedSettled =
     orderedSettled.length > settledLimit ? orderedSettled.slice(0, settledLimit) : orderedSettled;
+  const selectedSettled = orderedSettled
+    .slice(pagedSettled.length)
+    .find((thread) => `${thread.environmentId}:${thread.id}` === selectedThreadKey);
+  if (selectedSettled !== undefined) pagedSettled.push(selectedSettled);
+  const visibleSettled =
+    input.settledShelfExpanded !== false
+      ? pagedSettled
+      : pagedSettled.filter(
+          (thread) => `${thread.environmentId}:${thread.id}` === selectedThreadKey,
+        );
 
   const items: ThreadListV2Item[] = [];
   for (const thread of orderedActive) {
     items.push({
       thread,
       variant: "card",
-      showSettledDivider: false,
       snoozed: false,
       isLast: false,
     });
@@ -420,16 +447,15 @@ export function buildThreadListV2Items(input: {
     items.push({
       thread,
       variant: "slim",
-      showSettledDivider: false,
       snoozed: true,
       isLast: false,
     });
   }
-  for (const [index, thread] of visibleSettled.entries()) {
+  const settledShelfHeaderIndex = orderedSettled.length > 0 ? items.length : null;
+  for (const thread of visibleSettled) {
     items.push({
       thread,
       variant: "slim",
-      showSettledDivider: index === 0,
       snoozed: false,
       isLast: false,
     });
@@ -440,9 +466,11 @@ export function buildThreadListV2Items(input: {
   }
   return {
     items,
-    hiddenSettledCount: orderedSettled.length - visibleSettled.length,
+    hiddenSettledCount: orderedSettled.length - pagedSettled.length,
     snoozedCount: orderedSnoozed.length,
     snoozedShelfHeaderIndex,
+    settledCount: orderedSettled.length,
+    settledShelfHeaderIndex,
     nextSnoozeWakeAt,
   };
 }


### PR DESCRIPTION
## What Changed

- made the existing Settled section collapsible in mobile Thread List v2
- kept Settled expanded by default, matching desktop
- show `Settled (N)` while collapsed and keep the selected iPad thread visible
- hide settled paging controls until the shelf is expanded

## Why

#5053 already added the Snoozed shelf and the reverse **Wake** action on mobile. The remaining desktop-parity gap was that settled threads were always expanded.

## UI Changes

### iPhone

Both captures show the same current-main showcase data after #5053.

| Before | After |
| --- | --- |
| <img width="368" height="800" alt="iPhone before: Settled threads are permanently expanded below Pending" src="https://github.com/user-attachments/assets/78d572b7-8848-4138-98d2-a063c3ab39ea" /> | <img width="368" height="800" alt="iPhone after: Settled is collapsed to a counted shelf below Pending" src="https://github.com/user-attachments/assets/63ce42fb-83fb-45e1-a256-53ed5eac5895" /> |

### Android

Both 1080×1920 captures are scrolled past the active list and Pending rows to the Settled region.

| Before | After |
| --- | --- |
| <img width="390" alt="Android before: Settled threads are permanently expanded below Pending" src="https://github.com/user-attachments/assets/57bebc26-e236-4d64-8186-ad445b8c8caf" /> | <img width="390" alt="Android after: Settled is collapsed to Settled (3) below Pending" src="https://github.com/user-attachments/assets/126daf7a-8db5-4f80-a2cf-d5c76041302a" /> |

## Verification

- `vp test run apps/mobile/src/features/threads/threadListV2.test.ts` (35 tests)
- `vp run --filter @t3tools/mobile typecheck`
- targeted lint on the five changed mobile files
- iPhone 17 Pro Max: collapsed and re-expanded the Settled shelf with semantic UI automation
- Android Pixel_10_Pro: collapsed and re-expanded the Settled shelf; captured matched 1080×1920 evidence scrolled past Pending
- confirmed #5053 already provides Snoozed and Wake, so this PR does not duplicate either feature

## Checklist

- [x] Rebased onto current `main`
- [x] Scoped to collapsible Settled threads
- [x] Tested on iOS and Android
- [x] Before/after evidence embedded without committing images

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and list-partitioning changes in mobile thread list v2 with tests; no auth, API, or data contract changes.
> 
> **Overview**
> Mobile thread list v2 now treats **settled** threads like **snoozed** ones: a toggleable shelf header instead of a static divider on the first settled row.
> 
> **Settled shelf** defaults to **expanded** (Snoozed stays collapsed). Collapsing hides settled rows but keeps the **selected** thread visible on iPad split view. The settled **Show more** pager only appears while the shelf is expanded.
> 
> `buildThreadListV2Items` / `buildThreadListV2ListItems` expose `settledCount`, `settledShelfHeaderIndex`, and a new `v2-settled-shelf` list item; **`showSettledDivider`** is removed from row items. **Home** and **sidebar** both wire `ThreadListV2SettledShelfHeader`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f23d1bd2e9772c56990616374a6843be4a6a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add collapsible Settled shelf and snooze shelf to the v2 mobile thread list sidebar
> - Introduces a `ThreadListV2SettledShelfHeader` component that renders a pressable header showing the settled thread count and a chevron to collapse/expand the settled section in both the home screen and the sidebar.
> - Removes the per-row `showSettledDivider` flag from `ThreadListV2Item`; section labeling is now handled by the new shelf header list item (`v2-settled-shelf`).
> - Updates `buildThreadListV2Items` and `buildThreadListV2ListItems` in [threadListV2.ts](https://github.com/pingdotgg/t3code/pull/5056/files#diff-d629687d2b79a927cf01be39191d0e3fc66435674cd6f8a588469b55c70210ed) to compute `settledShelfHeaderIndex`, `settledCount`, and `snoozedShelfHeaderIndex`, and to filter settled rows when the shelf is collapsed (keeping the selected thread visible).
> - The "Show more" footer is only rendered when the Settled shelf is expanded and there are hidden settled threads.
> - Behavioral Change: callers that previously read `showSettledDivider` from list items must migrate to the new `v2-settled-shelf` item type.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 41f23d1. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->