### PR TITLE
fix(mobile): keep file rows above search toolbar

### DIFF
--- a/apps/mobile/src/features/files/FileTreeBrowser.tsx
+++ b/apps/mobile/src/features/files/FileTreeBrowser.tsx
@@ -106,6 +106,7 @@ const FileTreeRow = memo(function FileTreeRow(props: {
 });
 
 export function FileTreeBrowser(props: {
+  readonly bottomContentPadding?: number;
   readonly entries: ReadonlyArray<ProjectEntry>;
   readonly error: string | null;
   readonly isPending: boolean;
@@ -255,7 +256,10 @@ export function FileTreeBrowser(props: {
       maxToRenderPerBatch={FILE_TREE_RENDER_BATCH_SIZE}
       updateCellsBatchingPeriod={16}
       windowSize={5}
-      contentContainerStyle={{ paddingTop: 8, paddingBottom: 8 }}
+      contentContainerStyle={{
+        paddingTop: 8,
+        paddingBottom: props.bottomContentPadding ?? 8,
+      }}
       refreshControl={<RefreshControl refreshing={props.isPending} onRefresh={props.onRefresh} />}
       renderItem={renderItem}
       ListEmptyComponent={

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -446,6 +446,10 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
         </>
       )}
       <FileTreeBrowser
+        bottomContentPadding={
+          // Matches the h-28 toolbar fade: 28 spacing units at 4 points each.
+          isAndroid ? undefined : 112
+        }
         entries={entriesData?.entries ?? []}
         error={entriesQuery.error}
         isPending={entriesQuery.isPending}


### PR DESCRIPTION
## What Changed

- Allow the shared file tree to accept route-specific bottom content padding.
- Reserve 112 points below the iOS thread file list, matching the existing toolbar fade.
- Leave the Android in-flow search layout and iPad file navigator unchanged.

## Why

With enough files in a thread, the final row could scroll underneath the floating iOS search toolbar and become untappable. The added scrollable footer lets the final row settle fully above the toolbar.

## UI Changes

Before: the final file row could remain underneath the floating iOS search toolbar at the end of the list.

After: the final row scrolls above a toolbar-sized empty footer and remains tappable.

Before/after screenshots are unavailable because the current Linux test host has no iOS simulator; Android uses an in-flow search field and does not reproduce the overlap.

## Verification

- `vp fmt --check apps/mobile/src/features/files/FileTreeBrowser.tsx apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx`
- `vp lint apps/mobile/src/features/files/FileTreeBrowser.tsx apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx --report-unused-disable-directives`
- `vp run --filter @t3tools/mobile typecheck`
- `vp test run apps/mobile/src/features/files/fileTree.test.ts` (5 tests passed)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for UI changes (iOS simulator unavailable on this host)
- [x] Video is not applicable; this change has no animation or timing behavior

Created with gpt-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized scroll padding for one iOS screen; no auth, data, or shared business-logic changes.
> 
> **Overview**
> Fixes the thread **Files** list on iOS where the last file row could sit under the floating search toolbar and stay untappable after scrolling.
> 
> `FileTreeBrowser` now accepts optional **`bottomContentPadding`** on its `FlatList` (default **8**). `ThreadFilesTreeScreen` passes **112** on non-Android platforms to match the existing **`h-28`** toolbar fade height. Android (in-flow search) and other `FileTreeBrowser` callers such as the iPad file navigator are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 009270c6ba1c0ad4f00f830e6a70b6615eb1fae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep file rows above search toolbar by adding bottom padding to FileTreeBrowser
> Adds a `bottomContentPadding` prop to [`FileTreeBrowser`](https://github.com/pingdotgg/t3code/pull/5149/files#diff-8353fd7ee22cd906a02c3d0415f8ad40f8a91cd9cdfc919491f52e63499db6c4), defaulting to 8 when not set. In [`ThreadFilesRouteScreen`](https://github.com/pingdotgg/t3code/pull/5149/files#diff-9d701f672b12c7184cdf9b51e0e5b5417c35e688fe894ee38e91017bf15aea6a), this prop is set to 112 on non-Android platforms so list content scrolls clear of the search toolbar. Android behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 009270c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->