### PR TITLE
fix(server): follow agent-created branches

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -573,15 +573,10 @@ describe("CheckpointReactor", () => {
   });
 
   it("does not regress a generated thread branch to a stale temporary worktree branch", async () => {
-    const harness = await createHarness({ seedFilesystemCheckpoints: false });
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.meta.update",
-        commandId: CommandId.make("cmd-generated-branch-set"),
-        threadId: ThreadId.make("thread-1"),
-        branch: "t3code/generated-branch",
-      }),
-    );
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      threadBranch: "t3code/generated-branch",
+    });
     runGit(harness.cwd, ["switch", "-c", "t3code/deadbeef"]);
 
     harness.provider.emit({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -143,12 +143,14 @@ async function waitForThread(
   readModel: () => Promise<{
     readonly threads: ReadonlyArray<{
       readonly id: ThreadId;
+      readonly branch: string | null;
       readonly latestTurn: { readonly turnId: string } | null;
       readonly checkpoints: ReadonlyArray<{ readonly checkpointTurnCount: number }>;
       readonly activities: ReadonlyArray<{ readonly kind: string }>;
     }>;
   }>,
   predicate: (thread: {
+    branch: string | null;
     latestTurn: { turnId: string } | null;
     checkpoints: ReadonlyArray<{ checkpointTurnCount: number }>;
     activities: ReadonlyArray<{ kind: string }>;
@@ -158,6 +160,7 @@ async function waitForThread(
   const deadline = (await Effect.runPromise(Clock.currentTimeMillis)) + timeoutMs;
   const poll = async (): Promise<{
     latestTurn: { turnId: string } | null;
+    branch: string | null;
     checkpoints: ReadonlyArray<{ checkpointTurnCount: number }>;
     activities: ReadonlyArray<{ kind: string }>;
   }> => {
@@ -276,10 +279,13 @@ describe("CheckpointReactor", () => {
     readonly hasSession?: boolean;
     readonly seedFilesystemCheckpoints?: boolean;
     readonly projectWorkspaceRoot?: string;
+    readonly threadBranch?: string | null;
     readonly threadWorktreePath?: string | null;
     readonly providerSessionCwd?: string;
     readonly providerName?: ProviderDriverKind;
     readonly gitStatusRefreshCalls?: Array<string>;
+    readonly fullGitStatusRefreshCalls?: Array<string>;
+    readonly hasPrimaryRemote?: boolean;
   }) {
     const cwd = createGitRepository();
     tempDirs.push(cwd);
@@ -310,17 +316,35 @@ describe("CheckpointReactor", () => {
       refreshLocalStatus: (cwd: string) =>
         Effect.sync(() => {
           options?.gitStatusRefreshCalls?.push(cwd);
+          const refName = runGit(cwd, ["branch", "--show-current"]).trim();
+          return refName.length > 0 ? refName : null;
         }).pipe(
-          Effect.as({
+          Effect.map((refName) => ({
+            isRepo: true,
+            hasPrimaryRemote: options?.hasPrimaryRemote ?? false,
+            isDefaultRef: true,
+            refName,
+            hasWorkingTreeChanges: false,
+            workingTree: { files: [], insertions: 0, deletions: 0 },
+          })),
+        ),
+      refreshStatus: (cwd: string) =>
+        Effect.sync(() => {
+          options?.fullGitStatusRefreshCalls?.push(cwd);
+          const refName = runGit(cwd, ["branch", "--show-current"]).trim();
+          return {
             isRepo: true,
             hasPrimaryRemote: false,
             isDefaultRef: true,
-            refName: "main",
+            refName: refName.length > 0 ? refName : null,
             hasWorkingTreeChanges: false,
             workingTree: { files: [], insertions: 0, deletions: 0 },
-          }),
-        ),
-      refreshStatus: () => Effect.die("refreshStatus should not be called in this test"),
+            hasUpstream: false,
+            aheadCount: 0,
+            behindCount: 0,
+            pr: null,
+          };
+        }),
       streamStatus: () => Stream.empty,
     });
 
@@ -382,7 +406,7 @@ describe("CheckpointReactor", () => {
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
-        branch: null,
+        branch: options?.threadBranch ?? null,
         worktreePath: options?.threadWorktreePath ?? cwd,
         createdAt,
       }),
@@ -518,6 +542,65 @@ describe("CheckpointReactor", () => {
     expect(gitStatusRefreshCalls).toEqual([harness.cwd]);
   });
 
+  it("updates the thread to the branch checked out by the completed agent turn", async () => {
+    const fullGitStatusRefreshCalls: string[] = [];
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      fullGitStatusRefreshCalls,
+      hasPrimaryRemote: true,
+      threadBranch: "feature/original",
+    });
+    runGit(harness.cwd, ["switch", "-c", "feature/agent-branch"]);
+
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-branch-sync"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      turnId: asTurnId("turn-branch-sync"),
+      payload: { state: "completed" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.branch === "feature/agent-branch",
+    );
+    await harness.drain();
+
+    expect(thread.branch).toBe("feature/agent-branch");
+    expect(fullGitStatusRefreshCalls).toEqual([harness.cwd]);
+  });
+
+  it("does not regress a generated thread branch to a stale temporary worktree branch", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-generated-branch-set"),
+        threadId: ThreadId.make("thread-1"),
+        branch: "t3code/generated-branch",
+      }),
+    );
+    runGit(harness.cwd, ["switch", "-c", "t3code/deadbeef"]);
+
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-stale-temporary-branch"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      turnId: asTurnId("turn-stale-temporary-branch"),
+      payload: { state: "completed" },
+    });
+
+    await harness.drain();
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+
+    expect(thread?.branch).toBe("t3code/generated-branch");
+  });
+
   it("ignores auxiliary thread turn completion while primary turn is active", async () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });
     const createdAt = "2026-01-01T00:00:00.000Z";
