### PR TITLE
fix(shell): add ~/.local/bin to the Windows CLI resolver so native-installed providers are found

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -230,6 +230,7 @@ describe("DesktopShellEnvironment", () => {
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+          "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
           "C:\\Custom\\Bin",

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -158,7 +158,7 @@ const knownWindowsCliDirs = (env: NodeJS.ProcessEnv): ReadonlyArray<string> => [
   ...trimNonEmpty(env.USERPROFILE).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}\\.bun\\bin`, `${value}\\scoop\\shims`],
+      onSome: (value) => [`${value}\\.local\\bin`, `${value}\\.bun\\bin`, `${value}\\scoop\\shims`],
     }),
   ),
 ];

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -336,6 +336,7 @@ describe("resolveKnownWindowsCliDirs", () => {
       "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
       "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
       "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+      "C:\\Users\\testuser\\.local\\bin",
       "C:\\Users\\testuser\\.bun\\bin",
       "C:\\Users\\testuser\\scoop\\shims",
     ]);
@@ -476,6 +477,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+          "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
           "C:\\Shell\\Bin",
@@ -524,6 +526,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+          "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
           "C:\\Shell\\Bin",
@@ -564,6 +567,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
       ).toEqual({
         PATH: [
           "C:\\Users\\testuser\\AppData\\Roaming\\npm",
+          "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
           "C:\\Windows\\System32",

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -617,7 +617,9 @@ export function resolveKnownWindowsCliDirs(env: NodeJS.ProcessEnv): ReadonlyArra
     ...(appData ? [`${appData}\\npm`] : []),
     ...(localAppData ? [`${localAppData}\\Programs\\nodejs`, `${localAppData}\\Volta\\bin`] : []),
     ...(localAppData ? [`${localAppData}\\pnpm`] : []),
-    ...(userProfile ? [`${userProfile}\\.bun\\bin`, `${userProfile}\\scoop\\shims`] : []),
+    ...(userProfile
+      ? [`${userProfile}\\.local\\bin`, `${userProfile}\\.bun\\bin`, `${userProfile}\\scoop\\shims`]
+      : []),
   ];
 }
 


### PR DESCRIPTION
## What Changed

Added `%USERPROFILE%\.local\bin` to the known-Windows-CLI-directory list in both the shared `resolveKnownWindowsCliDirs` (`packages/shared/src/shell.ts`) and its desktop twin `knownWindowsCliDirs` (`apps/desktop/src/shell/DesktopShellEnvironment.ts`). Updated both existing byte-for-byte tests.

## Why

Closes #4846.

On Windows the process can start with a stale `PATH` that predates the installer writing to the User `Path`, so both resolvers merge a fixed list of known CLI install dirs into `PATH`. That list included Bun and Scoop but **not** `%USERPROFILE%\.local\bin` — the directory the **Claude native installer** uses on Windows. So `claude.exe` at `%USERPROFILE%\.local\bin\claude.exe` was never discovered even though it was installed (same PATH-resolution family as #4697).

The two copies are kept in sync (server-side resolver + desktop shell environment). Reverting either source file fails its updated test; both pass with the change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive PATH entry in two mirrored helpers with test-only verification; no auth or data handling changes.
> 
> **Overview**
> On Windows, when the process starts with a **stale `PATH`**, the app merges a fixed list of known CLI install directories so tools like **npm**, **Bun**, and **Scoop** still resolve. That list did not include **`%USERPROFILE%\.local\bin`**, where the **Claude native installer** (and similar tools) place binaries on Windows—so `claude.exe` could be installed but never found.
> 
> This PR adds **`%USERPROFILE%\.local\bin`** to that list in both places it is defined: shared **`resolveKnownWindowsCliDirs`** and desktop **`knownWindowsCliDirs`**, placed before `.bun\bin` and `scoop\shims`. Tests that assert the full merged `PATH` were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57add958be818a889f9b92ae6674c009b13bbaa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `~/.local/bin` to Windows CLI resolver so natively-installed providers are found
> Adds `%USERPROFILE%\.local\bin` to the known Windows CLI directories in both [`shell.ts`](https://github.com/pingdotgg/t3code/pull/5074/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) and [`DesktopShellEnvironment.ts`](https://github.com/pingdotgg/t3code/pull/5074/files#diff-ed26aa44c93ddc9fedab8bc7cf7aa64c7b0b8fc0e22a3960d5c02c30c940dabd). The path is inserted before `.bun\bin` and `scoop\shims` in the priority order, and is only included when `USERPROFILE` is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57add95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->