### PR TITLE
fix(tailscale): fall back to the macOS app binary when tailscale isn't on PATH

### DIFF
--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -14,6 +15,7 @@ import {
   disableTailscaleServe,
   ensureTailscaleServe,
   isTailscaleIpv4Address,
+  MACOS_TAILSCALE_APP_EXECUTABLE,
   parseTailscaleMagicDnsName,
   parseTailscaleStatus,
   readTailscaleStatus,
@@ -21,6 +23,7 @@ import {
   TailscaleCommandExitError,
   TailscaleCommandSpawnError,
   TailscaleCommandTimeoutError,
+  TailscaleExecutableFileCheck,
   TailscaleStatusParseError,
 } from "./tailscale.ts";
 
@@ -209,6 +212,93 @@ describe("tailscale", () => {
       assert.strictEqual(error.cause, cause);
       assert.equal(error.message, "Failed to spawn tailscale status.");
       assert.notInclude(error.message, systemCause.message);
+    });
+  });
+
+  it.effect("falls back to the macOS Tailscale.app binary when `tailscale` isn't on PATH", () => {
+    const notFoundCause = PlatformError.systemError({
+      _tag: "NotFound",
+      module: "ChildProcess",
+      method: "spawn",
+      cause: new Error("ENOENT"),
+    });
+    const spawnedCommands: Array<string> = [];
+    const layer = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        const childProcess = command as unknown as { readonly command: string };
+        spawnedCommands.push(childProcess.command);
+        return childProcess.command === "tailscale"
+          ? Effect.fail(notFoundCause)
+          : Effect.succeed(mockHandle({ stdout: tailscaleStatusWithSingleIpJson }));
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const status = yield* readTailscaleStatus.pipe(
+        Effect.provideService(HostProcessPlatform, "darwin"),
+        Effect.provideService(
+          TailscaleExecutableFileCheck,
+          (filePath) => filePath === MACOS_TAILSCALE_APP_EXECUTABLE,
+        ),
+        Effect.provide(layer),
+      );
+
+      assert.deepEqual(status, {
+        magicDnsName: "desktop.tail.ts.net",
+        tailnetIpv4Addresses: ["100.90.1.2"],
+      });
+      assert.deepEqual(spawnedCommands, ["tailscale", MACOS_TAILSCALE_APP_EXECUTABLE]);
+    });
+  });
+
+  it.effect("does not fall back when the macOS Tailscale.app binary isn't installed either", () => {
+    const notFoundCause = PlatformError.systemError({
+      _tag: "NotFound",
+      module: "ChildProcess",
+      method: "spawn",
+      cause: new Error("ENOENT"),
+    });
+    const layer = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => Effect.fail(notFoundCause)),
+    );
+
+    return Effect.gen(function* () {
+      const error = yield* readTailscaleStatus.pipe(
+        Effect.provideService(HostProcessPlatform, "darwin"),
+        Effect.provideService(TailscaleExecutableFileCheck, () => false),
+        Effect.provide(layer),
+        Effect.flip,
+      );
+
+      assert.instanceOf(error, TailscaleCommandSpawnError);
+      assert.strictEqual(error.cause, notFoundCause);
+    });
+  });
+
+  it.effect("does not fall back to the macOS binary on non-macOS platforms", () => {
+    const notFoundCause = PlatformError.systemError({
+      _tag: "NotFound",
+      module: "ChildProcess",
+      method: "spawn",
+      cause: new Error("ENOENT"),
+    });
+    const layer = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => Effect.fail(notFoundCause)),
+    );
+
+    return Effect.gen(function* () {
+      const error = yield* readTailscaleStatus.pipe(
+        Effect.provideService(HostProcessPlatform, "linux"),
+        Effect.provideService(TailscaleExecutableFileCheck, () => true),
+        Effect.provide(layer),
+        Effect.flip,
+      );
+
+      assert.instanceOf(error, TailscaleCommandSpawnError);
+      assert.strictEqual(error.cause, notFoundCause);
     });
   });
 

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -1,7 +1,12 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import type * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
@@ -16,6 +21,32 @@ export const TAILSCALE_PROBE_TIMEOUT = Duration.millis(2_500);
 // it is always spawned directly rather than through cmd.exe shell mode.
 const tailscaleCommandForPlatform = (platform: NodeJS.Platform): "tailscale" | "tailscale.exe" =>
   platform === "win32" ? "tailscale.exe" : "tailscale";
