### PR TITLE
fix(server): harden SQLite durability under streaming writes

### DIFF
--- a/apps/server/src/persistence/Layers/Sqlite.test.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.test.ts
@@ -1,0 +1,19 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { SqlitePersistenceMemory } from "./Sqlite.ts";
+
+const layer = it.layer(SqlitePersistenceMemory);
+
+layer("Sqlite persistence setup", (it) => {
+  it.effect("uses full synchronous durability", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      const rows = yield* sql<{ readonly synchronous: number }>`PRAGMA synchronous;`;
+
+      assert.equal(rows[0]?.synchronous, 2);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.ts
@@ -34,6 +34,7 @@ const setup = Layer.effectDiscard(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     yield* sql`PRAGMA journal_mode = WAL;`;
+    yield* sql`PRAGMA synchronous = FULL;`;
     yield* sql`PRAGMA foreign_keys = ON;`;
     yield* runMigrations();
   }),

--- a/apps/server/src/persistence/NodeSqliteClient.test.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.test.ts
@@ -42,6 +42,16 @@ layer("NodeSqliteClient", (it) => {
       assert.equal(error.reason.operation, "prepare");
     }),
   );
+
+  it.effect("uses full synchronous durability", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      const rows = yield* sql<{ readonly synchronous: number }>`PRAGMA synchronous;`;
+
+      assert.equal(rows[0]?.synchronous, 2);
+    }),
+  );
 });
 
 it.effect("returns a typed failure when the database cannot be opened", () =>

--- a/apps/server/src/persistence/NodeSqliteClient.test.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.test.ts
@@ -42,16 +42,6 @@ layer("NodeSqliteClient", (it) => {
       assert.equal(error.reason.operation, "prepare");
     }),
   );
-
-  it.effect("uses full synchronous durability", () =>
-    Effect.gen(function* () {
-      const sql = yield* SqlClient.SqlClient;
-
-      const rows = yield* sql<{ readonly synchronous: number }>`PRAGMA synchronous;`;
-
-      assert.equal(rows[0]?.synchronous, 2);
-    }),
-  );
 });
 
 it.effect("returns a typed failure when the database cannot be opened", () =>


### PR DESCRIPTION
Refs #961

## What Changed

Set `PRAGMA synchronous = FULL` for the production and in-memory SQLite persistence layers, and add focused coverage that the SQLite client is running with FULL durability.

## Why

T3's persisted state is a WAL SQLite database receiving a high volume of small streaming writes. When an I/O or transaction-state failure occurs during that stream, the transaction cleanup path can surface a later `cannot rollback - no transaction is active` error instead of the original SQLite error and leave the shared connection unusable until restart. In one local repro, the database passed `PRAGMA integrity_check` but every subsequent orchestration command failed at `OrchestrationCommandReceiptRepository.getByCommandId` with `disk I/O error`.

SQLite's WAL default is `synchronous = NORMAL`, which does not sync on every commit. Setting `FULL` makes committed transactions durable before SQLite reports success, reducing the window where WAL checkpoint/checkpoint-restart behavior can leave the main database inconsistent under heavy write streams. This keeps the existing WAL mode and schema unchanged.

Related upstream context:

- #1231 addressed startup recovery after an already-corrupted database.
- This PR targets a narrower runtime durability gap before corruption occurs.

## Validation

- `corepack pnpm exec vp test run apps/server/src/persistence/NodeSqliteClient.test.ts`
- `corepack pnpm exec vp test run apps/server/src/persistence/Layers/Sqlite.test.ts`
- `corepack pnpm exec vp lint apps/server/src/persistence/Layers/Sqlite.ts apps/server/src/persistence/Layers/Sqlite.test.ts apps/server/src/persistence/NodeSqliteClient.test.ts`
- `corepack pnpm --filter t3 exec tsgo --noEmit`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Kimi K3 via Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core persistence durability and write behavior (more disk sync per commit); scope is small and localized to SQLite setup with test coverage.
> 
> **Overview**
> Hardens SQLite persistence by setting **`PRAGMA synchronous = FULL`** during layer setup in `Sqlite.ts`, immediately after WAL journal mode and before foreign keys. WAL mode stays the same; commits are flushed more aggressively than the WAL default (`NORMAL`), targeting fewer I/O / transaction failures under heavy small writes.
> 
> Adds **`Sqlite.test.ts`** with a layer test that reads `PRAGMA synchronous` and asserts the value is **2** (FULL) on `SqlitePersistenceMemory`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f0a46447f1bb35faaa1b9a2ffb8d018154a625c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `PRAGMA synchronous = FULL` on SQLite connections to harden durability
> Adds `PRAGMA synchronous = FULL` to the SQLite setup in [Sqlite.ts](https://github.com/pingdotgg/t3code/pull/5104/files#diff-47b4fe6e24808f5d59f5b97892cce0d736c01e7a8323b77e0c6a3751ff7ba7fa), applied between the existing WAL journal mode and foreign keys pragmas during layer initialization. A new test in [Sqlite.test.ts](https://github.com/pingdotgg/t3code/pull/5104/files#diff-36d5664fefdd38c17b6bea202cf73c795e2b0f9d5bd51b61a0f4bd8c09384302) asserts the pragma value is set to 2. Risk: `FULL` sync mode flushes to disk on every write, which reduces throughput compared to the previous default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f0a464.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->