### PR TITLE
feat(web): optionally auto-send the next stashed prompt when a turn ends

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -14,6 +14,7 @@ import * as DesktopClientSettings from "./DesktopClientSettings.ts";
 
 const clientSettings: ClientSettings = {
   autoOpenPlanSidebar: false,
+  autoSendStashedPrompts: false,
   confirmThreadArchive: true,
   confirmThreadDelete: false,
   dismissedProviderUpdateNotificationKeys: [],

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -64,6 +64,7 @@ import {
 } from "../../promptStashStore";
 import { ComposerStashBadge } from "./ComposerStashBadge";
 import { ComposerStashMenu } from "./ComposerStashMenu";
+import { shouldAutoSendStashedPrompt } from "./composerStashAutoSend";
 import { compressImageForStash, compressImageToByteLimit } from "../../lib/imageCompression";
 import { isCommandPaletteOpen } from "../../commandPaletteBus";
 import { getTerminalFocusOwner } from "../../lib/terminalFocus";
@@ -973,6 +974,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const [isComposerFocused, setIsComposerFocused] = useState(false);
   const [composerMenuAnchor, setComposerMenuAnchor] = useState<HTMLDivElement | null>(null);
   const [isStashMenuOpen, setIsStashMenuOpen] = useState(false);
+  const [isAutoSendPending, setIsAutoSendPending] = useState(false);
   const [stashPulse, setStashPulse] = useState<{ key: number; active: boolean }>({
     key: 0,
     active: false,
@@ -998,6 +1000,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const dragDepthRef = useRef(0);
   const stashPulseKeyRef = useRef(0);
   const stashPulseTimeoutRef = useRef<number | null>(null);
+  /**
+   * Whether the thread was mid-turn at the last auto-send evaluation. Starts
+   * false so the first pass only records the state it found — opening a
+   * thread that is already idle must not count as a turn having just ended.
+   */
+  const wasThreadWorkingRef = useRef(false);
   /**
    * Snapshots currently being encoded, keyed by target+prompt+image ids.
    * Keyed rather than boolean so a genuinely different prompt (or a different
@@ -2288,6 +2296,64 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     stashCurrentPrompt,
     terminalOpen,
   ]);
+
+  // ------------------------------------------------------------------
+  // Prompt stash: auto-send
+  // ------------------------------------------------------------------
+  // Opt-in. With it on, each finished turn takes the oldest stashed prompt
+  // and sends it, so prompts written while the agent was busy go out in the
+  // order they were stashed — one per turn, never in a batch.
+  const isThreadWorking = phase === "running" || isSendBusy || isConnecting;
+  // Mirrors the ⌘S gate, plus the states that refuse a plain send.
+  const isAutoSendBlocked =
+    isSendDisabled ||
+    noProviderAvailable ||
+    projectSelectionRequired ||
+    environmentUnavailable !== null ||
+    isComposerApprovalState ||
+    pendingUserInputs.length > 0 ||
+    activePendingProgress !== null ||
+    showPlanFollowUpPrompt;
+
+  useEffect(() => {
+    const wasWorking = wasThreadWorkingRef.current;
+    wasThreadWorkingRef.current = isThreadWorking;
+    if (
+      !shouldAutoSendStashedPrompt({
+        enabled: settings.autoSendStashedPrompts,
+        hasStashedPrompt: stashQueue.length > 0,
+        wasWorking,
+        isWorking: isThreadWorking,
+        phase,
+        hasComposerContent: composerSendState.hasSendableContent,
+        sendBlocked: isAutoSendBlocked,
+      })
+    ) {
+      return;
+    }
+    const oldestEntry = stashQueue.at(-1);
+    if (!oldestEntry) return;
+    restoreStashEntry(oldestEntry);
+    setIsAutoSendPending(true);
+  }, [
+    composerSendState.hasSendableContent,
+    isAutoSendBlocked,
+    isThreadWorking,
+    phase,
+    restoreStashEntry,
+    settings.autoSendStashedPrompts,
+    stashQueue,
+  ]);
+
+  // The send is deferred by a commit: `restoreStashEntry` writes through the
+  // draft store, and the image ref `onSend` reads is only synced from it in
+  // an effect. Sending in the same pass would ship the prompt without its
+  // attachments.
+  useEffect(() => {
+    if (!isAutoSendPending) return;
+    setIsAutoSendPending(false);
+    submitComposer();
+  }, [isAutoSendPending, submitComposer]);
 
   // ------------------------------------------------------------------
   // Callbacks: images

--- a/apps/web/src/components/chat/composerStashAutoSend.test.ts
+++ b/apps/web/src/components/chat/composerStashAutoSend.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { shouldAutoSendStashedPrompt } from "./composerStashAutoSend";
+
+const settledTurn = {
+  enabled: true,
+  hasStashedPrompt: true,
+  wasWorking: true,
+  isWorking: false,
+  phase: "ready",
+  hasComposerContent: false,
+  sendBlocked: false,
+} as const;
+
+describe("shouldAutoSendStashedPrompt", () => {
+  it("sends the next stashed prompt once the turn settles", () => {
+    expect(shouldAutoSendStashedPrompt(settledTurn)).toBe(true);
+  });
+
+  it("stays parked while the setting is off", () => {
+    expect(shouldAutoSendStashedPrompt({ ...settledTurn, enabled: false })).toBe(false);
+  });
+
+  it("does nothing with an empty stash", () => {
+    expect(shouldAutoSendStashedPrompt({ ...settledTurn, hasStashedPrompt: false })).toBe(false);
+  });
+
+  it("ignores a thread that was already idle", () => {
+    expect(shouldAutoSendStashedPrompt({ ...settledTurn, wasWorking: false })).toBe(false);
+  });
+
+  it("waits until the thread stops working", () => {
+    expect(shouldAutoSendStashedPrompt({ ...settledTurn, isWorking: true, phase: "running" })).toBe(
+      false,
+    );
+  });
+
+  it("holds the stash when the turn was interrupted or failed", () => {
+    expect(shouldAutoSendStashedPrompt({ ...settledTurn, phase: "disconnected" })).toBe(false);
+  });
+
+  it("yields to a prompt the user is writing", () => {
+    expect(shouldAutoSendStashedPrompt({ ...settledTurn, hasComposerContent: true })).toBe(false);
+  });
+
+  it("holds while something else owns the composer", () => {
+    expect(shouldAutoSendStashedPrompt({ ...settledTurn, sendBlocked: true })).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/composerStashAutoSend.ts
+++ b/apps/web/src/components/chat/composerStashAutoSend.ts
@@ -1,0 +1,38 @@
+import { type SessionPhase } from "../../types";
+
+/**
+ * Whether a turn that just settled should pull the next stashed prompt into
+ * the composer and send it (Settings → General → "Stashed prompts").
+ *
+ * Edge-triggered on the turn ending rather than level-triggered on an idle
+ * thread: prompts stashed while nothing is running — or sitting there when
+ * the setting is switched on, or when the thread is opened — must stay put.
+ * Otherwise merely looking at an idle thread would fire one off.
+ */
+export function shouldAutoSendStashedPrompt(input: {
+  /** The `autoSendStashedPrompts` setting. */
+  enabled: boolean;
+  hasStashedPrompt: boolean;
+  /** Whether the thread was mid-turn at the previous evaluation. */
+  wasWorking: boolean;
+  isWorking: boolean;
+  /**
+   * Only a turn that ran to completion ("ready") qualifies. An interrupted or
+   * failed one settles as "disconnected", and carrying on from where the user
+   * hit stop is the opposite of what they asked for.
+   */
+  phase: SessionPhase;
+  /** The user has their own content in the composer; theirs wins. */
+  hasComposerContent: boolean;
+  /**
+   * A plain send is unavailable — an approval, a plan question, or a follow-up
+   * prompt owns the composer. What the user cannot send by hand right now, the
+   * stash must not send for them.
+   */
+  sendBlocked: boolean;
+}): boolean {
+  if (!input.enabled || !input.hasStashedPrompt) return false;
+  if (!input.wasWorking || input.isWorking) return false;
+  if (input.phase !== "ready") return false;
+  return !input.hasComposerContent && !input.sendBlocked;
+}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -592,6 +592,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar
         ? ["Auto-open task panel"]
         : []),
+      ...(settings.autoSendStashedPrompts !== DEFAULT_UNIFIED_SETTINGS.autoSendStashedPrompts
+        ? ["Stashed prompts"]
+        : []),
       ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
         ? ["Assistant output"]
         : []),
@@ -622,6 +625,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       isTextGenerationModelDirty,
       isBackgroundActivityDirty,
       settings.autoOpenPlanSidebar,
+      settings.autoSendStashedPrompts,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
@@ -660,6 +664,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
+      autoSendStashedPrompts: DEFAULT_UNIFIED_SETTINGS.autoSendStashedPrompts,
       enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
       enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
       backgroundActivity: DEFAULT_UNIFIED_SETTINGS.backgroundActivity,
@@ -1432,6 +1437,32 @@ export function GeneralSettingsPanel() {
                 updateSettings({ autoOpenPlanSidebar: Boolean(checked) })
               }
               aria-label="Open the task panel automatically"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("stashed-prompts")}
