### PR TITLE
feat(mobile): add live preview and markup

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.test.ts
+++ b/apps/desktop/src/ipc/methods/preview.test.ts
@@ -51,4 +51,41 @@ describe("preview IPC methods", () => {
       },
     ),
   );
+
+  effectIt.effect("forwards review mode while legacy snapshot calls stay full", () =>
+    Effect.gen(function* () {
+      const automationSnapshot = vi.fn(() =>
+        Effect.succeed({
+          url: "https://example.com",
+          title: "Example",
+          loading: false,
+          visibleText: "",
+          interactiveElements: [],
+          accessibilityTree: null,
+          consoleEntries: [],
+          networkEntries: [],
+          actionTimeline: [],
+          screenshot: {
+            mimeType: "image/png" as const,
+            data: "cG5n",
+            width: 1,
+            height: 1,
+          },
+        }),
+      );
+      const manager = { automationSnapshot } as never;
+
+      yield* PreviewIpc.automationSnapshot
+        .handler({ tabId: "tab-1", mode: "review" })
+        .pipe(Effect.provideService(PreviewManager.PreviewManager, manager));
+      yield* PreviewIpc.automationSnapshot
+        .handler({ tabId: "tab-1" })
+        .pipe(Effect.provideService(PreviewManager.PreviewManager, manager));
+
+      expect(automationSnapshot.mock.calls).toEqual([
+        ["tab-1", "review"],
+        ["tab-1", "full"],
+      ]);
+    }),
+  );
 });

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -5,6 +5,7 @@ import {
   DesktopPreviewAutomationEvaluateInputSchema,
   DesktopPreviewAutomationPressInputSchema,
   DesktopPreviewAutomationScrollInputSchema,
+  DesktopPreviewAutomationSnapshotInputSchema,
   DesktopPreviewAutomationTypeInputSchema,
   DesktopPreviewAutomationWaitForInputSchema,
   DesktopPreviewConfigInputSchema,
@@ -276,11 +277,11 @@ export const automationStatus = DesktopIpc.makeIpcMethod({
 
 export const automationSnapshot = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL,
-  payload: DesktopPreviewTabInputSchema,
+  payload: DesktopPreviewAutomationSnapshotInputSchema,
   result: PreviewAutomationSnapshot,
-  handler: Effect.fn("desktop.ipc.preview.automationSnapshot")(function* ({ tabId }) {
+  handler: Effect.fn("desktop.ipc.preview.automationSnapshot")(function* ({ tabId, mode }) {
     const manager = yield* PreviewManager.PreviewManager;
-    return yield* manager.automationSnapshot(tabId);
+    return yield* manager.automationSnapshot(tabId, mode === "review" ? "review" : "full");
   }),
 });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -209,8 +209,11 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     automation: {
       status: (tabId) =>
         ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_STATUS_CHANNEL, { tabId }),
-      snapshot: (tabId) =>
-        ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL, { tabId }),
+      snapshot: (tabId, options) =>
+        ipcRenderer.invoke(
+          IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL,
+          options?.mode === "review" ? { tabId, mode: "review" } : { tabId },
+        ),
       click: (tabId, input) =>
         ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_CLICK_CHANNEL, { tabId, input }),
       type: (tabId, input) =>

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -36,6 +36,122 @@ describe("fitPictureInPictureContentSize", () => {
   });
 });
 
+describe("compactPreviewAutomationElements", () => {
+  it("clips semantics to the viewport and drops invalid or oversized entries", () => {
+    const oversizedSelector = `#${"x".repeat(2_048)}`;
+    const result = PreviewManager.compactPreviewAutomationElements(
+      [
+        {
+          tag: "BUTTON",
+          role: "  button  ",
+          name: `  Save\n${"now ".repeat(200)}`,
+          selector: "#save",
+          x: -10,
+          y: 20,
+          width: 30,
+          height: 40,
+        },
+        {
+          tag: "a",
+          role: null,
+          name: "Outside",
+          selector: "#outside",
+          x: 900,
+          y: 20,
+          width: 30,
+          height: 40,
+        },
+        {
+          tag: "input",
+          role: null,
+          name: "Invalid geometry",
+          selector: "#invalid",
+          x: 20,
+          y: 20,
+          width: Number.NaN,
+          height: 40,
+        },
+        {
+          tag: "div",
+          role: "button",
+          name: "Oversized selector",
+          selector: oversizedSelector,
+          x: 20,
+          y: 20,
+          width: 40,
+          height: 40,
+        },
+      ],
+      { width: 800, height: 600 },
+    );
+
+    expect(result).toEqual([
+      {
+        tag: "button",
+        role: "button",
+        name: expect.stringMatching(/^Save now /),
+        selector: "#save",
+        x: 0,
+        y: 20,
+        width: 20,
+        height: 40,
+      },
+    ]);
+    expect(result[0]?.name.length).toBe(512);
+  });
+
+  it("caps the number of semantic elements retained", () => {
+    const result = PreviewManager.compactPreviewAutomationElements(
+      Array.from({ length: 250 }, (_, index) => ({
+        tag: "button",
+        role: null,
+        name: `Button ${index}`,
+        selector: `#button-${index}`,
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+      })),
+      { width: 800, height: 600 },
+    );
+
+    expect(result).toHaveLength(200);
+    expect(result.at(-1)?.selector).toBe("#button-199");
+  });
+});
+
+describe("previewAutomationSnapshotResizeWidth", () => {
+  it("keeps the legacy snapshot path width-only", () => {
+    expect(
+      PreviewManager.previewAutomationSnapshotResizeWidth({ width: 1_000, height: 3_000 }, "full"),
+    ).toBeNull();
+    expect(
+      PreviewManager.previewAutomationSnapshotResizeWidth({ width: 2_400, height: 1_200 }, "full"),
+    ).toBe(1_280);
+  });
+
+  it("caps review snapshots by width and approximately two million pixels", () => {
+    expect(
+      PreviewManager.previewAutomationSnapshotResizeWidth(
+        { width: 1_000, height: 3_000 },
+        "review",
+      ),
+    ).toBe(816);
+    expect(
+      PreviewManager.previewAutomationSnapshotResizeWidth(
+        { width: 2_400, height: 1_200 },
+        "review",
+      ),
+    ).toBe(1_280);
+    expect(
+      PreviewManager.previewAutomationSnapshotResizeWidth(
+        { width: 1_000, height: 1_000 },
+        "review",
+      ),
+    ).toBeNull();
+  });
+});
+
 const {
   browserWindowConstructor,
   createFromPath,
@@ -762,6 +878,235 @@ describe("PreviewManager", () => {
           webContentsId: 42,
           cause: captureCause,
         });
+      }),
+    ),
+  );
+
+  effectIt.effect("keeps legacy automation snapshots full", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const png = Buffer.from("review-snapshot-png");
+        const resizedImage = {
+          getSize: () => ({ width: 1_280, height: 768 }),
+          toPNG: () => png,
+        };
+        const resize = vi.fn(() => resizedImage);
+        const capturePage = vi.fn(async () => ({
+          getSize: () => ({ width: 1_600, height: 960 }),
+          resize,
+          toPNG: () => Buffer.from("unscaled"),
+        }));
+        const accessibilityTree = {
+          nodes: [{ nodeId: "1", role: { value: "button" } }],
+        };
+        const sendCommand = vi.fn(async (method: string) => {
+          if (method === "Runtime.evaluate") {
+            return {
+              result: {
+                value: {
+                  url: "https://example.com/review",
+                  title: "Review",
+                  loading: false,
+                  visibleText: "Save settings",
+                  viewport: {
+                    width: 1_000,
+                    height: 600,
+                    scrollX: 12,
+                    scrollY: 240,
+                    devicePixelRatio: 2,
+                  },
+                  interactiveElements: [
+                    {
+                      tag: "button",
+                      role: "button",
+                      name: "Save",
+                      selector: "#save",
+                      x: 990,
+                      y: 20,
+                      width: 40,
+                      height: 30,
+                    },
+                    {
+                      tag: "button",
+                      role: "button",
+                      name: "Below the frame",
+                      selector: "#below",
+                      x: 20,
+                      y: 700,
+                      width: 40,
+                      height: 30,
+                    },
+                  ],
+                },
+              },
+            };
+          }
+          if (method === "Accessibility.getFullAXTree") return accessibilityTree;
+          return undefined;
+        });
+        fromId.mockReturnValue({
+          id: 42,
+          isDestroyed: () => false,
+          getType: () => "webview",
+          getURL: () => "https://example.com/review",
+          getTitle: () => "Review",
+          isLoading: () => false,
+          isDevToolsOpened: () => false,
+          getZoomFactor: () => 1,
+          setZoomFactor: vi.fn(),
+          on: vi.fn(),
+          off: vi.fn(),
+          ipc: { on: vi.fn(), off: vi.fn() },
+          send: webviewSend,
+          navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+          setWindowOpenHandler: vi.fn(),
+          debugger: {
+            isAttached: () => false,
+            attach: vi.fn(),
+            sendCommand,
+            on: vi.fn(),
+            off: vi.fn(),
+          },
+          capturePage,
+        } as never);
+
+        yield* manager.createTab("tab_review");
+        yield* manager.registerWebview("tab_review", 42);
+        const snapshot = yield* manager.automationSnapshot("tab_review");
+
+        expect(snapshot.viewport).toEqual({
+          width: 1_000,
+          height: 600,
+          scrollX: 12,
+          scrollY: 240,
+          devicePixelRatio: 2,
+        });
+        expect(snapshot.interactiveElements).toEqual([
+          {
+            tag: "button",
+            role: "button",
+            name: "Save",
+            selector: "#save",
+            x: 990,
+            y: 20,
+            width: 10,
+            height: 30,
+          },
+        ]);
+        expect(snapshot.visibleText).toBe("Save settings");
+        expect(snapshot.accessibilityTree).toEqual(accessibilityTree);
+        expect(snapshot.screenshot).toEqual({
+          mimeType: "image/png",
+          data: png.toString("base64"),
+          width: 1_280,
+          height: 768,
+          scale: 1.28,
+        });
+        expect(resize).toHaveBeenCalledWith({ width: 1_280 });
+        expect(capturePage).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+
+  effectIt.effect("captures compact review snapshots without diagnostic context", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const png = Buffer.from("compact-review-snapshot-png");
+        const resizedImage = {
+          getSize: () => ({ width: 816, height: 2_448 }),
+          toPNG: () => png,
+        };
+        const resize = vi.fn(() => resizedImage);
+        const capturePage = vi.fn(async () => ({
+          getSize: () => ({ width: 1_000, height: 3_000 }),
+          resize,
+          toPNG: () => Buffer.from("unscaled"),
+        }));
+        const sendCommand = vi.fn(
+          async (method: string, _commandParams?: Record<string, unknown>) => {
+            if (method !== "Runtime.evaluate") return undefined;
+            return {
+              result: {
+                value: {
+                  url: "https://example.com/review",
+                  title: "Review",
+                  loading: false,
+                  visibleText: "Sensitive page text",
+                  viewport: {
+                    width: 1_000,
+                    height: 3_000,
+                    scrollX: 0,
+                    scrollY: 120,
+                    devicePixelRatio: 2,
+                  },
+                  interactiveElements: [
+                    {
+                      tag: "button",
+                      role: "button",
+                      name: "Save",
+                      selector: "#save",
+                      x: 20,
+                      y: 30,
+                      width: 80,
+                      height: 32,
+                    },
+                  ],
+                },
+              },
+            };
+          },
+        );
+        fromId.mockReturnValue({
+          id: 42,
+          isDestroyed: () => false,
+          getType: () => "webview",
+          getURL: () => "https://example.com/review",
+          getTitle: () => "Review",
+          isLoading: () => false,
+          isDevToolsOpened: () => false,
+          getZoomFactor: () => 1,
+          setZoomFactor: vi.fn(),
+          on: vi.fn(),
+          off: vi.fn(),
+          ipc: { on: vi.fn(), off: vi.fn() },
+          send: webviewSend,
+          navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+          setWindowOpenHandler: vi.fn(),
+          debugger: {
+            isAttached: () => false,
+            attach: vi.fn(),
+            sendCommand,
+            on: vi.fn(),
+            off: vi.fn(),
+          },
+          capturePage,
+        } as never);
+
+        yield* manager.createTab("tab_review_compact");
+        yield* manager.registerWebview("tab_review_compact", 42);
+        const snapshot = yield* manager.automationSnapshot("tab_review_compact", "review");
+
+        expect(snapshot.visibleText).toBe("");
+        expect(snapshot.accessibilityTree).toBeNull();
+        expect(snapshot.consoleEntries).toEqual([]);
+        expect(snapshot.networkEntries).toEqual([]);
+        expect(snapshot.actionTimeline).toEqual([]);
+        expect(snapshot.interactiveElements).toHaveLength(1);
+        expect(snapshot.screenshot).toEqual({
+          mimeType: "image/png",
+          data: png.toString("base64"),
+          width: 816,
+          height: 2_448,
+          scale: 0.816,
+        });
+        expect(sendCommand).not.toHaveBeenCalledWith("Accessibility.getFullAXTree");
+        const evaluateExpression = sendCommand.mock.calls.find(
+          ([method]) => method === "Runtime.evaluate",
+        )?.[1]?.expression;
+        expect(evaluateExpression).toEqual(expect.any(String));
+        expect(evaluateExpression).not.toContain("document.body?.innerText");
+        expect(resize).toHaveBeenCalledWith({ width: 816 });
+        expect(capturePage).toHaveBeenCalledOnce();
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -22,6 +22,7 @@ import type {
   PreviewAutomationNetworkEntry,
   PreviewAutomationScrollInput,
   PreviewAutomationSnapshot,
+  PreviewAutomationSnapshotViewport,
   PreviewAutomationStatus,
   PreviewAutomationTypeInput,
   PreviewAutomationWaitForInput,
@@ -97,7 +98,12 @@ const ZOOM_EPSILON = 0.001;
 const MAX_EVALUATION_BYTES = 64_000;
 const MAX_VISIBLE_TEXT_LENGTH = 20_000;
 const MAX_INTERACTIVE_ELEMENTS = 200;
+const MAX_INTERACTIVE_ELEMENT_NAME_LENGTH = 512;
+const MAX_INTERACTIVE_ELEMENT_ROLE_LENGTH = 128;
+const MAX_INTERACTIVE_ELEMENT_SELECTOR_LENGTH = 2_048;
+const MAX_INTERACTIVE_ELEMENT_TAG_LENGTH = 64;
 const MAX_SCREENSHOT_WIDTH = 1280;
+const MAX_REVIEW_SCREENSHOT_PIXELS = 2_000_000;
 const RECORDING_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
 const RECORDING_JPEG_QUALITY = 80;
 const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
@@ -202,6 +208,99 @@ interface CdpEvaluationResult {
     readonly text?: string;
     readonly exception?: { readonly description?: string };
   };
+}
+
+type PreviewAutomationSnapshotElement = PreviewAutomationSnapshot["interactiveElements"][number];
+export type PreviewAutomationSnapshotMode = "full" | "review";
+
+const compactSemanticText = (value: string, maximumLength: number): string =>
+  value.replace(/\s+/g, " ").trim().slice(0, maximumLength);
+
+export function previewAutomationSnapshotResizeWidth(
+  size: Readonly<{ width: number; height: number }>,
+  mode: PreviewAutomationSnapshotMode,
+): number | null {
+  if (
+    !Number.isFinite(size.width) ||
+    size.width <= 0 ||
+    !Number.isFinite(size.height) ||
+    size.height <= 0
+  ) {
+    return null;
+  }
+
+  const widthScale = MAX_SCREENSHOT_WIDTH / size.width;
+  const pixelScale =
+    mode === "review" ? Math.sqrt(MAX_REVIEW_SCREENSHOT_PIXELS / (size.width * size.height)) : 1;
+  const scale = Math.min(1, widthScale, pixelScale);
+  return scale < 1 ? Math.max(1, Math.floor(size.width * scale)) : null;
+}
+
+/**
+ * Keeps snapshot semantics in the same coordinate space as the captured
+ * viewport. Page scripts are not a trust boundary, so apply the clipping and
+ * payload limits again in the main process even though the injected collector
+ * performs the same viewport filtering before crossing CDP.
+ */
+export function compactPreviewAutomationElements(
+  elements: ReadonlyArray<PreviewAutomationSnapshotElement>,
+  viewport: Pick<PreviewAutomationSnapshotViewport, "width" | "height">,
+): ReadonlyArray<PreviewAutomationSnapshotElement> {
+  if (
+    !Number.isFinite(viewport.width) ||
+    viewport.width <= 0 ||
+    !Number.isFinite(viewport.height) ||
+    viewport.height <= 0
+  ) {
+    return [];
+  }
+
+  const compacted: PreviewAutomationSnapshotElement[] = [];
+  for (const element of elements) {
+    if (compacted.length >= MAX_INTERACTIVE_ELEMENTS) break;
+    if (
+      !Number.isFinite(element.x) ||
+      !Number.isFinite(element.y) ||
+      !Number.isFinite(element.width) ||
+      !Number.isFinite(element.height) ||
+      element.width <= 0 ||
+      element.height <= 0
+    ) {
+      continue;
+    }
+
+    const left = Math.max(0, element.x);
+    const top = Math.max(0, element.y);
+    const right = Math.min(viewport.width, element.x + element.width);
+    const bottom = Math.min(viewport.height, element.y + element.height);
+    if (right <= left || bottom <= top) continue;
+
+    const selector = element.selector.trim();
+    const tag = compactSemanticText(element.tag, MAX_INTERACTIVE_ELEMENT_TAG_LENGTH).toLowerCase();
+    if (
+      selector.length === 0 ||
+      selector.length > MAX_INTERACTIVE_ELEMENT_SELECTOR_LENGTH ||
+      tag.length === 0
+    ) {
+      continue;
+    }
+
+    const role =
+      element.role === null
+        ? null
+        : compactSemanticText(element.role, MAX_INTERACTIVE_ELEMENT_ROLE_LENGTH) || null;
+    compacted.push({
+      tag,
+      role,
+      name: compactSemanticText(element.name, MAX_INTERACTIVE_ELEMENT_NAME_LENGTH),
+      selector,
+      x: left,
+      y: top,
+      width: right - left,
+      height: bottom - top,
+    });
+  }
+  return compacted;
 }
 
 export const PreviewAutomationSelectorKind = Schema.Literals([
@@ -2601,16 +2700,27 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   });
 
   const captureAutomationSnapshot = Effect.fn("PreviewManager.captureAutomationSnapshot")(
-    function* (tabId: string, wc: Electron.WebContents, send: SendCommand) {
-      yield* Effect.all([send("Runtime.enable"), send("Accessibility.enable")], {
-        concurrency: 2,
-        discard: true,
-      });
+    function* (
+      tabId: string,
+      wc: Electron.WebContents,
+      send: SendCommand,
+      mode: PreviewAutomationSnapshotMode,
+    ) {
+      yield* Effect.all(
+        mode === "review"
+          ? [send("Runtime.enable")]
+          : [send("Runtime.enable"), send("Accessibility.enable")],
+        {
+          concurrency: 2,
+          discard: true,
+        },
+      );
       const page = yield* evaluateWithDebugger<{
         url: string;
         title: string;
         loading: boolean;
         visibleText: string;
+        viewport: PreviewAutomationSnapshotViewport;
         interactiveElements: PreviewAutomationSnapshot["interactiveElements"];
       }>(
         tabId,
@@ -2641,64 +2751,102 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           const visible = (element) => {
             const style = getComputedStyle(element);
             const rect = element.getBoundingClientRect();
-            return style.visibility !== "hidden" && style.display !== "none" && rect.width > 0 && rect.height > 0;
+            return style.visibility !== "hidden"
+              && style.display !== "none"
+              && style.opacity !== "0"
+              && rect.width > 0
+              && rect.height > 0
+              && rect.right > 0
+              && rect.bottom > 0
+              && rect.left < window.innerWidth
+              && rect.top < window.innerHeight;
           };
           const elements = Array.from(document.querySelectorAll(
             "a[href],button,input,textarea,select,[role],[tabindex]"
-          )).filter(visible).slice(0, ${MAX_INTERACTIVE_ELEMENTS}).map((element) => {
+          )).filter(visible).map((element) => {
             const rect = element.getBoundingClientRect();
+            const selector = selectorFor(element);
+            if (!selector || selector.length > ${MAX_INTERACTIVE_ELEMENT_SELECTOR_LENGTH}) {
+              return null;
+            }
+            const rawName = element.getAttribute("aria-label")
+              || element.innerText
+              || element.getAttribute("name")
+              || "";
             return {
               tag: element.tagName.toLowerCase(),
               role: element.getAttribute("role"),
-              name: element.getAttribute("aria-label") || element.innerText || element.getAttribute("name") || "",
-              selector: selectorFor(element),
+              name: String(rawName).replace(/\\s+/g, " ").trim().slice(0, ${MAX_INTERACTIVE_ELEMENT_NAME_LENGTH}),
+              selector,
               x: rect.x,
               y: rect.y,
               width: rect.width,
               height: rect.height
             };
-          });
+          }).filter((element) => element !== null).slice(0, ${MAX_INTERACTIVE_ELEMENTS});
           return {
             url: location.href,
             title: document.title,
             loading: document.readyState !== "complete",
-            visibleText: (document.body?.innerText || "").slice(0, ${MAX_VISIBLE_TEXT_LENGTH}),
+            visibleText: ${
+              mode === "review"
+                ? '""'
+                : `(document.body?.innerText || "").slice(0, ${MAX_VISIBLE_TEXT_LENGTH})`
+            },
+            viewport: {
+              width: Math.max(1, window.innerWidth),
+              height: Math.max(1, window.innerHeight),
+              scrollX: Number.isFinite(window.scrollX) ? window.scrollX : 0,
+              scrollY: Number.isFinite(window.scrollY) ? window.scrollY : 0,
+              devicePixelRatio: Number.isFinite(window.devicePixelRatio) && window.devicePixelRatio > 0
+                ? window.devicePixelRatio
+                : 1
+            },
             interactiveElements: elements
           };
         })()`,
         true,
       );
-      const [accessibility, sourceImage, diagnostics, timelines] = yield* Effect.all([
-        send("Accessibility.getFullAXTree"),
-        attemptPromise(
-          {
-            operation: "automationSnapshot.capturePage",
-            tabId,
-            webContentsId: wc.id,
-          },
-          () => wc.capturePage(),
-        ),
-        Ref.get(diagnosticsRef),
-        Ref.get(actionTimelineRef),
-      ]);
+      const capturePage = attemptPromise(
+        {
+          operation: "automationSnapshot.capturePage",
+          tabId,
+          webContentsId: wc.id,
+        },
+        () => wc.capturePage(),
+      );
+      const [accessibility, sourceImage, diagnostics, timelines] =
+        mode === "review"
+          ? ([null, yield* capturePage, null, null] as const)
+          : yield* Effect.all([
+              send("Accessibility.getFullAXTree"),
+              capturePage,
+              Ref.get(diagnosticsRef),
+              Ref.get(actionTimelineRef),
+            ]);
       const sourceSize = sourceImage.getSize();
-      const image =
-        sourceSize.width > MAX_SCREENSHOT_WIDTH
-          ? sourceImage.resize({ width: MAX_SCREENSHOT_WIDTH })
-          : sourceImage;
+      const resizeWidth = previewAutomationSnapshotResizeWidth(sourceSize, mode);
+      const image = resizeWidth === null ? sourceImage : sourceImage.resize({ width: resizeWidth });
       const size = image.getSize();
-      const browserDiagnostics = diagnostics.get(wc.id);
+      const browserDiagnostics = diagnostics?.get(wc.id);
+      const interactiveElements = compactPreviewAutomationElements(
+        page.interactiveElements,
+        page.viewport,
+      );
       return {
         ...page,
+        visibleText: mode === "review" ? "" : page.visibleText,
+        interactiveElements,
         accessibilityTree: accessibility,
         consoleEntries: [...(browserDiagnostics?.consoleEntries ?? [])],
         networkEntries: [...(browserDiagnostics?.networkEntries ?? [])],
-        actionTimeline: [...(timelines.get(tabId) ?? [])],
+        actionTimeline: [...(timelines?.get(tabId) ?? [])],
         screenshot: {
           mimeType: "image/png" as const,
           data: image.toPNG().toString("base64"),
           width: size.width,
           height: size.height,
+          scale: size.width / page.viewport.width,
         },
       };
     },
@@ -2706,10 +2854,11 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
 
   const automationSnapshot = Effect.fn("PreviewManager.automationSnapshot")(function* (
     tabId: string,
+    mode: PreviewAutomationSnapshotMode = "full",
   ) {
     const wc = yield* requireWebContents(tabId);
     return yield* withControlSession(tabId, wc, "snapshot", (send) =>
-      captureAutomationSnapshot(tabId, wc, send),
+      captureAutomationSnapshot(tabId, wc, send, mode),
     );
   });
 
@@ -3607,6 +3756,7 @@ export class PreviewManager extends Context.Service<
     ) => Effect.Effect<PreviewAutomationStatus, PreviewManagerError>;
     readonly automationSnapshot: (
       tabId: string,
+      mode?: PreviewAutomationSnapshotMode,
     ) => Effect.Effect<PreviewAutomationSnapshot, PreviewManagerError>;
     readonly automationClick: (
       tabId: string,

--- a/apps/desktop/src/preview/PickedElementPayload.test.ts
+++ b/apps/desktop/src/preview/PickedElementPayload.test.ts
@@ -180,6 +180,69 @@ describe("isPreviewAnnotationPayload", () => {
     expect(isPreviewAnnotationPayload(validAnnotation())).toBe(true);
   });
 
+  it("accepts valid portable source, callout, and editable-vector extensions", () => {
+    expect(
+      isPreviewAnnotationPayload(
+        validAnnotation({
+          schemaVersion: 1,
+          source: {
+            kind: "preview",
+            url: "https://example.com/",
+            title: "Example",
+          },
+          callouts: [
+            {
+              id: "callout_point",
+              number: 1,
+              comment: "Move this.",
+              anchor: { kind: "point", point: { x: 0.2, y: 0.3 } },
+            },
+            {
+              id: "callout_region",
+              number: 2,
+              comment: "Reduce this space.",
+              anchor: {
+                kind: "region",
+                rect: { x: 0.4, y: 0.1, width: 0.3, height: 0.2 },
+              },
+            },
+            {
+              id: "callout_element",
+              number: 3,
+              comment: "Use the primary style.",
+              anchor: {
+                kind: "element",
+                targetId: "element_1",
+                rect: { x: 0.1, y: 0.7, width: 0.4, height: 0.2 },
+              },
+            },
+          ],
+          editable: {
+            version: 1,
+            coordinateSpace: "normalized",
+            strokes: [
+              {
+                id: "stroke_editable",
+                color: "#7c3aed",
+                width: 0.01,
+                points: [
+                  { x: 0.1, y: 0.2 },
+                  { x: 0.2, y: 0.3 },
+                ],
+                bounds: { x: 0.08, y: 0.18, width: 0.14, height: 0.14 },
+              },
+            ],
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isPreviewAnnotationPayload(
+        validAnnotation({ source: { kind: "image", name: "checkout.png" }, editable: null }),
+      ),
+    ).toBe(true);
+  });
+
   it("rejects screenshots supplied by the guest preload", () => {
     expect(isPreviewAnnotationPayload(validAnnotation({ screenshot: { dataUrl: "bad" } }))).toBe(
       false,
@@ -197,5 +260,87 @@ describe("isPreviewAnnotationPayload", () => {
         validAnnotation({ elements: [{ id: "element_1", element: {}, rect: {} }] }),
       ),
     ).toBe(false);
+  });
+
+  it.each<[string, Record<string, unknown>]>([
+    ["an unknown schema version", validAnnotation({ schemaVersion: 2 })],
+    ["a malformed image source", validAnnotation({ source: { kind: "image", name: 42 } })],
+    [
+      "a malformed preview source",
+      validAnnotation({ source: { kind: "preview", url: null, title: "Example" } }),
+    ],
+    ["a non-array callout collection", validAnnotation({ callouts: "not-an-array" })],
+    [
+      "an out-of-bounds callout point",
+      validAnnotation({
+        callouts: [
+          {
+            id: "callout_1",
+            number: 1,
+            comment: "",
+            anchor: { kind: "point", point: { x: 1.1, y: 0.5 } },
+          },
+        ],
+      }),
+    ],
+    [
+      "an overflowing callout region",
+      validAnnotation({
+        callouts: [
+          {
+            id: "callout_1",
+            number: 1,
+            comment: "",
+            anchor: {
+              kind: "region",
+              rect: { x: 0.8, y: 0.2, width: 0.3, height: 0.2 },
+            },
+          },
+        ],
+      }),
+    ],
+    [
+      "a non-positive callout number",
+      validAnnotation({
+        callouts: [
+          {
+            id: "callout_1",
+            number: 0,
+            comment: "",
+            anchor: { kind: "point", point: { x: 0.5, y: 0.5 } },
+          },
+        ],
+      }),
+    ],
+    [
+      "a malformed editable vector document",
+      validAnnotation({
+        editable: {
+          version: 2,
+          coordinateSpace: "pixels",
+          strokes: [],
+        },
+      }),
+    ],
+    [
+      "an out-of-bounds editable stroke",
+      validAnnotation({
+        editable: {
+          version: 1,
+          coordinateSpace: "normalized",
+          strokes: [
+            {
+              id: "stroke_1",
+              color: "#7c3aed",
+              width: 0.01,
+              points: [{ x: Number.NaN, y: 0.5 }],
+              bounds: { x: 0.1, y: 0.1, width: 0.2, height: 0.2 },
+            },
+          ],
+        },
+      }),
+    ],
+  ])("rejects %s", (_label, value) => {
+    expect(isPreviewAnnotationPayload(value)).toBe(false);
   });
 });

--- a/apps/desktop/src/preview/PickedElementPayload.ts
+++ b/apps/desktop/src/preview/PickedElementPayload.ts
@@ -67,6 +67,97 @@ function isPoint(value: unknown): boolean {
   );
 }
 
+function isNormalizedNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+function isNormalizedPoint(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const point = value as Record<string, unknown>;
+  return isNormalizedNumber(point["x"]) && isNormalizedNumber(point["y"]);
+}
+
+function isNormalizedRect(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const rect = value as Record<string, unknown>;
+  if (
+    !isNormalizedNumber(rect["x"]) ||
+    !isNormalizedNumber(rect["y"]) ||
+    !isNormalizedNumber(rect["width"]) ||
+    !isNormalizedNumber(rect["height"]) ||
+    rect["width"] <= 0 ||
+    rect["height"] <= 0
+  ) {
+    return false;
+  }
+  return rect["x"] + rect["width"] <= 1 && rect["y"] + rect["height"] <= 1;
+}
+
+function isPreviewAnnotationSource(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const source = value as Record<string, unknown>;
+  if (source["kind"] === "image") {
+    return isStringOrNull(source["name"]);
+  }
+  if (source["kind"] === "preview") {
+    return typeof source["url"] === "string" && isStringOrNull(source["title"]);
+  }
+  return false;
+}
+
+function isPreviewAnnotationCallout(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const callout = value as Record<string, unknown>;
+  if (
+    typeof callout["id"] !== "string" ||
+    typeof callout["number"] !== "number" ||
+    !Number.isInteger(callout["number"]) ||
+    callout["number"] < 1 ||
+    typeof callout["comment"] !== "string"
+  ) {
+    return false;
+  }
+
+  const anchorValue = callout["anchor"];
+  if (typeof anchorValue !== "object" || anchorValue === null) return false;
+  const anchor = anchorValue as Record<string, unknown>;
+  if (anchor["kind"] === "point") {
+    return isNormalizedPoint(anchor["point"]);
+  }
+  if (anchor["kind"] === "region") {
+    return isNormalizedRect(anchor["rect"]);
+  }
+  if (anchor["kind"] === "element") {
+    return typeof anchor["targetId"] === "string" && isNormalizedRect(anchor["rect"]);
+  }
+  return false;
+}
+
+function isPreviewAnnotationEditableStroke(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const stroke = value as Record<string, unknown>;
+  return (
+    typeof stroke["id"] === "string" &&
+    typeof stroke["color"] === "string" &&
+    isNormalizedNumber(stroke["width"]) &&
+    stroke["width"] > 0 &&
+    Array.isArray(stroke["points"]) &&
+    stroke["points"].every(isNormalizedPoint) &&
+    isNormalizedRect(stroke["bounds"])
+  );
+}
+
+function isPreviewAnnotationEditable(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const editable = value as Record<string, unknown>;
+  return (
+    editable["version"] === 1 &&
+    editable["coordinateSpace"] === "normalized" &&
+    Array.isArray(editable["strokes"]) &&
+    editable["strokes"].every(isPreviewAnnotationEditableStroke)
+  );
+}
+
 export function isPreviewAnnotationPayload(value: unknown): value is PreviewAnnotationPayload {
   if (typeof value !== "object" || value === null) return false;
   const annotation = value as Record<string, unknown>;
@@ -75,7 +166,27 @@ export function isPreviewAnnotationPayload(value: unknown): value is PreviewAnno
   if (!isStringOrNull(annotation["pageTitle"])) return false;
   if (typeof annotation["comment"] !== "string") return false;
   if (typeof annotation["createdAt"] !== "string") return false;
+  // The guest submits structure only. The trusted main process captures and
+  // attaches the screenshot after this boundary.
   if (annotation["screenshot"] !== null) return false;
+  if (annotation["schemaVersion"] !== undefined && annotation["schemaVersion"] !== 1) return false;
+  if (annotation["source"] !== undefined && !isPreviewAnnotationSource(annotation["source"])) {
+    return false;
+  }
+  if (
+    annotation["callouts"] !== undefined &&
+    (!Array.isArray(annotation["callouts"]) ||
+      !annotation["callouts"].every(isPreviewAnnotationCallout))
+  ) {
+    return false;
+  }
+  if (
+    annotation["editable"] !== undefined &&
+    annotation["editable"] !== null &&
+    !isPreviewAnnotationEditable(annotation["editable"])
+  ) {
+    return false;
+  }
 
   const elements = annotation["elements"];
   if (!Array.isArray(elements)) return false;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -114,6 +114,7 @@
     "react-native-screens": "4.25.2",
     "react-native-shiki-engine": "^0.3.12",
     "react-native-svg": "15.15.4",
+    "react-native-view-shot": "5.1.0",
     "react-native-webview": "^13.16.1",
     "react-native-worklets": "0.8.3",
     "shiki": "4.2.0",

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -26,6 +26,7 @@ import { AdaptiveWorkspaceLayout } from "./features/layout/AdaptiveWorkspaceLayo
 import { HardwareKeyboardCommandProvider } from "./features/keyboard/HardwareKeyboardCommandProvider";
 import { ReviewCommentComposerSheet } from "./features/review/ReviewCommentComposerSheet";
 import { ReviewSheet } from "./features/review/ReviewSheet";
+import { ThreadPreviewRouteScreen } from "./features/preview/ThreadPreviewRouteScreen";
 import { ThreadTerminalRouteScreen } from "./features/terminal/ThreadTerminalRouteScreen";
 import { GitBranchesSheet } from "./features/threads/git/GitBranchesSheet";
 import { GitCommitSheet } from "./features/threads/git/GitCommitSheet";
@@ -421,6 +422,11 @@ export const RootStack = createNativeStackNavigator({
         sheetAllowedDetents: Platform.OS === "android" ? undefined : [0.55, 0.92],
         sheetGrabberVisible: Platform.OS !== "android",
       },
+    }),
+    ThreadPreview: createNativeStackScreen({
+      screen: ThreadPreviewRouteScreen,
+      linking: `${THREAD_LINKING_PREFIX}/preview`,
+      options: SOLID_HEADER_OPTIONS,
     }),
     ThreadFiles: createNativeStackScreen({
       screen: ThreadFilesTreeScreen,

--- a/apps/mobile/src/components/AppSymbol.tsx
+++ b/apps/mobile/src/components/AppSymbol.tsx
@@ -120,6 +120,7 @@ const ANDROID_ICON_BY_SF_SYMBOL: Partial<Record<SFSymbol, Icon>> = {
   "line.3.horizontal.decrease.circle.fill": IconFilter,
   magnifyingglass: IconSearch,
   paintbrush: IconPalette,
+  pencil: IconEdit,
   "person.crop.circle": IconUserCircle,
   play: IconPlayerPlay,
   plus: IconPlus,

--- a/apps/mobile/src/components/ComposerAttachmentStrip.tsx
+++ b/apps/mobile/src/components/ComposerAttachmentStrip.tsx
@@ -1,7 +1,9 @@
 import { SymbolView } from "../components/AppSymbol";
+import { useState } from "react";
 import { Image, Pressable, ScrollView, View } from "react-native";
 import { useThemeColor } from "../lib/useThemeColor";
 
+import { ImageMarkupModal } from "../features/annotations/ImageMarkupModal";
 import type { DraftComposerImageAttachment } from "../lib/composerImages";
 
 export interface ComposerAttachmentStripProps {
@@ -9,6 +11,8 @@ export interface ComposerAttachmentStripProps {
   readonly attachments: ReadonlyArray<DraftComposerImageAttachment>;
   /** Called when the user taps the remove button on an image. */
   readonly onRemove: (imageId: string) => void;
+  /** Replaces an attachment after adding, editing, or removing image markup. */
+  readonly onReplace?: (image: DraftComposerImageAttachment) => void;
   /** Called when the user taps on an image thumbnail to preview it. */
   readonly onPressImage?: (previewUri: string) => void;
   /** Image thumbnail size in points.  Defaults to 72. */
@@ -25,6 +29,9 @@ export interface ComposerAttachmentStripProps {
  */
 export function ComposerAttachmentStrip(props: ComposerAttachmentStripProps) {
   const subtleBg = useThemeColor("--color-subtle");
+  const [markupAttachment, setMarkupAttachment] = useState<DraftComposerImageAttachment | null>(
+    null,
+  );
   const size = props.imageSize ?? 72;
   const radius = props.imageBorderRadius ?? 16;
   const removeButtonPlacement = props.removeButtonPlacement ?? "overlay";
@@ -35,56 +42,91 @@ export function ComposerAttachmentStrip(props: ComposerAttachmentStripProps) {
   }
 
   return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      keyboardShouldPersistTaps="always"
-      className="grow-0"
-    >
-      <View className="flex-row gap-2.5">
-        {props.attachments.map((image) => (
-          <View
-            key={image.id}
-            className="relative"
-            style={{
-              paddingTop: removeButtonGutter,
-              paddingRight: removeButtonGutter,
-            }}
-          >
-            <Pressable
-              onPress={props.onPressImage ? () => props.onPressImage!(image.previewUri) : undefined}
-            >
-              <Image
-                source={{ uri: image.previewUri }}
-                style={{
-                  width: size,
-                  height: size,
-                  borderRadius: radius,
-                  backgroundColor: subtleBg,
-                }}
-                resizeMode="cover"
-              />
-            </Pressable>
-            <Pressable
-              className="absolute h-[22px] w-[22px] items-center justify-center rounded-[11px] bg-black/55"
+    <>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyboardShouldPersistTaps="always"
+        className="grow-0"
+      >
+        <View className="flex-row gap-2.5">
+          {props.attachments.map((image) => (
+            <View
+              key={image.id}
+              className="relative"
               style={{
-                top: removeButtonPlacement === "gutter" ? 0 : 4,
-                right: removeButtonPlacement === "gutter" ? 0 : 4,
+                paddingTop: removeButtonGutter,
+                paddingRight: removeButtonGutter,
               }}
-              hitSlop={6}
-              onPress={() => props.onRemove(image.id)}
             >
-              <SymbolView
-                name="xmark"
-                size={9}
-                tintColor="#ffffff"
-                type="monochrome"
-                weight="bold"
-              />
-            </Pressable>
-          </View>
-        ))}
-      </View>
-    </ScrollView>
+              <Pressable
+                onPress={
+                  props.onPressImage ? () => props.onPressImage!(image.previewUri) : undefined
+                }
+              >
+                <Image
+                  source={{ uri: image.previewUri }}
+                  style={{
+                    width: size,
+                    height: size,
+                    borderRadius: radius,
+                    backgroundColor: subtleBg,
+                  }}
+                  resizeMode="cover"
+                />
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`Remove ${image.name}`}
+                className="absolute h-[22px] w-[22px] items-center justify-center rounded-[11px] bg-black/55"
+                style={{
+                  top: removeButtonPlacement === "gutter" ? 0 : 4,
+                  right: removeButtonPlacement === "gutter" ? 0 : 4,
+                }}
+                hitSlop={6}
+                onPress={() => props.onRemove(image.id)}
+              >
+                <SymbolView
+                  name="xmark"
+                  size={9}
+                  tintColor="#ffffff"
+                  type="monochrome"
+                  weight="bold"
+                />
+              </Pressable>
+              {props.onReplace ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`${image.markup ? "Edit" : "Add"} markup for ${image.name}`}
+                  className="absolute h-7 w-7 items-center justify-center rounded-[14px] bg-black/60"
+                  style={{
+                    right: removeButtonGutter + 4,
+                    bottom: 4,
+                  }}
+                  hitSlop={6}
+                  onPress={() => setMarkupAttachment(image)}
+                >
+                  <SymbolView
+                    name="square.and.pencil"
+                    size={13}
+                    tintColor="#ffffff"
+                    type="monochrome"
+                  />
+                </Pressable>
+              ) : null}
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+      <ImageMarkupModal
+        attachment={markupAttachment}
+        visible={markupAttachment !== null}
+        onCancel={() => setMarkupAttachment(null)}
+        onDone={(image) => {
+          props.onReplace?.(image);
+          setMarkupAttachment(null);
+        }}
+      />
+    </>
   );
 }

--- a/apps/mobile/src/components/FullscreenImageViewer.tsx
+++ b/apps/mobile/src/components/FullscreenImageViewer.tsx
@@ -1,0 +1,115 @@
+import {
+  Image,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  useWindowDimensions,
+  View,
+  type ImageURISource,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from "react-native";
+import ImageViewing from "react-native-image-viewing";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { SymbolView } from "./AppSymbol";
+
+export type FullscreenImageSource = ImageURISource | number;
+
+export function FullscreenImageViewer(props: {
+  readonly source: FullscreenImageSource | null;
+  readonly visible: boolean;
+  readonly onRequestClose: () => void;
+}) {
+  const dimensions = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+
+  if (!props.visible || props.source === null) return null;
+
+  if (Platform.OS !== "ios") {
+    return (
+      <ImageViewing
+        images={[props.source]}
+        imageIndex={0}
+        visible
+        onRequestClose={props.onRequestClose}
+        swipeToCloseEnabled
+        doubleTapToZoomEnabled
+      />
+    );
+  }
+
+  const handleScrollEndDrag = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if ((event.nativeEvent.zoomScale ?? 1) > 1) return;
+    if (Math.abs(event.nativeEvent.velocity?.y ?? 0) > 1.55) {
+      props.onRequestClose();
+    }
+  };
+
+  return (
+    <Modal
+      visible
+      animationType="fade"
+      presentationStyle="fullScreen"
+      supportedOrientations={[
+        "portrait",
+        "portrait-upside-down",
+        "landscape",
+        "landscape-left",
+        "landscape-right",
+      ]}
+      onRequestClose={props.onRequestClose}
+    >
+      <View style={{ flex: 1, backgroundColor: "#000000" }}>
+        <ScrollView
+          centerContent
+          bouncesZoom
+          maximumZoomScale={4}
+          minimumZoomScale={1}
+          showsHorizontalScrollIndicator={false}
+          showsVerticalScrollIndicator={false}
+          style={{ flex: 1 }}
+          contentContainerStyle={{
+            width: dimensions.width,
+            height: dimensions.height,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+          onScrollEndDrag={handleScrollEndDrag}
+        >
+          <Image
+            source={props.source}
+            resizeMode="contain"
+            style={{ width: dimensions.width, height: dimensions.height }}
+          />
+        </ScrollView>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Close image preview"
+          hitSlop={12}
+          onPress={props.onRequestClose}
+          style={{
+            position: "absolute",
+            top: Math.max(insets.top, 12) + 8,
+            right: Math.max(insets.right, 12) + 8,
+            width: 44,
+            height: 44,
+            borderRadius: 22,
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: "rgba(0, 0, 0, 0.45)",
+          }}
+        >
+          <SymbolView
+            name="xmark"
+            size={18}
+            tintColor="#ffffff"
+            type="monochrome"
+            weight="semibold"
+          />
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/features/annotations/ImageMarkupModal.tsx
+++ b/apps/mobile/src/features/annotations/ImageMarkupModal.tsx
@@ -1,0 +1,1222 @@
+import {
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  type PreviewAnnotationCallout,
+  type PreviewAnnotationElementTarget,
+  type PreviewAnnotationNormalizedPoint,
+  type PreviewAnnotationNormalizedRect,
+} from "@t3tools/contracts";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Modal,
+  PixelRatio,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+  type LayoutChangeEvent,
+} from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+  runOnJS,
+  useAnimatedProps,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+import Svg, { Circle, G, Image as SvgImage, Path, Rect, Text as SvgText } from "react-native-svg";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { AppText as Text } from "../../components/AppText";
+import { SymbolView, type AppSymbolName } from "../../components/AppSymbol";
+import { estimateBase64ByteSize } from "../../lib/base64";
+import {
+  restoreComposerImageOriginal,
+  type DraftComposerImageAttachment,
+} from "../../lib/composerImages";
+import { useThemeColor } from "../../lib/useThemeColor";
+import { uuidv4 } from "../../lib/uuid";
+import {
+  buildAnnotatedImageAttachment,
+  markupDocumentFromAttachment,
+  originalImageFromAttachment,
+} from "./attachmentMarkup";
+import {
+  DEFAULT_NORMALIZED_STROKE_WIDTH,
+  DEFAULT_STROKE_COLOR,
+  EMPTY_MARKUP_DOCUMENT,
+  addElementCallout,
+  addPointCallout,
+  addRegionCallout,
+  addStroke,
+  annotationExportLayoutSize,
+  annotationExportSize,
+  aspectFit,
+  clearMarkupDocument,
+  commitMarkupDocument,
+  createMarkupHistory,
+  deleteMarkupObject,
+  eraseMarkupObjectAtPoint,
+  hitTestMarkupObject,
+  makeStroke,
+  markupDocumentIsEmpty,
+  nextSmallerExportSize,
+  normalizedPoint,
+  normalizedRectFromPoints,
+  pathForNormalizedPoints,
+  redoMarkupHistory,
+  remainingAnnotationExportByteBudget,
+  undoMarkupHistory,
+  updateCalloutComment,
+  type MarkupDocument,
+  type MarkupHistory,
+  type MarkupSelection,
+  type MarkupSize,
+  type MarkupTool,
+} from "./model";
+
+const AnimatedPath = Animated.createAnimatedComponent(Path);
+const AnimatedRect = Animated.createAnimatedComponent(Rect);
+
+const CALLOUT_BADGE_RADIUS = 0.019;
+const CALLOUT_SELECTION_RADIUS_SCALE = 1.28;
+const CALLOUT_REGION_STROKE_WIDTH = 0.003;
+const ACTIVE_REGION_FILL_OPACITY = 0.12;
+const ACTIVE_STROKE_CHUNK_COUNT = 16;
+const ACTIVE_STROKE_POINTS_PER_CHUNK = 64;
+const MAX_ACTIVE_STROKE_POINTS = ACTIVE_STROKE_CHUNK_COUNT * ACTIVE_STROKE_POINTS_PER_CHUNK;
+const MIN_ACTIVE_STROKE_DISTANCE = 0.001;
+
+interface ImageMarkupModalProps {
+  readonly attachment: DraftComposerImageAttachment | null;
+  readonly visible: boolean;
+  readonly semanticElements?: ReadonlyArray<ImageMarkupSemanticElement>;
+  readonly onCancel: () => void;
+  readonly onDone: (attachment: DraftComposerImageAttachment) => void;
+}
+
+export interface ImageMarkupSemanticElement {
+  readonly target: PreviewAnnotationElementTarget;
+  readonly rect: PreviewAnnotationNormalizedRect;
+}
+
+function MarkupToolbarButton(props: {
+  readonly label: string;
+  readonly icon?: AppSymbolName;
+  readonly active?: boolean;
+  readonly destructive?: boolean;
+  readonly disabled?: boolean;
+  readonly onPress: () => void;
+}) {
+  const foreground = useThemeColor("--color-foreground");
+  const muted = useThemeColor("--color-foreground-muted");
+  const primary = useThemeColor("--color-primary");
+  const danger = useThemeColor("--color-danger-foreground");
+  const tint = props.disabled
+    ? muted
+    : props.destructive
+      ? danger
+      : props.active
+        ? primary
+        : foreground;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ disabled: props.disabled, selected: props.active }}
+      accessibilityLabel={props.label}
+      disabled={props.disabled}
+      onPress={props.onPress}
+      className="h-11 min-w-14 items-center justify-center gap-0.5 rounded-xl px-2"
+      style={{ backgroundColor: props.active ? `${String(primary)}20` : "transparent" }}
+    >
+      {props.icon ? (
+        <SymbolView name={props.icon} size={17} tintColor={tint} type="monochrome" />
+      ) : null}
+      <Text style={{ color: tint }} className="text-2xs font-t3-medium">
+        {props.label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function selectedCallout(
+  document: MarkupDocument,
+  selection: MarkupSelection | null,
+): PreviewAnnotationCallout | null {
+  if (selection?.kind !== "callout") return null;
+  return document.callouts.find((callout) => callout.id === selection.id) ?? null;
+}
+
+function svgPngBase64(svg: Svg | null): Promise<string> {
+  if (!svg) {
+    return Promise.reject(new Error("The annotation image is not ready."));
+  }
+  return new Promise((resolve, reject) => {
+    svg.toDataURL((base64) => {
+      if (base64.length === 0) {
+        reject(new Error("The annotation image could not be rendered."));
+        return;
+      }
+      resolve(base64);
+    });
+  });
+}
+
+async function exportFlattenedPng(
+  render: (size: MarkupSize) => Promise<string>,
+  initialSize: MarkupSize,
+  maximumSizeBytes: number,
+): Promise<{
+  readonly base64: string;
+  readonly size: MarkupSize;
+  readonly sizeBytes: number;
+}> {
+  if (maximumSizeBytes <= 0) {
+    throw new Error(
+      "The original image leaves no room for markup within the 10 MB attachment storage limit.",
+    );
+  }
+  let size: MarkupSize | null = initialSize;
+  while (size) {
+    const base64 = await render(size);
+    const sizeBytes = estimateBase64ByteSize(base64);
+    if (sizeBytes > 0 && sizeBytes <= maximumSizeBytes) {
+      return { base64, size, sizeBytes };
+    }
+    size = nextSmallerExportSize(size);
+  }
+  throw new Error(
+    "The original and annotated PNG cannot both fit within the 10 MB attachment storage limit. Choose a smaller image.",
+  );
+}
+
+function dataUrlByteSize(dataUrl: string, fallbackSizeBytes: number): number {
+  const commaIndex = dataUrl.indexOf(",");
+  if (commaIndex < 0) return fallbackSizeBytes;
+  const estimated = estimateBase64ByteSize(dataUrl.slice(commaIndex + 1));
+  return estimated > 0 ? estimated : fallbackSizeBytes;
+}
+
+function badgeCenter(rawValue: number, radius: number, imageLength: number): number {
+  return Math.max(radius, Math.min(imageLength - radius, rawValue));
+}
+
+function CalloutShape(props: {
+  readonly callout: PreviewAnnotationCallout;
+  readonly imageSize: MarkupSize;
+}) {
+  const shortSide = Math.min(props.imageSize.width, props.imageSize.height);
+  const radius = shortSide * CALLOUT_BADGE_RADIUS;
+  const badgeInset = radius * CALLOUT_SELECTION_RADIUS_SCALE;
+  const borderWidth = shortSide * CALLOUT_REGION_STROKE_WIDTH;
+  const anchor = props.callout.anchor;
+  const rect = anchor.kind === "point" ? null : anchor.rect;
+  const badgeX = badgeCenter(
+    anchor.kind === "point"
+      ? anchor.point.x * props.imageSize.width
+      : rect!.x * props.imageSize.width + radius,
+    badgeInset,
+    props.imageSize.width,
+  );
+  const badgeY = badgeCenter(
+    anchor.kind === "point"
+      ? anchor.point.y * props.imageSize.height
+      : rect!.y * props.imageSize.height + radius,
+    badgeInset,
+    props.imageSize.height,
+  );
+
+  return (
+    <G>
+      {rect ? (
+        <Rect
+          x={rect.x * props.imageSize.width}
+          y={rect.y * props.imageSize.height}
+          width={rect.width * props.imageSize.width}
+          height={rect.height * props.imageSize.height}
+          fill={DEFAULT_STROKE_COLOR}
+          fillOpacity={0.08}
+          stroke={DEFAULT_STROKE_COLOR}
+          strokeWidth={borderWidth}
+          strokeDasharray={`${borderWidth * 2} ${borderWidth * 1.5}`}
+        />
+      ) : null}
+      <Circle
+        cx={badgeX}
+        cy={badgeY}
+        r={radius}
+        fill={DEFAULT_STROKE_COLOR}
+        stroke="#ffffff"
+        strokeWidth={borderWidth}
+      />
+      <SvgText
+        x={badgeX}
+        y={badgeY}
+        fill="#ffffff"
+        fontSize={radius * 1.05}
+        fontWeight="700"
+        textAnchor="middle"
+        alignmentBaseline="central"
+      >
+        {String(props.callout.number)}
+      </SvgText>
+    </G>
+  );
+}
+
+function CalloutSelectionShape(props: {
+  readonly callout: PreviewAnnotationCallout;
+  readonly imageSize: MarkupSize;
+}) {
+  const shortSide = Math.min(props.imageSize.width, props.imageSize.height);
+  const radius = shortSide * CALLOUT_BADGE_RADIUS;
+  const badgeInset = radius * CALLOUT_SELECTION_RADIUS_SCALE;
+  const borderWidth = shortSide * CALLOUT_REGION_STROKE_WIDTH;
+  const anchor = props.callout.anchor;
+  const rect = anchor.kind === "point" ? null : anchor.rect;
+  const badgeX = badgeCenter(
+    anchor.kind === "point"
+      ? anchor.point.x * props.imageSize.width
+      : rect!.x * props.imageSize.width + radius,
+    badgeInset,
+    props.imageSize.width,
+  );
+  const badgeY = badgeCenter(
+    anchor.kind === "point"
+      ? anchor.point.y * props.imageSize.height
+      : rect!.y * props.imageSize.height + radius,
+    badgeInset,
+    props.imageSize.height,
+  );
+
+  return (
+    <G>
+      {rect ? (
+        <Rect
+          x={rect.x * props.imageSize.width}
+          y={rect.y * props.imageSize.height}
+          width={rect.width * props.imageSize.width}
+          height={rect.height * props.imageSize.height}
+          fill="none"
+          stroke="#ffffff"
+          strokeWidth={borderWidth * 1.4}
+        />
+      ) : null}
+      <Circle
+        cx={badgeX}
+        cy={badgeY}
+        r={badgeInset}
+        fill="none"
+        stroke="#ffffff"
+        strokeWidth={borderWidth * 1.4}
+      />
+    </G>
+  );
+}
+
+function CommittedMarkupContent(props: {
+  readonly backgroundDataUrl: string;
+  readonly document: MarkupDocument;
+  readonly imageSize: MarkupSize;
+  readonly onBackgroundLoad?: () => void;
+}) {
+  const shortSide = Math.min(props.imageSize.width, props.imageSize.height);
+  return (
+    <>
+      <SvgImage
+        x={0}
+        y={0}
+        width={props.imageSize.width}
+        height={props.imageSize.height}
+        href={props.backgroundDataUrl}
+        preserveAspectRatio="none"
+        onLoad={props.onBackgroundLoad}
+      />
+      {props.document.strokes.map((stroke) => (
+        <Path
+          key={stroke.id}
+          d={pathForNormalizedPoints(stroke.points, props.imageSize)}
+          fill="none"
+          stroke={stroke.color}
+          strokeWidth={stroke.width * shortSide}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ))}
+      {props.document.callouts.map((callout) => (
+        <CalloutShape key={callout.id} callout={callout} imageSize={props.imageSize} />
+      ))}
+    </>
+  );
+}
+
+function ActiveStrokeChunk(props: {
+  readonly paths: SharedValue<ReadonlyArray<string>>;
+  readonly index: number;
+  readonly strokeWidth: number;
+}) {
+  const animatedProps = useAnimatedProps(() => ({
+    d: props.paths.value[props.index] ?? "",
+  }));
+  return (
+    <AnimatedPath
+      animatedProps={animatedProps}
+      fill="none"
+      stroke={DEFAULT_STROKE_COLOR}
+      strokeWidth={props.strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  );
+}
+
+function emptyActiveStrokePaths(): ReadonlyArray<string> {
+  return Array.from({ length: ACTIVE_STROKE_CHUNK_COUNT }, () => "");
+}
+
+interface ExportRenderRequest {
+  readonly id: number;
+  readonly document: MarkupDocument;
+  readonly layoutSize: MarkupSize;
+}
+
+export function ImageMarkupModal(props: ImageMarkupModalProps) {
+  const attachment = props.attachment;
+  const semanticElements = props.semanticElements ?? [];
+  const hasSemanticElements = semanticElements.length > 0;
+  const muted = useThemeColor("--color-foreground-muted");
+  const border = useThemeColor("--color-border");
+  const card = useThemeColor("--color-card");
+  const screen = useThemeColor("--color-screen");
+  const primary = useThemeColor("--color-primary");
+  const placeholder = useThemeColor("--color-placeholder");
+
+  const [tool, setTool] = useState<MarkupTool>("point");
+  const [history, setHistory] = useState<MarkupHistory>(() =>
+    createMarkupHistory(
+      attachment ? markupDocumentFromAttachment(attachment) : EMPTY_MARKUP_DOCUMENT,
+    ),
+  );
+  const [selection, setSelection] = useState<MarkupSelection | null>(null);
+  const [commentDraft, setCommentDraft] = useState("");
+  const [sourceSize, setSourceSize] = useState<MarkupSize | null>(null);
+  const [containerSize, setContainerSize] = useState<MarkupSize>({ width: 0, height: 0 });
+  const [backgroundReady, setBackgroundReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [annotationId, setAnnotationId] = useState("");
+  const [createdAt, setCreatedAt] = useState("");
+  const [exportRenderRequest, setExportRenderRequest] = useState<ExportRenderRequest | null>(null);
+  const exportSvgRef = useRef<Svg>(null);
+  const exportRenderIdRef = useRef(0);
+  const exportRenderPromiseRef = useRef<{
+    readonly id: number;
+    readonly resolve: (base64: string) => void;
+    readonly reject: (cause: Error) => void;
+  } | null>(null);
+  const sessionIdRef = useRef(0);
+  const activeExportIdRef = useRef(0);
+  const isSessionActiveRef = useRef(false);
+  const isExportingRef = useRef(false);
+
+  const activeStrokePaths = useSharedValue<ReadonlyArray<string>>(emptyActiveStrokePaths());
+  const activeStrokePoints = useSharedValue<Array<PreviewAnnotationNormalizedPoint>>([]);
+  const activeRegionStartX = useSharedValue(0);
+  const activeRegionStartY = useSharedValue(0);
+  const activeRegionX = useSharedValue(0);
+  const activeRegionY = useSharedValue(0);
+  const activeRegionWidth = useSharedValue(0);
+  const activeRegionHeight = useSharedValue(0);
+
+  const original = attachment ? originalImageFromAttachment(attachment) : null;
+  const fit = useMemo(
+    () => (sourceSize ? aspectFit(sourceSize, containerSize) : { x: 0, y: 0, width: 0, height: 0 }),
+    [containerSize, sourceSize],
+  );
+  const currentCallout = selectedCallout(history.present, selection);
+
+  useEffect(() => {
+    if (!props.visible || !attachment) return;
+    const sessionId = sessionIdRef.current + 1;
+    sessionIdRef.current = sessionId;
+    isSessionActiveRef.current = true;
+    isExportingRef.current = false;
+    setHistory(createMarkupHistory(markupDocumentFromAttachment(attachment)));
+    setSelection(null);
+    setCommentDraft("");
+    setTool(hasSemanticElements ? "element" : "point");
+    setSourceSize(null);
+    setBackgroundReady(false);
+    setError(null);
+    setIsExporting(false);
+    setExportRenderRequest(null);
+    setAnnotationId(attachment.markup?.annotation.id ?? uuidv4());
+    setCreatedAt(attachment.markup?.annotation.createdAt ?? new Date().toISOString());
+    activeStrokePaths.value = emptyActiveStrokePaths();
+    activeStrokePoints.value = [];
+    activeRegionWidth.value = 0;
+    activeRegionHeight.value = 0;
+
+    let cancelled = false;
+    const durableSource = originalImageFromAttachment(attachment).dataUrl;
+    void Image.getSize(durableSource)
+      .then((size) => {
+        if (!cancelled) {
+          setSourceSize({ width: size.width, height: size.height });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError("This image could not be opened for markup.");
+        }
+      });
+    return () => {
+      cancelled = true;
+      exportRenderPromiseRef.current?.reject(
+        new Error("The annotation image export was cancelled."),
+      );
+      exportRenderPromiseRef.current = null;
+      if (sessionIdRef.current === sessionId) {
+        sessionIdRef.current += 1;
+        isSessionActiveRef.current = false;
+      }
+    };
+  }, [
+    activeRegionHeight,
+    activeRegionWidth,
+    activeStrokePaths,
+    activeStrokePoints,
+    attachment,
+    hasSemanticElements,
+    props.visible,
+  ]);
+
+  useEffect(() => {
+    if (!selection) return;
+    const stillExists =
+      selection.kind === "callout"
+        ? history.present.callouts.some((callout) => callout.id === selection.id)
+        : history.present.strokes.some((stroke) => stroke.id === selection.id);
+    if (!stillExists) setSelection(null);
+  }, [history.present, selection]);
+
+  useEffect(() => {
+    setCommentDraft(currentCallout?.comment ?? "");
+  }, [currentCallout?.comment, currentCallout?.id]);
+
+  useEffect(() => {
+    activeStrokePaths.value = emptyActiveStrokePaths();
+    activeStrokePoints.value = [];
+    activeRegionWidth.value = 0;
+    activeRegionHeight.value = 0;
+  }, [activeRegionHeight, activeRegionWidth, activeStrokePaths, activeStrokePoints, tool]);
+
+  const renderExportPng = useCallback(
+    (size: MarkupSize, document: MarkupDocument) =>
+      new Promise<string>((resolve, reject) => {
+        exportRenderPromiseRef.current?.reject(
+          new Error("A newer annotation image export replaced this one."),
+        );
+        const id = exportRenderIdRef.current + 1;
+        exportRenderIdRef.current = id;
+        exportRenderPromiseRef.current = { id, resolve, reject };
+        setExportRenderRequest({
+          id,
+          document,
+          layoutSize: annotationExportLayoutSize(size, PixelRatio.get()),
+        });
+      }),
+    [],
+  );
+
+  const completeExportRender = useCallback((id: number) => {
+    requestAnimationFrame(() => {
+      const pending = exportRenderPromiseRef.current;
+      if (!pending || pending.id !== id) return;
+      void svgPngBase64(exportSvgRef.current)
+        .then((base64) => {
+          if (exportRenderPromiseRef.current?.id !== id) return;
+          exportRenderPromiseRef.current = null;
+          pending.resolve(base64);
+        })
+        .catch((cause: unknown) => {
+          if (exportRenderPromiseRef.current?.id !== id) return;
+          exportRenderPromiseRef.current = null;
+          pending.reject(
+            cause instanceof Error
+              ? cause
+              : new Error("The annotation image could not be rendered."),
+          );
+        })
+        .finally(() => {
+          setExportRenderRequest((current) => (current?.id === id ? null : current));
+        });
+    });
+  }, []);
+
+  const commitDocument = useCallback((update: (document: MarkupDocument) => MarkupDocument) => {
+    setHistory((current) => commitMarkupDocument(current, update(current.present)));
+  }, []);
+
+  const commitCurrentComment = useCallback(() => {
+    if (!currentCallout) return;
+    commitDocument((document) => updateCalloutComment(document, currentCallout.id, commentDraft));
+  }, [commentDraft, commitDocument, currentCallout]);
+
+  const handleCanvasTap = useCallback(
+    (x: number, y: number) => {
+      if (fit.width <= 0 || fit.height <= 0) return;
+      commitCurrentComment();
+      const point = normalizedPoint({ x, y }, fit);
+      if (tool === "point") {
+        const id = uuidv4();
+        commitDocument((document) => addPointCallout(document, { id, point }));
+        setSelection({ kind: "callout", id });
+        return;
+      }
+      if (tool === "element") {
+        let selected: ImageMarkupSemanticElement | null = null;
+        let selectedArea = Number.POSITIVE_INFINITY;
+        for (const candidate of semanticElements) {
+          const rect = candidate.rect;
+          const contains =
+            point.x >= rect.x &&
+            point.x <= rect.x + rect.width &&
+            point.y >= rect.y &&
+            point.y <= rect.y + rect.height;
+          const area = rect.width * rect.height;
+          if (contains && area < selectedArea) {
+            selected = candidate;
+            selectedArea = area;
+          }
+        }
+        if (!selected) {
+          setSelection(null);
+          return;
+        }
+        const id = uuidv4();
+        commitDocument((document) =>
+          addElementCallout(document, {
+            id,
+            targetId: selected!.target.id,
+            rect: selected!.rect,
+          }),
+        );
+        setSelection({ kind: "callout", id });
+        return;
+      }
+      setSelection(hitTestMarkupObject(history.present, point));
+    },
+    [commitCurrentComment, commitDocument, fit, history.present, semanticElements, tool],
+  );
+
+  const commitRegion = useCallback(
+    (startX: number, startY: number, endX: number, endY: number) => {
+      const rect = normalizedRectFromPoints({ x: startX, y: startY }, { x: endX, y: endY });
+      if (!rect) return;
+      commitCurrentComment();
+      const id = uuidv4();
+      commitDocument((document) => addRegionCallout(document, { id, rect }));
+      setSelection({ kind: "callout", id });
+    },
+    [commitCurrentComment, commitDocument],
+  );
+
+  const commitStroke = useCallback(
+    (points: ReadonlyArray<PreviewAnnotationNormalizedPoint>) => {
+      const stroke = makeStroke({
+        id: uuidv4(),
+        color: DEFAULT_STROKE_COLOR,
+        width: DEFAULT_NORMALIZED_STROKE_WIDTH,
+        points,
+      });
+      if (!stroke) return;
+      commitCurrentComment();
+      commitDocument((document) => addStroke(document, stroke));
+      setSelection({ kind: "stroke", id: stroke.id });
+    },
+    [commitCurrentComment, commitDocument],
+  );
+
+  const eraseAt = useCallback(
+    (x: number, y: number) => {
+      if (fit.width <= 0 || fit.height <= 0) return;
+      const point = normalizedPoint({ x, y }, fit);
+      commitCurrentComment();
+      commitDocument((document) => eraseMarkupObjectAtPoint(document, point));
+      setSelection(null);
+    },
+    [commitCurrentComment, commitDocument, fit],
+  );
+
+  const canvasGesture = useMemo(() => {
+    if (!sourceSize || fit.width <= 0 || fit.height <= 0) {
+      return Gesture.Tap().enabled(false);
+    }
+    if (tool === "select" || tool === "element" || tool === "point") {
+      return Gesture.Tap().onEnd((event, success) => {
+        if (success) runOnJS(handleCanvasTap)(event.x, event.y);
+      });
+    }
+    if (tool === "region") {
+      return Gesture.Pan()
+        .minDistance(0)
+        .maxPointers(1)
+        .onBegin((event) => {
+          const normalizedX = Math.max(0, Math.min(1, event.x / fit.width));
+          const normalizedY = Math.max(0, Math.min(1, event.y / fit.height));
+          activeRegionStartX.value = normalizedX;
+          activeRegionStartY.value = normalizedY;
+          activeRegionX.value = normalizedX * sourceSize.width;
+          activeRegionY.value = normalizedY * sourceSize.height;
+          activeRegionWidth.value = 0;
+          activeRegionHeight.value = 0;
+        })
+        .onUpdate((event) => {
+          const normalizedX = Math.max(0, Math.min(1, event.x / fit.width));
+          const normalizedY = Math.max(0, Math.min(1, event.y / fit.height));
+          activeRegionX.value = Math.min(activeRegionStartX.value, normalizedX) * sourceSize.width;
+          activeRegionY.value = Math.min(activeRegionStartY.value, normalizedY) * sourceSize.height;
+          activeRegionWidth.value =
+            Math.abs(normalizedX - activeRegionStartX.value) * sourceSize.width;
+          activeRegionHeight.value =
+            Math.abs(normalizedY - activeRegionStartY.value) * sourceSize.height;
+        })
+        .onEnd((event) => {
+          const endX = Math.max(0, Math.min(1, event.x / fit.width));
+          const endY = Math.max(0, Math.min(1, event.y / fit.height));
+          runOnJS(commitRegion)(activeRegionStartX.value, activeRegionStartY.value, endX, endY);
+          activeRegionWidth.value = 0;
+          activeRegionHeight.value = 0;
+        })
+        .onFinalize(() => {
+          activeRegionWidth.value = 0;
+          activeRegionHeight.value = 0;
+        });
+    }
+    if (tool === "erase") {
+      return Gesture.Pan()
+        .minDistance(0)
+        .maxPointers(1)
+        .onBegin((event) => {
+          runOnJS(eraseAt)(event.x, event.y);
+        })
+        .onUpdate((event) => {
+          runOnJS(eraseAt)(event.x, event.y);
+        });
+    }
+    return Gesture.Pan()
+      .minDistance(0)
+      .maxPointers(1)
+      .onBegin((event) => {
+        const x = Math.max(0, Math.min(1, event.x / fit.width));
+        const y = Math.max(0, Math.min(1, event.y / fit.height));
+        const point = { x, y };
+        activeStrokePoints.value = [point];
+        const sourcePoint = `${x * sourceSize.width} ${y * sourceSize.height}`;
+        activeStrokePaths.value = activeStrokePaths.value.map((_, index) =>
+          index === 0 ? `M ${sourcePoint} L ${sourcePoint}` : "",
+        );
+      })
+      .onUpdate((event) => {
+        const x = Math.max(0, Math.min(1, event.x / fit.width));
+        const y = Math.max(0, Math.min(1, event.y / fit.height));
+        const points = activeStrokePoints.value;
+        const previous = points.at(-1);
+        if (
+          !previous ||
+          points.length >= MAX_ACTIVE_STROKE_POINTS ||
+          Math.abs(previous.x - x) + Math.abs(previous.y - y) < MIN_ACTIVE_STROKE_DISTANCE
+        ) {
+          return;
+        }
+
+        const segmentIndex = points.length - 1;
+        const chunkIndex = Math.floor(segmentIndex / ACTIVE_STROKE_POINTS_PER_CHUNK);
+        const startsChunk = segmentIndex % ACTIVE_STROKE_POINTS_PER_CHUNK === 0;
+        const previousSourcePoint = `${previous.x * sourceSize.width} ${previous.y * sourceSize.height}`;
+        const sourcePoint = `${x * sourceSize.width} ${y * sourceSize.height}`;
+        activeStrokePoints.modify((current) => {
+          current.push({ x, y });
+          return current;
+        });
+        activeStrokePaths.modify((current) => {
+          const paths = [...current];
+          paths[chunkIndex] = startsChunk
+            ? `M ${previousSourcePoint} L ${sourcePoint}`
+            : `${paths[chunkIndex]} L ${sourcePoint}`;
+          return paths;
+        });
+      })
+      .onEnd(() => {
+        const points = [...activeStrokePoints.value];
+        if (points.length > 0) runOnJS(commitStroke)(points);
+        activeStrokePoints.value = [];
+        activeStrokePaths.value = activeStrokePaths.value.map(() => "");
+      })
+      .onFinalize(() => {
+        activeStrokePoints.value = [];
+        activeStrokePaths.value = activeStrokePaths.value.map(() => "");
+      });
+  }, [
+    activeRegionHeight,
+    activeRegionStartX,
+    activeRegionStartY,
+    activeRegionWidth,
+    activeRegionX,
+    activeRegionY,
+    activeStrokePaths,
+    activeStrokePoints,
+    commitRegion,
+    commitStroke,
+    eraseAt,
+    fit.height,
+    fit.width,
+    handleCanvasTap,
+    sourceSize,
+    tool,
+  ]);
+
+  const activeRegionAnimatedProps = useAnimatedProps(() => ({
+    x: activeRegionX.value,
+    y: activeRegionY.value,
+    width: activeRegionWidth.value,
+    height: activeRegionHeight.value,
+  }));
+
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    setContainerSize({
+      width: event.nativeEvent.layout.width,
+      height: event.nativeEvent.layout.height,
+    });
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    if (isExportingRef.current) return;
+    sessionIdRef.current += 1;
+    isSessionActiveRef.current = false;
+    props.onCancel();
+  }, [props.onCancel]);
+
+  const handleDone = useCallback(async () => {
+    if (
+      isExportingRef.current ||
+      !attachment ||
+      !sourceSize ||
+      !backgroundReady ||
+      markupDocumentIsEmpty(history.present)
+    ) {
+      return;
+    }
+    const document =
+      currentCallout === null
+        ? history.present
+        : updateCalloutComment(history.present, currentCallout.id, commentDraft);
+    const sessionId = sessionIdRef.current;
+    const exportId = activeExportIdRef.current + 1;
+    activeExportIdRef.current = exportId;
+    isExportingRef.current = true;
+    setIsExporting(true);
+    setError(null);
+    try {
+      const durableOriginal = originalImageFromAttachment(attachment);
+      const originalSizeBytes = dataUrlByteSize(durableOriginal.dataUrl, durableOriginal.sizeBytes);
+      const flattenedByteBudget = remainingAnnotationExportByteBudget(
+        originalSizeBytes,
+        PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+      );
+      const initialExportSize = annotationExportSize(sourceSize);
+      const flattened = await exportFlattenedPng(
+        (size) => renderExportPng(size, document),
+        initialExportSize,
+        flattenedByteBudget,
+      );
+      if (
+        !isSessionActiveRef.current ||
+        sessionIdRef.current !== sessionId ||
+        activeExportIdRef.current !== exportId
+      ) {
+        return;
+      }
+      const flattenedDataUrl = `data:image/png;base64,${flattened.base64}`;
+      props.onDone(
+        buildAnnotatedImageAttachment({
+          attachment,
+          document,
+          sourceSize,
+          exportSize: flattened.size,
+          annotationId,
+          createdAt,
+          flattenedDataUrl,
+          flattenedSizeBytes: flattened.sizeBytes,
+          semanticElements: semanticElements.map((candidate) => candidate.target),
+        }),
+      );
+    } catch (cause) {
+      if (
+        isSessionActiveRef.current &&
+        sessionIdRef.current === sessionId &&
+        activeExportIdRef.current === exportId
+      ) {
+        setError(
+          cause instanceof Error ? cause.message : "The annotated image could not be saved.",
+        );
+      }
+    } finally {
+      if (activeExportIdRef.current === exportId) {
+        isExportingRef.current = false;
+        if (isSessionActiveRef.current && sessionIdRef.current === sessionId) {
+          setIsExporting(false);
+        }
+      }
+    }
+  }, [
+    annotationId,
+    attachment,
+    backgroundReady,
+    commentDraft,
+    createdAt,
+    currentCallout,
+    history.present,
+    props,
+    renderExportPng,
+    semanticElements,
+    sourceSize,
+  ]);
+
+  if (!attachment || !original) {
+    return null;
+  }
+
+  const shortSide = sourceSize ? Math.min(sourceSize.width, sourceSize.height) : 1;
+  const canDelete = selection !== null;
+  const canUndo = history.past.length > 0;
+  const canRedo = history.future.length > 0;
+  const selectedStroke =
+    selection?.kind === "stroke"
+      ? (history.present.strokes.find((stroke) => stroke.id === selection.id) ?? null)
+      : null;
+  const canDone =
+    sourceSize !== null &&
+    backgroundReady &&
+    !markupDocumentIsEmpty(history.present) &&
+    !isExporting;
+
+  return (
+    <Modal
+      visible={props.visible}
+      animationType="slide"
+      presentationStyle="fullScreen"
+      onRequestClose={handleCancel}
+    >
+      <SafeAreaView style={{ flex: 1, backgroundColor: screen }}>
+        <View
+          className="h-14 flex-row items-center justify-between border-b px-4"
+          style={{ borderColor: border }}
+        >
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Cancel markup"
+            disabled={isExporting}
+            onPress={handleCancel}
+            className="h-11 justify-center pr-4"
+          >
+            <Text className="text-base">Cancel</Text>
+          </Pressable>
+          <View className="min-w-0 flex-1 items-center">
+            <Text numberOfLines={1} className="text-sm font-t3-bold">
+              Markup
+            </Text>
+            <Text numberOfLines={1} className="text-2xs text-foreground-muted">
+              {original.name}
+            </Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Save markup"
+            accessibilityState={{ disabled: !canDone }}
+            disabled={!canDone}
+            onPress={() => void handleDone()}
+            className="h-11 min-w-16 items-end justify-center pl-4"
+          >
+            {isExporting ? (
+              <ActivityIndicator size="small" color={primary} />
+            ) : (
+              <Text className="text-base font-t3-bold" style={{ color: canDone ? primary : muted }}>
+                Done
+              </Text>
+            )}
+          </Pressable>
+        </View>
+
+        <KeyboardAvoidingView automaticOffset behavior="padding" style={{ flex: 1, minHeight: 0 }}>
+          <View className="min-h-0 flex-1 bg-black" onLayout={handleLayout}>
+            {sourceSize && original && exportRenderRequest ? (
+              <Svg
+                key={exportRenderRequest.id}
+                ref={exportSvgRef}
+                width={exportRenderRequest.layoutSize.width}
+                height={exportRenderRequest.layoutSize.height}
+                viewBox={`0 0 ${sourceSize.width} ${sourceSize.height}`}
+                preserveAspectRatio="none"
+                pointerEvents="none"
+                style={{
+                  position: "absolute",
+                  left: -exportRenderRequest.layoutSize.width - 8,
+                  top: 0,
+                }}
+              >
+                <CommittedMarkupContent
+                  backgroundDataUrl={original.dataUrl}
+                  document={exportRenderRequest.document}
+                  imageSize={sourceSize}
+                  onBackgroundLoad={() => completeExportRender(exportRenderRequest.id)}
+                />
+              </Svg>
+            ) : null}
+            {sourceSize && fit.width > 0 && fit.height > 0 ? (
+              <View
+                style={{
+                  position: "absolute",
+                  left: fit.x,
+                  top: fit.y,
+                  width: fit.width,
+                  height: fit.height,
+                }}
+              >
+                <GestureDetector gesture={canvasGesture}>
+                  <Animated.View style={{ flex: 1 }}>
+                    <Svg
+                      width="100%"
+                      height="100%"
+                      viewBox={`0 0 ${sourceSize.width} ${sourceSize.height}`}
+                      preserveAspectRatio="xMidYMid meet"
+                      pointerEvents="none"
+                    >
+                      <CommittedMarkupContent
+                        backgroundDataUrl={original.dataUrl}
+                        document={history.present}
+                        imageSize={sourceSize}
+                        onBackgroundLoad={() => setBackgroundReady(true)}
+                      />
+                    </Svg>
+                    <Svg
+                      width="100%"
+                      height="100%"
+                      viewBox={`0 0 ${sourceSize.width} ${sourceSize.height}`}
+                      preserveAspectRatio="xMidYMid meet"
+                      pointerEvents="none"
+                      style={{
+                        position: "absolute",
+                        top: 0,
+                        right: 0,
+                        bottom: 0,
+                        left: 0,
+                      }}
+                    >
+                      {selectedStroke ? (
+                        <G>
+                          <Path
+                            d={pathForNormalizedPoints(selectedStroke.points, sourceSize)}
+                            fill="none"
+                            stroke="#ffffff"
+                            strokeWidth={selectedStroke.width * shortSide * 2}
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeOpacity={0.9}
+                          />
+                          <Path
+                            d={pathForNormalizedPoints(selectedStroke.points, sourceSize)}
+                            fill="none"
+                            stroke={selectedStroke.color}
+                            strokeWidth={selectedStroke.width * shortSide}
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </G>
+                      ) : null}
+                      {tool === "element"
+                        ? semanticElements.map((candidate) => (
+                            <Rect
+                              key={candidate.target.id}
+                              x={candidate.rect.x * sourceSize.width}
+                              y={candidate.rect.y * sourceSize.height}
+                              width={candidate.rect.width * sourceSize.width}
+                              height={candidate.rect.height * sourceSize.height}
+                              fill={DEFAULT_STROKE_COLOR}
+                              fillOpacity={0.035}
+                              stroke={DEFAULT_STROKE_COLOR}
+                              strokeOpacity={0.7}
+                              strokeWidth={CALLOUT_REGION_STROKE_WIDTH * shortSide}
+                            />
+                          ))
+                        : null}
+                      {currentCallout ? (
+                        <CalloutSelectionShape callout={currentCallout} imageSize={sourceSize} />
+                      ) : null}
+                      {Array.from({ length: ACTIVE_STROKE_CHUNK_COUNT }, (_, index) => (
+                        <ActiveStrokeChunk
+                          key={index}
+                          paths={activeStrokePaths}
+                          index={index}
+                          strokeWidth={DEFAULT_NORMALIZED_STROKE_WIDTH * shortSide}
+                        />
+                      ))}
+                      <AnimatedRect
+                        animatedProps={activeRegionAnimatedProps}
+                        fill={DEFAULT_STROKE_COLOR}
+                        fillOpacity={ACTIVE_REGION_FILL_OPACITY}
+                        stroke={DEFAULT_STROKE_COLOR}
+                        strokeWidth={CALLOUT_REGION_STROKE_WIDTH * shortSide}
+                        strokeDasharray={`${shortSide * 0.006} ${shortSide * 0.004}`}
+                      />
+                    </Svg>
+                  </Animated.View>
+                </GestureDetector>
+              </View>
+            ) : error ? (
+              <View className="flex-1 items-center justify-center px-8">
+                <Text className="text-center text-sm text-white">{error}</Text>
+              </View>
+            ) : (
+              <View className="flex-1 items-center justify-center">
+                <ActivityIndicator color="#ffffff" />
+              </View>
+            )}
+          </View>
+
+          {currentCallout ? (
+            <View
+              className="border-t px-4 py-3"
+              style={{ borderColor: border, backgroundColor: card }}
+            >
+              <Text className="mb-1.5 text-xs font-t3-bold">
+                Comment for #{currentCallout.number}
+              </Text>
+              <TextInput
+                value={commentDraft}
+                onChangeText={setCommentDraft}
+                onBlur={() =>
+                  commitDocument((document) =>
+                    updateCalloutComment(document, currentCallout.id, commentDraft),
+                  )
+                }
+                placeholder="Describe the requested change"
+                placeholderTextColor={placeholder}
+                multiline
+                className="min-h-11 rounded-xl border px-3 py-2 text-base text-foreground"
+                style={{ borderColor: border }}
+              />
+            </View>
+          ) : null}
+
+          {error && sourceSize ? (
+            <View className="border-t border-border bg-card px-4 py-2">
+              <Text className="text-center text-xs text-danger-foreground">{error}</Text>
+            </View>
+          ) : null}
+
+          <View className="border-t bg-card" style={{ borderColor: border }}>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={{ paddingHorizontal: 8, alignItems: "center" }}
+            >
+              <MarkupToolbarButton
+                label="Select"
+                icon="checkmark.circle"
+                active={tool === "select"}
+                onPress={() => setTool("select")}
+              />
+              {hasSemanticElements ? (
+                <MarkupToolbarButton
+                  label="Element"
+                  icon="eye"
+                  active={tool === "element"}
+                  onPress={() => setTool("element")}
+                />
+              ) : null}
+              <MarkupToolbarButton
+                label="Pin"
+                icon="plus"
+                active={tool === "point"}
+                onPress={() => setTool("point")}
+              />
+              <MarkupToolbarButton
+                label="Region"
+                icon="square.dashed"
+                active={tool === "region"}
+                onPress={() => setTool("region")}
+              />
+              <MarkupToolbarButton
+                label="Pen"
+                icon="pencil.tip"
+                active={tool === "pen"}
+                onPress={() => setTool("pen")}
+              />
+              <MarkupToolbarButton
+                label="Eraser"
+                icon="eraser"
+                active={tool === "erase"}
+                onPress={() => setTool("erase")}
+              />
+              <MarkupToolbarButton
+                label="Undo"
+                icon="arrow.uturn.backward"
+                disabled={!canUndo}
+                onPress={() => {
+                  setHistory(undoMarkupHistory);
+                  setSelection(null);
+                }}
+              />
+              <MarkupToolbarButton
+                label="Redo"
+                icon="arrow.uturn.forward"
+                disabled={!canRedo}
+                onPress={() => {
+                  setHistory(redoMarkupHistory);
+                  setSelection(null);
+                }}
+              />
+              <MarkupToolbarButton
+                label="Delete"
+                icon="trash"
+                destructive
+                disabled={!canDelete}
+                onPress={() => {
+                  commitDocument((document) => deleteMarkupObject(document, selection));
+                  setSelection(null);
+                }}
+              />
+              <MarkupToolbarButton
+                label="Clear"
+                icon="xmark.circle"
+                destructive
+                disabled={markupDocumentIsEmpty(history.present)}
+                onPress={() => {
+                  commitDocument(clearMarkupDocument);
+                  setSelection(null);
+                }}
+              />
+            </ScrollView>
+            {attachment.markup ? (
+              <View className="items-center border-t px-4 py-2" style={{ borderColor: border }}>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Remove markup"
+                  disabled={isExporting}
+                  onPress={() => props.onDone(restoreComposerImageOriginal(attachment))}
+                  className="h-9 justify-center px-4"
+                >
+                  <Text className="text-xs font-t3-bold text-danger-foreground">Remove markup</Text>
+                </Pressable>
+              </View>
+            ) : null}
+          </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/features/annotations/ImageMarkupModal.tsx
+++ b/apps/mobile/src/features/annotations/ImageMarkupModal.tsx
@@ -607,7 +607,7 @@ export function ImageMarkupModal(props: ImageMarkupModalProps) {
         setSelection({ kind: "callout", id });
         return;
       }
-      setSelection(hitTestMarkupObject(history.present, point));
+      setSelection(hitTestMarkupObject(history.present, point, fit));
     },
     [commitCurrentComment, commitDocument, fit, history.present, semanticElements, tool],
   );
@@ -645,7 +645,7 @@ export function ImageMarkupModal(props: ImageMarkupModalProps) {
       if (fit.width <= 0 || fit.height <= 0) return;
       const point = normalizedPoint({ x, y }, fit);
       commitCurrentComment();
-      commitDocument((document) => eraseMarkupObjectAtPoint(document, point));
+      commitDocument((document) => eraseMarkupObjectAtPoint(document, point, fit));
       setSelection(null);
     },
     [commitCurrentComment, commitDocument, fit],

--- a/apps/mobile/src/features/annotations/attachmentMarkup.test.ts
+++ b/apps/mobile/src/features/annotations/attachmentMarkup.test.ts
@@ -1,0 +1,244 @@
+import { PreviewAnnotationPayloadSchema } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import type { DraftComposerImageAttachment } from "../../lib/composerImages";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildAnnotatedImageAttachment,
+  markupDocumentFromAttachment,
+  originalImageFromAttachment,
+} from "./attachmentMarkup";
+import { EMPTY_MARKUP_DOCUMENT, addElementCallout, addPointCallout } from "./model";
+
+const decodeAnnotation = Schema.decodeUnknownSync(PreviewAnnotationPayloadSchema);
+
+const originalAttachment: DraftComposerImageAttachment = {
+  id: "image-1",
+  type: "image",
+  name: "screen.jpg",
+  mimeType: "image/jpeg",
+  sizeBytes: 123,
+  dataUrl: "data:image/jpeg;base64,b3JpZ2luYWw=",
+  previewUri: "file:///screen.jpg",
+};
+
+describe("mobile image annotation attachment adapter", () => {
+  it("creates a flattened PNG while preserving the durable original", () => {
+    const document = addPointCallout(EMPTY_MARKUP_DOCUMENT, {
+      id: "callout-1",
+      point: { x: 0.25, y: 0.75 },
+      comment: "Move this",
+    });
+    const attachment = buildAnnotatedImageAttachment({
+      attachment: originalAttachment,
+      document,
+      sourceSize: { width: 1_200, height: 800 },
+      exportSize: { width: 1_024, height: 683 },
+      annotationId: "annotation-1",
+      createdAt: "2026-07-30T12:00:00.000Z",
+      flattenedDataUrl: "data:image/png;base64,ZmxhdHRlbmVk",
+      flattenedSizeBytes: 222,
+    });
+
+    expect(attachment).toMatchObject({
+      id: "image-1",
+      name: "preview-annotation-annotation-1.png",
+      mimeType: "image/png",
+      sizeBytes: 222,
+      previewUri: "data:image/png;base64,ZmxhdHRlbmVk",
+      markup: {
+        original: {
+          name: "screen.jpg",
+          mimeType: "image/jpeg",
+          sizeBytes: 123,
+          dataUrl: "data:image/jpeg;base64,b3JpZ2luYWw=",
+          previewUri: "file:///screen.jpg",
+        },
+        annotation: {
+          schemaVersion: 1,
+          source: { kind: "image", name: "screen.jpg" },
+          callouts: document.callouts,
+          editable: {
+            version: 1,
+            coordinateSpace: "normalized",
+            strokes: [],
+          },
+          elements: [],
+          regions: [],
+          strokes: [],
+          styleChanges: [],
+          screenshot: {
+            dataUrl: "",
+            width: 1_024,
+            height: 683,
+            cropRect: { x: 0, y: 0, width: 1_200, height: 800 },
+          },
+        },
+      },
+    });
+    expect(decodeAnnotation(attachment.markup?.annotation)).toEqual(attachment.markup?.annotation);
+  });
+
+  it("reopens editable vectors and does not replace the original with a prior flatten", () => {
+    const first = buildAnnotatedImageAttachment({
+      attachment: originalAttachment,
+      document: EMPTY_MARKUP_DOCUMENT,
+      sourceSize: { width: 100, height: 100 },
+      exportSize: { width: 100, height: 100 },
+      annotationId: "annotation-1",
+      createdAt: "2026-07-30T12:00:00.000Z",
+      flattenedDataUrl: "data:image/png;base64,Zmlyc3Q=",
+      flattenedSizeBytes: 50,
+    });
+    const reopenedDocument = addPointCallout(markupDocumentFromAttachment(first), {
+      id: "callout-2",
+      point: { x: 0.5, y: 0.5 },
+    });
+    const second = buildAnnotatedImageAttachment({
+      attachment: first,
+      document: reopenedDocument,
+      sourceSize: { width: 100, height: 100 },
+      exportSize: { width: 100, height: 100 },
+      annotationId: "ignored-new-id",
+      createdAt: "2026-07-30T13:00:00.000Z",
+      flattenedDataUrl: "data:image/png;base64,c2Vjb25k",
+      flattenedSizeBytes: 60,
+    });
+
+    expect(second.markup?.annotation.id).toBe("annotation-1");
+    expect(second.markup?.annotation.createdAt).toBe("2026-07-30T12:00:00.000Z");
+    expect(originalImageFromAttachment(second).dataUrl).toBe(originalAttachment.dataUrl);
+    expect(markupDocumentFromAttachment(second).callouts).toEqual(reopenedDocument.callouts);
+    expect(second.markup?.annotation.screenshot?.scale).toBe(1);
+  });
+
+  it("derives a generic image re-edit scale from the previous flatten", () => {
+    const first = buildAnnotatedImageAttachment({
+      attachment: originalAttachment,
+      document: EMPTY_MARKUP_DOCUMENT,
+      sourceSize: { width: 1_200, height: 800 },
+      exportSize: { width: 600, height: 400 },
+      annotationId: "annotation-1",
+      createdAt: "2026-07-30T12:00:00.000Z",
+      flattenedDataUrl: "data:image/png;base64,Zmlyc3Q=",
+      flattenedSizeBytes: 50,
+    });
+    const second = buildAnnotatedImageAttachment({
+      attachment: first,
+      document: EMPTY_MARKUP_DOCUMENT,
+      sourceSize: { width: 1_200, height: 800 },
+      exportSize: { width: 300, height: 200 },
+      annotationId: "ignored-new-id",
+      createdAt: "2026-07-30T13:00:00.000Z",
+      flattenedDataUrl: "data:image/png;base64,c2Vjb25k",
+      flattenedSizeBytes: 60,
+    });
+
+    expect(first.markup?.annotation.screenshot?.scale).toBe(0.5);
+    expect(second.markup?.annotation.screenshot?.scale).toBe(0.25);
+  });
+
+  it("preserves preview identity and includes only selected semantic elements", () => {
+    const candidate = {
+      id: "element-submit",
+      rect: { x: 420, y: 180, width: 160, height: 64 },
+      element: {
+        pageUrl: "http://localhost:5173/checkout",
+        pageTitle: "Checkout",
+        tagName: "button",
+        selector: "button.submit",
+        htmlPreview: '<button role="button" aria-label="Pay now">',
+        componentName: null,
+        source: null,
+        stack: [],
+        styles: "",
+        pickedAt: "2026-07-30T12:00:00.000Z",
+      },
+    } as const;
+    const previewAttachment: DraftComposerImageAttachment = {
+      ...originalAttachment,
+      markup: {
+        original: {
+          name: originalAttachment.name,
+          mimeType: originalAttachment.mimeType,
+          sizeBytes: originalAttachment.sizeBytes,
+          dataUrl: originalAttachment.dataUrl,
+          previewUri: originalAttachment.previewUri,
+        },
+        annotation: {
+          id: "preview-annotation",
+          pageUrl: "http://localhost:5173/checkout",
+          pageTitle: "Checkout",
+          comment: "",
+          elements: [],
+          regions: [],
+          strokes: [],
+          styleChanges: [],
+          screenshot: {
+            dataUrl: "",
+            width: 1_280,
+            height: 1_024,
+            cropRect: { x: 0, y: 0, width: 1_000, height: 800 },
+            scale: 1.28,
+            pageRevision: "page-7",
+          },
+          createdAt: "2026-07-30T12:00:00.000Z",
+          schemaVersion: 1,
+          source: {
+            kind: "preview",
+            url: "http://localhost:5173/checkout",
+            title: "Checkout",
+          },
+          callouts: [],
+          editable: { version: 1, coordinateSpace: "normalized", strokes: [] },
+        },
+      },
+    };
+    const document = addElementCallout(EMPTY_MARKUP_DOCUMENT, {
+      id: "callout-submit",
+      targetId: candidate.id,
+      rect: { x: 0.42, y: 0.225, width: 0.16, height: 0.08 },
+      comment: "Make this primary",
+    });
+    const attachment = buildAnnotatedImageAttachment({
+      attachment: previewAttachment,
+      document,
+      semanticElements: [candidate],
+      sourceSize: { width: 1_280, height: 1_024 },
+      exportSize: { width: 640, height: 512 },
+      annotationId: "ignored",
+      createdAt: "2026-07-30T13:00:00.000Z",
+      flattenedDataUrl: "data:image/png;base64,ZmxhdHRlbmVk",
+      flattenedSizeBytes: 222,
+    });
+
+    expect(attachment.markup?.annotation).toMatchObject({
+      pageUrl: "http://localhost:5173/checkout",
+      pageTitle: "Checkout",
+      source: {
+        kind: "preview",
+        url: "http://localhost:5173/checkout",
+        title: "Checkout",
+      },
+      elements: [candidate],
+      screenshot: {
+        cropRect: { x: 0, y: 0, width: 1_000, height: 800 },
+        pageRevision: "page-7",
+        scale: 0.64,
+      },
+    });
+
+    const reedited = buildAnnotatedImageAttachment({
+      attachment,
+      document,
+      semanticElements: [candidate],
+      sourceSize: { width: 1_280, height: 1_024 },
+      exportSize: { width: 320, height: 256 },
+      annotationId: "ignored-again",
+      createdAt: "2026-07-30T14:00:00.000Z",
+      flattenedDataUrl: "data:image/png;base64,cmVlZGl0ZWQ=",
+      flattenedSizeBytes: 111,
+    });
+    expect(reedited.markup?.annotation.screenshot?.scale).toBe(0.32);
+  });
+});

--- a/apps/mobile/src/features/annotations/attachmentMarkup.ts
+++ b/apps/mobile/src/features/annotations/attachmentMarkup.ts
@@ -1,0 +1,135 @@
+import type { PreviewAnnotationElementTarget, PreviewAnnotationPayload } from "@t3tools/contracts";
+
+import type {
+  DraftComposerImageAttachment,
+  DraftComposerImageMarkupOriginal,
+} from "../../lib/composerImages";
+import type { MarkupDocument, MarkupSize } from "./model";
+
+export function markupDocumentFromAttachment(
+  attachment: DraftComposerImageAttachment,
+): MarkupDocument {
+  return {
+    callouts: attachment.markup?.annotation.callouts ?? [],
+    strokes: attachment.markup?.annotation.editable?.strokes ?? [],
+  };
+}
+
+export function originalImageFromAttachment(
+  attachment: DraftComposerImageAttachment,
+): DraftComposerImageMarkupOriginal {
+  return (
+    attachment.markup?.original ?? {
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      sizeBytes: attachment.sizeBytes,
+      dataUrl: attachment.dataUrl,
+      previewUri: attachment.previewUri,
+    }
+  );
+}
+
+export function buildMobileImageAnnotation(input: {
+  readonly attachment: DraftComposerImageAttachment;
+  readonly document: MarkupDocument;
+  readonly sourceSize: MarkupSize;
+  readonly exportSize: MarkupSize;
+  readonly annotationId: string;
+  readonly createdAt: string;
+  readonly semanticElements?: ReadonlyArray<PreviewAnnotationElementTarget>;
+}): PreviewAnnotationPayload {
+  const existing = input.attachment.markup?.annotation;
+  const original = originalImageFromAttachment(input.attachment);
+  const existingScreenshot = existing?.screenshot;
+  const exportScale =
+    existingScreenshot && existingScreenshot.width > 0
+      ? ((existingScreenshot.scale ?? 1) * input.exportSize.width) / existingScreenshot.width
+      : Math.min(
+          input.exportSize.width / input.sourceSize.width,
+          input.exportSize.height / input.sourceSize.height,
+        );
+  const scale = Number.isFinite(exportScale) && exportScale > 0 ? exportScale : 1;
+  const selectedElementIds = new Set(
+    input.document.callouts
+      .filter((callout) => callout.anchor.kind === "element")
+      .map((callout) =>
+        callout.anchor.kind === "element" ? callout.anchor.targetId : /* istanbul ignore next */ "",
+      ),
+  );
+  const elementsById = new Map(
+    (existing?.elements ?? []).map((target) => [target.id, target] as const),
+  );
+  for (const target of input.semanticElements ?? []) {
+    if (selectedElementIds.has(target.id)) {
+      elementsById.set(target.id, target);
+    }
+  }
+  const elements = [...elementsById.values()].filter((target) => selectedElementIds.has(target.id));
+  const previewSource = existing?.source?.kind === "preview";
+
+  return {
+    id: existing?.id ?? input.annotationId,
+    pageUrl: previewSource ? existing.pageUrl : "",
+    pageTitle: previewSource ? existing.pageTitle : original.name || null,
+    comment: existing?.comment ?? "",
+    elements,
+    regions: existing?.regions ?? [],
+    strokes: existing?.strokes ?? [],
+    styleChanges: existing?.styleChanges ?? [],
+    screenshot: {
+      dataUrl: "",
+      width: input.exportSize.width,
+      height: input.exportSize.height,
+      cropRect: existingScreenshot?.cropRect ?? {
+        x: 0,
+        y: 0,
+        width: input.sourceSize.width,
+        height: input.sourceSize.height,
+      },
+      scale: Number.isFinite(scale) && scale > 0 ? scale : 1,
+      pageRevision: existingScreenshot?.pageRevision ?? null,
+    },
+    createdAt: existing?.createdAt ?? input.createdAt,
+    schemaVersion: 1,
+    source:
+      previewSource && existing.source
+        ? existing.source
+        : {
+            kind: "image",
+            name: original.name || null,
+          },
+    callouts: input.document.callouts,
+    editable: {
+      version: 1,
+      coordinateSpace: "normalized",
+      strokes: input.document.strokes,
+    },
+  };
+}
+
+export function buildAnnotatedImageAttachment(input: {
+  readonly attachment: DraftComposerImageAttachment;
+  readonly document: MarkupDocument;
+  readonly sourceSize: MarkupSize;
+  readonly exportSize: MarkupSize;
+  readonly annotationId: string;
+  readonly createdAt: string;
+  readonly flattenedDataUrl: string;
+  readonly flattenedSizeBytes: number;
+  readonly semanticElements?: ReadonlyArray<PreviewAnnotationElementTarget>;
+}): DraftComposerImageAttachment {
+  const annotation = buildMobileImageAnnotation(input);
+  return {
+    id: input.attachment.id,
+    type: "image",
+    name: `preview-annotation-${annotation.id}.png`,
+    mimeType: "image/png",
+    sizeBytes: input.flattenedSizeBytes,
+    dataUrl: input.flattenedDataUrl,
+    previewUri: input.flattenedDataUrl,
+    markup: {
+      annotation,
+      original: originalImageFromAttachment(input.attachment),
+    },
+  };
+}

--- a/apps/mobile/src/features/annotations/model.test.ts
+++ b/apps/mobile/src/features/annotations/model.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  DEFAULT_NORMALIZED_STROKE_WIDTH,
+  EMPTY_MARKUP_DOCUMENT,
+  addElementCallout,
+  addPointCallout,
+  addRegionCallout,
+  addStroke,
+  annotationExportLayoutSize,
+  annotationExportSize,
+  aspectFit,
+  clearMarkupDocument,
+  commitMarkupDocument,
+  createMarkupHistory,
+  deleteMarkupObject,
+  eraseMarkupObjectAtPoint,
+  hitTestMarkupObject,
+  makeStroke,
+  nextSmallerExportSize,
+  normalizedPoint,
+  normalizedRectFromPoints,
+  redoMarkupHistory,
+  remainingAnnotationExportByteBudget,
+  undoMarkupHistory,
+  updateCalloutComment,
+} from "./model";
+
+describe("annotation markup geometry", () => {
+  it("aspect-fits an image without distorting it", () => {
+    expect(aspectFit({ width: 1_600, height: 900 }, { width: 1_000, height: 1_000 })).toEqual({
+      x: 0,
+      y: 218.75,
+      width: 1_000,
+      height: 562.5,
+    });
+    expect(normalizedPoint({ x: 500, y: 281.25 }, { width: 1_000, height: 562.5 })).toEqual({
+      x: 0.5,
+      y: 0.5,
+    });
+  });
+
+  it("normalizes dragged regions in either direction and rejects taps", () => {
+    expect(normalizedRectFromPoints({ x: 0.8, y: 0.6 }, { x: 0.2, y: 0.1 })).toEqual({
+      x: 0.2,
+      y: 0.1,
+      width: 0.6000000000000001,
+      height: 0.5,
+    });
+    expect(normalizedRectFromPoints({ x: 0.2, y: 0.2 }, { x: 0.202, y: 0.4 })).toBeNull();
+  });
+
+  it("downscales by both edge and pixel budgets without upscaling", () => {
+    expect(annotationExportSize({ width: 4_000, height: 3_000 })).toEqual({
+      width: 2_048,
+      height: 1_536,
+    });
+    expect(
+      annotationExportSize(
+        { width: 4_000, height: 3_000 },
+        { maxEdge: 10_000, maxPixels: 1_000_000 },
+      ),
+    ).toEqual({ width: 1_155, height: 866 });
+    expect(annotationExportSize({ width: 640, height: 480 })).toEqual({
+      width: 640,
+      height: 480,
+    });
+    expect(nextSmallerExportSize({ width: 2_048, height: 1_536 })).toEqual({
+      width: 1_536,
+      height: 1_152,
+    });
+    expect(nextSmallerExportSize({ width: 320, height: 240 })).toBeNull();
+  });
+
+  it("lays out export SVGs in logical points while preserving target pixels", () => {
+    expect(annotationExportLayoutSize({ width: 2_048, height: 1_536 }, 2)).toEqual({
+      width: 1_024,
+      height: 768,
+    });
+    expect(annotationExportLayoutSize({ width: 1_170, height: 2_532 }, 3)).toEqual({
+      width: 390,
+      height: 844,
+    });
+    expect(annotationExportLayoutSize({ width: 640, height: 480 }, 0)).toEqual({
+      width: 640,
+      height: 480,
+    });
+  });
+
+  it("shares a fixed persistence budget between the original and flattened PNG", () => {
+    expect(remainingAnnotationExportByteBudget(7_500_000, 10_000_000)).toBe(2_500_000);
+    expect(remainingAnnotationExportByteBudget(10_000_000, 10_000_000)).toBe(0);
+    expect(remainingAnnotationExportByteBudget(12_000_000, 10_000_000)).toBe(0);
+  });
+});
+
+describe("annotation markup document", () => {
+  it("assigns stable visible callout numbers and keeps per-callout comments", () => {
+    const first = addPointCallout(EMPTY_MARKUP_DOCUMENT, {
+      id: "point-1",
+      point: { x: 0.25, y: 0.5 },
+      comment: "First",
+    });
+    const second = addRegionCallout(first, {
+      id: "region-2",
+      rect: { x: 0.5, y: 0.25, width: 0.25, height: 0.2 },
+    });
+    const updated = updateCalloutComment(second, "region-2", "Tighten this space");
+    const afterDelete = deleteMarkupObject(updated, { kind: "callout", id: "point-1" });
+    const third = addPointCallout(afterDelete, {
+      id: "point-3",
+      point: { x: 0.9, y: 0.9 },
+    });
+
+    expect(updated.callouts.map(({ number, comment }) => ({ number, comment }))).toEqual([
+      { number: 1, comment: "First" },
+      { number: 2, comment: "Tighten this space" },
+    ]);
+    expect(third.callouts.map((callout) => callout.number)).toEqual([2, 3]);
+  });
+
+  it("keeps regions inside normalized bounds at the bottom-right edge", () => {
+    const document = addRegionCallout(EMPTY_MARKUP_DOCUMENT, {
+      id: "edge",
+      rect: { x: 1, y: 1, width: 0.25, height: 0.25 },
+    });
+    const rect = document.callouts[0]?.anchor;
+
+    expect(rect?.kind).toBe("region");
+    if (rect?.kind !== "region") return;
+    expect(rect.rect.x + rect.rect.width).toBeLessThanOrEqual(1);
+    expect(rect.rect.y + rect.rect.height).toBeLessThanOrEqual(1);
+    expect(rect.rect.width).toBeGreaterThan(0);
+    expect(rect.rect.height).toBeGreaterThan(0);
+  });
+
+  it("anchors numbered callouts to semantic preview elements", () => {
+    const document = addElementCallout(EMPTY_MARKUP_DOCUMENT, {
+      id: "callout-submit",
+      targetId: "element-submit",
+      rect: { x: 0.42, y: 0.18, width: 0.31, height: 0.12 },
+      comment: "Make this the primary action",
+    });
+
+    expect(document.callouts).toEqual([
+      {
+        id: "callout-submit",
+        number: 1,
+        comment: "Make this the primary action",
+        anchor: {
+          kind: "element",
+          targetId: "element-submit",
+          rect: { x: 0.42, y: 0.18, width: 0.31, height: 0.12 },
+        },
+      },
+    ]);
+  });
+
+  it("creates bounded editable strokes and hit-tests or erases whole objects", () => {
+    const stroke = makeStroke({
+      id: "stroke-1",
+      color: "#f00",
+      width: DEFAULT_NORMALIZED_STROKE_WIDTH,
+      points: [
+        { x: 0.1, y: 0.2 },
+        { x: 0.5, y: 0.6 },
+      ],
+    });
+    expect(stroke).not.toBeNull();
+    expect(stroke?.bounds.x).toBeGreaterThanOrEqual(0);
+    expect((stroke?.bounds.x ?? 0) + (stroke?.bounds.width ?? 0)).toBeLessThanOrEqual(1);
+
+    const document = addPointCallout(addStroke(EMPTY_MARKUP_DOCUMENT, stroke!), {
+      id: "point-1",
+      point: { x: 0.8, y: 0.2 },
+    });
+    expect(hitTestMarkupObject(document, { x: 0.3, y: 0.4 })).toEqual({
+      kind: "stroke",
+      id: "stroke-1",
+    });
+    expect(hitTestMarkupObject(document, { x: 0.8, y: 0.2 })).toEqual({
+      kind: "callout",
+      id: "point-1",
+    });
+    expect(eraseMarkupObjectAtPoint(document, { x: 0.3, y: 0.4 }).strokes).toEqual([]);
+  });
+
+  it("supports undo, redo, delete, and clear without mutating snapshots", () => {
+    const initial = createMarkupHistory(EMPTY_MARKUP_DOCUMENT);
+    const one = addPointCallout(initial.present, {
+      id: "point-1",
+      point: { x: 0.2, y: 0.3 },
+    });
+    const committed = commitMarkupDocument(initial, one);
+    const undone = undoMarkupHistory(committed);
+    const redone = redoMarkupHistory(undone);
+
+    expect(undone.present).toBe(EMPTY_MARKUP_DOCUMENT);
+    expect(redone.present).toBe(one);
+    expect(committed.present.callouts).toHaveLength(1);
+    expect(clearMarkupDocument(redone.present)).toBe(EMPTY_MARKUP_DOCUMENT);
+  });
+});

--- a/apps/mobile/src/features/annotations/model.test.ts
+++ b/apps/mobile/src/features/annotations/model.test.ts
@@ -60,7 +60,7 @@ describe("annotation markup geometry", () => {
         { width: 4_000, height: 3_000 },
         { maxEdge: 10_000, maxPixels: 1_000_000 },
       ),
-    ).toEqual({ width: 1_155, height: 866 });
+    ).toEqual({ width: 1_154, height: 866 });
     expect(annotationExportSize({ width: 640, height: 480 })).toEqual({
       width: 640,
       height: 480,
@@ -183,6 +183,22 @@ describe("annotation markup document", () => {
       id: "point-1",
     });
     expect(eraseMarkupObjectAtPoint(document, { x: 0.3, y: 0.4 }).strokes).toEqual([]);
+  });
+
+  it("hit-tests a single-point stroke across its rendered width", () => {
+    const stroke = makeStroke({
+      id: "dot-1",
+      color: "#f00",
+      width: 0.1,
+      points: [{ x: 0.5, y: 0.5 }],
+    });
+    expect(stroke).not.toBeNull();
+    const document = addStroke(EMPTY_MARKUP_DOCUMENT, stroke!);
+
+    expect(hitTestMarkupObject(document, { x: 0.56, y: 0.5 }, 0.02)).toEqual({
+      kind: "stroke",
+      id: "dot-1",
+    });
   });
 
   it("supports undo, redo, delete, and clear without mutating snapshots", () => {

--- a/apps/mobile/src/features/annotations/model.test.ts
+++ b/apps/mobile/src/features/annotations/model.test.ts
@@ -174,15 +174,17 @@ describe("annotation markup document", () => {
       id: "point-1",
       point: { x: 0.8, y: 0.2 },
     });
-    expect(hitTestMarkupObject(document, { x: 0.3, y: 0.4 })).toEqual({
+    expect(hitTestMarkupObject(document, { x: 0.3, y: 0.4 }, { width: 1, height: 1 })).toEqual({
       kind: "stroke",
       id: "stroke-1",
     });
-    expect(hitTestMarkupObject(document, { x: 0.8, y: 0.2 })).toEqual({
+    expect(hitTestMarkupObject(document, { x: 0.8, y: 0.2 }, { width: 1, height: 1 })).toEqual({
       kind: "callout",
       id: "point-1",
     });
-    expect(eraseMarkupObjectAtPoint(document, { x: 0.3, y: 0.4 }).strokes).toEqual([]);
+    expect(
+      eraseMarkupObjectAtPoint(document, { x: 0.3, y: 0.4 }, { width: 1, height: 1 }).strokes,
+    ).toEqual([]);
   });
 
   it("hit-tests a single-point stroke across its rendered width", () => {
@@ -195,10 +197,30 @@ describe("annotation markup document", () => {
     expect(stroke).not.toBeNull();
     const document = addStroke(EMPTY_MARKUP_DOCUMENT, stroke!);
 
-    expect(hitTestMarkupObject(document, { x: 0.56, y: 0.5 }, 0.02)).toEqual({
+    expect(
+      hitTestMarkupObject(document, { x: 0.56, y: 0.5 }, { width: 1, height: 1 }, 0.02),
+    ).toEqual({
       kind: "stroke",
       id: "dot-1",
     });
+  });
+
+  it("uses a circular pixel-space hit area on non-square images", () => {
+    const document = addPointCallout(EMPTY_MARKUP_DOCUMENT, {
+      id: "point-wide",
+      point: { x: 0.5, y: 0.5 },
+    });
+    const wideImage = { width: 4_000, height: 500 };
+
+    expect(hitTestMarkupObject(document, { x: 0.5025, y: 0.5 }, wideImage)).toEqual({
+      kind: "callout",
+      id: "point-wide",
+    });
+    expect(hitTestMarkupObject(document, { x: 0.5, y: 0.52 }, wideImage)).toEqual({
+      kind: "callout",
+      id: "point-wide",
+    });
+    expect(hitTestMarkupObject(document, { x: 0.51, y: 0.5 }, wideImage)).toBeNull();
   });
 
   it("supports undo, redo, delete, and clear without mutating snapshots", () => {

--- a/apps/mobile/src/features/annotations/model.ts
+++ b/apps/mobile/src/features/annotations/model.ts
@@ -382,7 +382,10 @@ export function hitTestMarkupObject(
       continue;
     }
     const points = stroke.points;
-    if (points.length === 1 && squaredDistance(point, points[0]!) <= tolerance * tolerance) {
+    if (
+      points.length === 1 &&
+      squaredDistance(point, points[0]!) <= (tolerance + stroke.width / 2) ** 2
+    ) {
       return { kind: "stroke", id: stroke.id };
     }
     for (let index = 1; index < points.length; index += 1) {
@@ -481,9 +484,13 @@ export function annotationExportSize(
   const edgeScale = maxEdge / Math.max(image.width, image.height);
   const pixelScale = Math.sqrt(maxPixels / (image.width * image.height));
   const scale = Math.min(1, edgeScale, pixelScale);
+  const width = Math.max(1, Math.round(image.width * scale));
+  const height = Math.max(1, Math.round(image.height * scale));
+  if (width * height <= maxPixels) return { width, height };
+  const adjustedScale = Math.sqrt(maxPixels / (image.width * image.height));
   return {
-    width: Math.max(1, Math.round(image.width * scale)),
-    height: Math.max(1, Math.round(image.height * scale)),
+    width: Math.max(1, Math.floor(image.width * adjustedScale)),
+    height: Math.max(1, Math.floor(image.height * adjustedScale)),
   };
 }
 

--- a/apps/mobile/src/features/annotations/model.ts
+++ b/apps/mobile/src/features/annotations/model.ts
@@ -323,9 +323,10 @@ export function clearMarkupDocument(document: MarkupDocument): MarkupDocument {
 function squaredDistance(
   left: PreviewAnnotationNormalizedPoint,
   right: PreviewAnnotationNormalizedPoint,
+  size: MarkupSize,
 ): number {
-  const dx = left.x - right.x;
-  const dy = left.y - right.y;
+  const dx = (left.x - right.x) * size.width;
+  const dy = (left.y - right.y) * size.height;
   return dx * dx + dy * dy;
 }
 
@@ -333,65 +334,89 @@ function squaredDistanceToSegment(
   point: PreviewAnnotationNormalizedPoint,
   start: PreviewAnnotationNormalizedPoint,
   end: PreviewAnnotationNormalizedPoint,
+  size: MarkupSize,
 ): number {
-  const dx = end.x - start.x;
-  const dy = end.y - start.y;
-  if (dx === 0 && dy === 0) return squaredDistance(point, start);
+  const dx = (end.x - start.x) * size.width;
+  const dy = (end.y - start.y) * size.height;
+  if (dx === 0 && dy === 0) return squaredDistance(point, start, size);
   const progress = Math.max(
     0,
-    Math.min(1, ((point.x - start.x) * dx + (point.y - start.y) * dy) / (dx * dx + dy * dy)),
+    Math.min(
+      1,
+      ((point.x - start.x) * size.width * dx + (point.y - start.y) * size.height * dy) /
+        (dx * dx + dy * dy),
+    ),
   );
-  return squaredDistance(point, {
-    x: start.x + progress * dx,
-    y: start.y + progress * dy,
-  });
+  return squaredDistance(
+    point,
+    {
+      x: start.x + progress * (end.x - start.x),
+      y: start.y + progress * (end.y - start.y),
+    },
+    size,
+  );
 }
 
 function pointTouchesRect(
   point: PreviewAnnotationNormalizedPoint,
   rect: PreviewAnnotationNormalizedRect,
-  tolerance: number,
+  horizontalTolerance: number,
+  verticalTolerance: number,
 ): boolean {
   return (
-    point.x >= rect.x - tolerance &&
-    point.x <= rect.x + rect.width + tolerance &&
-    point.y >= rect.y - tolerance &&
-    point.y <= rect.y + rect.height + tolerance
+    point.x >= rect.x - horizontalTolerance &&
+    point.x <= rect.x + rect.width + horizontalTolerance &&
+    point.y >= rect.y - verticalTolerance &&
+    point.y <= rect.y + rect.height + verticalTolerance
   );
 }
 
 export function hitTestMarkupObject(
   document: MarkupDocument,
   point: PreviewAnnotationNormalizedPoint,
+  size: MarkupSize,
   tolerance = 0.025,
 ): MarkupSelection | null {
+  if (size.width <= 0 || size.height <= 0) return null;
+  const shortSide = Math.min(size.width, size.height);
+  const tolerancePixels = tolerance * shortSide;
+  const horizontalTolerance = tolerancePixels / size.width;
+  const verticalTolerance = tolerancePixels / size.height;
   for (const callout of document.callouts.toReversed()) {
     if (callout.anchor.kind === "point") {
-      if (squaredDistance(point, callout.anchor.point) <= tolerance * tolerance) {
+      if (squaredDistance(point, callout.anchor.point, size) <= tolerancePixels * tolerancePixels) {
         return { kind: "callout", id: callout.id };
       }
       continue;
     }
-    if (pointTouchesRect(point, callout.anchor.rect, tolerance)) {
+    if (pointTouchesRect(point, callout.anchor.rect, horizontalTolerance, verticalTolerance)) {
       return { kind: "callout", id: callout.id };
     }
   }
 
   for (const stroke of document.strokes.toReversed()) {
-    if (!pointTouchesRect(point, stroke.bounds, tolerance + stroke.width / 2)) {
+    const strokeTolerancePixels = (tolerance + stroke.width / 2) * shortSide;
+    if (
+      !pointTouchesRect(
+        point,
+        stroke.bounds,
+        strokeTolerancePixels / size.width,
+        strokeTolerancePixels / size.height,
+      )
+    ) {
       continue;
     }
     const points = stroke.points;
     if (
       points.length === 1 &&
-      squaredDistance(point, points[0]!) <= (tolerance + stroke.width / 2) ** 2
+      squaredDistance(point, points[0]!, size) <= strokeTolerancePixels * strokeTolerancePixels
     ) {
       return { kind: "stroke", id: stroke.id };
     }
     for (let index = 1; index < points.length; index += 1) {
       if (
-        squaredDistanceToSegment(point, points[index - 1]!, points[index]!) <=
-        (tolerance + stroke.width / 2) ** 2
+        squaredDistanceToSegment(point, points[index - 1]!, points[index]!, size) <=
+        strokeTolerancePixels * strokeTolerancePixels
       ) {
         return { kind: "stroke", id: stroke.id };
       }
@@ -404,9 +429,10 @@ export function hitTestMarkupObject(
 export function eraseMarkupObjectAtPoint(
   document: MarkupDocument,
   point: PreviewAnnotationNormalizedPoint,
+  size: MarkupSize,
   tolerance = 0.035,
 ): MarkupDocument {
-  return deleteMarkupObject(document, hitTestMarkupObject(document, point, tolerance));
+  return deleteMarkupObject(document, hitTestMarkupObject(document, point, size, tolerance));
 }
 
 export function createMarkupHistory(document: MarkupDocument): MarkupHistory {

--- a/apps/mobile/src/features/annotations/model.ts
+++ b/apps/mobile/src/features/annotations/model.ts
@@ -1,0 +1,528 @@
+import type {
+  PreviewAnnotationCallout,
+  PreviewAnnotationEditableStrokeV1,
+  PreviewAnnotationNormalizedPoint,
+  PreviewAnnotationNormalizedRect,
+} from "@t3tools/contracts";
+
+export type MarkupTool = "select" | "element" | "point" | "region" | "pen" | "erase";
+
+export interface MarkupDocument {
+  readonly callouts: ReadonlyArray<PreviewAnnotationCallout>;
+  readonly strokes: ReadonlyArray<PreviewAnnotationEditableStrokeV1>;
+}
+
+export interface MarkupHistory {
+  readonly past: ReadonlyArray<MarkupDocument>;
+  readonly present: MarkupDocument;
+  readonly future: ReadonlyArray<MarkupDocument>;
+}
+
+export type MarkupSelection =
+  | { readonly kind: "callout"; readonly id: string }
+  | { readonly kind: "stroke"; readonly id: string };
+
+export interface MarkupSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface AspectFit extends MarkupSize {
+  readonly x: number;
+  readonly y: number;
+}
+
+export const EMPTY_MARKUP_DOCUMENT: MarkupDocument = {
+  callouts: [],
+  strokes: [],
+};
+
+export const DEFAULT_STROKE_COLOR = "#ff3b30";
+export const DEFAULT_NORMALIZED_STROKE_WIDTH = 0.006;
+export const MAX_ANNOTATION_EXPORT_EDGE = 2_048;
+export const MAX_ANNOTATION_EXPORT_PIXELS = 4_000_000;
+export const MIN_ANNOTATION_EXPORT_EDGE = 320;
+
+const MAX_HISTORY_ENTRIES = 100;
+const MIN_NORMALIZED_REGION_SIZE = 0.006;
+const MIN_NORMALIZED_DISTANCE = 0.000_001;
+
+export function clampNormalized(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+export function normalizedPoint(
+  point: { readonly x: number; readonly y: number },
+  size: MarkupSize,
+): PreviewAnnotationNormalizedPoint {
+  if (size.width <= 0 || size.height <= 0) {
+    return { x: 0, y: 0 };
+  }
+  return {
+    x: clampNormalized(point.x / size.width),
+    y: clampNormalized(point.y / size.height),
+  };
+}
+
+export function aspectFit(image: MarkupSize, container: MarkupSize): AspectFit {
+  if (image.width <= 0 || image.height <= 0 || container.width <= 0 || container.height <= 0) {
+    return { x: 0, y: 0, width: 0, height: 0 };
+  }
+
+  const scale = Math.min(container.width / image.width, container.height / image.height);
+  const width = image.width * scale;
+  const height = image.height * scale;
+  return {
+    x: (container.width - width) / 2,
+    y: (container.height - height) / 2,
+    width,
+    height,
+  };
+}
+
+export function normalizedRectFromPoints(
+  start: PreviewAnnotationNormalizedPoint,
+  end: PreviewAnnotationNormalizedPoint,
+): PreviewAnnotationNormalizedRect | null {
+  const x = clampNormalized(Math.min(start.x, end.x));
+  const y = clampNormalized(Math.min(start.y, end.y));
+  const right = clampNormalized(Math.max(start.x, end.x));
+  const bottom = clampNormalized(Math.max(start.y, end.y));
+  const width = right - x;
+  const height = bottom - y;
+
+  if (width < MIN_NORMALIZED_REGION_SIZE || height < MIN_NORMALIZED_REGION_SIZE) {
+    return null;
+  }
+
+  return { x, y, width, height };
+}
+
+function nextCalloutNumber(document: MarkupDocument): number {
+  return document.callouts.reduce((maximum, callout) => Math.max(maximum, callout.number), 0) + 1;
+}
+
+export function addPointCallout(
+  document: MarkupDocument,
+  input: {
+    readonly id: string;
+    readonly point: PreviewAnnotationNormalizedPoint;
+    readonly comment?: string;
+  },
+): MarkupDocument {
+  return {
+    ...document,
+    callouts: [
+      ...document.callouts,
+      {
+        id: input.id,
+        number: nextCalloutNumber(document),
+        comment: input.comment ?? "",
+        anchor: {
+          kind: "point",
+          point: {
+            x: clampNormalized(input.point.x),
+            y: clampNormalized(input.point.y),
+          },
+        },
+      },
+    ],
+  };
+}
+
+export function addRegionCallout(
+  document: MarkupDocument,
+  input: {
+    readonly id: string;
+    readonly rect: PreviewAnnotationNormalizedRect;
+    readonly comment?: string;
+  },
+): MarkupDocument {
+  const rect = boundedNormalizedRect(input.rect);
+
+  return {
+    ...document,
+    callouts: [
+      ...document.callouts,
+      {
+        id: input.id,
+        number: nextCalloutNumber(document),
+        comment: input.comment ?? "",
+        anchor: {
+          kind: "region",
+          rect,
+        },
+      },
+    ],
+  };
+}
+
+function boundedNormalizedRect(
+  input: PreviewAnnotationNormalizedRect,
+): PreviewAnnotationNormalizedRect {
+  const x = Math.min(clampNormalized(input.x), 1 - MIN_NORMALIZED_DISTANCE);
+  const y = Math.min(clampNormalized(input.y), 1 - MIN_NORMALIZED_DISTANCE);
+  const width = Math.max(MIN_NORMALIZED_DISTANCE, Math.min(clampNormalized(input.width), 1 - x));
+  const height = Math.max(MIN_NORMALIZED_DISTANCE, Math.min(clampNormalized(input.height), 1 - y));
+  return { x, y, width, height };
+}
+
+export function addElementCallout(
+  document: MarkupDocument,
+  input: {
+    readonly id: string;
+    readonly targetId: string;
+    readonly rect: PreviewAnnotationNormalizedRect;
+    readonly comment?: string;
+  },
+): MarkupDocument {
+  const rect = boundedNormalizedRect(input.rect);
+  return {
+    ...document,
+    callouts: [
+      ...document.callouts,
+      {
+        id: input.id,
+        number: nextCalloutNumber(document),
+        comment: input.comment ?? "",
+        anchor: {
+          kind: "element",
+          targetId: input.targetId,
+          rect,
+        },
+      },
+    ],
+  };
+}
+
+export function updateCalloutComment(
+  document: MarkupDocument,
+  calloutId: string,
+  comment: string,
+): MarkupDocument {
+  const calloutIndex = document.callouts.findIndex((callout) => callout.id === calloutId);
+  if (calloutIndex < 0 || document.callouts[calloutIndex]?.comment === comment) {
+    return document;
+  }
+
+  return {
+    ...document,
+    callouts: document.callouts.map((callout) =>
+      callout.id === calloutId ? { ...callout, comment } : callout,
+    ),
+  };
+}
+
+function expandedPositiveRange(
+  minimum: number,
+  maximum: number,
+  padding: number,
+): { readonly start: number; readonly length: number } {
+  let start = clampNormalized(minimum - padding);
+  let end = clampNormalized(maximum + padding);
+  if (end - start >= MIN_NORMALIZED_DISTANCE) {
+    return { start, length: end - start };
+  }
+
+  if (start >= 1) {
+    start = 1 - MIN_NORMALIZED_DISTANCE;
+    end = 1;
+  } else {
+    end = Math.min(1, start + MIN_NORMALIZED_DISTANCE);
+    start = Math.max(0, end - MIN_NORMALIZED_DISTANCE);
+  }
+  return { start, length: end - start };
+}
+
+export function strokeBounds(
+  points: ReadonlyArray<PreviewAnnotationNormalizedPoint>,
+  width: number,
+): PreviewAnnotationNormalizedRect {
+  const first = points[0] ?? { x: 0, y: 0 };
+  let minimumX = clampNormalized(first.x);
+  let maximumX = minimumX;
+  let minimumY = clampNormalized(first.y);
+  let maximumY = minimumY;
+
+  for (const point of points.slice(1)) {
+    const x = clampNormalized(point.x);
+    const y = clampNormalized(point.y);
+    minimumX = Math.min(minimumX, x);
+    maximumX = Math.max(maximumX, x);
+    minimumY = Math.min(minimumY, y);
+    maximumY = Math.max(maximumY, y);
+  }
+
+  const padding = Math.max(MIN_NORMALIZED_DISTANCE, width / 2);
+  const horizontal = expandedPositiveRange(minimumX, maximumX, padding);
+  const vertical = expandedPositiveRange(minimumY, maximumY, padding);
+  return {
+    x: horizontal.start,
+    y: vertical.start,
+    width: horizontal.length,
+    height: vertical.length,
+  };
+}
+
+export function makeStroke(input: {
+  readonly id: string;
+  readonly color: string;
+  readonly width: number;
+  readonly points: ReadonlyArray<PreviewAnnotationNormalizedPoint>;
+}): PreviewAnnotationEditableStrokeV1 | null {
+  if (input.points.length === 0) return null;
+  const width = Math.max(
+    MIN_NORMALIZED_DISTANCE,
+    Math.min(1, Number.isFinite(input.width) ? input.width : DEFAULT_NORMALIZED_STROKE_WIDTH),
+  );
+  const points = input.points.map((point) => ({
+    x: clampNormalized(point.x),
+    y: clampNormalized(point.y),
+  }));
+  return {
+    id: input.id,
+    color: input.color,
+    width,
+    points,
+    bounds: strokeBounds(points, width),
+  };
+}
+
+export function addStroke(
+  document: MarkupDocument,
+  stroke: PreviewAnnotationEditableStrokeV1,
+): MarkupDocument {
+  return {
+    ...document,
+    strokes: [...document.strokes, stroke],
+  };
+}
+
+export function deleteMarkupObject(
+  document: MarkupDocument,
+  selection: MarkupSelection | null,
+): MarkupDocument {
+  if (!selection) return document;
+  if (selection.kind === "callout") {
+    const callouts = document.callouts.filter((callout) => callout.id !== selection.id);
+    return callouts.length === document.callouts.length ? document : { ...document, callouts };
+  }
+
+  const strokes = document.strokes.filter((stroke) => stroke.id !== selection.id);
+  return strokes.length === document.strokes.length ? document : { ...document, strokes };
+}
+
+export function clearMarkupDocument(document: MarkupDocument): MarkupDocument {
+  if (document.callouts.length === 0 && document.strokes.length === 0) {
+    return document;
+  }
+  return EMPTY_MARKUP_DOCUMENT;
+}
+
+function squaredDistance(
+  left: PreviewAnnotationNormalizedPoint,
+  right: PreviewAnnotationNormalizedPoint,
+): number {
+  const dx = left.x - right.x;
+  const dy = left.y - right.y;
+  return dx * dx + dy * dy;
+}
+
+function squaredDistanceToSegment(
+  point: PreviewAnnotationNormalizedPoint,
+  start: PreviewAnnotationNormalizedPoint,
+  end: PreviewAnnotationNormalizedPoint,
+): number {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  if (dx === 0 && dy === 0) return squaredDistance(point, start);
+  const progress = Math.max(
+    0,
+    Math.min(1, ((point.x - start.x) * dx + (point.y - start.y) * dy) / (dx * dx + dy * dy)),
+  );
+  return squaredDistance(point, {
+    x: start.x + progress * dx,
+    y: start.y + progress * dy,
+  });
+}
+
+function pointTouchesRect(
+  point: PreviewAnnotationNormalizedPoint,
+  rect: PreviewAnnotationNormalizedRect,
+  tolerance: number,
+): boolean {
+  return (
+    point.x >= rect.x - tolerance &&
+    point.x <= rect.x + rect.width + tolerance &&
+    point.y >= rect.y - tolerance &&
+    point.y <= rect.y + rect.height + tolerance
+  );
+}
+
+export function hitTestMarkupObject(
+  document: MarkupDocument,
+  point: PreviewAnnotationNormalizedPoint,
+  tolerance = 0.025,
+): MarkupSelection | null {
+  for (const callout of document.callouts.toReversed()) {
+    if (callout.anchor.kind === "point") {
+      if (squaredDistance(point, callout.anchor.point) <= tolerance * tolerance) {
+        return { kind: "callout", id: callout.id };
+      }
+      continue;
+    }
+    if (pointTouchesRect(point, callout.anchor.rect, tolerance)) {
+      return { kind: "callout", id: callout.id };
+    }
+  }
+
+  for (const stroke of document.strokes.toReversed()) {
+    if (!pointTouchesRect(point, stroke.bounds, tolerance + stroke.width / 2)) {
+      continue;
+    }
+    const points = stroke.points;
+    if (points.length === 1 && squaredDistance(point, points[0]!) <= tolerance * tolerance) {
+      return { kind: "stroke", id: stroke.id };
+    }
+    for (let index = 1; index < points.length; index += 1) {
+      if (
+        squaredDistanceToSegment(point, points[index - 1]!, points[index]!) <=
+        (tolerance + stroke.width / 2) ** 2
+      ) {
+        return { kind: "stroke", id: stroke.id };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function eraseMarkupObjectAtPoint(
+  document: MarkupDocument,
+  point: PreviewAnnotationNormalizedPoint,
+  tolerance = 0.035,
+): MarkupDocument {
+  return deleteMarkupObject(document, hitTestMarkupObject(document, point, tolerance));
+}
+
+export function createMarkupHistory(document: MarkupDocument): MarkupHistory {
+  return {
+    past: [],
+    present: document,
+    future: [],
+  };
+}
+
+export function commitMarkupDocument(
+  history: MarkupHistory,
+  document: MarkupDocument,
+): MarkupHistory {
+  if (document === history.present) return history;
+  return {
+    past: [...history.past.slice(-(MAX_HISTORY_ENTRIES - 1)), history.present],
+    present: document,
+    future: [],
+  };
+}
+
+export function undoMarkupHistory(history: MarkupHistory): MarkupHistory {
+  const previous = history.past.at(-1);
+  if (!previous) return history;
+  return {
+    past: history.past.slice(0, -1),
+    present: previous,
+    future: [history.present, ...history.future].slice(0, MAX_HISTORY_ENTRIES),
+  };
+}
+
+export function redoMarkupHistory(history: MarkupHistory): MarkupHistory {
+  const next = history.future[0];
+  if (!next) return history;
+  return {
+    past: [...history.past.slice(-(MAX_HISTORY_ENTRIES - 1)), history.present],
+    present: next,
+    future: history.future.slice(1),
+  };
+}
+
+export function markupDocumentIsEmpty(document: MarkupDocument): boolean {
+  return document.callouts.length === 0 && document.strokes.length === 0;
+}
+
+export function pathForNormalizedPoints(
+  points: ReadonlyArray<PreviewAnnotationNormalizedPoint>,
+  imageSize: MarkupSize,
+): string {
+  const first = points[0];
+  if (!first) return "";
+  const start = `${first.x * imageSize.width} ${first.y * imageSize.height}`;
+  if (points.length === 1) return `M ${start} L ${start}`;
+  return [
+    `M ${start}`,
+    ...points
+      .slice(1)
+      .map((point) => `L ${point.x * imageSize.width} ${point.y * imageSize.height}`),
+  ].join(" ");
+}
+
+export function annotationExportSize(
+  image: MarkupSize,
+  options: {
+    readonly maxEdge?: number;
+    readonly maxPixels?: number;
+  } = {},
+): MarkupSize {
+  if (image.width <= 0 || image.height <= 0) {
+    return { width: 1, height: 1 };
+  }
+  const maxEdge = options.maxEdge ?? MAX_ANNOTATION_EXPORT_EDGE;
+  const maxPixels = options.maxPixels ?? MAX_ANNOTATION_EXPORT_PIXELS;
+  const edgeScale = maxEdge / Math.max(image.width, image.height);
+  const pixelScale = Math.sqrt(maxPixels / (image.width * image.height));
+  const scale = Math.min(1, edgeScale, pixelScale);
+  return {
+    width: Math.max(1, Math.round(image.width * scale)),
+    height: Math.max(1, Math.round(image.height * scale)),
+  };
+}
+
+export function annotationExportLayoutSize(
+  imagePixels: MarkupSize,
+  pixelRatio: number,
+): MarkupSize {
+  const safePixelRatio = Number.isFinite(pixelRatio) && pixelRatio > 0 ? pixelRatio : 1;
+  return {
+    width: Math.max(1 / safePixelRatio, imagePixels.width / safePixelRatio),
+    height: Math.max(1 / safePixelRatio, imagePixels.height / safePixelRatio),
+  };
+}
+
+export function remainingAnnotationExportByteBudget(
+  originalSizeBytes: number,
+  maximumCombinedBytes: number,
+): number {
+  const safeMaximum =
+    Number.isFinite(maximumCombinedBytes) && maximumCombinedBytes > 0
+      ? Math.floor(maximumCombinedBytes)
+      : 0;
+  const safeOriginal =
+    Number.isFinite(originalSizeBytes) && originalSizeBytes > 0 ? Math.ceil(originalSizeBytes) : 0;
+  return Math.max(0, safeMaximum - safeOriginal);
+}
+
+export function nextSmallerExportSize(size: MarkupSize): MarkupSize | null {
+  if (Math.max(size.width, size.height) <= MIN_ANNOTATION_EXPORT_EDGE) {
+    return null;
+  }
+  const scale = Math.max(
+    0.75,
+    Math.min(1, MIN_ANNOTATION_EXPORT_EDGE / Math.max(size.width, size.height)),
+  );
+  const next = {
+    width: Math.max(1, Math.floor(size.width * scale)),
+    height: Math.max(1, Math.floor(size.height * scale)),
+  };
+  if (next.width === size.width && next.height === size.height) return null;
+  return next;
+}

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -237,7 +237,6 @@ function FilesToolbarBottomFade() {
 }
 
 export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
-  useAdaptiveWorkspacePaneRole("inspector");
   const navigation = useNavigation();
   const { fileInspector, layout, panes, showAuxiliaryPane, togglePrimarySidebar } =
     useAdaptiveWorkspaceLayout();
@@ -334,6 +333,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
     if (fileInspector.supported) {
       return (
         <ThreadRouteScreen
+          auxiliaryRoute="files"
           onReturnToThread={handleReturnToThread}
           renderInspector={renderInspector}
           route={props.route}
@@ -350,6 +350,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
   if (fileInspector.supported) {
     return (
       <ThreadRouteScreen
+        auxiliaryRoute="files"
         onReturnToThread={handleReturnToThread}
         renderInspector={renderInspector}
         route={props.route}

--- a/apps/mobile/src/features/files/WorkspaceFileImagePreview.tsx
+++ b/apps/mobile/src/features/files/WorkspaceFileImagePreview.tsx
@@ -1,11 +1,11 @@
 import { useAtomValue } from "@effect/atom-react";
 import { useMemo, useState } from "react";
 import { ActivityIndicator, Image, Pressable, View } from "react-native";
-import ImageViewing from "react-native-image-viewing";
 import { AsyncResult } from "effect/unstable/reactivity";
 
 import { AppText as Text } from "../../components/AppText";
 import { EmptyState } from "../../components/EmptyState";
+import { FullscreenImageViewer } from "../../components/FullscreenImageViewer";
 import { workspaceFileImageAtom } from "./workspace-file-image-cache";
 
 function ResolvedWorkspaceFileImagePreview(props: {
@@ -18,7 +18,6 @@ function ResolvedWorkspaceFileImagePreview(props: {
     () => ({ uri: props.uri, cache: "force-cache" as const }),
     [props.uri],
   );
-  const fullScreenImages = useMemo(() => [imageSource], [imageSource]);
 
   return (
     <View className="relative flex-1 bg-subtle">
@@ -47,13 +46,10 @@ function ResolvedWorkspaceFileImagePreview(props: {
         </View>
       ) : null}
 
-      <ImageViewing
-        images={fullScreenImages}
-        imageIndex={0}
+      <FullscreenImageViewer
+        source={imageSource}
         visible={fullScreenVisible}
         onRequestClose={() => setFullScreenVisible(false)}
-        swipeToCloseEnabled
-        doubleTapToZoomEnabled
       />
     </View>
   );

--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -28,9 +28,13 @@ import { AsyncResult } from "effect/unstable/reactivity";
 import {
   deriveFileInspectorPaneLayout,
   deriveLayout,
+  derivePreviewPaneLayout,
   deriveWorkspacePaneLayout,
+  constrainAuxiliaryPaneWidth,
+  constrainPreviewPaneWidth,
   type FileInspectorPaneLayout,
   type Layout,
+  type PreviewPaneLayout,
   type WorkspaceAuxiliaryPaneRole,
   type WorkspacePaneLayout,
 } from "../../lib/layout";
@@ -50,6 +54,8 @@ interface AdaptiveWorkspaceContextValue {
   readonly layout: Layout;
   readonly panes: WorkspacePaneLayout;
   readonly fileInspector: FileInspectorPaneLayout;
+  readonly previewPane: PreviewPaneLayout;
+  readonly previewPaneFullscreen: boolean;
   readonly primarySidebarSearchQuery: string;
   readonly activateAuxiliaryPaneRole: (role: WorkspaceAuxiliaryPaneRole) => () => void;
   /**
@@ -66,6 +72,7 @@ interface AdaptiveWorkspaceContextValue {
   readonly toggleAuxiliaryPane: () => void;
   readonly togglePrimarySidebar: () => void;
   readonly setAuxiliaryPaneWidth: (width: number) => void;
+  readonly setPreviewPaneFullscreen: (fullscreen: boolean) => void;
 }
 
 const compactLayout = deriveLayout({ width: 0, height: 0 });
@@ -79,10 +86,16 @@ const compactFileInspector = deriveFileInspectorPaneLayout({
   layout: compactLayout,
   viewportWidth: 0,
 });
+const compactPreviewPane = derivePreviewPaneLayout({
+  layout: compactLayout,
+  viewportWidth: 0,
+});
 const AdaptiveWorkspaceContext = createContext<AdaptiveWorkspaceContextValue>({
   layout: compactLayout,
   panes: compactPanes,
   fileInspector: compactFileInspector,
+  previewPane: compactPreviewPane,
+  previewPaneFullscreen: false,
   primarySidebarSearchQuery: "",
   activateAuxiliaryPaneRole: () => () => undefined,
   registerWorkspaceInspector: () => () => undefined,
@@ -91,6 +104,7 @@ const AdaptiveWorkspaceContext = createContext<AdaptiveWorkspaceContextValue>({
   toggleAuxiliaryPane: () => undefined,
   togglePrimarySidebar: () => undefined,
   setAuxiliaryPaneWidth: () => undefined,
+  setPreviewPaneFullscreen: () => undefined,
 });
 
 export function useAdaptiveWorkspaceLayout(): AdaptiveWorkspaceContextValue {
@@ -225,6 +239,9 @@ function AdaptiveWorkspaceLayoutContent(
   const [fileInspectorPreferredWidth, setFileInspectorPreferredWidth] = useState<number | null>(
     null,
   );
+  const [previewPanePreferredVisible, setPreviewPanePreferredVisible] = useState(true);
+  const [previewPanePreferredWidth, setPreviewPanePreferredWidth] = useState<number | null>(null);
+  const [previewPaneFullscreen, setPreviewPaneFullscreen] = useState(false);
   const [primarySidebarSearchQuery, setPrimarySidebarSearchQuery] = useState("");
   const [focusedAuxiliaryPaneRole, setFocusedAuxiliaryPaneRole] =
     useState<WorkspaceAuxiliaryPaneRole | null>(null);
@@ -253,16 +270,29 @@ function AdaptiveWorkspaceLayoutContent(
       width,
     ],
   );
+  const previewPane = useMemo(
+    () =>
+      derivePreviewPaneLayout({
+        layout,
+        viewportWidth: width,
+        preferredWidth: previewPanePreferredWidth ?? undefined,
+      }),
+    [layout, previewPanePreferredWidth, width],
+  );
   const auxiliaryPaneRole: WorkspaceAuxiliaryPaneRole =
     focusedAuxiliaryPaneRole ?? (/\/files(?:\/|$)/.test(pathname) ? "inspector" : "supplementary");
   const auxiliaryPanePreferredVisible =
     auxiliaryPaneRole === "inspector"
       ? fileInspectorPreferredVisible
-      : supplementaryPanePreferredVisible;
+      : auxiliaryPaneRole === "preview"
+        ? previewPanePreferredVisible
+        : supplementaryPanePreferredVisible;
   const auxiliaryPanePreferredWidth =
     auxiliaryPaneRole === "inspector"
       ? fileInspectorPreferredWidth
-      : supplementaryPanePreferredWidth;
+      : auxiliaryPaneRole === "preview"
+        ? previewPanePreferredWidth
+        : supplementaryPanePreferredWidth;
   const panes = useMemo(
     () =>
       deriveWorkspacePaneLayout({
@@ -272,11 +302,13 @@ function AdaptiveWorkspaceLayoutContent(
         auxiliaryPanePreferredVisible,
         auxiliaryPaneRole,
         auxiliaryPanePreferredWidth: auxiliaryPanePreferredWidth ?? undefined,
+        auxiliaryPaneFullscreen: auxiliaryPaneRole === "preview" && previewPaneFullscreen,
       }),
     [
       auxiliaryPanePreferredVisible,
       auxiliaryPaneRole,
       auxiliaryPanePreferredWidth,
+      previewPaneFullscreen,
       layout,
       primarySidebarPreferredVisible,
       width,
@@ -326,6 +358,9 @@ function AdaptiveWorkspaceLayoutContent(
     const owner = Symbol(role);
     activeRoleOwner.current = owner;
     setFocusedAuxiliaryPaneRole(role);
+    if (role !== "preview") {
+      setPreviewPaneFullscreen(false);
+    }
 
     return () => {
       if (activeRoleOwner.current !== owner) {
@@ -333,22 +368,33 @@ function AdaptiveWorkspaceLayoutContent(
       }
       activeRoleOwner.current = null;
       setFocusedAuxiliaryPaneRole(null);
+      setPreviewPaneFullscreen(false);
     };
   }, []);
   const togglePrimarySidebar = useCallback(() => {
     if (!panes.primarySidebarVisible && panes.primarySidebarSuppressedByAuxiliary) {
-      setFileInspectorPreferredVisible(false);
+      if (auxiliaryPaneRole === "preview") {
+        setPreviewPanePreferredVisible(false);
+        setPreviewPaneFullscreen(false);
+      } else {
+        setFileInspectorPreferredVisible(false);
+      }
       setPrimarySidebarPreferredVisible(true);
       return;
     }
     setPrimarySidebarPreferredVisible((current) => !current);
-  }, [panes.primarySidebarSuppressedByAuxiliary, panes.primarySidebarVisible]);
+  }, [auxiliaryPaneRole, panes.primarySidebarSuppressedByAuxiliary, panes.primarySidebarVisible]);
   const revealPrimarySidebar = useCallback(() => {
     if (panes.primarySidebarSuppressedByAuxiliary) {
-      setFileInspectorPreferredVisible(false);
+      if (auxiliaryPaneRole === "preview") {
+        setPreviewPanePreferredVisible(false);
+        setPreviewPaneFullscreen(false);
+      } else {
+        setFileInspectorPreferredVisible(false);
+      }
     }
     setPrimarySidebarPreferredVisible(true);
-  }, [panes.primarySidebarSuppressedByAuxiliary]);
+  }, [auxiliaryPaneRole, panes.primarySidebarSuppressedByAuxiliary]);
   const handleToggleSidebarCommand = useCallback(() => {
     togglePrimarySidebar();
     return true;
@@ -358,6 +404,11 @@ function AdaptiveWorkspaceLayoutContent(
     if (role === "inspector") {
       setFocusedAuxiliaryPaneRole("inspector");
       setFileInspectorPreferredVisible(true);
+      return;
+    }
+    if (role === "preview") {
+      setFocusedAuxiliaryPaneRole("preview");
+      setPreviewPanePreferredVisible(true);
       return;
     }
     setFocusedAuxiliaryPaneRole("supplementary");
@@ -381,23 +432,49 @@ function AdaptiveWorkspaceLayoutContent(
       setFileInspectorPreferredVisible((current) => !current);
       return;
     }
+    if (auxiliaryPaneRole === "preview") {
+      setPreviewPanePreferredVisible((current) => !current);
+      setPreviewPaneFullscreen(false);
+      return;
+    }
     setSupplementaryPanePreferredVisible((current) => !current);
   }, [auxiliaryPaneRole]);
   const setAuxiliaryPaneWidth = useCallback(
     (nextWidth: number) => {
       if (auxiliaryPaneRole === "inspector") {
-        setFileInspectorPreferredWidth(nextWidth);
+        setFileInspectorPreferredWidth(
+          constrainAuxiliaryPaneWidth({
+            preferredWidth: nextWidth,
+            availableWidth: panes.contentPaneWidth,
+          }),
+        );
         return;
       }
-      setSupplementaryPanePreferredWidth(nextWidth);
+      if (auxiliaryPaneRole === "preview") {
+        setPreviewPanePreferredWidth(
+          constrainPreviewPaneWidth({
+            preferredWidth: nextWidth,
+            availableWidth: panes.contentPaneWidth,
+          }),
+        );
+        return;
+      }
+      setSupplementaryPanePreferredWidth(
+        constrainAuxiliaryPaneWidth({
+          preferredWidth: nextWidth,
+          availableWidth: panes.contentPaneWidth,
+        }),
+      );
     },
-    [auxiliaryPaneRole],
+    [auxiliaryPaneRole, panes.contentPaneWidth],
   );
   const contextValue = useMemo(
     () => ({
       layout,
       panes,
       fileInspector,
+      previewPane,
+      previewPaneFullscreen,
       primarySidebarSearchQuery,
       activateAuxiliaryPaneRole,
       registerWorkspaceInspector,
@@ -406,6 +483,7 @@ function AdaptiveWorkspaceLayoutContent(
       toggleAuxiliaryPane,
       togglePrimarySidebar,
       setAuxiliaryPaneWidth,
+      setPreviewPaneFullscreen,
     }),
     [
       activateAuxiliaryPaneRole,
@@ -413,10 +491,13 @@ function AdaptiveWorkspaceLayoutContent(
       layout,
       panes,
       primarySidebarSearchQuery,
+      previewPane,
+      previewPaneFullscreen,
       registerWorkspaceInspector,
       showAuxiliaryPane,
       setPrimarySidebarSearchQuery,
       setAuxiliaryPaneWidth,
+      setPreviewPaneFullscreen,
       toggleAuxiliaryPane,
       togglePrimarySidebar,
     ],
@@ -544,6 +625,7 @@ function AdaptiveWorkspaceLayoutContent(
             active={workspaceInspector?.active ?? false}
             panes={panes}
             renderInspector={workspaceInspector?.render}
+            resizable={auxiliaryPaneRole !== "preview" || !previewPaneFullscreen}
             setAuxiliaryPaneWidth={setAuxiliaryPaneWidth}
             onClosed={handleWorkspaceInspectorClosed}
           />

--- a/apps/mobile/src/features/layout/workspace-inspector-pane.tsx
+++ b/apps/mobile/src/features/layout/workspace-inspector-pane.tsx
@@ -6,7 +6,7 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
-import { constrainAuxiliaryPaneWidth, type WorkspacePaneLayout } from "../../lib/layout";
+import type { WorkspacePaneLayout } from "../../lib/layout";
 import { WORKSPACE_PANE_TIMING } from "./workspace-pane-animation";
 import { WorkspacePaneDivider } from "./workspace-pane-divider";
 
@@ -31,6 +31,7 @@ export function WorkspaceInspectorPane(props: {
   readonly onClosed?: () => void;
   readonly panes: WorkspacePaneLayout;
   readonly renderInspector?: () => ReactNode;
+  readonly resizable?: boolean;
   readonly setAuxiliaryPaneWidth: (width: number) => void;
 }) {
   const { panes, setAuxiliaryPaneWidth } = props;
@@ -38,6 +39,7 @@ export function WorkspaceInspectorPane(props: {
   const inspectorSupported = props.renderInspector !== undefined && inspectorWidth !== null;
   const inspectorVisible =
     inspectorSupported && panes.auxiliaryPaneVisible && (props.active ?? true);
+  const resizable = props.resizable ?? true;
   const resizeStartWidth = useRef(0);
   const [resizing, setResizing] = useState(false);
 
@@ -102,14 +104,9 @@ export function WorkspaceInspectorPane(props: {
   }, [inspectorWidth]);
   const resizeBy = useCallback(
     (delta: number) => {
-      setAuxiliaryPaneWidth(
-        constrainAuxiliaryPaneWidth({
-          preferredWidth: resizeStartWidth.current + delta,
-          availableWidth: panes.contentPaneWidth,
-        }),
-      );
+      setAuxiliaryPaneWidth(resizeStartWidth.current + delta);
     },
-    [panes.contentPaneWidth, setAuxiliaryPaneWidth],
+    [setAuxiliaryPaneWidth],
   );
   const endResize = useCallback(() => {
     setResizing(false);
@@ -117,7 +114,7 @@ export function WorkspaceInspectorPane(props: {
 
   return (
     <>
-      {inspectorVisible ? (
+      {inspectorVisible && resizable ? (
         <WorkspacePaneDivider
           accessibilityLabel="Resize detail pane"
           currentWidth={inspectorWidth ?? 0}

--- a/apps/mobile/src/features/preview/MobileLivePreview.tsx
+++ b/apps/mobile/src/features/preview/MobileLivePreview.tsx
@@ -1,0 +1,334 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Platform,
+  View,
+  type LayoutChangeEvent,
+  type View as NativeView,
+} from "react-native";
+import { WebView, type WebViewMessageEvent, type WebViewNavigation } from "react-native-webview";
+
+import { AppText as Text } from "../../components/AppText";
+import { LoadingStrip } from "../../components/LoadingStrip";
+import { uuidv4 } from "../../lib/uuid";
+import type { PreviewSnapshotMarkupSeed } from "./previewReviewModel";
+import { createPreviewSnapshotMarkupSeed } from "./previewReviewModel";
+import { captureMobilePreviewPng } from "./mobilePreviewCapture";
+import {
+  decodeMobilePreviewDomErrorMessage,
+  decodeMobilePreviewDomMessage,
+  mobilePreviewDomCaptureScript,
+  type MobilePreviewDomFrame,
+} from "./mobilePreviewDomBridge";
+import { mobilePreviewAnnotationUrl } from "./mobilePreviewSourceUrl";
+
+const DOM_CAPTURE_TIMEOUT_MS = 5_000;
+
+export interface MobileLivePreviewNavigation {
+  readonly canGoBack: boolean;
+  readonly canGoForward: boolean;
+  readonly title: string;
+  readonly url: string;
+}
+
+export interface MobileLivePreviewHandle {
+  readonly captureForMarkup: () => Promise<PreviewSnapshotMarkupSeed>;
+  readonly goBack: () => void;
+  readonly goForward: () => void;
+  readonly reload: () => void;
+}
+
+interface PendingDomCapture {
+  readonly generation: number;
+  readonly reject: (cause: Error) => void;
+  readonly requestId: string;
+  readonly resolve: (capture: MobilePreviewDomCapture) => void;
+  readonly timeout: ReturnType<typeof setTimeout>;
+}
+
+interface MobilePreviewDomCapture {
+  readonly frame: MobilePreviewDomFrame;
+  readonly generation: number;
+}
+
+export const MobileLivePreview = forwardRef<
+  MobileLivePreviewHandle,
+  {
+    readonly annotationSourceUrl: string;
+    readonly isolatedSession: boolean;
+    readonly uri: string;
+    readonly onGatewayExpired?: () => void;
+    readonly onNavigationChange?: (navigation: MobileLivePreviewNavigation) => void;
+    readonly onReadyChange?: (ready: boolean) => void;
+  }
+>(function MobileLivePreview(props, forwardedRef) {
+  const webViewRef = useRef<WebView>(null);
+  const captureViewRef = useRef<NativeView>(null);
+  const pendingDomCaptureRef = useRef<PendingDomCapture | null>(null);
+  const navigationGenerationRef = useRef(0);
+  const mountedRef = useRef(true);
+  const readyRef = useRef(false);
+  const onReadyChangeRef = useRef(props.onReadyChange);
+  const layoutRef = useRef({ width: 0, height: 0 });
+  const captureInProgressRef = useRef(false);
+  const gatewayExpiredRef = useRef(false);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [captureInProgress, setCaptureInProgress] = useState(false);
+  // Android's RN WebView incognito mode clears the process-wide cookie jar.
+  // Gateway previews are iOS-only, and this guard keeps that invariant safe if
+  // the component is reused elsewhere.
+  const useIncognitoCookieStore = props.isolatedSession && Platform.OS === "ios";
+  onReadyChangeRef.current = props.onReadyChange;
+
+  const setReady = useCallback((ready: boolean) => {
+    readyRef.current = ready;
+    onReadyChangeRef.current?.(ready);
+  }, []);
+
+  const rejectPendingDomCapture = useCallback((message: string) => {
+    const pending = pendingDomCaptureRef.current;
+    if (!pending) return;
+    pendingDomCaptureRef.current = null;
+    clearTimeout(pending.timeout);
+    pending.reject(new Error(message));
+  }, []);
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      onReadyChangeRef.current?.(false);
+      rejectPendingDomCapture("Browser closed before it could be captured.");
+    },
+    [rejectPendingDomCapture],
+  );
+
+  const requestDomFrame = useCallback((): Promise<MobilePreviewDomCapture> => {
+    const webView = webViewRef.current;
+    if (!webView || !readyRef.current) {
+      return Promise.reject(new Error("Wait for Browser to finish loading."));
+    }
+    rejectPendingDomCapture("A newer browser capture replaced this one.");
+    const requestId = uuidv4();
+    const generation = navigationGenerationRef.current;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = pendingDomCaptureRef.current;
+        if (pending?.requestId !== requestId) return;
+        pendingDomCaptureRef.current = null;
+        reject(new Error("The page did not respond to the markup capture request."));
+      }, DOM_CAPTURE_TIMEOUT_MS);
+      pendingDomCaptureRef.current = {
+        generation,
+        reject,
+        requestId,
+        resolve,
+        timeout,
+      };
+      try {
+        webView.injectJavaScript(mobilePreviewDomCaptureScript(requestId));
+      } catch (cause) {
+        pendingDomCaptureRef.current = null;
+        clearTimeout(timeout);
+        reject(
+          cause instanceof Error ? cause : new Error("The page could not be inspected for markup."),
+        );
+      }
+    });
+  }, [rejectPendingDomCapture]);
+
+  const captureForMarkup = useCallback(async (): Promise<PreviewSnapshotMarkupSeed> => {
+    if (captureInProgressRef.current) {
+      throw new Error("A browser capture is already in progress.");
+    }
+    const layout = layoutRef.current;
+    if (layout.width <= 0 || layout.height <= 0) {
+      throw new Error("Browser has not finished laying out.");
+    }
+    captureInProgressRef.current = true;
+    setCaptureInProgress(true);
+    try {
+      const { frame, generation } = await requestDomFrame();
+      if (navigationGenerationRef.current !== generation) {
+        throw new Error("Browser navigated while it was being captured.");
+      }
+      const screenshot = await captureMobilePreviewPng({
+        viewRef: captureViewRef,
+        layout,
+        viewport: frame.viewport,
+      });
+      if (navigationGenerationRef.current !== generation) {
+        throw new Error("Browser navigated while it was being captured.");
+      }
+      const snapshotId = uuidv4();
+      return createPreviewSnapshotMarkupSeed({
+        snapshot: {
+          snapshotId,
+          pageRevision: `mobile:${generation}:${snapshotId}`,
+          capturedAt: new Date().toISOString(),
+          url: mobilePreviewAnnotationUrl({
+            documentUrl: frame.url,
+            gatewayUrl: props.uri,
+            sourceUrl: props.annotationSourceUrl,
+            isolatedGateway: props.isolatedSession,
+          }),
+          title: frame.title,
+          viewport: frame.viewport,
+          screenshot,
+          elements: frame.elements,
+        },
+        attachmentId: uuidv4(),
+        annotationId: uuidv4(),
+      });
+    } finally {
+      captureInProgressRef.current = false;
+      if (mountedRef.current) setCaptureInProgress(false);
+    }
+  }, [props.annotationSourceUrl, props.isolatedSession, props.uri, requestDomFrame]);
+
+  useImperativeHandle(
+    forwardedRef,
+    () => ({
+      captureForMarkup,
+      goBack: () => webViewRef.current?.goBack(),
+      goForward: () => webViewRef.current?.goForward(),
+      reload: () => webViewRef.current?.reload(),
+    }),
+    [captureForMarkup],
+  );
+
+  const handleMessage = useCallback((event: WebViewMessageEvent) => {
+    const pending = pendingDomCaptureRef.current;
+    if (!pending) return;
+    const raw = event.nativeEvent.data;
+    const frame = decodeMobilePreviewDomMessage(raw, pending.requestId);
+    if (frame) {
+      pendingDomCaptureRef.current = null;
+      clearTimeout(pending.timeout);
+      if (pending.generation !== navigationGenerationRef.current) {
+        pending.reject(new Error("Browser navigated before it could be captured."));
+        return;
+      }
+      pending.resolve({ frame, generation: pending.generation });
+      return;
+    }
+    const pageError = decodeMobilePreviewDomErrorMessage(raw, pending.requestId);
+    if (!pageError) return;
+    pendingDomCaptureRef.current = null;
+    clearTimeout(pending.timeout);
+    pending.reject(new Error(pageError));
+  }, []);
+
+  const handleNavigation = useCallback(
+    (navigation: WebViewNavigation) => {
+      props.onNavigationChange?.({
+        canGoBack: navigation.canGoBack,
+        canGoForward: navigation.canGoForward,
+        title: navigation.title,
+        url: mobilePreviewAnnotationUrl({
+          documentUrl: navigation.url,
+          gatewayUrl: props.uri,
+          sourceUrl: props.annotationSourceUrl,
+          isolatedGateway: props.isolatedSession,
+        }),
+      });
+    },
+    [props.annotationSourceUrl, props.isolatedSession, props.onNavigationChange, props.uri],
+  );
+
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    layoutRef.current = {
+      width: event.nativeEvent.layout.width,
+      height: event.nativeEvent.layout.height,
+    };
+  }, []);
+
+  return (
+    <View className="relative min-h-0 flex-1 bg-card">
+      {progress > 0 && progress < 1 ? <LoadingStrip progress={progress} /> : null}
+      {error ? (
+        <View className="border-b border-border bg-card px-3 py-2">
+          <Text className="text-xs font-t3-bold text-foreground">Browser failed</Text>
+          <Text className="mt-0.5 text-xs leading-snug text-foreground-muted">{error}</Text>
+        </View>
+      ) : null}
+      <View
+        ref={captureViewRef}
+        collapsable={false}
+        className="min-h-0 flex-1 bg-card"
+        onLayout={handleLayout}
+      >
+        <WebView
+          ref={webViewRef}
+          source={{ uri: props.uri }}
+          originWhitelist={["http://*", "https://*"]}
+          allowsBackForwardNavigationGestures
+          allowsFullscreenVideo
+          cacheEnabled
+          domStorageEnabled
+          incognito={useIncognitoCookieStore}
+          setSupportMultipleWindows={false}
+          sharedCookiesEnabled={false}
+          thirdPartyCookiesEnabled={!props.isolatedSession}
+          useSharedProcessPool={!props.isolatedSession}
+          webviewDebuggingEnabled={__DEV__}
+          startInLoadingState
+          onContentProcessDidTerminate={() => {
+            navigationGenerationRef.current += 1;
+            rejectPendingDomCapture("The browser process restarted during capture.");
+            setReady(false);
+            webViewRef.current?.reload();
+          }}
+          onRenderProcessGone={() => {
+            navigationGenerationRef.current += 1;
+            rejectPendingDomCapture("The browser process restarted during capture.");
+            setReady(false);
+            webViewRef.current?.reload();
+          }}
+          onLoadProgress={(event) => setProgress(event.nativeEvent.progress)}
+          onLoadStart={() => {
+            navigationGenerationRef.current += 1;
+            rejectPendingDomCapture("Browser navigated during capture.");
+            setReady(false);
+            setProgress(0.05);
+            setError(null);
+          }}
+          onLoad={() => {
+            setProgress(0);
+            setReady(true);
+          }}
+          onLoadEnd={() => setProgress(0)}
+          onNavigationStateChange={handleNavigation}
+          onMessage={handleMessage}
+          onHttpError={(event) => {
+            const status = event.nativeEvent.statusCode;
+            if (props.isolatedSession && status === 511 && !gatewayExpiredRef.current) {
+              gatewayExpiredRef.current = true;
+              setReady(false);
+              props.onGatewayExpired?.();
+            }
+          }}
+          onError={(event) => {
+            setReady(false);
+            setProgress(0);
+            setError(event.nativeEvent.description || "The page could not be loaded.");
+          }}
+          renderLoading={() => (
+            <View className="absolute inset-0 items-center justify-center bg-card">
+              <ActivityIndicator />
+            </View>
+          )}
+          style={{ flex: 1, backgroundColor: "transparent" }}
+        />
+      </View>
+      {captureInProgress ? (
+        <View
+          accessibilityLabel="Freezing browser for markup"
+          className="absolute inset-0 items-center justify-center bg-black/10"
+        >
+          <ActivityIndicator />
+        </View>
+      ) : null}
+    </View>
+  );
+});

--- a/apps/mobile/src/features/preview/ThreadPreviewPane.tsx
+++ b/apps/mobile/src/features/preview/ThreadPreviewPane.tsx
@@ -1,0 +1,1087 @@
+import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
+import {
+  type EnvironmentId,
+  type PreviewReviewSnapshot,
+  type PreviewSessionSnapshot,
+  type ThreadId,
+} from "@t3tools/contracts";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Platform,
+  Pressable,
+  ScrollView,
+  TextInput as NativeTextInput,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
+import { SymbolView } from "../../components/AppSymbol";
+import { EmptyState } from "../../components/EmptyState";
+import { LoadingStrip } from "../../components/LoadingStrip";
+import { relativeTime } from "../../lib/time";
+import { uuidv4 } from "../../lib/uuid";
+import { scopedThreadKey } from "../../lib/scopedEntities";
+import type { DraftComposerImageAttachment } from "../../lib/composerImages";
+import { mergeComposerDraftContent } from "../../state/use-composer-drafts";
+import { useSavedRemoteConnection } from "../../state/use-remote-environment-registry";
+import { useEnvironmentQuery } from "../../state/query";
+import { previewEnvironment } from "../../state/preview";
+import { useAtomCommand } from "../../state/use-atom-command";
+import { ImageMarkupModal, type ImageMarkupSemanticElement } from "../annotations/ImageMarkupModal";
+import {
+  createPreviewSnapshotMarkupSeed,
+  normalizedRectForSemanticElement,
+  previewSnapshotIsStale,
+  type PreviewSnapshotMarkupSeed,
+} from "./previewReviewModel";
+import {
+  MobileLivePreview,
+  type MobileLivePreviewHandle,
+  type MobileLivePreviewNavigation,
+} from "./MobileLivePreview";
+import {
+  mobilePreviewGatewayRequestKey,
+  mobilePreviewGatewayTargetMatches,
+  resolveMobilePreviewGatewayUri,
+  type MobilePreviewGatewayTarget,
+} from "./mobilePreviewGatewayModel";
+import { previewCaptureErrorMessage } from "./previewPaneModel";
+import { resolveMobilePreviewLiveTarget } from "./previewLiveTarget";
+import {
+  mergePreviewSessionSnapshots,
+  previewCaptureCanCommit,
+  previewEventRequiresSessionRefresh,
+  previewLiveUrlForSelection,
+  upsertPreviewSessionSnapshot,
+} from "./previewPaneModel";
+
+function sessionTitle(session: PreviewSessionSnapshot): string {
+  if (session.navStatus._tag === "Idle") return "New tab";
+  const title = session.navStatus.title.trim();
+  if (title.length > 0) return title;
+  try {
+    return new URL(session.navStatus.url).host || "Browser";
+  } catch {
+    return "Browser";
+  }
+}
+
+function formatCaptureError(result: Parameters<typeof squashAtomCommandFailure>[0]): string {
+  return previewCaptureErrorMessage(squashAtomCommandFailure(result));
+}
+
+function formatCommandError(
+  result: Parameters<typeof squashAtomCommandFailure>[0],
+  fallback: string,
+): string {
+  const error = squashAtomCommandFailure(result);
+  const message =
+    error instanceof Error ? error.message.trim() : typeof error === "string" ? error.trim() : "";
+  return message || fallback;
+}
+
+function PreviewTabPicker(props: {
+  readonly creating: boolean;
+  readonly sessions: ReadonlyArray<PreviewSessionSnapshot>;
+  readonly selectedTabId: string | null;
+  readonly onCreate: () => void;
+  readonly onSelect: (tabId: string) => void;
+}) {
+  return (
+    <ScrollView
+      horizontal
+      className="min-w-0 flex-1"
+      contentContainerClassName="items-center gap-1.5 pr-2"
+      showsHorizontalScrollIndicator={false}
+    >
+      {props.sessions.map((session) => {
+        const selected = session.tabId === props.selectedTabId;
+        return (
+          <Pressable
+            key={session.tabId}
+            accessibilityRole="button"
+            accessibilityState={{ selected }}
+            className={`h-9 max-w-52 justify-center rounded-full border px-3 ${
+              selected ? "border-primary bg-primary/10" : "border-border bg-card"
+            }`}
+            onPress={() => props.onSelect(session.tabId)}
+          >
+            <Text
+              numberOfLines={1}
+              className={
+                selected
+                  ? "text-xs font-t3-bold text-primary"
+                  : "text-xs font-t3-medium text-foreground"
+              }
+            >
+              {sessionTitle(session)}
+            </Text>
+          </Pressable>
+        );
+      })}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="New browser tab"
+        disabled={props.creating}
+        className="size-9 items-center justify-center rounded-full bg-subtle active:opacity-70 disabled:opacity-45"
+        onPress={props.onCreate}
+      >
+        {props.creating ? (
+          <ActivityIndicator size="small" />
+        ) : (
+          <SymbolView name="plus" size={16} type="monochrome" />
+        )}
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function SnapshotImage(props: {
+  readonly snapshot: PreviewReviewSnapshot;
+  readonly capturing: boolean;
+}) {
+  return (
+    <View className="relative min-h-0 flex-1 bg-black">
+      {props.capturing ? <LoadingStrip /> : null}
+      <Image
+        accessibilityLabel={`Frozen preview of ${props.snapshot.title || props.snapshot.url}`}
+        source={{
+          uri: `data:${props.snapshot.screenshot.mimeType};base64,${props.snapshot.screenshot.data}`,
+        }}
+        resizeMode="contain"
+        className="flex-1"
+      />
+    </View>
+  );
+}
+
+export function ThreadPreviewPane(props: {
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+  readonly presentation: "inspector" | "screen";
+  readonly fullscreen?: boolean;
+  readonly onFullscreenChange?: (fullscreen: boolean) => void;
+  readonly headerInset?: number;
+  readonly onAttachmentAdded?: () => void;
+}) {
+  const insets = useSafeAreaInsets();
+  const savedConnection = useSavedRemoteConnection(props.environmentId);
+  const listQuery = useEnvironmentQuery(
+    previewEnvironment.list({
+      environmentId: props.environmentId,
+      input: { threadId: props.threadId },
+    }),
+  );
+  const eventsQuery = useEnvironmentQuery(
+    previewEnvironment.events({
+      environmentId: props.environmentId,
+      input: {},
+    }),
+  );
+  const openTab = useAtomCommand(previewEnvironment.open, {
+    label: "open browser tab",
+    reportDefect: false,
+    reportFailure: false,
+  });
+  const navigateTab = useAtomCommand(previewEnvironment.navigate, {
+    label: "navigate browser tab",
+    reportDefect: false,
+    reportFailure: false,
+  });
+  const reviewSnapshot = useAtomCommand(previewEnvironment.reviewSnapshot, {
+    label: "preview review snapshot",
+    reportDefect: false,
+    reportFailure: false,
+  });
+  const openLiveGateway = useAtomCommand(previewEnvironment.openLiveGateway, {
+    label: "open live preview gateway",
+    reportDefect: false,
+    reportFailure: false,
+  });
+  const [selectedTabId, setSelectedTabId] = useState<string | null>(null);
+  const [optimisticSessions, setOptimisticSessions] = useState<
+    ReadonlyArray<PreviewSessionSnapshot>
+  >([]);
+  const [creatingTab, setCreatingTab] = useState(false);
+  const [navigatingTab, setNavigatingTab] = useState(false);
+  const [addressDraft, setAddressDraft] = useState("");
+  const [addressFocused, setAddressFocused] = useState(false);
+  const [focusAddressTabId, setFocusAddressTabId] = useState<string | null>(null);
+  const [snapshot, setSnapshot] = useState<PreviewReviewSnapshot | null>(null);
+  const [capturing, setCapturing] = useState(false);
+  const [capturingLocalMarkup, setCapturingLocalMarkup] = useState(false);
+  const [captureError, setCaptureError] = useState<string | null>(null);
+  const [snapshotChanged, setSnapshotChanged] = useState(false);
+  const [showingDesktopSnapshot, setShowingDesktopSnapshot] = useState(false);
+  const [markupVisible, setMarkupVisible] = useState(false);
+  const [markupModalSeed, setMarkupModalSeed] = useState<PreviewSnapshotMarkupSeed | null>(null);
+  const [markupSeedGeneration, setMarkupSeedGeneration] = useState(0);
+  const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
+  const [liveReady, setLiveReady] = useState(false);
+  const [liveNavigation, setLiveNavigation] = useState<MobileLivePreviewNavigation | null>(null);
+  const [gatewayOpening, setGatewayOpening] = useState(false);
+  const [gatewayError, setGatewayError] = useState<string | null>(null);
+  const [gatewayTarget, setGatewayTarget] = useState<MobilePreviewGatewayTarget | null>(null);
+  const livePreviewRef = useRef<MobileLivePreviewHandle>(null);
+  const addressInputRef = useRef<NativeTextInput>(null);
+  const selectedTabIdRef = useRef<string | null>(selectedTabId);
+  const createTabRequestIdRef = useRef(0);
+  const navigateTabRequestIdRef = useRef(0);
+  const captureRequestIdRef = useRef(0);
+  const gatewayRequestIdRef = useRef(0);
+  const requestedGatewayRef = useRef<string | null>(null);
+  const refreshedEventRef = useRef<string | null>(null);
+  selectedTabIdRef.current = selectedTabId;
+  const serverSessions = useMemo(() => listQuery.data?.sessions ?? [], [listQuery.data?.sessions]);
+  const sessions = useMemo(
+    () => mergePreviewSessionSnapshots(serverSessions, optimisticSessions),
+    [optimisticSessions, serverSessions],
+  );
+  const selectedSession =
+    sessions.find((session) => session.tabId === selectedTabId) ?? sessions.at(-1) ?? null;
+
+  useEffect(
+    () => () => {
+      createTabRequestIdRef.current += 1;
+      navigateTabRequestIdRef.current += 1;
+      captureRequestIdRef.current += 1;
+      gatewayRequestIdRef.current += 1;
+    },
+    [],
+  );
+  useEffect(() => {
+    createTabRequestIdRef.current += 1;
+    navigateTabRequestIdRef.current += 1;
+    gatewayRequestIdRef.current += 1;
+    requestedGatewayRef.current = null;
+    setGatewayTarget(null);
+    setGatewayError(null);
+    setGatewayOpening(false);
+    setLiveNavigation(null);
+    setLiveReady(false);
+    setOptimisticSessions([]);
+    setCreatingTab(false);
+    setNavigatingTab(false);
+    setAddressDraft("");
+    setAddressFocused(false);
+    setFocusAddressTabId(null);
+  }, [props.environmentId, props.threadId]);
+
+  useEffect(() => {
+    setOptimisticSessions((current) => {
+      const pending = current.filter((optimistic) => {
+        const server = serverSessions.find((session) => session.tabId === optimistic.tabId);
+        return !server || server.updatedAt < optimistic.updatedAt;
+      });
+      return pending.length === current.length ? current : pending;
+    });
+  }, [serverSessions]);
+
+  useEffect(() => {
+    if (sessions.length === 0) {
+      if (!listQuery.isPending) {
+        captureRequestIdRef.current += 1;
+        setSelectedTabId(null);
+        setSnapshot(null);
+        setShowingDesktopSnapshot(false);
+        setCapturing(false);
+        setGatewayTarget(null);
+        setGatewayOpening(false);
+      }
+      return;
+    }
+    if (!selectedTabId || !sessions.some((session) => session.tabId === selectedTabId)) {
+      setSelectedTabId(sessions.at(-1)!.tabId);
+    }
+  }, [listQuery.isPending, selectedTabId, sessions]);
+
+  useEffect(() => {
+    if (focusAddressTabId === null || focusAddressTabId !== selectedTabId) return;
+    const requestedTabId = focusAddressTabId;
+    const frame = requestAnimationFrame(() => {
+      addressInputRef.current?.focus();
+      setFocusAddressTabId((current) => (current === requestedTabId ? null : current));
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [focusAddressTabId, selectedTabId]);
+
+  const selectBrowserTab = useCallback((tabId: string) => {
+    captureRequestIdRef.current += 1;
+    selectedTabIdRef.current = tabId;
+    addressInputRef.current?.blur();
+    setAddressFocused(false);
+    setFocusAddressTabId(null);
+    setSelectedTabId(tabId);
+    setSnapshot(null);
+    setSnapshotChanged(false);
+    setShowingDesktopSnapshot(false);
+    setCaptureError(null);
+    setAttachmentNotice(null);
+    gatewayRequestIdRef.current += 1;
+    requestedGatewayRef.current = null;
+    setGatewayTarget(null);
+    setGatewayError(null);
+    setGatewayOpening(false);
+    setLiveNavigation(null);
+    setLiveReady(false);
+  }, []);
+
+  const captureSnapshot = useCallback(
+    async (tabId: string) => {
+      const requestId = captureRequestIdRef.current + 1;
+      captureRequestIdRef.current = requestId;
+      setCapturing(true);
+      setShowingDesktopSnapshot(true);
+      setCaptureError(null);
+      setAttachmentNotice(null);
+      const result = await reviewSnapshot({
+        environmentId: props.environmentId,
+        input: {
+          version: 1,
+          threadId: props.threadId,
+          tabId,
+        },
+      });
+      const requestIsCurrent =
+        captureRequestIdRef.current === requestId && selectedTabIdRef.current === tabId;
+      if (!requestIsCurrent) return;
+      if (result._tag === "Failure") {
+        setCaptureError(formatCaptureError(result));
+        setCapturing(false);
+        return;
+      }
+      if (
+        !previewCaptureCanCommit({
+          activeRequestId: captureRequestIdRef.current,
+          requestId,
+          selectedTabId: selectedTabIdRef.current,
+          requestedTabId: tabId,
+          threadId: props.threadId,
+          snapshot: result.value,
+        })
+      ) {
+        setCaptureError("The desktop browser returned a snapshot for a different tab.");
+        setCapturing(false);
+        return;
+      }
+      setSnapshot(result.value);
+      setSnapshotChanged(false);
+      setCapturing(false);
+    },
+    [props.environmentId, props.threadId, reviewSnapshot],
+  );
+
+  const latestEvent = eventsQuery.data;
+  useEffect(() => {
+    if (
+      !latestEvent ||
+      !previewEventRequiresSessionRefresh({
+        event: latestEvent,
+        threadId: props.threadId,
+        serverEpoch: listQuery.data?.serverEpoch ?? null,
+        revision: listQuery.data?.revision ?? null,
+      })
+    ) {
+      return;
+    }
+    const eventKey = `${latestEvent.serverEpoch}:${latestEvent.revision}`;
+    if (refreshedEventRef.current === eventKey) return;
+    refreshedEventRef.current = eventKey;
+    listQuery.refresh();
+  }, [
+    latestEvent,
+    listQuery.data?.revision,
+    listQuery.data?.serverEpoch,
+    listQuery.refresh,
+    props.threadId,
+  ]);
+  useEffect(() => {
+    if (snapshot && latestEvent && previewSnapshotIsStale(snapshot, latestEvent)) {
+      setSnapshotChanged(true);
+    }
+  }, [latestEvent, snapshot]);
+
+  const livePreviewUrl = useMemo(
+    () =>
+      previewLiveUrlForSelection({
+        selectedTabId,
+        selectedSession,
+        snapshot,
+        latestEvent,
+        threadId: props.threadId,
+        serverEpoch: listQuery.data?.serverEpoch ?? null,
+        revision: listQuery.data?.revision ?? null,
+      }),
+    [
+      latestEvent,
+      listQuery.data?.revision,
+      listQuery.data?.serverEpoch,
+      props.threadId,
+      selectedSession,
+      selectedTabId,
+      snapshot,
+    ],
+  );
+  const liveTarget = useMemo(
+    () =>
+      livePreviewUrl
+        ? resolveMobilePreviewLiveTarget({
+            previewUrl: livePreviewUrl,
+            environmentHttpBaseUrl: savedConnection?.httpBaseUrl ?? null,
+            environmentRelayManaged: savedConnection?.relayManaged ?? false,
+            platform: Platform.OS === "android" ? "android" : "ios",
+          })
+        : null,
+    [livePreviewUrl, savedConnection?.httpBaseUrl, savedConnection?.relayManaged],
+  );
+  const gatewayEligible =
+    Platform.OS === "ios" &&
+    selectedTabId !== null &&
+    livePreviewUrl !== null &&
+    liveTarget?.kind === "unavailable" &&
+    liveTarget.reason === "gateway-required";
+  const requestLiveGateway = useCallback(
+    async (tabId: string, sourceUrl: string) => {
+      const httpBaseUrl = savedConnection?.httpBaseUrl;
+      if (!httpBaseUrl) {
+        setGatewayError("The environment address is unavailable.");
+        setGatewayOpening(false);
+        return;
+      }
+      const requestId = gatewayRequestIdRef.current + 1;
+      const serverEpoch = listQuery.data?.serverEpoch ?? null;
+      gatewayRequestIdRef.current = requestId;
+      setGatewayOpening(true);
+      setGatewayError(null);
+      setGatewayTarget(null);
+      const result = await openLiveGateway({
+        environmentId: props.environmentId,
+        input: {
+          version: 1,
+          threadId: props.threadId,
+          tabId,
+        },
+      });
+      if (gatewayRequestIdRef.current !== requestId || selectedTabIdRef.current !== tabId) {
+        return;
+      }
+      setGatewayOpening(false);
+      if (result._tag === "Failure") {
+        setGatewayError(
+          formatCommandError(result, "Browser could not be opened through the preview gateway."),
+        );
+        return;
+      }
+      try {
+        const uri = resolveMobilePreviewGatewayUri({
+          environmentHttpBaseUrl: httpBaseUrl,
+          relativeUrl: result.value.relativeUrl,
+        });
+        setGatewayTarget({
+          environmentHttpBaseUrl: httpBaseUrl,
+          expiresAt: result.value.expiresAt,
+          serverEpoch,
+          sourceUrl,
+          tabId,
+          uri,
+        });
+      } catch (cause) {
+        setGatewayError(
+          cause instanceof Error
+            ? cause.message
+            : "The browser gateway returned an invalid bootstrap address.",
+        );
+      }
+    },
+    [
+      openLiveGateway,
+      listQuery.data?.serverEpoch,
+      props.environmentId,
+      props.threadId,
+      savedConnection?.httpBaseUrl,
+    ],
+  );
+  const issueLiveGatewayRequest = useCallback(
+    (tabId: string, sourceUrl: string) => {
+      requestedGatewayRef.current = mobilePreviewGatewayRequestKey({
+        serverEpoch: listQuery.data?.serverEpoch ?? null,
+        sourceUrl,
+        tabId,
+      });
+      void requestLiveGateway(tabId, sourceUrl);
+    },
+    [listQuery.data?.serverEpoch, requestLiveGateway],
+  );
+  useEffect(() => {
+    if (!gatewayEligible || !selectedTabId || !livePreviewUrl) {
+      requestedGatewayRef.current = null;
+      if (liveTarget?.kind === "available") {
+        gatewayRequestIdRef.current += 1;
+        setGatewayOpening(false);
+        setGatewayError(null);
+        setGatewayTarget(null);
+      }
+      return;
+    }
+    if (
+      mobilePreviewGatewayTargetMatches({
+        target: gatewayTarget,
+        tabId: selectedTabId,
+        environmentHttpBaseUrl: savedConnection?.httpBaseUrl ?? "",
+        serverEpoch: listQuery.data?.serverEpoch ?? null,
+        sourceUrl: livePreviewUrl,
+      })
+    ) {
+      return;
+    }
+    const requestKey = mobilePreviewGatewayRequestKey({
+      serverEpoch: listQuery.data?.serverEpoch ?? null,
+      sourceUrl: livePreviewUrl,
+      tabId: selectedTabId,
+    });
+    if (requestedGatewayRef.current === requestKey) return;
+    issueLiveGatewayRequest(selectedTabId, livePreviewUrl);
+  }, [
+    gatewayEligible,
+    gatewayTarget,
+    listQuery.data?.serverEpoch,
+    livePreviewUrl,
+    liveTarget,
+    issueLiveGatewayRequest,
+    savedConnection?.httpBaseUrl,
+    selectedTabId,
+  ]);
+  const effectiveLiveTarget = useMemo(() => {
+    if (liveTarget?.kind === "available") {
+      return {
+        isolatedSession: false,
+        uri: liveTarget.uri,
+      };
+    }
+    if (
+      gatewayEligible &&
+      gatewayTarget &&
+      selectedTabId &&
+      livePreviewUrl &&
+      mobilePreviewGatewayTargetMatches({
+        target: gatewayTarget,
+        tabId: selectedTabId,
+        environmentHttpBaseUrl: savedConnection?.httpBaseUrl ?? "",
+        serverEpoch: listQuery.data?.serverEpoch ?? null,
+        sourceUrl: livePreviewUrl,
+      })
+    ) {
+      return {
+        isolatedSession: true,
+        uri: gatewayTarget.uri,
+      };
+    }
+    return null;
+  }, [
+    gatewayEligible,
+    gatewayTarget,
+    listQuery.data?.serverEpoch,
+    livePreviewUrl,
+    liveTarget,
+    savedConnection?.httpBaseUrl,
+    selectedTabId,
+  ]);
+  const reopenLiveGateway = useCallback(() => {
+    if (!gatewayEligible || !selectedTabId || !livePreviewUrl) return;
+    gatewayRequestIdRef.current += 1;
+    requestedGatewayRef.current = null;
+    setGatewayTarget(null);
+    setGatewayError(null);
+    setGatewayOpening(true);
+    setLiveReady(false);
+    issueLiveGatewayRequest(selectedTabId, livePreviewUrl);
+  }, [gatewayEligible, issueLiveGatewayRequest, livePreviewUrl, selectedTabId]);
+  const desktopMarkupSeed = useMemo(() => {
+    if (!snapshot) return { value: null, error: null };
+    try {
+      return {
+        value: createPreviewSnapshotMarkupSeed({
+          snapshot,
+          attachmentId: uuidv4(),
+          annotationId: uuidv4(),
+        }),
+        error: null,
+      };
+    } catch (cause) {
+      return {
+        value: null,
+        error: cause instanceof Error ? cause.message : "The snapshot cannot be attached.",
+      };
+    }
+  }, [markupSeedGeneration, snapshot]);
+  const markupSemanticElements = useMemo<ReadonlyArray<ImageMarkupSemanticElement>>(() => {
+    const seed = markupModalSeed;
+    const annotation = seed?.attachment.markup?.annotation;
+    if (!seed || !annotation) return [];
+    return seed.semanticElements.flatMap((target) => {
+      const rect = normalizedRectForSemanticElement(target, annotation);
+      return rect ? [{ target, rect }] : [];
+    });
+  }, [markupModalSeed]);
+
+  const handleAnnotate = useCallback(async () => {
+    setCaptureError(null);
+    setAttachmentNotice(null);
+    if (showingDesktopSnapshot) {
+      if (!desktopMarkupSeed.value) {
+        setCaptureError(desktopMarkupSeed.error ?? "The snapshot is not ready for markup.");
+        return;
+      }
+      setMarkupModalSeed(desktopMarkupSeed.value);
+      setMarkupVisible(true);
+      return;
+    }
+    const livePreview = livePreviewRef.current;
+    if (!livePreview) {
+      setCaptureError("Wait for Browser to finish loading.");
+      return;
+    }
+    setCapturingLocalMarkup(true);
+    try {
+      const seed = await livePreview.captureForMarkup();
+      setMarkupModalSeed(seed);
+      setMarkupVisible(true);
+    } catch (cause) {
+      setCaptureError(cause instanceof Error ? cause.message : "Browser could not be captured.");
+    } finally {
+      setCapturingLocalMarkup(false);
+    }
+  }, [desktopMarkupSeed.error, desktopMarkupSeed.value, showingDesktopSnapshot]);
+
+  const handleMarkupDone = useCallback(
+    async (attachment: DraftComposerImageAttachment) => {
+      setMarkupVisible(false);
+      setMarkupModalSeed(null);
+      try {
+        const result = await mergeComposerDraftContent(
+          scopedThreadKey(props.environmentId, props.threadId),
+          { text: "", attachments: [attachment] },
+        );
+        if (result.skippedAttachmentCount > 0) {
+          setCaptureError("This message already has the maximum of 8 image attachments.");
+          return;
+        }
+        setMarkupSeedGeneration((current) => current + 1);
+        setCaptureError(null);
+        setAttachmentNotice("Annotated snapshot added to your message.");
+        props.onAttachmentAdded?.();
+      } catch (cause) {
+        setCaptureError(
+          cause instanceof Error
+            ? cause.message
+            : "The annotated snapshot could not be saved to your message.",
+        );
+      }
+    },
+    [props.environmentId, props.onAttachmentAdded, props.threadId],
+  );
+
+  const topInset =
+    props.presentation === "inspector"
+      ? Math.max(insets.top, props.headerInset ?? 0)
+      : (props.headerInset ?? 0);
+  const showDesktopSnapshot = useCallback(() => {
+    if (!selectedTabId) return;
+    setCaptureError(null);
+    setAttachmentNotice(null);
+    if (snapshot?.tabId === selectedTabId) {
+      setShowingDesktopSnapshot(true);
+      return;
+    }
+    void captureSnapshot(selectedTabId);
+  }, [captureSnapshot, selectedTabId, snapshot?.tabId]);
+  const handleCreateTab = useCallback(async () => {
+    if (creatingTab) return;
+    const requestId = createTabRequestIdRef.current + 1;
+    createTabRequestIdRef.current = requestId;
+    setCreatingTab(true);
+    setCaptureError(null);
+    setAttachmentNotice(null);
+    const result = await openTab({
+      environmentId: props.environmentId,
+      input: { threadId: props.threadId },
+    });
+    if (createTabRequestIdRef.current !== requestId) return;
+    setCreatingTab(false);
+    if (result._tag === "Failure") {
+      setCaptureError(formatCommandError(result, "A new browser tab could not be created."));
+      return;
+    }
+    setOptimisticSessions((current) => upsertPreviewSessionSnapshot(current, result.value));
+    selectBrowserTab(result.value.tabId);
+    setAddressDraft("");
+    setFocusAddressTabId(result.value.tabId);
+    listQuery.refresh();
+  }, [
+    creatingTab,
+    listQuery.refresh,
+    openTab,
+    props.environmentId,
+    props.threadId,
+    selectBrowserTab,
+  ]);
+  const handleNavigateTab = useCallback(async () => {
+    const tabId = selectedTabId;
+    const url = addressDraft.trim();
+    if (!tabId || showingDesktopSnapshot || navigatingTab) return;
+    if (!url) {
+      setCaptureError("Enter an address for this browser tab.");
+      addressInputRef.current?.focus();
+      return;
+    }
+    const requestId = navigateTabRequestIdRef.current + 1;
+    navigateTabRequestIdRef.current = requestId;
+    setNavigatingTab(true);
+    setCaptureError(null);
+    setAttachmentNotice(null);
+    const result = await navigateTab({
+      environmentId: props.environmentId,
+      input: {
+        threadId: props.threadId,
+        tabId,
+        url,
+      },
+    });
+    if (navigateTabRequestIdRef.current !== requestId) return;
+    setNavigatingTab(false);
+    if (result._tag === "Failure") {
+      if (selectedTabIdRef.current === tabId) {
+        setCaptureError(formatCommandError(result, "This browser address could not be opened."));
+      }
+      return;
+    }
+    setOptimisticSessions((current) => upsertPreviewSessionSnapshot(current, result.value));
+    if (selectedTabIdRef.current === tabId) {
+      setAddressDraft(result.value.navStatus._tag === "Idle" ? url : result.value.navStatus.url);
+      setAddressFocused(false);
+      addressInputRef.current?.blur();
+    }
+    listQuery.refresh();
+  }, [
+    addressDraft,
+    listQuery.refresh,
+    navigateTab,
+    navigatingTab,
+    props.environmentId,
+    props.threadId,
+    selectedTabId,
+    showingDesktopSnapshot,
+  ]);
+  const browserBusy =
+    capturing || capturingLocalMarkup || gatewayOpening || creatingTab || navigatingTab;
+  const browserUrl = showingDesktopSnapshot
+    ? snapshot?.url
+    : liveNavigation?.url || livePreviewUrl || undefined;
+  useEffect(() => {
+    if (!addressFocused && !navigatingTab) {
+      setAddressDraft(browserUrl ?? "");
+    }
+  }, [addressFocused, browserUrl, navigatingTab, selectedTabId]);
+  const annotateDisabled =
+    browserBusy ||
+    (showingDesktopSnapshot
+      ? desktopMarkupSeed.value === null
+      : !effectiveLiveTarget || !liveReady);
+  const content = (() => {
+    if (sessions.length === 0 && !listQuery.isPending) {
+      return (
+        <View className="flex-1 items-center justify-center bg-sheet px-5">
+          <EmptyState
+            variant="plain"
+            title="No browser session"
+            detail="Create a tab here, or open one from another connected T3 client."
+            actionLabel="New tab"
+            onAction={() => void handleCreateTab()}
+          />
+        </View>
+      );
+    }
+    if (showingDesktopSnapshot) {
+      if (!snapshot) {
+        if (captureError && !capturing) {
+          return (
+            <View className="flex-1 items-center justify-center bg-sheet px-5">
+              <EmptyState
+                variant="plain"
+                title="Could not capture desktop snapshot"
+                detail={captureError}
+                actionLabel="Retry"
+                onAction={showDesktopSnapshot}
+              />
+            </View>
+          );
+        }
+        return (
+          <View className="flex-1 items-center justify-center gap-3 bg-sheet px-6">
+            <ActivityIndicator />
+            <Text className="text-center text-sm text-foreground-muted">
+              Capturing the desktop browser…
+            </Text>
+          </View>
+        );
+      }
+      return <SnapshotImage snapshot={snapshot} capturing={capturing} />;
+    }
+    if (selectedSession?.navStatus._tag === "Idle") {
+      return (
+        <View className="flex-1 items-center justify-center bg-sheet px-5">
+          <EmptyState
+            variant="plain"
+            title="New browser tab"
+            detail="Enter an address above to open a website."
+            actionLabel="Enter address"
+            onAction={() => addressInputRef.current?.focus()}
+          />
+        </View>
+      );
+    }
+    if (effectiveLiveTarget && livePreviewUrl) {
+      return (
+        <MobileLivePreview
+          ref={livePreviewRef}
+          key={`${selectedTabId ?? "browser"}:${effectiveLiveTarget.uri}`}
+          annotationSourceUrl={livePreviewUrl}
+          isolatedSession={effectiveLiveTarget.isolatedSession}
+          uri={effectiveLiveTarget.uri}
+          onGatewayExpired={reopenLiveGateway}
+          onNavigationChange={setLiveNavigation}
+          onReadyChange={setLiveReady}
+        />
+      );
+    }
+    if (gatewayEligible) {
+      if (gatewayError && !gatewayOpening) {
+        return (
+          <View className="flex-1 items-center justify-center bg-sheet px-5">
+            <EmptyState
+              variant="plain"
+              title="Could not open browser"
+              detail={gatewayError}
+              actionLabel="Retry"
+              onAction={() => {
+                if (!selectedTabId) return;
+                if (livePreviewUrl) issueLiveGatewayRequest(selectedTabId, livePreviewUrl);
+              }}
+            />
+          </View>
+        );
+      }
+      return (
+        <View className="flex-1 items-center justify-center gap-3 bg-sheet px-6">
+          <ActivityIndicator />
+          <Text className="text-center text-sm text-foreground-muted">
+            Opening Browser through the desktop…
+          </Text>
+        </View>
+      );
+    }
+    if (liveTarget?.kind === "unavailable") {
+      return (
+        <View className="flex-1 items-center justify-center bg-sheet px-5">
+          <EmptyState
+            variant="plain"
+            title="Browser unavailable"
+            detail={liveTarget.detail}
+            actionLabel="Use desktop snapshot"
+            onAction={showDesktopSnapshot}
+          />
+        </View>
+      );
+    }
+    return (
+      <View className="flex-1 items-center justify-center gap-3 bg-sheet px-6">
+        <ActivityIndicator />
+        <Text className="text-center text-sm text-foreground-muted">Preparing Browser…</Text>
+      </View>
+    );
+  })();
+
+  return (
+    <View className="flex-1 border-l border-border bg-sheet" style={{ paddingTop: topInset }}>
+      <View className="border-b border-border bg-sheet px-3 pb-2 pt-2">
+        <View className="flex-row items-center gap-2">
+          <PreviewTabPicker
+            creating={creatingTab}
+            sessions={sessions}
+            selectedTabId={selectedTabId}
+            onCreate={() => void handleCreateTab()}
+            onSelect={selectBrowserTab}
+          />
+          {props.onFullscreenChange ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={
+                props.fullscreen ? "Exit full screen browser" : "Open browser full screen"
+              }
+              className="size-10 items-center justify-center rounded-full bg-subtle active:opacity-70"
+              onPress={() => props.onFullscreenChange?.(!props.fullscreen)}
+            >
+              <SymbolView
+                name={
+                  props.fullscreen
+                    ? "arrow.down.right.and.arrow.up.left"
+                    : "arrow.up.left.and.arrow.down.right"
+                }
+                size={16}
+                type="monochrome"
+              />
+            </Pressable>
+          ) : null}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={
+              showingDesktopSnapshot ? "Annotate desktop snapshot" : "Annotate browser"
+            }
+            disabled={annotateDisabled}
+            className="size-10 items-center justify-center rounded-full bg-primary active:opacity-70 disabled:opacity-45"
+            onPress={() => void handleAnnotate()}
+          >
+            <SymbolView name="pencil" size={17} tintColor="#ffffff" type="monochrome" />
+          </Pressable>
+        </View>
+        <View className="mt-2 flex-row items-center gap-1.5">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
+            disabled={showingDesktopSnapshot || !liveNavigation?.canGoBack}
+            className="size-9 items-center justify-center rounded-full bg-subtle active:opacity-70 disabled:opacity-35"
+            onPress={() => livePreviewRef.current?.goBack()}
+          >
+            <SymbolView name="chevron.left" size={15} type="monochrome" />
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Go forward"
+            disabled={showingDesktopSnapshot || !liveNavigation?.canGoForward}
+            className="size-9 items-center justify-center rounded-full bg-subtle active:opacity-70 disabled:opacity-35"
+            onPress={() => livePreviewRef.current?.goForward()}
+          >
+            <SymbolView name="chevron.right" size={15} type="monochrome" />
+          </Pressable>
+          <View className="h-9 min-w-0 flex-1 flex-row items-center gap-2 rounded-xl bg-subtle px-3">
+            <SymbolView name="globe" size={13} type="monochrome" />
+            <TextInput
+              ref={addressInputRef}
+              accessibilityLabel="Browser address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              blurOnSubmit
+              className="h-9 min-h-0 min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 py-0 text-xs"
+              editable={!showingDesktopSnapshot && selectedTabId !== null && !navigatingTab}
+              keyboardType="url"
+              placeholder={selectedTabId ? "Enter address" : "No address"}
+              returnKeyType="go"
+              selectTextOnFocus
+              value={addressDraft}
+              onBlur={() => {
+                setAddressFocused(false);
+                if (addressDraft.trim().length === 0 && browserUrl) {
+                  setAddressDraft(browserUrl);
+                }
+              }}
+              onChangeText={setAddressDraft}
+              onFocus={() => setAddressFocused(true)}
+              onSubmitEditing={() => void handleNavigateTab()}
+            />
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={
+              showingDesktopSnapshot ? "Refresh desktop snapshot" : "Reload browser"
+            }
+            disabled={!selectedTabId || browserBusy}
+            className="size-9 items-center justify-center rounded-full bg-subtle active:opacity-70 disabled:opacity-45"
+            onPress={() => {
+              listQuery.refresh();
+              if (showingDesktopSnapshot) {
+                if (selectedTabId) void captureSnapshot(selectedTabId);
+                return;
+              }
+              if (effectiveLiveTarget?.isolatedSession) {
+                reopenLiveGateway();
+                return;
+              }
+              if (livePreviewRef.current) {
+                livePreviewRef.current.reload();
+              } else if (gatewayEligible && selectedTabId && livePreviewUrl) {
+                issueLiveGatewayRequest(selectedTabId, livePreviewUrl);
+              }
+            }}
+          >
+            {browserBusy ? (
+              <ActivityIndicator size="small" />
+            ) : (
+              <SymbolView name="arrow.clockwise" size={15} type="monochrome" />
+            )}
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={
+              showingDesktopSnapshot ? "Return to browser" : "Use desktop snapshot"
+            }
+            disabled={!selectedTabId || browserBusy}
+            className="size-9 items-center justify-center rounded-full bg-subtle active:opacity-70 disabled:opacity-45"
+            onPress={() => {
+              if (showingDesktopSnapshot) {
+                setShowingDesktopSnapshot(false);
+                setCaptureError(null);
+                return;
+              }
+              showDesktopSnapshot();
+            }}
+          >
+            <SymbolView
+              name={showingDesktopSnapshot ? "globe" : "photo"}
+              size={15}
+              type="monochrome"
+            />
+          </Pressable>
+        </View>
+        {showingDesktopSnapshot && snapshot ? (
+          <Text className="mt-2 text-2xs text-foreground-muted">
+            Desktop frame captured {relativeTime(snapshot.capturedAt)} ago ·{" "}
+            {snapshot.elements.length} selectable element
+            {snapshot.elements.length === 1 ? "" : "s"}
+          </Text>
+        ) : null}
+        {showingDesktopSnapshot && snapshotChanged ? (
+          <Text className="mt-1 text-2xs font-t3-bold text-amber-700 dark:text-amber-300">
+            The desktop browser changed. Refresh this frame before marking the latest page.
+          </Text>
+        ) : null}
+        {!showingDesktopSnapshot && liveTarget?.kind === "unavailable" && !gatewayEligible ? (
+          <Text className="mt-1 text-2xs leading-snug text-foreground-muted">
+            {liveTarget.detail}
+          </Text>
+        ) : null}
+        {(showingDesktopSnapshot ? desktopMarkupSeed.error : null) || captureError ? (
+          <Text className="mt-1 text-2xs leading-snug text-danger-foreground">
+            {(showingDesktopSnapshot ? desktopMarkupSeed.error : null) ?? captureError}
+          </Text>
+        ) : null}
+        {attachmentNotice ? (
+          <Text className="mt-1 text-2xs font-t3-bold text-primary">{attachmentNotice}</Text>
+        ) : null}
+      </View>
+      {content}
+      <ImageMarkupModal
+        attachment={markupModalSeed?.attachment ?? null}
+        semanticElements={markupSemanticElements}
+        visible={markupVisible && markupModalSeed !== null}
+        onCancel={() => {
+          setMarkupVisible(false);
+          setMarkupModalSeed(null);
+        }}
+        onDone={(attachment) => void handleMarkupDone(attachment)}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/features/preview/ThreadPreviewPane.tsx
+++ b/apps/mobile/src/features/preview/ThreadPreviewPane.tsx
@@ -255,8 +255,15 @@ export function ThreadPreviewPane(props: {
   useEffect(() => {
     createTabRequestIdRef.current += 1;
     navigateTabRequestIdRef.current += 1;
+    captureRequestIdRef.current += 1;
     gatewayRequestIdRef.current += 1;
     requestedGatewayRef.current = null;
+    setSnapshot(null);
+    setShowingDesktopSnapshot(false);
+    setMarkupVisible(false);
+    setMarkupModalSeed(null);
+    setCapturing(false);
+    setCapturingLocalMarkup(false);
     setGatewayTarget(null);
     setGatewayError(null);
     setGatewayOpening(false);
@@ -644,22 +651,27 @@ export function ThreadPreviewPane(props: {
       setCaptureError("Wait for Browser to finish loading.");
       return;
     }
+    const requestId = captureRequestIdRef.current + 1;
+    const tabId = selectedTabIdRef.current;
+    captureRequestIdRef.current = requestId;
     setCapturingLocalMarkup(true);
     try {
       const seed = await livePreview.captureForMarkup();
+      if (captureRequestIdRef.current !== requestId || selectedTabIdRef.current !== tabId) return;
       setMarkupModalSeed(seed);
       setMarkupVisible(true);
     } catch (cause) {
+      if (captureRequestIdRef.current !== requestId || selectedTabIdRef.current !== tabId) return;
       setCaptureError(cause instanceof Error ? cause.message : "Browser could not be captured.");
     } finally {
-      setCapturingLocalMarkup(false);
+      if (captureRequestIdRef.current === requestId && selectedTabIdRef.current === tabId) {
+        setCapturingLocalMarkup(false);
+      }
     }
   }, [desktopMarkupSeed.error, desktopMarkupSeed.value, showingDesktopSnapshot]);
 
   const handleMarkupDone = useCallback(
     async (attachment: DraftComposerImageAttachment) => {
-      setMarkupVisible(false);
-      setMarkupModalSeed(null);
       try {
         const result = await mergeComposerDraftContent(
           scopedThreadKey(props.environmentId, props.threadId),
@@ -669,6 +681,8 @@ export function ThreadPreviewPane(props: {
           setCaptureError("This message already has the maximum of 8 image attachments.");
           return;
         }
+        setMarkupVisible(false);
+        setMarkupModalSeed(null);
         setMarkupSeedGeneration((current) => current + 1);
         setCaptureError(null);
         setAttachmentNotice("Annotated snapshot added to your message.");

--- a/apps/mobile/src/features/preview/ThreadPreviewRouteScreen.tsx
+++ b/apps/mobile/src/features/preview/ThreadPreviewRouteScreen.tsx
@@ -1,0 +1,114 @@
+import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
+import { useCallback, useEffect, useRef } from "react";
+import { Platform, View } from "react-native";
+
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+
+import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
+import { EmptyState } from "../../components/EmptyState";
+import { NativeStackScreenOptions } from "../../native/StackHeader";
+import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
+import { ThreadRouteScreen } from "../threads/ThreadRouteScreen";
+import { ThreadPreviewPane } from "./ThreadPreviewPane";
+
+type ThreadPreviewRouteScreenProps = StaticScreenProps<{
+  readonly environmentId: string;
+  readonly threadId: string;
+}>;
+
+function firstRouteParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+export function ThreadPreviewRouteScreen(props: ThreadPreviewRouteScreenProps) {
+  const navigation = useNavigation();
+  const { previewPane, previewPaneFullscreen, setPreviewPaneFullscreen, showAuxiliaryPane } =
+    useAdaptiveWorkspaceLayout();
+  const revealedInspectorRef = useRef(false);
+  const environmentIdRaw = firstRouteParam(props.route.params.environmentId);
+  const threadIdRaw = firstRouteParam(props.route.params.threadId);
+  const environmentId = environmentIdRaw ? EnvironmentId.make(environmentIdRaw) : null;
+  const threadId = threadIdRaw ? ThreadId.make(threadIdRaw) : null;
+
+  useEffect(() => {
+    if (previewPane.supported && !revealedInspectorRef.current) {
+      revealedInspectorRef.current = true;
+      showAuxiliaryPane("preview");
+    }
+  }, [previewPane.supported, showAuxiliaryPane]);
+
+  const handleReturnToThread = useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+    if (environmentId && threadId) {
+      navigation.dispatch(
+        StackActions.replace("Thread", {
+          environmentId: String(environmentId),
+          threadId: String(threadId),
+        }),
+      );
+    }
+  }, [environmentId, navigation, threadId]);
+
+  const renderInspector = useCallback(
+    (headerInset: number) =>
+      environmentId && threadId ? (
+        <ThreadPreviewPane
+          environmentId={environmentId}
+          threadId={threadId}
+          headerInset={headerInset}
+          presentation="inspector"
+          fullscreen={previewPaneFullscreen}
+          onFullscreenChange={setPreviewPaneFullscreen}
+        />
+      ) : null,
+    [environmentId, previewPaneFullscreen, setPreviewPaneFullscreen, threadId],
+  );
+
+  if (!environmentId || !threadId) {
+    return (
+      <View className="flex-1 items-center justify-center bg-sheet px-6">
+        <EmptyState
+          variant="plain"
+          title="Browser unavailable"
+          detail="This thread browser link is invalid."
+        />
+      </View>
+    );
+  }
+
+  if (previewPane.supported) {
+    return (
+      <ThreadRouteScreen
+        auxiliaryRoute="browser"
+        onReturnToThread={handleReturnToThread}
+        renderInspector={renderInspector}
+        route={props.route}
+      />
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-sheet">
+      <NativeStackScreenOptions
+        options={{
+          headerShown: Platform.OS !== "android",
+          title: "Browser",
+          headerTitle: "Browser",
+        }}
+      />
+      {Platform.OS === "android" ? (
+        <AndroidScreenHeader title="Browser" onBack={handleReturnToThread} />
+      ) : null}
+      <ThreadPreviewPane
+        environmentId={environmentId}
+        threadId={threadId}
+        presentation="screen"
+        onAttachmentAdded={handleReturnToThread}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/features/preview/mobilePreviewCapture.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewCapture.ts
@@ -1,0 +1,78 @@
+import { PROVIDER_SEND_TURN_MAX_IMAGE_BYTES } from "@t3tools/contracts";
+import { File } from "expo-file-system";
+import { Image, PixelRatio, Platform, type View } from "react-native";
+import { captureRef, releaseCapture } from "react-native-view-shot";
+import type { RefObject } from "react";
+
+import { estimateBase64ByteSize } from "../../lib/base64";
+import {
+  MOBILE_PREVIEW_CAPTURE_MAX_ATTEMPTS,
+  mobilePreviewCaptureLogicalSize,
+  mobilePreviewScreenshotScale,
+  type MobilePreviewCaptureLayout,
+} from "./mobilePreviewCaptureModel";
+
+export interface MobilePreviewCapturedPng {
+  readonly mimeType: "image/png";
+  readonly data: string;
+  readonly width: number;
+  readonly height: number;
+  readonly scale: number;
+}
+
+export async function captureMobilePreviewPng(input: {
+  readonly viewRef: RefObject<View | null>;
+  readonly layout: MobilePreviewCaptureLayout;
+  readonly viewport: { readonly width: number; readonly height: number };
+}): Promise<MobilePreviewCapturedPng> {
+  if (!input.viewRef.current) {
+    throw new Error("Browser is not ready to capture.");
+  }
+  for (let attempt = 0; attempt < MOBILE_PREVIEW_CAPTURE_MAX_ATTEMPTS; attempt += 1) {
+    const targetSize = mobilePreviewCaptureLogicalSize({
+      layout: input.layout,
+      pixelRatio: PixelRatio.get(),
+      attempt,
+      platform: Platform.OS === "android" ? "android" : "ios",
+    });
+    const uri = await captureRef(input.viewRef, {
+      format: "png",
+      result: "tmpfile",
+      ...targetSize,
+    });
+    try {
+      const file = new File(uri);
+      const reportedSize = file.size;
+      if (
+        reportedSize !== null &&
+        (reportedSize <= 0 || reportedSize > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES)
+      ) {
+        continue;
+      }
+      const [{ width, height }, data] = await Promise.all([Image.getSize(uri), file.base64()]);
+      const sizeBytes = reportedSize ?? estimateBase64ByteSize(data);
+      if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+        continue;
+      }
+      const scale = mobilePreviewScreenshotScale({
+        imageWidth: width,
+        imageHeight: height,
+        viewportWidth: input.viewport.width,
+        viewportHeight: input.viewport.height,
+      });
+      if (scale === null) {
+        throw new Error("Browser changed size while it was being captured.");
+      }
+      return {
+        mimeType: "image/png",
+        data,
+        width,
+        height,
+        scale,
+      };
+    } finally {
+      releaseCapture(uri);
+    }
+  }
+  throw new Error("The browser image exceeds the 10 MB attachment limit.");
+}

--- a/apps/mobile/src/features/preview/mobilePreviewCaptureModel.test.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewCaptureModel.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  MOBILE_PREVIEW_CAPTURE_MAX_PIXELS,
+  MOBILE_PREVIEW_CAPTURE_MAX_WIDTH,
+  mobilePreviewCaptureLogicalSize,
+  mobilePreviewScreenshotScale,
+} from "./mobilePreviewCaptureModel";
+
+describe("mobile preview capture model", () => {
+  it("uses native size when the viewport is already within review limits", () => {
+    expect(
+      mobilePreviewCaptureLogicalSize({
+        layout: { width: 600, height: 800 },
+        pixelRatio: 2,
+        attempt: 0,
+        platform: "ios",
+      }),
+    ).toBeNull();
+  });
+
+  it("caps encoded width and pixel area before native capture", () => {
+    const layout = { width: 1_366, height: 1_024 };
+    const pixelRatio = 2;
+    const size = mobilePreviewCaptureLogicalSize({
+      layout,
+      pixelRatio,
+      attempt: 0,
+      platform: "ios",
+    });
+    expect(size).not.toBeNull();
+    const encodedWidth = size!.width * pixelRatio;
+    const encodedHeight = size!.height * pixelRatio;
+    expect(encodedWidth).toBeLessThanOrEqual(MOBILE_PREVIEW_CAPTURE_MAX_WIDTH);
+    expect(encodedWidth * encodedHeight).toBeLessThanOrEqual(MOBILE_PREVIEW_CAPTURE_MAX_PIXELS);
+  });
+
+  it("reduces repeated captures when PNG compression exceeds the byte budget", () => {
+    const first = mobilePreviewCaptureLogicalSize({
+      layout: { width: 1_000, height: 1_000 },
+      pixelRatio: 2,
+      attempt: 1,
+      platform: "ios",
+    });
+    const second = mobilePreviewCaptureLogicalSize({
+      layout: { width: 1_000, height: 1_000 },
+      pixelRatio: 2,
+      attempt: 2,
+      platform: "ios",
+    });
+    expect(second!.width).toBeLessThan(first!.width);
+    expect(second!.height).toBeLessThan(first!.height);
+  });
+
+  it("derives pixels per CSS viewport unit and rejects mismatched crops", () => {
+    expect(
+      mobilePreviewScreenshotScale({
+        imageWidth: 1_280,
+        imageHeight: 1_024,
+        viewportWidth: 1_000,
+        viewportHeight: 800,
+      }),
+    ).toBe(1.28);
+    expect(
+      mobilePreviewScreenshotScale({
+        imageWidth: 1_280,
+        imageHeight: 720,
+        viewportWidth: 1_000,
+        viewportHeight: 800,
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects invalid layouts and dimensions", () => {
+    expect(
+      mobilePreviewCaptureLogicalSize({
+        layout: { width: 0, height: 800 },
+        pixelRatio: 2,
+        attempt: 0,
+        platform: "ios",
+      }),
+    ).toBeNull();
+    expect(
+      mobilePreviewScreenshotScale({
+        imageWidth: 0,
+        imageHeight: 100,
+        viewportWidth: 100,
+        viewportHeight: 100,
+      }),
+    ).toBeNull();
+  });
+
+  it("passes physical bitmap dimensions to Android and point dimensions to iOS", () => {
+    const ios = mobilePreviewCaptureLogicalSize({
+      layout: { width: 1_366, height: 1_024 },
+      pixelRatio: 2,
+      attempt: 0,
+      platform: "ios",
+    });
+    const android = mobilePreviewCaptureLogicalSize({
+      layout: { width: 1_366, height: 1_024 },
+      pixelRatio: 2,
+      attempt: 0,
+      platform: "android",
+    });
+    expect(android?.width).toBe((ios?.width ?? 0) * 2);
+    expect(Math.abs((android?.height ?? 0) - (ios?.height ?? 0) * 2)).toBeLessThanOrEqual(1);
+    expect(android!.width).toBeLessThanOrEqual(MOBILE_PREVIEW_CAPTURE_MAX_WIDTH);
+  });
+});

--- a/apps/mobile/src/features/preview/mobilePreviewCaptureModel.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewCaptureModel.ts
@@ -1,0 +1,76 @@
+export const MOBILE_PREVIEW_CAPTURE_MAX_WIDTH = 1_280;
+export const MOBILE_PREVIEW_CAPTURE_MAX_PIXELS = 2_000_000;
+export const MOBILE_PREVIEW_CAPTURE_RETRY_SCALE = 0.72;
+export const MOBILE_PREVIEW_CAPTURE_MAX_ATTEMPTS = 4;
+
+export interface MobilePreviewCaptureLayout {
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface MobilePreviewCaptureLogicalSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+export function mobilePreviewCaptureLogicalSize(input: {
+  readonly layout: MobilePreviewCaptureLayout;
+  readonly pixelRatio: number;
+  readonly attempt: number;
+  readonly platform: "android" | "ios";
+}): MobilePreviewCaptureLogicalSize | null {
+  const { height, width } = input.layout;
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    !Number.isFinite(input.pixelRatio) ||
+    width <= 0 ||
+    height <= 0 ||
+    input.pixelRatio <= 0 ||
+    !Number.isInteger(input.attempt) ||
+    input.attempt < 0
+  ) {
+    return null;
+  }
+  const physicalWidth = width * input.pixelRatio;
+  const physicalHeight = height * input.pixelRatio;
+  const capScale = Math.min(
+    1,
+    MOBILE_PREVIEW_CAPTURE_MAX_WIDTH / physicalWidth,
+    Math.sqrt(MOBILE_PREVIEW_CAPTURE_MAX_PIXELS / (physicalWidth * physicalHeight)),
+  );
+  const retryScale = MOBILE_PREVIEW_CAPTURE_RETRY_SCALE ** input.attempt;
+  const scale = Math.min(1, capScale * retryScale);
+  if (scale >= 0.999 && input.attempt === 0) return null;
+  // view-shot interprets iOS options as points and renders at screen scale.
+  // Android interprets the same options as final bitmap pixels.
+  const optionUnitScale = input.platform === "android" ? input.pixelRatio : 1;
+  return {
+    width: Math.max(1, Math.floor(width * scale * optionUnitScale)),
+    height: Math.max(1, Math.floor(height * scale * optionUnitScale)),
+  };
+}
+
+export function mobilePreviewScreenshotScale(input: {
+  readonly imageWidth: number;
+  readonly imageHeight: number;
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+}): number | null {
+  if (
+    !Number.isFinite(input.imageWidth) ||
+    !Number.isFinite(input.imageHeight) ||
+    !Number.isFinite(input.viewportWidth) ||
+    !Number.isFinite(input.viewportHeight) ||
+    input.imageWidth <= 0 ||
+    input.imageHeight <= 0 ||
+    input.viewportWidth <= 0 ||
+    input.viewportHeight <= 0
+  ) {
+    return null;
+  }
+  const imageAspect = input.imageWidth / input.imageHeight;
+  const viewportAspect = input.viewportWidth / input.viewportHeight;
+  if (Math.abs(imageAspect / viewportAspect - 1) > 0.05) return null;
+  return input.imageWidth / input.viewportWidth;
+}

--- a/apps/mobile/src/features/preview/mobilePreviewDomBridge.test.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewDomBridge.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  decodeMobilePreviewDomErrorMessage,
+  decodeMobilePreviewDomMessage,
+  mobilePreviewDomCaptureScript,
+} from "./mobilePreviewDomBridge";
+
+function message(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    kind: "t3.preview.capture",
+    version: 1,
+    requestId: "request-1",
+    url: "http://192.168.1.20:5173/checkout",
+    title: "Checkout",
+    loading: false,
+    viewport: {
+      width: 1_000,
+      height: 800,
+      scrollX: 0,
+      scrollY: 240,
+      devicePixelRatio: 2,
+    },
+    elements: [
+      {
+        tag: "BUTTON",
+        role: " button ",
+        name: "  Pay\n now ",
+        selector: "#pay",
+        rect: { x: -10, y: 100, width: 150, height: 50 },
+      },
+      {
+        tag: "button",
+        role: null,
+        name: "Offscreen",
+        selector: "#offscreen",
+        rect: { x: 1_100, y: 100, width: 100, height: 40 },
+      },
+    ],
+    ...overrides,
+  });
+}
+
+describe("mobile preview DOM bridge", () => {
+  it("decodes, normalizes, and clips the current request", () => {
+    expect(decodeMobilePreviewDomMessage(message(), "request-1")).toEqual({
+      url: "http://192.168.1.20:5173/checkout",
+      title: "Checkout",
+      loading: false,
+      viewport: {
+        width: 1_000,
+        height: 800,
+        scrollX: 0,
+        scrollY: 240,
+        devicePixelRatio: 2,
+      },
+      elements: [
+        {
+          id: "mobile-element-0",
+          tag: "button",
+          role: "button",
+          name: "Pay now",
+          selector: "#pay",
+          rect: { x: 0, y: 100, width: 140, height: 50 },
+        },
+      ],
+    });
+  });
+
+  it("ignores unrelated page messages and stale capture responses", () => {
+    expect(decodeMobilePreviewDomMessage("not json", "request-1")).toBeNull();
+    expect(
+      decodeMobilePreviewDomMessage(JSON.stringify({ kind: "page-message" }), "request-1"),
+    ).toBeNull();
+    expect(decodeMobilePreviewDomMessage(message(), "request-2")).toBeNull();
+  });
+
+  it("decodes only capture errors for the current request", () => {
+    const error = JSON.stringify({
+      kind: "t3.preview.capture-error",
+      version: 1,
+      requestId: "request-1",
+      message: "Selector inspection failed",
+    });
+    expect(decodeMobilePreviewDomErrorMessage(error, "request-1")).toBe(
+      "Selector inspection failed",
+    );
+    expect(decodeMobilePreviewDomErrorMessage(error, "request-2")).toBeNull();
+  });
+
+  it("rejects invalid viewport data and drops malformed elements", () => {
+    expect(
+      decodeMobilePreviewDomMessage(
+        message({
+          viewport: {
+            width: Number.POSITIVE_INFINITY,
+            height: 800,
+            scrollX: 0,
+            scrollY: 0,
+            devicePixelRatio: 2,
+          },
+        }),
+        "request-1",
+      ),
+    ).toBeNull();
+    const decoded = decodeMobilePreviewDomMessage(
+      message({
+        elements: [
+          {
+            tag: "button",
+            role: null,
+            name: "Broken",
+            selector: "#broken",
+            rect: { x: 0, y: 0, width: Number.NaN, height: 40 },
+          },
+        ],
+      }),
+      "request-1",
+    );
+    expect(decoded?.elements).toEqual([]);
+  });
+
+  it("caps semantic output before it reaches markup", () => {
+    const decoded = decodeMobilePreviewDomMessage(
+      message({
+        elements: Array.from({ length: 250 }, (_, index) => ({
+          tag: "button",
+          role: null,
+          name: `Button ${index}`,
+          selector: `#button-${index}`,
+          rect: { x: 0, y: 0, width: 20, height: 20 },
+        })),
+      }),
+      "request-1",
+    );
+    expect(decoded?.elements).toHaveLength(200);
+    expect(decoded?.elements.at(-1)?.id).toBe("mobile-element-199");
+  });
+
+  it("quotes the request id and retains bounded collection logic in the injected script", () => {
+    const script = mobilePreviewDomCaptureScript('request-"quoted"');
+    expect(script).toContain('const requestId = "request-\\"quoted\\"";');
+    expect(script).toContain("window.ReactNativeWebView?.postMessage");
+    expect(script).toContain('kind: "t3.preview.capture-error"');
+    expect(script).toContain(".slice(0, 200)");
+    expect(script.trimEnd().endsWith("true;")).toBe(true);
+  });
+});

--- a/apps/mobile/src/features/preview/mobilePreviewDomBridge.test.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewDomBridge.test.ts
@@ -143,6 +143,9 @@ describe("mobile preview DOM bridge", () => {
     expect(script).toContain("window.ReactNativeWebView?.postMessage");
     expect(script).toContain('kind: "t3.preview.capture-error"');
     expect(script).toContain(".slice(0, 200)");
+    expect(script).toContain("document.querySelectorAll(selector)");
+    expect(script).toContain("Number.POSITIVE_INFINITY");
+    expect(script).toContain("current = current.parentElement");
     expect(script.trimEnd().endsWith("true;")).toBe(true);
   });
 });

--- a/apps/mobile/src/features/preview/mobilePreviewDomBridge.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewDomBridge.ts
@@ -159,15 +159,27 @@ export function mobilePreviewDomCaptureScript(requestId: string): string {
     const requestId = ${encodedRequestId};
     try {
       const selectorFor = (element) => {
-        if (element.id) return "#" + CSS.escape(element.id);
+        const identifiesElement = (selector) => {
+          try {
+            const matches = document.querySelectorAll(selector);
+            return matches.length === 1 && matches[0] === element;
+          } catch {
+            return false;
+          }
+        };
+        if (element.id) {
+          const selector = "#" + CSS.escape(element.id);
+          if (identifiesElement(selector)) return selector;
+        }
         for (const attribute of ["data-testid", "name"]) {
           const value = element.getAttribute(attribute);
           if (value) {
-            return element.tagName.toLowerCase() + "[" + attribute + "=" + JSON.stringify(value) + "]";
+            const selector = element.tagName.toLowerCase() + "[" + attribute + "=" + JSON.stringify(value) + "]";
+            if (identifiesElement(selector)) return selector;
           }
         }
-        const buildParts = (current, parts = []) => {
-          if (!current || current.nodeType !== Node.ELEMENT_NODE || parts.length >= 8) {
+        const buildParts = (current, parts = [], maximumDepth = 8) => {
+          if (!current || current.nodeType !== Node.ELEMENT_NODE || parts.length >= maximumDepth) {
             return parts;
           }
           const parent = current.parentElement;
@@ -178,22 +190,32 @@ export function mobilePreviewDomCaptureScript(requestId: string): string {
           const part = siblings.length > 1
             ? base + ":nth-of-type(" + (siblings.indexOf(current) + 1) + ")"
             : base;
-          return buildParts(parent, [part, ...parts]);
+          return buildParts(parent, [part, ...parts], maximumDepth);
         };
-        return buildParts(element).join(" > ");
+        const compactSelector = buildParts(element).join(" > ");
+        if (identifiesElement(compactSelector)) return compactSelector;
+        const exactSelector = buildParts(element, [], Number.POSITIVE_INFINITY).join(" > ");
+        return identifiesElement(exactSelector) ? exactSelector : "";
       };
       const visible = (element) => {
-        const style = getComputedStyle(element);
         const rect = element.getBoundingClientRect();
-        return style.visibility !== "hidden"
-          && style.display !== "none"
-          && style.opacity !== "0"
-          && rect.width > 0
+        if (!(rect.width > 0
           && rect.height > 0
           && rect.right > 0
           && rect.bottom > 0
           && rect.left < window.innerWidth
-          && rect.top < window.innerHeight;
+          && rect.top < window.innerHeight)) return false;
+        for (let current = element; current; current = current.parentElement) {
+          const style = getComputedStyle(current);
+          if (
+            style.visibility === "hidden" ||
+            style.display === "none" ||
+            Number(style.opacity) <= 0
+          ) {
+            return false;
+          }
+        }
+        return true;
       };
       const elements = Array.from(document.querySelectorAll(
         "a[href],button,input,textarea,select,[role],[tabindex]"

--- a/apps/mobile/src/features/preview/mobilePreviewDomBridge.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewDomBridge.ts
@@ -1,0 +1,267 @@
+import type { PreviewReviewSnapshot } from "@t3tools/contracts";
+import * as Predicate from "effect/Predicate";
+
+export type MobilePreviewDomFrame = Pick<
+  PreviewReviewSnapshot,
+  "loading" | "title" | "url" | "viewport" | "elements"
+>;
+
+const MOBILE_PREVIEW_DOM_MESSAGE_KIND = "t3.preview.capture";
+const MOBILE_PREVIEW_DOM_MESSAGE_VERSION = 1;
+const MAX_MESSAGE_LENGTH = 1024 * 1024;
+const MAX_ELEMENTS = 200;
+const MAX_SELECTOR_LENGTH = 2_048;
+const MAX_NAME_LENGTH = 512;
+const MAX_TAG_LENGTH = 64;
+const MAX_ROLE_LENGTH = 128;
+const MAX_URL_LENGTH = 2_048;
+const MAX_TITLE_LENGTH = 512;
+const MAX_VIEWPORT_DISTANCE = 100_000;
+
+const finiteNumber = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+const boundedString = (value: unknown, maximumLength: number): string | null =>
+  typeof value === "string" && value.length <= maximumLength ? value : null;
+
+function decodeViewport(value: unknown): MobilePreviewDomFrame["viewport"] | null {
+  if (!Predicate.isObject(value)) return null;
+  const width = finiteNumber(value["width"]);
+  const height = finiteNumber(value["height"]);
+  const scrollX = finiteNumber(value["scrollX"]);
+  const scrollY = finiteNumber(value["scrollY"]);
+  const devicePixelRatio = finiteNumber(value["devicePixelRatio"]);
+  if (
+    width === null ||
+    height === null ||
+    scrollX === null ||
+    scrollY === null ||
+    devicePixelRatio === null ||
+    width <= 0 ||
+    height <= 0 ||
+    width > MAX_VIEWPORT_DISTANCE ||
+    height > MAX_VIEWPORT_DISTANCE ||
+    Math.abs(scrollX) > MAX_VIEWPORT_DISTANCE ||
+    Math.abs(scrollY) > MAX_VIEWPORT_DISTANCE ||
+    devicePixelRatio <= 0 ||
+    devicePixelRatio > 16
+  ) {
+    return null;
+  }
+  return { width, height, scrollX, scrollY, devicePixelRatio };
+}
+
+function decodeElement(
+  value: unknown,
+  viewport: MobilePreviewDomFrame["viewport"],
+  index: number,
+): MobilePreviewDomFrame["elements"][number] | null {
+  if (!Predicate.isObject(value)) return null;
+  const tagValue = boundedString(value["tag"], MAX_TAG_LENGTH);
+  const roleValue = value["role"] === null ? null : boundedString(value["role"], MAX_ROLE_LENGTH);
+  const nameValue = boundedString(value["name"], MAX_NAME_LENGTH);
+  const selectorValue = boundedString(value["selector"], MAX_SELECTOR_LENGTH);
+  const rectValue = value["rect"];
+  if (
+    tagValue === null ||
+    (value["role"] !== null && roleValue === null) ||
+    nameValue === null ||
+    selectorValue === null ||
+    selectorValue.trim().length === 0 ||
+    !Predicate.isObject(rectValue)
+  ) {
+    return null;
+  }
+  const x = finiteNumber(rectValue["x"]);
+  const y = finiteNumber(rectValue["y"]);
+  const width = finiteNumber(rectValue["width"]);
+  const height = finiteNumber(rectValue["height"]);
+  if (x === null || y === null || width === null || height === null || width <= 0 || height <= 0) {
+    return null;
+  }
+  const left = Math.max(0, x);
+  const top = Math.max(0, y);
+  const right = Math.min(viewport.width, x + width);
+  const bottom = Math.min(viewport.height, y + height);
+  if (right <= left || bottom <= top) return null;
+  const tag = tagValue.trim().toLowerCase();
+  if (tag.length === 0) return null;
+  return {
+    id: `mobile-element-${index}`,
+    tag,
+    role: roleValue?.trim() || null,
+    name: nameValue.replace(/\s+/gu, " ").trim(),
+    selector: selectorValue.trim(),
+    rect: {
+      x: left,
+      y: top,
+      width: right - left,
+      height: bottom - top,
+    },
+  };
+}
+
+/**
+ * Messages originate in arbitrary preview pages. Decode them as hostile input
+ * and accept only the response for the capture request currently in flight.
+ */
+export function decodeMobilePreviewDomMessage(
+  raw: string,
+  expectedRequestId: string,
+): MobilePreviewDomFrame | null {
+  if (raw.length === 0 || raw.length > MAX_MESSAGE_LENGTH) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (
+    !Predicate.isObject(value) ||
+    value["kind"] !== MOBILE_PREVIEW_DOM_MESSAGE_KIND ||
+    value["version"] !== MOBILE_PREVIEW_DOM_MESSAGE_VERSION ||
+    value["requestId"] !== expectedRequestId
+  ) {
+    return null;
+  }
+  const url = boundedString(value["url"], MAX_URL_LENGTH);
+  const title = boundedString(value["title"], MAX_TITLE_LENGTH);
+  const viewport = decodeViewport(value["viewport"]);
+  if (
+    url === null ||
+    title === null ||
+    typeof value["loading"] !== "boolean" ||
+    !viewport ||
+    !Array.isArray(value["elements"])
+  ) {
+    return null;
+  }
+  const elements = value["elements"].slice(0, MAX_ELEMENTS).flatMap((element, index) => {
+    const decoded = decodeElement(element, viewport, index);
+    return decoded ? [decoded] : [];
+  });
+  return {
+    url,
+    title,
+    loading: value["loading"],
+    viewport,
+    elements,
+  };
+}
+
+/**
+ * Build a one-shot main-frame script instead of keeping a MutationObserver in
+ * every preview. The native view is captured immediately after this response.
+ */
+export function mobilePreviewDomCaptureScript(requestId: string): string {
+  const encodedRequestId = JSON.stringify(requestId);
+  return `(() => {
+    const requestId = ${encodedRequestId};
+    try {
+      const selectorFor = (element) => {
+        if (element.id) return "#" + CSS.escape(element.id);
+        for (const attribute of ["data-testid", "name"]) {
+          const value = element.getAttribute(attribute);
+          if (value) {
+            return element.tagName.toLowerCase() + "[" + attribute + "=" + JSON.stringify(value) + "]";
+          }
+        }
+        const buildParts = (current, parts = []) => {
+          if (!current || current.nodeType !== Node.ELEMENT_NODE || parts.length >= 8) {
+            return parts;
+          }
+          const parent = current.parentElement;
+          const siblings = parent
+            ? Array.from(parent.children).filter((child) => child.tagName === current.tagName)
+            : [];
+          const base = current.tagName.toLowerCase();
+          const part = siblings.length > 1
+            ? base + ":nth-of-type(" + (siblings.indexOf(current) + 1) + ")"
+            : base;
+          return buildParts(parent, [part, ...parts]);
+        };
+        return buildParts(element).join(" > ");
+      };
+      const visible = (element) => {
+        const style = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return style.visibility !== "hidden"
+          && style.display !== "none"
+          && style.opacity !== "0"
+          && rect.width > 0
+          && rect.height > 0
+          && rect.right > 0
+          && rect.bottom > 0
+          && rect.left < window.innerWidth
+          && rect.top < window.innerHeight;
+      };
+      const elements = Array.from(document.querySelectorAll(
+        "a[href],button,input,textarea,select,[role],[tabindex]"
+      )).filter(visible).map((element) => {
+        const rect = element.getBoundingClientRect();
+        const selector = selectorFor(element);
+        if (!selector || selector.length > ${MAX_SELECTOR_LENGTH}) return null;
+        const rawName = element.getAttribute("aria-label")
+          || element.innerText
+          || element.getAttribute("name")
+          || "";
+        return {
+          tag: element.tagName.toLowerCase().slice(0, ${MAX_TAG_LENGTH}),
+          role: element.getAttribute("role")?.slice(0, ${MAX_ROLE_LENGTH}) ?? null,
+          name: String(rawName).replace(/\\s+/g, " ").trim().slice(0, ${MAX_NAME_LENGTH}),
+          selector,
+          rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+        };
+      }).filter((element) => element !== null).slice(0, ${MAX_ELEMENTS});
+      window.ReactNativeWebView?.postMessage(JSON.stringify({
+        kind: ${JSON.stringify(MOBILE_PREVIEW_DOM_MESSAGE_KIND)},
+        version: ${MOBILE_PREVIEW_DOM_MESSAGE_VERSION},
+        requestId,
+        url: location.href.slice(0, ${MAX_URL_LENGTH}),
+        title: document.title.slice(0, ${MAX_TITLE_LENGTH}),
+        loading: document.readyState !== "complete",
+        viewport: {
+          width: Math.max(1, window.innerWidth),
+          height: Math.max(1, window.innerHeight),
+          scrollX: Number.isFinite(window.scrollX) ? window.scrollX : 0,
+          scrollY: Number.isFinite(window.scrollY) ? window.scrollY : 0,
+          devicePixelRatio: Number.isFinite(window.devicePixelRatio) && window.devicePixelRatio > 0
+            ? window.devicePixelRatio
+            : 1
+        },
+        elements
+      }));
+    } catch (error) {
+      window.ReactNativeWebView?.postMessage(JSON.stringify({
+        kind: "t3.preview.capture-error",
+        version: ${MOBILE_PREVIEW_DOM_MESSAGE_VERSION},
+        requestId,
+        message: String(error).slice(0, 512)
+      }));
+    }
+  })();
+  true;`;
+}
+
+export function decodeMobilePreviewDomErrorMessage(
+  raw: string,
+  expectedRequestId: string,
+): string | null {
+  if (raw.length === 0 || raw.length > MAX_MESSAGE_LENGTH) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (
+    !Predicate.isObject(value) ||
+    value["kind"] !== "t3.preview.capture-error" ||
+    value["version"] !== MOBILE_PREVIEW_DOM_MESSAGE_VERSION ||
+    value["requestId"] !== expectedRequestId
+  ) {
+    return null;
+  }
+  const message = boundedString(value["message"], 512);
+  return message?.trim() || "The page could not be inspected for markup.";
+}

--- a/apps/mobile/src/features/preview/mobilePreviewGatewayModel.test.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewGatewayModel.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  mobilePreviewGatewayRequestKey,
+  mobilePreviewGatewayTargetMatches,
+  resolveMobilePreviewGatewayUri,
+  type MobilePreviewGatewayTarget,
+} from "./mobilePreviewGatewayModel";
+
+const target: MobilePreviewGatewayTarget = {
+  environmentHttpBaseUrl: "https://environment.t3.codes",
+  expiresAt: 1_000,
+  serverEpoch: "server-1",
+  sourceUrl: "http://localhost:5173/checkout",
+  tabId: "tab-1",
+  uri: "https://environment.t3.codes/api/preview-gateway/bootstrap/ticket",
+};
+
+describe("mobile preview gateway model", () => {
+  it("keys one in-flight request to the exact server, tab, and preview URL", () => {
+    const key = mobilePreviewGatewayRequestKey({
+      serverEpoch: "server-1",
+      sourceUrl: "http://localhost:5173/checkout",
+      tabId: "tab-1",
+    });
+    expect(key).toBe(
+      mobilePreviewGatewayRequestKey({
+        serverEpoch: "server-1",
+        sourceUrl: "http://localhost:5173/checkout",
+        tabId: "tab-1",
+      }),
+    );
+    expect(key).not.toBe(
+      mobilePreviewGatewayRequestKey({
+        serverEpoch: "server-1",
+        sourceUrl: "http://localhost:4173/checkout",
+        tabId: "tab-1",
+      }),
+    );
+  });
+
+  it("resolves a same-origin bootstrap path", () => {
+    expect(
+      resolveMobilePreviewGatewayUri({
+        environmentHttpBaseUrl: "https://environment.t3.codes/some/base",
+        relativeUrl: "/api/preview-gateway/bootstrap/ticket",
+      }),
+    ).toBe("https://environment.t3.codes/api/preview-gateway/bootstrap/ticket");
+  });
+
+  it("rejects cross-origin and non-http bootstrap addresses", () => {
+    for (const relativeUrl of [
+      "//attacker.example/bootstrap",
+      "https://attacker.example/bootstrap",
+      "api/preview-gateway/bootstrap/ticket",
+      "/api/not-the-preview-gateway/ticket",
+    ]) {
+      expect(() =>
+        resolveMobilePreviewGatewayUri({
+          environmentHttpBaseUrl: "https://environment.t3.codes",
+          relativeUrl,
+        }),
+      ).toThrow("invalid bootstrap address");
+    }
+    expect(() =>
+      resolveMobilePreviewGatewayUri({
+        environmentHttpBaseUrl: "file:///tmp/environment",
+        relativeUrl: "/api/preview-gateway/bootstrap/ticket",
+      }),
+    ).toThrow("invalid bootstrap address");
+  });
+
+  it("matches a lease only to its tab, server epoch, and exact preview URL", () => {
+    expect(
+      mobilePreviewGatewayTargetMatches({
+        target,
+        environmentHttpBaseUrl: target.environmentHttpBaseUrl,
+        serverEpoch: "server-1",
+        sourceUrl: "http://localhost:5173/checkout",
+        tabId: "tab-1",
+      }),
+    ).toBe(true);
+    expect(
+      mobilePreviewGatewayTargetMatches({
+        target,
+        environmentHttpBaseUrl: target.environmentHttpBaseUrl,
+        serverEpoch: "server-1",
+        sourceUrl: "http://localhost:4173/checkout",
+        tabId: "tab-1",
+      }),
+    ).toBe(false);
+    expect(
+      mobilePreviewGatewayTargetMatches({
+        target,
+        environmentHttpBaseUrl: target.environmentHttpBaseUrl,
+        serverEpoch: "server-2",
+        sourceUrl: target.sourceUrl,
+        tabId: target.tabId,
+      }),
+    ).toBe(false);
+    expect(
+      mobilePreviewGatewayTargetMatches({
+        target,
+        environmentHttpBaseUrl: "https://new-environment.t3.codes",
+        serverEpoch: target.serverEpoch,
+        sourceUrl: target.sourceUrl,
+        tabId: target.tabId,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/preview/mobilePreviewGatewayModel.test.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewGatewayModel.test.ts
@@ -54,6 +54,7 @@ describe("mobile preview gateway model", () => {
       "https://attacker.example/bootstrap",
       "api/preview-gateway/bootstrap/ticket",
       "/api/not-the-preview-gateway/ticket",
+      "/api/preview-gateway/bootstrap/../other",
     ]) {
       expect(() =>
         resolveMobilePreviewGatewayUri({

--- a/apps/mobile/src/features/preview/mobilePreviewGatewayModel.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewGatewayModel.ts
@@ -22,10 +22,7 @@ export function resolveMobilePreviewGatewayUri(input: {
   readonly environmentHttpBaseUrl: string;
   readonly relativeUrl: string;
 }): string {
-  if (
-    !input.relativeUrl.startsWith(GATEWAY_BOOTSTRAP_PREFIX) ||
-    input.relativeUrl.startsWith("//")
-  ) {
+  if (!input.relativeUrl.startsWith("/") || input.relativeUrl.startsWith("//")) {
     throw new Error(INVALID_GATEWAY_ADDRESS);
   }
   let environmentUrl: URL;
@@ -39,6 +36,7 @@ export function resolveMobilePreviewGatewayUri(input: {
   if (
     (environmentUrl.protocol !== "http:" && environmentUrl.protocol !== "https:") ||
     gatewayUrl.origin !== environmentUrl.origin ||
+    !gatewayUrl.pathname.startsWith(GATEWAY_BOOTSTRAP_PREFIX) ||
     (gatewayUrl.protocol !== "http:" && gatewayUrl.protocol !== "https:")
   ) {
     throw new Error(INVALID_GATEWAY_ADDRESS);

--- a/apps/mobile/src/features/preview/mobilePreviewGatewayModel.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewGatewayModel.ts
@@ -1,0 +1,62 @@
+export interface MobilePreviewGatewayTarget {
+  readonly environmentHttpBaseUrl: string;
+  readonly expiresAt: number;
+  readonly serverEpoch: string | null;
+  readonly sourceUrl: string;
+  readonly tabId: string;
+  readonly uri: string;
+}
+
+const INVALID_GATEWAY_ADDRESS = "The preview gateway returned an invalid bootstrap address.";
+const GATEWAY_BOOTSTRAP_PREFIX = "/api/preview-gateway/bootstrap/";
+
+export function mobilePreviewGatewayRequestKey(input: {
+  readonly serverEpoch: string | null;
+  readonly sourceUrl: string;
+  readonly tabId: string;
+}): string {
+  return JSON.stringify([input.serverEpoch, input.tabId, input.sourceUrl]);
+}
+
+export function resolveMobilePreviewGatewayUri(input: {
+  readonly environmentHttpBaseUrl: string;
+  readonly relativeUrl: string;
+}): string {
+  if (
+    !input.relativeUrl.startsWith(GATEWAY_BOOTSTRAP_PREFIX) ||
+    input.relativeUrl.startsWith("//")
+  ) {
+    throw new Error(INVALID_GATEWAY_ADDRESS);
+  }
+  let environmentUrl: URL;
+  let gatewayUrl: URL;
+  try {
+    environmentUrl = new URL(input.environmentHttpBaseUrl);
+    gatewayUrl = new URL(input.relativeUrl, environmentUrl);
+  } catch {
+    throw new Error(INVALID_GATEWAY_ADDRESS);
+  }
+  if (
+    (environmentUrl.protocol !== "http:" && environmentUrl.protocol !== "https:") ||
+    gatewayUrl.origin !== environmentUrl.origin ||
+    (gatewayUrl.protocol !== "http:" && gatewayUrl.protocol !== "https:")
+  ) {
+    throw new Error(INVALID_GATEWAY_ADDRESS);
+  }
+  return gatewayUrl.toString();
+}
+
+export function mobilePreviewGatewayTargetMatches(input: {
+  readonly target: MobilePreviewGatewayTarget | null;
+  readonly environmentHttpBaseUrl: string;
+  readonly serverEpoch: string | null;
+  readonly sourceUrl: string;
+  readonly tabId: string;
+}): boolean {
+  return (
+    input.target?.tabId === input.tabId &&
+    input.target.environmentHttpBaseUrl === input.environmentHttpBaseUrl &&
+    input.target.serverEpoch === input.serverEpoch &&
+    input.target.sourceUrl === input.sourceUrl
+  );
+}

--- a/apps/mobile/src/features/preview/mobilePreviewSourceUrl.test.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewSourceUrl.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { mobilePreviewAnnotationUrl } from "./mobilePreviewSourceUrl";
+
+describe("mobile preview annotation URL", () => {
+  it("preserves direct WebView navigation URLs", () => {
+    expect(
+      mobilePreviewAnnotationUrl({
+        documentUrl: "http://192.168.1.20:5173/settings?tab=team#billing",
+        sourceUrl: "http://localhost:5173/",
+        isolatedGateway: false,
+      }),
+    ).toBe("http://192.168.1.20:5173/settings?tab=team#billing");
+  });
+
+  it("maps an isolated Connect document back to the original preview origin", () => {
+    expect(
+      mobilePreviewAnnotationUrl({
+        documentUrl: "https://environment.t3.codes/settings?tab=team#billing",
+        gatewayUrl:
+          "https://environment.t3.codes/api/preview-gateway/bootstrap/secret-bootstrap-token",
+        sourceUrl: "http://localhost:5173/checkout",
+        isolatedGateway: true,
+      }),
+    ).toBe("http://localhost:5173/settings?tab=team#billing");
+  });
+
+  it("retains external navigation URLs instead of mapping them to localhost", () => {
+    expect(
+      mobilePreviewAnnotationUrl({
+        documentUrl: "https://docs.example.com/guide?from=preview",
+        gatewayUrl:
+          "https://environment.t3.codes/api/preview-gateway/bootstrap/secret-bootstrap-token",
+        sourceUrl: "http://localhost:5173/checkout",
+        isolatedGateway: true,
+      }),
+    ).toBe("https://docs.example.com/guide?from=preview");
+  });
+
+  it("does not expose a one-time gateway bootstrap path as preview context", () => {
+    expect(
+      mobilePreviewAnnotationUrl({
+        documentUrl:
+          "https://environment.t3.codes/api/preview-gateway/bootstrap/secret-bootstrap-token",
+        gatewayUrl:
+          "https://environment.t3.codes/api/preview-gateway/bootstrap/secret-bootstrap-token",
+        sourceUrl: "http://localhost:5173/checkout",
+        isolatedGateway: true,
+      }),
+    ).toBe("http://localhost:5173/checkout");
+  });
+
+  it("never leaks a malformed gateway URL into annotation context", () => {
+    expect(
+      mobilePreviewAnnotationUrl({
+        documentUrl: "not a url",
+        gatewayUrl:
+          "https://environment.t3.codes/api/preview-gateway/bootstrap/secret-bootstrap-token",
+        sourceUrl: "http://localhost:5173/checkout",
+        isolatedGateway: true,
+      }),
+    ).toBe("http://localhost:5173/checkout");
+  });
+});

--- a/apps/mobile/src/features/preview/mobilePreviewSourceUrl.ts
+++ b/apps/mobile/src/features/preview/mobilePreviewSourceUrl.ts
@@ -1,0 +1,28 @@
+/**
+ * A Connect gateway intentionally renders at the environment origin. Preserve
+ * the preview's original origin in model context while following in-page path,
+ * query, and hash navigation from the isolated WebView.
+ */
+export function mobilePreviewAnnotationUrl(input: {
+  readonly documentUrl: string;
+  readonly gatewayUrl?: string;
+  readonly sourceUrl: string;
+  readonly isolatedGateway: boolean;
+}): string {
+  if (!input.isolatedGateway) return input.documentUrl;
+  try {
+    const documentUrl = new URL(input.documentUrl);
+    const gatewayUrl = new URL(input.gatewayUrl ?? "");
+    const sourceUrl = new URL(input.sourceUrl);
+    if (documentUrl.origin !== gatewayUrl.origin) return documentUrl.toString();
+    if (documentUrl.pathname === gatewayUrl.pathname && documentUrl.search === gatewayUrl.search) {
+      return sourceUrl.toString();
+    }
+    sourceUrl.pathname = documentUrl.pathname;
+    sourceUrl.search = documentUrl.search;
+    sourceUrl.hash = documentUrl.hash;
+    return sourceUrl.toString();
+  } catch {
+    return input.sourceUrl;
+  }
+}

--- a/apps/mobile/src/features/preview/previewLiveTarget.test.ts
+++ b/apps/mobile/src/features/preview/previewLiveTarget.test.ts
@@ -29,6 +29,19 @@ describe("resolveMobilePreviewLiveTarget", () => {
     });
   });
 
+  it("treats a DNS-root-qualified localhost as desktop loopback", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "http://localhost.:5173/dashboard",
+        environmentHttpBaseUrl: "http://192.168.1.25:3773",
+      }),
+    ).toEqual({
+      kind: "available",
+      uri: "http://192.168.1.25:5173/dashboard",
+      resolution: "environment-private-network",
+    });
+  });
+
   it("maps desktop localhost onto a Tailscale host", () => {
     expect(
       resolveMobilePreviewLiveTarget({

--- a/apps/mobile/src/features/preview/previewLiveTarget.test.ts
+++ b/apps/mobile/src/features/preview/previewLiveTarget.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveMobilePreviewLiveTarget } from "./previewLiveTarget";
+
+describe("resolveMobilePreviewLiveTarget", () => {
+  it("keeps public preview URLs direct", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "https://example.com/checkout?step=2#payment",
+        environmentHttpBaseUrl: "https://connect.t3.codes",
+      }),
+    ).toEqual({
+      kind: "available",
+      uri: "https://example.com/checkout?step=2#payment",
+      resolution: "direct",
+    });
+  });
+
+  it("maps desktop localhost onto a LAN environment host", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "http://localhost:5173/dashboard?mode=test#results",
+        environmentHttpBaseUrl: "http://192.168.1.25:3773",
+      }),
+    ).toEqual({
+      kind: "available",
+      uri: "http://192.168.1.25:5173/dashboard?mode=test#results",
+      resolution: "environment-private-network",
+    });
+  });
+
+  it("maps desktop localhost onto a Tailscale host", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "localhost:3000/app",
+        environmentHttpBaseUrl: "https://devbox.tailnet-name.ts.net",
+      }),
+    ).toEqual({
+      kind: "available",
+      uri: "http://devbox.tailnet-name.ts.net:3000/app",
+      resolution: "environment-private-network",
+    });
+  });
+
+  it("routes iPad LAN loopback previews through the authenticated gateway", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "http://localhost:5173/dashboard",
+        environmentHttpBaseUrl: "http://192.168.1.25:3773",
+        platform: "ios",
+      }),
+    ).toMatchObject({ kind: "unavailable", reason: "gateway-required" });
+  });
+
+  it("routes iPad Tailscale loopback previews through the authenticated gateway", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "http://localhost:3000/app",
+        environmentHttpBaseUrl: "https://devbox.tailnet-name.ts.net",
+        platform: "ios",
+      }),
+    ).toMatchObject({ kind: "unavailable", reason: "gateway-required" });
+  });
+
+  it("maps desktop localhost onto a single-label MagicDNS host", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "http://127.0.0.1:4173/app",
+        environmentHttpBaseUrl: "http://devbox:3773",
+      }),
+    ).toEqual({
+      kind: "available",
+      uri: "http://devbox:4173/app",
+      resolution: "environment-private-network",
+    });
+  });
+
+  it("maps every IPv4 loopback address onto the environment host", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "http://127.0.0.42:4173/app",
+        environmentHttpBaseUrl: "http://192.168.1.25:3773",
+      }),
+    ).toEqual({
+      kind: "available",
+      uri: "http://192.168.1.25:4173/app",
+      resolution: "environment-private-network",
+    });
+  });
+
+  it("does not send localhost subdomains to the iPad loopback interface", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "http://app.localhost:4173",
+        environmentHttpBaseUrl: "http://192.168.1.25:3773",
+      }),
+    ).toMatchObject({ kind: "unavailable", reason: "local-loopback" });
+  });
+
+  it("does not treat the iPad's loopback as the desktop", () => {
+    const target = resolveMobilePreviewLiveTarget({
+      previewUrl: "http://localhost:5173",
+      environmentHttpBaseUrl: "http://127.0.0.1:3773",
+    });
+    expect(target.kind).toBe("unavailable");
+    if (target.kind === "unavailable") {
+      expect(target.reason).toBe("local-loopback");
+    }
+  });
+
+  it("routes Connect-hosted environment ports through the live gateway", () => {
+    const target = resolveMobilePreviewLiveTarget({
+      previewUrl: "http://localhost:5173",
+      environmentHttpBaseUrl: "https://relay.example.com",
+      platform: "ios",
+    });
+    expect(target.kind).toBe("unavailable");
+    if (target.kind === "unavailable") {
+      expect(target.reason).toBe("gateway-required");
+      expect(target.detail).toMatch(/authenticated preview gateway/);
+    }
+  });
+
+  it("keeps Connect gateway previews snapshot-only on Android", () => {
+    const target = resolveMobilePreviewLiveTarget({
+      previewUrl: "http://localhost:5173",
+      environmentHttpBaseUrl: "https://relay.example.com",
+      platform: "android",
+    });
+    expect(target.kind).toBe("unavailable");
+    if (target.kind === "unavailable") {
+      expect(target.reason).toBe("gateway-required");
+      expect(target.detail).toMatch(/available on iPad only/);
+      expect(target.detail).toMatch(/snapshot review/);
+    }
+  });
+
+  it("keeps relay-managed private-looking endpoints snapshot-only", () => {
+    const target = resolveMobilePreviewLiveTarget({
+      previewUrl: "http://localhost:5173",
+      environmentHttpBaseUrl: "http://100.100.10.20:3773",
+      environmentRelayManaged: true,
+    });
+    expect(target.kind).toBe("unavailable");
+    if (target.kind === "unavailable") {
+      expect(target.reason).toBe("gateway-required");
+    }
+  });
+
+  it("rejects non-web preview URLs", () => {
+    expect(
+      resolveMobilePreviewLiveTarget({
+        previewUrl: "file:///tmp/index.html",
+        environmentHttpBaseUrl: "http://192.168.1.25:3773",
+      }),
+    ).toMatchObject({ kind: "unavailable", reason: "invalid-url" });
+  });
+});

--- a/apps/mobile/src/features/preview/previewLiveTarget.ts
+++ b/apps/mobile/src/features/preview/previewLiveTarget.ts
@@ -1,0 +1,171 @@
+import { isLoopbackHost, normalizePreviewUrl } from "@t3tools/shared/preview";
+
+export type MobilePreviewLiveTarget =
+  | {
+      readonly kind: "available";
+      readonly uri: string;
+      readonly resolution: "direct" | "environment-private-network";
+    }
+  | {
+      readonly kind: "unavailable";
+      readonly reason: "gateway-required" | "invalid-url" | "local-loopback";
+      readonly detail: string;
+    };
+
+const normalizeHostname = (host: string): string => host.toLowerCase().replace(/^\[|\]$/g, "");
+
+const parseIpv4Address = (host: string): readonly number[] | null => {
+  const parts = normalizeHostname(host).split(".").map(Number);
+  return parts.length === 4 &&
+    parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)
+    ? parts
+    : null;
+};
+
+const isLocalLoopbackHost = (host: string): boolean => {
+  const normalized = normalizeHostname(host);
+  if (normalized === "localhost" || normalized === "::1") return true;
+  return parseIpv4Address(normalized)?.[0] === 127;
+};
+
+const isDesktopLocalPreviewHost = (host: string): boolean => {
+  const normalized = normalizeHostname(host);
+  return (
+    isLoopbackHost(host) ||
+    isLocalLoopbackHost(normalized) ||
+    normalized === "::" ||
+    normalized.endsWith(".localhost")
+  );
+};
+
+const isPrivateNetworkHost = (host: string): boolean => {
+  const normalized = normalizeHostname(host);
+  if (normalized.endsWith(".local") || normalized.endsWith(".ts.net")) {
+    return true;
+  }
+  if (!normalized.includes(".") && !normalized.includes(":") && normalized !== "localhost") {
+    return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u.test(normalized);
+  }
+  const parts = parseIpv4Address(normalized);
+  if (parts) {
+    return (
+      parts[0] === 10 ||
+      (parts[0] === 100 && parts[1]! >= 64 && parts[1]! <= 127) ||
+      (parts[0] === 172 && parts[1]! >= 16 && parts[1]! <= 31) ||
+      (parts[0] === 192 && parts[1] === 168) ||
+      (parts[0] === 169 && parts[1] === 254)
+    );
+  }
+  const firstIpv6Token = normalized.split(":", 1)[0] ?? "";
+  if (!normalized.includes(":") || !/^[\da-f]{1,4}$/u.test(firstIpv6Token)) {
+    return false;
+  }
+  const firstIpv6Hextet = Number.parseInt(firstIpv6Token, 16);
+  return (
+    Number.isInteger(firstIpv6Hextet) &&
+    ((firstIpv6Hextet & 0xfe00) === 0xfc00 || (firstIpv6Hextet & 0xffc0) === 0xfe80)
+  );
+};
+
+const unavailable = (
+  reason: Extract<MobilePreviewLiveTarget, { readonly kind: "unavailable" }>["reason"],
+  detail: string,
+): MobilePreviewLiveTarget => ({ kind: "unavailable", reason, detail });
+
+/**
+ * Resolve a desktop preview URL for a WebView running on a different device.
+ *
+ * Public URLs are already directly reachable. Android can rewrite a
+ * desktop-local URL when the paired environment itself is reached over LAN,
+ * Bonjour, or Tailscale. iPad uses the authenticated preview gateway so
+ * loopback-only desktop servers remain reachable without exposing every
+ * project port.
+ */
+export function resolveMobilePreviewLiveTarget(input: {
+  readonly previewUrl: string;
+  readonly environmentHttpBaseUrl: string | null;
+  readonly environmentRelayManaged?: boolean;
+  readonly platform?: "android" | "ios";
+}): MobilePreviewLiveTarget {
+  let preview: URL;
+  try {
+    preview = new URL(normalizePreviewUrl(input.previewUrl));
+  } catch {
+    return unavailable("invalid-url", "This browser tab does not have a valid web address.");
+  }
+
+  if (preview.protocol !== "http:" && preview.protocol !== "https:") {
+    return unavailable("invalid-url", "Browser supports only HTTP and HTTPS addresses.");
+  }
+
+  if (!isDesktopLocalPreviewHost(preview.hostname)) {
+    return { kind: "available", uri: preview.toString(), resolution: "direct" };
+  }
+
+  if (input.environmentRelayManaged) {
+    return unavailable(
+      "gateway-required",
+      input.platform === "android"
+        ? "T3 Connect Browser is currently available on iPad only because Android WebView cannot isolate the gateway session. Desktop snapshot review still works through T3 Connect."
+        : "Browser needs the authenticated preview gateway.",
+    );
+  }
+
+  if (
+    normalizeHostname(preview.hostname).endsWith(".localhost") &&
+    normalizeHostname(preview.hostname) !== "localhost"
+  ) {
+    return unavailable(
+      "local-loopback",
+      "This browser tab uses a desktop-local hostname that cannot be mapped safely to the iPad. Use the environment's LAN or Tailscale host in its address.",
+    );
+  }
+
+  if (!input.environmentHttpBaseUrl) {
+    return unavailable(
+      "local-loopback",
+      "This browser tab points at the desktop's localhost. Connect to that environment over LAN or Tailscale to open it.",
+    );
+  }
+
+  let environment: URL;
+  try {
+    environment = new URL(input.environmentHttpBaseUrl);
+  } catch {
+    return unavailable(
+      "local-loopback",
+      "This browser tab points at the desktop's localhost, but the environment address is unavailable.",
+    );
+  }
+
+  if (isLocalLoopbackHost(environment.hostname)) {
+    return unavailable(
+      "local-loopback",
+      "The iPad cannot use the desktop's localhost address. Pair with the desktop's LAN or Tailscale address to open this preview live.",
+    );
+  }
+
+  if (input.platform === "ios") {
+    return unavailable(
+      "gateway-required",
+      "Browser will use the authenticated preview gateway for this desktop-local address.",
+    );
+  }
+
+  if (!isPrivateNetworkHost(environment.hostname)) {
+    return unavailable(
+      "gateway-required",
+      input.platform === "android"
+        ? "T3 Connect Browser is currently available on iPad only because Android WebView cannot isolate the gateway session. Desktop snapshot review still works through T3 Connect."
+        : "Browser needs the authenticated preview gateway.",
+    );
+  }
+
+  const environmentHost = normalizeHostname(environment.hostname);
+  preview.hostname = environmentHost.includes(":") ? `[${environmentHost}]` : environmentHost;
+  return {
+    kind: "available",
+    uri: preview.toString(),
+    resolution: "environment-private-network",
+  };
+}

--- a/apps/mobile/src/features/preview/previewLiveTarget.ts
+++ b/apps/mobile/src/features/preview/previewLiveTarget.ts
@@ -12,7 +12,11 @@ export type MobilePreviewLiveTarget =
       readonly detail: string;
     };
 
-const normalizeHostname = (host: string): string => host.toLowerCase().replace(/^\[|\]$/g, "");
+const normalizeHostname = (host: string): string =>
+  host
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/u, "");
 
 const parseIpv4Address = (host: string): readonly number[] | null => {
   const parts = normalizeHostname(host).split(".").map(Number);

--- a/apps/mobile/src/features/preview/previewPaneModel.test.ts
+++ b/apps/mobile/src/features/preview/previewPaneModel.test.ts
@@ -1,0 +1,251 @@
+import {
+  ThreadId,
+  type PreviewEvent,
+  type PreviewReviewSnapshot,
+  type PreviewSessionSnapshot,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  mergePreviewSessionSnapshots,
+  previewCaptureCanCommit,
+  previewCaptureErrorMessage,
+  previewEventRequiresSessionRefresh,
+  previewLiveUrlForSelection,
+  upsertPreviewSessionSnapshot,
+} from "./previewPaneModel";
+
+const threadId = ThreadId.make("thread-1");
+const session = {
+  threadId,
+  tabId: "tab-1",
+  navStatus: {
+    _tag: "Success",
+    url: "http://localhost:5173/old",
+    title: "Old",
+  },
+  canGoBack: false,
+  canGoForward: false,
+  updatedAt: "2026-07-30T12:00:00.000Z",
+} as const satisfies PreviewSessionSnapshot;
+
+const snapshot = {
+  version: 1,
+  tabId: "tab-1",
+  snapshotId: "snapshot-1",
+  pageRevision: "page-1",
+  serverEpoch: "epoch-1",
+  previewRevision: 1,
+  threadId,
+  capturedAt: "2026-07-30T12:00:00.000Z",
+  url: "http://localhost:5173/snapshot",
+  title: "Snapshot",
+  loading: false,
+  viewport: {
+    width: 1_000,
+    height: 800,
+    scrollX: 0,
+    scrollY: 0,
+    devicePixelRatio: 1,
+  },
+  screenshot: {
+    mimeType: "image/png",
+    data: "aGVsbG8=",
+    width: 1_000,
+    height: 800,
+    scale: 1,
+  },
+  elements: [],
+} as const satisfies PreviewReviewSnapshot;
+
+function navigatedEvent(overrides: Partial<PreviewEvent> = {}): PreviewEvent {
+  return {
+    type: "navigated",
+    threadId,
+    tabId: "tab-1",
+    createdAt: "2026-07-30T12:01:00.000Z",
+    serverEpoch: "epoch-1",
+    revision: 2,
+    snapshot: {
+      ...session,
+      navStatus: {
+        _tag: "Success",
+        url: "http://localhost:5173/current",
+        title: "Current",
+      },
+    },
+    ...overrides,
+  } as PreviewEvent;
+}
+
+describe("mobile preview pane state", () => {
+  it("keeps a newly-created optimistic tab until the server list includes it", () => {
+    const idle = {
+      ...session,
+      tabId: "tab-2",
+      navStatus: { _tag: "Idle" },
+      updatedAt: "2026-07-30T12:01:00.000Z",
+    } as const satisfies PreviewSessionSnapshot;
+
+    expect(mergePreviewSessionSnapshots([session], [idle])).toEqual([session, idle]);
+    expect(upsertPreviewSessionSnapshot([session], idle)).toEqual([session, idle]);
+  });
+
+  it("prefers a newer optimistic navigation over a stale server snapshot", () => {
+    const navigated = {
+      ...session,
+      navStatus: {
+        _tag: "Success",
+        url: "http://localhost:5173/new",
+        title: "",
+      },
+      updatedAt: "2026-07-30T12:02:00.000Z",
+    } as const satisfies PreviewSessionSnapshot;
+
+    expect(mergePreviewSessionSnapshots([session], [navigated])).toEqual([navigated]);
+    expect(upsertPreviewSessionSnapshot([session], navigated)).toEqual([navigated]);
+  });
+
+  it("turns an older server's unknown review RPC into upgrade guidance", () => {
+    expect(
+      previewCaptureErrorMessage(new Error("Unknown request tag: preview.reviewSnapshot")),
+    ).toMatch(/updated T3 desktop and server/);
+    expect(previewCaptureErrorMessage(null)).toBe(
+      "The desktop preview could not capture a review snapshot.",
+    );
+  });
+
+  it("ignores a capture that resolves after another tab became active", () => {
+    expect(
+      previewCaptureCanCommit({
+        activeRequestId: 2,
+        requestId: 1,
+        selectedTabId: "tab-2",
+        requestedTabId: "tab-1",
+        threadId,
+        snapshot,
+      }),
+    ).toBe(false);
+    expect(
+      previewCaptureCanCommit({
+        activeRequestId: 2,
+        requestId: 2,
+        selectedTabId: "tab-1",
+        requestedTabId: "tab-1",
+        threadId,
+        snapshot,
+      }),
+    ).toBe(true);
+  });
+
+  it("refreshes session membership and navigation state only for newer relevant events", () => {
+    expect(
+      previewEventRequiresSessionRefresh({
+        event: navigatedEvent(),
+        threadId,
+        serverEpoch: "epoch-1",
+        revision: 1,
+      }),
+    ).toBe(true);
+    expect(
+      previewEventRequiresSessionRefresh({
+        event: navigatedEvent(),
+        threadId,
+        serverEpoch: "epoch-1",
+        revision: 2,
+      }),
+    ).toBe(false);
+    expect(
+      previewEventRequiresSessionRefresh({
+        event: navigatedEvent({ threadId: ThreadId.make("thread-2") }),
+        threadId,
+        serverEpoch: "epoch-1",
+        revision: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("lets live mode follow a newer navigation event without waiting for another capture", () => {
+    expect(
+      previewLiveUrlForSelection({
+        selectedTabId: "tab-1",
+        selectedSession: session,
+        snapshot,
+        latestEvent: navigatedEvent(),
+        threadId,
+        serverEpoch: "epoch-1",
+        revision: 1,
+      }),
+    ).toBe("http://localhost:5173/current");
+    expect(
+      previewLiveUrlForSelection({
+        selectedTabId: "tab-1",
+        selectedSession: session,
+        snapshot: null,
+        latestEvent: null,
+        threadId,
+        serverEpoch: "epoch-1",
+        revision: 1,
+      }),
+    ).toBe("http://localhost:5173/old");
+  });
+
+  it("lets an optimistic navigation supersede the new tab's newer Idle event", () => {
+    const optimistic = {
+      ...session,
+      navStatus: {
+        _tag: "Success",
+        url: "http://localhost:5173/from-ipad",
+        title: "",
+      },
+      updatedAt: "2026-07-30T12:02:00.000Z",
+    } as const satisfies PreviewSessionSnapshot;
+    const opened = {
+      type: "opened",
+      threadId,
+      tabId: "tab-1",
+      createdAt: "2026-07-30T12:01:00.000Z",
+      serverEpoch: "epoch-1",
+      revision: 2,
+      snapshot: {
+        ...session,
+        navStatus: { _tag: "Idle" },
+        updatedAt: "2026-07-30T12:01:00.000Z",
+      },
+    } as const satisfies PreviewEvent;
+
+    expect(
+      previewLiveUrlForSelection({
+        selectedTabId: "tab-1",
+        selectedSession: optimistic,
+        snapshot: null,
+        latestEvent: opened,
+        threadId,
+        serverEpoch: "epoch-1",
+        revision: 1,
+      }),
+    ).toBe("http://localhost:5173/from-ipad");
+  });
+
+  it("removes a closed selected tab from the live target before list reconciliation", () => {
+    const closed = {
+      type: "closed",
+      threadId,
+      tabId: "tab-1",
+      createdAt: "2026-07-30T12:02:00.000Z",
+      serverEpoch: "epoch-1",
+      revision: 3,
+    } as const satisfies PreviewEvent;
+    expect(
+      previewLiveUrlForSelection({
+        selectedTabId: "tab-1",
+        selectedSession: session,
+        snapshot,
+        latestEvent: closed,
+        threadId,
+        serverEpoch: "epoch-1",
+        revision: 2,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/preview/previewPaneModel.test.ts
+++ b/apps/mobile/src/features/preview/previewPaneModel.test.ts
@@ -190,6 +190,32 @@ describe("mobile preview pane state", () => {
     ).toBe("http://localhost:5173/old");
   });
 
+  it("reconciles epoch changes without letting an old event override the new list", () => {
+    const oldEpochEvent = navigatedEvent({
+      serverEpoch: "epoch-1",
+      revision: 99,
+    });
+    expect(
+      previewEventRequiresSessionRefresh({
+        event: oldEpochEvent,
+        threadId,
+        serverEpoch: "epoch-2",
+        revision: 1,
+      }),
+    ).toBe(true);
+    expect(
+      previewLiveUrlForSelection({
+        selectedTabId: "tab-1",
+        selectedSession: session,
+        snapshot: null,
+        latestEvent: oldEpochEvent,
+        threadId,
+        serverEpoch: "epoch-2",
+        revision: 1,
+      }),
+    ).toBe("http://localhost:5173/old");
+  });
+
   it("lets an optimistic navigation supersede the new tab's newer Idle event", () => {
     const optimistic = {
       ...session,

--- a/apps/mobile/src/features/preview/previewPaneModel.ts
+++ b/apps/mobile/src/features/preview/previewPaneModel.ts
@@ -1,0 +1,146 @@
+import type {
+  PreviewEvent,
+  PreviewReviewSnapshot,
+  PreviewSessionSnapshot,
+  ThreadId,
+} from "@t3tools/contracts";
+
+function navigationUrl(session: PreviewSessionSnapshot): string | null {
+  return session.navStatus._tag === "Idle" ? null : session.navStatus.url;
+}
+
+function eventUrl(event: PreviewEvent): string | null {
+  switch (event.type) {
+    case "closed":
+      return null;
+    case "failed":
+      return event.url;
+    case "opened":
+    case "navigated":
+    case "resized":
+      return navigationUrl(event.snapshot);
+  }
+}
+
+function eventIsNewerThanList(input: {
+  readonly event: PreviewEvent;
+  readonly serverEpoch: string | null;
+  readonly revision: number | null;
+}): boolean {
+  return (
+    input.serverEpoch === null ||
+    input.revision === null ||
+    input.event.serverEpoch !== input.serverEpoch ||
+    input.event.revision > input.revision
+  );
+}
+
+export function mergePreviewSessionSnapshots(
+  serverSessions: ReadonlyArray<PreviewSessionSnapshot>,
+  optimisticSessions: ReadonlyArray<PreviewSessionSnapshot>,
+): ReadonlyArray<PreviewSessionSnapshot> {
+  const merged = [...serverSessions];
+  const indexByTabId = new Map(merged.map((session, index) => [session.tabId, index]));
+
+  for (const optimistic of optimisticSessions) {
+    const index = indexByTabId.get(optimistic.tabId);
+    if (index === undefined) {
+      indexByTabId.set(optimistic.tabId, merged.length);
+      merged.push(optimistic);
+      continue;
+    }
+    if (optimistic.updatedAt > merged[index]!.updatedAt) {
+      merged[index] = optimistic;
+    }
+  }
+
+  return merged;
+}
+
+export function upsertPreviewSessionSnapshot(
+  sessions: ReadonlyArray<PreviewSessionSnapshot>,
+  snapshot: PreviewSessionSnapshot,
+): ReadonlyArray<PreviewSessionSnapshot> {
+  const index = sessions.findIndex((session) => session.tabId === snapshot.tabId);
+  if (index === -1) return [...sessions, snapshot];
+  if (sessions[index] === snapshot) return sessions;
+  const next = [...sessions];
+  next[index] = snapshot;
+  return next;
+}
+
+export function previewCaptureErrorMessage(error: unknown): string {
+  const message =
+    error instanceof Error ? error.message.trim() : typeof error === "string" ? error.trim() : "";
+  if (/unknown request tag:\s*preview\.reviewSnapshot/iu.test(message)) {
+    return "Preview review requires the updated T3 desktop and server. Restart them from this build, then refresh.";
+  }
+  return message || "The desktop preview could not capture a review snapshot.";
+}
+
+export function previewEventRequiresSessionRefresh(input: {
+  readonly event: PreviewEvent;
+  readonly threadId: ThreadId;
+  readonly serverEpoch: string | null;
+  readonly revision: number | null;
+}): boolean {
+  if (input.event.threadId !== input.threadId) return false;
+  if (!eventIsNewerThanList(input)) return false;
+  return input.event.serverEpoch !== input.serverEpoch || input.event.type !== "resized";
+}
+
+export function previewLiveUrlForSelection(input: {
+  readonly selectedTabId: string | null;
+  readonly selectedSession: PreviewSessionSnapshot | null;
+  readonly snapshot: PreviewReviewSnapshot | null;
+  readonly latestEvent: PreviewEvent | null;
+  readonly threadId: ThreadId;
+  readonly serverEpoch: string | null;
+  readonly revision: number | null;
+}): string | null {
+  const tabId = input.selectedTabId;
+  if (!tabId) return null;
+
+  const event = input.latestEvent;
+  if (
+    event &&
+    event.threadId === input.threadId &&
+    event.tabId === tabId &&
+    eventIsNewerThanList({
+      event,
+      serverEpoch: input.serverEpoch,
+      revision: input.revision,
+    })
+  ) {
+    if (event.type === "closed") return null;
+    const url = eventUrl(event);
+    if (url) return url;
+  }
+
+  if (input.selectedSession?.tabId === tabId) {
+    const url = navigationUrl(input.selectedSession);
+    if (url) return url;
+  }
+
+  if (input.snapshot?.threadId === input.threadId && input.snapshot.tabId === tabId) {
+    return input.snapshot.url;
+  }
+
+  return null;
+}
+
+export function previewCaptureCanCommit(input: {
+  readonly activeRequestId: number;
+  readonly requestId: number;
+  readonly selectedTabId: string | null;
+  readonly requestedTabId: string;
+  readonly threadId: ThreadId;
+  readonly snapshot: PreviewReviewSnapshot;
+}): boolean {
+  return (
+    input.activeRequestId === input.requestId &&
+    input.selectedTabId === input.requestedTabId &&
+    input.snapshot.tabId === input.requestedTabId &&
+    input.snapshot.threadId === input.threadId
+  );
+}

--- a/apps/mobile/src/features/preview/previewPaneModel.ts
+++ b/apps/mobile/src/features/preview/previewPaneModel.ts
@@ -30,8 +30,7 @@ function eventIsNewerThanList(input: {
   return (
     input.serverEpoch === null ||
     input.revision === null ||
-    input.event.serverEpoch !== input.serverEpoch ||
-    input.event.revision > input.revision
+    (input.event.serverEpoch === input.serverEpoch && input.event.revision > input.revision)
   );
 }
 
@@ -85,8 +84,9 @@ export function previewEventRequiresSessionRefresh(input: {
   readonly revision: number | null;
 }): boolean {
   if (input.event.threadId !== input.threadId) return false;
+  if (input.serverEpoch !== null && input.event.serverEpoch !== input.serverEpoch) return true;
   if (!eventIsNewerThanList(input)) return false;
-  return input.event.serverEpoch !== input.serverEpoch || input.event.type !== "resized";
+  return input.event.type !== "resized";
 }
 
 export function previewLiveUrlForSelection(input: {

--- a/apps/mobile/src/features/preview/previewReviewModel.test.ts
+++ b/apps/mobile/src/features/preview/previewReviewModel.test.ts
@@ -192,5 +192,13 @@ describe("preview review model", () => {
         revision: snapshot.previewRevision + 1,
       }),
     ).toBe(false);
+    expect(
+      previewSnapshotIsStale(snapshot, {
+        ...baseEvent,
+        threadId: ThreadId.make("thread-2"),
+        tabId: "tab-2",
+        serverEpoch: "server-epoch-2",
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/mobile/src/features/preview/previewReviewModel.test.ts
+++ b/apps/mobile/src/features/preview/previewReviewModel.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { ThreadId, type PreviewAnnotationPayload } from "@t3tools/contracts";
+import {
+  createPreviewSnapshotMarkupSeed,
+  normalizePreviewElementRect,
+  normalizedRectForSemanticElement,
+  previewSnapshotIsStale,
+  previewSnapshotSemanticElements,
+  selectedSemanticElements,
+  semanticElementAtPoint,
+  type MobilePreviewReviewSnapshot,
+} from "./previewReviewModel";
+
+const snapshot = {
+  version: 1,
+  tabId: "tab-1",
+  snapshotId: "snapshot-1",
+  pageRevision: "page-7",
+  serverEpoch: "server-epoch-1",
+  previewRevision: 7,
+  threadId: ThreadId.make("thread-1"),
+  capturedAt: "2026-07-30T12:00:00.000Z",
+  url: "http://localhost:5173/checkout",
+  title: "Checkout",
+  loading: false,
+  viewport: {
+    width: 1_000,
+    height: 800,
+    scrollX: 0,
+    scrollY: 320,
+    devicePixelRatio: 2,
+  },
+  screenshot: {
+    mimeType: "image/png",
+    data: "aGVsbG8=",
+    width: 1_280,
+    height: 1_024,
+    scale: 1.28,
+  },
+  elements: [
+    {
+      id: "element-parent",
+      tag: "section",
+      role: "region",
+      name: "Payment",
+      selector: "#payment",
+      rect: { x: 100, y: 80, width: 500, height: 300 },
+    },
+    {
+      id: "element-button",
+      tag: "button",
+      role: "button",
+      name: 'Pay "now"',
+      selector: "button.submit",
+      rect: { x: 420, y: 180, width: 160, height: 64 },
+    },
+    {
+      id: "offscreen",
+      tag: "button",
+      role: "button",
+      name: "Hidden",
+      selector: "button.hidden",
+      rect: { x: 1_100, y: 10, width: 100, height: 40 },
+    },
+  ],
+} as const satisfies MobilePreviewReviewSnapshot;
+
+describe("preview review model", () => {
+  it("creates a preview-backed markup attachment with a stable page revision", () => {
+    const seed = createPreviewSnapshotMarkupSeed({
+      snapshot,
+      attachmentId: "attachment-1",
+      annotationId: "annotation-1",
+    });
+    expect(seed.attachment.previewUri).toMatch(/^data:image\/png;base64,/);
+    expect(seed.attachment.markup?.annotation).toMatchObject({
+      pageUrl: snapshot.url,
+      pageTitle: snapshot.title,
+      source: { kind: "preview", url: snapshot.url, title: snapshot.title },
+      screenshot: {
+        width: 1_280,
+        height: 1_024,
+        scale: 1.28,
+        pageRevision: "page-7",
+        cropRect: { x: 0, y: 0, width: 1_000, height: 800 },
+      },
+    });
+    expect(seed.semanticElements.map((element) => element.id)).toEqual([
+      "element-parent",
+      "element-button",
+    ]);
+    expect(seed.semanticElements[1]?.element.htmlPreview).toBe(
+      '<button role="button" aria-label="Pay &quot;now&quot;">',
+    );
+  });
+
+  it("clips partially visible rectangles and rejects offscreen rectangles", () => {
+    expect(
+      normalizePreviewElementRect({ x: -50, y: 700, width: 200, height: 200 }, snapshot.viewport),
+    ).toEqual({ x: 0, y: 0.875, width: 0.15, height: 0.125 });
+    expect(
+      normalizePreviewElementRect({ x: 1_100, y: 10, width: 100, height: 40 }, snapshot.viewport),
+    ).toBeNull();
+  });
+
+  it("selects the smallest semantic element under a point", () => {
+    const annotation = createPreviewSnapshotMarkupSeed({
+      snapshot,
+      attachmentId: "attachment-1",
+      annotationId: "annotation-1",
+    }).attachment.markup!.annotation;
+    const elements = previewSnapshotSemanticElements(snapshot).map((target) => ({
+      target,
+      rect: normalizedRectForSemanticElement(target, annotation)!,
+    }));
+    expect(
+      semanticElementAtPoint({
+        point: { x: 0.5, y: 0.25 },
+        elements,
+      })?.target.id,
+    ).toBe("element-button");
+  });
+
+  it("keeps only elements referenced by element callouts in agent context", () => {
+    const candidates = previewSnapshotSemanticElements(snapshot);
+    const base = createPreviewSnapshotMarkupSeed({
+      snapshot,
+      attachmentId: "attachment-1",
+      annotationId: "annotation-1",
+    }).attachment.markup!.annotation;
+    const annotation: PreviewAnnotationPayload = {
+      ...base,
+      callouts: [
+        {
+          id: "callout-1",
+          number: 1,
+          comment: "Make this primary",
+          anchor: {
+            kind: "element",
+            targetId: "element-button",
+            rect: { x: 0.42, y: 0.225, width: 0.16, height: 0.08 },
+          },
+        },
+      ],
+    };
+    expect(selectedSemanticElements({ annotation, candidates }).map((target) => target.id)).toEqual(
+      ["element-button"],
+    );
+  });
+
+  it("marks matching-tab snapshots stale after a revision or server restart", () => {
+    const baseEvent = {
+      type: "navigated",
+      threadId: snapshot.threadId,
+      tabId: snapshot.tabId,
+      createdAt: "2026-07-30T12:01:00.000Z",
+      serverEpoch: snapshot.serverEpoch,
+      revision: snapshot.previewRevision,
+      snapshot: {
+        tabId: snapshot.tabId,
+        threadId: snapshot.threadId,
+        navStatus: {
+          _tag: "Success",
+          url: snapshot.url,
+          title: snapshot.title,
+        },
+        canGoBack: false,
+        canGoForward: false,
+        viewport: { _tag: "freeform", width: 1_000, height: 800 },
+        updatedAt: "2026-07-30T12:01:00.000Z",
+      },
+    } as const;
+
+    expect(previewSnapshotIsStale(snapshot, baseEvent)).toBe(false);
+    expect(
+      previewSnapshotIsStale(snapshot, {
+        ...baseEvent,
+        revision: snapshot.previewRevision + 1,
+      }),
+    ).toBe(true);
+    expect(
+      previewSnapshotIsStale(snapshot, {
+        ...baseEvent,
+        serverEpoch: "server-epoch-2",
+      }),
+    ).toBe(true);
+    expect(
+      previewSnapshotIsStale(snapshot, {
+        ...baseEvent,
+        tabId: "tab-2",
+        revision: snapshot.previewRevision + 1,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/preview/previewReviewModel.ts
+++ b/apps/mobile/src/features/preview/previewReviewModel.ts
@@ -1,0 +1,275 @@
+import {
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  type PickedElementPayload,
+  type PreviewAnnotationElementTarget,
+  type PreviewAnnotationNormalizedPoint,
+  type PreviewAnnotationNormalizedRect,
+  type PreviewAnnotationPayload,
+  type PreviewAnnotationRect,
+  type PreviewEvent,
+  type PreviewReviewSnapshot,
+} from "@t3tools/contracts";
+
+import { estimateBase64ByteSize } from "../../lib/base64";
+import type { DraftComposerImageAttachment } from "../../lib/composerImages";
+
+export type MobilePreviewReviewSnapshot = PreviewReviewSnapshot;
+export type MobilePreviewMarkupFrame = Pick<
+  PreviewReviewSnapshot,
+  | "capturedAt"
+  | "elements"
+  | "pageRevision"
+  | "screenshot"
+  | "snapshotId"
+  | "title"
+  | "url"
+  | "viewport"
+>;
+type MobilePreviewReviewElement = MobilePreviewMarkupFrame["elements"][number];
+
+export interface PreviewSnapshotMarkupSeed {
+  readonly attachment: DraftComposerImageAttachment;
+  readonly semanticElements: ReadonlyArray<PreviewAnnotationElementTarget>;
+}
+
+const clip = (value: number, minimum: number, maximum: number): number =>
+  Math.max(minimum, Math.min(maximum, value));
+
+function clippedViewportRect(
+  rect: PreviewAnnotationRect,
+  viewport: { readonly width: number; readonly height: number },
+): PreviewAnnotationRect | null {
+  if (
+    !Number.isFinite(rect.x) ||
+    !Number.isFinite(rect.y) ||
+    !Number.isFinite(rect.width) ||
+    !Number.isFinite(rect.height) ||
+    rect.width <= 0 ||
+    rect.height <= 0 ||
+    viewport.width <= 0 ||
+    viewport.height <= 0
+  ) {
+    return null;
+  }
+  const left = clip(rect.x, 0, viewport.width);
+  const top = clip(rect.y, 0, viewport.height);
+  const right = clip(rect.x + rect.width, 0, viewport.width);
+  const bottom = clip(rect.y + rect.height, 0, viewport.height);
+  if (right <= left || bottom <= top) return null;
+  return { x: left, y: top, width: right - left, height: bottom - top };
+}
+
+export function normalizePreviewElementRect(
+  rect: PreviewAnnotationRect,
+  viewport: { readonly width: number; readonly height: number },
+): PreviewAnnotationNormalizedRect | null {
+  const clipped = clippedViewportRect(rect, viewport);
+  if (!clipped) return null;
+  return {
+    x: clipped.x / viewport.width,
+    y: clipped.y / viewport.height,
+    width: clipped.width / viewport.width,
+    height: clipped.height / viewport.height,
+  };
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function semanticHtmlPreview(element: MobilePreviewReviewElement): string {
+  const tag = element.tag.trim().toLowerCase() || "div";
+  const attributes = [
+    element.role?.trim() ? `role="${escapeHtmlAttribute(element.role.trim())}"` : null,
+    element.name.trim() ? `aria-label="${escapeHtmlAttribute(element.name.trim())}"` : null,
+  ].filter((attribute): attribute is string => attribute !== null);
+  return `<${tag}${attributes.length > 0 ? ` ${attributes.join(" ")}` : ""}>`;
+}
+
+function pickedElement(
+  snapshot: MobilePreviewMarkupFrame,
+  element: MobilePreviewReviewElement,
+): PickedElementPayload {
+  return {
+    pageUrl: snapshot.url,
+    pageTitle: snapshot.title || null,
+    tagName: element.tag.trim().toLowerCase() || "div",
+    selector: element.selector.trim() || null,
+    htmlPreview: semanticHtmlPreview(element),
+    componentName: null,
+    source: null,
+    stack: [],
+    styles: "",
+    pickedAt: snapshot.capturedAt,
+  };
+}
+
+export function previewSnapshotSemanticElements(
+  snapshot: MobilePreviewMarkupFrame,
+): ReadonlyArray<PreviewAnnotationElementTarget> {
+  const uniqueIds = new Set<string>();
+  const targets: PreviewAnnotationElementTarget[] = [];
+  for (const element of snapshot.elements) {
+    if (element.id.trim().length === 0 || uniqueIds.has(element.id)) continue;
+    const rect = clippedViewportRect(element.rect, snapshot.viewport);
+    if (!rect) continue;
+    uniqueIds.add(element.id);
+    targets.push({
+      id: element.id,
+      rect,
+      element: pickedElement(snapshot, element),
+    });
+  }
+  return targets;
+}
+
+export function normalizedRectForSemanticElement(
+  target: PreviewAnnotationElementTarget,
+  annotation: PreviewAnnotationPayload,
+): PreviewAnnotationNormalizedRect | null {
+  const crop = annotation.screenshot?.cropRect;
+  if (!crop || crop.width <= 0 || crop.height <= 0) return null;
+  return normalizePreviewElementRect(
+    {
+      x: target.rect.x - crop.x,
+      y: target.rect.y - crop.y,
+      width: target.rect.width,
+      height: target.rect.height,
+    },
+    crop,
+  );
+}
+
+export function semanticElementAtPoint(input: {
+  readonly point: PreviewAnnotationNormalizedPoint;
+  readonly elements: ReadonlyArray<{
+    readonly target: PreviewAnnotationElementTarget;
+    readonly rect: PreviewAnnotationNormalizedRect;
+  }>;
+}): {
+  readonly target: PreviewAnnotationElementTarget;
+  readonly rect: PreviewAnnotationNormalizedRect;
+} | null {
+  let selected: {
+    readonly target: PreviewAnnotationElementTarget;
+    readonly rect: PreviewAnnotationNormalizedRect;
+  } | null = null;
+  let selectedArea = Number.POSITIVE_INFINITY;
+  for (const candidate of input.elements) {
+    const rect = candidate.rect;
+    const contains =
+      input.point.x >= rect.x &&
+      input.point.x <= rect.x + rect.width &&
+      input.point.y >= rect.y &&
+      input.point.y <= rect.y + rect.height;
+    if (!contains) continue;
+    const area = rect.width * rect.height;
+    if (area < selectedArea) {
+      selected = candidate;
+      selectedArea = area;
+    }
+  }
+  return selected;
+}
+
+export function selectedSemanticElements(input: {
+  readonly annotation: PreviewAnnotationPayload;
+  readonly candidates: ReadonlyArray<PreviewAnnotationElementTarget>;
+}): ReadonlyArray<PreviewAnnotationElementTarget> {
+  const selectedIds = new Set(
+    (input.annotation.callouts ?? [])
+      .filter((callout) => callout.anchor.kind === "element")
+      .map((callout) =>
+        callout.anchor.kind === "element" ? callout.anchor.targetId : /* istanbul ignore next */ "",
+      ),
+  );
+  const targets = new Map(input.annotation.elements.map((target) => [target.id, target]));
+  for (const candidate of input.candidates) {
+    if (selectedIds.has(candidate.id)) targets.set(candidate.id, candidate);
+  }
+  return [...targets.values()].filter((target) => selectedIds.has(target.id));
+}
+
+export function previewSnapshotIsStale(
+  snapshot: PreviewReviewSnapshot,
+  event: PreviewEvent,
+): boolean {
+  return (
+    event.threadId === snapshot.threadId &&
+    event.tabId === snapshot.tabId &&
+    (event.serverEpoch !== snapshot.serverEpoch || event.revision > snapshot.previewRevision)
+  );
+}
+
+export function createPreviewSnapshotMarkupSeed(input: {
+  readonly snapshot: MobilePreviewMarkupFrame;
+  readonly attachmentId: string;
+  readonly annotationId: string;
+}): PreviewSnapshotMarkupSeed {
+  const { snapshot } = input;
+  const sizeBytes = estimateBase64ByteSize(snapshot.screenshot.data);
+  if (sizeBytes <= 0) {
+    throw new Error("The desktop preview returned an empty screenshot.");
+  }
+  if (sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+    throw new Error("The preview screenshot exceeds the 10 MB attachment limit.");
+  }
+  const dataUrl = `data:${snapshot.screenshot.mimeType};base64,${snapshot.screenshot.data}`;
+  const name = `preview-${snapshot.snapshotId}.png`;
+  const original = {
+    name,
+    mimeType: snapshot.screenshot.mimeType,
+    sizeBytes,
+    dataUrl,
+    previewUri: dataUrl,
+  };
+  const annotation: PreviewAnnotationPayload = {
+    id: input.annotationId,
+    pageUrl: snapshot.url,
+    pageTitle: snapshot.title || null,
+    comment: "",
+    elements: [],
+    regions: [],
+    strokes: [],
+    styleChanges: [],
+    screenshot: {
+      dataUrl: "",
+      width: snapshot.screenshot.width,
+      height: snapshot.screenshot.height,
+      cropRect: {
+        x: 0,
+        y: 0,
+        width: snapshot.viewport.width,
+        height: snapshot.viewport.height,
+      },
+      scale: snapshot.screenshot.scale,
+      pageRevision: snapshot.pageRevision,
+    },
+    createdAt: snapshot.capturedAt,
+    schemaVersion: 1,
+    source: {
+      kind: "preview",
+      url: snapshot.url,
+      title: snapshot.title || null,
+    },
+    callouts: [],
+    editable: {
+      version: 1,
+      coordinateSpace: "normalized",
+      strokes: [],
+    },
+  };
+  return {
+    attachment: {
+      id: input.attachmentId,
+      type: "image",
+      ...original,
+      markup: { annotation, original },
+    },
+    semanticElements: previewSnapshotSemanticElements(snapshot),
+  };
+}

--- a/apps/mobile/src/features/preview/previewReviewModel.ts
+++ b/apps/mobile/src/features/preview/previewReviewModel.ts
@@ -198,10 +198,11 @@ export function previewSnapshotIsStale(
   snapshot: PreviewReviewSnapshot,
   event: PreviewEvent,
 ): boolean {
+  if (event.serverEpoch !== snapshot.serverEpoch) return true;
   return (
     event.threadId === snapshot.threadId &&
     event.tabId === snapshot.tabId &&
-    (event.serverEpoch !== snapshot.serverEpoch || event.revision > snapshot.previewRevision)
+    event.revision > snapshot.previewRevision
   );
 }
 

--- a/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
@@ -279,6 +279,13 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
                         imageSize={60}
                         onPressImage={setPreviewImageUri}
                         removeButtonPlacement="gutter"
+                        onReplace={(replacement) => {
+                          setAttachments((current) =>
+                            current.map((image) =>
+                              image.id === replacement.id ? replacement : image,
+                            ),
+                          );
+                        }}
                         onRemove={(imageId) => {
                           setAttachments((current) =>
                             current.filter((image) => image.id !== imageId),

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -7,7 +7,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useFontFamily } from "../../lib/useFontFamily";
 
-import { EnvironmentId } from "@t3tools/contracts";
+import { EnvironmentId, PROVIDER_SEND_TURN_MAX_INPUT_CHARS } from "@t3tools/contracts";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -27,7 +27,11 @@ import { ProviderIcon } from "../../components/ProviderIcon";
 import { ComposerSurface } from "./ThreadComposer";
 
 import { makeTurnCommandMetadata } from "../../lib/commandMetadata";
-import { convertPastedImagesToAttachments, pickComposerImages } from "../../lib/composerImages";
+import {
+  appendComposerImageAnnotationPrompts,
+  convertPastedImagesToAttachments,
+  pickComposerImages,
+} from "../../lib/composerImages";
 import {
   applyProviderOptionMenuEvent,
   buildProviderOptionMenuActions,
@@ -47,7 +51,10 @@ import { resolveSelectableModelSelection } from "../../lib/modelOptions";
 import { deriveThreadTitleFromPrompt } from "../../lib/projectThreadStartTurn";
 import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/remoteRegistration";
 import { enqueueThreadOutboxMessage, removeThreadOutboxMessage } from "../../state/thread-outbox";
-import { useRemoteConnectionStatus } from "../../state/use-remote-environment-registry";
+import {
+  setPendingConnectionError,
+  useRemoteConnectionStatus,
+} from "../../state/use-remote-environment-registry";
 import { branchBadgeLabel, useNewTaskFlow } from "./new-task-flow-provider";
 import { useCreateProjectThread } from "./use-project-actions";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
@@ -815,13 +822,24 @@ export function NewTaskDraftScreen(props: {
     const runtimeMode = draft.runtimeMode ?? flow.runtimeMode;
     const interactionMode = draft.interactionMode ?? flow.interactionMode;
     const initialMessageText = draft.text.trim();
+    const initialAttachments = draft.attachments;
 
     if (
       !modelSelection ||
-      initialMessageText.length === 0 ||
+      (initialMessageText.length === 0 && initialAttachments.length === 0) ||
       flow.submitting ||
       (workspaceMode === "worktree" && !selectedBranchName)
     ) {
+      return;
+    }
+    const deliveryText = appendComposerImageAnnotationPrompts(
+      initialMessageText,
+      initialAttachments,
+    );
+    if (deliveryText.length > PROVIDER_SEND_TURN_MAX_INPUT_CHARS) {
+      setPendingConnectionError(
+        "This message is too long after adding image annotation comments. Shorten the message or its callouts and try again.",
+      );
       return;
     }
 
@@ -873,7 +891,7 @@ export function NewTaskDraftScreen(props: {
     // -only Activity start. If creation fails, the token registration's replay
     // finds no work and ends the card within seconds.
     armAgentAwarenessLiveActivityForLocalWork({
-      threadTitle: deriveThreadTitleFromPrompt(initialMessageText),
+      threadTitle: deriveThreadTitleFromPrompt(initialMessageText, initialAttachments),
       projectTitle: selectedProject.title,
     });
     const result = await createProjectThread({
@@ -886,7 +904,7 @@ export function NewTaskDraftScreen(props: {
       runtimeMode,
       interactionMode,
       initialMessageText,
-      initialAttachments: draft.attachments,
+      initialAttachments,
       ...(editingPendingTask
         ? {
             turnMetadata: {
@@ -952,7 +970,7 @@ export function NewTaskDraftScreen(props: {
   const canStart =
     Boolean(flow.selectedProject) &&
     Boolean(flow.selectedModel) &&
-    flow.prompt.trim().length > 0 &&
+    (flow.prompt.trim().length > 0 || flow.attachments.length > 0) &&
     isIncomingShareReady &&
     !isImportingShare &&
     !flow.submitting &&
@@ -1111,6 +1129,17 @@ export function NewTaskDraftScreen(props: {
                     onRemove={
                       isIncomingShareTransferPending ? () => undefined : flow.removeAttachment
                     }
+                    onReplace={
+                      isIncomingShareTransferPending
+                        ? undefined
+                        : (replacement) => {
+                            flow.replaceAttachments(
+                              flow.attachments.map((image) =>
+                                image.id === replacement.id ? replacement : image,
+                              ),
+                            );
+                          }
+                    }
                   />
                 </View>
               ) : null}
@@ -1155,6 +1184,17 @@ export function NewTaskDraftScreen(props: {
               <ComposerAttachmentStrip
                 attachments={flow.attachments}
                 onRemove={isIncomingShareTransferPending ? () => undefined : flow.removeAttachment}
+                onReplace={
+                  isIncomingShareTransferPending
+                    ? undefined
+                    : (replacement) => {
+                        flow.replaceAttachments(
+                          flow.attachments.map((image) =>
+                            image.id === replacement.id ? replacement : image,
+                          ),
+                        );
+                      }
+                }
                 imageSize={88}
                 imageBorderRadius={20}
               />

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -25,7 +25,6 @@ import {
   View,
   type ViewStyle,
 } from "react-native";
-import ImageViewing from "react-native-image-viewing";
 import Animated, {
   FadeIn,
   FadeInDown,
@@ -39,6 +38,7 @@ import { scopedThreadKey } from "../../lib/scopedEntities";
 
 import { AppText as Text } from "../../components/AppText";
 import { ComposerAttachmentStrip } from "../../components/ComposerAttachmentStrip";
+import { FullscreenImageViewer } from "../../components/FullscreenImageViewer";
 import {
   ComposerEditor,
   type ComposerEditorHandle,
@@ -108,6 +108,7 @@ export interface ThreadComposerProps {
   readonly onPickDraftImages: () => Promise<void>;
   readonly onNativePasteImages: (uris: ReadonlyArray<string>) => Promise<void>;
   readonly onRemoveDraftImage: (imageId: string) => void;
+  readonly onReplaceDraftImage: (image: DraftComposerImageAttachment) => void;
   readonly onStopThread: () => void;
   readonly onSendMessage: () => Promise<MessageId | null>;
   readonly onUpdateModelSelection: (modelSelection: ModelSelection) => void;
@@ -775,6 +776,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               <ComposerAttachmentStrip
                 attachments={props.draftAttachments}
                 onRemove={props.onRemoveDraftImage}
+                onReplace={props.onReplaceDraftImage}
                 onPressImage={onPressImage}
               />
             </Animated.View>
@@ -922,13 +924,10 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         ) : null}
       </Animated.View>
 
-      <ImageViewing
-        images={previewImageUri ? [{ uri: previewImageUri }] : []}
-        imageIndex={0}
+      <FullscreenImageViewer
+        source={previewImageUri ? { uri: previewImageUri } : null}
         visible={previewImageUri !== null}
         onRequestClose={closePreview}
-        swipeToCloseEnabled
-        doubleTapToZoomEnabled
       />
     </Animated.View>
   );

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -75,6 +75,7 @@ export interface ThreadDetailScreenProps {
   readonly onPickDraftImages: () => Promise<void>;
   readonly onNativePasteImages: (uris: ReadonlyArray<string>) => Promise<void>;
   readonly onRemoveDraftImage: (imageId: string) => void;
+  readonly onReplaceDraftImage: (image: DraftComposerImageAttachment) => void;
   readonly onStopThread: () => void;
   readonly onSendMessage: () => Promise<MessageId | null>;
   readonly onReconnectEnvironment: () => void;
@@ -437,6 +438,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
               onPickDraftImages={props.onPickDraftImages}
               onNativePasteImages={props.onNativePasteImages}
               onRemoveDraftImage={props.onRemoveDraftImage}
+              onReplaceDraftImage={props.onReplaceDraftImage}
               onStopThread={props.onStopThread}
               onSendMessage={handleSendMessage}
               onReconnectEnvironment={props.onReconnectEnvironment}

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -2,6 +2,7 @@ import * as Haptics from "expo-haptics";
 import { KeyboardAwareLegendList } from "@legendapp/list/keyboard";
 import { type LegendListRef } from "@legendapp/list/react-native";
 import type { EnvironmentId, MessageId, ThreadId, TurnId } from "@t3tools/contracts";
+import type { ParsedPreviewAnnotation } from "@t3tools/client-runtime/annotations";
 import { CHAT_LIST_ANCHOR_OFFSET, resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
 import { formatElapsed } from "@t3tools/shared/orchestrationTiming";
 import { SymbolView } from "../../components/AppSymbol";
@@ -43,7 +44,6 @@ import {
   View,
 } from "react-native";
 import { TouchableOpacity } from "react-native-gesture-handler";
-import ImageViewing from "react-native-image-viewing";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Animated, {
   FadeIn,
@@ -64,11 +64,9 @@ import {
 } from "../../native/SelectableMarkdownText";
 
 import { AppText as Text } from "../../components/AppText";
+import { FullscreenImageViewer } from "../../components/FullscreenImageViewer";
 import { CopyTextButton } from "../../components/CopyTextButton";
-import {
-  parseReviewCommentMessageSegments,
-  type ReviewInlineComment,
-} from "../review/reviewCommentSelection";
+import type { ReviewInlineComment } from "../review/reviewCommentSelection";
 import type { ReviewDiffTheme } from "../review/shikiReviewHighlighter";
 import { resolveNativeReviewDiffView } from "../diffs/nativeReviewDiffSurface";
 import {
@@ -104,6 +102,10 @@ import {
 import { useMarkdownCodeHighlight } from "./markdownCodeHighlightState";
 import { useAssetUrl } from "../../state/assets";
 import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
+import {
+  deriveThreadUserMessagePresentation,
+  type ThreadUserMessagePresentation,
+} from "./threadUserMessagePresentation";
 
 const MESSAGE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
@@ -885,7 +887,6 @@ function renderFeedEntry(
     const styles = isUser ? markdownStyles.user : markdownStyles.assistant;
     const timestampLabel = formatMessageTime(isUser ? message.createdAt : message.updatedAt);
     const attachments = message.attachments ?? [];
-    const hasReviewCommentContext = message.text.includes("<review_comment");
     const assistantTurnStillInProgress =
       message.role === "assistant" &&
       props.unsettledTurnId !== null &&
@@ -897,6 +898,7 @@ function renderFeedEntry(
       !message.streaming;
 
     if (isUser) {
+      const presentation = deriveThreadUserMessagePresentation(message.text);
       const enterAnimated = isFreshTimestamp(message.createdAt);
       return (
         <Animated.View
@@ -908,12 +910,12 @@ function renderFeedEntry(
             style={{
               backgroundColor: userBubbleColor,
               maxWidth: props.userBubbleMaxWidth,
-              ...(hasReviewCommentContext ? { width: props.reviewCommentBubbleWidth } : null),
+              ...(presentation.hasReviewComment ? { width: props.reviewCommentBubbleWidth } : null),
             }}
           >
             {message.text.trim().length > 0 ? (
               <UserMessageContent
-                text={message.text}
+                presentation={presentation}
                 markdownStyles={styles}
                 reviewCommentColors={props.reviewCommentColors}
                 skills={props.skills}
@@ -936,10 +938,10 @@ function renderFeedEntry(
             <Text className="font-t3-medium text-xs tabular-nums text-neutral-600 dark:text-neutral-400">
               {timestampLabel}
             </Text>
-            {message.text.trim().length > 0 ? (
+            {presentation.copyText.trim().length > 0 ? (
               <CopyTextButton
                 accessibilityLabel="Copy message"
-                text={message.text}
+                text={presentation.copyText}
                 tintColor={iconSubtleColor}
                 buttonSize={28}
                 iconSize={13}
@@ -1049,19 +1051,18 @@ const WorkingTimelineRow = memo(function WorkingTimelineRow(props: { readonly st
 });
 
 function UserMessageContent(props: {
-  readonly text: string;
+  readonly presentation: ThreadUserMessagePresentation;
   readonly markdownStyles: MarkdownStyleSet;
   readonly reviewCommentColors: ReviewCommentColors;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
   readonly onLinkPress: (href: string) => void;
 }) {
-  const segments = parseReviewCommentMessageSegments(props.text);
-  const hasReviewComment = segments.some((segment) => segment.kind === "review-comment");
-  if (!hasReviewComment) {
+  const { annotations, hasReviewComment, reviewSegments, visibleText } = props.presentation;
+  if (!hasReviewComment && annotations.length === 0) {
     if (hasNativeSelectableMarkdownText()) {
       return (
         <SelectableMarkdownText
-          markdown={props.text}
+          markdown={visibleText}
           skills={props.skills}
           textStyle={props.markdownStyles.nativeTextStyle}
           preserveSoftBreaks
@@ -1076,14 +1077,17 @@ function UserMessageContent(props: {
         styles={props.markdownStyles.styles}
         theme={props.markdownStyles.theme}
       >
-        {props.text}
+        {visibleText}
       </Markdown>
     );
   }
 
   return (
     <View className="w-full gap-2">
-      {segments.map((segment) => {
+      {annotations.map((annotation) => (
+        <PreviewAnnotationCard key={annotation.id} annotation={annotation} />
+      ))}
+      {reviewSegments.map((segment) => {
         if (segment.kind === "review-comment") {
           return (
             <ReviewCommentCard
@@ -1123,6 +1127,84 @@ function UserMessageContent(props: {
     </View>
   );
 }
+
+const PreviewAnnotationCard = memo(function PreviewAnnotationCard(props: {
+  readonly annotation: ParsedPreviewAnnotation;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const visibleCallouts = expanded
+    ? props.annotation.callouts
+    : props.annotation.callouts.slice(0, 3);
+  const hiddenCalloutCount = props.annotation.calloutCount - visibleCallouts.length;
+  const hasDetails =
+    props.annotation.callouts.length > 0 ||
+    props.annotation.comment.length > 0 ||
+    props.annotation.styleChanges.length > 0;
+  const targetSummary =
+    props.annotation.targetSummary ||
+    (props.annotation.calloutCount > 0
+      ? `${props.annotation.calloutCount} numbered callout${
+          props.annotation.calloutCount === 1 ? "" : "s"
+        }`
+      : props.annotation.title);
+
+  return (
+    <View className="gap-1.5 rounded-[14px] border border-white/20 bg-white/10 px-3 py-2.5">
+      <View className="flex-row items-center gap-1.5">
+        <SymbolView
+          name="text.bubble"
+          size={13}
+          tintColor="rgba(255,255,255,0.88)"
+          type="monochrome"
+        />
+        <Text className="min-w-0 flex-1 text-xs font-t3-bold text-white" numberOfLines={1}>
+          {props.annotation.title}
+        </Text>
+      </View>
+      {props.annotation.comment ? (
+        <Text
+          className="text-xs leading-snug text-white/90"
+          numberOfLines={expanded ? undefined : 2}
+        >
+          {props.annotation.comment}
+        </Text>
+      ) : null}
+      {visibleCallouts.map((callout) => (
+        <View key={`${props.annotation.id}:${callout.number}`} className="flex-row gap-1.5">
+          <Text className="font-t3-bold text-xs text-white">#{callout.number}</Text>
+          <Text
+            className="min-w-0 flex-1 text-xs leading-snug text-white/90"
+            numberOfLines={expanded ? undefined : 2}
+          >
+            {callout.comment || callout.anchorSummary}
+          </Text>
+        </View>
+      ))}
+      {hiddenCalloutCount > 0 ? (
+        <Text className="text-2xs text-white/65">
+          +{hiddenCalloutCount} more callout{hiddenCalloutCount === 1 ? "" : "s"}
+        </Text>
+      ) : null}
+      <Text className="text-2xs text-white/65" numberOfLines={1}>
+        {targetSummary}
+      </Text>
+      {hasDetails ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={
+            expanded ? "Collapse annotation details" : "Show all annotation details"
+          }
+          onPress={() => setExpanded((current) => !current)}
+          className="min-h-8 self-start justify-center"
+        >
+          <Text className="text-2xs font-t3-bold text-white/85">
+            {expanded ? "Show less" : "Show all details"}
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+});
 
 const ReviewCommentCard = memo(function ReviewCommentCard(props: {
   readonly comment: ReviewInlineComment;
@@ -1916,22 +1998,17 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
         ) : null}
       </View>
 
-      <ImageViewing
-        images={
+      <FullscreenImageViewer
+        source={
           expandedImage
-            ? [
-                {
-                  uri: expandedImage.uri,
-                  headers: expandedImage.headers,
-                },
-              ]
-            : []
+            ? {
+                uri: expandedImage.uri,
+                headers: expandedImage.headers,
+              }
+            : null
         }
-        imageIndex={0}
         visible={expandedImage !== null}
         onRequestClose={() => setExpandedImage(null)}
-        swipeToCloseEnabled
-        doubleTapToZoomEnabled
       />
     </>
   );

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -1185,6 +1185,14 @@ const PreviewAnnotationCard = memo(function PreviewAnnotationCard(props: {
           +{hiddenCalloutCount} more callout{hiddenCalloutCount === 1 ? "" : "s"}
         </Text>
       ) : null}
+      {expanded
+        ? Array.from(new Set(props.annotation.styleChanges)).map((change) => (
+            <View key={`${props.annotation.id}:style:${change}`} className="flex-row gap-1.5">
+              <Text className="font-t3-bold text-xs text-white">Style</Text>
+              <Text className="min-w-0 flex-1 text-xs leading-snug text-white/90">{change}</Text>
+            </View>
+          ))
+        : null}
       <Text className="text-2xs text-white/65" numberOfLines={1}>
         {targetSummary}
       </Text>

--- a/apps/mobile/src/features/threads/ThreadGitControls.tsx
+++ b/apps/mobile/src/features/threads/ThreadGitControls.tsx
@@ -67,6 +67,7 @@ function compactMenuStatus(gitStatus: VcsStatusResult | null): string {
 type HeaderItem = Record<string, unknown>;
 type HeaderItems = HeaderItem[];
 type ThreadGitHeaderActionItems = {
+  readonly preview: HeaderItem;
   readonly terminal: HeaderItem;
   readonly files: HeaderItem;
   readonly git: HeaderItem;
@@ -101,6 +102,7 @@ type ThreadGitControlsProps = ThreadGitMenuProps & {
   readonly terminalSessions: ReadonlyArray<TerminalMenuSession>;
   readonly showActionControls?: boolean;
   readonly showDirectFileControl?: boolean;
+  readonly onOpenPreview: () => void;
   readonly onOpenTerminal: (terminalId?: string | null) => void;
   readonly onOpenNewTerminal: () => void;
   readonly onRunProjectScript: (script: ProjectScript) => Promise<void>;
@@ -251,6 +253,16 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
 
   return useMemo(
     () => ({
+      preview: {
+        accessibilityLabel: "Open browser",
+        icon: { name: "globe", type: "sfSymbol" },
+        identifier: "thread-right-preview",
+        label: "Browser",
+        onPress: props.onOpenPreview,
+        sharesBackground: true,
+        type: "button",
+        variant: "plain",
+      },
       terminal: {
         accessibilityLabel: "Open terminal",
         disabled: !props.canOpenTerminal,
@@ -382,6 +394,7 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
       props.canOpenTerminal,
       props.gitStatus,
       props.onOpenNewTerminal,
+      props.onOpenPreview,
       props.onOpenTerminal,
       props.onRunProjectScript,
       props.projectScripts,
@@ -393,7 +406,13 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
 export function useThreadGitRightHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
   return useMemo(
-    () => [actionItems.git, actionItems.files, actionItems.terminal] as HeaderItems,
+    () =>
+      [
+        actionItems.preview,
+        actionItems.git,
+        actionItems.files,
+        actionItems.terminal,
+      ] as HeaderItems,
     [actionItems],
   );
 }
@@ -401,7 +420,13 @@ export function useThreadGitRightHeaderItems(props: ThreadGitControlsProps): Hea
 export function useThreadGitCenterHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
   return useMemo(
-    () => [actionItems.files, actionItems.git, actionItems.terminal] as HeaderItems,
+    () =>
+      [
+        actionItems.preview,
+        actionItems.files,
+        actionItems.git,
+        actionItems.terminal,
+      ] as HeaderItems,
     [actionItems],
   );
 }
@@ -421,6 +446,14 @@ export function ThreadGitControls(props: ThreadGitControlsProps) {
           accessibilityLabel={props.auxiliaryPaneControl.accessibilityLabel}
           icon="sidebar.right"
           onPress={props.auxiliaryPaneControl.onPress}
+          separateBackground
+        />
+      ) : null}
+      {showActionControls ? (
+        <NativeHeaderToolbar.Button
+          accessibilityLabel="Open browser"
+          icon="globe"
+          onPress={props.onOpenPreview}
           separateBackground
         />
       ) : null}

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -71,6 +71,10 @@ import {
   ThreadInspectorContentStack,
   type ThreadInspectorMode,
 } from "./thread-inspector-content-stack";
+import {
+  resolveThreadAuxiliaryRouteAction,
+  type ThreadAuxiliaryRoute,
+} from "./threadAuxiliaryRoute";
 
 interface ThreadInspectorSelection {
   readonly routeThreadIdentity: string | null;
@@ -79,8 +83,8 @@ interface ThreadInspectorSelection {
 
 type NativeHeaderItems = ReadonlyArray<Record<string, unknown>>;
 
-function InspectorPaneRoleActivation() {
-  useAdaptiveWorkspacePaneRole("inspector");
+function InspectorPaneRoleActivation(props: { readonly role: "inspector" | "preview" }) {
+  useAdaptiveWorkspacePaneRole(props.role);
   return null;
 }
 
@@ -102,6 +106,7 @@ type ThreadRouteScreenRouteProps = StaticScreenProps<{
 }>;
 
 interface ThreadRouteScreenProps extends ThreadRouteScreenRouteProps {
+  readonly auxiliaryRoute?: ThreadAuxiliaryRoute;
   readonly onReturnToThread?: () => void;
   readonly renderInspector?: (headerInset: number) => ReactNode;
 }
@@ -343,11 +348,25 @@ function ThreadRouteContent(
     if (selectedThread === null || selectedThreadCwd === null) {
       return;
     }
-    if (!fileInspector.supported) {
-      navigation.navigate("ThreadFiles", {
-        environmentId: String(selectedThread.environmentId),
-        threadId: String(selectedThread.id),
-      });
+    const action = resolveThreadAuxiliaryRouteAction({
+      current: props.auxiliaryRoute ?? null,
+      target: "files",
+      persistentFileInspector: fileInspector.supported,
+    });
+    if (action === "close") {
+      props.onReturnToThread?.();
+      return;
+    }
+    const params = {
+      environmentId: String(selectedThread.environmentId),
+      threadId: String(selectedThread.id),
+    };
+    if (action === "replace") {
+      navigation.dispatch(StackActions.replace("ThreadFiles", params));
+      return;
+    }
+    if (action === "navigate") {
+      navigation.navigate("ThreadFiles", params);
       return;
     }
     setInspectorSelection({
@@ -358,11 +377,42 @@ function ThreadRouteContent(
   }, [
     fileInspector.supported,
     navigation,
+    props.auxiliaryRoute,
+    props.onReturnToThread,
     props.renderInspector,
     routeThreadIdentity,
     selectedThread,
     selectedThreadCwd,
     showAuxiliaryPane,
+  ]);
+  const handleOpenPreview = useCallback(() => {
+    if (selectedThread === null) {
+      return;
+    }
+    const action = resolveThreadAuxiliaryRouteAction({
+      current: props.auxiliaryRoute ?? null,
+      target: "browser",
+      persistentFileInspector: fileInspector.supported,
+    });
+    if (action === "close") {
+      props.onReturnToThread?.();
+      return;
+    }
+    const params = {
+      environmentId: String(selectedThread.environmentId),
+      threadId: String(selectedThread.id),
+    };
+    if (action === "replace") {
+      navigation.dispatch(StackActions.replace("ThreadPreview", params));
+      return;
+    }
+    navigation.navigate("ThreadPreview", params);
+  }, [
+    fileInspector.supported,
+    navigation,
+    props.auxiliaryRoute,
+    props.onReturnToThread,
+    selectedThread,
   ]);
   const inspectorToggleActionRef = useRef({
     inspectorMode,
@@ -452,6 +502,8 @@ function ThreadRouteContent(
     [FilesInspector, GitInspector, RouteInspector, inspectorMode, props.renderInspector],
   );
   const activeInspectorRenderer = inspectorMode === null ? undefined : renderInspectorStack;
+  const activeInspectorRole =
+    inspectorMode === "route" && props.auxiliaryRoute === "browser" ? "preview" : "inspector";
   // Hand the inspector to the workspace so it renders beside the navigator,
   // outside this screen's native header — the terminal/git/files toolbar
   // stays anchored to the chat pane instead of floating above the inspector.
@@ -611,6 +663,7 @@ function ThreadRouteContent(
     projectScripts: selectedThreadProject?.scripts ?? [],
     terminalSessions: terminalMenuSessions,
     showDirectFileControl: layout.usesSplitView,
+    onOpenPreview: handleOpenPreview,
     onOpenTerminal: handleOpenTerminal,
     onOpenNewTerminal: handleOpenNewTerminal,
     onRunProjectScript: handleRunProjectScript,
@@ -671,6 +724,11 @@ function ThreadRouteContent(
         onPress: props.onReturnToThread,
       });
     }
+    actions.push({
+      accessibilityLabel: "Open browser",
+      icon: "globe",
+      onPress: handleOpenPreview,
+    });
     if (selectedThreadCwd !== null) {
       actions.push({
         accessibilityLabel: "Open files",
@@ -701,6 +759,7 @@ function ThreadRouteContent(
   }, [
     fileInspector.supported,
     handleOpenFilesInspector,
+    handleOpenPreview,
     handleOpenTerminal,
     handleOpenGitInspector,
     handleToggleInspector,
@@ -778,6 +837,7 @@ function ThreadRouteContent(
           onPickDraftImages={composer.onPickDraftImages}
           onNativePasteImages={composer.onNativePasteImages}
           onRemoveDraftImage={composer.onRemoveDraftImage}
+          onReplaceDraftImage={composer.onReplaceDraftImage}
           serverConfig={serverConfig}
           onStopThread={handleStopThread}
           onSendMessage={composer.onSendMessage}
@@ -796,7 +856,7 @@ function ThreadRouteContent(
 
   return (
     <>
-      {activeInspectorRenderer ? <InspectorPaneRoleActivation /> : null}
+      {activeInspectorRenderer ? <InspectorPaneRoleActivation role={activeInspectorRole} /> : null}
       <NativeStackScreenOptions
         options={{
           // Android draws its own in-flow header (AndroidScreenHeader below);

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -697,7 +697,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
           selectedEnvironmentServerConfig,
           draft.modelSelection ?? null,
         ) ?? selectedModel;
-      if (text.length === 0 || !draftModelSelection) {
+      if ((text.length === 0 && draft.attachments.length === 0) || !draftModelSelection) {
         return null;
       }
       const workspaceSelection = draft.workspaceSelection;

--- a/apps/mobile/src/features/threads/projectThreadCreationValidation.ts
+++ b/apps/mobile/src/features/threads/projectThreadCreationValidation.ts
@@ -38,8 +38,9 @@ export function validateProjectThreadCreation(input: {
   readonly environmentMode: "local" | "worktree";
   readonly branch: string | null;
   readonly initialMessageText: string;
+  readonly initialAttachmentCount: number;
 }): ProjectThreadCreationValidationError | null {
-  if (input.initialMessageText.trim().length === 0) {
+  if (input.initialMessageText.trim().length === 0 && input.initialAttachmentCount === 0) {
     return new ProjectThreadTaskRequiredError({
       environmentId: input.environmentId,
       projectId: input.projectId,

--- a/apps/mobile/src/features/threads/threadAuxiliaryRoute.test.ts
+++ b/apps/mobile/src/features/threads/threadAuxiliaryRoute.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveThreadAuxiliaryRouteAction } from "./threadAuxiliaryRoute";
+
+describe("thread auxiliary routes", () => {
+  it("toggles the active Browser or Files route closed", () => {
+    expect(
+      resolveThreadAuxiliaryRouteAction({
+        current: "browser",
+        target: "browser",
+        persistentFileInspector: true,
+      }),
+    ).toBe("close");
+    expect(
+      resolveThreadAuxiliaryRouteAction({
+        current: "files",
+        target: "files",
+        persistentFileInspector: true,
+      }),
+    ).toBe("close");
+  });
+
+  it("replaces one auxiliary route with the other", () => {
+    expect(
+      resolveThreadAuxiliaryRouteAction({
+        current: "browser",
+        target: "files",
+        persistentFileInspector: true,
+      }),
+    ).toBe("replace");
+    expect(
+      resolveThreadAuxiliaryRouteAction({
+        current: "files",
+        target: "browser",
+        persistentFileInspector: true,
+      }),
+    ).toBe("replace");
+  });
+
+  it("keeps Files in the workspace inspector when no auxiliary route is active", () => {
+    expect(
+      resolveThreadAuxiliaryRouteAction({
+        current: null,
+        target: "files",
+        persistentFileInspector: true,
+      }),
+    ).toBe("show-inspector");
+  });
+
+  it("navigates when Browser or compact Files needs its own route", () => {
+    expect(
+      resolveThreadAuxiliaryRouteAction({
+        current: null,
+        target: "browser",
+        persistentFileInspector: true,
+      }),
+    ).toBe("navigate");
+    expect(
+      resolveThreadAuxiliaryRouteAction({
+        current: null,
+        target: "files",
+        persistentFileInspector: false,
+      }),
+    ).toBe("navigate");
+  });
+});

--- a/apps/mobile/src/features/threads/threadAuxiliaryRoute.ts
+++ b/apps/mobile/src/features/threads/threadAuxiliaryRoute.ts
@@ -1,0 +1,20 @@
+export type ThreadAuxiliaryRoute = "browser" | "files";
+
+export type ThreadAuxiliaryRouteAction = "close" | "navigate" | "replace" | "show-inspector";
+
+export function resolveThreadAuxiliaryRouteAction(input: {
+  readonly current: ThreadAuxiliaryRoute | null;
+  readonly target: ThreadAuxiliaryRoute;
+  readonly persistentFileInspector: boolean;
+}): ThreadAuxiliaryRouteAction {
+  if (input.current === input.target) {
+    return "close";
+  }
+  if (input.current !== null) {
+    return "replace";
+  }
+  if (input.target === "files" && input.persistentFileInspector) {
+    return "show-inspector";
+  }
+  return "navigate";
+}

--- a/apps/mobile/src/features/threads/threadUserMessagePresentation.test.ts
+++ b/apps/mobile/src/features/threads/threadUserMessagePresentation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  appendPreviewAnnotationPrompt,
+  type ParsedPreviewAnnotation,
+} from "@t3tools/client-runtime/annotations";
+import type { PreviewAnnotationPayload } from "@t3tools/contracts";
+
+import { deriveThreadUserMessagePresentation } from "./threadUserMessagePresentation";
+
+function annotation(id: string, calloutNumber: number, comment: string): PreviewAnnotationPayload {
+  return {
+    id,
+    pageUrl: "",
+    pageTitle: "Screenshot.png",
+    comment: "",
+    elements: [],
+    regions: [],
+    strokes: [],
+    styleChanges: [],
+    screenshot: null,
+    createdAt: "2026-07-30T10:00:00.000Z",
+    callouts: [
+      {
+        id: `${id}-callout`,
+        number: calloutNumber,
+        comment,
+        anchor: {
+          kind: "point",
+          point: { x: 0.25, y: 0.5 },
+        },
+      },
+    ],
+  };
+}
+
+describe("deriveThreadUserMessagePresentation", () => {
+  it("removes multiple trailing annotation blocks without exposing their XML", () => {
+    const first = appendPreviewAnnotationPrompt(
+      "Update the checkout",
+      annotation("annotation-1", 1, "Increase contrast"),
+    );
+    const prompt = appendPreviewAnnotationPrompt(
+      first,
+      annotation("annotation-2", 2, "Reduce this gap"),
+    );
+
+    const presentation = deriveThreadUserMessagePresentation(prompt);
+    expect(presentation.visibleText).toBe("Update the checkout");
+    expect(presentation.visibleText).not.toContain("<preview_annotation>");
+    expect(presentation.annotations.map((entry: ParsedPreviewAnnotation) => entry.id)).toEqual([
+      "annotation-1",
+      "annotation-2",
+    ]);
+    expect(presentation.annotations.map((entry) => entry.callouts[0]?.comment)).toEqual([
+      "Increase contrast",
+      "Reduce this gap",
+    ]);
+    expect(presentation.copyText).toContain("Update the checkout");
+    expect(presentation.copyText).toContain("#1 [point: x=.25, y=.5]");
+    expect(presentation.copyText).toContain("Increase contrast");
+    expect(presentation.copyText).toContain("#2 [point: x=.25, y=.5]");
+    expect(presentation.copyText).toContain("Reduce this gap");
+    expect(presentation.copyText).not.toContain("<preview_annotation>");
+  });
+
+  it("preserves review-comment parsing before trailing annotations", () => {
+    const reviewComment = [
+      '<review_comment sectionId="section-1" sectionTitle="Working tree" filePath="src/app.ts" startIndex="0" endIndex="0" rangeLabel="+1">',
+      "Keep this change",
+      "```diff",
+      "+const enabled = true;",
+      "```",
+      "</review_comment>",
+    ].join("\n");
+    const prompt = appendPreviewAnnotationPrompt(
+      `Please review this\n\n${reviewComment}`,
+      annotation("annotation-1", 1, "Align this label"),
+    );
+
+    const presentation = deriveThreadUserMessagePresentation(prompt);
+    expect(presentation.hasReviewComment).toBe(true);
+    expect(presentation.annotations).toHaveLength(1);
+    expect(presentation.reviewSegments.some((segment) => segment.kind === "review-comment")).toBe(
+      true,
+    );
+    expect(presentation.visibleText).not.toContain("<preview_annotation>");
+  });
+
+  it("keeps callout-only annotations copyable without exposing their wrapper", () => {
+    const presentation = deriveThreadUserMessagePresentation(
+      appendPreviewAnnotationPrompt("", annotation("annotation-only", 1, "Make this primary")),
+    );
+
+    expect(presentation.visibleText).toBe("");
+    expect(presentation.copyText).toContain("Annotation: Screenshot.png");
+    expect(presentation.copyText).toContain("Make this primary");
+    expect(presentation.copyText).not.toContain("<preview_annotation>");
+  });
+
+  it("leaves ordinary user messages unchanged", () => {
+    const presentation = deriveThreadUserMessagePresentation("Just fix the bug");
+    expect(presentation.visibleText).toBe("Just fix the bug");
+    expect(presentation.copyText).toBe("Just fix the bug");
+    expect(presentation.annotations).toEqual([]);
+    expect(presentation.hasReviewComment).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/threads/threadUserMessagePresentation.ts
+++ b/apps/mobile/src/features/threads/threadUserMessagePresentation.ts
@@ -1,0 +1,33 @@
+import {
+  buildPreviewAnnotationCopyText,
+  extractTrailingPreviewAnnotations,
+  type ParsedPreviewAnnotation,
+} from "@t3tools/client-runtime/annotations";
+
+import {
+  parseReviewCommentMessageSegments,
+  type ReviewCommentMessageSegment,
+} from "../review/reviewCommentSelection";
+
+export interface ThreadUserMessagePresentation {
+  readonly visibleText: string;
+  readonly copyText: string;
+  readonly annotations: ReadonlyArray<ParsedPreviewAnnotation>;
+  readonly reviewSegments: ReadonlyArray<ReviewCommentMessageSegment>;
+  readonly hasReviewComment: boolean;
+}
+
+export function deriveThreadUserMessagePresentation(text: string): ThreadUserMessagePresentation {
+  const extracted = extractTrailingPreviewAnnotations(text);
+  const reviewSegments = parseReviewCommentMessageSegments(extracted.promptText);
+  return {
+    visibleText: extracted.promptText,
+    copyText:
+      extracted.annotations.length > 0
+        ? buildPreviewAnnotationCopyText(extracted.promptText, extracted.annotations)
+        : extracted.promptText,
+    annotations: extracted.annotations,
+    reviewSegments,
+    hasReviewComment: reviewSegments.some((segment) => segment.kind === "review-comment"),
+  };
+}

--- a/apps/mobile/src/features/threads/use-project-actions.ts
+++ b/apps/mobile/src/features/threads/use-project-actions.ts
@@ -50,6 +50,7 @@ export function useCreateProjectThread() {
         environmentMode: input.envMode,
         branch: input.branch,
         initialMessageText,
+        initialAttachmentCount: input.initialAttachments.length,
       });
       if (validationError !== null) {
         setPendingConnectionError(validationError.message);

--- a/apps/mobile/src/lib/composer-image-schema.ts
+++ b/apps/mobile/src/lib/composer-image-schema.ts
@@ -1,6 +1,41 @@
+import { PreviewAnnotationPayloadSchema } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+import * as SchemaTransformation from "effect/SchemaTransformation";
 
-export const DraftComposerImageAttachmentSchema = Schema.Struct({
+const PersistedDraftComposerImageMarkupOriginalSchema = Schema.Struct({
+  name: Schema.String,
+  mimeType: Schema.String,
+  sizeBytes: Schema.Number,
+  dataUrl: Schema.String,
+  previewUri: Schema.optional(Schema.String),
+});
+
+const DraftComposerImageMarkupOriginalSchema = Schema.Struct({
+  name: Schema.String,
+  mimeType: Schema.String,
+  sizeBytes: Schema.Number,
+  dataUrl: Schema.String,
+  previewUri: Schema.String,
+});
+
+const PersistedDraftComposerImageAttachmentSchema = Schema.Struct({
+  id: Schema.String,
+  previewUri: Schema.optional(Schema.String),
+  type: Schema.Literal("image"),
+  name: Schema.String,
+  mimeType: Schema.String,
+  sizeBytes: Schema.Number,
+  dataUrl: Schema.String,
+  markup: Schema.optional(
+    Schema.Struct({
+      annotation: PreviewAnnotationPayloadSchema,
+      original: PersistedDraftComposerImageMarkupOriginalSchema,
+    }),
+  ),
+});
+
+const RuntimeDraftComposerImageAttachmentSchema = Schema.Struct({
   id: Schema.String,
   previewUri: Schema.String,
   type: Schema.Literal("image"),
@@ -8,4 +43,60 @@ export const DraftComposerImageAttachmentSchema = Schema.Struct({
   mimeType: Schema.String,
   sizeBytes: Schema.Number,
   dataUrl: Schema.String,
+  markup: Schema.optional(
+    Schema.Struct({
+      annotation: PreviewAnnotationPayloadSchema,
+      original: DraftComposerImageMarkupOriginalSchema,
+    }),
+  ),
 });
+
+/**
+ * Keeps preview URIs available in memory while avoiding repeated base64 blobs
+ * in persisted drafts and outbox entries. A missing preview URI decodes to the
+ * durable data URL; non-data previews such as picker file URIs round-trip.
+ */
+export const DraftComposerImageAttachmentSchema = PersistedDraftComposerImageAttachmentSchema.pipe(
+  Schema.decodeTo(
+    RuntimeDraftComposerImageAttachmentSchema,
+    SchemaTransformation.transformOrFail({
+      decode: (attachment) =>
+        Effect.succeed({
+          ...attachment,
+          previewUri: attachment.previewUri ?? attachment.dataUrl,
+          ...(attachment.markup
+            ? {
+                markup: {
+                  ...attachment.markup,
+                  original: {
+                    ...attachment.markup.original,
+                    previewUri:
+                      attachment.markup.original.previewUri ?? attachment.markup.original.dataUrl,
+                  },
+                },
+              }
+            : {}),
+        } as typeof RuntimeDraftComposerImageAttachmentSchema.Encoded),
+      encode: (attachment) =>
+        Effect.succeed({
+          ...attachment,
+          ...(attachment.previewUri === attachment.dataUrl
+            ? { previewUri: undefined }
+            : { previewUri: attachment.previewUri }),
+          ...(attachment.markup
+            ? {
+                markup: {
+                  ...attachment.markup,
+                  original: {
+                    ...attachment.markup.original,
+                    ...(attachment.markup.original.previewUri === attachment.markup.original.dataUrl
+                      ? { previewUri: undefined }
+                      : { previewUri: attachment.markup.original.previewUri }),
+                  },
+                },
+              }
+            : {}),
+        } as typeof PersistedDraftComposerImageAttachmentSchema.Encoded),
+    }),
+  ),
+);

--- a/apps/mobile/src/lib/composerImageAnnotations.ts
+++ b/apps/mobile/src/lib/composerImageAnnotations.ts
@@ -1,0 +1,21 @@
+import { appendPreviewAnnotationPrompt } from "@t3tools/client-runtime/annotations";
+import type { PreviewAnnotationPayload } from "@t3tools/contracts";
+
+interface ComposerImageWithOptionalMarkup {
+  readonly markup?: {
+    readonly annotation: PreviewAnnotationPayload;
+  };
+}
+
+export function appendComposerImageAnnotationPrompts(
+  prompt: string,
+  attachments: ReadonlyArray<ComposerImageWithOptionalMarkup>,
+): string {
+  return attachments.reduce(
+    (current, attachment) =>
+      attachment.markup
+        ? appendPreviewAnnotationPrompt(current, attachment.markup.annotation)
+        : current,
+    prompt,
+  );
+}

--- a/apps/mobile/src/lib/composerImages.test.ts
+++ b/apps/mobile/src/lib/composerImages.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { PROVIDER_SEND_TURN_MAX_ATTACHMENTS } from "@t3tools/contracts";
+import {
+  PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  type PreviewAnnotationPayload,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 
 const files = new Map<string, { base64: string; deleted: boolean }>();
 
@@ -37,10 +41,26 @@ vi.mock("./uuid", () => ({
 }));
 
 import {
+  appendComposerImageAnnotationPrompts,
   convertPastedImagesToAttachments,
   isOwnedPastedImageUri,
+  restoreComposerImageOriginal,
   toUploadChatImageAttachments,
 } from "./composerImages";
+import { DraftComposerImageAttachmentSchema } from "./composer-image-schema";
+
+const annotation = (id: string, comment: string): PreviewAnnotationPayload => ({
+  id,
+  pageUrl: "",
+  pageTitle: "Attached screenshot",
+  comment,
+  elements: [],
+  regions: [],
+  strokes: [],
+  styleChanges: [],
+  screenshot: null,
+  createdAt: "2026-07-30T10:00:00.000Z",
+});
 
 describe("toUploadChatImageAttachments", () => {
   it("strips client draft id and previewUri for the startTurn wire shape", () => {
@@ -65,6 +85,128 @@ describe("toUploadChatImageAttachments", () => {
         dataUrl: "data:image/png;base64,AA==",
       },
     ]);
+  });
+
+  it("strips editable markup metadata from the startTurn wire shape", () => {
+    expect(
+      toUploadChatImageAttachments([
+        {
+          id: "client-draft-id",
+          type: "image",
+          name: "annotated.png",
+          mimeType: "image/png",
+          sizeBytes: 16,
+          dataUrl: "data:image/png;base64,YW5ub3RhdGVk",
+          previewUri: "data:image/png;base64,YW5ub3RhdGVk",
+          markup: {
+            annotation: annotation("annotation-1", "Move this button"),
+            original: {
+              name: "original.png",
+              mimeType: "image/png",
+              sizeBytes: 8,
+              dataUrl: "data:image/png;base64,b3JpZ2luYWw=",
+              previewUri: "file:///tmp/original.png",
+            },
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        type: "image",
+        name: "annotated.png",
+        mimeType: "image/png",
+        sizeBytes: 16,
+        dataUrl: "data:image/png;base64,YW5ub3RhdGVk",
+      },
+    ]);
+  });
+});
+
+describe("composer image markup", () => {
+  const markedAttachment = {
+    id: "attachment-1",
+    type: "image" as const,
+    name: "annotated.png",
+    mimeType: "image/png",
+    sizeBytes: 16,
+    dataUrl: "data:image/png;base64,YW5ub3RhdGVk",
+    previewUri: "data:image/png;base64,YW5ub3RhdGVk",
+    markup: {
+      annotation: annotation("annotation-1", "Move this button"),
+      original: {
+        name: "original.jpg",
+        mimeType: "image/jpeg",
+        sizeBytes: 8,
+        dataUrl: "data:image/jpeg;base64,b3JpZ2luYWw=",
+        previewUri: "file:///tmp/original.jpg",
+      },
+    },
+  };
+
+  it("persists annotation metadata and its restorable original image", () => {
+    const decode = Schema.decodeUnknownSync(DraftComposerImageAttachmentSchema);
+    expect(decode(markedAttachment)).toEqual(markedAttachment);
+  });
+
+  it("omits duplicate data-backed preview URIs when persisted and restores them on decode", () => {
+    const encode = Schema.encodeUnknownSync(DraftComposerImageAttachmentSchema);
+    const decode = Schema.decodeUnknownSync(DraftComposerImageAttachmentSchema);
+    const dataBackedOriginal = {
+      ...markedAttachment,
+      markup: {
+        ...markedAttachment.markup,
+        original: {
+          ...markedAttachment.markup.original,
+          previewUri: markedAttachment.markup.original.dataUrl,
+        },
+      },
+    };
+
+    const encoded = encode(dataBackedOriginal);
+    const persisted = JSON.parse(JSON.stringify(encoded)) as unknown;
+    expect(persisted).not.toHaveProperty("previewUri");
+    expect(persisted).not.toHaveProperty("markup.original.previewUri");
+    expect(decode(persisted)).toEqual(dataBackedOriginal);
+  });
+
+  it("appends attachment annotations in attachment order", () => {
+    const text = appendComposerImageAnnotationPrompts("Fix this screen", [
+      markedAttachment,
+      {
+        ...markedAttachment,
+        id: "attachment-2",
+        markup: {
+          ...markedAttachment.markup,
+          annotation: annotation("annotation-2", "Reduce this gap"),
+        },
+      },
+    ]);
+
+    expect(text).toContain("Fix this screen");
+    expect(text).not.toContain("<preview_annotation>\n<preview_annotation>");
+    expect(text.indexOf("Id: annotation-1")).toBeLessThan(text.indexOf("Id: annotation-2"));
+    expect(text.match(/<preview_annotation>/g)).toHaveLength(2);
+  });
+
+  it("restores the original image and removes markup metadata", () => {
+    expect(restoreComposerImageOriginal(markedAttachment)).toEqual({
+      id: "attachment-1",
+      type: "image",
+      ...markedAttachment.markup.original,
+    });
+  });
+
+  it("returns unmarked images unchanged", () => {
+    const plain = restoreComposerImageOriginal({
+      id: "attachment-plain",
+      type: "image",
+      name: "plain.png",
+      mimeType: "image/png",
+      sizeBytes: 3,
+      dataUrl: "data:image/png;base64,YWJj",
+      previewUri: "file:///tmp/plain.png",
+    });
+    expect(restoreComposerImageOriginal(plain)).toBe(plain);
   });
 });
 

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -1,14 +1,29 @@
 import {
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  type PreviewAnnotationPayload,
   type UploadChatImageAttachment,
 } from "@t3tools/contracts";
 import { estimateBase64ByteSize } from "./base64";
 import { uuidv4 } from "./uuid";
 
+export { appendComposerImageAnnotationPrompts } from "./composerImageAnnotations";
+
+export interface DraftComposerImageMarkupOriginal {
+  readonly name: string;
+  readonly mimeType: string;
+  readonly sizeBytes: number;
+  readonly dataUrl: string;
+  readonly previewUri: string;
+}
+
 export interface DraftComposerImageAttachment extends UploadChatImageAttachment {
   readonly id: string;
   readonly previewUri: string;
+  readonly markup?: {
+    readonly annotation: PreviewAnnotationPayload;
+    readonly original: DraftComposerImageMarkupOriginal;
+  };
 }
 
 /** Wire shape for startTurn: pure uploads without client draft id / previewUri. */
@@ -22,6 +37,20 @@ export function toUploadChatImageAttachments(
     sizeBytes: attachment.sizeBytes,
     dataUrl: attachment.dataUrl,
   }));
+}
+
+export function restoreComposerImageOriginal(
+  attachment: DraftComposerImageAttachment,
+): DraftComposerImageAttachment {
+  if (!attachment.markup) {
+    return attachment;
+  }
+
+  return {
+    id: attachment.id,
+    type: "image",
+    ...attachment.markup.original,
+  };
 }
 
 const OWNED_PASTED_IMAGE_DIRECTORY = "t3-composer-paste";

--- a/apps/mobile/src/lib/layout.test.ts
+++ b/apps/mobile/src/lib/layout.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   constrainAuxiliaryPaneWidth,
+  constrainPreviewPaneWidth,
   constrainPrimarySidebarWidth,
   deriveCenteredContentHorizontalPadding,
   deriveFileInspectorPaneLayout,
   deriveLayout,
+  derivePreviewPaneLayout,
   deriveStableFormSheetDetent,
   deriveWorkspacePaneLayout,
   SPLIT_LAYOUT_MIN_HEIGHT,
@@ -23,6 +25,12 @@ describe("resizable pane constraints", () => {
     expect(constrainAuxiliaryPaneWidth({ preferredWidth: 440, availableWidth: 1_100 })).toBe(440);
     expect(constrainAuxiliaryPaneWidth({ preferredWidth: 440, availableWidth: 900 })).toBe(340);
     expect(constrainAuxiliaryPaneWidth({ preferredWidth: 100, availableWidth: 1_100 })).toBe(260);
+  });
+
+  it("lets preview use half the window while preserving a useful chat pane", () => {
+    expect(constrainPreviewPaneWidth({ preferredWidth: 597, availableWidth: 1_194 })).toBe(597);
+    expect(constrainPreviewPaneWidth({ preferredWidth: 700, availableWidth: 1_024 })).toBe(664);
+    expect(constrainPreviewPaneWidth({ preferredWidth: 100, availableWidth: 1_024 })).toBe(320);
   });
 });
 
@@ -107,6 +115,60 @@ describe("deriveLayout", () => {
 });
 
 describe("deriveWorkspacePaneLayout", () => {
+  it("opens preview as a half-width workspace and suppresses the thread sidebar", () => {
+    const layout = deriveLayout({ width: 1_194, height: 834 });
+
+    expect(
+      deriveWorkspacePaneLayout({
+        layout,
+        viewportWidth: 1_194,
+        primarySidebarPreferredVisible: true,
+        auxiliaryPanePreferredVisible: true,
+        auxiliaryPaneRole: "preview",
+      }),
+    ).toEqual({
+      primarySidebarVisible: false,
+      primarySidebarSuppressedByAuxiliary: true,
+      contentPaneWidth: 1_194,
+      supportsAuxiliaryPane: true,
+      auxiliaryPaneVisible: true,
+      auxiliaryPaneWidth: 597,
+    });
+  });
+
+  it("lets preview take the full workspace width", () => {
+    const layout = deriveLayout({ width: 1_194, height: 834 });
+
+    expect(
+      deriveWorkspacePaneLayout({
+        layout,
+        viewportWidth: 1_194,
+        primarySidebarPreferredVisible: true,
+        auxiliaryPanePreferredVisible: true,
+        auxiliaryPaneRole: "preview",
+        auxiliaryPaneFullscreen: true,
+      }).auxiliaryPaneWidth,
+    ).toBe(1_194);
+  });
+
+  it("restores the thread sidebar when preview is hidden", () => {
+    const layout = deriveLayout({ width: 1_194, height: 834 });
+
+    expect(
+      deriveWorkspacePaneLayout({
+        layout,
+        viewportWidth: 1_194,
+        primarySidebarPreferredVisible: true,
+        auxiliaryPanePreferredVisible: false,
+        auxiliaryPaneRole: "preview",
+      }),
+    ).toMatchObject({
+      primarySidebarVisible: true,
+      primarySidebarSuppressedByAuxiliary: false,
+      auxiliaryPaneVisible: false,
+    });
+  });
+
   it("keeps the auxiliary pane out of a standard iPad detail column", () => {
     const layout = deriveLayout({ width: 1_194, height: 834 });
 
@@ -327,6 +389,24 @@ describe("deriveWorkspacePaneLayout", () => {
       supportsAuxiliaryPane: false,
       auxiliaryPaneVisible: false,
       auxiliaryPaneWidth: null,
+    });
+  });
+});
+
+describe("derivePreviewPaneLayout", () => {
+  it("supports review panes on iPad-sized windows", () => {
+    const layout = deriveLayout({ width: 1_024, height: 768 });
+    expect(derivePreviewPaneLayout({ layout, viewportWidth: 1_024 })).toEqual({
+      supported: true,
+      width: 512,
+    });
+  });
+
+  it("keeps preview on its own screen below the workspace breakpoint", () => {
+    const layout = deriveLayout({ width: 744, height: 1_133 });
+    expect(derivePreviewPaneLayout({ layout, viewportWidth: 744 })).toEqual({
+      supported: false,
+      width: null,
     });
   });
 });

--- a/apps/mobile/src/lib/layout.ts
+++ b/apps/mobile/src/lib/layout.ts
@@ -24,6 +24,9 @@ export const AUXILIARY_PANE_MAX_WIDTH = 480;
 const AUXILIARY_PANE_DEFAULT_MAX_WIDTH = 320;
 const FILE_INSPECTOR_MIN_VIEWPORT_WIDTH = 820;
 const FILE_INSPECTOR_MIN_MAIN_WIDTH = 560;
+const PREVIEW_PANE_MIN_VIEWPORT_WIDTH = 820;
+const PREVIEW_PANE_MIN_WIDTH = 320;
+const PREVIEW_PANE_MIN_CHAT_WIDTH = 360;
 const STABLE_FORM_SHEET_MAX_HEIGHT = 720;
 const STABLE_FORM_SHEET_VERTICAL_MARGIN = 64;
 const STABLE_FORM_SHEET_MIN_DETENT = 0.62;
@@ -52,7 +55,12 @@ export interface FileInspectorPaneLayout {
   readonly width: number | null;
 }
 
-export type WorkspaceAuxiliaryPaneRole = "supplementary" | "inspector";
+export interface PreviewPaneLayout {
+  readonly supported: boolean;
+  readonly width: number | null;
+}
+
+export type WorkspaceAuxiliaryPaneRole = "supplementary" | "inspector" | "preview";
 
 export function deriveLayout(input: { readonly width: number; readonly height: number }): Layout {
   const { width, height } = input;
@@ -86,6 +94,7 @@ export function deriveWorkspacePaneLayout(input: {
   readonly auxiliaryPanePreferredVisible: boolean;
   readonly auxiliaryPaneRole?: WorkspaceAuxiliaryPaneRole;
   readonly auxiliaryPanePreferredWidth?: number;
+  readonly auxiliaryPaneFullscreen?: boolean;
 }): WorkspacePaneLayout {
   const viewportWidth = Math.max(0, input.viewportWidth);
   const auxiliaryPaneRole = input.auxiliaryPaneRole ?? "supplementary";
@@ -121,6 +130,30 @@ export function deriveWorkspacePaneLayout(input: {
       supportsAuxiliaryPane: fileInspector.supported,
       auxiliaryPaneVisible,
       auxiliaryPaneWidth: fileInspector.width,
+    };
+  }
+
+  if (auxiliaryPaneRole === "preview") {
+    const previewPane = derivePreviewPaneLayout({
+      layout: input.layout,
+      viewportWidth,
+      preferredWidth: input.auxiliaryPanePreferredWidth,
+    });
+    const auxiliaryPaneVisible = previewPane.supported && input.auxiliaryPanePreferredVisible;
+    const primarySidebarSuppressedByAuxiliary =
+      preferredPrimarySidebarVisible && auxiliaryPaneVisible;
+    const primarySidebarVisible =
+      preferredPrimarySidebarVisible && !primarySidebarSuppressedByAuxiliary;
+    const primarySidebarWidth = primarySidebarVisible ? (input.layout.listPaneWidth ?? 0) : 0;
+
+    return {
+      primarySidebarVisible,
+      primarySidebarSuppressedByAuxiliary,
+      contentPaneWidth: Math.max(0, viewportWidth - primarySidebarWidth),
+      supportsAuxiliaryPane: previewPane.supported,
+      auxiliaryPaneVisible,
+      auxiliaryPaneWidth:
+        auxiliaryPaneVisible && input.auxiliaryPaneFullscreen ? viewportWidth : previewPane.width,
     };
   }
 
@@ -180,6 +213,25 @@ export function deriveFileInspectorPaneLayout(input: {
   };
 }
 
+export function derivePreviewPaneLayout(input: {
+  readonly layout: Layout;
+  readonly viewportWidth: number;
+  readonly preferredWidth?: number;
+}): PreviewPaneLayout {
+  const viewportWidth = Number.isFinite(input.viewportWidth) ? Math.max(0, input.viewportWidth) : 0;
+  const supported = input.layout.usesSplitView && viewportWidth >= PREVIEW_PANE_MIN_VIEWPORT_WIDTH;
+
+  return {
+    supported,
+    width: supported
+      ? constrainPreviewPaneWidth({
+          preferredWidth: input.preferredWidth ?? viewportWidth / 2,
+          availableWidth: viewportWidth,
+        })
+      : null,
+  };
+}
+
 /** Keep a user-selected sidebar width useful as a window is resized. */
 export function constrainPrimarySidebarWidth(
   preferredWidth: number,
@@ -215,6 +267,21 @@ export function constrainAuxiliaryPaneWidth(input: {
     Math.min(AUXILIARY_PANE_MAX_WIDTH, availableWidth - FILE_INSPECTOR_MIN_MAIN_WIDTH),
   );
   return clamp(Math.round(safePreferredWidth), AUXILIARY_PANE_MIN_WIDTH, maxWidth);
+}
+
+/** Keep preview and chat useful while allowing a true half-width review split. */
+export function constrainPreviewPaneWidth(input: {
+  readonly preferredWidth: number;
+  readonly availableWidth: number;
+}): number {
+  const safePreferredWidth = Number.isFinite(input.preferredWidth)
+    ? input.preferredWidth
+    : PREVIEW_PANE_MIN_WIDTH;
+  const availableWidth = Number.isFinite(input.availableWidth)
+    ? Math.max(0, input.availableWidth)
+    : 0;
+  const maxWidth = Math.max(PREVIEW_PANE_MIN_WIDTH, availableWidth - PREVIEW_PANE_MIN_CHAT_WIDTH);
+  return clamp(Math.round(safePreferredWidth), PREVIEW_PANE_MIN_WIDTH, maxWidth);
 }
 
 export function deriveCenteredContentHorizontalPadding(input: {

--- a/apps/mobile/src/lib/projectThreadStartTurn.test.ts
+++ b/apps/mobile/src/lib/projectThreadStartTurn.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  EnvironmentId,
+  ProjectId,
+  ProviderInstanceId,
+  type PreviewAnnotationPayload,
+} from "@t3tools/contracts";
+
+vi.mock("./uuid", () => ({
+  uuidv4: () => "unused",
+}));
+
+import { buildProjectThreadStartTurnInput } from "./projectThreadStartTurn";
+import { validateProjectThreadCreation } from "../features/threads/projectThreadCreationValidation";
+
+const ANNOTATION: PreviewAnnotationPayload = {
+  id: "annotation-1",
+  pageUrl: "",
+  pageTitle: "Attached screenshot",
+  comment: "Make the primary action more prominent",
+  elements: [],
+  regions: [],
+  strokes: [],
+  styleChanges: [],
+  screenshot: null,
+  createdAt: "2026-07-30T10:00:00.000Z",
+  callouts: [
+    {
+      id: "callout-1",
+      number: 1,
+      comment: "Make the primary action more prominent",
+      anchor: { kind: "point", point: { x: 0.5, y: 0.5 } },
+    },
+  ],
+};
+
+const MARKED_ATTACHMENT = {
+  id: "attachment-1",
+  type: "image" as const,
+  name: "checkout-markup.png",
+  mimeType: "image/png",
+  sizeBytes: 16,
+  dataUrl: "data:image/png;base64,YW5ub3RhdGVk",
+  previewUri: "data:image/png;base64,YW5ub3RhdGVk",
+  markup: {
+    annotation: ANNOTATION,
+    original: {
+      name: "checkout.png",
+      mimeType: "image/png",
+      sizeBytes: 8,
+      dataUrl: "data:image/png;base64,b3JpZ2luYWw=",
+      previewUri: "file:///tmp/checkout.png",
+    },
+  },
+};
+
+describe("buildProjectThreadStartTurnInput", () => {
+  it("delivers attachment annotations without including them in the thread title", () => {
+    const input = buildProjectThreadStartTurnInput({
+      projectId: ProjectId.make("project-1"),
+      projectCwd: "/repo",
+      threadId: "thread-1",
+      commandId: "command-1",
+      messageId: "message-1",
+      createdAt: "2026-07-30T10:00:00.000Z",
+      text: "Fix the checkout screen",
+      attachments: [MARKED_ATTACHMENT],
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5.4",
+      },
+      runtimeMode: "approval-required",
+      interactionMode: "default",
+      workspaceMode: "local",
+      branch: null,
+      worktreePath: null,
+      startFromOrigin: false,
+      worktreeBranchName: "unused",
+    });
+
+    expect(input.titleSeed).toBe("Fix the checkout screen");
+    expect(input.bootstrap.createThread.title).toBe("Fix the checkout screen");
+    expect(input.message.text).toContain("Fix the checkout screen");
+    expect(input.message.text).toContain("<preview_annotation>");
+    expect(input.message.text).toContain("Make the primary action more prominent");
+    expect(input.message.attachments).toEqual([
+      {
+        type: "image",
+        name: "checkout-markup.png",
+        mimeType: "image/png",
+        sizeBytes: 16,
+        dataUrl: "data:image/png;base64,YW5ub3RhdGVk",
+      },
+    ]);
+  });
+
+  it("uses an annotation comment as the title and instruction when raw text is empty", () => {
+    const input = buildProjectThreadStartTurnInput({
+      projectId: ProjectId.make("project-1"),
+      projectCwd: "/repo",
+      threadId: "thread-1",
+      commandId: "command-1",
+      messageId: "message-1",
+      createdAt: "2026-07-30T10:00:00.000Z",
+      text: "",
+      attachments: [MARKED_ATTACHMENT],
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5.4",
+      },
+      runtimeMode: "approval-required",
+      interactionMode: "default",
+      workspaceMode: "local",
+      branch: null,
+      worktreePath: null,
+      startFromOrigin: false,
+      worktreeBranchName: "unused",
+    });
+
+    expect(input.titleSeed).toBe("Make the primary action more prominent");
+    expect(input.bootstrap.createThread.title).toBe("Make the primary action more prominent");
+    expect(input.message.text).toContain("<preview_annotation>");
+    expect(input.message.text).toContain("Make the primary action more prominent");
+  });
+});
+
+describe("validateProjectThreadCreation", () => {
+  const base = {
+    environmentId: EnvironmentId.make("environment-1"),
+    projectId: ProjectId.make("project-1"),
+    environmentMode: "local" as const,
+    branch: null,
+    initialMessageText: "",
+  };
+
+  it("accepts an attachment-only task but still rejects a completely empty task", () => {
+    expect(validateProjectThreadCreation({ ...base, initialAttachmentCount: 1 })).toBeNull();
+    expect(validateProjectThreadCreation({ ...base, initialAttachmentCount: 0 })?._tag).toBe(
+      "ProjectThreadTaskRequiredError",
+    );
+  });
+});

--- a/apps/mobile/src/lib/projectThreadStartTurn.ts
+++ b/apps/mobile/src/lib/projectThreadStartTurn.ts
@@ -8,16 +8,45 @@ import {
   type RuntimeMode,
 } from "@t3tools/contracts";
 
-import { toUploadChatImageAttachments, type DraftComposerImageAttachment } from "./composerImages";
+import {
+  appendComposerImageAnnotationPrompts,
+  toUploadChatImageAttachments,
+  type DraftComposerImageAttachment,
+} from "./composerImages";
 
-export function deriveThreadTitleFromPrompt(value: string): string {
+function compactThreadTitle(value: string): string {
+  const compact = value.trim().replace(/\s+/g, " ");
+  return compact.length <= 72 ? compact : `${compact.slice(0, 69).trimEnd()}...`;
+}
+
+export function deriveThreadTitleFromPrompt(
+  value: string,
+  attachments: ReadonlyArray<DraftComposerImageAttachment> = [],
+): string {
   const trimmed = value.trim();
-  if (trimmed.length === 0) {
-    return "New thread";
+  if (trimmed.length > 0) {
+    return compactThreadTitle(trimmed);
   }
 
-  const compact = trimmed.replace(/\s+/g, " ");
-  return compact.length <= 72 ? compact : `${compact.slice(0, 69).trimEnd()}...`;
+  for (const attachment of attachments) {
+    for (const callout of attachment.markup?.annotation.callouts ?? []) {
+      if (callout.comment.trim().length > 0) {
+        return compactThreadTitle(callout.comment);
+      }
+    }
+    const legacyComment = attachment.markup?.annotation.comment.trim() ?? "";
+    if (legacyComment.length > 0) {
+      return compactThreadTitle(legacyComment);
+    }
+  }
+
+  const firstAttachment = attachments[0];
+  if (firstAttachment) {
+    return compactThreadTitle(
+      `Review ${firstAttachment.markup?.original.name || firstAttachment.name || "attached image"}`,
+    );
+  }
+  return "New thread";
 }
 
 export interface ProjectThreadStartTurnSpec {
@@ -46,7 +75,8 @@ export interface ProjectThreadStartTurnSpec {
  * offline outbox drain so both deliver identical commands.
  */
 export function buildProjectThreadStartTurnInput(spec: ProjectThreadStartTurnSpec) {
-  const title = deriveThreadTitleFromPrompt(spec.text);
+  const title = deriveThreadTitleFromPrompt(spec.text, spec.attachments);
+  const deliveryText = appendComposerImageAnnotationPrompts(spec.text, spec.attachments);
   const isWorktree = spec.workspaceMode === "worktree";
   return {
     commandId: CommandId.make(spec.commandId),
@@ -54,7 +84,7 @@ export function buildProjectThreadStartTurnInput(spec: ProjectThreadStartTurnSpe
     message: {
       messageId: MessageId.make(spec.messageId),
       role: "user" as const,
-      text: spec.text,
+      text: deliveryText,
       attachments: toUploadChatImageAttachments(spec.attachments),
     },
     modelSelection: spec.modelSelection,

--- a/apps/mobile/src/state/preview.ts
+++ b/apps/mobile/src/state/preview.ts
@@ -1,0 +1,5 @@
+import { createPreviewEnvironmentAtoms } from "@t3tools/client-runtime/state/preview";
+
+import { connectionAtomRuntime } from "../connection/runtime";
+
+export const previewEnvironment = createPreviewEnvironmentAtoms(connectionAtomRuntime);

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -6,6 +6,7 @@ import {
   IsoDateTime,
   MessageId,
   ModelSelection,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   ProjectId,
   ProviderInteractionMode,
   RuntimeMode,
@@ -18,6 +19,7 @@ import {
 import * as Schema from "effect/Schema";
 
 import { DraftComposerImageAttachmentSchema } from "../lib/composer-image-schema";
+import { appendComposerImageAnnotationPrompts } from "../lib/composerImageAnnotations";
 import type { DraftComposerImageAttachment } from "../lib/composerImages";
 import { scopedThreadKey } from "../lib/scopedEntities";
 
@@ -180,7 +182,12 @@ export function isQueuedThreadCreationSendable(message: QueuedThreadMessage): bo
   if (!message.creation) {
     return false;
   }
-  if (message.text.trim().length === 0 || message.modelSelection === undefined) {
+  const deliveryText = appendComposerImageAnnotationPrompts(message.text, message.attachments);
+  if (
+    (deliveryText.trim().length === 0 && message.attachments.length === 0) ||
+    deliveryText.length > PROVIDER_SEND_TURN_MAX_INPUT_CHARS ||
+    message.modelSelection === undefined
+  ) {
     return false;
   }
   return message.creation.workspaceMode !== "worktree" || Boolean(message.creation.branch);

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -3,6 +3,7 @@ import {
   CommandId,
   EnvironmentId,
   MessageId,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
@@ -567,6 +568,36 @@ describe("thread outbox", () => {
     expect(isQueuedThreadCreationSendable({ ...creationMessage, modelSelection: undefined })).toBe(
       false,
     );
+    expect(
+      isQueuedThreadCreationSendable({
+        ...creationMessage,
+        text: "",
+        attachments: [
+          {
+            id: "attachment-1",
+            type: "image",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            sizeBytes: 3,
+            dataUrl: "data:image/png;base64,YWJj",
+            previewUri: "file:///tmp/screenshot.png",
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      isQueuedThreadCreationSendable({
+        ...creationMessage,
+        text: "",
+        attachments: [],
+      }),
+    ).toBe(false);
+    expect(
+      isQueuedThreadCreationSendable({
+        ...creationMessage,
+        text: "x".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS + 1),
+      }),
+    ).toBe(false);
     expect(isQueuedThreadCreationSendable(base)).toBe(false);
   });
 

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -10,6 +10,7 @@ import {
   getComposerDraftSnapshot,
   mergeComposerDraftContentState,
   removeComposerDraftsForEnvironment,
+  replaceComposerDraftAttachmentState,
   restoreComposerDraftSnapshotState,
 } from "./use-composer-drafts";
 
@@ -223,6 +224,56 @@ describe("mobile composer drafts", () => {
     expect(merged[draftKey]?.attachments).toHaveLength(8);
     expect(merged[draftKey]?.attachments[0]).toEqual(existingImage);
     expect(merged[draftKey]?.attachments.at(-1)?.id).toBe("shared-6");
+  });
+
+  it("replaces one attachment in place without disturbing draft settings", () => {
+    const draftKey = "environment-1:thread-1";
+    const image = (id: string, name = `${id}.png`) => ({
+      id,
+      type: "image" as const,
+      name,
+      mimeType: "image/png",
+      sizeBytes: 3,
+      dataUrl: "data:image/png;base64,YWJj",
+      previewUri: `file:///tmp/${name}`,
+    });
+    const first = image("first");
+    const second = image("second");
+    const replacement = image("first", "first-annotated.png");
+    const current: Record<string, ComposerDraft> = {
+      [draftKey]: {
+        text: "Keep this text",
+        attachments: [first, second],
+        runtimeMode: "approval-required",
+      },
+    };
+
+    expect(replaceComposerDraftAttachmentState(current, draftKey, replacement)).toEqual({
+      [draftKey]: {
+        text: "Keep this text",
+        attachments: [replacement, second],
+        runtimeMode: "approval-required",
+      },
+    });
+  });
+
+  it("does not create or rewrite a draft when the replacement id is missing", () => {
+    const draftKey = "environment-1:thread-1";
+    const current: Record<string, ComposerDraft> = {
+      [draftKey]: DRAFT,
+    };
+    const replacement = {
+      id: "missing",
+      type: "image" as const,
+      name: "missing.png",
+      mimeType: "image/png",
+      sizeBytes: 3,
+      dataUrl: "data:image/png;base64,YWJj",
+      previewUri: "file:///tmp/missing.png",
+    };
+
+    expect(replaceComposerDraftAttachmentState(current, draftKey, replacement)).toBe(current);
+    expect(replaceComposerDraftAttachmentState({}, draftKey, replacement)).toEqual({});
   });
 
   it("restores the exact draft captured before an interrupted share import", () => {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -90,6 +90,9 @@ const PersistedComposerDraftsSchema = Schema.Struct({
 const decodePersistedComposerDraftsDocument = Schema.decodeUnknownSync(
   PersistedComposerDraftsSchema,
 );
+const encodePersistedComposerDraftsDocument = Schema.encodeUnknownSync(
+  PersistedComposerDraftsSchema,
+);
 
 const EMPTY_DRAFT: ComposerDraft = {
   text: "",
@@ -186,7 +189,7 @@ async function writePersistedComposerDrafts(drafts: Record<string, ComposerDraft
       schemaVersion: COMPOSER_DRAFTS_SCHEMA_VERSION,
       drafts: nonEmptyDrafts,
     } as const;
-    const encoded = JSON.stringify(document);
+    const encoded = JSON.stringify(encodePersistedComposerDraftsDocument(document));
     operation = "write";
     if (!file.exists) {
       file.create({ intermediates: true, overwrite: true });
@@ -327,6 +330,44 @@ export function replaceComposerDraftAttachments(
       [draftKey]: draft,
     };
   });
+}
+
+export function replaceComposerDraftAttachmentState(
+  current: Record<string, ComposerDraft>,
+  draftKey: string,
+  attachment: DraftComposerImageAttachment,
+): Record<string, ComposerDraft> {
+  const existing = current[draftKey];
+  if (!existing) {
+    return current;
+  }
+
+  const index = existing.attachments.findIndex((image) => image.id === attachment.id);
+  if (index < 0 || existing.attachments[index] === attachment) {
+    return current;
+  }
+
+  const attachments = [...existing.attachments];
+  attachments[index] = attachment;
+  return {
+    ...current,
+    [draftKey]: {
+      ...existing,
+      attachments,
+    },
+  };
+}
+
+export function replaceComposerDraftAttachment(
+  draftKey: string,
+  attachment: DraftComposerImageAttachment,
+): void {
+  const current = appAtomRegistry.get(composerDraftsAtom);
+  const next = replaceComposerDraftAttachmentState(current, draftKey, attachment);
+  if (next === current) {
+    return;
+  }
+  updateComposerDrafts(() => next);
 }
 
 export function removeComposerDraftAttachment(draftKey: string, imageId: string): void {

--- a/apps/mobile/src/state/use-pending-new-tasks.ts
+++ b/apps/mobile/src/state/use-pending-new-tasks.ts
@@ -26,7 +26,7 @@ export function usePendingNewTasks(): ReadonlyArray<PendingNewTask> {
       tasks.push({
         message,
         creation: message.creation,
-        title: deriveThreadTitleFromPrompt(message.text),
+        title: deriveThreadTitleFromPrompt(message.text, message.attachments),
       });
     }
     tasks.sort((left, right) => right.message.createdAt.localeCompare(left.message.createdAt));

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import {
   CommandId,
   MessageId,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   type EnvironmentId,
   type ModelSelection,
   type ProviderInteractionMode,
@@ -15,6 +16,7 @@ import { deriveActiveWorkStartedAt } from "@t3tools/shared/orchestrationTiming";
 
 import { makeQueuedMessageMetadata } from "../lib/commandMetadata";
 import {
+  appendComposerImageAnnotationPrompts,
   convertPastedImagesToAttachments,
   pasteComposerClipboard,
   pickComposerImages,
@@ -32,6 +34,7 @@ import {
   getComposerDraftSnapshot,
   mergeComposerDraftContent,
   removeComposerDraftAttachment,
+  replaceComposerDraftAttachment,
   setComposerDraftText,
   updateComposerDraftSettings,
   useComposerDraft,
@@ -144,6 +147,13 @@ export function useThreadComposerState() {
     const text = draft.text.trim();
     const attachments = draft.attachments;
     if (text.length === 0 && attachments.length === 0) {
+      return null;
+    }
+    const deliveryText = appendComposerImageAnnotationPrompts(text, attachments);
+    if (deliveryText.length > PROVIDER_SEND_TURN_MAX_INPUT_CHARS) {
+      setPendingConnectionError(
+        "This message is too long after adding image annotation comments. Shorten the message or its callouts and try again.",
+      );
       return null;
     }
 
@@ -269,6 +279,18 @@ export function useThreadComposerState() {
     [selectedThreadShell],
   );
 
+  const onReplaceDraftImage = useCallback(
+    (attachment: DraftComposerImageAttachment) => {
+      if (!selectedThreadShell) {
+        return;
+      }
+
+      const threadKey = scopedThreadKey(selectedThreadShell.environmentId, selectedThreadShell.id);
+      replaceComposerDraftAttachment(threadKey, attachment);
+    },
+    [selectedThreadShell],
+  );
+
   const onUpdateModelSelection = useCallback(
     (value: ModelSelection) => {
       if (!selectedThreadKey) {
@@ -314,6 +336,7 @@ export function useThreadComposerState() {
     onPasteIntoDraft,
     onNativePasteImages,
     onRemoveDraftImage,
+    onReplaceDraftImage,
     onSendMessage,
     onUpdateModelSelection,
     onUpdateRuntimeMode,

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -17,7 +17,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { scopedThreadKey } from "../lib/scopedEntities";
 import { buildProjectThreadStartTurnInput } from "../lib/projectThreadStartTurn";
-import { toUploadChatImageAttachments } from "../lib/composerImages";
+import {
+  appendComposerImageAnnotationPrompts,
+  toUploadChatImageAttachments,
+} from "../lib/composerImages";
 import { randomHex } from "../lib/uuid";
 import { appAtomRegistry } from "./atom-registry";
 import { useProjects, useThreadShells } from "./entities";
@@ -225,7 +228,10 @@ export function useThreadOutboxDrain(): void {
           message: {
             messageId: queuedMessage.messageId,
             role: "user",
-            text: queuedMessage.text,
+            text: appendComposerImageAnnotationPrompts(
+              queuedMessage.text,
+              queuedMessage.attachments,
+            ),
             attachments: toUploadChatImageAttachments(queuedMessage.attachments),
           },
           modelSelection: settings.modelSelection,

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -91,6 +91,8 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.previewClose]: AuthOrchestrationOperateScope,
   [WS_METHODS.previewList]: AuthOrchestrationReadScope,
   [WS_METHODS.previewReportStatus]: AuthOrchestrationOperateScope,
+  [WS_METHODS.previewReviewSnapshot]: AuthOrchestrationOperateScope,
+  [WS_METHODS.previewOpenLiveGateway]: AuthOrchestrationOperateScope,
   [WS_METHODS.previewAutomationConnect]: AuthOrchestrationOperateScope,
   [WS_METHODS.previewAutomationRespond]: AuthOrchestrationOperateScope,
   [WS_METHODS.previewAutomationFocusHost]: AuthOrchestrationOperateScope,

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -2,6 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
 import {
   EnvironmentId,
+  PreviewAutomationClientId,
   PreviewAutomationClientDisconnectedError,
   PreviewAutomationInvalidSelectorError,
   PreviewAutomationMalformedResponseError,
@@ -454,6 +455,107 @@ it.effect("rejects calls when no connected host exists", () =>
       providerInstanceId: scope.providerInstanceId,
     });
   }),
+);
+
+it.effect("routes authenticated client review flows without provider-shaped identity", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const clientScope: PreviewAutomationBroker.PreviewAutomationClientInvokeScope = {
+        environmentId: scope.environmentId,
+        threadId: scope.threadId,
+        assignmentId: "review-assignment-1",
+        requesterId: PreviewAutomationClientId.make("review-requester-1"),
+      };
+      const requests = requestsFrom(yield* broker.connect(makeHost()));
+      yield* Stream.runForEach(requests, (request) =>
+        broker.respond({
+          clientId: "client-1",
+          connectionId: request.connectionId,
+          requestId: request.requestId,
+          ok: true,
+          result: "review",
+        }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      expect(
+        yield* broker.invoke<string>({
+          scope: clientScope,
+          operation: "snapshot",
+          input: {},
+        }),
+      ).toBe("review");
+
+      const unavailable = yield* broker
+        .invoke<string>({
+          scope: { ...clientScope, environmentId: EnvironmentId.make("environment-missing") },
+          operation: "snapshot",
+          input: {},
+        })
+        .pipe(Effect.flip);
+      expect(unavailable).toMatchObject({
+        requesterId: "review-requester-1",
+      });
+      expect(unavailable).not.toHaveProperty("providerSessionId");
+      expect(unavailable).not.toHaveProperty("providerInstanceId");
+    }),
+  ),
+);
+
+it.effect("namespaces provider and authenticated-client host assignments", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const sharedAssignmentId = "shared-assignment";
+      const firstRequests = requestsFrom(yield* broker.connect(makeHost({ clientId: "client-1" })));
+      yield* Stream.runForEach(firstRequests, (request) =>
+        broker.respond({
+          clientId: "client-1",
+          connectionId: request.connectionId,
+          requestId: request.requestId,
+          ok: true,
+          result: "client-1",
+        }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      expect(
+        yield* broker.invoke<string>({
+          scope: { ...scope, providerSessionId: sharedAssignmentId },
+          operation: "snapshot",
+          input: {},
+        }),
+      ).toBe("client-1");
+
+      const secondRequests = requestsFrom(
+        yield* broker.connect(makeHost({ clientId: "client-2" })),
+      );
+      yield* Stream.runForEach(secondRequests, (request) =>
+        broker.respond({
+          clientId: "client-2",
+          connectionId: request.connectionId,
+          requestId: request.requestId,
+          ok: true,
+          result: "client-2",
+        }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      expect(
+        yield* broker.invoke<string>({
+          scope: {
+            environmentId: scope.environmentId,
+            threadId: scope.threadId,
+            assignmentId: sharedAssignmentId,
+            requesterId: PreviewAutomationClientId.make("review-requester-1"),
+          },
+          operation: "snapshot",
+          input: {},
+        }),
+      ).toBe("client-2");
+    }),
+  ),
 );
 
 it.effect("does not create host state from focus updates without a live stream", () =>

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -15,6 +15,7 @@ import {
   PreviewAutomationUnsupportedClientError,
   PreviewTabId,
   type PreviewAutomationError,
+  type PreviewAutomationClientId,
   type PreviewAutomationOperation,
   type PreviewAutomationHost,
   type PreviewAutomationHostFocus,
@@ -34,8 +35,21 @@ import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import * as McpInvocationContext from "./McpInvocationContext.ts";
 
+export interface PreviewAutomationClientInvokeScope {
+  readonly environmentId: McpInvocationContext.McpInvocationScope["environmentId"];
+  readonly threadId: McpInvocationContext.McpInvocationScope["threadId"];
+  /** Stable, caller-owned identity used only to pin this flow to one desktop host. */
+  readonly assignmentId: string;
+  /** Authenticated client identity copied into diagnostics without pretending it is a provider. */
+  readonly requesterId: PreviewAutomationClientId;
+}
+
+export type PreviewAutomationInvokeScope =
+  | McpInvocationContext.McpInvocationScope
+  | PreviewAutomationClientInvokeScope;
+
 export interface PreviewAutomationInvokeInput {
-  readonly scope: McpInvocationContext.McpInvocationScope;
+  readonly scope: PreviewAutomationInvokeScope;
   readonly operation: PreviewAutomationOperation;
   readonly input: unknown;
   readonly tabId?: PreviewTabId;
@@ -94,8 +108,9 @@ interface PreviewAutomationRequestErrorContext {
   readonly operation: PreviewAutomationOperation;
   readonly environmentId: McpInvocationContext.McpInvocationScope["environmentId"];
   readonly threadId: McpInvocationContext.McpInvocationScope["threadId"];
-  readonly providerSessionId: string;
-  readonly providerInstanceId: McpInvocationContext.McpInvocationScope["providerInstanceId"];
+  readonly providerSessionId?: string;
+  readonly providerInstanceId?: McpInvocationContext.McpInvocationScope["providerInstanceId"];
+  readonly requesterId?: string;
   readonly clientId: string;
   readonly connectionId: ClientConnection["connectionId"];
   readonly requestId: string;
@@ -150,8 +165,26 @@ const selectorDiagnosticsFromInput = (
   return {};
 };
 
-const hostAssignmentKey = (scope: McpInvocationContext.McpInvocationScope): string =>
-  `${scope.environmentId}\u0000${scope.providerSessionId}`;
+const invocationAssignmentId = (scope: PreviewAutomationInvokeScope): string =>
+  "assignmentId" in scope
+    ? `client\u0000${scope.assignmentId}`
+    : `provider\u0000${scope.providerSessionId}`;
+
+const invocationDiagnostics = (
+  scope: PreviewAutomationInvokeScope,
+): Pick<
+  PreviewAutomationRequestErrorContext,
+  "providerSessionId" | "providerInstanceId" | "requesterId"
+> =>
+  "assignmentId" in scope
+    ? { requesterId: scope.requesterId }
+    : {
+        providerSessionId: scope.providerSessionId,
+        providerInstanceId: scope.providerInstanceId,
+      };
+
+const hostAssignmentKey = (scope: PreviewAutomationInvokeScope): string =>
+  `${scope.environmentId}\u0000${invocationAssignmentId(scope)}`;
 
 const isPreviewTabId = Schema.is(PreviewTabId);
 
@@ -491,8 +524,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         operation: input.operation,
         environmentId: input.scope.environmentId,
         threadId: input.scope.threadId,
-        providerSessionId: input.scope.providerSessionId,
-        providerInstanceId: input.scope.providerInstanceId,
+        ...invocationDiagnostics(input.scope),
         clientId: connection.clientId,
         connectionId: connection.connectionId,
         requestId,
@@ -512,8 +544,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         operation: input.operation,
         environmentId: input.scope.environmentId,
         threadId: input.scope.threadId,
-        providerSessionId: input.scope.providerSessionId,
-        providerInstanceId: input.scope.providerInstanceId,
+        ...invocationDiagnostics(input.scope),
       });
     }
     const { connection, requestId, requestContext, requestSequence } = route;

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -48,6 +48,8 @@ import Migration0032 from "./Migrations/032_AuthPairingProofKeyThumbprint.ts";
 import Migration0033 from "./Migrations/033_ProjectionThreadsSettled.ts";
 import Migration0034 from "./Migrations/034_ProjectionThreadsSnoozed.ts";
 import Migration0035 from "./Migrations/035_ProjectionThreadTitleRegeneration.ts";
+import Migration0036 from "./Migrations/036_RepairAuthAuthorizationScopes.ts";
+import Migration0037 from "./Migrations/037_RepairAuthPairingProofKeyThumbprint.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -95,6 +97,8 @@ export const migrationEntries = [
   [33, "ProjectionThreadsSettled", Migration0033],
   [34, "ProjectionThreadsSnoozed", Migration0034],
   [35, "ProjectionThreadTitleRegeneration", Migration0035],
+  [36, "RepairAuthAuthorizationScopes", Migration0036],
+  [37, "RepairAuthPairingProofKeyThumbprint", Migration0037],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/036_RepairAuthAuthorizationScopes.test.ts
+++ b/apps/server/src/persistence/Migrations/036_RepairAuthAuthorizationScopes.test.ts
@@ -1,0 +1,85 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("036_RepairAuthAuthorizationScopes", (it) => {
+  it.effect("repairs databases that recorded an older migration at id 31", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 30 });
+
+      yield* sql`
+        INSERT INTO auth_pairing_links (
+          id,
+          credential,
+          method,
+          role,
+          subject,
+          created_at,
+          expires_at
+        )
+        VALUES (
+          'link-owner',
+          'bootstrap-owner',
+          'desktop-bootstrap',
+          'owner',
+          'desktop',
+          '2026-05-29T00:00:00.000Z',
+          '2026-05-29T01:00:00.000Z'
+        )
+      `;
+      yield* sql`
+        INSERT INTO auth_sessions (
+          session_id,
+          subject,
+          role,
+          method,
+          issued_at,
+          expires_at
+        )
+        VALUES (
+          'session-owner',
+          'desktop',
+          'owner',
+          'browser-session-cookie',
+          '2026-05-29T00:00:00.000Z',
+          '2026-05-29T01:00:00.000Z'
+        )
+      `;
+      yield* sql`
+        INSERT INTO effect_sql_migrations (migration_id, name)
+        VALUES (31, 'ProjectionThreadArtifactStates')
+      `;
+
+      yield* runMigrations({ toMigrationInclusive: 36 });
+
+      const pairingColumns = yield* sql<{ readonly name: string }>`
+        PRAGMA table_info(auth_pairing_links)
+      `;
+      const sessionColumns = yield* sql<{ readonly name: string }>`
+        PRAGMA table_info(auth_sessions)
+      `;
+      const pairingRows = yield* sql<{ readonly id: string }>`
+        SELECT id FROM auth_pairing_links
+      `;
+      const sessionRows = yield* sql<{ readonly sessionId: string }>`
+        SELECT session_id AS "sessionId" FROM auth_sessions
+      `;
+
+      assert.isTrue(pairingColumns.some((column) => column.name === "scopes"));
+      assert.isFalse(pairingColumns.some((column) => column.name === "role"));
+      assert.isTrue(pairingColumns.some((column) => column.name === "proof_key_thumbprint"));
+      assert.isTrue(sessionColumns.some((column) => column.name === "scopes"));
+      assert.isFalse(sessionColumns.some((column) => column.name === "role"));
+      assert.deepStrictEqual(pairingRows, []);
+      assert.deepStrictEqual(sessionRows, []);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/036_RepairAuthAuthorizationScopes.ts
+++ b/apps/server/src/persistence/Migrations/036_RepairAuthAuthorizationScopes.ts
@@ -1,0 +1,25 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import AuthAuthorizationScopes from "./031_AuthAuthorizationScopes.ts";
+import AuthPairingProofKeyThumbprint from "./032_AuthPairingProofKeyThumbprint.ts";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const pairingLinkColumns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(auth_pairing_links)
+  `;
+  const sessionColumns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(auth_sessions)
+  `;
+
+  const hasScopedAuthTables =
+    pairingLinkColumns.some((column) => column.name === "scopes") &&
+    sessionColumns.some((column) => column.name === "scopes");
+
+  if (!hasScopedAuthTables) {
+    yield* AuthAuthorizationScopes;
+    yield* AuthPairingProofKeyThumbprint;
+  }
+});

--- a/apps/server/src/persistence/Migrations/037_RepairAuthPairingProofKeyThumbprint.test.ts
+++ b/apps/server/src/persistence/Migrations/037_RepairAuthPairingProofKeyThumbprint.test.ts
@@ -1,0 +1,36 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("037_RepairAuthPairingProofKeyThumbprint", (it) => {
+  it.effect("repairs databases where migration 36 removed the proof-key column", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 31 });
+      yield* sql`
+        INSERT INTO effect_sql_migrations (migration_id, name)
+        VALUES
+          (32, 'AuthPairingProofKeyThumbprint'),
+          (33, 'ProjectionThreadsSettled'),
+          (34, 'ProjectionThreadsSnoozed'),
+          (35, 'ProjectionThreadTitleRegeneration'),
+          (36, 'RepairAuthAuthorizationScopes')
+      `;
+
+      yield* runMigrations({ toMigrationInclusive: 37 });
+
+      const pairingColumns = yield* sql<{ readonly name: string }>`
+        PRAGMA table_info(auth_pairing_links)
+      `;
+
+      assert.isTrue(pairingColumns.some((column) => column.name === "proof_key_thumbprint"));
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/037_RepairAuthPairingProofKeyThumbprint.ts
+++ b/apps/server/src/persistence/Migrations/037_RepairAuthPairingProofKeyThumbprint.ts
@@ -1,0 +1,3 @@
+import AuthPairingProofKeyThumbprint from "./032_AuthPairingProofKeyThumbprint.ts";
+
+export default AuthPairingProofKeyThumbprint;

--- a/apps/server/src/preview/LiveGateway.test.ts
+++ b/apps/server/src/preview/LiveGateway.test.ts
@@ -122,6 +122,26 @@ it.layer(NodeServices.layer)("PreviewLiveGateway", (it) => {
     }),
   );
 
+  it.effect("keeps pending bootstraps for different tabs in the same session", () =>
+    Effect.gen(function* () {
+      const gateway = yield* make;
+      const first = yield* gateway.issue({
+        sessionId,
+        snapshot: snapshot("http://localhost:5173/first"),
+      });
+      const second = yield* gateway.issue({
+        sessionId,
+        snapshot: {
+          ...snapshot("http://localhost:5173/second"),
+          tabId: PreviewTabId.make("tab-live-gateway-2"),
+        },
+      });
+
+      expect(yield* gateway.consumeBootstrap(bootstrapToken(first.relativeUrl))).not.toBeNull();
+      expect(yield* gateway.consumeBootstrap(bootstrapToken(second.relativeUrl))).not.toBeNull();
+    }),
+  );
+
   it.effect("expires bootstraps and leases and supports explicit tab/session revocation", () =>
     Effect.gen(function* () {
       const gateway = yield* make;

--- a/apps/server/src/preview/LiveGateway.test.ts
+++ b/apps/server/src/preview/LiveGateway.test.ts
@@ -1,0 +1,235 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import {
+  AuthSessionId,
+  PreviewTabId,
+  type PreviewSessionSnapshot,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
+
+import {
+  LIVE_GATEWAY_BOOTSTRAP_TTL_MS,
+  LIVE_GATEWAY_LEASE_TTL_MS,
+  type LiveGatewayLease,
+  isLiveGatewayRuntimeSupported,
+  make,
+  resolveLiveGatewayTarget,
+} from "./LiveGateway.ts";
+
+const threadId = ThreadId.make("thread-live-gateway");
+const tabId = PreviewTabId.make("tab-live-gateway");
+const sessionId = AuthSessionId.make("session-live-gateway");
+
+function snapshot(url?: string): PreviewSessionSnapshot {
+  return {
+    threadId,
+    tabId,
+    navStatus: url === undefined ? { _tag: "Idle" } : { _tag: "Success", url, title: "Preview" },
+    canGoBack: false,
+    canGoForward: false,
+    updatedAt: "2026-07-30T00:00:00.000Z",
+  };
+}
+
+function bootstrapToken(relativeUrl: string): string {
+  return relativeUrl.slice(relativeUrl.lastIndexOf("/") + 1);
+}
+
+function leaseFields(lease: LiveGatewayLease) {
+  const { invalidated: _invalidated, ...fields } = lease;
+  return fields;
+}
+
+it.layer(NodeServices.layer)("PreviewLiveGateway", (it) => {
+  it.effect("accepts only explicit loopback HTTP targets and preserves host family", () =>
+    Effect.gen(function* () {
+      expect(yield* resolveLiveGatewayTarget(snapshot("http://localhost:5173/a?q=1#hash"))).toEqual(
+        {
+          origin: "http://localhost:5173",
+          redirectPath: "/a?q=1#hash",
+        },
+      );
+      expect(yield* resolveLiveGatewayTarget(snapshot("http://0.0.0.0:4173/"))).toEqual({
+        origin: "http://127.0.0.1:4173",
+        redirectPath: "/",
+      });
+      expect(yield* resolveLiveGatewayTarget(snapshot("http://[::1]:3000/"))).toEqual({
+        origin: "http://[::1]:3000",
+        redirectPath: "/",
+      });
+
+      const publicError = yield* resolveLiveGatewayTarget(snapshot("https://example.com/")).pipe(
+        Effect.flip,
+      );
+      expect(publicError.reason).toBe("target_not_loopback");
+
+      const credentialError = yield* resolveLiveGatewayTarget(
+        snapshot("http://user:password@localhost:5173/"),
+      ).pipe(Effect.flip);
+      expect(credentialError.reason).toBe("target_invalid");
+
+      const idleError = yield* resolveLiveGatewayTarget(snapshot()).pipe(Effect.flip);
+      expect(idleError.reason).toBe("preview_idle");
+      expect(isLiveGatewayRuntimeSupported()).toBe(true);
+    }),
+  );
+
+  it.effect("uses one-use bootstraps and keeps an active lease through RPC reconnects", () =>
+    Effect.gen(function* () {
+      const gateway = yield* make;
+      const first = yield* gateway.issue({
+        sessionId,
+        snapshot: snapshot("http://localhost:5173/"),
+      });
+      const firstConsumed = yield* gateway.consumeBootstrap(bootstrapToken(first.relativeUrl));
+      expect(firstConsumed).not.toBeNull();
+      if (firstConsumed === null) return;
+
+      expect(yield* gateway.consumeBootstrap(bootstrapToken(first.relativeUrl))).toBeNull();
+      expect(yield* gateway.resolveLease(firstConsumed.cookieValue)).toMatchObject(
+        leaseFields(firstConsumed.lease),
+      );
+      const firstInvalidated = yield* firstConsumed.lease.invalidated.pipe(Effect.forkChild);
+
+      // Issuing a replacement bootstrap is what a reconnected RPC client does.
+      // It must not invalidate the WebView until the replacement is consumed.
+      const replacement = yield* gateway.issue({
+        sessionId,
+        snapshot: snapshot("http://localhost:5173/next"),
+      });
+      expect(yield* gateway.resolveLease(firstConsumed.cookieValue)).toMatchObject(
+        leaseFields(firstConsumed.lease),
+      );
+      yield* Effect.yieldNow;
+      expect(firstInvalidated.pollUnsafe()).toBeUndefined();
+
+      const replacementConsumed = yield* gateway.consumeBootstrap(
+        bootstrapToken(replacement.relativeUrl),
+      );
+      yield* Fiber.join(firstInvalidated);
+      expect(replacementConsumed).not.toBeNull();
+      expect(yield* gateway.resolveLease(firstConsumed.cookieValue)).toBeNull();
+      if (replacementConsumed !== null) {
+        expect(yield* gateway.resolveLease(replacementConsumed.cookieValue)).toMatchObject(
+          leaseFields(replacementConsumed.lease),
+        );
+      }
+    }),
+  );
+
+  it.effect("expires bootstraps and leases and supports explicit tab/session revocation", () =>
+    Effect.gen(function* () {
+      const gateway = yield* make;
+      const expiredBootstrap = yield* gateway.issue({
+        sessionId,
+        snapshot: snapshot("http://localhost:5173/"),
+      });
+      yield* TestClock.adjust(Duration.millis(LIVE_GATEWAY_BOOTSTRAP_TTL_MS));
+      expect(
+        yield* gateway.consumeBootstrap(bootstrapToken(expiredBootstrap.relativeUrl)),
+      ).toBeNull();
+
+      const issued = yield* gateway.issue({
+        sessionId,
+        snapshot: snapshot("http://localhost:5173/"),
+      });
+      const consumed = yield* gateway.consumeBootstrap(bootstrapToken(issued.relativeUrl));
+      expect(consumed).not.toBeNull();
+      if (consumed === null) return;
+
+      const tabInvalidated = yield* consumed.lease.invalidated.pipe(Effect.forkChild);
+      yield* gateway.revokeTab({ threadId, tabId });
+      yield* Fiber.join(tabInvalidated);
+      expect(yield* gateway.resolveLease(consumed.cookieValue)).toBeNull();
+
+      const sessionIssued = yield* gateway.issue({
+        sessionId,
+        snapshot: snapshot("http://localhost:5173/"),
+      });
+      const sessionConsumed = yield* gateway.consumeBootstrap(
+        bootstrapToken(sessionIssued.relativeUrl),
+      );
+      expect(sessionConsumed).not.toBeNull();
+      if (sessionConsumed === null) return;
+      const sessionInvalidated = yield* sessionConsumed.lease.invalidated.pipe(Effect.forkChild);
+      yield* gateway.revokeSession(sessionId);
+      yield* Fiber.join(sessionInvalidated);
+      expect(yield* gateway.resolveLease(sessionConsumed.cookieValue)).toBeNull();
+
+      const ttlIssued = yield* gateway.issue({
+        sessionId,
+        snapshot: snapshot("http://localhost:5173/"),
+      });
+      const ttlConsumed = yield* gateway.consumeBootstrap(bootstrapToken(ttlIssued.relativeUrl));
+      expect(ttlConsumed).not.toBeNull();
+      if (ttlConsumed === null) return;
+      const ttlInvalidated = yield* ttlConsumed.lease.invalidated.pipe(Effect.forkChild);
+      yield* TestClock.adjust(Duration.millis(LIVE_GATEWAY_LEASE_TTL_MS));
+      yield* Fiber.join(ttlInvalidated);
+      expect(yield* gateway.resolveLease(ttlConsumed.cookieValue)).toBeNull();
+    }),
+  );
+
+  it.effect("caps bootstraps and active leases at the parent authentication expiry", () =>
+    Effect.gen(function* () {
+      const gateway = yield* make;
+      const now = yield* Clock.currentTimeMillis;
+      const sessionExpiresAt = now + 1_000;
+      const issued = yield* gateway.issue({
+        sessionId,
+        sessionExpiresAt,
+        snapshot: snapshot("http://localhost:5173/"),
+      });
+      expect(issued.expiresAt).toBe(sessionExpiresAt);
+
+      const consumed = yield* gateway.consumeBootstrap(bootstrapToken(issued.relativeUrl));
+      expect(consumed).not.toBeNull();
+      if (consumed === null) return;
+      expect(consumed.lease.expiresAt).toBe(sessionExpiresAt);
+
+      const invalidated = yield* consumed.lease.invalidated.pipe(Effect.forkChild);
+      yield* TestClock.adjust(Duration.seconds(1));
+      yield* Fiber.join(invalidated);
+      expect(yield* gateway.resolveLease(consumed.cookieValue)).toBeNull();
+
+      const expired = yield* gateway
+        .issue({
+          sessionId,
+          sessionExpiresAt,
+          snapshot: snapshot("http://localhost:5173/"),
+        })
+        .pipe(Effect.flip);
+      expect(expired.reason).toBe("session_expired");
+    }),
+  );
+
+  it.effect("keeps an active lease alive for the authenticated session", () =>
+    Effect.gen(function* () {
+      const gateway = yield* make;
+      const now = yield* Clock.currentTimeMillis;
+      const sessionExpiresAt = now + LIVE_GATEWAY_LEASE_TTL_MS * 4;
+      const issued = yield* gateway.issue({
+        sessionId,
+        sessionExpiresAt,
+        snapshot: snapshot("http://localhost:5173/"),
+      });
+
+      const consumed = yield* gateway.consumeBootstrap(bootstrapToken(issued.relativeUrl));
+      expect(consumed).not.toBeNull();
+      if (consumed === null) return;
+      expect(consumed.lease.expiresAt).toBe(sessionExpiresAt);
+
+      const invalidated = yield* consumed.lease.invalidated.pipe(Effect.forkChild);
+      yield* TestClock.adjust(Duration.millis(LIVE_GATEWAY_LEASE_TTL_MS));
+      expect(invalidated.pollUnsafe()).toBeUndefined();
+      yield* TestClock.adjust(Duration.millis(LIVE_GATEWAY_LEASE_TTL_MS * 3));
+      yield* Fiber.join(invalidated);
+      expect(yield* gateway.resolveLease(consumed.cookieValue)).toBeNull();
+    }),
+  );
+});

--- a/apps/server/src/preview/LiveGateway.ts
+++ b/apps/server/src/preview/LiveGateway.ts
@@ -382,4 +382,4 @@ export const makeLive = Effect.gen(function* PreviewLiveGatewayMakeLive() {
   return gateway;
 });
 
-export const liveLayer = Layer.effect(PreviewLiveGateway, makeLive);
+export const layer = Layer.effect(PreviewLiveGateway, makeLive);

--- a/apps/server/src/preview/LiveGateway.ts
+++ b/apps/server/src/preview/LiveGateway.ts
@@ -81,12 +81,19 @@ const withoutSession = (state: LiveGatewayState, sessionId: AuthSessionId): Live
   leases: new Map([...state.leases].filter(([, lease]) => lease.sessionId !== sessionId)),
 });
 
-const withoutSessionTickets = (
+const withoutTargetTickets = (
   state: LiveGatewayState,
-  sessionId: AuthSessionId,
+  target: Pick<LiveGatewayGrant, "sessionId" | "threadId" | "tabId">,
 ): LiveGatewayState => ({
   ...state,
-  tickets: new Map([...state.tickets].filter(([, ticket]) => ticket.sessionId !== sessionId)),
+  tickets: new Map(
+    [...state.tickets].filter(
+      ([, ticket]) =>
+        ticket.sessionId !== target.sessionId ||
+        ticket.threadId !== target.threadId ||
+        ticket.tabId !== target.tabId,
+    ),
+  ),
 });
 
 const withoutTarget = (
@@ -244,7 +251,11 @@ export const make = Effect.gen(function* PreviewLiveGatewayMake() {
         input.sessionExpiresAt ?? now + LIVE_GATEWAY_BOOTSTRAP_TTL_MS,
       );
       yield* SynchronizedRef.modifyEffect(stateRef, (current) => {
-        const state = withoutSessionTickets(withoutExpired(current, now), input.sessionId);
+        const state = withoutTargetTickets(withoutExpired(current, now), {
+          sessionId: input.sessionId,
+          threadId: ThreadId.make(input.snapshot.threadId),
+          tabId: input.snapshot.tabId,
+        });
         const tickets = new Map(state.tickets);
         tickets.set(digest, {
           sessionId: input.sessionId,

--- a/apps/server/src/preview/LiveGateway.ts
+++ b/apps/server/src/preview/LiveGateway.ts
@@ -1,0 +1,376 @@
+import {
+  type AuthSessionId,
+  type PreviewLiveGatewayOpenResult,
+  type PreviewTabId,
+  PreviewLiveGatewayUnavailableError,
+  type PreviewSessionSnapshot,
+  ThreadId,
+} from "@t3tools/contracts";
+import { isLoopbackHost } from "@t3tools/shared/preview";
+import * as Clock from "effect/Clock";
+import * as Context from "effect/Context";
+import * as Crypto from "effect/Crypto";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Encoding from "effect/Encoding";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+
+import * as SessionStore from "../auth/SessionStore.ts";
+
+export const LIVE_GATEWAY_BOOTSTRAP_PREFIX = "/api/preview-gateway/bootstrap";
+export const LIVE_GATEWAY_COOKIE_NAME = "__Host-t3_preview_gateway";
+export const LIVE_GATEWAY_HTTP_COOKIE_NAME = "t3_preview_gateway";
+export const LIVE_GATEWAY_BOOTSTRAP_TTL_MS = 30_000;
+export const LIVE_GATEWAY_LEASE_TTL_MS = 15 * 60_000;
+
+export interface LiveGatewayTarget {
+  readonly origin: string;
+  readonly redirectPath: string;
+}
+
+interface LiveGatewayGrant {
+  readonly sessionId: AuthSessionId;
+  readonly threadId: ThreadId;
+  readonly tabId: PreviewTabId;
+  readonly target: LiveGatewayTarget;
+  readonly expiresAt: number;
+}
+
+export interface LiveGatewayLease extends LiveGatewayGrant {
+  /**
+   * Completes when the lease expires, is replaced, or is explicitly revoked.
+   * Active proxy streams race their lifetime against this signal.
+   */
+  readonly invalidated: Effect.Effect<void>;
+}
+
+interface StoredLiveGatewayLease extends LiveGatewayGrant {
+  readonly invalidation: Deferred.Deferred<void>;
+}
+
+interface LiveGatewayTicket extends LiveGatewayGrant {
+  readonly sessionExpiresAt?: number | undefined;
+}
+
+interface LiveGatewayState {
+  readonly tickets: ReadonlyMap<string, LiveGatewayTicket>;
+  readonly leases: ReadonlyMap<string, StoredLiveGatewayLease>;
+}
+
+const EMPTY_STATE: LiveGatewayState = {
+  tickets: new Map(),
+  leases: new Map(),
+};
+
+const textEncoder = new TextEncoder();
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const randomToken = (crypto: Crypto.Crypto) =>
+  crypto.randomBytes(32).pipe(Effect.map(Encoding.encodeBase64Url), Effect.orDie);
+
+const tokenDigest = (crypto: Crypto.Crypto, token: string) =>
+  crypto.digest("SHA-256", textEncoder.encode(token)).pipe(Effect.map(bytesToHex), Effect.orDie);
+
+const withoutSession = (state: LiveGatewayState, sessionId: AuthSessionId): LiveGatewayState => ({
+  tickets: new Map([...state.tickets].filter(([, ticket]) => ticket.sessionId !== sessionId)),
+  leases: new Map([...state.leases].filter(([, lease]) => lease.sessionId !== sessionId)),
+});
+
+const withoutSessionTickets = (
+  state: LiveGatewayState,
+  sessionId: AuthSessionId,
+): LiveGatewayState => ({
+  ...state,
+  tickets: new Map([...state.tickets].filter(([, ticket]) => ticket.sessionId !== sessionId)),
+});
+
+const withoutTarget = (
+  state: LiveGatewayState,
+  target: Pick<LiveGatewayGrant, "sessionId" | "threadId" | "tabId">,
+): LiveGatewayState => {
+  const matches = (entry: LiveGatewayGrant) =>
+    entry.sessionId === target.sessionId &&
+    entry.threadId === target.threadId &&
+    entry.tabId === target.tabId;
+  return {
+    tickets: new Map([...state.tickets].filter(([, ticket]) => !matches(ticket))),
+    leases: new Map([...state.leases].filter(([, lease]) => !matches(lease))),
+  };
+};
+
+const completeRemovedLeases = (
+  before: LiveGatewayState,
+  after: LiveGatewayState,
+): Effect.Effect<void> =>
+  Effect.forEach(
+    [...before.leases].filter(([digest, lease]) => after.leases.get(digest) !== lease),
+    ([, lease]) => Deferred.succeed(lease.invalidation, undefined),
+    { discard: true },
+  );
+
+const leaseHandle = (stored: StoredLiveGatewayLease): LiveGatewayLease => {
+  const { invalidation, ...lease } = stored;
+  return {
+    ...lease,
+    invalidated: Clock.currentTimeMillis.pipe(
+      Effect.flatMap((now) =>
+        Effect.raceFirst(
+          Deferred.await(invalidation),
+          Effect.sleep(Duration.millis(Math.max(0, lease.expiresAt - now))),
+        ),
+      ),
+    ),
+  };
+};
+
+const withoutExpired = (state: LiveGatewayState, now: number): LiveGatewayState => ({
+  tickets: new Map([...state.tickets].filter(([, ticket]) => ticket.expiresAt > now)),
+  leases: new Map([...state.leases].filter(([, lease]) => lease.expiresAt > now)),
+});
+
+const unavailable = (
+  snapshot: PreviewSessionSnapshot,
+  reason: PreviewLiveGatewayUnavailableError["reason"],
+) =>
+  new PreviewLiveGatewayUnavailableError({
+    threadId: ThreadId.make(snapshot.threadId),
+    tabId: snapshot.tabId,
+    reason,
+  });
+
+export function resolveLiveGatewayTarget(
+  snapshot: PreviewSessionSnapshot,
+): Effect.Effect<LiveGatewayTarget, PreviewLiveGatewayUnavailableError> {
+  if (snapshot.navStatus._tag === "Idle") {
+    return Effect.fail(unavailable(snapshot, "preview_idle"));
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(snapshot.navStatus.url);
+  } catch {
+    return Effect.fail(unavailable(snapshot, "target_invalid"));
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return Effect.fail(unavailable(snapshot, "target_protocol_unsupported"));
+  }
+  if (
+    !isLoopbackHost(parsed.hostname) ||
+    parsed.username.length > 0 ||
+    parsed.password.length > 0 ||
+    parsed.pathname.startsWith("//")
+  ) {
+    return Effect.fail(
+      unavailable(
+        snapshot,
+        isLoopbackHost(parsed.hostname) ? "target_invalid" : "target_not_loopback",
+      ),
+    );
+  }
+
+  const port = parsed.port || (parsed.protocol === "https:" ? "443" : "80");
+  const numericPort = Number(port);
+  if (!Number.isInteger(numericPort) || numericPort < 1 || numericPort > 65_535) {
+    return Effect.fail(unavailable(snapshot, "target_invalid"));
+  }
+
+  const proxyHost =
+    parsed.hostname === "0.0.0.0"
+      ? "127.0.0.1"
+      : parsed.hostname === "::1" || parsed.hostname === "[::1]"
+        ? "[::1]"
+        : parsed.hostname;
+  const origin = `${parsed.protocol}//${proxyHost}:${numericPort}`;
+  const redirectPath = `${parsed.pathname || "/"}${parsed.search}${parsed.hash}`;
+  return Effect.succeed({ origin, redirectPath });
+}
+
+export function isLiveGatewayRuntimeSupported(): boolean {
+  return typeof Bun === "undefined";
+}
+
+export class PreviewLiveGateway extends Context.Service<
+  PreviewLiveGateway,
+  {
+    readonly issue: (input: {
+      readonly sessionId: AuthSessionId;
+      readonly sessionExpiresAt?: number | undefined;
+      readonly snapshot: PreviewSessionSnapshot;
+    }) => Effect.Effect<PreviewLiveGatewayOpenResult, PreviewLiveGatewayUnavailableError>;
+    readonly consumeBootstrap: (token: string) => Effect.Effect<{
+      readonly cookieValue: string;
+      readonly lease: LiveGatewayLease;
+    } | null>;
+    readonly resolveLease: (cookieValue: string) => Effect.Effect<LiveGatewayLease | null>;
+    readonly revokeTab: (input: {
+      readonly threadId: ThreadId;
+      readonly tabId?: PreviewTabId | undefined;
+    }) => Effect.Effect<void>;
+    readonly revokeSession: (sessionId: AuthSessionId) => Effect.Effect<void>;
+  }
+>()("t3/preview/LiveGateway/PreviewLiveGateway") {}
+
+export const make = Effect.gen(function* PreviewLiveGatewayMake() {
+  const crypto = yield* Crypto.Crypto;
+  const stateRef = yield* SynchronizedRef.make<LiveGatewayState>(EMPTY_STATE);
+
+  const issue: PreviewLiveGateway["Service"]["issue"] = Effect.fn("PreviewLiveGateway.issue")(
+    function* (input) {
+      if (!isLiveGatewayRuntimeSupported()) {
+        return yield* new PreviewLiveGatewayUnavailableError({
+          threadId: ThreadId.make(input.snapshot.threadId),
+          tabId: input.snapshot.tabId,
+          reason: "runtime_unsupported",
+        });
+      }
+      const target = yield* resolveLiveGatewayTarget(input.snapshot);
+      const now = yield* Clock.currentTimeMillis;
+      if (input.sessionExpiresAt !== undefined && input.sessionExpiresAt <= now) {
+        return yield* new PreviewLiveGatewayUnavailableError({
+          threadId: ThreadId.make(input.snapshot.threadId),
+          tabId: input.snapshot.tabId,
+          reason: "session_expired",
+        });
+      }
+      const token = yield* randomToken(crypto);
+      const digest = yield* tokenDigest(crypto, token);
+      const ticketExpiresAt = Math.min(
+        now + LIVE_GATEWAY_BOOTSTRAP_TTL_MS,
+        input.sessionExpiresAt ?? now + LIVE_GATEWAY_BOOTSTRAP_TTL_MS,
+      );
+      yield* SynchronizedRef.modifyEffect(stateRef, (current) => {
+        const state = withoutSessionTickets(withoutExpired(current, now), input.sessionId);
+        const tickets = new Map(state.tickets);
+        tickets.set(digest, {
+          sessionId: input.sessionId,
+          threadId: ThreadId.make(input.snapshot.threadId),
+          tabId: input.snapshot.tabId,
+          target,
+          expiresAt: ticketExpiresAt,
+          ...(input.sessionExpiresAt === undefined
+            ? {}
+            : { sessionExpiresAt: input.sessionExpiresAt }),
+        });
+        const next = { ...state, tickets };
+        return completeRemovedLeases(current, next).pipe(Effect.as([undefined, next] as const));
+      });
+      return {
+        version: 1,
+        relativeUrl: `${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/${token}`,
+        expiresAt: ticketExpiresAt,
+      };
+    },
+  );
+
+  const consumeBootstrap: PreviewLiveGateway["Service"]["consumeBootstrap"] = Effect.fn(
+    "PreviewLiveGateway.consumeBootstrap",
+  )(function* (token) {
+    const [digest, cookieValue, now, invalidation] = yield* Effect.all(
+      [
+        tokenDigest(crypto, token),
+        randomToken(crypto),
+        Clock.currentTimeMillis,
+        Deferred.make<void>(),
+      ],
+      { concurrency: 4 },
+    );
+    const cookieDigest = yield* tokenDigest(crypto, cookieValue);
+    return yield* SynchronizedRef.modifyEffect(stateRef, (current) => {
+      const state = withoutExpired(current, now);
+      const ticket = state.tickets.get(digest);
+      if (!ticket) {
+        return completeRemovedLeases(current, state).pipe(Effect.as([null, state] as const));
+      }
+
+      const withoutCurrentTarget = withoutTarget(state, ticket);
+      const leases = new Map(withoutCurrentTarget.leases);
+      const { sessionExpiresAt, ...grant } = ticket;
+      const stored: StoredLiveGatewayLease = {
+        ...grant,
+        // An authenticated browser lease follows its parent session. A shorter
+        // independent TTL can silently strand long-lived WebSockets such as
+        // Vite HMR while the already-rendered preview still appears healthy.
+        // Tab and session revocation still invalidate the lease immediately.
+        expiresAt: sessionExpiresAt ?? now + LIVE_GATEWAY_LEASE_TTL_MS,
+        invalidation,
+      };
+      leases.set(cookieDigest, stored);
+      const next = {
+        tickets: withoutCurrentTarget.tickets,
+        leases,
+      };
+      return completeRemovedLeases(current, next).pipe(
+        Effect.as([{ cookieValue, lease: leaseHandle(stored) }, next] as const),
+      );
+    });
+  });
+
+  const resolveLease: PreviewLiveGateway["Service"]["resolveLease"] = Effect.fn(
+    "PreviewLiveGateway.resolveLease",
+  )(function* (cookieValue) {
+    const [digest, now] = yield* Effect.all(
+      [tokenDigest(crypto, cookieValue), Clock.currentTimeMillis],
+      { concurrency: 2 },
+    );
+    return yield* SynchronizedRef.modifyEffect(stateRef, (current) => {
+      const state = withoutExpired(current, now);
+      const stored = state.leases.get(digest);
+      return completeRemovedLeases(current, state).pipe(
+        Effect.as([stored === undefined ? null : leaseHandle(stored), state] as const),
+      );
+    });
+  });
+
+  const revokeSession: PreviewLiveGateway["Service"]["revokeSession"] = Effect.fn(
+    "PreviewLiveGateway.revokeSession",
+  )((sessionId) =>
+    SynchronizedRef.modifyEffect(stateRef, (state) => {
+      const next = withoutSession(state, sessionId);
+      return completeRemovedLeases(state, next).pipe(Effect.as([undefined, next] as const));
+    }),
+  );
+
+  const revokeTab: PreviewLiveGateway["Service"]["revokeTab"] = Effect.fn(
+    "PreviewLiveGateway.revokeTab",
+  )((input) =>
+    SynchronizedRef.modifyEffect(stateRef, (state) => {
+      const matches = (entry: LiveGatewayGrant) =>
+        entry.threadId === input.threadId &&
+        (input.tabId === undefined || entry.tabId === input.tabId);
+      const next = {
+        tickets: new Map([...state.tickets].filter(([, ticket]) => !matches(ticket))),
+        leases: new Map([...state.leases].filter(([, lease]) => !matches(lease))),
+      };
+      return completeRemovedLeases(state, next).pipe(Effect.as([undefined, next] as const));
+    }),
+  );
+
+  return PreviewLiveGateway.of({
+    issue,
+    consumeBootstrap,
+    resolveLease,
+    revokeTab,
+    revokeSession,
+  });
+});
+
+export const layer = Layer.effect(PreviewLiveGateway, make);
+
+export const makeLive = Effect.gen(function* PreviewLiveGatewayMakeLive() {
+  const gateway = yield* make;
+  const sessions = yield* SessionStore.SessionStore;
+  yield* sessions.streamChanges.pipe(
+    Stream.runForEach((change) =>
+      change.type === "clientRemoved" ? gateway.revokeSession(change.sessionId) : Effect.void,
+    ),
+    Effect.forkScoped,
+  );
+  return gateway;
+});
+
+export const liveLayer = Layer.effect(PreviewLiveGateway, makeLive);

--- a/apps/server/src/preview/LiveGateway.ts
+++ b/apps/server/src/preview/LiveGateway.ts
@@ -359,8 +359,6 @@ export const make = Effect.gen(function* PreviewLiveGatewayMake() {
   });
 });
 
-export const layer = Layer.effect(PreviewLiveGateway, make);
-
 export const makeLive = Effect.gen(function* PreviewLiveGatewayMakeLive() {
   const gateway = yield* make;
   const sessions = yield* SessionStore.SessionStore;

--- a/apps/server/src/preview/LiveGatewayHttp.test.ts
+++ b/apps/server/src/preview/LiveGatewayHttp.test.ts
@@ -1,0 +1,266 @@
+import { expect, it } from "@effect/vitest";
+import { AuthSessionId, PreviewTabId, ThreadId } from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+import { Cookies, Headers, HttpClientRequest, type HttpServerRequest } from "effect/unstable/http";
+import * as Socket from "effect/unstable/socket/Socket";
+
+import {
+  LIVE_GATEWAY_COOKIE_NAME,
+  LIVE_GATEWAY_HTTP_COOKIE_NAME,
+  type LiveGatewayLease,
+} from "./LiveGateway.ts";
+import {
+  LIVE_GATEWAY_WEBSOCKET_MAX_FRAME_BYTES,
+  LIVE_GATEWAY_WEBSOCKET_MAX_PENDING_FRAMES,
+  bridgeLiveGatewaySockets,
+  interruptLiveGatewayStream,
+  isLiveGatewayControlCookie,
+  isForwardableWebSocketCloseCode,
+  liveGatewayCookieName,
+  liveGatewayResponseCookies,
+  liveGatewayResponseHeaders,
+  liveGatewayUpstreamHeaders,
+  liveGatewayUpstreamUrl,
+  liveGatewayWebSocketProtocols,
+  retargetLiveGatewayRequest,
+} from "./LiveGatewayHttp.ts";
+
+const environmentSessionCookieName = "t3_session_3773_deadbeef";
+const lease: LiveGatewayLease = {
+  sessionId: AuthSessionId.make("session-http-gateway"),
+  threadId: ThreadId.make("thread-http-gateway"),
+  tabId: PreviewTabId.make("tab-http-gateway"),
+  target: {
+    origin: "http://127.0.0.1:5173",
+    redirectPath: "/",
+  },
+  expiresAt: 1_785_369_600_000,
+  invalidated: Effect.never,
+};
+
+function request(input: {
+  readonly cookies?: Readonly<Record<string, string>>;
+  readonly headers?: Readonly<Record<string, string>>;
+}): HttpServerRequest.HttpServerRequest {
+  return {
+    cookies: input.cookies ?? {},
+    headers: Headers.fromInput(input.headers ?? {}),
+  } as unknown as HttpServerRequest.HttpServerRequest;
+}
+
+function testSocket(input?: {
+  readonly blockDataWrites?: boolean;
+  readonly frames?: ReadonlyArray<string | Uint8Array>;
+}) {
+  const closes: Socket.CloseEvent[] = [];
+  const socket = Socket.make({
+    runRaw: ((handler: (frame: string | Uint8Array) => unknown) =>
+      Effect.sync(() => {
+        for (const frame of input?.frames ?? []) handler(frame);
+      }).pipe(Effect.andThen(Effect.never))) as Socket.Socket["runRaw"],
+    writer: Effect.succeed((frame) => {
+      if (Socket.isCloseEvent(frame)) {
+        return Effect.sync(() => {
+          closes.push(frame);
+        });
+      }
+      return input?.blockDataWrites === true ? Effect.never : Effect.void;
+    }),
+  });
+  return { closes, socket };
+}
+
+it("keeps gateway paths pinned to the lease origin, including double-slash paths", () => {
+  const upstream = liveGatewayUpstreamUrl(
+    new URL("https://environment.example//attacker.example/pwn?q=1"),
+    lease,
+  );
+  expect(upstream.origin).toBe(lease.target.origin);
+  expect(upstream.pathname).toBe("//attacker.example/pwn");
+  expect(upstream.search).toBe("?q=1");
+});
+
+it("preserves bare query flags when retargeting gateway requests", () => {
+  const requestUrl = new URL("https://environment.example/src/styles.css?url");
+  const upstreamUrl = liveGatewayUpstreamUrl(requestUrl, lease);
+  const downstream = HttpClientRequest.get(requestUrl.toString());
+  const upstream = retargetLiveGatewayRequest(downstream, upstreamUrl, Headers.empty);
+
+  expect(Option.getOrThrow(HttpClientRequest.toUrl(upstream)).search).toBe("?url");
+});
+
+it("uses the downstream-selected websocket protocol and sanitizes close codes", () => {
+  expect(liveGatewayWebSocketProtocols(" vite-hmr, fallback ")).toBe("vite-hmr");
+  expect(liveGatewayWebSocketProtocols(undefined)).toBeUndefined();
+  expect(isForwardableWebSocketCloseCode(1_000)).toBe(true);
+  expect(isForwardableWebSocketCloseCode(1_006)).toBe(false);
+  expect(isForwardableWebSocketCloseCode(3_001)).toBe(true);
+  expect(isForwardableWebSocketCloseCode(5_000)).toBe(false);
+});
+
+it("uses a Secure host cookie over HTTPS and an HTTP-compatible host cookie over LAN", () => {
+  expect(liveGatewayCookieName(new URL("https://environment.example/bootstrap"))).toBe(
+    LIVE_GATEWAY_COOKIE_NAME,
+  );
+  expect(liveGatewayCookieName(new URL("http://192.168.1.53:13773/bootstrap"))).toBe(
+    LIVE_GATEWAY_HTTP_COOKIE_NAME,
+  );
+});
+
+it("strips environment credentials while preserving application cookies and request context", () => {
+  const serverRequest = request({
+    cookies: {
+      [LIVE_GATEWAY_COOKIE_NAME]: "gateway-secret",
+      [LIVE_GATEWAY_HTTP_COOKIE_NAME]: "lan-gateway-secret",
+      [environmentSessionCookieName]: "environment-secret",
+      t3_session: "legacy-secret",
+      t3_session_other: "other-environment-secret",
+      app_session: "application-value",
+    },
+    headers: {
+      authorization: "Bearer environment-secret",
+      "cf-ray": "cloudflare-metadata",
+      cookie: "raw-cookie-header",
+      dpop: "environment-proof",
+      host: "environment.example",
+      origin: "https://environment.example",
+      referer: "https://environment.example/app/page?q=1",
+      "sec-websocket-key": "downstream-key",
+      "x-forwarded-host": "environment.example",
+    },
+  });
+  const upstreamUrl = new URL("http://127.0.0.1:5173/asset");
+  const headers = liveGatewayUpstreamHeaders({
+    request: serverRequest,
+    requestUrl: new URL("https://environment.example/asset"),
+    upstreamUrl,
+    environmentSessionCookieName,
+  });
+
+  expect(headers.authorization).toBeUndefined();
+  expect(headers.dpop).toBeUndefined();
+  expect(headers["cf-ray"]).toBeUndefined();
+  expect(headers["x-forwarded-host"]).toBeUndefined();
+  expect(headers["sec-websocket-key"]).toBeUndefined();
+  expect(headers.cookie).toBe("app_session=application-value");
+  expect(headers.host).toBe("127.0.0.1:5173");
+  expect(headers.origin).toBe("http://127.0.0.1:5173");
+  expect(headers.referer).toBe("http://127.0.0.1:5173/app/page?q=1");
+  expect(headers["accept-encoding"]).toBe("identity");
+});
+
+it("rewrites loopback redirects and strips transport headers after fetch decompression", () => {
+  const headers = liveGatewayResponseHeaders({
+    headers: Headers.fromInput({
+      "access-control-allow-origin": "http://127.0.0.1:5173",
+      "content-encoding": "gzip",
+      "content-length": "123",
+      location: "http://localhost:5173/next?q=1#fragment",
+      "set-cookie": "secret=value",
+    }),
+    requestUrl: new URL("https://environment.example/current"),
+    upstreamOrigin: "http://127.0.0.1:5173",
+  });
+
+  expect(headers.location).toBe("/next?q=1#fragment");
+  expect(headers["access-control-allow-origin"]).toBe("https://environment.example");
+  expect(headers["content-encoding"]).toBeUndefined();
+  expect(headers["content-length"]).toBeUndefined();
+  expect(headers["set-cookie"]).toBeUndefined();
+});
+
+it("prevents upstream cookies from replacing gateway or environment credentials", () => {
+  const upstream = Cookies.fromIterable([
+    Cookies.makeCookieUnsafe("app_session", "value", {
+      domain: "localhost",
+      path: "/",
+    }),
+    Cookies.makeCookieUnsafe(environmentSessionCookieName, "attack"),
+    Cookies.makeCookieUnsafe("t3_session", "legacy-attack"),
+    Cookies.makeCookieUnsafe("t3_session_other", "other-attack"),
+    Cookies.makeCookieUnsafe(LIVE_GATEWAY_COOKIE_NAME, "gateway-attack"),
+    Cookies.makeCookieUnsafe(LIVE_GATEWAY_HTTP_COOKIE_NAME, "lan-gateway-attack"),
+  ]);
+  const filtered = liveGatewayResponseCookies(upstream, environmentSessionCookieName);
+
+  expect(Object.keys(filtered.cookies)).toEqual(["app_session"]);
+  expect(filtered.cookies.app_session?.options?.domain).toBeUndefined();
+  expect(isLiveGatewayControlCookie("app_session", environmentSessionCookieName)).toBe(false);
+  expect(isLiveGatewayControlCookie("t3_session_other", environmentSessionCookieName)).toBe(true);
+});
+
+it.effect("interrupts an active HTTP stream when its gateway lease is invalidated", () =>
+  Effect.gen(function* () {
+    const invalidated = yield* Deferred.make<void>();
+    const firstChunk = yield* Deferred.make<void>();
+    const activeLease: LiveGatewayLease = {
+      ...lease,
+      invalidated: Deferred.await(invalidated),
+    };
+    const stream = Stream.concat(Stream.make("first"), Stream.never).pipe(
+      Stream.tap(() => Deferred.succeed(firstChunk, undefined)),
+      (active) => interruptLiveGatewayStream(active, activeLease),
+    );
+    const fiber = yield* Stream.runCollect(stream).pipe(
+      Effect.forkChild({ startImmediately: true }),
+    );
+
+    yield* Deferred.await(firstChunk);
+    yield* Deferred.succeed(invalidated, undefined);
+
+    expect(Array.from(yield* Fiber.join(fiber))).toEqual(["first"]);
+  }),
+);
+
+it.effect("closes both websocket peers when one frame exceeds the payload cap", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const source = testSocket({
+        frames: [new Uint8Array(LIVE_GATEWAY_WEBSOCKET_MAX_FRAME_BYTES + 1)],
+      });
+      const destination = testSocket({ blockDataWrites: true });
+
+      yield* bridgeLiveGatewaySockets(source.socket, destination.socket);
+
+      expect(source.closes).toMatchObject([{ code: 1_013 }]);
+      expect(destination.closes).toMatchObject([{ code: 1_013 }]);
+    }),
+  ),
+);
+
+it.effect("bounds pending websocket frames while the destination is backpressured", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const source = testSocket({
+        frames: Array.from({ length: LIVE_GATEWAY_WEBSOCKET_MAX_PENDING_FRAMES + 1 }, () => "x"),
+      });
+      const destination = testSocket({ blockDataWrites: true });
+
+      yield* bridgeLiveGatewaySockets(source.socket, destination.socket);
+
+      expect(source.closes).toMatchObject([{ code: 1_013 }]);
+      expect(destination.closes).toMatchObject([{ code: 1_013 }]);
+    }),
+  ),
+);
+
+it.effect("bounds pending websocket bytes while the destination is backpressured", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const maximumFrame = new Uint8Array(LIVE_GATEWAY_WEBSOCKET_MAX_FRAME_BYTES);
+      const source = testSocket({
+        frames: [maximumFrame, maximumFrame, maximumFrame, maximumFrame, maximumFrame],
+      });
+      const destination = testSocket({ blockDataWrites: true });
+
+      yield* bridgeLiveGatewaySockets(source.socket, destination.socket);
+
+      expect(source.closes).toMatchObject([{ code: 1_013 }]);
+      expect(destination.closes).toMatchObject([{ code: 1_013 }]);
+    }),
+  ),
+);

--- a/apps/server/src/preview/LiveGatewayHttp.test.ts
+++ b/apps/server/src/preview/LiveGatewayHttp.test.ts
@@ -126,10 +126,12 @@ it("strips environment credentials while preserving application cookies and requ
       "cf-ray": "cloudflare-metadata",
       cookie: "raw-cookie-header",
       dpop: "environment-proof",
+      connection: "keep-alive, x-internal",
       host: "environment.example",
       origin: "https://environment.example",
       referer: "https://environment.example/app/page?q=1",
       "sec-websocket-key": "downstream-key",
+      "x-internal": "connection-specific",
       "x-forwarded-host": "environment.example",
     },
   });
@@ -146,6 +148,7 @@ it("strips environment credentials while preserving application cookies and requ
   expect(headers["cf-ray"]).toBeUndefined();
   expect(headers["x-forwarded-host"]).toBeUndefined();
   expect(headers["sec-websocket-key"]).toBeUndefined();
+  expect(headers["x-internal"]).toBeUndefined();
   expect(headers.cookie).toBe("app_session=application-value");
   expect(headers.host).toBe("127.0.0.1:5173");
   expect(headers.origin).toBe("http://127.0.0.1:5173");
@@ -159,8 +162,10 @@ it("rewrites loopback redirects and strips transport headers after fetch decompr
       "access-control-allow-origin": "http://127.0.0.1:5173",
       "content-encoding": "gzip",
       "content-length": "123",
+      connection: "keep-alive, x-private",
       location: "http://localhost:5173/next?q=1#fragment",
       "set-cookie": "secret=value",
+      "x-private": "connection-specific",
     }),
     requestUrl: new URL("https://environment.example/current"),
     upstreamOrigin: "http://127.0.0.1:5173",
@@ -171,6 +176,7 @@ it("rewrites loopback redirects and strips transport headers after fetch decompr
   expect(headers["content-encoding"]).toBeUndefined();
   expect(headers["content-length"]).toBeUndefined();
   expect(headers["set-cookie"]).toBeUndefined();
+  expect(headers["x-private"]).toBeUndefined();
 });
 
 it("prevents upstream cookies from replacing gateway or environment credentials", () => {

--- a/apps/server/src/preview/LiveGatewayHttp.ts
+++ b/apps/server/src/preview/LiveGatewayHttp.ts
@@ -21,6 +21,7 @@ import {
 } from "effect/unstable/http";
 import * as Socket from "effect/unstable/socket/Socket";
 
+import * as SessionStore from "../auth/SessionStore.ts";
 import {
   LIVE_GATEWAY_BOOTSTRAP_PREFIX,
   LIVE_GATEWAY_COOKIE_NAME,
@@ -53,11 +54,6 @@ const bootstrapResponseHeaders = {
   "referrer-policy": "no-referrer",
   "x-content-type-options": "nosniff",
 } as const;
-
-export interface LiveGatewayHttpOptions {
-  readonly gateway: PreviewLiveGateway["Service"];
-  readonly environmentSessionCookieName: string;
-}
 
 export function isLiveGatewayControlCookie(
   name: string,
@@ -528,100 +524,100 @@ function expiredGatewayResponse(): HttpServerResponse.HttpServerResponse {
   });
 }
 
-export const makeLiveGatewayBootstrapRouteLayer = (gateway: PreviewLiveGateway["Service"]) =>
-  HttpRouter.add(
-    "GET",
-    `${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/*`,
+export const liveGatewayBootstrapRouteLayer = HttpRouter.add(
+  "GET",
+  `${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/*`,
+  Effect.gen(function* () {
+    const gateway = yield* PreviewLiveGateway;
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const requestUrl = HttpServerRequest.toURL(request);
+    if (Option.isNone(requestUrl)) {
+      return HttpServerResponse.text("Bad Request", { status: 400 });
+    }
+    const token = requestUrl.value.pathname.slice(`${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/`.length);
+    if (!BOOTSTRAP_TOKEN_PATTERN.test(token)) {
+      return expiredGatewayResponse();
+    }
+    const consumed = yield* gateway.consumeBootstrap(token);
+    if (consumed === null) {
+      return expiredGatewayResponse();
+    }
+    const cookieName = liveGatewayCookieName(requestUrl.value);
+    const cookie = yield* Effect.fromResult(
+      Cookies.set(Cookies.empty, cookieName, consumed.cookieValue, {
+        path: "/",
+        secure: cookieName === LIVE_GATEWAY_COOKIE_NAME,
+        httpOnly: true,
+        sameSite: "strict",
+        expires: DateTime.toDate(DateTime.makeUnsafe(consumed.lease.expiresAt)),
+      }),
+    ).pipe(Effect.orDie);
+    return HttpServerResponse.redirect(consumed.lease.target.redirectPath, {
+      status: 302,
+      headers: bootstrapResponseHeaders,
+      cookies: cookie,
+    });
+  }),
+);
+
+export const liveGatewayProxyLayer = HttpRouter.middleware(
+  (httpEffect) =>
     Effect.gen(function* () {
+      const gateway = yield* PreviewLiveGateway;
+      const sessions = yield* SessionStore.SessionStore;
       const request = yield* HttpServerRequest.HttpServerRequest;
       const requestUrl = HttpServerRequest.toURL(request);
-      if (Option.isNone(requestUrl)) {
-        return HttpServerResponse.text("Bad Request", { status: 400 });
+      if (
+        Option.isNone(requestUrl) ||
+        requestUrl.value.pathname.startsWith(`${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/`)
+      ) {
+        return yield* httpEffect;
       }
-      const token = requestUrl.value.pathname.slice(`${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/`.length);
-      if (!BOOTSTRAP_TOKEN_PATTERN.test(token)) {
-        return expiredGatewayResponse();
-      }
-      const consumed = yield* gateway.consumeBootstrap(token);
-      if (consumed === null) {
-        return expiredGatewayResponse();
-      }
-      const cookieName = liveGatewayCookieName(requestUrl.value);
-      const cookie = yield* Effect.fromResult(
-        Cookies.set(Cookies.empty, cookieName, consumed.cookieValue, {
-          path: "/",
-          secure: cookieName === LIVE_GATEWAY_COOKIE_NAME,
-          httpOnly: true,
-          sameSite: "strict",
-          expires: DateTime.toDate(DateTime.makeUnsafe(consumed.lease.expiresAt)),
-        }),
-      ).pipe(Effect.orDie);
-      return HttpServerResponse.redirect(consumed.lease.target.redirectPath, {
-        status: 302,
-        headers: bootstrapResponseHeaders,
-        cookies: cookie,
-      });
-    }),
-  );
+      const cookieValue =
+        request.cookies[LIVE_GATEWAY_COOKIE_NAME] ?? request.cookies[LIVE_GATEWAY_HTTP_COOKIE_NAME];
+      if (!cookieValue) return yield* httpEffect;
 
-export const makeLiveGatewayProxyLayer = (options: LiveGatewayHttpOptions) =>
-  HttpRouter.middleware(
-    (httpEffect) =>
-      Effect.gen(function* () {
-        const request = yield* HttpServerRequest.HttpServerRequest;
-        const requestUrl = HttpServerRequest.toURL(request);
-        if (
-          Option.isNone(requestUrl) ||
-          requestUrl.value.pathname.startsWith(`${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/`)
-        ) {
-          return yield* httpEffect;
-        }
-        const cookieValue =
-          request.cookies[LIVE_GATEWAY_COOKIE_NAME] ??
-          request.cookies[LIVE_GATEWAY_HTTP_COOKIE_NAME];
-        if (!cookieValue) return yield* httpEffect;
+      const lease = yield* gateway.resolveLease(cookieValue);
+      if (lease === null) return expiredGatewayResponse();
 
-        const lease = yield* options.gateway.resolveLease(cookieValue);
-        if (lease === null) return expiredGatewayResponse();
-
-        if (request.headers.upgrade?.toLowerCase() === "websocket") {
-          return yield* proxyWebSocketRequest(
-            request,
-            requestUrl.value,
-            lease,
-            options.environmentSessionCookieName,
-          ).pipe(
-            Effect.catchCause((cause) =>
-              Effect.logWarning("Live preview gateway websocket failed", {
-                cause,
-                threadId: lease.threadId,
-                tabId: lease.tabId,
-                upstreamOrigin: lease.target.origin,
-              }).pipe(Effect.as(HttpServerResponse.empty())),
-            ),
-          );
-        }
-
-        return yield* Effect.raceFirst(
-          proxyHttpRequest(request, requestUrl.value, lease, options.environmentSessionCookieName),
-          lease.invalidated.pipe(Effect.as(expiredGatewayResponse())),
+      if (request.headers.upgrade?.toLowerCase() === "websocket") {
+        return yield* proxyWebSocketRequest(
+          request,
+          requestUrl.value,
+          lease,
+          sessions.cookieName,
         ).pipe(
           Effect.catchCause((cause) =>
-            Effect.logWarning("Live preview gateway upstream request failed", {
+            Effect.logWarning("Live preview gateway websocket failed", {
               cause,
               threadId: lease.threadId,
               tabId: lease.tabId,
               upstreamOrigin: lease.target.origin,
-            }).pipe(
-              Effect.as(
-                HttpServerResponse.text("Live preview upstream is unavailable.", {
-                  status: 502,
-                  headers: bootstrapResponseHeaders,
-                }),
-              ),
-            ),
+            }).pipe(Effect.as(HttpServerResponse.empty())),
           ),
         );
-      }),
-    { global: true },
-  );
+      }
+
+      return yield* Effect.raceFirst(
+        proxyHttpRequest(request, requestUrl.value, lease, sessions.cookieName),
+        lease.invalidated.pipe(Effect.as(expiredGatewayResponse())),
+      ).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("Live preview gateway upstream request failed", {
+            cause,
+            threadId: lease.threadId,
+            tabId: lease.tabId,
+            upstreamOrigin: lease.target.origin,
+          }).pipe(
+            Effect.as(
+              HttpServerResponse.text("Live preview upstream is unavailable.", {
+                status: 502,
+                headers: bootstrapResponseHeaders,
+              }),
+            ),
+          ),
+        ),
+      );
+    }),
+  { global: true },
+);

--- a/apps/server/src/preview/LiveGatewayHttp.ts
+++ b/apps/server/src/preview/LiveGatewayHttp.ts
@@ -1,0 +1,627 @@
+import * as NodeSocket from "@effect/platform-node/NodeSocket";
+import { isLoopbackHost } from "@t3tools/shared/preview";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Queue from "effect/Queue";
+import * as Stream from "effect/Stream";
+import {
+  Cookies,
+  FetchHttpClient,
+  Headers,
+  HttpClient,
+  HttpClientError,
+  HttpClientRequest,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+  UrlParams,
+} from "effect/unstable/http";
+import * as Socket from "effect/unstable/socket/Socket";
+
+import {
+  LIVE_GATEWAY_BOOTSTRAP_PREFIX,
+  LIVE_GATEWAY_COOKIE_NAME,
+  LIVE_GATEWAY_HTTP_COOKIE_NAME,
+  type LiveGatewayLease,
+  PreviewLiveGateway,
+} from "./LiveGateway.ts";
+
+const UPSTREAM_CONNECT_TIMEOUT = Duration.seconds(10);
+const BOOTSTRAP_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/u;
+export const LIVE_GATEWAY_EXPIRED_STATUS = 511;
+export const LIVE_GATEWAY_WEBSOCKET_MAX_FRAME_BYTES = 2 * 1024 * 1024;
+export const LIVE_GATEWAY_WEBSOCKET_MAX_PENDING_BYTES = 8 * 1024 * 1024;
+export const LIVE_GATEWAY_WEBSOCKET_MAX_PENDING_FRAMES = 64;
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+] as const;
+const PRIVATE_REQUEST_HEADERS = new Set([...HOP_BY_HOP_HEADERS, "authorization", "dpop", "host"]);
+
+const bootstrapResponseHeaders = {
+  "cache-control": "no-store",
+  pragma: "no-cache",
+  "referrer-policy": "no-referrer",
+  "x-content-type-options": "nosniff",
+} as const;
+
+export interface LiveGatewayHttpOptions {
+  readonly gateway: PreviewLiveGateway["Service"];
+  readonly environmentSessionCookieName: string;
+}
+
+export function isLiveGatewayControlCookie(
+  name: string,
+  environmentSessionCookieName: string,
+): boolean {
+  return (
+    name === LIVE_GATEWAY_COOKIE_NAME ||
+    name === LIVE_GATEWAY_HTTP_COOKIE_NAME ||
+    name === environmentSessionCookieName ||
+    name === "t3_session" ||
+    name.startsWith("t3_session_")
+  );
+}
+
+export function liveGatewayCookieName(requestUrl: URL): string {
+  return requestUrl.protocol === "https:"
+    ? LIVE_GATEWAY_COOKIE_NAME
+    : LIVE_GATEWAY_HTTP_COOKIE_NAME;
+}
+
+function requestOrigin(requestUrl: URL): string {
+  return requestUrl.origin;
+}
+
+function proxyCookieHeader(
+  request: HttpServerRequest.HttpServerRequest,
+  environmentSessionCookieName: string,
+): string | undefined {
+  const cookies: Cookies.Cookie[] = [];
+  for (const [name, value] of Object.entries(request.cookies)) {
+    if (isLiveGatewayControlCookie(name, environmentSessionCookieName)) continue;
+    try {
+      cookies.push(Cookies.makeCookieUnsafe(name, value));
+    } catch {
+      // An invalid application cookie must not make the gateway unusable.
+    }
+  }
+  const header = Cookies.toCookieHeader(Cookies.fromIterable(cookies));
+  return header.length > 0 ? header : undefined;
+}
+
+export function liveGatewayUpstreamHeaders(input: {
+  readonly request: HttpServerRequest.HttpServerRequest;
+  readonly requestUrl: URL;
+  readonly upstreamUrl: URL;
+  readonly environmentSessionCookieName: string;
+}): Headers.Headers {
+  const forwarded: Record<string, string> = {};
+  for (const [name, value] of Object.entries(input.request.headers)) {
+    if (
+      PRIVATE_REQUEST_HEADERS.has(name) ||
+      name === "cookie" ||
+      name === "forwarded" ||
+      name.startsWith("cf-") ||
+      name.startsWith("sec-websocket-") ||
+      name.startsWith("x-forwarded-")
+    ) {
+      continue;
+    }
+    forwarded[name] = value;
+  }
+  forwarded.host = input.upstreamUrl.host;
+  forwarded["accept-encoding"] = "identity";
+  const cookie = proxyCookieHeader(input.request, input.environmentSessionCookieName);
+  if (cookie !== undefined) forwarded.cookie = cookie;
+  if (input.request.headers.origin !== undefined) {
+    forwarded.origin = input.upstreamUrl.origin;
+  }
+  if (input.request.headers.referer !== undefined) {
+    try {
+      const referer = new URL(input.request.headers.referer);
+      forwarded.referer = new URL(
+        `${referer.pathname}${referer.search}${referer.hash}`,
+        input.upstreamUrl.origin,
+      ).toString();
+    } catch {
+      // Drop malformed referrers instead of forwarding the gateway origin.
+    }
+  }
+  return Headers.fromInput(forwarded);
+}
+
+function effectivePort(url: URL): string {
+  return url.port || (url.protocol === "https:" ? "443" : "80");
+}
+
+function isEquivalentUpstreamOrigin(candidate: URL, upstream: URL): boolean {
+  return (
+    candidate.protocol === upstream.protocol &&
+    effectivePort(candidate) === effectivePort(upstream) &&
+    isLoopbackHost(candidate.hostname) &&
+    isLoopbackHost(upstream.hostname)
+  );
+}
+
+function rewriteLocation(location: string | undefined, upstreamOrigin: string): string | undefined {
+  if (!location) return undefined;
+  try {
+    const resolved = new URL(location, upstreamOrigin);
+    const upstream = new URL(upstreamOrigin);
+    return resolved.origin === upstream.origin || isEquivalentUpstreamOrigin(resolved, upstream)
+      ? `${resolved.pathname}${resolved.search}${resolved.hash}`
+      : resolved.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export function liveGatewayResponseHeaders(input: {
+  readonly headers: Headers.Headers;
+  readonly requestUrl: URL;
+  readonly upstreamOrigin: string;
+}): Headers.Headers {
+  let headers = Headers.removeMany(input.headers, [
+    ...HOP_BY_HOP_HEADERS,
+    "set-cookie",
+    "content-encoding",
+    "content-length",
+  ]);
+  const location = rewriteLocation(headers.location, input.upstreamOrigin);
+  headers =
+    location === undefined
+      ? Headers.remove(headers, "location")
+      : Headers.set(headers, "location", location);
+  if (headers["access-control-allow-origin"] === input.upstreamOrigin) {
+    headers = Headers.set(headers, "access-control-allow-origin", requestOrigin(input.requestUrl));
+  }
+  return headers;
+}
+
+export function liveGatewayResponseCookies(
+  upstream: Cookies.Cookies,
+  environmentSessionCookieName: string,
+): Cookies.Cookies {
+  const cookies: Cookies.Cookie[] = [];
+  for (const cookie of Object.values(upstream.cookies)) {
+    if (isLiveGatewayControlCookie(cookie.name, environmentSessionCookieName)) continue;
+    try {
+      cookies.push(
+        Cookies.makeCookieUnsafe(cookie.name, cookie.value, {
+          ...cookie.options,
+          domain: undefined,
+        }),
+      );
+    } catch {
+      // Invalid upstream cookies are ignored at this trust boundary.
+    }
+  }
+  return Cookies.fromIterable(cookies);
+}
+
+export function liveGatewayUpstreamUrl(requestUrl: URL, lease: LiveGatewayLease): URL {
+  const upstreamUrl = new URL(lease.target.origin);
+  upstreamUrl.pathname = requestUrl.pathname;
+  upstreamUrl.search = requestUrl.search;
+  return upstreamUrl;
+}
+
+export function retargetLiveGatewayRequest(
+  request: HttpClientRequest.HttpClientRequest,
+  upstreamUrl: URL,
+  headers: Headers.Headers,
+): HttpClientRequest.HttpClientRequest {
+  // Keep the query in the raw URL: Vite distinguishes flag queries such as
+  // `?url` from their URLSearchParams-normalized form, `?url=`.
+  return HttpClientRequest.makeWith(
+    request.method,
+    upstreamUrl.toString(),
+    UrlParams.empty,
+    request.hash,
+    headers,
+    request.body,
+  );
+}
+
+type LiveGatewaySocketFrame = string | Uint8Array | Socket.CloseEvent;
+
+interface BufferedLiveGatewaySocketFrame {
+  readonly frame: LiveGatewaySocketFrame;
+  readonly byteLength: number;
+}
+
+export function liveGatewayWebSocketProtocols(header: string | undefined): string | undefined {
+  const first = header
+    ?.split(",")
+    .map((protocol) => protocol.trim())
+    .find((protocol) => protocol.length > 0);
+  return first;
+}
+
+export function isForwardableWebSocketCloseCode(code: number): boolean {
+  return (
+    (code >= 1_000 && code <= 1_014 && code !== 1_004 && code !== 1_005 && code !== 1_006) ||
+    (code >= 3_000 && code <= 4_999)
+  );
+}
+
+function forwardedCloseEvent(error: Socket.SocketError): Socket.CloseEvent {
+  if (
+    error.reason._tag === "SocketCloseError" &&
+    isForwardableWebSocketCloseCode(error.reason.code)
+  ) {
+    return new Socket.CloseEvent(error.reason.code, error.reason.closeReason);
+  }
+  return new Socket.CloseEvent(1_011, "Live preview websocket peer disconnected");
+}
+
+function liveGatewaySocketFrameByteLength(frame: string | Uint8Array): number {
+  // UTF-8 needs at most three bytes per JavaScript code unit. This deliberately
+  // overestimates surrogate pairs so the pending-byte bound stays conservative
+  // without allocating another encoded copy of every text frame.
+  return typeof frame === "string" ? frame.length * 3 : frame.byteLength;
+}
+
+const closeSocketPair = Effect.fn("PreviewLiveGatewayHttp.closeSocketPair")(function* (
+  left: Socket.Socket,
+  right: Socket.Socket,
+  close: Socket.CloseEvent,
+) {
+  const [writeLeft, writeRight] = yield* Effect.all([left.writer, right.writer], {
+    concurrency: 2,
+  });
+  yield* Effect.all([writeLeft(close), writeRight(close)], {
+    concurrency: 2,
+    discard: true,
+  });
+});
+
+const forwardSocket = Effect.fn("PreviewLiveGatewayHttp.forwardSocket")(function* (
+  source: Socket.Socket,
+  destination: Socket.Socket,
+) {
+  // One extra slot is reserved for the terminal close event. Data admission is
+  // governed separately by both frame-count and pending-byte limits.
+  const frames = yield* Queue.dropping<BufferedLiveGatewaySocketFrame>(
+    LIVE_GATEWAY_WEBSOCKET_MAX_PENDING_FRAMES + 1,
+  );
+  const overloaded = yield* Deferred.make<void>();
+  const write = yield* destination.writer;
+  let bufferedBytes = 0;
+  let bufferedFrames = 0;
+  let didOverload = false;
+
+  const signalOverload = () => {
+    if (didOverload) return;
+    didOverload = true;
+    Deferred.doneUnsafe(overloaded, Effect.void);
+  };
+  const offerData = (frame: string | Uint8Array) => {
+    if (didOverload) return;
+    const byteLength = liveGatewaySocketFrameByteLength(frame);
+    if (
+      byteLength > LIVE_GATEWAY_WEBSOCKET_MAX_FRAME_BYTES ||
+      bufferedFrames >= LIVE_GATEWAY_WEBSOCKET_MAX_PENDING_FRAMES ||
+      bufferedBytes + byteLength > LIVE_GATEWAY_WEBSOCKET_MAX_PENDING_BYTES
+    ) {
+      signalOverload();
+      return;
+    }
+    if (!Queue.offerUnsafe(frames, { frame, byteLength })) {
+      signalOverload();
+      return;
+    }
+    bufferedFrames += 1;
+    bufferedBytes += byteLength;
+  };
+  const offerClose = (frame: Socket.CloseEvent) => {
+    if (didOverload) return;
+    if (!Queue.offerUnsafe(frames, { frame, byteLength: 0 })) {
+      signalOverload();
+    }
+  };
+  const read = source.runRaw(offerData).pipe(
+    Effect.matchEffect({
+      onFailure: (error) =>
+        Effect.sync(() => {
+          offerClose(forwardedCloseEvent(error));
+        }),
+      onSuccess: () =>
+        Effect.sync(() => {
+          offerClose(new Socket.CloseEvent(1_000));
+        }),
+    }),
+  );
+  const drain = Effect.gen(function* () {
+    while (true) {
+      const buffered = yield* Queue.take(frames);
+      yield* write(buffered.frame);
+      if (Socket.isCloseEvent(buffered.frame)) return;
+      bufferedFrames -= 1;
+      bufferedBytes -= buffered.byteLength;
+    }
+  });
+  const transfer = Effect.all([read, drain], {
+    concurrency: "unbounded",
+    discard: true,
+  });
+  const rejectOverload = Deferred.await(overloaded).pipe(
+    Effect.flatMap(() =>
+      closeSocketPair(
+        source,
+        destination,
+        new Socket.CloseEvent(1_013, "Live preview websocket buffer exceeded"),
+      ),
+    ),
+  );
+  yield* Effect.raceFirst(transfer, rejectOverload);
+});
+
+export const bridgeLiveGatewaySockets = Effect.fn("PreviewLiveGatewayHttp.bridgeSockets")(
+  function* (left: Socket.Socket, right: Socket.Socket) {
+    yield* Effect.raceFirst(forwardSocket(left, right), forwardSocket(right, left));
+  },
+);
+
+function makeUpstreamWebSocket(input: {
+  readonly request: HttpServerRequest.HttpServerRequest;
+  readonly requestUrl: URL;
+  readonly lease: LiveGatewayLease;
+  readonly environmentSessionCookieName: string;
+}): Effect.Effect<Socket.Socket> {
+  const upstreamHttpUrl = liveGatewayUpstreamUrl(input.requestUrl, input.lease);
+  const headers = liveGatewayUpstreamHeaders({
+    request: input.request,
+    requestUrl: input.requestUrl,
+    upstreamUrl: upstreamHttpUrl,
+    environmentSessionCookieName: input.environmentSessionCookieName,
+  });
+  const upstreamUrl = new URL(upstreamHttpUrl);
+  upstreamUrl.protocol = upstreamUrl.protocol === "https:" ? "wss:" : "ws:";
+  const protocols = liveGatewayWebSocketProtocols(input.request.headers["sec-websocket-protocol"]);
+  const acquire = Effect.acquireRelease(
+    Effect.try({
+      try: () =>
+        new NodeSocket.NodeWS.WebSocket(upstreamUrl, protocols, {
+          followRedirects: false,
+          headers: { ...headers },
+          maxPayload: LIVE_GATEWAY_WEBSOCKET_MAX_FRAME_BYTES,
+        }) as unknown as globalThis.WebSocket,
+      catch: (cause) =>
+        new Socket.SocketError({
+          reason: new Socket.SocketOpenError({
+            kind: "Unknown",
+            cause,
+          }),
+        }),
+    }),
+    (webSocket) =>
+      Effect.sync(() => {
+        const nodeWebSocket = webSocket as unknown as NodeSocket.NodeWS.WebSocket;
+        if (nodeWebSocket.readyState === nodeWebSocket.CONNECTING) {
+          nodeWebSocket.terminate();
+        } else if (nodeWebSocket.readyState === nodeWebSocket.OPEN) {
+          nodeWebSocket.close(1_000);
+        }
+      }),
+  );
+  return Socket.fromWebSocket(acquire, {
+    closeCodeIsError: () => true,
+    openTimeout: UPSTREAM_CONNECT_TIMEOUT,
+  });
+}
+
+const proxyWebSocketRequest = Effect.fn("PreviewLiveGatewayHttp.proxyWebSocketRequest")(function* (
+  request: HttpServerRequest.HttpServerRequest,
+  requestUrl: URL,
+  lease: LiveGatewayLease,
+  environmentSessionCookieName: string,
+) {
+  const upstream = yield* makeUpstreamWebSocket({
+    request,
+    requestUrl,
+    lease,
+    environmentSessionCookieName,
+  });
+  const downstream = yield* request.upgrade;
+  yield* Effect.raceFirst(
+    bridgeLiveGatewaySockets(downstream, upstream),
+    lease.invalidated.pipe(
+      Effect.flatMap(() =>
+        closeSocketPair(
+          downstream,
+          upstream,
+          new Socket.CloseEvent(1_008, "Live preview lease expired or was revoked"),
+        ),
+      ),
+    ),
+  );
+  return HttpServerResponse.empty();
+});
+
+const isEmptyBodyError = (error: HttpClientError.HttpClientError): boolean =>
+  error.reason._tag === "EmptyBodyError";
+
+export const interruptLiveGatewayStream = <A, E, R>(
+  stream: Stream.Stream<A, E, R>,
+  lease: LiveGatewayLease,
+): Stream.Stream<A, E, R> => stream.pipe(Stream.interruptWhen(lease.invalidated));
+
+const proxyHttpRequest = Effect.fn("PreviewLiveGatewayHttp.proxyHttpRequest")(function* (
+  request: HttpServerRequest.HttpServerRequest,
+  requestUrl: URL,
+  lease: LiveGatewayLease,
+  environmentSessionCookieName: string,
+) {
+  const httpClient = yield* HttpClient.HttpClient;
+  const upstreamUrl = liveGatewayUpstreamUrl(requestUrl, lease);
+  const upstreamRequest = retargetLiveGatewayRequest(
+    HttpServerRequest.toClientRequest(request),
+    upstreamUrl,
+    liveGatewayUpstreamHeaders({
+      request,
+      requestUrl,
+      upstreamUrl,
+      environmentSessionCookieName,
+    }),
+  );
+  const upstream = yield* httpClient
+    .execute(upstreamRequest)
+    .pipe(
+      Effect.provideService(FetchHttpClient.RequestInit, { redirect: "manual" }),
+      Effect.timeout(UPSTREAM_CONNECT_TIMEOUT),
+    );
+  const headers = liveGatewayResponseHeaders({
+    headers: upstream.headers,
+    requestUrl,
+    upstreamOrigin: lease.target.origin,
+  });
+  return HttpServerResponse.stream(
+    interruptLiveGatewayStream(
+      Stream.catchIf(upstream.stream, isEmptyBodyError, () => Stream.empty),
+      lease,
+    ),
+    {
+      status: upstream.status,
+      headers,
+      cookies: liveGatewayResponseCookies(upstream.cookies, environmentSessionCookieName),
+    },
+  );
+});
+
+function expiredGatewayResponse(): HttpServerResponse.HttpServerResponse {
+  const expiredAt = DateTime.toDate(DateTime.makeUnsafe(0));
+  const cookies = Cookies.setUnsafe(
+    Cookies.setUnsafe(Cookies.empty, LIVE_GATEWAY_COOKIE_NAME, "", {
+      path: "/",
+      secure: true,
+      httpOnly: true,
+      sameSite: "strict",
+      maxAge: 0,
+      expires: expiredAt,
+    }),
+    LIVE_GATEWAY_HTTP_COOKIE_NAME,
+    "",
+    {
+      path: "/",
+      secure: false,
+      httpOnly: true,
+      sameSite: "strict",
+      maxAge: 0,
+      expires: expiredAt,
+    },
+  );
+  return HttpServerResponse.text("Live preview session expired.", {
+    status: LIVE_GATEWAY_EXPIRED_STATUS,
+    headers: bootstrapResponseHeaders,
+    cookies,
+  });
+}
+
+export const makeLiveGatewayBootstrapRouteLayer = (gateway: PreviewLiveGateway["Service"]) =>
+  HttpRouter.add(
+    "GET",
+    `${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/*`,
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const requestUrl = HttpServerRequest.toURL(request);
+      if (Option.isNone(requestUrl)) {
+        return HttpServerResponse.text("Bad Request", { status: 400 });
+      }
+      const token = requestUrl.value.pathname.slice(`${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/`.length);
+      if (!BOOTSTRAP_TOKEN_PATTERN.test(token)) {
+        return expiredGatewayResponse();
+      }
+      const consumed = yield* gateway.consumeBootstrap(token);
+      if (consumed === null) {
+        return expiredGatewayResponse();
+      }
+      const cookieName = liveGatewayCookieName(requestUrl.value);
+      const cookie = yield* Effect.fromResult(
+        Cookies.set(Cookies.empty, cookieName, consumed.cookieValue, {
+          path: "/",
+          secure: cookieName === LIVE_GATEWAY_COOKIE_NAME,
+          httpOnly: true,
+          sameSite: "strict",
+          expires: DateTime.toDate(DateTime.makeUnsafe(consumed.lease.expiresAt)),
+        }),
+      ).pipe(Effect.orDie);
+      return HttpServerResponse.redirect(consumed.lease.target.redirectPath, {
+        status: 302,
+        headers: bootstrapResponseHeaders,
+        cookies: cookie,
+      });
+    }),
+  );
+
+export const makeLiveGatewayProxyLayer = (options: LiveGatewayHttpOptions) =>
+  HttpRouter.middleware(
+    (httpEffect) =>
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const requestUrl = HttpServerRequest.toURL(request);
+        if (
+          Option.isNone(requestUrl) ||
+          requestUrl.value.pathname.startsWith(`${LIVE_GATEWAY_BOOTSTRAP_PREFIX}/`)
+        ) {
+          return yield* httpEffect;
+        }
+        const cookieValue =
+          request.cookies[LIVE_GATEWAY_COOKIE_NAME] ??
+          request.cookies[LIVE_GATEWAY_HTTP_COOKIE_NAME];
+        if (!cookieValue) return yield* httpEffect;
+
+        const lease = yield* options.gateway.resolveLease(cookieValue);
+        if (lease === null) return expiredGatewayResponse();
+
+        if (request.headers.upgrade?.toLowerCase() === "websocket") {
+          return yield* proxyWebSocketRequest(
+            request,
+            requestUrl.value,
+            lease,
+            options.environmentSessionCookieName,
+          ).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("Live preview gateway websocket failed", {
+                cause,
+                threadId: lease.threadId,
+                tabId: lease.tabId,
+                upstreamOrigin: lease.target.origin,
+              }).pipe(Effect.as(HttpServerResponse.empty())),
+            ),
+          );
+        }
+
+        return yield* Effect.raceFirst(
+          proxyHttpRequest(request, requestUrl.value, lease, options.environmentSessionCookieName),
+          lease.invalidated.pipe(Effect.as(expiredGatewayResponse())),
+        ).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("Live preview gateway upstream request failed", {
+              cause,
+              threadId: lease.threadId,
+              tabId: lease.tabId,
+              upstreamOrigin: lease.target.origin,
+            }).pipe(
+              Effect.as(
+                HttpServerResponse.text("Live preview upstream is unavailable.", {
+                  status: 502,
+                  headers: bootstrapResponseHeaders,
+                }),
+              ),
+            ),
+          ),
+        );
+      }),
+    { global: true },
+  );

--- a/apps/server/src/preview/LiveGatewayHttp.ts
+++ b/apps/server/src/preview/LiveGatewayHttp.ts
@@ -47,6 +47,7 @@ const HOP_BY_HOP_HEADERS = [
   "upgrade",
 ] as const;
 const PRIVATE_REQUEST_HEADERS = new Set([...HOP_BY_HOP_HEADERS, "authorization", "dpop", "host"]);
+const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~\dA-Za-z]+$/u;
 
 const bootstrapResponseHeaders = {
   "cache-control": "no-store",
@@ -54,6 +55,15 @@ const bootstrapResponseHeaders = {
   "referrer-policy": "no-referrer",
   "x-content-type-options": "nosniff",
 } as const;
+
+function connectionHeaderNames(value: string | undefined): ReadonlySet<string> {
+  return new Set(
+    (value ?? "")
+      .split(",")
+      .map((name) => name.trim().toLowerCase())
+      .filter((name) => HTTP_HEADER_NAME_PATTERN.test(name)),
+  );
+}
 
 export function isLiveGatewayControlCookie(
   name: string,
@@ -102,9 +112,11 @@ export function liveGatewayUpstreamHeaders(input: {
   readonly environmentSessionCookieName: string;
 }): Headers.Headers {
   const forwarded: Record<string, string> = {};
+  const connectionSpecificHeaders = connectionHeaderNames(input.request.headers.connection);
   for (const [name, value] of Object.entries(input.request.headers)) {
     if (
       PRIVATE_REQUEST_HEADERS.has(name) ||
+      connectionSpecificHeaders.has(name) ||
       name === "cookie" ||
       name === "forwarded" ||
       name.startsWith("cf-") ||
@@ -167,8 +179,10 @@ export function liveGatewayResponseHeaders(input: {
   readonly requestUrl: URL;
   readonly upstreamOrigin: string;
 }): Headers.Headers {
+  const connectionSpecificHeaders = connectionHeaderNames(input.headers.connection);
   let headers = Headers.removeMany(input.headers, [
     ...HOP_BY_HOP_HEADERS,
+    ...connectionSpecificHeaders,
     "set-cookie",
     "content-encoding",
     "content-length",

--- a/apps/server/src/preview/ReviewSnapshot.test.ts
+++ b/apps/server/src/preview/ReviewSnapshot.test.ts
@@ -1,0 +1,206 @@
+import { expect, it } from "@effect/vitest";
+import {
+  PREVIEW_REVIEW_SNAPSHOT_MAX_IMAGE_BYTES,
+  PREVIEW_REVIEW_SNAPSHOT_MAX_PAGE_REVISION_LENGTH,
+  PreviewReviewSnapshotMalformedError,
+  PreviewReviewSnapshotTooLargeError,
+  PreviewTabId,
+  ThreadId,
+  type PreviewAutomationSnapshot,
+  type PreviewReviewSnapshotInput,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import { compactPreviewReviewSnapshot } from "./ReviewSnapshot.ts";
+
+const request = {
+  version: 1,
+  threadId: ThreadId.make("thread-1"),
+  tabId: PreviewTabId.make("tab-1"),
+} as const satisfies PreviewReviewSnapshotInput;
+
+const snapshot = {
+  url: "http://localhost:5173",
+  title: "T3",
+  loading: false,
+  visibleText: "Send",
+  interactiveElements: [
+    {
+      tag: "button",
+      role: "button",
+      name: "Send",
+      selector: "#send",
+      x: -5,
+      y: 10,
+      width: 20,
+      height: 30,
+    },
+    {
+      tag: "button",
+      role: "button",
+      name: "Offscreen",
+      selector: "#offscreen",
+      x: 900,
+      y: 10,
+      width: 20,
+      height: 30,
+    },
+  ],
+  accessibilityTree: {},
+  consoleEntries: [],
+  networkEntries: [],
+  actionTimeline: [],
+  screenshot: {
+    mimeType: "image/png",
+    data: "iVBORw0KGgoAAAANSUhEUgAAAyAAAAJY",
+    width: 800,
+    height: 600,
+  },
+} as const satisfies PreviewAutomationSnapshot;
+
+const compact = (value: PreviewAutomationSnapshot = snapshot) =>
+  compactPreviewReviewSnapshot({
+    request,
+    snapshot: value,
+    snapshotId: "snapshot-1",
+    capturedAt: "2026-07-30T12:00:00.000Z",
+    previewState: { serverEpoch: "server-1", revision: 7 },
+  });
+
+it.effect("compacts a legacy automation snapshot with deterministic fallbacks", () =>
+  Effect.gen(function* () {
+    const result = yield* compact();
+
+    expect(result).toMatchObject({
+      version: 1,
+      snapshotId: "snapshot-1",
+      pageRevision: "snapshot-1",
+      serverEpoch: "server-1",
+      previewRevision: 7,
+      threadId: "thread-1",
+      tabId: "tab-1",
+      viewport: {
+        width: 800,
+        height: 600,
+        scrollX: 0,
+        scrollY: 0,
+        devicePixelRatio: 1,
+      },
+      screenshot: { scale: 1 },
+      elements: [
+        {
+          id: "element-1",
+          rect: { x: 0, y: 10, width: 15, height: 30 },
+        },
+      ],
+    });
+  }),
+);
+
+it.effect("preserves host viewport, scale, and frame metadata", () =>
+  Effect.gen(function* () {
+    const result = yield* compact({
+      ...snapshot,
+      pageRevision: "page-8",
+      capturedAt: "2026-07-30T11:59:59.000Z",
+      viewport: {
+        width: 400,
+        height: 300,
+        scrollX: 8,
+        scrollY: 16,
+        devicePixelRatio: 2,
+      },
+      screenshot: {
+        ...snapshot.screenshot,
+        scale: 2,
+      },
+    });
+
+    expect(result.pageRevision).toBe("page-8");
+    expect(result.capturedAt).toBe("2026-07-30T11:59:59.000Z");
+    expect(result.viewport).toEqual({
+      width: 400,
+      height: 300,
+      scrollX: 8,
+      scrollY: 16,
+      devicePixelRatio: 2,
+    });
+    expect(result.screenshot.scale).toBe(2);
+  }),
+);
+
+it.effect("rejects malformed screenshot data", () =>
+  Effect.gen(function* () {
+    const error = yield* compact({
+      ...snapshot,
+      screenshot: { ...snapshot.screenshot, data: "not base64" },
+    }).pipe(Effect.flip);
+
+    expect(error).toBeInstanceOf(PreviewReviewSnapshotMalformedError);
+  }),
+);
+
+it.effect("rejects base64 that is not a matching PNG frame", () =>
+  Effect.gen(function* () {
+    const invalidSignature = yield* compact({
+      ...snapshot,
+      screenshot: {
+        ...snapshot.screenshot,
+        data: Buffer.from("this is not a png").toString("base64"),
+      },
+    }).pipe(Effect.flip);
+    const mismatchedDimensions = yield* compact({
+      ...snapshot,
+      screenshot: { ...snapshot.screenshot, width: snapshot.screenshot.width + 1 },
+    }).pipe(Effect.flip);
+
+    expect(invalidSignature).toBeInstanceOf(PreviewReviewSnapshotMalformedError);
+    expect(mismatchedDimensions).toBeInstanceOf(PreviewReviewSnapshotMalformedError);
+  }),
+);
+
+it.effect("rejects a screenshot whose aspect ratio does not match its viewport", () =>
+  Effect.gen(function* () {
+    const error = yield* compact({
+      ...snapshot,
+      viewport: {
+        width: 400,
+        height: 280,
+        scrollX: 0,
+        scrollY: 0,
+        devicePixelRatio: 2,
+      },
+      screenshot: { ...snapshot.screenshot, scale: 2 },
+    }).pipe(Effect.flip);
+
+    expect(error).toBeInstanceOf(PreviewReviewSnapshotMalformedError);
+  }),
+);
+
+it.effect("rejects an unbounded host page revision before returning it", () =>
+  Effect.gen(function* () {
+    const error = yield* compact({
+      ...snapshot,
+      pageRevision: "r".repeat(PREVIEW_REVIEW_SNAPSHOT_MAX_PAGE_REVISION_LENGTH + 1),
+    }).pipe(Effect.flip);
+
+    expect(error).toBeInstanceOf(PreviewReviewSnapshotMalformedError);
+  }),
+);
+
+it.effect("rejects review images above the shared upload limit", () =>
+  Effect.gen(function* () {
+    const error = yield* compact({
+      ...snapshot,
+      screenshot: {
+        ...snapshot.screenshot,
+        data: Buffer.alloc(PREVIEW_REVIEW_SNAPSHOT_MAX_IMAGE_BYTES + 1).toString("base64"),
+      },
+    }).pipe(Effect.flip);
+
+    expect(error).toBeInstanceOf(PreviewReviewSnapshotTooLargeError);
+    if (error._tag === "PreviewReviewSnapshotTooLargeError") {
+      expect(error.maximumBytes).toBe(PREVIEW_REVIEW_SNAPSHOT_MAX_IMAGE_BYTES);
+    }
+  }),
+);

--- a/apps/server/src/preview/ReviewSnapshot.ts
+++ b/apps/server/src/preview/ReviewSnapshot.ts
@@ -1,0 +1,222 @@
+import {
+  PREVIEW_REVIEW_SNAPSHOT_MAX_BASE64_CHARS,
+  PREVIEW_REVIEW_SNAPSHOT_MAX_ELEMENTS,
+  PREVIEW_REVIEW_SNAPSHOT_MAX_IMAGE_BYTES,
+  PREVIEW_REVIEW_SNAPSHOT_MAX_PAGE_REVISION_LENGTH,
+  PreviewReviewSnapshotMalformedError,
+  PreviewReviewSnapshotTooLargeError,
+  type PreviewAutomationReviewSnapshot,
+  type PreviewListResult,
+  type PreviewReviewSnapshot,
+  type PreviewReviewSnapshotElementV1,
+  type PreviewReviewSnapshotInput,
+  type PreviewReviewSnapshotRectV1,
+  type PreviewReviewSnapshotViewportV1,
+} from "@t3tools/contracts";
+import * as NodeBuffer from "node:buffer";
+import * as Effect from "effect/Effect";
+
+const bounded = (value: string, maximumLength: number): string => value.slice(0, maximumLength);
+
+const decodedBase64Length = (value: string): number | null => {
+  if (value.length === 0 || value.length % 4 !== 0) return null;
+  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+  const encodedLength = value.length - padding;
+  if (encodedLength % 4 === 1) return null;
+  for (let index = 0; index < encodedLength; index += 1) {
+    const code = value.charCodeAt(index);
+    const valid =
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      (code >= 48 && code <= 57) ||
+      code === 43 ||
+      code === 47;
+    if (!valid) return null;
+  }
+  for (let index = encodedLength; index < value.length; index += 1) {
+    if (value.charCodeAt(index) !== 61) return null;
+  }
+  return (value.length / 4) * 3 - padding;
+};
+
+const readPngDimensions = (
+  value: string,
+): { readonly width: number; readonly height: number } | null => {
+  if (value.length < 32) return null;
+  const header = NodeBuffer.Buffer.from(value.slice(0, 32), "base64");
+  if (
+    header.length < 24 ||
+    header[0] !== 0x89 ||
+    header[1] !== 0x50 ||
+    header[2] !== 0x4e ||
+    header[3] !== 0x47 ||
+    header[4] !== 0x0d ||
+    header[5] !== 0x0a ||
+    header[6] !== 0x1a ||
+    header[7] !== 0x0a ||
+    header.readUInt32BE(8) !== 13 ||
+    header.toString("ascii", 12, 16) !== "IHDR"
+  ) {
+    return null;
+  }
+  return {
+    width: header.readUInt32BE(16),
+    height: header.readUInt32BE(20),
+  };
+};
+
+const nearlyEqualScale = (left: number, right: number): boolean =>
+  Math.abs(left - right) / Math.max(left, right) <= 0.02;
+
+const fallbackViewport = (
+  snapshot: PreviewAutomationReviewSnapshot,
+): PreviewReviewSnapshotViewportV1 => ({
+  width: snapshot.screenshot.width,
+  height: snapshot.screenshot.height,
+  scrollX: 0,
+  scrollY: 0,
+  devicePixelRatio: 1,
+});
+
+const clipRect = (
+  rect: PreviewReviewSnapshotRectV1,
+  viewport: PreviewReviewSnapshotViewportV1,
+): PreviewReviewSnapshotRectV1 | null => {
+  const right = Math.min(viewport.width, rect.x + rect.width);
+  const bottom = Math.min(viewport.height, rect.y + rect.height);
+  const x = Math.max(0, rect.x);
+  const y = Math.max(0, rect.y);
+  const width = right - x;
+  const height = bottom - y;
+  return width > 0 && height > 0 ? { x, y, width, height } : null;
+};
+
+const compactElements = (
+  snapshot: PreviewAutomationReviewSnapshot,
+  viewport: PreviewReviewSnapshotViewportV1,
+): ReadonlyArray<PreviewReviewSnapshotElementV1> => {
+  const elements: PreviewReviewSnapshotElementV1[] = [];
+  for (const element of snapshot.interactiveElements) {
+    if (elements.length >= PREVIEW_REVIEW_SNAPSHOT_MAX_ELEMENTS) break;
+    if (
+      !Number.isFinite(element.x) ||
+      !Number.isFinite(element.y) ||
+      !Number.isFinite(element.width) ||
+      !Number.isFinite(element.height)
+    ) {
+      continue;
+    }
+    const rect = clipRect(
+      {
+        x: element.x,
+        y: element.y,
+        width: Math.max(0, element.width),
+        height: Math.max(0, element.height),
+      },
+      viewport,
+    );
+    if (!rect) continue;
+    elements.push({
+      id: `element-${elements.length + 1}`,
+      tag: bounded(element.tag, 64),
+      role: element.role === null ? null : bounded(element.role, 128),
+      name: bounded(element.name, 1_024),
+      selector: bounded(element.selector, 2_048),
+      rect,
+    });
+  }
+  return elements;
+};
+
+export interface CompactPreviewReviewSnapshotInput {
+  readonly request: PreviewReviewSnapshotInput;
+  readonly snapshot: PreviewAutomationReviewSnapshot;
+  readonly snapshotId: string;
+  readonly capturedAt: string;
+  readonly previewState: Pick<PreviewListResult, "serverEpoch" | "revision">;
+}
+
+export const compactPreviewReviewSnapshot = Effect.fn("PreviewReviewSnapshot.compact")(function* (
+  input: CompactPreviewReviewSnapshotInput,
+): Effect.fn.Return<
+  PreviewReviewSnapshot,
+  PreviewReviewSnapshotMalformedError | PreviewReviewSnapshotTooLargeError
+> {
+  const { request, snapshot } = input;
+  const malformed = () =>
+    new PreviewReviewSnapshotMalformedError({
+      threadId: request.threadId,
+      tabId: request.tabId,
+    });
+  if (
+    snapshot.screenshot.width <= 0 ||
+    snapshot.screenshot.height <= 0 ||
+    !Number.isInteger(snapshot.screenshot.width) ||
+    !Number.isInteger(snapshot.screenshot.height)
+  ) {
+    return yield* malformed();
+  }
+  const tooLarge = () =>
+    new PreviewReviewSnapshotTooLargeError({
+      threadId: request.threadId,
+      tabId: request.tabId,
+      maximumBytes: PREVIEW_REVIEW_SNAPSHOT_MAX_IMAGE_BYTES,
+    });
+  if (snapshot.screenshot.data.length > PREVIEW_REVIEW_SNAPSHOT_MAX_BASE64_CHARS) {
+    return yield* tooLarge();
+  }
+  const imageBytes = decodedBase64Length(snapshot.screenshot.data);
+  if (imageBytes === null) return yield* malformed();
+  if (imageBytes > PREVIEW_REVIEW_SNAPSHOT_MAX_IMAGE_BYTES) {
+    return yield* tooLarge();
+  }
+  const pngDimensions = readPngDimensions(snapshot.screenshot.data);
+  if (
+    pngDimensions === null ||
+    pngDimensions.width !== snapshot.screenshot.width ||
+    pngDimensions.height !== snapshot.screenshot.height
+  ) {
+    return yield* malformed();
+  }
+  const viewport = snapshot.viewport ?? fallbackViewport(snapshot);
+  const horizontalScale = snapshot.screenshot.width / viewport.width;
+  const verticalScale = snapshot.screenshot.height / viewport.height;
+  const scale = snapshot.screenshot.scale ?? horizontalScale;
+  if (
+    !Number.isFinite(scale) ||
+    scale <= 0 ||
+    !nearlyEqualScale(horizontalScale, verticalScale) ||
+    !nearlyEqualScale(scale, horizontalScale)
+  ) {
+    return yield* malformed();
+  }
+  if (
+    snapshot.pageRevision !== undefined &&
+    snapshot.pageRevision.length > PREVIEW_REVIEW_SNAPSHOT_MAX_PAGE_REVISION_LENGTH
+  ) {
+    return yield* malformed();
+  }
+
+  return {
+    version: 1,
+    snapshotId: input.snapshotId,
+    pageRevision: snapshot.pageRevision ?? input.snapshotId,
+    serverEpoch: input.previewState.serverEpoch,
+    previewRevision: input.previewState.revision,
+    threadId: request.threadId,
+    tabId: request.tabId,
+    capturedAt: snapshot.capturedAt ?? input.capturedAt,
+    url: bounded(snapshot.url, 2_048),
+    title: bounded(snapshot.title, 512),
+    loading: snapshot.loading,
+    viewport,
+    screenshot: {
+      mimeType: "image/png",
+      data: snapshot.screenshot.data,
+      width: snapshot.screenshot.width,
+      height: snapshot.screenshot.height,
+      scale,
+    },
+    elements: compactElements(snapshot, viewport),
+  };
+});

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -22,6 +22,7 @@ import {
   type OrchestrationEvent,
   ORCHESTRATION_WS_METHODS,
   type PreviewEvent,
+  PreviewTabId,
   ProjectId,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -92,6 +93,8 @@ import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as ServerSettings from "./serverSettings.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewManager from "./preview/Manager.ts";
+import { LIVE_GATEWAY_COOKIE_NAME, LIVE_GATEWAY_HTTP_COOKIE_NAME } from "./preview/LiveGateway.ts";
+import { LIVE_GATEWAY_EXPIRED_STATUS, liveGatewayCookieName } from "./preview/LiveGatewayHttp.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as BrowserTraceCollector from "./observability/BrowserTraceCollector.ts";
 import * as ProjectFaviconResolver from "./project/ProjectFaviconResolver.ts";
@@ -364,6 +367,7 @@ const buildAppUnderTest = (options?: {
     desktopTelemetryReceiver?: Partial<
       DesktopTelemetryReceiver.DesktopTelemetryReceiver["Service"]
     >;
+    previewManager?: Partial<PreviewManager.PreviewManager["Service"]>;
   };
 }) =>
   Effect.gen(function* () {
@@ -692,6 +696,7 @@ const buildAppUnderTest = (options?: {
             subscribeEvents: Effect.flatMap(PubSub.unbounded<PreviewEvent>(), (pubsub) =>
               PubSub.subscribe(pubsub),
             ),
+            ...options?.layers?.previewManager,
           }),
           Layer.mock(PortScanner.PortDiscovery)({
             scan: () => Effect.succeed([]),
@@ -4321,6 +4326,308 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("bootstraps and proxies a live preview after its issuing socket disconnects", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const upstreamRequests: Array<{
+          readonly cookie: string;
+          readonly host: string;
+          readonly origin: string;
+          readonly url: string;
+        }> = [];
+        const upstreamWebSocketRequests: Array<{
+          readonly cookie: string;
+          readonly origin: string;
+          readonly protocol: string;
+        }> = [];
+        const upstream = yield* Effect.acquireRelease(
+          Effect.promise(async () => {
+            const NodeHttp = await import("node:http");
+            return await new Promise<{
+              readonly close: () => Promise<void>;
+              readonly origin: string;
+            }>((resolve, reject) => {
+              const server = NodeHttp.createServer((request, response) => {
+                upstreamRequests.push({
+                  cookie: request.headers.cookie ?? "",
+                  host: request.headers.host ?? "",
+                  origin: request.headers.origin ?? "",
+                  url: request.url ?? "",
+                });
+                response.setHeader("set-cookie", [
+                  "app_session=server; Domain=127.0.0.1; Path=/",
+                  "t3_session=upstream-attack; Path=/",
+                  `${LIVE_GATEWAY_COOKIE_NAME}=upstream-attack; Secure; Path=/`,
+                  `${LIVE_GATEWAY_HTTP_COOKIE_NAME}=upstream-http-attack; Path=/`,
+                ]);
+                if (request.url?.startsWith("/upstream-auth")) {
+                  response.statusCode = 401;
+                  response.end("app-auth-required");
+                  return;
+                }
+                response.statusCode = 200;
+                response.end(`proxied:${request.url}`);
+              });
+              const webSocketServer = new NodeSocket.NodeWS.WebSocketServer({
+                noServer: true,
+                handleProtocols: (protocols) => (protocols.has("vite-hmr") ? "vite-hmr" : false),
+              });
+              webSocketServer.on("connection", (webSocket, request) => {
+                upstreamWebSocketRequests.push({
+                  cookie: request.headers.cookie ?? "",
+                  origin: request.headers.origin ?? "",
+                  protocol: webSocket.protocol,
+                });
+                webSocket.on("message", (data, isBinary) => {
+                  webSocket.send(data, { binary: isBinary });
+                });
+              });
+              server.on("upgrade", (request, socket, head) => {
+                webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+                  webSocketServer.emit("connection", webSocket, request);
+                });
+              });
+              server.on("error", reject);
+              server.listen(0, "127.0.0.1", () => {
+                const address = server.address();
+                if (!address || typeof address === "string") {
+                  reject(new Error("Expected TCP live-preview test address"));
+                  return;
+                }
+                resolve({
+                  origin: `http://127.0.0.1:${address.port}`,
+                  close: () =>
+                    new Promise<void>((resolveClose, rejectClose) => {
+                      for (const webSocket of webSocketServer.clients) {
+                        webSocket.terminate();
+                      }
+                      server.closeAllConnections();
+                      server.close((error) => {
+                        if (error) {
+                          rejectClose(error);
+                          return;
+                        }
+                        resolveClose();
+                      });
+                    }),
+                });
+              });
+            });
+          }),
+          (server) => Effect.promise(server.close),
+        );
+        const tabId = PreviewTabId.make("preview-live-gateway-tab");
+        yield* buildAppUnderTest({
+          layers: {
+            previewManager: {
+              list: () =>
+                Effect.succeed({
+                  sessions: [
+                    {
+                      threadId: defaultThreadId,
+                      tabId,
+                      navStatus: {
+                        _tag: "Success",
+                        url: `${upstream.origin}/app/start?hello=1#view`,
+                        title: "Live preview",
+                      },
+                      canGoBack: false,
+                      canGoForward: false,
+                      updatedAt: "2026-07-30T12:00:00.000Z",
+                    },
+                  ],
+                  serverEpoch: "preview-server-1",
+                  revision: 1,
+                }),
+            },
+          },
+        });
+
+        const sessionCookie = yield* getAuthenticatedSessionCookieHeader();
+        const bareWsUrl = yield* getWsServerUrl("/ws", { authenticated: false });
+        const wsUrl = appendSessionCookieToWsUrl(bareWsUrl, sessionCookie);
+        const issued = yield* Effect.scoped(
+          withWsRpcClient(wsUrl, (client) =>
+            client[WS_METHODS.previewOpenLiveGateway]({
+              version: 1,
+              threadId: defaultThreadId,
+              tabId,
+            }),
+          ),
+        );
+
+        // The RPC scope has ended here. Its disconnect must not revoke a lease
+        // owned by the longer-lived authenticated session.
+        const bootstrap = yield* fetchEffect(issued.relativeUrl, { redirect: "manual" });
+        assert.equal(bootstrap.status, 302);
+        assert.equal(bootstrap.headers.location, "/app/start?hello=1#view");
+        const setCookie = bootstrap.headers["set-cookie"] ?? "";
+        const gatewayCookieName = liveGatewayCookieName(
+          new URL(yield* getHttpServerUrl(issued.relativeUrl)),
+        );
+        const gatewayCookieValue = new RegExp(`${gatewayCookieName}=([^;]+)`, "u").exec(
+          setCookie,
+        )?.[1];
+        assert.isDefined(gatewayCookieValue);
+        const gatewayCookie = `${gatewayCookieName}=${gatewayCookieValue}`;
+
+        const proxied = yield* fetchEffect("/asset?x=1", {
+          headers: {
+            cookie: [
+              gatewayCookie,
+              sessionCookie,
+              "t3_session_legacy=secret",
+              "app_session=client",
+            ].join("; "),
+            origin: "https://environment.example",
+          },
+        });
+        assert.equal(proxied.status, 200);
+        assert.equal(yield* proxied.text, "proxied:/asset?x=1");
+        assert.equal(upstreamRequests[0]?.url, "/asset?x=1");
+        assert.equal(upstreamRequests[0]?.origin, upstream.origin);
+        assert.equal(upstreamRequests[0]?.host, new URL(upstream.origin).host);
+        assert.equal(upstreamRequests[0]?.cookie, "app_session=client");
+
+        const upstreamCookies = proxied.headers["set-cookie"] ?? "";
+        assert.include(upstreamCookies, "app_session=server");
+        assert.notInclude(upstreamCookies.toLowerCase(), "domain=");
+        assert.notInclude(upstreamCookies, "t3_session");
+        assert.notInclude(upstreamCookies, LIVE_GATEWAY_COOKIE_NAME);
+        assert.notInclude(upstreamCookies, LIVE_GATEWAY_HTTP_COOKIE_NAME);
+
+        const appAuth = yield* fetchEffect("/upstream-auth", {
+          headers: { cookie: gatewayCookie },
+        });
+        assert.equal(appAuth.status, 401);
+        assert.equal(yield* appAuth.text, "app-auth-required");
+
+        const gatewaySocketUrl = new URL(yield* getHttpServerUrl("/hmr"));
+        gatewaySocketUrl.protocol = "ws:";
+        const echoedFramesReady = yield* Deferred.make<
+          | {
+              readonly _tag: "Success";
+              readonly frames: ReadonlyArray<{
+                readonly binary: boolean;
+                readonly value: string;
+              }>;
+            }
+          | { readonly _tag: "Failure"; readonly cause: unknown }
+        >();
+        const gatewaySocketClosed = yield* Deferred.make<{
+          readonly code: number;
+          readonly reason: string;
+        }>();
+        const gatewayWebSocket = yield* Effect.acquireRelease(
+          Effect.sync(() => {
+            const webSocket = new NodeSocket.NodeWS.WebSocket(gatewaySocketUrl, ["vite-hmr"], {
+              headers: {
+                cookie: [
+                  gatewayCookie,
+                  sessionCookie,
+                  "t3_session_legacy=secret",
+                  "app_session=client",
+                ].join("; "),
+                origin: "https://environment.example",
+              },
+            });
+            const frames: Array<{ readonly binary: boolean; readonly value: string }> = [];
+            webSocket.on("open", () => {
+              webSocket.send("first");
+              webSocket.send(new Uint8Array([1, 2, 3]));
+              webSocket.send("third");
+            });
+            webSocket.on("message", (data, isBinary) => {
+              frames.push({
+                binary: isBinary,
+                value: isBinary
+                  ? Buffer.from(data as ArrayBuffer).toString("hex")
+                  : data.toString(),
+              });
+              if (frames.length === 3) {
+                Deferred.doneUnsafe(echoedFramesReady, Effect.succeed({ _tag: "Success", frames }));
+              }
+            });
+            webSocket.on("close", (code, reason) => {
+              Deferred.doneUnsafe(
+                gatewaySocketClosed,
+                Effect.succeed({
+                  code,
+                  reason: reason.toString(),
+                }),
+              );
+              if (frames.length < 3) {
+                Deferred.doneUnsafe(
+                  echoedFramesReady,
+                  Effect.succeed({
+                    _tag: "Failure",
+                    cause: new Error(`Gateway websocket closed after ${frames.length} frames`),
+                  }),
+                );
+              }
+            });
+            webSocket.on("error", (error) => {
+              Deferred.doneUnsafe(
+                echoedFramesReady,
+                Effect.succeed({ _tag: "Failure", cause: error }),
+              );
+            });
+            return webSocket;
+          }),
+          (webSocket) =>
+            Effect.sync(() => {
+              if (
+                webSocket.readyState === webSocket.CONNECTING ||
+                webSocket.readyState === webSocket.OPEN
+              ) {
+                webSocket.terminate();
+              }
+            }),
+        );
+        const echoedFramesResult = yield* Deferred.await(echoedFramesReady);
+        if (echoedFramesResult._tag === "Failure") {
+          return yield* Effect.die(echoedFramesResult.cause);
+        }
+        const echoedFrames = echoedFramesResult.frames;
+        assert.equal(gatewayWebSocket.protocol, "vite-hmr");
+        assert.deepEqual(echoedFrames, [
+          { binary: false, value: "first" },
+          { binary: true, value: "010203" },
+          { binary: false, value: "third" },
+        ]);
+        assert.deepEqual(upstreamWebSocketRequests, [
+          {
+            cookie: "app_session=client",
+            origin: upstream.origin,
+            protocol: "vite-hmr",
+          },
+        ]);
+
+        yield* Effect.scoped(
+          withWsRpcClient(wsUrl, (client) =>
+            client[WS_METHODS.previewClose]({
+              threadId: defaultThreadId,
+              tabId,
+            }),
+          ),
+        );
+        assert.deepEqual(yield* Deferred.await(gatewaySocketClosed), {
+          code: 1_008,
+          reason: "Live preview lease expired or was revoked",
+        });
+        const revokedLease = yield* fetchEffect("/asset-after-close", {
+          headers: { cookie: gatewayCookie },
+        });
+        assert.equal(revokedLease.status, LIVE_GATEWAY_EXPIRED_STATUS);
+
+        const replayedBootstrap = yield* fetchEffect(issued.relativeUrl, {
+          redirect: "manual",
+        });
+        assert.equal(replayedBootstrap.status, LIVE_GATEWAY_EXPIRED_STATUS);
+      }),
+    ).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
+  );
+
   it.effect("shares one preview automation broker across websocket sessions", () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -4357,6 +4664,137 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         assert.equal(replacementEvent.type, "connected");
         assert.notEqual(replacementEvent.connectionId, firstConnectionId);
         assert.isTrue(Option.isSome(firstStreamClosed));
+      }),
+    ).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("routes a compact review snapshot across websocket sessions", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const tabId = PreviewTabId.make("preview-review-tab");
+        yield* buildAppUnderTest({
+          layers: {
+            previewManager: {
+              list: () =>
+                Effect.succeed({
+                  sessions: [
+                    {
+                      threadId: defaultThreadId,
+                      tabId,
+                      navStatus: { _tag: "Idle" },
+                      canGoBack: false,
+                      canGoForward: false,
+                      updatedAt: "2026-07-30T12:00:00.000Z",
+                    },
+                  ],
+                  serverEpoch: "preview-server-1",
+                  revision: 7,
+                }),
+            },
+          },
+        });
+
+        const wsUrl = yield* getWsServerUrl("/ws");
+        const hostConnected = yield* Deferred.make<void>();
+        const missingTabId = PreviewTabId.make("missing-preview-review-tab");
+        let requestCount = 0;
+        let respondedAt = 0;
+        const host = {
+          clientId: "review-preview-host",
+          environmentId: testEnvironmentDescriptor.environmentId,
+        } as const;
+
+        yield* withWsRpcClient(wsUrl, (client) =>
+          client[WS_METHODS.previewAutomationConnect](host).pipe(
+            Stream.runForEach((event) => {
+              if (event.type === "connected") {
+                return Deferred.succeed(hostConnected, undefined);
+              }
+              requestCount += 1;
+              assert.deepEqual(event.request.input, { mode: "review" });
+              return Effect.gen(function* () {
+                respondedAt = yield* Clock.currentTimeMillis;
+                yield* client[WS_METHODS.previewAutomationRespond]({
+                  clientId: host.clientId,
+                  connectionId: event.connectionId,
+                  requestId: event.request.requestId,
+                  ok: true,
+                  result: {
+                    url: "http://localhost:5173",
+                    title: "Review",
+                    loading: false,
+                    visibleText: "Send",
+                    interactiveElements: [
+                      {
+                        tag: "button",
+                        role: "button",
+                        name: "Send",
+                        selector: "#send",
+                        x: 10,
+                        y: 20,
+                        width: 80,
+                        height: 32,
+                      },
+                    ],
+                    accessibilityTree: {},
+                    consoleEntries: [],
+                    networkEntries: [],
+                    actionTimeline: [],
+                    screenshot: {
+                      mimeType: "image/png",
+                      data: "iVBORw0KGgoAAAANSUhEUgAAAyAAAAJY",
+                      width: 800,
+                      height: 600,
+                    },
+                  },
+                });
+              });
+            }),
+          ),
+        ).pipe(Effect.forkScoped);
+        yield* Deferred.await(hostConnected);
+
+        const result = yield* withWsRpcClient(wsUrl, (client) =>
+          Effect.gen(function* () {
+            const missing = yield* client[WS_METHODS.previewReviewSnapshot]({
+              version: 1,
+              threadId: defaultThreadId,
+              tabId: missingTabId,
+            }).pipe(Effect.flip);
+            assert.equal(missing._tag, "PreviewSessionLookupError");
+
+            return yield* client[WS_METHODS.previewReviewSnapshot]({
+              version: 1,
+              threadId: defaultThreadId,
+              tabId,
+            });
+          }),
+        );
+
+        assert.equal(requestCount, 1);
+        assert.equal(result.version, 1);
+        assert.equal(result.threadId, defaultThreadId);
+        assert.equal(result.tabId, tabId);
+        assert.equal(result.pageRevision, result.snapshotId);
+        assert.equal(result.previewRevision, 7);
+        assert.isAtLeast(Date.parse(result.capturedAt), respondedAt);
+        assert.deepEqual(result.viewport, {
+          width: 800,
+          height: 600,
+          scrollX: 0,
+          scrollY: 0,
+          devicePixelRatio: 1,
+        });
+        assert.deepEqual(result.elements, [
+          {
+            id: "element-1",
+            tag: "button",
+            role: "button",
+            name: "Send",
+            selector: "#send",
+            rect: { x: 10, y: 20, width: 80, height: 32 },
+          },
+        ]);
       }),
     ).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -93,11 +93,7 @@ import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as ServerSettings from "./serverSettings.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewManager from "./preview/Manager.ts";
-import {
-  LIVE_GATEWAY_COOKIE_NAME,
-  LIVE_GATEWAY_HTTP_COOKIE_NAME,
-  liveLayer as previewLiveGatewayLayer,
-} from "./preview/LiveGateway.ts";
+import * as PreviewLiveGateway from "./preview/LiveGateway.ts";
 import { LIVE_GATEWAY_EXPIRED_STATUS, liveGatewayCookieName } from "./preview/LiveGatewayHttp.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as BrowserTraceCollector from "./observability/BrowserTraceCollector.ts";
@@ -564,7 +560,7 @@ const buildAppUnderTest = (options?: {
     }).pipe(
       Layer.provide(
         Layer.mergeAll(
-          previewLiveGatewayLayer,
+          PreviewLiveGateway.layer,
           Layer.mock(Keybindings.Keybindings)({
             loadConfigState: Effect.succeed({
               keybindings: [],
@@ -4364,8 +4360,8 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
                 response.setHeader("set-cookie", [
                   "app_session=server; Domain=127.0.0.1; Path=/",
                   "t3_session=upstream-attack; Path=/",
-                  `${LIVE_GATEWAY_COOKIE_NAME}=upstream-attack; Secure; Path=/`,
-                  `${LIVE_GATEWAY_HTTP_COOKIE_NAME}=upstream-http-attack; Path=/`,
+                  `${PreviewLiveGateway.LIVE_GATEWAY_COOKIE_NAME}=upstream-attack; Secure; Path=/`,
+                  `${PreviewLiveGateway.LIVE_GATEWAY_HTTP_COOKIE_NAME}=upstream-http-attack; Path=/`,
                 ]);
                 if (request.url?.startsWith("/upstream-auth")) {
                   response.statusCode = 401;
@@ -4500,8 +4496,8 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         assert.include(upstreamCookies, "app_session=server");
         assert.notInclude(upstreamCookies.toLowerCase(), "domain=");
         assert.notInclude(upstreamCookies, "t3_session");
-        assert.notInclude(upstreamCookies, LIVE_GATEWAY_COOKIE_NAME);
-        assert.notInclude(upstreamCookies, LIVE_GATEWAY_HTTP_COOKIE_NAME);
+        assert.notInclude(upstreamCookies, PreviewLiveGateway.LIVE_GATEWAY_COOKIE_NAME);
+        assert.notInclude(upstreamCookies, PreviewLiveGateway.LIVE_GATEWAY_HTTP_COOKIE_NAME);
 
         const appAuth = yield* fetchEffect("/upstream-auth", {
           headers: { cookie: gatewayCookie },

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -93,7 +93,11 @@ import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as ServerSettings from "./serverSettings.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewManager from "./preview/Manager.ts";
-import { LIVE_GATEWAY_COOKIE_NAME, LIVE_GATEWAY_HTTP_COOKIE_NAME } from "./preview/LiveGateway.ts";
+import {
+  LIVE_GATEWAY_COOKIE_NAME,
+  LIVE_GATEWAY_HTTP_COOKIE_NAME,
+  liveLayer as previewLiveGatewayLayer,
+} from "./preview/LiveGateway.ts";
 import { LIVE_GATEWAY_EXPIRED_STATUS, liveGatewayCookieName } from "./preview/LiveGatewayHttp.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as BrowserTraceCollector from "./observability/BrowserTraceCollector.ts";
@@ -559,14 +563,17 @@ const buildAppUnderTest = (options?: {
       disableLogger: true,
     }).pipe(
       Layer.provide(
-        Layer.mock(Keybindings.Keybindings)({
-          loadConfigState: Effect.succeed({
-            keybindings: [],
-            issues: [],
+        Layer.mergeAll(
+          previewLiveGatewayLayer,
+          Layer.mock(Keybindings.Keybindings)({
+            loadConfigState: Effect.succeed({
+              keybindings: [],
+              issues: [],
+            }),
+            streamChanges: Stream.empty,
+            ...options?.layers?.keybindings,
           }),
-          streamChanges: Stream.empty,
-          ...options?.layers?.keybindings,
-        }),
+        ),
       ),
       Layer.provide(
         Layer.mock(ProviderRegistry.ProviderRegistry)({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -585,7 +585,7 @@ export const makeServerLayer = Layer.unwrap(
     );
 
     return serverApplicationLayer.pipe(
-      Layer.provide(PreviewLiveGateway.liveLayer),
+      Layer.provide(PreviewLiveGateway.layer),
       Layer.provideMerge(RuntimeServicesLive),
       Layer.provideMerge(serverRelayBrokerTracingLayer),
       Layer.provideMerge(HttpResponseCompressionLive),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -19,7 +19,7 @@ import {
   httpCompressionLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
-import { makeWebsocketRpcRouteLayer } from "./ws.ts";
+import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
@@ -46,8 +46,8 @@ import * as PreviewAutomationBroker from "./mcp/PreviewAutomationBroker.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import * as PreviewLiveGateway from "./preview/LiveGateway.ts";
 import {
-  makeLiveGatewayBootstrapRouteLayer,
-  makeLiveGatewayProxyLayer,
+  liveGatewayBootstrapRouteLayer,
+  liveGatewayProxyLayer,
 } from "./preview/LiveGatewayHttp.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as ProcessRunner from "./processRunner.ts";
@@ -86,7 +86,6 @@ import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import { authHttpApiLayer, environmentAuthenticatedAuthLayer } from "./auth/http.ts";
 import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
-import * as SessionStore from "./auth/SessionStore.ts";
 import {
   connectHttpApiLayer,
   reconcileDesiredCloudLink,
@@ -406,39 +405,28 @@ const RuntimeServicesLive = ServerRuntimeStartup.layer.pipe(
   Layer.provideMerge(RuntimeDependenciesLive),
 );
 
-export const makeRoutesLayer = Layer.unwrap(
-  Effect.gen(function* () {
-    const previewLiveGateway = yield* PreviewLiveGateway.makeLive;
-    const sessions = yield* SessionStore.SessionStore;
-    return Layer.mergeAll(
-      Layer.mergeAll(
-        HttpApiBuilder.layer(EnvironmentHttpApi).pipe(
-          Layer.provide(authHttpApiLayer),
-          Layer.provide(connectHttpApiLayer),
-          Layer.provide(orchestrationHttpApiLayer),
-          Layer.provide(serverEnvironmentHttpApiLayer),
-          Layer.provide(environmentAuthenticatedAuthLayer),
-        ),
-        otlpTracesProxyRouteLayer,
-        assetRouteLayer,
-        makeLiveGatewayBootstrapRouteLayer(previewLiveGateway),
-        staticAndDevRouteLayer,
-        makeWebsocketRpcRouteLayer(previewLiveGateway),
-      ),
-      McpHttpServer.layer.pipe(Layer.provide(McpSessionRegistry.layer)),
-    ).pipe(
-      Layer.provide(PreviewAutomationBroker.layer),
-      Layer.provide(ServerSelfUpdate.layer),
-      Layer.provide(browserApiCorsLayer),
-      Layer.provide(httpCompressionLayer),
-      Layer.provide(
-        makeLiveGatewayProxyLayer({
-          gateway: previewLiveGateway,
-          environmentSessionCookieName: sessions.cookieName,
-        }),
-      ),
-    );
-  }),
+export const makeRoutesLayer = Layer.mergeAll(
+  Layer.mergeAll(
+    HttpApiBuilder.layer(EnvironmentHttpApi).pipe(
+      Layer.provide(authHttpApiLayer),
+      Layer.provide(connectHttpApiLayer),
+      Layer.provide(orchestrationHttpApiLayer),
+      Layer.provide(serverEnvironmentHttpApiLayer),
+      Layer.provide(environmentAuthenticatedAuthLayer),
+    ),
+    otlpTracesProxyRouteLayer,
+    assetRouteLayer,
+    liveGatewayBootstrapRouteLayer,
+    staticAndDevRouteLayer,
+    websocketRpcRouteLayer,
+  ),
+  McpHttpServer.layer.pipe(Layer.provide(McpSessionRegistry.layer)),
+).pipe(
+  Layer.provide(PreviewAutomationBroker.layer),
+  Layer.provide(ServerSelfUpdate.layer),
+  Layer.provide(browserApiCorsLayer),
+  Layer.provide(httpCompressionLayer),
+  Layer.provide(liveGatewayProxyLayer),
 );
 
 export const makeServerLayer = Layer.unwrap(
@@ -597,6 +585,7 @@ export const makeServerLayer = Layer.unwrap(
     );
 
     return serverApplicationLayer.pipe(
+      Layer.provide(PreviewLiveGateway.liveLayer),
       Layer.provideMerge(RuntimeServicesLive),
       Layer.provideMerge(serverRelayBrokerTracingLayer),
       Layer.provideMerge(HttpResponseCompressionLive),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -19,7 +19,7 @@ import {
   httpCompressionLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
-import { websocketRpcRouteLayer } from "./ws.ts";
+import { makeWebsocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
@@ -44,6 +44,11 @@ import * as McpHttpServer from "./mcp/McpHttpServer.ts";
 import * as McpSessionRegistry from "./mcp/McpSessionRegistry.ts";
 import * as PreviewAutomationBroker from "./mcp/PreviewAutomationBroker.ts";
 import * as PreviewManager from "./preview/Manager.ts";
+import * as PreviewLiveGateway from "./preview/LiveGateway.ts";
+import {
+  makeLiveGatewayBootstrapRouteLayer,
+  makeLiveGatewayProxyLayer,
+} from "./preview/LiveGatewayHttp.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as ProcessRunner from "./processRunner.ts";
 import * as GitManager from "./git/GitManager.ts";
@@ -81,6 +86,7 @@ import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import { authHttpApiLayer, environmentAuthenticatedAuthLayer } from "./auth/http.ts";
 import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
+import * as SessionStore from "./auth/SessionStore.ts";
 import {
   connectHttpApiLayer,
   reconcileDesiredCloudLink,
@@ -400,26 +406,39 @@ const RuntimeServicesLive = ServerRuntimeStartup.layer.pipe(
   Layer.provideMerge(RuntimeDependenciesLive),
 );
 
-export const makeRoutesLayer = Layer.mergeAll(
-  Layer.mergeAll(
-    HttpApiBuilder.layer(EnvironmentHttpApi).pipe(
-      Layer.provide(authHttpApiLayer),
-      Layer.provide(connectHttpApiLayer),
-      Layer.provide(orchestrationHttpApiLayer),
-      Layer.provide(serverEnvironmentHttpApiLayer),
-      Layer.provide(environmentAuthenticatedAuthLayer),
-    ),
-    otlpTracesProxyRouteLayer,
-    assetRouteLayer,
-    staticAndDevRouteLayer,
-    websocketRpcRouteLayer,
-  ),
-  McpHttpServer.layer.pipe(Layer.provide(McpSessionRegistry.layer)),
-).pipe(
-  Layer.provide(PreviewAutomationBroker.layer),
-  Layer.provide(ServerSelfUpdate.layer),
-  Layer.provide(browserApiCorsLayer),
-  Layer.provide(httpCompressionLayer),
+export const makeRoutesLayer = Layer.unwrap(
+  Effect.gen(function* () {
+    const previewLiveGateway = yield* PreviewLiveGateway.makeLive;
+    const sessions = yield* SessionStore.SessionStore;
+    return Layer.mergeAll(
+      Layer.mergeAll(
+        HttpApiBuilder.layer(EnvironmentHttpApi).pipe(
+          Layer.provide(authHttpApiLayer),
+          Layer.provide(connectHttpApiLayer),
+          Layer.provide(orchestrationHttpApiLayer),
+          Layer.provide(serverEnvironmentHttpApiLayer),
+          Layer.provide(environmentAuthenticatedAuthLayer),
+        ),
+        otlpTracesProxyRouteLayer,
+        assetRouteLayer,
+        makeLiveGatewayBootstrapRouteLayer(previewLiveGateway),
+        staticAndDevRouteLayer,
+        makeWebsocketRpcRouteLayer(previewLiveGateway),
+      ),
+      McpHttpServer.layer.pipe(Layer.provide(McpSessionRegistry.layer)),
+    ).pipe(
+      Layer.provide(PreviewAutomationBroker.layer),
+      Layer.provide(ServerSelfUpdate.layer),
+      Layer.provide(browserApiCorsLayer),
+      Layer.provide(httpCompressionLayer),
+      Layer.provide(
+        makeLiveGatewayProxyLayer({
+          gateway: previewLiveGateway,
+          environmentSessionCookieName: sessions.cookieName,
+        }),
+      ),
+    );
+  }),
 );
 
 export const makeServerLayer = Layer.unwrap(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -55,6 +55,12 @@ import {
   type TerminalError,
   type TerminalEvent,
   type TerminalMetadataStreamEvent,
+  PreviewAutomationClientId,
+  PreviewAutomationReviewSnapshot,
+  type PreviewTabId,
+  PreviewSessionLookupError,
+  type PreviewReviewSnapshotInput,
+  PreviewReviewSnapshotMalformedError,
   WS_METHODS,
   WsRpcGroup,
 } from "@t3tools/contracts";
@@ -87,6 +93,8 @@ import * as ServerSettings from "./serverSettings.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewAutomationBroker from "./mcp/PreviewAutomationBroker.ts";
 import * as PreviewManager from "./preview/Manager.ts";
+import * as PreviewLiveGateway from "./preview/LiveGateway.ts";
+import { compactPreviewReviewSnapshot } from "./preview/ReviewSnapshot.ts";
 import { issueAssetUrl } from "./assets/AssetAccess.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as WorkspaceEntries from "./workspace/WorkspaceEntries.ts";
@@ -121,9 +129,15 @@ import * as SessionStore from "./auth/SessionStore.ts";
 import { failEnvironmentAuthInvalid, failEnvironmentInternal } from "./auth/http.ts";
 import * as RelayClient from "@t3tools/shared/relayClient";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
+const decodePreviewAutomationReviewSnapshot = Schema.decodeUnknownEffect(
+  PreviewAutomationReviewSnapshot,
+);
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const EDITOR_DISCOVERY_TIMEOUT = Duration.seconds(5);
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 
 export const resolveAvailableEditorsForConfig = <A, E, R>(
   discovery: Effect.Effect<ReadonlyArray<A>, E, R>,
@@ -348,6 +362,7 @@ function toAuthAccessStreamEvent(
 const makeWsRpcLayer = (
   currentSession: EnvironmentAuth.AuthenticatedSession,
   previewAutomationBroker: PreviewAutomationBroker.PreviewAutomationBroker["Service"],
+  previewLiveGateway: PreviewLiveGateway.PreviewLiveGateway["Service"],
 ) =>
   WsRpcGroup.toLayer(
     Effect.gen(function* () {
@@ -412,6 +427,84 @@ const makeWsRpcLayer = (
       const processResourceMonitor = yield* ProcessResourceMonitor.ProcessResourceMonitor;
       const resourceTelemetry = yield* ResourceTelemetry.ResourceTelemetry;
       const relayClient = yield* RelayClient.RelayClient;
+      const previewReviewRequesterId = PreviewAutomationClientId.make(
+        `review-${bytesToHex(
+          yield* crypto
+            .digest("SHA-256", new TextEncoder().encode(currentSessionId))
+            .pipe(Effect.orDie),
+        )}`,
+      );
+      const previewReviewAssignmentId = Effect.fn("ws.previewReviewSnapshot.assignmentId")(
+        function* (threadId: PreviewReviewSnapshotInput["threadId"]) {
+          const digest = yield* crypto
+            .digest("SHA-256", new TextEncoder().encode(`${currentSessionId}\n${threadId}`))
+            .pipe(Effect.orDie);
+          return `review-${bytesToHex(digest)}`;
+        },
+      );
+      const capturePreviewReviewSnapshot = Effect.fn("ws.previewReviewSnapshot.capture")(function* (
+        input: PreviewReviewSnapshotInput,
+      ) {
+        const previewState = yield* previewManager.list({ threadId: input.threadId });
+        if (!previewState.sessions.some((session) => session.tabId === input.tabId)) {
+          return yield* new PreviewSessionLookupError({
+            threadId: input.threadId,
+            tabId: input.tabId,
+          });
+        }
+        const [snapshotId, assignmentId] = yield* Effect.all(
+          [crypto.randomUUIDv4.pipe(Effect.orDie), previewReviewAssignmentId(input.threadId)],
+          { concurrency: 2 },
+        );
+        const rawSnapshot = yield* previewAutomationBroker.invoke<unknown>({
+          scope: {
+            environmentId: yield* serverEnvironment.getEnvironmentId,
+            threadId: input.threadId,
+            assignmentId,
+            requesterId: previewReviewRequesterId,
+          },
+          operation: "snapshot",
+          input: { mode: "review" },
+          tabId: input.tabId,
+        });
+        const snapshot = yield* decodePreviewAutomationReviewSnapshot(rawSnapshot).pipe(
+          Effect.mapError(
+            () =>
+              new PreviewReviewSnapshotMalformedError({
+                threadId: input.threadId,
+                tabId: input.tabId,
+              }),
+          ),
+        );
+        const capturedAt = yield* nowIso;
+        return yield* compactPreviewReviewSnapshot({
+          request: input,
+          snapshot,
+          snapshotId,
+          capturedAt,
+          previewState,
+        });
+      });
+      const openPreviewLiveGateway = Effect.fn("ws.previewOpenLiveGateway")(function* (input: {
+        readonly threadId: ThreadId;
+        readonly tabId: PreviewTabId;
+      }) {
+        const previewState = yield* previewManager.list({ threadId: input.threadId });
+        const snapshot = previewState.sessions.find((session) => session.tabId === input.tabId);
+        if (!snapshot) {
+          return yield* new PreviewSessionLookupError({
+            threadId: input.threadId,
+            tabId: input.tabId,
+          });
+        }
+        return yield* previewLiveGateway.issue({
+          sessionId: currentSessionId,
+          ...(currentSession.expiresAt === undefined
+            ? {}
+            : { sessionExpiresAt: currentSession.expiresAt.epochMilliseconds }),
+          snapshot,
+        });
+      });
       const authorizationError = (requiredScope: AuthEnvironmentScope) =>
         new EnvironmentAuthorizationError({
           message: `The authenticated token is missing required scope: ${requiredScope}.`,
@@ -1928,15 +2021,27 @@ const makeWsRpcLayer = (
             "rpc.aggregate": "preview",
           }),
         [WS_METHODS.previewClose]: (input) =>
-          observeRpcEffect(WS_METHODS.previewClose, previewManager.close(input), {
-            "rpc.aggregate": "preview",
-          }),
+          observeRpcEffect(
+            WS_METHODS.previewClose,
+            Effect.andThen(previewManager.close(input), previewLiveGateway.revokeTab(input)),
+            {
+              "rpc.aggregate": "preview",
+            },
+          ),
         [WS_METHODS.previewList]: (input) =>
           observeRpcEffect(WS_METHODS.previewList, previewManager.list(input), {
             "rpc.aggregate": "preview",
           }),
         [WS_METHODS.previewReportStatus]: (input) =>
           observeRpcEffect(WS_METHODS.previewReportStatus, previewManager.reportStatus(input), {
+            "rpc.aggregate": "preview",
+          }),
+        [WS_METHODS.previewReviewSnapshot]: (input) =>
+          observeRpcEffect(WS_METHODS.previewReviewSnapshot, capturePreviewReviewSnapshot(input), {
+            "rpc.aggregate": "preview",
+          }),
+        [WS_METHODS.previewOpenLiveGateway]: (input) =>
+          observeRpcEffect(WS_METHODS.previewOpenLiveGateway, openPreviewLiveGateway(input), {
             "rpc.aggregate": "preview",
           }),
         [WS_METHODS.previewAutomationConnect]: (input) =>
@@ -2105,68 +2210,71 @@ const makeWsRpcLayer = (
     }),
   );
 
-export const websocketRpcRouteLayer = Layer.unwrap(
-  Effect.gen(function* () {
-    const previewAutomationBroker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
-    const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
-    return HttpRouter.add(
-      "GET",
-      "/ws",
-      Effect.gen(function* () {
-        const request = yield* HttpServerRequest.HttpServerRequest;
-        const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
-        const sessions = yield* SessionStore.SessionStore;
-        const session = yield* serverAuth.authenticateWebSocketUpgrade(request).pipe(
-          Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
-            failEnvironmentAuthInvalid(EnvironmentAuth.serverAuthCredentialReason(error)),
-          ),
-          Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
-            failEnvironmentInternal("internal_error", error),
-          ),
-        );
-        const rpcWebSocketHttpEffect = yield* RpcServer.toHttpEffectWebsocket(WsRpcGroup, {
-          disableTracing: true,
-        }).pipe(
-          Effect.provide(
-            makeWsRpcLayer(session, previewAutomationBroker).pipe(
-              Layer.provideMerge(RpcSerialization.layerJson),
-              Layer.provide(ProviderMaintenanceRunner.layer),
-              Layer.provide(Layer.succeed(ServerSelfUpdate.ServerSelfUpdate, serverSelfUpdate)),
-              Layer.provide(
-                SourceControlDiscovery.layer.pipe(
-                  Layer.provide(
-                    SourceControlProviderRegistry.layer.pipe(
-                      Layer.provide(
-                        Layer.mergeAll(
-                          AzureDevOpsCli.layer,
-                          BitbucketApi.layer,
-                          GitHubCli.layer,
-                          GitLabCli.layer,
+export const makeWebsocketRpcRouteLayer = (
+  previewLiveGateway: PreviewLiveGateway.PreviewLiveGateway["Service"],
+) =>
+  Layer.unwrap(
+    Effect.gen(function* () {
+      const previewAutomationBroker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+      const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
+      return HttpRouter.add(
+        "GET",
+        "/ws",
+        Effect.gen(function* () {
+          const request = yield* HttpServerRequest.HttpServerRequest;
+          const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
+          const sessions = yield* SessionStore.SessionStore;
+          const session = yield* serverAuth.authenticateWebSocketUpgrade(request).pipe(
+            Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
+              failEnvironmentAuthInvalid(EnvironmentAuth.serverAuthCredentialReason(error)),
+            ),
+            Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
+              failEnvironmentInternal("internal_error", error),
+            ),
+          );
+          const rpcWebSocketHttpEffect = yield* RpcServer.toHttpEffectWebsocket(WsRpcGroup, {
+            disableTracing: true,
+          }).pipe(
+            Effect.provide(
+              makeWsRpcLayer(session, previewAutomationBroker, previewLiveGateway).pipe(
+                Layer.provideMerge(RpcSerialization.layerJson),
+                Layer.provide(ProviderMaintenanceRunner.layer),
+                Layer.provide(Layer.succeed(ServerSelfUpdate.ServerSelfUpdate, serverSelfUpdate)),
+                Layer.provide(
+                  SourceControlDiscovery.layer.pipe(
+                    Layer.provide(
+                      SourceControlProviderRegistry.layer.pipe(
+                        Layer.provide(
+                          Layer.mergeAll(
+                            AzureDevOpsCli.layer,
+                            BitbucketApi.layer,
+                            GitHubCli.layer,
+                            GitLabCli.layer,
+                          ),
+                        ),
+                        Layer.provideMerge(GitVcsDriver.layer),
+                        Layer.provide(
+                          VcsDriverRegistry.layer.pipe(Layer.provide(VcsProjectConfig.layer)),
                         ),
                       ),
-                      Layer.provideMerge(GitVcsDriver.layer),
-                      Layer.provide(
-                        VcsDriverRegistry.layer.pipe(Layer.provide(VcsProjectConfig.layer)),
-                      ),
                     ),
+                    Layer.provide(VcsProcess.layer),
                   ),
-                  Layer.provide(VcsProcess.layer),
                 ),
               ),
             ),
-          ),
-        );
-        return yield* Effect.acquireUseRelease(
-          sessions.markConnected(session.sessionId),
-          () => rpcWebSocketHttpEffect,
-          () => sessions.markDisconnected(session.sessionId),
-        );
-      }).pipe(
-        Effect.catchTags({
-          EnvironmentAuthInvalidError: HttpServerRespondable.toResponse,
-          EnvironmentInternalError: HttpServerRespondable.toResponse,
-        }),
-      ),
-    );
-  }),
-);
+          );
+          return yield* Effect.acquireUseRelease(
+            sessions.markConnected(session.sessionId),
+            () => rpcWebSocketHttpEffect,
+            () => sessions.markDisconnected(session.sessionId),
+          );
+        }).pipe(
+          Effect.catchTags({
+            EnvironmentAuthInvalidError: HttpServerRespondable.toResponse,
+            EnvironmentInternalError: HttpServerRespondable.toResponse,
+          }),
+        ),
+      );
+    }),
+  );

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -469,10 +469,11 @@ const makeWsRpcLayer = (
         });
         const snapshot = yield* decodePreviewAutomationReviewSnapshot(rawSnapshot).pipe(
           Effect.mapError(
-            () =>
+            (cause) =>
               new PreviewReviewSnapshotMalformedError({
                 threadId: input.threadId,
                 tabId: input.tabId,
+                cause,
               }),
           ),
         );

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2210,71 +2210,69 @@ const makeWsRpcLayer = (
     }),
   );
 
-export const makeWebsocketRpcRouteLayer = (
-  previewLiveGateway: PreviewLiveGateway.PreviewLiveGateway["Service"],
-) =>
-  Layer.unwrap(
-    Effect.gen(function* () {
-      const previewAutomationBroker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
-      const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
-      return HttpRouter.add(
-        "GET",
-        "/ws",
-        Effect.gen(function* () {
-          const request = yield* HttpServerRequest.HttpServerRequest;
-          const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
-          const sessions = yield* SessionStore.SessionStore;
-          const session = yield* serverAuth.authenticateWebSocketUpgrade(request).pipe(
-            Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
-              failEnvironmentAuthInvalid(EnvironmentAuth.serverAuthCredentialReason(error)),
-            ),
-            Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
-              failEnvironmentInternal("internal_error", error),
-            ),
-          );
-          const rpcWebSocketHttpEffect = yield* RpcServer.toHttpEffectWebsocket(WsRpcGroup, {
-            disableTracing: true,
-          }).pipe(
-            Effect.provide(
-              makeWsRpcLayer(session, previewAutomationBroker, previewLiveGateway).pipe(
-                Layer.provideMerge(RpcSerialization.layerJson),
-                Layer.provide(ProviderMaintenanceRunner.layer),
-                Layer.provide(Layer.succeed(ServerSelfUpdate.ServerSelfUpdate, serverSelfUpdate)),
-                Layer.provide(
-                  SourceControlDiscovery.layer.pipe(
-                    Layer.provide(
-                      SourceControlProviderRegistry.layer.pipe(
-                        Layer.provide(
-                          Layer.mergeAll(
-                            AzureDevOpsCli.layer,
-                            BitbucketApi.layer,
-                            GitHubCli.layer,
-                            GitLabCli.layer,
-                          ),
-                        ),
-                        Layer.provideMerge(GitVcsDriver.layer),
-                        Layer.provide(
-                          VcsDriverRegistry.layer.pipe(Layer.provide(VcsProjectConfig.layer)),
+export const websocketRpcRouteLayer = Layer.unwrap(
+  Effect.gen(function* () {
+    const previewAutomationBroker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+    const previewLiveGateway = yield* PreviewLiveGateway.PreviewLiveGateway;
+    const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
+    return HttpRouter.add(
+      "GET",
+      "/ws",
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
+        const sessions = yield* SessionStore.SessionStore;
+        const session = yield* serverAuth.authenticateWebSocketUpgrade(request).pipe(
+          Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
+            failEnvironmentAuthInvalid(EnvironmentAuth.serverAuthCredentialReason(error)),
+          ),
+          Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
+            failEnvironmentInternal("internal_error", error),
+          ),
+        );
+        const rpcWebSocketHttpEffect = yield* RpcServer.toHttpEffectWebsocket(WsRpcGroup, {
+          disableTracing: true,
+        }).pipe(
+          Effect.provide(
+            makeWsRpcLayer(session, previewAutomationBroker, previewLiveGateway).pipe(
+              Layer.provideMerge(RpcSerialization.layerJson),
+              Layer.provide(ProviderMaintenanceRunner.layer),
+              Layer.provide(Layer.succeed(ServerSelfUpdate.ServerSelfUpdate, serverSelfUpdate)),
+              Layer.provide(
+                SourceControlDiscovery.layer.pipe(
+                  Layer.provide(
+                    SourceControlProviderRegistry.layer.pipe(
+                      Layer.provide(
+                        Layer.mergeAll(
+                          AzureDevOpsCli.layer,
+                          BitbucketApi.layer,
+                          GitHubCli.layer,
+                          GitLabCli.layer,
                         ),
                       ),
+                      Layer.provideMerge(GitVcsDriver.layer),
+                      Layer.provide(
+                        VcsDriverRegistry.layer.pipe(Layer.provide(VcsProjectConfig.layer)),
+                      ),
                     ),
-                    Layer.provide(VcsProcess.layer),
                   ),
+                  Layer.provide(VcsProcess.layer),
                 ),
               ),
             ),
-          );
-          return yield* Effect.acquireUseRelease(
-            sessions.markConnected(session.sessionId),
-            () => rpcWebSocketHttpEffect,
-            () => sessions.markDisconnected(session.sessionId),
-          );
-        }).pipe(
-          Effect.catchTags({
-            EnvironmentAuthInvalidError: HttpServerRespondable.toResponse,
-            EnvironmentInternalError: HttpServerRespondable.toResponse,
-          }),
-        ),
-      );
-    }),
-  );
+          ),
+        );
+        return yield* Effect.acquireUseRelease(
+          sessions.markConnected(session.sessionId),
+          () => rpcWebSocketHttpEffect,
+          () => sessions.markDisconnected(session.sessionId),
+        );
+      }).pipe(
+        Effect.catchTags({
+          EnvironmentAuthInvalidError: HttpServerRespondable.toResponse,
+          EnvironmentInternalError: HttpServerRespondable.toResponse,
+        }),
+      ),
+    );
+  }),
+);

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1,8 +1,15 @@
-import { CheckpointRef, EnvironmentId, MessageId, TurnId } from "@t3tools/contracts";
+import {
+  CheckpointRef,
+  EnvironmentId,
+  MessageId,
+  TurnId,
+  type PreviewAnnotationPayload,
+} from "@t3tools/contracts";
 import { createRef, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import type { LegendListRef } from "@legendapp/list/react";
+import { appendPreviewAnnotationPrompt } from "~/lib/previewAnnotation";
 
 vi.mock("@legendapp/list/react", async () => {
   const legendListTestId = "legend-list";
@@ -488,6 +495,59 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("SubmitButton");
     expect(markup).not.toContain("&lt;element_context");
     expect(markup).not.toContain("<element_context");
+  });
+
+  it("renders compact numbered preview annotation callouts without exposing prompt markup", () => {
+    const calloutInstructions = [
+      "Increase contrast instruction",
+      "Reduce this gap instruction",
+      "Align the label instruction",
+      "Fourth instruction",
+      "Fifth instruction",
+    ];
+    const annotation: PreviewAnnotationPayload = {
+      id: "annotation-callouts",
+      pageUrl: "",
+      pageTitle: "Checkout screenshot",
+      comment: "Polish this flow.",
+      elements: [],
+      regions: [],
+      strokes: [],
+      styleChanges: [],
+      screenshot: null,
+      createdAt: MESSAGE_CREATED_AT,
+      callouts: calloutInstructions.map((comment, index) => ({
+        id: `callout-${index + 1}`,
+        number: index + 1,
+        comment,
+        anchor: {
+          kind: "point" as const,
+          point: { x: 0.1 * (index + 1), y: 0.5 },
+        },
+      })),
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          buildUserTimelineEntry(appendPreviewAnnotationPrompt("Update checkout", annotation)),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Polish this flow.");
+    expect(markup).toContain("Callout 1:");
+    expect(markup).toContain("Increase contrast instruction");
+    expect(markup).toContain("Reduce this gap instruction");
+    expect(markup).toContain("Align the label instruction");
+    expect(markup).toContain("+2 more callouts");
+    expect(markup.match(/data-preview-annotation-callout=/g)).toHaveLength(3);
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain("Show all 5 callouts");
+    expect(markup).not.toContain("Fourth instruction");
+    expect(markup).not.toContain("Fifth instruction");
+    expect(markup).not.toContain("&lt;preview_annotation&gt;");
+    expect(markup).not.toContain("&lt;/preview_annotation&gt;");
   });
 
   it("keeps the copy button for collapsed long user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -92,7 +92,7 @@ import {
   type ParsedElementContextEntry,
 } from "~/lib/elementContext";
 import {
-  extractTrailingPreviewAnnotation,
+  extractTrailingPreviewAnnotations,
   type ParsedPreviewAnnotation,
 } from "~/lib/previewAnnotation";
 import { cn } from "~/lib/utils";
@@ -113,6 +113,10 @@ import {
   parseReviewCommentMessageSegments,
   type ReviewCommentContext,
 } from "../../reviewCommentContext";
+import {
+  deriveUserMessagePreviewAnnotationCardContent,
+  deriveUserMessagePreviewAnnotationCopyText,
+} from "./userMessagePreviewAnnotation";
 
 // ---------------------------------------------------------------------------
 // Context — shared state consumed by every row component via Context.
@@ -869,17 +873,21 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
 function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);
   const userImages = row.message.attachments ?? [];
-  const displayedUserMessage = deriveDisplayedUserMessageState(row.message.text);
+  const outerPreviewAnnotationState = extractTrailingPreviewAnnotations(row.message.text);
+  const displayedUserMessage = deriveDisplayedUserMessageState(
+    outerPreviewAnnotationState.promptText,
+  );
   const terminalContexts = displayedUserMessage.contexts;
-  const previewAnnotations: ParsedPreviewAnnotation[] = [];
-  let visibleText = displayedUserMessage.visibleText;
-  while (true) {
-    const extracted = extractTrailingPreviewAnnotation(visibleText);
-    if (!extracted.annotation) break;
-    previewAnnotations.unshift(extracted.annotation);
-    visibleText = extracted.promptText;
-  }
-  const elementContextState = extractTrailingElementContexts(visibleText);
+  const innerPreviewAnnotationState = extractTrailingPreviewAnnotations(
+    displayedUserMessage.visibleText,
+  );
+  const previewAnnotations: ParsedPreviewAnnotation[] = [
+    ...innerPreviewAnnotationState.annotations,
+    ...outerPreviewAnnotationState.annotations,
+  ];
+  const elementContextState = extractTrailingElementContexts(
+    innerPreviewAnnotationState.promptText,
+  );
   const elementContexts = [
     ...displayedUserMessage.elementContexts,
     ...elementContextState.contexts,
@@ -887,6 +895,11 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
   const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
+  const copyText = deriveUserMessagePreviewAnnotationCopyText({
+    visibleText: elementContextState.promptText,
+    annotations: previewAnnotations,
+    fallbackCopyText: displayedUserMessage.copyText,
+  });
 
   return (
     <div className="group flex flex-col items-end gap-1">
@@ -960,9 +973,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
           </Tooltip>
           <div className="flex items-center gap-0.5">
             {canRevertAgentWork && <RevertUserMessageButton messageId={row.message.id} />}
-            {displayedUserMessage.copyText && (
-              <MessageCopyButton text={displayedUserMessage.copyText} variant="ghost" />
-            )}
+            {copyText && <MessageCopyButton text={copyText} variant="ghost" />}
           </div>
         </div>
       </div>
@@ -1348,8 +1359,17 @@ function UserMessagePreviewAnnotationCard(props: {
   image: NonNullable<TimelineMessage["attachments"]>[number] | null;
 }) {
   const ctx = use(TimelineRowCtx);
+  const [expanded, setExpanded] = useState(false);
+  const { callouts, hiddenCalloutCount, canExpand } = deriveUserMessagePreviewAnnotationCardContent(
+    props.annotation,
+    expanded,
+  );
+  const expandLabel =
+    hiddenCalloutCount > 0
+      ? `Show all ${props.annotation.calloutCount} callouts`
+      : "Show full annotation";
   return (
-    <div className="mb-2 flex max-w-full items-center overflow-hidden rounded-lg border border-border/70 bg-background/70">
+    <div className="mb-2 flex max-w-full items-start overflow-hidden rounded-lg border border-border/70 bg-background/70">
       {props.image?.previewUrl ? (
         <button
           type="button"
@@ -1368,16 +1388,50 @@ function UserMessagePreviewAnnotationCard(props: {
           />
         </button>
       ) : null}
-      <div className="min-w-0 px-2.5 py-2">
+      <div className="min-w-0 flex-1 px-2.5 py-2">
         {props.annotation.comment ? (
-          <div className="max-w-80 truncate text-xs font-medium text-foreground/90">
+          <div
+            className={cn(
+              "text-xs font-medium text-foreground/90",
+              expanded ? "whitespace-pre-wrap break-words" : "max-w-80 truncate",
+            )}
+          >
             {props.annotation.comment}
+          </div>
+        ) : null}
+        {callouts.length > 0 ? (
+          <ol className={cn("space-y-1", props.annotation.comment && "mt-1.5")}>
+            {callouts.map((callout) => (
+              <li
+                key={`${props.annotation.id}:${callout.number}`}
+                className="flex min-w-0 items-start gap-1.5 text-xs text-foreground/90"
+                data-preview-annotation-callout={callout.number}
+              >
+                <span className="shrink-0 font-medium" aria-hidden="true">
+                  #{callout.number}
+                </span>
+                <span className="sr-only">Callout {callout.number}: </span>
+                <span
+                  className={cn(
+                    "min-w-0 flex-1",
+                    expanded ? "whitespace-pre-wrap break-words" : "truncate",
+                  )}
+                >
+                  {callout.comment || callout.anchorSummary}
+                </span>
+              </li>
+            ))}
+          </ol>
+        ) : null}
+        {hiddenCalloutCount > 0 ? (
+          <div className="mt-1 text-[10px] text-muted-foreground">
+            +{hiddenCalloutCount} more callout{hiddenCalloutCount === 1 ? "" : "s"}
           </div>
         ) : null}
         <div
           className={cn(
             "flex items-center gap-2 text-[10px] text-muted-foreground",
-            props.annotation.comment && "mt-1",
+            (props.annotation.comment || callouts.length > 0 || hiddenCalloutCount > 0) && "mt-1",
           )}
         >
           {props.annotation.targetSummary ? (
@@ -1390,6 +1444,22 @@ function UserMessagePreviewAnnotationCard(props: {
             </span>
           ) : null}
         </div>
+        {canExpand ? (
+          <Button
+            type="button"
+            size="xs"
+            variant="ghost"
+            aria-expanded={expanded}
+            data-scroll-anchor-ignore
+            onClick={() => setExpanded((value) => !value)}
+            className="-ml-1 mt-1 h-5 rounded-md px-1 text-[10px] text-muted-foreground/80 hover:bg-muted/55 hover:text-foreground/85"
+          >
+            {expanded ? "Show less" : expandLabel}
+            <ChevronDownIcon
+              className={cn("size-3 transition-transform", expanded && "rotate-180")}
+            />
+          </Button>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/userMessagePreviewAnnotation.test.ts
+++ b/apps/web/src/components/chat/userMessagePreviewAnnotation.test.ts
@@ -1,0 +1,67 @@
+import type { ParsedPreviewAnnotation } from "~/lib/previewAnnotation";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  deriveUserMessagePreviewAnnotationCardContent,
+  deriveUserMessagePreviewAnnotationCopyText,
+} from "./userMessagePreviewAnnotation";
+
+const annotation: ParsedPreviewAnnotation = {
+  id: "annotation-1",
+  title: "Checkout screenshot",
+  comment: "Polish the whole flow.",
+  targetSummary: "5 numbered callouts.",
+  styleChanges: [],
+  hasScreenshot: true,
+  calloutCount: 5,
+  callouts: Array.from({ length: 5 }, (_, index) => ({
+    number: index + 1,
+    anchorSummary: `point: x=.${index + 1}, y=.5`,
+    comment: `Instruction ${index + 1}`,
+  })),
+};
+
+describe("deriveUserMessagePreviewAnnotationCardContent", () => {
+  it("keeps the collapsed card compact and exposes every callout when expanded", () => {
+    expect(deriveUserMessagePreviewAnnotationCardContent(annotation, false)).toMatchObject({
+      callouts: annotation.callouts.slice(0, 3),
+      hiddenCalloutCount: 2,
+      canExpand: true,
+    });
+    expect(deriveUserMessagePreviewAnnotationCardContent(annotation, true)).toMatchObject({
+      callouts: annotation.callouts,
+      hiddenCalloutCount: 0,
+      canExpand: true,
+    });
+  });
+
+  it("keeps comment-only annotations expandable so truncated text remains recoverable", () => {
+    expect(
+      deriveUserMessagePreviewAnnotationCardContent(
+        { ...annotation, calloutCount: 0, callouts: [] },
+        false,
+      ),
+    ).toMatchObject({
+      callouts: [],
+      hiddenCalloutCount: 0,
+      canExpand: true,
+    });
+  });
+
+  it("replaces raw annotation markup with complete human-readable copy", () => {
+    const copyText = deriveUserMessagePreviewAnnotationCopyText({
+      visibleText: "Update checkout",
+      annotations: [annotation],
+      fallbackCopyText: "Update checkout\n\n<preview_annotation>raw</preview_annotation>",
+    });
+
+    expect(copyText).toContain("Update checkout\n\nAnnotation: Checkout screenshot");
+    expect(copyText).toContain("Polish the whole flow.");
+    for (const callout of annotation.callouts) {
+      expect(copyText).toContain(`#${callout.number} [${callout.anchorSummary}]`);
+      expect(copyText).toContain(callout.comment);
+    }
+    expect(copyText).not.toContain("<preview_annotation>");
+    expect(copyText).not.toContain("</preview_annotation>");
+  });
+});

--- a/apps/web/src/components/chat/userMessagePreviewAnnotation.ts
+++ b/apps/web/src/components/chat/userMessagePreviewAnnotation.ts
@@ -1,0 +1,41 @@
+import {
+  buildPreviewAnnotationCopyText,
+  type ParsedPreviewAnnotation,
+  type ParsedPreviewAnnotationCallout,
+} from "~/lib/previewAnnotation";
+
+const COLLAPSED_CALLOUT_LIMIT = 3;
+
+export interface UserMessagePreviewAnnotationCardContent {
+  readonly callouts: ReadonlyArray<ParsedPreviewAnnotationCallout>;
+  readonly hiddenCalloutCount: number;
+  readonly canExpand: boolean;
+}
+
+export function deriveUserMessagePreviewAnnotationCardContent(
+  annotation: ParsedPreviewAnnotation,
+  expanded: boolean,
+): UserMessagePreviewAnnotationCardContent {
+  const callouts = expanded
+    ? annotation.callouts
+    : annotation.callouts.slice(0, COLLAPSED_CALLOUT_LIMIT);
+  return {
+    callouts,
+    hiddenCalloutCount: Math.max(0, annotation.callouts.length - callouts.length),
+    canExpand:
+      annotation.comment.trim().length > 0 ||
+      annotation.callouts.some(
+        (callout) => callout.comment.trim().length > 0 || callout.anchorSummary.length > 0,
+      ),
+  };
+}
+
+export function deriveUserMessagePreviewAnnotationCopyText(input: {
+  readonly visibleText: string;
+  readonly annotations: ReadonlyArray<ParsedPreviewAnnotation>;
+  readonly fallbackCopyText: string;
+}): string {
+  return input.annotations.length > 0
+    ? buildPreviewAnnotationCopyText(input.visibleText, input.annotations)
+    : input.fallbackCopyText;
+}

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -64,6 +64,7 @@ import {
   waitForNavigationReadiness,
 } from "./previewNavigationReadiness";
 import { createPreviewAutomationRequestConsumerAtom } from "./previewAutomationRequestConsumer";
+import { capturePreviewAutomationSnapshotResponse } from "./previewAutomationReviewSnapshot";
 import { createPreviewAutomationClientId } from "./previewAutomationClientId";
 import {
   needsPreviewAutomationSessionSync,
@@ -577,7 +578,13 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           }
           case "snapshot": {
             const ready = await requireReadyTab();
-            return await ready.bridge.automation.snapshot(ready.runtimeTabId);
+            return await capturePreviewAutomationSnapshotResponse({
+              requestInput: request.input,
+              capture: (options) =>
+                options === undefined
+                  ? ready.bridge.automation.snapshot(ready.runtimeTabId)
+                  : ready.bridge.automation.snapshot(ready.runtimeTabId, options),
+            });
           }
           case "click": {
             const ready = await requireReadyTab();

--- a/apps/web/src/components/preview/previewAutomationReviewSnapshot.test.ts
+++ b/apps/web/src/components/preview/previewAutomationReviewSnapshot.test.ts
@@ -1,0 +1,138 @@
+import type { PreviewAutomationSnapshot } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { capturePreviewAutomationSnapshotResponse } from "./previewAutomationReviewSnapshot";
+
+const fullSnapshot: PreviewAutomationSnapshot = {
+  url: "https://example.com/review",
+  title: "Review",
+  loading: false,
+  viewport: {
+    width: 1_000,
+    height: 600,
+    scrollX: 0,
+    scrollY: 120,
+    devicePixelRatio: 2,
+  },
+  pageRevision: "page-1",
+  capturedAt: "2026-07-30T12:00:00.000Z",
+  visibleText: "Private diagnostic text",
+  interactiveElements: [
+    {
+      tag: "button",
+      role: "button",
+      name: "Save",
+      selector: "#save",
+      x: 10,
+      y: 20,
+      width: 80,
+      height: 32,
+    },
+  ],
+  accessibilityTree: { nodes: [{ nodeId: "1" }] },
+  consoleEntries: [
+    {
+      level: "log",
+      text: "private console entry",
+      timestamp: "2026-07-30T12:00:00.000Z",
+    },
+  ],
+  networkEntries: [
+    {
+      url: "https://example.com/api/private",
+      method: "GET",
+      status: 200,
+      failed: false,
+      timestamp: "2026-07-30T12:00:00.000Z",
+    },
+  ],
+  actionTimeline: [
+    {
+      id: "action-1",
+      action: "click",
+      status: "succeeded",
+      startedAt: "2026-07-30T12:00:00.000Z",
+    },
+  ],
+  screenshot: {
+    mimeType: "image/png",
+    data: "cG5n",
+    width: 1_280,
+    height: 768,
+    scale: 1.28,
+  },
+};
+
+describe("capturePreviewAutomationSnapshotResponse", () => {
+  it("requests review mode and strips diagnostic fields before relay", async () => {
+    const capture = vi.fn(async () => fullSnapshot);
+
+    const result = await capturePreviewAutomationSnapshotResponse({
+      requestInput: { mode: "review" },
+      capture,
+    });
+
+    expect(capture).toHaveBeenCalledWith({ mode: "review" });
+    expect(result).toEqual({
+      url: fullSnapshot.url,
+      title: fullSnapshot.title,
+      loading: fullSnapshot.loading,
+      viewport: fullSnapshot.viewport,
+      pageRevision: fullSnapshot.pageRevision,
+      capturedAt: fullSnapshot.capturedAt,
+      interactiveElements: fullSnapshot.interactiveElements,
+      screenshot: fullSnapshot.screenshot,
+    });
+    expect(result).not.toHaveProperty("visibleText");
+    expect(result).not.toHaveProperty("accessibilityTree");
+    expect(result).not.toHaveProperty("consoleEntries");
+    expect(result).not.toHaveProperty("networkEntries");
+    expect(result).not.toHaveProperty("actionTimeline");
+  });
+
+  it("keeps legacy snapshot requests full and calls the bridge without options", async () => {
+    const capture = vi.fn(async () => fullSnapshot);
+
+    const result = await capturePreviewAutomationSnapshotResponse({
+      requestInput: {},
+      capture,
+    });
+
+    expect(capture.mock.calls).toEqual([[]]);
+    expect(result).toBe(fullSnapshot);
+  });
+
+  it("accepts review responses from legacy hosts without viewport metadata", async () => {
+    const legacyHostSnapshot: PreviewAutomationSnapshot = {
+      url: fullSnapshot.url,
+      title: fullSnapshot.title,
+      loading: fullSnapshot.loading,
+      visibleText: fullSnapshot.visibleText,
+      interactiveElements: fullSnapshot.interactiveElements,
+      accessibilityTree: fullSnapshot.accessibilityTree,
+      consoleEntries: fullSnapshot.consoleEntries,
+      networkEntries: fullSnapshot.networkEntries,
+      actionTimeline: fullSnapshot.actionTimeline,
+      screenshot: {
+        mimeType: "image/png",
+        data: "cG5n",
+        width: 1_000,
+        height: 600,
+      },
+    };
+    const capture = vi.fn(async () => legacyHostSnapshot);
+
+    const result = await capturePreviewAutomationSnapshotResponse({
+      requestInput: { mode: "review" },
+      capture,
+    });
+
+    expect(result).toEqual({
+      url: legacyHostSnapshot.url,
+      title: legacyHostSnapshot.title,
+      loading: legacyHostSnapshot.loading,
+      interactiveElements: legacyHostSnapshot.interactiveElements,
+      screenshot: legacyHostSnapshot.screenshot,
+    });
+  });
+});

--- a/apps/web/src/components/preview/previewAutomationReviewSnapshot.ts
+++ b/apps/web/src/components/preview/previewAutomationReviewSnapshot.ts
@@ -1,0 +1,29 @@
+import {
+  PreviewAutomationReviewSnapshot as PreviewAutomationReviewSnapshotSchema,
+  type DesktopPreviewAutomationSnapshotOptions,
+  type PreviewAutomationReviewSnapshot,
+  type PreviewAutomationSnapshot,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+const decodeReviewSnapshot = Schema.decodeUnknownSync(PreviewAutomationReviewSnapshotSchema);
+
+const isReviewSnapshotRequest = (input: unknown): boolean =>
+  typeof input === "object" &&
+  input !== null &&
+  !Array.isArray(input) &&
+  "mode" in input &&
+  input.mode === "review";
+
+export async function capturePreviewAutomationSnapshotResponse(input: {
+  readonly requestInput: unknown;
+  readonly capture: (
+    options?: DesktopPreviewAutomationSnapshotOptions,
+  ) => Promise<PreviewAutomationSnapshot>;
+}): Promise<PreviewAutomationSnapshot | PreviewAutomationReviewSnapshot> {
+  if (!isReviewSnapshotRequest(input.requestInput)) {
+    return await input.capture();
+  }
+  const snapshot = await input.capture({ mode: "review" });
+  return decodeReviewSnapshot(snapshot);
+}

--- a/apps/web/src/lib/previewAnnotation.ts
+++ b/apps/web/src/lib/previewAnnotation.ts
@@ -1,103 +1,15 @@
 import type { PreviewAnnotationPayload } from "@t3tools/contracts";
-import { buildElementContextBlock, normalizeElementContextSelection } from "./elementContext";
-
-const TRAILING_PREVIEW_ANNOTATION_BLOCK_PATTERN =
-  /\n*<preview_annotation>\n((?:(?!<preview_annotation>)[\s\S])*)\n<\/preview_annotation>\s*$/;
-
-export interface ParsedPreviewAnnotation {
-  id: string;
-  title: string;
-  comment: string;
-  targetSummary: string;
-  styleChanges: string[];
-  hasScreenshot: boolean;
-}
-
-export interface ExtractedPreviewAnnotation {
-  promptText: string;
-  annotation: ParsedPreviewAnnotation | null;
-}
-
-export function buildPreviewAnnotationPrompt(annotation: PreviewAnnotationPayload): string {
-  const lines = ["Preview annotation:"];
-  lines.push(`Id: ${annotation.id}`);
-  const title = annotation.pageTitle?.trim() || annotation.pageUrl.trim() || "Preview";
-  lines.push(`Page: ${title}`);
-  if (annotation.comment.trim()) lines.push(`Comment: ${annotation.comment.trim()}`);
-  const targets: string[] = [];
-  if (annotation.elements.length > 0) {
-    targets.push(
-      `${annotation.elements.length} selected element${annotation.elements.length === 1 ? "" : "s"}`,
-    );
-  }
-  if (annotation.regions.length > 0) {
-    targets.push(
-      `${annotation.regions.length} marked region${annotation.regions.length === 1 ? "" : "s"}`,
-    );
-  }
-  if (annotation.strokes.length > 0) {
-    targets.push(
-      `${annotation.strokes.length} drawing${annotation.strokes.length === 1 ? "" : "s"}`,
-    );
-  }
-  if (targets.length > 0) lines.push(`Targets: ${targets.join(", ")}.`);
-  if (annotation.styleChanges.length > 0) {
-    lines.push("Requested visual changes:");
-    for (const change of annotation.styleChanges) {
-      lines.push(`- ${change.property}: ${change.previousValue || "(unset)"} → ${change.value}`);
-    }
-  }
-  if (annotation.screenshot) {
-    lines.push("The attached screenshot is the annotated preview crop.");
-  }
-  const elementContexts = annotation.elements
-    .map((target) => normalizeElementContextSelection(target.element))
-    .filter((context) => context !== null);
-  const elementBlock = buildElementContextBlock(elementContexts);
-  if (elementBlock) lines.push(elementBlock);
-  return ["<preview_annotation>", ...lines, "</preview_annotation>"].join("\n");
-}
-
-export function appendPreviewAnnotationPrompt(
-  prompt: string,
-  annotation: PreviewAnnotationPayload,
-): string {
-  const annotationText = buildPreviewAnnotationPrompt(annotation);
-  const trimmed = prompt.trim();
-  return trimmed ? `${trimmed}\n\n${annotationText}` : annotationText;
-}
-
-export function extractTrailingPreviewAnnotation(prompt: string): ExtractedPreviewAnnotation {
-  const match = TRAILING_PREVIEW_ANNOTATION_BLOCK_PATTERN.exec(prompt);
-  if (!match) return { promptText: prompt, annotation: null };
-  const body = match[1] ?? "";
-  const lines = body.split("\n");
-  const pageLine = lines.find((line) => line.startsWith("Page: "));
-  const idLine = lines.find((line) => line.startsWith("Id: "));
-  const commentLine = lines.find((line) => line.startsWith("Comment: "));
-  const targetsLine = lines.find((line) => line.startsWith("Targets: "));
-  const styleHeadingIndex = lines.indexOf("Requested visual changes:");
-  const linesAfterStyleHeading = lines.slice(styleHeadingIndex + 1);
-  const elementContextIndex = linesAfterStyleHeading.indexOf("<element_context>");
-  const styleChanges =
-    styleHeadingIndex < 0
-      ? []
-      : linesAfterStyleHeading
-          .slice(0, elementContextIndex < 0 ? undefined : elementContextIndex)
-          .filter((line) => line.startsWith("- "))
-          .map((line) => line.slice(2));
-  return {
-    promptText: prompt.slice(0, match.index).replace(/\n+$/, ""),
-    annotation: {
-      id: idLine?.slice("Id: ".length).trim() || `${match.index}`,
-      title: pageLine?.slice("Page: ".length).trim() || "Preview annotation",
-      comment: commentLine?.slice("Comment: ".length).trim() || "",
-      targetSummary: targetsLine?.slice("Targets: ".length).trim() || "",
-      styleChanges,
-      hasScreenshot: body.includes("The attached screenshot is the annotated preview crop."),
-    },
-  };
-}
+export {
+  appendPreviewAnnotationPrompt,
+  buildPreviewAnnotationCopyText,
+  buildPreviewAnnotationPrompt,
+  extractTrailingPreviewAnnotation,
+  extractTrailingPreviewAnnotations,
+  type ExtractedPreviewAnnotation,
+  type ExtractedPreviewAnnotations,
+  type ParsedPreviewAnnotation,
+  type ParsedPreviewAnnotationCallout,
+} from "@t3tools/client-runtime/annotations";
 
 export async function previewAnnotationScreenshotFile(
   annotation: PreviewAnnotationPayload,

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,13 @@
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
 - [Remote access](./user/remote-access.md)
+- [Mobile Browser and image markup](./user/mobile.md)
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)
 - [Background service (Linux)](./user/background-service.md)
 - Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md)
 
-Mobile app: [apps/mobile/README.md](../apps/mobile/README.md)
+Mobile development: [apps/mobile/README.md](../apps/mobile/README.md)
 
 ---
 

--- a/docs/internals/remote.md
+++ b/docs/internals/remote.md
@@ -155,6 +155,69 @@ A T3-managed `tailscale serve` mapping exposes the server on the tailnet over HT
 resulting private-network endpoints are advertised for pairing. Connection then follows the ordinary
 bearer path.
 
+### Preview review versus preview browsing
+
+A preview browser session belongs to the desktop host that owns its Electron webview, cookies, and
+page state. Remote clients must not infer that reaching a T3 environment also makes arbitrary
+development ports reachable.
+
+Remote preview review therefore uses the environment WebSocket as a control path:
+
+```text
+mobile review request
+        ↓
+T3 server preview broker
+        ↓
+connected desktop preview host captures one frame
+        ↓
+compact PNG + visible interactive bounds
+        ↓
+mobile freezes and annotates the frame locally
+```
+
+This path works through direct, relay, and T3 Connect environment connections and does not expose a
+development server. The server authorizes the capture as an orchestration operation and routes it to
+the desktop host already assigned to that environment.
+
+Live mobile browsing is separate and client-rendered:
+
+```text
+public URL ───────────────────────────────→ mobile WebView
+desktop loopback + LAN/Tailscale endpoint → rewritten private host + same port
+desktop loopback + T3 Connect endpoint ───→ authenticated whole-origin gateway
+                                             ↓
+                                          exact loopback origin
+```
+
+The mobile WebView, not the T3 server, owns page rendering, navigation, cookies, storage, DOM
+inspection, and screenshot capture. LAN and Tailscale remain direct connections. T3 Connect exposes
+only the T3 server origin, so an operate-scoped RPC validates the selected server-owned preview tab
+and issues a one-use, 30-second bootstrap ticket. Consuming it creates a short-lived, HTTP-only
+gateway lease for that exact loopback origin.
+
+Gateway routing is whole-origin within an isolated iOS WebView session. This is intentional: a
+path-prefixed reverse proxy breaks root-relative assets, redirects, service-worker scope, and
+development-server WebSockets. The gateway strips environment authorization, DPoP, forwarding,
+Cloudflare, and hop-by-hop headers; filters T3 session cookies in both directions; does not follow
+upstream redirects; and revokes leases when the authenticated client is removed, its parent auth
+session expires, the preview tab closes, the lease expires, or the server restarts. Active HTTP
+streams and WebSockets terminate with the lease, and each WebSocket direction has bounded frame and
+byte buffering.
+
+Connect Live mode is iOS-only until the Android client can provide a genuinely isolated browser data
+store or on-device proxy. Android WebView's incognito mode clears a process-global cookie jar without
+creating an isolated one, so Android retains direct LAN/Tailscale browsing and the snapshot fallback.
+
+The gateway deliberately targets one loopback origin. Fully qualified localhost URLs are not
+rewritten and therefore still refer to the mobile device, even when they name the selected preview
+port; preview applications should use same-origin relative URLs or expose additional services through
+an explicit endpoint.
+
+The gateway is available on the normal Node-based server runtime used by `npx t3` and desktop. The
+Bun HTTP upgrade API cannot select the WebSocket subprotocol requested by a browser, so direct Bun
+launches report the Connect gateway as unavailable and retain Snapshot review rather than exposing a
+partially working live path.
+
 ### Desktop-managed SSH access
 
 SSH is an access and launch helper, not a separate environment type. `DesktopSshEnvironment`

--- a/docs/user/mobile.md
+++ b/docs/user/mobile.md
@@ -1,0 +1,103 @@
+# Mobile
+
+T3 Code Mobile connects to the same environments and threads as the web and
+desktop clients. Image attachments use the normal composer and provider
+pipeline, including when a message waits in the offline outbox.
+
+## Mark up an image attachment
+
+Image markup works on attachments in an existing thread, a new task, or a
+review comment:
+
+1. Attach or paste an image.
+2. Tap the pencil action on its thumbnail.
+3. Draw with Pencil, a finger, or a pointer, or add a numbered point or region.
+4. Add a comment to each numbered callout and tap **Done**.
+
+The composer replaces the attachment with a flattened PNG. Reopen the pencil
+action to edit its retained callouts and strokes, or use **Remove markup** to
+restore the original image. Removing the attachment removes its annotation as
+well.
+
+T3 sends the flattened PNG and a compact numbered callout summary to the
+selected provider. The editable vectors stay in the local mobile draft and are
+not added to model context. Exported images are downscaled when needed. The
+retained original and flattened PNG share the normal 10 MB attachment storage
+budget so markup does not double draft or outbox payloads.
+
+The first release uses the same cross-platform canvas on iOS and Android.
+Apple Pencil works as a drawing pointer, but pressure-sensitive ink, native
+Pencil eraser/selection, and PencilKit palm handling are follow-up work. T3
+forwards the annotated image through the existing provider pipeline; the
+selected model must support image input until model capability advertising can
+gate that choice in the composer.
+
+This screenshot-first flow does not require the mobile device to reach a
+development server or share the desktop preview's browser session. DOM and
+element metadata is included when annotations come from a controlled desktop
+snapshot or the mobile Browser. React component and source metadata is
+included only when the desktop preview host can provide it.
+
+## Use Browser on iPad
+
+Open a thread and choose **Browser** from its header actions. T3 shows the
+thread and Browser side by side at equal widths on iPad. Browser has its own
+tabs along the top plus back, forward, address, reload, and annotation controls.
+Use the expand action to give Browser the full workspace, then use it again to
+return to the equal split. The divider remains draggable while split. Choosing
+**Browser** again closes the pane; choosing **Files** switches the trailing pane
+without stacking one over the other.
+
+Use the **+** action after the tabs to create another thread-scoped browser tab
+from the iPad. The new tab opens with the address field focused; enter a URL and
+choose **Go** on the keyboard. The tab and its current address are synchronized
+through the environment, so other connected T3 clients can reopen it.
+
+Browser is an iPad-owned WKWebView, not a stream of the desktop window. Public
+URLs load directly. On iPad, a desktop-local URL uses a one-use bootstrap URL
+for an authenticated, short-lived gateway to the exact loopback browser tab.
+The same path works when the iPad reaches its environment over LAN, Tailscale,
+or T3 Connect, so the development server can remain bound to desktop loopback
+and its port does not need to be exposed separately.
+
+Choose the pencil action to freeze the current WKWebView, sample bounded DOM
+metadata, and open that exact frame in the markup canvas. Interactive elements
+can be tapped to create semantic callouts alongside points, regions, and
+freehand marks. Completing the markup adds the flattened PNG and numbered
+callout context to the thread composer; sending remains an explicit action.
+
+The photo action is a review fallback rather than another browsing mode. It
+asks a connected T3 desktop host to freeze the selected browser tab and sends
+the PNG and compact interactive-element bounds through the existing
+environment connection. This works over LAN, Tailscale, and T3 Connect without
+exposing the development port to the iPad. Use the globe action to return to
+the local Browser.
+
+The live browser owns its own cookies, storage, navigation history, and page
+state; the preview gateway transports its requests but does not render or
+continuously stream screenshots from the server. The bootstrap token is
+one-use, the resulting cookie is HTTP-only and short-lived, and environment
+authorization cookies are never forwarded to the development server.
+
+Gateway browsing is currently iOS/iPad-only. React Native WebView does not
+provide an isolated Android cookie and storage container, so Android keeps
+direct LAN/Tailscale browsing and the cross-platform desktop snapshot fallback.
+For Android direct browsing, the development server must listen on the network
+interface and its port must be allowed through the host firewall.
+
+Desktop snapshots are immutable review frames. If the desktop tab navigates,
+resizes, or refreshes after capture, the iPad marks the frame as stale instead
+of moving existing annotations. Refresh the snapshot to review the new frame.
+The desktop app must be connected to the same environment and hosting the
+selected browser tab for capture; Browser does not need to be visibly open on
+the desktop.
+
+The preview gateway preserves same-origin and root-relative HTTP and WebSocket
+traffic for the selected loopback origin. A page that hard-codes any fully
+qualified `localhost` URL still points at the iPad's own loopback; use relative
+URLs, or expose an additional service through a separately reachable endpoint.
+
+Gateway Browser requires the normal Node-based T3 server runtime used by
+`npx t3` and the desktop app. A server launched directly under Bun cannot
+complete WebSocket subprotocol negotiation for this gateway and reports
+Browser as unavailable; desktop snapshot review remains available.

--- a/packages/client-runtime/README.md
+++ b/packages/client-runtime/README.md
@@ -8,6 +8,7 @@ subpath. The package intentionally has no root export.
 | Subpath               | Responsibility                                                   |
 | --------------------- | ---------------------------------------------------------------- |
 | `authorization`       | Bearer and DPoP authorization plus token persistence contracts   |
+| `annotations`         | Portable annotation prompt formatting and transcript parsing     |
 | `connection`          | Targets, catalog, supervision, retries, registry, and onboarding |
 | `environment`         | Environment identity, descriptors, endpoints, and scoped keys    |
 | `errors`              | Shared client error inspection                                   |

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -11,6 +11,10 @@
       "types": "./src/authorization/index.ts",
       "default": "./src/authorization/index.ts"
     },
+    "./annotations": {
+      "types": "./src/annotations/index.ts",
+      "default": "./src/annotations/index.ts"
+    },
     "./environment": {
       "types": "./src/environment/index.ts",
       "default": "./src/environment/index.ts"

--- a/packages/client-runtime/src/annotations/elementContext.ts
+++ b/packages/client-runtime/src/annotations/elementContext.ts
@@ -1,0 +1,140 @@
+import type { PickedElementPayload, PickedElementStackFrame } from "@t3tools/contracts";
+
+const ELEMENT_CONTEXT_HTML_PREVIEW_LIMIT = 4000;
+const ELEMENT_CONTEXT_STYLES_LIMIT = 4000;
+const ELEMENT_CONTEXT_LABEL_TAG_MAX = 24;
+const ELEMENT_CONTEXT_BLOCK_MAX_CHARS = 48_000;
+
+interface ElementContextSelection {
+  pageUrl: string;
+  pageTitle: string | null;
+  tagName: string;
+  selector: string | null;
+  htmlPreview: string;
+  componentName: string | null;
+  source: PickedElementStackFrame | null;
+  styles: string;
+}
+
+function truncateString(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, Math.max(0, limit - 1))}…`;
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\r\n/g, "\n").replace(/^\n+|\n+$/g, "");
+}
+
+export function normalizeElementContextSelection(
+  raw: PickedElementPayload,
+): ElementContextSelection | null {
+  const pageUrl = raw.pageUrl.trim();
+  const tagName = raw.tagName.trim().toLowerCase();
+  if (pageUrl.length === 0 || tagName.length === 0) {
+    return null;
+  }
+  const stackFrame = raw.source ?? raw.stack[0] ?? null;
+  return {
+    pageUrl,
+    pageTitle: raw.pageTitle?.trim() ?? null,
+    tagName,
+    selector: raw.selector?.trim() || null,
+    htmlPreview: truncateString(normalizeText(raw.htmlPreview), ELEMENT_CONTEXT_HTML_PREVIEW_LIMIT),
+    componentName: raw.componentName?.trim() || null,
+    source: stackFrame
+      ? {
+          functionName: stackFrame.functionName?.trim() || null,
+          fileName: stackFrame.fileName?.trim() || null,
+          lineNumber: stackFrame.lineNumber ?? null,
+          columnNumber: stackFrame.columnNumber ?? null,
+        }
+      : null,
+    styles: truncateString(normalizeText(raw.styles), ELEMENT_CONTEXT_STYLES_LIMIT),
+  };
+}
+
+function shortenTagLabel(tagName: string): string {
+  if (tagName.length <= ELEMENT_CONTEXT_LABEL_TAG_MAX) return tagName;
+  return `${tagName.slice(0, ELEMENT_CONTEXT_LABEL_TAG_MAX - 1)}…`;
+}
+
+function formatElementContextLabel(context: ElementContextSelection): string {
+  if (context.componentName) return `<${context.componentName}>`;
+  return `<${shortenTagLabel(context.tagName)}>`;
+}
+
+function basenameFromPath(filePath: string): string {
+  const parts = filePath.split(/[\\/]/);
+  return parts[parts.length - 1] ?? filePath;
+}
+
+function formatElementContextSourceLabel(context: ElementContextSelection): string | null {
+  const source = context.source;
+  if (!source?.fileName) return null;
+  const base = basenameFromPath(source.fileName);
+  if (source.lineNumber == null) return base;
+  return `${base}:${source.lineNumber}`;
+}
+
+function buildContextHeader(context: ElementContextSelection): string {
+  const label = formatElementContextLabel(context);
+  const source = formatElementContextSourceLabel(context);
+  return source ? `${label} (${source})` : label;
+}
+
+function indentLines(value: string): string[] {
+  return value.split("\n").map((line) => `  ${line}`);
+}
+
+function buildSingleContextLines(context: ElementContextSelection): string[] {
+  const lines: string[] = [];
+  lines.push(`- ${buildContextHeader(context)}:`);
+  if (context.pageUrl.length > 0) {
+    lines.push(`  url: ${context.pageUrl}`);
+  }
+  if (context.selector) {
+    lines.push(`  selector: ${context.selector}`);
+  }
+  if (context.source?.fileName) {
+    const { fileName, lineNumber, columnNumber } = context.source;
+    const location =
+      lineNumber != null
+        ? `${fileName}:${lineNumber}${columnNumber != null ? `:${columnNumber}` : ""}`
+        : fileName;
+    lines.push(`  source: ${location}`);
+  }
+  const html = context.htmlPreview.trim();
+  if (html.length > 0) {
+    lines.push("  html:");
+    lines.push(...indentLines(html));
+  }
+  const styles = context.styles.trim();
+  if (styles.length > 0) {
+    lines.push("  styles:");
+    lines.push(...indentLines(styles));
+  }
+  return lines;
+}
+
+export function buildElementContextBlock(contexts: ReadonlyArray<ElementContextSelection>): string {
+  if (contexts.length === 0) return "";
+  const lines = ["<element_context>"];
+  for (let index = 0; index < contexts.length; index += 1) {
+    const context = contexts[index]!;
+    const contextLines = buildSingleContextLines(context);
+    const separator = lines.length > 1 ? [""] : [];
+    const closingLine = "</element_context>";
+    const candidate = [...lines, ...separator, ...contextLines, closingLine].join("\n");
+    if (candidate.length > ELEMENT_CONTEXT_BLOCK_MAX_CHARS) {
+      const omitted = contexts.length - index;
+      lines.push(
+        "",
+        `- … ${omitted} additional element context${omitted === 1 ? "" : "s"} omitted to fit the annotation context budget.`,
+      );
+      break;
+    }
+    lines.push(...separator, ...contextLines);
+  }
+  lines.push("</element_context>");
+  return lines.join("\n");
+}

--- a/packages/client-runtime/src/annotations/index.ts
+++ b/packages/client-runtime/src/annotations/index.ts
@@ -1,0 +1,11 @@
+export {
+  appendPreviewAnnotationPrompt,
+  buildPreviewAnnotationCopyText,
+  buildPreviewAnnotationPrompt,
+  extractTrailingPreviewAnnotation,
+  extractTrailingPreviewAnnotations,
+  type ExtractedPreviewAnnotation,
+  type ExtractedPreviewAnnotations,
+  type ParsedPreviewAnnotation,
+  type ParsedPreviewAnnotationCallout,
+} from "./previewAnnotation.ts";

--- a/packages/client-runtime/src/annotations/previewAnnotation.test.ts
+++ b/packages/client-runtime/src/annotations/previewAnnotation.test.ts
@@ -1,0 +1,353 @@
+import type { PreviewAnnotationPayload } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  appendPreviewAnnotationPrompt,
+  buildPreviewAnnotationCopyText,
+  buildPreviewAnnotationPrompt,
+  extractTrailingPreviewAnnotation,
+  extractTrailingPreviewAnnotations,
+} from "./previewAnnotation.ts";
+
+const legacyAnnotation: PreviewAnnotationPayload = {
+  id: "annotation_1",
+  pageUrl: "http://localhost:3000",
+  pageTitle: "Example",
+  comment: "Make these cards feel related.",
+  elements: [],
+  regions: [{ id: "region_1", rect: { x: 10, y: 20, width: 100, height: 80 } }],
+  strokes: [
+    {
+      id: "stroke_1",
+      color: "#7c3aed",
+      width: 4,
+      points: [
+        { x: 10, y: 10 },
+        { x: 20, y: 20 },
+      ],
+      bounds: { x: 6, y: 6, width: 18, height: 18 },
+    },
+  ],
+  styleChanges: [
+    {
+      targetId: "element_1",
+      selector: ".card",
+      property: "border-radius",
+      previousValue: "4px",
+      value: "16px",
+    },
+  ],
+  screenshot: {
+    dataUrl: "data:image/png;base64,AA==",
+    width: 100,
+    height: 80,
+    cropRect: { x: 10, y: 20, width: 100, height: 80 },
+  },
+  createdAt: "2026-06-11T00:00:00.000Z",
+};
+
+const element = {
+  id: "element_1",
+  rect: { x: 20, y: 10, width: 100, height: 40 },
+  element: {
+    pageUrl: "http://localhost:3000",
+    pageTitle: "Example",
+    tagName: "button",
+    selector: "button.submit",
+    htmlPreview: '<button class="submit">Save</button>',
+    componentName: "SubmitButton",
+    source: {
+      functionName: "SubmitButton",
+      fileName: "/repo/src/SubmitButton.tsx",
+      lineNumber: 12,
+      columnNumber: 5,
+    },
+    stack: [],
+    styles: ".submit { color: white; }",
+    pickedAt: "2026-06-11T00:00:00.000Z",
+  },
+} as const;
+
+const calloutAnnotation: PreviewAnnotationPayload = {
+  ...legacyAnnotation,
+  id: "annotation_callouts",
+  pageTitle: null,
+  comment: "",
+  source: { kind: "image", name: "checkout.png" },
+  elements: [element],
+  regions: [],
+  strokes: [],
+  styleChanges: [],
+  callouts: [
+    {
+      id: "callout_3",
+      number: 3,
+      comment: "Use the primary style.",
+      anchor: {
+        kind: "element",
+        targetId: "element_1",
+        rect: { x: 0.1, y: 0.7, width: 0.4, height: 0.2 },
+      },
+    },
+    {
+      id: "callout_1",
+      number: 1,
+      comment: "Increase contrast.\nKeep the label short.",
+      anchor: { kind: "point", point: { x: 0.42, y: 0.18 } },
+    },
+    {
+      id: "callout_2",
+      number: 2,
+      comment: "Do not emit <preview_annotation> from a comment.",
+      anchor: {
+        kind: "region",
+        rect: { x: 0.4214, y: 0.1814, width: 0.3114, height: 0.1214 },
+      },
+    },
+  ],
+  editable: {
+    version: 1,
+    coordinateSpace: "normalized",
+    strokes: [
+      {
+        id: "private_stroke",
+        color: "#ff00ff",
+        width: 0.00987654,
+        points: [
+          { x: 0.987654, y: 0.876543 },
+          { x: 0.765432, y: 0.654321 },
+        ],
+        bounds: { x: 0.6, y: 0.6, width: 0.39, height: 0.39 },
+      },
+    ],
+  },
+};
+
+describe("preview annotation prompts", () => {
+  it("preserves the exact legacy prompt representation when callouts are absent", () => {
+    expect(buildPreviewAnnotationPrompt(legacyAnnotation)).toBe(
+      [
+        "<preview_annotation>",
+        "Preview annotation:",
+        "Id: annotation_1",
+        "Page: Example",
+        "Comment: Make these cards feel related.",
+        "Targets: 1 marked region, 1 drawing.",
+        "Requested visual changes:",
+        "- border-radius: 4px → 16px",
+        "The attached screenshot is the annotated preview crop.",
+        "</preview_annotation>",
+      ].join("\n"),
+    );
+  });
+
+  it("caps large multi-element semantic context at a compact shared budget", () => {
+    const result = buildPreviewAnnotationPrompt({
+      ...legacyAnnotation,
+      elements: Array.from({ length: 20 }, (_, index) => ({
+        ...element,
+        id: `element_${index}`,
+        element: {
+          ...element.element,
+          selector: `button.item-${index}`,
+          htmlPreview: `<button>${"x".repeat(4_000)}</button>`,
+          styles: `.item-${index} { content: "${"y".repeat(4_000)}"; }`,
+        },
+      })),
+    });
+
+    expect(result.length).toBeLessThan(60_000);
+    expect(result).toContain("additional element contexts omitted");
+    expect(result).toContain("</element_context>");
+    expect(result).toMatch(/<\/element_context>\n<\/preview_annotation>$/);
+  });
+
+  it("describes portable image source and drawings without serializing their points", () => {
+    const result = buildPreviewAnnotationPrompt({
+      ...legacyAnnotation,
+      source: { kind: "image", name: "drawing-only.png" },
+      regions: [],
+      strokes: [],
+      editable: calloutAnnotation.editable!,
+    });
+    expect(result).toContain("Page: drawing-only.png");
+    expect(result).toContain("Targets: 1 drawing.");
+    expect(result).toContain("The attached screenshot is the annotated image.");
+    expect(result).not.toContain("private_stroke");
+    expect(result).not.toContain("0.987654");
+  });
+
+  it("formats sorted point, region, and semantic element callouts compactly", () => {
+    const result = buildPreviewAnnotationPrompt(calloutAnnotation);
+    expect(result).toContain("Page: checkout.png");
+    expect(result).toContain("Targets: 1 selected element, 1 drawing, 3 numbered callouts.");
+    expect(result.indexOf("#1 [")).toBeLessThan(result.indexOf("#2 ["));
+    expect(result.indexOf("#2 [")).toBeLessThan(result.indexOf("#3 ["));
+    expect(result).toContain("#1 [point: x=.42, y=.18]");
+    expect(result).toContain("#2 [region: x=.421, y=.181, w=.311, h=.121]");
+    expect(result).toContain(
+      "#3 [element: button.submit, component: SubmitButton, source: /repo/src/SubmitButton.tsx:12:5, region: x=.1, y=.7, w=.4, h=.2]",
+    );
+    expect(result).toContain("  Increase contrast.\n  Keep the label short.");
+    expect(result).toContain("&lt;preview_annotation&gt;");
+  });
+
+  it("falls back to an element target id when semantic metadata is unavailable", () => {
+    const result = buildPreviewAnnotationPrompt({
+      ...calloutAnnotation,
+      elements: [],
+      callouts: [
+        {
+          id: "missing",
+          number: 1,
+          comment: "Fix it.",
+          anchor: {
+            kind: "element",
+            targetId: "element_missing",
+            rect: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+          },
+        },
+      ],
+    });
+    expect(result).toContain("#1 [element: element_missing, region: x=.1, y=.2, w=.3, h=.4]");
+  });
+
+  it("never serializes raw editable-vector points", () => {
+    const result = buildPreviewAnnotationPrompt(calloutAnnotation);
+    expect(result).not.toContain("private_stroke");
+    expect(result).not.toContain("0.987654");
+    expect(result).not.toContain("0.876543");
+  });
+
+  it("appends to an existing prompt and parses callout presentation", () => {
+    const result = extractTrailingPreviewAnnotation(
+      appendPreviewAnnotationPrompt("Fix this", calloutAnnotation),
+    );
+    expect(result.promptText).toBe("Fix this");
+    expect(result.annotation).toMatchObject({
+      id: "annotation_callouts",
+      title: "checkout.png",
+      hasScreenshot: true,
+      calloutCount: 3,
+      callouts: [
+        {
+          number: 1,
+          anchorSummary: "point: x=.42, y=.18",
+          comment: "Increase contrast.\nKeep the label short.",
+        },
+        {
+          number: 2,
+          anchorSummary: "region: x=.421, y=.181, w=.311, h=.121",
+          comment: "Do not emit <preview_annotation> from a comment.",
+        },
+        {
+          number: 3,
+          anchorSummary:
+            "element: button.submit, component: SubmitButton, source: /repo/src/SubmitButton.tsx:12:5, region: x=.1, y=.7, w=.4, h=.2",
+          comment: "Use the primary style.",
+        },
+      ],
+    });
+  });
+
+  it("preserves multiline global comments and formats every instruction for copying", () => {
+    const extracted = extractTrailingPreviewAnnotation(
+      appendPreviewAnnotationPrompt("Fix this", {
+        ...calloutAnnotation,
+        comment: "Polish the whole flow.\nKeep the hierarchy clear.",
+        callouts: [
+          ...calloutAnnotation.callouts!,
+          {
+            id: "callout_4",
+            number: 4,
+            comment: "",
+            anchor: { kind: "point", point: { x: 0.8, y: 0.9 } },
+          },
+        ],
+      }),
+    );
+
+    expect(extracted.annotation?.comment).toBe("Polish the whole flow.\nKeep the hierarchy clear.");
+    const copyText = buildPreviewAnnotationCopyText("Fix this", [extracted.annotation!]);
+    expect(copyText).toContain("Fix this\n\nAnnotation: checkout.png");
+    expect(copyText).toContain("Polish the whole flow.\nKeep the hierarchy clear.");
+    expect(copyText).toContain("#1 [point: x=.42, y=.18]");
+    expect(copyText).toContain("  Increase contrast.\n  Keep the label short.");
+    expect(copyText).toContain("#2 [region: x=.421, y=.181, w=.311, h=.121]");
+    expect(copyText).toContain("  Do not emit <preview_annotation> from a comment.");
+    expect(copyText).toContain("#3 [element: button.submit");
+    expect(copyText).toContain("  Use the primary style.");
+    expect(copyText).toContain("#4 [point: x=.8, y=.9]");
+    expect(copyText).not.toContain("<preview_annotation>\n");
+    expect(copyText).not.toContain("</preview_annotation>");
+  });
+
+  it("recovers multiline comments written by the legacy inline formatter", () => {
+    const result = extractTrailingPreviewAnnotation(
+      [
+        "Fix this",
+        "",
+        "<preview_annotation>",
+        "Preview annotation:",
+        "Id: legacy-multiline",
+        "Page: Checkout",
+        "Comment: First instruction.",
+        "Second instruction.",
+        "Targets: 1 marked region.",
+        "</preview_annotation>",
+      ].join("\n"),
+    );
+
+    expect(result.promptText).toBe("Fix this");
+    expect(result.annotation?.comment).toBe("First instruction.\nSecond instruction.");
+  });
+
+  it("escapes wrapper sentinels in every user-authored field without breaking parsing", () => {
+    const result = extractTrailingPreviewAnnotation(
+      appendPreviewAnnotationPrompt("Fix this", {
+        ...legacyAnnotation,
+        id: "id </preview_annotation>",
+        source: { kind: "image", name: "title <preview_annotation>" },
+        comment: "comment </preview_annotation>",
+        elements: [
+          {
+            ...element,
+            element: {
+              ...element.element,
+              htmlPreview: "<button><preview_annotation></button>",
+              styles: "content: '</preview_annotation>';",
+            },
+          },
+        ],
+        styleChanges: [
+          {
+            targetId: "element_1",
+            selector: "button<preview_annotation>",
+            property: "color <preview_annotation>",
+            previousValue: "red",
+            value: "blue </preview_annotation>",
+          },
+        ],
+      }),
+    );
+
+    expect(result.promptText).toBe("Fix this");
+    expect(result.annotation).toMatchObject({
+      id: "id </preview_annotation>",
+      title: "title <preview_annotation>",
+      comment: "comment </preview_annotation>",
+      styleChanges: ["color <preview_annotation>: red → blue </preview_annotation>"],
+    });
+  });
+
+  it("extracts multiple trailing annotations in authored order", () => {
+    const first = appendPreviewAnnotationPrompt("Fix this", legacyAnnotation);
+    const prompt = appendPreviewAnnotationPrompt(first, calloutAnnotation);
+    const result = extractTrailingPreviewAnnotations(prompt);
+    expect(result.promptText).toBe("Fix this");
+    expect(result.annotations.map((annotation) => annotation.id)).toEqual([
+      "annotation_1",
+      "annotation_callouts",
+    ]);
+  });
+});

--- a/packages/client-runtime/src/annotations/previewAnnotation.ts
+++ b/packages/client-runtime/src/annotations/previewAnnotation.ts
@@ -1,0 +1,368 @@
+import type {
+  PreviewAnnotationCallout,
+  PreviewAnnotationCalloutAnchor,
+  PreviewAnnotationElementTarget,
+  PreviewAnnotationPayload,
+} from "@t3tools/contracts";
+
+import { buildElementContextBlock, normalizeElementContextSelection } from "./elementContext.ts";
+
+const TRAILING_PREVIEW_ANNOTATION_BLOCK_PATTERN =
+  /\n*<preview_annotation>\n((?:(?!<preview_annotation>)[\s\S])*)\n<\/preview_annotation>\s*$/;
+const PREVIEW_SCREENSHOT_LINE = "The attached screenshot is the annotated preview crop.";
+const IMAGE_SCREENSHOT_LINE = "The attached screenshot is the annotated image.";
+
+export interface ParsedPreviewAnnotationCallout {
+  number: number;
+  anchorSummary: string;
+  comment: string;
+}
+
+export interface ParsedPreviewAnnotation {
+  id: string;
+  title: string;
+  comment: string;
+  targetSummary: string;
+  styleChanges: string[];
+  hasScreenshot: boolean;
+  calloutCount: number;
+  callouts: ParsedPreviewAnnotationCallout[];
+}
+
+export interface ExtractedPreviewAnnotation {
+  promptText: string;
+  annotation: ParsedPreviewAnnotation | null;
+}
+
+export interface ExtractedPreviewAnnotations {
+  promptText: string;
+  annotations: ParsedPreviewAnnotation[];
+}
+
+export function buildPreviewAnnotationCopyText(
+  visibleText: string,
+  annotations: ReadonlyArray<ParsedPreviewAnnotation>,
+): string {
+  const sections = annotations.map((annotation) => {
+    const lines = [`Annotation: ${annotation.title}`];
+    const comment = annotation.comment.trim();
+    if (comment) {
+      lines.push(comment);
+    }
+    if (annotation.targetSummary) {
+      lines.push(`Targets: ${annotation.targetSummary}`);
+    }
+    if (annotation.callouts.length > 0) {
+      lines.push("Callouts:");
+      for (const callout of annotation.callouts) {
+        lines.push(`#${callout.number} [${callout.anchorSummary}]`);
+        const instruction = callout.comment.trim();
+        if (instruction) {
+          lines.push(...instruction.split("\n").map((line) => `  ${line}`));
+        }
+      }
+    }
+    if (annotation.styleChanges.length > 0) {
+      lines.push("Requested visual changes:");
+      lines.push(...annotation.styleChanges.map((change) => `- ${change}`));
+    }
+    return lines.join("\n");
+  });
+  const promptText = visibleText.trim();
+  return [promptText, ...sections].filter((section) => section.length > 0).join("\n\n");
+}
+
+function compactCoordinate(value: number): string {
+  const fixed = value.toFixed(3).replace(/\.?0+$/, "");
+  if (fixed.startsWith("0.")) return fixed.slice(1);
+  if (fixed.startsWith("-0.")) return `-${fixed.slice(2)}`;
+  return fixed;
+}
+
+function formatRect(rect: { x: number; y: number; width: number; height: number }): string {
+  return [
+    `x=${compactCoordinate(rect.x)}`,
+    `y=${compactCoordinate(rect.y)}`,
+    `w=${compactCoordinate(rect.width)}`,
+    `h=${compactCoordinate(rect.height)}`,
+  ].join(", ");
+}
+
+function formatElementSource(target: PreviewAnnotationElementTarget): string | null {
+  const source = target.element.source ?? target.element.stack[0] ?? null;
+  if (!source?.fileName) return null;
+  if (source.lineNumber == null) return source.fileName;
+  return `${source.fileName}:${source.lineNumber}${
+    source.columnNumber == null ? "" : `:${source.columnNumber}`
+  }`;
+}
+
+function formatElementAnchor(
+  anchor: Extract<PreviewAnnotationCalloutAnchor, { kind: "element" }>,
+  elements: ReadonlyArray<PreviewAnnotationElementTarget>,
+): string {
+  const target = elements.find((entry) => entry.id === anchor.targetId);
+  if (!target) {
+    return `element: ${anchor.targetId}, region: ${formatRect(anchor.rect)}`;
+  }
+  const elementLabel =
+    target.element.selector?.trim() || target.element.tagName.trim() || anchor.targetId;
+  const parts = [`element: ${elementLabel}`];
+  const componentName = target.element.componentName?.trim();
+  if (componentName) parts.push(`component: ${componentName}`);
+  const source = formatElementSource(target);
+  if (source) parts.push(`source: ${source}`);
+  parts.push(`region: ${formatRect(anchor.rect)}`);
+  return parts.join(", ");
+}
+
+function formatCalloutAnchor(
+  anchor: PreviewAnnotationCalloutAnchor,
+  elements: ReadonlyArray<PreviewAnnotationElementTarget>,
+): string {
+  switch (anchor.kind) {
+    case "point":
+      return `point: x=${compactCoordinate(anchor.point.x)}, y=${compactCoordinate(anchor.point.y)}`;
+    case "region":
+      return `region: ${formatRect(anchor.rect)}`;
+    case "element":
+      return formatElementAnchor(anchor, elements);
+  }
+}
+
+function escapeAnnotationSentinels(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .replaceAll("<preview_annotation>", "&lt;preview_annotation&gt;")
+    .replaceAll("</preview_annotation>", "&lt;/preview_annotation&gt;");
+}
+
+function unescapeAnnotationSentinels(value: string): string {
+  return value
+    .replaceAll("&lt;preview_annotation&gt;", "<preview_annotation>")
+    .replaceAll("&lt;/preview_annotation&gt;", "</preview_annotation>");
+}
+
+function appendCalloutLines(
+  lines: string[],
+  callouts: ReadonlyArray<PreviewAnnotationCallout>,
+  elements: ReadonlyArray<PreviewAnnotationElementTarget>,
+): void {
+  if (callouts.length === 0) return;
+  lines.push("Callouts:");
+  const ordered = [...callouts].sort(
+    (left, right) => left.number - right.number || left.id.localeCompare(right.id),
+  );
+  for (const callout of ordered) {
+    lines.push(`#${callout.number} [${formatCalloutAnchor(callout.anchor, elements)}]`);
+    const comment = escapeAnnotationSentinels(callout.comment).trim();
+    if (!comment) continue;
+    for (const commentLine of comment.split("\n")) {
+      lines.push(`  ${commentLine}`);
+    }
+  }
+}
+
+function annotationTitle(annotation: PreviewAnnotationPayload): string {
+  if (annotation.source?.kind === "image") {
+    return annotation.source.name?.trim() || annotation.pageTitle?.trim() || "Image";
+  }
+  if (annotation.source?.kind === "preview") {
+    return (
+      annotation.source.title?.trim() ||
+      annotation.source.url.trim() ||
+      annotation.pageTitle?.trim() ||
+      annotation.pageUrl.trim() ||
+      "Preview"
+    );
+  }
+  return annotation.pageTitle?.trim() || annotation.pageUrl.trim() || "Preview";
+}
+
+export function buildPreviewAnnotationPrompt(annotation: PreviewAnnotationPayload): string {
+  const lines = ["Preview annotation:"];
+  lines.push(`Id: ${annotation.id}`);
+  lines.push(`Page: ${annotationTitle(annotation)}`);
+  const comment = annotation.comment.replace(/\r\n/g, "\n").trim();
+  if (comment) {
+    if (comment.includes("\n")) {
+      lines.push("Comment:", ...comment.split("\n").map((line) => `  ${line}`));
+    } else {
+      lines.push(`Comment: ${comment}`);
+    }
+  }
+  const targets: string[] = [];
+  if (annotation.elements.length > 0) {
+    targets.push(
+      `${annotation.elements.length} selected element${annotation.elements.length === 1 ? "" : "s"}`,
+    );
+  }
+  if (annotation.regions.length > 0) {
+    targets.push(
+      `${annotation.regions.length} marked region${annotation.regions.length === 1 ? "" : "s"}`,
+    );
+  }
+  const drawingCount =
+    annotation.strokes.length > 0
+      ? annotation.strokes.length
+      : (annotation.editable?.strokes.length ?? 0);
+  if (drawingCount > 0) {
+    targets.push(`${drawingCount} drawing${drawingCount === 1 ? "" : "s"}`);
+  }
+  const calloutCount = annotation.callouts?.length ?? 0;
+  if (calloutCount > 0) {
+    targets.push(`${calloutCount} numbered callout${calloutCount === 1 ? "" : "s"}`);
+  }
+  if (targets.length > 0) lines.push(`Targets: ${targets.join(", ")}.`);
+  appendCalloutLines(lines, annotation.callouts ?? [], annotation.elements);
+  if (annotation.styleChanges.length > 0) {
+    lines.push("Requested visual changes:");
+    for (const change of annotation.styleChanges) {
+      lines.push(`- ${change.property}: ${change.previousValue || "(unset)"} → ${change.value}`);
+    }
+  }
+  if (annotation.screenshot) {
+    lines.push(
+      annotation.source?.kind === "image" ? IMAGE_SCREENSHOT_LINE : PREVIEW_SCREENSHOT_LINE,
+    );
+  }
+  const elementContexts = annotation.elements
+    .map((target) => normalizeElementContextSelection(target.element))
+    .filter((context) => context !== null);
+  const elementBlock = buildElementContextBlock(elementContexts);
+  if (elementBlock) lines.push(elementBlock);
+  return [
+    "<preview_annotation>",
+    ...lines.map(escapeAnnotationSentinels),
+    "</preview_annotation>",
+  ].join("\n");
+}
+
+export function appendPreviewAnnotationPrompt(
+  prompt: string,
+  annotation: PreviewAnnotationPayload,
+): string {
+  const annotationText = buildPreviewAnnotationPrompt(annotation);
+  const trimmed = prompt.trim();
+  return trimmed ? `${trimmed}\n\n${annotationText}` : annotationText;
+}
+
+function parseCallouts(lines: ReadonlyArray<string>): ParsedPreviewAnnotationCallout[] {
+  const headingIndex = lines.indexOf("Callouts:");
+  if (headingIndex < 0) return [];
+  const callouts: ParsedPreviewAnnotationCallout[] = [];
+  let current: ParsedPreviewAnnotationCallout | null = null;
+  const commit = () => {
+    if (!current) return;
+    callouts.push({
+      ...current,
+      comment: unescapeAnnotationSentinels(current.comment.trimEnd()),
+    });
+    current = null;
+  };
+  for (const line of lines.slice(headingIndex + 1)) {
+    const header = /^#(\d+) \[(.*)\]$/.exec(line);
+    if (header) {
+      commit();
+      current = {
+        number: Number(header[1]),
+        anchorSummary: header[2] ?? "",
+        comment: "",
+      };
+      continue;
+    }
+    if (current && line.startsWith("  ")) {
+      current.comment += `${current.comment ? "\n" : ""}${line.slice(2)}`;
+      continue;
+    }
+    if (current) break;
+    if (
+      line === "Requested visual changes:" ||
+      line === PREVIEW_SCREENSHOT_LINE ||
+      line === IMAGE_SCREENSHOT_LINE ||
+      line === "<element_context>"
+    ) {
+      break;
+    }
+  }
+  commit();
+  return callouts;
+}
+
+function parseAnnotationComment(lines: ReadonlyArray<string>): string {
+  const inlineCommentIndex = lines.findIndex((line) => line.startsWith("Comment: "));
+  if (inlineCommentIndex >= 0) {
+    const commentLines = [lines[inlineCommentIndex]!.slice("Comment: ".length)];
+    for (const line of lines.slice(inlineCommentIndex + 1)) {
+      if (
+        line.startsWith("Targets: ") ||
+        line === "Callouts:" ||
+        line === "Requested visual changes:" ||
+        line === PREVIEW_SCREENSHOT_LINE ||
+        line === IMAGE_SCREENSHOT_LINE ||
+        line === "<element_context>"
+      ) {
+        break;
+      }
+      commentLines.push(line);
+    }
+    return unescapeAnnotationSentinels(commentLines.join("\n").trim());
+  }
+  const headingIndex = lines.indexOf("Comment:");
+  if (headingIndex < 0) return "";
+  const commentLines: string[] = [];
+  for (const line of lines.slice(headingIndex + 1)) {
+    if (!line.startsWith("  ")) break;
+    commentLines.push(line.slice(2));
+  }
+  return unescapeAnnotationSentinels(commentLines.join("\n").trim());
+}
+
+export function extractTrailingPreviewAnnotation(prompt: string): ExtractedPreviewAnnotation {
+  const match = TRAILING_PREVIEW_ANNOTATION_BLOCK_PATTERN.exec(prompt);
+  if (!match) return { promptText: prompt, annotation: null };
+  const body = match[1] ?? "";
+  const lines = body.split("\n");
+  const pageLine = lines.find((line) => line.startsWith("Page: "));
+  const idLine = lines.find((line) => line.startsWith("Id: "));
+  const targetsLine = lines.find((line) => line.startsWith("Targets: "));
+  const styleHeadingIndex = lines.indexOf("Requested visual changes:");
+  const linesAfterStyleHeading = lines.slice(styleHeadingIndex + 1);
+  const elementContextIndex = linesAfterStyleHeading.indexOf("<element_context>");
+  const styleChanges =
+    styleHeadingIndex < 0
+      ? []
+      : linesAfterStyleHeading
+          .slice(0, elementContextIndex < 0 ? undefined : elementContextIndex)
+          .filter((line) => line.startsWith("- "))
+          .map((line) => line.slice(2));
+  const callouts = parseCallouts(lines);
+  return {
+    promptText: prompt.slice(0, match.index).replace(/\n+$/, ""),
+    annotation: {
+      id:
+        unescapeAnnotationSentinels(idLine?.slice("Id: ".length).trim() ?? "") || `${match.index}`,
+      title:
+        unescapeAnnotationSentinels(pageLine?.slice("Page: ".length).trim() ?? "") ||
+        "Preview annotation",
+      comment: parseAnnotationComment(lines),
+      targetSummary: targetsLine?.slice("Targets: ".length).trim() || "",
+      styleChanges: styleChanges.map(unescapeAnnotationSentinels),
+      hasScreenshot: body.includes(PREVIEW_SCREENSHOT_LINE) || body.includes(IMAGE_SCREENSHOT_LINE),
+      calloutCount: callouts.length,
+      callouts,
+    },
+  };
+}
+
+export function extractTrailingPreviewAnnotations(prompt: string): ExtractedPreviewAnnotations {
+  const annotations: ParsedPreviewAnnotation[] = [];
+  let promptText = prompt;
+  while (true) {
+    const extracted = extractTrailingPreviewAnnotation(promptText);
+    if (!extracted.annotation) break;
+    annotations.unshift(extracted.annotation);
+    promptText = extracted.promptText;
+  }
+  return { promptText, annotations };
+}

--- a/packages/client-runtime/src/state/preview.test.ts
+++ b/packages/client-runtime/src/state/preview.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { previewAutomationHostFocusConcurrencyKey } from "./preview.ts";
+import {
+  previewAutomationHostFocusConcurrencyKey,
+  previewLiveGatewayConcurrencyKey,
+  previewReviewSnapshotConcurrencyKey,
+} from "./preview.ts";
 
 describe("preview state commands", () => {
   it("keeps focus updates from replacement host connections independent", () => {
@@ -14,5 +18,46 @@ describe("preview state commands", () => {
     });
 
     expect(first).not.toBe(replacement);
+  });
+
+  it("deduplicates review captures only for the same environment, thread, and tab", () => {
+    const first = previewReviewSnapshotConcurrencyKey({
+      environmentId: "environment-1",
+      input: { threadId: "thread-1", tabId: "tab-1" },
+    });
+    const same = previewReviewSnapshotConcurrencyKey({
+      environmentId: "environment-1",
+      input: { threadId: "thread-1", tabId: "tab-1" },
+    });
+    const otherTab = previewReviewSnapshotConcurrencyKey({
+      environmentId: "environment-1",
+      input: { threadId: "thread-1", tabId: "tab-2" },
+    });
+    const otherEnvironment = previewReviewSnapshotConcurrencyKey({
+      environmentId: "environment-2",
+      input: { threadId: "thread-1", tabId: "tab-1" },
+    });
+
+    expect(first).toBe(same);
+    expect(first).not.toBe(otherTab);
+    expect(first).not.toBe(otherEnvironment);
+  });
+
+  it("deduplicates live-gateway opens only for the same environment, thread, and tab", () => {
+    const first = previewLiveGatewayConcurrencyKey({
+      environmentId: "environment-1",
+      input: { threadId: "thread-1", tabId: "tab-1" },
+    });
+    const same = previewLiveGatewayConcurrencyKey({
+      environmentId: "environment-1",
+      input: { threadId: "thread-1", tabId: "tab-1" },
+    });
+    const otherTab = previewLiveGatewayConcurrencyKey({
+      environmentId: "environment-1",
+      input: { threadId: "thread-1", tabId: "tab-2" },
+    });
+
+    expect(first).toBe(same);
+    expect(first).not.toBe(otherTab);
   });
 });

--- a/packages/client-runtime/src/state/preview.ts
+++ b/packages/client-runtime/src/state/preview.ts
@@ -17,12 +17,30 @@ export const previewAutomationHostFocusConcurrencyKey = (value: {
   };
 }): string => JSON.stringify([value.environmentId, value.input.clientId, value.input.connectionId]);
 
+export const previewReviewSnapshotConcurrencyKey = (value: {
+  readonly environmentId: string;
+  readonly input: {
+    readonly threadId: string;
+    readonly tabId: string;
+  };
+}): string => JSON.stringify([value.environmentId, value.input.threadId, value.input.tabId]);
+
+export const previewLiveGatewayConcurrencyKey = (value: {
+  readonly environmentId: string;
+  readonly input: {
+    readonly threadId: string;
+    readonly tabId: string;
+  };
+}): string => JSON.stringify([value.environmentId, value.input.threadId, value.input.tabId]);
+
 export function createPreviewEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
 ) {
   const lifecycleScheduler = createAtomCommandScheduler();
   const statusScheduler = createAtomCommandScheduler();
   const automationScheduler = createAtomCommandScheduler();
+  const reviewScheduler = createAtomCommandScheduler();
+  const liveGatewayScheduler = createAtomCommandScheduler();
   const lifecycleConcurrency = {
     mode: "serial" as const,
     key: ({ environmentId, input }: { environmentId: string; input: { threadId: string } }) =>
@@ -88,6 +106,24 @@ export function createPreviewEnvironmentAtoms<R, E>(
         mode: "latest",
         key: ({ environmentId, input }) =>
           JSON.stringify([environmentId, input.threadId, input.tabId]),
+      },
+    }),
+    reviewSnapshot: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:preview:review-snapshot",
+      tag: WS_METHODS.previewReviewSnapshot,
+      scheduler: reviewScheduler,
+      concurrency: {
+        mode: "singleFlight",
+        key: previewReviewSnapshotConcurrencyKey,
+      },
+    }),
+    openLiveGateway: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:preview:open-live-gateway",
+      tag: WS_METHODS.previewOpenLiveGateway,
+      scheduler: liveGatewayScheduler,
+      concurrency: {
+        mode: "singleFlight",
+        key: previewLiveGatewayConcurrencyKey,
       },
     }),
     respondToAutomation: createEnvironmentRpcCommand(runtime, {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -26,6 +26,7 @@ export * from "./filesystem.ts";
 export * from "./assets.ts";
 export * from "./review.ts";
 export * from "./preview.ts";
+export * from "./previewAnnotation.ts";
 export * from "./previewAutomation.ts";
 export * from "./resourceTelemetry.ts";
 export * from "./rpc.ts";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -95,6 +95,7 @@ import type {
   SourceControlRepositoryInfo,
   SourceControlRepositoryLookupInput,
 } from "./sourceControl.ts";
+import type { PreviewAnnotationPayload } from "./previewAnnotation.ts";
 
 export interface ContextMenuItem<T extends string = string> {
   id: T;
@@ -700,197 +701,6 @@ export const DesktopPreviewScreenshotArtifactSchema: Schema.Codec<DesktopPreview
     createdAt: Schema.String,
   });
 
-/**
- * Single stack frame captured by react-grab's `getElementContext`. We surface
- * the source file/line so coding agents can jump straight to the JSX that
- * produced the picked DOM node.
- */
-export interface PickedElementStackFrame {
-  functionName: string | null;
-  fileName: string | null;
-  lineNumber: number | null;
-  columnNumber: number | null;
-}
-
-export const PickedElementStackFrameSchema: Schema.Codec<PickedElementStackFrame> = Schema.Struct({
-  functionName: Schema.NullOr(Schema.String),
-  fileName: Schema.NullOr(Schema.String),
-  lineNumber: Schema.NullOr(Schema.Number),
-  columnNumber: Schema.NullOr(Schema.Number),
-});
-
-/**
- * A successful element pick from the preview webview. All fields are
- * best-effort — pages that don't ship a React fiber tree (or aren't running
- * in dev) will still produce a usable payload (selector + html preview),
- * just without component / source attribution.
- */
-export interface PickedElementPayload {
-  /** URL of the page the element was picked on. */
-  pageUrl: string;
-  /** Optional `<title>` of that page (best-effort). */
-  pageTitle: string | null;
-  /** Lowercase tag name, e.g. `"button"`. */
-  tagName: string;
-  /** CSS selector resolving back to the element on a re-render. */
-  selector: string | null;
-  /** Truncated outer-HTML preview (matches react-grab's `htmlPreview`). */
-  htmlPreview: string;
-  /** Nearest React component display name, or null when unavailable. */
-  componentName: string | null;
-  /** First source-mapped stack frame (file + line of the JSX source). */
-  source: PickedElementStackFrame | null;
-  /** Full owner-stack frames; can be empty. Useful for richer context. */
-  stack: ReadonlyArray<PickedElementStackFrame>;
-  /** Author CSS only (UA defaults stripped) — react-grab's `styles`. */
-  styles: string;
-  /** Wall-clock pick time as ISO-8601 string. */
-  pickedAt: string;
-}
-
-export const PickedElementPayloadSchema: Schema.Codec<PickedElementPayload> = Schema.Struct({
-  pageUrl: Schema.String,
-  pageTitle: Schema.NullOr(Schema.String),
-  tagName: Schema.String,
-  selector: Schema.NullOr(Schema.String),
-  htmlPreview: Schema.String,
-  componentName: Schema.NullOr(Schema.String),
-  source: Schema.NullOr(PickedElementStackFrameSchema),
-  stack: Schema.Array(PickedElementStackFrameSchema),
-  styles: Schema.String,
-  pickedAt: Schema.String,
-});
-
-export interface PreviewAnnotationRect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
-export const PreviewAnnotationRectSchema: Schema.Codec<PreviewAnnotationRect> = Schema.Struct({
-  x: Schema.Number,
-  y: Schema.Number,
-  width: Schema.Number,
-  height: Schema.Number,
-});
-
-export interface PreviewAnnotationPoint {
-  x: number;
-  y: number;
-}
-
-export const PreviewAnnotationPointSchema: Schema.Codec<PreviewAnnotationPoint> = Schema.Struct({
-  x: Schema.Number,
-  y: Schema.Number,
-});
-
-export interface PreviewAnnotationElementTarget {
-  id: string;
-  element: PickedElementPayload;
-  rect: PreviewAnnotationRect;
-}
-
-export const PreviewAnnotationElementTargetSchema: Schema.Codec<PreviewAnnotationElementTarget> =
-  Schema.Struct({
-    id: Schema.String,
-    element: PickedElementPayloadSchema,
-    rect: PreviewAnnotationRectSchema,
-  });
-
-export interface PreviewAnnotationRegionTarget {
-  id: string;
-  rect: PreviewAnnotationRect;
-}
-
-export const PreviewAnnotationRegionTargetSchema: Schema.Codec<PreviewAnnotationRegionTarget> =
-  Schema.Struct({
-    id: Schema.String,
-    rect: PreviewAnnotationRectSchema,
-  });
-
-export interface PreviewAnnotationStrokeTarget {
-  id: string;
-  color: string;
-  width: number;
-  points: ReadonlyArray<PreviewAnnotationPoint>;
-  bounds: PreviewAnnotationRect;
-}
-
-export const PreviewAnnotationStrokeTargetSchema: Schema.Codec<PreviewAnnotationStrokeTarget> =
-  Schema.Struct({
-    id: Schema.String,
-    color: Schema.String,
-    width: Schema.Number,
-    points: Schema.Array(PreviewAnnotationPointSchema),
-    bounds: PreviewAnnotationRectSchema,
-  });
-
-export interface PreviewAnnotationStyleChange {
-  targetId: string;
-  selector: string | null;
-  property: string;
-  previousValue: string;
-  value: string;
-}
-
-export const PreviewAnnotationStyleChangeSchema: Schema.Codec<PreviewAnnotationStyleChange> =
-  Schema.Struct({
-    targetId: Schema.String,
-    selector: Schema.NullOr(Schema.String),
-    property: Schema.String,
-    previousValue: Schema.String,
-    value: Schema.String,
-  });
-
-export interface PreviewAnnotationScreenshot {
-  dataUrl: string;
-  width: number;
-  height: number;
-  cropRect: PreviewAnnotationRect;
-}
-
-export const PreviewAnnotationScreenshotSchema: Schema.Codec<PreviewAnnotationScreenshot> =
-  Schema.Struct({
-    dataUrl: Schema.String,
-    width: Schema.Number,
-    height: Schema.Number,
-    cropRect: PreviewAnnotationRectSchema,
-  });
-
-/**
- * A submitted preview annotation. One annotation may reference multiple DOM
- * elements, freeform regions, and ink strokes. The desktop main process adds
- * the screenshot after the guest preload submits the structured draft.
- */
-export interface PreviewAnnotationPayload {
-  id: string;
-  pageUrl: string;
-  pageTitle: string | null;
-  comment: string;
-  elements: ReadonlyArray<PreviewAnnotationElementTarget>;
-  regions: ReadonlyArray<PreviewAnnotationRegionTarget>;
-  strokes: ReadonlyArray<PreviewAnnotationStrokeTarget>;
-  styleChanges: ReadonlyArray<PreviewAnnotationStyleChange>;
-  screenshot: PreviewAnnotationScreenshot | null;
-  createdAt: string;
-}
-
-export const PreviewAnnotationPayloadSchema: Schema.Codec<PreviewAnnotationPayload> = Schema.Struct(
-  {
-    id: Schema.String,
-    pageUrl: Schema.String,
-    pageTitle: Schema.NullOr(Schema.String),
-    comment: Schema.String,
-    elements: Schema.Array(PreviewAnnotationElementTargetSchema),
-    regions: Schema.Array(PreviewAnnotationRegionTargetSchema),
-    strokes: Schema.Array(PreviewAnnotationStrokeTargetSchema),
-    styleChanges: Schema.Array(PreviewAnnotationStyleChangeSchema),
-    screenshot: Schema.NullOr(PreviewAnnotationScreenshotSchema),
-    createdAt: Schema.String,
-  },
-);
-
 export const DesktopPreviewTabInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,
 });
@@ -931,6 +741,17 @@ export const DesktopPreviewRecordingSaveInputSchema = Schema.Struct({
 export const DesktopPreviewAutomationClickInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,
   input: PreviewAutomationClickInput,
+});
+
+export const DesktopPreviewAutomationSnapshotOptionsSchema = Schema.Struct({
+  mode: Schema.Literal("review"),
+});
+export type DesktopPreviewAutomationSnapshotOptions =
+  typeof DesktopPreviewAutomationSnapshotOptionsSchema.Type;
+
+export const DesktopPreviewAutomationSnapshotInputSchema = Schema.Struct({
+  tabId: DesktopPreviewTabIdSchema,
+  mode: Schema.optional(DesktopPreviewAutomationSnapshotOptionsSchema.fields.mode),
 });
 
 export const DesktopPreviewAutomationTypeInputSchema = Schema.Struct({
@@ -1082,7 +903,10 @@ export interface DesktopPreviewBridge {
   };
   automation: {
     status: (tabId: string) => Promise<PreviewAutomationStatus>;
-    snapshot: (tabId: string) => Promise<PreviewAutomationSnapshot>;
+    snapshot: (
+      tabId: string,
+      options?: DesktopPreviewAutomationSnapshotOptions,
+    ) => Promise<PreviewAutomationSnapshot>;
     click: (tabId: string, input: PreviewAutomationClickInput) => Promise<void>;
     type: (tabId: string, input: PreviewAutomationTypeInput) => Promise<void>;
     press: (tabId: string, input: PreviewAutomationPressInput) => Promise<void>;

--- a/packages/contracts/src/preview.ts
+++ b/packages/contracts/src/preview.ts
@@ -1,10 +1,10 @@
 /**
  * Preview - Schemas for the in-app browser preview surface.
  *
- * The preview is desktop-only (Chromium <webview>); the server tracks per-thread
- * tab metadata so it survives client reconnects and multi-window. The desktop
- * renderer mediates: it owns the actual <webview> and reports navigation back to
- * the server via these RPCs, the server fans events to all subscribers.
+ * The server tracks per-thread preview tab metadata so it survives client
+ * reconnects and multi-window. Desktop owns the canonical Chromium <webview>
+ * and reports navigation through these RPCs; mobile can render the recorded URL
+ * in its own WebView or request a short-lived Connect gateway for loopback tabs.
  *
  * @module Preview
  */
@@ -198,6 +198,49 @@ export const PreviewListResult = Schema.Struct({
   revision: NonNegativeInt,
 });
 export type PreviewListResult = typeof PreviewListResult.Type;
+
+export const PreviewLiveGatewayOpenInput = Schema.Struct({
+  version: Schema.Literal(1),
+  threadId: ThreadId,
+  tabId: PreviewTabId,
+});
+export type PreviewLiveGatewayOpenInput = typeof PreviewLiveGatewayOpenInput.Type;
+
+/**
+ * A short-lived, same-environment URL that hands an isolated browser view to
+ * the live-preview gateway. The bootstrap token is deliberately returned as a
+ * relative URL so clients resolve it against the already-authenticated
+ * environment endpoint instead of trusting another origin.
+ */
+export const PreviewLiveGatewayOpenResult = Schema.Struct({
+  version: Schema.Literal(1),
+  relativeUrl: Schema.String.check(Schema.isPattern(/^\/api\/preview-gateway\/bootstrap\//u)),
+  expiresAt: Schema.Number.check(Schema.isGreaterThan(0)),
+});
+export type PreviewLiveGatewayOpenResult = typeof PreviewLiveGatewayOpenResult.Type;
+
+export const PreviewLiveGatewayUnavailableReason = Schema.Literals([
+  "preview_idle",
+  "runtime_unsupported",
+  "session_expired",
+  "target_invalid",
+  "target_not_loopback",
+  "target_protocol_unsupported",
+]);
+export type PreviewLiveGatewayUnavailableReason = typeof PreviewLiveGatewayUnavailableReason.Type;
+
+export class PreviewLiveGatewayUnavailableError extends Schema.TaggedErrorClass<PreviewLiveGatewayUnavailableError>()(
+  "PreviewLiveGatewayUnavailableError",
+  {
+    threadId: ThreadId,
+    tabId: PreviewTabId,
+    reason: PreviewLiveGatewayUnavailableReason,
+  },
+) {
+  override get message(): string {
+    return `Live preview gateway is unavailable (${this.reason}): thread=${this.threadId}, tab=${this.tabId}`;
+  }
+}
 
 const PreviewEventBaseSchema = Schema.Struct({
   threadId: TrimmedNonEmptyString,

--- a/packages/contracts/src/previewAnnotation.test.ts
+++ b/packages/contracts/src/previewAnnotation.test.ts
@@ -1,0 +1,211 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+
+import { PreviewAnnotationPayloadSchema } from "./previewAnnotation.ts";
+
+const decode = Schema.decodeUnknownSync(PreviewAnnotationPayloadSchema);
+
+const legacyAnnotation = {
+  id: "annotation_1",
+  pageUrl: "http://localhost:3000",
+  pageTitle: "Example",
+  comment: "Tighten this area.",
+  elements: [],
+  regions: [{ id: "region_1", rect: { x: 10, y: 20, width: 100, height: 80 } }],
+  strokes: [],
+  styleChanges: [],
+  screenshot: null,
+  createdAt: "2026-06-11T00:00:00.000Z",
+} as const;
+
+const pickedElement = {
+  pageUrl: "http://localhost:3000",
+  pageTitle: "Example",
+  tagName: "button",
+  selector: "button.submit",
+  htmlPreview: '<button class="submit">Save</button>',
+  componentName: "SubmitButton",
+  source: {
+    functionName: "SubmitButton",
+    fileName: "/repo/src/SubmitButton.tsx",
+    lineNumber: 12,
+    columnNumber: 5,
+  },
+  stack: [],
+  styles: ".submit { color: white; }",
+  pickedAt: "2026-06-11T00:00:00.000Z",
+} as const;
+
+describe("PreviewAnnotationPayloadSchema", () => {
+  it("continues to decode the legacy desktop payload unchanged", () => {
+    expect(decode(legacyAnnotation)).toEqual(legacyAnnotation);
+  });
+
+  it("decodes portable source, snapshot, callout, and editable-vector metadata", () => {
+    const annotation = {
+      ...legacyAnnotation,
+      schemaVersion: 1,
+      source: {
+        kind: "preview",
+        url: "http://localhost:3000",
+        title: "Example",
+      },
+      elements: [
+        {
+          id: "element_1",
+          element: pickedElement,
+          rect: { x: 40, y: 20, width: 120, height: 48 },
+        },
+      ],
+      callouts: [
+        {
+          id: "callout_1",
+          number: 1,
+          comment: "Move this action.",
+          anchor: { kind: "point", point: { x: 0.2, y: 0.3 } },
+        },
+        {
+          id: "callout_2",
+          number: 2,
+          comment: "Reduce this gap.",
+          anchor: {
+            kind: "region",
+            rect: { x: 0.4, y: 0.1, width: 0.3, height: 0.2 },
+          },
+        },
+        {
+          id: "callout_3",
+          number: 3,
+          comment: "Use the primary action style.",
+          anchor: {
+            kind: "element",
+            targetId: "element_1",
+            rect: { x: 0.1, y: 0.7, width: 0.4, height: 0.2 },
+          },
+        },
+      ],
+      editable: {
+        version: 1,
+        coordinateSpace: "normalized",
+        strokes: [
+          {
+            id: "stroke_1",
+            color: "#7c3aed",
+            width: 0.01,
+            points: [
+              { x: 0.1, y: 0.2 },
+              { x: 0.2, y: 0.3 },
+            ],
+            bounds: { x: 0.08, y: 0.18, width: 0.14, height: 0.14 },
+          },
+        ],
+      },
+      screenshot: {
+        dataUrl: "data:image/png;base64,AA==",
+        width: 800,
+        height: 600,
+        cropRect: { x: 20, y: 30, width: 400, height: 300 },
+        scale: 2,
+        pageRevision: "revision_4",
+      },
+    } as const;
+
+    expect(decode(annotation)).toEqual(annotation);
+  });
+
+  it("accepts an arbitrary image source", () => {
+    expect(
+      decode({
+        ...legacyAnnotation,
+        schemaVersion: 1,
+        source: { kind: "image", name: "checkout.png" },
+      }).source,
+    ).toEqual({ kind: "image", name: "checkout.png" });
+  });
+
+  it("rejects non-finite and out-of-bounds normalized anchors", () => {
+    expect(() =>
+      decode({
+        ...legacyAnnotation,
+        callouts: [
+          {
+            id: "callout_nan",
+            number: 1,
+            comment: "",
+            anchor: { kind: "point", point: { x: Number.NaN, y: 0.5 } },
+          },
+        ],
+      }),
+    ).toThrow();
+
+    expect(() =>
+      decode({
+        ...legacyAnnotation,
+        callouts: [
+          {
+            id: "callout_overflow",
+            number: 1,
+            comment: "",
+            anchor: {
+              kind: "region",
+              rect: { x: 0.8, y: 0.2, width: 0.3, height: 0.2 },
+            },
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects zero-sized regions and non-positive callout numbers", () => {
+    expect(() =>
+      decode({
+        ...legacyAnnotation,
+        callouts: [
+          {
+            id: "callout_zero",
+            number: 0,
+            comment: "",
+            anchor: {
+              kind: "region",
+              rect: { x: 0.2, y: 0.2, width: 0, height: 0.2 },
+            },
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-normalized editable strokes and invalid screenshot scale", () => {
+    expect(() =>
+      decode({
+        ...legacyAnnotation,
+        editable: {
+          version: 1,
+          coordinateSpace: "normalized",
+          strokes: [
+            {
+              id: "stroke_overflow",
+              color: "#000000",
+              width: 0.01,
+              points: [{ x: 1.1, y: 0.5 }],
+              bounds: { x: 0.1, y: 0.1, width: 0.2, height: 0.2 },
+            },
+          ],
+        },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      decode({
+        ...legacyAnnotation,
+        screenshot: {
+          dataUrl: "data:image/png;base64,AA==",
+          width: 100,
+          height: 100,
+          cropRect: { x: 0, y: 0, width: 100, height: 100 },
+          scale: 0,
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/contracts/src/previewAnnotation.ts
+++ b/packages/contracts/src/previewAnnotation.ts
@@ -1,0 +1,380 @@
+import * as Schema from "effect/Schema";
+
+/**
+ * Single stack frame captured by react-grab's `getElementContext`. We surface
+ * the source file/line so coding agents can jump straight to the JSX that
+ * produced the picked DOM node.
+ */
+export interface PickedElementStackFrame {
+  functionName: string | null;
+  fileName: string | null;
+  lineNumber: number | null;
+  columnNumber: number | null;
+}
+
+export const PickedElementStackFrameSchema: Schema.Codec<PickedElementStackFrame> = Schema.Struct({
+  functionName: Schema.NullOr(Schema.String),
+  fileName: Schema.NullOr(Schema.String),
+  lineNumber: Schema.NullOr(Schema.Number),
+  columnNumber: Schema.NullOr(Schema.Number),
+});
+
+/**
+ * A successful element pick from the preview webview. All fields are
+ * best-effort — pages that don't ship a React fiber tree (or aren't running
+ * in dev) will still produce a usable payload (selector + html preview),
+ * just without component / source attribution.
+ */
+export interface PickedElementPayload {
+  /** URL of the page the element was picked on. */
+  pageUrl: string;
+  /** Optional `<title>` of that page (best-effort). */
+  pageTitle: string | null;
+  /** Lowercase tag name, e.g. `"button"`. */
+  tagName: string;
+  /** CSS selector resolving back to the element on a re-render. */
+  selector: string | null;
+  /** Truncated outer-HTML preview (matches react-grab's `htmlPreview`). */
+  htmlPreview: string;
+  /** Nearest React component display name, or null when unavailable. */
+  componentName: string | null;
+  /** First source-mapped stack frame (file + line of the JSX source). */
+  source: PickedElementStackFrame | null;
+  /** Full owner-stack frames; can be empty. Useful for richer context. */
+  stack: ReadonlyArray<PickedElementStackFrame>;
+  /** Author CSS only (UA defaults stripped) — react-grab's `styles`. */
+  styles: string;
+  /** Wall-clock pick time as ISO-8601 string. */
+  pickedAt: string;
+}
+
+export const PickedElementPayloadSchema: Schema.Codec<PickedElementPayload> = Schema.Struct({
+  pageUrl: Schema.String,
+  pageTitle: Schema.NullOr(Schema.String),
+  tagName: Schema.String,
+  selector: Schema.NullOr(Schema.String),
+  htmlPreview: Schema.String,
+  componentName: Schema.NullOr(Schema.String),
+  source: Schema.NullOr(PickedElementStackFrameSchema),
+  stack: Schema.Array(PickedElementStackFrameSchema),
+  styles: Schema.String,
+  pickedAt: Schema.String,
+});
+
+/** Legacy preview geometry measured in viewport-relative CSS pixels. */
+export interface PreviewAnnotationRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export const PreviewAnnotationRectSchema: Schema.Codec<PreviewAnnotationRect> = Schema.Struct({
+  x: Schema.Number,
+  y: Schema.Number,
+  width: Schema.Number,
+  height: Schema.Number,
+});
+
+/** Legacy preview point measured in viewport-relative CSS pixels. */
+export interface PreviewAnnotationPoint {
+  x: number;
+  y: number;
+}
+
+export const PreviewAnnotationPointSchema: Schema.Codec<PreviewAnnotationPoint> = Schema.Struct({
+  x: Schema.Number,
+  y: Schema.Number,
+});
+
+export interface PreviewAnnotationElementTarget {
+  id: string;
+  element: PickedElementPayload;
+  rect: PreviewAnnotationRect;
+}
+
+export const PreviewAnnotationElementTargetSchema: Schema.Codec<PreviewAnnotationElementTarget> =
+  Schema.Struct({
+    id: Schema.String,
+    element: PickedElementPayloadSchema,
+    rect: PreviewAnnotationRectSchema,
+  });
+
+export interface PreviewAnnotationRegionTarget {
+  id: string;
+  rect: PreviewAnnotationRect;
+}
+
+export const PreviewAnnotationRegionTargetSchema: Schema.Codec<PreviewAnnotationRegionTarget> =
+  Schema.Struct({
+    id: Schema.String,
+    rect: PreviewAnnotationRectSchema,
+  });
+
+export interface PreviewAnnotationStrokeTarget {
+  id: string;
+  color: string;
+  width: number;
+  points: ReadonlyArray<PreviewAnnotationPoint>;
+  bounds: PreviewAnnotationRect;
+}
+
+export const PreviewAnnotationStrokeTargetSchema: Schema.Codec<PreviewAnnotationStrokeTarget> =
+  Schema.Struct({
+    id: Schema.String,
+    color: Schema.String,
+    width: Schema.Number,
+    points: Schema.Array(PreviewAnnotationPointSchema),
+    bounds: PreviewAnnotationRectSchema,
+  });
+
+export interface PreviewAnnotationStyleChange {
+  targetId: string;
+  selector: string | null;
+  property: string;
+  previousValue: string;
+  value: string;
+}
+
+export const PreviewAnnotationStyleChangeSchema: Schema.Codec<PreviewAnnotationStyleChange> =
+  Schema.Struct({
+    targetId: Schema.String,
+    selector: Schema.NullOr(Schema.String),
+    property: Schema.String,
+    previousValue: Schema.String,
+    value: Schema.String,
+  });
+
+const NormalizedCoordinateSchema = Schema.Finite.check(
+  Schema.isBetween({ minimum: 0, maximum: 1 }),
+);
+const PositiveNormalizedDistanceSchema = NormalizedCoordinateSchema.check(Schema.isGreaterThan(0));
+
+/** A point normalized against the final flattened annotation image. */
+export interface PreviewAnnotationNormalizedPoint {
+  x: number;
+  y: number;
+}
+
+export const PreviewAnnotationNormalizedPointSchema: Schema.Codec<PreviewAnnotationNormalizedPoint> =
+  Schema.Struct({
+    x: NormalizedCoordinateSchema,
+    y: NormalizedCoordinateSchema,
+  });
+
+/** A rectangle normalized against the final flattened annotation image. */
+export interface PreviewAnnotationNormalizedRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const normalizedRectBoundsFilter = Schema.makeFilter(
+  (rect: PreviewAnnotationNormalizedRect) =>
+    (rect.x + rect.width <= 1 && rect.y + rect.height <= 1) ||
+    "Normalized annotation rectangles must fit within the flattened image.",
+);
+
+export const PreviewAnnotationNormalizedRectSchema: Schema.Codec<PreviewAnnotationNormalizedRect> =
+  Schema.Struct({
+    x: NormalizedCoordinateSchema,
+    y: NormalizedCoordinateSchema,
+    width: PositiveNormalizedDistanceSchema,
+    height: PositiveNormalizedDistanceSchema,
+  }).check(normalizedRectBoundsFilter);
+
+export interface PreviewAnnotationPointAnchor {
+  kind: "point";
+  point: PreviewAnnotationNormalizedPoint;
+}
+
+export const PreviewAnnotationPointAnchorSchema: Schema.Codec<PreviewAnnotationPointAnchor> =
+  Schema.Struct({
+    kind: Schema.Literal("point"),
+    point: PreviewAnnotationNormalizedPointSchema,
+  });
+
+export interface PreviewAnnotationRegionAnchor {
+  kind: "region";
+  rect: PreviewAnnotationNormalizedRect;
+}
+
+export const PreviewAnnotationRegionAnchorSchema: Schema.Codec<PreviewAnnotationRegionAnchor> =
+  Schema.Struct({
+    kind: Schema.Literal("region"),
+    rect: PreviewAnnotationNormalizedRectSchema,
+  });
+
+export interface PreviewAnnotationElementAnchor {
+  kind: "element";
+  /** References a target in the payload's legacy-compatible `elements` array. */
+  targetId: string;
+  rect: PreviewAnnotationNormalizedRect;
+}
+
+export const PreviewAnnotationElementAnchorSchema: Schema.Codec<PreviewAnnotationElementAnchor> =
+  Schema.Struct({
+    kind: Schema.Literal("element"),
+    targetId: Schema.String,
+    rect: PreviewAnnotationNormalizedRectSchema,
+  });
+
+export type PreviewAnnotationCalloutAnchor =
+  | PreviewAnnotationPointAnchor
+  | PreviewAnnotationRegionAnchor
+  | PreviewAnnotationElementAnchor;
+
+export const PreviewAnnotationCalloutAnchorSchema: Schema.Codec<PreviewAnnotationCalloutAnchor> =
+  Schema.Union([
+    PreviewAnnotationPointAnchorSchema,
+    PreviewAnnotationRegionAnchorSchema,
+    PreviewAnnotationElementAnchorSchema,
+  ]);
+
+export interface PreviewAnnotationCallout {
+  id: string;
+  /** Visible number burned into the flattened image. */
+  number: number;
+  comment: string;
+  anchor: PreviewAnnotationCalloutAnchor;
+}
+
+export const PreviewAnnotationCalloutSchema: Schema.Codec<PreviewAnnotationCallout> = Schema.Struct(
+  {
+    id: Schema.String,
+    number: Schema.Int.check(Schema.isGreaterThanOrEqualTo(1)),
+    comment: Schema.String,
+    anchor: PreviewAnnotationCalloutAnchorSchema,
+  },
+);
+
+export interface PreviewAnnotationEditableStrokeV1 {
+  id: string;
+  color: string;
+  /**
+   * Stroke width normalized against the shorter side of the flattened image.
+   */
+  width: number;
+  points: ReadonlyArray<PreviewAnnotationNormalizedPoint>;
+  bounds: PreviewAnnotationNormalizedRect;
+}
+
+export const PreviewAnnotationEditableStrokeV1Schema: Schema.Codec<PreviewAnnotationEditableStrokeV1> =
+  Schema.Struct({
+    id: Schema.String,
+    color: Schema.String,
+    width: PositiveNormalizedDistanceSchema,
+    points: Schema.Array(PreviewAnnotationNormalizedPointSchema),
+    bounds: PreviewAnnotationNormalizedRectSchema,
+  });
+
+export interface PreviewAnnotationEditableVectorV1 {
+  version: 1;
+  coordinateSpace: "normalized";
+  strokes: ReadonlyArray<PreviewAnnotationEditableStrokeV1>;
+}
+
+export const PreviewAnnotationEditableVectorV1Schema: Schema.Codec<PreviewAnnotationEditableVectorV1> =
+  Schema.Struct({
+    version: Schema.Literal(1),
+    coordinateSpace: Schema.Literal("normalized"),
+    strokes: Schema.Array(PreviewAnnotationEditableStrokeV1Schema),
+  });
+
+export interface PreviewAnnotationImageSource {
+  kind: "image";
+  name: string | null;
+}
+
+export const PreviewAnnotationImageSourceSchema: Schema.Codec<PreviewAnnotationImageSource> =
+  Schema.Struct({
+    kind: Schema.Literal("image"),
+    name: Schema.NullOr(Schema.String),
+  });
+
+export interface PreviewAnnotationPreviewSource {
+  kind: "preview";
+  url: string;
+  title: string | null;
+}
+
+export const PreviewAnnotationPreviewSourceSchema: Schema.Codec<PreviewAnnotationPreviewSource> =
+  Schema.Struct({
+    kind: Schema.Literal("preview"),
+    url: Schema.String,
+    title: Schema.NullOr(Schema.String),
+  });
+
+export type PreviewAnnotationSource = PreviewAnnotationImageSource | PreviewAnnotationPreviewSource;
+
+export const PreviewAnnotationSourceSchema: Schema.Codec<PreviewAnnotationSource> = Schema.Union([
+  PreviewAnnotationImageSourceSchema,
+  PreviewAnnotationPreviewSourceSchema,
+]);
+
+export interface PreviewAnnotationScreenshot {
+  dataUrl: string;
+  /** Encoded image width in pixels. */
+  width: number;
+  /** Encoded image height in pixels. */
+  height: number;
+  /** Crop in the source preview's viewport-relative CSS-pixel coordinate space. */
+  cropRect: PreviewAnnotationRect;
+  /** Encoded-image pixels per source coordinate unit, when known. */
+  scale?: number;
+  /** Host-provided page revision captured with this exact frame, when known. */
+  pageRevision?: string | null;
+}
+
+export const PreviewAnnotationScreenshotSchema: Schema.Codec<PreviewAnnotationScreenshot> =
+  Schema.Struct({
+    dataUrl: Schema.String,
+    width: Schema.Number,
+    height: Schema.Number,
+    cropRect: PreviewAnnotationRectSchema,
+    scale: Schema.optionalKey(Schema.Finite.check(Schema.isGreaterThan(0))),
+    pageRevision: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  });
+
+/**
+ * A submitted preview or image annotation. Legacy arrays remain required so
+ * persisted drafts and mixed-version desktop hosts continue to round-trip.
+ * New producers may additionally provide normalized numbered callouts and an
+ * editable vector document.
+ */
+export interface PreviewAnnotationPayload {
+  id: string;
+  pageUrl: string;
+  pageTitle: string | null;
+  comment: string;
+  elements: ReadonlyArray<PreviewAnnotationElementTarget>;
+  regions: ReadonlyArray<PreviewAnnotationRegionTarget>;
+  strokes: ReadonlyArray<PreviewAnnotationStrokeTarget>;
+  styleChanges: ReadonlyArray<PreviewAnnotationStyleChange>;
+  screenshot: PreviewAnnotationScreenshot | null;
+  createdAt: string;
+  schemaVersion?: 1;
+  source?: PreviewAnnotationSource;
+  callouts?: ReadonlyArray<PreviewAnnotationCallout>;
+  editable?: PreviewAnnotationEditableVectorV1 | null;
+}
+
+export const PreviewAnnotationPayloadSchema: Schema.Codec<PreviewAnnotationPayload> = Schema.Struct(
+  {
+    id: Schema.String,
+    pageUrl: Schema.String,
+    pageTitle: Schema.NullOr(Schema.String),
+    comment: Schema.String,
+    elements: Schema.Array(PreviewAnnotationElementTargetSchema),
+    regions: Schema.Array(PreviewAnnotationRegionTargetSchema),
+    strokes: Schema.Array(PreviewAnnotationStrokeTargetSchema),
+    styleChanges: Schema.Array(PreviewAnnotationStyleChangeSchema),
+    screenshot: Schema.NullOr(PreviewAnnotationScreenshotSchema),
+    createdAt: Schema.String,
+    schemaVersion: Schema.optionalKey(Schema.Literal(1)),
+    source: Schema.optionalKey(PreviewAnnotationSourceSchema),
+    callouts: Schema.optionalKey(Schema.Array(PreviewAnnotationCalloutSchema)),
+    editable: Schema.optionalKey(Schema.NullOr(PreviewAnnotationEditableVectorV1Schema)),
+  },
+);

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
 
-import { EnvironmentId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { EnvironmentId, NonNegativeInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import {
   PREVIEW_VIEWPORT_MAX_AREA,
   PreviewRenderedViewportSize,
@@ -504,6 +504,15 @@ export const PreviewAutomationElement = Schema.Struct({
 });
 export type PreviewAutomationElement = typeof PreviewAutomationElement.Type;
 
+export const PreviewAutomationSnapshotViewport = Schema.Struct({
+  width: Schema.Int.check(Schema.isGreaterThan(0)),
+  height: Schema.Int.check(Schema.isGreaterThan(0)),
+  scrollX: Schema.Finite,
+  scrollY: Schema.Finite,
+  devicePixelRatio: Schema.Finite.check(Schema.isGreaterThan(0)),
+});
+export type PreviewAutomationSnapshotViewport = typeof PreviewAutomationSnapshotViewport.Type;
+
 export const PreviewAutomationConsoleEntry = Schema.Struct({
   level: Schema.String,
   text: Schema.String,
@@ -536,6 +545,12 @@ export const PreviewAutomationSnapshot = Schema.Struct({
   url: Schema.String,
   title: Schema.String,
   loading: Schema.Boolean,
+  /** Missing for desktop hosts predating human review snapshots. */
+  viewport: Schema.optional(PreviewAutomationSnapshotViewport),
+  /** Host-provided identifier for the exact rendered page frame, when available. */
+  pageRevision: Schema.optional(TrimmedNonEmptyString),
+  /** Host capture time, when available. */
+  capturedAt: Schema.optional(Schema.String),
   visibleText: Schema.String,
   interactiveElements: Schema.Array(PreviewAutomationElement),
   accessibilityTree: Schema.Unknown,
@@ -547,9 +562,127 @@ export const PreviewAutomationSnapshot = Schema.Struct({
     data: Schema.String,
     width: Schema.Int,
     height: Schema.Int,
+    /** Encoded-image pixels per viewport CSS pixel. Missing on legacy hosts. */
+    scale: Schema.optional(Schema.Finite.check(Schema.isGreaterThan(0))),
   }),
 });
 export type PreviewAutomationSnapshot = typeof PreviewAutomationSnapshot.Type;
+
+/**
+ * The human review capture path deliberately decodes only fields that can be
+ * shown or attached. Schema.Struct accepts the extra diagnostics returned by
+ * legacy hosts, so mixed-version desktop/server pairs remain compatible.
+ */
+export const PreviewAutomationReviewSnapshot = Schema.Struct({
+  url: PreviewAutomationSnapshot.fields.url,
+  title: PreviewAutomationSnapshot.fields.title,
+  loading: PreviewAutomationSnapshot.fields.loading,
+  viewport: PreviewAutomationSnapshot.fields.viewport,
+  pageRevision: PreviewAutomationSnapshot.fields.pageRevision,
+  capturedAt: PreviewAutomationSnapshot.fields.capturedAt,
+  interactiveElements: PreviewAutomationSnapshot.fields.interactiveElements,
+  screenshot: PreviewAutomationSnapshot.fields.screenshot,
+});
+export type PreviewAutomationReviewSnapshot = typeof PreviewAutomationReviewSnapshot.Type;
+
+export const PREVIEW_REVIEW_SNAPSHOT_MAX_ELEMENTS = 200;
+export const PREVIEW_REVIEW_SNAPSHOT_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const PREVIEW_REVIEW_SNAPSHOT_MAX_BASE64_CHARS =
+  Math.ceil(PREVIEW_REVIEW_SNAPSHOT_MAX_IMAGE_BYTES / 3) * 4;
+export const PREVIEW_REVIEW_SNAPSHOT_MAX_PAGE_REVISION_LENGTH = 128;
+
+const PreviewReviewSnapshotBoundedString = (maximumLength: number) =>
+  Schema.String.check(Schema.isMaxLength(maximumLength));
+const PreviewReviewSnapshotNonNegativeFinite = Schema.Finite.check(
+  Schema.isGreaterThanOrEqualTo(0),
+);
+
+export const PreviewReviewSnapshotInput = Schema.Struct({
+  version: Schema.Literal(1),
+  threadId: ThreadId,
+  tabId: PreviewTabId,
+});
+export type PreviewReviewSnapshotInput = typeof PreviewReviewSnapshotInput.Type;
+
+export const PreviewReviewSnapshotRectV1 = Schema.Struct({
+  x: PreviewReviewSnapshotNonNegativeFinite,
+  y: PreviewReviewSnapshotNonNegativeFinite,
+  width: PreviewReviewSnapshotNonNegativeFinite,
+  height: PreviewReviewSnapshotNonNegativeFinite,
+});
+export type PreviewReviewSnapshotRectV1 = typeof PreviewReviewSnapshotRectV1.Type;
+
+export const PreviewReviewSnapshotElementV1 = Schema.Struct({
+  id: TrimmedNonEmptyString.check(Schema.isMaxLength(128)),
+  tag: PreviewReviewSnapshotBoundedString(64),
+  role: Schema.NullOr(PreviewReviewSnapshotBoundedString(128)),
+  name: PreviewReviewSnapshotBoundedString(1_024),
+  selector: PreviewReviewSnapshotBoundedString(2_048),
+  rect: PreviewReviewSnapshotRectV1,
+});
+export type PreviewReviewSnapshotElementV1 = typeof PreviewReviewSnapshotElementV1.Type;
+
+export const PreviewReviewSnapshotViewportV1 = PreviewAutomationSnapshotViewport;
+export type PreviewReviewSnapshotViewportV1 = typeof PreviewReviewSnapshotViewportV1.Type;
+
+export const PreviewReviewSnapshotScreenshotV1 = Schema.Struct({
+  mimeType: Schema.Literal("image/png"),
+  data: Schema.String.check(Schema.isMaxLength(PREVIEW_REVIEW_SNAPSHOT_MAX_BASE64_CHARS)),
+  width: Schema.Int.check(Schema.isGreaterThan(0)),
+  height: Schema.Int.check(Schema.isGreaterThan(0)),
+  scale: Schema.Finite.check(Schema.isGreaterThan(0)),
+});
+export type PreviewReviewSnapshotScreenshotV1 = typeof PreviewReviewSnapshotScreenshotV1.Type;
+
+export const PreviewReviewSnapshotV1 = Schema.Struct({
+  version: Schema.Literal(1),
+  snapshotId: TrimmedNonEmptyString.check(Schema.isMaxLength(128)),
+  pageRevision: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(PREVIEW_REVIEW_SNAPSHOT_MAX_PAGE_REVISION_LENGTH),
+  ),
+  serverEpoch: TrimmedNonEmptyString,
+  previewRevision: NonNegativeInt,
+  threadId: ThreadId,
+  tabId: PreviewTabId,
+  capturedAt: Schema.String,
+  url: PreviewReviewSnapshotBoundedString(2_048),
+  title: PreviewReviewSnapshotBoundedString(512),
+  loading: Schema.Boolean,
+  viewport: PreviewReviewSnapshotViewportV1,
+  screenshot: PreviewReviewSnapshotScreenshotV1,
+  elements: Schema.Array(PreviewReviewSnapshotElementV1).check(
+    Schema.isMaxLength(PREVIEW_REVIEW_SNAPSHOT_MAX_ELEMENTS),
+  ),
+});
+export type PreviewReviewSnapshotV1 = typeof PreviewReviewSnapshotV1.Type;
+
+export const PreviewReviewSnapshot = PreviewReviewSnapshotV1;
+export type PreviewReviewSnapshot = typeof PreviewReviewSnapshot.Type;
+
+export class PreviewReviewSnapshotTooLargeError extends Schema.TaggedErrorClass<PreviewReviewSnapshotTooLargeError>()(
+  "PreviewReviewSnapshotTooLargeError",
+  {
+    threadId: ThreadId,
+    tabId: PreviewTabId,
+    maximumBytes: Schema.Int.check(Schema.isGreaterThan(0)),
+  },
+) {
+  override get message(): string {
+    return `Preview snapshot image exceeds the ${this.maximumBytes}-byte review limit.`;
+  }
+}
+
+export class PreviewReviewSnapshotMalformedError extends Schema.TaggedErrorClass<PreviewReviewSnapshotMalformedError>()(
+  "PreviewReviewSnapshotMalformedError",
+  {
+    threadId: ThreadId,
+    tabId: PreviewTabId,
+  },
+) {
+  override get message(): string {
+    return "The desktop preview host returned an invalid review snapshot.";
+  }
+}
 
 export const PreviewAutomationRecordingStatus = Schema.Struct({
   tabId: PreviewTabId,
@@ -655,8 +788,9 @@ const PreviewAutomationScopeErrorFields = {
   operation: PreviewAutomationOperation,
   environmentId: EnvironmentId,
   threadId: ThreadId,
-  providerSessionId: TrimmedNonEmptyString,
-  providerInstanceId: ProviderInstanceId,
+  providerSessionId: Schema.optional(TrimmedNonEmptyString),
+  providerInstanceId: Schema.optional(ProviderInstanceId),
+  requesterId: Schema.optional(PreviewAutomationClientId),
 };
 
 const PreviewAutomationRequestErrorFields = {

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -677,6 +677,7 @@ export class PreviewReviewSnapshotMalformedError extends Schema.TaggedErrorClass
   {
     threadId: ThreadId,
     tabId: PreviewTabId,
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {

--- a/packages/contracts/src/previewLiveGateway.test.ts
+++ b/packages/contracts/src/previewLiveGateway.test.ts
@@ -1,0 +1,71 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  PreviewLiveGatewayOpenInput,
+  PreviewLiveGatewayOpenResult,
+  PreviewLiveGatewayUnavailableError,
+} from "./preview.ts";
+
+const decodeInput = Schema.decodeUnknownSync(PreviewLiveGatewayOpenInput);
+const decodeResult = Schema.decodeUnknownSync(PreviewLiveGatewayOpenResult);
+const decodeUnavailable = Schema.decodeUnknownSync(PreviewLiveGatewayUnavailableError);
+
+describe("preview live gateway contracts", () => {
+  it("targets one exact versioned preview tab", () => {
+    expect(
+      decodeInput({
+        version: 1,
+        threadId: "thread-1",
+        tabId: "tab-1",
+      }),
+    ).toEqual({
+      version: 1,
+      threadId: "thread-1",
+      tabId: "tab-1",
+    });
+    expect(() => decodeInput({ version: 1, threadId: "thread-1" })).toThrow();
+  });
+
+  it("accepts only same-environment relative bootstrap URLs", () => {
+    expect(
+      decodeResult({
+        version: 1,
+        relativeUrl: "/api/preview-gateway/bootstrap/opaque-token",
+        expiresAt: 1_785_369_600_000,
+      }),
+    ).toEqual({
+      version: 1,
+      relativeUrl: "/api/preview-gateway/bootstrap/opaque-token",
+      expiresAt: 1_785_369_600_000,
+    });
+    expect(() =>
+      decodeResult({
+        version: 1,
+        relativeUrl: "https://attacker.example/bootstrap",
+        expiresAt: 1_785_369_600_000,
+      }),
+    ).toThrow();
+  });
+
+  it("serializes stable unavailability reasons", () => {
+    for (const reason of [
+      "runtime_unsupported",
+      "session_expired",
+      "target_not_loopback",
+    ] as const) {
+      expect(
+        decodeUnavailable({
+          _tag: "PreviewLiveGatewayUnavailableError",
+          threadId: "thread-1",
+          tabId: "tab-1",
+          reason,
+        }),
+      ).toMatchObject({
+        threadId: "thread-1",
+        tabId: "tab-1",
+        reason,
+      });
+    }
+  });
+});

--- a/packages/contracts/src/previewReview.test.ts
+++ b/packages/contracts/src/previewReview.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as Schema from "effect/Schema";
+
+import {
+  PREVIEW_REVIEW_SNAPSHOT_MAX_ELEMENTS,
+  PreviewAutomationReviewSnapshot,
+  PreviewAutomationSnapshot,
+  PreviewReviewSnapshot,
+  PreviewReviewSnapshotInput,
+} from "./previewAutomation.ts";
+
+const decodeInput = Schema.decodeUnknownSync(PreviewReviewSnapshotInput);
+const decodeSnapshot = Schema.decodeUnknownSync(PreviewReviewSnapshot);
+const decodeAutomationSnapshot = Schema.decodeUnknownSync(PreviewAutomationSnapshot);
+const decodeAutomationReviewSnapshot = Schema.decodeUnknownSync(PreviewAutomationReviewSnapshot);
+
+const reviewSnapshot = {
+  version: 1,
+  snapshotId: "snapshot-1",
+  pageRevision: "page-1",
+  serverEpoch: "server-1",
+  previewRevision: 4,
+  threadId: "thread-1",
+  tabId: "tab-1",
+  capturedAt: "2026-07-30T12:00:00.000Z",
+  url: "http://localhost:5173",
+  title: "T3",
+  loading: false,
+  viewport: {
+    width: 1_280,
+    height: 800,
+    scrollX: 0,
+    scrollY: 120,
+    devicePixelRatio: 2,
+  },
+  screenshot: {
+    mimeType: "image/png",
+    data: "iVBORw0KGgo=",
+    width: 1_280,
+    height: 800,
+    scale: 1,
+  },
+  elements: [
+    {
+      id: "element-1",
+      tag: "button",
+      role: "button",
+      name: "Send",
+      selector: "#send",
+      rect: { x: 12, y: 20, width: 100, height: 40 },
+    },
+  ],
+} as const;
+
+describe("preview review snapshot contracts", () => {
+  it("requires a versioned exact thread and tab target", () => {
+    expect(
+      decodeInput({
+        version: 1,
+        threadId: "thread-1",
+        tabId: "tab-1",
+      }),
+    ).toEqual({
+      version: 1,
+      threadId: "thread-1",
+      tabId: "tab-1",
+    });
+    expect(() => decodeInput({ version: 1, threadId: "thread-1" })).toThrow();
+  });
+
+  it("decodes the compact versioned review result", () => {
+    expect(decodeSnapshot(reviewSnapshot)).toEqual(reviewSnapshot);
+  });
+
+  it("caps semantic elements at the desktop snapshot bound", () => {
+    expect(() =>
+      decodeSnapshot({
+        ...reviewSnapshot,
+        elements: Array.from({ length: PREVIEW_REVIEW_SNAPSHOT_MAX_ELEMENTS + 1 }, (_, index) => ({
+          ...reviewSnapshot.elements[0],
+          id: `element-${index}`,
+        })),
+      }),
+    ).toThrow();
+  });
+
+  it("keeps viewport and image scale optional on mixed-version automation hosts", () => {
+    const legacy = {
+      url: "http://localhost:5173",
+      title: "T3",
+      loading: false,
+      visibleText: "Send",
+      interactiveElements: [],
+      accessibilityTree: {},
+      consoleEntries: [],
+      networkEntries: [],
+      actionTimeline: [],
+      screenshot: {
+        mimeType: "image/png",
+        data: "iVBORw0KGgo=",
+        width: 1_280,
+        height: 800,
+      },
+    } as const;
+    expect(decodeAutomationSnapshot(legacy)).toEqual(legacy);
+    expect(
+      decodeAutomationSnapshot({
+        ...legacy,
+        viewport: reviewSnapshot.viewport,
+        screenshot: reviewSnapshot.screenshot,
+      }),
+    ).toMatchObject({
+      viewport: reviewSnapshot.viewport,
+      screenshot: { scale: 1 },
+    });
+    expect(decodeAutomationReviewSnapshot(legacy)).toEqual({
+      url: legacy.url,
+      title: legacy.title,
+      loading: legacy.loading,
+      interactiveElements: legacy.interactiveElements,
+      screenshot: legacy.screenshot,
+    });
+  });
+});

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -105,6 +105,9 @@ import {
   PreviewCloseInput,
   PreviewError,
   PreviewEvent,
+  PreviewLiveGatewayOpenInput,
+  PreviewLiveGatewayOpenResult,
+  PreviewLiveGatewayUnavailableError,
   PreviewListInput,
   PreviewListResult,
   PreviewNavigateInput,
@@ -120,6 +123,10 @@ import {
   PreviewAutomationHostFocus,
   PreviewAutomationResponse,
   PreviewAutomationStreamEvent,
+  PreviewReviewSnapshot,
+  PreviewReviewSnapshotInput,
+  PreviewReviewSnapshotMalformedError,
+  PreviewReviewSnapshotTooLargeError,
 } from "./previewAutomation.ts";
 import {
   ServerConfigStreamEvent,
@@ -215,6 +222,8 @@ export const WS_METHODS = {
   previewClose: "preview.close",
   previewList: "preview.list",
   previewReportStatus: "preview.reportStatus",
+  previewReviewSnapshot: "preview.reviewSnapshot",
+  previewOpenLiveGateway: "preview.openLiveGateway",
   previewAutomationConnect: "previewAutomation.connect",
   previewAutomationRespond: "previewAutomation.respond",
   previewAutomationFocusHost: "previewAutomation.focusHost",
@@ -644,6 +653,28 @@ export const WsPreviewReportStatusRpc = Rpc.make(WS_METHODS.previewReportStatus,
   error: Schema.Union([PreviewError, EnvironmentAuthorizationError]),
 });
 
+export const WsPreviewReviewSnapshotRpc = Rpc.make(WS_METHODS.previewReviewSnapshot, {
+  payload: PreviewReviewSnapshotInput,
+  success: PreviewReviewSnapshot,
+  error: Schema.Union([
+    PreviewError,
+    PreviewAutomationError,
+    PreviewReviewSnapshotMalformedError,
+    PreviewReviewSnapshotTooLargeError,
+    EnvironmentAuthorizationError,
+  ]),
+});
+
+export const WsPreviewOpenLiveGatewayRpc = Rpc.make(WS_METHODS.previewOpenLiveGateway, {
+  payload: PreviewLiveGatewayOpenInput,
+  success: PreviewLiveGatewayOpenResult,
+  error: Schema.Union([
+    PreviewError,
+    PreviewLiveGatewayUnavailableError,
+    EnvironmentAuthorizationError,
+  ]),
+});
+
 export const WsPreviewAutomationConnectRpc = Rpc.make(WS_METHODS.previewAutomationConnect, {
   payload: PreviewAutomationHost,
   success: PreviewAutomationStreamEvent,
@@ -846,6 +877,8 @@ export const WsRpcGroup = RpcGroup.make(
   WsPreviewCloseRpc,
   WsPreviewListRpc,
   WsPreviewReportStatusRpc,
+  WsPreviewReviewSnapshotRpc,
+  WsPreviewOpenLiveGatewayRpc,
   WsPreviewAutomationConnectRpc,
   WsPreviewAutomationRespondRpc,
   WsPreviewAutomationFocusHostRpc,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,9 @@ importers:
       react-native-svg:
         specifier: 15.15.4
         version: 15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-view-shot:
+        specifier: 5.1.0
+        version: 5.1.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-webview:
         specifier: ^13.16.1
         version: 13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -5544,6 +5547,10 @@ packages:
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -5961,6 +5968,9 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -7183,6 +7193,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -9021,6 +9035,13 @@ packages:
     peerDependencies:
       react-native: '*'
 
+  react-native-view-shot@5.1.0:
+    resolution: {integrity: sha512-JZgElCD82aO+hejIF/leUzI7JufL9mgJ6ChzGWIcdZ2ajpaEvvSnvIcw0qD32XWkrbId8wfSbyz/4u/ulTQzQA==}
+    engines: {node: '>=20', npm: '>=10'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-native: '>=0.76.0'
+
   react-native-webview@13.16.1:
     resolution: {integrity: sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==}
     peerDependencies:
@@ -9704,6 +9725,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
@@ -10072,6 +10096,9 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
@@ -15846,6 +15873,8 @@ snapshots:
 
   base-64@1.0.0: {}
 
+  base64-arraybuffer@1.0.2: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.33: {}
@@ -16263,6 +16292,10 @@ snapshots:
       uncrypto: 0.1.3
 
   crypto-js@4.2.0: {}
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -17845,6 +17878,11 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   http-cache-semantics@4.2.0: {}
 
@@ -19942,6 +19980,12 @@ snapshots:
     dependencies:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
+  react-native-view-shot@5.1.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+    dependencies:
+      html2canvas: 1.4.1
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+
   react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       escape-string-regexp: 4.0.0
@@ -20971,6 +21015,10 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   throat@5.0.0: {}
 
   timestring@6.0.0: {}
@@ -21288,6 +21336,10 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@14.0.1: {}
 


### PR DESCRIPTION
## What changed

- Adds an iPad browser pane with split and full-screen layouts, tab management, navigation controls, and direct LAN or Tailscale loading.
- Adds an authenticated live-preview gateway for loopback desktop previews so remote mobile clients and T3 Connect can reach the same development server.
- Adds screenshot markup with numbered callouts, regions, freehand ink, editable attachment state, and shared structured annotation context.
- Extends desktop preview capture with viewport, page revision, element bounds, and human-review snapshots.
- Preserves raw Vite query flags through the gateway so client bootstrap and Fast Refresh work in the iPad WebView.
- Documents the mobile preview and markup workflow.

## Why

Mobile could see preview metadata but could not reliably browse, annotate, or refresh the active desktop preview. Loopback URLs were unreachable from iPad, remote paths lacked an authenticated bridge, and URL normalization changed Vite flag queries such as `?url` into `?url=`, preventing the client entry from hydrating and registering JavaScript HMR modules.

## Impact

Users can review the active app from iPad, work across local network, Tailscale, or T3 Connect paths, annotate a frozen frame, and send both the rendered image and source-aware context to an agent. Browser state remains isolated per mobile WebView while preview tab metadata stays synchronized through the existing server model.

## Validation

- 34 changed test files: 443 tests passed
- Server typecheck passed
- Mobile typecheck passed
- Diff whitespace check passed
- Verified the workflow on a connected iPad and desktop preview

Implemented with GPT-5.6-Sol through the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live preview gateway and image markup to mobile app
> - Adds a live browser preview pane to the mobile app via a new `MobileLivePreview` WebView component with DOM capture, navigation controls, and a `ThreadPreviewRouteScreen` that renders inline or fullscreen depending on layout.
> - Introduces a server-side reverse proxy gateway (`LiveGateway`, `LiveGatewayHttp`) that issues single-use bootstrap tokens and leases to securely proxy loopback desktop preview servers to mobile clients over HTTPS.
> - Adds two new WebSocket RPC endpoints: `previewReviewSnapshot` (compact, bounded snapshot for review) and `previewOpenLiveGateway` (returns a short-lived bootstrap URL); both require the orchestration operate scope.
> - Adds image markup/annotation support: a new `ImageMarkupModal` lets users draw callouts on draft images; annotated attachments are flattened to PNG and stored with the original for re-editing; annotation prompts are appended to outgoing messages.
> - Extends the desktop `PreviewManager` with a `review` snapshot mode that omits accessibility trees and diagnostics, caps screenshot pixels to ~2M, and normalizes interactive elements.
> - Adds two repair migrations (036, 037) to backfill missing `scopes` and `proof_key_thumbprint` auth columns on databases that missed prior migrations.
> - Risk: live gateway leases are in-memory only; a server restart invalidates all active preview sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a77ca3f. 78 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->