### PR TITLE
fix(server): stopping a Claude turn no longer surfaces a raw stream error

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1515,13 +1515,11 @@ describe("ClaudeAdapterLive", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
-      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
 
-      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
-        Effect.sync(() => {
-          runtimeEvents.push(event);
-        }),
-      ).pipe(Effect.forkChild);
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
 
       const session = yield* adapter.startSession({
         threadId: THREAD_ID,
@@ -1546,10 +1544,7 @@ describe("ClaudeAdapterLive", () => {
         uuid: "result-ede",
       } as unknown as SDKMessage);
 
-      yield* Effect.yieldNow;
-      yield* Effect.yieldNow;
-      yield* Effect.yieldNow;
-      runtimeEventsFiber.interruptUnsafe();
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
 
       const runtimeError = runtimeEvents.find((event) => event.type === "runtime.error");
       assert.equal(runtimeError, undefined);
@@ -1887,13 +1882,11 @@ describe("ClaudeAdapterLive", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
-      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
 
-      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
-        Effect.sync(() => {
-          runtimeEvents.push(event);
-        }),
-      ).pipe(Effect.forkChild);
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "session.exited",
+      ).pipe(Stream.runCollect, Effect.forkChild);
 
       yield* adapter.startSession({
         threadId: THREAD_ID,
@@ -1912,10 +1905,7 @@ describe("ClaudeAdapterLive", () => {
 
       harness.query.fail(new Error("Claude Code process exited with code 143"));
 
-      yield* Effect.yieldNow;
-      yield* Effect.yieldNow;
-      yield* Effect.yieldNow;
-      runtimeEventsFiber.interruptUnsafe();
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
 
       const runtimeError = runtimeEvents.find((event) => event.type === "runtime.error");
       assert.equal(runtimeError, undefined);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1511,6 +1511,61 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("treats an error result as interrupted when the user requested a stop", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      yield* adapter.interruptTurn(THREAD_ID);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null"],
+        session_id: "sdk-session-ede",
+        uuid: "result-ede",
+      } as unknown as SDKMessage);
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      runtimeEventsFiber.interruptUnsafe();
+
+      const runtimeError = runtimeEvents.find((event) => event.type === "runtime.error");
+      assert.equal(runtimeError, undefined);
+
+      const turnCompleted = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(String(turnCompleted.turnId), String(turn.turnId));
+        assert.equal(turnCompleted.payload.state, "interrupted");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("interruptTurn settles every acknowledged live task before interrupting", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -1822,6 +1877,58 @@ describe("ClaudeAdapterLive", () => {
       const sessions = yield* adapter.listSessions();
       assert.equal(sessions.length, 0);
       assert.equal(harness.query.closeCalls, 1);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("treats a stream failure as an interruption when the user requested a stop", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "hello",
+        attachments: [],
+      });
+
+      yield* adapter.interruptTurn(THREAD_ID, turn.turnId);
+      assert.equal(harness.query.interruptCalls.length, 1);
+
+      harness.query.fail(new Error("Claude Code process exited with code 143"));
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      runtimeEventsFiber.interruptUnsafe();
+
+      const runtimeError = runtimeEvents.find((event) => event.type === "runtime.error");
+      assert.equal(runtimeError, undefined);
+
+      const turnCompleted = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(String(turnCompleted.turnId), String(turn.turnId));
+        assert.equal(turnCompleted.payload.state, "interrupted");
+        assert.equal(turnCompleted.payload.errorMessage, "Claude runtime interrupted.");
+      }
+
+      assert.equal(yield* adapter.hasSession(THREAD_ID), false);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
 import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -59,6 +60,9 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   public readonly setModelCalls: Array<string | undefined> = [];
   public readonly setPermissionModeCalls: Array<string> = [];
   public readonly setMaxThinkingTokensCalls: Array<number | null> = [];
+  public interruptFailure: unknown | undefined;
+  public setModelImplementation: (model?: string) => Promise<void> = async () => {};
+  public stopTaskImplementation: (taskId: string) => Promise<void> = async () => {};
   public closeCalls = 0;
 
   emit(message: SDKMessage): void {
@@ -97,14 +101,19 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
 
   readonly interrupt = async (): Promise<void> => {
     this.interruptCalls.push(undefined);
+    if (this.interruptFailure !== undefined) {
+      throw this.interruptFailure;
+    }
   };
 
   readonly stopTask = async (taskId: string): Promise<void> => {
     this.stopTaskCalls.push(taskId);
+    await this.stopTaskImplementation(taskId);
   };
 
   readonly setModel = async (model?: string): Promise<void> => {
     this.setModelCalls.push(model);
+    await this.setModelImplementation(model);
   };
 
   readonly setPermissionMode = async (mode: PermissionMode): Promise<void> => {
@@ -1561,6 +1570,333 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("keeps stop intent while a turn model is being prepared", () => {
+    const harness = makeHarness();
+    const setModelStarted = Promise.withResolvers<void>();
+    const releaseSetModel = Promise.withResolvers<void>();
+    harness.query.setModelImplementation = async () => {
+      setModelStarted.resolve();
+      await releaseSetModel.promise;
+    };
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
+      const sendTurnFiber = yield* adapter
+        .sendTurn({
+          threadId: THREAD_ID,
+          input: "hello",
+          attachments: [],
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("claudeAgent"),
+            "claude-opus-4-6",
+          ),
+        })
+        .pipe(Effect.forkChild);
+
+      yield* Effect.promise(() => setModelStarted.promise);
+      yield* adapter.interruptTurn(THREAD_ID);
+      assert.equal(harness.query.interruptCalls.length, 1);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["Unrecognized failure after stop"],
+        session_id: "sdk-session-preparing-stop",
+        uuid: "result-preparing-stop",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.equal(
+        runtimeEvents.find((event) => event.type === "runtime.error"),
+        undefined,
+      );
+      const turnCompleted = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(turnCompleted.payload.state, "interrupted");
+        assert.notEqual(turnCompleted.turnId, undefined);
+      }
+
+      releaseSetModel.resolve();
+      const sendTurnExit = yield* Fiber.await(sendTurnFiber);
+      assert.equal(sendTurnExit._tag, "Failure");
+      if (sendTurnExit._tag === "Failure") {
+        assert.isTrue(Cause.hasInterruptsOnly(sendTurnExit.cause));
+      }
+      yield* adapter.stopSession(THREAD_ID);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("treats a preparation rejection after Stop as cancellation", () => {
+    const harness = makeHarness();
+    const setModelStarted = Promise.withResolvers<void>();
+    const releaseSetModel = Promise.withResolvers<void>();
+    harness.query.setModelImplementation = async () => {
+      setModelStarted.resolve();
+      await releaseSetModel.promise;
+      throw new Error("setModel canceled");
+    };
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const sendTurnFiber = yield* adapter
+        .sendTurn({
+          threadId: THREAD_ID,
+          input: "hello",
+          attachments: [],
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("claudeAgent"),
+            "claude-opus-4-6",
+          ),
+        })
+        .pipe(Effect.forkChild);
+
+      yield* Effect.promise(() => setModelStarted.promise);
+      yield* adapter.interruptTurn(THREAD_ID);
+      releaseSetModel.resolve();
+
+      const sendTurnExit = yield* Fiber.await(sendTurnFiber);
+      assert.equal(sendTurnExit._tag, "Failure");
+      if (sendTurnExit._tag === "Failure") {
+        assert.isTrue(Cause.hasInterruptsOnly(sendTurnExit.cause));
+      }
+
+      const preparingSessions = yield* adapter.listSessions();
+      assert.equal(preparingSessions[0]?.status, "running");
+      const interruptedTurnId = preparingSessions[0]?.activeTurnId;
+      assert.notEqual(interruptedTurnId, undefined);
+
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["Delayed failure after canceled preparation"],
+        session_id: "sdk-session-preparation-rejection",
+        uuid: "result-preparation-rejection",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.equal(
+        runtimeEvents.find((event) => event.type === "runtime.error"),
+        undefined,
+      );
+      const turnCompleted = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(String(turnCompleted.turnId), String(interruptedTurnId));
+        assert.equal(turnCompleted.payload.state, "interrupted");
+      }
+      yield* adapter.stopSession(THREAD_ID);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps a prepared turn bound until its delayed interrupt result", () => {
+    const harness = makeHarness();
+    const setModelStarted = Promise.withResolvers<void>();
+    const releaseSetModel = Promise.withResolvers<void>();
+    harness.query.setModelImplementation = async () => {
+      setModelStarted.resolve();
+      await releaseSetModel.promise;
+    };
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const sendTurnFiber = yield* adapter
+        .sendTurn({
+          threadId: THREAD_ID,
+          input: "hello",
+          attachments: [],
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("claudeAgent"),
+            "claude-opus-4-6",
+          ),
+        })
+        .pipe(Effect.forkChild);
+
+      yield* Effect.promise(() => setModelStarted.promise);
+      yield* adapter.interruptTurn(THREAD_ID);
+      releaseSetModel.resolve();
+      const sendTurnExit = yield* Fiber.await(sendTurnFiber);
+      assert.equal(sendTurnExit._tag, "Failure");
+      if (sendTurnExit._tag === "Failure") {
+        assert.isTrue(Cause.hasInterruptsOnly(sendTurnExit.cause));
+      }
+
+      const preparingSessions = yield* adapter.listSessions();
+      assert.equal(preparingSessions[0]?.status, "running");
+      const interruptedTurnId = preparingSessions[0]?.activeTurnId;
+      assert.notEqual(interruptedTurnId, undefined);
+
+      const prematureFollowUp = yield* adapter
+        .sendTurn({
+          threadId: THREAD_ID,
+          input: "too early",
+          attachments: [],
+        })
+        .pipe(Effect.result);
+      assert.equal(prematureFollowUp._tag, "Failure");
+      if (prematureFollowUp._tag === "Failure") {
+        assert.equal(prematureFollowUp.failure._tag, "ProviderAdapterRequestError");
+      }
+      const stillPreparingSessions = yield* adapter.listSessions();
+      assert.equal(String(stillPreparingSessions[0]?.activeTurnId), String(interruptedTurnId));
+
+      const interruptedEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["Delayed failure after stop"],
+        session_id: "sdk-session-delayed-stop",
+        uuid: "result-delayed-stop",
+      } as unknown as SDKMessage);
+
+      const interruptedEvents = Array.from(yield* Fiber.join(interruptedEventsFiber));
+      assert.equal(
+        interruptedEvents.find((event) => event.type === "runtime.error"),
+        undefined,
+      );
+      const interruptedCompletion = interruptedEvents.find(
+        (event) => event.type === "turn.completed",
+      );
+      assert.equal(interruptedCompletion?.type, "turn.completed");
+      if (interruptedCompletion?.type === "turn.completed") {
+        assert.equal(String(interruptedCompletion.turnId), String(interruptedTurnId));
+        assert.equal(interruptedCompletion.payload.state, "interrupted");
+      }
+
+      const readySessions = yield* adapter.listSessions();
+      assert.equal(readySessions[0]?.status, "ready");
+      assert.equal(readySessions[0]?.activeTurnId, undefined);
+
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
+      const followUpTurn = yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "follow up",
+        attachments: [],
+      });
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["Real follow-up failure"],
+        session_id: "sdk-session-follow-up-failure",
+        uuid: "result-follow-up-failure",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const runtimeError = runtimeEvents.find((event) => event.type === "runtime.error");
+      assert.equal(runtimeError?.type, "runtime.error");
+      if (runtimeError?.type === "runtime.error") {
+        assert.equal(runtimeError.payload.message, "Real follow-up failure");
+      }
+      const turnCompleted = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(String(turnCompleted.turnId), String(followUpTurn.turnId));
+        assert.equal(turnCompleted.payload.state, "failed");
+      }
+
+      yield* adapter.stopSession(THREAD_ID);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps real failures when the interrupt request is rejected", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.interruptFailure = new Error("interrupt rejected");
+      const interruptExit = yield* Effect.exit(adapter.interruptTurn(THREAD_ID, turn.turnId));
+      assert.equal(interruptExit._tag, "Failure");
+
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["Real Claude failure"],
+        session_id: "sdk-session-real-failure",
+        uuid: "result-real-failure",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const runtimeError = runtimeEvents.find((event) => event.type === "runtime.error");
+      assert.equal(runtimeError?.type, "runtime.error");
+      if (runtimeError?.type === "runtime.error") {
+        assert.equal(runtimeError.payload.message, "Real Claude failure");
+      }
+
+      const turnCompleted = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(String(turnCompleted.turnId), String(turn.turnId));
+        assert.equal(turnCompleted.payload.state, "failed");
+        assert.equal(turnCompleted.payload.errorMessage, "Real Claude failure");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("interruptTurn settles every acknowledged live task before interrupting", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -1640,6 +1976,93 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(stoppedTaskEvent.payload.taskType, "local_agent");
         assert.equal(stoppedTaskEvent.payload.title, "Agent A");
       }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not interrupt a follow-up turn after stopTask delays", () => {
+    const harness = makeHarness();
+    const stopTaskStarted = Promise.withResolvers<void>();
+    const releaseStopTask = Promise.withResolvers<void>();
+    harness.query.stopTaskImplementation = async () => {
+      stopTaskStarted.resolve();
+      await releaseStopTask.promise;
+    };
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const taskStartedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "task.started"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const firstTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "spawn an agent",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-delayed-stop",
+        description: "Agent A",
+        task_type: "local_agent",
+        uuid: "task-delayed-stop-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+      yield* Fiber.join(taskStartedFiber);
+
+      const interruptFiber = yield* adapter
+        .interruptTurn(session.threadId, firstTurn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => stopTaskStarted.promise);
+
+      const firstTurnEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["Failure while child tasks are stopping"],
+        session_id: "sdk-session-first-complete",
+        uuid: "result-first-complete",
+      } as unknown as SDKMessage);
+      const firstTurnEvents = Array.from(yield* Fiber.join(firstTurnEventsFiber));
+      assert.equal(
+        firstTurnEvents.find((event) => event.type === "runtime.error"),
+        undefined,
+      );
+      const firstTurnCompleted = firstTurnEvents.find((event) => event.type === "turn.completed");
+      assert.equal(firstTurnCompleted?.type, "turn.completed");
+      if (firstTurnCompleted?.type === "turn.completed") {
+        assert.equal(firstTurnCompleted.payload.state, "interrupted");
+      }
+
+      const followUpTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "follow up",
+        attachments: [],
+      });
+      assert.notEqual(String(followUpTurn.turnId), String(firstTurn.turnId));
+
+      releaseStopTask.resolve();
+      yield* Fiber.join(interruptFiber);
+
+      assert.deepEqual(harness.query.stopTaskCalls, ["task-delayed-stop"]);
+      assert.equal(harness.query.interruptCalls.length, 0);
+      yield* adapter.stopSession(session.threadId);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -1918,6 +2341,64 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(turnCompleted.payload.errorMessage, "Claude runtime interrupted.");
       }
 
