### PR TITLE
fix(web): persist sidebar shelf collapse state

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -180,6 +180,7 @@ const SETTLED_TAIL_INITIAL_COUNT = 10;
 const SETTLED_TAIL_PAGE_COUNT = 25;
 // Keep the v2 key so existing preferences survive the v2-to-default rename.
 const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:settled-expanded";
+const SNOOZED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:snoozed-expanded";
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -2060,8 +2061,15 @@ export default function Sidebar() {
   // The snoozed shelf is collapsed by default: out of the way, never gone.
   // Collapsed threads don't render (and so don't participate in jump
   // shortcuts or multi-select), matching the settled tail's paging model.
-  const [snoozedShelfExpanded, setSnoozedShelfExpanded] = useState(false);
-  const toggleSnoozedShelf = useCallback(() => setSnoozedShelfExpanded((value) => !value), []);
+  const [snoozedShelfExpanded, setSnoozedShelfExpanded] = useLocalStorage(
+    SNOOZED_SHELF_EXPANDED_KEY,
+    false,
+    Schema.Boolean,
+  );
+  const toggleSnoozedShelf = useCallback(
+    () => setSnoozedShelfExpanded((value) => !value),
+    [setSnoozedShelfExpanded],
+  );
   const visibleSnoozedThreads = useMemo(() => {
     if (snoozedShelfExpanded) return snoozedThreads;
     // The open thread must never vanish behind the collapsed shelf: a

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { autoAnimate } from "@formkit/auto-animate";
 import { useAtomValue } from "@effect/atom-react";
+import * as Schema from "effect/Schema";
 import {
   DndContext,
   PointerSensor,
@@ -100,6 +101,7 @@ import { openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
@@ -176,6 +178,8 @@ import {
 // stays behind an explicit Show more.
 const SETTLED_TAIL_INITIAL_COUNT = 10;
 const SETTLED_TAIL_PAGE_COUNT = 25;
+// Keep the v2 key so existing preferences survive the v2-to-default rename.
+const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:settled-expanded";
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -2034,8 +2038,15 @@ export default function Sidebar() {
     () => setSettledVisibleCount((count) => count + SETTLED_TAIL_PAGE_COUNT),
     [],
   );
-  const [settledShelfExpanded, setSettledShelfExpanded] = useState(true);
-  const toggleSettledShelf = useCallback(() => setSettledShelfExpanded((value) => !value), []);
+  const [settledShelfExpanded, setSettledShelfExpanded] = useLocalStorage(
+    SETTLED_SHELF_EXPANDED_KEY,
+    true,
+    Schema.Boolean,
+  );
+  const toggleSettledShelf = useCallback(
+    () => setSettledShelfExpanded((value) => !value),
+    [setSettledShelfExpanded],
+  );
   const renderedSettledThreads = useMemo(() => {
     if (settledShelfExpanded) return visibleSettledThreads;
     if (routeThreadKey === null) return [];


### PR DESCRIPTION
## Summary

- persist the default sidebar’s Settled and Snoozed expansion states across desktop restarts and web reloads
- keep the first-run defaults: Settled expanded and Snoozed collapsed
- use the existing schema-validated `useLocalStorage` hook with an independent key for each shelf

## Why

Collapsing a shelf reads as a lasting preference. Today both shelves reset when the desktop app restarts, so users have to restore their preferred sidebar layout every launch.

This includes the Settled persistence change from #4573 by @ipanasenko with the original commit authorship preserved, then adds the missing Snoozed persistence.

## Before / After

Both captures use the same isolated synthetic showcase dataset: three settled threads plus two showcase threads explicitly seeded with future snooze times. Before each restart, Snoozed was expanded and Settled was collapsed.

| Before: current main after restart | After: this branch after restart |
| --- | --- |
| <img width="800" alt="Current main after restart: Snoozed resets collapsed and Settled resets expanded" src="https://github.com/user-attachments/assets/c78297e4-fb89-4c15-9a56-4a77e79449e5" /> | <img width="800" alt="This branch after restart: Snoozed remains expanded and Settled remains collapsed" src="https://github.com/user-attachments/assets/5d464349-9ed9-4dfd-bbab-9337d19449e5" /> |

## Verification

- `pnpm exec vp test run apps/web/src/hooks/useLocalStorage.test.ts` (4 tests)
- `pnpm exec vp lint --report-unused-disable-directives apps/web/src/components/Sidebar.tsx`
- `pnpm --filter @t3tools/web typecheck`
- reproduced the reset on current main with a full T3 Code Desktop quit and relaunch against the synthetic showcase fixture
- verified the branch preserves expanded Snoozed and collapsed Settled states through the same full desktop restart

## Checklist

- [x] rebased on current `main`
- [x] tested in the desktop client with isolated synthetic data
- [x] matched before/after restart evidence embedded without committing images
- [x] original #4573 authorship preserved

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/5136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only client preference persistence with no server, auth, or data-model impact; behavior is limited to sidebar shelf visibility.
> 
> **Overview**
> **Settled** and **Snoozed** sidebar shelf expand/collapse state now survives desktop restarts and page reloads instead of resetting every launch.
> 
> The sidebar replaces in-memory `useState` for both shelf toggles with **`useLocalStorage`**, using **`effect/Schema.Boolean`** validation and separate keys (`t3code:sidebar-v2:settled-expanded`, `t3code:sidebar-v2:snoozed-expanded`). The **v2** key prefix is kept so preferences written before the sidebar rename still apply. First-run defaults stay **Settled expanded** and **Snoozed collapsed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6f922abb427dca67bbfb26406fb94e6669f41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist sidebar shelf collapse state across reloads
> Replaces `useState` with `useLocalStorage` for the Settled and Snoozed shelf expanded/collapsed state in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/5136/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1). State is stored under `t3code:sidebar-v2:settled-expanded` and `t3code:sidebar-v2:snoozed-expanded`, and restored on page reload.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b6f922.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->