### PR TITLE
fix(desktop): skip unreadable legacy credentials during migration

### DIFF
--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
@@ -83,13 +83,14 @@ function makeLayer(
 const withStore = <A, E, R>(
   effect: Effect.Effect<A, E, R | DesktopConnectionCatalogStore.DesktopConnectionCatalogStore>,
   encryptionAvailable = true,
+  failDecrypt: Ref.Ref<boolean> | null = null,
 ) =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
     const baseDir = yield* fileSystem.makeTempDirectoryScoped({
       prefix: "t3-desktop-connection-catalog-test-",
     });
-    return yield* effect.pipe(Effect.provide(makeLayer(baseDir, encryptionAvailable)));
+    return yield* effect.pipe(Effect.provide(makeLayer(baseDir, encryptionAvailable, failDecrypt)));
   }).pipe(Effect.provide(NodeServices.layer), Effect.scoped);
 
 describe("DesktopConnectionCatalogStore", () => {
@@ -220,6 +221,63 @@ describe("DesktopConnectionCatalogStore", () => {
         assert.deepEqual(yield* store.get, migrated);
       }),
     ),
+  );
+
+  it.effect("migrates legacy connection metadata when its credential is unreadable", () =>
+    Effect.gen(function* () {
+      const failDecrypt = yield* Ref.make(false);
+      return yield* withStore(
+        Effect.gen(function* () {
+          const environment = yield* DesktopEnvironment.DesktopEnvironment;
+          const fileSystem = yield* FileSystem.FileSystem;
+          const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore;
+          const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
+          const record: PersistedSavedEnvironmentRecord = {
+            environmentId: EnvironmentId.make("unreadable-credential-environment"),
+            label: "Unreadable credential",
+            httpBaseUrl: "https://unreadable.example.com/",
+            wsBaseUrl: "wss://unreadable.example.com/",
+            createdAt: "2026-06-04T00:00:00.000Z",
+            lastConnectedAt: null,
+          };
+          yield* savedEnvironments.setRegistry([record]);
+          assert.isTrue(
+            yield* savedEnvironments.setSecret({
+              environmentId: record.environmentId,
+              secret: "legacy-token",
+            }),
+          );
+
+          yield* Ref.set(failDecrypt, true);
+          const migrated = yield* store.get;
+          assert.isTrue(Option.isSome(migrated));
+          if (Option.isNone(migrated)) {
+            return;
+          }
+          const catalog = yield* decodeConnectionCatalog(migrated.value);
+          assert.deepInclude(catalog.targets[0], {
+            _tag: "BearerConnectionTarget",
+            environmentId: record.environmentId,
+            connectionId: `bearer:${record.environmentId}`,
+          });
+          assert.equal(catalog.profiles.length, 1);
+          assert.equal(catalog.credentials.length, 0);
+          assert.isTrue(
+            yield* fileSystem.exists(`${environment.stateDir}/connection-catalog.json`),
+          );
+
+          yield* Ref.set(failDecrypt, false);
+          assert.deepEqual(
+            yield* savedEnvironments.getSecret(record.environmentId),
+            Option.some("legacy-token"),
+          );
+          yield* savedEnvironments.setRegistry([]);
+          assert.deepEqual(yield* store.get, migrated);
+        }),
+        true,
+        failDecrypt,
+      );
+    }),
   );
 
   it.effect("surfaces malformed catalog documents without deleting them", () =>

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
@@ -347,7 +347,21 @@ const migrateSavedEnvironmentRecords = Effect.fn(
         wsBaseUrl: record.wsBaseUrl,
       }),
     );
