### PR TITLE
fix(server): follow branch drift in dedicated worktrees so PRs link to their thread

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -277,6 +277,9 @@ describe("CheckpointReactor", () => {
     readonly seedFilesystemCheckpoints?: boolean;
     readonly projectWorkspaceRoot?: string;
     readonly threadWorktreePath?: string | null;
+    readonly threadBranch?: string | null;
+    readonly secondThreadSharingWorktree?: boolean;
+    readonly localStatusRefName?: string | null;
     readonly providerSessionCwd?: string;
     readonly providerName?: ProviderDriverKind;
     readonly gitStatusRefreshCalls?: Array<string>;
@@ -315,7 +318,8 @@ describe("CheckpointReactor", () => {
             isRepo: true,
             hasPrimaryRemote: false,
             isDefaultRef: true,
-            refName: "main",
+            refName:
+              options?.localStatusRefName !== undefined ? options.localStatusRefName : "main",
             hasWorkingTreeChanges: false,
             workingTree: { files: [], insertions: 0, deletions: 0 },
           }),
@@ -370,22 +374,45 @@ describe("CheckpointReactor", () => {
       }),
     );
     await Effect.runPromise(
-      engine.dispatch({
-        type: "thread.create",
-        commandId: CommandId.make("cmd-thread-create"),
-        threadId: ThreadId.make("thread-1"),
-        projectId: asProjectId("project-1"),
-        title: "Thread",
-        modelSelection: {
-          instanceId: ProviderInstanceId.make("codex"),
-          model: "gpt-5-codex",
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        branch: null,
-        worktreePath: options?.threadWorktreePath ?? cwd,
-        createdAt,
-      }),
+      engine
+        .dispatch({
+          type: "thread.create",
+          commandId: CommandId.make("cmd-thread-create"),
+          threadId: ThreadId.make("thread-1"),
+          projectId: asProjectId("project-1"),
+          title: "Thread",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          branch: options?.threadBranch ?? null,
+          worktreePath: options?.threadWorktreePath ?? cwd,
+          createdAt,
+        })
+        .pipe(
+          options?.secondThreadSharingWorktree
+            ? Effect.andThen(
+                engine.dispatch({
+                  type: "thread.create",
+                  commandId: CommandId.make("cmd-thread-create-2"),
+                  threadId: ThreadId.make("thread-2"),
+                  projectId: asProjectId("project-1"),
+                  title: "Thread 2",
+                  modelSelection: {
+                    instanceId: ProviderInstanceId.make("codex"),
+                    model: "gpt-5-codex",
+                  },
+                  interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+                  runtimeMode: "approval-required",
+                  branch: null,
+                  worktreePath: options?.threadWorktreePath ?? cwd,
+                  createdAt,
+                }),
+              )
+            : Effect.asVoid,
+        ),
     );
 
     if (options?.seedFilesystemCheckpoints ?? true) {
@@ -516,6 +543,86 @@ describe("CheckpointReactor", () => {
     await harness.drain();
 
     expect(gitStatusRefreshCalls).toEqual([harness.cwd]);
+  });
+
+  it("adopts a drifted checkout as the thread branch on a dedicated worktree", async () => {
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      threadBranch: "t3code/original-branch",
+      localStatusRefName: "t3code/renamed-by-agent",
+    });
+
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-branch-drift"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      turnId: asTurnId("turn-branch-drift"),
+      payload: { state: "completed" },
+    });
+
+    await harness.drain();
+    await waitForEvent(
+      harness.engine,
+      (event) =>
+        event.type === "thread.meta-updated" &&
+        (event as unknown as { payload: { branch?: string } }).payload.branch ===
+          "t3code/renamed-by-agent",
+    );
+
+    const snapshot = await harness.readModel();
+    const thread = snapshot.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.branch).toBe("t3code/renamed-by-agent");
+  });
+
+  it("does not adopt a drifted checkout when the worktree is shared by another thread", async () => {
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      threadBranch: "t3code/original-branch",
+      localStatusRefName: "t3code/renamed-by-agent",
+      secondThreadSharingWorktree: true,
+    });
+
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-branch-drift-shared"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      turnId: asTurnId("turn-branch-drift-shared"),
+      payload: { state: "completed" },
+    });
+
+    await harness.drain();
+
+    const snapshot = await harness.readModel();
+    const thread = snapshot.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.branch).toBe("t3code/original-branch");
+  });
+
+  it("does not adopt a temporary placeholder checkout as the thread branch", async () => {
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      threadBranch: "t3code/original-branch",
+      localStatusRefName: "t3code/0a1b2c3d",
+    });
+
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-branch-drift-temp"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      turnId: asTurnId("turn-branch-drift-temp"),
+      payload: { state: "completed" },
+    });
+
+    await harness.drain();
+
+    const snapshot = await harness.readModel();
+    const thread = snapshot.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.branch).toBe("t3code/original-branch");
   });
 
   it("ignores auxiliary thread turn completion while primary turn is active", async () => {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -8,6 +8,7 @@ import {
   TurnId,
   type OrchestrationEvent,
   type ProviderRuntimeEvent,
+  type VcsStatusLocalResult,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -18,6 +19,7 @@ import * as Option from "effect/Option";
 import type * as PlatformError from "effect/PlatformError";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 
 import { parseTurnDiffFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
 import {
@@ -534,15 +536,92 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    yield* vcsStatusBroadcaster.refreshLocalStatus(sessionRuntime.value.cwd).pipe(
+    const local = yield* vcsStatusBroadcaster.refreshLocalStatus(sessionRuntime.value.cwd).pipe(
       Effect.catch((error) =>
         Effect.logWarning("failed to refresh local git status after turn completion", {
           threadId: event.threadId,
           turnId: event.turnId ?? null,
           cwd: sessionRuntime.value.cwd,
           detail: error.message,
-        }),
+        }).pipe(Effect.as(null)),
       ),
+    );
+    if (local !== null) {
+      yield* followWorktreeBranchDrift({
+        threadId: event.threadId,
+        cwd: sessionRuntime.value.cwd,
+        local,
+      });
+    }
+  });
+
+  // A `git checkout` run inside a thread's dedicated worktree (by an agent or
+  // the user) bypasses T3's commands, so the thread's recorded branch goes
+  // stale. Since #4460 the client only attributes PR state to a thread when
+  // the checked-out branch equals the recorded one, so stale metadata silently
+  // orphans the thread's PR. Follow the drift here: adopt the checked-out
+  // branch as the thread's branch, but only when the worktree belongs to
+  // exactly this thread — for shared cwds the strict matching is the point.
+  const followWorktreeBranchDrift = Effect.fn("followWorktreeBranchDrift")(function* (input: {
+    readonly threadId: ThreadId;
+    readonly cwd: string;
+    readonly local: VcsStatusLocalResult;
+  }) {
+    // Detached HEAD has no branch to adopt; a temporary placeholder checkout
+    // means the first-turn auto-rename is still in flight — don't race it.
+    const checkedOutBranch = input.local.refName;
+    if (checkedOutBranch === null || isTemporaryWorktreeBranch(checkedOutBranch)) {
+      return;
+    }
+
+    yield* Effect.gen(function* () {
+      const thread = yield* projectionSnapshotQuery
+        .getThreadShellById(input.threadId)
+        .pipe(Effect.map(Option.getOrUndefined));
+      if (
+        !thread ||
+        thread.branch === null ||
+        thread.branch === checkedOutBranch ||
+        thread.worktreePath === null ||
+        thread.worktreePath !== input.cwd ||
+        isTemporaryWorktreeBranch(thread.branch)
+      ) {
+        return;
+      }
+
+      const shell = yield* projectionSnapshotQuery.getShellSnapshot();
+      const worktreeIsShared = shell.threads.some(
+        (other) => other.id !== thread.id && other.worktreePath === thread.worktreePath,
+      );
+      if (worktreeIsShared) {
+        return;
+      }
+
+      // expectedBranch makes this a compare-and-swap in the decider: if the
+      // recorded branch moved between our read and the dispatch (rename,
+      // concurrent drift-follow), the stale update is dropped.
+      yield* orchestrationEngine.dispatch({
+        type: "thread.meta.update",
+        commandId: yield* serverCommandId("worktree-branch-drift"),
+        threadId: thread.id,
+        branch: checkedOutBranch,
+        expectedBranch: thread.branch,
+      });
+      yield* Effect.logInfo("thread branch followed worktree checkout", {
+        threadId: thread.id,
+        previousBranch: thread.branch,
+        branch: checkedOutBranch,
+      });
+    }).pipe(
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) {
+          return Effect.failCause(cause);
+        }
+        return Effect.logWarning("failed to follow worktree branch drift", {
+          threadId: input.threadId,
+          cause: Cause.pretty(cause),
+        });
+      }),
     );
   });
 


