### PR TITLE
fix(server): prevent MCP traffic from extending credentials

### DIFF
--- a/apps/server/src/mcp/McpSessionRegistry.test.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.test.ts
@@ -88,6 +88,25 @@ it.effect("expires credentials once their session stops showing signs of life", 
   }),
 );
 
+it.effect("does not let MCP traffic keep an abandoned credential alive", () =>
+  Effect.gen(function* () {
+    let timestamp = 1_000;
+    const registry = yield* makeRegistry(() => timestamp);
+    const issued = yield* registry.issue({
+      threadId: ThreadId.make("thread-abandoned"),
+      providerInstanceId: ProviderInstanceId.make("claude"),
+    });
+    const token = issued.config.authorizationHeader.replace(/^Bearer\s+/, "");
+
+    timestamp += 99;
+    expect(yield* registry.resolve(token)).toBeDefined();
+    timestamp += 1;
+    expect(yield* registry.resolve(token)).toBeDefined();
+    timestamp += 1;
+    expect(yield* registry.resolve(token)).toBeUndefined();
+  }),
+);
+
 it.effect("keeps a credential alive across turns that never touch an MCP tool", () =>
   Effect.gen(function* () {
     let timestamp = 1_000;

--- a/apps/server/src/mcp/McpSessionRegistry.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.ts
@@ -44,7 +44,7 @@ export class McpSessionRegistry extends Context.Service<
 interface CredentialRecord {
   readonly tokenHash: string;
   readonly scope: McpInvocationContext.McpInvocationScope;
-  readonly lastAliveAt: number;
+  readonly lastProviderAliveAt: number;
 }
 
 interface RegistryState {
@@ -60,11 +60,12 @@ export interface McpSessionRegistryOptions {
  * How long a credential outlives the last sign of life from its provider
  * session.
  *
- * Liveness is refreshed both by MCP traffic and by `touch` on every provider
- * turn, so a session that is still doing work never expires no matter how long
- * it goes between browser tool calls. This window therefore only bounds
- * credentials whose session died without a clean stop — the normal paths
- * (`stopSession`, `stopAll`) revoke eagerly and do not wait for it.
+ * Liveness is refreshed by `touch` on every provider turn, so a session that is
+ * still receiving work never expires just because it goes a long time between
+ * browser tool calls. MCP traffic does not refresh this timestamp: a bearer
+ * credential cannot prove that its provider session is still alive. This window
+ * therefore bounds credentials whose session died without a clean stop — the
+ * normal paths (`stopSession`, `stopAll`) revoke eagerly and do not wait for it.
  *
  * The bound matters because `/mcp` is mounted outside the environment auth
  * stack and is reachable on whatever host the server binds to, so this token is
@@ -111,7 +112,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
   const pruneDead = (records: ReadonlyMap<string, CredentialRecord>, timestamp: number) => {
     const next = new Map(
       Array.from(records).filter(
-        ([, record]) => timestamp - record.lastAliveAt <= livenessWindowMs,
+        ([, record]) => timestamp - record.lastProviderAliveAt <= livenessWindowMs,
       ),
     );
     return next.size === records.size ? records : next;
@@ -133,7 +134,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
       };
       yield* SynchronizedRef.update(state, ({ records }) => {
         const next = new Map(pruneDead(records, issuedAt));
-        next.set(tokenHash, { tokenHash, scope, lastAliveAt: issuedAt });
+        next.set(tokenHash, { tokenHash, scope, lastProviderAliveAt: issuedAt });
         return { records: next };
       });
       return {
@@ -158,9 +159,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
         const current = pruneDead(records, timestamp);
         const record = current.get(tokenHash);
         if (!record) return [undefined, { records: current }] as const;
-        const next = new Map(current);
-        next.set(tokenHash, { ...record, lastAliveAt: timestamp });
-        return [record.scope, { records: next }] as const;
+        return [record.scope, { records: current }] as const;
       });
     },
   );
@@ -173,7 +172,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
         const next = new Map(current);
         for (const [tokenHash, record] of current) {
           if (record.scope.threadId === threadId) {
-            next.set(tokenHash, { ...record, lastAliveAt: timestamp });
+            next.set(tokenHash, { ...record, lastProviderAliveAt: timestamp });
           }
         }
         return { records: next };


### PR DESCRIPTION
## Problem

MCP credential liveness was refreshed by every successful bearer-authenticated request. Request activity could therefore keep a credential alive after its provider session stopped reporting liveness, defeating the 24-hour abandonment window.

## Fix

- Track the last trusted provider activity separately as `lastProviderAliveAt`.
- Refresh credential liveness only when the credential is issued or a provider turn calls `touch()`.
- Keep `resolve()` responsible for pruning and authentication without allowing bearer traffic to renew the credential.
- Add regression coverage for the exact expiry boundary while preserving long-lived sessions that continue receiving provider turns.

Abandoned credentials now expire relative to the last trusted provider signal. Active provider sessions still remain valid across multiple liveness windows.

## Verification

- `./node_modules/.bin/vp test run apps/server/src/mcp/McpSessionRegistry.test.ts apps/server/src/mcp/McpHttpServer.test.ts` — 10 tests passed
- `./node_modules/.bin/vp lint --type-aware --type-check --deny-warnings apps/server/src/mcp/McpSessionRegistry.ts apps/server/src/mcp/McpSessionRegistry.test.ts`
- `./node_modules/.bin/vp fmt --check apps/server/src/mcp/McpSessionRegistry.ts apps/server/src/mcp/McpSessionRegistry.test.ts`
- `git diff --check`

Model: OpenAI Codex (GPT-5.6); harness: Codex desktop.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop `McpSessionRegistry.resolve` from refreshing credential liveness
> Previously, resolving a bearer token updated `lastAliveAt`, meaning ongoing MCP traffic could keep abandoned credentials alive indefinitely. Now only provider turns (via `touch`) refresh the liveness timestamp, renamed to `lastProviderAliveAt` for clarity. Behavioral Change: credentials now expire based on the last provider turn, not the last MCP request, so long-running MCP sessions with no provider activity will have their credentials pruned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd5586d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication liveness for `/mcp` bearer tokens guarding the preview toolkit on remotely reachable servers; the fix tightens abandonment behavior but alters how long valid-looking tokens remain usable without provider activity.
> 
> **Overview**
> **MCP bearer credentials no longer stay alive from `/mcp` traffic alone.** Liveness is tracked as `lastProviderAliveAt` and is updated only on **issue** and provider **`touch`** (per turn), not when `resolve` authenticates a request.
> 
> `resolve` still prunes expired records and returns the scope, but repeated bearer use cannot push out the abandonment window. That closes the gap where a dead provider session could keep preview toolkit access if something kept calling MCP with a stolen or leftover token.
> 
> A regression test confirms that resolving near the window boundary does not extend life past the last provider signal, while existing coverage still expects long sessions to survive when `touch` runs on each turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5586d891304482b8a7a299c3e09f49f11036d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->