### PR TITLE
fix(server): self-update no longer rolls itself back on restart

### DIFF
--- a/apps/server/src/cloud/selfUpdate.test.ts
+++ b/apps/server/src/cloud/selfUpdate.test.ts
@@ -550,6 +550,14 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
       assert.lengthOf(context.spawns, 0);
       // systemd replaces the process; the server must not exit itself.
       assert.equal(context.exitCount(), 0);
+
+      // The queued restart returns while this process is still shutting
+      // down; the lock must stay held so a second update cannot rewrite the
+      // unit mid-teardown.
+      const concurrentError = yield* context.service
+        .update({ targetVersion: "0.0.30" })
+        .pipe(Effect.flip);
+      assert.include(concurrentError.reason, "already in progress");
     }).pipe(Effect.provide(TestClock.layer())),
   );
 

--- a/apps/server/src/cloud/selfUpdate.test.ts
+++ b/apps/server/src/cloud/selfUpdate.test.ts
@@ -545,7 +545,7 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
       yield* TestClock.adjust(Duration.seconds(10));
       assert.deepEqual(context.commands[3], {
         command: "systemctl",
-        args: ["--user", "restart", "t3code.service"],
+        args: ["--user", "restart", "--no-block", "t3code.service"],
       });
       assert.lengthOf(context.spawns, 0);
       // systemd replaces the process; the server must not exit itself.
@@ -583,7 +583,7 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
       assert.deepEqual(
         context.commands.slice(-2).map((entry) => entry.args),
         [
-          ["--user", "restart", BOOT_SERVICE_UNIT_FILE],
+          ["--user", "restart", "--no-block", BOOT_SERVICE_UNIT_FILE],
           ["--user", "daemon-reload"],
         ],
       );

--- a/apps/server/src/cloud/selfUpdate.ts
+++ b/apps/server/src/cloud/selfUpdate.ts
@@ -394,9 +394,13 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
             Effect.catch((error) =>
               Effect.logError("Server self-update could not restart the boot service.").pipe(
                 Effect.annotateLogs({ targetVersion, error: error.reason }),
+                // Permit a retry only after the failed handoff was rolled
+                // back. A queued restart returns while this process is still
+                // shutting down; releasing the lock then would let a second
+                // update rewrite the unit mid-teardown.
+                Effect.andThen(Ref.set(inFlight, false)),
               ),
             ),
-            Effect.ensuring(Ref.set(inFlight, false)),
           ),
         );
       } else {

--- a/apps/server/src/cloud/selfUpdate.ts
+++ b/apps/server/src/cloud/selfUpdate.ts
@@ -354,14 +354,19 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
           targetVersion,
         });
         // Restart after the acknowledgement has had time to cross any relay
-        // hop. If systemd rejects the handoff, restore the previous unit while
-        // this process is still alive and log the failure for diagnostics.
+        // hop. --no-block queues the restart job and exits before systemd
+        // stops this unit: a blocking restart's SIGTERM reaches the systemctl
+        // child (it shares this service's cgroup), which read as a restart
+        // failure and rolled the new unit back while the old server finished
+        // shutting down. With the handoff race gone, a non-zero exit or spawn
+        // error means systemd genuinely rejected the job while this process is
+        // still alive, so restoring the previous unit below stays correct.
         yield* scheduleRestart(
           Effect.gen(function* () {
             const restart = yield* runner
               .run({
                 command: "systemctl",
-                args: ["--user", "restart", BOOT_SERVICE_UNIT_FILE],
+                args: ["--user", "restart", "--no-block", BOOT_SERVICE_UNIT_FILE],
               })
               .pipe(
                 Effect.mapError((cause) =>


### PR DESCRIPTION
## Problem

Remote server updates on boot-service (systemd) machines fail at the resume step: download and install succeed, then the client reports "The server did not resume on t3@<target>" and the server comes back on the **old** version.

The updater runs `systemctl --user restart` from inside the service being restarted. systemd's default `KillMode=control-group` SIGTERMs the entire cgroup — including that `systemctl` child — so the blocking restart call dies mid-flight. The updater interprets the dead child as a failed restart and its rollback handler rewrites the unit back to the previous version while the old server process is still in its multi-second graceful shutdown. systemd then starts the unit pointing at the old install. The freshly installed target version is left on disk, unused, and every retry hits the same race.

Observed on bb-1 (two consecutive failures, `0.0.32-nightly.20260730.956 → 0.0.32-nightly.20260731.963`): the boot log shows "Server self-update installed; restarting boot service" followed ~2s later by "Server self-update could not restart the boot service", and the unit file's mtime matches the rollback write.

## Fix

Queue the restart with `systemctl --user restart --no-block`. It enqueues the job and exits before the stop signal reaches the cgroup, so its exit code only reflects whether systemd accepted the job. The existing rollback path is unchanged and now fires only for genuine rejections (bad unit, unreachable manager) — the case it was written for — instead of for the updater's own death.

Updated the two test assertions on the restart argv; the rollback-on-failure and retry tests pass unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/5095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes critical remote self-update handoff on systemd hosts (unit rewrite + restart timing and concurrency lock), though scope is limited to the boot-service path and rollback behavior is intentionally preserved for real failures.
> 
> **Overview**
> Fixes boot-service self-updates that **rolled back to the old version** after install succeeded. The updater ran a **blocking** `systemctl --user restart` from inside the unit being restarted; systemd SIGTERM’d the shared cgroup and killed that `systemctl` child, which was treated as restart failure and restored the previous unit file.
> 
> **Restart** now uses `systemctl --user restart --no-block` so the job is queued and the command exits before the stop signal. Rollback on non-zero exit still applies only when systemd genuinely rejects the job.
> 
> The **in-flight update lock** is no longer cleared on every restart fiber completion (`Effect.ensuring` removed). It is released only when restart fails after rollback, because `--no-block` returns while this process is still shutting down—holding the lock blocks a second update from rewriting the unit mid-teardown. Tests assert `--no-block` on restart argv and that a concurrent update is rejected after a successful queued restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001b2c4adde95d98b96b53d42f397290d4089332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix self-update lock to remain held during systemd restart, preventing rollback on process exit
> - Changes the `systemctl restart` invocation in [`selfUpdate.ts`](https://github.com/pingdotgg/t3code/pull/5095/files#diff-ec2e07779fe6544111c93dbc73b0783e8d6f7a09caa236f543bd500d08c4617b) to use `--no-block`, so the process exits before systemd restarts it rather than waiting for the restart to complete.
> - Removes the unconditional `finally` release of the in-flight lock; the lock is now only released on error (after rollback), while a queued restart keeps the lock held until process termination.
> - Concurrent update attempts during the shutdown window now fail with an 'already in progress' error instead of being allowed to proceed.
> - Behavioral Change: the in-flight lock is no longer released on successful update — it stays held until the process is killed by systemd.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 001b2c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service restart handling during updates by allowing restarts to proceed asynchronously.
  * Updated restart behavior to reduce failures during the handoff and retry process.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->