### PR TITLE
fix(desktop): tolerate tailscale spawn defects

### DIFF
--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -68,6 +68,15 @@ function dieOnSpawnLayer() {
   );
 }
 
+function throwOnSpawnLayer() {
+  return Layer.succeed(
+    ChildProcessSpawner.ChildProcessSpawner,
+    ChildProcessSpawner.make(() => {
+      throw new Error("unexpected tailscale spawn");
+    }),
+  );
+}
+
 function makeEnvironmentLayer(baseDir: string, env: Record<string, string | undefined> = {}) {
   return DesktopEnvironment.layer({
     dirname: "/repo/apps/desktop/src",
@@ -321,6 +330,25 @@ describe("DesktopServerExposure", () => {
           ["http://127.0.0.1:4173/", "http://192.168.1.20:4173/", "http://100.90.1.2:4173/"],
         );
       }),
+    ),
+  );
+
+  it.effect("keeps core endpoints when tailscale resolution dies", () =>
+    withHarness(
+      { ...lanNetworkInterfaces, ...tailnetNetworkInterfaces },
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+        yield* serverExposure.setMode("network-accessible");
+
+        const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          endpoints.map((endpoint) => endpoint.httpBaseUrl),
+          ["http://127.0.0.1:4173/", "http://192.168.1.20:4173/"],
+        );
+      }),
+      {},
+      throwOnSpawnLayer(),
     ),
   );
 

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -546,6 +546,7 @@ export const make = Effect.gen(function* () {
     }).pipe(
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
       Effect.provideService(HttpClient.HttpClient, httpClient),
+      Effect.catchDefect(() => Effect.succeed([])),
     );
     return [...coreEndpoints, ...tailscaleEndpoints];
   }).pipe(Effect.withSpan("desktop.serverExposure.getAdvertisedEndpoints"));

--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -212,6 +212,26 @@ describe("tailscale", () => {
     });
   });
 
