### PR TITLE
chore(ci): bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -144,7 +144,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -95,7 +95,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -123,7 +123,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -37,7 +37,7 @@ jobs:
       ALCHEMY_TELEMETRY_DISABLED: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -65,7 +65,7 @@ jobs:
           APNS_PRIVATE_KEY: ${{ secrets.APNS_PRIVATE_KEY }}
 
       - name: Publish relay deploy commit status
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const result = "${{ steps.deploy.outputs.result }}";

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Ensure managed issue labels exist
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const managedLabels = [

--- a/.github/workflows/mobile-eas-preview.yml
+++ b/.github/workflows/mobile-eas-preview.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         if: steps.expo-token.outputs.present == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # No sparse-checkout here: it makes actions/checkout fetch with
@@ -64,7 +64,7 @@ jobs:
 
       - name: Setup EAS
         if: steps.expo-token.outputs.present == 'true'
-        uses: expo/expo-github-action@v8
+        uses: expo/expo-github-action@v9
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Deploy with fingerprint check
         if: steps.expo-token.outputs.present == 'true'
-        uses: expo/expo-github-action/continuous-deploy-fingerprint@main
+        uses: expo/expo-github-action/continuous-deploy-fingerprint@v9
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         with:

--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -98,7 +98,7 @@ jobs:
       - id: version_app_token
         name: Mint release app token for version override
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build' && inputs.version != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Checkout
         if: steps.expo-token.outputs.present == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ steps.version_app_token.outputs.token || github.token }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Setup EAS
         if: steps.expo-token.outputs.present == 'true'
-        uses: expo/expo-github-action@v8
+        uses: expo/expo-github-action@v9
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout
         if: steps.expo-token.outputs.present == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # No sparse-checkout here: it makes actions/checkout fetch with
@@ -82,7 +82,7 @@ jobs:
 
       - name: Setup EAS
         if: steps.expo-token.outputs.present == 'true'
-        uses: expo/expo-github-action@v8
+        uses: expo/expo-github-action@v9
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/mobile-fingerprint-check.yml
+++ b/.github/workflows/mobile-fingerprint-check.yml
@@ -42,7 +42,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Default pull_request checkout is the merge commit (PR applied on
           # top of base), so the "head" fingerprint is the state main would
@@ -117,7 +117,7 @@ jobs:
         # advisory there (summary only). This workflow must not move to
         # pull_request_target — it installs and runs PR code.
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           CHANGED_PLATFORMS: ${{ steps.compare.outputs.changed_platforms }}
         with:

--- a/.github/workflows/mobile-showcase-screenshots.yml
+++ b/.github/workflows/mobile-showcase-screenshots.yml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: ${{ inputs.theme == 'all' && 300 || 60 }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -102,7 +102,7 @@ jobs:
       T3_SHOWCASE_ANDROID_ABI: x86_64
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -134,7 +134,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle cache
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/mobile-showcase-screenshots.yml
+++ b/.github/workflows/mobile-showcase-screenshots.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -85,7 +85,7 @@ jobs:
       T3_SHOWCASE_ANDROID_ABI: x86_64
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             /*
@@ -117,7 +117,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle cache
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - id: config
         name: Build PR size label config
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           result-encoding: string
           script: |
@@ -64,7 +64,7 @@ jobs:
       issues: write
     steps:
       - name: Ensure PR size labels exist
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           PR_SIZE_LABELS_JSON: ${{ needs.prepare-config.outputs.labels_json }}
         with:
@@ -128,11 +128,11 @@ jobs:
       # git data. Do not add dependency installs, build/test scripts, or cache
       # actions here; use pull_request plus workflow_run for that pattern instead.
       - name: Checkout base repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Sync PR size label
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           PR_SIZE_LABELS_JSON: ${{ needs.prepare-config.outputs.labels_json }}
         with:

--- a/.github/workflows/pr-vouch.yml
+++ b/.github/workflows/pr-vouch.yml
@@ -25,7 +25,7 @@ jobs:
       targets: ${{ steps.collect.outputs.targets }}
     steps:
       - id: collect
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             if (context.eventName === "pull_request_target") {
@@ -85,7 +85,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sync PR labels
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ matrix.target.number }}
           VOUCH_STATUS: ${{ steps.vouch.outputs.status }}

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -47,7 +47,7 @@ jobs:
         run: pacman -Syu --noconfirm --needed git github-cli jq namcap openssh sudo
 
       - name: Checkout packaging sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create unprivileged build user
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           sparse-checkout: |
@@ -85,7 +85,7 @@ jobs:
       ref: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           sparse-checkout: |
@@ -197,7 +197,7 @@ jobs:
       CLERK_CLI_OAUTH_CLIENT_ID: ${{ vars.CLERK_CLI_OAUTH_CLIENT_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -278,7 +278,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -373,7 +373,7 @@ jobs:
           #   arch: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -416,7 +416,7 @@ jobs:
 
       - name: Download WSL node-pty prebuild
         if: matrix.platform == 'win'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: wsl-node-pty-x64
           path: wsl-prebuild
@@ -678,7 +678,7 @@ jobs:
       T3CODE_RELAY_URL: ${{ needs.relay_public_config.outputs.relay_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -751,7 +751,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -886,7 +886,7 @@ jobs:
       VERCEL_TEAM_SLUG: ${{ vars.VERCEL_TEAM_SLUG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -994,14 +994,14 @@ jobs:
     steps:
       - id: app_token
         name: Mint release app token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -1078,7 +1078,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           sparse-checkout: |
@@ -85,7 +85,7 @@ jobs:
       ref: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           sparse-checkout: |
@@ -197,7 +197,7 @@ jobs:
       CLERK_CLI_OAUTH_CLIENT_ID: ${{ vars.CLERK_CLI_OAUTH_CLIENT_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -278,7 +278,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -373,7 +373,7 @@ jobs:
           #   arch: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -416,7 +416,7 @@ jobs:
 
       - name: Download WSL node-pty prebuild
         if: matrix.platform == 'win'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: wsl-node-pty-x64
           path: wsl-prebuild
@@ -678,7 +678,7 @@ jobs:
       T3CODE_RELAY_URL: ${{ needs.relay_public_config.outputs.relay_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -750,14 +750,14 @@ jobs:
     steps:
       - id: app_token
         name: Mint release app token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -823,7 +823,7 @@ jobs:
 
       - name: Publish release
         if: needs.preflight.outputs.previous_tag != ''
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.preflight.outputs.tag }}
           target_commitish: ${{ needs.preflight.outputs.ref }}
@@ -844,7 +844,7 @@ jobs:
 
       - name: Publish first release
         if: needs.preflight.outputs.previous_tag == ''
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.preflight.outputs.tag }}
           target_commitish: ${{ needs.preflight.outputs.ref }}
@@ -882,7 +882,7 @@ jobs:
       VERCEL_TEAM_SLUG: ${{ vars.VERCEL_TEAM_SLUG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |
@@ -990,14 +990,14 @@ jobs:
     steps:
       - id: app_token
         name: Mint release app token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -1074,7 +1074,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           sparse-checkout: |

--- a/.github/workflows/thread-transfer-report.yml
+++ b/.github/workflows/thread-transfer-report.yml
@@ -22,7 +22,7 @@ jobs:
       # workflow_run has a write-capable token even for fork PRs. Only load the
       # publisher from the trusted default branch and never execute PR code.
       - name: Checkout trusted publisher
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: .github/scripts
@@ -32,7 +32,7 @@ jobs:
 
       - id: resolve
         name: Resolve PR and baseline artifacts
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const reporter = require("./.github/scripts/thread-transfer-report.cjs");
@@ -58,7 +58,7 @@ jobs:
 
       - name: Update thread transfer comment
         if: steps.resolve.outputs.publish == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ steps.resolve.outputs.pull_number }}
           PR_SHA: ${{ steps.resolve.outputs.pr_sha }}

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -46,7 +46,7 @@ jobs:
       VERCEL_TEAM_SLUG: ${{ vars.VERCEL_TEAM_SLUG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           sparse-checkout: |
@@ -89,7 +89,7 @@ jobs:
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
 
       - name: Comment deployment URL
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## What Changed

Bumped every GitHub Action in `.github/workflows/` to the latest major version and rebased onto `upstream/main` (`b2e2ccfd`).

| Action | From | To | Workflows |
| --- | --- | --- | --- |
| `actions/checkout` | `v6` (and `v4` in pr-size on old base) | `v7` | `ci`, `deploy-relay`, `mobile-eas-preview`, `mobile-eas-production`, `mobile-fingerprint-check`, `mobile-showcase-screenshots`, `pr-size`, `publish-aur`, `release`, `thread-transfer-report`, `web-preview` |
| `actions/github-script` | `v8` (and `v7` in issue-labels) | `v9` | `deploy-relay`, `issue-labels`, `mobile-fingerprint-check`, `pr-size`, `pr-vouch`, `thread-transfer-report`, `web-preview` |
| `actions/download-artifact` | `v7` (one step in release) | `v8` | `release` |
| `actions/create-github-app-token` | `v2` | `v3` | `mobile-eas-production`, `release` (finalize) |
| `expo/expo-github-action` | `v8` (+ `continuous-deploy-fingerprint@main`) | `v9` | `mobile-eas-preview`, `mobile-eas-production` |
| `gradle/actions/setup-gradle` | `v5` | `v6` | `mobile-showcase-screenshots` |

All 13 workflows in `.github/workflows/` now pinned to latest majors. Actions already on latest were left alone (`setup-vp@v1`, `rust-toolchain@stable`, `upload-artifact@v7`, `download-artifact@v8` elsewhere, `setup-java@v5`, `android-emulator-runner@v2`, `vouch@v1`, `softprops/action-gh-release@v3`). The `expo` fingerprint sub-action is pinned to the released `v9` tag instead of `@main`.

Rebase resolved the `release.yml` conflict — upstream removed the `release` job's app-token step and switched to `github.token` with `timeout-minutes: 30` + `permissions: contents: write`; this PR keeps that upstream shape and only bumps `checkout`/`download-artifact` there.

## Why

CI/CD had drifted behind upstream releases. The original sweep found no PR updating Actions to latest majors. After 429 commits on `main` since the branch was cut (`ca72e381` → `b2e2ccfd`), 4 new workflows landed (`mobile-fingerprint-check.yml`, `publish-aur.yml`, `thread-transfer-report.yml`, `web-preview.yml`) — all were still on old pins, so this update now covers them too. Kept scope tight: no workflow logic changes, only version pins.

Compatibility checked before bumping:
- `github-script@v9` breaks `require('@actions/github')`; no workflow script uses it.
- All inputs in use exist in the new majors (`create-github-app-token@v3`, `expo-github-action@v9`).
- `checkout@v7`'s safer `pull_request_target` default is safe here — the pr-size label job only checks out the base repo.

## UI Changes

N/A — CI-only changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

---

Note: `gradle/actions/setup-gradle@v6` moves the caching component to Gradle's proprietary `gradle-actions-caching` library (MIT only when caching is disabled) — flagging in case that's a blocker; it only affects the manual screenshot workflow.

Rebased: `chore/update-github-actions-to-latest` now on top of `upstream/main` @ `b2e2ccfd` (`fix(server): preserve tool lifecycle identity (#7151)`).
