### PR TITLE
fix(desktop,web): advertise all usable network interfaces as selectable endpoints

### DIFF
--- a/apps/desktop/src/backend/DesktopNetworkInterfaces.ts
+++ b/apps/desktop/src/backend/DesktopNetworkInterfaces.ts
@@ -20,6 +20,13 @@ export type NetworkInterfaces = Readonly<
   Record<string, readonly DesktopNetworkInterfaceInfo[] | undefined>
 >;
 
+// Some Node builds report the address family as the number 4/6 instead of
+// "IPv4"/"IPv6" (see DesktopBackendConfiguration.isLocalHostIpv4).
+export const isIpv4Family = (family: string | number): boolean => {
+  const normalized = String(family);
+  return normalized === "IPv4" || normalized === "4";
+};
+
 export class DesktopNetworkInterfacesReadError extends Schema.TaggedErrorClass<DesktopNetworkInterfacesReadError>()(
   "DesktopNetworkInterfacesReadError",
   {

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -552,6 +552,25 @@ describe("DesktopServerExposure", () => {
     ),
   );
 
+  it.effect("dedupes tailnet addresses reported with numeric family values", () =>
+    withHarness(
+      { tailscale0: [{ address: "100.90.1.2", family: 4, internal: false }] },
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+        yield* serverExposure.setMode("network-accessible");
+
+        const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+        const matches = endpoints.filter(
+          (endpoint) => endpoint.httpBaseUrl === "http://100.90.1.2:4173/",
+        );
+        assert.equal(matches.length, 1);
+        assert.isTrue(matches[0]!.id.startsWith("tailscale-ip:"));
+        assert.equal(matches[0]!.isDefault, true);
+      }),
+    ),
+  );
+
   it.effect("dedupes an address reported by multiple interfaces", () =>
     withHarness(
       {

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -38,6 +38,16 @@ const tailnetNetworkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces = {
   ],
 };
 
+const multiNicNetworkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces = {
+  wg0: [{ address: "10.8.0.5", family: "IPv4", internal: false }],
+  en0: [
+    { address: "192.168.1.20", family: "IPv4", internal: false },
+    { address: "fe80::1", family: "IPv6", internal: false },
+  ],
+  en1: [{ address: "169.254.10.10", family: "IPv4", internal: false }],
+  lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+};
+
 function mockSpawnerLayer(statusJson = "{}") {
   return Layer.succeed(
     ChildProcessSpawner.ChildProcessSpawner,
@@ -468,4 +478,134 @@ describe("DesktopServerExposure", () => {
       },
     ),
   );
+
+  it.effect("advertises one LAN endpoint per usable interface", () =>
+    withHarness(
+      multiNicNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        const change = yield* serverExposure.setMode("network-accessible");
+        assert.equal(change.state.advertisedHost, "10.8.0.5");
+        assert.equal(change.state.endpointUrl, "http://10.8.0.5:4173");
+
+        const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          endpoints.map((endpoint) => endpoint.httpBaseUrl),
+          ["http://127.0.0.1:4173/", "http://10.8.0.5:4173/", "http://192.168.1.20:4173/"],
+        );
+
+        const wgEndpoint = endpoints.find(
+          (endpoint) => endpoint.httpBaseUrl === "http://10.8.0.5:4173/",
+        );
+        const enEndpoint = endpoints.find(
+          (endpoint) => endpoint.httpBaseUrl === "http://192.168.1.20:4173/",
+        );
+        assert.equal(wgEndpoint?.label, "Local network (wg0)");
+        assert.equal(enEndpoint?.label, "Local network (en0)");
+        assert.equal(wgEndpoint?.isDefault, true);
+        assert.isTrue(enEndpoint !== undefined && !("isDefault" in enEndpoint));
+      }),
+    ),
+  );
+
+  it.effect("accepts numeric IPv4 family values", () =>
+    withHarness(
+      { eth0: [{ address: "192.168.7.7", family: 4, internal: false }] },
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        const change = yield* serverExposure.setMode("network-accessible");
+        assert.equal(change.state.advertisedHost, "192.168.7.7");
+
+        const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          endpoints.map((endpoint) => endpoint.httpBaseUrl),
+          ["http://127.0.0.1:4173/", "http://192.168.7.7:4173/"],
+        );
+      }),
+    ),
+  );
+
+  it.effect("stays network-accessible on tailnet-only machines without duplicate endpoints", () =>
+    withHarness(
+      tailnetNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        const change = yield* serverExposure.setMode("network-accessible");
+        assert.equal(change.state.advertisedHost, "100.90.1.2");
+
+        const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+        const matches = endpoints.filter(
+          (endpoint) => endpoint.httpBaseUrl === "http://100.90.1.2:4173/",
+        );
+        assert.equal(matches.length, 1);
+        assert.isTrue(matches[0]!.id.startsWith("tailscale-ip:"));
+        // The dropped LAN duplicate carried the default marker; it must move
+        // to the surviving Tailscale entry instead of disappearing.
+        assert.equal(matches[0]!.isDefault, true);
+      }),
+    ),
+  );
+
+  it.effect("dedupes an address reported by multiple interfaces", () =>
+    withHarness(
+      {
+        en0: [{ address: "192.168.1.20", family: "IPv4", internal: false }],
+        en1: [{ address: "192.168.1.20", family: "IPv4", internal: false }],
+      },
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+        yield* serverExposure.setMode("network-accessible");
+
+        const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          endpoints.map((endpoint) => endpoint.httpBaseUrl),
+          ["http://127.0.0.1:4173/", "http://192.168.1.20:4173/"],
+        );
+        assert.equal(endpoints[1]!.label, "Local network");
+      }),
+    ),
+  );
+
+  it.effect("reflects interface changes without reconfiguring", () => {
+    const mutableInterfaces: {
+      [name: string]: readonly DesktopNetworkInterfaces.DesktopNetworkInterfaceInfo[];
+    } = {
+      en0: [{ address: "192.168.1.20", family: "IPv4", internal: false }],
+    };
+    return withHarness(
+      mutableInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+        yield* serverExposure.setMode("network-accessible");
+
+        const initial = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          initial.map((endpoint) => endpoint.httpBaseUrl),
+          ["http://127.0.0.1:4173/", "http://192.168.1.20:4173/"],
+        );
+
+        mutableInterfaces["wg0"] = [{ address: "10.8.0.5", family: "IPv4", internal: false }];
+        const afterConnect = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          afterConnect.map((endpoint) => endpoint.httpBaseUrl),
+          ["http://127.0.0.1:4173/", "http://192.168.1.20:4173/", "http://10.8.0.5:4173/"],
+        );
+
+        delete mutableInterfaces["wg0"];
+        const afterDisconnect = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          afterDisconnect.map((endpoint) => endpoint.httpBaseUrl),
+          ["http://127.0.0.1:4173/", "http://192.168.1.20:4173/"],
+        );
+      }),
+    );
+  });
 });

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -9,7 +9,7 @@ import {
   type DesktopServerExposureMode,
   type DesktopServerExposureState,
 } from "@t3tools/contracts";
