### PR TITLE
fix(web): hide T3 Connect toggle in web app settings

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1649,23 +1649,25 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
 
   return (
     <>
-      <SettingsRow
-        title="T3 Connect"
-        description={
-          managedTunnelActive
-            ? "This environment is available to your other devices through T3 Connect."
-            : "Make this environment available to your other devices through T3 Connect."
-        }
-        status={operationError ?? primaryCloudLinkState.error}
-        control={
-          <CloudLinkSwitch
-            checked={managedTunnelActive}
-            disabled={!canManageRelay || !isSignedIn || primaryCloudLinkState.isPending || isBusy}
-            disabledReason={disabledReason}
-            onCheckedChange={(enabled) => void updateManagedTunnel(enabled)}
-          />
-        }
-      />
+      {window.desktopBridge ? (
+        <SettingsRow
+          title="T3 Connect"
+          description={
+            managedTunnelActive
+              ? "This environment is available to your other devices through T3 Connect."
+              : "Make this environment available to your other devices through T3 Connect."
+          }
+          status={operationError ?? primaryCloudLinkState.error}
+          control={
+            <CloudLinkSwitch
+              checked={managedTunnelActive}
+              disabled={!canManageRelay || !isSignedIn || primaryCloudLinkState.isPending || isBusy}
+              disabledReason={disabledReason}
+              onCheckedChange={(enabled) => void updateManagedTunnel(enabled)}
+            />
+          }
+        />
+      ) : null}
       <SettingsRow
         title="Publish agent activity"
         description="Send activity from this environment to your mobile clients for push notifications and Live Activities. Works without a T3 Connect tunnel."


### PR DESCRIPTION
## What Changed

- Gate the "T3 Connect" toggle on `window.desktopBridge` so it only renders in the desktop app.

## Why

T3 Connect managed tunnel is desktop-only. The web app showed the toggle (off by default), making it look like the environment isn't connected when it is. "Publish agent activity" stays — it works without a tunnel.

Closes #5046.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes to screenshot (hiding a row)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide T3 Connect toggle in web app settings when not running on desktop
> In [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/5068/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9), the T3 Connect `SettingsRow` is now conditionally rendered only when `window.desktopBridge` is truthy, hiding it in the web app where it has no effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32d032f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only conditional rendering in settings; no changes to cloud link or tunnel logic.
> 
> **Overview**
> The **T3 Connect** settings row in `ConfiguredCloudLinkRow` now renders only when `window.desktopBridge` is present, so the hosted web app no longer shows a managed-tunnel toggle that only applies to the desktop app.
> 
> **Publish agent activity** is unchanged and still appears in the web app, since mobile publishing does not require a T3 Connect tunnel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d032f535b21422a1af6bd686f6f5096da8ac0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->