+    // A legacy token that safe storage cannot read is unusable. Keep its
+    // connection metadata so the user can authenticate it again without
+    // blocking migration of the rest of the catalog.
     const token = yield* savedEnvironments.getSecret(record.environmentId).pipe(
+      Effect.catchTag(
+        [
+          "DesktopSavedEnvironmentSecretDecodeError",
+          "DesktopSavedEnvironmentSecretProtectionError",
+        ],
+        (error) =>
+          Effect.logWarning("Skipping an unreadable legacy desktop connection credential.", {
+            environmentId: record.environmentId,
+            error: error.message,
+          }).pipe(Effect.as(Option.none<string>())),
+      ),
       Effect.mapError(
         (cause) =>
           new DesktopConnectionCatalogStoreMigrationError({

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
@@ -351,17 +351,18 @@ const migrateSavedEnvironmentRecords = Effect.fn(
     // connection metadata so the user can authenticate it again without
     // blocking migration of the rest of the catalog.
     const token = yield* savedEnvironments.getSecret(record.environmentId).pipe(
-      Effect.catchTag(
-        [
-          "DesktopSavedEnvironmentSecretDecodeError",
-          "DesktopSavedEnvironmentSecretProtectionError",
-        ],
-        (error) =>
+      Effect.catchTags({
+        DesktopSavedEnvironmentSecretDecodeError: (error) =>
           Effect.logWarning("Skipping an unreadable legacy desktop connection credential.", {
             environmentId: record.environmentId,
             error: error.message,
           }).pipe(Effect.as(Option.none<string>())),
-      ),
+        DesktopSavedEnvironmentSecretProtectionError: (error) =>
+          Effect.logWarning("Skipping an unreadable legacy desktop connection credential.", {
+            environmentId: record.environmentId,
+            error: error.message,
+          }).pipe(Effect.as(Option.none<string>())),
+      }),
       Effect.mapError(
         (cause) =>
           new DesktopConnectionCatalogStoreMigrationError({


### PR DESCRIPTION
## Problem

A single legacy bearer credential that Electron safe storage can no longer decode or decrypt aborts the entire desktop connection catalog migration. That makes Connections unavailable and blocks unrelated work such as adding an SSH host even though the saved connection metadata is still valid.

Fixes #4991.

## Fix

Per-credential decode and protection failures now log a warning and omit only the unreadable credential. The target and profile still migrate, the rest of the catalog is persisted, and global registry read or decode failures remain fatal.

The legacy registry and encrypted secret are left untouched. The affected connection can be authenticated again without blocking SSH, relay, or other saved connections.

## Validation

- `vp test run apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts` — 10 passed
- targeted type-aware lint and typecheck on both changed files
- targeted format check and `git diff --check`
- read-only reviews with Claude Opus 5 and Grok 4.5

No UI changed, so screenshots do not apply.

Implemented with Codex (GPT-5) in the Codex desktop app.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip unreadable legacy credentials during desktop connection catalog migration
> - In `migrateSavedEnvironmentRecords`, decryption errors (`DesktopSavedEnvironmentSecretDecodeError`, `DesktopSavedEnvironmentSecretProtectionError`) are now caught and logged as warnings instead of failing the migration.
> - When a legacy credential is unreadable, migration continues and still creates the connection target and profile, but omits the credential for that environment.
> - Adds a test in [DesktopConnectionCatalogStore.test.ts](https://github.com/pingdotgg/t3code/pull/5105/files#diff-1da54ad65990d5632d31c5ed70fe370172c110f41b2f35793b0ea50a2aa838f7) that injects a `failDecrypt` ref to simulate decryption failures and asserts the above behavior.
> - Behavioral Change: Previously, an unreadable legacy credential would abort migration entirely; now it is silently skipped with a warning log.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ef459e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop migration behavior with no auth or data-model changes beyond omitting unusable credentials; global migration failures are unchanged.
> 
> **Overview**
> **Legacy connection catalog migration** no longer fails when Electron safe storage cannot decrypt a single bearer token. In `migrateSavedEnvironmentRecords`, `getSecret` errors tagged `DesktopSavedEnvironmentSecretDecodeError` or `DesktopSavedEnvironmentSecretProtectionError` are caught, logged as warnings, and treated as missing credentials instead of aborting migration.
> 
> **Bearer targets and profiles still migrate** for those environments so users can re-authenticate; only the unreadable credential is omitted. Registry-wide read/decode failures remain fatal.
> 
> A test exercises this by toggling a `failDecrypt` flag on the mock safe storage during catalog read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef459ee71879c82516abb4b9017000652a8caed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->