### PR TITLE
feat(clients): add PR auto-settle toggle

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -23,6 +23,7 @@ const clientSettings: ClientSettings = {
   glassOpacity: 80,
   providerModelPreferences: {},
   sidebarAutoSettleAfterDays: 3,
+  sidebarAutoSettleOnChangeRequestCompletion: true,
   sidebarProjectGroupingMode: "repository_path",
   sidebarProjectGroupingOverrides: {
     "environment-1:/tmp/project-a": "separate",
@@ -153,6 +154,7 @@ describe("DesktopClientSettings", () => {
         assert.isTrue(Option.isSome(persisted));
         if (Option.isSome(persisted)) {
           assert.equal(persisted.value.timestampFormat, "24-hour");
+          assert.isTrue(persisted.value.sidebarAutoSettleOnChangeRequestCompletion);
         }
       }),
     ),

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -32,7 +32,10 @@ import { scopedProjectKey } from "../../lib/scopedEntities";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
 import { useThreadSearch } from "../../state/queries";
-import { useThreadListV2Enabled } from "../threads/use-thread-list-v2-enabled";
+import {
+  useThreadListV2Enabled,
+  useThreadListV2SettlementPreferences,
+} from "../threads/use-thread-list-v2-enabled";
 import { environmentServerConfigsAtom } from "../../state/server";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 import {
@@ -202,6 +205,7 @@ export function HomeScreen(props: HomeScreenProps) {
   >(() => new Map());
   const preferencesResult = useAtomValue(mobilePreferencesAtom);
   const threadListV2Enabled = useThreadListV2Enabled();
+  const threadListV2SettlementPreferences = useThreadListV2SettlementPreferences();
   const savePreferences = useAtomSet(updateMobilePreferencesAtom);
   const openSwipeableRef = useRef<SwipeableMethods | null>(null);
   const listRef = useRef<LegendListRef | null>(null);
@@ -597,6 +601,7 @@ export function HomeScreen(props: HomeScreenProps) {
       changeRequestStateByKey,
       settlementEnvironmentIds,
       snoozeEnvironmentIds,
+      ...threadListV2SettlementPreferences,
       settledLimit: settledVisibleCount,
       now: `${nowMinute}:00.000Z`,
       snoozeNow: new Date().toISOString(),
@@ -613,6 +618,7 @@ export function HomeScreen(props: HomeScreenProps) {
     settledVisibleCount,
     settlementEnvironmentIds,
     snoozeEnvironmentIds,
+    threadListV2SettlementPreferences,
     props.searchQuery,
     props.selectedEnvironmentId,
     props.threads,

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -37,7 +37,10 @@ import { WorkspaceSidebarToolbar } from "../layout/workspace-sidebar-toolbar";
 import { runtime } from "../../lib/runtime";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
-import { useThreadListV2Enabled } from "../threads/use-thread-list-v2-enabled";
+import {
+  useThreadListV2Enabled,
+  useThreadListV2SettlementPreferences,
+} from "../threads/use-thread-list-v2-enabled";
 import {
   type AppUpdateCheckState,
   registerHiddenUpdateTap,
@@ -555,6 +558,8 @@ function GeneralSettingsSection() {
 function BetaSettingsSection() {
   const savePreferences = useAtomSet(updateMobilePreferencesAtom);
   const threadListV2Enabled = useThreadListV2Enabled();
+  const { autoSettleAfterDays, autoSettleOnChangeRequestCompletion } =
+    useThreadListV2SettlementPreferences();
 
   return (
     <View className="gap-3">
@@ -565,10 +570,31 @@ function BetaSettingsSection() {
           value={threadListV2Enabled}
           onValueChange={(value) => savePreferences({ threadListV2Enabled: value })}
         />
+        {threadListV2Enabled ? (
+          <>
+            <SettingsSwitchRow
+              icon="clock"
+              label="Auto-settle inactive threads"
+              value={autoSettleAfterDays !== null}
+              onValueChange={(value) => savePreferences({ threadListV2AutoSettleInactive: value })}
+            />
+            <SettingsSwitchRow
+              icon="arrow.triangle.pull"
+              label="Auto-settle merged/closed PRs"
+              value={autoSettleOnChangeRequestCompletion}
+              onValueChange={(value) =>
+                savePreferences({
+                  threadListV2AutoSettleOnChangeRequestCompletion: value,
+                })
+              }
+            />
+          </>
+        ) : null}
       </SettingsSection>
       <Text className="px-2 text-sm text-foreground-muted">
         One flat thread list in creation order. Active work renders as cards; settled threads
-        collapse to compact rows. Switch back any time.
+        collapse to compact rows. Inactive threads use a three-day window when automatic settling is
+        on. Switch back any time.
       </Text>
     </View>
   );

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -29,7 +29,10 @@ import { scopedProjectKey, scopedThreadKey } from "../../lib/scopedEntities";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { useThreadSearch } from "../../state/queries";
-import { useThreadListV2Enabled } from "./use-thread-list-v2-enabled";
+import {
+  useThreadListV2Enabled,
+  useThreadListV2SettlementPreferences,
+} from "./use-thread-list-v2-enabled";
 import { environmentServerConfigsAtom } from "../../state/server";
 import { usePendingNewTasks } from "../../state/use-pending-new-tasks";
 import { useWorkspaceState } from "../../state/workspace";
@@ -207,6 +210,7 @@ function ThreadNavigationSidebarPane(
     unsettleThread,
   } = useThreadListActions();
   const threadListV2Enabled = useThreadListV2Enabled();
+  const threadListV2SettlementPreferences = useThreadListV2SettlementPreferences();
   const pendingTasks = usePendingNewTasks();
   const { openPendingTask, confirmDeletePendingTask } = usePendingTaskListActions();
   const environments = useMemo(
@@ -501,6 +505,7 @@ function ThreadNavigationSidebarPane(
       changeRequestStateByKey,
       settlementEnvironmentIds,
       snoozeEnvironmentIds,
+      ...threadListV2SettlementPreferences,
       settledLimit: settledVisibleCount,
       now: `${nowMinute}:00.000Z`,
       snoozeNow: new Date().toISOString(),
@@ -521,6 +526,7 @@ function ThreadNavigationSidebarPane(
     settledVisibleCount,
     settlementEnvironmentIds,
     snoozeEnvironmentIds,
+    threadListV2SettlementPreferences,
     threadListV2Enabled,
     threads,
     selectedProjectScope,

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -124,9 +124,16 @@ describe("resolveThreadListV2Enabled", () => {
 
 describe("resolveThreadListV2SettlementPreferences", () => {
   it("defaults both automatic triggers on", () => {
-    expect(resolveThreadListV2SettlementPreferences({})).toEqual({
+    expect(resolveThreadListV2SettlementPreferences({ preferencesLoaded: true })).toEqual({
       autoSettleAfterDays: 3,
       autoSettleOnChangeRequestCompletion: true,
+    });
+  });
+
+  it("holds both automatic triggers off while preferences are loading", () => {
+    expect(resolveThreadListV2SettlementPreferences({ preferencesLoaded: false })).toEqual({
+      autoSettleAfterDays: null,
+      autoSettleOnChangeRequestCompletion: false,
     });
   });
 
@@ -135,6 +142,7 @@ describe("resolveThreadListV2SettlementPreferences", () => {
       resolveThreadListV2SettlementPreferences({
         autoSettleInactive: false,
         autoSettleOnChangeRequestCompletion: false,
+        preferencesLoaded: true,
       }),
     ).toEqual({
       autoSettleAfterDays: null,

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -17,6 +17,7 @@ import {
   buildThreadListV2Items,
   buildThreadListV2ListItems,
   resolveThreadListV2Enabled,
+  resolveThreadListV2SettlementPreferences,
   resolveThreadListV2SnoozeMenuSelection,
   resolveThreadListV2SnoozeGateExpiryMs,
   resolveThreadListV2Status,
@@ -118,6 +119,27 @@ describe("resolveThreadListV2Enabled", () => {
     expect(resolveThreadListV2Enabled({ preference: undefined, preferencesLoaded: false })).toBe(
       true,
     );
+  });
+});
+
+describe("resolveThreadListV2SettlementPreferences", () => {
+  it("defaults both automatic triggers on", () => {
+    expect(resolveThreadListV2SettlementPreferences({})).toEqual({
+      autoSettleAfterDays: 3,
+      autoSettleOnChangeRequestCompletion: true,
+    });
+  });
+
+  it("supports fully manual settlement", () => {
+    expect(
+      resolveThreadListV2SettlementPreferences({
+        autoSettleInactive: false,
+        autoSettleOnChangeRequestCompletion: false,
+      }),
+    ).toEqual({
+      autoSettleAfterDays: null,
+      autoSettleOnChangeRequestCompletion: false,
+    });
   });
 });
 
@@ -259,6 +281,27 @@ describe("sortThreadsForListV2", () => {
 });
 
 describe("buildThreadListV2Items", () => {
+  it("keeps a stale merged-review thread active when both auto-settle triggers are disabled", () => {
+    const thread = makeThread({
+      id: ThreadId.make("manual-only"),
+      title: "Manual only",
+      latestUserMessageAt: "2026-05-01T00:00:00.000Z",
+    });
+    const layout = buildThreadListV2Items({
+      threads: [thread],
+      environmentId: null,
+      searchQuery: "",
+      changeRequestStateByKey: new Map([[`${environmentId}:${thread.id}`, "merged"]]),
+      autoSettleAfterDays: null,
+      autoSettleOnChangeRequestCompletion: false,
+      now: NOW,
+    });
+
+    expect(layout.items.map((item) => [item.thread.id, item.variant])).toEqual([
+      ["manual-only", "card"],
+    ]);
+  });
+
   it("hides snoozed threads and counts them — visibility parity with web", () => {
     const layout = buildThreadListV2Items({
       threads: [

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -33,10 +33,14 @@ export type ThreadListV2SwipeAction = "archive" | "settle" | "unsettle" | "snooz
 export function resolveThreadListV2SettlementPreferences(input: {
   readonly autoSettleInactive?: boolean;
   readonly autoSettleOnChangeRequestCompletion?: boolean;
-}): {
-  readonly autoSettleAfterDays: number | null;
-  readonly autoSettleOnChangeRequestCompletion: boolean;
-} {
+  readonly preferencesLoaded: boolean;
+}) {
+  if (!input.preferencesLoaded) {
+    return {
+      autoSettleAfterDays: null,
+      autoSettleOnChangeRequestCompletion: false,
+    };
+  }
   return {
     autoSettleAfterDays:
       input.autoSettleInactive === false ? null : DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -9,7 +9,11 @@ import {
 import type { SnoozePreset } from "@t3tools/client-runtime/state/thread-settled";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
-import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import {
+  DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+  type EnvironmentId,
+  type ProjectId,
+} from "@t3tools/contracts";
 
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 
@@ -25,6 +29,20 @@ export { snoozeWakeLabel };
  */
 export type ThreadListV2Status = "approval" | "input" | "working" | "failed" | "ready";
 export type ThreadListV2SwipeAction = "archive" | "settle" | "unsettle" | "snooze" | "unsnooze";
+
+export function resolveThreadListV2SettlementPreferences(input: {
+  readonly autoSettleInactive?: boolean;
+  readonly autoSettleOnChangeRequestCompletion?: boolean;
+}): {
+  readonly autoSettleAfterDays: number | null;
+  readonly autoSettleOnChangeRequestCompletion: boolean;
+} {
+  return {
+    autoSettleAfterDays:
+      input.autoSettleInactive === false ? null : DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+    autoSettleOnChangeRequestCompletion: input.autoSettleOnChangeRequestCompletion !== false,
+  };
+}
 
 export function resolveThreadListV2SnoozeMenuSelection(input: {
   readonly event: string;
@@ -303,9 +321,9 @@ export function buildThreadListV2ListItems(input: {
 
 /**
  * Partitions visible threads into the active card block (creation order) and
- * the settled recency tail, matching the web v2 list. `autoSettleAfterDays`
- * mirrors the web default of 3 — mobile has no client-settings sync yet, so
- * the default is fixed here rather than user-configurable.
+ * the settled recency tail, matching the web v2 list. Automatic-settlement
+ * preferences are device-local on mobile and default to the existing
+ * three-day inactivity window plus terminal-review settlement.
  */
 export function buildThreadListV2Items(input: {
   readonly threads: ReadonlyArray<EnvironmentThreadShell>;
@@ -325,7 +343,8 @@ export function buildThreadListV2Items(input: {
   /** Environments whose server supports thread.snooze/unsnooze. Same
       contract as settlementEnvironmentIds. */
   readonly snoozeEnvironmentIds?: ReadonlySet<EnvironmentId>;
-  readonly autoSettleAfterDays?: number;
+  readonly autoSettleAfterDays?: number | null;
+  readonly autoSettleOnChangeRequestCompletion?: boolean;
   /** Max settled rows to render; the rest are counted, not built. */
   readonly settledLimit?: number;
   /** Injectable for tests; defaults to now. */
@@ -345,7 +364,11 @@ export function buildThreadListV2Items(input: {
 }): ThreadListV2Layout {
   const now = input.now ?? new Date().toISOString();
   const snoozeNow = input.snoozeNow ?? now;
-  const autoSettleAfterDays = input.autoSettleAfterDays ?? 3;
+  const autoSettleAfterDays =
+    input.autoSettleAfterDays === undefined
+      ? DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS
+      : input.autoSettleAfterDays;
+  const autoSettleOnChangeRequestCompletion = input.autoSettleOnChangeRequestCompletion !== false;
   const query = input.searchQuery.trim().toLocaleLowerCase();
   const projectKeys = input.projectRefs
     ? new Set(input.projectRefs.map((ref) => `${ref.environmentId}:${ref.projectId}`))
@@ -394,7 +417,12 @@ export function buildThreadListV2Items(input: {
     }
     if (
       supportsSettlement &&
-      effectiveSettled(thread, { now, autoSettleAfterDays, changeRequestState })
+      effectiveSettled(thread, {
+        now,
+        autoSettleAfterDays,
+        autoSettleOnChangeRequestCompletion,
+        changeRequestState,
+      })
     ) {
       settled.push(thread);
     } else {

--- a/apps/mobile/src/features/threads/use-thread-list-v2-enabled.ts
+++ b/apps/mobile/src/features/threads/use-thread-list-v2-enabled.ts
@@ -22,14 +22,10 @@ export function useThreadListV2Enabled(): boolean {
   });
 }
 
-export function useThreadListV2SettlementPreferences(): {
-  readonly autoSettleAfterDays: number | null;
-  readonly autoSettleOnChangeRequestCompletion: boolean;
-} {
+export function useThreadListV2SettlementPreferences() {
   const preferencesResult = useAtomValue(mobilePreferencesAtom);
-  const preferences = AsyncResult.isSuccess(preferencesResult)
-    ? preferencesResult.value
-    : undefined;
+  const preferencesLoaded = AsyncResult.isSuccess(preferencesResult);
+  const preferences = preferencesLoaded ? preferencesResult.value : undefined;
   const autoSettleInactive = preferences?.threadListV2AutoSettleInactive;
   const autoSettleOnChangeRequestCompletion =
     preferences?.threadListV2AutoSettleOnChangeRequestCompletion;
@@ -38,7 +34,8 @@ export function useThreadListV2SettlementPreferences(): {
       resolveThreadListV2SettlementPreferences({
         autoSettleInactive,
         autoSettleOnChangeRequestCompletion,
+        preferencesLoaded,
       }),
-    [autoSettleInactive, autoSettleOnChangeRequestCompletion],
+    [autoSettleInactive, autoSettleOnChangeRequestCompletion, preferencesLoaded],
   );
 }

--- a/apps/mobile/src/features/threads/use-thread-list-v2-enabled.ts
+++ b/apps/mobile/src/features/threads/use-thread-list-v2-enabled.ts
@@ -1,8 +1,12 @@
 import { useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
+import { useMemo } from "react";
 
 import { mobilePreferencesAtom } from "../../state/preferences";
-import { resolveThreadListV2Enabled } from "./threadListV2";
+import {
+  resolveThreadListV2Enabled,
+  resolveThreadListV2SettlementPreferences,
+} from "./threadListV2";
 
 /**
  * Resolved Thread List v2 state: the device-local preference if the user has
@@ -16,4 +20,25 @@ export function useThreadListV2Enabled(): boolean {
     preference: loaded ? preferencesResult.value.threadListV2Enabled : undefined,
     preferencesLoaded: loaded,
   });
+}
+
+export function useThreadListV2SettlementPreferences(): {
+  readonly autoSettleAfterDays: number | null;
+  readonly autoSettleOnChangeRequestCompletion: boolean;
+} {
+  const preferencesResult = useAtomValue(mobilePreferencesAtom);
+  const preferences = AsyncResult.isSuccess(preferencesResult)
+    ? preferencesResult.value
+    : undefined;
+  const autoSettleInactive = preferences?.threadListV2AutoSettleInactive;
+  const autoSettleOnChangeRequestCompletion =
+    preferences?.threadListV2AutoSettleOnChangeRequestCompletion;
+  return useMemo(
+    () =>
+      resolveThreadListV2SettlementPreferences({
+        autoSettleInactive,
+        autoSettleOnChangeRequestCompletion,
+      }),
+    [autoSettleInactive, autoSettleOnChangeRequestCompletion],
+  );
 }

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -30,6 +30,9 @@ export interface Preferences {
    * see `resolveThreadListV2Enabled`.
    */
   readonly threadListV2Enabled?: boolean;
+  /** Device-local counterparts of the web Sidebar v2 auto-settle settings. */
+  readonly threadListV2AutoSettleInactive?: boolean;
+  readonly threadListV2AutoSettleOnChangeRequestCompletion?: boolean;
 }
 
 export class MobilePreferencesLoadError extends Schema.TaggedErrorClass<MobilePreferencesLoadError>()(
@@ -81,6 +84,8 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     collapsedProjectGroups?: readonly string[];
     projectGroupingEnabled?: boolean;
     threadListV2Enabled?: boolean;
+    threadListV2AutoSettleInactive?: boolean;
+    threadListV2AutoSettleOnChangeRequestCompletion?: boolean;
   } = {};
 
   if (typeof parsed.liveActivitiesEnabled === "boolean") {
@@ -112,6 +117,13 @@ function sanitizePreferences(parsed: Preferences): Preferences {
   }
   if (typeof parsed.threadListV2Enabled === "boolean") {
     preferences.threadListV2Enabled = parsed.threadListV2Enabled;
+  }
+  if (typeof parsed.threadListV2AutoSettleInactive === "boolean") {
+    preferences.threadListV2AutoSettleInactive = parsed.threadListV2AutoSettleInactive;
+  }
+  if (typeof parsed.threadListV2AutoSettleOnChangeRequestCompletion === "boolean") {
+    preferences.threadListV2AutoSettleOnChangeRequestCompletion =
+      parsed.threadListV2AutoSettleOnChangeRequestCompletion;
   }
   return preferences;
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3962,6 +3962,9 @@ function ChatViewContent(props: ChatViewProps) {
   // so the banner and the sidebar row never disagree.
   const activeThreadShell = useThreadShell(isServerThread ? activeThreadRef : null);
   const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
+  const autoSettleOnChangeRequestCompletion = useClientSettings(
+    (settings) => settings.sidebarAutoSettleOnChangeRequestCompletion,
+  );
   const activeThreadPr = resolveThreadPr({
     threadBranch: activeThread?.branch ?? null,
     gitStatus: gitStatusQuery.data ?? null,
@@ -3990,12 +3993,14 @@ function ChatViewContent(props: ChatViewProps) {
     return effectiveSettled(activeThreadShell, {
       now: `${nowMinute}:00.000Z`,
       autoSettleAfterDays,
+      autoSettleOnChangeRequestCompletion,
       changeRequestState: activeThreadPr?.state ?? null,
     });
   }, [
     activeThreadPr?.state,
     activeThreadShell,
     autoSettleAfterDays,
+    autoSettleOnChangeRequestCompletion,
     nowMinute,
     supportsSettlement,
   ]);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -166,7 +166,7 @@ import {
 import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
 import { getProviderModelCapabilities, resolveSelectableProvider } from "../providerModels";
 import { NO_PROVIDER_MODEL_SELECTION } from "../providerInstances";
-import { useClientSettings, useEnvironmentSettings } from "../hooks/useSettings";
+import { useClientThreadSettlementPreferences, useEnvironmentSettings } from "../hooks/useSettings";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
@@ -3961,10 +3961,8 @@ function ChatViewContent(props: ChatViewProps) {
   // partition (same shell, same capability gate, same PR auto-settle input)
   // so the banner and the sidebar row never disagree.
   const activeThreadShell = useThreadShell(isServerThread ? activeThreadRef : null);
-  const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
-  const autoSettleOnChangeRequestCompletion = useClientSettings(
-    (settings) => settings.sidebarAutoSettleOnChangeRequestCompletion,
-  );
+  const { autoSettleAfterDays, autoSettleOnChangeRequestCompletion } =
+    useClientThreadSettlementPreferences();
   const activeThreadPr = resolveThreadPr({
     threadBranch: activeThread?.branch ?? null,
     gitStatus: gitStatusQuery.data ?? null,

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -87,7 +87,11 @@ import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
-import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
+import {
+  useClientSettings,
+  useClientThreadSettlementPreferences,
+  useUpdateClientSettings,
+} from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
@@ -1175,10 +1179,8 @@ export default function SidebarV2() {
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
-  const autoSettleOnChangeRequestCompletion = useClientSettings(
-    (s) => s.sidebarAutoSettleOnChangeRequestCompletion,
-  );
+  const { autoSettleAfterDays, autoSettleOnChangeRequestCompletion } =
+    useClientThreadSettlementPreferences();
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1176,6 +1176,9 @@ export default function SidebarV2() {
   const { isMobile, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
+  const autoSettleOnChangeRequestCompletion = useClientSettings(
+    (s) => s.sidebarAutoSettleOnChangeRequestCompletion,
+  );
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
@@ -1592,7 +1595,12 @@ export default function SidebarV2() {
         snoozed.push(thread);
       } else if (
         supportsSettlement &&
-        effectiveSettled(thread, { now, autoSettleAfterDays, changeRequestState })
+        effectiveSettled(thread, {
+          now,
+          autoSettleAfterDays,
+          autoSettleOnChangeRequestCompletion,
+          changeRequestState,
+        })
       ) {
         settled.push(thread);
       } else {
@@ -1612,6 +1620,7 @@ export default function SidebarV2() {
     };
   }, [
     autoSettleAfterDays,
+    autoSettleOnChangeRequestCompletion,
     changeRequestStateByKey,
     nowMinute,
     scopedProjectKeys,

--- a/apps/web/src/components/settings/BetaSettingsPanel.tsx
+++ b/apps/web/src/components/settings/BetaSettingsPanel.tsx
@@ -1,4 +1,9 @@
 import { useEffect, useState } from "react";
+import {
+  DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+  MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+  MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+} from "@t3tools/contracts";
 
 import {
   useClientSettings,
@@ -9,10 +14,6 @@ import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
 import { SettingsPageContainer, SettingsRow, SettingsSection } from "./settingsLayout";
 import { searchableSetting } from "./settingsSearch";
-
-const AUTO_SETTLE_MIN_DAYS = 1;
-const AUTO_SETTLE_MAX_DAYS = 90;
-const AUTO_SETTLE_DEFAULT_DAYS = 3;
 
 function AutoSettleDaysInput({
   value,
@@ -31,8 +32,8 @@ function AutoSettleDaysInput({
   return (
     <Input
       type="number"
-      min={AUTO_SETTLE_MIN_DAYS}
-      max={AUTO_SETTLE_MAX_DAYS}
+      min={MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS}
+      max={MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS}
       className="w-full sm:w-24"
       value={draft}
       onChange={(event) => {
@@ -43,8 +44,8 @@ function AutoSettleDaysInput({
         const parsed = Number(event.target.value);
         if (
           Number.isInteger(parsed) &&
-          parsed >= AUTO_SETTLE_MIN_DAYS &&
-          parsed <= AUTO_SETTLE_MAX_DAYS
+          parsed >= MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS &&
+          parsed <= MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS
         ) {
           onCommit(parsed);
         }
@@ -59,6 +60,9 @@ export function BetaSettingsPanel() {
   const sidebarV2Enabled = useSidebarV2Enabled();
   const sidebarAutoSettleAfterDays = useClientSettings(
     (settings) => settings.sidebarAutoSettleAfterDays,
+  );
+  const sidebarAutoSettleOnChangeRequestCompletion = useClientSettings(
+    (settings) => settings.sidebarAutoSettleOnChangeRequestCompletion,
   );
   const updateSettings = useUpdateClientSettings();
 
@@ -87,13 +91,15 @@ export function BetaSettingsPanel() {
           <>
             <SettingsRow
               title={searchableSetting("auto-settle-inactive-threads").title}
-              description="Threads with no activity for this long settle automatically. Threads on merged or closed PRs always settle."
+              description="Threads with no activity for this long settle automatically."
               control={
                 <Switch
                   checked={sidebarAutoSettleAfterDays !== null}
                   onCheckedChange={(checked) =>
                     updateSettings({
-                      sidebarAutoSettleAfterDays: checked ? AUTO_SETTLE_DEFAULT_DAYS : null,
+                      sidebarAutoSettleAfterDays: checked
+                        ? DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS
+                        : null,
                     })
                   }
                   aria-label="Auto-settle inactive threads"
@@ -112,6 +118,21 @@ export function BetaSettingsPanel() {
                 }
               />
             ) : null}
+            <SettingsRow
+              title={searchableSetting("auto-settle-merged-or-closed-pr-threads").title}
+              description="Threads settle automatically when their pull request is merged or closed."
+              control={
+                <Switch
+                  checked={sidebarAutoSettleOnChangeRequestCompletion}
+                  onCheckedChange={(checked) =>
+                    updateSettings({
+                      sidebarAutoSettleOnChangeRequestCompletion: Boolean(checked),
+                    })
+                  }
+                  aria-label="Auto-settle merged or closed PR threads"
+                />
+              }
+            />
           </>
         ) : null}
       </SettingsSection>

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -64,6 +64,13 @@ describe("searchSettings", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
+  it("indexes both Sidebar v2 auto-settle controls", () => {
+    expect(searchSettings("auto-settle").map((item) => item.id)).toEqual([
+      "auto-settle-inactive-threads",
+      "auto-settle-merged-or-closed-pr-threads",
+    ]);
+  });
+
   it("serves anchor props to panels from the catalog", () => {
     expect(searchableSetting("word-wrap")).toEqual({ id: "word-wrap", title: "Word wrap" });
     expect(searchableSetting("archive")).toEqual({ id: "archive", title: "Archived threads" });

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -158,6 +158,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     targetId: "sidebar-v2",
   },
   {
+    id: "auto-settle-merged-or-closed-pr-threads",
+    title: "Auto-settle merged or closed PR threads",
+    to: "/settings/beta",
+    targetId: "sidebar-v2",
+  },
+  {
     id: "archive",
     title: "Archived threads",
     to: "/settings/archived",

--- a/apps/web/src/hooks/useSettings.test.ts
+++ b/apps/web/src/hooks/useSettings.test.ts
@@ -6,7 +6,39 @@ import {
 import { DEFAULT_CLIENT_SETTINGS } from "@t3tools/contracts/settings";
 import { describe, expect, it } from "vite-plus/test";
 
-import { mergeEnvironmentSettings, resolveEnvironmentIdentificationMode } from "./useSettings";
+import {
+  mergeEnvironmentSettings,
+  resolveClientThreadSettlementPreferences,
+  resolveEnvironmentIdentificationMode,
+} from "./useSettings";
+
+describe("resolveClientThreadSettlementPreferences", () => {
+  it("holds both automatic triggers off until client settings hydrate", () => {
+    expect(
+      resolveClientThreadSettlementPreferences({
+        autoSettleAfterDays: 3,
+        autoSettleOnChangeRequestCompletion: true,
+        settingsHydrated: false,
+      }),
+    ).toEqual({
+      autoSettleAfterDays: null,
+      autoSettleOnChangeRequestCompletion: false,
+    });
+  });
+
+  it("uses the persisted preferences after hydration", () => {
+    expect(
+      resolveClientThreadSettlementPreferences({
+        autoSettleAfterDays: 7,
+        autoSettleOnChangeRequestCompletion: false,
+        settingsHydrated: true,
+      }),
+    ).toEqual({
+      autoSettleAfterDays: 7,
+      autoSettleOnChangeRequestCompletion: false,
+    });
+  });
+});
 
 describe("resolveEnvironmentIdentificationMode", () => {
   it("keeps identification hidden until client settings hydrate", () => {

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -223,6 +223,41 @@ export function useClientSettings<T = ClientSettings>(
   return useMemo(() => (selector ? selector(settings) : (settings as T)), [selector, settings]);
 }
 
+export function resolveClientThreadSettlementPreferences(input: {
+  readonly autoSettleAfterDays: number | null;
+  readonly autoSettleOnChangeRequestCompletion: boolean;
+  readonly settingsHydrated: boolean;
+}) {
+  if (!input.settingsHydrated) {
+    return {
+      autoSettleAfterDays: null,
+      autoSettleOnChangeRequestCompletion: false,
+    };
+  }
+  return {
+    autoSettleAfterDays: input.autoSettleAfterDays,
+    autoSettleOnChangeRequestCompletion: input.autoSettleOnChangeRequestCompletion,
+  };
+}
+
+export function useClientThreadSettlementPreferences() {
+  const settingsHydrated = useClientSettingsHydrated();
+  const settings = useClientSettingsValue();
+  return useMemo(
+    () =>
+      resolveClientThreadSettlementPreferences({
+        autoSettleAfterDays: settings.sidebarAutoSettleAfterDays,
+        autoSettleOnChangeRequestCompletion: settings.sidebarAutoSettleOnChangeRequestCompletion,
+        settingsHydrated,
+      }),
+    [
+      settings.sidebarAutoSettleAfterDays,
+      settings.sidebarAutoSettleOnChangeRequestCompletion,
+      settingsHydrated,
+    ],
+  );
+}
+
 export function resolveEnvironmentIdentificationMode(input: {
   mode: EnvironmentIdentificationMode;
   settingsHydrated: boolean;

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -41,6 +41,20 @@ T3 Code works with the platforms your team already uses:
 - Open the review directly in your browser with one click
 - Check out a teammate's branch to review code locally
 
+### Control When Finished Threads Settle
+
+Sidebar v2 (Thread List v2 on mobile) keeps completed work close at hand without forcing every
+thread out of your active list. Open **Settings → Beta** to control its two automatic settle
+triggers independently:
+
+- **Auto-settle inactive threads** moves threads after the configured inactivity window. On mobile,
+  this window is three days.
+- **Auto-settle merged or closed PR threads** moves threads when their pull request or merge request
+  reaches a terminal state.
+
+Turn both options off if you want threads to settle only when you do it manually. Existing installs
+keep both options on by default. Mobile stores these choices per device.
+
 ### Know Your Setup at a Glance
 
 The **Source Control settings** page shows you exactly what's connected:

--- a/packages/client-runtime/src/state/threadSettled.test.ts
+++ b/packages/client-runtime/src/state/threadSettled.test.ts
@@ -178,6 +178,45 @@ describe("effectiveSettled", () => {
     }
   });
 
+  it("keeps merged and closed change request threads active when their auto-settle is disabled", () => {
+    const recentlyActive = makeShell({ activityAt: "2026-04-09T23:59:59.999Z" });
+    for (const changeRequestState of ["merged", "closed"] as const) {
+      expect(
+        effectiveSettled(recentlyActive, {
+          now: NOW,
+          autoSettleAfterDays: null,
+          autoSettleOnChangeRequestCompletion: false,
+          changeRequestState,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("keeps inactivity and manual settlement independent from change request auto-settle", () => {
+    const stale = makeShell({ activityAt: STALE });
+    expect(
+      effectiveSettled(stale, {
+        now: NOW,
+        autoSettleAfterDays: 3,
+        autoSettleOnChangeRequestCompletion: false,
+        changeRequestState: "merged",
+      }),
+    ).toBe(true);
+
+    const manuallySettled = makeShell({
+      settledOverride: "settled",
+      activityAt: FRESH,
+    });
+    expect(
+      effectiveSettled(manuallySettled, {
+        now: NOW,
+        autoSettleAfterDays: null,
+        autoSettleOnChangeRequestCompletion: false,
+        changeRequestState: "merged",
+      }),
+    ).toBe(true);
+  });
+
   it("never auto-settles a stale thread with an open change request", () => {
     const stale = makeShell({ activityAt: STALE });
     expect(

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -221,17 +221,20 @@ export function threadWokeAt(
  * queued turn) are checked first and hold a thread active regardless of any
  * override. Past the blockers, the explicit user override (thread.settle /
  * thread.unsettle commands, projected into settledOverride + settledAt)
- * wins in both directions; without one, a thread auto-settles on a
- * merged/closed PR immediately or on inactivity past the window — except
- * that an open PR blocks the inactivity path entirely. The server
- * un-settles on real activity (user message, session start, approval/
- * user-input request), so an override never goes stale silently.
+ * wins in both directions; without one, a thread may auto-settle on a
+ * merged/closed PR or on inactivity past the window, according to the two
+ * independent client preferences. An open PR blocks the inactivity path
+ * entirely. The server un-settles on real activity (user message, session
+ * start, approval/user-input request), so an override never goes stale
+ * silently.
  */
 export function effectiveSettled(
   shell: OrchestrationThreadShell,
   options: {
     readonly now: string;
     readonly autoSettleAfterDays: number | null;
+    /** Defaults to true for callers that omit this preference. */
+    readonly autoSettleOnChangeRequestCompletion?: boolean;
     readonly changeRequestState?: ChangeRequestStateLike | null;
   },
 ): boolean {
@@ -258,7 +261,10 @@ export function effectiveSettled(
   // "active" is the explicit keep-active pin: it suppresses auto-settle
   // until real activity clears it server-side.
   if (shell.settledOverride === "active") return false;
-  if (options.changeRequestState === "merged" || options.changeRequestState === "closed") {
+  if (
+    options.autoSettleOnChangeRequestCompletion !== false &&
+    (options.changeRequestState === "merged" || options.changeRequestState === "closed")
+  ) {
     return true;
   }
   // An open PR is unfinished business regardless of how long the thread has

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -72,6 +72,7 @@ describe("ClientSettings sidebar v2", () => {
     const settings = decodeClientSettings({});
     expect(settings.sidebarV2Enabled).toBe(false);
     expect(settings.sidebarAutoSettleAfterDays).toBe(3);
+    expect(settings.sidebarAutoSettleOnChangeRequestCompletion).toBe(true);
   });
 
   it("treats settings written before the beta had a per-channel default as unconfigured", () => {
@@ -103,6 +104,17 @@ describe("ClientSettings sidebar v2", () => {
     expect(
       decodeClientSettings({ sidebarAutoSettleAfterDays: null }).sidebarAutoSettleAfterDays,
     ).toBeNull();
+  });
+
+  it("allows auto-settle on merged or closed change requests to be disabled", () => {
+    expect(
+      decodeClientSettings({ sidebarAutoSettleOnChangeRequestCompletion: false })
+        .sidebarAutoSettleOnChangeRequestCompletion,
+    ).toBe(false);
+    expect(
+      decodeClientSettingsPatch({ sidebarAutoSettleOnChangeRequestCompletion: false })
+        .sidebarAutoSettleOnChangeRequestCompletion,
+    ).toBe(false);
   });
 
   it.each([-1, 0, 91])("rejects an auto-settle threshold outside 1..90: %s", (value) => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -104,6 +104,9 @@ export const ClientSettingsSchema = Schema.Struct({
   sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
   ),
+  sidebarAutoSettleOnChangeRequestCompletion: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),
@@ -702,6 +705,7 @@ export const ClientSettingsPatch = Schema.Struct({
     ),
   ),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
+  sidebarAutoSettleOnChangeRequestCompletion: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),


### PR DESCRIPTION
## What Changed

- Add an independent setting for settling Sidebar v2 threads when their pull request is merged or closed, enabled by default for backward compatibility.
- Gate the shared settlement calculation on that setting while preserving manual settlement, explicit un-settlement, pending-work guards, and inactivity-based settlement.
- Expose the control on web/desktop and mobile, and document how disabling both automatic triggers enables fully manual settlement.

Closes #4982.

## Why

Sidebar v2 previously classified merged and closed pull-request threads as settled unconditionally. Disabling “Auto-settle inactive threads” therefore could not keep those threads active for follow-up work.

The merged/closed trigger is now configurable independently from the inactivity trigger. Existing users keep the current behavior unless they opt out.

This composes with #5151: open PRs remain protected from inactivity auto-settle; this setting only controls the merged/closed completion trigger.

## UI Changes

### Before

The inactivity setting also stated that merged and closed PR threads always settle, with no separate control.

<img width="900" alt="Before: Sidebar v2 has no separate pull-request auto-settle setting" src="https://raw.githubusercontent.com/caezium/t3code/f565de38e12f585fb522d8b12e1db92806058350/before.png">

### After

A separate toggle controls merged/closed-PR settlement. Here it is disabled while inactivity-based settlement remains enabled.

<img width="900" alt="After: Sidebar v2 has an independent merged-or-closed PR auto-settle toggle" src="https://raw.githubusercontent.com/caezium/t3code/f565de38e12f585fb522d8b12e1db92806058350/after.png">

## Validation

- `bun test packages/contracts/src/settings.test.ts packages/client-runtime/src/state/threadSettled.test.ts apps/mobile/src/features/threads/threadListV2.test.ts` — 251 passed
- `bun --cwd apps/web test -- src/components/settings/settingsSearch.test.ts` — 8 passed
- `bun --cwd apps/desktop test -- DesktopClientSettings.test.ts` — 7 passed
- Typechecks passed for contracts, client runtime, web, and mobile
- Targeted lint and formatting checks passed for all 18 changed files
- Verified in an empty, isolated local T3 home that the setting defaults on, persists off across reload, remains independent from inactivity settlement, and persists when re-enabled

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or timing behavior changed, so a video is not applicable

Built with GPT-5.6-Sol via the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add auto-settle toggle for merged/closed PR threads across web and mobile
> - Adds `sidebarAutoSettleOnChangeRequestCompletion` to [`ClientSettingsSchema`](https://github.com/pingdotgg/t3code/pull/5141/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) (default `true`) so users can disable auto-settling threads when a PR is merged or closed.
> - Extends [`effectiveSettled`](https://github.com/pingdotgg/t3code/pull/5141/files#diff-89ad1700cfc6c0784f0813b572a6b6110e04b480f108c404b4c755705748083c) to gate the PR-completion branch on the new flag; existing behavior is unchanged when the flag is omitted.
> - Web: adds a toggle in [`BetaSettingsPanel`](https://github.com/pingdotgg/t3code/pull/5141/files#diff-7cc018b55a78281318b114e44898712836d74582a8148368ac46409808a9260c), wires it through `useClientThreadSettlementPreferences` into [`SidebarV2`](https://github.com/pingdotgg/t3code/pull/5141/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) and [`ChatView`](https://github.com/pingdotgg/t3code/pull/5141/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
> - Mobile: persists two new device-local preferences (`threadListV2AutoSettleInactive`, `threadListV2AutoSettleOnChangeRequestCompletion`), exposed via toggles in [`SettingsRouteScreen`](https://github.com/pingdotgg/t3code/pull/5141/files#diff-2f7a2e66b652454e7fd1b30226a5146d595dfe05945b34d90ffd5f3a5037cb1e) and consumed by `HomeScreen` and `ThreadNavigationSidebar`.
> - Behavioral Change: preferences are held off (no auto-settling) until client settings are fully hydrated, preventing premature thread classification on load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2689452.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate controls for automatically settling inactive threads and threads linked to merged or closed pull requests.
  - Applied these preferences across web and mobile thread lists, with sensible defaults.
  - Added settings search support for the new automatic-settling option.

- **Documentation**
  - Documented automatic thread-settling behavior, defaults, mobile support, and manual-only options.

- **Bug Fixes**
  - Threads remain active when automatic settling for completed pull requests is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preference and UI changes around thread list classification; defaults preserve existing behavior and settlement logic is covered by targeted tests.
> 
> **Overview**
> Adds **`sidebarAutoSettleOnChangeRequestCompletion`** (default **on**) so merged/closed PR auto-settling is no longer tied to the inactivity setting. **`effectiveSettled`** only auto-settles on terminal PR states when that flag is enabled; manual settle, open-PR inactivity blocking, and the inactivity window stay unchanged.
> 
> **Web/desktop** expose a separate Beta toggle and **`useClientThreadSettlementPreferences`** (hydration-safe) feeds **Sidebar v2**, **ChatView**, and settings search. **Mobile** mirrors the two triggers via device-local preferences, **`resolveThreadListV2SettlementPreferences`**, and switches under Thread List v2 Beta.
> 
> User docs describe controlling both automatic settle paths independently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26894525dec9e71e154b75fa4044be5adbb98f69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->