### PR TITLE
fix(mobile): persist thread shelf collapse state

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -572,10 +572,26 @@ export function HomeScreen(props: HomeScreenProps) {
     () => setSettledVisibleCount((count) => count + THREAD_LIST_V2_SETTLED_PAGE_COUNT),
     [],
   );
-  const [snoozedShelfExpanded, setSnoozedShelfExpanded] = useState(false);
-  const toggleSnoozedShelf = useCallback(() => setSnoozedShelfExpanded((value) => !value), []);
-  const [settledShelfExpanded, setSettledShelfExpanded] = useState(true);
-  const toggleSettledShelf = useCallback(() => setSettledShelfExpanded((value) => !value), []);
+  const snoozedShelfExpanded =
+    AsyncResult.isSuccess(preferencesResult) &&
+    preferencesResult.value.threadListV2SnoozedShelfExpanded === true;
+  const toggleSnoozedShelf = useCallback(
+    () =>
+      savePreferences({
+        threadListV2SnoozedShelfExpanded: !snoozedShelfExpanded,
+      }),
+    [savePreferences, snoozedShelfExpanded],
+  );
+  const settledShelfExpanded =
+    !AsyncResult.isSuccess(preferencesResult) ||
+    preferencesResult.value.threadListV2SettledShelfExpanded !== false;
+  const toggleSettledShelf = useCallback(
+    () =>
+      savePreferences({
+        threadListV2SettledShelfExpanded: !settledShelfExpanded,
+      }),
+    [savePreferences, settledShelfExpanded],
+  );
   // now is quantized to the minute and ticks so the inactivity auto-settle
   // boundary is actually crossed while the app stays open (mirrors web);
   // without a clock dependency the partition memoizes a frozen "now".

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -56,6 +56,7 @@ import {
   THREAD_LIST_V2_SETTLED_PAGE_COUNT,
   type ThreadListV2ListItem,
 } from "../threads/threadListV2";
+import { useThreadListV2ShelfPreferences } from "../threads/use-thread-list-v2-shelf-preferences";
 import type { HomeListFilterMenuEnvironment } from "./home-list-filter-menu";
 import {
   buildHomeListLayout,
@@ -572,26 +573,13 @@ export function HomeScreen(props: HomeScreenProps) {
     () => setSettledVisibleCount((count) => count + THREAD_LIST_V2_SETTLED_PAGE_COUNT),
     [],
   );
-  const snoozedShelfExpanded =
-    AsyncResult.isSuccess(preferencesResult) &&
-    preferencesResult.value.threadListV2SnoozedShelfExpanded === true;
-  const toggleSnoozedShelf = useCallback(
-    () =>
-      savePreferences({
-        threadListV2SnoozedShelfExpanded: !snoozedShelfExpanded,
-      }),
-    [savePreferences, snoozedShelfExpanded],
-  );
-  const settledShelfExpanded =
-    !AsyncResult.isSuccess(preferencesResult) ||
-    preferencesResult.value.threadListV2SettledShelfExpanded !== false;
-  const toggleSettledShelf = useCallback(
-    () =>
-      savePreferences({
-        threadListV2SettledShelfExpanded: !settledShelfExpanded,
-      }),
-    [savePreferences, settledShelfExpanded],
-  );
+  const {
+    loaded: shelfPreferencesLoaded,
+    settledShelfExpanded,
+    snoozedShelfExpanded,
+    toggleSettledShelf,
+    toggleSnoozedShelf,
+  } = useThreadListV2ShelfPreferences();
   // now is quantized to the minute and ticks so the inactivity auto-settle
   // boundary is actually crossed while the app stays open (mirrors web);
   // without a clock dependency the partition memoizes a frozen "now".
@@ -801,6 +789,7 @@ export function HomeScreen(props: HomeScreenProps) {
         return (
           <ThreadListV2SnoozedShelfHeader
             count={item.count}
+            disabled={!shelfPreferencesLoaded}
             expanded={item.expanded}
             onToggle={toggleSnoozedShelf}
           />
@@ -810,6 +799,7 @@ export function HomeScreen(props: HomeScreenProps) {
         return (
           <ThreadListV2SettledShelfHeader
             count={item.count}
+            disabled={!shelfPreferencesLoaded}
             expanded={item.expanded}
             onToggle={toggleSettledShelf}
           />
@@ -906,6 +896,7 @@ export function HomeScreen(props: HomeScreenProps) {
       props.onSelectThread,
       props.savedConnectionsById,
       serverConfigs,
+      shelfPreferencesLoaded,
       settlementEnvironmentIds,
       snoozeEnvironmentIds,
       threadListV2Items,

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -9,7 +9,7 @@ import {
 } from "@t3tools/client-runtime/state/thread-search";
 import { LegendList } from "@legendapp/list/react-native";
 import type { MenuAction } from "@react-native-menu/menu";
-import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
 import type { EnvironmentId } from "@t3tools/contracts";
 import { sortPinnedThreadsByOrderKey } from "@t3tools/client-runtime/state/thread-sort";
@@ -31,9 +31,10 @@ import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { scopedProjectKey, scopedThreadKey } from "../../lib/scopedEntities";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useProjects, useThreadShells } from "../../state/entities";
-import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
+import { mobilePreferencesAtom } from "../../state/preferences";
 import { useThreadSearch } from "../../state/queries";
 import { useThreadListV2Enabled } from "./use-thread-list-v2-enabled";
+import { useThreadListV2ShelfPreferences } from "./use-thread-list-v2-shelf-preferences";
 import { environmentServerConfigsAtom } from "../../state/server";
 import { usePendingNewTasks } from "../../state/use-pending-new-tasks";
 import { useWorkspaceState } from "../../state/workspace";
@@ -193,8 +194,6 @@ function NativeSidebarContainer(props: ThreadNavigationSidebarProps) {
 function ThreadNavigationSidebarPane(
   props: ThreadNavigationSidebarProps & { readonly nativeChrome: boolean },
 ) {
-  const preferencesResult = useAtomValue(mobilePreferencesAtom);
-  const savePreferences = useAtomSet(updateMobilePreferencesAtom);
   const insets = useSafeAreaInsets();
   const { themeAppearance: colorScheme } = useAppearancePreferences();
   const projects = useProjects();
@@ -462,26 +461,13 @@ function ThreadNavigationSidebarPane(
     () => setSettledVisibleCount((count) => count + THREAD_LIST_V2_SETTLED_PAGE_COUNT),
     [],
   );
-  const snoozedShelfExpanded =
-    AsyncResult.isSuccess(preferencesResult) &&
-    preferencesResult.value.threadListV2SnoozedShelfExpanded === true;
-  const toggleSnoozedShelf = useCallback(
-    () =>
-      savePreferences({
-        threadListV2SnoozedShelfExpanded: !snoozedShelfExpanded,
-      }),
-    [savePreferences, snoozedShelfExpanded],
-  );
-  const settledShelfExpanded =
-    !AsyncResult.isSuccess(preferencesResult) ||
-    preferencesResult.value.threadListV2SettledShelfExpanded !== false;
-  const toggleSettledShelf = useCallback(
-    () =>
-      savePreferences({
-        threadListV2SettledShelfExpanded: !settledShelfExpanded,
-      }),
-    [savePreferences, settledShelfExpanded],
-  );
+  const {
+    loaded: shelfPreferencesLoaded,
+    settledShelfExpanded,
+    snoozedShelfExpanded,
+    toggleSettledShelf,
+    toggleSnoozedShelf,
+  } = useThreadListV2ShelfPreferences();
   // now ticks per minute so the inactivity auto-settle boundary is actually
   // crossed while the pane stays open; without a clock dependency the
   // partition memoizes a frozen "now".
@@ -1026,6 +1012,7 @@ function ThreadNavigationSidebarPane(
           return (
             <ThreadListV2SnoozedShelfHeader
               count={item.count}
+              disabled={!shelfPreferencesLoaded}
               expanded={item.expanded}
               onToggle={toggleSnoozedShelf}
               pane="sidebar"
@@ -1035,6 +1022,7 @@ function ThreadNavigationSidebarPane(
           return (
             <ThreadListV2SettledShelfHeader
               count={item.count}
+              disabled={!shelfPreferencesLoaded}
               expanded={item.expanded}
               onToggle={toggleSettledShelf}
               pane="sidebar"
@@ -1158,6 +1146,7 @@ function ThreadNavigationSidebarPane(
       props.width,
       savedConnectionsById,
       serverConfigs,
+      shelfPreferencesLoaded,
       threadSearchMatchByKey,
       titleRegenerationEnvironmentIds,
       settleThread,

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -9,7 +9,7 @@ import {
 } from "@t3tools/client-runtime/state/thread-search";
 import { LegendList } from "@legendapp/list/react-native";
 import type { MenuAction } from "@react-native-menu/menu";
-import { useAtomValue } from "@effect/atom-react";
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
 import type { EnvironmentId } from "@t3tools/contracts";
 import { sortPinnedThreadsByOrderKey } from "@t3tools/client-runtime/state/thread-sort";
@@ -31,7 +31,7 @@ import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { scopedProjectKey, scopedThreadKey } from "../../lib/scopedEntities";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useProjects, useThreadShells } from "../../state/entities";
-import { mobilePreferencesAtom } from "../../state/preferences";
+import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
 import { useThreadSearch } from "../../state/queries";
 import { useThreadListV2Enabled } from "./use-thread-list-v2-enabled";
 import { environmentServerConfigsAtom } from "../../state/server";
@@ -193,6 +193,8 @@ function NativeSidebarContainer(props: ThreadNavigationSidebarProps) {
 function ThreadNavigationSidebarPane(
   props: ThreadNavigationSidebarProps & { readonly nativeChrome: boolean },
 ) {
+  const preferencesResult = useAtomValue(mobilePreferencesAtom);
+  const savePreferences = useAtomSet(updateMobilePreferencesAtom);
   const insets = useSafeAreaInsets();
   const { themeAppearance: colorScheme } = useAppearancePreferences();
   const projects = useProjects();
@@ -460,10 +462,26 @@ function ThreadNavigationSidebarPane(
     () => setSettledVisibleCount((count) => count + THREAD_LIST_V2_SETTLED_PAGE_COUNT),
     [],
   );
-  const [snoozedShelfExpanded, setSnoozedShelfExpanded] = useState(false);
-  const toggleSnoozedShelf = useCallback(() => setSnoozedShelfExpanded((value) => !value), []);
-  const [settledShelfExpanded, setSettledShelfExpanded] = useState(true);
-  const toggleSettledShelf = useCallback(() => setSettledShelfExpanded((value) => !value), []);
+  const snoozedShelfExpanded =
+    AsyncResult.isSuccess(preferencesResult) &&
+    preferencesResult.value.threadListV2SnoozedShelfExpanded === true;
+  const toggleSnoozedShelf = useCallback(
+    () =>
+      savePreferences({
+        threadListV2SnoozedShelfExpanded: !snoozedShelfExpanded,
+      }),
+    [savePreferences, snoozedShelfExpanded],
+  );
+  const settledShelfExpanded =
+    !AsyncResult.isSuccess(preferencesResult) ||
+    preferencesResult.value.threadListV2SettledShelfExpanded !== false;
+  const toggleSettledShelf = useCallback(
+    () =>
+      savePreferences({
+        threadListV2SettledShelfExpanded: !settledShelfExpanded,
+      }),
+    [savePreferences, settledShelfExpanded],
+  );
   // now ticks per minute so the inactivity auto-settle boundary is actually
   // crossed while the pane stays open; without a clock dependency the
   // partition memoizes a frozen "now".

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -114,6 +114,7 @@ const SNOOZE_ACCENT_DARK = "#60a5fa";
 
 export const ThreadListV2SnoozedShelfHeader = memo(function ThreadListV2SnoozedShelfHeader(props: {
   readonly count: number;
+  readonly disabled?: boolean;
   readonly expanded: boolean;
   readonly onToggle: () => void;
   readonly pane?: "screen" | "sidebar";
@@ -126,11 +127,12 @@ export const ThreadListV2SnoozedShelfHeader = memo(function ThreadListV2SnoozedS
       }
       accessibilityLabel={props.count === 1 ? "1 snoozed thread" : `${props.count} snoozed threads`}
       accessibilityRole="button"
-      accessibilityState={{ expanded: props.expanded }}
+      accessibilityState={{ disabled: props.disabled, expanded: props.expanded }}
       className={cn(
         "mb-1.5 mt-4 flex-row items-center gap-2.5",
         props.pane === "sidebar" ? "px-3" : "px-5",
       )}
+      disabled={props.disabled}
       onPress={props.onToggle}
       style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
     >
@@ -151,6 +153,7 @@ export const ThreadListV2SnoozedShelfHeader = memo(function ThreadListV2SnoozedS
 
 export const ThreadListV2SettledShelfHeader = memo(function ThreadListV2SettledShelfHeader(props: {
   readonly count: number;
+  readonly disabled?: boolean;
   readonly expanded: boolean;
   readonly onToggle: () => void;
   readonly pane?: "screen" | "sidebar";
@@ -163,11 +166,12 @@ export const ThreadListV2SettledShelfHeader = memo(function ThreadListV2SettledS
       }
       accessibilityLabel={props.count === 1 ? "1 settled thread" : `${props.count} settled threads`}
       accessibilityRole="button"
-      accessibilityState={{ expanded: props.expanded }}
+      accessibilityState={{ disabled: props.disabled, expanded: props.expanded }}
       className={cn(
         "mb-1.5 mt-4 flex-row items-center gap-2.5",
         props.pane === "sidebar" ? "px-3" : "px-5",
       )}
+      disabled={props.disabled}
       onPress={props.onToggle}
       style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
     >

--- a/apps/mobile/src/features/threads/use-thread-list-v2-shelf-preferences.ts
+++ b/apps/mobile/src/features/threads/use-thread-list-v2-shelf-preferences.ts
@@ -1,0 +1,45 @@
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { useCallback, useRef } from "react";
+
+import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
+
+/**
+ * Shared persisted shelf state for the compact Home list and iPad sidebar.
+ * Refs advance before persistence starts so consecutive presses always toggle
+ * the latest value, even if React has not rendered the optimistic patch yet.
+ */
+export function useThreadListV2ShelfPreferences() {
+  const preferencesResult = useAtomValue(mobilePreferencesAtom);
+  const savePreferences = useAtomSet(updateMobilePreferencesAtom);
+  const loaded = AsyncResult.isSuccess(preferencesResult);
+  const snoozedShelfExpanded =
+    loaded && preferencesResult.value.threadListV2SnoozedShelfExpanded === true;
+  const settledShelfExpanded =
+    !loaded || preferencesResult.value.threadListV2SettledShelfExpanded !== false;
+  const snoozedShelfExpandedRef = useRef(snoozedShelfExpanded);
+  const settledShelfExpandedRef = useRef(settledShelfExpanded);
+  snoozedShelfExpandedRef.current = snoozedShelfExpanded;
+  settledShelfExpandedRef.current = settledShelfExpanded;
+
+  const toggleSnoozedShelf = useCallback(() => {
+    if (!loaded) return;
+    const expanded = !snoozedShelfExpandedRef.current;
+    snoozedShelfExpandedRef.current = expanded;
+    savePreferences({ threadListV2SnoozedShelfExpanded: expanded });
+  }, [loaded, savePreferences]);
+  const toggleSettledShelf = useCallback(() => {
+    if (!loaded) return;
+    const expanded = !settledShelfExpandedRef.current;
+    settledShelfExpandedRef.current = expanded;
+    savePreferences({ threadListV2SettledShelfExpanded: expanded });
+  }, [loaded, savePreferences]);
+
+  return {
+    loaded,
+    settledShelfExpanded,
+    snoozedShelfExpanded,
+    toggleSettledShelf,
+    toggleSnoozedShelf,
+  } as const;
+}

--- a/apps/mobile/src/lib/storage.test.ts
+++ b/apps/mobile/src/lib/storage.test.ts
@@ -207,6 +207,40 @@ describe("mobile connection storage", () => {
     expect(fallback.updatedAt).toEqual(expect.any(Number));
   });
 
+  it("persists Thread List v2 shelf expansion preferences", async () => {
+    await expect(
+      savePreferencesPatch({
+        threadListV2SettledShelfExpanded: false,
+        threadListV2SnoozedShelfExpanded: true,
+      }),
+    ).resolves.toEqual({
+      threadListV2SettledShelfExpanded: false,
+      threadListV2SnoozedShelfExpanded: true,
+    });
+
+    await expect(loadPreferences()).resolves.toEqual({
+      threadListV2SettledShelfExpanded: false,
+      threadListV2SnoozedShelfExpanded: true,
+    });
+    expect(JSON.parse(mocks.getPreferencesJson() ?? "")).toEqual({
+      threadListV2SettledShelfExpanded: false,
+      threadListV2SnoozedShelfExpanded: true,
+    });
+  });
+
+  it("ignores invalid Thread List v2 shelf expansion preference types", async () => {
+    mocks.setPreferencesJson(
+      JSON.stringify({
+        baseFontSize: 17,
+        threadListV2SettledShelfExpanded: "false",
+        threadListV2SnoozedShelfExpanded: 1,
+      }),
+      10,
+    );
+
+    await expect(loadPreferences()).resolves.toEqual({ baseFontSize: 17 });
+  });
+
   it("reconciles fallback preferences after SQLite recovers", async () => {
     mocks.setPreferencesJson(JSON.stringify({ baseFontSize: 15 }), 10);
     await mocks.setItemAsync(

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -42,6 +42,10 @@ export interface Preferences {
   readonly legacyThreadListEnabled?: boolean;
   /** Device-local counterpart of desktop's `planModeEnabled` legacy flag. */
   readonly planModeEnabled?: boolean;
+  /** Undefined preserves the default expanded Settled shelf. */
+  readonly threadListV2SettledShelfExpanded?: boolean;
+  /** Undefined preserves the default collapsed Snoozed shelf. */
+  readonly threadListV2SnoozedShelfExpanded?: boolean;
 }
 
 export class MobilePreferencesLoadError extends Schema.TaggedErrorClass<MobilePreferencesLoadError>()(
@@ -100,6 +104,8 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     autoSettleOnMerge?: boolean;
     legacyThreadListEnabled?: boolean;
     planModeEnabled?: boolean;
+    threadListV2SettledShelfExpanded?: boolean;
+    threadListV2SnoozedShelfExpanded?: boolean;
   } = {};
 
   if (typeof parsed.liveActivitiesEnabled === "boolean") {
@@ -169,6 +175,12 @@ function sanitizePreferences(parsed: Preferences): Preferences {
   }
   if (typeof parsed.planModeEnabled === "boolean") {
     preferences.planModeEnabled = parsed.planModeEnabled;
+  }
+  if (typeof parsed.threadListV2SettledShelfExpanded === "boolean") {
+    preferences.threadListV2SettledShelfExpanded = parsed.threadListV2SettledShelfExpanded;
+  }
+  if (typeof parsed.threadListV2SnoozedShelfExpanded === "boolean") {
+    preferences.threadListV2SnoozedShelfExpanded = parsed.threadListV2SnoozedShelfExpanded;
   }
   return preferences;
 }


### PR DESCRIPTION
## What Changed

- persist the mobile Thread List v2 Settled and Snoozed shelf expansion states across app restarts
- use the existing device preference store so the Home list and iPad sidebar stay synchronized
- keep rapid toggles ordered and disable shelf interaction until preferences finish loading
- keep the first-run defaults: Settled expanded and Snoozed collapsed
- ignore invalid persisted shelf preference values

## Why

#5056 made the mobile Settled shelf collapsible, but both mobile shelves still reset whenever the app restarts. This brings mobile in line with the persistence fix in #5136 without adding another storage mechanism.

## UI Changes

No visual changes. The existing shelf layout and interactions are unchanged; only the chosen expansion state now survives a restart.

## Verification

- `vp test run apps/mobile/src/lib/storage.test.ts apps/mobile/src/features/threads/threadListV2.test.ts` (47 tests)
- `vp run --filter @t3tools/mobile typecheck`
- targeted lint and formatting checks on the six changed mobile files
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] Defaults remain Settled expanded and Snoozed collapsed
- [x] No screenshots or video needed because the rendered UI is unchanged

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI preference persistence with boolean sanitization and no auth or data-model changes.
> 
> **Overview**
> Thread List v2 **Settled** and **Snoozed** shelf expand/collapse now survives app restarts on mobile, aligned with the web persistence fix.
> 
> Local `useState` in **Home** and the **iPad sidebar** is replaced by `useThreadListV2ShelfPreferences`, which reads/writes `threadListV2SettledShelfExpanded` and `threadListV2SnoozedShelfExpanded` through the existing device preference store so both surfaces stay in sync. Defaults stay **Settled expanded** and **Snoozed collapsed**; rapid toggles use refs so ordering stays correct before the optimistic save lands.
> 
> Shelf header controls get a **`disabled`** state until preferences finish loading. Invalid persisted values are dropped during sanitization; storage tests cover round-trip and type rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de56503cece8a44d43ab2160050b5e7ff20b3acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist thread shelf collapse state across sessions in mobile
> - Adds a new `useThreadListV2ShelfPreferences` hook in [`use-thread-list-v2-shelf-preferences.ts`](https://github.com/pingdotgg/t3code/pull/5152/files#diff-e4398d706991215e74db2f1945cb4ba0fd474cb58520a28c790a431fff64b5fd) that reads and writes snoozed/settled shelf expansion state to `mobilePreferencesAtom`, replacing local component state in `HomeScreen` and `ThreadNavigationSidebarPane`.
> - Snoozed shelf defaults to collapsed (`false`) and settled shelf defaults to expanded (`true`) when no persisted value exists.
> - Adds `threadListV2SettledShelfExpanded` and `threadListV2SnoozedShelfExpanded` fields to the [`Preferences`](https://github.com/pingdotgg/t3code/pull/5152/files#diff-3aa27c7cc6d8de9ee5cea2957f2ae3f02d47323310fab6293827508e890b7be7) interface with sanitization that drops non-boolean values.
> - Shelf header buttons accept a new `disabled` prop and are disabled until preferences finish loading to prevent toggling before state is known.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de56503.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