@@ -571,6 +654,7 @@ describe("CheckpointReactor", () => {
     const midReadModel = await harness.readModel();
     const midThread = midReadModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(midThread?.checkpoints).toHaveLength(0);
+    expect(midThread?.branch).toBeNull();
 
     harness.provider.emit({
       type: "turn.completed",

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -18,6 +18,7 @@ import * as Option from "effect/Option";
 import type * as PlatformError from "effect/PlatformError";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 
 import { parseTurnDiffFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
 import {
@@ -526,24 +527,81 @@ const make = Effect.gen(function* () {
     },
   );
 
-  const refreshLocalGitStatusFromTurnCompletion = Effect.fn(
-    "refreshLocalGitStatusFromTurnCompletion",
+  const refreshGitStatusAndSyncThreadBranchFromTurnCompletion = Effect.fn(
+    "refreshGitStatusAndSyncThreadBranchFromTurnCompletion",
   )(function* (event: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>) {
     const sessionRuntime = yield* resolveSessionRuntimeForThread(event.threadId);
     if (Option.isNone(sessionRuntime)) {
       return;
     }
 
-    yield* vcsStatusBroadcaster.refreshLocalStatus(sessionRuntime.value.cwd).pipe(
+    const status = yield* vcsStatusBroadcaster.refreshLocalStatus(sessionRuntime.value.cwd).pipe(
+      Effect.map(Option.some),
       Effect.catch((error) =>
         Effect.logWarning("failed to refresh local git status after turn completion", {
           threadId: event.threadId,
           turnId: event.turnId ?? null,
           cwd: sessionRuntime.value.cwd,
           detail: error.message,
-        }),
+        }).pipe(Effect.as(Option.none())),
       ),
     );
+    if (Option.isNone(status) || status.value.refName === null) {
+      return;
+    }
+
+    const thread = yield* resolveThreadDetail(event.threadId);
+    if (!thread) {
+      return;
+    }
+    const turnId = toTurnId(event.turnId);
+    if (thread.session?.activeTurnId && !sameId(thread.session.activeTurnId, turnId)) {
+      return;
+    }
+
+    const refName = status.value.refName;
+    if (
+      refName === thread.branch ||
+      (thread.branch !== null &&
+        !isTemporaryWorktreeBranch(thread.branch) &&
+        isTemporaryWorktreeBranch(refName))
+    ) {
+      return;
+    }
+
+    yield* orchestrationEngine
+      .dispatch({
+        type: "thread.meta.update",
+        commandId: yield* serverCommandId("turn-completion-branch-sync"),
+        threadId: event.threadId,
+        branch: refName,
+        expectedBranch: thread.branch,
+      })
+      .pipe(
+        Effect.catch((error) =>
+          Effect.logWarning("failed to sync thread branch after turn completion", {
+            threadId: event.threadId,
+            turnId: event.turnId ?? null,
+            cwd: sessionRuntime.value.cwd,
+            refName,
+            detail: error.message,
+          }),
+        ),
+      );
+
+    if (status.value.hasPrimaryRemote) {
+      yield* vcsStatusBroadcaster.refreshStatus(sessionRuntime.value.cwd).pipe(
+        Effect.catch((error) =>
+          Effect.logWarning("failed to refresh remote git status after thread branch sync", {
+            threadId: event.threadId,
+            turnId: event.turnId ?? null,
+            cwd: sessionRuntime.value.cwd,
+            refName,
+            detail: error.message,
+          }),
+        ),
+      );
+    }
   });
 
   const ensurePreTurnBaselineFromDomainTurnStart = Effect.fn(
@@ -790,7 +848,7 @@ const make = Effect.gen(function* () {
 
     if (event.type === "turn.completed") {
       const turnId = toTurnId(event.turnId);
-      yield* refreshLocalGitStatusFromTurnCompletion(event);
+      yield* refreshGitStatusAndSyncThreadBranchFromTurnCompletion(event);
       yield* captureCheckpointFromTurnCompletion(event).pipe(
         Effect.catch((error) =>
           Effect.flatMap(nowIso, (createdAt) =>


### PR DESCRIPTION
## Problem

When an agent creates or checks out a branch during a turn, the thread keeps its previous branch metadata. The sidebar PR card then rejects the live PR status because the stored thread branch and checkout branch do not match.

## Fix

- Reconcile the thread branch from the provider session checkout when the primary agent turn completes.
- Guard the metadata update with the previously observed branch so concurrent branch naming cannot be overwritten.
- Preserve generated worktree branch names when a stale temporary branch is observed.
- Refresh full source-control status after a remote-backed branch change so a newly opened PR can appear immediately.
- Ignore auxiliary turn completions while a primary turn remains active.

This is server-side orchestration behavior, so web, desktop, and mobile receive the corrected thread metadata through the existing event stream.

## Validation

- Server typecheck passes.
- Formatting and implementation lint pass for the changed files.
- Diff whitespace checks pass.
- Focused CheckpointReactor tests were added for branch adoption, remote PR refresh, temporary-branch protection, and auxiliary-turn protection.
- The focused suite cannot currently collect under the local Vite+ runner because describe.config is undefined. The same pre-collection failure reproduces on the untouched OrchestrationEngine suite.

Generated by GPT-5.6 using Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync thread branch to current git ref on agent turn completion
> - On `turn.completed`, `CheckpointReactor` now calls `refreshGitStatusAndSyncThreadBranchFromTurnCompletion`, which reads the current git ref and dispatches `thread.meta.update` with the new branch name.
> - Skips the update if the ref matches the existing thread branch, or if the thread already has a non-temporary branch and the new ref is a temporary worktree branch (prevents regressions to stale temp branches).
> - If the local status reports a primary remote, triggers a full VCS status refresh via `vcsStatusBroadcaster.refreshStatus`.
> - Behavioral Change: turn completion now mutates thread branch metadata and may trigger a remote status refresh, where previously it only refreshed local status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab408b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration metadata and turn-completion side effects (new `thread.meta.update` dispatches and optional full VCS refresh), which affect all clients via the event stream but are guarded by expected-branch and temporary-branch rules.
> 
> **Overview**
> When a primary agent turn completes, **CheckpointReactor** now reconciles stored **thread branch** metadata with the git ref checked out in the provider session workspace—not only refreshing local VCS status.
> 
> On `turn.completed`, it reads the current ref from `refreshLocalStatus`, skips updates when the ref is unchanged, when an auxiliary turn completes while another turn is still active, or when checkout would **regress** a non-temporary thread branch to a temporary `t3code/*` worktree ref. Otherwise it dispatches **`thread.meta.update`** with `expectedBranch` for safe concurrent updates. If the repo has a primary remote, it also runs a full **`refreshStatus`** so PR-related UI can pick up a newly opened PR.
> 
> Tests extend the harness with real git refs and cover branch adoption, temporary-branch protection, remote refresh, and auxiliary-turn behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab408b86364100494bb495a6bc0f576d937e2980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->