### PR TITLE
fix(desktop): Windows app now launches past Chromium GPU sandbox fatal

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -383,13 +383,25 @@ function resolveLinuxSandboxArgs(electronBinaryPath) {
 }
 
 /**
- * Windows packaged/dev Electron can fatal with "GPU process isn't usable"
- * unless Chromium's sandbox is disabled (#1357, #4543). Mirror the Linux
- * launcher fallback so local `vp` desktop launches match packaged behavior.
+ * Windows Chromium sandbox stays enabled by default (#5108 review). Match
+ * packaged recovery: only pass `--no-sandbox` when explicitly opted in via
+ * `T3CODE_DISABLE_CHROMIUM_SANDBOX=1` or a prior GPU-crash recovery marker.
  */
-export function resolveSandboxArgs(electronBinaryPath, platform = hostPlatform) {
+export function shouldDisableWindowsChromiumSandbox(
+  env = process.env,
+  { homedir = NodeOS.homedir, existsSync = NodeFS.existsSync } = {},
+) {
+  if (env.T3CODE_DISABLE_CHROMIUM_SANDBOX === "1") {
+    return true;
+  }
+  const configuredHome = typeof env.T3CODE_HOME === "string" ? env.T3CODE_HOME.trim() : "";
+  const baseDir = configuredHome.length > 0 ? configuredHome : NodePath.join(homedir(), ".t3");
+  return existsSync(NodePath.join(baseDir, "userdata", "windows-chromium-sandbox-workaround"));
+}
+
+export function resolveSandboxArgs(electronBinaryPath, platform = hostPlatform, env = process.env) {
   if (platform === "win32") {
-    return ["--no-sandbox"];
+    return shouldDisableWindowsChromiumSandbox(env) ? ["--no-sandbox"] : [];
   }
   if (platform !== "linux") {
     return [];

--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -382,6 +382,21 @@ function resolveLinuxSandboxArgs(electronBinaryPath) {
   return ["--no-sandbox"];
 }
 
+/**
+ * Windows packaged/dev Electron can fatal with "GPU process isn't usable"
+ * unless Chromium's sandbox is disabled (#1357, #4543). Mirror the Linux
+ * launcher fallback so local `vp` desktop launches match packaged behavior.
+ */
+export function resolveSandboxArgs(electronBinaryPath, platform = hostPlatform) {
+  if (platform === "win32") {
+    return ["--no-sandbox"];
+  }
+  if (platform !== "linux") {
+    return [];
+  }
+  return resolveLinuxSandboxArgs(electronBinaryPath);
+}
+
 export function resolveElectronPath() {
   const electronBinaryPath = resolveElectronBinaryPath();
 
@@ -396,7 +411,7 @@ export function resolveElectronLaunchCommand(args = []) {
   const electronPath = resolveElectronPath();
   return {
     electronPath,
-    args: [...resolveLinuxSandboxArgs(electronPath), ...args],
+    args: [...resolveSandboxArgs(electronPath), ...args],
   };
 }
 

--- a/apps/desktop/scripts/electron-launcher.test.mjs
+++ b/apps/desktop/scripts/electron-launcher.test.mjs
@@ -82,8 +82,23 @@ describe("electron development launcher", () => {
 });
 
 describe("resolveSandboxArgs", () => {
-  it("always disables the Chromium sandbox on Windows", () => {
-    assert.deepEqual(resolveSandboxArgs("/unused/electron", "win32"), ["--no-sandbox"]);
+  it("keeps the Chromium sandbox enabled on Windows by default", () => {
+    assert.deepEqual(
+      resolveSandboxArgs("/unused/electron", "win32", {
+        T3CODE_DISABLE_CHROMIUM_SANDBOX: undefined,
+        T3CODE_HOME: "C:\\missing-t3-home",
+      }),
+      [],
+    );
+  });
+
+  it("disables the Chromium sandbox on Windows when explicitly opted in", () => {
+    assert.deepEqual(
+      resolveSandboxArgs("/unused/electron", "win32", {
+        T3CODE_DISABLE_CHROMIUM_SANDBOX: "1",
+      }),
+      ["--no-sandbox"],
+    );
   });
 
   it("leaves sandbox args empty on macOS", () => {

--- a/apps/desktop/scripts/electron-launcher.test.mjs
+++ b/apps/desktop/scripts/electron-launcher.test.mjs
@@ -4,6 +4,7 @@ import {
   makeDevelopmentLauncherScript,
   resolveElectronBinaryPath,
   resolveMacLauncherPaths,
+  resolveSandboxArgs,
 } from "./electron-launcher.mjs";
 
 describe("electron development launcher", () => {
@@ -77,5 +78,15 @@ describe("electron development launcher", () => {
       "exec '/repo/apps/desktop/.electron-runtime/T3 Code (Dev).app/Contents/MacOS/Electron'",
     );
     assert.notInclude(script, "node_modules/electron");
+  });
+});
+
+describe("resolveSandboxArgs", () => {
+  it("always disables the Chromium sandbox on Windows", () => {
+    assert.deepEqual(resolveSandboxArgs("/unused/electron", "win32"), ["--no-sandbox"]);
+  });
+
+  it("leaves sandbox args empty on macOS", () => {
+    assert.deepEqual(resolveSandboxArgs("/unused/electron", "darwin"), []);
   });
 });

--- a/apps/desktop/src/app/windowsChromiumSandbox.test.ts
+++ b/apps/desktop/src/app/windowsChromiumSandbox.test.ts
@@ -3,15 +3,74 @@ import { assert, describe, it } from "@effect/vitest";
 import * as WindowsChromiumSandbox from "./windowsChromiumSandbox.ts";
 
 describe("windowsChromiumSandbox", () => {
-  it("enables no-sandbox on Windows so the GPU process does not fatal startup", () => {
-    assert.deepEqual(WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches("win32"), [
-      "no-sandbox",
-    ]);
+  it("keeps the Chromium sandbox enabled on Windows by default", () => {
+    assert.deepEqual(
+      WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches({
+        platform: "win32",
+        env: {},
+        argv: ["electron"],
+        markerExists: () => false,
+      }),
+      [],
+    );
+  });
+
+  it("disables the Chromium sandbox when explicitly opted in via env", () => {
+    assert.deepEqual(
+      WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches({
+        platform: "win32",
+        env: { [WindowsChromiumSandbox.WINDOWS_CHROMIUM_SANDBOX_DISABLE_ENV]: "1" },
+        argv: ["electron"],
+        markerExists: () => false,
+      }),
+      ["no-sandbox"],
+    );
+  });
+
+  it("disables the Chromium sandbox when argv already requests it", () => {
+    assert.deepEqual(
+      WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches({
+        platform: "win32",
+        env: {},
+        argv: ["electron", "--no-sandbox"],
+        markerExists: () => false,
+      }),
+      ["no-sandbox"],
+    );
+  });
+
+  it("disables the Chromium sandbox when a recovery marker is present", () => {
+    assert.deepEqual(
+      WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches({
+        platform: "win32",
+        env: {},
+        argv: ["electron"],
+        markerPath: "C:\\marker",
+        markerExists: (path) => path === "C:\\marker",
+      }),
+      ["no-sandbox"],
+    );
   });
 
   it("leaves Chromium sandbox switches alone on macOS and Linux", () => {
-    assert.deepEqual(WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches("darwin"), []);
-    assert.deepEqual(WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches("linux"), []);
+    assert.deepEqual(
+      WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches({
+        platform: "darwin",
+        env: { [WindowsChromiumSandbox.WINDOWS_CHROMIUM_SANDBOX_DISABLE_ENV]: "1" },
+        argv: ["electron", "--no-sandbox"],
+        markerExists: () => true,
+      }),
+      [],
+    );
+    assert.deepEqual(
+      WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches({
+        platform: "linux",
+        env: { [WindowsChromiumSandbox.WINDOWS_CHROMIUM_SANDBOX_DISABLE_ENV]: "1" },
+        argv: ["electron", "--no-sandbox"],
+        markerExists: () => true,
+      }),
+      [],
+    );
   });
 
   it("applies resolved switches through the provided append callback", () => {
@@ -19,6 +78,9 @@ describe("windowsChromiumSandbox", () => {
 
     const switches = WindowsChromiumSandbox.applyWindowsChromiumSandboxSwitches({
       platform: "win32",
+      env: { [WindowsChromiumSandbox.WINDOWS_CHROMIUM_SANDBOX_DISABLE_ENV]: "1" },
+      argv: ["electron"],
+      markerExists: () => false,
       appendSwitch: (switchName) => {
         applied.push(switchName);
       },
@@ -33,6 +95,7 @@ describe("windowsChromiumSandbox", () => {
 
     const switches = WindowsChromiumSandbox.applyWindowsChromiumSandboxSwitches({
       platform: "darwin",
+      env: { [WindowsChromiumSandbox.WINDOWS_CHROMIUM_SANDBOX_DISABLE_ENV]: "1" },
       appendSwitch: (switchName) => {
         applied.push(switchName);
       },
@@ -40,5 +103,119 @@ describe("windowsChromiumSandbox", () => {
 
     assert.deepEqual(switches, []);
     assert.deepEqual(applied, []);
+  });
+
+  it("resolves the recovery marker under T3CODE_HOME userdata", () => {
+    assert.equal(
+      WindowsChromiumSandbox.resolveWindowsChromiumSandboxMarkerPath("C:\\Users\\test", {
+        T3CODE_HOME: "D:\\t3-home",
+      }),
+      "D:\\t3-home\\userdata\\windows-chromium-sandbox-workaround",
+    );
+  });
+
+  it("identifies the Windows GPU STATUS_BREAKPOINT crash", () => {
+    assert.isTrue(
+      WindowsChromiumSandbox.isWindowsGpuSandboxBreakpointCrash({
+        type: "GPU",
+        exitCode: WindowsChromiumSandbox.WINDOWS_GPU_SANDBOX_BREAKPOINT_EXIT_CODE,
+      }),
+    );
+    assert.isFalse(
+      WindowsChromiumSandbox.isWindowsGpuSandboxBreakpointCrash({
+        type: "Utility",
+        exitCode: WindowsChromiumSandbox.WINDOWS_GPU_SANDBOX_BREAKPOINT_EXIT_CODE,
+      }),
+    );
+  });
+
+  it("adds --no-sandbox to relaunch args when missing", () => {
+    assert.deepEqual(
+      WindowsChromiumSandbox.buildWindowsChromiumSandboxRelaunchArgs([
+        "C:\\T3 Code (Alpha).exe",
+        "--some-flag",
+      ]),
+      ["--some-flag", "--no-sandbox"],
+    );
+  });
+
+  it("installs GPU crash recovery that writes a marker and relaunches once", () => {
+    const written: string[] = [];
+    const relaunchArgs: Array<ReadonlyArray<string>> = [];
+    const exits: number[] = [];
+    let listener:
+      | ((
+          event: unknown,
+          details: {
+            readonly type?: string;
+            readonly exitCode?: number;
+          },
+        ) => void)
+      | undefined;
+
+    const installed = WindowsChromiumSandbox.installWindowsChromiumSandboxRecovery({
+      platform: "win32",
+      env: {},
+      argv: ["C:\\T3 Code (Alpha).exe"],
+      markerPath: "C:\\marker",
+      writeMarker: (path) => {
+        written.push(path);
+      },
+      app: {
+        on: (event, nextListener) => {
+          assert.equal(event, "child-process-gone");
+          listener = nextListener;
+        },
+        relaunch: ({ args }) => {
+          relaunchArgs.push(args);
+        },
+        exit: (code = 0) => {
+          exits.push(code);
+        },
+      },
+    });
+
+    assert.isTrue(installed);
+    assert.isFunction(listener);
+
+    listener?.(
+      {},
+      {
+        type: "GPU",
+        exitCode: WindowsChromiumSandbox.WINDOWS_GPU_SANDBOX_BREAKPOINT_EXIT_CODE,
+      },
+    );
+    listener?.(
+      {},
+      {
+        type: "GPU",
+        exitCode: WindowsChromiumSandbox.WINDOWS_GPU_SANDBOX_BREAKPOINT_EXIT_CODE,
+      },
+    );
+
+    assert.deepEqual(written, ["C:\\marker"]);
+    assert.deepEqual(relaunchArgs, [["--no-sandbox"]]);
+    assert.deepEqual(exits, [0]);
+  });
+
+  it("skips recovery installation when the workaround is already active", () => {
+    const installed = WindowsChromiumSandbox.installWindowsChromiumSandboxRecovery({
+      platform: "win32",
+      env: { [WindowsChromiumSandbox.WINDOWS_CHROMIUM_SANDBOX_DISABLE_ENV]: "1" },
+      argv: ["electron"],
+      app: {
+        on: () => {
+          assert.fail("should not register recovery when already opted in");
+        },
+        relaunch: () => {
+          assert.fail("should not relaunch when already opted in");
+        },
+        exit: () => {
+          assert.fail("should not exit when already opted in");
+        },
+      },
+    });
+
+    assert.isFalse(installed);
   });
 });

--- a/apps/desktop/src/app/windowsChromiumSandbox.test.ts
+++ b/apps/desktop/src/app/windowsChromiumSandbox.test.ts
@@ -39,6 +39,25 @@ describe("windowsChromiumSandbox", () => {
     );
   });
 
+  it("ignores a bare positional no-sandbox argv entry", () => {
+    assert.isFalse(
+      WindowsChromiumSandbox.argvRequestsWindowsChromiumSandboxDisable([
+        "electron",
+        "C:\\projects\\no-sandbox",
+        "no-sandbox",
+      ]),
+    );
+    assert.deepEqual(
+      WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches({
+        platform: "win32",
+        env: {},
+        argv: ["electron", "no-sandbox"],
+        markerExists: () => false,
+      }),
+      [],
+    );
+  });
+
   it("disables the Chromium sandbox when a recovery marker is present", () => {
     assert.deepEqual(
       WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches({
@@ -217,5 +236,28 @@ describe("windowsChromiumSandbox", () => {
     });
 
     assert.isFalse(installed);
+  });
+
+  it("does not install GPU recovery on macOS or Linux", () => {
+    for (const platform of ["darwin", "linux"] as const) {
+      const installed = WindowsChromiumSandbox.installWindowsChromiumSandboxRecovery({
+        platform,
+        env: {},
+        argv: ["electron"],
+        app: {
+          on: () => {
+            assert.fail(`should not register recovery on ${platform}`);
+          },
+          relaunch: () => {
+            assert.fail(`should not relaunch on ${platform}`);
+          },
+          exit: () => {
+            assert.fail(`should not exit on ${platform}`);
+          },
+        },
+      });
+
+      assert.isFalse(installed);
+    }
   });
 });

--- a/apps/desktop/src/app/windowsChromiumSandbox.test.ts
+++ b/apps/desktop/src/app/windowsChromiumSandbox.test.ts
@@ -1,0 +1,44 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import * as WindowsChromiumSandbox from "./windowsChromiumSandbox.ts";
+
+describe("windowsChromiumSandbox", () => {
+  it("enables no-sandbox on Windows so the GPU process does not fatal startup", () => {
+    assert.deepEqual(WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches("win32"), [
+      "no-sandbox",
+    ]);
+  });
+
+  it("leaves Chromium sandbox switches alone on macOS and Linux", () => {
+    assert.deepEqual(WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches("darwin"), []);
+    assert.deepEqual(WindowsChromiumSandbox.resolveWindowsChromiumSandboxSwitches("linux"), []);
+  });
+
+  it("applies resolved switches through the provided append callback", () => {
+    const applied: string[] = [];
+
+    const switches = WindowsChromiumSandbox.applyWindowsChromiumSandboxSwitches({
+      platform: "win32",
+      appendSwitch: (switchName) => {
+        applied.push(switchName);
+      },
+    });
+
+    assert.deepEqual(switches, ["no-sandbox"]);
+    assert.deepEqual(applied, ["no-sandbox"]);
+  });
+
+  it("does not append switches on non-Windows platforms", () => {
+    const applied: string[] = [];
+
+    const switches = WindowsChromiumSandbox.applyWindowsChromiumSandboxSwitches({
+      platform: "darwin",
+      appendSwitch: (switchName) => {
+        applied.push(switchName);
+      },
+    });
+
+    assert.deepEqual(switches, []);
+    assert.deepEqual(applied, []);
+  });
+});

--- a/apps/desktop/src/app/windowsChromiumSandbox.ts
+++ b/apps/desktop/src/app/windowsChromiumSandbox.ts
@@ -55,10 +55,9 @@ export function resolveWindowsChromiumSandboxMarkerPath(
 }
 
 export function argvRequestsWindowsChromiumSandboxDisable(argv: ReadonlyArray<string>): boolean {
-  return argv.some(
-    (entry) =>
-      entry === `--${WINDOWS_CHROMIUM_SANDBOX_SWITCH}` || entry === WINDOWS_CHROMIUM_SANDBOX_SWITCH,
-  );
+  // Only the Chromium switch form. A bare positional `no-sandbox` must not
+  // disable process isolation just because a path/project uses that name.
+  return argv.some((entry) => entry === `--${WINDOWS_CHROMIUM_SANDBOX_SWITCH}`);
 }
 
 export function shouldDisableWindowsChromiumSandbox(
@@ -165,6 +164,12 @@ export function installWindowsChromiumSandboxRecovery(input: {
   readonly markerPath?: string;
   readonly writeMarker?: (markerPath: string) => void;
 }): boolean {
+  // Never register on macOS/Linux: a matching GPU exitCode there must not
+  // write the Windows marker or relaunch with --no-sandbox.
+  if (input.platform !== "win32") {
+    return false;
+  }
+
   if (
     shouldDisableWindowsChromiumSandbox({
       platform: input.platform,

--- a/apps/desktop/src/app/windowsChromiumSandbox.ts
+++ b/apps/desktop/src/app/windowsChromiumSandbox.ts
@@ -1,3 +1,8 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
 /**
  * Windows Chromium/Electron can fatal the whole desktop process with
  * `GPU process isn't usable. Goodbye.` / exit_code=-2147483645
@@ -9,24 +14,188 @@
  * - `--no-sandbox`: process stays alive and the main window shows
  *
  * See https://github.com/pingdotgg/t3code/issues/1357 and #4543.
- * Linux already opts into `--no-sandbox` from the desktop launcher when
- * chrome-sandbox is not setuid; this is the packaged-Windows equivalent.
+ *
+ * The Chromium process sandbox stays enabled by default so preview webviews
+ * keep the OS-level containment documented in WebviewPreferences. The
+ * workaround is applied only when:
+ * - `T3CODE_DISABLE_CHROMIUM_SANDBOX=1` (explicit opt-in), or
+ * - argv already includes `--no-sandbox`, or
+ * - a previous GPU STATUS_BREAKPOINT crash wrote the recovery marker
+ *
+ * `installWindowsChromiumSandboxRecovery` watches for that GPU death, writes
+ * the marker, and relaunches once with `--no-sandbox`.
  */
 export type WindowsChromiumSandboxSwitch = "no-sandbox";
 
+export const WINDOWS_CHROMIUM_SANDBOX_DISABLE_ENV = "T3CODE_DISABLE_CHROMIUM_SANDBOX";
+export const WINDOWS_CHROMIUM_SANDBOX_SWITCH = "no-sandbox" satisfies WindowsChromiumSandboxSwitch;
+/** Signed form of STATUS_BREAKPOINT (0x80000003) observed on affected Windows hosts. */
+export const WINDOWS_GPU_SANDBOX_BREAKPOINT_EXIT_CODE = -2147483645;
+const WINDOWS_CHROMIUM_SANDBOX_MARKER_FILE = "windows-chromium-sandbox-workaround";
+
+export interface WindowsChromiumSandboxDecisionInput {
+  readonly platform: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly argv?: ReadonlyArray<string>;
+  readonly homeDirectory?: string;
+  readonly markerPath?: string;
+  readonly markerExists?: (markerPath: string) => boolean;
+}
+
+export function resolveWindowsChromiumSandboxMarkerPath(
+  homeDirectory = NodeOS.homedir(),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const configuredHome = env.T3CODE_HOME?.trim();
+  const baseDir =
+    configuredHome && configuredHome.length > 0
+      ? configuredHome
+      : NodePath.join(homeDirectory, ".t3");
+  return NodePath.join(baseDir, "userdata", WINDOWS_CHROMIUM_SANDBOX_MARKER_FILE);
+}
+
+export function argvRequestsWindowsChromiumSandboxDisable(argv: ReadonlyArray<string>): boolean {
+  return argv.some(
+    (entry) =>
+      entry === `--${WINDOWS_CHROMIUM_SANDBOX_SWITCH}` || entry === WINDOWS_CHROMIUM_SANDBOX_SWITCH,
+  );
+}
+
+export function shouldDisableWindowsChromiumSandbox(
+  input: WindowsChromiumSandboxDecisionInput,
+): boolean {
+  if (input.platform !== "win32") return false;
+
+  const env = input.env ?? process.env;
+  if (env[WINDOWS_CHROMIUM_SANDBOX_DISABLE_ENV] === "1") return true;
+
+  const argv = input.argv ?? process.argv;
+  if (argvRequestsWindowsChromiumSandboxDisable(argv)) return true;
+
+  const markerPath =
+    input.markerPath ??
+    resolveWindowsChromiumSandboxMarkerPath(input.homeDirectory ?? NodeOS.homedir(), env);
+  const markerExists = input.markerExists ?? ((path) => NodeFS.existsSync(path));
+  return markerExists(markerPath);
+}
+
 export function resolveWindowsChromiumSandboxSwitches(
-  platform: NodeJS.Platform,
+  input: WindowsChromiumSandboxDecisionInput,
 ): ReadonlyArray<WindowsChromiumSandboxSwitch> {
-  return platform === "win32" ? ["no-sandbox"] : [];
+  return shouldDisableWindowsChromiumSandbox(input) ? [WINDOWS_CHROMIUM_SANDBOX_SWITCH] : [];
 }
 
 export function applyWindowsChromiumSandboxSwitches(input: {
   readonly platform: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly argv?: ReadonlyArray<string>;
+  readonly homeDirectory?: string;
+  readonly markerPath?: string;
+  readonly markerExists?: (markerPath: string) => boolean;
   readonly appendSwitch: (switchName: WindowsChromiumSandboxSwitch) => void;
 }): ReadonlyArray<WindowsChromiumSandboxSwitch> {
-  const switches = resolveWindowsChromiumSandboxSwitches(input.platform);
+  const switches = resolveWindowsChromiumSandboxSwitches(input);
   for (const switchName of switches) {
     input.appendSwitch(switchName);
   }
   return switches;
+}
+
+export function writeWindowsChromiumSandboxMarker(
+  markerPath: string,
+  writeFile: (path: string, contents: string) => void = (path, contents) => {
+    NodeFS.mkdirSync(NodePath.dirname(path), { recursive: true });
+    NodeFS.writeFileSync(path, contents, "utf8");
+  },
+): void {
+  writeFile(
+    markerPath,
+    [
+      "T3 Code enables Chromium --no-sandbox on this Windows host after a GPU",
+      "STATUS_BREAKPOINT crash (GPU process isn't usable). Delete this file to",
+      "retry with the Chromium sandbox enabled.",
+      "",
+    ].join("\n"),
+  );
+}
+
+export function isWindowsGpuSandboxBreakpointCrash(details: {
+  readonly type?: string;
+  readonly exitCode?: number;
+}): boolean {
+  return details.type === "GPU" && details.exitCode === WINDOWS_GPU_SANDBOX_BREAKPOINT_EXIT_CODE;
+}
+
+export function buildWindowsChromiumSandboxRelaunchArgs(
+  argv: ReadonlyArray<string>,
+): Array<string> {
+  const args = argv.slice(1).filter((entry) => entry !== "--");
+  if (!argvRequestsWindowsChromiumSandboxDisable(args)) {
+    args.push(`--${WINDOWS_CHROMIUM_SANDBOX_SWITCH}`);
+  }
+  return args;
+}
+
+export interface WindowsChromiumSandboxRecoveryApp {
+  readonly on: (
+    event: "child-process-gone",
+    listener: (
+      event: unknown,
+      details: {
+        readonly type?: string;
+        readonly exitCode?: number;
+      },
+    ) => void,
+  ) => void;
+  readonly relaunch: (options: { readonly args: ReadonlyArray<string> }) => void;
+  readonly exit: (code?: number) => void;
+}
+
+/**
+ * When the Chromium sandbox is still enabled on Windows, watch for the known
+ * GPU STATUS_BREAKPOINT failure, persist a marker, and relaunch once with
+ * `--no-sandbox` so unaffected hosts keep sandbox containment by default.
+ */
+export function installWindowsChromiumSandboxRecovery(input: {
+  readonly platform: NodeJS.Platform;
+  readonly app: WindowsChromiumSandboxRecoveryApp;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly argv?: ReadonlyArray<string>;
+  readonly homeDirectory?: string;
+  readonly markerPath?: string;
+  readonly writeMarker?: (markerPath: string) => void;
+}): boolean {
+  if (
+    shouldDisableWindowsChromiumSandbox({
+      platform: input.platform,
+      env: input.env,
+      argv: input.argv,
+      homeDirectory: input.homeDirectory,
+      markerPath: input.markerPath,
+    })
+  ) {
+    return false;
+  }
+
+  const env = input.env ?? process.env;
+  const argv = input.argv ?? process.argv;
+  const markerPath =
+    input.markerPath ??
+    resolveWindowsChromiumSandboxMarkerPath(input.homeDirectory ?? NodeOS.homedir(), env);
+  const writeMarker = input.writeMarker ?? writeWindowsChromiumSandboxMarker;
+  let recovering = false;
+
+  input.app.on("child-process-gone", (_event, details) => {
+    if (recovering || !isWindowsGpuSandboxBreakpointCrash(details)) return;
+    recovering = true;
+    try {
+      writeMarker(markerPath);
+    } catch {
+      // Still relaunch with the switch even if the marker cannot be persisted.
+    }
+    input.app.relaunch({ args: buildWindowsChromiumSandboxRelaunchArgs(argv) });
+    input.app.exit(0);
+  });
+
+  return true;
 }

--- a/apps/desktop/src/app/windowsChromiumSandbox.ts
+++ b/apps/desktop/src/app/windowsChromiumSandbox.ts
@@ -1,0 +1,32 @@
+/**
+ * Windows Chromium/Electron can fatal the whole desktop process with
+ * `GPU process isn't usable. Goodbye.` / exit_code=-2147483645
+ * (STATUS_BREAKPOINT) when the GPU sandbox is enabled. Affected machines
+ * never show a window; Task Manager only shows background helpers.
+ *
+ * Empirically on Windows:
+ * - no flags / `--disable-gpu-sandbox` / `--in-process-gpu`: no usable window
+ * - `--no-sandbox`: process stays alive and the main window shows
+ *
+ * See https://github.com/pingdotgg/t3code/issues/1357 and #4543.
+ * Linux already opts into `--no-sandbox` from the desktop launcher when
+ * chrome-sandbox is not setuid; this is the packaged-Windows equivalent.
+ */
+export type WindowsChromiumSandboxSwitch = "no-sandbox";
+
+export function resolveWindowsChromiumSandboxSwitches(
+  platform: NodeJS.Platform,
+): ReadonlyArray<WindowsChromiumSandboxSwitch> {
+  return platform === "win32" ? ["no-sandbox"] : [];
+}
+
+export function applyWindowsChromiumSandboxSwitches(input: {
+  readonly platform: NodeJS.Platform;
+  readonly appendSwitch: (switchName: WindowsChromiumSandboxSwitch) => void;
+}): ReadonlyArray<WindowsChromiumSandboxSwitch> {
+  const switches = resolveWindowsChromiumSandboxSwitches(input.platform);
+  for (const switchName of switches) {
+    input.appendSwitch(switchName);
+  }
+  return switches;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -37,6 +37,7 @@ import * as DesktopConnectionCatalogStore from "./app/DesktopConnectionCatalogSt
 import * as DesktopClerk from "./app/DesktopClerk.ts";
 import * as DesktopApplicationMenu from "./window/DesktopApplicationMenu.ts";
 import * as DesktopAssets from "./app/DesktopAssets.ts";
+import * as WindowsChromiumSandbox from "./app/windowsChromiumSandbox.ts";
 import * as DesktopBackendConfiguration from "./backend/DesktopBackendConfiguration.ts";
 import * as DesktopBackendPool from "./backend/DesktopBackendPool.ts";
 import * as DesktopLocalEnvironmentAuth from "./backend/DesktopLocalEnvironmentAuth.ts";
@@ -60,6 +61,15 @@ import * as PreviewManager from "./preview/Manager.ts";
 import * as DesktopWindow from "./window/DesktopWindow.ts";
 import * as DesktopWslBackend from "./wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "./wsl/DesktopWslEnvironment.ts";
+
+// Must run before Electron starts the GPU process. On affected Windows hosts
+// the default Chromium sandbox fatals startup with "GPU process isn't usable".
+WindowsChromiumSandbox.applyWindowsChromiumSandboxSwitches({
+  platform: process.platform,
+  appendSwitch: (switchName) => {
+    Electron.app.commandLine.appendSwitch(switchName);
+  },
+});
 
 const desktopEnvironmentLayer = Layer.unwrap(
   Effect.gen(function* () {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -68,6 +68,7 @@ import * as DesktopWslEnvironment from "./wsl/DesktopWslEnvironment.ts";
 // a recovery marker. Otherwise watch for that crash and relaunch once.
 // Must run before the Effect runtime / GPU process starts, so HostProcessPlatform
 // is unavailable here.
+// oxlint-disable-next-line t3code/no-global-process-runtime -- Early Chromium switch bootstrap runs before Effect HostProcessPlatform is provided.
 const hostPlatform = NodeOS.platform();
 WindowsChromiumSandbox.applyWindowsChromiumSandboxSwitches({
   platform: hostPlatform,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -76,10 +76,12 @@ WindowsChromiumSandbox.applyWindowsChromiumSandboxSwitches({
     Electron.app.commandLine.appendSwitch(switchName);
   },
 });
-WindowsChromiumSandbox.installWindowsChromiumSandboxRecovery({
-  platform: hostPlatform,
-  app: Electron.app,
-});
+if (hostPlatform === "win32") {
+  WindowsChromiumSandbox.installWindowsChromiumSandboxRecovery({
+    platform: hostPlatform,
+    app: Electron.app,
+  });
+}
 
 const desktopEnvironmentLayer = Layer.unwrap(
   Effect.gen(function* () {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -62,13 +62,22 @@ import * as DesktopWindow from "./window/DesktopWindow.ts";
 import * as DesktopWslBackend from "./wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "./wsl/DesktopWslEnvironment.ts";
 
-// Must run before Electron starts the GPU process. On affected Windows hosts
-// the default Chromium sandbox fatals startup with "GPU process isn't usable".
+// Keep Chromium's process sandbox enabled by default on Windows (preview
+// webviews rely on that containment). Only disable it when explicitly opted
+// in, already requested via argv, or a prior GPU STATUS_BREAKPOINT crash left
+// a recovery marker. Otherwise watch for that crash and relaunch once.
+// Must run before the Effect runtime / GPU process starts, so HostProcessPlatform
+// is unavailable here.
+const hostPlatform = NodeOS.platform();
 WindowsChromiumSandbox.applyWindowsChromiumSandboxSwitches({
-  platform: process.platform,
+  platform: hostPlatform,
   appendSwitch: (switchName) => {
     Electron.app.commandLine.appendSwitch(switchName);
   },
+});
+WindowsChromiumSandbox.installWindowsChromiumSandboxRecovery({
+  platform: hostPlatform,
+  app: Electron.app,
 });
 
 const desktopEnvironmentLayer = Layer.unwrap(


### PR DESCRIPTION
## Summary

- Fixes Windows desktop launch failure where Electron fatals with `GPU process isn't usable` / `exit_code=-2147483645` before any window appears (background helpers only in Task Manager).
- Applies Chromium `--no-sandbox` on Windows in packaged `main` startup and in the desktop Electron launcher (same class of workaround already used on Linux when `chrome-sandbox` is unset).
- Adds focused unit coverage for the Windows switch resolution.

### Related issues / PRs

- Fixes Windows no-UI launch reported in https://github.com/pingdotgg/t3code/issues/4543 (and matches the earlier investigation in https://github.com/pingdotgg/t3code/issues/1357).
- Related Windows packaging launch failure: https://github.com/pingdotgg/t3code/issues/4154 (`effect` missing from `app.asar.unpacked`). This PR does **not** replace the packaging repair in https://github.com/pingdotgg/t3code/pull/4160; on current `0.0.31` installs `effect` is present — the crash reproduced here was the GPU/sandbox fatal instead.
- Noted per request: https://github.com/pingdotgg/t3code/pull/4153 (OpenCode health-check change) — separate from this Windows launch fix.

### Evidence on Windows

| Launch args | Result |
| --- | --- |
| (none) | App exits: `GPU process isn't usable. Goodbye.` |
| `--disable-gpu-sandbox` / `--in-process-gpu` | Process may stay alive, but no usable window |
| `--no-sandbox` | Main window shows (`T3 Code (Alpha)`) |

## Test plan

- [x] `vp test run apps/desktop/src/app/windowsChromiumSandbox.test.ts`
- [x] `vp test run apps/desktop/scripts/electron-launcher.test.mjs -t resolveSandboxArgs`
- [x] Manual Windows launch of installed Alpha with `--no-sandbox` shows a real window
- [ ] CI desktop checks on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Disabling Chromium process sandbox reduces OS-level containment when env, marker, or recovery path triggers `--no-sandbox`; logic is gated and Windows-only but still security-sensitive.
> 
> **Overview**
> Fixes Windows desktop launches that fatal with **GPU process isn't usable** / `STATUS_BREAKPOINT` before any window appears.
> 
> **Chromium sandbox stays enabled on Windows by default** (preview webviews keep containment). `--no-sandbox` is applied only when `T3CODE_DISABLE_CHROMIUM_SANDBOX=1`, argv already has `--no-sandbox` (not bare positional `no-sandbox`), or a recovery marker exists under `T3CODE_HOME` / `~/.t3/userdata/windows-chromium-sandbox-workaround`.
> 
> New `windowsChromiumSandbox` module handles switch resolution, GPU crash detection, marker persistence, and a one-time relaunch with `--no-sandbox`. **`main.ts` runs this bootstrap before the Effect/GPU process starts** and registers `child-process-gone` recovery on Windows only.
> 
> Dev launches align via `resolveSandboxArgs` in `electron-launcher.mjs` (Linux setuid sandbox logic unchanged; macOS unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832d93af2dee032d0fa6ae68ef99046a1c848438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows desktop app crash by adding Chromium GPU sandbox recovery and `--no-sandbox` fallback
> - Adds `shouldDisableWindowsChromiumSandbox` to check an env var (`T3CODE_DISABLE_CHROMIUM_SANDBOX=1`), a `--no-sandbox` argv flag, or a persistent marker file to decide whether to disable the Chromium sandbox on Windows.
> - At startup, sandbox switches are applied via `app.commandLine.appendSwitch`; on macOS/Linux no switches are added.
> - Installs a one-time GPU crash recovery handler (`installWindowsChromiumSandboxRecovery`) that detects the `STATUS_BREAKPOINT` GPU process crash, writes a marker file, and relaunches with `--no-sandbox` so future boots skip the sandbox automatically.
> - The launcher script gains `resolveSandboxArgs` to pass the correct CLI switches per platform when spawning Electron.
> - Behavioral Change: Windows users who hit the GPU sandbox fatal will be silently relaunched once with `--no-sandbox` and will remain in that mode on subsequent launches until the marker file is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 832d93a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->