### PR TITLE
fix(mobile): server model, worktree, and origin preferences now apply to new tasks

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -42,7 +42,8 @@ import {
   restoreComposerDraftSnapshot,
   type ComposerDraft,
 } from "../../state/use-composer-drafts";
-import { useProjects } from "../../state/entities";
+import { useEnvironmentServerConfig, useProjects } from "../../state/entities";
+import { resolveSelectableModelSelection } from "../../lib/modelOptions";
 import { deriveThreadTitleFromPrompt } from "../../lib/projectThreadStartTurn";
 import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/remoteRegistration";
 import { enqueueThreadOutboxMessage, removeThreadOutboxMessage } from "../../state/thread-outbox";
@@ -90,6 +91,9 @@ export function NewTaskDraftScreen(props: {
   const controlsBottomPadding = isKeyboardVisible ? 8 : Math.max(insets.bottom, 10);
   const { logicalProjects, selectedProject, setProject } = flow;
   const { connectedEnvironments } = useRemoteConnectionStatus();
+  const selectedEnvironmentServerConfig = useEnvironmentServerConfig(
+    selectedProject?.environmentId ?? null,
+  );
   const environmentConnected =
     selectedProject !== null &&
     connectedEnvironments.find(
@@ -795,7 +799,14 @@ export function NewTaskDraftScreen(props: {
       return;
     }
     const draft = getComposerDraftSnapshot(draftKey);
-    const modelSelection = draft.modelSelection ?? flow.selectedModel;
+    // Snapshot read keeps just-typed selector state; the availability gate
+    // still applies so a stored selection on a disabled provider falls back
+    // to the flow's resolved model.
+    const modelSelection =
+      resolveSelectableModelSelection(
+        selectedEnvironmentServerConfig,
+        draft.modelSelection ?? null,
+      ) ?? flow.selectedModel;
     const workspaceMode = draft.workspaceSelection?.mode ?? flow.workspaceMode;
     const selectedBranchName = draft.workspaceSelection?.branch ?? flow.selectedBranchName;
     const selectedWorktreePath =
@@ -847,7 +858,10 @@ export function NewTaskDraftScreen(props: {
       if (editingPendingTask) {
         flow.finishEditingPendingTask();
       } else {
-        clearComposerDraftContent(draftKey);
+        // Drop the workspace selection with the content: the next task should
+        // re-resolve mode/branch/origin from the server's configured defaults
+        // instead of resurrecting this task's picks.
+        clearComposerDraftContent(draftKey, { clearWorkspaceSelection: true });
       }
       navigation.getParent()?.goBack();
       return;
@@ -905,7 +919,7 @@ export function NewTaskDraftScreen(props: {
       }
       flow.finishEditingPendingTask();
     } else {
-      clearComposerDraftContent(draftKey);
+      clearComposerDraftContent(draftKey, { clearWorkspaceSelection: true });
     }
     navigation.dispatch(
       StackActions.replace("Thread", {

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -22,7 +22,11 @@ import { useEnvironmentServerConfig, useProjects, useThreadShells } from "../../
 import type { TurnCommandMetadata } from "../../lib/commandMetadata";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import type { ModelOption, ProviderGroup } from "../../lib/modelOptions";
-import { buildModelOptions, groupByProvider } from "../../lib/modelOptions";
+import {
+  buildModelOptions,
+  groupByProvider,
+  resolveSelectableModelSelection,
+} from "../../lib/modelOptions";
 import { groupProjectsByRepository } from "../../lib/repositoryGroups";
 import { scopedProjectKey } from "../../lib/scopedEntities";
 import { appAtomRegistry } from "../../state/atom-registry";
@@ -347,7 +351,11 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const selectedProjectDraft = useComposerDraft(selectedProjectDraftKey);
   const prompt = selectedProjectDraft.text;
   const attachments = selectedProjectDraft.attachments;
-  const workspaceMode = selectedProjectDraft.workspaceSelection?.mode ?? "local";
+  // The server's configured default decides the mode until the user picks one
+  // explicitly — same resolution web uses for new draft threads.
+  const defaultWorkspaceMode: WorkspaceMode =
+    selectedEnvironmentServerConfig?.settings.defaultThreadEnvMode ?? "local";
+  const workspaceMode = selectedProjectDraft.workspaceSelection?.mode ?? defaultWorkspaceMode;
   const selectedBranchName = selectedProjectDraft.workspaceSelection?.branch ?? null;
   const selectedWorktreePath = selectedProjectDraft.workspaceSelection?.worktreePath ?? null;
   // Keep the user's explicit choice separate from the resolved display value:
@@ -361,22 +369,29 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const runtimeMode = selectedProjectDraft.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const interactionMode = selectedProjectDraft.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE;
 
+  // Stored selections (draft and project default) only count while their
+  // provider is usable on the server; otherwise the server's default model
+  // wins instead of silently targeting a disabled provider.
+  const draftModelSelection = resolveSelectableModelSelection(
+    selectedEnvironmentServerConfig,
+    selectedProjectDraft.modelSelection ?? null,
+  );
+  const projectDefaultModelSelection = resolveSelectableModelSelection(
+    selectedEnvironmentServerConfig,
+    selectedProject?.defaultModelSelection ?? null,
+  );
   const modelOptions = useMemo(
     () =>
       buildModelOptions(
         selectedEnvironmentServerConfig,
-        selectedProjectDraft.modelSelection ?? selectedProject?.defaultModelSelection ?? null,
+        draftModelSelection ?? projectDefaultModelSelection,
       ),
-    [
-      selectedEnvironmentServerConfig,
-      selectedProject?.defaultModelSelection,
-      selectedProjectDraft.modelSelection,
-    ],
+    [selectedEnvironmentServerConfig, draftModelSelection, projectDefaultModelSelection],
   );
 
   const selectedModel =
-    selectedProjectDraft.modelSelection ??
-    selectedProject?.defaultModelSelection ??
+    draftModelSelection ??
+    projectDefaultModelSelection ??
     modelOptions.find((option) => option.isDefault)?.selection ??
     modelOptions[0]?.selection ??
     null;
@@ -675,12 +690,20 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       }
       const draft = getComposerDraftSnapshot(selectedProjectDraftKey);
       const text = draft.text.trim();
-      const draftModelSelection = draft.modelSelection ?? selectedModel;
+      // Same availability gate the composer display applies: a stored
+      // selection targeting a disabled provider must not ride into the queue.
+      const draftModelSelection =
+        resolveSelectableModelSelection(
+          selectedEnvironmentServerConfig,
+          draft.modelSelection ?? null,
+        ) ?? selectedModel;
       if (text.length === 0 || !draftModelSelection) {
         return null;
       }
       const workspaceSelection = draft.workspaceSelection;
-      const mode = workspaceSelection?.mode ?? "local";
+      // Fall back to the resolved mode (server default) so queued tasks drain
+      // with the same mode the composer displayed.
+      const mode = workspaceSelection?.mode ?? workspaceMode;
       // When the selection is the stand-in built from the queued snapshot,
       // persist the original (possibly absent) snapshot values — the
       // stand-in's placeholder title/workspaceRoot must never be written back
@@ -722,10 +745,12 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     [
       editingPendingProject,
       editingPendingTask,
+      selectedEnvironmentServerConfig,
       selectedModel,
       selectedProject,
       selectedProjectDraftKey,
       startFromOrigin,
+      workspaceMode,
     ],
   );
 

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { ProviderInstanceId, type ServerConfig } from "@t3tools/contracts";
 
-import { buildModelOptions } from "./modelOptions";
+import { buildModelOptions, resolveSelectableModelSelection } from "./modelOptions";
 
 describe("mobile model options", () => {
   it("normalizes a legacy fallback selection against current capabilities", () => {
@@ -48,5 +48,47 @@ describe("mobile model options", () => {
 
     expect(option?.capabilities?.optionDescriptors?.[0]?.id).toBe("serviceTier");
     expect(option?.selection.options).toEqual([{ id: "serviceTier", value: "default" }]);
+  });
+
+  it("rejects stored selections whose provider is not usable", () => {
+    const config = {
+      providers: [
+        {
+          instanceId: "codex",
+          driver: "codex",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          models: [],
+        },
+        {
+          instanceId: "claudeAgent",
+          driver: "claudeAgent",
+          enabled: false,
+          installed: true,
+          auth: { status: "authenticated" },
+          models: [],
+        },
+      ],
+    } as unknown as ServerConfig;
+
+    const usable = {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5.6-sol",
+    };
+    const disabled = {
+      instanceId: ProviderInstanceId.make("claudeAgent"),
+      model: "claude-sonnet-5",
+    };
+    const removed = {
+      instanceId: ProviderInstanceId.make("codex_personal"),
+      model: "gpt-5.6-sol",
+    };
+
+    expect(resolveSelectableModelSelection(config, usable)).toBe(usable);
+    expect(resolveSelectableModelSelection(config, disabled)).toBeNull();
+    expect(resolveSelectableModelSelection(config, removed)).toBeNull();
+    // No config (environment offline) — nothing to validate against.
+    expect(resolveSelectableModelSelection(null, disabled)).toBe(disabled);
   });
 });

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -58,6 +58,31 @@ function normalizeSelectionOptions(
       };
 }
 
+/**
+ * A stored model selection is only usable when its provider instance is
+ * currently enabled, installed, and authenticated on the server. Returns the
+ * selection unchanged when usable, otherwise `null` so callers fall through to
+ * the server's default model. A missing config (environment offline) cannot be
+ * validated, so stored selections pass through untouched.
+ */
+export function resolveSelectableModelSelection(
+  config: T3ServerConfig | null | undefined,
+  selection: ModelSelection | null,
+): ModelSelection | null {
+  if (!selection || !config) {
+    return selection;
+  }
+  const provider = config.providers.find(
+    (candidate) => candidate.instanceId === selection.instanceId,
+  );
+  return provider &&
+    provider.enabled &&
+    provider.installed &&
+    provider.auth.status !== "unauthenticated"
+    ? selection
+    : null;
+}
+
 export function buildModelOptions(
   config: T3ServerConfig | null | undefined,
   fallbackModelSelection: ModelSelection | null,

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -119,6 +119,36 @@ describe("mobile composer drafts", () => {
     });
   });
 
+  it("drops the workspace selection when clearing a sent new-task draft", () => {
+    const draftKey = "new-task:environment-1:project-1";
+    const draft: ComposerDraft = {
+      text: "send this",
+      attachments: [],
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5.4",
+      },
+      workspaceSelection: {
+        mode: "worktree",
+        branch: "main",
+        worktreePath: null,
+        startFromOrigin: false,
+      },
+    };
+
+    expect(
+      clearComposerDraftContentState({ [draftKey]: draft }, draftKey, {
+        clearWorkspaceSelection: true,
+      }),
+    ).toEqual({
+      [draftKey]: {
+        modelSelection: draft.modelSelection,
+        text: "",
+        attachments: [],
+      },
+    });
+  });
+
   it("reads the latest selector state synchronously for send", () => {
     const draftKey = "environment-1:thread-1";
     const selectedDraft: ComposerDraft = {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -372,14 +372,18 @@ export function updateComposerDraftSettings(
 export function clearComposerDraftContentState(
   current: Record<string, ComposerDraft>,
   draftKey: string,
+  options?: { readonly clearWorkspaceSelection?: boolean },
 ): Record<string, ComposerDraft> {
   const existing = current[draftKey];
   if (!existing) {
     return current;
   }
-  const { importedShareIds: _importedShareIds, ...retained } = existing;
+  const { importedShareIds: _importedShareIds, workspaceSelection, ...retained } = existing;
   const draft = {
     ...retained,
+    ...(options?.clearWorkspaceSelection || workspaceSelection === undefined
+      ? {}
+      : { workspaceSelection }),
     text: "",
     attachments: [],
   };
@@ -526,8 +530,11 @@ export async function restoreComposerDraftSnapshot(
   await persistenceQueue.run(() => writePersistedComposerDrafts(next));
 }
 
-export function clearComposerDraftContent(draftKey: string): void {
-  updateComposerDrafts((current) => clearComposerDraftContentState(current, draftKey));
+export function clearComposerDraftContent(
+  draftKey: string,
+  options?: { readonly clearWorkspaceSelection?: boolean },
+): void {
+  updateComposerDrafts((current) => clearComposerDraftContentState(current, draftKey, options));
 }
 
 export function clearComposerDraft(draftKey: string): void {


### PR DESCRIPTION
New tasks on mobile ignored the preferences configured on the server. Setting the default thread mode to "New worktree" did nothing (mobile hardcoded local), a project's default model kept being used even after its provider was disabled or signed out on the server, and one explicit branch/origin pick was silently pinned for that project forever, overriding server defaults for every task after it.

Now mobile resolves these the same way web does:

- Workspace mode falls back to the server's `defaultThreadEnvMode` instead of `"local"`, in both the composer display and the queued-task (offline outbox) path.
- Stored model selections (draft or project default) only apply while their provider instance is enabled, installed, and authenticated; otherwise the server's default model wins. The gate applies at display and at send, so what you see is what dispatches. Offline environments can't be validated, so stored selections pass through untouched there.
- After a task is sent or queued, the draft's workspace selection is dropped so the next task re-resolves mode/branch/origin from server settings (matches web's #4411 decision that workspace context never carries implicitly). Model, runtime, and interaction-mode stickiness are unchanged, as is the regular thread composer.

Verified with mobile typecheck, lint, and the full mobile test suite (98 files / 589 tests), plus new unit tests for the availability gate and the workspace-dropping clear.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what model and workspace settings mobile dispatches when starting or queueing new tasks, including offline outbox payloads; behavior is intentional parity with web and is covered by new tests, but incorrect resolution could mis-target providers or worktrees.
> 
> **Overview**
> Mobile **new-task** flow now matches web for server-driven defaults and stops pinning workspace choices across tasks.
> 
> **Workspace:** Default mode uses the server’s `defaultThreadEnvMode` (not hardcoded local) in the composer and when building **queued/offline** outbox messages. After send or queue, `clearComposerDraftContent` can drop **workspace selection** so the next task re-resolves branch/mode/origin from server settings; model, runtime, and interaction mode stay on the draft.
> 
> **Model:** `resolveSelectableModelSelection` only honors draft or project-default models when the provider is enabled, installed, and authenticated; otherwise resolution falls through to the server default. The same gate runs in the flow provider, send path, and pending-task queue builder. With no server config (offline), stored selections are left unchanged.
> 
> Unit tests cover the availability gate and workspace clearing on new-task draft reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 940f69dfd4c51ab6f8b48ebb361770ae62402cdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix server model, worktree, and origin preferences applying to new tasks in mobile
> - Adds `resolveSelectableModelSelection` in [modelOptions.ts](https://github.com/pingdotgg/t3code/pull/5064/files#diff-e728e5b82529c8d8d8ae7017fbd0ee4021eea3e722dc156b9f3b209951cc7dea) to validate stored model selections against server provider availability, returning null when the provider is disabled, not installed, or unauthenticated.
> - Updates `NewTaskFlowProvider` and `NewTaskDraftScreen` to use this resolver so stale model selections targeting unavailable providers fall back to the server or flow default.
> - Resolves workspace mode from the server's `defaultThreadEnvMode` setting instead of hardcoding `'local'`, so new tasks respect the server's configured default.
> - Extends `clearComposerDraftContent` to accept a `clearWorkspaceSelection` option, used after task creation so the next task re-resolves workspace defaults rather than inheriting the previous selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 940f69d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->