### PR TITLE
fix(server): preview external files

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -72,7 +72,7 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
-  it.effect("rejects workspace files outside the authorized root", () =>
+  it.effect("rejects relative workspace paths outside the authorized root", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -80,16 +80,18 @@ describe("AssetAccess", () => {
         prefix: "t3-asset-root-",
       });
       const outside = yield* fileSystem.makeTempDirectoryScoped({
+        directory: process.cwd(),
         prefix: "t3-asset-outside-",
       });
       const htmlPath = path.join(outside, "report.html");
       yield* fileSystem.writeFileString(htmlPath, "<p>outside</p>");
+      const relativePath = path.relative(root, htmlPath);
 
       const error = yield* issueAssetUrl({
         resource: {
           _tag: "workspace-file",
           threadId: ThreadId.make("thread-1"),
-          path: htmlPath,
+          path: relativePath,
         },
         workspaceRoot: root,
       }).pipe(Effect.flip);
@@ -99,10 +101,47 @@ describe("AssetAccess", () => {
         resource: {
           _tag: "workspace-file",
           threadId: "thread-1",
-          path: htmlPath,
+          path: relativePath,
         },
       });
       expect(error.cause).toBeInstanceOf(WorkspacePaths.WorkspacePathOutsideRootError);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("issues exact URLs for absolute files outside the workspace", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-root-",
+      });
+      const delivery = yield* fileSystem.makeTempDirectoryScoped({
+        directory: process.cwd(),
+        prefix: "t3-asset-delivery-",
+      });
+      const htmlPath = path.join(delivery, "report.html");
+      const siblingPath = path.join(delivery, "other.html");
+      yield* fileSystem.writeFileString(htmlPath, "<p>report</p>");
+      yield* fileSystem.writeFileString(siblingPath, "<p>other</p>");
+      const canonicalHtmlPath = yield* fileSystem.realPath(htmlPath);
+
+      const result = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: htmlPath,
+        },
+        workspaceRoot: root,
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      expect(yield* resolveAsset(token, "report.html")).toEqual({
+        kind: "file",
+        path: canonicalHtmlPath,
+      });
+      expect(yield* resolveAsset(token, "other.html")).toBeNull();
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -97,6 +97,16 @@ const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
 export type ResolvedAsset = { readonly kind: "file"; readonly path: string };
 
+function isWithinRoot(path: Path.Path, root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
     return Option.getOrNull(decodeAssetClaims(base64UrlDecodeUtf8(encodedPayload)));
@@ -193,11 +203,15 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
             }),
         ),
       );
+      const isExternalFile =
+        path.isAbsolute(input.resource.path) &&
+        !isWithinRoot(path, workspaceRoot, input.resource.path);
+      const assetRoot = isExternalFile ? path.dirname(input.resource.path) : workspaceRoot;
       const relativePath = path.isAbsolute(input.resource.path)
-        ? path.relative(workspaceRoot, input.resource.path)
+        ? path.relative(assetRoot, input.resource.path)
         : input.resource.path;
       const resolved = yield* workspacePaths
-        .resolveRelativePathWithinRoot({ workspaceRoot, relativePath })
+        .resolveRelativePathWithinRoot({ workspaceRoot: assetRoot, relativePath })
         .pipe(
           Effect.mapError(
             (cause) =>
@@ -213,7 +227,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         });
       }
       const canonicalFile = yield* resolveCanonicalWorkspaceFile({
-        workspaceRoot,
+        workspaceRoot: assetRoot,
         relativePath: resolved.relativePath,
       }).pipe(
         Effect.mapError(
@@ -229,7 +243,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
           resource: input.resource,
         });
       }
-      const canonicalWorkspaceRoot = yield* fileSystem.realPath(workspaceRoot).pipe(
+      const canonicalWorkspaceRoot = yield* fileSystem.realPath(assetRoot).pipe(
         Effect.mapError(
           (cause) =>
             new AssetWorkspaceResolutionError({
@@ -238,7 +252,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
             }),
         ),
       );
-      claims = isWorkspaceImagePreviewPath(resolved.relativePath)
+      const isExactAsset = isExternalFile || isWorkspaceImagePreviewPath(resolved.relativePath);
+      claims = isExactAsset
         ? {
             version: 1,
             kind: "workspace-file-exact",


### PR DESCRIPTION
## Problem

Opening an absolute linked file outside the project root fails with `Workspace file path must be relative to the project root.` The agent may be allowed to create or modify the file, but T3 Code cannot issue a browser-preview URL for it.

## Fix

- recognize absolute files outside the workspace as external files
- reuse the existing canonical path and regular-file checks
- issue a short-lived exact-file capability so sibling files are not exposed
- preserve sibling-asset behavior for workspace HTML previews
- continue rejecting relative paths that escape the workspace

This keeps the change server-only and requires no contract, web, or desktop changes.

## Security boundary

The broader path support does not grant directory access. An external token resolves only the selected canonical regular file; sibling requests, relative parent traversal, missing files, directories, and symlink escapes remain blocked.

## Testing

- `vp test run apps/server/src/assets/AssetAccess.test.ts` (9 tests)
- `vp lint --report-unused-disable-directives apps/server/src/assets/AssetAccess.ts apps/server/src/assets/AssetAccess.test.ts`
- `vp fmt --check apps/server/src/assets/AssetAccess.ts apps/server/src/assets/AssetAccess.test.ts`
- `vp run --filter t3 typecheck`

Fixes #5125

Built with Codex (GPT-5.6) in T3 Code.