### PR TITLE
fix(server): OpenCode model parsing drops models with a slash in the JSON body

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
@@ -125,6 +125,31 @@ describe("parseModelsCliOutput", () => {
     NodeAssert.ok(model.variants);
     NodeAssert.equal(model.variants!["medium"] !== undefined, true);
   });
+
+  it("keeps a model whose JSON body has a slash and no interior whitespace", () => {
+    // OpenRouter-style: the model id contains a `/` and no string value has a
+    // space, so the JSON body line itself matches the slug regex. It must still
+    // be treated as the body of the preceding slug, not a new slug.
+    const stdout = [
+      "openrouter/qwen/qwen3-coder",
+      JSON.stringify({
+        id: "qwen/qwen3-coder",
+        providerID: "openrouter",
+        name: "qwen3-coder",
+        status: "active",
+      }),
+    ].join("\n");
+
+    const result = parseModelsCliOutput(stdout);
+    NodeAssert.equal(result.providers.size, 1);
+    NodeAssert.deepEqual([...result.connected], ["openrouter"]);
+    const provider = result.providers.get("openrouter")!;
+    NodeAssert.ok(provider);
+    const model = provider.models["qwen/qwen3-coder"]!;
+    NodeAssert.ok(model);
+    NodeAssert.equal(model.id, "qwen/qwen3-coder");
+    NodeAssert.equal(model.providerID, "openrouter");
+  });
 });
 
 describe("parseAgentListCliOutput", () => {

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -216,7 +216,13 @@ export function parseModelsCliOutput(stdout: string): {
   };
 
   for (const line of lines) {
-    const slugMatch = SLUG_LINE_RE.exec(line);
+    // A model's JSON body is a single `JSON.stringify` line starting with `{`,
+    // while a provider/model slug is a bare `provider/model` header. Only the
+    // latter can be a slug: without this guard a body line with no interior
+    // whitespace and a `/` in one of its values (e.g. an OpenRouter model whose
+    // `id` is `vendor/model`) matches SLUG_LINE_RE, so flushModel runs against
+    // an empty body and the model is silently dropped.
+    const slugMatch = line.trimStart().startsWith("{") ? null : SLUG_LINE_RE.exec(line);
     if (slugMatch) {
       flushModel();
       currentSlug = slugMatch[1]!;


### PR DESCRIPTION
## What Changed

`parseModelsCliOutput` (`apps/server/src/provider/opencodeRuntime.ts`) now only treats a non-`{` line as a provider/model slug header. Added a regression test.

## Why

The `opencode models` output alternates a `provider/model` slug line and the model's single-line `JSON.stringify` body. The two were told apart with `SLUG_LINE_RE = /^(\S+\/\S+)\s*$/`, which matches **any** line with no interior whitespace that contains a `/`. A JSON body line can satisfy that: an OpenRouter-style model whose `id` is `vendor/model` and whose string values contain no spaces —

```
openrouter/qwen/qwen3-coder
{"id":"qwen/qwen3-coder","providerID":"openrouter","name":"qwen3-coder","status":"active"}
```

— has its body line classified as a new slug, so `flushModel` runs against an empty body and the model is **silently dropped** from the provider list.

A model body is always a single `JSON.stringify` line starting with `{`, and a slug line never is, so a line starting with `{` is never a slug candidate. The added test fails before this change and passes after; all existing parser tests still pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/5072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow parser guard in CLI inventory loading with a targeted regression test; no auth, security, or UI surface.
> 
> **Overview**
> Fixes **silent loss of OpenCode models** when CLI `models` output includes a JSON body line that contains a `/` but no spaces (typical OpenRouter `id` values like `qwen/qwen3-coder`). Those lines incorrectly matched the slug regex and were parsed as new headers, so the preceding model was flushed with an empty body and dropped from the provider list.
> 
> `parseModelsCliOutput` now **skips slug matching** for lines that start with `{` after trimming, since model bodies are always single-line `JSON.stringify` output and slug headers never start that way.
> 
> Adds a regression test for the OpenRouter-style slug + body pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0229ff255cfc51ca7dd270412db3573e5fe62fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseModelsCliOutput` dropping models with a slash in their JSON body
> In [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/5072/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8), `parseModelsCliOutput` was applying `SLUG_LINE_RE` to every line, causing JSON body lines that start with `{` and contain a `/` (e.g. `id: 'qwen/qwen3-coder'`) to be misclassified as new provider/model slugs, which flushed the current model prematurely. The fix skips slug matching for any trimmed line starting with `{`, so those lines are correctly appended to the current JSON body instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0229ff2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->