### PR TITLE
fix(web): animate command palette when closing

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -28,7 +28,7 @@ describe("reduceCommandPaletteUiState", () => {
 
     expect(
       reduceCommandPaletteUiState(contentOpen, { _tag: "ToggleMode", mode: "content" }),
-    ).toEqual({ open: false, mode: "command", openIntent: null });
+    ).toEqual({ open: false, mode: "content", openIntent: null });
   });
 
   it("switches between open modes without closing", () => {
@@ -62,7 +62,7 @@ describe("reduceCommandPaletteUiState", () => {
     });
   });
 
-  it("resets to command mode for dialog-driven opens and closes", () => {
+  it("preserves the mode on close and resets it on open", () => {
     const filesOpen = reduceCommandPaletteUiState(closedState, {
       _tag: "ToggleMode",
       mode: "files",
@@ -70,7 +70,7 @@ describe("reduceCommandPaletteUiState", () => {
 
     expect(reduceCommandPaletteUiState(filesOpen, { _tag: "SetOpen", open: false })).toEqual({
       open: false,
-      mode: "command",
+      mode: "files",
       openIntent: null,
     });
     expect(reduceCommandPaletteUiState(filesOpen, { _tag: "SetOpen", open: true })).toEqual({

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -46,14 +46,12 @@ export function reduceCommandPaletteUiState(
 ): CommandPaletteUiState {
   switch (action._tag) {
     case "SetOpen":
-      return {
-        open: action.open,
-        mode: "command",
-        openIntent: action.open ? state.openIntent : null,
-      };
+      return action.open
+        ? { open: true, mode: "command", openIntent: state.openIntent }
+        : { ...state, open: false, openIntent: null };
     case "ToggleMode":
       return state.open && state.mode === action.mode
-        ? { open: false, mode: "command", openIntent: null }
+        ? { ...state, open: false, openIntent: null }
         : { open: true, mode: action.mode, openIntent: null };
     case "OpenAddProject":
       return { open: true, mode: "command", openIntent: { kind: "add-project" } };

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -458,7 +458,6 @@ export function CommandPalette({ children }: { children: ReactNode }) {
       >
         {children}
         <CommandPaletteDialog
-          open={state.open}
           mode={state.mode}
           openIntent={state.openIntent}
           setOpen={setOpen}
@@ -471,7 +470,6 @@ export function CommandPalette({ children }: { children: ReactNode }) {
 }
 
 function CommandPaletteDialog(props: {
-  readonly open: boolean;
   readonly mode: SearchOverlayMode;
   readonly openIntent: CommandPaletteOpenIntent | null;
   readonly setOpen: (open: boolean) => void;
@@ -479,10 +477,6 @@ function CommandPaletteDialog(props: {
   readonly clearOpenIntent: () => void;
 }) {
   const composerHandleRef = useComposerHandleContext();
-
-  if (!props.open) {
-    return null;
-  }
 
   return (
     <CommandDialogPopup


### PR DESCRIPTION
## What Changed

Keep the command palette dialog mounted while Base UI runs its closing transition.

## Why

The dialog returned `null` as soon as its open state changed to false, which skipped Base UI's ending transition and made the palette disappear immediately.

## UI Changes

Before:

https://github.com/user-attachments/assets/3c7222c1-58f4-4e42-922d-01bccd16f986

After:

https://github.com/user-attachments/assets/450cca12-34a8-4e92-aa0d-9c4f5dc1c609

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included a video for animation/interaction changes

Model: GPT-5
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized command-palette UI state and mount behavior with no auth, data, or API changes; regression risk is limited to palette open/close and mode shortcuts.
> 
> **Overview**
> Fixes the command palette disappearing instantly on close by **keeping `CommandPaletteDialog` mounted** instead of returning `null` when closed. Visibility is left to the parent **`CommandDialog`** (`open={state.open}`), so Base UI can run its closing transition on **`CommandDialogPopup`**.
> 
> The UI reducer **`reduceCommandPaletteUiState`** is adjusted to match that lifecycle: **closing** via `SetOpen(false)` or toggling off the active mode no longer forces `mode` back to `command`; the current mode (files/content) is preserved while closed. **Reopening** with `SetOpen(true)` still opens in **command** mode and clears `openIntent` on close as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd2bb324ce9ec57f165bbad6ca6e946fa1a8dfa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Animate command palette when closing by keeping dialog subtree mounted
> - The `CommandPaletteDialog` component no longer unmounts when the palette closes; the outer `CommandDialog` controls visibility so the subtree stays mounted and can animate out.
> - The `reduceCommandPaletteUiState` reducer now preserves the current mode on close instead of resetting to `'command'`; mode resets to `'command'` only when reopening via `SetOpen(true)`.
> - `ToggleMode` on the active mode now closes the palette without resetting the mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd2bb32.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->