### PR TITLE
fix(server): use a Cursor todo's title when its content is blank

### DIFF
--- a/apps/server/src/provider/acp/CursorAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpExtension.test.ts
@@ -107,6 +107,25 @@ describe("CursorAcpExtension", () => {
     });
   });
 
+  it("falls back to the title when content is present but blank", () => {
+    expect(
+      extractTodosAsPlan({
+        toolCallId: "todos-2",
+        todos: [
+          { id: "1", content: "", title: "Titled step", status: "pending" },
+          { id: "2", content: "   ", title: "Whitespace content", status: "in_progress" },
+          { id: "3", content: "", title: "", status: "pending" },
+        ],
+        merge: true,
+      }),
+    ).toEqual({
+      plan: [
+        { step: "Titled step", status: "pending" },
+        { step: "Whitespace content", status: "inProgress" },
+      ],
+    });
+  });
+
   it("decodes Cursor list_available_models responses with per-model config options", () => {
     const decoded = CursorListAvailableModelsResponse.make({
       models: [

--- a/apps/server/src/provider/acp/CursorAcpExtension.ts
+++ b/apps/server/src/provider/acp/CursorAcpExtension.ts
@@ -94,7 +94,10 @@ export function extractTodosAsPlan(params: typeof CursorUpdateTodosRequest.Type)
   }>;
 } {
   const plan = params.todos.flatMap((todo) => {
-    const step = todo.content?.trim() ?? todo.title?.trim() ?? "";
+    // Fall back to the title when content is missing OR blank. `??` only
+    // covers a missing content, so a present-but-empty content ("" or
+    // whitespace) would shadow a real title and drop the step below.
+    const step = todo.content?.trim() || todo.title?.trim() || "";
     if (step === "") {
       return [];
     }


### PR DESCRIPTION
## What Changed

`extractTodosAsPlan` (`apps/server/src/provider/acp/CursorAcpExtension.ts`) now uses `||` instead of `??` when falling back from a todo's `content` to its `title`. Added a regression test.

## Why

The step was derived with `todo.content?.trim() ?? todo.title?.trim() ?? ""`. `??` only falls back on null/undefined, so a todo whose `content` is present but empty or whitespace (`""` / `"   "`) keeps the empty string and never falls back to `title` — and is then dropped by the `if (step === "") return []` guard. Both `content` and `title` are optional in `CursorTodo`, so a blank-content-with-title todo is a valid payload that silently loses a real plan step.

Using `||` makes a blank content fall back to the title (matching the trailing `|| ""` default's intent); a missing/blank content with no title still yields `""` and is dropped as before. The added test fails before and passes after.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/5073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parsing fix in Cursor ACP todo-to-plan mapping with a targeted test; no auth, security, or broad behavioral surface beyond plan UI updates from `cursor/update_todos`.
> 
> **Overview**
> **`extractTodosAsPlan`** now picks plan step text with `||` instead of `??` when combining `content` and `title`. Empty or whitespace-only `content` no longer blocks fallback to `title`, so those todos are not dropped by the empty-step guard.
> 
> A regression test covers blank `content` with a real `title`, whitespace `content`, and both fields empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc08c186a2c6e2cde294b4014e90c0ea7363fcf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `extractTodosAsPlan` to use a Cursor todo's title when content is blank
> In [CursorAcpExtension.ts](https://github.com/pingdotgg/t3code/pull/5073/files#diff-253a39f0df72941d62ebf067c20543e5f060f4ef874c813608f6bf40fe905bb0), the fallback from `content` to `title` used `??` (nullish coalescing), so whitespace-only content suppressed a valid title. Switching to `||` (logical OR) ensures blank or whitespace-only content falls back to the title, preventing those todos from being silently dropped from the plan.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc08c18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->