### PR TITLE
perf(desktop): unblock Windows startup and shrink the installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Full docs live in [docs/](./docs). There's no docs site yet.
 - [Install and first run](./docs/user/install.md)
 - [Permission modes](./docs/user/permission-modes.md)
 - [Keyboard shortcuts](./docs/user/keybindings.md)
+- [Choose the default terminal shell](./docs/user/terminal-shell.md)
 - [Remote access from a phone or another machine](./docs/user/remote-access.md)
 - [Keeping app and server in sync](./docs/user/updating.md)
 - [Source control integrations](./docs/user/source-control.md)

--- a/apps/desktop/resources/installer.nsh
+++ b/apps/desktop/resources/installer.nsh
@@ -1,0 +1,54 @@
+!include "getProcessInfo.nsh"
+
+Var pid
+
+!macro setInstallerPhaseText TEXT
+  !ifndef BUILD_UNINSTALLER
+    ${IfNot} ${Silent}
+      FindWindow $0 "#32770" "" $hwndparent
+      FindWindow $0 "#32770" "" $hwndparent $0
+      GetDlgItem $0 $0 1000
+      SendMessage $0 ${WM_SETTEXT} 0 "STR:${TEXT}"
+    ${EndIf}
+  !endif
+!macroend
+
+# electron-builder calls this immediately before checking for and removing the
+# installed version. Keep its standard app-running check, then make the long
+# silent-uninstaller phase explicit in the one-click installer banner.
+!macro customCheckAppRunning
+  !insertmacro IS_POWERSHELL_AVAILABLE
+  !insertmacro _CHECK_APP_RUNNING
+  !insertmacro setInstallerPhaseText "Removing the previous version..."
+!macroend
+
+# electron-builder delegates these hooks the old uninstaller result handling.
+# Preserve its standard failure behavior before advancing the phase text.
+!macro handleOldUninstallerResult NEXT_TEXT
+  IfErrors 0 +3
+  DetailPrint `Uninstall was not successful. Not able to launch uninstaller!`
+  Return
+
+  ${If} $R0 != 0
+    MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
+    DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+    SetErrorLevel 2
+    Quit
+  ${EndIf}
+
+  !insertmacro setInstallerPhaseText "${NEXT_TEXT}"
+!macroend
+
+!macro customUnInstallCheck
+  # An all-users installation can also remove a per-user installation next.
+  # Keep showing the removal phase until both checks have completed.
+  ${If} $installMode == "all"
+    !insertmacro handleOldUninstallerResult "Removing the previous version..."
+  ${Else}
+    !insertmacro handleOldUninstallerResult "Installing the new version..."
+  ${EndIf}
+!macroend
+
+!macro customUnInstallCheckCurrentUser
+  !insertmacro handleOldUninstallerResult "Installing the new version..."
+!macroend

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -197,7 +197,7 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
-  it.effect("loads PowerShell profile environment on Windows", () =>
+  it.effect("hydrates the Windows PATH without starting a shell", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {
         PATH: "C:\\Windows\\System32",
@@ -206,41 +206,29 @@ describe("DesktopShellEnvironment", () => {
         USERPROFILE: "C:\\Users\\testuser",
       };
 
+      const commands: ChildProcess.Command[] = [];
       yield* runShellEnvironment({
         env,
         platform: "win32",
         handler: (command) => {
-          if (command._tag !== "StandardCommand") return "";
-          const loadProfile = !command.args.includes("-NoProfile");
-          return loadProfile
-            ? envOutput({
-                PATH: "C:\\Profile\\Node;C:\\Windows\\System32",
-                FNM_DIR: "C:\\Users\\testuser\\AppData\\Roaming\\fnm",
-                FNM_MULTISHELL_PATH: "C:\\Users\\testuser\\AppData\\Local\\fnm_multishells\\123",
-              })
-            : envOutput({ PATH: "C:\\Custom\\Bin;C:\\Windows\\System32" });
+          commands.push(command);
+          return "";
         },
       });
 
       assert.equal(
         env.PATH,
         [
-          "C:\\Profile\\Node",
-          "C:\\Windows\\System32",
           "C:\\Users\\testuser\\AppData\\Roaming\\npm",
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
-          "C:\\Custom\\Bin",
+          "C:\\Windows\\System32",
         ].join(";"),
       );
-      assert.equal(env.FNM_DIR, "C:\\Users\\testuser\\AppData\\Roaming\\fnm");
-      assert.equal(
-        env.FNM_MULTISHELL_PATH,
-        "C:\\Users\\testuser\\AppData\\Local\\fnm_multishells\\123",
-      );
+      assert.lengthOf(commands, 0);
     }),
   );
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -18,16 +18,7 @@ interface ShellEnvironmentConfig {
   readonly userShell: Option.Option<string>;
 }
 
-interface WindowsProbeOptions {
-  readonly loadProfile: boolean;
-}
-
-const DesktopShellEnvironmentProbe = Schema.Literals([
-  "login-shell",
-  "launchctl-path",
-  "powershell-profile",
-  "powershell-no-profile",
-]);
+const DesktopShellEnvironmentProbe = Schema.Literals(["login-shell", "launchctl-path"]);
 type DesktopShellEnvironmentProbe = typeof DesktopShellEnvironmentProbe.Type;
 
 const desktopShellEnvironmentCommandFields = {
@@ -83,8 +74,6 @@ const LOGIN_SHELL_ENV_NAMES = [
   "XDG_SESSION_TYPE",
   "WAYLAND_DISPLAY",
 ] as const;
-const WINDOWS_PROFILE_ENV_NAMES = ["PATH", "FNM_DIR", "FNM_MULTISHELL_PATH"] as const;
-const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
 const LOGIN_SHELL_TIMEOUT = Duration.seconds(5);
 const LAUNCHCTL_TIMEOUT = Duration.seconds(2);
 const PROCESS_TERMINATE_GRACE = Duration.seconds(1);
@@ -238,19 +227,6 @@ const capturePosixEnvironmentCommand = (names: ReadonlyArray<string>) =>
     })
     .join("; ");
 
-const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
-  [
-    "$ErrorActionPreference = 'Stop'",
-    ...names.flatMap((name) => {
-      return [
-        `Write-Output '${startMarker(name)}'`,
-        `$value = [Environment]::GetEnvironmentVariable('${name}')`,
-        "if ($null -ne $value -and $value.Length -gt 0) { Write-Output $value }",
-        `Write-Output '${endMarker(name)}'`,
-      ];
-    }),
-  ].join("; ");
-
 const extractEnvironment = (output: string, names: ReadonlyArray<string>): EnvironmentPatch => {
   const environment: EnvironmentPatch = {};
 
@@ -343,64 +319,17 @@ const readLaunchctlPath = runCommandOutput({
   timeout: LAUNCHCTL_TIMEOUT,
 }).pipe(Effect.map(trimNonEmpty));
 
-const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEnvironment")(
-  function* (
-    names: ReadonlyArray<string>,
-    options: WindowsProbeOptions,
-  ): Effect.fn.Return<EnvironmentPatch, never, ChildProcessSpawner.ChildProcessSpawner> {
-    if (names.length === 0) return {};
-
-    const args = [
-      "-NoLogo",
-      ...(options.loadProfile ? ([] as const) : (["-NoProfile"] as const)),
-      "-NonInteractive",
-      "-Command",
-      captureWindowsEnvironmentCommand(names),
-    ];
-
-    for (const command of WINDOWS_SHELL_CANDIDATES) {
-      const output = yield* runCommandOutput({
-        probe: options.loadProfile ? "powershell-profile" : "powershell-no-profile",
-        command,
-        args,
-        timeout: LOGIN_SHELL_TIMEOUT,
-      });
-      const environment = extractEnvironment(output, names);
-      if (Object.keys(environment).length > 0) {
-        return environment;
-      }
-    }
-
-    return {};
-  },
-);
-
-const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWindowsEnvironment")(
-  function* (
-    config: ShellEnvironmentConfig,
-  ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner> {
-    const noProfile = yield* readWindowsEnvironment(["PATH"], { loadProfile: false });
-    const profile = yield* readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, {
-      loadProfile: true,
-    });
+const installWindowsEnvironment = (config: ShellEnvironmentConfig): Effect.Effect<void> =>
+  Effect.sync(() => {
     const mergedPath = mergePaths("win32", [
-      trimNonEmpty(profile.PATH),
       trimNonEmpty(knownWindowsCliDirs(config.env).join(";")),
-      trimNonEmpty(noProfile.PATH),
       readEnvPath(config.env),
     ]);
 
     if (Option.isSome(mergedPath)) {
       config.env.PATH = mergedPath.value;
     }
-    if (!config.env.FNM_DIR && profile.FNM_DIR) {
-      config.env.FNM_DIR = profile.FNM_DIR;
-    }
-    if (!config.env.FNM_MULTISHELL_PATH && profile.FNM_MULTISHELL_PATH) {
-      config.env.FNM_MULTISHELL_PATH = profile.FNM_MULTISHELL_PATH;
-    }
-  },
-);
+  });
 
 const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosixEnvironment")(
   function* (

--- a/apps/server/src/os-jank.test.ts
+++ b/apps/server/src/os-jank.test.ts
@@ -1,7 +1,17 @@
 import * as NodeOS from "node:os";
-import { assert, it } from "vite-plus/test";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { AsyncWindowsShellEnvironment } from "@t3tools/shared/shell";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 
-import { hydratePosixHome } from "./os-jank.ts";
+import {
+  HostEnvironmentHydration,
+  hostEnvironmentHydrationLayer,
+  hydratePosixHome,
+} from "./os-jank.ts";
 
 it("hydrates HOME for minimal service environments from the user account", () => {
   const env: NodeJS.ProcessEnv = {};
@@ -37,4 +47,45 @@ it("preserves an explicitly configured HOME", () => {
   });
 
   assert.equal(env.HOME, "/custom/home");
+});
+
+it.effect("does not block startup on a PowerShell profile and eventually hydrates tools", () => {
+  const env: NodeJS.ProcessEnv = {
+    PATH: "C:\\Windows\\System32",
+    APPDATA: "C:\\Users\\test\\AppData\\Roaming",
+  };
+  const started = Deferred.makeUnsafe<void>();
+  const release = Deferred.makeUnsafe<void>();
+  const reader = () =>
+    Deferred.succeed(started, undefined).pipe(
+      Effect.andThen(Deferred.await(release)),
+      Effect.as({
+        PATH: "C:\\Profile\\mise\\shims;C:\\Tools\\custom",
+        FNM_DIR: "C:\\Users\\test\\AppData\\Roaming\\fnm",
+      }),
+    );
+  const layer = hostEnvironmentHydrationLayer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.succeed(HostProcessPlatform, "win32"),
+        Layer.succeed(HostProcessEnvironment, env),
+        Layer.succeed(AsyncWindowsShellEnvironment, reader),
+        NodeServices.layer,
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const hydration = yield* HostEnvironmentHydration;
+    yield* Deferred.await(started);
+    assert.notInclude(env.PATH, "C:\\Profile\\mise\\shims");
+    yield* Deferred.succeed(release, undefined);
+    assert.equal(hydration.windowsProfile._tag, "Some");
+    if (hydration.windowsProfile._tag === "Some") {
+      yield* hydration.windowsProfile.value;
+    }
+    assert.include(env.PATH, "C:\\Profile\\mise\\shims");
+    assert.include(env.PATH, "C:\\Tools\\custom");
+    assert.equal(env.FNM_DIR, "C:\\Users\\test\\AppData\\Roaming\\fnm");
+  }).pipe(Effect.provide(layer));
 });

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -4,10 +4,16 @@ import {
   mergePathEntries,
   readPathFromLoginShell,
   readPathFromLaunchctl,
+  resolveWindowsBaselineEnvironment,
   resolveWindowsEnvironment,
+  resolveWindowsProfileEnvironment,
 } from "@t3tools/shared/shell";
+import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as NodeOS from "node:os";
 
@@ -90,6 +96,47 @@ export const fixPath = Effect.fn("fixPath")(function* (): Effect.fn.Return<
     ),
   );
 });
