### PR TITLE
fix: threads with open PRs no longer auto-settle

### DIFF
--- a/packages/client-runtime/src/state/threadSettled.test.ts
+++ b/packages/client-runtime/src/state/threadSettled.test.ts
@@ -115,13 +115,15 @@ describe("effectiveSettled", () => {
             // Settled iff nothing blocks (pending work / live session) AND
             // the override says settled, or (with no override) a merged PR
             // or staleness auto-settles. The "active" pin suppresses both
-            // auto signals.
+            // auto signals, and an open PR suppresses the inactivity path:
+            // a thread with a PR out for review is never done, however quiet.
             expected:
               pending === undefined &&
               !running &&
               (settledOverride === "settled" ||
                 (settledOverride === null &&
-                  (changeRequestState === "merged" || inactivity === "stale"))),
+                  (changeRequestState === "merged" ||
+                    (changeRequestState !== "open" && inactivity === "stale")))),
           })),
         ),
       ),
@@ -174,6 +176,26 @@ describe("effectiveSettled", () => {
         }),
       ).toBe(true);
     }
+  });
+
+  it("never auto-settles a stale thread with an open change request", () => {
+    const stale = makeShell({ activityAt: STALE });
+    expect(
+      effectiveSettled(stale, {
+        now: NOW,
+        autoSettleAfterDays: 3,
+        changeRequestState: "open",
+      }),
+    ).toBe(false);
+    // An explicit user settle still wins: open PR only blocks the auto path.
+    const settled = makeShell({ settledOverride: "settled", activityAt: STALE });
+    expect(
+      effectiveSettled(settled, {
+        now: NOW,
+        autoSettleAfterDays: 3,
+        changeRequestState: "open",
+      }),
+    ).toBe(true);
   });
 
   it("keeps an explicitly un-settled merged-PR thread active", () => {

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -222,7 +222,8 @@ export function threadWokeAt(
  * override. Past the blockers, the explicit user override (thread.settle /
  * thread.unsettle commands, projected into settledOverride + settledAt)
  * wins in both directions; without one, a thread auto-settles on a
- * merged/closed PR immediately or on inactivity past the window. The server
+ * merged/closed PR immediately or on inactivity past the window — except
+ * that an open PR blocks the inactivity path entirely. The server
  * un-settles on real activity (user message, session start, approval/
  * user-input request), so an override never goes stale silently.
  */
@@ -260,6 +261,11 @@ export function effectiveSettled(
   if (options.changeRequestState === "merged" || options.changeRequestState === "closed") {
     return true;
   }
+  // An open PR is unfinished business regardless of how long the thread has
+  // been quiet: review can take days, and hiding the thread would bury the
+  // work waiting on it. Only merge/close (above) or an explicit user settle
+  // resolves it.
+  if (options.changeRequestState === "open") return false;
   if (options.autoSettleAfterDays === null) return false;
 
   const lastActivityAt = threadLastActivityAt(shell);


### PR DESCRIPTION
Threads with a PR out for review were auto-settling after the inactivity window, hiding unfinished work in the settled tail. Review can take days of silence; quiet is not done.

An open change request now blocks the inactivity path in the shared `effectiveSettled` (used by web sidebar, ChatView, and mobile). Merge/close still settles immediately, an explicit user settle still wins, and the existing activity blockers are unchanged. Client-side only — the server has no inactivity auto-settle.

Extended the truth table plus a focused test for open-PR staleness and explicit settle.

Written by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only settled-state logic with expanded tests; no server or auth changes, but inbox visibility behavior shifts for stale threads with open PRs.
> 
> **Overview**
> **Threads with an open change request no longer auto-settle** when they pass the inactivity window. Quiet time during review was incorrectly moving them into the settled tail and hiding unfinished PR work.
> 
> `effectiveSettled` in **client-runtime** now treats **`changeRequestState === "open"`** as blocking the inactivity path only: merged/closed PRs still auto-settle immediately, explicit **`settledOverride === "settled"`** still wins, and existing blockers (pending approvals, live session, queued turn) are unchanged. This is **client-side classification** for sidebar/ChatView/mobile list partitioning.
> 
> Tests extend the truth table and add a case for stale + open PR (plus explicit settle still settling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 944c87ca05bf048b08df41fcd696f01b5cb4e3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent threads with open PRs from auto-settling due to inactivity
> Adds an early return in `effectiveSettled` so that threads with `changeRequestState === "open"` always return `false`, bypassing the inactivity-based auto-settle path. Threads with open PRs now only settle via an explicit user action or when the change request is merged or closed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 944c87c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->