### PR TITLE
fix(desktop): stop AppImage from contaminating XDG_DATA_DIRS and GSETTINGS_SCHEMA_DIR in spawned terminals

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -173,6 +173,32 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
+  it.effect("restores XDG_DATA_DIRS from the login shell, overwriting the AppImage value", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/bash",
+        PATH: "/usr/bin",
+        XDG_DATA_DIRS: "/tmp/.mount_T3-XXXX/usr/share",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        handler: () =>
+          envOutput({
+            PATH: "/usr/local/bin:/usr/bin:/bin",
+            XDG_DATA_DIRS:
+              "/home/test/.local/share/flatpak/exports/share:/usr/local/share:/usr/share",
+          }),
+      });
+
+      assert.equal(
+        env.XDG_DATA_DIRS,
+        "/home/test/.local/share/flatpak/exports/share:/usr/local/share:/usr/share",
+      );
+    }),
+  );
+
   it.effect("falls back to launchctl PATH on macOS when shell probing does not return one", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -74,6 +74,7 @@ const LOGIN_SHELL_ENV_NAMES = [
   "HOMEBREW_REPOSITORY",
   "XDG_CONFIG_HOME",
   "XDG_DATA_HOME",
+  "XDG_DATA_DIRS",
 ] as const;
 const WINDOWS_PROFILE_ENV_NAMES = ["PATH", "FNM_DIR", "FNM_MULTISHELL_PATH"] as const;
 const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
@@ -381,6 +382,10 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
     }
     if (!config.env.SSH_AUTH_SOCK && shellEnvironment.SSH_AUTH_SOCK) {
       config.env.SSH_AUTH_SOCK = shellEnvironment.SSH_AUTH_SOCK;
+    }
+
+    if (shellEnvironment.XDG_DATA_DIRS) {
+      config.env.XDG_DATA_DIRS = shellEnvironment.XDG_DATA_DIRS;
     }
 
     for (const name of [

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1345,6 +1345,8 @@ it.layer(
           OWD: "/home/user/project",
           PATH: `${appDir}/usr/bin:${appDir}:/usr/local/bin:/usr/bin:/bin`,
           LD_LIBRARY_PATH: `${appDir}/usr/lib:/home/user/.local/lib`,
+          XDG_DATA_DIRS: `${appDir}/usr/share:/home/user/.local/share/flatpak/exports/share`,
+          GSETTINGS_SCHEMA_DIR: `${appDir}/usr/share/glib-2.0/schemas`,
           TEST_TERMINAL_KEEP: "keep-me",
         },
       });
@@ -1364,8 +1366,29 @@ it.layer(
       // mount segments that the runtime prepended.
       expect(spawnInput.env.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
       expect(spawnInput.env.LD_LIBRARY_PATH).toBe("/home/user/.local/lib");
-      // Unrelated host vars still pass through untouched.
+      expect(spawnInput.env.XDG_DATA_DIRS).toBe("/home/user/.local/share/flatpak/exports/share");
+      expect(spawnInput.env.GSETTINGS_SCHEMA_DIR).toBeUndefined();
       expect(spawnInput.env.TEST_TERMINAL_KEEP).toBe("keep-me");
+    }),
+  );
+
+  it.effect("preserves host-set GSETTINGS_SCHEMA_DIR outside the AppImage mount", () =>
+    Effect.gen(function* () {
+      const appDir = "/tmp/.mount_T3Codeabc123";
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        env: {
+          APPIMAGE: "/home/user/T3-Code.AppImage",
+          APPDIR: appDir,
+          GSETTINGS_SCHEMA_DIR: "/usr/share/glib-2.0/schemas",
+          TEST_TERMINAL_KEEP: "keep-me",
+        },
+      });
+      yield* manager.open(openInput());
+      const spawnInput = ptyAdapter.spawnInputs[0];
+      expect(spawnInput).toBeDefined();
+      if (!spawnInput) return;
+
+      expect(spawnInput.env.GSETTINGS_SCHEMA_DIR).toBe("/usr/share/glib-2.0/schemas");
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1072,7 +1072,8 @@ const APPIMAGE_RUNTIME_ENV_KEYS = ["APPIMAGE", "APPDIR", "ARGV0", "OWD"] as cons
 // PATH-style variables the AppImage runtime prepends with its temporary mount
 // (e.g. /tmp/.mount_T3-XXXX/usr/bin). Only the mount segments are dropped; the
 // user's real entries are preserved.
-const APPIMAGE_PATH_LIKE_ENV_KEYS = ["PATH", "LD_LIBRARY_PATH"] as const;
+const APPIMAGE_PATH_LIKE_ENV_KEYS = ["PATH", "LD_LIBRARY_PATH", "XDG_DATA_DIRS"] as const;
+const APPIMAGE_SINGLE_PATH_ENV_KEYS = ["GSETTINGS_SCHEMA_DIR"] as const;
 
 function isPathSegmentUnderAppDir(segment: string, appDir: string): boolean {
   return segment === appDir || segment.startsWith(`${appDir}/`);
@@ -1104,6 +1105,14 @@ function stripAppImageRuntimeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
       if (kept.length > 0) {
         scrubbed[key] = kept.join(":");
       } else {
+        delete scrubbed[key];
+      }
+    }
+
+    for (const key of APPIMAGE_SINGLE_PATH_ENV_KEYS) {
+      const value = scrubbed[key];
+      if (value === undefined) continue;
+      if (isPathSegmentUnderAppDir(value, appDir)) {
         delete scrubbed[key];
       }
     }


### PR DESCRIPTION
## What Changed

- Desktop: probe `XDG_DATA_DIRS` from the login shell and overwrite the AppImage value (same as PATH).
- Server: strip AppImage mount segments from `XDG_DATA_DIRS` and drop `GSETTINGS_SCHEMA_DIR` when it points under the mount.

## Why

Linux AppImage replaces `XDG_DATA_DIRS` and sets `GSETTINGS_SCHEMA_DIR` to its own mount, so spawned terminals can't find system GTK/gsettings schemas. The existing AppImage scrub handled PATH but missed these two.

Closes #5059.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes