### PR TITLE
fix(web): stop wrapping partial code block selections in markdown fences

### DIFF
--- a/apps/web/src/markdown-clipboard.ts
+++ b/apps/web/src/markdown-clipboard.ts
@@ -301,6 +301,17 @@ export function chatMarkdownClipboardPayload(
     if (range.collapsed) continue;
     const container = document.createElement("div");
     container.appendChild(range.cloneContents());
+    const ancestor = range.commonAncestorContainer;
+    const ancestorElement =
+      ancestor.nodeType === Node.ELEMENT_NODE ? (ancestor as Element) : ancestor.parentElement;
+    if (ancestorElement?.closest("pre")) {
+      const text = range.toString();
+      if (text) {
+        texts.push(text);
+        htmls.push(sanitizedHtmlFrom(container));
+      }
+      continue;
+    }
     const text = serializeRenderedMarkdownFragment(container);
     if (!text) continue;
     texts.push(text);


### PR DESCRIPTION
## What Changed

- In `chatMarkdownClipboardPayload`, return `range.toString()` when the selection is inside a `<pre>` instead of running it through the markdown serializer.

## Why

Partial code block selections were wrapped in fences and a language tag. Should copy as plain text.

Closes #4741.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes