### PR TITLE
fix(server): scrub AppImage XDG_DATA_DIRS and GSETTINGS_SCHEMA_DIR from terminals

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1345,6 +1345,8 @@ it.layer(
           OWD: "/home/user/project",
           PATH: `${appDir}/usr/bin:${appDir}:/usr/local/bin:/usr/bin:/bin`,
           LD_LIBRARY_PATH: `${appDir}/usr/lib:/home/user/.local/lib`,
+          XDG_DATA_DIRS: `${appDir}/usr/share:/usr/local/share:/usr/share`,
+          GSETTINGS_SCHEMA_DIR: `${appDir}/usr/share/glib-2.0/schemas`,
           TEST_TERMINAL_KEEP: "keep-me",
         },
       });
@@ -1364,6 +1366,11 @@ it.layer(
       // mount segments that the runtime prepended.
       expect(spawnInput.env.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
       expect(spawnInput.env.LD_LIBRARY_PATH).toBe("/home/user/.local/lib");
+      // XDG_DATA_DIRS keeps the host entries but drops the AppImage share dir.
+      expect(spawnInput.env.XDG_DATA_DIRS).toBe("/usr/local/share:/usr/share");
+      // GSETTINGS_SCHEMA_DIR pointed only at the mount, so it is removed and
+      // gsettings falls back to the host schema location.
+      expect(spawnInput.env.GSETTINGS_SCHEMA_DIR).toBeUndefined();
       // Unrelated host vars still pass through untouched.
       expect(spawnInput.env.TEST_TERMINAL_KEEP).toBe("keep-me");
     }),

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1069,10 +1069,19 @@ function shouldExcludeTerminalEnvKey(key: string): boolean {
 // They describe the AppImage itself, not the user's session, so terminals must
 // not inherit them.
 const APPIMAGE_RUNTIME_ENV_KEYS = ["APPIMAGE", "APPDIR", "ARGV0", "OWD"] as const;
-// PATH-style variables the AppImage runtime prepends with its temporary mount
-// (e.g. /tmp/.mount_T3-XXXX/usr/bin). Only the mount segments are dropped; the
-// user's real entries are preserved.
-const APPIMAGE_PATH_LIKE_ENV_KEYS = ["PATH", "LD_LIBRARY_PATH"] as const;
+// Colon-separated search-path variables the AppImage runtime points at its
+// temporary mount (e.g. /tmp/.mount_T3-XXXX/usr/bin, the bundled glib schemas,
+// and an $APPDIR/usr/share XDG data entry). Only the mount segments are
+// dropped; the user's real entries are preserved. When nothing but mount
+// segments remain the variable is removed entirely so consumers fall back to
+// their platform default (e.g. gsettings finds the host schemas instead of
+// reporting "No schemas installed"). See issues #1699 and #5059.
+const APPIMAGE_PATH_LIKE_ENV_KEYS = [
+  "PATH",
+  "LD_LIBRARY_PATH",
+  "XDG_DATA_DIRS",
+  "GSETTINGS_SCHEMA_DIR",
+] as const;
 
 function isPathSegmentUnderAppDir(segment: string, appDir: string): boolean {
   return segment === appDir || segment.startsWith(`${appDir}/`);


### PR DESCRIPTION
## What Changed

Added `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR` to the AppImage environment scrub in `apps/server/src/terminal/Manager.ts`. Extended the existing AppImage terminal test.

## Why

Closes #5059.

The integrated terminal inherits the server process environment. On Linux AppImage builds the runtime's `AppRun` points `XDG_DATA_DIRS` at an `$APPDIR/usr/share` entry and `GSETTINGS_SCHEMA_DIR` at the bundled `$APPDIR/usr/share/glib-2.0/schemas`. The existing scrub (added for #1699) only cleaned `PATH`/`LD_LIBRARY_PATH`, so those two leaked into the PTY and `gsettings` inside the terminal reported "No schemas installed".

Both are colon-separated search paths, so they join the same `APPIMAGE_PATH_LIKE_ENV_KEYS` scrub: the AppImage mount segments are dropped, the user's real entries preserved, and when only mount segments remain the variable is removed so the shell falls back to the platform default. The added assertions fail before and pass after; all 50 Manager tests pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Linux AppImage terminal spawn env scrubbing with existing path-filter logic and test coverage; no change when not launched from an AppImage.
> 
> **Overview**
> Extends the **AppImage terminal environment scrub** so integrated PTYs no longer inherit `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR` mount paths from the server process (fixes **#5059**, alongside existing **#1699** scrub for `PATH` / `LD_LIBRARY_PATH`).
> 
> Both variables are treated like other colon-separated search paths: AppImage `$APPDIR` segments are stripped, host entries stay, and if only mount segments remain the variable is **removed** so tools like `gsettings` use host defaults instead of reporting missing bundled schemas.
> 
> The AppImage terminal test now asserts scrubbed `XDG_DATA_DIRS` and undefined `GSETTINGS_SCHEMA_DIR` when it pointed only at the mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23781bb1a78974c64d8fdafeefe7cc1756220b4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scrub `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR` from terminal environments when launched via AppImage
> Extends `APPIMAGE_PATH_LIKE_ENV_VARS` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/5075/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e) to strip AppImage mount segments from `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR` when spawning terminals. If stripping leaves a variable with no remaining entries, the variable is removed entirely from the environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23781bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->