### PR TITLE
fix(server): surface cloudflared FTL/PNC relay logs as warnings, not debug

### DIFF
--- a/apps/server/src/cloud/ManagedEndpointRuntime.test.ts
+++ b/apps/server/src/cloud/ManagedEndpointRuntime.test.ts
@@ -96,6 +96,15 @@ describe("CloudManagedEndpointRuntime", () => {
         "2026-06-17T02:00:00Z INF Starting metrics server",
       ),
     ).toBe("debug");
+    // FTL (fatal) and PNC (panic) are more severe than ERR and must surface.
+    expect(
+      ManagedEndpointRuntime.classifyRelayClientOutput(
+        "2026-06-17T02:00:00Z FTL Cannot determine default origin certificate path",
+      ),
+    ).toBe("warning");
+    expect(
+      ManagedEndpointRuntime.classifyRelayClientOutput("2026-06-17T02:00:00Z PNC runtime panic"),
+    ).toBe("warning");
   });
 
   it.effect("starts, deduplicates, rotates, and stops the Cloudflare connector", () =>

--- a/apps/server/src/cloud/ManagedEndpointRuntime.ts
+++ b/apps/server/src/cloud/ManagedEndpointRuntime.ts
@@ -72,7 +72,10 @@ export function classifyRelayClientOutput(line: string): "connected" | "warning"
   if (/\bRegistered tunnel connection\b/iu.test(line)) {
     return "connected";
   }
-  return /\b(?:ERR|WRN)\b/u.test(line) ? "warning" : "debug";
+  // cloudflared uses zerolog level tokens. FTL (fatal) and PNC (panic) are more
+  // severe than ERR, so they must surface at least as loudly — without them a
+  // fatal connector failure would be logged at debug and hidden.
+  return /\b(?:ERR|WRN|FTL|PNC)\b/u.test(line) ? "warning" : "debug";
 }
 
 function runtimeConfigKey(config: RelayManagedEndpointRuntimeConfig): string {


### PR DESCRIPTION
## What Changed

`classifyRelayClientOutput` (`apps/server/src/cloud/ManagedEndpointRuntime.ts`) now treats the cloudflared `FTL` and `PNC` zerolog level tokens as warnings, alongside the existing `ERR`/`WRN`. Extended the existing classifier test.

## Why

The function classifies relay-connector (cloudflared) output into `connected` / `warning` / `debug` severities. It only matched `ERR` and `WRN`, so `FTL` (fatal) and `PNC` (panic) — both strictly **more** severe than `ERR` — fell through to `debug`, the quietest level. A fatal connector failure (e.g. `FTL Cannot determine default origin certificate path`, or a runtime panic that takes T3 Connect down) was therefore logged at debug and effectively hidden exactly when someone is diagnosing why the relay went offline.

Adding `FTL`/`PNC` to the warning set makes the most severe relay failures surface at least as loudly as ordinary errors. The added assertions fail before this change and pass after.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow logging-severity tweak in relay output classification with matching unit tests; no auth, data, or runtime behavior changes beyond log visibility.
> 
> **Overview**
> **Relay log classification** for cloudflared output now treats zerolog **`FTL`** (fatal) and **`PNC`** (panic) like **`ERR`**/`WRN`, so those lines are logged via `logWarning` instead of `logDebug`.
> 
> Before this change, the most severe connector failures (certificate path fatals, runtime panics) were effectively hidden at debug level when diagnosing relay outages. Tests assert FTL and PNC map to `warning`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1add90c145a585fb054a4505be77ec2c01989fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface cloudflared FTL and PNC relay logs as warnings instead of debug
> Expands the regex in `classifyRelayClientOutput` in [ManagedEndpointRuntime.ts](https://github.com/pingdotgg/t3code/pull/5076/files#diff-7e51d782034aeae3187abebda413ecbd44a5d6b4f7caf5ede93d4e38a474ec53) from `/\b(?:ERR|WRN)\b/u` to `/\b(?:ERR|WRN|FTL|PNC)\b/u`, so zerolog fatal and panic level tokens are treated as warnings rather than debug output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1add90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->