### PR TITLE
fix(oxlint-plugin): Resolve the oxlint bin without assuming a pnpm layout

### DIFF
--- a/oxlint-plugin-t3code/test/utils.ts
+++ b/oxlint-plugin-t3code/test/utils.ts
@@ -9,6 +9,17 @@ import * as Predicate from "effect/Predicate";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as NodeModule from "node:module";
+
+// oxlint is only a transitive dependency (via vite-plus), so its bin placement
+// varies by package manager: pnpm hoists it into the virtual store, while
+// other layouts expose vite-plus's LSP-only wrapper instead. Resolve the real
+// package through vite-plus rather than hardcoding either layout, and do it at
+// module scope so a broken install fails once with a resolution error instead
+// of as an opaque defect in every test.
+const oxlintPackageJsonPath = NodeModule.createRequire(
+  NodeModule.createRequire(import.meta.url).resolve("vite-plus/package.json"),
+).resolve("oxlint/package.json");
 
 class OxlintFixtureFailure extends Data.TaggedError("OxlintFixtureFailure")<{
   readonly exitCode: number;
@@ -93,14 +104,7 @@ export const createOxlintRuleHarness = (
     const configPath = path.join(fixtureDir, ".oxlintrc.json");
     const sourcePath = path.join(fixtureDir, options.filename ?? "fixture.ts");
     const repoRoot = path.join(import.meta.dirname, "..", "..");
-    const oxlintBin = path.join(
-      repoRoot,
-      "node_modules",
-      ".pnpm",
-      "node_modules",
-      ".bin",
-      "oxlint",
-    );
+    const oxlintBin = path.join(path.dirname(oxlintPackageJsonPath), "bin", "oxlint");
     const pluginPath = path.join(repoRoot, "oxlint-plugin-t3code", "index.ts");
 
     yield* fs.writeFileString(
@@ -112,8 +116,13 @@ export const createOxlintRuleHarness = (
     );
     yield* fs.writeFileString(sourcePath, source);
 
+    // Run through the current Node binary: oxlint's bin is an extensionless
+    // shebang script, which Windows cannot spawn directly and which would
+    // otherwise pick up whatever node is first on PATH.
     const output = yield* spawnAndCollectOutput(
-      ChildProcess.make(oxlintBin, ["--config", configPath, sourcePath], { cwd: repoRoot }),
+      ChildProcess.make(process.execPath, [oxlintBin, "--config", configPath, sourcePath], {
+        cwd: repoRoot,
+      }),
     );
 
     if (output.exitCode !== 0) {


### PR DESCRIPTION
## Summary

- The oxlint rule-harness tests hardcoded pnpm's virtual-store hoist path for
  the `oxlint` binary. Resolve the real package through `vite-plus` instead and
  run its bin through the current Node binary, so the suite runs under any
  install layout.

## Problem and Fix

| Problem and Why it Happened | Fix |
| --- | --- |
| `oxlint-plugin-t3code/test/utils.ts` spawned `node_modules/.pnpm/node_modules/.bin/oxlint`, a pnpm-internal hoist path. `oxlint` is only a transitive dependency (via `vite-plus`), so no package manager guarantees a stable `.bin` shim for it: under Bun-style hoisted installs that path does not exist, and the root `node_modules/.bin/oxlint` is vite-plus's LSP-only wrapper ("This oxlint wrapper is for IDE extension use only"). All 35 rule tests fail with `spawn ... ENOENT` on such layouts. | Resolve `oxlint/package.json` with `createRequire`, starting from `vite-plus`'s resolved package directory (the dependency that actually pulls oxlint in), and run the package's own `bin/oxlint`. Module resolution works identically through pnpm's virtual store and hoisted layouts, so the harness no longer depends on any package manager's `.bin` placement. Resolution happens once at module scope, so a broken install fails with a single clear resolution error rather than one opaque defect per test. |

## Defensive Fixes

| Problem and Why it Happened | Fix |
| --- | --- |
| `bin/oxlint` is an extensionless `#!/usr/bin/env node` script. Spawning it directly cannot work on Windows (no shebang handling; the old `.bin` POSIX shim had the same limitation), and on any platform it runs whichever `node` is first on `PATH`, which under version managers can differ from the Node running the tests. | Spawn `process.execPath` with the resolved bin script as the first argument, pinning the interpreter to the Node running vitest and removing the dependence on shebang support and the file's exec bit. |

## Validation

- `vp check`: pass (0 errors, 11 pre-existing warnings)
- `vp run typecheck`: pass
- `oxlint-plugin-t3code`: `vp test run` passes 35/35 under a non-pnpm hoisted
  install layout; before the change all 35 failed with `spawn ENOENT`. Under a
  standard pnpm install the resolved path is the same real `oxlint` package the
  old hardcoded shim pointed at (the pnpm shim ends in
  `exec node "$basedir/../oxlint/bin/oxlint"`), and CI's Test job passes under
  a real pnpm install.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness changes with no production runtime or security impact; behavior under a correct pnpm install stays equivalent to the old shim target.
> 
> **Overview**
> The oxlint rule-harness in `test/utils.ts` no longer spawns a hardcoded pnpm virtual-store path to `oxlint`. It resolves `oxlint/package.json` at module load via `createRequire`, anchored on `vite-plus` (the package that pulls in oxlint), and builds the path to that package’s `bin/oxlint`.
> 
> Harness runs invoke **`process.execPath`** with that script as an argument instead of executing the bin directly, so Windows avoids shebang/extensionless spawn issues and the same Node that runs Vitest interprets the script.
> 
> A bad install now fails once at import with a resolution error instead of `ENOENT` on every rule test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da07e27508bc13abef03fe943cbbaed30f3ad63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix oxlint binary resolution in `oxlint-plugin` to work without a pnpm layout
> - Replaces a hardcoded `.pnpm`-based path with a dynamic resolution using `node:module`'s `createRequire`, resolving `oxlint/package.json` relative to `vite-plus` and deriving the bin path from its directory.
> - Updates process spawning to invoke the oxlint bin script via the current Node executable (`process.execPath`) rather than directly, which avoids shebang issues on Windows.
> - Behavioral Change: module load now fails immediately with a resolution error if `vite-plus` or `oxlint` cannot be resolved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3da07e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->