### PR TITLE
fix(web): settle the connection database open when IndexedDB reports "blocked"

### DIFF
--- a/apps/web/src/connection/storage.test.ts
+++ b/apps/web/src/connection/storage.test.ts
@@ -5,7 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { afterEach, vi } from "vite-plus/test";
 
-import { makeCatalogBackend, makeCatalogStore } from "./storage";
+import { makeCatalogBackend, makeCatalogStore, openDatabase } from "./storage";
 
 const emptyCatalog = {
   schemaVersion: 1,
@@ -72,6 +72,25 @@ describe("makeCatalogBackend", () => {
       expect(error).toBeInstanceOf(ConnectionTransientError);
       expect(error.message).toContain("Desktop secure storage is unavailable");
       expect(setConnectionCatalog).toHaveBeenCalledWith("{}");
+    }),
+  );
+});
+
+describe("openDatabase", () => {
+  it.effect("fails instead of hanging when another tab blocks the version change", () =>
+    Effect.gen(function* () {
+      const request = new EventTarget();
+      vi.stubGlobal("indexedDB", {
+        open: vi.fn(() => {
+          queueMicrotask(() => request.dispatchEvent(new Event("blocked")));
+          return request;
+        }),
+      });
+
+      const error = yield* openDatabase().pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ConnectionTransientError);
+      expect(error.message).toContain("close the other T3 Code tabs");
     }),
   );
 });

--- a/apps/web/src/connection/storage.test.ts
+++ b/apps/web/src/connection/storage.test.ts
@@ -93,4 +93,24 @@ describe("openDatabase", () => {
       expect(error.message).toContain("close the other T3 Code tabs");
     }),
   );
+
+  it.effect("closes the database when the blocked open later succeeds", () =>
+    Effect.gen(function* () {
+      const close = vi.fn();
+      const request = Object.assign(new EventTarget(), { result: { close } });
+      vi.stubGlobal("indexedDB", {
+        open: vi.fn(() => {
+          queueMicrotask(() => request.dispatchEvent(new Event("blocked")));
+          return request;
+        }),
+      });
+
+      yield* openDatabase().pipe(Effect.flip);
+      // The blocking tab closes and the request completes after we already
+      // failed; nothing will take ownership of the handle, so it must not leak.
+      request.dispatchEvent(new Event("success"));
+
+      expect(close).toHaveBeenCalledTimes(1);
+    }),
+  );
 });

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -116,7 +116,7 @@ function persistenceError(
   });
 }
 