+  it.effect("converts tailscale status spawn defects to typed failures", () => {
+    const cause = new Error("spawn ENOTDIR");
+    const layer = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => Effect.die(cause)),
+    );
+
+    return Effect.gen(function* () {
+      const error = yield* readTailscaleStatus.pipe(Effect.flip, Effect.provide(layer));
+
+      assert.instanceOf(error, TailscaleCommandSpawnError);
+      assert.equal(error.executable, "tailscale");
+      assert.equal(error.subcommand, "status");
+      assert.equal(error.argumentCount, 2);
+      assert.strictEqual(error.cause, cause);
+      assert.equal(error.message, "Failed to spawn tailscale status.");
+      assert.notInclude(error.message, cause.message);
+    });
+  });
+
   it.effect("keeps nonzero exit diagnostics structured", () => {
     const layer = mockSpawnerLayer(() => ({
       code: 7,
@@ -288,6 +308,29 @@ describe("tailscale", () => {
     });
 
     return ensureTailscaleServe({ localPort: 13773, servePort: 8443 }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("converts tailscale serve spawn defects to typed failures", () => {
+    const cause = new Error("spawn ENOTDIR");
+    const layer = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => Effect.die(cause)),
+    );
+
+    return Effect.gen(function* () {
+      const error = yield* ensureTailscaleServe({ localPort: 13773, servePort: 8443 }).pipe(
+        Effect.flip,
+        Effect.provide(layer),
+      );
+
+      assert.instanceOf(error, TailscaleCommandSpawnError);
+      assert.equal(error.executable, "tailscale");
+      assert.equal(error.subcommand, "serve");
+      assert.equal(error.argumentCount, 4);
+      assert.strictEqual(error.cause, cause);
+      assert.equal(error.message, "Failed to spawn tailscale serve.");
+      assert.notInclude(error.message, cause.message);
+    });
   });
 
   it.effect("retains tailscale serve exit diagnostics", () => {

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -228,11 +228,12 @@ export const readTailscaleStatus = Effect.gen(function* () {
     argumentCount: args.length,
   };
   return yield* Effect.gen(function* () {
-    const child = yield* spawner
-      .spawn(ChildProcess.make(executable, args))
-      .pipe(
-        Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
-      );
+    const child = yield* spawner.spawn(ChildProcess.make(executable, args)).pipe(
+      Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
+      Effect.catchDefect((cause) =>
+        Effect.fail(new TailscaleCommandSpawnError({ ...commandContext, cause })),
+      ),
+    );
     const [stdout, stderr, exitCode] = yield* Effect.all(
       [
         collectStdout(child.stdout),
@@ -299,11 +300,12 @@ const runTailscaleCommand = (
     };
     const timeout = Duration.fromInputUnsafe(timeoutInput);
     return yield* Effect.gen(function* () {
-      const child = yield* spawner
-        .spawn(ChildProcess.make(executable, args))
-        .pipe(
-          Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
-        );
+      const child = yield* spawner.spawn(ChildProcess.make(executable, args)).pipe(
+        Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
+        Effect.catchDefect((cause) =>
+          Effect.fail(new TailscaleCommandSpawnError({ ...commandContext, cause })),
+        ),
+      );
       const [stderr, exitCode] = yield* Effect.all(
         [collectStderr(child.stderr), child.exitCode.pipe(Effect.map(Number))],
         { concurrency: "unbounded" },


### PR DESCRIPTION
A malformed PATH entry can make Node throw an ENOTDIR defect while spawning the Tailscale CLI. That defect bypasses typed Effect fallbacks and causes the desktop advertised-endpoints IPC call to reject.

Convert defects from both Tailscale spawn effects into the existing typed spawn error, while keeping timeout, exit, and parse handling unchanged. Add a desktop safety net so any residual Tailscale resolution defect drops only Tailscale endpoints and preserves loopback and LAN endpoints.

Tests cover status and serve spawn defects plus the desktop residual-defect fallback.

Verification:
- pnpm exec vp run --filter @t3tools/tailscale test
- pnpm exec vp run --filter @t3tools/desktop test
- pnpm exec vp run --filter @t3tools/tailscale --filter @t3tools/desktop typecheck
- pnpm exec vp fmt --check packages/tailscale/src/tailscale.ts packages/tailscale/src/tailscale.test.ts apps/desktop/src/backend/DesktopServerExposure.ts apps/desktop/src/backend/DesktopServerExposure.test.ts
- pnpm exec vp lint packages/tailscale/src/tailscale.ts packages/tailscale/src/tailscale.test.ts apps/desktop/src/backend/DesktopServerExposure.ts apps/desktop/src/backend/DesktopServerExposure.test.ts --report-unused-disable-directives

Model: GPT-5.6
Harness: Codex in T3 Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/5096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tailscale spawn defects to surface as typed failures instead of crashing
> - In [`tailscale.ts`](https://github.com/pingdotgg/t3code/pull/5096/files#diff-580f62662917cf32d498487b66719be157805c6a8b3cd04d84bb278fef541e43), `readTailscaleStatus` and `runTailscaleCommand` now catch spawner defects via `Effect.catchDefect` and convert them to `TailscaleCommandSpawnError` typed failures.
> - In [`DesktopServerExposure.ts`](https://github.com/pingdotgg/t3code/pull/5096/files#diff-87d5808073ddb6ad6696185597726c0867bb1276e88997a57829cf9839e8abcb), `getAdvertisedEndpoints` catches defects during tailscale endpoint resolution and falls back to returning an empty list, so loopback and LAN endpoints are still advertised.
> - Behavioral Change: previously, a tailscale spawn defect would crash the effect pipeline; now it is caught and treated as a recoverable typed failure or an empty result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d1f83f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Tailscale command failures with clearer, consistent error reporting.
  - Preserved advertised core endpoints when Tailscale endpoint resolution fails.
  - Prevented unexpected command-spawning defects from disrupting desktop server exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->