-import { readTailscaleStatus } from "@t3tools/tailscale";
+import { isTailscaleIpv4Address, readTailscaleStatus } from "@t3tools/tailscale";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -42,6 +42,7 @@ interface ResolvedDesktopServerExposure {
 interface DesktopAdvertisedEndpointInput {
   readonly port: number;
   readonly exposure: ResolvedDesktopServerExposure;
+  readonly advertisedLanHosts: readonly LanAdvertisedHost[];
   readonly customHttpsEndpointUrls?: readonly string[];
 }
 
@@ -67,6 +68,18 @@ const normalizeOptionalHost = (value: string | undefined): string | undefined =>
 const isUsableLanIpv4Address = (address: string): boolean =>
   !address.startsWith("127.") && !address.startsWith("169.254.");
 
+interface LanAdvertisedHost {
+  readonly address: string;
+  readonly interfaceName: string | null;
+}
+
+// Some Node builds report the address family as the number 4/6 instead of
+// "IPv4"/"IPv6" (see DesktopBackendConfiguration.isLocalHostIpv4).
+const isIpv4Family = (family: string | number): boolean => {
+  const normalized = String(family);
+  return normalized === "IPv4" || normalized === "4";
+};
+
 const isHttpsEndpointUrl = (value: string): boolean => {
   try {
     return new URL(value).protocol === "https:";
@@ -75,27 +88,39 @@ const isHttpsEndpointUrl = (value: string): boolean => {
   }
 };
 
-const resolveLanAdvertisedHost = (
+const resolveLanAdvertisedHosts = (
   networkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces,
   explicitHost: string | undefined,
-): string | null => {
+): readonly LanAdvertisedHost[] => {
   const normalizedExplicitHost = normalizeOptionalHost(explicitHost);
   if (normalizedExplicitHost) {
-    return normalizedExplicitHost;
+    return [{ address: normalizedExplicitHost, interfaceName: null }];
   }
 
-  for (const interfaceAddresses of Object.values(networkInterfaces)) {
+  const seenAddresses = new Set<string>();
+  const lanHosts: LanAdvertisedHost[] = [];
+  const tailnetHosts: LanAdvertisedHost[] = [];
+
+  for (const [interfaceName, interfaceAddresses] of Object.entries(networkInterfaces)) {
     if (!interfaceAddresses) continue;
 
     for (const address of interfaceAddresses) {
       if (address.internal) continue;
-      if (address.family !== "IPv4") continue;
+      if (!isIpv4Family(address.family)) continue;
       if (!isUsableLanIpv4Address(address.address)) continue;
-      return address.address;
+      if (seenAddresses.has(address.address)) continue;
+      seenAddresses.add(address.address);
+
+      const host: LanAdvertisedHost = { address: address.address, interfaceName };
+      if (isTailscaleIpv4Address(address.address)) {
+        tailnetHosts.push(host);
+      } else {
+        lanHosts.push(host);
+      }
     }
   }
 
-  return null;
+  return [...lanHosts, ...tailnetHosts];
 };
 
 const resolveDesktopServerExposure = (input: {
@@ -118,10 +143,11 @@ const resolveDesktopServerExposure = (input: {
     };
   }
 
-  const advertisedHost = resolveLanAdvertisedHost(
+  const advertisedLanHosts = resolveLanAdvertisedHosts(
     input.networkInterfaces,
     input.advertisedHostOverride,
   );
+  const advertisedHost = advertisedLanHosts[0]?.address ?? null;
 
   return {
     mode: input.mode,
@@ -165,19 +191,30 @@ const resolveDesktopCoreAdvertisedEndpoints = (
     }),
   ];
 
-  if (input.exposure.endpointUrl) {
+  const advertisedLanHosts = input.advertisedLanHosts;
+  // Tailnet addresses are replaced by the Tailscale provider's own entries
+  // below, so only the remaining hosts count toward needing disambiguation.
+  const namedLanHostCount = advertisedLanHosts.filter(
+    (host) => !isTailscaleIpv4Address(host.address),
+  ).length;
+  advertisedLanHosts.forEach((host, index) => {
+    const httpBaseUrl = `http://${host.address}:${input.port}`;
+    const label =
+      namedLanHostCount >= 2 && host.interfaceName !== null
+        ? `Local network (${host.interfaceName})`
+        : "Local network";
     endpoints.push(
       createDesktopEndpoint({
-        id: `desktop-lan:${input.exposure.endpointUrl}`,
-        label: "Local network",
-        httpBaseUrl: input.exposure.endpointUrl,
+        id: `desktop-lan:${httpBaseUrl}`,
+        label,
+        httpBaseUrl,
         reachability: "lan",
         status: "available",
-        isDefault: true,
+        ...(index === 0 ? { isDefault: true } : {}),
         description: "Reachable from devices on the same network.",
       }),
     );
-  }
+  });
 
   for (const customEndpointUrl of input.customHttpsEndpointUrls ?? []) {
     try {
@@ -524,9 +561,21 @@ export const make = Effect.gen(function* () {
   const getAdvertisedEndpoints = Effect.gen(function* () {
     const state = yield* Ref.get(stateRef);
     const currentNetworkInterfaces = yield* readNetworkInterfaces;
+    // Re-resolve LAN hosts on every read so interfaces that appear or vanish
+    // after startup (VPNs connecting/disconnecting, hot-plugged NICs) stay
+    // accurate. The backend binds 0.0.0.0 in network-accessible mode, so any
+    // currently-present address is reachable.
+    const advertisedLanHosts =
+      state.mode === "network-accessible"
+        ? resolveLanAdvertisedHosts(
+            currentNetworkInterfaces,
+            Option.getOrUndefined(config.desktopLanHostOverride),
+          )
+        : [];
     const coreEndpoints = resolveDesktopCoreAdvertisedEndpoints({
       port: state.port,
       exposure: toResolvedExposure(state),
+      advertisedLanHosts,
       customHttpsEndpointUrls: config.desktopHttpsEndpointUrls,
     });
 
@@ -547,7 +596,23 @@ export const make = Effect.gen(function* () {
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
       Effect.provideService(HttpClient.HttpClient, httpClient),
     );
-    return [...coreEndpoints, ...tailscaleEndpoints];
+    // A tailnet address surfaces through the Tailscale provider's richer
+    // entry; drop the plain LAN duplicate but keep the default marker on
+    // whichever entry survives.
+    const tailscaleUrls = new Set(tailscaleEndpoints.map((endpoint) => endpoint.httpBaseUrl));
+    const isDuplicateLanEndpoint = (endpoint: AdvertisedEndpoint): boolean =>
+      endpoint.id.startsWith("desktop-lan:") && tailscaleUrls.has(endpoint.httpBaseUrl);
+    const droppedDefault = coreEndpoints.find(
+      (endpoint) => isDuplicateLanEndpoint(endpoint) && endpoint.isDefault === true,
+    );
+    return [
+      ...coreEndpoints.filter((endpoint) => !isDuplicateLanEndpoint(endpoint)),
+      ...tailscaleEndpoints.map((endpoint) =>
+        endpoint.httpBaseUrl === droppedDefault?.httpBaseUrl
+          ? { ...endpoint, isDefault: true }
+          : endpoint,
+      ),
+    ];
   }).pipe(Effect.withSpan("desktop.serverExposure.getAdvertisedEndpoints"));
 
   return DesktopServerExposure.of({

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -73,13 +73,6 @@ interface LanAdvertisedHost {
   readonly interfaceName: string | null;
 }
 
-// Some Node builds report the address family as the number 4/6 instead of
-// "IPv4"/"IPv6" (see DesktopBackendConfiguration.isLocalHostIpv4).
-const isIpv4Family = (family: string | number): boolean => {
-  const normalized = String(family);
-  return normalized === "IPv4" || normalized === "4";
-};
-
 const isHttpsEndpointUrl = (value: string): boolean => {
   try {
     return new URL(value).protocol === "https:";
@@ -106,7 +99,7 @@ const resolveLanAdvertisedHosts = (
 
     for (const address of interfaceAddresses) {
       if (address.internal) continue;
-      if (!isIpv4Family(address.family)) continue;
+      if (!DesktopNetworkInterfaces.isIpv4Family(address.family)) continue;
       if (!isUsableLanIpv4Address(address.address)) continue;
       if (seenAddresses.has(address.address)) continue;
       seenAddresses.add(address.address);

--- a/apps/desktop/src/backend/tailscaleEndpointProvider.ts
+++ b/apps/desktop/src/backend/tailscaleEndpointProvider.ts
@@ -12,7 +12,7 @@ import * as Option from "effect/Option";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
-import type { NetworkInterfaces } from "./DesktopNetworkInterfaces.ts";
+import { isIpv4Family, type NetworkInterfaces } from "./DesktopNetworkInterfaces.ts";
 
 export { isTailscaleIpv4Address, parseTailscaleMagicDnsName } from "@t3tools/tailscale";
 
@@ -35,7 +35,7 @@ function resolveTailscaleIpAdvertisedEndpoints(input: {
 
     for (const address of interfaceAddresses) {
       if (address.internal) continue;
-      if (address.family !== "IPv4") continue;
+      if (!isIpv4Family(address.family)) continue;
       if (!isTailscaleIpv4Address(address.address)) continue;
       if (seen.has(address.address)) continue;
       seen.add(address.address);

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -2,9 +2,60 @@ import type { AdvertisedEndpoint, DesktopWslState } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   applyWslEnableSelection,
+  endpointDefaultPreferenceKey,
   isQrShareableEndpoint,
+  selectPairingEndpoint,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
+
+const DESKTOP_CORE_PROVIDER: AdvertisedEndpoint["provider"] = {
+  id: "desktop-core",
+  label: "Desktop",
+  kind: "core",
+  isAddon: false,
+};
+
+const COMPATIBLE_COMPATIBILITY: AdvertisedEndpoint["compatibility"] = {
+  hostedHttpsApp: "mixed-content-blocked",
+  desktopApp: "compatible",
+};
+
+function makeLanEndpoint(input: {
+  readonly address: string;
+  readonly port: number;
+  readonly isDefault?: boolean;
+}): AdvertisedEndpoint {
+  const httpBaseUrl = `http://${input.address}:${input.port}/`;
+  return {
+    id: `desktop-lan:http://${input.address}:${input.port}`,
+    label: "Local network",
+    provider: DESKTOP_CORE_PROVIDER,
+    httpBaseUrl,
+    wsBaseUrl: `ws://${input.address}:${input.port}/`,
+    reachability: "lan",
+    compatibility: COMPATIBLE_COMPATIBILITY,
+    source: "desktop-core",
+    status: "available",
+    ...(input.isDefault ? { isDefault: true } : {}),
+    description: "Reachable from devices on the same network.",
+  };
+}
+
+function makeLoopbackEndpoint(port: number): AdvertisedEndpoint {
+  const httpBaseUrl = `http://127.0.0.1:${port}/`;
+  return {
+    id: `desktop-loopback:${port}`,
+    label: "This machine",
+    provider: DESKTOP_CORE_PROVIDER,
+    httpBaseUrl,
+    wsBaseUrl: `ws://127.0.0.1:${port}/`,
+    reachability: "loopback",
+    compatibility: COMPATIBLE_COMPATIBILITY,
+    source: "desktop-core",
+    status: "available",
+    description: "Loopback endpoint for this desktop app.",
+  };
+}
 
 const baseWslState: DesktopWslState = {
   enabled: false,
@@ -161,5 +212,59 @@ describe("selectQrEndpointOption", () => {
     const loopbackOnly = options.slice(0, 1);
     expect(selectQrEndpointOption(loopbackOnly, null, null)?.id).toBe("desktop-loopback:4780");
     expect(selectQrEndpointOption([], "anything", "anything")).toBeNull();
+  });
+});
+
+describe("endpointDefaultPreferenceKey", () => {
+  it("gives distinct desktop-lan endpoints on different hosts distinct preference keys", () => {
+    const first = makeLanEndpoint({ address: "10.8.0.5", port: 4173 });
+    const second = makeLanEndpoint({ address: "192.168.1.20", port: 4173 });
+
+    expect(endpointDefaultPreferenceKey(first)).toBe("desktop-core:lan:http:10.8.0.5:4173");
+    expect(endpointDefaultPreferenceKey(second)).toBe("desktop-core:lan:http:192.168.1.20:4173");
+    expect(endpointDefaultPreferenceKey(first)).not.toBe(endpointDefaultPreferenceKey(second));
+  });
+
+  it("keeps the loopback preference key stable", () => {
+    expect(endpointDefaultPreferenceKey(makeLoopbackEndpoint(4173))).toBe(
+      "desktop-core:loopback:http",
+    );
+  });
+
+  it("embeds the host in tailscale-ip preference keys", () => {
+    const endpoint: AdvertisedEndpoint = {
+      id: "tailscale-ip:http://100.90.1.2:4173",
+      label: "Tailscale IP",
+      provider: { id: "tailscale", label: "Tailscale", kind: "private-network", isAddon: true },
+      httpBaseUrl: "http://100.90.1.2:4173/",
+      wsBaseUrl: "ws://100.90.1.2:4173/",
+      reachability: "private-network",
+      compatibility: COMPATIBLE_COMPATIBILITY,
+      source: "desktop-addon",
+      status: "available",
+      description: "Reachable from devices on the same Tailnet.",
+    };
+
+    expect(endpointDefaultPreferenceKey(endpoint)).toBe("tailscale:ip:http:100.90.1.2:4173");
+  });
+});
+
+describe("selectPairingEndpoint", () => {
+  it("selects the endpoint matching a stored preference key for the second LAN address", () => {
+    const first = makeLanEndpoint({ address: "10.8.0.5", port: 4173, isDefault: true });
+    const second = makeLanEndpoint({ address: "192.168.1.20", port: 4173 });
+
+    const selected = selectPairingEndpoint([first, second], endpointDefaultPreferenceKey(second));
+
+    expect(selected).toBe(second);
+  });
+
+  it("falls back to the default endpoint when a legacy preference key matches nothing", () => {
+    const first = makeLanEndpoint({ address: "10.8.0.5", port: 4173, isDefault: true });
+    const second = makeLanEndpoint({ address: "192.168.1.20", port: 4173 });
+
+    const selected = selectPairingEndpoint([first, second], "desktop-core:lan:http");
+
+    expect(selected).toBe(first);
   });
 });

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -231,6 +231,25 @@ describe("endpointDefaultPreferenceKey", () => {
     );
   });
 
+  it("distinguishes manual endpoints that share a label by host", () => {
+    const makeManualEndpoint = (url: string): AdvertisedEndpoint => ({
+      id: `manual:${url}`,
+      label: "Custom HTTPS",
+      provider: { id: "manual", label: "Manual", kind: "manual", isAddon: false },
+      httpBaseUrl: `${url}/`,
+      wsBaseUrl: `${url.replace("https:", "wss:")}/`,
+      reachability: "public",
+      compatibility: { hostedHttpsApp: "compatible", desktopApp: "compatible" },
+      source: "user",
+      status: "unknown",
+      description: "User-configured HTTPS endpoint for this desktop backend.",
+    });
+    const first = makeManualEndpoint("https://one.example.test");
+    const second = makeManualEndpoint("https://two.example.test");
+
+    expect(endpointDefaultPreferenceKey(first)).not.toBe(endpointDefaultPreferenceKey(second));
+  });
+
   it("embeds the host in tailscale-ip preference keys", () => {
     const endpoint: AdvertisedEndpoint = {
       id: "tailscale-ip:http://100.90.1.2:4173",

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -62,3 +62,60 @@ export async function applyWslEnableSelection(input: {
   }
   return await bridge.setWslBackendEnabled(true);
 }
+
+function endpointHostKey(endpoint: AdvertisedEndpoint): string {
+  try {
+    return new URL(endpoint.httpBaseUrl).host;
+  } catch {
+    return endpoint.httpBaseUrl;
+  }
+}
+
+export function selectPairingEndpoint(
+  endpoints: ReadonlyArray<AdvertisedEndpoint>,
+  defaultEndpointKey?: string | null,
+): AdvertisedEndpoint | null {
+  const availableEndpoints = endpoints.filter((endpoint) => endpoint.status !== "unavailable");
+  if (defaultEndpointKey) {
+    const selectedEndpoint = availableEndpoints.find(
+      (endpoint) => endpointDefaultPreferenceKey(endpoint) === defaultEndpointKey,
+    );
+    if (selectedEndpoint) {
+      return selectedEndpoint;
+    }
+  }
+  return (
+    availableEndpoints.find((endpoint) => endpoint.isDefault) ??
+    availableEndpoints.find((endpoint) => endpoint.reachability !== "loopback") ??
+    availableEndpoints.find((endpoint) => endpoint.compatibility.hostedHttpsApp === "compatible") ??
+    null
+  );
+}
+
+export function isTailscaleHttpsEndpoint(endpoint: AdvertisedEndpoint): boolean {
+  return endpoint.id.startsWith("tailscale-magicdns:");
+}
+
+export function endpointDefaultPreferenceKey(endpoint: AdvertisedEndpoint): string {
+  if (endpoint.id.startsWith("desktop-loopback:")) {
+    return "desktop-core:loopback:http";
+  }
+  if (endpoint.id.startsWith("desktop-lan:")) {
+    return `desktop-core:lan:http:${endpointHostKey(endpoint)}`;
+  }
+  if (endpoint.id.startsWith("tailscale-ip:")) {
+    return `tailscale:ip:http:${endpointHostKey(endpoint)}`;
+  }
+  if (isTailscaleHttpsEndpoint(endpoint)) {
+    return "tailscale:magicdns:https";
+  }
+
+  let scheme = "unknown";
+  try {
+    scheme = new URL(endpoint.httpBaseUrl).protocol.replace(/:$/u, "");
+  } catch {
+    // Keep the stored preference stable even if a custom endpoint is malformed.
+  }
+
+  return `${endpoint.provider.id}:${endpoint.reachability}:${scheme}:${endpoint.label}`;
+}

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -117,5 +117,5 @@ export function endpointDefaultPreferenceKey(endpoint: AdvertisedEndpoint): stri
     // Keep the stored preference stable even if a custom endpoint is malformed.
   }
 
-  return `${endpoint.provider.id}:${endpoint.reachability}:${scheme}:${endpoint.label}`;
+  return `${endpoint.provider.id}:${endpoint.reachability}:${scheme}:${endpoint.label}:${endpointHostKey(endpoint)}`;
 }

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -42,7 +42,10 @@ import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestam
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
 import {
   applyWslEnableSelection,
+  endpointDefaultPreferenceKey,
   isQrShareableEndpoint,
+  isTailscaleHttpsEndpoint,
+  selectPairingEndpoint,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
 import {
@@ -420,55 +423,6 @@ function toDesktopClientSessionRecord(clientSession: AuthClientSession): ServerC
         ? null
         : DateTime.formatIso(clientSession.lastConnectedAt),
   };
-}
-
-function selectPairingEndpoint(
-  endpoints: ReadonlyArray<AdvertisedEndpoint>,
-  defaultEndpointKey?: string | null,
-): AdvertisedEndpoint | null {
-  const availableEndpoints = endpoints.filter((endpoint) => endpoint.status !== "unavailable");
-  if (defaultEndpointKey) {
-    const selectedEndpoint = availableEndpoints.find(
-      (endpoint) => endpointDefaultPreferenceKey(endpoint) === defaultEndpointKey,
-    );
-    if (selectedEndpoint) {
-      return selectedEndpoint;
-    }
-  }
-  return (
-    availableEndpoints.find((endpoint) => endpoint.isDefault) ??
-    availableEndpoints.find((endpoint) => endpoint.reachability !== "loopback") ??
-    availableEndpoints.find((endpoint) => endpoint.compatibility.hostedHttpsApp === "compatible") ??
-    null
-  );
-}
-
-function isTailscaleHttpsEndpoint(endpoint: AdvertisedEndpoint): boolean {
-  return endpoint.id.startsWith("tailscale-magicdns:");
-}
-
-function endpointDefaultPreferenceKey(endpoint: AdvertisedEndpoint): string {
-  if (endpoint.id.startsWith("desktop-loopback:")) {
-    return "desktop-core:loopback:http";
-  }
-  if (endpoint.id.startsWith("desktop-lan:")) {
-    return "desktop-core:lan:http";
-  }
-  if (endpoint.id.startsWith("tailscale-ip:")) {
-    return "tailscale:ip:http";
-  }
-  if (isTailscaleHttpsEndpoint(endpoint)) {
-    return "tailscale:magicdns:https";
-  }
-
-  let scheme = "unknown";
-  try {
-    scheme = new URL(endpoint.httpBaseUrl).protocol.replace(/:$/u, "");
-  } catch {
-    // Keep the stored preference stable even if a custom endpoint is malformed.
-  }
-
-  return `${endpoint.provider.id}:${endpoint.reachability}:${scheme}:${endpoint.label}`;
 }
 
 function resolveAdvertisedEndpointPairingUrl(


### PR DESCRIPTION
## What Changed

Settings → Connections → Network access advertised a single "Local network" endpoint: the first non-internal IPv4 that `os.networkInterfaces()` happened to enumerate. On multi-homed machines (VPN + LAN) the VPN adapter often wins, and the addresses other devices can actually reach are never shown or selectable.

Now every usable IPv4 interface is advertised as its own selectable endpoint:

- `resolveLanAdvertisedHost` → `resolveLanAdvertisedHosts`: enumerates all non-internal, non-loopback, non-link-local IPv4 addresses with their interface names, deduped. Regular LAN/VPN addresses order ahead of Tailscale CGNAT addresses, so a real NIC wins the default while Tailnet-only machines keep working.
- One `desktop-lan:` endpoint per address, labeled with the interface name — "Local network (en0)" — when more than one would show; `isDefault` stays on the first.
- Endpoints are re-resolved from live interfaces on every `getAdvertisedEndpoints` read, so a VPN connecting or dropping after launch is reflected on the settings UI's normal refresh. The backend already binds `0.0.0.0` in network-accessible mode, so any currently-present address is reachable.
- A Tailnet address that would appear as both "Local network" and "Tailscale IP" keeps only the Tailscale entry; the default marker transfers with it if it was the default.
- Web: `endpointDefaultPreferenceKey` now embeds `host:port` for `desktop-lan:`/`tailscale-ip:` endpoints so each interface can individually be set as default. Previously all LAN endpoints collapsed to one key, so with several rows every one would have matched the stored default. A stored legacy key matches nothing and falls back to the `isDefault` endpoint — no migration needed.
- Accepts numeric `family: 4` from `os.networkInterfaces()`, matching the existing normalizations in `startupAccess.ts:41` and `DesktopBackendConfiguration.ts:348`.

The wire contract is unchanged: `DesktopServerExposureState.advertisedHost`/`endpointUrl` still carry the first host, `T3CODE_DESKTOP_LAN_HOST` still overrides to a single host, and "no usable address → fall back to local-only" behaves identically. Only the advertised-endpoints list grew.

Verification: 5 new desktop tests (per-interface enumeration/labels/default, numeric family, tailnet dedupe with default transfer, cross-interface address dedupe, live interface changes) and 3 new web tests for the preference keys; full desktop suite 411 passing, web unit suite passing, typecheck and `vp check` clean.

## Why

Fixes #2031. On hosts with several interfaces (VPN/WireGuard + LAN), the auto-picked address is frequently one other devices can't reach, so the "Reachable at" note and copied pairing URLs need hand-editing. #2031 proposed a manual hostname override (#2086, closed as superseded by the endpoint catalog); the catalog can instead offer all interfaces directly, which keeps the copy/pairing flows working with zero typing and lets the user pick a different default per machine.

## UI Changes

Before/after screenshots coming before this leaves draft: the Network access row previously listed one "Local network" entry; it now lists one entry per interface with the interface name, each selectable as default.

<img width="791" height="423" alt="Before" src="https://github.com/user-attachments/assets/fd658f90-3e5b-4f3a-8874-70ed184852c4" />
<img width="948" height="506" alt="After" src="https://github.com/user-attachments/assets/738ce0bf-fe5a-4d54-888e-b768628cd9e3" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (n/a)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Advertise all usable network interfaces as selectable endpoints in desktop and web
> - Replaces single-LAN-endpoint logic with `resolveLanAdvertisedHosts` in [`DesktopServerExposure.ts`](https://github.com/pingdotgg/t3code/pull/5165/files#diff-87d5808073ddb6ad6696185597726c0867bb1276e88997a57829cf9839e8abcb), which iterates all interfaces, filters to non-loopback IPv4 addresses, deduplicates by IP, and returns LAN addresses followed by Tailscale addresses.
> - `resolveDesktopCoreAdvertisedEndpoints` now emits one `AdvertisedEndpoint` per resolved LAN host; labels include the interface name (e.g. "Local network (en0)") when multiple non-Tailscale interfaces are present.
> - `getAdvertisedEndpoints` re-reads interfaces on every call to reflect VPN/NIC changes without reconfiguration, and deduplicates LAN entries that share an IP with a Tailscale endpoint, transferring the `isDefault` flag when needed.
> - Adds `isIpv4Family` helper in [`DesktopNetworkInterfaces.ts`](https://github.com/pingdotgg/t3code/pull/5165/files#diff-7a853546c1249bac45306a6a573ec0821ed866dea7be3e5780cdbaa5017e3a04) to treat numeric family `4` as IPv4, fixing Tailscale IP discovery in those environments.
> - Adds `endpointDefaultPreferenceKey` in [`ConnectionsSettings.logic.ts`](https://github.com/pingdotgg/t3code/pull/5165/files#diff-a7a170d2c0884c270c94cda8b4f4498c1488857ae1c1cfda21e6233e15ec0110) that encodes host information in preference keys to avoid collisions between multiple LAN or Tailscale-IP endpoints sharing the same label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ab2ef5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how advertised LAN endpoints and stored default preferences are computed; multi-NIC users may see more endpoints and old single-key LAN defaults may not match until they pick a default again—pairing URL selection behavior is user-visible but bounded to network exposure settings.
> 
> **Overview**
> **Network-accessible desktop** now discovers **every usable IPv4** (non-internal, non-link-local, deduped), not just the first interface—so VPN + LAN machines get separate **Local network** rows (with interface names when there are multiple) and pairing/copy URLs can target the address peers can actually reach.
> 
> **Desktop exposure** re-resolves interfaces on each `getAdvertisedEndpoints` read (VPN connect/disconnect), orders non-Tailscale addresses before tailnet IPs for the primary/default host, and **drops duplicate LAN rows** when Tailscale already advertises the same URL—moving **`isDefault`** to the Tailscale entry. **`isIpv4Family`** centralizes handling of Node’s numeric `family: 4`.
> 
> **Web Connections** moves pairing/default helpers into `ConnectionsSettings.logic` and changes **`endpointDefaultPreferenceKey`** to include **host:port** per `desktop-lan` / `tailscale-ip` so each interface can be saved as default; legacy keys fall back to the marked default endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ab2ef514adc2be1d7efbdfcda8949f3fb3364fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->