### PR TITLE
fix(server): wait for concurrent SQLite writers instead of failing with SQLITE_BUSY

### DIFF
--- a/apps/server/src/persistence/Layers/Sqlite.test.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.test.ts
@@ -1,0 +1,66 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { SqlitePersistenceMemory, makeSqlitePersistenceLive } from "./Sqlite.ts";
+
+const lockHolderSource = `
+const { DatabaseSync } = require("node:sqlite");
+const db = new DatabaseSync(process.argv[1]);
+db.exec("BEGIN IMMEDIATE");
+process.stdout.write("locked\\n");
+setTimeout(() => {
+  db.exec("COMMIT");
+  db.close();
+}, Number(process.argv[2]));
+`;
+
+const spawnWriteLockHolder = (dbPath: string, holdMs: number) =>
+  Effect.promise(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const holder = NodeChildProcess.spawn(
+          process.execPath,
+          ["-e", lockHolderSource, dbPath, String(holdMs)],
+          { stdio: ["ignore", "pipe", "ignore"] },
+        );
+        holder.stdout.once("data", () => resolve());
+        holder.on("error", reject);
+        holder.on("exit", () =>
+          reject(new Error("lock holder exited before acquiring the write lock")),
+        );
+      }),
+  );
+
+it.effect("waits out a concurrent writer instead of failing with SQLITE_BUSY", () => {
+  const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-sqlite-busy-"));
+  const dbPath = NodePath.join(tempDir, "state.sqlite");
+
+  return Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* sql`CREATE TABLE busy_probe(id INTEGER PRIMARY KEY)`;
+    yield* spawnWriteLockHolder(dbPath, 300);
+    yield* sql`INSERT INTO busy_probe(id) VALUES (${1})`;
+    const rows = yield* sql<{ readonly id: number }>`SELECT id FROM busy_probe`;
+    assert.deepEqual([...rows], [{ id: 1 }]);
+  }).pipe(
+    Effect.provide(makeSqlitePersistenceLive(dbPath).pipe(Layer.provide(NodeServices.layer))),
+    Effect.ensuring(Effect.sync(() => NodeFS.rmSync(tempDir, { recursive: true, force: true }))),
+  );
+});
+
+it.effect("applies busy_timeout in the shared persistence setup", () =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<{ readonly timeout: number }>`PRAGMA busy_timeout`;
+    assert.equal(rows[0]?.timeout, 5000);
+  }).pipe(Effect.provide(SqlitePersistenceMemory)),
+);

--- a/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.ts
@@ -33,6 +33,8 @@ const makeRuntimeSqliteLayer = Effect.fn("makeRuntimeSqliteLayer")(function* (
 const setup = Layer.effectDiscard(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
+    // CLI and server write from separate processes; wait rather than fail with SQLITE_BUSY.
+    yield* sql`PRAGMA busy_timeout = 5000;`;
     yield* sql`PRAGMA foreign_keys = ON;`;
     yield* sql`PRAGMA journal_mode = WAL;`;
     yield* runMigrations();


### PR DESCRIPTION
Fixes #5099

Concurrent writes to the state database from separate processes — e.g. `t3 auth session issue` while a server is running, or a few CLI invocations in parallel — intermittently fail with `database is locked`. The persistence layer never sets `busy_timeout`, so SQLite gives up on a contended write lock immediately instead of waiting for it to clear.

The shared `setup` layer now applies `PRAGMA busy_timeout = 5000` (the value `scripts/t3-sqlite-state.ts` already uses) ahead of the WAL/foreign-keys pragmas and migrations, so it covers the server, the CLI, and both the node and bun clients through the one place every writable connection goes through.

Verified:

- New test reproduces the failure cross-process: a child process holds `BEGIN IMMEDIATE` on the same file while the layer writes. It fails with `database is locked` on main and passes with the fix (a second test pins the pragma value). Stable across repeated runs.
- The repro from the issue: on main, parallel `t3 auth session issue` runs against one state dir failed intermittently with the exact stack from the issue (`AuthSessionRepository.create` → `database is locked`); with the fix, 24/24 runs succeeded.

Scope: this only makes writers wait out short-lived lock contention; it does not change WAL or durability behavior.

Written by Claude (Fable 5) in Claude Code, directed and reviewed by @ostapondo.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/5134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized persistence tuning with no auth or schema changes; writers may block briefly under contention but behavior otherwise matches prior WAL/durability setup.
> 
> **Overview**
> Fixes intermittent **`database is locked` / SQLITE_BUSY** when the server and CLI (or parallel CLI runs) write the same state DB by having every writable connection wait up to **5 seconds** for a lock instead of failing immediately.
> 
> The shared SQLite **`setup`** layer in `Sqlite.ts` now runs **`PRAGMA busy_timeout = 5000`** before foreign keys, WAL, and migrations, so server, CLI, and in-memory test layers all pick it up from one place.
> 
> **`Sqlite.test.ts`** adds a cross-process repro (child holds `BEGIN IMMEDIATE` while the layer inserts) and asserts the pragma is **5000** via `SqlitePersistenceMemory`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd2121d618791ade409313345c0da48308fefcbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SQLite busy_timeout to wait up to 5s instead of failing with SQLITE_BUSY
> Sets `PRAGMA busy_timeout = 5000` in the SQLite layer setup in [Sqlite.ts](https://github.com/pingdotgg/t3code/pull/5134/files#diff-47b4fe6e24808f5d59f5b97892cce0d736c01e7a8323b77e0c6a3751ff7ba7fa), applied before enabling foreign keys and WAL mode. Adds tests in [Sqlite.test.ts](https://github.com/pingdotgg/t3code/pull/5134/files#diff-36d5664fefdd38c17b6bea202cf73c795e2b0f9d5bd51b61a0f4bd8c09384302) that verify the pragma value and confirm concurrent write locks are waited out rather than causing immediate failures.
>
> - Behavioral Change: SQLite operations that previously failed immediately with `SQLITE_BUSY` under write contention now block for up to 5 seconds before failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd2121d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite handling for concurrent writes.
  * Write operations now wait up to five seconds when the database is temporarily locked, reducing immediate failures during simultaneous CLI and server activity.

* **Tests**
  * Added coverage for concurrent write handling and the shared database lock timeout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->