### PR TITLE
fix(web): render HTML files in file preview

### DIFF
--- a/apps/web/src/components/files/FilePreviewPanel.test.ts
+++ b/apps/web/src/components/files/FilePreviewPanel.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   isHtmlPreviewFile,
   isMarkdownPreviewFile,
+  prepareHtmlPreviewDocument,
   setMarkdownTaskChecked,
 } from "./filePreviewMode";
 
@@ -79,6 +80,38 @@ describe("isHtmlPreviewFile", () => {
   it("does not treat other files as HTML", () => {
     expect(isHtmlPreviewFile("report.html.ts")).toBe(false);
     expect(isHtmlPreviewFile("docs/html.md")).toBe(false);
+  });
+});
+
+describe("prepareHtmlPreviewDocument", () => {
+  const assetUrl = "https://example.test/api/assets/signed-token/report.html";
+
+  it("inserts the signed asset directory at the start of an existing head", () => {
+    expect(
+      prepareHtmlPreviewDocument(
+        '<!doctype html><html><head><link href="styles.css"></head><body></body></html>',
+        assetUrl,
+      ),
+    ).toBe(
+      '<!doctype html><html><head><base href="https://example.test/api/assets/signed-token/"><link href="styles.css"></head><body></body></html>',
+    );
+  });
+
+  it("adds a head when the document omits one", () => {
+    expect(prepareHtmlPreviewDocument("<!doctype html><main>Report</main>", assetUrl)).toBe(
+      '<!doctype html><head><base href="https://example.test/api/assets/signed-token/"></head><main>Report</main>',
+    );
+  });
+
+  it("resolves an authored relative base against the signed asset directory", () => {
+    expect(
+      prepareHtmlPreviewDocument(
+        '<html><head><base target="_blank" href="assets/"></head></html>',
+        assetUrl,
+      ),
+    ).toBe(
+      '<html><head><base target="_blank" href="https://example.test/api/assets/signed-token/assets/"></head></html>',
+    );
   });
 });
 

--- a/apps/web/src/components/files/FilePreviewPanel.test.ts
+++ b/apps/web/src/components/files/FilePreviewPanel.test.ts
@@ -5,7 +5,11 @@ import {
   normalizeFileCommentRange,
   remapFileCommentAnnotations,
 } from "./fileCommentAnnotations";
