### PR TITLE
test(mobile): seed snoozed showcase threads

### DIFF
--- a/scripts/mobile-showcase-environment.ts
+++ b/scripts/mobile-showcase-environment.ts
@@ -154,6 +154,19 @@ export const SHOWCASE_ENVIRONMENTS = [
   },
 ] as const;
 
+type ShowcaseThreadFixture = {
+  readonly id: string;
+  readonly projectId: string;
+  readonly title: string;
+  readonly branch: string;
+  readonly minutesAgo: number;
+  readonly state?: "working" | "approval" | "plan";
+  readonly settled?: boolean;
+  readonly snoozeMinutes?: number;
+  readonly request: string;
+  readonly response: string | null;
+};
+
 export const SHOWCASE_THREADS = [
   {
     id: SHOWCASE_THREAD_ID,
@@ -198,6 +211,7 @@ export const SHOWCASE_THREADS = [
       "Keep hydration errors precise, but make the development copy unexpectedly delightful.",
     response:
       "The diagnostics still lead with the exact mismatch and component stack. A tiny optional haiku now closes the expanded explanation.",
+    snoozeMinutes: 90,
   },
   {
     id: "beautiful-boot",
@@ -210,6 +224,17 @@ export const SHOWCASE_THREADS = [
       "Design a clearer boot timeline that remains useful over serial and never hides kernel detail.",
     response:
       "The plan groups milestones without changing the underlying log stream, preserves plain-text output, and adds zero work to the hot path.",
+  },
+  {
+    id: "patient-penguins",
+    projectId: "linux",
+    title: "Teach penguins to wait patiently",
+    branch: "feat/patient-penguins",
+    minutesAgo: 52,
+    request: "Make delayed work easier to follow without adding noise to the scheduler trace.",
+    response:
+      "Delayed work now carries a concise reason through the trace, so the wait is legible without changing scheduling behavior.",
+    snoozeMinutes: 8 * 60,
   },
   // Finished work, settled by hand: the list keeps it as a receded tail so
   // the active block above reads as everything still in flight. The active
@@ -248,7 +273,7 @@ export const SHOWCASE_THREADS = [
     response:
       "Kills now report the winning heuristic and the runner-up alongside the usual dump, assembled entirely from data the path already had.",
   },
-] as const;
+] as const satisfies ReadonlyArray<ShowcaseThreadFixture>;
 
 function minutesBefore(now: number, minutes: number): string {
   return new Date(now - minutes * 60_000).toISOString();
@@ -337,20 +362,29 @@ function insertThread(
     readonly minutesAgo: number;
     readonly state?: "working" | "approval" | "plan";
     readonly settled?: boolean;
+    readonly snoozeMinutes?: number;
     readonly workspaceRoot: string;
   },
 ): void {
   const turnId = `${input.id}-turn`;
   const updatedAt = minutesBefore(now, input.minutesAgo);
   const isWorking = input.state === "working";
+  const snoozedUntil =
+    input.snoozeMinutes === undefined
+      ? null
+      : new Date(now + input.snoozeMinutes * 60_000).toISOString();
+  const snoozedAt =
+    input.snoozeMinutes === undefined
+      ? null
+      : minutesBefore(now, Math.max(1, Math.floor(input.minutesAgo / 2)));
   database
     .prepare(
       `INSERT INTO projection_threads (
         thread_id, project_id, title, model_selection_json, runtime_mode, interaction_mode,
         branch, worktree_path, latest_turn_id, latest_user_message_at, pending_approval_count,
         pending_user_input_count, has_actionable_proposed_plan, created_at, updated_at,
-        archived_at, deleted_at, settled_override, settled_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, NULL, ?, ?)`,
+        archived_at, deleted_at, settled_override, settled_at, snoozed_until, snoozed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, NULL, ?, ?, ?, ?)`,
     )
     .run(
       input.id,
@@ -369,6 +403,8 @@ function insertThread(
       updatedAt,
       input.settled ? "settled" : null,
       input.settled ? updatedAt : null,
+      snoozedUntil,
+      snoozedAt,
     );
   database
     .prepare(

--- a/scripts/mobile-showcase-environment.ts
+++ b/scripts/mobile-showcase-environment.ts
@@ -154,19 +154,6 @@ export const SHOWCASE_ENVIRONMENTS = [
   },
 ] as const;
 
-type ShowcaseThreadFixture = {
-  readonly id: string;
-  readonly projectId: string;
-  readonly title: string;
-  readonly branch: string;
-  readonly minutesAgo: number;
-  readonly state?: "working" | "approval" | "plan";
-  readonly settled?: boolean;
-  readonly snoozeMinutes?: number;
-  readonly request: string;
-  readonly response: string | null;
-};
-
 export const SHOWCASE_THREADS = [
   {
     id: SHOWCASE_THREAD_ID,
@@ -273,7 +260,7 @@ export const SHOWCASE_THREADS = [
     response:
       "Kills now report the winning heuristic and the runner-up alongside the usual dump, assembled entirely from data the path already had.",
   },
-] as const satisfies ReadonlyArray<ShowcaseThreadFixture>;
+] as const;
 
 function minutesBefore(now: number, minutes: number): string {
   return new Date(now - minutes * 60_000).toISOString();

--- a/scripts/mobile-showcase-environment.ts
+++ b/scripts/mobile-showcase-environment.ts
@@ -445,6 +445,8 @@ const SEEDED_PROJECTION_TABLES = [
   "projection_state",
 ] as const;
 
+const SEEDED_THREAD_COLUMNS = ["snoozed_until", "snoozed_at"] as const;
+
 function hasSeedableSchema(dbPath: string): boolean {
   let database: NodeSqlite.DatabaseSync;
   try {
@@ -453,12 +455,18 @@ function hasSeedableSchema(dbPath: string): boolean {
     return false;
   }
   try {
-    const row = database
+    const tableCount = database
       .prepare(
         `SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name IN (${SEEDED_PROJECTION_TABLES.map(() => "?").join(", ")})`,
       )
       .get(...SEEDED_PROJECTION_TABLES) as { count: number };
-    return row.count === SEEDED_PROJECTION_TABLES.length;
+    if (tableCount.count !== SEEDED_PROJECTION_TABLES.length) return false;
+
+    const threadColumns = database.prepare("PRAGMA table_info(projection_threads)").all() as Array<{
+      name: string;
+    }>;
+    const threadColumnNames = new Set(threadColumns.map((column) => column.name));
+    return SEEDED_THREAD_COLUMNS.every((column) => threadColumnNames.has(column));
   } catch {
     return false;
   } finally {

--- a/scripts/mobile-showcase.test.ts
+++ b/scripts/mobile-showcase.test.ts
@@ -270,8 +270,23 @@ it("seeds a playful multi-environment project spectrum", () => {
     SHOWCASE_ENVIRONMENTS.map((environment) => environment.label),
     ["Moonbase Terminal", "Suspense Station", "Kernel Cabin"],
   );
-  assert.equal(SHOWCASE_THREADS.length, 8);
+  assert.equal(SHOWCASE_THREADS.length, 9);
   assert.equal(new Set(SHOWCASE_THREADS.map((thread) => thread.projectId)).size, 3);
+  const snoozedThreads = SHOWCASE_THREADS.filter((thread) => "snoozeMinutes" in thread);
+  assert.equal(snoozedThreads.length, 2);
+  assert.deepStrictEqual(
+    snoozedThreads.map((thread) => thread.id),
+    ["hydration-haikus", "patient-penguins"],
+  );
+  assert.equal(new Set(snoozedThreads.map((thread) => thread.snoozeMinutes)).size, 2);
+  for (const thread of snoozedThreads) {
+    assert.equal(thread.response !== null, true, `${thread.title} is not completed`);
+    assert.equal("state" in thread, false, `${thread.title} is blocked or working`);
+    assert.equal("settled" in thread, false, `${thread.title} is settled`);
+    assert.equal(thread.snoozeMinutes > 60, true, `${thread.title} wakes too soon`);
+  }
+  const primaryThread = SHOWCASE_THREADS.find((thread) => thread.id === "remote-command-center");
+  assert.equal(primaryThread !== undefined && !("snoozeMinutes" in primaryThread), true);
   // Every project contributes to both the active block and the settled tail,
   // so each list scope screenshots with the same two-part structure.
   for (const project of SHOWCASE_PROJECTS) {


### PR DESCRIPTION
## What Changed

- seed two completed showcase threads with distinct future snooze times
- persist `snoozed_until` and `snoozed_at` in the generated showcase projection data
- keep the deep-linked primary thread and blocked, working, and settled examples unsnoozed
- cover the fixture shape with focused regression assertions

## Why

The mobile screenshot harness generates realistic thread data, but it did not include snoozed threads. That left the Snoozed shelf absent from generated screenshots and from disposable mobile test fixtures based on the showcase seeder.

## UI Changes

No production UI code changed. Generated thread-list captures now include a collapsed `Snoozed (2)` shelf backed by two expandable rows with different wake times.

## Verification

- `pnpm exec vp test run scripts/mobile-showcase.test.ts` (19 tests)
- `pnpm exec vp run --filter @t3tools/scripts typecheck`
- `pnpm exec vp lint --report-unused-disable-directives scripts/mobile-showcase-environment.ts scripts/mobile-showcase.test.ts`
- `pnpm exec vp fmt --check scripts/mobile-showcase-environment.ts scripts/mobile-showcase.test.ts`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No production UI changed, so no before/after screenshots are needed

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to showcase seed data and tests; no production runtime or UI behavior is modified.
> 
> **Overview**
> Extends the **mobile screenshot/showcase seeder** so generated thread lists can include a **Snoozed** shelf, without touching production UI.
> 
> `insertThread` now accepts optional **`snoozeMinutes`** and writes **`snoozed_until`** / **`snoozed_at`** on `projection_threads` (derived from seed time). **`hasSeedableSchema`** waits for those columns before seeding. Fixture data adds **`snoozeMinutes`** on **hydration-haikus** (90m), a new **patient-penguins** thread (8h snooze), and bumps the showcase thread count **8 → 9**.
> 
> **`mobile-showcase.test.ts`** asserts exactly two snoozed, completed, non-settled threads with distinct wake offsets, and that the deep-linked primary thread stays unsnoozed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553963a46e858619e6e8bbb536cb021b4dcf1545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed snoozed showcase threads in the mobile showcase environment
> - Adds `snoozeMinutes` to the `insertThread` function in [mobile-showcase-environment.ts](https://github.com/pingdotgg/t3code/pull/5155/files#diff-95c0bb2e3bb85661aaa22b8a7ac77c72bf3d7f5d49b3e0594a3c67522bedb111), writing `snoozed_until` and `snoozed_at` into `projection_threads` when provided (NULLs otherwise).
> - Seeds two snoozed threads (`hydration-haikus`, `patient-penguins`) and adds a new `patient-penguins` entry, bringing the total from 8 to 9 showcase threads.
> - `hasSeedableSchema` now checks for the presence of `snoozed_until` and `snoozed_at` columns in `projection_threads` before allowing seeding.
> - Updates tests in [mobile-showcase.test.ts](https://github.com/pingdotgg/t3code/pull/5155/files#diff-6de202f722af38ab44ba815ae9796f257fbe58b118cd9bce2d665c0b26be0d3d) to assert the new thread count and validate snooze properties.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 553963a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->