+
+// The Tailscale macOS app doesn't put `tailscale` on PATH; Tailscale's own
+// docs have users add a shell alias to this binary instead, which is
+// invisible to a direct (non-shell) subprocess spawn.
+export const MACOS_TAILSCALE_APP_EXECUTABLE =
+  "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
+
+export type TailscaleExecutableFileCheck = (filePath: string) => boolean;
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return NodeFS.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Injectable file-existence check so tests can run against a fake filesystem. */
+export const TailscaleExecutableFileCheck = Context.Reference<TailscaleExecutableFileCheck>(
+  "@t3tools/tailscale/TailscaleExecutableFileCheck",
+  { defaultValue: () => isExistingFile },
+);
+
+function isSpawnNotFoundError(error: PlatformError.PlatformError): boolean {
+  return error.reason._tag === "NotFound";
+}
 
 const TailscaleCommandContext = {
   executable: Schema.Literals(["tailscale", "tailscale.exe"]),
@@ -221,6 +252,7 @@ export const readTailscaleStatus = Effect.gen(function* () {
   const args = ["status", "--json"];
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const hostPlatform = yield* HostProcessPlatform;
+  const isExecutableFile = yield* TailscaleExecutableFileCheck;
   const executable = tailscaleCommandForPlatform(hostPlatform);
   const commandContext = {
     executable,
@@ -228,11 +260,16 @@ export const readTailscaleStatus = Effect.gen(function* () {
     argumentCount: args.length,
   };
   return yield* Effect.gen(function* () {
-    const child = yield* spawner
-      .spawn(ChildProcess.make(executable, args))
-      .pipe(
-        Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
-      );
+    const child = yield* spawner.spawn(ChildProcess.make(executable, args)).pipe(
+      Effect.catchIf(
+        (error) => hostPlatform === "darwin" && isSpawnNotFoundError(error),
+        (error) =>
+          isExecutableFile(MACOS_TAILSCALE_APP_EXECUTABLE)
+            ? spawner.spawn(ChildProcess.make(MACOS_TAILSCALE_APP_EXECUTABLE, args))
+            : Effect.fail(error),
+      ),
+      Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
+    );
     const [stdout, stderr, exitCode] = yield* Effect.all(
       [
         collectStdout(child.stdout),
@@ -291,6 +328,7 @@ const runTailscaleCommand = (
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const hostPlatform = yield* HostProcessPlatform;
+    const isExecutableFile = yield* TailscaleExecutableFileCheck;
     const executable = tailscaleCommandForPlatform(hostPlatform);
     const commandContext = {
       executable,
@@ -299,11 +337,16 @@ const runTailscaleCommand = (
     };
     const timeout = Duration.fromInputUnsafe(timeoutInput);
     return yield* Effect.gen(function* () {
-      const child = yield* spawner
-        .spawn(ChildProcess.make(executable, args))
-        .pipe(
-          Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
-        );
+      const child = yield* spawner.spawn(ChildProcess.make(executable, args)).pipe(
+        Effect.catchIf(
+          (error) => hostPlatform === "darwin" && isSpawnNotFoundError(error),
+          (error) =>
+            isExecutableFile(MACOS_TAILSCALE_APP_EXECUTABLE)
+              ? spawner.spawn(ChildProcess.make(MACOS_TAILSCALE_APP_EXECUTABLE, args))
+              : Effect.fail(error),
+        ),
+        Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
+      );
       const [stderr, exitCode] = yield* Effect.all(
         [collectStderr(child.stderr), child.exitCode.pipe(Effect.map(Number))],
         { concurrency: "unbounded" },


### PR DESCRIPTION
## What changed

`packages/tailscale/src/tailscale.ts`: when spawning `tailscale` fails with `ENOENT` on macOS, retry once against `/Applications/Tailscale.app/Contents/MacOS/Tailscale` if that file exists, instead of surfacing the spawn failure immediately. This applies to both `readTailscaleStatus` (Tailnet/MagicDNS detection) and `runTailscaleCommand` (`serve`/`serve off`). The file-existence check is exposed as an injectable `TailscaleExecutableFileCheck` (mirrors the existing `ClaudeExecutableFileCheck` pattern in `apps/server/src/provider/Drivers/ClaudeExecutable.ts`) so tests can fake the filesystem instead of touching real paths. Added three tests covering the retry, the no-retry-when-binary-absent case, and the no-retry-on-non-macOS case. No behavior change on Linux/Windows or when the app binary isn't installed.

## Why

Tailscale's macOS app does not put a `tailscale` binary on `PATH`. Their own docs have users work around this with a shell alias (`alias tailscale=/Applications/Tailscale.app/Contents/MacOS/Tailscale`) or by manually symlinking it into `/usr/local/bin`. A shell alias only exists inside an interactive shell — it's invisible to `child_process.spawn`, which does a direct `PATH` lookup without going through a shell. So on any Mac where the user relies on the alias (rather than a manual symlink), every tailscale spawn in this codebase fails with `ENOENT`, and that failure is currently swallowed as "not on Tailscale" (e.g. `apps/desktop/src/backend/tailscaleEndpointProvider.ts` treats the read failure as `magicDnsName: null`). The user's machine is actually on the Tailnet and `tailscale status --json` works fine when typed at a prompt — this is purely a subprocess PATH-resolution gap, not a networking issue.

I hit this locally: `tailscale` resolved via `type tailscale` as a zsh alias only, and a bare `child_process.spawn('tailscale', ...)` reproduced `SPAWN ERROR: spawn tailscale ENOENT` even though `tailscale status --json` succeeded when run directly in the shell.

## Test plan

- [x] `pnpm --filter @t3tools/tailscale typecheck`
- [x] `pnpm --filter @t3tools/tailscale test` (16/16 passing, including 3 new cases)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to macOS subprocess resolution with existence-gated fallback; no change to Linux/Windows or when the app binary is absent, and tests cover the new paths.
> 
> **Overview**
> On **macOS**, when spawning `tailscale` fails with **ENOENT**, the package now retries once using `/Applications/Tailscale.app/Contents/MacOS/Tailscale` if that file exists. This covers **status** reads and **serve** / **serve off** commands, so Tailnet detection works when users rely on a shell alias instead of a PATH binary.
> 
> File existence is checked via an injectable **`TailscaleExecutableFileCheck`** (default `statSync`), so tests can fake the filesystem. **Linux, Windows, and macOS without the app binary** keep the previous behavior—no fallback off darwin or when the app executable is missing.
> 
> Three tests cover successful fallback, missing app binary, and no fallback on non-macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17cca1b7700c0a3f8c3c402d3802e4858967c65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to the macOS Tailscale.app binary when `tailscale` is not on PATH
> - When spawning `tailscale` fails with a `NotFound` error on macOS, `readTailscaleStatus` and `runTailscaleCommand` now retry using `/Applications/Tailscale.app/Contents/MacOS/Tailscale` if that file exists.
> - A new `TailscaleExecutableFileCheck` Effect context reference wraps the file-existence check, allowing tests to inject a mock without touching the filesystem.
> - If the fallback binary does not exist, or the platform is not macOS, the original `NotFound` error is preserved and surfaced as a `TailscaleCommandSpawnError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e17cca1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->