-const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(function* () {
+export const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(function* () {
   return yield* Effect.callback<IDBDatabase, ConnectionTransientError>((resume) => {
     if (typeof indexedDB === "undefined") {
       resume(
@@ -141,6 +141,20 @@ const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(function* (
       if (!request.result.objectStoreNames.contains(VCS_REFS_STORE_NAME)) {
         request.result.createObjectStore(VCS_REFS_STORE_NAME);
       }
+    });
+    // `blocked` fires *instead of* `success`/`error` when another tab holds the
+    // database open and this open needs a version change. Without resuming here
+    // the request never settles, so the boot hangs on the splash screen with no
+    // error and no retry until every other tab is closed.
+    request.addEventListener("blocked", () => {
+      resume(
+        Effect.fail(
+          catalogError(
+            "open",
+            "another tab is using an older version of the local database — close the other T3 Code tabs and reload",
+          ),
+        ),
+      );
     });
     request.addEventListener("error", () => {
       resume(Effect.fail(catalogError("open", request.error ?? "Unknown IndexedDB error")));

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -124,6 +124,7 @@ export const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(func
       );
       return;
     }
+    let settled = false;
     const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
     request.addEventListener("upgradeneeded", () => {
       if (!request.result.objectStoreNames.contains(CATALOG_STORE_NAME)) {
@@ -147,6 +148,7 @@ export const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(func
     // the request never settles, so the boot hangs on the splash screen with no
     // error and no retry until every other tab is closed.
     request.addEventListener("blocked", () => {
+      settled = true;
       resume(
         Effect.fail(
           catalogError(
@@ -157,9 +159,21 @@ export const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(func
       );
     });
     request.addEventListener("error", () => {
+      settled = true;
       resume(Effect.fail(catalogError("open", request.error ?? "Unknown IndexedDB error")));
     });
     request.addEventListener("success", () => {
+      // `blocked` does not cancel the request — it still completes once the
+      // other connection closes. Resuming again is a no-op on a settled
+      // callback, so nothing would ever hand this database to `acquireRelease`
+      // and close it. Left open it holds the connection for the lifetime of the
+      // page and blocks every later version change, which is the deadlock this
+      // whole handler exists to avoid.
+      if (settled) {
+        request.result.close();
+        return;
+      }
+      settled = true;
       resume(Effect.succeed(request.result));
     });
   });


### PR DESCRIPTION
## What Changed

`openDatabase` in `apps/web/src/connection/storage.ts` now registers a `blocked` listener on the `indexedDB.open` request, resuming with the same `ConnectionTransientError` the existing `error` path uses. A second commit closes the database handle if the request later succeeds after having reported blocked.

Two files, 35 lines including the test.

## Why

`IDBOpenDBRequest` fires **`blocked`** — *instead of* `success` or `error` — when another connection holds the database open and the open request needs a version change. `openDatabase` registered only `upgradeneeded`, `error`, and `success`, so in that case `resume` is never called and the `Effect.callback` never settles. There is no timeout on it, so it hangs for the lifetime of the page.

**Scope of the claim, up front:** this is spec-driven hardening for a path I have *not* observed in the wild. I originally opened this believing it explained a splash-screen hang I was chasing. It did not — that turned out to be a corrupted browser HTTP disk cache, written up in #5116. The first version of this description claimed a multi-tab reproduction and a live verification against a wedged profile; I performed neither. Both are removed. The full correction is in the comment thread below and in #5116.

What remains is a real hole regardless of how often it is reached. The realistic trigger is a **`DATABASE_VERSION` bump**: every existing user's next open becomes an upgrade open, and any user with a second tab still holding a connection at that moment gets `blocked` and hangs — no error, no retry, no log. That version has already been bumped twice (v2, then v4 in #3795), so this is a predictable consequence of each schema change rather than an exotic race.

The second commit fixes a related leak found in review: `blocked` does not cancel the request, so a later `success` handed back an `IDBDatabase` that nothing owned or closed — a connection held for the lifetime of the page, blocking every future version change. The callback now tracks whether it settled and closes the late handle.

### Scope

Deliberately narrow. The connection is held for the lifetime of the page via `Effect.acquireRelease` with no `versionchange` handler, so an older tab still blocks a newer tab's upgrade — the newer tab now reports it cleanly rather than hanging, but the upgrade cannot proceed until the old tab closes. Fixing that means adding `versionchange` → `database.close()`, which first needs the read/write helpers hardened, since `database.transaction()` throws synchronously on a closed handle and would surface as a defect rather than a typed failure. Happy to do it as a follow-up; kept out of here to keep the change small.

## Testing

- New test dispatches `blocked` at a stubbed `indexedDB.open` and asserts the effect fails. `openDatabase` is exported for it, matching how `makeCatalogStore` / `makeCatalogBackend` are already exposed to the same test file.
- The test is not vacuous: with the `blocked` handler removed it hangs and times out at 60s, reproducing the non-settling request in the harness. With the handler it passes.
- The second commit's late-`success` guard has its own test; removing the guard fails it.
- `vp test run --project unit src/connection/storage.test.ts` → **5 passed**.
- `tsgo --noEmit` on `apps/web` → exit 0. `vp lint` on both files → clean.

Not verified in a browser — see the scope note above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — no visual change; the only user-visible difference is that an existing error state is reached instead of an indefinite hang
- [ ] I included a video for animation/interaction changes — n/a