-import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
+import {
+  isHtmlPreviewFile,
+  isMarkdownPreviewFile,
+  setMarkdownTaskChecked,
+} from "./filePreviewMode";
 
 describe("file comment annotations", () => {
   it("normalizes and formats selected line ranges", () => {
@@ -63,6 +67,18 @@ describe("isMarkdownPreviewFile", () => {
   it("does not treat other text files as markdown", () => {
     expect(isMarkdownPreviewFile("docs/guide.txt")).toBe(false);
     expect(isMarkdownPreviewFile("docs/markdown.ts")).toBe(false);
+  });
+});
+
+describe("isHtmlPreviewFile", () => {
+  it("recognizes HTML files case-insensitively", () => {
+    expect(isHtmlPreviewFile("report.html")).toBe(true);
+    expect(isHtmlPreviewFile("artifacts/demo.HTM")).toBe(true);
+  });
+
+  it("does not treat other files as HTML", () => {
+    expect(isHtmlPreviewFile("report.html.ts")).toBe(false);
+    expect(isHtmlPreviewFile("docs/html.md")).toBe(false);
   });
 });
 

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -58,6 +58,7 @@ import { fileBreadcrumbs } from "./filePath";
 import {
   isHtmlPreviewFile,
   isMarkdownPreviewFile,
+  prepareHtmlPreviewDocument,
   setMarkdownTaskChecked,
 } from "./filePreviewMode";
 import { FileSaveCoordinator } from "./fileSaveCoordinator";
@@ -741,19 +742,44 @@ function RenderedMarkdownSurface({
 }
 
 function RenderedHtmlSurface({
+  environmentId,
+  threadRef,
+  absolutePath,
   relativePath,
   contents,
 }: {
+  environmentId: EnvironmentId;
+  threadRef: ScopedThreadRef;
+  absolutePath: string;
   relativePath: string;
   contents: string;
 }) {
+  const assetUrl = useAssetUrlState(environmentId, {
+    _tag: "workspace-file",
+    threadId: threadRef.threadId,
+    path: absolutePath,
+  });
+  const resolvedAssetUrl = assetUrl._tag === "Success" ? assetUrl.url : null;
+  const previewDocument = useMemo(
+    () => (resolvedAssetUrl ? prepareHtmlPreviewDocument(contents, resolvedAssetUrl) : contents),
+    [contents, resolvedAssetUrl],
+  );
+
+  if (assetUrl._tag === "Loading") {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
+        <LoaderCircle className="size-5 animate-spin" />
+      </div>
+    );
+  }
+
   return (
     <iframe
       className="min-h-0 flex-1 border-0 bg-white"
       title={`Rendered preview of ${relativePath}`}
       sandbox="allow-scripts"
       referrerPolicy="no-referrer"
-      srcDoc={contents}
+      srcDoc={previewDocument}
     />
   );
 }
@@ -1039,8 +1065,14 @@ export default function FilePreviewPanel({
                 contents={file.data.contents}
                 onPendingChange={onPendingChange}
               />
-            ) : isHtml && renderHtml ? (
-              <RenderedHtmlSurface relativePath={relativePath} contents={file.data.contents} />
+            ) : isHtml && renderHtml && absolutePath ? (
+              <RenderedHtmlSurface
+                environmentId={environmentId}
+                threadRef={threadRef}
+                absolutePath={absolutePath}
+                relativePath={relativePath}
+                contents={file.data.contents}
+              />
             ) : file.data.truncated ? (
               <Virtualizer
                 key={`${relativePath}:${resolvedTheme}:${file.data.byteLength}`}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -55,7 +55,11 @@ import { resolveCenteredFileLineScrollTop } from "./fileLineReveal";
 import { LocalCommentAnnotation } from "./LocalCommentAnnotation";
 import { projectFileCacheKey, projectFileEditorCacheKey } from "./fileContentRevision";
 import { fileBreadcrumbs } from "./filePath";
-import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
+import {
+  isHtmlPreviewFile,
+  isMarkdownPreviewFile,
+  setMarkdownTaskChecked,
+} from "./filePreviewMode";
 import { FileSaveCoordinator } from "./fileSaveCoordinator";
 import {
   confirmProjectFileQueryData,
@@ -81,6 +85,7 @@ interface FilePreviewPanelProps {
 
 const FILE_EXPLORER_STORAGE_KEY = "t3code.fileExplorerOpen";
 const RENDER_MARKDOWN_STORAGE_KEY = "t3code.renderMarkdown";
+const RENDER_HTML_STORAGE_KEY = "t3code.renderHtml";
 const FILE_SAVE_DEBOUNCE_MS = 500;
 const FILE_LINK_REVEAL_ATTRIBUTE = "data-file-link-reveal";
 const FILE_LINK_REVEAL_UNSAFE_CSS = `
@@ -735,6 +740,24 @@ function RenderedMarkdownSurface({
   );
 }
 
+function RenderedHtmlSurface({
+  relativePath,
+  contents,
+}: {
+  relativePath: string;
+  contents: string;
+}) {
+  return (
+    <iframe
+      className="min-h-0 flex-1 border-0 bg-white"
+      title={`Rendered preview of ${relativePath}`}
+      sandbox="allow-scripts"
+      referrerPolicy="no-referrer"
+      srcDoc={contents}
+    />
+  );
+}
+
 function initialExplorerOpen(): boolean {
   try {
     return getLocalStorageItem(FILE_EXPLORER_STORAGE_KEY, Schema.Boolean) ?? true;
@@ -778,6 +801,11 @@ export default function FilePreviewPanel({
     false,
     Schema.Boolean,
   );
+  const [renderHtmlPreferred, setRenderHtmlPreferred] = useLocalStorage(
+    RENDER_HTML_STORAGE_KEY,
+    false,
+    Schema.Boolean,
+  );
   // Paired with the path on purpose: each file surface counts its reveals from
   // one, so a bare id would let a dismissed reveal on one file swallow the first
   // reveal on the next.
@@ -786,12 +814,20 @@ export default function FilePreviewPanel({
   );
   const breadcrumbRef = useRef<HTMLDivElement>(null);
   const isMarkdown = relativePath ? isMarkdownPreviewFile(relativePath) : false;
+  const isHtml = relativePath ? isHtmlPreviewFile(relativePath) : false;
   // A reveal still wins over the preference: the line only exists in the source.
   const renderMarkdown =
     isMarkdown &&
     renderMarkdownPreferred &&
     (revealLine === null ||
       (handledReveal?.path === relativePath && handledReveal.requestId === revealRequestId));
+  const renderHtml =
+    isHtml &&
+    renderHtmlPreferred &&
+    (revealLine === null ||
+      (handledReveal?.path === relativePath && handledReveal.requestId === revealRequestId));
+  const renderDocument = renderMarkdown || renderHtml;
+  const renderDocumentLabel = isMarkdown ? "markdown" : "HTML";
   const canOpenInBrowser =
     relativePath !== null && isPreviewSupportedInRuntime() && isBrowserPreviewFile(relativePath);
   const absolutePath = relativePath ? resolvePathLinkTarget(relativePath, cwd) : null;
@@ -890,31 +926,38 @@ export default function FilePreviewPanel({
               enableShortcut={false}
             />
           ) : null}
-          {isMarkdown ? (
+          {isMarkdown || isHtml ? (
             <Tooltip>
               <TooltipTrigger
                 render={
                   <Toggle
                     className="shrink-0"
-                    pressed={renderMarkdown}
+                    pressed={renderDocument}
                     onPressedChange={(pressed) => {
-                      setRenderMarkdownPreferred(pressed);
+                      if (isMarkdown) setRenderMarkdownPreferred(pressed);
+                      if (isHtml) setRenderHtmlPreferred(pressed);
                       setHandledReveal(
                         pressed && relativePath !== null
                           ? { path: relativePath, requestId: revealRequestId }
                           : null,
                       );
                     }}
-                    aria-label={renderMarkdown ? "Show markdown source" : "Show rendered markdown"}
+                    aria-label={
+                      renderDocument
+                        ? `Show ${renderDocumentLabel} source`
+                        : `Show rendered ${renderDocumentLabel}`
+                    }
                     variant="ghost"
                     size="sm"
                   >
-                    {renderMarkdown ? <Code2 className="size-3.5" /> : <Eye className="size-3.5" />}
+                    {renderDocument ? <Code2 className="size-3.5" /> : <Eye className="size-3.5" />}
                   </Toggle>
                 }
               />
               <TooltipPopup>
-                {renderMarkdown ? "Show markdown source" : "Show rendered markdown"}
+                {renderDocument
+                  ? `Show ${renderDocumentLabel} source`
+                  : `Show rendered ${renderDocumentLabel}`}
               </TooltipPopup>
             </Tooltip>
           ) : null}
@@ -996,6 +1039,8 @@ export default function FilePreviewPanel({
                 contents={file.data.contents}
                 onPendingChange={onPendingChange}
               />
+            ) : isHtml && renderHtml ? (
+              <RenderedHtmlSurface relativePath={relativePath} contents={file.data.contents} />
             ) : file.data.truncated ? (
               <Virtualizer
                 key={`${relativePath}:${resolvedTheme}:${file.data.byteLength}`}

--- a/apps/web/src/components/files/filePreviewMode.ts
+++ b/apps/web/src/components/files/filePreviewMode.ts
@@ -1,5 +1,7 @@
 export const isMarkdownPreviewFile = (path: string): boolean => /\.(?:md|mdx)$/i.test(path);
 
+export const isHtmlPreviewFile = (path: string): boolean => /\.html?$/i.test(path);
+
 export function setMarkdownTaskChecked(
   markdown: string,
   markerOffset: number,

--- a/apps/web/src/components/files/filePreviewMode.ts
+++ b/apps/web/src/components/files/filePreviewMode.ts
@@ -2,6 +2,59 @@ export const isMarkdownPreviewFile = (path: string): boolean => /\.(?:md|mdx)$/i
 
 export const isHtmlPreviewFile = (path: string): boolean => /\.html?$/i.test(path);
 
+const HTML_HEAD_OPEN_PATTERN = /<head\b[^>]*>/i;
+const HTML_HEAD_CLOSE_PATTERN = /<\/head\s*>/i;
+const HTML_OPEN_PATTERN = /<html\b[^>]*>/i;
+const HTML_DOCTYPE_PATTERN = /^\s*<!doctype\b[^>]*>/i;
+const HTML_BASE_HREF_PATTERN =
+  /(<base\b[^>]*?\bhref\s*=\s*)(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/i;
+
+const escapeHtmlAttribute = (value: string): string =>
+  value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
+
+export function prepareHtmlPreviewDocument(contents: string, assetUrl: string): string {
+  const assetDirectoryUrl = new URL(".", assetUrl).toString();
+  const escapedAssetDirectoryUrl = escapeHtmlAttribute(assetDirectoryUrl);
+  const baseTag = `<base href="${escapedAssetDirectoryUrl}">`;
+  const headOpenMatch = HTML_HEAD_OPEN_PATTERN.exec(contents);
+
+  if (headOpenMatch?.index !== undefined) {
+    const headContentsStart = headOpenMatch.index + headOpenMatch[0].length;
+    const headCloseMatch = HTML_HEAD_CLOSE_PATTERN.exec(contents.slice(headContentsStart));
+    const headContentsEnd = headCloseMatch
+      ? headContentsStart + headCloseMatch.index
+      : contents.length;
+    const headContents = contents.slice(headContentsStart, headContentsEnd);
+    const existingBaseMatch = HTML_BASE_HREF_PATTERN.exec(headContents);
+
+    if (existingBaseMatch?.index !== undefined) {
+      const existingHref =
+        existingBaseMatch[2] ?? existingBaseMatch[3] ?? existingBaseMatch[4] ?? "";
+      let resolvedHref = assetDirectoryUrl;
+      try {
+        resolvedHref = new URL(existingHref, assetUrl).toString();
+      } catch {
+        // An invalid authored base behaves like no usable base for the preview.
+      }
+      const matchStart = headContentsStart + existingBaseMatch.index;
+      const matchEnd = matchStart + existingBaseMatch[0].length;
+      return `${contents.slice(0, matchStart)}${existingBaseMatch[1]}"${escapeHtmlAttribute(resolvedHref)}"${contents.slice(matchEnd)}`;
+    }
+
+    return `${contents.slice(0, headContentsStart)}${baseTag}${contents.slice(headContentsStart)}`;
+  }
+
+  const htmlOpenMatch = HTML_OPEN_PATTERN.exec(contents);
+  if (htmlOpenMatch?.index !== undefined) {
+    const insertAt = htmlOpenMatch.index + htmlOpenMatch[0].length;
+    return `${contents.slice(0, insertAt)}<head>${baseTag}</head>${contents.slice(insertAt)}`;
+  }
+
+  const doctypeMatch = HTML_DOCTYPE_PATTERN.exec(contents);
+  const insertAt = doctypeMatch?.[0].length ?? 0;
+  return `${contents.slice(0, insertAt)}<head>${baseTag}</head>${contents.slice(insertAt)}`;
+}
+
 export function setMarkdownTaskChecked(
   markdown: string,
   markerOffset: number,


### PR DESCRIPTION
Opening an HTML workspace file currently shows source only, and served-web users cannot fall back to the Electron-only preview browser.

This adds the existing Source/Rendered toggle pattern to .html and .htm files. Rendered mode uses an iframe srcdoc sandbox that permits scripts while withholding same-origin access, forms, popups, top-level navigation, and downloads. Source remains the default, and line-reveal requests continue to select source mode.

Closes #5100

### Screenshots

| Before | After |
| --- | --- |
| ![HTML source shown in the file preview](https://raw.githubusercontent.com/tastelessjolt/t3code/pr-assets-html-preview-5100/html-preview-5100/before.png) | ![Rendered HTML shown in the file preview](https://raw.githubusercontent.com/tastelessjolt/t3code/pr-assets-html-preview-5100/html-preview-5100/after.png) |

### Verification

- vp test run apps/web/src/components/files/FilePreviewPanel.test.ts
- vp run --filter @t3tools/web typecheck
- targeted lint and formatting checks
- served-web verification with styled .html and interactive .htm fixtures
- verified source switching, sandbox isolation, and in-frame script interaction

Built with GPT-5.6 Codex through the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render HTML files in the file preview panel with sandboxed iframe
> - Adds `isHtmlPreviewFile` to detect `.html`/`.htm` files and `prepareHtmlPreviewDocument` to rewrite the document's `<base href>` to the signed asset directory URL, enabling relative assets to resolve correctly in preview.
> - Adds a `RenderedHtmlSurface` component that fetches the signed asset URL, prepares the HTML document, and renders it in a sandboxed iframe with `referrerPolicy=no-referrer`.
> - Integrates HTML rendering into `FilePreviewPanel` with a localStorage-backed toggle (`t3code.renderHtml`), sharing toggle UX with the existing Markdown render preference.
> - Behavioral Change: `.html`/`.htm` files now default to a rendered preview (iframe) rather than raw source; users can toggle back to source view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a63d845.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sandboxed iframe preview runs authored scripts with `allow-scripts`, which is intentional but still a security-sensitive surface; base URL rewriting touches served asset paths.
> 
> **Overview**
> Workspace **`.html` / `.htm`** files can now switch between source and rendered preview, mirroring the existing markdown toggle. The preference is stored in **`t3code.renderHtml`**; source stays the default, and line-reveal still forces source view.
> 
> Rendered HTML is shown in a **sandboxed iframe** (`allow-scripts`, `no-referrer`) via `srcDoc`. **`prepareHtmlPreviewDocument`** injects or rewrites a `<base href>` so relative assets resolve against the signed workspace asset URL.
> 
> Unit tests cover HTML file detection and base-tag preparation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63d84510c62444bf7fa335e8adbfb7fe9b1fc48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->