### PR TITLE
fix(mobile): handle long multi-select user input forms

### DIFF
--- a/apps/mobile/src/features/threads/PendingUserInputCard.tsx
+++ b/apps/mobile/src/features/threads/PendingUserInputCard.tsx
@@ -1,5 +1,5 @@
 import type { ApprovalRequestId, UserInputQuestion } from "@t3tools/contracts";
-import { Pressable, ScrollView, useWindowDimensions, View } from "react-native";
+import { Pressable, ScrollView, View } from "react-native";
 
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { cn } from "../../lib/cn";
@@ -7,6 +7,7 @@ import type { PendingUserInput, PendingUserInputDraftAnswer } from "../../lib/th
 
 export interface PendingUserInputCardProps {
   readonly pendingUserInput: PendingUserInput;
+  readonly maxHeight: number;
   readonly drafts: Record<string, PendingUserInputDraftAnswer>;
   readonly answers: Record<string, string | ReadonlyArray<string>> | null;
   readonly respondingUserInputId: ApprovalRequestId | null;
@@ -24,16 +25,13 @@ export interface PendingUserInputCardProps {
 }
 
 export function PendingUserInputCard(props: PendingUserInputCardProps) {
-  const { height: windowHeight } = useWindowDimensions();
-  const maxHeight = Math.max(180, Math.min(560, Math.floor(windowHeight * 0.62)));
-
   // The surface is opaque on purpose: the card floats over the thread feed
   // with no blur behind it, so a translucent background renders the questions
   // on top of whatever message happens to sit underneath.
   return (
     <View
-      className="gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100 p-4 dark:border-white/6 dark:bg-neutral-900"
-      style={{ maxHeight }}
+      className="overflow-hidden gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100 p-4 dark:border-white/6 dark:bg-neutral-900"
+      style={{ maxHeight: props.maxHeight }}
     >
       <Text className="font-t3-bold text-2xs uppercase tracking-[1.1px] text-sky-700 dark:text-sky-300">
         User input needed

--- a/apps/mobile/src/features/threads/PendingUserInputCard.tsx
+++ b/apps/mobile/src/features/threads/PendingUserInputCard.tsx
@@ -1,5 +1,5 @@
-import type { ApprovalRequestId } from "@t3tools/contracts";
-import { Pressable, View } from "react-native";
+import type { ApprovalRequestId, UserInputQuestion } from "@t3tools/contracts";
+import { Pressable, ScrollView, useWindowDimensions, View } from "react-native";
 
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { cn } from "../../lib/cn";
@@ -8,11 +8,11 @@ import type { PendingUserInput, PendingUserInputDraftAnswer } from "../../lib/th
 export interface PendingUserInputCardProps {
   readonly pendingUserInput: PendingUserInput;
   readonly drafts: Record<string, PendingUserInputDraftAnswer>;
-  readonly answers: Record<string, string> | null;
+  readonly answers: Record<string, string | ReadonlyArray<string>> | null;
   readonly respondingUserInputId: ApprovalRequestId | null;
   readonly onSelectOption: (
     requestId: ApprovalRequestId,
-    questionId: string,
+    question: UserInputQuestion,
     label: string,
   ) => void;
   readonly onChangeCustomAnswer: (
@@ -24,73 +24,90 @@ export interface PendingUserInputCardProps {
 }
 
 export function PendingUserInputCard(props: PendingUserInputCardProps) {
+  const { height: windowHeight } = useWindowDimensions();
+  const maxHeight = Math.max(180, Math.min(560, Math.floor(windowHeight * 0.62)));
+
   // The surface is opaque on purpose: the card floats over the thread feed
   // with no blur behind it, so a translucent background renders the questions
   // on top of whatever message happens to sit underneath.
   return (
-    <View className="gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100 p-4 dark:border-white/6 dark:bg-neutral-900">
+    <View
+      className="gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100 p-4 dark:border-white/6 dark:bg-neutral-900"
+      style={{ maxHeight }}
+    >
       <Text className="font-t3-bold text-2xs uppercase tracking-[1.1px] text-sky-700 dark:text-sky-300">
         User input needed
       </Text>
       <Text className="font-t3-bold text-lg text-neutral-950 dark:text-neutral-50">
         Fill in the pending answers
       </Text>
-      {props.pendingUserInput.questions.map((question) => {
-        const draft = props.drafts[question.id];
-        return (
-          <View key={question.id} className="gap-2 pt-1">
-            <Text className="font-t3-bold text-xs uppercase tracking-[1px] text-neutral-500 dark:text-neutral-500">
-              {question.header}
-            </Text>
-            <Text className="font-sans text-base leading-snug text-neutral-950 dark:text-neutral-50">
-              {question.question}
-            </Text>
-            <View className="flex-row flex-wrap gap-2.5">
-              {question.options.map((option) => {
-                const selected =
-                  draft?.selectedOptionLabel === option.label && !draft.customAnswer?.trim().length;
-                return (
-                  <Pressable
-                    key={option.label}
-                    className={cn(
-                      "rounded-full border px-3 py-2.5 ",
-                      selected
-                        ? "border-blue-300/50 bg-blue-50 dark:border-blue-400/28 dark:bg-blue-400/14"
-                        : "border-neutral-200 bg-white dark:border-white/6 dark:bg-neutral-950/70",
-                    )}
-                    onPress={() =>
-                      props.onSelectOption(
-                        props.pendingUserInput.requestId,
-                        question.id,
-                        option.label,
-                      )
-                    }
-                  >
-                    <Text
+      <ScrollView
+        bounces={false}
+        className="min-h-0"
+        contentContainerClassName="gap-2.5 pb-1"
+        keyboardShouldPersistTaps="handled"
+        nestedScrollEnabled
+        showsVerticalScrollIndicator
+        style={{ flexShrink: 1 }}
+      >
+        {props.pendingUserInput.questions.map((question) => {
+          const draft = props.drafts[question.id];
+          return (
+            <View key={question.id} className="gap-2 pt-1">
+              <Text className="font-t3-bold text-xs uppercase tracking-[1px] text-neutral-500 dark:text-neutral-500">
+                {question.header}
+              </Text>
+              <Text className="font-sans text-base leading-snug text-neutral-950 dark:text-neutral-50">
+                {question.question}
+              </Text>
+              <View className="flex-row flex-wrap gap-2.5">
+                {question.options.map((option) => {
+                  const selected =
+                    draft?.selectedOptionLabels?.includes(option.label) === true &&
+                    !draft.customAnswer?.trim().length;
+                  return (
+                    <Pressable
+                      key={option.label}
                       className={cn(
-                        "font-t3-bold text-sm",
+                        "rounded-full border px-3 py-2.5 ",
                         selected
-                          ? "text-sky-700 dark:text-sky-300"
-                          : "text-neutral-600 dark:text-neutral-300",
+                          ? "border-blue-300/50 bg-blue-50 dark:border-blue-400/28 dark:bg-blue-400/14"
+                          : "border-neutral-200 bg-white dark:border-white/6 dark:bg-neutral-950/70",
                       )}
+                      onPress={() =>
+                        props.onSelectOption(
+                          props.pendingUserInput.requestId,
+                          question,
+                          option.label,
+                        )
+                      }
                     >
-                      {option.label}
-                    </Text>
-                  </Pressable>
-                );
-              })}
+                      <Text
+                        className={cn(
+                          "font-t3-bold text-sm",
+                          selected
+                            ? "text-sky-700 dark:text-sky-300"
+                            : "text-neutral-600 dark:text-neutral-300",
+                        )}
+                      >
+                        {option.label}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+              <TextInput
+                value={draft?.customAnswer ?? ""}
+                onChangeText={(value) =>
+                  props.onChangeCustomAnswer(props.pendingUserInput.requestId, question.id, value)
+                }
+                placeholder="Or type a custom answer"
+                className="min-h-[54px] rounded-2xl border border-neutral-200 bg-white px-3.5 py-3 font-sans text-base text-neutral-950 dark:border-white/8 dark:bg-neutral-950/70 dark:text-neutral-50"
+              />
             </View>
-            <TextInput
-              value={draft?.customAnswer ?? ""}
-              onChangeText={(value) =>
-                props.onChangeCustomAnswer(props.pendingUserInput.requestId, question.id, value)
-              }
-              placeholder="Or type a custom answer"
-              className="min-h-[54px] rounded-2xl border border-neutral-200 bg-white px-3.5 py-3 font-sans text-base text-neutral-950 dark:border-white/8 dark:bg-neutral-950/70 dark:text-neutral-50"
-            />
-          </View>
-        );
-      })}
+          );
+        })}
+      </ScrollView>
       <Pressable
         className={cn(
           "items-center justify-center rounded-2xl px-4 py-3.5",

--- a/apps/mobile/src/features/threads/PendingUserInputCard.tsx
+++ b/apps/mobile/src/features/threads/PendingUserInputCard.tsx
@@ -3,7 +3,11 @@ import { Pressable, ScrollView, View } from "react-native";
 
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { cn } from "../../lib/cn";
-import type { PendingUserInput, PendingUserInputDraftAnswer } from "../../lib/threadActivity";
+import {
+  isPendingUserInputOptionSelected,
+  type PendingUserInput,
+  type PendingUserInputDraftAnswer,
+} from "../../lib/threadActivity";
 
 export interface PendingUserInputCardProps {
   readonly pendingUserInput: PendingUserInput;
@@ -60,9 +64,7 @@ export function PendingUserInputCard(props: PendingUserInputCardProps) {
               </Text>
               <View className="flex-row flex-wrap gap-2.5">
                 {question.options.map((option) => {
-                  const selected =
-                    draft?.selectedOptionLabels?.includes(option.label) === true &&
-                    !draft.customAnswer?.trim().length;
+                  const selected = isPendingUserInputOptionSelected(draft, option.label);
                   return (
                     <Pressable
                       key={option.label}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -13,6 +13,7 @@ import type {
   RuntimeMode,
   ServerConfig as T3ServerConfig,
   ThreadId,
+  UserInputQuestion,
 } from "@t3tools/contracts";
 import * as Haptics from "expo-haptics";
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -54,7 +55,7 @@ export interface ThreadDetailScreenProps {
   readonly respondingApprovalId: ApprovalRequestId | null;
   readonly activePendingUserInput: PendingUserInput | null;
   readonly activePendingUserInputDrafts: Record<string, PendingUserInputDraftAnswer>;
-  readonly activePendingUserInputAnswers: Record<string, string> | null;
+  readonly activePendingUserInputAnswers: Record<string, string | ReadonlyArray<string>> | null;
   readonly respondingUserInputId: ApprovalRequestId | null;
   readonly draftMessage: string;
   readonly draftAttachments: ReadonlyArray<DraftComposerImageAttachment>;
@@ -89,7 +90,7 @@ export interface ThreadDetailScreenProps {
   ) => Promise<unknown>;
   readonly onSelectUserInputOption: (
     requestId: ApprovalRequestId,
-    questionId: string,
+    question: UserInputQuestion,
     label: string,
   ) => void;
   readonly onChangeUserInputCustomAnswer: (

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -409,6 +409,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
       {/* Floating composer — sticks to keyboard via KeyboardStickyView */}
       {showContent ? (
         <KeyboardStickyView
+          enabled={keyboardVisible}
           style={{ position: "absolute", bottom: 0, left: 0, right: 0 }}
           offset={{ closed: 0, opened: 0 }}
         >

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -2,6 +2,7 @@ import { type EnvironmentConnectionPhase } from "@t3tools/client-runtime/connect
 import type { EnvironmentThreadStatus } from "@t3tools/client-runtime/state/threads";
 import { useKeyboardChatComposerInset, useKeyboardScrollToEnd } from "@legendapp/list/keyboard";
 import type { LegendListRef } from "@legendapp/list/react-native";
+import { HeaderHeightContext } from "@react-navigation/elements";
 import type {
   ApprovalRequestId,
   EnvironmentId,
@@ -16,9 +17,22 @@ import type {
   UserInputQuestion,
 } from "@t3tools/contracts";
 import * as Haptics from "expo-haptics";
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Platform, View, type GestureResponderEvent } from "react-native";
-import { KeyboardController, KeyboardStickyView } from "react-native-keyboard-controller";
+import {
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Platform, useWindowDimensions, View, type GestureResponderEvent } from "react-native";
+import {
+  KeyboardController,
+  KeyboardStickyView,
+  useKeyboardState,
+} from "react-native-keyboard-controller";
 import Animated, { FadeInDown, FadeOut } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -35,6 +49,7 @@ import type {
 } from "../../lib/threadActivity";
 import { PendingApprovalCard } from "./PendingApprovalCard";
 import { PendingUserInputCard } from "./PendingUserInputCard";
+import { derivePendingUserInputMaxHeight } from "./pendingUserInputLayout";
 import {
   COMPOSER_COLLAPSED_CHROME,
   COMPOSER_EXPANDED_CHROME,
@@ -174,6 +189,10 @@ function useStreamingHaptics(threadId: ThreadId, feed: ReadonlyArray<ThreadFeedE
 
 export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: ThreadDetailScreenProps) {
   const insets = useSafeAreaInsets();
+  const windowHeight = useWindowDimensions().height;
+  const keyboardVisible = useKeyboardState((state) => state.isVisible);
+  const keyboardHeight = useKeyboardState((state) => state.height);
+  const navigationHeaderHeight = useContext(HeaderHeightContext) || insets.top + 44;
   const agentLabel = `${props.selectedThread.modelSelection.instanceId} agent`;
   const selectedThreadKey = scopedThreadKey(props.environmentId, props.selectedThread.id);
   const composerEditorRef = useRef<ComposerEditorHandle>(null);
@@ -205,6 +224,12 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const selectedThreadFeed = props.selectedThreadFeed;
   const composerChrome = composerExpanded ? COMPOSER_EXPANDED_CHROME : COMPOSER_COLLAPSED_CHROME;
   const composerOverlapHeight = composerChrome + composerBottomInset;
+  const pendingUserInputMaxHeight = derivePendingUserInputMaxHeight({
+    windowHeight,
+    keyboardHeight: keyboardVisible ? keyboardHeight : 0,
+    navigationHeaderHeight,
+    composerOverlapHeight,
+  });
   const estimatedOverlayHeight = composerOverlapHeight;
   // The overlay's measured height includes the home-indicator inset (the
   // composer pads it), but contentInsetAdjustmentBehavior="automatic" makes
@@ -408,6 +433,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                   {props.activePendingUserInput ? (
                     <PendingUserInputCard
                       pendingUserInput={props.activePendingUserInput}
+                      maxHeight={pendingUserInputMaxHeight}
                       drafts={props.activePendingUserInputDrafts}
                       answers={props.activePendingUserInputAnswers}
                       respondingUserInputId={props.respondingUserInputId}

--- a/apps/mobile/src/features/threads/pendingUserInputLayout.test.ts
+++ b/apps/mobile/src/features/threads/pendingUserInputLayout.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { derivePendingUserInputMaxHeight } from "./pendingUserInputLayout";
+
+describe("derivePendingUserInputMaxHeight", () => {
+  it("caps a tall portrait viewport", () => {
+    expect(
+      derivePendingUserInputMaxHeight({
+        windowHeight: 932,
+        keyboardHeight: 0,
+        navigationHeaderHeight: 103,
+        composerOverlapHeight: 94,
+      }),
+    ).toBe(560);
+  });
+
+  it("subtracts the keyboard while editing a custom answer", () => {
+    expect(
+      derivePendingUserInputMaxHeight({
+        windowHeight: 932,
+        keyboardHeight: 336,
+        navigationHeaderHeight: 103,
+        composerOverlapHeight: 94,
+      }),
+    ).toBe(387);
+  });
+
+  it("never forces the card beyond a short landscape viewport", () => {
+    expect(
+      derivePendingUserInputMaxHeight({
+        windowHeight: 375,
+        keyboardHeight: 240,
+        navigationHeaderHeight: 44,
+        composerOverlapHeight: 94,
+      }),
+    ).toBe(0);
+  });
+});

--- a/apps/mobile/src/features/threads/pendingUserInputLayout.test.ts
+++ b/apps/mobile/src/features/threads/pendingUserInputLayout.test.ts
@@ -25,7 +25,7 @@ describe("derivePendingUserInputMaxHeight", () => {
     ).toBe(387);
   });
 
-  it("never forces the card beyond a short landscape viewport", () => {
+  it("keeps the fixed action area usable in a short keyboard-open viewport", () => {
     expect(
       derivePendingUserInputMaxHeight({
         windowHeight: 375,
@@ -33,6 +33,6 @@ describe("derivePendingUserInputMaxHeight", () => {
         navigationHeaderHeight: 44,
         composerOverlapHeight: 94,
       }),
-    ).toBe(0);
+    ).toBe(160);
   });
 });

--- a/apps/mobile/src/features/threads/pendingUserInputLayout.ts
+++ b/apps/mobile/src/features/threads/pendingUserInputLayout.ts
@@ -1,0 +1,18 @@
+const PENDING_USER_INPUT_MAX_HEIGHT = 560;
+const PENDING_USER_INPUT_VERTICAL_GAP = 12;
+
+export function derivePendingUserInputMaxHeight(input: {
+  readonly windowHeight: number;
+  readonly keyboardHeight: number;
+  readonly navigationHeaderHeight: number;
+  readonly composerOverlapHeight: number;
+}): number {
+  const availableHeight =
+    input.windowHeight -
+    Math.max(0, input.keyboardHeight) -
+    Math.max(0, input.navigationHeaderHeight) -
+    Math.max(0, input.composerOverlapHeight) -
+    PENDING_USER_INPUT_VERTICAL_GAP;
+
+  return Math.min(PENDING_USER_INPUT_MAX_HEIGHT, Math.max(0, availableHeight));
+}

--- a/apps/mobile/src/features/threads/pendingUserInputLayout.ts
+++ b/apps/mobile/src/features/threads/pendingUserInputLayout.ts
@@ -1,4 +1,5 @@
 const PENDING_USER_INPUT_MAX_HEIGHT = 560;
+const PENDING_USER_INPUT_MIN_HEIGHT = 160;
 const PENDING_USER_INPUT_VERTICAL_GAP = 12;
 
 export function derivePendingUserInputMaxHeight(input: {
@@ -14,5 +15,8 @@ export function derivePendingUserInputMaxHeight(input: {
     Math.max(0, input.composerOverlapHeight) -
     PENDING_USER_INPUT_VERTICAL_GAP;
 
-  return Math.min(PENDING_USER_INPUT_MAX_HEIGHT, Math.max(0, availableHeight));
+  return Math.min(
+    PENDING_USER_INPUT_MAX_HEIGHT,
+    Math.max(PENDING_USER_INPUT_MIN_HEIGHT, availableHeight),
+  );
 }

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -66,6 +66,16 @@ describe("pending user input answers", () => {
     expect(
       togglePendingUserInputOptionSelection(multiSelectQuestion, ordersAndListings, "Orders"),
     ).toEqual({ customAnswer: "", selectedOptionLabels: ["Listings"] });
+
+    const paddedOrders = togglePendingUserInputOptionSelection(
+      multiSelectQuestion,
+      undefined,
+      "  Orders  ",
+    );
+    expect(paddedOrders).toEqual({ customAnswer: "", selectedOptionLabels: ["Orders"] });
+    expect(
+      togglePendingUserInputOptionSelection(multiSelectQuestion, paddedOrders, "  Orders  "),
+    ).toEqual({ customAnswer: "" });
   });
 
   it("builds array answers for multi-select questions", () => {

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -12,11 +12,83 @@ import {
 } from "@t3tools/contracts";
 
 import {
+  buildPendingUserInputAnswers,
   buildThreadFeed,
   deriveThreadFeedPresentation,
+  setPendingUserInputCustomAnswer,
+  togglePendingUserInputOptionSelection,
   type ThreadFeedActivity,
   type ThreadFeedEntry,
 } from "./threadActivity";
+
+const singleSelectQuestion = {
+  id: "runtime",
+  header: "Runtime",
+  question: "Which runtime should be used?",
+  options: [
+    { label: "Go", description: "One binary" },
+    { label: "Node.js", description: "Reuse TypeScript" },
+  ],
+  multiSelect: false,
+} as const;
+
+const multiSelectQuestion = {
+  id: "scope",
+  header: "Scope",
+  question: "Which data should be collected?",
+  options: [
+    { label: "Orders", description: "Receipts" },
+    { label: "Listings", description: "Inventory" },
+  ],
+  multiSelect: true,
+} as const;
+
+describe("pending user input answers", () => {
+  it("replaces single-select options and toggles multi-select options", () => {
+    expect(
+      togglePendingUserInputOptionSelection(
+        singleSelectQuestion,
+        { selectedOptionLabels: ["Go"] },
+        "Node.js",
+      ),
+    ).toEqual({ customAnswer: "", selectedOptionLabels: ["Node.js"] });
+
+    const orders = togglePendingUserInputOptionSelection(multiSelectQuestion, undefined, "Orders");
+    const ordersAndListings = togglePendingUserInputOptionSelection(
+      multiSelectQuestion,
+      orders,
+      "Listings",
+    );
+    expect(ordersAndListings).toEqual({
+      customAnswer: "",
+      selectedOptionLabels: ["Orders", "Listings"],
+    });
+    expect(
+      togglePendingUserInputOptionSelection(multiSelectQuestion, ordersAndListings, "Orders"),
+    ).toEqual({ customAnswer: "", selectedOptionLabels: ["Listings"] });
+  });
+
+  it("builds array answers for multi-select questions", () => {
+    expect(
+      buildPendingUserInputAnswers([singleSelectQuestion, multiSelectQuestion], {
+        runtime: { selectedOptionLabels: ["Go"] },
+        scope: { selectedOptionLabels: ["Orders", "Listings"] },
+      }),
+    ).toEqual({
+      runtime: "Go",
+      scope: ["Orders", "Listings"],
+    });
+  });
+
+  it("clears selected options while a custom answer is active", () => {
+    expect(
+      setPendingUserInputCustomAnswer(
+        { selectedOptionLabels: ["Orders", "Listings"] },
+        "Orders first",
+      ),
+    ).toEqual({ customAnswer: "Orders first" });
+  });
+});
 
 function makeActivity(
   input: Partial<OrchestrationThreadActivity> &

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -15,6 +15,7 @@ import {
   buildPendingUserInputAnswers,
   buildThreadFeed,
   deriveThreadFeedPresentation,
+  isPendingUserInputOptionSelected,
   setPendingUserInputCustomAnswer,
   togglePendingUserInputOptionSelection,
   type ThreadFeedActivity,
@@ -97,6 +98,18 @@ describe("pending user input answers", () => {
         "Orders first",
       ),
     ).toEqual({ customAnswer: "Orders first" });
+  });
+
+  it("matches selected chips against normalized option labels", () => {
+    expect(
+      isPendingUserInputOptionSelected({ selectedOptionLabels: ["Orders"] }, "  Orders  "),
+    ).toBe(true);
+    expect(
+      isPendingUserInputOptionSelected(
+        { selectedOptionLabels: ["Orders"], customAnswer: "Orders first" },
+        "  Orders  ",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -26,7 +26,7 @@ export interface PendingUserInput {
 }
 
 export interface PendingUserInputDraftAnswer {
-  readonly selectedOptionLabel?: string;
+  readonly selectedOptionLabels?: ReadonlyArray<string>;
   readonly customAnswer?: string;
 }
 
@@ -227,14 +227,32 @@ function normalizeDraftAnswer(value: string | undefined): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function normalizeSelectedOptionLabels(
+  value: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(value.map((entry) => entry.trim()).filter((entry) => entry.length > 0)),
+  );
+}
+
 function resolvePendingUserInputAnswer(
+  question: UserInputQuestion,
   draft: PendingUserInputDraftAnswer | undefined,
-): string | null {
+): string | ReadonlyArray<string> | null {
   const customAnswer = normalizeDraftAnswer(draft?.customAnswer);
   if (customAnswer) {
     return customAnswer;
   }
-  return normalizeDraftAnswer(draft?.selectedOptionLabel);
+
+  const selectedOptionLabels = normalizeSelectedOptionLabels(draft?.selectedOptionLabels);
+  if (question.multiSelect) {
+    return selectedOptionLabels.length > 0 ? selectedOptionLabels : null;
+  }
+  return selectedOptionLabels[0] ?? null;
 }
 
 /** Codex children settle via task.updated (idle/failed/interrupted), never
@@ -1428,22 +1446,49 @@ export function setPendingUserInputCustomAnswer(
   draft: PendingUserInputDraftAnswer | undefined,
   customAnswer: string,
 ): PendingUserInputDraftAnswer {
-  const selectedOptionLabel =
-    customAnswer.trim().length > 0 ? undefined : draft?.selectedOptionLabel;
+  const selectedOptionLabels =
+    customAnswer.trim().length > 0
+      ? undefined
+      : normalizeSelectedOptionLabels(draft?.selectedOptionLabels);
   return {
     customAnswer,
-    ...(selectedOptionLabel ? { selectedOptionLabel } : {}),
+    ...(selectedOptionLabels && selectedOptionLabels.length > 0 ? { selectedOptionLabels } : {}),
+  };
+}
+
+export function togglePendingUserInputOptionSelection(
+  question: UserInputQuestion,
+  draft: PendingUserInputDraftAnswer | undefined,
+  optionLabel: string,
+): PendingUserInputDraftAnswer {
+  if (question.multiSelect) {
+    const selectedOptionLabels = normalizeSelectedOptionLabels(draft?.selectedOptionLabels);
+    const nextSelectedOptionLabels = selectedOptionLabels.includes(optionLabel)
+      ? selectedOptionLabels.filter((label) => label !== optionLabel)
+      : [...selectedOptionLabels, optionLabel];
+
+    return {
+      customAnswer: "",
+      ...(nextSelectedOptionLabels.length > 0
+        ? { selectedOptionLabels: nextSelectedOptionLabels }
+        : {}),
+    };
+  }
+
+  return {
+    customAnswer: "",
+    selectedOptionLabels: [optionLabel],
   };
 }
 
 export function buildPendingUserInputAnswers(
   questions: ReadonlyArray<UserInputQuestion>,
   draftAnswers: Record<string, PendingUserInputDraftAnswer>,
-): Record<string, string> | null {
-  const answers: Record<string, string> = {};
+): Record<string, string | ReadonlyArray<string>> | null {
+  const answers: Record<string, string | ReadonlyArray<string>> = {};
 
   for (const question of questions) {
-    const answer = resolvePendingUserInputAnswer(draftAnswers[question.id]);
+    const answer = resolvePendingUserInputAnswer(question, draftAnswers[question.id]);
     if (!answer) {
       return null;
     }

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1456,6 +1456,17 @@ export function setPendingUserInputCustomAnswer(
   };
 }
 
+export function isPendingUserInputOptionSelected(
+  draft: PendingUserInputDraftAnswer | undefined,
+  optionLabel: string,
+): boolean {
+  if (normalizeDraftAnswer(draft?.customAnswer)) {
+    return false;
+  }
+
+  return normalizeSelectedOptionLabels(draft?.selectedOptionLabels).includes(optionLabel.trim());
+}
+
 export function togglePendingUserInputOptionSelection(
   question: UserInputQuestion,
   draft: PendingUserInputDraftAnswer | undefined,

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1461,11 +1461,13 @@ export function togglePendingUserInputOptionSelection(
   draft: PendingUserInputDraftAnswer | undefined,
   optionLabel: string,
 ): PendingUserInputDraftAnswer {
+  const normalizedOptionLabel = optionLabel.trim();
+
   if (question.multiSelect) {
     const selectedOptionLabels = normalizeSelectedOptionLabels(draft?.selectedOptionLabels);
-    const nextSelectedOptionLabels = selectedOptionLabels.includes(optionLabel)
-      ? selectedOptionLabels.filter((label) => label !== optionLabel)
-      : [...selectedOptionLabels, optionLabel];
+    const nextSelectedOptionLabels = selectedOptionLabels.includes(normalizedOptionLabel)
+      ? selectedOptionLabels.filter((label) => label !== normalizedOptionLabel)
+      : [...selectedOptionLabels, normalizedOptionLabel];
 
     return {
       customAnswer: "",
@@ -1477,7 +1479,7 @@ export function togglePendingUserInputOptionSelection(
 
   return {
     customAnswer: "",
-    selectedOptionLabels: [optionLabel],
+    selectedOptionLabels: [normalizedOptionLabel],
   };
 }
 

--- a/apps/mobile/src/state/use-selected-thread-requests.ts
+++ b/apps/mobile/src/state/use-selected-thread-requests.ts
@@ -1,7 +1,11 @@
 import { useAtomValue } from "@effect/atom-react";
 import { useCallback, useMemo, useState } from "react";
 
-import { ApprovalRequestId, type ProviderApprovalDecision } from "@t3tools/contracts";
+import {
+  ApprovalRequestId,
+  type ProviderApprovalDecision,
+  type UserInputQuestion,
+} from "@t3tools/contracts";
 import { Atom } from "effect/unstable/reactivity";
 
 import { threadEnvironment } from "../state/threads";
@@ -12,6 +16,7 @@ import {
   derivePendingUserInputs,
   setPendingUserInputCustomAnswer,
   sortThreadActivities,
+  togglePendingUserInputOptionSelection,
   type PendingUserInputDraftAnswer,
 } from "../lib/threadActivity";
 import { appAtomRegistry } from "./atom-registry";
@@ -23,15 +28,21 @@ const userInputDraftsByRequestKeyAtom = Atom.make<
   Record<string, Record<string, PendingUserInputDraftAnswer>>
 >({}).pipe(Atom.keepAlive, Atom.withLabel("mobile:user-input-drafts"));
 
-function setUserInputDraftOption(requestKey: string, questionId: string, label: string): void {
+function setUserInputDraftOption(
+  requestKey: string,
+  question: UserInputQuestion,
+  label: string,
+): void {
   const current = appAtomRegistry.get(userInputDraftsByRequestKeyAtom);
   appAtomRegistry.set(userInputDraftsByRequestKeyAtom, {
     ...current,
     [requestKey]: {
       ...current[requestKey],
-      [questionId]: {
-        selectedOptionLabel: label,
-      },
+      [question.id]: togglePendingUserInputOptionSelection(
+        question,
+        current[requestKey]?.[question.id],
+        label,
+      ),
     },
   });
 }
@@ -97,13 +108,13 @@ export function useSelectedThreadRequests() {
     : null;
 
   const onSelectUserInputOption = useCallback(
-    (requestId: ApprovalRequestId, questionId: string, label: string) => {
+    (requestId: ApprovalRequestId, question: UserInputQuestion, label: string) => {
       if (!selectedThreadShell) {
         return;
       }
 
       const requestKey = scopedRequestKey(selectedThreadShell.environmentId, requestId);
-      setUserInputDraftOption(requestKey, questionId, label);
+      setUserInputDraftOption(requestKey, question, label);
     },
     [selectedThreadShell],
   );


### PR DESCRIPTION
## What Changed

Long pending user input forms now stay within the mobile viewport and scroll their questions independently, keeping the card header and submit action reachable. Multi-select questions retain every selected option and submit an array, while single-select answers remain scalar.

## Why

The mobile client rendered every question inside a non-scrollable sticky card. Forms with several questions overflowed above the screen, and swiping could not reach the clipped content. The same flow reduced `multiSelect` questions to one option, so users could not provide the answer shape requested by the provider.

## UI Changes

Before: the card exceeds the viewport and its beginning is clipped.

![Pending user input before](https://raw.githubusercontent.com/thuongtin/t3code/66170d1c7f6d7adc0a91ecbe9937fc1fa1eacd3b/before.png)

After: the card is bounded, with a scrollable question area and fixed submit action.

![Pending user input after](https://raw.githubusercontent.com/thuongtin/t3code/66170d1c7f6d7adc0a91ecbe9937fc1fa1eacd3b/after.png)

[Short scroll interaction video](https://raw.githubusercontent.com/thuongtin/t3code/66170d1c7f6d7adc0a91ecbe9937fc1fa1eacd3b/scroll-demo.mp4)

## Validation

- `vp lint` passed for all five changed files.
- `vp test run apps/mobile/src/lib/threadActivity.test.ts` passed 12 tests.
- `pnpm --filter @t3tools/mobile typecheck` passed.
- A self-contained preview Release APK was exercised on a Pixel 10 Pro XL: the form scrolled through all questions, two multi-select options remained selected together, and the app stayed connected for 35 seconds without a fatal exception or connection-failure loop.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-5. Harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile thread UI and answer-shaping logic with unit tests; no auth or server changes. Minor keyboard-sticky behavior change when the keyboard is hidden.
> 
> **Overview**
> Long pending user-input forms on mobile no longer clip off-screen: **`PendingUserInputCard`** gets a computed **`maxHeight`**, wraps questions in a **`ScrollView`**, and keeps the header and **Submit** action fixed while the question list scrolls.
> 
> **`derivePendingUserInputMaxHeight`** sizes that card from window height, keyboard, nav header, and composer overlap (with min/max caps). **`ThreadDetailScreen`** wires keyboard/window/header state into it and only enables **`KeyboardStickyView`** while the keyboard is visible.
> 
> Draft/answer handling now supports **`multiSelect`**: drafts track **`selectedOptionLabels`**, **`togglePendingUserInputOptionSelection`** toggles chips vs replaces for single-select, **`buildPendingUserInputAnswers`** emits string arrays for multi-select, and option selection passes the full **`UserInputQuestion`** through the screen and request hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85c75ac87bd15a0fa3369e9f915fe980a5a82c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-select support and scrollable layout to pending user input forms on mobile
> - Replaces single-select option logic with `togglePendingUserInputOptionSelection`, allowing multi-select questions to accumulate or remove selected options; single-select continues to work as before.
> - Adds `isPendingUserInputOptionSelected` to accurately reflect chip state, ignoring selections when a custom answer is present; entering a custom answer clears selections and vice versa.
> - Wraps the question list in a `ScrollView` in [`PendingUserInputCard`](https://github.com/pingdotgg/t3code/pull/5118/files#diff-7e638162740719ba1f11003bf9376f0b089c32c5b55bedd73929281fc98ff7bf) and computes a responsive max height via [`derivePendingUserInputMaxHeight`](https://github.com/pingdotgg/t3code/pull/5118/files#diff-3cc7cf9a69dbcf6d088736bc12d782b2af05c3977f4f559a7f0280ac950aa181), accounting for keyboard height, navigation header, and composer overlap.
> - `KeyboardStickyView` is now only enabled while the keyboard is visible.
> - `buildPendingUserInputAnswers` return type is broadened to allow `ReadonlyArray<string>` for multi-select questions instead of only strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85c75ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->