### PR TITLE
fix(web): unstick /connect after in-modal sign-in by redirecting to the authorize endpoint

### DIFF
--- a/apps/web/src/cloud/connectCliAuth.test.ts
+++ b/apps/web/src/cloud/connectCliAuth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   buildConnectCliClerkAuthorizeUrl,
+  connectCliSignInRedirectUrl,
   hasConnectCliAuthConfig,
   readConnectCliCallbackResult,
 } from "./connectCliAuth";
@@ -67,6 +68,29 @@ describe("connectCliAuth", () => {
     expect(
       buildConnectCliClerkAuthorizeUrl({ state: "state-1", challenge: "challenge-1" }),
     ).toBeNull();
+  });
+
+  it("sends the sign-in redirect to the authorize endpoint, not back to /connect", () => {
+    vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", TEST_PUBLISHABLE_KEY);
+    vi.stubEnv("VITE_CLERK_CLI_OAUTH_CLIENT_ID", "oauthapp_123");
+
+    const connectUrl = "https://app.t3.codes/connect#state=state-1&challenge=challenge-1";
+    const redirectUrl = connectCliSignInRedirectUrl(
+      { state: "state-1", challenge: "challenge-1" },
+      connectUrl,
+    );
+
+    expect(redirectUrl).not.toBe(connectUrl);
+    expect(new URL(redirectUrl).pathname).toBe("/oauth/authorize");
+  });
+
+  it("falls back to the current URL when the authorize URL cannot be built", () => {
+    vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", TEST_PUBLISHABLE_KEY);
+
+    const connectUrl = "https://app.t3.codes/connect#state=state-1&challenge=challenge-1";
+    expect(
+      connectCliSignInRedirectUrl({ state: "state-1", challenge: "challenge-1" }, connectUrl),
+    ).toBe(connectUrl);
   });
 
   it("reads the code and state Clerk echoes back to the callback", () => {

--- a/apps/web/src/cloud/connectCliAuth.test.ts
+++ b/apps/web/src/cloud/connectCliAuth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   buildConnectCliClerkAuthorizeUrl,
+  connectCliSignInRedirectUrl,
   hasConnectCliAuthConfig,
   readConnectCliCallbackResult,
 } from "./connectCliAuth";
@@ -51,6 +52,29 @@ describe("connectCliAuth", () => {
     expect(
       buildConnectCliClerkAuthorizeUrl({ state: "state-1", challenge: "challenge-1" }),
     ).toBeNull();
+  });
+
+  it("sends the sign-in redirect to the authorize endpoint, not back to /connect", () => {
+    vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", TEST_PUBLISHABLE_KEY);
+    vi.stubEnv("VITE_CLERK_CLI_OAUTH_CLIENT_ID", "oauthapp_123");
+
+    const connectUrl = "https://app.t3.codes/connect#state=state-1&challenge=challenge-1";
+    const redirectUrl = connectCliSignInRedirectUrl(
+      { state: "state-1", challenge: "challenge-1" },
+      connectUrl,
+    );
+
+    expect(redirectUrl).not.toBe(connectUrl);
+    expect(new URL(redirectUrl).pathname).toBe("/oauth/authorize");
+  });
+
+  it("falls back to the current URL when the authorize URL cannot be built", () => {
+    vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", TEST_PUBLISHABLE_KEY);
+
+    const connectUrl = "https://app.t3.codes/connect#state=state-1&challenge=challenge-1";
+    expect(
+      connectCliSignInRedirectUrl({ state: "state-1", challenge: "challenge-1" }, connectUrl),
+    ).toBe(connectUrl);
   });
 
   it("reads the code and state Clerk echoes back to the callback", () => {

--- a/apps/web/src/cloud/connectCliAuth.ts
+++ b/apps/web/src/cloud/connectCliAuth.ts
@@ -60,6 +60,23 @@ export function buildConnectCliClerkAuthorizeUrl(request: ConnectAuthorizeReques
   });
 }
 
+/**
+ * Where Clerk sends the browser once the sign-in modal on /connect completes.
+ * It has to be the authorize endpoint rather than this page: /connect carries
+ * the CLI request in its fragment, so navigating back to the same URL is a
+ * same-document fragment navigation the browser never reloads — and Clerk
+ * treats any post-sign-in navigation as a page unload and skips the state emit
+ * that would otherwise re-render the surface, so the session never arrives
+ * either. Falls back to the current URL when the authorize URL cannot be
+ * built, which only happens on a deployment without the CLI OAuth config.
+ */
+export function connectCliSignInRedirectUrl(
+  request: ConnectAuthorizeRequest,
+  currentHref: string,
+): string {
+  return buildConnectCliClerkAuthorizeUrl(request) ?? currentHref;
+}
+
 export function rememberConnectCliAuthState(state: string): void {
   try {
     window.sessionStorage.setItem(CONNECT_CLI_AUTH_STATE_STORAGE_KEY, state);

--- a/apps/web/src/cloud/connectCliAuth.ts
+++ b/apps/web/src/cloud/connectCliAuth.ts
@@ -51,6 +51,23 @@ export function buildConnectCliClerkAuthorizeUrl(request: ConnectAuthorizeReques
   });
 }
 
+/**
+ * Where Clerk sends the browser once the sign-in modal on /connect completes.
+ * It has to be the authorize endpoint rather than this page: /connect carries
+ * the CLI request in its fragment, so navigating back to the same URL is a
+ * same-document fragment navigation the browser never reloads — and Clerk
+ * treats any post-sign-in navigation as a page unload and skips the state emit
+ * that would otherwise re-render the surface, so the session never arrives
+ * either. Falls back to the current URL when the authorize URL cannot be
+ * built, which only happens on a deployment without the CLI OAuth config.
+ */
+export function connectCliSignInRedirectUrl(
+  request: ConnectAuthorizeRequest,
+  currentHref: string,
+): string {
+  return buildConnectCliClerkAuthorizeUrl(request) ?? currentHref;
+}
+
 export function rememberConnectCliAuthState(state: string): void {
   try {
     window.sessionStorage.setItem(CONNECT_CLI_AUTH_STATE_STORAGE_KEY, state);

--- a/apps/web/src/components/clerk/authRedirect.test.ts
+++ b/apps/web/src/components/clerk/authRedirect.test.ts
@@ -5,7 +5,10 @@ import { resolveClerkSignInProps } from "./authRedirect";
 describe("resolveClerkSignInProps", () => {
   it("returns to the current browser URL on the web", () => {
     const href = "https://app.t3.codes/connect?state=state-1#details";
-    expect(resolveClerkSignInProps(href, false)).toEqual({ forceRedirectUrl: href });
+    expect(resolveClerkSignInProps(href, false)).toEqual({
+      forceRedirectUrl: href,
+      signUpForceRedirectUrl: href,
+    });
   });
 
   it("removes a Clerk virtual pathname and callback params while preserving the desktop route", () => {

--- a/apps/web/src/components/clerk/authRedirect.test.ts
+++ b/apps/web/src/components/clerk/authRedirect.test.ts
@@ -5,7 +5,10 @@ import { resolveClerkSignInProps } from "./authRedirect";
 describe("resolveClerkSignInProps", () => {
   it("returns to the current browser URL on the web", () => {
     const href = "https://app.t3.codes/connect?state=state-1#details";
-    expect(resolveClerkSignInProps(href, false)).toEqual({ forceRedirectUrl: href });
+    expect(resolveClerkSignInProps(href, false)).toEqual({
+      forceRedirectUrl: href,
+      signUpForceRedirectUrl: href,
+    });
   });
 
   it("omits the redirect override on packaged desktop", () => {

--- a/apps/web/src/components/clerk/authRedirect.ts
+++ b/apps/web/src/components/clerk/authRedirect.ts
@@ -15,5 +15,7 @@ export function resolveClerkSignInProps(href: string, isElectron: boolean): Cler
       signUpForceRedirectUrl: redirectUrl.toString(),
     };
   }
-  return { forceRedirectUrl: href };
+  // The sign-in modal can switch to sign-up, which follows its own redirect
+  // target; without one Clerk falls back to the URL the modal was opened from.
+  return { forceRedirectUrl: href, signUpForceRedirectUrl: href };
 }

--- a/apps/web/src/components/clerk/authRedirect.ts
+++ b/apps/web/src/components/clerk/authRedirect.ts
@@ -1,5 +1,6 @@
 export interface ClerkSignInProps {
   forceRedirectUrl?: string;
+  signUpForceRedirectUrl?: string;
 }
 
 // Clerk's native-app allowlist only authorizes the bare renderer root
@@ -8,5 +9,7 @@ export interface ClerkSignInProps {
 // rejected. On Electron, omit the override and let Clerk use its defaults.
 export function resolveClerkSignInProps(href: string, isElectron: boolean): ClerkSignInProps {
   if (isElectron) return {};
-  return { forceRedirectUrl: href };
+  // The sign-in modal can switch to sign-up, which follows its own redirect
+  // target; without one Clerk falls back to the URL the modal was opened from.
+  return { forceRedirectUrl: href, signUpForceRedirectUrl: href };
 }

--- a/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
+++ b/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
@@ -1,9 +1,10 @@
 import { useAuth, useClerk, useUser } from "@clerk/react";
 import { encodeConnectAuthCode, readConnectAuthorizeRequest } from "@t3tools/shared/connectAuth";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   buildConnectCliClerkAuthorizeUrl,
+  connectCliSignInRedirectUrl,
   readConnectCliAuthState,
   readConnectCliCallbackResult,
   rememberConnectCliAuthState,
@@ -56,6 +57,21 @@ export function ConnectCliAuthorizeSurface() {
   const signInOpened = useRef(false);
   const redirecting = useRef(false);
 
+  const openSignIn = useCallback(() => {
+    if (!request) {
+      return;
+    }
+    // Clerk redirects to the authorize endpoint itself once sign-in completes,
+    // so the callback's state check has to be armed before handing off.
+    rememberConnectCliAuthState(request.state);
+    clerk.openSignIn(
+      resolveClerkSignInProps(
+        connectCliSignInRedirectUrl(request, window.location.href),
+        isElectron,
+      ),
+    );
+  }, [clerk, request]);
+
   useEffect(() => {
     if (!request || !isLoaded || redirecting.current) {
       return;
@@ -63,7 +79,7 @@ export function ConnectCliAuthorizeSurface() {
     if (!isSignedIn) {
       if (!signInOpened.current) {
         signInOpened.current = true;
-        clerk.openSignIn(resolveClerkSignInProps(window.location.href, isElectron));
+        openSignIn();
       }
       return;
     }
@@ -74,7 +90,7 @@ export function ConnectCliAuthorizeSurface() {
     redirecting.current = true;
     rememberConnectCliAuthState(request.state);
     window.location.assign(authorizeUrl);
-  }, [clerk, isLoaded, isSignedIn, request]);
+  }, [isLoaded, isSignedIn, openSignIn, request]);
 
   if (!request) {
     return (
@@ -101,12 +117,7 @@ export function ConnectCliAuthorizeSurface() {
       />
       {isLoaded && !isSignedIn ? (
         <div className="mt-6">
-          <Button
-            type="button"
-            onClick={() =>
-              clerk.openSignIn(resolveClerkSignInProps(window.location.href, isElectron))
-            }
-          >
+          <Button type="button" onClick={openSignIn}>
             Sign in
           </Button>
         </div>

--- a/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
+++ b/apps/web/src/components/cloud/ConnectCliAuthSurface.tsx
@@ -1,9 +1,10 @@
 import { useAuth, useClerk, useUser } from "@clerk/react";
 import { encodeConnectAuthCode, readConnectAuthorizeRequest } from "@t3tools/shared/connectAuth";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   buildConnectCliClerkAuthorizeUrl,
+  connectCliSignInRedirectUrl,
   readConnectCliAuthState,
   readConnectCliCallbackResult,
   rememberConnectCliAuthState,
@@ -54,6 +55,21 @@ export function ConnectCliAuthorizeSurface() {
   const signInOpened = useRef(false);
   const redirecting = useRef(false);
 
+  const openSignIn = useCallback(() => {
+    if (!request) {
+      return;
+    }
+    // Clerk redirects to the authorize endpoint itself once sign-in completes,
+    // so the callback's state check has to be armed before handing off.
+    rememberConnectCliAuthState(request.state);
+    clerk.openSignIn(
+      resolveClerkSignInProps(
+        connectCliSignInRedirectUrl(request, window.location.href),
+        isElectron,
+      ),
+    );
+  }, [clerk, request]);
+
   useEffect(() => {
     if (!request || !isLoaded || redirecting.current) {
       return;
@@ -61,7 +77,7 @@ export function ConnectCliAuthorizeSurface() {
     if (!isSignedIn) {
       if (!signInOpened.current) {
         signInOpened.current = true;
-        clerk.openSignIn(resolveClerkSignInProps(window.location.href, isElectron));
+        openSignIn();
       }
       return;
     }
@@ -72,7 +88,7 @@ export function ConnectCliAuthorizeSurface() {
     redirecting.current = true;
     rememberConnectCliAuthState(request.state);
     window.location.assign(authorizeUrl);
-  }, [clerk, isLoaded, isSignedIn, request]);
+  }, [isLoaded, isSignedIn, openSignIn, request]);
 
   if (!request) {
     return (
@@ -95,12 +111,7 @@ export function ConnectCliAuthorizeSurface() {
       />
       {isLoaded && !isSignedIn ? (
         <div className="mt-6">
-          <Button
-            type="button"
-            onClick={() =>
-              clerk.openSignIn(resolveClerkSignInProps(window.location.href, isElectron))
-            }
-          >
+          <Button type="button" onClick={openSignIn}>
             Sign in
           </Button>
         </div>


### PR DESCRIPTION
Fixes #5130

## What happens
In the `t3 connect` headless flow, app.t3.codes/connect opens the Clerk sign-in modal with `forceRedirectUrl: window.location.href`. On `/connect` that URL carries the `#state=…&challenge=…` fragment — and a same-URL navigation with a fragment is a same-document navigation the browser never performs as a reload. In the pinned `@clerk/clerk-js@6.25.12`, `windowNavigate` dispatches `clerk:beforeunload` unconditionally and `setActive` returns at its unload-tracker check *before* updating the session accessors (confirmed in the shipped bundle). Result: the modal closes, `isSignedIn` never flips, and the page sits on "Step 1 of 2" until a manual refresh. `/connect` is the only web route carrying a fragment, which is why only this flow is affected.

## The fix (apps/web)
Point the post-sign-in redirect straight at the Clerk authorize endpoint — a real cross-origin navigation, and exactly where the page's own effect would have sent an already-signed-in user (also saves a round trip). The callback page's sessionStorage state check is armed before hand-off, and `signUpForceRedirectUrl` covers the modal's sign-up branch against the same trap.

## Validation
- `pnpm test` in `apps/web`: 196 files / 1747 tests pass, including 2 new tests for the redirect URL builder; `pnpm typecheck`, root `pnpm lint`, `vp fmt --check` clean.
- The authorize origin passes Clerk's `allowedRedirectOrigins` allowlist; `signUpForceRedirectUrl` verified present in the pinned `@clerk/shared` types.
- Caveat: the live passkey flow was not re-run in a browser against a patched build (the affected page is the hosted app), so a manual pass before merge is recommended. Repro recording of the broken flow: see #5130 (screenshots); happy to add a video of the "before" behavior if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SnL8Kiba6YBbxNnunPiHg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted CLI OAuth and Clerk redirect behavior; misconfiguration could break connect sign-in, but changes are scoped with tests and sessionStorage state is armed before hand-off.
> 
> **Overview**
> Fixes the **`t3 connect`** hosted flow where signing in from the Clerk modal on `/connect` left **`isSignedIn`** stuck and the UI on “Step 1 of 2” until a refresh.
> 
> Post–sign-in redirect no longer targets **`window.location.href`** on `/connect` (same URL + fragment → no real navigation, so Clerk never updates session state). It now uses a new **`connectCliSignInRedirectUrl`** helper that points at Clerk’s **`/oauth/authorize`** URL (same destination an already-signed-in user would get), with fallback to the current URL if CLI OAuth isn’t configured.
> 
> **`ConnectCliAuthorizeSurface`** centralizes **`openSignIn`**, arms **`rememberConnectCliAuthState`** before opening the modal, and passes the authorize URL into **`resolveClerkSignInProps`**. Web sign-in props now set **`signUpForceRedirectUrl`** alongside **`forceRedirectUrl`** so the sign-up path in the modal doesn’t hit the same trap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a839fbe561ac7c761d62f19d2ee2d6479bee3d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix /connect page getting stuck after in-modal sign-in by redirecting to the authorize endpoint
> - When a user signs in via the Clerk modal on `/connect`, the post-sign-in redirect now points to the `/oauth/authorize` endpoint (built via `buildConnectCliClerkAuthorizeUrl`) instead of the current `/connect` URL, which previously left the page stuck.
> - A new `connectCliSignInRedirectUrl` helper in [`connectCliAuth.ts`](https://github.com/pingdotgg/t3code/pull/5133/files#diff-a5477f8f4d4e58591d7f38df6c88acf9c10e1558e17e4040548277526ef4f83d) constructs this redirect URL, falling back to the current `href` if the authorize URL cannot be built.
> - [`ConnectCliAuthorizeSurface`](https://github.com/pingdotgg/t3code/pull/5133/files#diff-4d2edee788842fd8bde98fe5bae1e43d591e62e8b9ab9351fb37abb8b4c9acff) now calls `rememberConnectCliAuthState` to persist request state before opening the Clerk sign-in modal.
> - `resolveClerkSignInProps` now includes `signUpForceRedirectUrl` matching `forceRedirectUrl` on web, so switching from sign-in to sign-up inside the modal also redirects correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a839fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->