### PR DESCRIPTION
## Problem

When an agent (or the user) runs a plain \`git checkout -b\` inside a thread's dedicated worktree and files a PR from the new branch, the PR never links to the thread. The thread's recorded \`branch\` only updates through T3 commands (creation, first-turn auto-rename), so it goes stale — and since #4460 the client only attributes PR state to a thread when the checked-out branch exactly equals the recorded one. Stale metadata silently orphans the PR, and (via #5151) also re-enables inactivity auto-settle for threads that actually have an open PR.

This happened in the wild: a thread recorded \`t3code/ios-background-websocket-reconnect\`, the agent branched off to \`t3code/mobile-reconnect-hardening\` mid-thread and filed #5154 from it, and the link never formed.

## Solution

Keep #4460's strict matching and fix the stale data instead: after each turn completes, the CheckpointReactor already refreshes local git status for the session cwd. Use that fresh status to detect drift — if the checked-out branch differs from the thread's recorded branch **and the worktree belongs to exactly that thread**, dispatch a \`thread.meta.update\` adopting the checked-out branch. The command's existing \`expectedBranch\` compare-and-swap drops the update if the recorded branch moved concurrently.

Guards: shared cwds are never touched (that's where #4460's protection matters), detached HEAD and temporary \`t3code/<hex>\` placeholder checkouts are ignored, and threads with no recorded branch are left alone.

No schema changes, no client changes, no new polling — one server-side hook on an existing refresh path.

## Tests

Three focused cases in \`CheckpointReactor.test.ts\`: adopts drift on a dedicated worktree, refuses when the worktree is shared, refuses temporary placeholder checkouts.

---
Diagnosed and implemented by Claude Fable 5 (claude-fable-5, 1m context) running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread metadata on an existing turn-completion path with compare-and-swap guards; wrong adoption could mis-link PRs, but shared-worktree and temporary-branch guards limit blast radius.
> 
> **Overview**
> When an agent or user checks out a different branch inside a thread’s **dedicated** worktree (outside T3’s branch commands), the thread’s stored `branch` can stay stale. That breaks PR↔thread linking and related behavior that only matches when checkout equals recorded branch.
> 
> **CheckpointReactor** now uses the local git status already refreshed on `turn.completed`. If the checked-out ref differs from the thread’s recorded branch, it dispatches `thread.meta.update` with `expectedBranch` so concurrent renames are ignored. Adoption only runs when the session cwd is that thread’s sole worktree; shared worktrees, detached HEAD, and temporary `t3code/<hex>` placeholder branches are skipped.
> 
> Tests extend the harness and add three cases: adopt on dedicated worktree, no adopt when worktree is shared, no adopt for temporary placeholder checkouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2566f5c4a094ab6fe4f1289418aedce1e07ec86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Follow branch drift in dedicated worktrees so PRs link to their thread
> - After a `turn.completed` event, `CheckpointReactor` now calls a new `followWorktreeBranchDrift` helper that compares the checked-out branch (from local git status) against the thread's recorded branch.
> - When the two differ, the helper dispatches a `thread.meta.update` with `expectedBranch` (CAS semantics) to adopt the drifted branch, allowing PRs on the new branch to link back to the thread.
> - The helper skips adoption if the ref is null, temporary, or shared by multiple threads, or if the worktree path doesn't match.
> - New tests in [CheckpointReactor.test.ts](https://github.com/pingdotgg/t3code/pull/5159/files#diff-80f47e48c3258a501e94a5ba8b5ee0e8871faf64acfe837965b6ca6caf324279) cover drift adoption, shared-worktree suppression, and temporary-ref suppression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2566f5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->