+          description="Send the oldest stashed prompt automatically when the open thread finishes a turn."
+          resetAction={
+            settings.autoSendStashedPrompts !== DEFAULT_UNIFIED_SETTINGS.autoSendStashedPrompts ? (
+              <SettingResetButton
+                label="stashed prompts"
+                onClick={() =>
+                  updateSettings({
+                    autoSendStashedPrompts: DEFAULT_UNIFIED_SETTINGS.autoSendStashedPrompts,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.autoSendStashedPrompts}
+              onCheckedChange={(checked) =>
+                updateSettings({ autoSendStashedPrompts: Boolean(checked) })
+              }
+              aria-label="Send stashed prompts automatically"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -91,6 +91,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "stashed-prompts",
+    title: "Stashed prompts",
+    to: "/settings/general",
+  },
+  {
     id: "new-threads",
     title: "New threads",
     to: "/settings/general",

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -111,6 +111,15 @@ describe("ClientSettings sidebar v2", () => {
   });
 });
 
+describe("ClientSettings stash auto-send", () => {
+  it("leaves stashed prompts parked until the user opts in", () => {
+    expect(decodeClientSettings({}).autoSendStashedPrompts).toBe(false);
+    expect(decodeClientSettingsPatch({ autoSendStashedPrompts: true }).autoSendStashedPrompts).toBe(
+      true,
+    );
+  });
+});
+
 describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   it("defaults to an empty record so legacy configs without the key still decode", () => {
     expect(DEFAULT_SERVER_SETTINGS.providerInstances).toEqual({});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -64,6 +64,9 @@ export const DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE: EnvironmentIdentificationM
 
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  // Off by default: a stashed prompt is parked, not queued, until the user
+  // says otherwise.
+  autoSendStashedPrompts: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   dismissedProviderUpdateNotificationKeys: Schema.Array(TrimmedNonEmptyString).pipe(
@@ -675,6 +678,7 @@ export type ServerSettingsPatch = typeof ServerSettingsPatch.Type;
 
 export const ClientSettingsPatch = Schema.Struct({
   autoOpenPlanSidebar: Schema.optionalKey(Schema.Boolean),
+  autoSendStashedPrompts: Schema.optionalKey(Schema.Boolean),
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
## What

Adds an opt-in setting that drains the prompt stash automatically: when the open thread finishes a turn, the oldest stashed prompt is restored into the composer and sent.

**Settings → General → "Stashed prompts"**, off by default — the stash stays a parking spot unless you ask for a queue.

Motivation: the stash already exists for prompts you write while an agent is busy (⌘S), but every one of them has to be restored by hand afterwards. With this on, follow-ups go out in the order they were stashed, one per turn.

## How

- `autoSendStashedPrompts` joins `ClientSettings` (per-client, like the stash itself, which lives in `localStorage`), defaulting to `false`.
- `shouldAutoSendStashedPrompt` (`apps/web/src/components/chat/composerStashAutoSend.ts`) is the whole decision, kept pure and unit-tested rather than buried in the composer.
- `ChatComposer` evaluates it on every render pass and, when it passes, restores the oldest entry through the existing `restoreStashEntry` path and submits.

The trigger is **edge-triggered on the turn settling**, not level-triggered on an idle thread. A stash sitting in a thread that is already idle — or one that predates switching the setting on — stays put; otherwise merely opening a thread would fire off a prompt. It also holds back when:

- the turn was interrupted or failed (the session settles as `disconnected`, not `ready`) — carrying on from where you hit stop is the opposite of what you asked for;
- you have your own content in the composer — yours wins;
- an approval, a plan question, or a plan follow-up owns the composer, i.e. anything you could not send by hand right now.

The send is deliberately deferred by one commit: `restoreStashEntry` writes through the draft store, and the image ref `onSend` reads is only synced from it in an effect, so sending in the same pass would ship the prompt without its attachments.

## Testing

- `composerStashAutoSend.test.ts` — 8 cases over the predicate (each hold-back branch, plus the happy path).
- `settings.test.ts` — the default stays off and the patch carries an opt-in.
- End-to-end against a local dev instance with real Claude turns, driven headlessly: stashed a prompt mid-turn → with the setting off it survived the finished turn unsent → enabled the setting → on the next turn ending, the stashed prompt was sent on its own and the stash emptied.
- `pnpm fmt:check`, `typecheck` (contracts/web/desktop), `lint` (no new findings), contracts + touched web suites.

## Notes

- The stash is global while the auto-send fires in the thread whose composer is mounted, so entries drain into the thread you are looking at. Deliberate: nothing is ever sent into a thread you are not watching.
- Nothing in the stash menu advertises that auto-send is armed. Happy to add a hint there if reviewers want the discoverability.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add auto-send for stashed prompts when a chat turn ends
> - Adds a new `autoSendStashedPrompts` boolean setting (default `false`) to `ClientSettingsSchema` and exposes a toggle in the General settings panel under 'Stashed prompts'.
> - When enabled, [`ChatComposer`](https://github.com/pingdotgg/t3code/pull/5156/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) detects the transition from a working to idle thread state and automatically restores and sends the oldest stashed prompt, provided the composer is empty and sending is not blocked.
> - The auto-send decision is extracted into a pure function [`shouldAutoSendStashedPrompt`](https://github.com/pingdotgg/t3code/pull/5156/files#diff-6a285db044e3aafb17f1220cd4f5d4db0821536b21b5c464756cb7f30814df7b) with full unit test coverage.
> - 'Stashed prompts' is added to settings search and to the restore-defaults flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d0d81b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->