### PR TITLE
refactor(clients): share thread list v2 sort in client-runtime

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -4,6 +4,7 @@ import type {
 } from "@t3tools/client-runtime/state/shell";
 import type { EnvironmentThreadSearchMatch } from "@t3tools/client-runtime/state/thread-search";
 import { canSnooze, resolveSnoozePresets } from "@t3tools/client-runtime/state/thread-settled";
+import { resolveSettledTimestamp } from "@t3tools/client-runtime/state/thread-sort";
 import type { MenuAction } from "@react-native-menu/menu";
 import { memo, useCallback, useEffect, useMemo, useState, type ComponentProps } from "react";
 import {
@@ -764,9 +765,12 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
             )}
             style={{ fontFamily: MONO_FONT }}
           >
+            {/* Snoozed rows show the wake countdown; settled rows read "how
+                long ago did this wrap up", matching their sort key so label
+                and order can't disagree. */}
             {snoozedRow && props.snoozeWakeLabelText !== undefined
               ? props.snoozeWakeLabelText
-              : relativeTime(thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt)}
+              : relativeTime(resolveSettledTimestamp(thread) ?? thread.createdAt)}
           </Text>
         </View>
       </Pressable>

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -649,7 +649,9 @@ describe("buildThreadListV2Items settled paging", () => {
           id: ThreadId.make(`settled-${index}`),
           title: `Settled ${index}`,
           settledOverride: "settled",
-          settledAt: NOW,
+          // Explicit settle stamps order the tail (shared resolver): most
+          // recently settled first.
+          settledAt: `2026-06-01T1${index}:00:00.000Z`,
           latestUserMessageAt: `2026-06-01T0${index}:00:00.000Z`,
           // A turn adopted the message (same requestedAt): without it the
           // thread reads as a queued turn start, which never settles.

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -8,7 +8,11 @@ import {
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
 import type { SnoozePreset } from "@t3tools/client-runtime/state/thread-settled";
-import { sortThreadsForListV2 } from "@t3tools/client-runtime/state/thread-sort";
+import {
+  sortSettledThreadsForListV2,
+  sortThreadsForListV2,
+  threadListV2Priority,
+} from "@t3tools/client-runtime/state/thread-sort";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
 import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
@@ -146,17 +150,6 @@ export function resolveThreadListV2Status(
 function parseTimestampMs(isoDate: string): number {
   const parsed = Date.parse(isoDate);
   return Number.isNaN(parsed) ? 0 : parsed;
-}
-
-/** First VALID timestamp wins: a present-yet-malformed string falls through
-    to the next candidate rather than sinking the row to the epoch. */
-function firstValidTimestampMs(...candidates: ReadonlyArray<string | null | undefined>): number {
-  for (const candidate of candidates) {
-    if (candidate == null) continue;
-    const parsed = Date.parse(candidate);
-    if (!Number.isNaN(parsed)) return parsed;
-  }
-  return 0;
 }
 
 export interface ThreadListV2Item {
@@ -339,7 +332,7 @@ export function buildThreadListV2Items(input: {
   const active: EnvironmentThreadShell[] = [];
   const settled: EnvironmentThreadShell[] = [];
   const snoozed: EnvironmentThreadShell[] = [];
-  const wokeThreadKeys = new Set<string>();
+  const wokeAtByThreadKey = new Map<string, string>();
   let nextSnoozeWakeAt: string | null = null;
   for (const thread of input.threads) {
     // Callers pass live (unarchived) shells; settled threads are among them
@@ -366,11 +359,12 @@ export function buildThreadListV2Items(input: {
       input.changeRequestStateByKey?.get(`${thread.environmentId}:${thread.id}`) ?? null;
     const wokeAt = supportsSnooze ? threadWokeAt(thread, { now: snoozeNow }) : null;
     if (wokeAt !== null) {
-      wokeThreadKeys.add(
+      wokeAtByThreadKey.set(
         threadSearchMatchKey({
           environmentId: thread.environmentId,
           threadId: thread.id,
         }),
+        wokeAt,
       );
     }
     // Visibility parity with web: a snoozed thread leaves the list until it
@@ -402,20 +396,17 @@ export function buildThreadListV2Items(input: {
     }
   }
 
-  const orderedActive = sortThreadsForListV2(active, (thread) => {
-    if (
-      wokeThreadKeys.has(
-        threadSearchMatchKey({
-          environmentId: thread.environmentId,
-          threadId: thread.id,
-        }),
-      )
-    ) {
-      return "woke";
-    }
-    if (thread.settledOverride === "active") return "unsettled";
-    return "default";
-  });
+  const orderedActive = sortThreadsForListV2(active, (thread) =>
+    threadListV2Priority(thread, {
+      wokeAt:
+        wokeAtByThreadKey.get(
+          threadSearchMatchKey({
+            environmentId: thread.environmentId,
+            threadId: thread.id,
+          }),
+        ) ?? null,
+    }),
+  );
   const orderedSnoozed = [...snoozed].sort(
     (left, right) =>
       parseTimestampMs(left.snoozedUntil ?? "") - parseTimestampMs(right.snoozedUntil ?? ""),
@@ -427,11 +418,7 @@ export function buildThreadListV2Items(input: {
       : orderedSnoozed.filter(
           (thread) => `${thread.environmentId}:${thread.id}` === selectedThreadKey,
         );
-  const orderedSettled = [...settled].sort(
-    (left, right) =>
-      firstValidTimestampMs(right.latestUserMessageAt, right.updatedAt) -
-      firstValidTimestampMs(left.latestUserMessageAt, left.updatedAt),
-  );
+  const orderedSettled = sortSettledThreadsForListV2(settled);
   const settledLimit = input.settledLimit ?? Number.POSITIVE_INFINITY;
   const pagedSettled =
     orderedSettled.length > settledLimit ? orderedSettled.slice(0, settledLimit) : orderedSettled;

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -26,7 +26,6 @@ import {
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
   sortLogicalProjectsForSidebar,
-  sortSettledThreadsForSidebarV2,
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
@@ -729,74 +728,6 @@ describe("isSidebarV2ThreadWoke", () => {
   it("keeps a valid wake visible when local visit data is malformed", () => {
     expect(isSidebarV2ThreadWoke({ wokeAt, lastVisitedAt: "not-a-date" })).toBe(true);
     expect(isSidebarV2ThreadWoke({ wokeAt: "not-a-date", lastVisitedAt: undefined })).toBe(false);
-  });
-});
-
-describe("sortSettledThreadsForSidebarV2", () => {
-  const settled = (input: {
-    id: string;
-    settledAt?: string | null;
-    latestUserMessageAt?: string | null;
-    latestTurn?: OrchestrationLatestTurn | null;
-    updatedAt?: string;
-  }) => ({
-    id: input.id,
-    settledAt: input.settledAt ?? null,
-    latestUserMessageAt: input.latestUserMessageAt ?? null,
-    latestTurn: input.latestTurn ?? null,
-    updatedAt: input.updatedAt ?? "2026-03-09T09:00:00.000Z",
-  });
-
-  it("orders by settle time, most recently settled first", () => {
-    const sorted = sortSettledThreadsForSidebarV2([
-      settled({
-        id: "settled-first",
-        settledAt: "2026-03-09T10:00:00.000Z",
-        // Created/active later than the other thread: settle time must win.
-        latestUserMessageAt: "2026-03-09T09:59:00.000Z",
-      }),
-      settled({
-        id: "settled-last",
-        settledAt: "2026-03-09T12:00:00.000Z",
-        latestUserMessageAt: "2026-03-09T08:00:00.000Z",
-      }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["settled-last", "settled-first"]);
-  });
-
-  it("falls back to last activity for auto-settled threads without a settledAt stamp", () => {
-    const sorted = sortSettledThreadsForSidebarV2([
-      settled({ id: "auto-old", latestUserMessageAt: "2026-03-09T08:00:00.000Z" }),
-      settled({ id: "explicit", settledAt: "2026-03-09T10:00:00.000Z" }),
-      settled({ id: "auto-recent", latestUserMessageAt: "2026-03-09T11:00:00.000Z" }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["auto-recent", "explicit", "auto-old"]);
-  });
-
-  it("counts a turn completion as activity for auto-settled threads", () => {
-    // The message came in before the other thread's, but its turn finished
-    // after: completion time is the real "work ended" moment.
-    const sorted = sortSettledThreadsForSidebarV2([
-      settled({ id: "message-only", latestUserMessageAt: "2026-03-09T10:04:00.000Z" }),
-      settled({
-        id: "completed-later",
-        latestUserMessageAt: "2026-03-09T10:00:00.000Z",
-        latestTurn: makeLatestTurn({ completedAt: "2026-03-09T10:30:00.000Z" }),
-      }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["completed-later", "message-only"]);
-  });
-
-  it("breaks timestamp ties by id so the order is stable", () => {
-    const sorted = sortSettledThreadsForSidebarV2([
-      settled({ id: "b", settledAt: "2026-03-09T10:00:00.000Z" }),
-      settled({ id: "a", settledAt: "2026-03-09T10:00:00.000Z" }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["a", "b"]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -508,51 +508,6 @@ export function searchSidebarThreadsByTitle<T extends { readonly title: string }
   return threads.filter((thread) => thread.title.toLowerCase().includes(normalizedQuery));
 }
 
-type SettledTimestampInput = Pick<
-  SidebarThreadSummary,
-  "settledAt" | "latestUserMessageAt" | "latestTurn" | "updatedAt"
->;
-
-/** The timestamp a settled row sorts and labels by: settledAt when stamped
-    (explicit settles), otherwise last activity — the same candidates
-    threadLastActivityAt feeds the auto-settle window (user message plus all
-    latestTurn stamps), so a thread whose last activity was a turn completion
-    doesn't sort by an older message time. updatedAt is the final net. */
-export function resolveSettledTimestamp(thread: SettledTimestampInput): string | null {
-  const settledAt = firstValidTimestamp(thread.settledAt);
-  if (settledAt !== null) return settledAt;
-  let latest: string | null = null;
-  let latestMs = Number.NEGATIVE_INFINITY;
-  for (const candidate of [
-    thread.latestUserMessageAt,
-    thread.latestTurn?.requestedAt,
-    thread.latestTurn?.startedAt,
-    thread.latestTurn?.completedAt,
-  ]) {
-    if (candidate == null) continue;
-    const parsed = Date.parse(candidate);
-    if (!Number.isNaN(parsed) && parsed > latestMs) {
-      latest = candidate;
-      latestMs = parsed;
-    }
-  }
-  return latest ?? firstValidTimestamp(thread.updatedAt);
-}
-
-// Settled rows are history, so they order by when the work ENDED, not when
-// the thread was created or last touched.
-export function sortSettledThreadsForSidebarV2<
-  T extends SettledTimestampInput & { readonly id: string },
->(threads: readonly T[]): T[] {
-  const timestampMs = (thread: T) => {
-    const timestamp = resolveSettledTimestamp(thread);
-    return timestamp === null ? 0 : Date.parse(timestamp);
-  };
-  return [...threads].toSorted(
-    (left, right) => timestampMs(right) - timestampMs(left) || left.id.localeCompare(right.id),
-  );
-}
-
 /** The timestamp a working thread's elapsed label counts from: the running
     turn's start (request time until adoption), falling back to the session's
     last transition when the turn projection lags behind. Malformed

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -6,7 +6,12 @@ import {
   effectiveSnoozed,
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
-import { sortThreadsForListV2 } from "@t3tools/client-runtime/state/thread-sort";
+import {
+  resolveSettledTimestamp,
+  sortSettledThreadsForListV2,
+  sortThreadsForListV2,
+  threadListV2Priority,
+} from "@t3tools/client-runtime/state/thread-sort";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
 import {
   scopeProjectRef,
@@ -116,13 +121,11 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveAdjacentThreadId,
-  resolveSettledTimestamp,
   resolveSidebarV2Status,
   searchSidebarThreadsByTitle,
   resolveWorkingStartedAt,
   shouldNavigateAfterProjectRemoval,
   sortLogicalProjectsForSidebar,
-  sortSettledThreadsForSidebarV2,
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
@@ -1578,7 +1581,7 @@ export default function SidebarV2() {
     const active: EnvironmentThreadShell[] = [];
     const snoozed: EnvironmentThreadShell[] = [];
     const settled: EnvironmentThreadShell[] = [];
-    const wokeThreadKeys = new Set<string>();
+    const wokeAtByThreadKey = new Map<string, string>();
     for (const thread of visible) {
       // Threads on servers without the settlement capability (old server,
       // or descriptor not loaded yet) never classify as settled: the user
@@ -1591,7 +1594,7 @@ export default function SidebarV2() {
       const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
       const changeRequestState = changeRequestStateByKey.get(threadKey) ?? null;
       const wokeAt = supportsSnooze ? threadWokeAt(thread, { now: preciseNow }) : null;
-      if (wokeAt !== null) wokeThreadKeys.add(threadKey);
+      if (wokeAt !== null) wokeAtByThreadKey.set(threadKey, wokeAt);
       // Snooze outranks settled classification: an explicitly snoozed thread
       // belongs to the shelf even if it would also auto-settle (the shelf's
       // wake time is a stronger statement about when it matters again).
@@ -1612,19 +1615,21 @@ export default function SidebarV2() {
       }
     }
     return {
-      activeThreads: sortThreadsForListV2(active, (thread) => {
-        const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-        if (wokeThreadKeys.has(threadKey)) return "woke";
-        if (thread.settledOverride === "active") return "unsettled";
-        return "default";
-      }),
+      activeThreads: sortThreadsForListV2(active, (thread) =>
+        threadListV2Priority(thread, {
+          wokeAt:
+            wokeAtByThreadKey.get(
+              scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+            ) ?? null,
+        }),
+      ),
       // Soonest wake first: "what comes back next" is the shelf's question.
       snoozedThreads: snoozed.toSorted(
         (left, right) =>
           firstValidTimestampMs(left.snoozedUntil ?? null) -
           firstValidTimestampMs(right.snoozedUntil ?? null),
       ),
-      settledThreads: sortSettledThreadsForSidebarV2(settled),
+      settledThreads: sortSettledThreadsForListV2(settled),
       snoozeNow: preciseNow,
     };
   }, [

--- a/packages/client-runtime/src/state/threadSort.test.ts
+++ b/packages/client-runtime/src/state/threadSort.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  sortSettledThreadsForListV2,
   sortThreads,
   sortThreadsForListV2,
+  threadListV2Priority,
   type ThreadListV2Priority,
   type ThreadSortInput,
 } from "./threadSort.ts";
@@ -111,5 +113,90 @@ describe("sortThreadsForListV2", () => {
     ];
 
     expect(sortThreadsForListV2(tied).map((thread) => thread.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("threadListV2Priority", () => {
+  it("ranks a wake above the manual keep-active pin", () => {
+    expect(
+      threadListV2Priority({ settledOverride: "active" }, { wokeAt: "2026-06-01T10:00:00.000Z" }),
+    ).toBe("woke");
+    expect(threadListV2Priority({ settledOverride: "active" }, { wokeAt: null })).toBe("unsettled");
+    expect(threadListV2Priority({ settledOverride: null }, { wokeAt: null })).toBe("default");
+  });
+});
+
+describe("sortSettledThreadsForListV2", () => {
+  const makeLatestTurn = (overrides?: { completedAt?: string | null }) => ({
+    requestedAt: "2026-03-09T10:00:00.000Z",
+    startedAt: "2026-03-09T10:00:00.000Z",
+    completedAt:
+      overrides?.completedAt !== undefined ? overrides.completedAt : "2026-03-09T10:05:00.000Z",
+  });
+
+  const settled = (input: {
+    id: string;
+    settledAt?: string | null;
+    latestUserMessageAt?: string | null;
+    latestTurn?: ReturnType<typeof makeLatestTurn> | null;
+    updatedAt?: string;
+  }) => ({
+    id: input.id,
+    settledAt: input.settledAt ?? null,
+    latestUserMessageAt: input.latestUserMessageAt ?? null,
+    latestTurn: input.latestTurn ?? null,
+    updatedAt: input.updatedAt ?? "2026-03-09T09:00:00.000Z",
+  });
+
+  it("orders by settle time, most recently settled first", () => {
+    const sorted = sortSettledThreadsForListV2([
+      settled({
+        id: "settled-first",
+        settledAt: "2026-03-09T10:00:00.000Z",
+        // Created/active later than the other thread: settle time must win.
+        latestUserMessageAt: "2026-03-09T09:59:00.000Z",
+      }),
+      settled({
+        id: "settled-last",
+        settledAt: "2026-03-09T12:00:00.000Z",
+        latestUserMessageAt: "2026-03-09T08:00:00.000Z",
+      }),
+    ]);
+
+    expect(sorted.map((thread) => thread.id)).toEqual(["settled-last", "settled-first"]);
+  });
+
+  it("falls back to last activity for auto-settled threads without a settledAt stamp", () => {
+    const sorted = sortSettledThreadsForListV2([
+      settled({ id: "auto-old", latestUserMessageAt: "2026-03-09T08:00:00.000Z" }),
+      settled({ id: "explicit", settledAt: "2026-03-09T10:00:00.000Z" }),
+      settled({ id: "auto-recent", latestUserMessageAt: "2026-03-09T11:00:00.000Z" }),
+    ]);
+
+    expect(sorted.map((thread) => thread.id)).toEqual(["auto-recent", "explicit", "auto-old"]);
+  });
+
+  it("counts a turn completion as activity for auto-settled threads", () => {
+    // The message came in before the other thread's, but its turn finished
+    // after: completion time is the real "work ended" moment.
+    const sorted = sortSettledThreadsForListV2([
+      settled({ id: "message-only", latestUserMessageAt: "2026-03-09T10:04:00.000Z" }),
+      settled({
+        id: "completed-later",
+        latestUserMessageAt: "2026-03-09T10:00:00.000Z",
+        latestTurn: makeLatestTurn({ completedAt: "2026-03-09T10:30:00.000Z" }),
+      }),
+    ]);
+
+    expect(sorted.map((thread) => thread.id)).toEqual(["completed-later", "message-only"]);
+  });
+
+  it("breaks timestamp ties by id so the order is stable", () => {
+    const sorted = sortSettledThreadsForListV2([
+      settled({ id: "b", settledAt: "2026-03-09T10:00:00.000Z" }),
+      settled({ id: "a", settledAt: "2026-03-09T10:00:00.000Z" }),
+    ]);
+
+    expect(sorted.map((thread) => thread.id)).toEqual(["a", "b"]);
   });
 });

--- a/packages/client-runtime/src/state/threadSort.ts
+++ b/packages/client-runtime/src/state/threadSort.ts
@@ -21,6 +21,18 @@ const THREAD_LIST_V2_PRIORITY_RANK: Record<ThreadListV2Priority, number> = {
   default: 2,
 };
 
+/** Priority from server-backed state only: every client (and every device)
+    must derive the same order, so per-client data like lastVisitedAt cannot
+    feed it. A wake outranks the manual keep-active pin. */
+export function threadListV2Priority(
+  thread: { readonly settledOverride: "settled" | "active" | null },
+  options: { readonly wokeAt: string | null },
+): ThreadListV2Priority {
+  if (options.wokeAt !== null) return "woke";
+  if (thread.settledOverride === "active") return "unsettled";
+  return "default";
+}
+
 export function toSortableTimestamp(iso: string | undefined): number | null {
   if (!iso) return null;
   const ms = Date.parse(iso);
@@ -81,6 +93,60 @@ export function sortThreadsForListV2<T extends { readonly id: string; readonly c
         THREAD_LIST_V2_PRIORITY_RANK[getPriority(right)] ||
       (toSortableTimestamp(right.createdAt) ?? 0) - (toSortableTimestamp(left.createdAt) ?? 0) ||
       left.id.localeCompare(right.id),
+  );
+}
+
+export interface SettledSortInput {
+  readonly settledAt: string | null;
+  readonly latestUserMessageAt: string | null;
+  readonly latestTurn: {
+    readonly requestedAt: string;
+    readonly startedAt: string | null;
+    readonly completedAt: string | null;
+  } | null;
+  readonly updatedAt: string;
+}
+
+/** The timestamp a settled row sorts and labels by: settledAt when stamped
+    (explicit settles), otherwise last activity — the same candidates the
+    auto-settle window uses (user message plus all latestTurn stamps), so a
+    thread whose last activity was a turn completion doesn't sort by an
+    older message time. updatedAt is the final net. */
+export function resolveSettledTimestamp(thread: SettledSortInput): string | null {
+  if (thread.settledAt !== null && toSortableTimestamp(thread.settledAt) !== null) {
+    return thread.settledAt;
+  }
+  let latest: string | null = null;
+  let latestMs = Number.NEGATIVE_INFINITY;
+  for (const candidate of [
+    thread.latestUserMessageAt,
+    thread.latestTurn?.requestedAt,
+    thread.latestTurn?.startedAt,
+    thread.latestTurn?.completedAt,
+  ]) {
+    if (candidate == null) continue;
+    const parsed = toSortableTimestamp(candidate);
+    if (parsed !== null && parsed > latestMs) {
+      latest = candidate;
+      latestMs = parsed;
+    }
+  }
+  if (latest !== null) return latest;
+  return toSortableTimestamp(thread.updatedAt) !== null ? thread.updatedAt : null;
+}
+
+// Settled rows are history, so they order by when the work ENDED, not when
+// the thread was created or last touched.
+export function sortSettledThreadsForListV2<T extends SettledSortInput & { readonly id: string }>(
+  threads: readonly T[],
+): T[] {
+  const timestampMs = (thread: T) => {
+    const timestamp = resolveSettledTimestamp(thread);
+    return timestamp === null ? 0 : (toSortableTimestamp(timestamp) ?? 0);
+  };
+  // Hermes does not ship the ES2023 change-by-copy array methods.
+  return [...threads].sort(
+    (left, right) => timestampMs(right) - timestampMs(left) || left.id.localeCompare(right.id),
   );
 }
 


### PR DESCRIPTION
Stacked on #4745.

Web and mobile each carried their own copy of the thread list v2 ordering rules: the active-list priority callback was duplicated at both call sites, and the settled tails used different comparators — mobile sorted by `latestUserMessageAt ?? updatedAt` and ignored `settledAt` entirely, so an explicitly settled thread could land in a different position on each client.

This moves the ordering rules into `@t3tools/client-runtime/state/thread-sort`, next to the already-shared `sortThreadsForListV2`:

- `threadListV2Priority` — the woke / un-settled / default ranking, derived only from server-backed state (`wokeAt`, `settledOverride`), so every client and device computes the same order by construction.
- `resolveSettledTimestamp` + `sortSettledThreadsForListV2` — moved from web's `Sidebar.logic.ts`; settled rows order by when the work ended (`settledAt`, else last activity). Mobile's settled tail now uses it too, and its slim-row time label reads from the same resolver so label and order can't disagree.

Both clients delete their local copies; web's settled-sort tests moved to the shared package with the code.

Verification:
- `vp test run packages/client-runtime apps/mobile apps/web/src/components` (1764 tests)
- `vp run --filter @t3tools/{client-runtime,web,mobile} typecheck`
- targeted lint and format checks

Made with Claude Fable 5 using Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/5144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared list ordering and mobile settled timestamps/labels across web and mobile; behavior is intentional but users may notice different settled order or time labels on mobile.
> 
> **Overview**
> Centralizes thread list v2 ordering in `@t3tools/client-runtime/state/thread-sort` so web and mobile no longer diverge.
> 
> **`threadListV2Priority`** replaces duplicated active-list callbacks (woke → keep-active pin → default), using only server-backed `wokeAt` and `settledOverride`. **`resolveSettledTimestamp`** and **`sortSettledThreadsForListV2`** move out of web `Sidebar.logic.ts`; settled rows sort by `settledAt` when present, else last activity (user message and `latestTurn` stamps), with stable id tie-breaks.
> 
> Web `SidebarV2` and mobile `threadListV2` call the shared helpers; local settled sort and priority logic are removed. Settled-sort tests relocate to `threadSort.test.ts`. On mobile, the settled tail now uses the shared comparator (fixing cases that ignored `settledAt`), and slim-row relative time uses `resolveSettledTimestamp` so labels match sort order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff72da4c0d548e361626c03de48291bfa070a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share thread list v2 sort logic into client-runtime for web and mobile
> - Extracts `resolveSettledTimestamp`, `sortSettledThreadsForListV2`, and `threadListV2Priority` into [`packages/client-runtime/src/state/threadSort.ts`](https://github.com/pingdotgg/t3code/pull/5144/files#diff-a06bd97596d6426983ec2b77aeab0f1bbcdf6b395f70b9ab52fc16b0fa7b7d6d) so web and mobile share a single implementation.
> - Removes duplicate local implementations from [`apps/web/src/components/Sidebar.logic.ts`](https://github.com/pingdotgg/t3code/pull/5144/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) and updates [`SidebarV2.tsx`](https://github.com/pingdotgg/t3code/pull/5144/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) and [`threadListV2.ts`](https://github.com/pingdotgg/t3code/pull/5144/files#diff-d629687d2b79a927cf01be39191d0e3fc66435674cd6f8a588469b55c70210ed) to use the shared functions.
> - Settled threads are now ordered by explicit `settledAt` first, then by last activity including `latestTurn` timestamps, with a stable id tie-break.
> - Active thread priority now uses a shared helper that ranks wake timestamps above manual keep-active pins.
> - Behavioral Change: non-snoozed rows in the mobile thread list now show elapsed time based on the settled timestamp rather than `latestUserMessageAt`/`updatedAt`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aff72da.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->