### PR TITLE
feat(server): make workspace list cap configurable

### DIFF
--- a/apps/server/scripts/workspace-index-memory-probe.ts
+++ b/apps/server/scripts/workspace-index-memory-probe.ts
@@ -1,0 +1,118 @@
+// @effect-diagnostics nodeBuiltinImport:off - Standalone Node performance probe.
+import * as NodeChildProcess from "node:child_process";
+import * as NodeProcess from "node:process";
+
+import * as Effect from "effect/Effect";
+
+import * as WorkspaceSearchIndex from "../src/workspace/WorkspaceSearchIndex.ts";
+
+const DEFAULT_LIMITS = [1_000, 5_000, 25_000];
+const CHILD_FLAG = "--child";
+
+interface MemorySample {
+  readonly maxEntries: number;
+  readonly returnedEntries: number;
+  readonly truncated: boolean;
+  readonly indexedRssMiB: number;
+  readonly listedRssMiB: number;
+  readonly listDeltaRssMiB: number;
+  readonly indexedPeakRssMiB: number;
+  readonly listedPeakRssMiB: number;
+  readonly listPeakDeltaRssMiB: number;
+}
+
+function memorySample(): { readonly rssMiB: number; readonly peakRssMiB: number } {
+  globalThis.gc?.();
+  return {
+    rssMiB: Math.round((NodeProcess.memoryUsage().rss / 1024 / 1024) * 10) / 10,
+    peakRssMiB: Math.round((NodeProcess.resourceUsage().maxRSS / 1024) * 10) / 10,
+  };
+}
+
+function parsePositiveInteger(input: string, label: string): number {
+  const value = Number(input);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer, received '${input}'.`);
+  }
+  return value;
+}
+
+async function measure(cwd: string, maxEntries: number): Promise<MemorySample> {
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const index = yield* WorkspaceSearchIndex.make(cwd, "paths", {
+          maxListEntries: maxEntries,
+        });
+        const indexed = memorySample();
+        const result = yield* index.list();
+        const listed = memorySample();
+
+        return {
+          maxEntries,
+          returnedEntries: result.entries.length,
+          truncated: result.truncated,
+          indexedRssMiB: indexed.rssMiB,
+          listedRssMiB: listed.rssMiB,
+          listDeltaRssMiB: Math.round((listed.rssMiB - indexed.rssMiB) * 10) / 10,
+          indexedPeakRssMiB: indexed.peakRssMiB,
+          listedPeakRssMiB: listed.peakRssMiB,
+          listPeakDeltaRssMiB: Math.round((listed.peakRssMiB - indexed.peakRssMiB) * 10) / 10,
+        };
+      }),
+    ),
+  );
+}
+
+function runChild(cwd: string, maxEntries: number): MemorySample {
+  if (NodeProcess.release.name !== "node") {
+    throw new Error("Run the workspace memory probe with Node.js.");
+  }
+  const execArgs = NodeProcess.execArgv.includes("--expose-gc")
+    ? NodeProcess.execArgv
+    : [...NodeProcess.execArgv, "--expose-gc"];
+  const child = NodeChildProcess.spawnSync(
+    NodeProcess.execPath,
+    [...execArgs, import.meta.filename, CHILD_FLAG, cwd, String(maxEntries)],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 },
+  );
+  if (child.error) {
+    throw new Error("Unable to start the workspace memory probe child process.", {
+      cause: child.error,
+    });
+  }
+  if (child.status !== 0) {
+    const detail = child.stderr?.trim();
+    throw new Error(
+      detail ||
+        `Memory probe exited with status ${String(child.status)} and signal ${String(child.signal)}.`,
+    );
+  }
+  try {
+    return JSON.parse(child.stdout) as MemorySample;
+  } catch (cause) {
+    throw new Error("Workspace memory probe child returned invalid JSON.", { cause });
+  }
+}
+
+const args = NodeProcess.argv.slice(2);
+if (args[0] === CHILD_FLAG) {
+  const cwd = args[1];
+  const maxEntriesText = args[2];
+  if (!cwd || !maxEntriesText) {
+    throw new Error("Child probe requires a cwd and maximum entry count.");
+  }
+  NodeProcess.stdout.write(
+    JSON.stringify(await measure(cwd, parsePositiveInteger(maxEntriesText, "maxEntries"))),
+  );
+} else {
+  const cwd = args[0] ?? NodeProcess.cwd();
+  const limits =
+    args.length > 1
+      ? args.slice(1).map((input) => parsePositiveInteger(input, "maxEntries"))
+      : DEFAULT_LIMITS;
+  const samples = limits.map((limit) => runChild(cwd, limit));
+
+  NodeProcess.stdout.write(`Workspace: ${cwd}\n`);
+  console.table(samples);
+}

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -1,8 +1,16 @@
-import { FileFinder, type GrepCursor, type GrepOptions, type GrepResult } from "@ff-labs/fff-node";
+import {
+  FileFinder,
+  type GrepCursor,
+  type GrepOptions,
+  type GrepResult,
+  type MixedSearchResult,
+} from "@ff-labs/fff-node";
 import { afterEach, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
 import { vi } from "vite-plus/test";
 
 import * as WorkspaceSearchIndex from "./WorkspaceSearchIndex.ts";
@@ -63,6 +71,109 @@ it.effect("waits for the full content index warmup before returning", () =>
     yield* Effect.scoped(WorkspaceSearchIndex.make("/workspace/project", "content"));
 
     expect(waitForIndexReady).toHaveBeenCalledWith(15_000);
+  }),
+);
+
+it.effect("bounds workspace listings with the configured maximum", () =>
+  Effect.gen(function* () {
+    const mixedSearch = vi.fn(() => ({
+      ok: true as const,
+      value: {
+        items: [
+          {
+            type: "directory" as const,
+            item: { relativePath: "", dirName: "", maxAccessFrecency: 0 },
+          },
+          {
+            type: "directory" as const,
+            item: { relativePath: "alpha/", dirName: "alpha/", maxAccessFrecency: 0 },
+          },
+          {
+            type: "directory" as const,
+            item: { relativePath: "beta/", dirName: "beta/", maxAccessFrecency: 0 },
+          },
+          {
+            type: "directory" as const,
+            item: { relativePath: "gamma/", dirName: "gamma/", maxAccessFrecency: 0 },
+          },
+        ],
+        scores: [],
+        totalMatched: 4,
+        totalFiles: 0,
+        totalDirs: 4,
+      } satisfies MixedSearchResult,
+    }));
+    const finder = {
+      destroy: vi.fn(),
+      waitForIndexReady: vi.fn(async () => ({ ok: true as const, value: true })),
+      mixedSearch,
+    } as unknown as FileFinder;
+    vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+
+    const indexLayer = WorkspaceSearchIndex.layer(
+      WorkspaceSearchIndex.workspaceSearchIndexKey("/workspace/project", "paths"),
+    ).pipe(
+      Layer.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromEnv({ env: { T3CODE_WORKSPACE_LIST_MAX_ENTRIES: "2" } }),
+        ),
+      ),
+    );
+    const result = yield* Effect.gen(function* () {
+      const searchIndex = yield* WorkspaceSearchIndex.WorkspaceSearchIndex;
+      return yield* searchIndex.list();
+    }).pipe(Effect.provide(indexLayer));
+
+    expect(mixedSearch).toHaveBeenCalledWith("", { pageSize: 4 });
+    expect(result).toEqual({
+      entries: [
+        { path: "alpha", kind: "directory" },
+        { path: "beta", kind: "directory" },
+      ],
+      truncated: true,
+    });
+  }),
+);
+
+it.effect("falls back to the default listing maximum for invalid configuration", () =>
+  Effect.gen(function* () {
+    const createFinder = vi.spyOn(FileFinder, "create");
+    for (const configuredValue of ["0", "25001", "not-a-number"]) {
+      const mixedSearch = vi.fn(() => ({
+        ok: true as const,
+        value: {
+          items: [],
+          scores: [],
+          totalMatched: 0,
+          totalFiles: 0,
+          totalDirs: 0,
+        } satisfies MixedSearchResult,
+      }));
+      const finder = {
+        destroy: vi.fn(),
+        waitForIndexReady: vi.fn(async () => ({ ok: true as const, value: true })),
+        mixedSearch,
+      } as unknown as FileFinder;
+      createFinder.mockReturnValueOnce({ ok: true, value: finder });
+
+      const indexLayer = WorkspaceSearchIndex.layer(
+        WorkspaceSearchIndex.workspaceSearchIndexKey("/workspace/project", "paths"),
+      ).pipe(
+        Layer.provide(
+          ConfigProvider.layer(
+            ConfigProvider.fromEnv({
+              env: { T3CODE_WORKSPACE_LIST_MAX_ENTRIES: configuredValue },
+            }),
+          ),
+        ),
+      );
+      yield* Effect.gen(function* () {
+        const searchIndex = yield* WorkspaceSearchIndex.WorkspaceSearchIndex;
+        yield* searchIndex.list();
+      }).pipe(Effect.provide(indexLayer));
+
+      expect(mixedSearch).toHaveBeenCalledWith("", { pageSize: 25_002 });
+    }
   }),
 );
 

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -9,6 +9,7 @@ import {
   type Result,
   type SearchResult,
 } from "@ff-labs/fff-node";
+import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -24,8 +25,24 @@ import type {
   ProjectSearchEntriesResult,
 } from "@t3tools/contracts";
 
-const WORKSPACE_INDEX_MAX_ENTRIES = 25_000;
-const WORKSPACE_INDEX_PAGE_SIZE = WORKSPACE_INDEX_MAX_ENTRIES + 2;
+const DEFAULT_WORKSPACE_LIST_MAX_ENTRIES = 25_000;
+const WORKSPACE_LIST_MAX_ENTRIES_CONFIG = Config.schema(
+  Schema.Int.check(
+    Schema.isGreaterThan(0),
+    Schema.isLessThanOrEqualTo(DEFAULT_WORKSPACE_LIST_MAX_ENTRIES),
+  ),
+  "T3CODE_WORKSPACE_LIST_MAX_ENTRIES",
+).pipe(Config.withDefault(DEFAULT_WORKSPACE_LIST_MAX_ENTRIES));
+const loadWorkspaceListMaxEntries = WORKSPACE_LIST_MAX_ENTRIES_CONFIG.pipe(
+  Effect.catch((cause) =>
+    Effect.logWarning(
+      `Invalid workspace list entry limit; expected an integer from 1 to ${DEFAULT_WORKSPACE_LIST_MAX_ENTRIES} and will use the default.`,
+    ).pipe(
+      Effect.annotateLogs({ cause, defaultMaxEntries: DEFAULT_WORKSPACE_LIST_MAX_ENTRIES }),
+      Effect.as(DEFAULT_WORKSPACE_LIST_MAX_ENTRIES),
+    ),
+  ),
+);
 const WORKSPACE_INDEX_SCAN_TIMEOUT = "15 seconds";
 const WORKSPACE_INDEX_SCAN_TIMEOUT_MS = 15_000;
 const WORKSPACE_INDEX_IDLE_TTL = "15 minutes";
@@ -350,7 +367,10 @@ const waitForIndexReady = Effect.fn("WorkspaceSearchIndex.waitForIndexReady")(fu
 export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
   cwd: string,
   variant: WorkspaceSearchIndexVariant = "paths",
+  options: { readonly maxListEntries?: number } = {},
 ) {
+  const maxListEntries = options.maxListEntries ?? DEFAULT_WORKSPACE_LIST_MAX_ENTRIES;
+  const listPageSize = maxListEntries + 2;
   const finder = yield* Effect.acquireRelease(createFinder(cwd, variant), (finder) =>
     Effect.try({
       try: () => finder.destroy(),
@@ -428,14 +448,14 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
 
   const list: WorkspaceSearchIndex["Service"]["list"] = Effect.fn("WorkspaceSearchIndex.list")(
     function* () {
-      const result = yield* runSearch("", WORKSPACE_INDEX_PAGE_SIZE, "mixedSearch", () =>
-        finder.mixedSearch("", { pageSize: WORKSPACE_INDEX_PAGE_SIZE }),
+      const result = yield* runSearch("", listPageSize, "mixedSearch", () =>
+        finder.mixedSearch("", { pageSize: listPageSize }),
       );
-      const mapped = mapMixedSearchResult(result, WORKSPACE_INDEX_MAX_ENTRIES);
+      const mapped = mapMixedSearchResult(result, maxListEntries);
       const sortedEntries = withDirectoryAncestors(mapped.entries).toSorted((left, right) =>
         left.path.localeCompare(right.path),
       );
-      const entries = sortedEntries.slice(0, WORKSPACE_INDEX_MAX_ENTRIES);
+      const entries = sortedEntries.slice(0, maxListEntries);
       return {
         entries,
         truncated: mapped.truncated || entries.length < sortedEntries.length,
@@ -549,7 +569,13 @@ function parseWorkspaceSearchIndexKey(key: string): {
  */
 export const layer = (key: string) => {
   const { cwd, variant } = parseWorkspaceSearchIndexKey(key);
-  return Layer.effect(WorkspaceSearchIndex, make(cwd, variant));
+  return Layer.effect(
+    WorkspaceSearchIndex,
+    Effect.gen(function* () {
+      const maxListEntries = yield* loadWorkspaceListMaxEntries;
+      return yield* make(cwd, variant, { maxListEntries });
+    }),
+  );
 };
 
 export class WorkspaceSearchIndexMap extends LayerMap.Service<WorkspaceSearchIndexMap>()(

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -41,6 +41,24 @@ Arch Linux:
 yay -S t3code-bin
 ```
 
+## Large Workspace Memory
+
+The Files panel lists at most 25,000 indexed paths by default. On very large workspace roots,
+loading that many entries can retain significant server memory. Set
+`T3CODE_WORKSPACE_LIST_MAX_ENTRIES` to an integer from 1 through 25,000 before starting the server
+to trade a shorter Files-panel listing for lower memory use. Invalid values use the 25,000-entry
+default and emit a server-log warning. Path and content search still use the complete workspace
+index.
+
+```bash
+T3CODE_WORKSPACE_LIST_MAX_ENTRIES=5000 npx t3@latest
+```
+
+For a desktop-hosted server, launch the desktop app from a shell where the variable is already
+set. A variable exported only in a shell profile is not imported when the app starts from the
+macOS Dock or Windows desktop. For WSL backend mode, set it inside WSL rather than only in the
+Windows environment. Restart T3 Code after changing it.
+
 ## Providers
 
 T3 Code drives provider CLIs; it does not ship them. Install the CLI for each provider you want


### PR DESCRIPTION
## Problem

The workspace Files listing always asks FFF for 25,002 results and materializes up to 25,000 paths. Large workspace roots therefore retain substantial server memory even when users do not need that many entries in the Files panel, and there was no way to trade listing depth for memory use.

Using the included probe against a workspace root with roughly 222,000 entries, each limit ran in a fresh Node process and sampled RSS after forced GC:

| list limit | listed RSS | RSS added by `list()` | peak RSS added |
| ---: | ---: | ---: | ---: |
| 1,000 | 196.2 MiB | 24.1 MiB | 3.5 MiB |
| 5,000 | 219.5 MiB | 44.7 MiB | 24.4 MiB |
| 25,000 | 290.1 MiB | 117.5 MiB | 99.8 MiB |

Reproduce with:

```bash
node apps/server/scripts/workspace-index-memory-probe.ts /path/to/large/workspace 1000 5000 25000
```

## How this helps

- Add `T3CODE_WORKSPACE_LIST_MAX_ENTRIES` with an allowed range of 1 through 25,000.
- Preserve the existing 25,000 default, so this is an opt-in memory mitigation rather than a behavior change for existing installs.
- Apply the limit before FFF result materialization and to the returned Files listing. Path and content search continue to use the full index.
- Fall back to 25,000 with a warning for invalid values.
- Document the setting and add focused tests for valid, zero, over-limit, and non-numeric configuration.

## Verification

- `vp lint apps/server/scripts/workspace-index-memory-probe.ts apps/server/src/workspace/WorkspaceSearchIndex.ts apps/server/src/workspace/WorkspaceSearchIndex.test.ts`
- `vp test run apps/server/src/workspace/WorkspaceSearchIndex.test.ts` (10 tests passed)
- `vp run -F t3 typecheck`
- Production-path memory probe shown above
- Reviewed by Claude Fable 5 directly and Claude Opus 5 through Paseo

Implemented with Codex (GPT-5.6 Sol) in T3 Code; reviewed by Claude Fable 5 and Claude Opus 5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in configuration with the same 25,000 default; changes only workspace listing depth and memory, not auth or search over the full index.
> 
> **Overview**
> Adds **`T3CODE_WORKSPACE_LIST_MAX_ENTRIES`** (1–25,000, default 25,000) so the Files panel listing can cap how many paths are fetched and returned from the workspace index, trading shorter lists for lower server memory on huge roots. Invalid values keep the default and log a warning; path and content search still use the full index.
> 
> `WorkspaceSearchIndex.make` and the layer path honor the limit for `list()` page size and truncation. A new **`workspace-index-memory-probe`** script measures RSS across limits in isolated child processes. Install docs describe the setting and desktop/WSL launch caveats. Tests cover configured caps and invalid env fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7e692aa75549a0d0f6032f469bf2a3f1ef39bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make workspace list entry cap configurable via `T3CODE_WORKSPACE_LIST_MAX_ENTRIES`
> - Replaces the fixed 25,000-entry cap in `WorkspaceSearchIndex` with a value read from the `T3CODE_WORKSPACE_LIST_MAX_ENTRIES` env var (range 1–25,000, default 25,000).
> - Invalid config values log a warning and fall back to the default; the cap is applied to both the search page size and the final slice in `list()`.
> - Adds a [workspace-index-memory-probe script](https://github.com/pingdotgg/t3code/pull/5107/files#diff-11ba4b4ce5356c8686090b73179a935d8a3f11c309c8f4c578011b8a459a54e9) to measure RSS before/after listing at configurable limits.
> - Documents the new env var and large-workspace memory guidance in [install.md](https://github.com/pingdotgg/t3code/pull/5107/files#diff-5445c9485dbf19d6da7ef0ed9335ef230c4eb448b7a58ebc7810d3f1eca744c2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee7e692.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->