### PR TITLE
Show provider usage-limit stops in the UI instead of failing silently

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1081,6 +1081,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         runtimeMode: event.payload.session.runtimeMode,
         activeTurnId: event.payload.session.activeTurnId,
         lastError: event.payload.session.lastError,
+        usageLimit: event.payload.session.usageLimit ?? null,
         updatedAt: event.payload.session.updatedAt,
       });
     });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -5,6 +5,7 @@ import {
   MessageId,
   NonNegativeInt,
   OrchestrationCheckpointFile,
+  OrchestrationSessionUsageLimit,
   OrchestrationProposedPlanId,
   OrchestrationReadModel,
   OrchestrationThreadSearchSource,
@@ -87,7 +88,12 @@ const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
     sequence: Schema.NullOr(NonNegativeInt),
   }),
 );
-const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession;
+// `usage_limit` is a nullable JSON text column.
+const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession.mapFields(
+  Struct.assign({
+    usageLimit: Schema.NullOr(Schema.fromJsonString(OrchestrationSessionUsageLimit)),
+  }),
+);
 const ProjectionCheckpointDbRowSchema = ProjectionCheckpoint.mapFields(
   Struct.assign({
     files: Schema.fromJsonString(Schema.Array(OrchestrationCheckpointFile)),
@@ -266,6 +272,7 @@ function mapSessionRow(
     runtimeMode: row.runtimeMode,
     activeTurnId: row.activeTurnId,
     lastError: row.lastError,
+    ...(row.usageLimit !== null ? { usageLimit: row.usageLimit } : {}),
     updatedAt: row.updatedAt,
   };
 }
@@ -546,6 +553,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          usage_limit AS "usageLimit",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         ORDER BY thread_id ASC
@@ -567,6 +575,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.runtime_mode AS "runtimeMode",
           sessions.active_turn_id AS "activeTurnId",
           sessions.last_error AS "lastError",
+          sessions.usage_limit AS "usageLimit",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
         INNER JOIN projection_threads threads
@@ -592,6 +601,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.runtime_mode AS "runtimeMode",
           sessions.active_turn_id AS "activeTurnId",
           sessions.last_error AS "lastError",
+          sessions.usage_limit AS "usageLimit",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
         INNER JOIN projection_threads threads
@@ -983,6 +993,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          usage_limit AS "usageLimit",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         WHERE thread_id = ${threadId}
@@ -1290,6 +1301,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   runtimeMode: row.runtimeMode,
                   activeTurnId: row.activeTurnId,
                   lastError: row.lastError,
+                  ...(row.usageLimit !== null ? { usageLimit: row.usageLimit } : {}),
                   updatedAt: row.updatedAt,
                 });
               }

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1248,6 +1248,9 @@ const make = Effect.gen(function* () {
         runtimeMode: thread.session?.runtimeMode ?? DEFAULT_RUNTIME_MODE,
         activeTurnId: null,
         lastError: thread.session?.lastError ?? null,
+        // A session stopped while out of usage keeps its banner; only a new
+        // turn (or a reopened window) clears it.
+        usageLimit: thread.session?.usageLimit ?? null,
         updatedAt: now,
       },
       createdAt: now,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -361,6 +361,125 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("turn failed");
   });
 