+
+export const HostEnvironmentHydration = Context.Reference<{
+  readonly windowsProfile: Option.Option<Effect.Effect<void>>;
+}>("t3/os-jank/HostEnvironmentHydration", {
+  defaultValue: () => ({ windowsProfile: Option.none() }),
+});
+
+function applyEnvironmentPatch(env: NodeJS.ProcessEnv, patch: Partial<NodeJS.ProcessEnv>): void {
+  for (const [key, value] of Object.entries(patch)) {
+    if (value !== undefined) env[key] = value;
+  }
+}
+
+export const hostEnvironmentHydrationLayer = Layer.effect(
+  HostEnvironmentHydration,
+  Effect.gen(function* () {
+    const platform = yield* HostProcessPlatform;
+    const env = yield* HostProcessEnvironment;
+    if (platform !== "win32") {
+      yield* fixPath();
+      return { windowsProfile: Option.none() };
+    }
+
+    yield* Effect.sync(() => applyEnvironmentPatch(env, resolveWindowsBaselineEnvironment(env)));
+    const completed = yield* Deferred.make<void>();
+    yield* resolveWindowsProfileEnvironment(env).pipe(
+      Effect.tap((patch) => Effect.sync(() => applyEnvironmentPatch(env, patch))),
+      Effect.catchCause((cause) =>
+        Effect.sync(() =>
+          logPathHydrationWarning("Failed to hydrate PATH from the PowerShell profile.", cause),
+        ),
+      ),
+      Effect.ensuring(Deferred.succeed(completed, undefined)),
+      Effect.forkScoped,
+    );
+
+    return {
+      windowsProfile: Option.some(Deferred.await(completed)),
+    };
+  }),
+);
 
 export const expandHomePath = Effect.fn(function* (input: string) {
   const { join } = yield* Path.Path;

--- a/apps/server/src/provider/Drivers/ClaudeDriver.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.test.ts
@@ -1,0 +1,55 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Path from "effect/Path";
+
+import { makeClaudeInstanceEnvironment } from "./ClaudeDriver.ts";
+
+it.layer(NodeServices.layer)("ClaudeDriver environment", (it) => {
+  it.effect("refreshes configured homes independently through the driver environment source", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const processPath = process.env.PATH;
+      const processClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+      const baseEnv: NodeJS.ProcessEnv = {
+        PATH: "before-path",
+        TOKEN: "host-before",
+        REMOVE_ME: "stale",
+        CLAUDE_CONFIG_DIR: "host-home",
+      };
+      const firstHome = path.resolve("claude-first-home");
+      const secondHome = path.resolve("claude-second-home");
+      const first = yield* makeClaudeInstanceEnvironment(
+        { homePath: firstHome },
+        [{ name: "TOKEN", value: "first-instance", sensitive: true }],
+        baseEnv,
+      );
+      const second = yield* makeClaudeInstanceEnvironment(
+        { homePath: secondHome },
+        [{ name: "TOKEN", value: "second-instance", sensitive: true }],
+        baseEnv,
+      );
+      const firstEnvironment = first.claudeEnvironment;
+      const secondEnvironment = second.claudeEnvironment;
+
+      baseEnv.PATH = "after-path";
+      baseEnv.TOKEN = "host-after";
+      baseEnv.CLAUDE_CONFIG_DIR = "host-after-home";
+      delete baseEnv.REMOVE_ME;
+      yield* first.refresh;
+
+      expect(first.claudeEnvironment).toBe(firstEnvironment);
+      expect(firstEnvironment.PATH).toBe("after-path");
+      expect(firstEnvironment.TOKEN).toBe("first-instance");
+      expect(firstEnvironment.REMOVE_ME).toBeUndefined();
+      expect(firstEnvironment.CLAUDE_CONFIG_DIR).toBe(firstHome);
+      expect(second.claudeEnvironment).toBe(secondEnvironment);
+      expect(secondEnvironment.PATH).toBe("before-path");
+      expect(secondEnvironment.TOKEN).toBe("second-instance");
+      expect(secondEnvironment.REMOVE_ME).toBe("stale");
+      expect(secondEnvironment.CLAUDE_CONFIG_DIR).toBe(secondHome);
+      expect(process.env.PATH).toBe(processPath);
+      expect(process.env.CLAUDE_CONFIG_DIR).toBe(processClaudeConfigDir);
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -12,7 +12,12 @@
  *
  * @module provider/Drivers/ClaudeDriver
  */
-import { ClaudeSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import {
+  ClaudeSettings,
+  type ProviderInstanceEnvironment,
+  ProviderDriverKind,
+  type ServerProvider,
+} from "@t3tools/contracts";
 import * as Cache from "effect/Cache";
 import * as Duration from "effect/Duration";
 import * as Crypto from "effect/Crypto";
@@ -54,7 +59,11 @@ import {
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
-import { makeClaudeCapabilitiesCacheKey, makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import {
+  makeClaudeCapabilitiesCacheKey,
+  makeClaudeContinuationGroupKey,
+  makeClaudeEnvironmentSource,
+} from "./ClaudeHome.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
@@ -79,6 +88,20 @@ const UPDATE = makePackageManagedProviderMaintenanceResolver({
     lockKey: "claude-native",
     isCommandPath: isClaudeNativeCommandPath,
   },
+});
+
+export const makeClaudeInstanceEnvironment = Effect.fn("makeClaudeInstanceEnvironment")(function* (
+  config: Pick<ClaudeSettings, "homePath">,
+  environment: ProviderInstanceEnvironment | undefined,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+) {
+  const provider = makeProviderInstanceEnvironmentSource(environment, baseEnv);
+  const claude = yield* makeClaudeEnvironmentSource(config, provider.environment);
+  return {
+    providerEnvironment: provider.environment,
+    claudeEnvironment: claude.environment,
+    refresh: provider.refresh.pipe(Effect.andThen(claude.refresh)),
+  };
 });
 
 export type ClaudeDriverEnv =
@@ -125,13 +148,14 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
-      const environmentSource = makeProviderInstanceEnvironmentSource(environment);
-      const processEnv = environmentSource.environment;
+      const effectiveConfig = { ...config, enabled } satisfies ClaudeSettings;
+      const environmentSource = yield* makeClaudeInstanceEnvironment(effectiveConfig, environment);
+      const processEnv = environmentSource.providerEnvironment;
       const fallbackContinuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
         instanceId,
       });
-      const effectiveConfig = { ...config, enabled } satisfies ClaudeSettings;
+      const claudeEnvironment = environmentSource.claudeEnvironment;
       const maintenanceCapabilities = yield* makeProviderMaintenanceCapabilitiesSource(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
@@ -146,11 +170,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
 
       const adapterOptions = {
         instanceId,
-        environment: processEnv,
+        environment: claudeEnvironment,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       };
       const adapter = yield* makeClaudeAdapter(effectiveConfig, adapterOptions);
-      const textGeneration = yield* makeClaudeTextGeneration(effectiveConfig, processEnv);
+      const textGeneration = yield* makeClaudeTextGeneration(effectiveConfig, claudeEnvironment);
 
       // Per-instance capabilities cache: keyed on binary + resolved HOME so
       // account-specific probes never share auth metadata across instances.

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -42,7 +42,7 @@ import {
   type ProviderInstance,
 } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
-import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { makeProviderInstanceEnvironmentSource } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
   makeProviderMaintenanceCapabilitiesSource,
@@ -125,7 +125,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const environmentSource = makeProviderInstanceEnvironmentSource(environment);
+      const processEnv = environmentSource.environment;
       const fallbackContinuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
         instanceId,
@@ -216,6 +217,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         displayName,
         accentColor,
         enabled,
+        refreshEnvironment: environmentSource.refresh.pipe(
+          Effect.andThen(maintenanceCapabilities.invalidate),
+          Effect.andThen(Cache.invalidate(capabilitiesProbeCache, capabilitiesCacheKey)),
+        ),
         snapshot,
         adapter,
         textGeneration,

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -45,9 +45,9 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
+  makeProviderMaintenanceCapabilitiesSource,
   makePackageManagedProviderMaintenanceResolver,
   normalizeCommandPath,
-  resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
   haveProviderSnapshotSettingsChanged,
@@ -131,7 +131,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         instanceId,
       });
       const effectiveConfig = { ...config, enabled } satisfies ClaudeSettings;
-      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+      const maintenanceCapabilities = yield* makeProviderMaintenanceCapabilitiesSource(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
       });
@@ -177,7 +177,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<ClaudeSettings>>({
-        maintenanceCapabilities,
+        maintenanceCapabilities: maintenanceCapabilities.get,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -185,9 +185,12 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
           makePendingClaudeProvider(settings.provider).pipe(Effect.map(stampIdentity)),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
-          enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
-            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
-          }).pipe(
+          maintenanceCapabilities.refresh.pipe(
+            Effect.flatMap(() =>
+              enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities.get(), {
+                enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+              }),
+            ),
             Effect.provideService(HttpClient.HttpClient, httpClient),
             Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
           ),

--- a/apps/server/src/provider/Drivers/ClaudeHome.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.test.ts
@@ -9,8 +9,10 @@ import {
   makeClaudeCapabilitiesCacheKey,
   makeClaudeContinuationGroupKey,
   makeClaudeEnvironment,
+  makeClaudeEnvironmentSource,
   resolveClaudeHomePath,
 } from "./ClaudeHome.ts";
+import { makeProviderInstanceEnvironmentSource } from "../ProviderInstanceEnvironment.ts";
 
 it.layer(NodeServices.layer)("ClaudeHome", (it) => {
   describe("Claude home resolution", () => {
@@ -36,6 +38,47 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         expect(yield* makeClaudeCapabilitiesCacheKey({ binaryPath: "claude", homePath })).toBe(
           `claude\0${resolved}\0`,
         );
+      }),
+    );
+
+    it.effect("refreshes an isolated Claude environment in place", () =>
+      Effect.gen(function* () {
+        const baseEnv: NodeJS.ProcessEnv = {
+          PATH: "before-path",
+          API_KEY: "host-before",
+          REMOVE_ME: "stale",
+          CLAUDE_CONFIG_DIR: "host-claude-home",
+        };
+        const instanceEnvironment = makeProviderInstanceEnvironmentSource(
+          [{ name: "API_KEY", value: "instance-key", sensitive: true }],
+          baseEnv,
+        );
+        const claudeEnvironment = yield* makeClaudeEnvironmentSource(
+          { homePath: "~/.claude-work" },
+          instanceEnvironment.environment,
+        );
+        const captured = claudeEnvironment.environment;
+        const processPath = process.env.PATH;
+        const processClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+        expect(captured.PATH).toBe("before-path");
+        expect(captured.API_KEY).toBe("instance-key");
+        expect(captured.CLAUDE_CONFIG_DIR).not.toBe("host-claude-home");
+
+        baseEnv.PATH = "after-path";
+        baseEnv.API_KEY = "host-after";
+        baseEnv.CLAUDE_CONFIG_DIR = "host-after-claude-home";
+        delete baseEnv.REMOVE_ME;
+        yield* instanceEnvironment.refresh;
+        yield* claudeEnvironment.refresh;
+
+        expect(claudeEnvironment.environment).toBe(captured);
+        expect(captured.PATH).toBe("after-path");
+        expect(captured.API_KEY).toBe("instance-key");
+        expect(captured.REMOVE_ME).toBeUndefined();
+        expect(captured.CLAUDE_CONFIG_DIR).not.toBe("host-after-claude-home");
+        expect(process.env.PATH).toBe(processPath);
+        expect(process.env.CLAUDE_CONFIG_DIR).toBe(processClaudeConfigDir);
       }),
     );
 

--- a/apps/server/src/provider/Drivers/ClaudeHome.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Path from "effect/Path";
 
 import { expandHomePath } from "../../pathExpansion.ts";
+import { makeProviderInstanceEnvironmentSource } from "../ProviderInstanceEnvironment.ts";
 
 export const resolveClaudeHomePath = Effect.fn("resolveClaudeHomePath")(function* (
   config: Pick<ClaudeSettings, "homePath">,
@@ -22,6 +23,7 @@ export const makeClaudeEnvironment = Effect.fn("makeClaudeEnvironment")(function
   const homePath = config.homePath.trim();
   if (homePath.length === 0) return resolvedBaseEnv;
   const resolvedHomePath = yield* resolveClaudeHomePath(config);
+  if (resolvedBaseEnv.CLAUDE_CONFIG_DIR === resolvedHomePath) return resolvedBaseEnv;
   return {
     ...resolvedBaseEnv,
     // Isolate this instance's config via CLAUDE_CONFIG_DIR rather than HOME.
@@ -32,6 +34,22 @@ export const makeClaudeEnvironment = Effect.fn("makeClaudeEnvironment")(function
     // keychain) intact.
     CLAUDE_CONFIG_DIR: resolvedHomePath,
   };
+});
+
+export const makeClaudeEnvironmentSource = Effect.fn("makeClaudeEnvironmentSource")(function* (
+  config: Pick<ClaudeSettings, "homePath">,
+  baseEnv: NodeJS.ProcessEnv,
+) {
+  const homePath = config.homePath.trim();
+  if (homePath.length === 0) {
+    return makeProviderInstanceEnvironmentSource(undefined, baseEnv);
+  }
+
+  const resolvedHomePath = yield* resolveClaudeHomePath(config);
+  return makeProviderInstanceEnvironmentSource(
+    [{ name: "CLAUDE_CONFIG_DIR", value: resolvedHomePath, sensitive: false }],
+    baseEnv,
+  );
 });
 
 export const makeClaudeContinuationGroupKey = Effect.fn("makeClaudeContinuationGroupKey")(

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -44,8 +44,8 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
+  makeProviderMaintenanceCapabilitiesSource,
   makePackageManagedProviderMaintenanceResolver,
-  resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
   haveProviderSnapshotSettingsChanged,
@@ -144,7 +144,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         enabled,
         homePath: homeLayout.effectiveHomePath ?? "",
       } satisfies CodexSettings;
-      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+      const maintenanceCapabilities = yield* makeProviderMaintenanceCapabilitiesSource(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
       });
@@ -172,7 +172,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       );
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CodexSettings>>({
-        maintenanceCapabilities,
+        maintenanceCapabilities: maintenanceCapabilities.get,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -180,9 +180,12 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
           makePendingCodexProvider(settings.provider).pipe(Effect.map(stampIdentity)),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
-          enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
-            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
-          }).pipe(
+          maintenanceCapabilities.refresh.pipe(
+            Effect.flatMap(() =>
+              enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities.get(), {
+                enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+              }),
+            ),
             Effect.provideService(HttpClient.HttpClient, httpClient),
             Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
           ),

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -41,7 +41,7 @@ import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import type { ProviderDriver, ProviderInstance } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
-import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { makeProviderInstanceEnvironmentSource } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
   makeProviderMaintenanceCapabilitiesSource,
@@ -119,7 +119,8 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const environmentSource = makeProviderInstanceEnvironmentSource(environment);
+      const processEnv = environmentSource.environment;
       const homeLayout = yield* resolveCodexHomeLayout(config);
       const continuationIdentity = codexContinuationIdentity(homeLayout);
       const stampIdentity = withInstanceIdentity({
@@ -208,6 +209,9 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         displayName,
         accentColor,
         enabled,
+        refreshEnvironment: environmentSource.refresh.pipe(
+          Effect.andThen(maintenanceCapabilities.invalidate),
+        ),
         snapshot,
         adapter,
         textGeneration,

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -39,7 +39,7 @@ import {
   type ProviderInstance,
 } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
-import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { makeProviderInstanceEnvironmentSource } from "../ProviderInstanceEnvironment.ts";
 import {
   makeProviderMaintenanceCapabilities,
   makeProviderMaintenanceCapabilitiesSource,
@@ -108,7 +108,8 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const environmentSource = makeProviderInstanceEnvironmentSource(environment);
+      const processEnv = environmentSource.environment;
       const continuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
         instanceId,
@@ -184,6 +185,9 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         displayName,
         accentColor,
         enabled,
+        refreshEnvironment: environmentSource.refresh.pipe(
+          Effect.andThen(maintenanceCapabilities.invalidate),
+        ),
         snapshot,
         adapter,
         textGeneration,

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -42,8 +42,8 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   makeProviderMaintenanceCapabilities,
+  makeProviderMaintenanceCapabilitiesSource,
   type ProviderMaintenanceCapabilitiesResolver,
-  resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
   haveProviderSnapshotSettingsChanged,
@@ -120,7 +120,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       const effectiveConfig = { ...config, enabled } satisfies CursorSettings;
-      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+      const maintenanceCapabilities = yield* makeProviderMaintenanceCapabilitiesSource(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
       });
@@ -142,7 +142,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CursorSettings>>({
-        maintenanceCapabilities,
+        maintenanceCapabilities: maintenanceCapabilities.get,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -152,15 +152,19 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         // Model catalog and capabilities come exclusively from Cursor's
         // list_available_models extension method during provider checks.
         enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
-          enrichCursorSnapshot({
-            settings: settings.provider,
-            snapshot: currentSnapshot,
-            maintenanceCapabilities,
-            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
-            publishSnapshot,
-            stampIdentity,
-            httpClient,
-          }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner)),
+          maintenanceCapabilities.refresh.pipe(
+            Effect.flatMap(() =>
+              enrichCursorSnapshot({
+                settings: settings.provider,
+                snapshot: currentSnapshot,
+                maintenanceCapabilities: maintenanceCapabilities.get(),
+                enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+                publishSnapshot,
+                stampIdentity,
+                httpClient,
+              }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner)),
+            ),
+          ),
       }).pipe(
         Effect.mapError(
           (cause) =>

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -29,8 +29,8 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   makeManualOnlyProviderMaintenanceCapabilities,
+  makeProviderMaintenanceCapabilitiesSource,
   makeStaticProviderMaintenanceResolver,
-  resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
   haveProviderSnapshotSettingsChanged,
@@ -101,7 +101,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       const effectiveConfig = { ...config, enabled } satisfies GrokSettings;
-      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+      const maintenanceCapabilities = yield* makeProviderMaintenanceCapabilitiesSource(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
       });
@@ -121,7 +121,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<GrokSettings>>({
-        maintenanceCapabilities,
+        maintenanceCapabilities: maintenanceCapabilities.get,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -129,13 +129,17 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
           buildInitialGrokProviderSnapshot(settings.provider).pipe(Effect.map(stampIdentity)),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
-          enrichGrokSnapshot({
-            snapshot: currentSnapshot,
-            maintenanceCapabilities,
-            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
-            publishSnapshot,
-            httpClient,
-          }),
+          maintenanceCapabilities.refresh.pipe(
+            Effect.flatMap(() =>
+              enrichGrokSnapshot({
+                snapshot: currentSnapshot,
+                maintenanceCapabilities: maintenanceCapabilities.get(),
+                enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+                publishSnapshot,
+                httpClient,
+              }),
+            ),
+          ),
       }).pipe(
         Effect.mapError(
           (cause) =>

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -26,7 +26,7 @@ import {
   type ProviderInstance,
 } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
-import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { makeProviderInstanceEnvironmentSource } from "../ProviderInstanceEnvironment.ts";
 import {
   makeManualOnlyProviderMaintenanceCapabilities,
   makeProviderMaintenanceCapabilitiesSource,
@@ -89,7 +89,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const environmentSource = makeProviderInstanceEnvironmentSource(environment);
+      const processEnv = environmentSource.environment;
       const continuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
         instanceId,
@@ -159,6 +160,9 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         displayName,
         accentColor,
         enabled,
+        refreshEnvironment: environmentSource.refresh.pipe(
+          Effect.andThen(maintenanceCapabilities.invalidate),
+        ),
         snapshot,
         adapter,
         textGeneration,

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -43,9 +43,9 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
+  makeProviderMaintenanceCapabilitiesSource,
   makePackageManagedProviderMaintenanceResolver,
   normalizeCommandPath,
-  resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
   haveProviderSnapshotSettingsChanged,
@@ -131,7 +131,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       const effectiveConfig = { ...config, enabled } satisfies OpenCodeSettings;
-      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+      const maintenanceCapabilities = yield* makeProviderMaintenanceCapabilitiesSource(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
       });
@@ -152,7 +152,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<OpenCodeSettings>>(
         {
-          maintenanceCapabilities,
+          maintenanceCapabilities: maintenanceCapabilities.get,
           getSettings: snapshotSettings.getSettings,
           streamSettings: snapshotSettings.streamSettings,
           haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -160,9 +160,12 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
             makePendingOpenCodeProvider(settings.provider).pipe(Effect.map(stampIdentity)),
           checkProvider,
           enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
-            enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
-              enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
-            }).pipe(
+            maintenanceCapabilities.refresh.pipe(
+              Effect.flatMap(() =>
+                enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities.get(), {
+                  enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+                }),
+              ),
               Effect.provideService(HttpClient.HttpClient, httpClient),
               Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
             ),

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -40,7 +40,7 @@ import {
   type ProviderInstance,
 } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
-import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { makeProviderInstanceEnvironmentSource } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
   makeProviderMaintenanceCapabilitiesSource,
@@ -119,7 +119,8 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const environmentSource = makeProviderInstanceEnvironmentSource(environment);
+      const processEnv = environmentSource.environment;
       const continuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
         instanceId,
@@ -189,6 +190,9 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         displayName,
         accentColor,
         enabled,
+        refreshEnvironment: environmentSource.refresh.pipe(
+          Effect.andThen(maintenanceCapabilities.invalidate),
+        ),
         snapshot,
         adapter,
         textGeneration,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -22,6 +22,8 @@ import {
   ProviderInstanceId,
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { SpawnExecutableResolution } from "@t3tools/shared/shell";
 import { assert, describe, it } from "@effect/vitest";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -36,6 +38,7 @@ import { attachmentRelativePath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderAdapterProcessError, ProviderAdapterValidationError } from "../Errors.ts";
+import { ClaudeExecutableFileCheck } from "../Drivers/ClaudeExecutable.ts";
 import type { ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
 import { makeClaudeAdapter, type ClaudeAdapterLiveOptions } from "./ClaudeAdapter.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
@@ -156,6 +159,13 @@ function makeHarness(config?: {
   readonly baseDir?: string;
   readonly claudeConfig?: Partial<ClaudeSettings>;
   readonly instanceId?: ProviderInstanceId;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly platform?: "win32" | "linux" | "darwin";
+  readonly resolveExecutable?: (
+    command: string,
+    platform: string,
+    env: NodeJS.ProcessEnv,
+  ) => string;
 }) {
   const query = new FakeClaudeQuery();
   let createInput:
@@ -167,6 +177,7 @@ function makeHarness(config?: {
 
   const adapterOptions: ClaudeAdapterLiveOptions = {
     ...(config?.instanceId ? { instanceId: config.instanceId } : {}),
+    ...(config?.environment ? { environment: config.environment } : {}),
     createQuery: (input) => {
       createInput = input;
       return query;
@@ -188,7 +199,14 @@ function makeHarness(config?: {
       ClaudeAdapter,
       Effect.gen(function* () {
         const claudeConfig = decodeClaudeSettings(config?.claudeConfig ?? {});
-        return yield* makeClaudeAdapter(claudeConfig, adapterOptions);
+        const platform = config?.platform ?? (yield* HostProcessPlatform);
+        const resolveExecutable = config?.resolveExecutable ?? (yield* SpawnExecutableResolution);
+        const executableFileCheck = yield* ClaudeExecutableFileCheck;
+        return yield* makeClaudeAdapter(claudeConfig, adapterOptions).pipe(
+          Effect.provideService(HostProcessPlatform, platform),
+          Effect.provideService(SpawnExecutableResolution, resolveExecutable),
+          Effect.provideService(ClaudeExecutableFileCheck, executableFileCheck),
+        );
       }),
     ).pipe(
       Layer.provideMerge(
@@ -350,6 +368,49 @@ describe("ClaudeAdapterLive", () => {
       assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
       assert.equal(createInput?.options.permissionMode, "bypassPermissions");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("uses refreshed environment values for future sessions with a configured home", () => {
+    const homePath = NodePath.join(NodeOS.tmpdir(), "claude-refreshed-home");
+    const environment: NodeJS.ProcessEnv = {
+      PATH: process.env.PATH,
+      CLAUDE_CONFIG_DIR: NodePath.resolve(homePath),
+      CLAUDE_CREDENTIAL: "before",
+      REMOVE_ME: "stale",
+    };
+    const harness = makeHarness({
+      claudeConfig: { homePath, binaryPath: "claude" },
+      environment,
+      platform: "win32",
+      resolveExecutable: (command, _platform, env) =>
+        NodePath.win32.join(env.PATH ?? "", `${command}.exe`),
+    });
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      environment.PATH = "refreshed-path";
+      environment.CLAUDE_CREDENTIAL = "after";
+      delete environment.REMOVE_ME;
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const sessionEnvironment = harness.getLastCreateQueryInput()?.options.env;
+      assert.equal(sessionEnvironment?.PATH, "refreshed-path");
+      assert.equal(sessionEnvironment?.CLAUDE_CREDENTIAL, "after");
+      assert.equal(sessionEnvironment?.REMOVE_ME, undefined);
+      assert.equal(sessionEnvironment?.CLAUDE_CONFIG_DIR, NodePath.resolve(homePath));
+      assert.equal(
+        harness.getLastCreateQueryInput()?.options.pathToClaudeCodeExecutable,
+        NodePath.win32.join("refreshed-path", "claude.exe"),
+      );
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -21,6 +21,8 @@ import {
   type ModelUsage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { SpawnExecutableResolution } from "@t3tools/shared/shell";
 import {
   ApprovalRequestId,
   type CanonicalItemType,
@@ -70,7 +72,10 @@ import * as Stream from "effect/Stream";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
-import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
+import {
+  ClaudeExecutableFileCheck,
+  resolveClaudeSdkExecutablePath,
+} from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import {
   getClaudeModelCapabilities,
@@ -1340,13 +1345,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig;
   const crypto = yield* Crypto.Crypto;
+  const hostProcessPlatform = yield* HostProcessPlatform;
+  const spawnExecutableResolution = yield* SpawnExecutableResolution;
+  const claudeExecutableFileCheck = yield* ClaudeExecutableFileCheck;
   const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, options?.environment).pipe(
     Effect.provideService(Path.Path, path),
   );
-  const claudeSdkExecutablePath = yield* resolveClaudeSdkExecutablePath(
-    claudeSettings.binaryPath,
-    claudeEnvironment,
-  );
+  const resolveSdkExecutablePath = () =>
+    resolveClaudeSdkExecutablePath(claudeSettings.binaryPath, claudeEnvironment).pipe(
+      Effect.provideService(HostProcessPlatform, hostProcessPlatform),
+      Effect.provideService(SpawnExecutableResolution, spawnExecutableResolution),
+      Effect.provideService(ClaudeExecutableFileCheck, claudeExecutableFileCheck),
+    );
   const nativeEventLogger =
     options?.nativeEventLogger ??
     (options?.nativeEventLogPath !== undefined
@@ -3485,7 +3495,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const canUseTool: CanUseTool = (toolName, toolInput, callbackOptions) =>
         runPromise(canUseToolEffect(toolName, toolInput, callbackOptions));
 
-      const claudeBinaryPath = claudeSdkExecutablePath;
+      const claudeBinaryPath = yield* resolveSdkExecutablePath();
       const extraArgs = parseCliArgs(claudeSettings.launchArgs).flags;
       const modelSelection =
         input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_SERVER_SETTINGS,
   ProviderDriverKind,
   ProviderInstanceId,
+  ServerSettingsError,
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { resolveCommandPath } from "@t3tools/shared/shell";
@@ -34,17 +35,62 @@ import {
   SettingsWatcherLive,
 } from "./ProviderInstanceRegistryHydration.ts";
 
-it.effect("reconciles the subscribed settings payload without re-reading secrets", () =>
+it.effect("preserves known secrets and defers unresolved settings when a re-read fails", () =>
   Effect.scoped(
     Effect.gen(function* () {
       const instanceId = ProviderInstanceId.make("delivered_settings");
+      const unresolvedInstanceId = ProviderInstanceId.make("unresolved_settings");
       const driverKind = ProviderDriverKind.make("delivered");
-      const settings = {
+      const initialSettings: typeof DEFAULT_SERVER_SETTINGS = {
         ...DEFAULT_SERVER_SETTINGS,
         providerInstances: {
           [instanceId]: {
             driver: driverKind,
+            config: { enabled: false },
+            environment: [
+              {
+                name: "PROVIDER_TOKEN",
+                value: "materialized-secret",
+                sensitive: true,
+                valueRedacted: true,
+              },
+            ],
+          },
+        },
+      };
+      const deliveredSettings: typeof DEFAULT_SERVER_SETTINGS = {
+        ...initialSettings,
+        providerInstances: {
+          [instanceId]: {
+            ...initialSettings.providerInstances[instanceId],
+            driver: driverKind,
             config: { enabled: true },
+            environment: [
+              {
+                name: "PROVIDER_TOKEN",
+                value: "",
+                sensitive: true,
+                valueRedacted: true,
+              },
+            ],
+          },
+        },
+      };
+      const unresolvedSettings: typeof DEFAULT_SERVER_SETTINGS = {
+        ...deliveredSettings,
+        providerInstances: {
+          ...deliveredSettings.providerInstances,
+          [unresolvedInstanceId]: {
+            driver: driverKind,
+            config: { enabled: true },
+            environment: [
+              {
+                name: "NEW_PROVIDER_TOKEN",
+                value: "",
+                sensitive: true,
+                valueRedacted: true,
+              },
+            ],
           },
         },
       };
@@ -52,7 +98,7 @@ it.effect("reconciles the subscribed settings payload without re-reading secrets
       const reconciled = yield* Ref.make<ReadonlyArray<unknown>>([]);
       const settingsReads = yield* Ref.make(0);
       const registryChanges = yield* PubSub.unbounded<void>();
-      const settingsChanges = Stream.make(settings).pipe(
+      const settingsChanges = Stream.make(deliveredSettings, unresolvedSettings).pipe(
         Stream.concat(Stream.fromEffect(Deferred.succeed(consumed, undefined)).pipe(Stream.drain)),
       );
       const registry = ProviderInstanceRegistry.of({
@@ -69,7 +115,17 @@ it.effect("reconciles the subscribed settings payload without re-reading secrets
         start: Effect.void,
         ready: Effect.void,
         getSettings: Ref.update(settingsReads, (count) => count + 1).pipe(
-          Effect.andThen(Effect.die("must not re-read an emitted settings payload")),
+          Effect.andThen(
+            Effect.fail(
+              new ServerSettingsError({
+                settingsPath: "settings.json",
+                operation: "read-secret",
+                providerInstanceId: instanceId,
+                environmentVariable: "PROVIDER_TOKEN",
+                cause: "secret store unavailable",
+              }),
+            ),
+          ),
         ),
         updateSettings: () => Effect.die("unused"),
         streamChanges: Stream.empty,
@@ -77,7 +133,7 @@ it.effect("reconciles the subscribed settings payload without re-reading secrets
       });
 
       yield* Layer.build(
-        SettingsWatcherLive(settingsChanges).pipe(
+        SettingsWatcherLive(settingsChanges, initialSettings).pipe(
           Layer.provide(
             Layer.mergeAll(
               Layer.succeed(ProviderInstanceRegistry, registry),
@@ -89,10 +145,19 @@ it.effect("reconciles the subscribed settings payload without re-reading secrets
       );
       yield* Deferred.await(consumed);
 
-      expect(yield* Ref.get(settingsReads)).toBe(0);
+      expect(yield* Ref.get(settingsReads)).toBe(2);
       expect(yield* Ref.get(reconciled)).toEqual([
         expect.objectContaining({
-          [instanceId]: expect.objectContaining({ driver: driverKind }),
+          [instanceId]: expect.objectContaining({
+            driver: driverKind,
+            config: { enabled: true },
+            environment: [
+              expect.objectContaining({
+                name: "PROVIDER_TOKEN",
+                value: "materialized-secret",
+              }),
+            ],
+          }),
         }),
       ]);
     }),

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
@@ -1,7 +1,11 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import { expect, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
+import {
+  DEFAULT_SERVER_SETTINGS,
+  ProviderDriverKind,
+  ProviderInstanceId,
+} from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { resolveCommandPath } from "@t3tools/shared/shell";
 import * as NodeFS from "node:fs";
@@ -10,9 +14,12 @@ import * as NodePath from "node:path";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 
+import { ServerSettingsService } from "../../serverSettings.ts";
 import type { ProviderInstance } from "../ProviderDriver.ts";
 import { makeProviderInstanceEnvironmentSource } from "../ProviderInstanceEnvironment.ts";
 import {
@@ -21,7 +28,76 @@ import {
   normalizeCommandPath,
 } from "../providerMaintenance.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
-import { refreshProviderInstancesAfterEnvironmentHydration } from "./ProviderInstanceRegistryHydration.ts";
+import { ProviderInstanceRegistryMutator } from "../Services/ProviderInstanceRegistryMutator.ts";
+import {
+  refreshProviderInstancesAfterEnvironmentHydration,
+  SettingsWatcherLive,
+} from "./ProviderInstanceRegistryHydration.ts";
+
+it.effect("reconciles the subscribed settings payload without re-reading secrets", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const instanceId = ProviderInstanceId.make("delivered_settings");
+      const driverKind = ProviderDriverKind.make("delivered");
+      const settings = {
+        ...DEFAULT_SERVER_SETTINGS,
+        providerInstances: {
+          [instanceId]: {
+            driver: driverKind,
+            config: { enabled: true },
+          },
+        },
+      };
+      const consumed = yield* Deferred.make<void>();
+      const reconciled = yield* Ref.make<ReadonlyArray<unknown>>([]);
+      const settingsReads = yield* Ref.make(0);
+      const registryChanges = yield* PubSub.unbounded<void>();
+      const settingsChanges = Stream.make(settings).pipe(
+        Stream.concat(Stream.fromEffect(Deferred.succeed(consumed, undefined)).pipe(Stream.drain)),
+      );
+      const registry = ProviderInstanceRegistry.of({
+        getInstance: () => Effect.sync(() => undefined),
+        listInstances: Effect.succeed([]),
+        listUnavailable: Effect.succeed([]),
+        streamChanges: Stream.empty,
+        subscribeChanges: PubSub.subscribe(registryChanges),
+      });
+      const mutator = ProviderInstanceRegistryMutator.of({
+        reconcile: (configMap) => Ref.update(reconciled, (seen) => [...seen, configMap]),
+      });
+      const serverSettings = ServerSettingsService.of({
+        start: Effect.void,
+        ready: Effect.void,
+        getSettings: Ref.update(settingsReads, (count) => count + 1).pipe(
+          Effect.andThen(Effect.die("must not re-read an emitted settings payload")),
+        ),
+        updateSettings: () => Effect.die("unused"),
+        streamChanges: Stream.empty,
+        subscribeChanges: Effect.succeed(Stream.empty),
+      });
+
+      yield* Layer.build(
+        SettingsWatcherLive(settingsChanges).pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.succeed(ProviderInstanceRegistry, registry),
+              Layer.succeed(ProviderInstanceRegistryMutator, mutator),
+              Layer.succeed(ServerSettingsService, serverSettings),
+            ),
+          ),
+        ),
+      );
+      yield* Deferred.await(consumed);
+
+      expect(yield* Ref.get(settingsReads)).toBe(0);
+      expect(yield* Ref.get(reconciled)).toEqual([
+        expect.objectContaining({
+          [instanceId]: expect.objectContaining({ driver: driverKind }),
+        }),
+      ]);
+    }),
+  ),
+);
 
 it.effect("refreshes profile-discovered tools without replacing active provider instances", () =>
   Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
@@ -1,0 +1,118 @@
+import { expect, it } from "@effect/vitest";
+import { ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+
+import type { ProviderInstance } from "../ProviderDriver.ts";
+import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
+import { refreshProviderInstancesAfterEnvironmentHydration } from "./ProviderInstanceRegistryHydration.ts";
+
+it.effect("refreshes profile-discovered tools without replacing active provider instances", () =>
+  Effect.gen(function* () {
+    const refreshes = yield* Ref.make<ReadonlyArray<string>>([]);
+    const stopped = yield* Ref.make(0);
+    const driverKind = ProviderDriverKind.make("test");
+    const active = {
+      instanceId: ProviderInstanceId.make("active"),
+      driverKind,
+      continuationIdentity: { driverKind, continuationKey: "test:active" },
+      displayName: "active",
+      enabled: true,
+      snapshot: {
+        getSnapshot: Effect.die("unused"),
+        refresh: Ref.update(refreshes, (ids) => [...ids, "active"]).pipe(
+          Effect.andThen(Effect.die("profile refresh failure")),
+        ),
+      } as unknown as ProviderInstance["snapshot"],
+      adapter: {
+        listSessions: () =>
+          Effect.succeed([
+            {
+              activeTurnId: "turn-active",
+            },
+          ]),
+        stopAll: () => Ref.update(stopped, (count) => count + 1),
+      } as unknown as ProviderInstance["adapter"],
+      textGeneration: {} as ProviderInstance["textGeneration"],
+    } satisfies ProviderInstance;
+    const idle = {
+      ...active,
+      instanceId: ProviderInstanceId.make("idle"),
+      displayName: "idle",
+      continuationIdentity: { driverKind, continuationKey: "test:idle" },
+      snapshot: {
+        getSnapshot: Effect.die("unused"),
+        refresh: Ref.update(refreshes, (ids) => [...ids, "idle"]).pipe(Effect.as({} as never)),
+      } as unknown as ProviderInstance["snapshot"],
+    } satisfies ProviderInstance;
+    const instances = [active, idle] as const;
+    const registry = ProviderInstanceRegistry.of({
+      getInstance: (id) => Effect.succeed(instances.find((instance) => instance.instanceId === id)),
+      listInstances: Effect.succeed(instances),
+      listUnavailable: Effect.succeed([]),
+      streamChanges: Stream.empty,
+      subscribeChanges: Effect.die("unused"),
+    });
+
+    yield* refreshProviderInstancesAfterEnvironmentHydration(registry);
+
+    expect(yield* registry.getInstance(active.instanceId)).toBe(active);
+    expect([...(yield* Ref.get(refreshes))].toSorted()).toEqual(["active", "idle"]);
+    expect(yield* Ref.get(stopped)).toBe(0);
+  }),
+);
+
+it.effect("does not restore a stale instance when settings overlap profile hydration", () =>
+  Effect.gen(function* () {
+    const driverKind = ProviderDriverKind.make("test");
+    const instanceId = ProviderInstanceId.make("test_default");
+    const refreshStarted = yield* Deferred.make<void>();
+    const releaseRefresh = yield* Deferred.make<void>();
+    const makeInstance = (
+      displayName: string,
+      refresh: Effect.Effect<never>,
+    ): ProviderInstance => ({
+      instanceId,
+      driverKind,
+      continuationIdentity: { driverKind, continuationKey: `test:${displayName}` },
+      displayName,
+      enabled: true,
+      snapshot: {
+        getSnapshot: Effect.die("unused"),
+        refresh,
+      } as unknown as ProviderInstance["snapshot"],
+      adapter: {} as ProviderInstance["adapter"],
+      textGeneration: {} as ProviderInstance["textGeneration"],
+    });
+    const stale = makeInstance(
+      "stale",
+      Deferred.succeed(refreshStarted, undefined).pipe(
+        Effect.andThen(Deferred.await(releaseRefresh)),
+        Effect.andThen(Effect.die("unused result")),
+      ),
+    );
+    const newest = makeInstance("newest", Effect.die("must not refresh the replacement"));
+    const current = yield* Ref.make(stale);
+    const registry = ProviderInstanceRegistry.of({
+      getInstance: () => Ref.get(current).pipe(Effect.map((instance) => instance)),
+      listInstances: Ref.get(current).pipe(Effect.map((instance) => [instance])),
+      listUnavailable: Effect.succeed([]),
+      streamChanges: Stream.empty,
+      subscribeChanges: Effect.die("unused"),
+    });
+
+    const hydration = yield* Effect.forkChild(
+      refreshProviderInstancesAfterEnvironmentHydration(registry),
+      { startImmediately: true },
+    );
+    yield* Deferred.await(refreshStarted);
+    yield* Ref.set(current, newest);
+    yield* Deferred.succeed(releaseRefresh, undefined);
+    yield* Fiber.join(hydration);
+
+    expect(yield* registry.getInstance(instanceId)).toBe(newest);
+  }),
+);

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
@@ -1,5 +1,12 @@
+// @effect-diagnostics nodeBuiltinImport:off
 import { expect, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { resolveCommandPath } from "@t3tools/shared/shell";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -7,6 +14,12 @@ import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 
 import type { ProviderInstance } from "../ProviderDriver.ts";
+import { makeProviderInstanceEnvironmentSource } from "../ProviderInstanceEnvironment.ts";
+import {
+  makePackageManagedProviderMaintenanceResolver,
+  makeProviderMaintenanceCapabilitiesSource,
+  normalizeCommandPath,
+} from "../providerMaintenance.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { refreshProviderInstancesAfterEnvironmentHydration } from "./ProviderInstanceRegistryHydration.ts";
 
@@ -115,4 +128,116 @@ it.effect("does not restore a stale instance when settings overlap profile hydra
 
     expect(yield* registry.getInstance(instanceId)).toBe(newest);
   }),
+);
+
+it.effect("refreshes a profile-only CLI through an existing provider environment", () =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-profile-provider-"))),
+    (tempDir) =>
+      Effect.gen(function* () {
+        const platform = yield* HostProcessPlatform;
+        const nativeBinDir = NodePath.join(tempDir, ".local", "bin");
+        const executableName = platform === "win32" ? "profile-tool.exe" : "profile-tool";
+        const executable = NodePath.join(nativeBinDir, executableName);
+        NodeFS.mkdirSync(nativeBinDir, { recursive: true });
+        NodeFS.writeFileSync(executable, platform === "win32" ? "MZ" : "#!/bin/sh\n");
+        if (platform !== "win32") NodeFS.chmodSync(executable, 0o755);
+
+        const baseEnv: NodeJS.ProcessEnv = {
+          PATH: tempDir,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+          PROFILE_VALUE: "host-before",
+        };
+        const environmentSource = makeProviderInstanceEnvironmentSource(
+          [
+            { name: "UNRELATED", value: "custom", sensitive: false },
+            { name: "PROFILE_VALUE", value: "instance", sensitive: false },
+          ],
+          baseEnv,
+        );
+        const capturedEnvironment = environmentSource.environment;
+        const driverKind = ProviderDriverKind.make("profileTool");
+        const maintenance = yield* makeProviderMaintenanceCapabilitiesSource(
+          makePackageManagedProviderMaintenanceResolver({
+            provider: driverKind,
+            npmPackageName: "@example/profile-tool",
+            homebrewFormula: null,
+            nativeUpdate: {
+              executable: "profile-tool",
+              args: ["update"],
+              lockKey: "profile-tool-native",
+              isCommandPath: (commandPath) =>
+                normalizeCommandPath(commandPath).includes("/.local/bin/profile-tool"),
+            },
+          }),
+          { binaryPath: "profile-tool", env: capturedEnvironment },
+        );
+        const state = yield* Ref.make({ installed: false, maintenance: "npm-global" });
+        const refreshSnapshot = resolveCommandPath("profile-tool", {
+          env: capturedEnvironment,
+        }).pipe(
+          Effect.option,
+          Effect.flatMap((resolved) =>
+            maintenance.refresh.pipe(Effect.as(resolved._tag === "Some")),
+          ),
+          Effect.flatMap((installed) =>
+            Ref.set(state, {
+              installed,
+              maintenance: maintenance.get().update?.lockKey ?? "manual",
+            }),
+          ),
+        );
+        const instanceId = ProviderInstanceId.make("profile-tool");
+        const instance = {
+          instanceId,
+          driverKind,
+          continuationIdentity: { driverKind, continuationKey: "profileTool:profile-tool" },
+          displayName: "Profile tool",
+          enabled: true,
+          refreshEnvironment: environmentSource.refresh.pipe(
+            Effect.andThen(maintenance.invalidate),
+          ),
+          snapshot: {
+            getSnapshot: Effect.die("unused"),
+            refresh: refreshSnapshot,
+          } as unknown as ProviderInstance["snapshot"],
+          adapter: {} as ProviderInstance["adapter"],
+          textGeneration: {} as ProviderInstance["textGeneration"],
+        } satisfies ProviderInstance;
+        const registry = ProviderInstanceRegistry.of({
+          getInstance: () => Effect.succeed(instance),
+          listInstances: Effect.succeed([instance]),
+          listUnavailable: Effect.succeed([]),
+          streamChanges: Stream.empty,
+          subscribeChanges: Effect.die("unused"),
+        });
+
+        yield* refreshSnapshot;
+        expect(yield* Ref.get(state)).toEqual({ installed: false, maintenance: "npm-global" });
+
+        const releaseProfile = yield* Deferred.make<void>();
+        const profilePatch = yield* Deferred.await(releaseProfile).pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              baseEnv.PATH = nativeBinDir;
+              baseEnv.PROFILE_VALUE = "host-after";
+            }),
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Deferred.succeed(releaseProfile, undefined);
+        yield* Fiber.join(profilePatch);
+        yield* refreshProviderInstancesAfterEnvironmentHydration(registry);
+
+        expect(yield* registry.getInstance(instanceId)).toBe(instance);
+        expect(environmentSource.environment).toBe(capturedEnvironment);
+        expect(capturedEnvironment.UNRELATED).toBe("custom");
+        expect(capturedEnvironment.PROFILE_VALUE).toBe("instance");
+        expect(yield* Ref.get(state)).toEqual({
+          installed: true,
+          maintenance: "profile-tool-native",
+        });
+      }),
+    (tempDir) => Effect.sync(() => NodeFS.rmSync(tempDir, { recursive: true, force: true })),
+  ).pipe(Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -140,23 +140,21 @@ export const refreshProviderInstancesAfterEnvironmentHydration = Effect.fn(
  * configs, so the only way the watcher could fail is a settings stream
  * tear-down, which logs and exits cleanly.
  */
-const SettingsWatcherLive = (settingsChanges: Stream.Stream<ServerSettings>) =>
+export const SettingsWatcherLive = (settingsChanges: Stream.Stream<ServerSettings>) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const mutator = yield* ProviderInstanceRegistryMutator;
       const registry = yield* ProviderInstanceRegistry;
-      const serverSettings = yield* ServerSettingsService;
       const environmentHydration = yield* HostEnvironmentHydration;
       yield* settingsChanges.pipe(
-        Stream.runForEach(() =>
-          serverSettings.getSettings.pipe(
-            Effect.flatMap((current) =>
-              mutator.reconcile(deriveProviderInstanceConfigMap(current)),
+        Stream.runForEach((next) =>
+          mutator
+            .reconcile(deriveProviderInstanceConfigMap(next))
+            .pipe(
+              Effect.catchCause((cause) =>
+                Effect.logError("ProviderInstanceRegistry reconcile failed", cause),
+              ),
             ),
-            Effect.catchCause((cause) =>
-              Effect.logError("ProviderInstanceRegistry reconcile failed", cause),
-            ),
-          ),
         ),
         Effect.forkScoped,
       );

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -28,11 +28,15 @@
  * Hot-reload
  * ----------
  * On layer build we:
- *   1. Read the current `ServerSettings` once and use it to seed the
+ *   1. Subscribe to settings changes, then read the current
+ *      `ServerSettings` once and use it to seed the
  *      registry's initial state via `ProviderInstanceRegistryMutableLayer`.
  *   2. Fork a daemon fiber (lifetime tied to the layer's scope) that
  *      subscribes to `ServerSettingsService.streamChanges` and calls
  *      `ProviderInstanceRegistryMutator.reconcile` on every emission.
+ *   3. Once Windows profile hydration completes, refresh provider health
+ *      snapshots in place. PATH hydration does not change provider config,
+ *      so it must not replace adapters or interrupt their active turns.
  *
  * Failures inside the watcher are logged and swallowed so a single bad
  * settings emission cannot kill the registry. Unknown drivers and invalid
@@ -105,6 +109,25 @@ export const deriveProviderInstanceConfigMap = (
   return merged as ProviderInstanceConfigMap;
 };
 
+export const refreshProviderInstancesAfterEnvironmentHydration = Effect.fn(
+  "refreshProviderInstancesAfterEnvironmentHydration",
+)(function* (registry: ProviderInstanceRegistry["Service"]) {
+  const instances = yield* registry.listInstances;
+  yield* Effect.forEach(
+    instances,
+    (instance) =>
+      instance.snapshot.refresh.pipe(
+        Effect.catchCause((cause) =>
+          Effect.logError("Provider instance failed to refresh after environment hydration", {
+            instanceId: instance.instanceId,
+            cause,
+          }),
+        ),
+      ),
+    { concurrency: "unbounded", discard: true },
+  );
+});
+
 /**
  * Layer that consumes `ProviderInstanceRegistryMutator` and forks a
  * settings-watcher fiber. The fiber's lifetime is tied to the enclosing
@@ -116,40 +139,40 @@ export const deriveProviderInstanceConfigMap = (
  * configs, so the only way the watcher could fail is a settings stream
  * tear-down, which logs and exits cleanly.
  */
-const SettingsWatcherLive = Layer.effectDiscard(
-  Effect.gen(function* () {
-    const mutator = yield* ProviderInstanceRegistryMutator;
-    const serverSettings = yield* ServerSettingsService;
-    const environmentHydration = yield* HostEnvironmentHydration;
-    yield* serverSettings.streamChanges.pipe(
-      Stream.runForEach((next) =>
-        mutator
-          .reconcile(deriveProviderInstanceConfigMap(next))
-          .pipe(
+const SettingsWatcherLive = (settingsChanges: Stream.Stream<ServerSettings>) =>
+  Layer.effectDiscard(
+    Effect.gen(function* () {
+      const mutator = yield* ProviderInstanceRegistryMutator;
+      const registry = yield* ProviderInstanceRegistry;
+      const serverSettings = yield* ServerSettingsService;
+      const environmentHydration = yield* HostEnvironmentHydration;
+      yield* settingsChanges.pipe(
+        Stream.runForEach(() =>
+          serverSettings.getSettings.pipe(
+            Effect.flatMap((current) =>
+              mutator.reconcile(deriveProviderInstanceConfigMap(current)),
+            ),
             Effect.catchCause((cause) =>
               Effect.logError("ProviderInstanceRegistry reconcile failed", cause),
             ),
           ),
-      ),
-      Effect.forkScoped,
-    );
-    if (Option.isSome(environmentHydration.windowsProfile)) {
-      yield* environmentHydration.windowsProfile.value.pipe(
-        Effect.andThen(serverSettings.getSettings),
-        Effect.flatMap((settings) =>
-          mutator.reconcile(deriveProviderInstanceConfigMap(settings), { force: true }),
-        ),
-        Effect.catchCause((cause) =>
-          Effect.logError(
-            "Provider instances failed to refresh after environment hydration",
-            cause,
-          ),
         ),
         Effect.forkScoped,
       );
-    }
-  }),
-);
+      if (Option.isSome(environmentHydration.windowsProfile)) {
+        yield* environmentHydration.windowsProfile.value.pipe(
+          Effect.andThen(refreshProviderInstancesAfterEnvironmentHydration(registry)),
+          Effect.catchCause((cause) =>
+            Effect.logError(
+              "Provider instances failed to refresh after environment hydration",
+              cause,
+            ),
+          ),
+          Effect.forkScoped,
+        );
+      }
+    }),
+  );
 
 /**
  * Hydrate `ProviderInstanceRegistry` from `ServerSettings` and keep it in
@@ -174,6 +197,7 @@ export const ProviderInstanceRegistryHydrationLive: Layer.Layer<
 > = Layer.unwrap(
   Effect.gen(function* () {
     const serverSettings = yield* ServerSettingsService;
+    const settingsChanges = yield* serverSettings.subscribeChanges;
     const initialSettings: ServerSettings | undefined = yield* serverSettings.getSettings.pipe(
       Effect.orElseSucceed(() => undefined),
     );
@@ -187,6 +211,6 @@ export const ProviderInstanceRegistryHydrationLive: Layer.Layer<
       configMap: initialConfigMap,
     });
 
-    return SettingsWatcherLive.pipe(Layer.provideMerge(mutableLayer));
+    return SettingsWatcherLive(settingsChanges).pipe(Layer.provideMerge(mutableLayer));
   }),
 ) as Layer.Layer<ProviderInstanceRegistry, never, BuiltInDriversEnv | ServerSettingsService>;

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -116,7 +116,8 @@ export const refreshProviderInstancesAfterEnvironmentHydration = Effect.fn(
   yield* Effect.forEach(
     instances,
     (instance) =>
-      instance.snapshot.refresh.pipe(
+      (instance.refreshEnvironment ?? Effect.void).pipe(
+        Effect.andThen(instance.snapshot.refresh),
         Effect.catchCause((cause) =>
           Effect.logError("Provider instance failed to refresh after environment hydration", {
             instanceId: instance.instanceId,

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -49,11 +49,14 @@ import {
   defaultInstanceIdForDriver,
   type ProviderInstanceConfig,
   type ProviderInstanceConfigMap,
+  type ProviderInstanceEnvironmentVariable,
+  ProviderInstanceId,
   ServerSettings,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 
 import { HostEnvironmentHydration } from "../../os-jank.ts";
@@ -130,31 +133,101 @@ export const refreshProviderInstancesAfterEnvironmentHydration = Effect.fn(
 });
 
 /**
+ * Retain the last materialized value for redacted provider secrets when a
+ * settings notification outlives a transient secret-store failure. If a
+ * redacted value has never been materialized, the whole notification is
+ * deferred rather than rebuilding a provider with incomplete credentials.
+ */
+const restoreMaterializedProviderSecrets = (
+  next: ServerSettings,
+  previous: ServerSettings | undefined,
+): ServerSettings | undefined => {
+  const providerInstances: Record<string, ProviderInstanceConfig> = {};
+
+  for (const [instanceId, instance] of Object.entries(next.providerInstances)) {
+    if (instance.environment === undefined) {
+      providerInstances[instanceId] = instance;
+      continue;
+    }
+
+    const previousEnvironment =
+      previous?.providerInstances[ProviderInstanceId.make(instanceId)]?.environment ?? [];
+    const environment: ProviderInstanceEnvironmentVariable[] = [];
+    for (const variable of instance.environment) {
+      if (!variable.sensitive || !variable.valueRedacted || variable.value.length > 0) {
+        environment.push(variable);
+        continue;
+      }
+
+      const materialized = previousEnvironment.find(
+        (candidate) => candidate.name === variable.name && candidate.sensitive,
+      );
+      if (materialized === undefined) {
+        return undefined;
+      }
+      environment.push({ ...variable, value: materialized.value });
+    }
+
+    providerInstances[instanceId] = { ...instance, environment };
+  }
+
+  return {
+    ...next,
+    providerInstances: providerInstances as ServerSettings["providerInstances"],
+  };
+};
+
+/**
  * Layer that consumes `ProviderInstanceRegistryMutator` and forks a
  * settings-watcher fiber. The fiber's lifetime is tied to the enclosing
  * layer scope (process lifetime in production), so it is interrupted on
  * shutdown without leaking.
  *
- * Errors inside the watcher are logged and swallowed — the registry's own
- * "unavailable" bucket already absorbs unknown drivers and invalid
- * configs, so the only way the watcher could fail is a settings stream
- * tear-down, which logs and exits cleanly.
+ * Each notification is re-read to prefer a fully materialized current
+ * snapshot. If that read fails, non-secret changes can still land by
+ * restoring redacted values from the last materialized snapshot. An update
+ * containing a secret that has never been materialized is deferred. Other
+ * watcher errors are logged and swallowed so one bad emission cannot stop
+ * subsequent reconciles.
  */
-export const SettingsWatcherLive = (settingsChanges: Stream.Stream<ServerSettings>) =>
+export const SettingsWatcherLive = (
+  settingsChanges: Stream.Stream<ServerSettings>,
+  initialSettings: ServerSettings | undefined,
+) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const mutator = yield* ProviderInstanceRegistryMutator;
       const registry = yield* ProviderInstanceRegistry;
+      const serverSettings = yield* ServerSettingsService;
       const environmentHydration = yield* HostEnvironmentHydration;
+      const lastMaterializedSettings = yield* Ref.make(initialSettings);
       yield* settingsChanges.pipe(
         Stream.runForEach((next) =>
-          mutator
-            .reconcile(deriveProviderInstanceConfigMap(next))
-            .pipe(
-              Effect.catchCause((cause) =>
-                Effect.logError("ProviderInstanceRegistry reconcile failed", cause),
-              ),
+          serverSettings.getSettings.pipe(
+            Effect.catch((error) =>
+              Effect.gen(function* () {
+                const previous = yield* Ref.get(lastMaterializedSettings);
+                const recovered = restoreMaterializedProviderSecrets(next, previous);
+                if (recovered === undefined) {
+                  yield* Effect.logWarning(
+                    "Provider instance settings update deferred because secrets are unavailable",
+                    { cause: error },
+                  );
+                }
+                return recovered;
+              }),
             ),
+            Effect.flatMap((current) =>
+              current === undefined
+                ? Effect.void
+                : Ref.set(lastMaterializedSettings, current).pipe(
+                    Effect.andThen(mutator.reconcile(deriveProviderInstanceConfigMap(current))),
+                  ),
+            ),
+            Effect.catchCause((cause) =>
+              Effect.logError("ProviderInstanceRegistry reconcile failed", cause),
+            ),
+          ),
         ),
         Effect.forkScoped,
       );
@@ -210,6 +283,8 @@ export const ProviderInstanceRegistryHydrationLive: Layer.Layer<
       configMap: initialConfigMap,
     });
 
-    return SettingsWatcherLive(settingsChanges).pipe(Layer.provideMerge(mutableLayer));
+    return SettingsWatcherLive(settingsChanges, initialSettings).pipe(
+      Layer.provideMerge(mutableLayer),
+    );
   }),
 ) as Layer.Layer<ProviderInstanceRegistry, never, BuiltInDriversEnv | ServerSettingsService>;

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -49,8 +49,10 @@ import {
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 
+import { HostEnvironmentHydration } from "../../os-jank.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { BUILT_IN_DRIVERS, type BuiltInDriversEnv } from "../builtInDrivers.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
@@ -118,6 +120,7 @@ const SettingsWatcherLive = Layer.effectDiscard(
   Effect.gen(function* () {
     const mutator = yield* ProviderInstanceRegistryMutator;
     const serverSettings = yield* ServerSettingsService;
+    const environmentHydration = yield* HostEnvironmentHydration;
     yield* serverSettings.streamChanges.pipe(
       Stream.runForEach((next) =>
         mutator
@@ -130,6 +133,21 @@ const SettingsWatcherLive = Layer.effectDiscard(
       ),
       Effect.forkScoped,
     );
+    if (Option.isSome(environmentHydration.windowsProfile)) {
+      yield* environmentHydration.windowsProfile.value.pipe(
+        Effect.andThen(serverSettings.getSettings),
+        Effect.flatMap((settings) =>
+          mutator.reconcile(deriveProviderInstanceConfigMap(settings), { force: true }),
+        ),
+        Effect.catchCause((cause) =>
+          Effect.logError(
+            "Provider instances failed to refresh after environment hydration",
+            cause,
+          ),
+        ),
+        Effect.forkScoped,
+      );
+    }
   }),
 );
 

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -37,6 +37,7 @@ import {
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
@@ -140,6 +141,104 @@ const makeOpenCodeConfig = (overrides: Partial<OpenCodeSettings>): OpenCodeSetti
 });
 
 describe("ProviderInstanceRegistryLive — reconcile lifecycle", () => {
+  it.effect("keeps scope ownership safe when replacement is interrupted", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const instanceId = ProviderInstanceId.make("test_default");
+        const driverKind = ProviderDriverKind.make("test");
+        const enteredInitialClose = yield* Deferred.make<void>();
+        const releaseInitialClose = yield* Deferred.make<void>();
+        const enteredBlockedCreate = yield* Deferred.make<void>();
+        const created = yield* Ref.make<ReadonlyArray<string>>([]);
+        const finalized = yield* Ref.make<ReadonlyArray<string>>([]);
+        const openScopes = yield* Ref.make(0);
+
+        const driver = {
+          driverKind,
+          metadata: { displayName: "Test" },
+          configSchema: Schema.Struct({ version: Schema.String }),
+          defaultConfig: () => ({ version: "default" }),
+          create: Effect.fn("InterruptibleTestDriver.create")(function* (input) {
+            const version = input.config.version;
+            yield* Ref.update(created, (versions) => [...versions, version]);
+            yield* Ref.update(openScopes, (count) => count + 1);
+            yield* Effect.addFinalizer(() =>
+              Effect.gen(function* () {
+                if (version === "initial") {
+                  yield* Deferred.succeed(enteredInitialClose, undefined);
+                  yield* Deferred.await(releaseInitialClose);
+                }
+                yield* Ref.update(openScopes, (count) => count - 1);
+                yield* Ref.update(finalized, (versions) => [...versions, version]);
+              }),
+            );
+            if (version === "blocked-create") {
+              yield* Deferred.succeed(enteredBlockedCreate, undefined);
+              return yield* Effect.never;
+            }
+            return {
+              instanceId: input.instanceId,
+              driverKind,
+              continuationIdentity: {
+                driverKind,
+                continuationKey: `test:${version}`,
+              },
+              displayName: version,
+              enabled: true,
+              snapshot: {} as ProviderInstance["snapshot"],
+              adapter: {} as ProviderInstance["adapter"],
+              textGeneration: {} as ProviderInstance["textGeneration"],
+            } satisfies ProviderInstance;
+          }),
+        } satisfies ProviderDriver<{ readonly version: string }>;
+
+        const configMap = (version: string): ProviderInstanceConfigMap => ({
+          [instanceId]: {
+            driver: driverKind,
+            config: { version },
+          },
+        });
+        const { registry, mutator } = yield* makeProviderInstanceRegistry({
+          drivers: [driver],
+          configMap: configMap("initial"),
+        });
+
+        const interruptedClose = yield* Effect.forkChild(
+          mutator.reconcile(configMap("not-created")),
+        );
+        yield* Deferred.await(enteredInitialClose);
+        expect(yield* registry.getInstance(instanceId)).toBeUndefined();
+
+        yield* Effect.sync(() => interruptedClose.interruptUnsafe());
+        expect(interruptedClose.pollUnsafe()).toBeUndefined();
+        yield* Deferred.succeed(releaseInitialClose, undefined);
+        expect(Exit.hasInterrupts(yield* Fiber.await(interruptedClose))).toBe(true);
+        expect(yield* Ref.get(created)).toEqual(["initial"]);
+        expect(yield* Ref.get(finalized)).toEqual(["initial"]);
+        expect(yield* Ref.get(openScopes)).toBe(0);
+        expect(yield* registry.getInstance(instanceId)).toBeUndefined();
+
+        yield* mutator.reconcile(configMap("steady"));
+        const interruptedCreate = yield* Effect.forkChild(
+          mutator.reconcile(configMap("blocked-create")),
+        );
+        yield* Deferred.await(enteredBlockedCreate);
+        expect(yield* registry.getInstance(instanceId)).toBeUndefined();
+        expect(yield* Ref.get(openScopes)).toBe(1);
+
+        yield* Fiber.interrupt(interruptedCreate);
+        expect(Exit.hasInterrupts(yield* Fiber.await(interruptedCreate))).toBe(true);
+        expect(yield* Ref.get(finalized)).toEqual(["initial", "steady", "blocked-create"]);
+        expect(yield* Ref.get(openScopes)).toBe(0);
+        expect(yield* registry.getInstance(instanceId)).toBeUndefined();
+
+        yield* mutator.reconcile(configMap("recovered"));
+        expect((yield* registry.getInstance(instanceId))?.displayName).toBe("recovered");
+        expect(yield* Ref.get(openScopes)).toBe(1);
+      }),
+    ),
+  );
+
   it.effect("serializes concurrent replacements and leaves only the newest scope live", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -178,7 +178,7 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
         },
       };
 
-      const { registry } = yield* makeProviderInstanceRegistry({
+      const { registry, mutator } = yield* makeProviderInstanceRegistry({
         drivers: [CodexDriver],
         configMap,
       });
@@ -220,6 +220,12 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
       // Nothing goes to the unavailable bucket — both drivers are registered.
       const unavailable = yield* registry.listUnavailable;
       expect(unavailable).toEqual([]);
+
+      yield* mutator.reconcile(configMap, { force: true });
+      const rebuiltPersonal = yield* registry.getInstance(personalId);
+      const rebuiltWork = yield* registry.getInstance(workId);
+      expect(rebuiltPersonal).not.toBe(personal);
+      expect(rebuiltWork).not.toBe(work);
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -35,8 +35,12 @@ import {
   ProviderInstanceId,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
@@ -49,6 +53,7 @@ import { CursorDriver } from "../Drivers/CursorDriver.ts";
 import { GrokDriver } from "../Drivers/GrokDriver.ts";
 import { OpenCodeDriver } from "../Drivers/OpenCodeDriver.ts";
 import { OpenCodeRuntimeLive } from "../opencodeRuntime.ts";
+import type { ProviderDriver, ProviderInstance } from "../ProviderDriver.ts";
 import { NoOpProviderEventLoggers, ProviderEventLoggers } from "./ProviderEventLoggers.ts";
 import { makeProviderInstanceRegistry } from "./ProviderInstanceRegistryLive.ts";
 
@@ -131,6 +136,82 @@ const makeOpenCodeConfig = (overrides: Partial<OpenCodeSettings>): OpenCodeSetti
   serverPassword: "",
   customModels: [],
   ...overrides,
+});
+
+describe("ProviderInstanceRegistryLive — reconcile lifecycle", () => {
+  it.effect("serializes concurrent replacements and leaves only the newest scope live", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const instanceId = ProviderInstanceId.make("test_default");
+        const driverKind = ProviderDriverKind.make("test");
+        const enteredBlockedCreate = yield* Deferred.make<void>();
+        const releaseBlockedCreate = yield* Deferred.make<void>();
+        const created = yield* Ref.make<ReadonlyArray<string>>([]);
+        const finalized = yield* Ref.make<ReadonlyArray<string>>([]);
+        const openScopes = yield* Ref.make(0);
+
+        const driver = {
+          driverKind,
+          metadata: { displayName: "Test" },
+          configSchema: Schema.Struct({ version: Schema.String }),
+          defaultConfig: () => ({ version: "default" }),
+          create: Effect.fn("TestDriver.create")(function* (input) {
+            const version = input.config.version;
+            yield* Ref.update(created, (versions) => [...versions, version]);
+            if (version === "blocked") {
+              yield* Deferred.succeed(enteredBlockedCreate, undefined);
+              yield* Deferred.await(releaseBlockedCreate);
+            }
+            yield* Ref.update(openScopes, (count) => count + 1);
+            yield* Effect.addFinalizer(() =>
+              Ref.update(openScopes, (count) => count - 1).pipe(
+                Effect.andThen(Ref.update(finalized, (versions) => [...versions, version])),
+              ),
+            );
+            return {
+              instanceId: input.instanceId,
+              driverKind,
+              continuationIdentity: {
+                driverKind,
+                continuationKey: `test:${version}`,
+              },
+              displayName: version,
+              enabled: true,
+              snapshot: {} as ProviderInstance["snapshot"],
+              adapter: {} as ProviderInstance["adapter"],
+              textGeneration: {} as ProviderInstance["textGeneration"],
+            } satisfies ProviderInstance;
+          }),
+        } satisfies ProviderDriver<{ readonly version: string }>;
+
+        const configMap = (version: string): ProviderInstanceConfigMap => ({
+          [instanceId]: {
+            driver: driverKind,
+            config: { version },
+          },
+        });
+        const { registry, mutator } = yield* makeProviderInstanceRegistry({
+          drivers: [driver],
+          configMap: configMap("initial"),
+        });
+
+        const blocked = yield* Effect.forkChild(mutator.reconcile(configMap("blocked")));
+        yield* Deferred.await(enteredBlockedCreate);
+        const newest = yield* Effect.forkChild(mutator.reconcile(configMap("newest")));
+        yield* Effect.yieldNow;
+
+        expect(yield* Ref.get(created)).toEqual(["initial", "blocked"]);
+        yield* Deferred.succeed(releaseBlockedCreate, undefined);
+        yield* Fiber.join(blocked);
+        yield* Fiber.join(newest);
+
+        expect((yield* registry.getInstance(instanceId))?.displayName).toBe("newest");
+        expect(yield* Ref.get(created)).toEqual(["initial", "blocked", "newest"]);
+        expect(yield* Ref.get(finalized)).toEqual(["initial", "blocked"]);
+        expect(yield* Ref.get(openScopes)).toBe(1);
+      }),
+    ),
+  );
 });
 
 describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -141,6 +141,75 @@ const makeOpenCodeConfig = (overrides: Partial<OpenCodeSettings>): OpenCodeSetti
 });
 
 describe("ProviderInstanceRegistryLive — reconcile lifecycle", () => {
+  it.effect("keeps unavailable snapshots visible when replacement is interrupted", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const instanceId = ProviderInstanceId.make("shadow_default");
+        const unavailableDriverKind = ProviderDriverKind.make("missing");
+        const driverKind = ProviderDriverKind.make("test");
+        const enteredBlockedCreate = yield* Deferred.make<void>();
+
+        const driver = {
+          driverKind,
+          metadata: { displayName: "Test" },
+          configSchema: Schema.Struct({ version: Schema.String }),
+          defaultConfig: () => ({ version: "default" }),
+          create: Effect.fn("UnavailableTransitionTestDriver.create")(function* (input) {
+            const version = input.config.version;
+            if (version === "blocked") {
+              yield* Deferred.succeed(enteredBlockedCreate, undefined);
+              return yield* Effect.never;
+            }
+            return {
+              instanceId: input.instanceId,
+              driverKind,
+              continuationIdentity: {
+                driverKind,
+                continuationKey: `test:${version}`,
+              },
+              displayName: version,
+              enabled: true,
+              snapshot: {} as ProviderInstance["snapshot"],
+              adapter: {} as ProviderInstance["adapter"],
+              textGeneration: {} as ProviderInstance["textGeneration"],
+            } satisfies ProviderInstance;
+          }),
+        } satisfies ProviderDriver<{ readonly version: string }>;
+
+        const initialConfig: ProviderInstanceConfigMap = {
+          [instanceId]: {
+            driver: unavailableDriverKind,
+            config: { version: "unavailable" },
+          },
+        };
+        const liveConfig = (version: string): ProviderInstanceConfigMap => ({
+          [instanceId]: {
+            driver: driverKind,
+            config: { version },
+          },
+        });
+        const { registry, mutator } = yield* makeProviderInstanceRegistry({
+          drivers: [driver],
+          configMap: initialConfig,
+        });
+        const initialUnavailable = yield* registry.listUnavailable;
+        expect(initialUnavailable.map((snapshot) => snapshot.instanceId)).toEqual([instanceId]);
+
+        const interrupted = yield* Effect.forkChild(mutator.reconcile(liveConfig("blocked")));
+        yield* Deferred.await(enteredBlockedCreate);
+        expect(yield* registry.listUnavailable).toEqual(initialUnavailable);
+
+        yield* Fiber.interrupt(interrupted);
+        expect(Exit.hasInterrupts(yield* Fiber.await(interrupted))).toBe(true);
+        expect(yield* registry.listUnavailable).toEqual(initialUnavailable);
+
+        yield* mutator.reconcile(liveConfig("recovered"));
+        expect(yield* registry.listUnavailable).toEqual([]);
+        expect((yield* registry.getInstance(instanceId))?.displayName).toBe("recovered");
+      }),
+    ),
+  );
+
   it.effect("keeps scope ownership safe when replacement is interrupted", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -39,6 +39,7 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
@@ -232,9 +233,12 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
 
   it.live("boots two independent codex instances from a ProviderInstanceConfigMap", () =>
     Effect.gen(function* () {
+      const path = yield* Path.Path;
       const personalId = ProviderInstanceId.make("codex_personal");
       const workId = ProviderInstanceId.make("codex_work");
       const codexDriverKind = ProviderDriverKind.make("codex");
+      const personalHomePath = path.resolve(path.sep, "home", "julius", ".codex_personal");
+      const workHomePath = path.resolve(path.sep, "home", "julius", ".codex");
 
       const configMap: ProviderInstanceConfigMap = {
         [personalId]: {
@@ -243,7 +247,7 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
           enabled: false,
           config: makeCodexConfig({
             binaryPath: "/opt/codex-personal/bin/codex",
-            homePath: "/home/julius/.codex_personal",
+            homePath: personalHomePath,
             customModels: ["personal-preview"],
           }),
         },
@@ -253,7 +257,7 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
           enabled: false,
           config: makeCodexConfig({
             binaryPath: "/opt/codex-work/bin/codex",
-            homePath: "/home/julius/.codex",
+            homePath: workHomePath,
             customModels: ["work-preview"],
           }),
         },
@@ -288,15 +292,13 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
       expect(personalSnapshot.instanceId).toBe(personalId);
       expect(personalSnapshot.driver).toBe(codexDriverKind);
       expect(personalSnapshot.enabled).toBe(false);
-      expect(personalSnapshot.continuation?.groupKey).toBe(
-        "codex:home:/home/julius/.codex_personal",
-      );
+      expect(personalSnapshot.continuation?.groupKey).toBe(`codex:home:${personalHomePath}`);
 
       const workSnapshot = yield* work!.snapshot.getSnapshot;
       expect(workSnapshot.instanceId).toBe(workId);
       expect(workSnapshot.driver).toBe(codexDriverKind);
       expect(workSnapshot.enabled).toBe(false);
-      expect(workSnapshot.continuation?.groupKey).toBe("codex:home:/home/julius/.codex");
+      expect(workSnapshot.continuation?.groupKey).toBe(`codex:home:${workHomePath}`);
 
       // Nothing goes to the unavailable bucket — both drivers are registered.
       const unavailable = yield* registry.listUnavailable;
@@ -377,11 +379,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
 
   it.live("boots one instance of every shipped driver from a single config map", () =>
     Effect.gen(function* () {
+      const path = yield* Path.Path;
       const codexId = ProviderInstanceId.make("codex_default");
       const claudeId = ProviderInstanceId.make("claude_default");
       const cursorId = ProviderInstanceId.make("cursor_default");
       const grokId = ProviderInstanceId.make("grok_default");
       const openCodeId = ProviderInstanceId.make("opencode_default");
+      const codexHomePath = path.resolve(path.sep, "home", "julius", ".codex");
+      const claudeHomePath = path.resolve(path.sep, "home", "julius", ".claude-work");
 
       const codexDriverKind = ProviderDriverKind.make("codex");
       const claudeDriverKind = ProviderDriverKind.make("claudeAgent");
@@ -394,14 +399,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
           driver: codexDriverKind,
           displayName: "Codex",
           enabled: false,
-          config: makeCodexConfig({ homePath: "/home/julius/.codex" }),
+          config: makeCodexConfig({ homePath: codexHomePath }),
         },
         [claudeId]: {
           driver: claudeDriverKind,
           displayName: "Claude",
           enabled: false,
           config: makeClaudeConfig({
-            homePath: "/home/julius/.claude-work",
+            homePath: claudeHomePath,
             launchArgs: "--verbose",
           }),
         },
@@ -500,13 +505,13 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       expect(codexSnapshot.instanceId).toBe(codexId);
       expect(codexSnapshot.driver).toBe(codexDriverKind);
       expect(codexSnapshot.enabled).toBe(false);
-      expect(codexSnapshot.continuation?.groupKey).toBe("codex:home:/home/julius/.codex");
+      expect(codexSnapshot.continuation?.groupKey).toBe(`codex:home:${codexHomePath}`);
 
       const claudeSnapshot = yield* claude!.snapshot.getSnapshot;
       expect(claudeSnapshot.instanceId).toBe(claudeId);
       expect(claudeSnapshot.driver).toBe(claudeDriverKind);
       expect(claudeSnapshot.enabled).toBe(false);
-      expect(claudeSnapshot.continuation?.groupKey).toBe("claude:home:/home/julius/.claude-work");
+      expect(claudeSnapshot.continuation?.groupKey).toBe(`claude:home:${claudeHomePath}`);
 
       const cursorSnapshot = yield* cursor!.snapshot.getSnapshot;
       expect(cursorSnapshot.instanceId).toBe(cursorId);

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
@@ -49,6 +49,7 @@ import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 
 import { buildUnavailableProviderSnapshot } from "../unavailableProviderSnapshot.ts";
@@ -364,12 +365,15 @@ export const makeProviderInstanceRegistry = <R>(input: {
     const entries = yield* Ref.make<ReadonlyMap<ProviderInstanceId, LiveEntry>>(new Map());
     const unavailable = yield* Ref.make<ReadonlyMap<ProviderInstanceId, ServerProvider>>(new Map());
     const changes = yield* PubSub.unbounded<void>();
+    const reconcileSemaphore = yield* Semaphore.make(1);
     yield* Effect.addFinalizer(() => PubSub.shutdown(changes));
 
     const state: RegistryState = { entries, unavailable, changes };
     const reconcileWithR = makeReconcile({ state, driversById, parentScope });
     const reconcile: ProviderInstanceRegistryMutatorShape["reconcile"] = (configMap, options) =>
-      reconcileWithR(configMap, options).pipe(Effect.provideContext(driverContext));
+      reconcileSemaphore.withPermits(1)(
+        reconcileWithR(configMap, options).pipe(Effect.provideContext(driverContext)),
+      );
 
     // Hydrate the initial configMap synchronously so callers can read
     // `listInstances` immediately after this effect completes.

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
@@ -110,6 +110,7 @@ const decodedConfigEnabled = (config: unknown): boolean | undefined => {
 const buildEntry = <R>(input: {
   readonly driversById: ReadonlyMap<ProviderDriverKind, AnyProviderDriver<R>>;
   readonly parentScope: Scope.Scope;
+  readonly onScopeOpened: (scope: Scope.Closeable) => void;
   readonly instanceId: ProviderInstanceId;
   readonly rawInstanceId: string;
   readonly entry: ProviderInstanceConfig;
@@ -120,7 +121,7 @@ const buildEntry = <R>(input: {
   R
 > =>
   Effect.gen(function* () {
-    const { driversById, parentScope, instanceId, rawInstanceId, entry } = input;
+    const { driversById, parentScope, onScopeOpened, instanceId, rawInstanceId, entry } = input;
     const driver = driversById.get(entry.driver);
     if (!driver) {
       return {
@@ -158,13 +159,26 @@ const buildEntry = <R>(input: {
     }
 
     const typedConfig = decodeResult.success;
-    const childScope = yield* Scope.make();
-    // Attach the child scope to the registry's parent scope: if the
-    // registry scope closes, each surviving instance's child scope is
-    // closed through this finalizer. `reconcile` manually closes the
-    // child scope on remove/replace; subsequent close via the parent's
-    // finalizer is a no-op because `Scope.close` is idempotent.
-    yield* Scope.addFinalizer(parentScope, Scope.close(childScope, Exit.void).pipe(Effect.ignore));
+    const childScope = yield* Effect.acquireUseRelease(
+      Effect.gen(function* () {
+        const scope = yield* Scope.make();
+        // Register ownership before acquisition completes. If driver
+        // creation is interrupted, reconcile can close this unpublished
+        // scope immediately instead of leaving it alive until the registry
+        // itself shuts down.
+        yield* Effect.sync(() => onScopeOpened(scope));
+        // Attach the child scope to the registry's parent scope: if the
+        // registry scope closes, each surviving instance's child scope is
+        // closed through this finalizer. `reconcile` manually closes the
+        // child scope on remove/replace; subsequent close via the parent's
+        // finalizer is a no-op because `Scope.close` is idempotent.
+        yield* Scope.addFinalizer(parentScope, Scope.close(scope, Exit.void).pipe(Effect.ignore));
+        return scope;
+      }),
+      Effect.succeed,
+      (scope, exit) =>
+        Exit.isFailure(exit) ? Scope.close(scope, Exit.void).pipe(Effect.ignore) : Effect.void,
+    );
 
     const createResult = yield* driver
       .create({
@@ -219,103 +233,139 @@ const makeReconcile = <R>(input: {
 ) => Effect.Effect<void, never, R>) => {
   const { state, driversById, parentScope } = input;
   return (configMap: ProviderInstanceConfigMap, options) =>
-    Effect.gen(function* () {
-      const previousEntries = yield* Ref.get(state.entries);
-      const previousUnavailable = yield* Ref.get(state.unavailable);
-      const nextRaw = Object.entries(configMap);
-      const nextKeys = new Set<ProviderInstanceId>(
-        nextRaw.map(([raw]) => ProviderInstanceId.make(raw)),
-      );
+    Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const previousEntries = yield* Ref.get(state.entries);
+        const previousUnavailable = yield* Ref.get(state.unavailable);
+        const nextRaw = Object.entries(configMap);
+        const nextKeys = new Set<ProviderInstanceId>(
+          nextRaw.map(([raw]) => ProviderInstanceId.make(raw)),
+        );
 
-      // 1. Close scopes for instances that disappeared or whose config
-      //    changed. Do this BEFORE creating replacements so ids map 1-to-1
-      //    to live scopes at all times.
-      const removedIds: Array<ProviderInstanceId> = [];
-      const replacedIds = new Set<ProviderInstanceId>();
-      for (const [instanceId, live] of previousEntries) {
-        if (!nextKeys.has(instanceId)) {
-          removedIds.push(instanceId);
-          continue;
-        }
-        const nextEntry = configMap[instanceId];
-        if (
-          nextEntry !== undefined &&
-          (options?.force === true || !entryEqual(live.entry, nextEntry))
-        ) {
-          replacedIds.add(instanceId);
-        }
-      }
-      for (const id of [...removedIds, ...replacedIds]) {
-        const live = previousEntries.get(id);
-        if (live) {
-          yield* Scope.close(live.scope, Exit.void).pipe(Effect.ignore);
-        }
-      }
-
-      // 2. Build additions and replacements. Walk `nextRaw` so the final
-      //    entry order follows settings-author order.
-      const builtEntries = new Map<ProviderInstanceId, LiveEntry>();
-      const builtUnavailable = new Map<ProviderInstanceId, ServerProvider>();
-      let orderChanged = false;
-      const previousOrder = [...previousEntries.keys()];
-      const nextOrder: Array<ProviderInstanceId> = [];
-
-      for (const [rawInstanceId, entry] of nextRaw) {
-        const instanceId = ProviderInstanceId.make(rawInstanceId);
-        nextOrder.push(instanceId);
-
-        const existing = previousEntries.get(instanceId);
-        if (existing !== undefined && !replacedIds.has(instanceId)) {
-          // No-op update: keep the existing live entry and scope.
-          builtEntries.set(instanceId, existing);
-          continue;
-        }
-
-        const result = yield* buildEntry({
-          driversById,
-          parentScope,
-          instanceId,
-          rawInstanceId,
-          entry,
-        });
-        if (result.kind === "live") {
-          builtEntries.set(instanceId, result.live);
-        } else {
-          builtUnavailable.set(instanceId, result.snapshot);
-        }
-      }
-
-      if (previousOrder.length === nextOrder.length) {
-        for (let i = 0; i < previousOrder.length; i++) {
-          if (previousOrder[i] !== nextOrder[i]) {
-            orderChanged = true;
-            break;
+        // Stage the public state before teardown so readers can never receive
+        // an instance whose scope has already closed. Unavailable snapshots
+        // are rebuilt below because they do not retain their source envelope.
+        const removedIds: Array<ProviderInstanceId> = [];
+        const replacedIds = new Set<ProviderInstanceId>();
+        for (const [instanceId, live] of previousEntries) {
+          if (!nextKeys.has(instanceId)) {
+            removedIds.push(instanceId);
+            continue;
+          }
+          const nextEntry = configMap[instanceId];
+          if (
+            nextEntry !== undefined &&
+            (options?.force === true || !entryEqual(live.entry, nextEntry))
+          ) {
+            replacedIds.add(instanceId);
           }
         }
-      } else {
-        orderChanged = true;
-      }
+        const stagedEntries = new Map<ProviderInstanceId, LiveEntry>();
+        const previousOrder = [...previousEntries.keys()];
+        const nextOrder: Array<ProviderInstanceId> = [];
+        const openedScopes: Array<Scope.Closeable> = [];
 
-      const entriesChanged =
-        orderChanged ||
-        removedIds.length > 0 ||
-        replacedIds.size > 0 ||
-        builtEntries.size !== previousEntries.size;
-      const unavailableChanged =
-        builtUnavailable.size !== previousUnavailable.size ||
-        [...builtUnavailable].some(([id, snapshot]) => {
-          const prev = previousUnavailable.get(id);
-          return prev === undefined || !Equal.equals(prev, snapshot);
-        }) ||
-        [...previousUnavailable].some(([id]) => !builtUnavailable.has(id));
+        for (const [rawInstanceId] of nextRaw) {
+          const instanceId = ProviderInstanceId.make(rawInstanceId);
+          nextOrder.push(instanceId);
+          const existing = previousEntries.get(instanceId);
+          if (existing !== undefined && !replacedIds.has(instanceId)) {
+            stagedEntries.set(instanceId, existing);
+          }
+        }
 
-      yield* Ref.set(state.entries, builtEntries);
-      yield* Ref.set(state.unavailable, builtUnavailable);
+        const stagedEntriesChanged =
+          stagedEntries.size !== previousEntries.size ||
+          [...stagedEntries].some(
+            ([id, live], index) => previousOrder[index] !== id || previousEntries.get(id) !== live,
+          );
+        const stagedStateChanged = stagedEntriesChanged || previousUnavailable.size > 0;
 
-      if (entriesChanged || unavailableChanged) {
-        yield* PubSub.publish(state.changes, undefined);
-      }
-    });
+        yield* Ref.set(state.entries, stagedEntries);
+        yield* Ref.set(state.unavailable, new Map());
+
+        for (const id of [...removedIds, ...replacedIds]) {
+          const live = previousEntries.get(id);
+          if (live) {
+            yield* Scope.close(live.scope, Exit.void).pipe(Effect.ignore);
+          }
+        }
+
+        // Driver creation is the only interruptible phase. The old scopes are
+        // already closed and unpublished; if cancellation arrives, close every
+        // newly opened scope before releasing the reconcile semaphore.
+        const builtEntries = new Map(stagedEntries);
+        const builtUnavailable = new Map<ProviderInstanceId, ServerProvider>();
+        yield* restore(
+          Effect.gen(function* () {
+            for (const [rawInstanceId, entry] of nextRaw) {
+              const instanceId = ProviderInstanceId.make(rawInstanceId);
+              if (builtEntries.has(instanceId)) {
+                continue;
+              }
+
+              const result = yield* buildEntry({
+                driversById,
+                parentScope,
+                onScopeOpened: (scope) => openedScopes.push(scope),
+                instanceId,
+                rawInstanceId,
+                entry,
+              });
+              if (result.kind === "live") {
+                builtEntries.set(instanceId, result.live);
+              } else {
+                builtUnavailable.set(instanceId, result.snapshot);
+              }
+            }
+          }),
+        ).pipe(
+          Effect.onInterrupt(() =>
+            Effect.forEach(openedScopes, (scope) =>
+              Scope.close(scope, Exit.void).pipe(Effect.ignore),
+            ).pipe(
+              Effect.andThen(
+                stagedStateChanged ? PubSub.publish(state.changes, undefined) : Effect.void,
+              ),
+              Effect.asVoid,
+            ),
+          ),
+        );
+
+        let orderChanged = false;
+
+        if (previousOrder.length === nextOrder.length) {
+          for (let i = 0; i < previousOrder.length; i++) {
+            if (previousOrder[i] !== nextOrder[i]) {
+              orderChanged = true;
+              break;
+            }
+          }
+        } else {
+          orderChanged = true;
+        }
+
+        const entriesChanged =
+          orderChanged ||
+          removedIds.length > 0 ||
+          replacedIds.size > 0 ||
+          builtEntries.size !== previousEntries.size;
+        const unavailableChanged =
+          builtUnavailable.size !== previousUnavailable.size ||
+          [...builtUnavailable].some(([id, snapshot]) => {
+            const prev = previousUnavailable.get(id);
+            return prev === undefined || !Equal.equals(prev, snapshot);
+          }) ||
+          [...previousUnavailable].some(([id]) => !builtUnavailable.has(id));
+
+        yield* Ref.set(state.entries, builtEntries);
+        yield* Ref.set(state.unavailable, builtUnavailable);
+
+        if (entriesChanged || unavailableChanged) {
+          yield* PubSub.publish(state.changes, undefined);
+        }
+      }),
+    );
 };
 
 /**

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
@@ -212,9 +212,12 @@ const makeReconcile = <R>(input: {
   readonly state: RegistryState;
   readonly driversById: ReadonlyMap<ProviderDriverKind, AnyProviderDriver<R>>;
   readonly parentScope: Scope.Scope;
-}): ((configMap: ProviderInstanceConfigMap) => Effect.Effect<void, never, R>) => {
+}): ((
+  configMap: ProviderInstanceConfigMap,
+  options?: { readonly force?: boolean },
+) => Effect.Effect<void, never, R>) => {
   const { state, driversById, parentScope } = input;
-  return (configMap: ProviderInstanceConfigMap) =>
+  return (configMap: ProviderInstanceConfigMap, options) =>
     Effect.gen(function* () {
       const previousEntries = yield* Ref.get(state.entries);
       const previousUnavailable = yield* Ref.get(state.unavailable);
@@ -234,7 +237,10 @@ const makeReconcile = <R>(input: {
           continue;
         }
         const nextEntry = configMap[instanceId];
-        if (nextEntry !== undefined && !entryEqual(live.entry, nextEntry)) {
+        if (
+          nextEntry !== undefined &&
+          (options?.force === true || !entryEqual(live.entry, nextEntry))
+        ) {
           replacedIds.add(instanceId);
         }
       }
@@ -362,8 +368,8 @@ export const makeProviderInstanceRegistry = <R>(input: {
 
     const state: RegistryState = { entries, unavailable, changes };
     const reconcileWithR = makeReconcile({ state, driversById, parentScope });
-    const reconcile: ProviderInstanceRegistryMutatorShape["reconcile"] = (configMap) =>
-      reconcileWithR(configMap).pipe(Effect.provideContext(driverContext));
+    const reconcile: ProviderInstanceRegistryMutatorShape["reconcile"] = (configMap, options) =>
+      reconcileWithR(configMap, options).pipe(Effect.provideContext(driverContext));
 
     // Hydrate the initial configMap synchronously so callers can read
     // `listInstances` immediately after this effect completes.

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
@@ -242,9 +242,10 @@ const makeReconcile = <R>(input: {
           nextRaw.map(([raw]) => ProviderInstanceId.make(raw)),
         );
 
-        // Stage the public state before teardown so readers can never receive
-        // an instance whose scope has already closed. Unavailable snapshots
-        // are rebuilt below because they do not retain their source envelope.
+        // Stage live state before teardown so readers can never receive an
+        // instance whose scope has already closed. Unavailable snapshots own
+        // no resources, so keep the last complete map published until the
+        // rebuilt map commits below.
         const removedIds: Array<ProviderInstanceId> = [];
         const replacedIds = new Set<ProviderInstanceId>();
         for (const [instanceId, live] of previousEntries) {
@@ -279,10 +280,7 @@ const makeReconcile = <R>(input: {
           [...stagedEntries].some(
             ([id, live], index) => previousOrder[index] !== id || previousEntries.get(id) !== live,
           );
-        const stagedStateChanged = stagedEntriesChanged || previousUnavailable.size > 0;
-
         yield* Ref.set(state.entries, stagedEntries);
-        yield* Ref.set(state.unavailable, new Map());
 
         for (const id of [...removedIds, ...replacedIds]) {
           const live = previousEntries.get(id);
@@ -325,7 +323,7 @@ const makeReconcile = <R>(input: {
               Scope.close(scope, Exit.void).pipe(Effect.ignore),
             ).pipe(
               Effect.andThen(
-                stagedStateChanged ? PubSub.publish(state.changes, undefined) : Effect.void,
+                stagedEntriesChanged ? PubSub.publish(state.changes, undefined) : Effect.void,
               ),
               Effect.asVoid,
             ),

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -68,6 +68,8 @@ export interface ProviderInstance {
   readonly displayName: string | undefined;
   readonly accentColor?: string | undefined;
   readonly enabled: boolean;
+  /** Refresh inherited host environment values without replacing this instance. */
+  readonly refreshEnvironment?: Effect.Effect<void>;
   readonly snapshot: ServerProviderShape;
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
   readonly textGeneration: TextGeneration.TextGeneration["Service"];

--- a/apps/server/src/provider/ProviderInstanceEnvironment.test.ts
+++ b/apps/server/src/provider/ProviderInstanceEnvironment.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it } from "@effect/vitest";
 
-import { mergeProviderInstanceEnvironment } from "./ProviderInstanceEnvironment.ts";
+import * as Effect from "effect/Effect";
+
+import {
+  makeProviderInstanceEnvironmentSource,
+  mergeProviderInstanceEnvironment,
+} from "./ProviderInstanceEnvironment.ts";
 
 describe("mergeProviderInstanceEnvironment", () => {
   it("overrides inherited environment values and preserves empty strings", () => {
@@ -18,4 +23,29 @@ describe("mergeProviderInstanceEnvironment", () => {
       PATH: "/bin",
     });
   });
+
+  it.effect("refreshes inherited values in place while explicit overrides keep precedence", () =>
+    Effect.gen(function* () {
+      const baseEnv = { PATH: "C:\\baseline", PROFILE_VALUE: "host-before" };
+      const source = makeProviderInstanceEnvironmentSource(
+        [
+          { name: "UNRELATED", value: "custom", sensitive: false },
+          { name: "PROFILE_VALUE", value: "instance", sensitive: false },
+        ],
+        baseEnv,
+      );
+      const captured = source.environment;
+
+      baseEnv.PATH = "C:\\profile";
+      baseEnv.PROFILE_VALUE = "host-after";
+      yield* source.refresh;
+
+      expect(source.environment).toBe(captured);
+      expect(captured).toMatchObject({
+        PATH: "C:\\profile",
+        PROFILE_VALUE: "instance",
+        UNRELATED: "custom",
+      });
+    }),
+  );
 });

--- a/apps/server/src/provider/ProviderInstanceEnvironment.ts
+++ b/apps/server/src/provider/ProviderInstanceEnvironment.ts
@@ -1,16 +1,46 @@
 import type { ProviderInstanceEnvironment } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+export interface ProviderInstanceEnvironmentSource {
+  readonly environment: NodeJS.ProcessEnv;
+  readonly refresh: Effect.Effect<void>;
+}
+
+export function makeProviderInstanceEnvironmentSource(
+  overrides: ProviderInstanceEnvironment | undefined,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): ProviderInstanceEnvironmentSource {
+  if (!overrides || overrides.length === 0) {
+    return { environment: baseEnv, refresh: Effect.void };
+  }
+
+  const environment: NodeJS.ProcessEnv = {};
+  const inheritedKeys = new Set<string>();
+  const overrideKeys = new Set(overrides.map((variable) => variable.name));
+  const apply = () => {
+    for (const key of inheritedKeys) {
+      if (!overrideKeys.has(key)) delete environment[key];
+    }
+    inheritedKeys.clear();
+    for (const [key, value] of Object.entries(baseEnv)) {
+      environment[key] = value;
+      inheritedKeys.add(key);
+    }
+    for (const variable of overrides) {
+      environment[variable.name] = variable.value;
+    }
+  };
+  apply();
+
+  return {
+    environment,
+    refresh: Effect.sync(apply),
+  };
+}
 
 export function mergeProviderInstanceEnvironment(
   environment: ProviderInstanceEnvironment | undefined,
   baseEnv: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
-  if (!environment || environment.length === 0) {
-    return baseEnv;
-  }
-
-  const next: NodeJS.ProcessEnv = { ...baseEnv };
-  for (const variable of environment) {
-    next[variable.name] = variable.value;
-  }
-  return next;
+  return makeProviderInstanceEnvironmentSource(environment, baseEnv).environment;
 }

--- a/apps/server/src/provider/Services/ProviderInstanceRegistryMutator.ts
+++ b/apps/server/src/provider/Services/ProviderInstanceRegistryMutator.ts
@@ -43,7 +43,10 @@ export interface ProviderInstanceRegistryMutatorShape {
    * `makeProviderInstanceRegistry`. This keeps settings-watcher loops from
    * erroring out on a single bad entry.
    */
-  readonly reconcile: (configMap: ProviderInstanceConfigMap) => Effect.Effect<void>;
+  readonly reconcile: (
+    configMap: ProviderInstanceConfigMap,
+    options?: { readonly force?: boolean },
+  ) => Effect.Effect<void>;
 }
 
 export class ProviderInstanceRegistryMutator extends Context.Service<

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -27,7 +27,9 @@ interface ProviderSnapshotState {
 export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(function* <
   Settings,
 >(input: {
-  readonly maintenanceCapabilities: ServerProviderShape["maintenanceCapabilities"];
+  readonly maintenanceCapabilities:
+    | ServerProviderShape["maintenanceCapabilities"]
+    | (() => ServerProviderShape["maintenanceCapabilities"]);
   readonly getSettings: Effect.Effect<Settings, ServerSettingsError>;
   readonly streamSettings: Stream.Stream<Settings>;
   readonly haveSettingsChanged: (previous: Settings, next: Settings) => boolean;
@@ -219,7 +221,11 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
   );
 
   return {
-    maintenanceCapabilities: input.maintenanceCapabilities,
+    get maintenanceCapabilities() {
+      return typeof input.maintenanceCapabilities === "function"
+        ? input.maintenanceCapabilities()
+        : input.maintenanceCapabilities;
+    },
     getSnapshot: Ref.get(snapshotStateRef).pipe(Effect.map((state) => state.snapshot)),
     refresh: refreshSnapshot().pipe(Effect.tapError(Effect.logError), Effect.orDie),
     get streamChanges() {

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -14,6 +14,7 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   makePackageManagedProviderMaintenanceResolver,
   makeProviderMaintenanceCapabilities,
+  makeProviderMaintenanceCapabilitiesSource,
   makeStaticProviderMaintenanceResolver,
   normalizeCommandPath,
   ProviderVersionCache,
@@ -197,6 +198,27 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       },
     });
   });
+
+  it.effect("defers command-path discovery until maintenance capabilities are resolved", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-lazy-provider-capabilities");
+      const bunBinDir = NodePath.join(tempDir, ".bun", "bin");
+      NodeFS.mkdirSync(bunBinDir, { recursive: true });
+      NodeFS.writeFileSync(NodePath.join(bunBinDir, "native-package-tool.exe"), "MZ");
+
+      const source = yield* makeProviderMaintenanceCapabilitiesSource(nativePackageToolUpdate, {
+        binaryPath: "native-package-tool",
+        env: {
+          PATH: bunBinDir,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        },
+      }).pipe(Effect.provideService(HostProcessPlatform, "win32"));
+
+      expect(source.get().update?.lockKey).toBe("npm-global");
+      expect((yield* source.resolve).update?.lockKey).toBe("bun-global");
+      expect(source.get().update?.lockKey).toBe("bun-global");
+    }),
+  );
 
   it.effect(
     "switches package-managed providers to vite-plus updates when the resolved binary lives in vite-plus global bin",

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -592,6 +592,8 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
 
   it.effect("keeps npm updates for binaries symlinked into npm's global node_modules tree", () =>
     Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") return;
+
       const tempDir = yield* makeTempDir("t3-npm-capabilities");
       const binDir = NodePath.join(tempDir, "bin");
       const packageBinDir = NodePath.join(
@@ -635,6 +637,8 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
 
   it.effect("uses Effect FileSystem realPath when detecting pnpm global symlinks", () =>
     Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") return;
+
       const tempDir = yield* makeTempDir("t3-pnpm-realpath-capabilities");
       const binDir = NodePath.join(tempDir, "bin");
       const packageBinDir = NodePath.join(

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -215,8 +215,9 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       }).pipe(Effect.provideService(HostProcessPlatform, "win32"));
 
       expect(source.get().update?.lockKey).toBe("npm-global");
-      expect((yield* source.resolve).update?.lockKey).toBe("bun-global");
+      yield* source.refresh;
       expect(source.get().update?.lockKey).toBe("bun-global");
+      expect((yield* source.resolve).update?.lockKey).toBe("bun-global");
     }),
   );
 

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -7,7 +7,10 @@ import * as NodePath from "node:path";
 import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Crypto from "effect/Crypto";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
 import { HttpClient } from "effect/unstable/http";
 import {
   createProviderVersionAdvisory,
@@ -69,6 +72,17 @@ const staticToolUpdate = makeStaticProviderMaintenanceResolver(
     updateLockKey: "static-tool",
   }),
 );
+const pathAwareToolUpdate = {
+  requiresCommandPath: true,
+  resolve: (options?: { readonly realCommandPath?: string | null }) =>
+    makeProviderMaintenanceCapabilities({
+      provider: driver("pathAwareTool"),
+      packageName: null,
+      updateExecutable: "path-aware-tool",
+      updateArgs: ["update"],
+      updateLockKey: options?.realCommandPath ? "resolved-path" : "unresolved-path",
+    }),
+};
 const installedPackageToolProvider: ServerProvider = {
   instanceId: ProviderInstanceId.make("packageTool"),
   driver: driver("packageTool"),
@@ -218,6 +232,108 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       yield* source.refresh;
       expect(source.get().update?.lockKey).toBe("bun-global");
       expect((yield* source.resolve).update?.lockKey).toBe("bun-global");
+    }),
+  );
+
+  it.effect("retries maintenance capability discovery after its first lookup is interrupted", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const tempDir = yield* makeTempDir("t3-interrupted-provider-capabilities");
+      const executable = NodePath.join(tempDir, "path-aware-tool");
+      NodeFS.mkdirSync(tempDir, { recursive: true });
+      NodeFS.writeFileSync(executable, "#!/bin/sh\n");
+      NodeFS.chmodSync(executable, 0o755);
+
+      const firstLookupStarted = yield* Deferred.make<void>();
+      let lookupCount = 0;
+      const instrumentedFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        realPath: (path) => {
+          if (path !== executable) return fileSystem.realPath(path);
+          lookupCount += 1;
+          return lookupCount === 1
+            ? Deferred.succeed(firstLookupStarted, undefined).pipe(Effect.andThen(Effect.never))
+            : fileSystem.realPath(path);
+        },
+      });
+      const source = yield* makeProviderMaintenanceCapabilitiesSource(pathAwareToolUpdate, {
+        binaryPath: executable,
+      }).pipe(Effect.provideService(FileSystem.FileSystem, instrumentedFileSystem));
+
+      const firstLookup = yield* source.refresh.pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(firstLookupStarted);
+      yield* Fiber.interrupt(firstLookup);
+
+      expect(source.get().update?.lockKey).toBe("unresolved-path");
+      expect((yield* source.resolve).update?.lockKey).toBe("resolved-path");
+      expect(source.get().update?.lockKey).toBe("resolved-path");
+      expect(lookupCount).toBe(2);
+    }),
+  );
+
+  it.effect("shares concurrent successful maintenance capability discovery", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const tempDir = yield* makeTempDir("t3-shared-provider-capabilities");
+      const executable = NodePath.join(tempDir, "path-aware-tool");
+      NodeFS.mkdirSync(tempDir, { recursive: true });
+      NodeFS.writeFileSync(executable, "#!/bin/sh\n");
+      NodeFS.chmodSync(executable, 0o755);
+
+      const lookupStarted = yield* Deferred.make<void>();
+      const releaseLookup = yield* Deferred.make<void>();
+      let lookupCount = 0;
+      const instrumentedFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        realPath: (path) => {
+          if (path !== executable) return fileSystem.realPath(path);
+          lookupCount += 1;
+          return Deferred.succeed(lookupStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseLookup)),
+            Effect.andThen(fileSystem.realPath(path)),
+          );
+        },
+      });
+      const source = yield* makeProviderMaintenanceCapabilitiesSource(pathAwareToolUpdate, {
+        binaryPath: executable,
+      }).pipe(Effect.provideService(FileSystem.FileSystem, instrumentedFileSystem));
+
+      const first = yield* source.resolve.pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(lookupStarted);
+      const second = yield* source.resolve.pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.succeed(releaseLookup, undefined);
+
+      expect((yield* Fiber.join(first)).update?.lockKey).toBe("resolved-path");
+      expect((yield* Fiber.join(second)).update?.lockKey).toBe("resolved-path");
+      expect(lookupCount).toBe(1);
+    }),
+  );
+
+  it.effect("memoizes successful maintenance capability discovery", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const tempDir = yield* makeTempDir("t3-memoized-provider-capabilities");
+      const executable = NodePath.join(tempDir, "path-aware-tool");
+      NodeFS.mkdirSync(tempDir, { recursive: true });
+      NodeFS.writeFileSync(executable, "#!/bin/sh\n");
+      NodeFS.chmodSync(executable, 0o755);
+
+      let lookupCount = 0;
+      const instrumentedFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        realPath: (path) => {
+          if (path !== executable) return fileSystem.realPath(path);
+          lookupCount += 1;
+          return fileSystem.realPath(path);
+        },
+      });
+      const source = yield* makeProviderMaintenanceCapabilitiesSource(pathAwareToolUpdate, {
+        binaryPath: executable,
+      }).pipe(Effect.provideService(FileSystem.FileSystem, instrumentedFileSystem));
+
+      expect((yield* source.resolve).update?.lockKey).toBe("resolved-path");
+      expect((yield* source.resolve).update?.lockKey).toBe("resolved-path");
+      expect(lookupCount).toBe(1);
     }),
   );
 

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -11,6 +11,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
@@ -58,6 +59,7 @@ export interface ProviderMaintenanceCapabilityResolutionOptions {
 }
 
 export interface ProviderMaintenanceCapabilitiesResolver {
+  readonly requiresCommandPath?: boolean;
   readonly resolve: (
     options?: ProviderMaintenanceCapabilityResolutionOptions,
   ) => ProviderMaintenanceCapabilities;
@@ -322,6 +324,7 @@ export function makePackageManagedProviderMaintenanceResolver(
   definition: PackageManagedProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilitiesResolver {
   return {
+    requiresCommandPath: true,
     resolve: (options) => resolvePackageManagedProviderMaintenance(definition, options),
   };
 }
@@ -330,6 +333,7 @@ export function makeStaticProviderMaintenanceResolver(
   capabilities: ProviderMaintenanceCapabilities,
 ): ProviderMaintenanceCapabilitiesResolver {
   return {
+    requiresCommandPath: false,
     resolve: () => capabilities,
   };
 }
@@ -349,6 +353,9 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
   resolver: ProviderMaintenanceCapabilitiesResolver,
   options?: Omit<ProviderMaintenanceCapabilityResolutionOptions, "realCommandPath">,
 ) {
+  if (resolver.requiresCommandPath !== true) {
+    return resolver.resolve(options);
+  }
   const binaryPath = nonEmptyString(options?.binaryPath);
   if (!binaryPath) {
     return resolver.resolve(options);
@@ -373,6 +380,40 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
     resolvedCommandPath,
     realCommandPath,
   });
+});
+
+export interface ProviderMaintenanceCapabilitiesSource {
+  readonly get: () => ProviderMaintenanceCapabilities;
+  readonly resolve: Effect.Effect<ProviderMaintenanceCapabilities>;
+  readonly refresh: Effect.Effect<void>;
+}
+
+export const makeProviderMaintenanceCapabilitiesSource = Effect.fn(
+  "makeProviderMaintenanceCapabilitiesSource",
+)(function* (
+  resolver: ProviderMaintenanceCapabilitiesResolver,
+  options?: Omit<ProviderMaintenanceCapabilityResolutionOptions, "realCommandPath">,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  let current = resolver.resolve(options);
+  const resolve = yield* Effect.cached(
+    resolveProviderMaintenanceCapabilitiesEffect(resolver, options).pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(Path.Path, path),
+      Effect.tap((capabilities) =>
+        Effect.sync(() => {
+          current = capabilities;
+        }),
+      ),
+    ),
+  );
+
+  return {
+    get: () => current,
+    resolve,
+    refresh: Effect.forkDetach(resolve, { startImmediately: true }).pipe(Effect.asVoid),
+  } satisfies ProviderMaintenanceCapabilitiesSource;
 });
 
 function deriveVersionAdvisory(input: {

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -5,6 +5,7 @@ import {
 } from "@t3tools/contracts";
 import { compareSemverVersions } from "@t3tools/shared/semver";
 import { resolveCommandPath } from "@t3tools/shared/shell";
+import * as Cache from "effect/Cache";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -397,17 +398,20 @@ export const makeProviderMaintenanceCapabilitiesSource = Effect.fn(
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   let current = resolver.resolve(options);
-  const resolve = yield* Effect.cached(
-    resolveProviderMaintenanceCapabilitiesEffect(resolver, options).pipe(
-      Effect.provideService(FileSystem.FileSystem, fileSystem),
-      Effect.provideService(Path.Path, path),
-      Effect.tap((capabilities) =>
-        Effect.sync(() => {
-          current = capabilities;
-        }),
+  const cache = yield* Cache.make({
+    capacity: 1,
+    lookup: () =>
+      resolveProviderMaintenanceCapabilitiesEffect(resolver, options).pipe(
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+        Effect.tap((capabilities) =>
+          Effect.sync(() => {
+            current = capabilities;
+          }),
+        ),
       ),
-    ),
-  );
+  });
+  const resolve = Cache.get(cache, "capabilities");
 
   return {
     get: () => current,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -412,7 +412,7 @@ export const makeProviderMaintenanceCapabilitiesSource = Effect.fn(
   return {
     get: () => current,
     resolve,
-    refresh: Effect.forkDetach(resolve, { startImmediately: true }).pipe(Effect.asVoid),
+    refresh: resolve.pipe(Effect.asVoid),
   } satisfies ProviderMaintenanceCapabilitiesSource;
 });
 

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -387,6 +387,7 @@ export interface ProviderMaintenanceCapabilitiesSource {
   readonly get: () => ProviderMaintenanceCapabilities;
   readonly resolve: Effect.Effect<ProviderMaintenanceCapabilities>;
   readonly refresh: Effect.Effect<void>;
+  readonly invalidate: Effect.Effect<void>;
 }
 
 export const makeProviderMaintenanceCapabilitiesSource = Effect.fn(
@@ -417,6 +418,7 @@ export const makeProviderMaintenanceCapabilitiesSource = Effect.fn(
     get: () => current,
     resolve,
     refresh: resolve.pipe(Effect.asVoid),
+    invalidate: Cache.invalidate(cache, "capabilities"),
   } satisfies ProviderMaintenanceCapabilitiesSource;
 });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -18,7 +18,7 @@ import {
   browserApiCorsLayer,
   httpCompressionLayer,
 } from "./http.ts";
-import { fixPath } from "./os-jank.ts";
+import { hostEnvironmentHydrationLayer } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
@@ -459,8 +459,6 @@ export const makeServerLayer = Layer.unwrap(
     const routesReady = yield* Deferred.make<void>();
     const launcherLayer = ServiceLauncherClient.layer;
 
-    yield* fixPath();
-
     const httpListeningLayer = Layer.effectDiscard(
       Effect.gen(function* () {
         yield* HttpServer.HttpServer;
@@ -638,6 +636,7 @@ export const makeServerLayer = Layer.unwrap(
     return serverApplicationLayer.pipe(
       Layer.provideMerge(runtimeServicesLive),
       Layer.provide(activationLayer),
+      Layer.provideMerge(hostEnvironmentHydrationLayer),
       Layer.provideMerge(serverRelayBrokerTracingLayer),
       Layer.provideMerge(HttpServerLive),
       Layer.provide(ApplicationObservabilityLive),

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1336,6 +1336,35 @@ it.layer(
     }),
   );
 
+  it.effect("resolves a configured Windows shell through PATH before spawning", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-terminal-shell-",
+      });
+      const shellPath = path.join(binDir, "jz.EXE");
+      yield* fileSystem.writeFileString(shellPath, "MZ");
+
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => "jz",
+        env: {
+          PATH: binDir,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+          SystemRoot: "C:\\Windows",
+        },
+      }).pipe(Effect.provide(withHostPlatform("win32")));
+
+      yield* manager.open(openInput());
+
+      expect(ptyAdapter.spawnInputs[0]).toEqual(
+        expect.objectContaining({
+          shell: shellPath,
+        }),
+      );
+    }),
+  );
+
   it.effect("falls back to built-in PowerShell by absolute path on Windows", () =>
     Effect.gen(function* () {
       const ptyAdapter = new FakePtyAdapter();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1,6 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import {
+  DEFAULT_SERVER_SETTINGS,
   DEFAULT_TERMINAL_ID,
   type TerminalAttachStreamEvent,
   type TerminalEvent,
@@ -10,6 +11,7 @@ import {
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Data from "effect/Data";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
@@ -20,13 +22,18 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import { expect } from "vite-plus/test";
 
+import * as ServerConfig from "../config.ts";
+import * as PortScanner from "../preview/PortScanner.ts";
 import * as ProcessRunner from "../processRunner.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as TerminalManager from "./Manager.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
@@ -279,6 +286,53 @@ it.layer(
   Layer.merge(NodeServices.layer, ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer))),
   { excludeTestServices: true },
 )("TerminalManager", (it) => {
+  it.effect("does not lose a terminal shell setting changed during the initial snapshot", () =>
+    Effect.gen(function* () {
+      const settingsChanges = yield* PubSub.unbounded<typeof DEFAULT_SERVER_SETTINGS>();
+      const appliedChange = yield* Deferred.make<void>();
+      const changedSettings = {
+        ...DEFAULT_SERVER_SETTINGS,
+        defaultTerminalShell: "race-shell.exe",
+      };
+      const serverSettings = ServerSettings.ServerSettingsService.of({
+        start: Effect.void,
+        ready: Effect.void,
+        getSettings: PubSub.publish(settingsChanges, changedSettings).pipe(
+          Effect.as(DEFAULT_SERVER_SETTINGS),
+        ),
+        updateSettings: () => Effect.die(new Error("unused in this test")),
+        streamChanges: Stream.empty,
+        subscribeChanges: PubSub.subscribe(settingsChanges).pipe(
+          Effect.map((subscription) =>
+            Stream.fromSubscription(subscription).pipe(
+              Stream.tap(() => Deferred.succeed(appliedChange, undefined)),
+            ),
+          ),
+        ),
+      });
+      const ptyAdapter = new FakePtyAdapter();
+      const portDiscovery = PortScanner.PortDiscovery.of({
+        scan: () => Effect.succeed([]),
+        subscribe: () => Effect.void,
+        retain: Effect.void,
+        registerTerminalProcesses: () => Effect.void,
+        unregisterTerminal: () => Effect.void,
+      });
+
+      const manager = yield* TerminalManager.make().pipe(
+        Effect.provideService(PtyAdapter.PtyAdapter, ptyAdapter),
+        Effect.provideService(PortScanner.PortDiscovery, portDiscovery),
+        Effect.provideService(ServerSettings.ServerSettingsService, serverSettings),
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-terminal-settings-" })),
+      );
+      yield* Deferred.await(appliedChange);
+      yield* manager.open(openInput());
+
+      expect(ptyAdapter.spawnInputs[0]?.shell).toBe("race-shell.exe");
+    }),
+  );
+
   it.effect("spawns lazily and reuses running terminal per thread", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
@@ -1282,7 +1336,7 @@ it.layer(
     Effect.gen(function* () {
       const platform = yield* HostProcessPlatform;
       const missingShell =
-        platform === "win32" ? "C:\\definitely\\missing-shell.exe" : "/definitely/missing-shell -l";
+        platform === "win32" ? "C:\\definitely\\missing-shell.exe" : "/definitely/missing-shell";
       const { manager, ptyAdapter } = yield* createManager(5, {
         shellResolver: () => missingShell,
       });
@@ -1362,6 +1416,112 @@ it.layer(
           shell: shellPath,
         }),
       );
+    }),
+  );
+
+  it.effect("resolves a configured Windows shell against the terminal runtime PATH", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseBinDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-terminal-base-shell-",
+      });
+      const runtimeBinDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-terminal-runtime-shell-",
+      });
+      yield* fileSystem.writeFileString(path.join(baseBinDir, "jz.EXE"), "MZ");
+      const runtimeShellPath = path.join(runtimeBinDir, "jz.EXE");
+      yield* fileSystem.writeFileString(runtimeShellPath, "MZ");
+
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => "jz",
+        env: {
+          PATH: baseBinDir,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+          SystemRoot: "C:\\Windows",
+        },
+      }).pipe(Effect.provide(withHostPlatform("win32")));
+
+      yield* manager.open(openInput({ env: { PATH: runtimeBinDir } }));
+
+      expect(ptyAdapter.spawnInputs[0]).toEqual(
+        expect.objectContaining({
+          shell: runtimeShellPath,
+          env: expect.objectContaining({ PATH: runtimeBinDir }),
+        }),
+      );
+    }),
+  );
+
+  it.effect("accepts a quoted configured Windows shell path containing spaces", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const shellDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code quoted terminal shell ",
+      });
+      const shellPath = path.join(shellDir, "custom shell.EXE");
+      yield* fileSystem.writeFileString(shellPath, "MZ");
+      for (const configured of [shellPath, `"${shellPath}"`]) {
+        const { manager, ptyAdapter } = yield* createManager(5, {
+          shellResolver: () => configured,
+          env: {
+            PATH: "",
+            PATHEXT: ".COM;.EXE;.BAT;.CMD",
+            SystemRoot: "C:\\Windows",
+          },
+        }).pipe(Effect.provide(withHostPlatform("win32")));
+
+        yield* manager.open(openInput());
+
+        expect(ptyAdapter.spawnInputs[0]?.shell).toBe(shellPath);
+        expect(ptyAdapter.spawnInputs[0]?.args).toBeUndefined();
+      }
+    }),
+  );
+
+  it.effect("does not interpret shell metacharacters in a configured Windows executable", () =>
+    Effect.gen(function* () {
+      const configured = '"C:\\Program Files\\custom shell.exe" & calc.exe';
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => configured,
+        env: { PATH: "", PATHEXT: ".COM;.EXE;.BAT;.CMD", SystemRoot: "C:\\Windows" },
+      }).pipe(Effect.provide(withHostPlatform("win32")));
+
+      yield* manager.open(openInput());
+
+      expect(ptyAdapter.spawnInputs[0]?.shell).toBe(configured);
+      expect(ptyAdapter.spawnInputs[0]?.args).toBeUndefined();
+    }),
+  );
+
+  it.effect("accepts quoted and unquoted POSIX shell executable paths containing spaces", () =>
+    Effect.gen(function* () {
+      const shellPath = "/opt/custom shells/zsh";
+      for (const configured of [shellPath, `"${shellPath}"`]) {
+        const { manager, ptyAdapter } = yield* createManager(5, {
+          shellResolver: () => configured,
+          env: { PATH: "/usr/bin:/bin" },
+        }).pipe(Effect.provide(withHostPlatform("linux")));
+
+        yield* manager.open(openInput());
+
+        expect(ptyAdapter.spawnInputs[0]?.shell).toBe(shellPath);
+      }
+    }),
+  );
+
+  it.effect("does not parse arguments from a configured POSIX executable", () =>
+    Effect.gen(function* () {
+      const configured = '/bin/bash -lc "touch /tmp/should-not-run"';
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => configured,
+      }).pipe(Effect.provide(withHostPlatform("linux")));
+
+      yield* manager.open(openInput());
+
+      expect(ptyAdapter.spawnInputs[0]?.shell).toBe(configured);
+      expect(ptyAdapter.spawnInputs[0]?.args).toBeUndefined();
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -543,7 +543,9 @@ const resolveShellCandidates = Effect.fn("terminal.resolveShellCandidates")(func
     platform === "win32" && requestedCommand !== null
       ? yield* resolveCommandPath(requestedCommand, { env }).pipe(
           Effect.provideService(HostProcessPlatform, platform),
-          Effect.catchTag("CommandResolutionError", () => Effect.succeed(requestedCommand)),
+          Effect.catchTags({
+            CommandResolutionError: () => Effect.succeed(requestedCommand),
+          }),
         )
       : requestedCommand;
   const requested = shellCandidateFromCommand(resolvedRequestedCommand, platform);

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -446,21 +446,17 @@ function defaultShellResolver(platform: NodeJS.Platform, env: NodeJS.ProcessEnv)
   return env.SHELL ?? "bash";
 }
 
-function normalizeShellCommand(
-  value: string | undefined,
-  platform: NodeJS.Platform,
-): string | null {
+function normalizeShellCommand(value: string | undefined): string | null {
   if (!value) return null;
   const trimmed = value.trim();
   if (trimmed.length === 0) return null;
 
-  if (platform === "win32") {
-    return trimmed;
+  const quote = trimmed[0];
+  if ((quote === '"' || quote === "'") && trimmed.at(-1) === quote) {
+    const unquoted = trimmed.slice(1, -1).trim();
+    return unquoted.length > 0 ? unquoted : null;
   }
-
-  const firstToken = trimmed.split(/\s+/g)[0]?.trim();
-  if (!firstToken) return null;
-  return firstToken.replace(/^['"]|['"]$/g, "");
+  return trimmed;
 }
 
 function basenameForPlatform(command: string, platform: NodeJS.Platform): string {
@@ -538,7 +534,7 @@ const resolveShellCandidates = Effect.fn("terminal.resolveShellCandidates")(func
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
 ): Effect.fn.Return<ShellCandidate[], never, FileSystem.FileSystem | Path.Path> {
-  const requestedCommand = normalizeShellCommand(shellResolver(), platform);
+  const requestedCommand = normalizeShellCommand(shellResolver());
   const resolvedRequestedCommand =
     platform === "win32" && requestedCommand !== null
       ? yield* resolveCommandPath(requestedCommand, { env }).pipe(
@@ -564,7 +560,7 @@ const resolveShellCandidates = Effect.fn("terminal.resolveShellCandidates")(func
 
   return uniqueShellCandidates([
     requested,
-    shellCandidateFromCommand(normalizeShellCommand(env.SHELL, platform), platform),
+    shellCandidateFromCommand(normalizeShellCommand(env.SHELL), platform),
     shellCandidateFromCommand("/bin/zsh", platform),
     shellCandidateFromCommand("/bin/bash", platform),
     shellCandidateFromCommand("/bin/sh", platform),
@@ -1212,8 +1208,9 @@ export const make = Effect.fn("TerminalManager.make")(function* () {
   const ptyAdapter = yield* PtyAdapter.PtyAdapter;
   const portDiscovery = yield* PortScanner.PortDiscovery;
   const settingsService = yield* ServerSettings.ServerSettingsService;
+  const settingsChanges = yield* settingsService.subscribeChanges;
   let configuredShell = (yield* settingsService.getSettings).defaultTerminalShell;
-  yield* settingsService.streamChanges.pipe(
+  yield* settingsChanges.pipe(
     Stream.runForEach((settings) =>
       Effect.sync(() => {
         configuredShell = settings.defaultTerminalShell;
@@ -1941,15 +1938,15 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
         Effect.andThen(
           Effect.gen(function* () {
+            const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const shellCandidates = yield* resolveShellCandidates(
               shellResolver,
               platform,
-              baseEnv,
+              terminalEnv,
             ).pipe(
               Effect.provideService(FileSystem.FileSystem, fileSystem),
               Effect.provideService(Path.Path, path),
             );
-            const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;
             startedShell = spawnResult.shellLabel;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -34,6 +34,7 @@ import {
 } from "@t3tools/contracts";
 import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { resolveCommandPath } from "@t3tools/shared/shell";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
@@ -49,6 +50,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import * as ServerConfig from "../config.ts";
@@ -59,6 +61,7 @@ import {
 } from "../observability/Metrics.ts";
 import * as ProcessRunner from "../processRunner.ts";
 import * as PortScanner from "../preview/PortScanner.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
 export {
@@ -530,15 +533,20 @@ function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellC
   return ordered;
 }
 
-function resolveShellCandidates(
+const resolveShellCandidates = Effect.fn("terminal.resolveShellCandidates")(function* (
   shellResolver: () => string,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
-): ShellCandidate[] {
-  const requested = shellCandidateFromCommand(
-    normalizeShellCommand(shellResolver(), platform),
-    platform,
-  );
+): Effect.fn.Return<ShellCandidate[], never, FileSystem.FileSystem | Path.Path> {
+  const requestedCommand = normalizeShellCommand(shellResolver(), platform);
+  const resolvedRequestedCommand =
+    platform === "win32" && requestedCommand !== null
+      ? yield* resolveCommandPath(requestedCommand, { env }).pipe(
+          Effect.provideService(HostProcessPlatform, platform),
+          Effect.catchTag("CommandResolutionError", () => Effect.succeed(requestedCommand)),
+        )
+      : requestedCommand;
+  const requested = shellCandidateFromCommand(resolvedRequestedCommand, platform);
 
   if (platform === "win32") {
     return uniqueShellCandidates([
@@ -562,7 +570,7 @@ function resolveShellCandidates(
     shellCandidateFromCommand("bash", platform),
     shellCandidateFromCommand("sh", platform),
   ]);
-}
+});
 
 function isRetryableShellSpawnError(error: PtyAdapter.PtySpawnError): boolean {
   const queue: unknown[] = [error];
@@ -1201,9 +1209,20 @@ export const make = Effect.fn("TerminalManager.make")(function* () {
   const { terminalLogsDir } = yield* ServerConfig.ServerConfig;
   const ptyAdapter = yield* PtyAdapter.PtyAdapter;
   const portDiscovery = yield* PortScanner.PortDiscovery;
+  const settingsService = yield* ServerSettings.ServerSettingsService;
+  let configuredShell = (yield* settingsService.getSettings).defaultTerminalShell;
+  yield* settingsService.streamChanges.pipe(
+    Stream.runForEach((settings) =>
+      Effect.sync(() => {
+        configuredShell = settings.defaultTerminalShell;
+      }),
+    ),
+    Effect.forkScoped,
+  );
   return yield* makeWithOptions({
     logsDir: terminalLogsDir,
     ptyAdapter,
+    shellResolver: () => configuredShell,
     registerTerminalProcesses: portDiscovery.registerTerminalProcesses,
     unregisterTerminal: portDiscovery.unregisterTerminal,
   });
@@ -1920,7 +1939,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
         Effect.andThen(
           Effect.gen(function* () {
-            const shellCandidates = resolveShellCandidates(shellResolver, platform, baseEnv);
+            const shellCandidates = yield* resolveShellCandidates(
+              shellResolver,
+              platform,
+              baseEnv,
+            ).pipe(
+              Effect.provideService(FileSystem.FileSystem, fileSystem),
+              Effect.provideService(Path.Path, path),
+            );
             const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -6,6 +6,9 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
 import { createModelSelection } from "@t3tools/shared/model";
 import { expect } from "vite-plus/test";
 
@@ -13,6 +16,8 @@ import * as ServerConfig from "../config.ts";
 import * as TextGeneration from "./TextGeneration.ts";
 import { sanitizeThreadTitle } from "./TextGenerationUtils.ts";
 import { makeClaudeTextGeneration } from "./ClaudeTextGeneration.ts";
+import { makeClaudeEnvironmentSource } from "../provider/Drivers/ClaudeHome.ts";
+import { makeProviderInstanceEnvironmentSource } from "../provider/ProviderInstanceEnvironment.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const ClaudeTextGenerationTestLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
@@ -190,6 +195,83 @@ function withFakeClaudeEnv<A, E, R>(
 }
 
 it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
+  it.effect("uses refreshed environment values for future commands with a configured home", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const homePath = path.resolve("claude-refreshed-home");
+      const baseEnv: NodeJS.ProcessEnv = {
+        PATH: "before-path",
+        CLAUDE_CREDENTIAL: "host-before",
+        REMOVE_ME: "stale",
+        CLAUDE_CONFIG_DIR: "host-home",
+      };
+      const instanceEnvironment = makeProviderInstanceEnvironmentSource(
+        [{ name: "CLAUDE_CREDENTIAL", value: "instance-credential", sensitive: true }],
+        baseEnv,
+      );
+      const claudeEnvironment = yield* makeClaudeEnvironmentSource(
+        { homePath },
+        instanceEnvironment.environment,
+      );
+      let spawnedEnvironment: NodeJS.ProcessEnv | undefined;
+      const spawner = ChildProcessSpawner.make((command) => {
+        const childProcessCommand = command as unknown as {
+          readonly options: { readonly env?: NodeJS.ProcessEnv };
+        };
+        spawnedEnvironment = childProcessCommand.options.env;
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.encodeText(
+              Stream.make(
+                JSON.stringify({
+                  structured_output: { subject: "Use refreshed environment", body: "" },
+                }),
+              ),
+            ),
+            stderr: Stream.empty,
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      });
+      const config = decodeClaudeSettings({ homePath, binaryPath: "claude" });
+      const textGeneration = yield* makeClaudeTextGeneration(
+        config,
+        claudeEnvironment.environment,
+      ).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+
+      baseEnv.PATH = "after-path";
+      baseEnv.CLAUDE_CREDENTIAL = "host-after";
+      baseEnv.CLAUDE_CONFIG_DIR = "host-after-home";
+      delete baseEnv.REMOVE_ME;
+      yield* instanceEnvironment.refresh;
+      yield* claudeEnvironment.refresh;
+
+      yield* textGeneration.generateCommitMessage({
+        cwd: process.cwd(),
+        branch: "feature/refreshed-environment",
+        stagedSummary: "M README.md",
+        stagedPatch: "diff --git a/README.md b/README.md",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-haiku-4-5",
+        ),
+      });
+
+      expect(spawnedEnvironment?.PATH).toBe("after-path");
+      expect(spawnedEnvironment?.CLAUDE_CREDENTIAL).toBe("instance-credential");
+      expect(spawnedEnvironment?.REMOVE_ME).toBeUndefined();
+      expect(spawnedEnvironment?.CLAUDE_CONFIG_DIR).toBe(homePath);
+    }),
+  );
+
   it.effect("forwards Claude thinking settings for Haiku without passing effort", () =>
     withFakeClaudeEnv(
       {

--- a/apps/web/src/components/settings/SettingsPanels.terminal.test.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.terminal.test.tsx
@@ -1,0 +1,46 @@
+import type { ComponentProps, ReactElement } from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { DraftInput } from "../ui/draft-input";
+import { DefaultTerminalShellSettingRow } from "./SettingsPanels";
+import { SettingResetButton, SettingsRow } from "./settingsLayout";
+
+function renderRow(value: string, desktop = false) {
+  const onChange = vi.fn();
+  const row = DefaultTerminalShellSettingRow({ value, desktop, onChange }) as ReactElement<
+    ComponentProps<typeof SettingsRow>
+  >;
+  return { onChange, row };
+}
+
+describe("DefaultTerminalShellSettingRow", () => {
+  it("commits a shell through the accessible input", () => {
+    const { onChange, row } = renderRow("", true);
+    const input = row.props.control as ReactElement<ComponentProps<typeof DraftInput>>;
+
+    expect(row.props.title).toBe("Default terminal shell");
+    expect(input.props["aria-label"]).toBe("Default terminal shell");
+    expect(input.props.placeholder).toBe("pwsh.exe");
+
+    input.props.onCommit("C:\\Program Files\\Git\\bin\\bash.exe");
+    expect(onChange).toHaveBeenCalledWith("C:\\Program Files\\Git\\bin\\bash.exe");
+  });
+
+  it("only offers reset for a non-default value", () => {
+    expect(renderRow("").row.props.resetAction).toBeNull();
+
+    const { onChange, row } = renderRow("zsh");
+    const reset = row.props.resetAction as ReactElement<ComponentProps<typeof SettingResetButton>>;
+    expect(reset.props.label).toBe("default terminal shell");
+
+    reset.props.onClick();
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("describes the browser default without implying a local executable", () => {
+    const input = renderRow("").row.props.control as ReactElement<
+      ComponentProps<typeof DraftInput>
+    >;
+    expect(input.props.placeholder).toBe("Platform default");
+  });
+});

--- a/apps/web/src/components/settings/SettingsPanels.terminal.test.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.terminal.test.tsx
@@ -5,9 +5,9 @@ import { DraftInput } from "../ui/draft-input";
 import { DefaultTerminalShellSettingRow } from "./SettingsPanels";
 import { SettingResetButton, SettingsRow } from "./settingsLayout";
 
-function renderRow(value: string, desktop = false) {
+function renderRow(value: string, environmentOs?: "darwin" | "linux" | "windows" | "unknown") {
   const onChange = vi.fn();
-  const row = DefaultTerminalShellSettingRow({ value, desktop, onChange }) as ReactElement<
+  const row = DefaultTerminalShellSettingRow({ value, environmentOs, onChange }) as ReactElement<
     ComponentProps<typeof SettingsRow>
   >;
   return { onChange, row };
@@ -15,7 +15,7 @@ function renderRow(value: string, desktop = false) {
 
 describe("DefaultTerminalShellSettingRow", () => {
   it("commits a shell through the accessible input", () => {
-    const { onChange, row } = renderRow("", true);
+    const { onChange, row } = renderRow("", "windows");
     const input = row.props.control as ReactElement<ComponentProps<typeof DraftInput>>;
 
     expect(row.props.title).toBe("Default terminal shell");
@@ -37,7 +37,7 @@ describe("DefaultTerminalShellSettingRow", () => {
     expect(onChange).toHaveBeenCalledWith("");
   });
 
-  it("describes the browser default without implying a local executable", () => {
+  it("stays neutral when the connected environment platform is unknown", () => {
     const input = renderRow("").row.props.control as ReactElement<
       ComponentProps<typeof DraftInput>
     >;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -16,6 +16,7 @@ import {
   type BackgroundActivityProfile,
   type BackgroundActivitySettings,
   type DesktopUpdateChannel,
+  type ExecutionEnvironmentPlatformOs,
   PROVIDER_DISPLAY_NAMES,
   ProviderDriverKind,
   type ProviderInstanceConfig,
@@ -90,6 +91,7 @@ import { ensureLocalApi, readLocalApi } from "../../localApi";
 import { isMacPlatform } from "../../lib/utils";
 import {
   primaryServerObservabilityAtom,
+  primaryServerConfigAtom,
   primaryServerProvidersAtom,
   serverEnvironment,
 } from "../../state/server";
@@ -1614,6 +1616,7 @@ export function GeneralSettingsPanel() {
     readLastEnabledProjectGroupingMode(),
   );
   const observability = useAtomValue(primaryServerObservabilityAtom);
+  const serverConfig = useAtomValue(primaryServerConfigAtom);
   const serverProviders = useAtomValue(primaryServerProvidersAtom);
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
@@ -2034,7 +2037,7 @@ export function GeneralSettingsPanel() {
 
         <DefaultTerminalShellSettingRow
           value={settings.defaultTerminalShell}
-          desktop={isElectron}
+          environmentOs={serverConfig?.environment.platform.os}
           onChange={(defaultTerminalShell) => updateSettings({ defaultTerminalShell })}
         />
 
@@ -2190,11 +2193,11 @@ export function GeneralSettingsPanel() {
 
 export function DefaultTerminalShellSettingRow({
   value,
-  desktop,
+  environmentOs,
   onChange,
 }: {
   readonly value: string;
-  readonly desktop: boolean;
+  readonly environmentOs: ExecutionEnvironmentPlatformOs | undefined;
   readonly onChange: (value: string) => void;
 }) {
   return (
@@ -2214,7 +2217,7 @@ export function DefaultTerminalShellSettingRow({
           className="w-full sm:w-72"
           value={value}
           onCommit={onChange}
-          placeholder={desktop ? "pwsh.exe" : "Platform default"}
+          placeholder={environmentOs === "windows" ? "pwsh.exe" : "Platform default"}
           spellCheck={false}
           aria-label="Default terminal shell"
         />

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2032,31 +2032,10 @@ export function GeneralSettingsPanel() {
           }
         />
 
-        <SettingsRow
-          {...searchableSetting("default-terminal-shell")}
-          description="Executable used for new terminals in this environment. Leave empty for the platform default; paths such as Git Bash are supported."
-          resetAction={
-            settings.defaultTerminalShell !== DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell ? (
-              <SettingResetButton
-                label="default terminal shell"
-                onClick={() =>
-                  updateSettings({
-                    defaultTerminalShell: DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <DraftInput
-              className="w-full sm:w-72"
-              value={settings.defaultTerminalShell}
-              onCommit={(next) => updateSettings({ defaultTerminalShell: next })}
-              placeholder={isElectron ? "pwsh.exe" : "Platform default"}
-              spellCheck={false}
-              aria-label="Default terminal shell"
-            />
-          }
+        <DefaultTerminalShellSettingRow
+          value={settings.defaultTerminalShell}
+          desktop={isElectron}
+          onChange={(defaultTerminalShell) => updateSettings({ defaultTerminalShell })}
         />
 
         <SettingsRow
@@ -2206,6 +2185,41 @@ export function GeneralSettingsPanel() {
         />
       </SettingsSection>
     </SettingsPageContainer>
+  );
+}
+
+export function DefaultTerminalShellSettingRow({
+  value,
+  desktop,
+  onChange,
+}: {
+  readonly value: string;
+  readonly desktop: boolean;
+  readonly onChange: (value: string) => void;
+}) {
+  return (
+    <SettingsRow
+      {...searchableSetting("default-terminal-shell")}
+      description="Executable used for new terminals in this environment. Leave empty for the platform default; paths such as Git Bash are supported."
+      resetAction={
+        value !== DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell ? (
+          <SettingResetButton
+            label="default terminal shell"
+            onClick={() => onChange(DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell)}
+          />
+        ) : null
+      }
+      control={
+        <DraftInput
+          className="w-full sm:w-72"
+          value={value}
+          onCommit={onChange}
+          placeholder={desktop ? "pwsh.exe" : "Platform default"}
+          spellCheck={false}
+          aria-label="Default terminal shell"
+        />
+      }
+    />
   );
 }
 

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -644,6 +644,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
+      ...(settings.defaultTerminalShell !== DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell
+        ? ["Default terminal shell"]
+        : []),
       ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
         ? ["Archive confirmation"]
         : []),
@@ -659,6 +662,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
+      settings.defaultTerminalShell,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
@@ -711,6 +715,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+      defaultTerminalShell: DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
       textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
@@ -2023,6 +2028,33 @@ export function GeneralSettingsPanel() {
               placeholder="~/"
               spellCheck={false}
               aria-label="Add project base directory"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("default-terminal-shell")}
+          description="Executable used for new terminals in this environment. Leave empty for the platform default; paths such as Git Bash are supported."
+          resetAction={
+            settings.defaultTerminalShell !== DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell ? (
+              <SettingResetButton
+                label="default terminal shell"
+                onClick={() =>
+                  updateSettings({
+                    defaultTerminalShell: DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <DraftInput
+              className="w-full sm:w-72"
+              value={settings.defaultTerminalShell}
+              onCommit={(next) => updateSettings({ defaultTerminalShell: next })}
+              placeholder={isElectron ? "pwsh.exe" : "Platform default"}
+              spellCheck={false}
+              aria-label="Default terminal shell"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -132,6 +132,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "default-terminal-shell",
+    title: "Default terminal shell",
+    to: "/settings/general",
+  },
+  {
     id: "archive-confirmation",
     title: "Archive confirmation",
     to: "/settings/general",

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Install and first run](./user/install.md)
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
+- [Choose the default terminal shell](./user/terminal-shell.md)
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)

--- a/docs/user/terminal-shell.md
+++ b/docs/user/terminal-shell.md
@@ -1,0 +1,23 @@
+# Choose the default terminal shell
+
+T3 Code uses an environment-wide shell preference when it opens a new terminal. To change it,
+open **Settings** → **General** → **Default terminal shell** and enter either an executable name
+available on the environment's `PATH` or an absolute executable path.
+
+For example, on Windows you can enter `pwsh.exe`, `cmd.exe`, or a full path such as
+`C:\Program Files\Git\bin\bash.exe`. On macOS and Linux, values such as `zsh`, `bash`, or an
+absolute path are supported.
+
+Leave the field empty to use the platform default. Windows prefers PowerShell and falls back to
+Windows PowerShell or Command Prompt when needed. macOS and Linux prefer the environment's
+`SHELL`, then fall back to common system shells. If a configured shell cannot be started, T3 Code
+tries those platform fallbacks instead.
+
+The change applies to terminals opened after the setting is saved; existing terminals keep their
+current shell.
+
+## Client availability
+
+The setting is available in the web and desktop clients. Mobile does not currently expose the
+control. Because the preference belongs to the connected environment, terminals opened from any
+client use the value configured from web or desktop.

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -214,6 +214,22 @@ describe("ServerSettings.sourceControlWritingStyle", () => {
   });
 });
 
+describe("ServerSettings terminal shell", () => {
+  it("defaults to automatic shell selection and trims configured commands", () => {
+    expect(decodeServerSettings({}).defaultTerminalShell).toBe("");
+    expect(
+      decodeServerSettings({ defaultTerminalShell: "  C:\\Program Files\\Git\\bin\\bash.exe  " })
+        .defaultTerminalShell,
+    ).toBe("C:\\Program Files\\Git\\bin\\bash.exe");
+  });
+
+  it("accepts a terminal shell settings patch", () => {
+    expect(decodeServerSettingsPatch({ defaultTerminalShell: "pwsh.exe" })).toEqual({
+      defaultTerminalShell: "pwsh.exe",
+    });
+  });
+});
+
 describe("ServerSettingsPatch.providerInstances", () => {
   it("treats providerInstances as an optional whole-map replacement", () => {
     const patch = decodeServerSettingsPatch({});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -560,6 +560,7 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  defaultTerminalShell: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
       Effect.succeed({
@@ -714,6 +715,7 @@ export const ServerSettingsPatch = Schema.Struct({
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
+  defaultTerminalShell: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(
     Schema.Struct({

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -2,6 +2,8 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -362,6 +364,44 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
       }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
 
       expect(result._tag).toBe("Failure");
+    }),
+  );
+
+  it.effect("preserves Windows PATH precedence and invalidates stale cached hits", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectory({ prefix: "t3-shell-resolution-" });
+
+      return yield* Effect.gen(function* () {
+        const firstDir = path.join(tempDir, "first");
+        const secondDir = path.join(tempDir, "second");
+        yield* fileSystem.makeDirectory(firstDir);
+        yield* fileSystem.makeDirectory(secondDir);
+        const executable = path.join(secondDir, "provider-tool.CMD");
+        yield* fileSystem.writeFileString(executable, "@echo off\r\n");
+        const env = {
+          PATH: `${firstDir};${firstDir};${secondDir}`,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        };
+
+        expect(
+          yield* resolveCommandPath("provider-tool", { env }).pipe(
+            Effect.provideService(HostProcessPlatform, "win32"),
+          ),
+        ).toBe(executable);
+
+        yield* fileSystem.remove(executable);
+        const result = yield* resolveCommandPath("provider-tool", { env }).pipe(
+          Effect.provideService(HostProcessPlatform, "win32"),
+          Effect.result,
+        );
+        expect(result._tag).toBe("Failure");
+      }).pipe(
+        Effect.ensuring(
+          fileSystem.remove(tempDir, { recursive: true, force: true }).pipe(Effect.orDie),
+        ),
+      );
     }),
   );
 });

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -4,6 +4,7 @@ import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hos
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -391,6 +392,15 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
           ),
         ).toBe(executable);
 
+        const higherPriorityExecutable = path.join(firstDir, "provider-tool.CMD");
+        yield* fileSystem.writeFileString(higherPriorityExecutable, "@echo off\r\n");
+        expect(
+          yield* resolveCommandPath("provider-tool", { env }).pipe(
+            Effect.provideService(HostProcessPlatform, "win32"),
+          ),
+        ).toBe(higherPriorityExecutable);
+
+        yield* fileSystem.remove(higherPriorityExecutable);
         yield* fileSystem.remove(executable);
         const result = yield* resolveCommandPath("provider-tool", { env }).pipe(
           Effect.provideService(HostProcessPlatform, "win32"),
@@ -402,6 +412,62 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
           fileSystem.remove(tempDir, { recursive: true, force: true }).pipe(Effect.orDie),
         ),
       );
+    }),
+  );
+
+  it.effect("probes Windows command candidates when a PATH directory cannot be listed", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectory({ prefix: "t3-shell-acl-" });
+
+      return yield* Effect.gen(function* () {
+        const executable = path.join(tempDir, "provider-tool.CMD");
+        yield* fileSystem.writeFileString(executable, "@echo off\r\n");
+        const listingDenied = PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method: "readDirectory",
+          pathOrDescriptor: tempDir,
+        });
+        const listingDeniedFileSystem = FileSystem.FileSystem.of({
+          ...fileSystem,
+          readDirectory: (directory) =>
+            directory === tempDir
+              ? Effect.fail(listingDenied)
+              : fileSystem.readDirectory(directory),
+        });
+
+        expect(
+          yield* resolveCommandPath("provider-tool", {
+            env: { PATH: tempDir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+          }).pipe(
+            Effect.provideService(HostProcessPlatform, "win32"),
+            Effect.provideService(FileSystem.FileSystem, listingDeniedFileSystem),
+          ),
+        ).toBe(executable);
+      }).pipe(
+        Effect.ensuring(
+          fileSystem.remove(tempDir, { recursive: true, force: true }).pipe(Effect.orDie),
+        ),
+      );
+    }),
+  );
+
+  it.effect("continues through PATHEXT when an earlier candidate is not a file", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-shell-pathext-" });
+      yield* fileSystem.makeDirectory(path.join(tempDir, "provider-tool.COM"));
+      const executable = path.join(tempDir, "provider-tool.EXE");
+      yield* fileSystem.writeFileString(executable, "MZ");
+
+      expect(
+        yield* resolveCommandPath("provider-tool", {
+          env: { PATH: tempDir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+        }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
+      ).toBe(executable);
     }),
   );
 });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -473,22 +473,22 @@ function resolveCommandCandidates(
   const normalizedExtension = extension.toUpperCase();
 
   if (extension.length > 0 && windowsPathExtensions.includes(normalizedExtension)) {
-    const commandWithoutExtension = command.slice(0, -extension.length);
-    return Array.from(
-      new Set([
-        command,
-        `${commandWithoutExtension}${normalizedExtension}`,
-        `${commandWithoutExtension}${normalizedExtension.toLowerCase()}`,
-      ]),
-    );
+    return [command];
   }
 
-  const candidates: string[] = [];
-  for (const candidateExtension of windowsPathExtensions) {
-    candidates.push(`${command}${candidateExtension}`);
-    candidates.push(`${command}${candidateExtension.toLowerCase()}`);
-  }
-  return Array.from(new Set(candidates));
+  return windowsPathExtensions.map((candidateExtension) => `${command}${candidateExtension}`);
+}
+
+const WINDOWS_COMMAND_LOOKUP_BATCH_SIZE = 32;
+const WINDOWS_COMMAND_LOOKUP_CONCURRENCY = 16;
+const resolvedCommandPathCache = new Map<string, string>();
+
+function commandResolutionCacheKey(
+  command: string,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  return [platform, command, readEnvPath(env) ?? "", env.PATHEXT ?? ""].join("\u0000");
 }
 
 const isExecutableFile = Effect.fn("shell.isExecutableFile")(function* (
@@ -524,10 +524,19 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
     windowsPathExtensions,
     path.extname,
   );
+  const cacheKey = commandResolutionCacheKey(command, platform, env);
+  const cachedPath = resolvedCommandPathCache.get(cacheKey);
+  if (cachedPath !== undefined) {
+    if (yield* isExecutableFile(cachedPath, platform, windowsPathExtensions)) {
+      return cachedPath;
+    }
+    resolvedCommandPathCache.delete(cacheKey);
+  }
 
   if (command.includes("/") || command.includes("\\")) {
     for (const candidate of commandCandidates) {
       if (yield* isExecutableFile(candidate, platform, windowsPathExtensions)) {
+        resolvedCommandPathCache.set(cacheKey, candidate);
         return candidate;
       }
     }
@@ -539,19 +548,67 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
     return yield* new CommandResolutionError({ command, reason: "not-found" });
   }
   const pathEntries: string[] = [];
+  const seenPathEntries = new Set<string>();
   for (const entry of pathValue.split(pathDelimiterForPlatform(platform))) {
     const pathEntry = stripWrappingQuotes(entry.trim());
-    if (pathEntry.length > 0) {
-      pathEntries.push(pathEntry);
-    }
+    if (pathEntry.length === 0) continue;
+    const normalized = normalizePathEntryForComparison(pathEntry, platform);
+    if (seenPathEntries.has(normalized)) continue;
+    seenPathEntries.add(normalized);
+    pathEntries.push(pathEntry);
   }
 
-  for (const pathEntry of pathEntries) {
-    for (const candidate of commandCandidates) {
-      const candidatePath = path.join(pathEntry, candidate);
-      if (yield* isExecutableFile(candidatePath, platform, windowsPathExtensions)) {
-        return candidatePath;
+  if (platform === "win32") {
+    const fileSystem = yield* FileSystem.FileSystem;
+    for (let offset = 0; offset < pathEntries.length; offset += WINDOWS_COMMAND_LOOKUP_BATCH_SIZE) {
+      const batch = pathEntries.slice(offset, offset + WINDOWS_COMMAND_LOOKUP_BATCH_SIZE);
+      const matches = yield* Effect.forEach(
+        batch,
+        (pathEntry) =>
+          fileSystem.readDirectory(pathEntry).pipe(
+            Effect.orElseSucceed(() => []),
+            Effect.map((entries) => {
+              const names = new Map(entries.map((entry) => [entry.toUpperCase(), entry]));
+              const candidate = commandCandidates.find((name) => names.has(name.toUpperCase()));
+              return candidate === undefined
+                ? null
+                : path.join(pathEntry, names.get(candidate.toUpperCase()) ?? candidate);
+            }),
+          ),
+        { concurrency: WINDOWS_COMMAND_LOOKUP_CONCURRENCY },
+      );
+      for (const candidatePath of matches) {
+        if (
+          candidatePath !== null &&
+          (yield* isExecutableFile(candidatePath, platform, windowsPathExtensions))
+        ) {
+          resolvedCommandPathCache.set(cacheKey, candidatePath);
+          return candidatePath;
+        }
       }
+    }
+    return yield* new CommandResolutionError({ command, reason: "not-found" });
+  }
+
+  const candidatePaths = pathEntries.flatMap((pathEntry) =>
+    commandCandidates.map((candidate) => path.join(pathEntry, candidate)),
+  );
+  for (let offset = 0; offset < candidatePaths.length; offset += 1) {
+    const batch = candidatePaths.slice(offset, offset + 1);
+    const matches = yield* Effect.forEach(
+      batch,
+      (candidatePath) =>
+        isExecutableFile(candidatePath, platform, windowsPathExtensions).pipe(
+          Effect.map((isExecutable) => (isExecutable ? candidatePath : null)),
+        ),
+      { concurrency: 1 },
+    );
+    const resolved = matches.find(
+      (candidatePath): candidatePath is string => candidatePath !== null,
+    );
+    if (resolved !== undefined) {
+      resolvedCommandPathCache.set(cacheKey, resolved);
+      return resolved;
     }
   }
   return yield* new CommandResolutionError({ command, reason: "not-found" });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -515,6 +515,42 @@ const isExecutableFile = Effect.fn("shell.isExecutableFile")(function* (
   return canExecuteFile(filePath);
 });
 
+const resolveWindowsCommandInDirectory = Effect.fn("shell.resolveWindowsCommandInDirectory")(
+  function* (
+    pathEntry: string,
+    commandCandidates: ReadonlyArray<string>,
+    windowsPathExtensions: ReadonlyArray<string>,
+  ): Effect.fn.Return<string | null, never, FileSystem.FileSystem | Path.Path> {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const directoryEntries = yield* fileSystem.readDirectory(pathEntry).pipe(
+      Effect.map((entries) => ({ entries })),
+      Effect.orElseSucceed(() => null),
+    );
+
+    if (directoryEntries !== null) {
+      const names = new Map(directoryEntries.entries.map((entry) => [entry.toUpperCase(), entry]));
+      for (const candidate of commandCandidates) {
+        const entry = names.get(candidate.toUpperCase());
+        if (entry === undefined) continue;
+        const candidatePath = path.join(pathEntry, entry);
+        if (yield* isExecutableFile(candidatePath, "win32", windowsPathExtensions)) {
+          return candidatePath;
+        }
+      }
+      return null;
+    }
+
+    for (const candidate of commandCandidates) {
+      const candidatePath = path.join(pathEntry, candidate);
+      if (yield* isExecutableFile(candidatePath, "win32", windowsPathExtensions)) {
+        return candidatePath;
+      }
+    }
+    return null;
+  },
+);
+
 const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlatform")(function* (
   command: string,
   options: CommandAvailabilityOptions & { readonly platform: NodeJS.Platform },
@@ -532,11 +568,16 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
   );
   const cacheKey = commandResolutionCacheKey(command, platform, env);
   const cachedPath = resolvedCommandPathCache.get(cacheKey);
+  let validCachedPath: string | undefined;
   if (cachedPath !== undefined) {
     if (yield* isExecutableFile(cachedPath, platform, windowsPathExtensions)) {
-      return cachedPath;
+      validCachedPath = cachedPath;
+      if (command.includes("/") || command.includes("\\")) {
+        return cachedPath;
+      }
+    } else {
+      resolvedCommandPathCache.delete(cacheKey);
     }
-    resolvedCommandPathCache.delete(cacheKey);
   }
 
   if (command.includes("/") || command.includes("\\")) {
@@ -564,30 +605,34 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
     pathEntries.push(pathEntry);
   }
 
+  const cachedPathEntryIndex =
+    validCachedPath === undefined
+      ? -1
+      : pathEntries.findIndex((pathEntry) =>
+          commandCandidates.some(
+            (candidate) =>
+              normalizePathEntryForComparison(path.join(pathEntry, candidate), platform) ===
+              normalizePathEntryForComparison(validCachedPath, platform),
+          ),
+        );
+  const lookupPathEntries =
+    cachedPathEntryIndex < 0 ? pathEntries : pathEntries.slice(0, cachedPathEntryIndex + 1);
+
   if (platform === "win32") {
-    const fileSystem = yield* FileSystem.FileSystem;
-    for (let offset = 0; offset < pathEntries.length; offset += WINDOWS_COMMAND_LOOKUP_BATCH_SIZE) {
-      const batch = pathEntries.slice(offset, offset + WINDOWS_COMMAND_LOOKUP_BATCH_SIZE);
+    for (
+      let offset = 0;
+      offset < lookupPathEntries.length;
+      offset += WINDOWS_COMMAND_LOOKUP_BATCH_SIZE
+    ) {
+      const batch = lookupPathEntries.slice(offset, offset + WINDOWS_COMMAND_LOOKUP_BATCH_SIZE);
       const matches = yield* Effect.forEach(
         batch,
         (pathEntry) =>
-          fileSystem.readDirectory(pathEntry).pipe(
-            Effect.orElseSucceed(() => []),
-            Effect.map((entries) => {
-              const names = new Map(entries.map((entry) => [entry.toUpperCase(), entry]));
-              const candidate = commandCandidates.find((name) => names.has(name.toUpperCase()));
-              return candidate === undefined
-                ? null
-                : path.join(pathEntry, names.get(candidate.toUpperCase()) ?? candidate);
-            }),
-          ),
+          resolveWindowsCommandInDirectory(pathEntry, commandCandidates, windowsPathExtensions),
         { concurrency: WINDOWS_COMMAND_LOOKUP_CONCURRENCY },
       );
       for (const candidatePath of matches) {
-        if (
-          candidatePath !== null &&
-          (yield* isExecutableFile(candidatePath, platform, windowsPathExtensions))
-        ) {
+        if (candidatePath !== null) {
           resolvedCommandPathCache.set(cacheKey, candidatePath);
           return candidatePath;
         }
@@ -596,7 +641,7 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
     return yield* new CommandResolutionError({ command, reason: "not-found" });
   }
 
-  const candidatePaths = pathEntries.flatMap((pathEntry) =>
+  const candidatePaths = lookupPathEntries.flatMap((pathEntry) =>
     commandCandidates.map((candidate) => path.join(pathEntry, candidate)),
   );
   for (let offset = 0; offset < candidatePaths.length; offset += 1) {

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -339,6 +339,60 @@ export const WindowsShellEnvironment = Context.Reference<WindowsShellEnvironment
   },
 );
 
+export type AsyncWindowsShellEnvironmentReader = (
+  names: ReadonlyArray<string>,
+  options?: WindowsEnvironmentProbeOptions,
+) => Effect.Effect<Partial<Record<string, string>>>;
+
+function execFileOutput(
+  file: string,
+  args: ReadonlyArray<string>,
+  timeout: number,
+): Effect.Effect<string, Error> {
+  return Effect.callback<string, Error>((resume) => {
+    const child = NodeChildProcess.execFile(
+      file,
+      [...args],
+      { encoding: "utf8", timeout, windowsHide: true },
+      (error, stdout) => {
+        resume(error ? Effect.fail(error) : Effect.succeed(stdout));
+      },
+    );
+    return Effect.sync(() => child.kill());
+  });
+}
+
+export const readEnvironmentFromWindowsShellAsync: AsyncWindowsShellEnvironmentReader = Effect.fn(
+  "shell.readEnvironmentFromWindowsShellAsync",
+)(function* (names, options = {}) {
+  if (names.length === 0) return {};
+
+  const args = [
+    "-NoLogo",
+    ...(options.loadProfile ? ([] as const) : (["-NoProfile"] as const)),
+    "-NonInteractive",
+    "-Command",
+    buildWindowsEnvironmentCaptureCommand(names),
+  ];
+  for (const shell of WINDOWS_SHELL_CANDIDATES) {
+    const output = yield* execFileOutput(shell, args, 5000).pipe(Effect.option);
+    if (output._tag === "None") continue;
+
+    const environment: Partial<Record<string, string>> = {};
+    for (const name of names) {
+      const value = extractEnvironmentValue(output.value, name);
+      if (value !== undefined) environment[name] = value;
+    }
+    return environment;
+  }
+  return {};
+});
+
+export const AsyncWindowsShellEnvironment = Context.Reference<AsyncWindowsShellEnvironmentReader>(
+  "@t3tools/shared/shell/AsyncWindowsShellEnvironment",
+  { defaultValue: () => readEnvironmentFromWindowsShellAsync },
+);
+
 export const CommandAvailability = Context.Reference<CommandAvailabilityChecker>(
   "@t3tools/shared/shell/CommandAvailability",
   {
@@ -753,6 +807,29 @@ function mergeWindowsEnv(
   }
   return nextEnv;
 }
+
+export function resolveWindowsBaselineEnvironment(
+  env: NodeJS.ProcessEnv,
+): Partial<NodeJS.ProcessEnv> {
+  const knownCliPath = resolveKnownWindowsCliDirs(env).join(WINDOWS_PATH_DELIMITER);
+  const path = mergePathValues(knownCliPath, readEnvPath(env), "win32");
+  return path ? { PATH: path } : {};
+}
+
+export const resolveWindowsProfileEnvironment = Effect.fn("shell.resolveWindowsProfileEnvironment")(
+  function* (env: NodeJS.ProcessEnv) {
+    const readEnvironment = yield* AsyncWindowsShellEnvironment;
+    const profile = yield* readEnvironment(["PATH", "FNM_DIR", "FNM_MULTISHELL_PATH"], {
+      loadProfile: true,
+    });
+    const path = mergePathValues(profile.PATH, readEnvPath(env), "win32");
+    return {
+      ...(path ? { PATH: path } : {}),
+      ...(profile.FNM_DIR ? { FNM_DIR: profile.FNM_DIR } : {}),
+      ...(profile.FNM_MULTISHELL_PATH ? { FNM_MULTISHELL_PATH: profile.FNM_MULTISHELL_PATH } : {}),
+    } satisfies Partial<NodeJS.ProcessEnv>;
+  },
+);
 
 export const resolveWindowsEnvironment = Effect.fn("shell.resolveWindowsEnvironment")(function* (
   env: NodeJS.ProcessEnv,

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -481,7 +481,12 @@ function resolveCommandCandidates(
 
 const WINDOWS_COMMAND_LOOKUP_BATCH_SIZE = 32;
 const WINDOWS_COMMAND_LOOKUP_CONCURRENCY = 16;
-const resolvedCommandPathCache = new Map<string, string>();
+export const ResolvedCommandPathCache = Context.Reference<Map<string, string>>(
+  "@t3tools/shared/shell/ResolvedCommandPathCache",
+  {
+    defaultValue: () => new Map(),
+  },
+);
 
 function commandResolutionCacheKey(
   command: string,
@@ -515,6 +520,7 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
   options: CommandAvailabilityOptions & { readonly platform: NodeJS.Platform },
 ): Effect.fn.Return<string, CommandResolutionError, FileSystem.FileSystem | Path.Path> {
   const path = yield* Path.Path;
+  const resolvedCommandPathCache = yield* ResolvedCommandPathCache;
   const platform = options.platform;
   const env = options.env ?? process.env;
   const windowsPathExtensions = platform === "win32" ? resolveWindowsPathExtensions(env) : [];

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -228,22 +228,24 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         libc: ["glibc"],
       },
     });
-    // Windows artifacts also bundle the same-architecture WSL (Linux, glibc) backend, so the
-    // staged install must fetch its native optional deps (e.g. ffi-rs) too.
+    // A Windows artifact without a supplied WSL runtime only installs Windows optional deps.
     assert.deepStrictEqual(createStageWorkspaceConfig({ platform: "win", arch: "x64" }), {
       supportedArchitectures: {
-        os: ["win32", "linux"],
+        os: ["win32"],
         cpu: ["x64"],
-        libc: ["glibc"],
       },
     });
-    assert.deepStrictEqual(createStageWorkspaceConfig({ platform: "win", arch: "arm64" }), {
-      supportedArchitectures: {
-        os: ["win32", "linux"],
-        cpu: ["arm64"],
-        libc: ["glibc"],
+    // Supplying the WSL runtime opts into Linux/glibc native dependencies too.
+    assert.deepStrictEqual(
+      createStageWorkspaceConfig({ platform: "win", arch: "x64", includeWslRuntime: true }),
+      {
+        supportedArchitectures: {
+          os: ["win32", "linux"],
+          cpu: ["x64"],
+          libc: ["glibc"],
+        },
       },
-    });
+    );
     assert.deepStrictEqual(createStageWorkspaceConfig({ platform: "mac", arch: "universal" }), {
       supportedArchitectures: {
         os: ["darwin"],
@@ -348,7 +350,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
 
       assert.notProperty(mac, "asarUnpack");
       assert.notProperty(linux, "asarUnpack");
-      assert.deepStrictEqual(win.asarUnpack, WINDOWS_ASAR_UNPACK);
+      assert.notProperty(win, "asarUnpack");
       // Linux must register the renderer schemes so the generated .desktop
       // entry advertises MimeType=x-scheme-handler/t3code; for OAuth deep links.
       assert.deepStrictEqual((linux.linux as Record<string, unknown>).protocols, [
@@ -549,6 +551,19 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       assert.equal(win.icon, "icon.ico");
       assert.equal(win.signAndEditExecutable, true);
       assert.notProperty(win, "azureSignOptions");
+      assert.notProperty(config, "asarUnpack");
+
+      const wslConfig = yield* createBuildConfig(
+        "win",
+        "nsis",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+        true,
+      );
+      assert.deepStrictEqual(wslConfig.asarUnpack, WINDOWS_ASAR_UNPACK);
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
   );
 

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -2,6 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Sink from "effect/Sink";
@@ -10,6 +11,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   BuildCommandFailedError,
+  createStageDependencies,
   createStageWorkspaceConfig,
   createStagePatchedDependencies,
   createBuildConfig,
@@ -46,6 +48,24 @@ import {
 } from "./build-desktop-artifact.ts";
 import { BRAND_ASSET_PATHS } from "./lib/brand-assets.ts";
 import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+function nsisMacroBody(installerInclude: string, name: string): string {
+  const lines = installerInclude.split(/\r?\n/u);
+  const start = lines.findIndex((line) => line.startsWith(`!macro ${name}`));
+  assert.isAtLeast(start, 0, `Missing NSIS macro ${name}`);
+  const endOffset = lines.slice(start + 1).findIndex((line) => line.trim() === "!macroend");
+  assert.isAtLeast(endOffset, 0, `Unterminated NSIS macro ${name}`);
+  return lines.slice(start + 1, start + 1 + endOffset).join("\n");
+}
+
+function assertInOrder(source: string, fragments: readonly string[]): void {
+  let cursor = 0;
+  for (const fragment of fragments) {
+    const index = source.indexOf(fragment, cursor);
+    assert.isAtLeast(index, cursor, `Expected ${JSON.stringify(fragment)} after offset ${cursor}`);
+    cursor = index + fragment.length;
+  }
+}
 
 function mockProcess(exitCode: number) {
   return ChildProcessSpawner.makeHandle({
@@ -251,6 +271,32 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         os: ["darwin"],
         cpu: ["arm64", "x64"],
       },
+    });
+  });
+
+  it("only stages Linux native dependencies when a Windows artifact includes WSL", () => {
+    const base = {
+      platform: "win" as const,
+      arch: "x64" as const,
+      serverDependencies: { effect: "4.0.0" },
+      desktopRuntimeDependencies: { electron: "41.5.0" },
+      fffVersion: "0.9.4",
+    };
+
+    const withoutWsl = createStageDependencies({ ...base, includeWslRuntime: false });
+    assert.deepStrictEqual(withoutWsl, {
+      effect: "4.0.0",
+      electron: "41.5.0",
+      "@ff-labs/fff-bin-win32-x64": "0.9.4",
+    });
+
+    const withWsl = createStageDependencies({ ...base, includeWslRuntime: true });
+    assert.deepStrictEqual(withWsl, {
+      effect: "4.0.0",
+      electron: "41.5.0",
+      "@ff-labs/fff-bin-win32-x64": "0.9.4",
+      "@ff-labs/fff-bin-linux-x64-gnu": "0.9.4",
+      "@ff-labs/fff-bin-linux-x64-musl": "0.9.4",
     });
   });
 
@@ -567,6 +613,45 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       );
       assert.deepStrictEqual(wslConfig.asarUnpack, WINDOWS_ASAR_UNPACK);
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
+  );
+
+  it.effect("wires installer hooks to truthful uninstall and install phases", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const installerInclude = yield* fs.readFileString("apps/desktop/resources/installer.nsh");
+      const phaseText = nsisMacroBody(installerInclude, "setInstallerPhaseText");
+      assert.include(phaseText, "!ifndef BUILD_UNINSTALLER");
+      assert.include(phaseText, "${IfNot} ${Silent}");
+      assert.include(phaseText, "${WM_SETTEXT}");
+
+      assertInOrder(nsisMacroBody(installerInclude, "customCheckAppRunning"), [
+        "!insertmacro IS_POWERSHELL_AVAILABLE",
+        "!insertmacro _CHECK_APP_RUNNING",
+        '!insertmacro setInstallerPhaseText "Removing the previous version..."',
+      ]);
+
+      assertInOrder(nsisMacroBody(installerInclude, "handleOldUninstallerResult"), [
+        "IfErrors",
+        "${If} $R0 != 0",
+        "SetErrorLevel 2",
+        "Quit",
+        '!insertmacro setInstallerPhaseText "${NEXT_TEXT}"',
+      ]);
+
+      const allUsersCheck = nsisMacroBody(installerInclude, "customUnInstallCheck");
+      assert.include(
+        allUsersCheck,
+        '!insertmacro handleOldUninstallerResult "Removing the previous version..."',
+      );
+      assert.include(
+        allUsersCheck,
+        '!insertmacro handleOldUninstallerResult "Installing the new version..."',
+      );
+      assert.include(
+        nsisMacroBody(installerInclude, "customUnInstallCheckCurrentUser"),
+        '!insertmacro handleOldUninstallerResult "Installing the new version..."',
+      );
+    }),
   );
 
   it("stages the resource monitor as an external executable resource", () => {

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -548,9 +548,11 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       );
 
       const win = config.win as Record<string, unknown>;
+      const nsis = config.nsis as Record<string, unknown>;
       assert.equal(win.icon, "icon.ico");
       assert.equal(win.signAndEditExecutable, true);
       assert.notProperty(win, "azureSignOptions");
+      assert.equal(nsis.include, "apps/desktop/resources/installer.nsh");
       assert.notProperty(config, "asarUnpack");
 
       const wslConfig = yield* createBuildConfig(

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -890,6 +890,24 @@ export function resolveFffNativeDependencies(
   );
 }
 
+export function createStageDependencies(input: {
+  readonly platform: typeof BuildPlatform.Type;
+  readonly arch: typeof BuildArch.Type;
+  readonly includeWslRuntime: boolean;
+  readonly serverDependencies: Record<string, string>;
+  readonly desktopRuntimeDependencies: Record<string, string>;
+  readonly fffVersion: string;
+}): Record<string, string> {
+  return {
+    ...input.serverDependencies,
+    ...input.desktopRuntimeDependencies,
+    ...resolveFffNativeDependencies(input.platform, input.arch, input.fffVersion),
+    ...(input.platform === "win" && input.includeWslRuntime
+      ? resolveFffNativeDependencies("linux", input.arch, input.fffVersion)
+      : {}),
+  };
+}
+
 export interface ClerkPasskeyNativeArtifact {
   readonly packageName: string;
   readonly binaryFileName: string;
@@ -1558,9 +1576,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     // prebuild the WSL backend cannot start, so avoid expanding the full server
     // and node_modules payload onto disk. Smart unpack still extracts native
     // libraries required by the primary Windows backend.
-    ...(platform === "win" && includeWslRuntime
-      ? { asarUnpack: [...WINDOWS_ASAR_UNPACK] }
-      : {}),
+    ...(platform === "win" && includeWslRuntime ? { asarUnpack: [...WINDOWS_ASAR_UNPACK] } : {}),
     extraResources: DESKTOP_EXTRA_RESOURCES,
   };
   const updateChannel = resolveDesktopUpdateChannel(version);
@@ -1903,26 +1919,15 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     yield* fs.writeFileString(macEntitlementsPath, renderMacPasskeyEntitlements(macPasskeySigning));
   }
 
-  const stageDependencies = {
-    ...resolvedServerDependencies,
-    ...resolvedDesktopRuntimeDependencies,
-    ...resolveFffNativeDependencies(
-      options.platform,
-      options.arch,
-      serverPackageJson.dependencies["@ff-labs/fff-node"],
-    ),
-    // Windows artifacts also bundle the same-architecture WSL Linux backend, which loads the
-    // fff native binary through ffi-rs. The platform fff binary above is the
-    // host's (win32), so promote the matching Linux fff binaries too; without
-    // them file-finding in WSL fails to load its Linux native package.
-    ...(options.platform === "win"
-      ? resolveFffNativeDependencies(
-          "linux",
-          options.arch,
-          serverPackageJson.dependencies["@ff-labs/fff-node"],
-        )
-      : {}),
-  };
+  const includeWslRuntime = options.platform === "win" && options.wslPrebuild !== undefined;
+  const stageDependencies = createStageDependencies({
+    platform: options.platform,
+    arch: options.arch,
+    includeWslRuntime,
+    serverDependencies: resolvedServerDependencies,
+    desktopRuntimeDependencies: resolvedDesktopRuntimeDependencies,
+    fffVersion: serverPackageJson.dependencies["@ff-labs/fff-node"],
+  });
   const stagePatchedDependencies = createStagePatchedDependencies(
     workspacePatchedDependencies,
     stageDependencies,
@@ -1950,7 +1955,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
             provisioningProfilePath: macPasskeySigning.provisioningProfilePath,
           }
         : undefined,
-      options.platform === "win" && options.wslPrebuild !== undefined,
+      includeWslRuntime,
     ),
     dependencies: stageDependencies,
     devDependencies: {
@@ -1963,7 +1968,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const stageWorkspaceConfig = createStageWorkspaceConfig({
     platform: options.platform,
     arch: options.arch,
-    includeWslRuntime: options.platform === "win" && options.wslPrebuild !== undefined,
+    includeWslRuntime,
     allowBuilds: workspaceAllowBuilds,
     patchedDependencies: stagePatchedDependencies,
     overrides: resolvedOverrides,

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1621,6 +1621,9 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
 
   if (platform === "win") {
     buildConfig.npmRebuild = false;
+    buildConfig.nsis = {
+      include: "apps/desktop/resources/installer.nsh",
+    };
     const winConfig: Record<string, unknown> = {
       target: [target],
       icon: "icon.ico",

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -954,11 +954,19 @@ const stageClerkPasskeyNativeBinaries = Effect.fn("stageClerkPasskeyNativeBinari
 export function createStageWorkspaceConfig(input: {
   readonly platform: typeof BuildPlatform.Type;
   readonly arch: typeof BuildArch.Type;
+  readonly includeWslRuntime?: boolean;
   readonly allowBuilds?: Record<string, boolean>;
   readonly patchedDependencies?: Record<string, string>;
   readonly overrides?: Record<string, string>;
 }): StageWorkspaceConfig {
-  const { platform, arch, allowBuilds, patchedDependencies, overrides } = input;
+  const {
+    platform,
+    arch,
+    includeWslRuntime = false,
+    allowBuilds,
+    patchedDependencies,
+    overrides,
+  } = input;
   const hostOs = platform === "mac" ? "darwin" : platform === "win" ? "win32" : "linux";
   const hostCpu = arch === "universal" ? ["arm64", "x64"] : [arch];
   // Linux AppImages and Windows WSL backends both execute a Linux/glibc Node
@@ -972,7 +980,7 @@ export function createStageWorkspaceConfig(input: {
           cpu: hostCpu,
           libc: ["glibc"],
         }
-      : platform === "win"
+      : platform === "win" && includeWslRuntime
         ? {
             os: Array.from(new Set([hostOs, "linux"])),
             cpu: hostCpu,
@@ -1534,6 +1542,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
         readonly provisioningProfilePath: string;
       }
     | undefined,
+  includeWslRuntime = false,
 ) {
   const buildConfig: Record<string, unknown> = {
     appId: DESKTOP_APP_ID,
@@ -1544,10 +1553,14 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     directories: {
       buildResources: "apps/desktop/resources",
     },
-    // Only the Windows WSL backend needs files outside the asar (see
-    // WINDOWS_ASAR_UNPACK); macOS and Linux stay packed — smart unpack
-    // extracts native libraries, which fff-node finds in app.asar.unpacked.
-    ...(platform === "win" ? { asarUnpack: [...WINDOWS_ASAR_UNPACK] } : {}),
+    // Only a Windows build carrying the WSL backend needs files outside the
+    // asar (see WINDOWS_ASAR_UNPACK). Without a supplied Linux node-pty
+    // prebuild the WSL backend cannot start, so avoid expanding the full server
+    // and node_modules payload onto disk. Smart unpack still extracts native
+    // libraries required by the primary Windows backend.
+    ...(platform === "win" && includeWslRuntime
+      ? { asarUnpack: [...WINDOWS_ASAR_UNPACK] }
+      : {}),
     extraResources: DESKTOP_EXTRA_RESOURCES,
   };
   const updateChannel = resolveDesktopUpdateChannel(version);
@@ -1934,6 +1947,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
             provisioningProfilePath: macPasskeySigning.provisioningProfilePath,
           }
         : undefined,
+      options.platform === "win" && options.wslPrebuild !== undefined,
     ),
     dependencies: stageDependencies,
     devDependencies: {
@@ -1946,6 +1960,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const stageWorkspaceConfig = createStageWorkspaceConfig({
     platform: options.platform,
     arch: options.arch,
+    includeWslRuntime: options.platform === "win" && options.wslPrebuild !== undefined,
     allowBuilds: workspaceAllowBuilds,
     patchedDependencies: stagePatchedDependencies,
     overrides: resolvedOverrides,


### PR DESCRIPTION
## Problem

On Windows, the installed desktop app could spend nearly a minute with no window while synchronous command discovery and provider initialization blocked backend readiness. Upgrade installation was similarly opaque and slow because oversized packages contained thousands of unpacked files that the previous uninstaller and antivirus scanned individually.

Windows users also could not choose the executable used for new T3 terminal sessions.

## How this fixes it

- Resolves Windows shell commands with a cached, bounded native lookup instead of thousands of sequential filesystem probes.
- Preserves PATH/PATHEXT precedence, handles directories that permit direct probing but deny listing, and invalidates stale cached hits safely.
- Installs a cheap Windows PATH baseline synchronously, then hydrates PowerShell profile PATH/FNM state asynchronously without delaying backend readiness.
- Refreshes live provider environment objects and environment-sensitive caches after hydration without rebuilding adapters or interrupting active turns.
- Serializes provider reconciliation and makes cancellation cleanup transactional so scopes cannot leak or remain publicly visible after closure.
- Defers provider maintenance path discovery, shares concurrent work, retries interrupted discovery, and invalidates successful results only when environment hydration requires it.
- Omits the optional Linux/WSL runtime and Linux-only staged dependencies from Windows packages unless a Linux node-pty prebuild is supplied.
- Shows explicit removing, installing, and finishing phases in the Windows installer.
- Adds an environment-owned default terminal executable setting for new T3 terminal sessions, including remote clients. This does not change shells chosen internally by provider CLIs.

## Windows performance results

The original comparison used installed production builds on the same Windows host. Startup was measured from process spawn to the first completed HTTP 200 and to the first visible Electron window.

| Build | Backend ready | Window |
|---|---:|---:|
| Previous Nightly | 46.0 s | 46.6 s to window creation |
| New release, cold | 4.352 s | 5.866 s visible |
| New release, warm 1 | 4.492 s | 5.994 s visible |
| New release, warm 2 | 4.234 s | 5.724 s visible |
| New release median | **4.352 s** | **5.866 s** visible |

Performance test head (`e4a322213`) was rebuilt as a production Windows package and rerun from its staged executable with isolated `APPDATA`, isolated `T3CODE_HOME`, and a dedicated port. The staged package was used to avoid overwriting the developer's installed app.

| Latest-head rerun | Backend ready | Window visible |
|---|---:|---:|
| Run 1 | 4.160 s | 5.600 s |
| Run 2 | 11.290 s | 18.250 s |
| Run 3 | 4.282 s | 5.814 s |
| Median | **4.282 s** | **5.814 s** |

The latest-head median is 1.6% faster to HTTP readiness and 0.9% faster to a visible window than the original new-release median. Run 2 is retained as a host-level outlier rather than discarded; temporary unpacked builds showed intermittent Windows scanning/contention, while the other two runs and the median remained in the original range. Individual Windows command-resolution spans remained bounded rather than reproducing the previous synchronous startup stall.

All measurements require HTTP 200 rather than treating an open TCP socket as ready. Each run was fully stopped before the next launch and used isolated state rather than the live user database.

## Packaging and installation results

| Metric | Before | After | Change |
|---|---:|---:|---:|
| NSIS installer | 324.19 MB | 134.55 MB | **58.5% smaller** |
| Unpacked runtime payload | 890 MB | 29.07 MB | **96.7% smaller** |
| Unpacked files | 3,532 | 200 | **94.3% fewer** |
| Observed upgrade | ~100 s removing the previous build alone | ~21 s complete upgrade | substantially faster |

Upgrade timings are observational rather than a controlled benchmark: the old measurement removed the original 2,494-file Nightly, while the final measurement replaced an already-compacted build.

## User-visible behavior

- General Settings exposes the default terminal executable, searchable and resettable.
- The setting belongs to the connected environment, so web, desktop, and mobile-created terminals use the same value. Mobile does not currently expose the editing control.
- Windows installer banners show removal, installation, and completion phases.
- User documentation describes scope, quoting, fallback behavior, and remote environments.

## Verification

- Rebased onto upstream `main` at `2a04db134c2d88f06e5b8d61a8410cb51ea07430`.
- **211 focused tests passed across 12 files** under Node 24.13.1; the final Claude environment fix then passed 90/90 core tests plus its portable text-generation regression.
- Post-review provider registry regressions passed **10/10 focused tests across 2 files**, including secret-materialization failure and interrupted reconciliation coverage.
- Affected server, web, desktop, contracts, shared, and scripts typechecks passed.
- Targeted lint, formatting, and `git diff --check` passed.
- The custom NSIS include compiled with warnings-as-errors using Electron Builder's pinned NSIS 3.12; the latest head also completed a fresh production Windows package build and startup rerun.
- Focused coverage includes command cache/PATH/PATHEXT behavior, inaccessible directory fallback, runtime PATH shell resolution, settings subscription ordering, asynchronous environment hydration, provider environment override precedence, maintenance cancellation/invalidation, concurrent and interrupted provider reconciliation, settings UI/search/reset behavior, WSL package inclusion/omission, and installer phase/error ordering.

## Checklist

- [x] This PR is focused on the Windows experience
- [x] I explained what changed and why
- [x] The branch is rebased onto current upstream main
- [x] Focused tests and affected typechecks pass
- [ ] I included before/after screenshots for UI changes
- [ ] I included a short video for timing/interaction changes

Model: GPT-5 / GPT-5.4  
Harness: OpenAI Codex desktop app with dev-loop specialist review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Windows PATH timing at startup, provider registry reconciliation, and live environment refresh for all drivers; incorrect hydration or refresh ordering could leave tools undiscovered until profile load completes or briefly stale maintenance metadata.
> 
> **Overview**
> This PR targets **Windows startup and upgrades** by stopping synchronous PowerShell profile work from blocking server readiness, tightening command/PATH resolution, and refreshing provider state in place after the profile finishes loading.
> 
> **Startup and environment:** The server applies a **baseline Windows PATH** immediately and **forks PowerShell profile hydration** (`PATH`, FNM vars) in the background. The desktop app no longer spawns PowerShell to build `PATH` at launch. Shared **`resolveCommandPath`** gains caching, PATH/PATHEXT precedence, concurrent probing, and safer invalidation when directories are unreadable.
> 
> **Providers:** Instance env is built from **`makeProviderInstanceEnvironmentSource`** with **`refreshEnvironment`** so host PATH changes merge without recreating adapters. Maintenance capabilities are **lazy/cached** and refresh after hydration. After Windows profile hydration completes, the registry **refreshes snapshots in place** (no reconcile/replace). Reconcile is **serialized and interrupt-safe** with staged entries during rebuilds. Settings watcher **re-reads settings** and can **restore redacted secrets** when secret-store reads fail.
> 
> **Terminals and settings:** New **`defaultTerminalShell`** setting (General settings, contracts, docs) drives spawn behavior; Windows resolves configured names through PATH, treats the value as an executable only (no embedded args), and subscribes to live settings updates.
> 
> **Installer / docs:** NSIS hooks show explicit **“Removing the previous version…”** / install phase text. README links **terminal shell** user docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b990f526e9bb5121e67a4c7c74b526a09955fc93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve Windows environment hydration, command-path resolution, and terminal shell configuration
> - On Windows, server startup now applies a baseline PATH immediately and hydrates PowerShell profile environment variables (PATH, FNM) asynchronously in the background via `hostEnvironmentHydrationLayer` in [os-jank.ts](https://github.com/pingdotgg/t3code/pull/5122/files#diff-01387cb8f0521a1e152ae377c15805f328384e404ccf93da7a82c02d30cf694c), unblocking startup.
> - Adds a `defaultTerminalShell` setting to `ServerSettings` and the General settings panel; on Windows the configured shell name is resolved against PATH/PATHEXT before spawning.
> - Windows command-path resolution in [shell.ts](https://github.com/pingdotgg/t3code/pull/5122/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) now uses a per-process cache keyed on platform/command/PATH/PATHEXT, probes PATH directories concurrently (batched 32, concurrency 16), and handles directory-listing failures and case-insensitive semantics.
> - Provider drivers (Claude, Codex, Cursor, Grok, OpenCode) gain a `refreshEnvironment` effect that re-syncs inherited host env values and invalidates maintenance capability caches without replacing the instance.
> - `ProviderInstanceRegistry.reconcile` is now serialized, interruption-safe, and supports a `{ force: true }` option; previous snapshots remain visible during rebuild.
> - Windows Desktop builds without a WSL runtime no longer unpack the full asar payload; NSIS installer now displays phase text ('Removing the previous version…' / 'Installing the new version…') during one-click install.
> - Risk: FNM_DIR and FNM_MULTISHELL_PATH are no longer populated by `installWindowsEnvironment` on Desktop; PATH enrichment from the PowerShell profile happens asynchronously and may arrive after the first terminal is opened.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b990f52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->