### PR TITLE
fix(server): tombstone deletion of missing threads

### DIFF
--- a/apps/server/src/orchestration/decider.delete.test.ts
+++ b/apps/server/src/orchestration/decider.delete.test.ts
@@ -137,6 +137,34 @@ function normalizeDeleteEvent(event: PlannedEvent | ReadonlyArray<PlannedEvent>)
 }
 
 it.layer(NodeServices.layer)("decider deletion flows", (it) => {
+  it.effect("emits a deletion tombstone for a missing thread", () =>
+    Effect.gen(function* () {
+      const threadId = asThreadId("ghost-thread");
+      const commandId = asCommandId("cmd-delete-ghost-thread");
+      const readModel = yield* seedReadModel;
+
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.delete",
+          commandId,
+          threadId,
+        },
+        readModel,
+      });
+
+      expect(normalizeDeleteEvent(result)).toEqual([
+        {
+          type: "thread.deleted",
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          commandId,
+          correlationId: commandId,
+          payload: { threadId },
+        },
+      ]);
+    }),
+  );
+
   it.effect("rejects deleting a non-empty project without force", () =>
     Effect.gen(function* () {
       const readModel = yield* seedReadModel;

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -379,11 +379,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.delete": {
-      yield* requireThread({
-        readModel,
-        command,
-        threadId: command.threadId,
-      });
+      // Keep deletion idempotent for clients holding a stale shell entry. The
+      // tombstone advances the stream and lets every client remove that ghost.
       const occurredAt = yield* nowIso;
       return {
         ...(yield* withEventBase({


### PR DESCRIPTION
## What Changed

Make `thread.delete` idempotent by emitting a `thread.deleted` tombstone even when the thread is missing. Add focused coverage for deleting a stale or ghost thread entry.

## Why

Clients may retain stale thread entries after the underlying thread is gone. Emitting a deletion event lets every client remove the ghost consistently while advancing the event stream.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized orchestration decider behavior change with test coverage; no auth or data-model migration, though clients may now see extra tombstone events for already-absent threads.
> 
> **Overview**
> **`thread.delete` no longer requires the thread to exist** in the read model. Stale shell entries can be cleared by always emitting a **`thread.deleted`** tombstone, which advances the event stream so every client drops the ghost thread consistently.
> 
> A new decider test covers deleting a non-existent **`ghost-thread`** and asserts the tombstone event shape (aggregate, command/correlation IDs, payload).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aadd5f032704dacc05cf1c3f057b0eab77b32f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `thread.delete` to emit a tombstone event for missing threads
> Previously, issuing a `thread.delete` command for a non-existent thread required the thread to exist (via a `requireThread` precondition check), which caused an error. The `decideOrchestrationCommand` function in [decider.ts](https://github.com/pingdotgg/t3code/pull/5062/files#diff-6f7345ef9257e77e02acccced5be5251aa0f108aa0620614c5c80cc072949dc6) now always emits a `thread.deleted` tombstone event regardless of whether the thread exists, making deletion idempotent. A test case is added in [decider.delete.test.ts](https://github.com/pingdotgg/t3code/pull/5062/files#diff-dbf1b1d80b0bef3c22ae8c845841fb8be388e30a01f0b2808c1d24fb408e2434) to cover this behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aadd5f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->