### PR TITLE
fix(web): long lists no longer clip their numbers

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -73,6 +73,7 @@ import {
   serializeTableElementToMarkdown,
 } from "../markdown-clipboard";
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
+import { orderedListMarkerExtraDigits } from "../markdown-ordered-list";
 import {
   normalizeMarkdownLinkDestination,
   resolveInlineCodeFileLinkMeta,
@@ -1502,6 +1503,12 @@ function ChatMarkdown({
             {children}
           </div>
         );
+      },
+      ol({ node, start, style, ...props }) {
+        const items = node?.children.filter((c) => c.type === "element" && c.tagName === "li");
+        const extra = orderedListMarkerExtraDigits(start, items?.length ?? 0);
+        const olStyle = { ...style, "--chat-markdown-ol-marker-extra": String(extra) };
+        return <ol {...props} start={start} style={olStyle as React.CSSProperties} />;
       },
       li({ node, children, ...props }) {
         const listItemStart = node?.position?.start.offset;

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -67,6 +67,7 @@ import {
   serializeTableElementToMarkdown,
 } from "../markdown-clipboard";
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
+import { orderedListMarkerExtraDigits } from "../markdown-ordered-list";
 import {
   normalizeMarkdownLinkDestination,
   resolveInlineCodeFileLinkMeta,
@@ -1415,6 +1416,30 @@ function ChatMarkdown({
     return {
       p({ node: _node, children, ...props }) {
         return <p {...props}>{renderSkillInlineMarkdownChildren(children, skills)}</p>;
+      },
+      ol({ node, start, style, ...props }) {
+        const itemCount =
+          node?.children.reduce(
+            (count, child) =>
+              child.type === "element" && child.tagName === "li" ? count + 1 : count,
+            0,
+          ) ?? 0;
+        const extraMarkerDigits = orderedListMarkerExtraDigits(
+          typeof start === "number" ? start : undefined,
+          itemCount,
+        );
+        return (
+          <ol
+            {...props}
+            start={start}
+            style={
+              {
+                ...style,
+                "--chat-markdown-ol-marker-extra": String(extraMarkerDigits),
+              } as React.CSSProperties
+            }
+          />
+        );
       },
       li({ node, children, ...props }) {
         const listItemStart = node?.position?.start.offset;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1864,8 +1864,13 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown ol {
-  padding-left: 1.25rem;
+  /* --chat-markdown-ol-marker-extra: marker digits past two, set by ChatMarkdown. */
+  padding-left: calc(1.25rem + var(--chat-markdown-ol-marker-extra, 0) * 1ch);
   list-style-type: decimal;
+}
+
+.chat-markdown ol > li::marker {
+  font-variant-numeric: tabular-nums;
 }
 
 .chat-markdown ul ul {
@@ -1896,6 +1901,10 @@ label:has(> select#reasoning-effort) select {
 .chat-markdown li.task-list-item input[type="checkbox"] {
   margin: 0 0.35em 0.15em -1.25rem;
   vertical-align: middle;
+}
+
+.chat-markdown ol > li.task-list-item input[type="checkbox"] {
+  margin-left: calc(-1.25rem - var(--chat-markdown-ol-marker-extra, 0) * 1ch);
 }
 
 /* Markdown assumes inline images — GitHub comments lay button images out in a row — and the
@@ -1945,7 +1954,6 @@ label:has(> select#reasoning-effort) select {
 
 .chat-markdown section[data-footnotes] ol {
   margin: 0;
-  padding-left: 1.25rem;
 }
 
 .chat-markdown section[data-footnotes] li + li {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1667,9 +1667,18 @@ label:has(> select#reasoning-effort) select {
   list-style-type: disc;
 }
 
+/* --chat-markdown-ol-marker-extra: digits beyond two in the list's widest
+   marker, set inline by ChatMarkdown so long or high-`start` lists don't clip
+   their numbers. */
 .chat-markdown ol {
-  padding-left: 1.25rem;
+  padding-left: calc(1.25rem + var(--chat-markdown-ol-marker-extra, 0) * 1ch);
   list-style-type: decimal;
+}
+
+/* Markers right-align against the text edge, so proportional digits leave
+   narrow numbers ("101.") starting further right than wide ones ("100."). */
+.chat-markdown ol > li::marker {
+  font-variant-numeric: tabular-nums;
 }
 
 .chat-markdown ul ul {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1752,7 +1752,6 @@ label:has(> select#reasoning-effort) select {
 
 .chat-markdown section[data-footnotes] ol {
   margin: 0;
-  padding-left: 1.25rem;
 }
 
 .chat-markdown section[data-footnotes] li + li {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1711,6 +1711,10 @@ label:has(> select#reasoning-effort) select {
   vertical-align: middle;
 }
 
+.chat-markdown ol > li.task-list-item input[type="checkbox"] {
+  margin-left: calc(-1.25rem - var(--chat-markdown-ol-marker-extra, 0) * 1ch);
+}
+
 .chat-markdown a {
   color: var(--info-foreground);
   text-decoration: none;

--- a/apps/web/src/markdown-ordered-list.test.ts
+++ b/apps/web/src/markdown-ordered-list.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { orderedListMarkerExtraDigits } from "./markdown-ordered-list";
+
+describe("orderedListMarkerExtraDigits", () => {
+  it("keeps the base padding for lists whose markers fit two digits", () => {
+    expect(orderedListMarkerExtraDigits(undefined, 1)).toBe(0);
+    expect(orderedListMarkerExtraDigits(undefined, 9)).toBe(0);
+    expect(orderedListMarkerExtraDigits(undefined, 99)).toBe(0);
+    expect(orderedListMarkerExtraDigits(98, 2)).toBe(0);
+  });
+
+  it("adds one ch per digit past two in the widest marker", () => {
+    expect(orderedListMarkerExtraDigits(undefined, 100)).toBe(1);
+    expect(orderedListMarkerExtraDigits(undefined, 200)).toBe(1);
+    expect(orderedListMarkerExtraDigits(undefined, 1000)).toBe(2);
+  });
+
+  it("sizes from the start attribute, not just the item count", () => {
+    // A short list continuing earlier numbering: `98.`–`102.`
+    expect(orderedListMarkerExtraDigits(98, 5)).toBe(1);
+    // Raw HTML start attributes stay strings: `999995.`–`999999.`
+    expect(orderedListMarkerExtraDigits("999995", 5)).toBe(4);
+    // A single-item nested list parsed out of `- 101. text`
+    expect(orderedListMarkerExtraDigits(101, 1)).toBe(1);
+  });
+
+  it("sizes negative-start lists from their widest marker including the sign", () => {
+    expect(orderedListMarkerExtraDigits(-1000, 1001)).toBe(3);
+    expect(orderedListMarkerExtraDigits(-5, 3)).toBe(0);
+    expect(orderedListMarkerExtraDigits(-15, 3)).toBe(1);
+  });
+
+  it("tolerates empty and streaming-partial lists", () => {
+    expect(orderedListMarkerExtraDigits(undefined, 0)).toBe(0);
+    expect(orderedListMarkerExtraDigits(100, 0)).toBe(1);
+  });
+});

--- a/apps/web/src/markdown-ordered-list.test.ts
+++ b/apps/web/src/markdown-ordered-list.test.ts
@@ -25,6 +25,12 @@ describe("orderedListMarkerExtraDigits", () => {
     expect(orderedListMarkerExtraDigits(101, 1)).toBe(1);
   });
 
+  it("sizes negative-start lists from their widest marker including the sign", () => {
+    expect(orderedListMarkerExtraDigits(-1000, 1001)).toBe(3);
+    expect(orderedListMarkerExtraDigits(-5, 3)).toBe(0);
+    expect(orderedListMarkerExtraDigits(-15, 3)).toBe(1);
+  });
+
   it("tolerates empty and streaming-partial lists", () => {
     expect(orderedListMarkerExtraDigits(undefined, 0)).toBe(0);
     expect(orderedListMarkerExtraDigits(100, 0)).toBe(1);

--- a/apps/web/src/markdown-ordered-list.test.ts
+++ b/apps/web/src/markdown-ordered-list.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { orderedListMarkerExtraDigits } from "./markdown-ordered-list";
+
+describe("orderedListMarkerExtraDigits", () => {
+  it("keeps the base padding for lists whose markers fit two digits", () => {
+    expect(orderedListMarkerExtraDigits(undefined, 1)).toBe(0);
+    expect(orderedListMarkerExtraDigits(undefined, 9)).toBe(0);
+    expect(orderedListMarkerExtraDigits(undefined, 99)).toBe(0);
+    expect(orderedListMarkerExtraDigits(98, 2)).toBe(0);
+  });
+
+  it("adds one ch per digit past two in the widest marker", () => {
+    expect(orderedListMarkerExtraDigits(undefined, 100)).toBe(1);
+    expect(orderedListMarkerExtraDigits(undefined, 200)).toBe(1);
+    expect(orderedListMarkerExtraDigits(undefined, 1000)).toBe(2);
+  });
+
+  it("sizes from the start attribute, not just the item count", () => {
+    // A short list continuing earlier numbering: `98.`–`102.`
+    expect(orderedListMarkerExtraDigits(98, 5)).toBe(1);
+    // High-start lists clip immediately without this: `999995.`–`999999.`
+    expect(orderedListMarkerExtraDigits(999995, 5)).toBe(4);
+    // A single-item nested list parsed out of `- 101. text`
+    expect(orderedListMarkerExtraDigits(101, 1)).toBe(1);
+  });
+
+  it("tolerates empty and streaming-partial lists", () => {
+    expect(orderedListMarkerExtraDigits(undefined, 0)).toBe(0);
+    expect(orderedListMarkerExtraDigits(100, 0)).toBe(1);
+  });
+});

--- a/apps/web/src/markdown-ordered-list.ts
+++ b/apps/web/src/markdown-ordered-list.ts
@@ -1,0 +1,7 @@
+/** Digits past two in the list's widest marker (`String` keeps a negative marker's minus sign). */
+export function orderedListMarkerExtraDigits(start: unknown, itemCount: number): number {
+  const parsedStart = Number.parseInt(String(start ?? 1), 10);
+  const first = Number.isNaN(parsedStart) ? 1 : parsedStart;
+  const last = first + Math.max(itemCount - 1, 0);
+  return Math.max(String(first).length, String(last).length, 2) - 2;
+}

--- a/apps/web/src/markdown-ordered-list.ts
+++ b/apps/web/src/markdown-ordered-list.ts
@@ -1,0 +1,8 @@
+/**
+ * Digits past two in the list's widest marker — the multiplier for the
+ * `--chat-markdown-ol-marker-extra` CSS variable.
+ */
+export function orderedListMarkerExtraDigits(start: number | undefined, itemCount: number): number {
+  const lastMarker = (start ?? 1) + Math.max(itemCount - 1, 0);
+  return Math.max(String(Math.abs(lastMarker)).length - 2, 0);
+}

--- a/apps/web/src/markdown-ordered-list.ts
+++ b/apps/web/src/markdown-ordered-list.ts
@@ -3,6 +3,10 @@
  * `--chat-markdown-ol-marker-extra` CSS variable.
  */
 export function orderedListMarkerExtraDigits(start: number | undefined, itemCount: number): number {
-  const lastMarker = (start ?? 1) + Math.max(itemCount - 1, 0);
-  return Math.max(String(Math.abs(lastMarker)).length - 2, 0);
+  const firstMarker = start ?? 1;
+  const lastMarker = firstMarker + Math.max(itemCount - 1, 0);
+  // Raw HTML can set a negative `start`, where the first marker is the widest
+  // and its minus sign takes a character of its own.
+  const markerLength = (value: number) => String(Math.abs(value)).length + (value < 0 ? 1 : 0);
+  return Math.max(Math.max(markerLength(firstMarker), markerLength(lastMarker)) - 2, 0);
 }


### PR DESCRIPTION
## What Changed

Ordered lists in chat markdown now widen their left padding to fit the marker digits, and markers use tabular numerals. A small tested helper computes the padding.

## Why

The old padding was fixed at two digits wide. Item numbers past 99 spilled out and got clipped, so `187.` displayed as `87.`. Uneven digit widths also made some numbers sit misaligned. In the odd case that there is a `ol` in a `ul` bullet items that start with a long number would render through the marker.

## UI Changes

### Before:
(Fable really struggled to follow directions for this test, see the PS below for more `fable fumbles`)

<img width="762" height="1289" alt="li-ul-ui-bug-2" src="https://github.com/user-attachments/assets/341759a2-555e-460b-bd0c-099c10832eee" />

### After:
<img width="764" height="1192" alt="li-ul-ui-fixpng" src="https://github.com/user-attachments/assets/44dd78ce-1ba3-4596-9139-1f95ea33a57f" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes



<details>
<summary>PS: Open to see fable struggling to follow directions lol, found that haikus lack of brain really helped test this.</summary>

<img width="858" height="376" alt="markdown-wtf-1" src="https://github.com/user-attachments/assets/5b97c1a6-15c7-43d6-af7d-244c2e1da935" />
<img width="812" height="336" alt="markdown-wtf-2" src="https://github.com/user-attachments/assets/6efe6344-13bb-4af9-a733-2eb793e08d15" />
<img width="944" height="515" alt="markdown-wtf-3" src="https://github.com/user-attachments/assets/ead355dd-917c-413e-822f-9620ac2887e2" />
<img width="907" height="332" alt="markdown-wtf-4" src="https://github.com/user-attachments/assets/5651408d-55c5-4072-affd-2b13daff5343" />

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped chat markdown presentation and CSS with unit tests on the padding helper; no auth, data, or API changes.
> 
> **Overview**
> Fixes **ordered list numbers getting clipped** in chat markdown when markers need more than two digits (e.g. `187.` showing as `87.`).
> 
> Adds `orderedListMarkerExtraDigits`, which looks at the list `start` and item count to compute how many digits past two the widest marker needs. **ChatMarkdown** customizes `<ol>` rendering to set `--chat-markdown-ol-marker-extra` on each list.
> 
> **CSS** uses that variable to grow `padding-left` by `1ch` per extra digit, applies **tabular numerals** on `::marker`, and nudges **task-list checkboxes** inside ordered lists so they stay aligned. Footnote ordered lists drop the redundant fixed left padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0741755f0dbd5a0f2806ad3b6cfc3f5f0678840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ordered list number clipping in chat markdown for long lists
> - Adds a `orderedListMarkerExtraDigits` utility in [markdown-ordered-list.ts](https://github.com/pingdotgg/t3code/pull/5163/files#diff-8131c8b5266979c5ea27f81fe1fcb13a1f0d91c0441de736e62879f60eefe69d) that computes how many digits beyond two a list's widest marker requires, accounting for `start` offset and negative values.
> - The `ChatMarkdown` component overrides `<ol>` rendering to inject a `--chat-markdown-ol-marker-extra` CSS variable via inline style.
> - [index.css](https://github.com/pingdotgg/t3code/pull/5163/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) uses this variable to expand `padding-left` with `calc(1.25rem + var(--chat-markdown-ol-marker-extra, 0) * 1ch)`, adds `tabular-nums` to markers, and adjusts task-list checkbox alignment inside ordered lists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f074175.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->