### PR TITLE
fix(desktop,web): contain renderer memory growth and recover from renderer OOM crashes

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -1,3 +1,4 @@
+import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -25,6 +26,12 @@ const TITLEBAR_LIGHT_SYMBOL_COLOR = "#1f2937";
 const TITLEBAR_DARK_SYMBOL_COLOR = "#f8fafc";
 const MAIN_WINDOW_BOUNDS_PERSIST_DEBOUNCE_MS = 500;
 const DEVELOPMENT_LOAD_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000] as const;
+// Renderer crash (usually V8 OOM on long sessions) recovery: reload after a
+// short delay, at most MAX_ATTEMPTS times per rolling WINDOW so a renderer
+// that dies on boot cannot reload-loop forever.
+const RENDERER_RECOVERY_RELOAD_DELAY_MS = 500;
+const RENDERER_RECOVERY_MAX_ATTEMPTS = 3;
+const RENDERER_RECOVERY_WINDOW_MS = 60_000;
 const DEVELOPMENT_RETRYABLE_LOAD_ERROR_CODES = new Set([
   -2, // ERR_FAILED
   -7, // ERR_TIMED_OUT
@@ -537,6 +544,7 @@ export const make = Effect.gen(function* () {
 
     let developmentLoadRetryIndex = 0;
     let developmentLoadRetryFiber: Fiber.Fiber<void, never> | undefined;
+    let rendererRecoveryTimestamps: number[] = [];
     const clearDevelopmentLoadRetry = () => {
       if (developmentLoadRetryFiber === undefined) {
         return;
@@ -618,10 +626,39 @@ export const make = Effect.gen(function* () {
       },
     );
     window.webContents.on("render-process-gone", (_event, details) => {
-      void runPromise(
-        logWindowWarning("main window render process gone", {
-          reason: details.reason,
-          exitCode: details.exitCode,
+      const recoverable =
+        details.reason === "crashed" ||
+        details.reason === "oom" ||
+        details.reason === "abnormal-exit";
+      // Long sessions can OOM the renderer (V8 heap exhaustion from
+      // accumulated thread state). Without a reload the user is left staring
+      // at a dead white window while agents keep running invisibly, so
+      // recover by reloading — the renderer rehydrates from the backend,
+      // which is unaffected. Recovery attempts are bounded so a renderer
+      // that dies immediately on boot cannot reload-loop forever.
+      runFork(
+        Effect.gen(function* () {
+          const now = yield* Clock.currentTimeMillis;
+          rendererRecoveryTimestamps = rendererRecoveryTimestamps.filter(
+            (timestamp) => now - timestamp < RENDERER_RECOVERY_WINDOW_MS,
+          );
+          const shouldRecover =
+            recoverable &&
+            !window.isDestroyed() &&
+            rendererRecoveryTimestamps.length < RENDERER_RECOVERY_MAX_ATTEMPTS;
+          yield* logWindowWarning("main window render process gone", {
+            reason: details.reason,
+            exitCode: details.exitCode,
+            recovering: shouldRecover,
+          });
+          if (!shouldRecover) {
+            return;
+          }
+          rendererRecoveryTimestamps.push(now);
+          yield* Effect.sleep(RENDERER_RECOVERY_RELOAD_DELAY_MS);
+          if (!window.isDestroyed()) {
+            loadApplication();
+          }
         }),
       );
     });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -16,8 +16,12 @@ import { resolveServerBackedAppStageLabel } from "../branding.logic";
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
 // Visible sidebar rows are prewarmed into the thread-detail cache so opening a
-// nearby thread usually reuses an already-hot subscription.
-export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
+// nearby thread usually reuses an already-hot subscription. Each prewarmed
+// thread holds a live, fully hydrated detail subscription (all messages and
+// activities, growing as agents work) for as long as the row stays visible,
+// so this limit is a direct renderer-heap and server-load multiplier — keep
+// it small; cold opens still render instantly from the cached snapshot.
+export const SIDEBAR_THREAD_PREWARM_LIMIT = 3;
 
 type SidebarProject = {
   id: string;

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -633,6 +633,94 @@ describe("applyThreadDetailEvent", () => {
         expect(result.thread.activities[0]?.id).toBe("activity-0");
       }
     });
+
+    it("replaces earlier resolvable context-window updates for the same turn", () => {
+      const contextWindowActivity = (id: string, sequence: number, usedTokens: unknown) => ({
+        id: EventId.make(id),
+        tone: "info" as const,
+        kind: "context-window.updated",
+        summary: "Context window updated",
+        payload: { usedTokens },
+        turnId: TurnId.make("turn-1"),
+        sequence,
+        createdAt: "2026-04-01T11:00:00.000Z",
+      });
+      const otherTurnActivity = contextWindowActivity("activity-other-turn", 2, 500);
+      const existingActivities = [
+        contextWindowActivity("activity-cw-1", 1, 1_000),
+        { ...otherTurnActivity, turnId: TurnId.make("turn-0") },
+        // Malformed row (no usedTokens): must survive, and must not be
+        // treated as the latest value by consumers.
+        contextWindowActivity("activity-cw-malformed", 3, undefined),
+        contextWindowActivity("activity-cw-2", 4, 2_000),
+      ];
+
+      const result = applyThreadDetailEvent(
+        { ...baseThread, activities: existingActivities },
+        {
+          ...baseEventFields,
+          sequence: 20,
+          occurredAt: "2026-04-01T11:02:00.000Z",
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-1"),
+          type: "thread.activity-appended",
+          payload: {
+            threadId: ThreadId.make("thread-1"),
+            activity: contextWindowActivity("activity-cw-3", 5, 3_000),
+          },
+        },
+      );
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        const ids = result.thread.activities.map((activity) => activity.id);
+        // Same-turn resolvable rows collapse to the newest; the other turn's
+        // row and the malformed row are untouched.
+        expect(ids).toEqual(["activity-other-turn", "activity-cw-malformed", "activity-cw-3"]);
+      }
+    });
+
+    it("does not collapse context-window history for a malformed update", () => {
+      const resolvable = {
+        id: EventId.make("activity-cw-resolvable"),
+        tone: "info" as const,
+        kind: "context-window.updated",
+        summary: "Context window updated",
+        payload: { usedTokens: 1_000 },
+        turnId: TurnId.make("turn-1"),
+        sequence: 1,
+        createdAt: "2026-04-01T11:00:00.000Z",
+      };
+
+      const result = applyThreadDetailEvent(
+        { ...baseThread, activities: [resolvable] },
+        {
+          ...baseEventFields,
+          sequence: 21,
+          occurredAt: "2026-04-01T11:03:00.000Z",
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-1"),
+          type: "thread.activity-appended",
+          payload: {
+            threadId: ThreadId.make("thread-1"),
+            activity: {
+              ...resolvable,
+              id: EventId.make("activity-cw-broken"),
+              payload: { usedTokens: Number.NaN },
+              sequence: 2,
+            },
+          },
+        },
+      );
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        // The resolvable row must survive so consumers can still derive a
+        // usage value by walking backwards past the malformed row.
+        const ids = result.thread.activities.map((activity) => activity.id);
+        expect(ids).toEqual(["activity-cw-resolvable", "activity-cw-broken"]);
+      }
+    });
   });
 
   describe("thread.turn-diff-completed", () => {

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -36,6 +36,24 @@ const activityOrder = O.combineAll<OrchestrationThreadActivity>([
 ]);
 
 /**
+ * Matches the validity rule in `deriveLatestContextWindowSnapshot` (and the
+ * server's snapshot-side `dropStaleContextWindowActivities`): rows without a
+ * finite, non-negative `usedTokens` are skipped during the consumer's backward
+ * walk, so they must not replace an earlier resolvable row here.
+ */
+function isResolvableContextWindowActivity(activity: OrchestrationThreadActivity): boolean {
+  if (activity.kind !== "context-window.updated") {
+    return false;
+  }
+  const payload =
+    activity.payload && typeof activity.payload === "object"
+      ? (activity.payload as Record<string, unknown>)
+      : null;
+  const usedTokens = payload?.usedTokens;
+  return typeof usedTokens === "number" && Number.isFinite(usedTokens) && usedTokens >= 0;
+}
+
+/**
  * Apply a single orchestration event to an `OrchestrationThread`, returning
  * the updated thread, a deletion signal, or an "unchanged" marker when the
  * event doesn't affect this thread.
@@ -509,10 +527,28 @@ export function applyThreadDetailEvent(
 
     // ── Activities ──────────────────────────────────────────────────
     case "thread.activity-appended": {
+      const activity = event.payload.activity;
+      // A resolvable context-window update supersedes earlier resolvable ones
+      // for the same turn: consumers only read the latest value (walking the
+      // array backwards), and providers stream these updates continuously, so
+      // retaining the history grows the thread by thousands of rows over a
+      // long session. Mirrors the server-side snapshot rule in
+      // dropStaleContextWindowActivities; retention stays per turn so a
+      // thread.reverted that discards turns can still resolve a value from
+      // the turns that survive.
+      const supersedesContextWindow = isResolvableContextWindowActivity(activity);
       const activities = pipe(
         thread.activities,
-        Arr.filter((activity) => activity.id !== event.payload.activity.id),
-        Arr.append(event.payload.activity),
+        Arr.filter(
+          (entry) =>
+            entry.id !== activity.id &&
+            !(
+              supersedesContextWindow &&
+              entry.turnId === activity.turnId &&
+              isResolvableContextWindowActivity(entry)
+            ),
+        ),
+        Arr.append(activity),
         Arr.sort(activityOrder),
       );
 


### PR DESCRIPTION
The desktop renderer OOMs at V8's heap ceiling (~3.7 GB) on long sessions and dies to a white screen (#1686, and the claudeissues mirror users keep hitting). The window frame survives, the renderer doesn't, and agents keep running invisibly behind a dead UI.

Investigation on current main found three renderer-side growth/recovery gaps:

1. **Live `context-window.updated` rows accumulate forever.** Providers stream these continuously; consumers only ever read the latest value per turn (walking backwards). The server already collapses them in snapshots (`dropStaleContextWindowActivities`, #4791) but deliberately left live events untouched — so a long-running session still retains thousands of rows per thread client-side. The reducer now applies the same per-turn collapse on the live path, with identical malformed-row semantics (an unresolvable row never replaces a resolvable one, so the meter can always derive a value).
2. **The sidebar pins up to 10 fully hydrated live thread subscriptions.** Each prewarmed row holds every message and activity of its thread, growing as agents work, for as long as the row is visible — the 5-minute idle TTL never fires. Dropped to 3. Cold opens still render instantly from the cached snapshot, then transition to live.
3. **`render-process-gone` only logged.** The window now reloads on crashed/oom/abnormal-exit, bounded to 3 attempts per rolling minute so a boot-crash can't reload-loop. The backend is a separate process and unaffected, so a reload fully rehydrates — the white screen becomes a ~1s blip instead of data loss.

No user-visible behavior change outside crash recovery itself.

Companion to #5147 (server-side OOM containment). Long term, the real fix is moving tool.completed payloads out of the hot paths entirely.

Verification:
- 2 new reducer tests (same-turn collapse incl. malformed rows and cross-turn retention; malformed update never displaces a resolvable row)
- client-runtime suite 510 passed, web suite 1754 passed, desktop suite 406 passed
- typecheck (client-runtime, web, desktop, mobile), lint, format clean

Built by Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live event reduction and desktop crash recovery paths; bounded reload limits boot-loop risk, but incorrect collapse rules could affect context-window display or thread activity history.
> 
> **Overview**
> Targets **renderer heap growth** and **dead UI after V8 OOM** on long desktop sessions without changing normal UX except when the renderer actually crashes.
> 
> **Client thread state:** On live `thread.activity-appended`, **resolvable** `context-window.updated` rows for the same turn now **collapse to the newest** (matching server snapshot `dropStaleContextWindowActivities`). Malformed rows do not replace earlier resolvable ones. This cuts thousands of redundant activity rows per thread over long agent runs.
> 
> **Web sidebar:** `SIDEBAR_THREAD_PREWARM_LIMIT` drops from **10 → 3**, reducing how many visible rows keep **full live thread-detail subscriptions** (messages + activities) in memory.
> 
> **Desktop main window:** `render-process-gone` for **crashed / oom / abnormal-exit** triggers a **bounded reload** (500ms delay, max **3** attempts per rolling **60s**), so users get a brief rehydrate instead of a permanent white screen while the backend keeps running.
> 
> Tests cover context-window collapse semantics in `threadReducer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d46b9522071705f165467a66c1c0e24952b7976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix renderer memory growth and recover from renderer OOM crashes in desktop and web
> - Adds auto-reload recovery to the desktop `DesktopWindow` renderer: on `crashed`, `oom`, or `abnormal-exit`, waits 500ms then reloads, up to 3 times per 60s window before giving up and logging only.
> - Reduces the sidebar thread prewarm limit from 10 to 3 in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/5148/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to lower concurrent detail subscriptions and memory pressure.
> - Collapses redundant `context-window.updated` activities in `threadReducer`: when a valid (finite, non-negative `usedTokens`) update is appended, earlier valid updates for the same turn are dropped; malformed updates are preserved and do not displace valid history.
> - Behavioral Change: the desktop app will now silently reload up to 3 times on renderer failure before requiring a manual restart.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d46b95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->