+      assert.equal(yield* adapter.hasSession(THREAD_ID), false);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("suppresses a stream failure after an interrupted result", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.tap((event) =>
+          event.type === "turn.completed"
+            ? Effect.sync(() => {
+                harness.query.fail(new Error("Claude Code process exited with code 143"));
+              })
+            : Effect.void,
+        ),
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "hello",
+        attachments: [],
+      });
+      yield* adapter.interruptTurn(THREAD_ID, turn.turnId);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["Failure after stop"],
+        session_id: "sdk-session-result-before-exit",
+        uuid: "result-before-exit",
+      } as unknown as SDKMessage);
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+
+      assert.equal(
+        runtimeEvents.find((event) => event.type === "runtime.error"),
+        undefined,
+      );
+      const turnCompletions = runtimeEvents.filter((event) => event.type === "turn.completed");
+      assert.equal(turnCompletions.length, 1);
+      const turnCompleted = turnCompletions[0];
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(String(turnCompleted.turnId), String(turn.turnId));
+        assert.equal(turnCompleted.payload.state, "interrupted");
+      }
       assert.equal(yield* adapter.hasSession(THREAD_ID), false);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -245,6 +245,7 @@ interface ClaudeSessionContext {
   lastKnownTotalProcessedTokens: number | undefined;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
+  lastTurnHadStopRequest: boolean;
   stopped: boolean;
   readonly interruptedTurnIds: Set<TurnId>;
 }
