### PR TITLE
fix(web): label sidebar v2 slim rows with their project

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1167,6 +1167,17 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 fallbackIcon={MessageSquareIcon}
               />
             </span>
+            {/* Card rows carry this label already; slim rows left the favicon
+              as the only project cue. That cue is absent whenever the icon
+              doesn't resolve — every such row falls back to the same
+              message-square glyph — and dimmed even when it does, so a
+              settled tail spanning several projects reads as one flat list.
+              Shrinks before the title does: the title identifies the row. */}
+            {props.projectTitle ? (
+              <span className="min-w-6 shrink truncate text-xs text-muted-foreground/70 group-hover/sidebar-row:text-muted-foreground">
+                {props.projectTitle}
+              </span>
+            ) : null}
             {title}
             {terminalStatusIcon}
             {isRegeneratingTitle ? (

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -818,6 +818,17 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 fallbackIcon={MessageSquareIcon}
               />
             </span>
+            {/* Card rows carry this label already; slim rows left the favicon
+              as the only project cue. That cue is absent whenever the icon
+              doesn't resolve — every such row falls back to the same
+              message-square glyph — and dimmed even when it does, so a
+              settled tail spanning several projects reads as one flat list.
+              Shrinks before the title does: the title identifies the row. */}
+            {props.projectTitle ? (
+              <span className="min-w-6 shrink truncate text-xs text-muted-foreground/70 group-hover/v2-row:text-muted-foreground">
+                {props.projectTitle}
+              </span>
+            ) : null}
             {title}
             {terminalStatusIcon}
             {isRegeneratingTitle ? (


### PR DESCRIPTION
Closes #5083

## What Changed

Sidebar V2 slim rows — the settled shelf and snoozed threads — now render the project label that card rows already show, using the same `projectTitle` prop the component receives.

Six lines of JSX in the slim branch. No new props, no new settings, no logic.

## Why

Slim rows identified their project by favicon alone, and the favicon does not carry that on its own:

- When resolution fails the row falls back to `MessageSquareIcon`, so *every* project without a resolvable icon gets the same glyph and those rows become indistinguishable from one another. That is common outside React-shaped repos — see #4304, #1020, #4935.
- When it succeeds, settled favicons are deliberately dimmed and grayscaled at rest (`opacity-40 grayscale`) so history recedes.

So a settled tail spanning several projects reads as one flat list of thread titles. The tail is where you go when you remember the project but not the thread title, which makes it the spot where the label matters most and the only spot that lacked it.

## Layout

The label sits between the favicon and the title with `min-w-6 shrink truncate text-xs`. `shrink` without `flex-1` means it yields width before the title does — the title is what identifies the row, so it wins any contest for space. Styling mirrors the card row's label (`text-xs`, muted), a shade dimmer at rest to match the slim row's receded treatment, and it lifts to `text-muted-foreground` on row hover alongside the favicon and title.

## Verification

- `tsc --noEmit` clean.
- `vp lint` and `vp format --check` clean.
- Checked against a settled shelf holding threads from several projects, including projects whose icons don't resolve — previously those rows were mutually indistinguishable.

No test added: `SidebarV2.tsx` has no component tests in the repo (sidebar coverage lives in `Sidebar.logic.test.ts` / `Sidebar.snooze.test.ts`), and this change is presentational with no logic to extract.

## One thing worth flagging

`projectTitle` is the *group* display name — `projectDisplayNameByKey` is built from `group.displayName` — so for a nested repository it can read as a long path rather than the project's own title. That is pre-existing behavior already visible on card rows and this PR does not change it, but it is more noticeable on a dense slim row. If you'd prefer the project's own title there, I'm happy to send that as a separate PR rather than widen this one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational JSX only in the sidebar slim row layout; no logic, props, or API changes.
> 
> **Overview**
> Slim sidebar rows (settled shelf and snoozed threads) now show the same **project label** card rows already get, using the existing `projectTitle` prop—no new data or settings.
> 
> The label sits between the favicon and thread title with `shrink`/`truncate` so it gives up width before the title. Styling matches card rows (small muted text), slightly dimmer at rest and brighter on row hover, which fixes rows that were only identifiable by favicon (including identical fallback icons when favicons fail).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910a88c73cd72d94c1635a79b3fa46c3a1328242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Display project title label in slim sidebar thread rows
> Adds a small, truncated project title label before the thread title in `SidebarThreadRow` when `props.projectTitle` is provided. This affects slim rows in the sidebar v2, giving users more context about which project a thread belongs to.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 910a88c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->