### PR TITLE
fix(ssh): surface a failed remote t3 install instead of a silent 0-byte server.log

### DIFF
--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -108,6 +108,9 @@ describe("ssh tunnel scripts", () => {
     assert.include(script, "exec npx --yes 't3@latest' \"$@\"");
     assert.include(script, "exec npm exec --yes 't3@latest' -- \"$@\"");
     assert.include(script, "could not install 't3@latest'");
+    assert.include(script, "require_installed_t3_cli npx --yes --package 't3@latest'");
+    assert.include(script, "require_installed_t3_cli npm exec --yes --package 't3@latest'");
+    assert.include(script, "npm produced no t3 executable");
     assert.include(script, 'prepend_path_if_dir "$HOME/.local/bin"');
     assert.include(script, `T3_NODE_ENGINE_RANGE='${TEST_NODE_ENGINE_RANGE}'`);
     assert.include(script, "remote_node_satisfies_engine()");
@@ -140,6 +143,10 @@ describe("ssh tunnel scripts", () => {
 
     assert.include(script, "exec npx --yes 't3@nightly; touch /tmp/t3-owned' \"$@\"");
     assert.include(script, "exec npm exec --yes 't3@nightly; touch /tmp/t3-owned' -- \"$@\"");
+    assert.include(
+      script,
+      "require_installed_t3_cli npx --yes --package 't3@nightly; touch /tmp/t3-owned'",
+    );
     assert.notInclude(script, "exec npx --yes t3@nightly; touch /tmp/t3-owned");
   });
 
@@ -185,6 +192,8 @@ describe("ssh tunnel scripts", () => {
     assert.notInclude(buildRemoteLaunchScript(), "server-home");
     assert.include(buildRemoteLaunchScript(), "Remote T3 server did not become ready");
     assert.include(buildRemoteLaunchScript(), 'wait_ready "60000"');
+    assert.include(buildRemoteLaunchScript(), 'if [ -s "$LOG_FILE" ]; then');
+    assert.include(buildRemoteLaunchScript(), "It wrote nothing to %s");
     assert.include(buildRemoteLaunchScript({ packageSpec: "t3@nightly" }), "t3@nightly");
     assert.include(
       buildRemotePairingScript(target),

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -97,6 +97,9 @@ describe("ssh tunnel scripts", () => {
     assert.include(script, "exec npx --yes 't3@latest' \"$@\"");
     assert.include(script, "exec npm exec --yes 't3@latest' -- \"$@\"");
     assert.include(script, "could not install 't3@latest'");
+    assert.include(script, "require_installed_t3_cli npx --yes --package 't3@latest'");
+    assert.include(script, "require_installed_t3_cli npm exec --yes --package 't3@latest'");
+    assert.include(script, "npm produced no t3 executable");
     assert.include(script, 'prepend_path_if_dir "$HOME/.local/bin"');
     assert.include(script, `T3_NODE_ENGINE_RANGE='${TEST_NODE_ENGINE_RANGE}'`);
     assert.include(script, "remote_node_satisfies_engine()");
@@ -129,6 +132,10 @@ describe("ssh tunnel scripts", () => {
 
     assert.include(script, "exec npx --yes 't3@nightly; touch /tmp/t3-owned' \"$@\"");
     assert.include(script, "exec npm exec --yes 't3@nightly; touch /tmp/t3-owned' -- \"$@\"");
+    assert.include(
+      script,
+      "require_installed_t3_cli npx --yes --package 't3@nightly; touch /tmp/t3-owned'",
+    );
     assert.notInclude(script, "exec npx --yes t3@nightly; touch /tmp/t3-owned");
   });
 
@@ -173,6 +180,8 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteLaunchScript(), '--base-dir "$DEFAULT_SERVER_HOME"');
     assert.notInclude(buildRemoteLaunchScript(), "server-home");
     assert.include(buildRemoteLaunchScript(), "Remote T3 server did not become ready");
+    assert.include(buildRemoteLaunchScript(), 'if [ -s "$LOG_FILE" ]; then');
+    assert.include(buildRemoteLaunchScript(), "It wrote nothing to %s");
     assert.include(buildRemoteLaunchScript({ packageSpec: "t3@nightly" }), "t3@nightly");
     assert.include(
       buildRemotePairingScript(target),

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -437,7 +437,7 @@ require_installed_t3_cli() {
   if [ -n "$T3_CLI_PATH" ]; then
     return 0
   fi
-  printf 'Remote host installed @@T3_PACKAGE_SPEC@@ but npm produced no t3 executable, which usually means a native dependency (node-pty) failed to build. Install a C toolchain on the remote host (Debian/Ubuntu: build-essential, Fedora/RHEL: gcc-c++ make, macOS: xcode-select --install) and try again.\\n' >&2
+  printf 'Remote host installed %s but npm produced no t3 executable, which usually means a native dependency (node-pty) failed to build. Install a C toolchain on the remote host (Debian/Ubuntu: build-essential, Fedora/RHEL: gcc-c++ make, macOS: xcode-select --install) and try again.\\n' @@T3_PACKAGE_SPEC@@ >&2
   return 1
 }
 if command -v npx >/dev/null 2>&1; then

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -426,10 +426,26 @@ fi
 if command -v t3 >/dev/null 2>&1; then
   exec t3 "$@"
 fi
+# npm extracts a package before it runs the native builds of its dependencies,
+# so a failed build (t3 depends on node-pty, which needs a C toolchain) leaves
+# the npx cache without a t3 executable. \`npx --yes\` then exits 0 without
+# running anything at all, which the caller only ever sees as a server that
+# never becomes ready. Resolve the CLI once up front so that install failure is
+# reported here, with npm's own output on stderr.
+require_installed_t3_cli() {
+  T3_CLI_PATH="$("$@" -- sh -c 'command -v t3' || true)"
+  if [ -n "$T3_CLI_PATH" ]; then
+    return 0
+  fi
+  printf 'Remote host installed @@T3_PACKAGE_SPEC@@ but npm produced no t3 executable, which usually means a native dependency (node-pty) failed to build. Install a C toolchain on the remote host (Debian/Ubuntu: build-essential, Fedora/RHEL: gcc-c++ make, macOS: xcode-select --install) and try again.\\n' >&2
+  return 1
+}
 if command -v npx >/dev/null 2>&1; then
+  require_installed_t3_cli npx --yes --package @@T3_PACKAGE_SPEC@@ || exit 1
   exec npx --yes @@T3_PACKAGE_SPEC@@ "$@"
 fi
 if command -v npm >/dev/null 2>&1; then
+  require_installed_t3_cli npm exec --yes --package @@T3_PACKAGE_SPEC@@ || exit 1
   exec npm exec --yes @@T3_PACKAGE_SPEC@@ -- "$@"
 fi
 printf 'Remote host is missing the t3 CLI and could not install @@T3_PACKAGE_SPEC@@ because node/npm/npx are unavailable on PATH. Install Node or configure a supported version manager for non-interactive shells.\\n' >&2
@@ -581,7 +597,11 @@ if [ -z "$REMOTE_PORT" ]; then
   printf 'managed\\n' >"$MANAGED_FILE"
   if ! wait_ready "@@T3_READY_TIMEOUT_MS@@"; then
     printf 'Remote T3 server did not become ready on 127.0.0.1:%s.\\n' "$REMOTE_PORT" >&2
-    tail -n 80 "$LOG_FILE" >&2 2>/dev/null || true
+    if [ -s "$LOG_FILE" ]; then
+      tail -n 80 "$LOG_FILE" >&2 2>/dev/null || true
+    else
+      printf 'It wrote nothing to %s, so it exited before producing any output.\\n' "$LOG_FILE" >&2
+    fi
     kill "$REMOTE_PID" 2>/dev/null || true
     wait_for_pid_exit "$REMOTE_PID"
     rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -425,10 +425,26 @@ fi
 if command -v t3 >/dev/null 2>&1; then
   exec t3 "$@"
 fi
+# npm extracts a package before it runs the native builds of its dependencies,
+# so a failed build (t3 depends on node-pty, which needs a C toolchain) leaves
+# the npx cache without a t3 executable. \`npx --yes\` then exits 0 without
+# running anything at all, which the caller only ever sees as a server that
+# never becomes ready. Resolve the CLI once up front so that install failure is
+# reported here, with npm's own output on stderr.
+require_installed_t3_cli() {
+  T3_CLI_PATH="$("$@" -- sh -c 'command -v t3' || true)"
+  if [ -n "$T3_CLI_PATH" ]; then
+    return 0
+  fi
+  printf 'Remote host installed @@T3_PACKAGE_SPEC@@ but npm produced no t3 executable, which usually means a native dependency (node-pty) failed to build. Install a C toolchain on the remote host (Debian/Ubuntu: build-essential, Fedora/RHEL: gcc-c++ make, macOS: xcode-select --install) and try again.\\n' >&2
+  return 1
+}
 if command -v npx >/dev/null 2>&1; then
+  require_installed_t3_cli npx --yes --package @@T3_PACKAGE_SPEC@@ || exit 1
   exec npx --yes @@T3_PACKAGE_SPEC@@ "$@"
 fi
 if command -v npm >/dev/null 2>&1; then
+  require_installed_t3_cli npm exec --yes --package @@T3_PACKAGE_SPEC@@ || exit 1
   exec npm exec --yes @@T3_PACKAGE_SPEC@@ -- "$@"
 fi
 printf 'Remote host is missing the t3 CLI and could not install @@T3_PACKAGE_SPEC@@ because node/npm/npx are unavailable on PATH. Install Node or configure a supported version manager for non-interactive shells.\\n' >&2
@@ -580,7 +596,11 @@ if [ -z "$REMOTE_PORT" ]; then
   printf 'managed\\n' >"$MANAGED_FILE"
   if ! wait_ready "@@T3_READY_TIMEOUT_MS@@"; then
     printf 'Remote T3 server did not become ready on 127.0.0.1:%s.\\n' "$REMOTE_PORT" >&2
-    tail -n 80 "$LOG_FILE" >&2 2>/dev/null || true
+    if [ -s "$LOG_FILE" ]; then
+      tail -n 80 "$LOG_FILE" >&2 2>/dev/null || true
+    else
+      printf 'It wrote nothing to %s, so it exited before producing any output.\\n' "$LOG_FILE" >&2
+    fi
     kill "$REMOTE_PID" 2>/dev/null || true
     wait_for_pid_exit "$REMOTE_PID"
     rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -436,7 +436,7 @@ require_installed_t3_cli() {
   if [ -n "$T3_CLI_PATH" ]; then
     return 0
   fi
-  printf 'Remote host installed @@T3_PACKAGE_SPEC@@ but npm produced no t3 executable, which usually means a native dependency (node-pty) failed to build. Install a C toolchain on the remote host (Debian/Ubuntu: build-essential, Fedora/RHEL: gcc-c++ make, macOS: xcode-select --install) and try again.\\n' >&2
+  printf 'Remote host installed %s but npm produced no t3 executable, which usually means a native dependency (node-pty) failed to build. Install a C toolchain on the remote host (Debian/Ubuntu: build-essential, Fedora/RHEL: gcc-c++ make, macOS: xcode-select --install) and try again.\\n' @@T3_PACKAGE_SPEC@@ >&2
   return 1
 }
 if command -v npx >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes #5129

## What happens
On a Linux host without a C toolchain, `npx --yes t3@… <anything>` exits 0 having executed nothing: npm extracts the package before running its dependencies' native builds, so a failed `node-pty` compile leaves the npx cache with no `t3` executable. In the desktop SSH-launch flow the generated `run-t3.sh` `exec`s that npx call, so the launch "succeeds" instantly, `server.log` stays 0 bytes, and the desktop only ever reports `Remote T3 server did not become ready on 127.0.0.1:3773`. (The cloud/boot path already guards this npm behavior in `pinnedRuntime.ts`; only the SSH path used bare npx.)

## The fix (packages/ssh/src/tunnel.ts)
- `run-t3.sh` now resolves the CLI up front (`npx --yes --package '<spec>' -- sh -c 'command -v t3'`) so an install failure is reported at launch time, with npm's own stderr flowing into `server.log`, and a clear message naming the likely cause (missing C toolchain / node-pty).
- When the readiness probe times out with an *empty* log, the error now says so explicitly instead of tailing nothing.

## Validation
- `pnpm test` in `packages/ssh`: 25/25 pass (assertions extended for the new script content); `pnpm typecheck`, root `pnpm lint`, `vp fmt --check` all clean.
- Generated scripts pass `sh -n`; runner exercised against a stub npx reproducing the broken shape (exit 0, no output → now exit 1 with the new message) and the healthy shape (unchanged `exec` path).
- Real-registry check on npm 11 / node 24: the preflight resolves and prints the bin path.
- Caveat: original repro box was fixed by installing `build-essential` before this patch existed, so the patched script was validated against a simulated broken host, not the live one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SnL8Kiba6YBbxNnunPiHg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to generated shell scripts and test assertions for the SSH tunnel path; no auth or data-handling logic.
> 
> **Overview**
> Fixes a case where **SSH remote launch** looked healthy but the server never started: on hosts without a C toolchain, `npx --yes t3@…` can exit **0** with no `t3` binary after a failed **node-pty** build, leaving an empty `server.log` and only a generic readiness timeout.
> 
> The generated **`run-t3.sh`** now runs **`require_installed_t3_cli`** before `exec` via `npx`/`npm exec` (resolves `command -v t3` after install) and fails with a message that points at missing build tools. The **launch script** only tails the log when it is non-empty; otherwise it states that nothing was written to the log path.
> 
> Tests in **`tunnel.test.ts`** assert the new script fragments and empty-log messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d037e31f38f5dd4e5abae6474fb3d660075f750b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface failed remote t3 install errors instead of a silent 0-byte server.log
> - Adds a `require_installed_t3_cli` helper to the remote runner script ([tunnel.ts](https://github.com/pingdotgg/t3code/pull/5132/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072)) that pre-resolves the `t3` executable after `npx`/`npm exec` installs it, aborting with a descriptive stderr message if no executable is found (likely due to native dependency build failure).
> - Updates the launch script failure path to check if the log file is non-empty before tailing it; prints `'It wrote nothing to %s, so it exited before producing any output.'` when the log is empty.
> - Adds test coverage in [tunnel.test.ts](https://github.com/pingdotgg/t3code/pull/5132/files#diff-76d3724ec8959625b119aff8272a5d733f73551706a487e303ddbd13e10a06ad) for both the preflight CLI check and the conditional log-tailing behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d037e31.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->