@@ -2172,6 +2173,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     errorMessage?: string,
     result?: SDKResultMessage,
   ) {
+    const completedTurnId = context.turnState?.turnId ?? context.session.activeTurnId;
+    context.lastTurnHadStopRequest =
+      status === "interrupted" ||
+      (completedTurnId !== undefined && context.interruptedTurnIds.has(completedTurnId));
+
     const resultContextWindow = maxClaudeContextWindowFromModelUsage(result?.modelUsage);
     if (resultContextWindow !== undefined) {
       context.lastKnownContextWindow = resultContextWindow;
@@ -2244,6 +2250,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     const turnState = context.turnState;
     if (!turnState) {
+      const pendingTurnId = context.session.activeTurnId;
       yield* emitThreadTokenUsage(context, usageSnapshot, {
         rawMethod: "claude/result",
         rawPayload: result ?? { status },
@@ -2256,6 +2263,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         provider: PROVIDER,
         createdAt: stamp.createdAt,
         threadId: context.session.threadId,
+        ...(pendingTurnId !== undefined ? { turnId: pendingTurnId } : {}),
         payload: {
           state: status,
           ...(result?.stop_reason !== undefined ? { stopReason: result.stop_reason } : {}),
@@ -2268,6 +2276,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         },
         providerRefs: {},
       });
+      if (pendingTurnId !== undefined) {
+        context.interruptedTurnIds.delete(pendingTurnId);
+        context.session = {
+          ...context.session,
+          status: "ready",
+          activeTurnId: undefined,
+          updatedAt: yield* nowIso,
+          ...(status === "failed" && errorMessage ? { lastError: errorMessage } : {}),
+        };
+        yield* updateResumeCursor(context);
+      }
       return;
     }
 
@@ -2860,6 +2879,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (!context.turnState) {
       const turnId = TurnId.make(yield* randomUUIDv4);
       const startedAt = yield* nowIso;
+      context.lastTurnHadStopRequest = false;
       context.turnState = {
         turnId,
         startedAt,
@@ -2943,8 +2963,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
-    const interrupted =
-      context.turnState !== undefined && context.interruptedTurnIds.has(context.turnState.turnId);
+    const activeTurnId = context.turnState?.turnId ?? context.session.activeTurnId;
+    const interrupted = activeTurnId !== undefined && context.interruptedTurnIds.has(activeTurnId);
     const status =
       interrupted && message.subtype !== "success" ? "interrupted" : turnStatusFromResult(message);
     const errorMessage = resultUserFacingError(message);
@@ -3572,12 +3592,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    const activeTurnId = context.turnState?.turnId ?? context.session.activeTurnId;
     const interrupted =
-      context.turnState !== undefined && context.interruptedTurnIds.has(context.turnState.turnId);
+      context.lastTurnHadStopRequest ||
+      (activeTurnId !== undefined && context.interruptedTurnIds.has(activeTurnId));
 
     if (Exit.isFailure(exit)) {
       if (interrupted || isClaudeInterruptedCause(exit.cause)) {
-        if (context.turnState) {
+        if (activeTurnId !== undefined) {
           yield* completeTurn(context, "interrupted", "Claude runtime interrupted.");
         }
       } else {
@@ -4221,6 +4243,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastKnownTotalProcessedTokens: undefined,
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
+        lastTurnHadStopRequest: false,
         stopped: false,
         interruptedTurnIds: new Set(),
       };
@@ -4303,6 +4326,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
   const sendTurn: ClaudeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
     const context = yield* requireSession(input.threadId);
+    if (context.turnState === undefined && context.session.activeTurnId !== undefined) {
+      return yield* new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method: "turn/start",
+        detail: "Claude is still finishing the previous turn.",
+      });
+    }
     const modelSelection =
       input.modelSelection !== undefined && input.modelSelection.instanceId === boundInstanceId
         ? input.modelSelection
@@ -4319,45 +4349,96 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       yield* completeTurn(context, "completed");
     }
 
-    if (modelSelection?.model) {
-      const apiModelId = resolveClaudeApiModelId(modelSelection);
-      if (context.currentApiModelId !== apiModelId) {
-        yield* Effect.tryPromise({
-          try: () => context.query.setModel(apiModelId),
-          catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
-        });
-        context.currentApiModelId = apiModelId;
-      }
+    const turnId = steeringTurnState?.turnId ?? TurnId.make(yield* randomUUIDv4);
+    if (steeringTurnState === null) {
+      context.lastTurnHadStopRequest = false;
       context.session = {
         ...context.session,
-        model: modelSelection.model,
+        status: "running",
+        activeTurnId: turnId,
+        updatedAt: yield* nowIso,
       };
-      const turnCaps = getClaudeModelCapabilities(modelSelection.model);
-      const turnEffort = resolveClaudeEffort(
-        turnCaps,
-        getModelSelectionStringOptionValue(modelSelection, "effort"),
-      );
-      context.currentEffort =
-        getEffectiveClaudeAgentEffort(turnEffort ?? null, modelSelection.model) ?? undefined;
     }
 
-    // Apply interaction mode by switching the SDK's permission mode.
-    // "plan" maps directly to the SDK's "plan" permission mode;
-    // "default" restores the session's original permission mode.
-    // When interactionMode is absent we leave the current mode unchanged.
-    if (input.interactionMode === "plan") {
-      yield* Effect.tryPromise({
-        try: () => context.query.setPermissionMode("plan"),
-        catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
+    const message = yield* Effect.gen(function* () {
+      if (modelSelection?.model) {
+        const apiModelId = resolveClaudeApiModelId(modelSelection);
+        if (context.currentApiModelId !== apiModelId) {
+          yield* Effect.tryPromise({
+            try: () => context.query.setModel(apiModelId),
+            catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
+          });
+          context.currentApiModelId = apiModelId;
+        }
+        context.session = {
+          ...context.session,
+          model: modelSelection.model,
+        };
+        const turnCaps = getClaudeModelCapabilities(modelSelection.model);
+        const turnEffort = resolveClaudeEffort(
+          turnCaps,
+          getModelSelectionStringOptionValue(modelSelection, "effort"),
+        );
+        context.currentEffort =
+          getEffectiveClaudeAgentEffort(turnEffort ?? null, modelSelection.model) ?? undefined;
+      }
+
+      // Apply interaction mode by switching the SDK's permission mode.
+      // "plan" maps directly to the SDK's "plan" permission mode;
+      // "default" restores the session's original permission mode.
+      // When interactionMode is absent we leave the current mode unchanged.
+      if (input.interactionMode === "plan") {
+        yield* Effect.tryPromise({
+          try: () => context.query.setPermissionMode("plan"),
+          catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
+        });
+      } else if (input.interactionMode === "default") {
+        yield* Effect.tryPromise({
+          try: () => context.query.setPermissionMode(context.basePermissionMode ?? "default"),
+          catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
+        });
+      }
+
+      return yield* buildUserMessageEffect(input, {
+        fileSystem,
+        attachmentsDir: serverConfig.attachmentsDir,
+        boundInstanceId,
       });
-    } else if (input.interactionMode === "default") {
-      yield* Effect.tryPromise({
-        try: () => context.query.setPermissionMode(context.basePermissionMode ?? "default"),
-        catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
-      });
+    }).pipe(
+      Effect.catch((error) =>
+        Effect.gen(function* () {
+          const activeTurnId = context.turnState?.turnId ?? context.session.activeTurnId;
+          if (activeTurnId !== turnId || context.interruptedTurnIds.has(turnId)) {
+            return yield* Effect.interrupt;
+          }
+          if (
+            steeringTurnState === null &&
+            context.turnState === undefined &&
+            context.session.activeTurnId === turnId
+          ) {
+            context.interruptedTurnIds.delete(turnId);
+            context.session = {
+              ...context.session,
+              status: "ready",
+              activeTurnId: undefined,
+              updatedAt: yield* nowIso,
+            };
+          }
+          return yield* error;
+        }),
+      ),
+    );
+
+    const preparedTurnId = context.turnState?.turnId ?? context.session.activeTurnId;
+    if (preparedTurnId !== turnId || context.interruptedTurnIds.has(turnId)) {
+      // A concurrent Stop is cancellation, not a provider start failure. Keep
+      // its turn binding and stop intent until the SDK's terminal result (or
+      // stream exit) arrives so that delayed failures cannot leak into a later
+      // turn. Interrupting this fiber also lets orchestration ignore the
+      // canceled start without recording provider.turn.start.failed.
+      return yield* Effect.interrupt;
     }
 
-    const turnId = steeringTurnState?.turnId ?? TurnId.make(yield* randomUUIDv4);
     if (steeringTurnState === null) {
       const turnState: ClaudeTurnState = {
         turnId,
@@ -4391,11 +4472,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       });
     }
 
-    const message = yield* buildUserMessageEffect(input, {
-      fileSystem,
-      attachmentsDir: serverConfig.attachmentsDir,
-      boundInstanceId,
-    });
+    if (context.turnState?.turnId !== turnId || context.interruptedTurnIds.has(turnId)) {
+      return yield* Effect.interrupt;
+    }
 
     yield* Queue.offer(context.promptQueue, {
       type: "message",
@@ -4414,8 +4493,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   const interruptTurn: ClaudeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
     function* (threadId, turnId) {
       const context = yield* requireSession(threadId);
-      const targetTurnId = turnId ?? context.turnState?.turnId;
+      const targetTurnId = turnId ?? context.turnState?.turnId ?? context.session.activeTurnId;
+
       if (targetTurnId !== undefined) {
+        // Record intent before stopping child tasks: a terminal result can race
+        // any awaited stopTask call and must already be classified as stopped.
         context.interruptedTurnIds.add(targetTurnId);
       }
 
@@ -4457,9 +4539,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
                 provider: PROVIDER,
                 createdAt: stamp.createdAt,
                 threadId: context.session.threadId,
-                ...(context.turnState
-                  ? { turnId: asCanonicalTurnId(context.turnState.turnId) }
-                  : {}),
+                ...(targetTurnId !== undefined ? { turnId: asCanonicalTurnId(targetTurnId) } : {}),
                 payload: {
                   taskId: RuntimeTaskId.make(taskId),
                   status: "stopped",
@@ -4471,10 +4551,34 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           { concurrency: 8, discard: true },
         ).pipe(Effect.timeoutOption("10 seconds"), Effect.ignore);
       }
+
+      // stopTask can take several seconds. Do not let a completed target turn
+      // hand its delayed interrupt to a follow-up turn that started meanwhile.
+      const activeTurnId = context.turnState?.turnId ?? context.session.activeTurnId;
+      if (activeTurnId !== targetTurnId) {
+        if (targetTurnId !== undefined) {
+          context.interruptedTurnIds.delete(targetTurnId);
+        }
+        return;
+      }
+
       yield* Effect.tryPromise({
         try: () => context.query.interrupt(),
         catch: (cause) => toRequestError(threadId, "turn/interrupt", cause),
-      });
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.gen(function* () {
+            const activeTurnId = context.turnState?.turnId ?? context.session.activeTurnId;
+            if (activeTurnId !== targetTurnId) {
+              return;
+            }
+            if (targetTurnId !== undefined) {
+              context.interruptedTurnIds.delete(targetTurnId);
+            }
+            return yield* error;
+          }),
+        ),
+      );
     },
   );
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -246,6 +246,7 @@ interface ClaudeSessionContext {
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
   stopped: boolean;
+  readonly interruptedTurnIds: Set<TurnId>;
 }
 
 interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
@@ -2345,6 +2346,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     const updatedAt = yield* nowIso;
     context.turnState = undefined;
+    context.interruptedTurnIds.delete(turnState.turnId);
     context.session = {
       ...context.session,
       status: "ready",
@@ -2941,7 +2943,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
-    const status = turnStatusFromResult(message);
+    const interrupted =
+      context.turnState !== undefined && context.interruptedTurnIds.has(context.turnState.turnId);
+    const status =
+      interrupted && message.subtype !== "success" ? "interrupted" : turnStatusFromResult(message);
     const errorMessage = resultUserFacingError(message);
 
     if (status === "failed") {
@@ -3567,8 +3572,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    const interrupted =
+      context.turnState !== undefined && context.interruptedTurnIds.has(context.turnState.turnId);
+
     if (Exit.isFailure(exit)) {
-      if (isClaudeInterruptedCause(exit.cause)) {
+      if (interrupted || isClaudeInterruptedCause(exit.cause)) {
         if (context.turnState) {
           yield* completeTurn(context, "interrupted", "Claude runtime interrupted.");
         }
@@ -4214,6 +4222,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
         stopped: false,
+        interruptedTurnIds: new Set(),
       };
       yield* Ref.set(contextRef, context);
       sessions.set(threadId, context);
@@ -4403,8 +4412,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   });
 
   const interruptTurn: ClaudeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
-    function* (threadId, _turnId) {
+    function* (threadId, turnId) {
       const context = yield* requireSession(threadId);
+      const targetTurnId = turnId ?? context.turnState?.turnId;
+      if (targetTurnId !== undefined) {
+        context.interruptedTurnIds.add(targetTurnId);
+      }
+
       // Stop-everything semantics: users reach for Stop precisely when a
       // fleet ran away. interrupt() alone only ends the parent turn —
       // background subagents/shells keep running and keep burning tokens.


### PR DESCRIPTION
The interrupt bug will be fixed with the new ClaudeAdapterV2 in #2829. Fixes are [here](https://github.com/pingdotgg/t3code/blob/a543fd4e6d7aea9f55e9c11027aa11fc952af9e7/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts#L3821-L3826) and [here](https://github.com/pingdotgg/t3code/blob/a543fd4e6d7aea9f55e9c11027aa11fc952af9e7/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts#L3025-L3028). Since that PR has been open for awhile I figured I'd open a request for the current ClaudeAdapter:

## What Changed

Stopping a Claude turn no longer surfaces a raw runtime error. interruptTurn records the stop request on the session context, and both places that classify how a turn ended (handleStreamExit for stream failures, handleResultMessage for error results like ede_diagnostic) treat what follows as an interruption, completing the turn with a graceful message. The flag resets on turn start and completion. Includes a test for each path.

## Why
The adapter inferred interruption by matching error text against known phrases, so any stop producing an unrecognized message was recorded as failed with a runtime error (#4713, #3836). Claude is the only provider with this problem: the other adapters get typed stop signals, while the Claude SDK's interrupt() returns nothing and the turn ends with an arbitrary error. Tracking intent is the approach Grok already uses.

<img width="844" height="524" alt="original-test" src="https://github.com/user-attachments/assets/b41498ae-27e4-4f3f-8bfb-7c8da83f5f5d" />

After fix:
<img width="875" height="499" alt="fix-test" src="https://github.com/user-attachments/assets/75afc187-8402-4bee-a438-f92e3e081395" />

Thread before/after:
<img width="263" height="177" alt="before-after" src="https://github.com/user-attachments/assets/ffd2188d-d589-4d98-b9bc-ae270372cdb0" />

Verified with 
vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts (64 passed), 
pnpm run tc, 
and a manual test for the photos above

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes 
- [ ] I included a video for animation/interaction changes (none)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Claude turn completion, interrupt, and sendTurn concurrency in the provider adapter; behavior shifts for stop vs real failure, though scoped to Claude and heavily tested.
> 
> **Overview**
> **Stopping a Claude turn** no longer surfaces `runtime.error` for arbitrary SDK failures or stream exits. The adapter records stop intent per turn (`interruptedTurnIds`, `lastTurnHadStopRequest`) in `interruptTurn` before child `stopTask` work, and `handleResultMessage` / `handleStreamExit` treat matching non-success results and failures as **`turn.completed` with `state: interrupted`** instead of failed.
> 
> **Turn lifecycle** is tightened so stop races do not leak into the next message: `sendTurn` binds `activeTurnId` earlier during model/permission prep, cancels preparation via interrupt when stop wins, rejects a new turn while the previous one is still settling, and `interruptTurn` skips calling `query.interrupt()` if the active turn changed during slow `stopTask`. Real failures remain when interrupt is rejected or stop was never recorded.
> 
> Tests extend the fake SDK query (configurable `setModel`/`stopTask`/`interrupt` failures) and add coverage for stop-during-prep, delayed results, stream exit after stop, and follow-up turns after delayed task stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3139319138ef1383407040b244c714ac4253892f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude turn stops to emit interrupted completions instead of raw stream errors
> - When a user stops a Claude turn, stream failures and non-success result messages are now classified as interrupted turn completions rather than surfacing as runtime errors.
> - `interruptTurn` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/5162/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) records stop intent early (via `interruptedTurnIds`) and ties task completion events to the specific target turn, preventing a delayed interrupt from affecting a follow-up turn.
> - `sendTurn` now rejects new turns while a previous turn is still finishing, and treats a concurrent stop racing with model/message preparation as a canceled fiber rather than a provider start failure.
> - Behavioral Change: stream exits after a user stop now emit `turn.completed` with status `interrupted` instead of `runtime.error`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3139319.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->