+  it("surfaces a usage-limit turn completion as a session banner plus work-log row", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-usage-limit-turn-started"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-usage-limit"),
+    });
+
+    await waitForThread(harness.readModel, (thread) => thread.session?.status === "running");
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-usage-limit-turn-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-usage-limit"),
+      payload: {
+        state: "interrupted",
+        errorMessage: "5-hour usage limit reached.",
+        usageLimit: {
+          windowType: "five_hour",
+          resetsAt: 1_800_000_000_000,
+          message: "5-hour usage limit reached.",
+        },
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.session?.usageLimit != null &&
+        entry.activities.some(
+          (activity: ProviderRuntimeTestActivity) => activity.kind === "usage-limit.reached",
+        ),
+    );
+
+    // Out of usage is not an error status and must not populate lastError.
+    expect(thread.session?.status).toBe("ready");
+    expect(thread.session?.lastError).toBe(null);
+    expect(thread.session?.usageLimit).toEqual({
+      windowType: "five_hour",
+      resetsAt: 1_800_000_000_000,
+      message: "5-hour usage limit reached.",
+      provider: "codex",
+    });
+    const activity = thread.activities.find(
+      (entry: ProviderRuntimeTestActivity) => entry.kind === "usage-limit.reached",
+    );
+    expect(activity?.summary).toBe("Usage limit reached");
+    expect(activity?.tone).toBe("info");
+    expect(activity?.payload).toEqual({
+      message: "5-hour usage limit reached.",
+      windowType: "five_hour",
+      resetsAt: 1_800_000_000_000,
+      provider: "codex",
+    });
+  });
+
+  it("sets and clears the usage-limit banner from account.rate-limits.updated", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    // Raw provider shape only (no normalized fields): ingestion must tolerate it.
+    harness.emit({
+      type: "account.rate-limits.updated",
+      eventId: asEventId("evt-rate-limits-rejected"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      payload: {
+        rateLimits: {
+          rate_limit_info: {
+            status: "rejected",
+            rateLimitType: "seven_day",
+            resetsAt: 1_800_000_000,
+          },
+        },
+      },
+    });
+
+    let thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.usageLimit != null,
+    );
+    expect(thread.session?.usageLimit).toEqual({
+      windowType: "seven_day",
+      resetsAt: 1_800_000_000_000,
+      message: "weekly usage limit reached. Resets at 2027-01-15T08:00:00.000Z.",
+      provider: "codex",
+    });
+    // A rejected window on its own is not a work-log event.
+    expect(
+      thread.activities.some(
+        (entry: ProviderRuntimeTestActivity) => entry.kind === "usage-limit.reached",
+      ),
+    ).toBe(false);
+
+    harness.emit({
+      type: "account.rate-limits.updated",
+      eventId: asEventId("evt-rate-limits-allowed"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      payload: {
+        rateLimits: {},
+        status: "allowed",
+      },
+    });
+
+    thread = await waitForThread(harness.readModel, (entry) => entry.session?.usageLimit == null);
+    expect(thread.session?.usageLimit ?? null).toBe(null);
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -16,6 +16,10 @@ import {
   type OrchestrationThread,
   type OrchestrationThreadActivity,
   type ProviderRuntimeEvent,
+  type AccountRateLimitsUpdatedPayload,
+  type OrchestrationSessionUsageLimit,
+  type RuntimeRateLimitStatus,
+  type RuntimeUsageLimit,
 } from "@t3tools/contracts";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
@@ -26,6 +30,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { buildUsageLimitMessage, normalizeUsageLimitResetsAt } from "@t3tools/shared/usageLimit";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
@@ -306,6 +311,87 @@ function requestKindFromCanonicalRequestType(
   }
 }
 
+/**
+ * Provider-agnostic read of an `account.rate-limits.updated` payload.
+ *
+ * Adapters normalize onto the `status`/`windowType`/`resetsAt` fields, but the
+ * raw provider snapshot is tolerated as a fallback so an emitter that hasn't
+ * been updated (or a replayed historical event) still parses instead of
+ * throwing. Returns `undefined` when no window state can be determined.
+ */
+export function readRuntimeRateLimitSnapshot(payload: AccountRateLimitsUpdatedPayload): {
+  readonly status: RuntimeRateLimitStatus;
+  readonly windowType?: string;
+  readonly resetsAt?: number;
+} | null {
+  const fallback = (() => {
+    const raw = payload.rateLimits;
+    if (!raw || typeof raw !== "object") {
+      return null;
+    }
+    const info = (raw as Record<string, unknown>).rate_limit_info;
+    if (!info || typeof info !== "object") {
+      return null;
+    }
+    const record = info as Record<string, unknown>;
+    const status =
+      record.status === "rejected"
+        ? ("rejected" as const)
+        : record.status === "allowed_warning"
+          ? ("warning" as const)
+          : record.status === "allowed"
+            ? ("allowed" as const)
+            : null;
+    if (status === null) {
+      return null;
+    }
+    return {
+      status,
+      ...(typeof record.rateLimitType === "string" ? { windowType: record.rateLimitType } : {}),
+      ...(normalizeUsageLimitResetsAt(record.resetsAt) !== undefined
+        ? { resetsAt: normalizeUsageLimitResetsAt(record.resetsAt) as number }
+        : {}),
+    };
+  })();
+
+  if (payload.status === undefined) {
+    return fallback;
+  }
+  const windowType = payload.windowType ?? fallback?.windowType;
+  const resetsAt = payload.resetsAt ?? fallback?.resetsAt;
+  return {
+    status: payload.status,
+    ...(windowType ? { windowType } : {}),
+    ...(resetsAt !== undefined ? { resetsAt } : {}),
+  };
+}
+
+/**
+ * Field-wise equality so repeated rate-limit notifications for an unchanged
+ * window don't churn the session projection.
+ */
+function sameUsageLimit(
+  left: OrchestrationSessionUsageLimit | null,
+  right: OrchestrationSessionUsageLimit | null,
+): boolean {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  return (
+    left.message === right.message &&
+    left.windowType === right.windowType &&
+    left.resetsAt === right.resetsAt &&
+    left.provider === right.provider
+  );
+}
+
+/**
+ * Usage-limit marker carried by a `turn.completed` event, if any.
+ */
+function usageLimitFromTurnCompleted(event: ProviderRuntimeEvent): RuntimeUsageLimit | null {
+  return event.type === "turn.completed" ? (event.payload.usageLimit ?? null) : null;
+}
+
 export function runtimeEventToActivities(
   event: ProviderRuntimeEvent,
   taskTitle?: string,
@@ -382,6 +468,34 @@ export function runtimeEventToActivities(
           summary: "Runtime error",
           payload: {
             message: truncateDetail(event.payload.message),
+          },
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
+    // Emitted at the point the run stopped, so the work log shows the reason
+    // inline. Deliberately sourced from `turn.completed` rather than from
+    // `account.rate-limits.updated`: a rejected window can be announced
+    // repeatedly (and while idle), but only one of those actually halts a run.
+    case "turn.completed": {
+      const usageLimit = event.payload.usageLimit;
+      if (!usageLimit) {
+        return [];
+      }
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "usage-limit.reached",
+          summary: "Usage limit reached",
+          payload: {
+            message: usageLimit.message,
+            ...(usageLimit.windowType ? { windowType: usageLimit.windowType } : {}),
+            ...(usageLimit.resetsAt !== undefined ? { resetsAt: usageLimit.resetsAt } : {}),
+            provider: event.provider,
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
@@ -1380,7 +1494,10 @@ const make = Effect.gen(function* () {
             case "session.exited":
               return "stopped";
             case "turn.completed":
-              return normalizeRuntimeTurnState(event.payload.state) === "failed"
+              // A usage-limit stop is an expected pause, never an error
+              // status: the banner (session.usageLimit) carries the meaning.
+              return normalizeRuntimeTurnState(event.payload.state) === "failed" &&
+                event.payload.usageLimit === undefined
                 ? "error"
                 : "ready";
             case "session.started":
@@ -1401,15 +1518,34 @@ const make = Effect.gen(function* () {
                   )
                 ? null
                 : activeTurnId;
+        const turnUsageLimit = usageLimitFromTurnCompleted(event);
         const lastError =
-          event.type === "session.state.changed" && event.payload.state === "error"
-            ? (event.payload.reason ?? thread.session?.lastError ?? "Provider session error")
-            : event.type === "turn.completed" &&
-                normalizeRuntimeTurnState(event.payload.state) === "failed"
-              ? (event.payload.errorMessage ?? thread.session?.lastError ?? "Turn failed")
-              : status === "ready"
-                ? null
-                : (thread.session?.lastError ?? null);
+          turnUsageLimit !== null
+            ? null
+            : event.type === "session.state.changed" && event.payload.state === "error"
+              ? (event.payload.reason ?? thread.session?.lastError ?? "Provider session error")
+              : event.type === "turn.completed" &&
+                  normalizeRuntimeTurnState(event.payload.state) === "failed"
+                ? (event.payload.errorMessage ?? thread.session?.lastError ?? "Turn failed")
+                : status === "ready"
+                  ? null
+                  : (thread.session?.lastError ?? null);
+        // A new turn means usage was available again; anything else carries
+        // the previously observed limit forward until it is explicitly
+        // cleared by a turn start or an "allowed" rate-limit event.
+        const usageLimit =
+          turnUsageLimit !== null
+            ? {
+                ...(turnUsageLimit.windowType ? { windowType: turnUsageLimit.windowType } : {}),
+                ...(turnUsageLimit.resetsAt !== undefined
+                  ? { resetsAt: turnUsageLimit.resetsAt }
+                  : {}),
+                message: turnUsageLimit.message,
+                provider: event.provider,
+              }
+            : event.type === "turn.started"
+              ? null
+              : (thread.session?.usageLimit ?? null);
 
         if (shouldApplyThreadLifecycle) {
           if (event.type === "turn.started" && acceptedTurnStartedSourcePlan !== null) {
@@ -1446,6 +1582,7 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: nextActiveTurnId,
               lastError,
+              usageLimit,
               updatedAt: now,
             },
             createdAt: now,
@@ -1674,6 +1811,40 @@ const make = Effect.gen(function* () {
         yield* clearTurnStateForSession(thread.id);
       }
 
+      // A rejected window sets (and an open window clears) the session-level
+      // usage-limit banner without touching lifecycle status: being out of
+      // usage is not a session malfunction.
+      if (event.type === "account.rate-limits.updated") {
+        const snapshot = readRuntimeRateLimitSnapshot(event.payload);
+        const nextUsageLimit =
+          snapshot === null
+            ? undefined
+            : snapshot.status === "rejected"
+              ? {
+                  ...(snapshot.windowType ? { windowType: snapshot.windowType } : {}),
+                  ...(snapshot.resetsAt !== undefined ? { resetsAt: snapshot.resetsAt } : {}),
+                  message: buildUsageLimitMessage(snapshot),
+                  provider: event.provider,
+                }
+              : null;
+        const currentUsageLimit = thread.session?.usageLimit ?? null;
+        const changed =
+          nextUsageLimit !== undefined && !sameUsageLimit(nextUsageLimit, currentUsageLimit);
+        if (changed && thread.session) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.session.set",
+            commandId: yield* providerCommandId(event, "rate-limits-session-set"),
+            threadId: thread.id,
+            session: {
+              ...thread.session,
+              usageLimit: nextUsageLimit ?? null,
+              updatedAt: now,
+            },
+            createdAt: now,
+          });
+        }
+      }
+
       if (event.type === "runtime.error") {
         const runtimeErrorMessage = event.payload.message;
 
@@ -1696,6 +1867,7 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: eventTurnId ?? null,
               lastError: runtimeErrorMessage,
+              usageLimit: thread.session?.usageLimit ?? null,
               updatedAt: now,
             },
             createdAt: now,

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -7,6 +7,7 @@ import {
   type OrchestrationEvent,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import { it as effectIt } from "@effect/vitest";
 import { describe, expect, it } from "vite-plus/test";
 
 import { createEmptyReadModel, projectEvent } from "./projector.ts";
@@ -237,6 +238,100 @@ describe("orchestration projector", () => {
     expect(next.updatedAt).toBe("2026-01-01T00:00:00.000Z");
     expect(next.threads).toEqual([]);
   });
+
+  effectIt.effect("settles a usage-limited turn as interrupted rather than completed", () =>
+    Effect.gen(function* () {
+      const createdAt = "2026-02-23T08:00:00.000Z";
+      const startedAt = "2026-02-23T08:00:05.000Z";
+      const settledAt = "2026-02-23T08:01:00.000Z";
+
+      const afterCreate = yield* projectEvent(
+        createEmptyReadModel(createdAt),
+        makeEvent({
+          sequence: 1,
+          type: "thread.created",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: createdAt,
+          commandId: "cmd-create",
+          payload: {
+            threadId: "thread-1",
+            projectId: "project-1",
+            title: "demo",
+            modelSelection: {
+              provider: ProviderDriverKind.make("codex"),
+              model: "gpt-5.3-codex",
+            },
+            runtimeMode: "full-access",
+            branch: null,
+            worktreePath: null,
+            createdAt,
+            updatedAt: createdAt,
+          },
+        }),
+      );
+
+      const afterRunning = yield* projectEvent(
+        afterCreate,
+        makeEvent({
+          sequence: 2,
+          type: "thread.session-set",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: startedAt,
+          commandId: "cmd-running",
+          payload: {
+            threadId: "thread-1",
+            session: {
+              threadId: "thread-1",
+              status: "running",
+              providerName: "codex",
+              runtimeMode: "approval-required",
+              activeTurnId: "turn-1",
+              lastError: null,
+              updatedAt: startedAt,
+            },
+          },
+        }),
+      );
+
+      const afterLimit = yield* projectEvent(
+        afterRunning,
+        makeEvent({
+          sequence: 3,
+          type: "thread.session-set",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: settledAt,
+          commandId: "cmd-usage-limit",
+          payload: {
+            threadId: "thread-1",
+            session: {
+              threadId: "thread-1",
+              status: "ready",
+              providerName: "codex",
+              runtimeMode: "approval-required",
+              activeTurnId: null,
+              lastError: null,
+              usageLimit: {
+                windowType: "five_hour",
+                resetsAt: 1_800_000_000_000,
+                message: "5-hour usage limit reached.",
+                provider: "codex",
+              },
+              updatedAt: settledAt,
+            },
+          },
+        }),
+      );
+
+      const thread = afterLimit.threads[0];
+      expect(thread?.session?.usageLimit?.windowType).toBe("five_hour");
+      // The run did not finish, it ran out of usage.
+      expect(thread?.latestTurn?.state).toBe("interrupted");
+      expect(thread?.latestTurn?.completedAt).toBe(settledAt);
+    }),
+  );
 
   it("tracks latest turn id from session lifecycle events", async () => {
     const createdAt = "2026-02-23T08:00:00.000Z";

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -523,7 +523,12 @@ export function projectEvent(
 
         // Leaving the "running" session status is the turn-end signal: settle
         // a still-running latest turn so its duration reflects the whole turn.
-        const settledTurnState = settledTurnStateForSessionStatus(session.status);
+        // A usage-limit stop settles as "interrupted", not "completed":
+        // the run did not finish, it ran out of usage.
+        const settledTurnState =
+          session.usageLimit != null
+            ? ("interrupted" as const)
+            : settledTurnStateForSessionStatus(session.status);
         return {
           ...nextBase,
           threads: updateThread(nextBase.threads, payload.threadId, {

--- a/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
@@ -1,9 +1,12 @@
+import { OrchestrationSessionUsageLimit } from "@t3tools/contracts";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Struct from "effect/Struct";
 
-import { toPersistenceSqlError } from "../Errors.ts";
+import { toPersistenceDecodeError, toPersistenceSqlError } from "../Errors.ts";
 
 import {
   ProjectionThreadSession,
@@ -13,11 +16,25 @@ import {
   GetProjectionThreadSessionInput,
 } from "../Services/ProjectionThreadSessions.ts";
 
+// `usage_limit` is a nullable JSON text column.
+const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession.mapFields(
+  Struct.assign({
+    usageLimit: Schema.NullOr(Schema.fromJsonString(OrchestrationSessionUsageLimit)),
+  }),
+);
+
+function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: string) {
+  return (cause: unknown) =>
+    Schema.isSchemaError(cause)
+      ? toPersistenceDecodeError(decodeOperation)(cause)
+      : toPersistenceSqlError(sqlOperation)(cause);
+}
+
 const makeProjectionThreadSessionRepository = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
 
   const upsertProjectionThreadSessionRow = SqlSchema.void({
-    Request: ProjectionThreadSession,
+    Request: ProjectionThreadSessionDbRowSchema,
     execute: (row) =>
       sql`
         INSERT INTO projection_thread_sessions (
@@ -28,6 +45,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode,
           active_turn_id,
           last_error,
+          usage_limit,
           updated_at
         )
         VALUES (
@@ -38,6 +56,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           ${row.runtimeMode},
           ${row.activeTurnId},
           ${row.lastError},
+          ${row.usageLimit},
           ${row.updatedAt}
         )
         ON CONFLICT (thread_id)
@@ -48,13 +67,14 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode = excluded.runtime_mode,
           active_turn_id = excluded.active_turn_id,
           last_error = excluded.last_error,
+          usage_limit = excluded.usage_limit,
           updated_at = excluded.updated_at
       `,
   });
 
   const getProjectionThreadSessionRow = SqlSchema.findOneOption({
     Request: GetProjectionThreadSessionInput,
-    Result: ProjectionThreadSession,
+    Result: ProjectionThreadSessionDbRowSchema,
     execute: ({ threadId }) =>
       sql`
         SELECT
@@ -65,6 +85,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          usage_limit AS "usageLimit",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         WHERE thread_id = ${threadId}
@@ -82,13 +103,21 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
 
   const upsert: ProjectionThreadSessionRepositoryShape["upsert"] = (row) =>
     upsertProjectionThreadSessionRow(row).pipe(
-      Effect.mapError(toPersistenceSqlError("ProjectionThreadSessionRepository.upsert:query")),
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProjectionThreadSessionRepository.upsert:query",
+          "ProjectionThreadSessionRepository.upsert:encode",
+        ),
+      ),
     );
 
   const getByThreadId: ProjectionThreadSessionRepositoryShape["getByThreadId"] = (input) =>
     getProjectionThreadSessionRow(input).pipe(
       Effect.mapError(
-        toPersistenceSqlError("ProjectionThreadSessionRepository.getByThreadId:query"),
+        toPersistenceSqlOrDecodeError(
+          "ProjectionThreadSessionRepository.getByThreadId:query",
+          "ProjectionThreadSessionRepository.getByThreadId:decode",
+        ),
       ),
     );
 

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -48,6 +48,7 @@ import Migration0032 from "./Migrations/032_AuthPairingProofKeyThumbprint.ts";
 import Migration0033 from "./Migrations/033_ProjectionThreadsSettled.ts";
 import Migration0034 from "./Migrations/034_ProjectionThreadsSnoozed.ts";
 import Migration0035 from "./Migrations/035_ProjectionThreadTitleRegeneration.ts";
+import Migration0036 from "./Migrations/036_ProjectionThreadSessionUsageLimit.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -95,6 +96,7 @@ export const migrationEntries = [
   [33, "ProjectionThreadsSettled", Migration0033],
   [34, "ProjectionThreadsSnoozed", Migration0034],
   [35, "ProjectionThreadTitleRegeneration", Migration0035],
+  [36, "ProjectionThreadSessionUsageLimit", Migration0036],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/036_ProjectionThreadSessionUsageLimit.ts
+++ b/apps/server/src/persistence/Migrations/036_ProjectionThreadSessionUsageLimit.ts
@@ -1,0 +1,16 @@
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as Effect from "effect/Effect";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_thread_sessions)
+  `;
+  if (!columns.some((column) => column.name === "usage_limit")) {
+    yield* sql`
+      ALTER TABLE projection_thread_sessions
+      ADD COLUMN usage_limit TEXT
+    `;
+  }
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
@@ -10,6 +10,7 @@ import {
   RuntimeMode,
   IsoDateTime,
   OrchestrationSessionStatus,
+  OrchestrationSessionUsageLimit,
   ProviderInstanceId,
   ThreadId,
   TurnId,
@@ -29,6 +30,7 @@ export const ProjectionThreadSession = Schema.Struct({
   runtimeMode: RuntimeMode,
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(Schema.String),
+  usageLimit: Schema.NullOr(OrchestrationSessionUsageLimit),
   updatedAt: IsoDateTime,
 });
 export type ProjectionThreadSession = typeof ProjectionThreadSession.Type;

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1559,6 +1559,181 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("completes a blocking_limit result as a usage-limit stop, not a failure", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hello", attachments: [] });
+
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "rejected",
+          rateLimitType: "five_hour",
+          resetsAt: 1_800_000_000,
+        },
+        uuid: "11111111-1111-4111-8111-111111111111",
+        session_id: "session-1",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        duration_ms: 1,
+        duration_api_ms: 1,
+        is_error: true,
+        num_turns: 1,
+        stop_reason: null,
+        total_cost_usd: 0,
+        usage: {},
+        modelUsage: {},
+        permission_denials: [],
+        errors: [],
+        terminal_reason: "blocking_limit",
+        uuid: "22222222-2222-4222-8222-222222222222",
+        session_id: "session-1",
+      } as unknown as SDKMessage);
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      runtimeEventsFiber.interruptUnsafe();
+
+      const rateLimits = runtimeEvents.find(
+        (event) => event.type === "account.rate-limits.updated",
+      );
+      assert.equal(rateLimits?.type, "account.rate-limits.updated");
+      if (rateLimits?.type === "account.rate-limits.updated") {
+        assert.equal(rateLimits.payload.status, "rejected");
+        assert.equal(rateLimits.payload.windowType, "five_hour");
+        assert.equal(rateLimits.payload.resetsAt, 1_800_000_000_000);
+      }
+
+      // A usage-limit stop is not a malfunction: no runtime.error row.
+      assert.equal(
+        runtimeEvents.some((event) => event.type === "runtime.error"),
+        false,
+      );
+
+      const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(completed?.type, "turn.completed");
+      if (completed?.type === "turn.completed") {
+        assert.equal(completed.payload.state, "interrupted");
+        assert.deepEqual(completed.payload.usageLimit, {
+          windowType: "five_hour",
+          resetsAt: 1_800_000_000_000,
+          message: "5-hour usage limit reached. Resets at 2027-01-15T08:00:00.000Z.",
+        });
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("attributes a silent stream end to a rejected usage window", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hello", attachments: [] });
+
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "rejected", rateLimitType: "seven_day" },
+        uuid: "33333333-3333-4333-8333-333333333333",
+        session_id: "session-1",
+      } as unknown as SDKMessage);
+      yield* Effect.yieldNow;
+      harness.query.finish();
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      runtimeEventsFiber.interruptUnsafe();
+
+      const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(completed?.type, "turn.completed");
+      if (completed?.type === "turn.completed") {
+        assert.equal(completed.payload.state, "interrupted");
+        assert.equal(completed.payload.errorMessage, "weekly usage limit reached.");
+        assert.deepEqual(completed.payload.usageLimit, {
+          windowType: "seven_day",
+          message: "weekly usage limit reached.",
+        });
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("treats the CLI stderr usage-limit line as a fallback limit signal", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hello", attachments: [] });
+
+      const stderr = harness.getLastCreateQueryInput()?.options.stderr;
+      assert.equal(typeof stderr, "function");
+      stderr?.("Claude AI usage limit reached|1800000000");
+
+      yield* Effect.yieldNow;
+      harness.query.finish();
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      runtimeEventsFiber.interruptUnsafe();
+
+      const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(completed?.type, "turn.completed");
+      if (completed?.type === "turn.completed") {
+        // Only the structured epoch survives — the raw stderr line does not.
+        assert.deepEqual(completed.payload.usageLimit, {
+          resetsAt: 1_800_000_000_000,
+          message: "Usage limit reached. Resets at 2027-01-15T08:00:00.000Z.",
+        });
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("closes the previous session before replacing an existing thread session", () => {
     const queries: FakeClaudeQuery[] = [];
     const layer = Layer.effect(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -22,6 +22,11 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
 import {
+  buildUsageLimitMessage,
+  normalizeUsageLimitResetsAt,
+  parseUsageLimitStderrLine,
+} from "@t3tools/shared/usageLimit";
+import {
   ApprovalRequestId,
   type CanonicalItemType,
   type CanonicalRequestType,
@@ -39,6 +44,8 @@ import {
   type ThreadTokenUsageSnapshot,
   type ProviderUserInputAnswers,
   type RuntimeContentStreamKind,
+  type RuntimeRateLimitStatus,
+  type RuntimeUsageLimit,
   RuntimeItemId,
   RuntimeRequestId,
   RuntimeTaskId,
@@ -201,6 +208,16 @@ interface ClaudeSessionContext {
   lastKnownTotalProcessedTokens: number | undefined;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
+  /**
+   * Latest *rejected* rate-limit window observed for this session.
+   *
+   * Set by `rate_limit_event`, by a `blocking_limit` result, or by the CLI's
+   * stderr usage-limit line; cleared when a new turn starts or a later
+   * rate-limit event reports the window is open again. While set, an
+   * otherwise-silent stream end is attributed to the usage limit instead of
+   * being reported as a bare interruption.
+   */
+  usageLimit: RuntimeUsageLimit | undefined;
   stopped: boolean;
 }
 
@@ -1007,6 +1024,69 @@ function turnStatusFromResult(result: SDKResultMessage): ProviderRuntimeTurnStat
     return "cancelled";
   }
   return "failed";
+}
+
+/**
+ * `terminal_reason` values that mean "the account ran out of usage", not
+ * "something went wrong". `rapid_refill_breaker` is the burst-protection
+ * cousin of `blocking_limit`; both stop the run until a window reopens.
+ */
+const USAGE_LIMIT_TERMINAL_REASONS = new Set(["blocking_limit", "rapid_refill_breaker"]);
+
+function isUsageLimitResult(result: SDKResultMessage): boolean {
+  const terminalReason = (result as { readonly terminal_reason?: string }).terminal_reason;
+  return terminalReason !== undefined && USAGE_LIMIT_TERMINAL_REASONS.has(terminalReason);
+}
+
+/**
+ * Map the SDK's rate-limit status onto the provider-agnostic vocabulary.
+ */
+function normalizeClaudeRateLimitStatus(status: unknown): RuntimeRateLimitStatus | undefined {
+  switch (status) {
+    case "allowed":
+      return "allowed";
+    case "allowed_warning":
+      return "warning";
+    case "rejected":
+      return "rejected";
+    default:
+      return undefined;
+  }
+}
+
+interface ClaudeRateLimitSnapshot {
+  readonly status: RuntimeRateLimitStatus | undefined;
+  readonly windowType: string | undefined;
+  readonly resetsAt: number | undefined;
+}
+
+/**
+ * Pull `rate_limit_info` off an SDK rate-limit message without trusting its
+ * runtime shape (the SDK's union does not narrow here).
+ */
+function readClaudeRateLimitSnapshot(message: SDKMessage): ClaudeRateLimitSnapshot {
+  const info = (message as { readonly rate_limit_info?: unknown }).rate_limit_info;
+  if (!info || typeof info !== "object") {
+    return { status: undefined, windowType: undefined, resetsAt: undefined };
+  }
+  const record = info as Record<string, unknown>;
+  const windowType = typeof record.rateLimitType === "string" ? record.rateLimitType : undefined;
+  return {
+    status: normalizeClaudeRateLimitStatus(record.status),
+    ...(windowType ? { windowType } : { windowType: undefined }),
+    resetsAt: normalizeUsageLimitResetsAt(record.resetsAt),
+  };
+}
+
+function makeUsageLimit(input: {
+  readonly windowType?: string | undefined;
+  readonly resetsAt?: number | undefined;
+}): RuntimeUsageLimit {
+  return {
+    ...(input.windowType ? { windowType: input.windowType } : {}),
+    ...(input.resetsAt !== undefined ? { resetsAt: input.resetsAt } : {}),
+    message: buildUsageLimitMessage(input),
+  };
 }
 
 function streamKindFromDeltaType(deltaType: string): ClaudeTextStreamKind {
@@ -1883,7 +1963,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     status: ProviderRuntimeTurnStatus,
     errorMessage?: string,
     result?: SDKResultMessage,
+    options?: { readonly usageLimit?: RuntimeUsageLimit | undefined },
   ) {
+    const usageLimitPayload = options?.usageLimit ? { usageLimit: options.usageLimit } : {};
     const resultContextWindow = maxClaudeContextWindowFromModelUsage(result?.modelUsage);
     if (resultContextWindow !== undefined) {
       context.lastKnownContextWindow = resultContextWindow;
@@ -1977,6 +2059,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             ? { totalCostUsd: result.total_cost_usd }
             : {}),
           ...(errorMessage ? { errorMessage } : {}),
+          ...usageLimitPayload,
         },
         providerRefs: {},
       });
@@ -2052,6 +2135,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ? { totalCostUsd: result.total_cost_usd }
           : {}),
         ...(errorMessage ? { errorMessage } : {}),
+        ...usageLimitPayload,
       },
       providerRefs: nativeProviderRefs(context),
     });
@@ -2553,6 +2637,16 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    // A usage-limit terminal reason is an expected stop, not a malfunction:
+    // it completes the turn with a structured marker (never raw error text)
+    // and skips the runtime.error row that would style it as a failure.
+    if (isUsageLimitResult(message)) {
+      const usageLimit = context.usageLimit ?? makeUsageLimit({});
+      context.usageLimit = usageLimit;
+      yield* completeTurn(context, "interrupted", usageLimit.message, message, { usageLimit });
+      return;
+    }
+
     const status = turnStatusFromResult(message);
     const errorMessage = message.subtype === "success" ? undefined : message.errors[0];
 
@@ -2906,11 +3000,22 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (message.type === "rate_limit_event") {
+      const snapshot = readClaudeRateLimitSnapshot(message);
+      // Remember a rejected window so a subsequent silent stream end can be
+      // attributed to it; a reopened window clears the marker.
+      if (snapshot.status === "rejected") {
+        context.usageLimit = makeUsageLimit(snapshot);
+      } else if (snapshot.status !== undefined) {
+        context.usageLimit = undefined;
+      }
       yield* offerRuntimeEvent({
         ...base,
         type: "account.rate-limits.updated",
         payload: {
           rateLimits: message,
+          ...(snapshot.status ? { status: snapshot.status } : {}),
+          ...(snapshot.windowType ? { windowType: snapshot.windowType } : {}),
+          ...(snapshot.resetsAt !== undefined ? { resetsAt: snapshot.resetsAt } : {}),
         },
       });
       return;
@@ -3001,11 +3106,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    // A rejected usage window recorded during this turn outranks the generic
+    // exit reasons below: without it, a limit-blocked run ends as a bare
+    // "stream ended" interruption and the client shows a clean completion.
+    const usageLimit = context.usageLimit;
+
     if (Exit.isFailure(exit)) {
       if (isClaudeInterruptedCause(exit.cause)) {
         if (context.turnState) {
           yield* completeTurn(context, "interrupted", "Claude runtime interrupted.");
         }
+      } else if (usageLimit) {
+        yield* completeTurn(context, "interrupted", usageLimit.message, undefined, { usageLimit });
       } else {
         const failures = exit.cause.reasons.flatMap((reason) =>
           Cause.isFailReason(reason) ? [reason.error] : [],
@@ -3018,7 +3130,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         yield* completeTurn(context, "failed", message);
       }
     } else if (context.turnState) {
-      yield* completeTurn(context, "interrupted", "Claude runtime stream ended.");
+      yield* usageLimit
+        ? completeTurn(context, "interrupted", usageLimit.message, undefined, { usageLimit })
+        : completeTurn(context, "interrupted", "Claude runtime stream ended.");
     }
 
     yield* stopSessionInternal(context, {
@@ -3521,6 +3635,27 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(ultracode ? { ultracode: true } : {}),
       };
       const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+
+      // Last-resort usage-limit signal. When the CLI is blocked before it can
+      // emit a rate_limit_event or a blocking_limit result it still prints
+      // "Claude AI usage limit reached|<epoch>" on stderr. Only the structured
+      // epoch is kept — raw stderr never reaches user-facing copy. Buffered
+      // until the session context exists, since stderr can precede it.
+      let pendingStderrUsageLimit: RuntimeUsageLimit | undefined;
+      const handleQueryStderr = (data: string) => {
+        const parsed = parseUsageLimitStderrLine(data);
+        if (!parsed) {
+          return;
+        }
+        const usageLimit = makeUsageLimit(parsed);
+        const active = sessions.get(threadId);
+        if (active) {
+          active.usageLimit = usageLimit;
+        } else {
+          pendingStderrUsageLimit = usageLimit;
+        }
+      };
+
       const queryOptions: ClaudeQueryOptions = {
         ...(input.cwd ? { cwd: input.cwd } : {}),
         ...(apiModelId ? { model: apiModelId } : {}),
@@ -3542,6 +3677,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(existingResumeSessionId ? { resume: existingResumeSessionId } : {}),
         ...(newSessionId ? { sessionId: newSessionId } : {}),
         includePartialMessages: true,
+        stderr: handleQueryStderr,
         canUseTool,
         env: claudeEnvironment,
         ...(input.cwd ? { additionalDirectories: [input.cwd] } : {}),
@@ -3640,6 +3776,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastKnownTotalProcessedTokens: undefined,
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
+        usageLimit: pendingStderrUsageLimit,
         stopped: false,
       };
       yield* Ref.set(contextRef, context);
@@ -3782,6 +3919,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
       const updatedAt = yield* nowIso;
       context.turnState = turnState;
+      // A new turn means the caller believes usage is available again; a
+      // still-closed window re-announces itself via rate_limit_event.
+      context.usageLimit = undefined;
       context.session = {
         ...context.session,
         status: "running",

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -16,6 +16,7 @@ import {
   ProviderInstanceId,
   type ProviderRuntimeEvent,
   type ProviderRequestKind,
+  type RuntimeRateLimitStatus,
   type ThreadTokenUsageSnapshot,
   type ProviderUserInputAnswers,
   RuntimeItemId,
@@ -38,6 +39,7 @@ import * as CodexErrors from "effect-codex-app-server/errors";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import { normalizeUsageLimitResetsAt } from "@t3tools/shared/usageLimit";
 import { getCodexServiceTierOptionValue } from "../../codexModelOptions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 
@@ -145,6 +147,49 @@ function readPayload<A>(
 function trimText(value: string | undefined | null): string | undefined {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Codex reports window length in minutes rather than a named window; map the
+ * common ones onto the same vocabulary the Claude SDK uses so downstream
+ * consumers stay provider-agnostic.
+ */
+function codexWindowType(windowDurationMins: number | null | undefined): string | undefined {
+  if (typeof windowDurationMins !== "number" || !Number.isFinite(windowDurationMins)) {
+    return undefined;
+  }
+  if (windowDurationMins <= 60 * 8) {
+    return "five_hour";
+  }
+  return "seven_day";
+}
+
+/**
+ * Normalize Codex's rate-limit snapshot onto the shared
+ * `account.rate-limits.updated` fields.
+ *
+ * `rateLimitReachedType` is Codex's authoritative "this account is blocked"
+ * flag; anything else is treated as an open window.
+ */
+function normalizeCodexRateLimitSnapshot(
+  snapshot: EffectCodexSchema.V2AccountRateLimitsUpdatedNotification["rateLimits"],
+): {
+  readonly status?: RuntimeRateLimitStatus;
+  readonly windowType?: string;
+  readonly resetsAt?: number;
+} {
+  const reached = snapshot.rateLimitReachedType ?? null;
+  if (reached === null) {
+    return { status: "allowed" };
+  }
+  const window = snapshot.primary ?? snapshot.secondary ?? null;
+  const windowType = codexWindowType(window?.windowDurationMins);
+  const resetsAt = normalizeUsageLimitResetsAt(window?.resetsAt);
+  return {
+    status: "rejected",
+    ...(windowType ? { windowType } : {}),
+    ...(resetsAt !== undefined ? { resetsAt } : {}),
+  };
 }
 
 const FATAL_CODEX_STDERR_SNIPPETS = ["failed to connect to websocket"];
@@ -1125,7 +1170,11 @@ function mapToRuntimeEvents(
   }
 
   if (event.method === "account/rateLimits/updated") {
-    if (!readPayload(EffectCodexSchema.V2AccountRateLimitsUpdatedNotification, event.payload)) {
+    const rateLimitsPayload = readPayload(
+      EffectCodexSchema.V2AccountRateLimitsUpdatedNotification,
+      event.payload,
+    );
+    if (!rateLimitsPayload) {
       return [];
     }
     return [
@@ -1134,6 +1183,7 @@ function mapToRuntimeEvents(
         ...runtimeEventBase(event, canonicalThreadId),
         payload: {
           rateLimits: event.payload ?? {},
+          ...normalizeCodexRateLimitSnapshot(rateLimitsPayload.rateLimits),
         },
       },
     ];

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -238,6 +238,7 @@ import {
 import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
 import { resolveThreadPr } from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
+import { ComposerUsageLimitStrip } from "./chat/ComposerUsageLimitStrip";
 import { ThreadSyncStatusPill } from "./chat/ThreadSyncStatusPill";
 import {
   DRAFT_HERO_TRANSITION_ANIMATION_ID,
@@ -1443,6 +1444,11 @@ function ChatViewContent(props: ChatViewProps) {
   const threadError = isServerThread
     ? (localServerError ?? activeServerThread?.session?.lastError ?? null)
     : localDraftError;
+  // Running out of plan usage is a "can I keep going?" state, not an error, so
+  // it docks to the composer instead of the timeline's error slot.
+  const threadUsageLimit = isServerThread
+    ? (activeServerThread?.session?.usageLimit ?? null)
+    : null;
   const runtimeMode = composerRuntimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const interactionMode =
     composerInteractionMode ?? activeThread?.interactionMode ?? DEFAULT_INTERACTION_MODE;
@@ -5878,6 +5884,7 @@ function ChatViewContent(props: ChatViewProps) {
                   {threadSyncPhase && !activeEnvironmentUnavailable ? (
                     <ThreadSyncStatusPill phase={threadSyncPhase} />
                   ) : null}
+                  <ComposerUsageLimitStrip usageLimit={threadUsageLimit} />
                   <div
                     className="relative"
                     style={

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -19,6 +19,7 @@ import {
   CheckIcon,
   ChevronDownIcon,
   CircleAlertIcon,
+  HourglassIcon,
   CircleCheckIcon,
   CircleDashedIcon,
   ClockIcon,
@@ -319,7 +320,12 @@ function SidebarV2ThreadTooltip({
               </div>
             </div>
           ) : null}
-          {thread.session?.lastError ? (
+          {thread.session?.usageLimit ? (
+            <div className="flex min-w-0 items-center gap-2 text-warning">
+              <HourglassIcon className="size-3 shrink-0 stroke-current" />
+              <div className="min-w-0 truncate">Usage limit</div>
+            </div>
+          ) : thread.session?.lastError ? (
             <div className="flex min-w-0 items-center gap-2 text-red-600 dark:text-red-400">
               <CircleAlertIcon className="size-3 shrink-0 stroke-current" />
               <div className="min-w-0 truncate">Error occurred</div>

--- a/apps/web/src/components/chat/ComposerUsageLimitStrip.test.tsx
+++ b/apps/web/src/components/chat/ComposerUsageLimitStrip.test.tsx
@@ -1,0 +1,72 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  ComposerUsageLimitStrip,
+  formatUsageLimitCountdown,
+  formatUsageLimitStripLabel,
+} from "./ComposerUsageLimitStrip";
+
+describe("formatUsageLimitCountdown", () => {
+  it("renders hours and minutes compactly", () => {
+    expect(formatUsageLimitCountdown(84 * 60_000)).toBe("1h 24m");
+    expect(formatUsageLimitCountdown(24 * 60_000)).toBe("24m");
+    expect(formatUsageLimitCountdown(60 * 60_000)).toBe("1h 0m");
+  });
+
+  it("never rounds a live window down to zero", () => {
+    expect(formatUsageLimitCountdown(30_000)).toBe("<1m");
+    expect(formatUsageLimitCountdown(0)).toBe("<1m");
+  });
+});
+
+describe("formatUsageLimitStripLabel", () => {
+  it("keeps the window label on one line", () => {
+    expect(formatUsageLimitStripLabel({ windowType: "five_hour", remainingMs: 84 * 60_000 })).toBe(
+      "5-hour limit reached · resets in 1h 24m",
+    );
+    expect(formatUsageLimitStripLabel({ windowType: "seven_day", remainingMs: 24 * 60_000 })).toBe(
+      "weekly limit reached · resets in 24m",
+    );
+  });
+
+  it("falls back for unknown windows and missing reset times", () => {
+    expect(formatUsageLimitStripLabel({ windowType: "mystery", remainingMs: 60_000 })).toBe(
+      "Usage limit reached · resets in 1m",
+    );
+    expect(formatUsageLimitStripLabel({})).toBe("Usage limit reached · resets soon");
+  });
+});
+
+describe("ComposerUsageLimitStrip", () => {
+  it("docks to the composer's top edge and renders the countdown", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerUsageLimitStrip
+        usageLimit={{
+          windowType: "five_hour",
+          // Slack so render time cannot floor the countdown into the next minute down.
+          resetsAt: Date.now() + 84 * 60_000 + 5_000,
+          message: "5-hour usage limit reached.",
+          provider: "claudeAgent",
+        }}
+      />,
+    );
+
+    expect(markup).toContain("chat-composer-notice-strip");
+    // Mirrors the branch toolbar's dock geometry, one composer width wide.
+    expect(markup).toContain("-mb-4");
+    expect(markup).toContain("max-w-[calc(48rem-2.75rem)]");
+    expect(markup).toContain("5-hour limit reached · resets in 1h 24m");
+  });
+
+  it("renders nothing without a usage limit or once the window has reopened", () => {
+    expect(renderToStaticMarkup(<ComposerUsageLimitStrip usageLimit={null} />)).toBe("");
+    expect(
+      renderToStaticMarkup(
+        <ComposerUsageLimitStrip
+          usageLimit={{ resetsAt: Date.now() - 1_000, message: "Usage limit reached." }}
+        />,
+      ),
+    ).toBe("");
+  });
+});

--- a/apps/web/src/components/chat/ComposerUsageLimitStrip.tsx
+++ b/apps/web/src/components/chat/ComposerUsageLimitStrip.tsx
@@ -1,0 +1,126 @@
+import type { OrchestrationSessionUsageLimit } from "@t3tools/contracts";
+import { HourglassIcon } from "lucide-react";
+import { memo, useEffect, useState } from "react";
+import { usageLimitWindowLabel } from "@t3tools/shared/usageLimit";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+
+/**
+ * Compact "1h 24m" / "24m" countdown. Under a minute collapses to "<1m" so the
+ * strip never reads as though the window has already reopened.
+ */
+export function formatUsageLimitCountdown(remainingMs: number): string {
+  if (remainingMs < MINUTE_MS) {
+    return "<1m";
+  }
+  const hours = Math.floor(remainingMs / HOUR_MS);
+  const minutes = Math.floor((remainingMs % HOUR_MS) / MINUTE_MS);
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+/**
+ * One-line strip copy, e.g. `5-hour limit reached · resets in 1h 24m`.
+ *
+ * Falls back to the generic headline for unknown window types and to
+ * "resets soon" when the provider gave no reset timestamp.
+ */
+export function formatUsageLimitStripLabel(input: {
+  readonly windowType?: string | undefined;
+  readonly remainingMs?: number | undefined;
+}): string {
+  const windowLabel = usageLimitWindowLabel(input.windowType);
+  const headline = windowLabel ? `${windowLabel} limit reached` : "Usage limit reached";
+  return input.remainingMs === undefined
+    ? `${headline} · resets soon`
+    : `${headline} · resets in ${formatUsageLimitCountdown(input.remainingMs)}`;
+}
+
+/**
+ * Re-render on the minute (and exactly at `resetsAt`) rather than every second.
+ *
+ * The next tick is scheduled at whichever comes first: the upcoming minute
+ * boundary, or the reset itself — so the strip hides the instant the window
+ * reopens without polling the server.
+ */
+function useUsageLimitNow(resetsAt: number | undefined): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (resetsAt === undefined) {
+      return;
+    }
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const schedule = () => {
+      const current = Date.now();
+      setNow(current);
+      if (current >= resetsAt) {
+        return;
+      }
+      const untilNextMinute = MINUTE_MS - (current % MINUTE_MS);
+      timeout = setTimeout(schedule, Math.min(untilNextMinute, resetsAt - current));
+    };
+    schedule();
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
+  }, [resetsAt]);
+
+  return now;
+}
+
+/**
+ * Slim usage-limit notice docked to the top edge of the composer.
+ *
+ * Lives at the composer rather than the timeline's error slot because "am I
+ * out of usage?" is a can-I-keep-going question about the next message, not a
+ * failure of the last one. Renders purely from `session.usageLimit`.
+ */
+export const ComposerUsageLimitStrip = memo(function ComposerUsageLimitStrip({
+  usageLimit,
+}: {
+  usageLimit: OrchestrationSessionUsageLimit | null | undefined;
+}) {
+  const resetsAt =
+    usageLimit?.resetsAt !== undefined && Number.isFinite(usageLimit.resetsAt)
+      ? usageLimit.resetsAt
+      : undefined;
+  const now = useUsageLimitNow(resetsAt);
+
+  if (!usageLimit) return null;
+  // The window reopened while the strip was mounted; hide without waiting for
+  // the server to clear `session.usageLimit`.
+  if (resetsAt !== undefined && now >= resetsAt) return null;
+
+  const label = formatUsageLimitStripLabel({
+    ...(usageLimit.windowType !== undefined ? { windowType: usageLimit.windowType } : {}),
+    ...(resetsAt !== undefined ? { remainingMs: resetsAt - now } : {}),
+  });
+  const absolute =
+    resetsAt === undefined
+      ? "The provider did not report a reset time."
+      : `Resets at ${new Date(resetsAt).toLocaleString(undefined, {
+          weekday: "short",
+          hour: "numeric",
+          minute: "2-digit",
+        })}`;
+
+  return (
+    <div className="chat-composer-notice-strip -mb-4 mx-auto flex w-[calc(100%-2.75rem)] max-w-[calc(48rem-2.75rem)] items-center gap-1.5 px-3 pt-1.5 pb-5 text-xs">
+      <HourglassIcon aria-hidden className="size-3 shrink-0 text-warning" />
+      <Tooltip>
+        {/* Amber is carried by the icon and surface tint; 12px amber body text
+            would not clear contrast on the light surface. */}
+        <TooltipTrigger
+          render={<div className="min-w-0 truncate font-medium text-foreground/80" />}
+        >
+          {label}
+        </TooltipTrigger>
+        <TooltipPopup side="top">{absolute}</TooltipPopup>
+      </Tooltip>
+    </div>
+  );
+});

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -47,6 +47,7 @@ import {
   EyeIcon,
   GlobeIcon,
   HammerIcon,
+  HourglassIcon,
   MessageCircleIcon,
   MousePointerClickIcon,
   PaintbrushIcon,
@@ -1756,6 +1757,7 @@ type WorkEntryIconName =
   | "eye"
   | "globe"
   | "hammer"
+  | "hourglass"
   | "message-circle"
   | "square-pen"
   | "terminal"
@@ -1777,6 +1779,8 @@ function WorkEntryIconSvg({ name, className }: { name: WorkEntryIconName; classN
       return <GlobeIcon className={className} aria-hidden />;
     case "hammer":
       return <HammerIcon className={className} aria-hidden />;
+    case "hourglass":
+      return <HourglassIcon className={className} aria-hidden />;
     case "message-circle":
       return <MessageCircleIcon className={className} aria-hidden />;
     case "square-pen":
@@ -1929,8 +1933,16 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const activity = use(TimelineRowActivityCtx);
   const [expanded, setExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
-  const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
-  const entryIconName = showWarningIndicator ? "x" : workEntryIconName(workEntry);
+  // Running out of plan usage is a warning, not a failure: same amber chrome
+  // as runtime warnings, but an hourglass instead of the failure "x".
+  const isUsageLimitEntry = workEntry.sourceActivityKind === "usage-limit.reached";
+  const showWarningIndicator =
+    workEntry.sourceActivityKind === "runtime.warning" || isUsageLimitEntry;
+  const entryIconName = isUsageLimitEntry
+    ? "hourglass"
+    : showWarningIndicator
+      ? "x"
+      : workEntryIconName(workEntry);
   const heading = toolWorkEntryHeading(workEntry);
   const rawPreview = workEntryPreview(workEntry, workspaceRoot);
   const preview =
@@ -1948,13 +1960,15 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
     (workEntry.sourceActivityKind === "runtime.error" || !workLogEntryIsToolLike(workEntry));
   const iconWrapperClass = cn(
     "flex size-5 shrink-0 items-center justify-center",
-    showWarningIndicator
-      ? "text-destructive"
-      : showDestructiveRowStyle
+    isUsageLimitEntry
+      ? "text-warning"
+      : showWarningIndicator
         ? "text-destructive"
-        : workEntry.tone === "tool" || showFailedIndicator
-          ? "text-muted-foreground/65"
-          : iconConfig.className,
+        : showDestructiveRowStyle
+          ? "text-destructive"
+          : workEntry.tone === "tool" || showFailedIndicator
+            ? "text-muted-foreground/65"
+            : iconConfig.className,
   );
   const headingClass = showWarningIndicator
     ? "font-medium text-warning"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -494,6 +494,45 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     content: "";
   }
 
+  /*
+   * Vertical mirror of .chat-composer-context-strip: a slim notice docked to
+   * the composer's top edge instead of its bottom. The mask ends the outline
+   * exactly where the composer's 22px top curve reaches its tangent, so the
+   * two outlines read as one continuous piece of composer chrome.
+   *
+   * Unlike the context strip this sits outside .chat-composer-glass-shell (the
+   * shell's clip-path only extends downward), so it restates the shell's
+   * outline token and paints its own opaque surface instead of inheriting the
+   * shared glass layer.
+   */
+  .chat-composer-notice-strip {
+    --chat-composer-outline: rgb(0 0 0 / 8%);
+
+    position: relative;
+    isolation: isolate;
+  }
+
+  .dark .chat-composer-notice-strip {
+    --chat-composer-outline: color-mix(in srgb, var(--color-white) 5%, transparent);
+  }
+
+  .chat-composer-notice-strip::before {
+    position: absolute;
+    z-index: -1;
+    inset: 0;
+    border: 1px solid var(--chat-composer-outline);
+    border-radius: 16px 16px 0 0;
+    background: color-mix(in srgb, var(--warning) 7%, var(--background));
+    -webkit-mask-image: linear-gradient(to top, transparent 0 1rem, black 1rem);
+    mask-image: linear-gradient(to top, transparent 0 1rem, black 1rem);
+    content: "";
+  }
+
+  .dark .chat-composer-notice-strip::before {
+    border-color: rgb(255 255 255 / 7%);
+    background: color-mix(in srgb, var(--warning) 10%, var(--background));
+  }
+
   .dark .chat-composer-glass-shell {
     --chat-composer-glass-surface: color-mix(in srgb, var(--background) 96%, var(--color-white));
     --chat-composer-outline: color-mix(in srgb, var(--color-white) 5%, transparent);

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -691,6 +691,47 @@ describe("workEntryIndicatesToolFailure", () => {
 });
 
 describe("deriveWorkLogEntries", () => {
+  it("labels a usage-limit stop with the locale-formatted reset time", () => {
+    const resetsAt = Date.parse("2026-02-23T19:00:00.000Z");
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "usage-limit",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "usage-limit.reached",
+        summary: "Usage limit reached",
+        tone: "info",
+        payload: {
+          message: "5-hour usage limit reached.",
+          windowType: "five_hour",
+          resetsAt,
+          provider: "claudeAgent",
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry?.sourceActivityKind).toBe("usage-limit.reached");
+    expect(entry?.tone).toBe("info");
+    expect(entry?.label).toContain("5-hour usage limit reached - resets at");
+    // Formatted in the viewer's locale, not echoed from the server message.
+    expect(entry?.label).not.toContain("Z");
+  });
+
+  it("falls back to the bare headline when no reset time is known", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "usage-limit-no-reset",
+        kind: "usage-limit.reached",
+        summary: "Usage limit reached",
+        tone: "info",
+        payload: { message: "Usage limit reached." },
+      }),
+    ]);
+
+    expect(entries[0]?.label).toBe("Usage limit reached");
+  });
+
   it("omits tool started entries and keeps completed entries", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1,3 +1,4 @@
+import { usageLimitWindowLabel } from "@t3tools/shared/usageLimit";
 import * as Option from "effect/Option";
 import * as Arr from "effect/Array";
 import {
@@ -674,6 +675,35 @@ function extractWorkLogToolLifecycleStatus(
   return undefined;
 }
 
+/**
+ * Timeline label for a usage-limit stop, e.g.
+ * "Usage limit reached - resets at 7:00 PM".
+ *
+ * Built from the structured payload so the reset time renders in the viewer's
+ * locale rather than the server's.
+ */
+function usageLimitWorkLogLabel(payload: Record<string, unknown> | null): string {
+  const windowLabel = usageLimitWindowLabel(
+    typeof payload?.windowType === "string" ? payload.windowType : null,
+  );
+  const headline = windowLabel ? `${windowLabel} usage limit reached` : "Usage limit reached";
+  const resetsAt = typeof payload?.resetsAt === "number" ? payload.resetsAt : undefined;
+  if (resetsAt === undefined || !Number.isFinite(resetsAt)) {
+    return headline;
+  }
+  const reset = new Date(resetsAt);
+  const sameDay = new Date().toDateString() === reset.toDateString();
+  const formatted = sameDay
+    ? reset.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })
+    : reset.toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      });
+  return `${headline} - resets at ${formatted}`;
+}
+
 function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWorkLogEntry {
   const payload =
     activity.payload && typeof activity.payload === "object"
@@ -708,7 +738,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     id: activity.id,
     createdAt: activity.createdAt,
     turnId: activity.turnId,
-    label: taskLabel || activity.summary,
+    label:
+      activity.kind === "usage-limit.reached"
+        ? usageLimitWorkLogLabel(payload)
+        : taskLabel || activity.summary,
     tone:
       activity.kind === "task.progress"
         ? "thinking"

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -330,7 +330,12 @@ export function applyThreadDetailEvent(
     case "thread.session-set": {
       // Leaving the "running" session status is the turn-end signal: settle a
       // still-running latest turn so its duration reflects the whole turn.
-      const settledTurnState = settledTurnStateForSessionStatus(event.payload.session.status);
+      // A usage-limit stop settles as "interrupted", not "completed":
+      // the run did not finish, it ran out of usage.
+      const settledTurnState =
+        event.payload.session.usageLimit != null
+          ? ("interrupted" as const)
+          : settledTurnStateForSessionStatus(event.payload.session.status);
       const latestTurn: OrchestrationLatestTurn | null =
         event.payload.session.status === "running" && event.payload.session.activeTurnId !== null
           ? {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -270,6 +270,21 @@ export const OrchestrationSessionStatus = Schema.Literals([
 ]);
 export type OrchestrationSessionStatus = typeof OrchestrationSessionStatus.Type;
 
+/**
+ * Provider-agnostic "this account's usage window is exhausted" state.
+ *
+ * Distinct from `lastError`: hitting a plan's usage window is an expected,
+ * non-destructive stop, so clients render it as a warning rather than a
+ * failure. `resetsAt` is epoch milliseconds, formatted client-side.
+ */
+export const OrchestrationSessionUsageLimit = Schema.Struct({
+  provider: Schema.optional(TrimmedNonEmptyString),
+  windowType: Schema.optional(TrimmedNonEmptyString),
+  resetsAt: Schema.optional(Schema.Number),
+  message: TrimmedNonEmptyString,
+});
+export type OrchestrationSessionUsageLimit = typeof OrchestrationSessionUsageLimit.Type;
+
 export const OrchestrationSession = Schema.Struct({
   threadId: ThreadId,
   status: OrchestrationSessionStatus,
@@ -278,6 +293,7 @@ export const OrchestrationSession = Schema.Struct({
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(TrimmedNonEmptyString),
+  usageLimit: Schema.optional(Schema.NullOr(OrchestrationSessionUsageLimit)),
   updatedAt: IsoDateTime,
 });
 export type OrchestrationSession = typeof OrchestrationSession.Type;

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -72,6 +72,30 @@ export type RuntimeThreadState = typeof RuntimeThreadState.Type;
 const RuntimeTurnState = Schema.Literals(["completed", "failed", "interrupted", "cancelled"]);
 export type RuntimeTurnState = typeof RuntimeTurnState.Type;
 
+/**
+ * Provider-agnostic rate-limit window state.
+ *
+ * Adapters normalize their native vocabulary onto this triple so ingestion can
+ * react without knowing which provider produced the event.
+ */
+export const RuntimeRateLimitStatus = Schema.Literals(["allowed", "warning", "rejected"]);
+export type RuntimeRateLimitStatus = typeof RuntimeRateLimitStatus.Type;
+
+/**
+ * Normalized "the provider's usage window is exhausted" marker.
+ *
+ * Built exclusively from structured provider fields (never raw error text) so
+ * the message stays safe to surface verbatim in clients.
+ *
+ * `resetsAt` is epoch milliseconds; clients format it in the viewer's locale.
+ */
+export const RuntimeUsageLimit = Schema.Struct({
+  windowType: Schema.optional(TrimmedNonEmptyStringSchema),
+  resetsAt: Schema.optional(Schema.Number),
+  message: TrimmedNonEmptyStringSchema,
+});
+export type RuntimeUsageLimit = typeof RuntimeUsageLimit.Type;
+
 const RuntimePlanStepStatus = Schema.Literals(["pending", "inProgress", "completed"]);
 export type RuntimePlanStepStatus = typeof RuntimePlanStepStatus.Type;
 
@@ -366,6 +390,9 @@ const TurnCompletedPayload = Schema.Struct({
   modelUsage: Schema.optional(UnknownRecordSchema),
   totalCostUsd: Schema.optional(Schema.Number),
   errorMessage: Schema.optional(TrimmedNonEmptyStringSchema),
+  // Set when the turn stopped because the provider's usage window ran out.
+  // Distinguishes "out of usage" from a malfunction for any `state`.
+  usageLimit: Schema.optional(RuntimeUsageLimit),
 });
 export type TurnCompletedPayload = typeof TurnCompletedPayload.Type;
 
@@ -536,6 +563,12 @@ export type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
 
 const AccountRateLimitsUpdatedPayload = Schema.Struct({
   rateLimits: Schema.Unknown,
+  // Normalized view of `rateLimits`, filled in by the adapter. Optional so
+  // legacy/raw-only emitters keep validating; ingestion falls back to reading
+  // the provider-native shape out of `rateLimits` when these are absent.
+  status: Schema.optional(RuntimeRateLimitStatus),
+  windowType: Schema.optional(TrimmedNonEmptyStringSchema),
+  resetsAt: Schema.optional(Schema.Number),
 });
 export type AccountRateLimitsUpdatedPayload = typeof AccountRateLimitsUpdatedPayload.Type;
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -67,6 +67,10 @@
       "types": "./src/schemaYaml.ts",
       "import": "./src/schemaYaml.ts"
     },
+    "./usageLimit": {
+      "types": "./src/usageLimit.ts",
+      "import": "./src/usageLimit.ts"
+    },
     "./toolActivity": {
       "types": "./src/toolActivity.ts",
       "import": "./src/toolActivity.ts"

--- a/packages/shared/src/usageLimit.test.ts
+++ b/packages/shared/src/usageLimit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildUsageLimitMessage,
+  normalizeUsageLimitResetsAt,
+  parseUsageLimitStderrLine,
+  usageLimitWindowLabel,
+} from "./usageLimit.ts";
+
+describe("normalizeUsageLimitResetsAt", () => {
+  it("promotes epoch seconds to milliseconds and leaves milliseconds alone", () => {
+    expect(normalizeUsageLimitResetsAt(1_800_000_000)).toBe(1_800_000_000_000);
+    expect(normalizeUsageLimitResetsAt(1_800_000_000_000)).toBe(1_800_000_000_000);
+  });
+
+  it("rejects non-timestamps", () => {
+    expect(normalizeUsageLimitResetsAt(0)).toBe(undefined);
+    expect(normalizeUsageLimitResetsAt(-1)).toBe(undefined);
+    expect(normalizeUsageLimitResetsAt("1800000000")).toBe(undefined);
+    expect(normalizeUsageLimitResetsAt(undefined)).toBe(undefined);
+    expect(normalizeUsageLimitResetsAt(Number.NaN)).toBe(undefined);
+  });
+});
+
+describe("usageLimitWindowLabel", () => {
+  it("labels known windows and refuses to leak unknown identifiers", () => {
+    expect(usageLimitWindowLabel("five_hour")).toBe("5-hour");
+    expect(usageLimitWindowLabel("seven_day")).toBe("weekly");
+    expect(usageLimitWindowLabel("something_new")).toBe(null);
+    expect(usageLimitWindowLabel(undefined)).toBe(null);
+  });
+});
+
+describe("buildUsageLimitMessage", () => {
+  it("builds copy from structured fields only", () => {
+    expect(buildUsageLimitMessage({ windowType: "five_hour", resetsAt: 1_800_000_000 })).toBe(
+      "5-hour usage limit reached. Resets at 2027-01-15T08:00:00.000Z.",
+    );
+    expect(buildUsageLimitMessage({ windowType: "seven_day" })).toBe("weekly usage limit reached.");
+    expect(buildUsageLimitMessage({})).toBe("Usage limit reached.");
+  });
+});
+
+describe("parseUsageLimitStderrLine", () => {
+  it("extracts only the reset epoch from the CLI line", () => {
+    expect(parseUsageLimitStderrLine("Claude AI usage limit reached|1800000000")).toEqual({
+      resetsAt: 1_800_000_000_000,
+    });
+  });
+
+  it("still flags the limit when no epoch is present", () => {
+    expect(parseUsageLimitStderrLine("claude ai usage limit reached")).toEqual({});
+  });
+
+  it("ignores unrelated stderr", () => {
+    expect(parseUsageLimitStderrLine("some token=secret debug line")).toBe(undefined);
+  });
+});

--- a/packages/shared/src/usageLimit.ts
+++ b/packages/shared/src/usageLimit.ts
@@ -1,0 +1,92 @@
+/**
+ * Provider-agnostic helpers for the "usage limit reached" surface.
+ *
+ * Every value here is derived from structured provider fields (window type,
+ * reset timestamp) — never from raw provider error text — so the resulting
+ * strings are safe to persist and render verbatim.
+ *
+ * @module usageLimit
+ */
+
+import * as DateTime from "effect/DateTime";
+
+/**
+ * Timestamps below this are unambiguously epoch *seconds* rather than
+ * milliseconds (1e12 ms is 2001-09-09; 1e12 s is the year 33658).
+ */
+const EPOCH_SECONDS_CEILING = 1e12;
+
+/**
+ * Normalize a provider reset timestamp to epoch milliseconds.
+ *
+ * Providers are inconsistent: the Claude Agent SDK and the Claude CLI's
+ * stderr line report epoch seconds, Codex reports epoch seconds too, and some
+ * transports already hand back milliseconds. Returns `undefined` for anything
+ * that isn't a usable positive finite number.
+ */
+export function normalizeUsageLimitResetsAt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return value < EPOCH_SECONDS_CEILING ? Math.round(value * 1000) : Math.round(value);
+}
+
+/**
+ * Human label for a provider window type, e.g. `five_hour` -> `5-hour`.
+ *
+ * Unknown window types return `null` so callers fall back to generic copy
+ * rather than leaking a provider-internal identifier.
+ */
+export function usageLimitWindowLabel(windowType: string | null | undefined): string | null {
+  switch (windowType) {
+    case "five_hour":
+      return "5-hour";
+    case "seven_day":
+      return "weekly";
+    case "seven_day_opus":
+      return "weekly Opus";
+    case "seven_day_sonnet":
+      return "weekly Sonnet";
+    case "overage":
+      return "overage";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Plain-text message stored on the session / turn.
+ *
+ * Clients that can format timestamps (the web app) prefer rebuilding the copy
+ * from `windowType` + `resetsAt`; this is the persisted, locale-independent
+ * fallback.
+ */
+export function buildUsageLimitMessage(input: {
+  readonly windowType?: string | null | undefined;
+  readonly resetsAt?: number | null | undefined;
+}): string {
+  const label = usageLimitWindowLabel(input.windowType);
+  const headline = label ? `${label} usage limit reached` : "Usage limit reached";
+  const resetsAt = normalizeUsageLimitResetsAt(input.resetsAt);
+  return resetsAt === undefined
+    ? `${headline}.`
+    : `${headline}. Resets at ${DateTime.formatIso(DateTime.makeUnsafe(resetsAt))}.`;
+}
+
+/**
+ * Detect the Claude CLI's stderr usage-limit line.
+ *
+ * The CLI prints `Claude AI usage limit reached|<epoch seconds>` on stderr
+ * when a run is blocked. Only the epoch is extracted — the raw line never
+ * reaches user-facing copy.
+ */
+export function parseUsageLimitStderrLine(
+  chunk: string,
+): { readonly resetsAt?: number } | undefined {
+  if (!chunk.toLowerCase().includes("usage limit reached")) {
+    return undefined;
+  }
+  const epoch = /usage limit reached\s*\|\s*(\d+)/i.exec(chunk)?.[1];
+  const resetsAt = epoch === undefined ? undefined : normalizeUsageLimitResetsAt(Number(epoch));
+  return resetsAt === undefined ? {} : { resetsAt };
+}


### PR DESCRIPTION
## Problem

When a provider hits a usage window (e.g. Claude's 5-hour or weekly limit), the run just stops with no indication why. Three paths conspired to make the stop silent:

- the SDK's `rate_limit_event` (which carries `status: "rejected"`, the window type, and the reset timestamp) was forwarded as `account.rate-limits.updated` and then dropped — the event had no consumer anywhere in ingestion
- `handleResultMessage` ignored `terminal_reason`, so `blocking_limit` results collapsed into the generic failed/interrupted buckets with no message
- a stream that died mid-turn was completed as `interrupted`, which ingestion + projector mapped to session `ready` / turn `completed` / `lastError: null` — i.e. the UI showed a clean, successful finish

## What this does

**Contracts** — a structured usage-limit concept (`windowType`, `resetsAt`, `message`) flows end to end: `TurnCompletedPayload.usageLimit`, normalized fields on `AccountRateLimitsUpdatedPayload`, and `OrchestrationSession.usageLimit` (persisted via migration 036). Provider-agnostic: messaging is built from structured fields, never raw error strings, so the existing redaction guarantees hold.

**Claude adapter** — records rejected rate-limit windows on the session context; maps `blocking_limit` / `rapid_refill_breaker` terminal reasons; attributes silent stream ends to the recorded limit instead of a benign interrupt; adds a `stderr` callback that parses the CLI's `usage limit reached|<epoch>` line as a fallback (only the epoch is kept).

**Codex adapter** — normalizes its `rateLimitReachedType` / `primary` / `secondary` snapshot onto the same fields (window ≤ 8h → `five_hour`, else `seven_day`), driving the same UI.

**Ingestion / projector** — a `usage-limit.reached` activity row, session `usageLimit` set/carried/cleared at the right lifecycle points, and limit-stopped turns settle as `interrupted` rather than `completed`.

**Web UI** — a slim strip docked to the top edge of the composer (a vertical mirror of the branch toolbar below it): hourglass, `5-hour limit reached · resets in 1h 23m`, live per-minute countdown, absolute time on hover, and client-side auto-hide the moment the reset passes. The work log gets an amber row at the exact point the run stopped, and the sidebar shows "Usage limit" instead of "Error occurred". No top-of-timeline banner — that slot stays reserved for real errors.

## Screenshots

The composer strip while a window is exhausted:

![Usage-limit strip above the composer](https://raw.githubusercontent.com/Zeus-Deus/t3code/assets/usage-limit-ui/pr-strip-full.png)

Close-up — it reads as part of the composer chrome:

![Close-up of the strip](https://raw.githubusercontent.com/Zeus-Deus/t3code/assets/usage-limit-ui/pr-strip-closeup.png)

The work-log row marking where the run stopped:

![Work-log row](https://raw.githubusercontent.com/Zeus-Deus/t3code/assets/usage-limit-ui/pr-worklog.png)

## Testing

- `pnpm typecheck` (all 15 workspaces) and `pnpm lint` clean
- new tests: blocking-limit result handling, silent-stream-end attribution, stderr fallback (ClaudeAdapter); banner + work-log row and raw-shape rate-limit set/clear (ingestion); interrupted settle (projector); countdown formatting, dock geometry, and hide-on-expiry (ComposerUsageLimitStrip); plus shared `usageLimit` helpers
- full suites green: server 700 passed, web 1699 passed, shared 320, client-runtime 502; the pre-existing `imageCompression.test.ts` timing flake under parallel load passes in isolation
- the existing "keeps Claude stream failure events structural" redaction test passes unchanged
- verified visually against a live dev stack (screenshots above); the auto-hide was also observed live once the seeded reset time passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider lifecycle, session projection, and persistence across Claude/Codex ingestion paths; behavior changes how limit stops are classified (ready vs error) and how turns settle, though coverage is strong in adapter and ingestion tests.
> 
> **Overview**
> Provider usage-window exhaustion is now modeled end-to-end instead of looking like a clean stop or a generic failure.
> 
> **Contracts & persistence** — `OrchestrationSession.usageLimit`, `TurnCompletedPayload.usageLimit`, and normalized fields on `account.rate-limits.updated` carry structured window type, reset time, and messages built from shared `@t3tools/shared/usageLimit` helpers (not raw provider error text). Migration **036** adds `usage_limit` on `projection_thread_sessions`; projection upserts and snapshot queries read/write it.
> 
> **Claude & Codex adapters** — Claude maps `blocking_limit` / `rapid_refill_breaker`, rate-limit events, silent stream ends, and CLI stderr `usage limit reached|<epoch>` into `turn.completed` with `usageLimit` and `account.rate-limits.updated`. Codex normalizes `rateLimitReachedType` onto the same vocabulary.
> 
> **Ingestion & projection** — Usage-limit stops keep session **ready** (not **error**), clear `lastError`, emit **`usage-limit.reached`** work-log activities from `turn.completed`, set/clear the session banner from rate-limit updates and turn lifecycle, and settle turns as **interrupted** when `usageLimit` is set (including in `projector` and client `threadReducer`).
> 
> **Web UI** — **`ComposerUsageLimitStrip`** docks above the composer with countdown and client-side hide after reset; sidebar prefers “Usage limit” over error; timeline work log uses amber hourglass styling and locale-formatted reset labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7d85add8107285aa7d4b7aa3eae9f9f5b1fc3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show provider usage-limit stops in the chat UI instead of failing silently
> - Adds `OrchestrationSessionUsageLimit` to session contracts and persists it in a new `usage_limit` column (migration 036) on `projection_thread_sessions`.
> - Claude and Codex adapters now emit normalized `status`, `windowType`, and `resetsAt` fields on `account.rate-limits.updated`; Claude also detects `blocking_limit`/`rapid_refill_breaker` terminal reasons and stderr usage-limit lines, completing turns as `interrupted` with a structured `usageLimit` instead of emitting `runtime.error`.
> - The orchestration layer sets `session.usageLimit` on usage-limit turn completions, clears it on new turn starts, and propagates it through rate-limit update events; turns with a `usageLimit` settle as `interrupted` in both the server projector and the client reducer.
> - A new `ComposerUsageLimitStrip` component renders a warning-toned strip above the composer with a live countdown and tooltip; it auto-hides when the reset time passes.
> - The sidebar thread tooltip shows a 'Usage limit' hourglass indicator (taking precedence over error indicators), and timeline work-log rows for `usage-limit.reached` show an amber hourglass instead of the failure 'x'.
> - Behavioral Change: usage-limit stops no longer set `lastError` or error status on the session; they are shown as `interrupted` turns with a dedicated UI strip rather than appearing as errors in the timeline.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fe7d85a. 20 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->