### PR TITLE
fix(web): separate image attachments from message text

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -306,9 +306,8 @@ import {
   serverUpdateGuidance,
 } from "../versionSkew";
 import { useAssetUrls } from "../assets/assetUrls";
+import { IMAGE_ONLY_BOOTSTRAP_PROMPT } from "~/lib/userMessage";
 
-const IMAGE_ONLY_BOOTSTRAP_PROMPT =
-  "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_PROVIDERS: ServerProvider[] = [];
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -428,9 +428,66 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain('alt="screenshot.png"');
+    expect(markup).toContain('data-user-message-attachments="true"');
     expect(markup).not.toContain("User attached one or more images");
+    expect(markup).not.toContain('data-user-message-content="true"');
     expect(markup).not.toContain('data-user-message-body="true"');
     expect(markup).not.toContain('aria-label="Copy link"');
+  });
+
+  it("renders attachments above a separate text bubble", () => {
+    const captionedImageEntry = {
+      ...buildUserTimelineEntry("Caption for the image."),
+      message: {
+        ...buildUserTimelineEntry("Caption for the image.").message,
+        attachments: [
+          {
+            type: "image" as const,
+            id: "attachment-captioned",
+            name: "captioned.png",
+            mimeType: "image/png",
+            sizeBytes: 1,
+            previewUrl: "data:image/png;base64,iVBORw0KGgo=",
+          },
+        ],
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[captionedImageEntry]} />,
+    );
+    const attachmentsIndex = markup.indexOf('data-user-message-attachments="true"');
+    const contentIndex = markup.indexOf('data-user-message-content="true"');
+
+    expect(attachmentsIndex).toBeGreaterThan(-1);
+    expect(contentIndex).toBeGreaterThan(attachmentsIndex);
+    expect(markup).toContain("Caption for the image.");
+    expect(markup).toContain("grid-cols-1");
+  });
+
+  it("collapses larger attachment sets into a four-tile mosaic", () => {
+    const mosaicEntry = {
+      ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT),
+      message: {
+        ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT).message,
+        attachments: Array.from({ length: 6 }, (_, index) => ({
+          type: "image" as const,
+          id: `attachment-${index + 1}`,
+          name: `image-${index + 1}.png`,
+          mimeType: "image/png",
+          sizeBytes: 1,
+          previewUrl: `data:image/png;base64,image-${index + 1}`,
+        })),
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[mosaicEntry]} />,
+    );
+
+    expect(markup).toContain('data-user-message-attachments-collapsed="true"');
+    expect(markup).toContain('alt="image-4.png"');
+    expect(markup).not.toContain('alt="image-5.png"');
+    expect(markup).toContain('aria-label="Preview image-4.png and 2 more images"');
+    expect(markup).toContain(">+2</span>");
   });
 
   it("renders collapse controls for long user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -464,6 +464,33 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("grid-cols-1");
   });
 
+  it("preserves a user caption that matches the readable bootstrap instruction", () => {
+    const caption =
+      "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
+    const captionedImageEntry = {
+      ...buildUserTimelineEntry(caption),
+      message: {
+        ...buildUserTimelineEntry(caption).message,
+        attachments: [
+          {
+            type: "image" as const,
+            id: "attachment-caption-collision",
+            name: "captioned.png",
+            mimeType: "image/png",
+            sizeBytes: 1,
+            previewUrl: "data:image/png;base64,iVBORw0KGgo=",
+          },
+        ],
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[captionedImageEntry]} />,
+    );
+
+    expect(markup).toContain("User attached one or more images without additional text");
+    expect(markup).toContain('data-user-message-content="true"');
+  });
+
   it("collapses larger attachment sets into a four-tile mosaic", () => {
     const mosaicEntry = {
       ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT),
@@ -501,9 +528,7 @@ describe("MessagesTimeline", () => {
       name: `image-${index + 1}.png`,
       mimeType: "image/png",
       sizeBytes: 1,
-      ...(index === 3
-        ? {}
-        : { previewUrl: `data:image/png;base64,image-${index + 1}` }),
+      ...(index === 3 ? {} : { previewUrl: `data:image/png;base64,image-${index + 1}` }),
     }));
     const mosaicEntry = {
       ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT),
@@ -519,6 +544,8 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('alt="image-5.png"');
     expect(markup).toContain('aria-label="Preview image-5.png and 2 more images"');
     expect(markup).toContain(">+2</span>");
+    expect(markup).toContain('data-user-message-attachments-without-previews="true"');
+    expect(markup).toContain("image-4.png");
   });
 
   it("shows the collapsed count when no attachments have previews", () => {
@@ -542,6 +569,8 @@ describe("MessagesTimeline", () => {
 
     expect(markup).toContain("image-4.png");
     expect(markup).toContain(">+2</span>");
+    expect(markup).toContain('data-user-message-attachments-without-previews="true"');
+    expect(markup).toContain("image-5.png, image-6.png");
   });
 
   it("uses one large square and two stacked squares for three attachments", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -3,6 +3,7 @@ import { createRef, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import type { LegendListRef } from "@legendapp/list/react";
+import { IMAGE_ONLY_BOOTSTRAP_PROMPT } from "~/lib/userMessage";
 
 vi.mock("@legendapp/list/react", async () => {
   const legendListTestId = "legend-list";
@@ -403,6 +404,33 @@ describe("MessagesTimeline", () => {
     expect(onAnchorReady).toHaveBeenCalledOnce();
     expect(onAnchorReady).toHaveBeenCalledWith(secondEntry.message.id, 1);
     expect(onAnchorSizeChanged).toHaveBeenCalledWith(secondEntry.message.id, 240);
+  });
+
+  it("renders an image-only message without its bootstrap prompt", () => {
+    const imageOnlyEntry = {
+      ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT),
+      message: {
+        ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT).message,
+        attachments: [
+          {
+            type: "image" as const,
+            id: "attachment-1",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            sizeBytes: 1,
+            previewUrl: "data:image/png;base64,iVBORw0KGgo=",
+          },
+        ],
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[imageOnlyEntry]} />,
+    );
+
+    expect(markup).toContain('alt="screenshot.png"');
+    expect(markup).not.toContain("User attached one or more images");
+    expect(markup).not.toContain('data-user-message-body="true"');
+    expect(markup).not.toContain('aria-label="Copy link"');
   });
 
   it("renders collapse controls for long user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -487,6 +487,10 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('alt="image-4.png"');
     expect(markup).not.toContain('alt="image-5.png"');
     expect(markup).toContain('aria-label="Preview image-4.png and 2 more images"');
+    expect(markup).toContain("aspect-[3/2]");
+    expect(markup).toContain("grid-cols-[1.15fr_1fr_1fr]");
+    expect(markup).toContain("row-span-2");
+    expect(markup).toContain("col-span-2");
     expect(markup).toContain("backdrop-blur-md");
     expect(markup).toContain(">+2</span>");
   });

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -494,6 +494,56 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain(">+2</span>");
   });
 
+  it("uses a previewable overflow attachment for the collapsed tile", () => {
+    const attachments = Array.from({ length: 6 }, (_, index) => ({
+      type: "image" as const,
+      id: `attachment-${index + 1}`,
+      name: `image-${index + 1}.png`,
+      mimeType: "image/png",
+      sizeBytes: 1,
+      ...(index === 3
+        ? {}
+        : { previewUrl: `data:image/png;base64,image-${index + 1}` }),
+    }));
+    const mosaicEntry = {
+      ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT),
+      message: {
+        ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT).message,
+        attachments,
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[mosaicEntry]} />,
+    );
+
+    expect(markup).toContain('alt="image-5.png"');
+    expect(markup).toContain('aria-label="Preview image-5.png and 2 more images"');
+    expect(markup).toContain(">+2</span>");
+  });
+
+  it("shows the collapsed count when no attachments have previews", () => {
+    const attachments = Array.from({ length: 6 }, (_, index) => ({
+      type: "image" as const,
+      id: `attachment-${index + 1}`,
+      name: `image-${index + 1}.png`,
+      mimeType: "image/png",
+      sizeBytes: 1,
+    }));
+    const mosaicEntry = {
+      ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT),
+      message: {
+        ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT).message,
+        attachments,
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[mosaicEntry]} />,
+    );
+
+    expect(markup).toContain("image-4.png");
+    expect(markup).toContain(">+2</span>");
+  });
+
   it("uses one large square and two stacked squares for three attachments", () => {
     const threeImageEntry = {
       ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT),

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -487,6 +487,7 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('alt="image-4.png"');
     expect(markup).not.toContain('alt="image-5.png"');
     expect(markup).toContain('aria-label="Preview image-4.png and 2 more images"');
+    expect(markup).toContain("backdrop-blur-md");
     expect(markup).toContain(">+2</span>");
   });
 

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -487,12 +487,35 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('alt="image-4.png"');
     expect(markup).not.toContain('alt="image-5.png"');
     expect(markup).toContain('aria-label="Preview image-4.png and 2 more images"');
-    expect(markup).toContain("aspect-[3/2]");
-    expect(markup).toContain("grid-cols-[1.15fr_1fr_1fr]");
-    expect(markup).toContain("row-span-2");
-    expect(markup).toContain("col-span-2");
+    expect(markup).toContain("aspect-square");
+    expect(markup).toContain("max-w-[360px]");
+    expect(markup).toContain("grid-cols-2");
     expect(markup).toContain("backdrop-blur-md");
     expect(markup).toContain(">+2</span>");
+  });
+
+  it("uses one large square and two stacked squares for three attachments", () => {
+    const threeImageEntry = {
+      ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT),
+      message: {
+        ...buildUserTimelineEntry(IMAGE_ONLY_BOOTSTRAP_PROMPT).message,
+        attachments: Array.from({ length: 3 }, (_, index) => ({
+          type: "image" as const,
+          id: `attachment-${index + 1}`,
+          name: `image-${index + 1}.png`,
+          mimeType: "image/png",
+          sizeBytes: 1,
+          previewUrl: `data:image/png;base64,image-${index + 1}`,
+        })),
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[threeImageEntry]} />,
+    );
+
+    expect(markup).toContain("aspect-[3/2]");
+    expect(markup).toContain("grid-cols-[2fr_1fr]");
+    expect(markup).toContain("row-span-2");
   });
 
   it("renders collapse controls for long user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -99,6 +99,7 @@ import { cn } from "~/lib/utils";
 import { useUiStateStore } from "~/uiStateStore";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
 import { formatChatTimestampTooltip, formatShortTimestamp } from "../../timestampFormat";
+import { resolveUserMessageDisplayText } from "~/lib/userMessage";
 
 import {
   buildInlineTerminalContextText,
@@ -869,7 +870,9 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
 function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);
   const userImages = row.message.attachments ?? [];
-  const displayedUserMessage = deriveDisplayedUserMessageState(row.message.text);
+  const displayedUserMessage = deriveDisplayedUserMessageState(
+    resolveUserMessageDisplayText(row.message.text, userImages.length > 0),
+  );
   const terminalContexts = displayedUserMessage.contexts;
   const previewAnnotations: ParsedPreviewAnnotation[] = [];
   let visibleText = displayedUserMessage.visibleText;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -64,6 +64,7 @@ import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesCard } from "./ChangedFilesTree";
 import { shouldAutoExpandChangedFiles } from "./changedFilesPresentation";
 import { MessageCopyButton } from "./MessageCopyButton";
+import { UserMessageAttachments } from "./UserMessageAttachments";
 import {
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
@@ -889,68 +890,46 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   ];
   const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
   const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
+  const hasMessageContent =
+    previewAnnotations.length > 0 ||
+    elementContexts.length > 0 ||
+    elementContextState.promptText.trim().length > 0 ||
+    terminalContexts.length > 0;
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
 
   return (
     <div className="group flex flex-col items-end gap-1">
-      <div className="relative max-w-[80%] rounded-2xl bg-accent p-3">
-        {regularImages.length > 0 && (
-          <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
-            {regularImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (
-              <div
-                key={image.id}
-                className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
-              >
-                {image.previewUrl ? (
-                  <button
-                    type="button"
-                    className="h-full w-full cursor-zoom-in"
-                    aria-label={`Preview ${image.name}`}
-                    onClick={() => {
-                      const preview = buildExpandedImagePreview(regularImages, image.id);
-                      if (!preview) return;
-                      ctx.onImageExpand(preview);
-                    }}
-                  >
-                    <img
-                      src={image.previewUrl}
-                      alt={image.name}
-                      className="block h-auto max-h-[220px] w-full object-cover"
-                    />
-                  </button>
-                ) : (
-                  <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
-                    {image.name}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-        {previewAnnotations.map((annotation, index) => (
-          <UserMessagePreviewAnnotationCard
-            key={annotation.id}
-            annotation={annotation}
-            image={previewImages[index] ?? null}
+      <UserMessageAttachments images={regularImages} onImageExpand={ctx.onImageExpand} />
+      {hasMessageContent ? (
+        <div
+          className="relative max-w-[80%] rounded-2xl bg-accent p-3"
+          data-user-message-content="true"
+        >
+          {previewAnnotations.map((annotation, index) => (
+            <UserMessagePreviewAnnotationCard
+              key={annotation.id}
+              annotation={annotation}
+              image={previewImages[index] ?? null}
+            />
+          ))}
+          {elementContexts.length > 0 ? (
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {elementContexts.map((context) => (
+                <UserMessageElementContextChip
+                  key={`${context.header}:${context.body}`}
+                  context={context}
+                />
+              ))}
+            </div>
+          ) : null}
+          <CollapsibleUserMessageBody
+            text={elementContextState.promptText}
+            terminalContexts={terminalContexts}
+            skills={ctx.skills}
+            markdownCwd={ctx.markdownCwd}
           />
-        ))}
-        {elementContexts.length > 0 ? (
-          <div className="mb-2 flex flex-wrap gap-1.5">
-            {elementContexts.map((context) => (
-              <UserMessageElementContextChip
-                key={`${context.header}:${context.body}`}
-                context={context}
-              />
-            ))}
-          </div>
-        ) : null}
-        <CollapsibleUserMessageBody
-          text={elementContextState.promptText}
-          terminalContexts={terminalContexts}
-          skills={ctx.skills}
-          markdownCwd={ctx.markdownCwd}
-        />
-      </div>
+        </div>
+      ) : null}
       <div className="flex w-full max-w-[80%] items-center justify-end pe-1 text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
         <div className="flex shrink-0 items-center gap-2">
           <Tooltip>

--- a/apps/web/src/components/chat/UserMessageAttachments.tsx
+++ b/apps/web/src/components/chat/UserMessageAttachments.tsx
@@ -17,7 +17,15 @@ export const UserMessageAttachments = memo(function UserMessageAttachments(
     return null;
   }
 
-  const visibleImages = props.images.slice(0, MAX_VISIBLE_IMAGES);
+  const initialVisibleImages = props.images.slice(0, MAX_VISIBLE_IMAGES);
+  const collapsedPreview =
+    props.images.length > MAX_VISIBLE_IMAGES &&
+    !initialVisibleImages[MAX_VISIBLE_IMAGES - 1]?.previewUrl
+      ? props.images.slice(MAX_VISIBLE_IMAGES).find((image) => image.previewUrl)
+      : undefined;
+  const visibleImages = collapsedPreview
+    ? [...initialVisibleImages.slice(0, MAX_VISIBLE_IMAGES - 1), collapsedPreview]
+    : initialVisibleImages;
   const collapsedImageCount = props.images.length - visibleImages.length;
   const visibleImageCount = visibleImages.length;
   const isMosaic = visibleImageCount > 1;
@@ -85,6 +93,14 @@ export const UserMessageAttachments = memo(function UserMessageAttachments(
                 )}
               >
                 {image.name}
+                {isCollapsedTile ? (
+                  <span
+                    className="absolute inset-0 flex items-center justify-center bg-black/55 text-lg font-medium text-white backdrop-blur-md"
+                    aria-hidden="true"
+                  >
+                    +{collapsedImageCount}
+                  </span>
+                ) : null}
               </div>
             )}
           </div>

--- a/apps/web/src/components/chat/UserMessageAttachments.tsx
+++ b/apps/web/src/components/chat/UserMessageAttachments.tsx
@@ -22,15 +22,19 @@ export const UserMessageAttachments = memo(function UserMessageAttachments(
 
   const visibleImages = props.images.slice(0, MAX_VISIBLE_IMAGES);
   const collapsedImageCount = props.images.length - visibleImages.length;
-  const isMosaic = props.images.length > 1;
+  const visibleImageCount = visibleImages.length;
+  const isMosaic = visibleImageCount > 1;
 
   return (
     <div
       className={cn(
         "grid w-full max-w-[420px] self-end overflow-hidden rounded-lg border border-border/80 bg-border/80",
         !isMosaic && "grid-cols-1",
-        isMosaic && "h-[220px] grid-cols-2 gap-px",
-        props.images.length >= 3 && "grid-rows-2",
+        visibleImageCount === 2 && "aspect-[8/5] grid-cols-2 gap-px",
+        visibleImageCount === 3 &&
+          "aspect-[3/2] grid-cols-[1.15fr_0.85fr] grid-rows-2 gap-px",
+        visibleImageCount >= 4 &&
+          "aspect-[3/2] grid-cols-[1.15fr_1fr_1fr] grid-rows-2 gap-px",
       )}
       data-user-message-attachments="true"
       data-user-message-attachments-collapsed={collapsedImageCount > 0 ? "true" : "false"}
@@ -42,7 +46,8 @@ export const UserMessageAttachments = memo(function UserMessageAttachments(
             key={image.id}
             className={cn(
               "relative min-h-0 overflow-hidden bg-background/70",
-              props.images.length === 3 && index === 0 && "row-span-2",
+              visibleImageCount >= 3 && index === 0 && "row-span-2",
+              visibleImageCount >= 4 && index === 1 && "col-span-2",
             )}
           >
             {image.previewUrl ? (

--- a/apps/web/src/components/chat/UserMessageAttachments.tsx
+++ b/apps/web/src/components/chat/UserMessageAttachments.tsx
@@ -29,83 +29,97 @@ export const UserMessageAttachments = memo(function UserMessageAttachments(
   const collapsedImageCount = props.images.length - visibleImages.length;
   const visibleImageCount = visibleImages.length;
   const isMosaic = visibleImageCount > 1;
+  const visibleImageIds = new Set(visibleImages.map((image) => image.id));
+  const hiddenImagesWithoutPreviews = props.images.filter(
+    (image) => !visibleImageIds.has(image.id) && !image.previewUrl,
+  );
 
   return (
-    <div
-      className={cn(
-        "grid w-full max-w-[420px] self-end overflow-hidden rounded-lg border border-border/80 bg-border/80",
-        !isMosaic && "grid-cols-1",
-        visibleImageCount === 2 && "aspect-[2/1] grid-cols-2 gap-px",
-        visibleImageCount === 3 && "aspect-[3/2] grid-cols-[2fr_1fr] grid-rows-2 gap-px",
-        visibleImageCount >= 4 && "aspect-square max-w-[360px] grid-cols-2 grid-rows-2 gap-px",
-      )}
-      data-user-message-attachments="true"
-      data-user-message-attachments-collapsed={collapsedImageCount > 0 ? "true" : "false"}
-    >
-      {visibleImages.map((image, index) => {
-        const isCollapsedTile = collapsedImageCount > 0 && index === visibleImages.length - 1;
-        return (
-          <div
-            key={image.id}
-            className={cn(
-              "relative min-h-0 overflow-hidden bg-background/70",
-              visibleImageCount === 3 && index === 0 && "row-span-2",
-            )}
-          >
-            {image.previewUrl ? (
-              <button
-                type="button"
-                className="relative h-full w-full cursor-zoom-in"
-                aria-label={
-                  isCollapsedTile
-                    ? `Preview ${image.name} and ${collapsedImageCount} more images`
-                    : `Preview ${image.name}`
-                }
-                onClick={() => {
-                  const preview = buildExpandedImagePreview(props.images, image.id);
-                  if (preview) {
-                    props.onImageExpand(preview);
+    <div className="flex w-full max-w-[420px] flex-col items-end gap-1 self-end">
+      <div
+        className={cn(
+          "grid w-full overflow-hidden rounded-lg border border-border/80 bg-border/80",
+          !isMosaic && "grid-cols-1",
+          visibleImageCount === 2 && "aspect-[2/1] grid-cols-2 gap-px",
+          visibleImageCount === 3 && "aspect-[3/2] grid-cols-[2fr_1fr] grid-rows-2 gap-px",
+          visibleImageCount >= 4 && "aspect-square max-w-[360px] grid-cols-2 grid-rows-2 gap-px",
+        )}
+        data-user-message-attachments="true"
+        data-user-message-attachments-collapsed={collapsedImageCount > 0 ? "true" : "false"}
+      >
+        {visibleImages.map((image, index) => {
+          const isCollapsedTile = collapsedImageCount > 0 && index === visibleImages.length - 1;
+          return (
+            <div
+              key={image.id}
+              className={cn(
+                "relative min-h-0 overflow-hidden bg-background/70",
+                visibleImageCount === 3 && index === 0 && "row-span-2",
+              )}
+            >
+              {image.previewUrl ? (
+                <button
+                  type="button"
+                  className="relative h-full w-full cursor-zoom-in"
+                  aria-label={
+                    isCollapsedTile
+                      ? `Preview ${image.name} and ${collapsedImageCount} more images`
+                      : `Preview ${image.name}`
                   }
-                }}
-              >
-                <img
-                  src={image.previewUrl}
-                  alt={image.name}
+                  onClick={() => {
+                    const preview = buildExpandedImagePreview(props.images, image.id);
+                    if (preview) {
+                      props.onImageExpand(preview);
+                    }
+                  }}
+                >
+                  <img
+                    src={image.previewUrl}
+                    alt={image.name}
+                    className={cn(
+                      "block w-full object-cover",
+                      isMosaic ? "size-full" : "h-auto max-h-[220px]",
+                    )}
+                  />
+                  {isCollapsedTile ? (
+                    <span
+                      className="absolute inset-0 flex items-center justify-center bg-black/55 text-lg font-medium text-white backdrop-blur-md"
+                      aria-hidden="true"
+                    >
+                      +{collapsedImageCount}
+                    </span>
+                  ) : null}
+                </button>
+              ) : (
+                <div
                   className={cn(
-                    "block w-full object-cover",
-                    isMosaic ? "size-full" : "h-auto max-h-[220px]",
+                    "flex items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70",
+                    isMosaic ? "h-full" : "min-h-[72px]",
                   )}
-                />
-                {isCollapsedTile ? (
-                  <span
-                    className="absolute inset-0 flex items-center justify-center bg-black/55 text-lg font-medium text-white backdrop-blur-md"
-                    aria-hidden="true"
-                  >
-                    +{collapsedImageCount}
-                  </span>
-                ) : null}
-              </button>
-            ) : (
-              <div
-                className={cn(
-                  "flex items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70",
-                  isMosaic ? "h-full" : "min-h-[72px]",
-                )}
-              >
-                {image.name}
-                {isCollapsedTile ? (
-                  <span
-                    className="absolute inset-0 flex items-center justify-center bg-black/55 text-lg font-medium text-white backdrop-blur-md"
-                    aria-hidden="true"
-                  >
-                    +{collapsedImageCount}
-                  </span>
-                ) : null}
-              </div>
-            )}
-          </div>
-        );
-      })}
+                >
+                  {image.name}
+                  {isCollapsedTile ? (
+                    <span
+                      className="absolute inset-0 flex items-center justify-center bg-black/55 text-lg font-medium text-white backdrop-blur-md"
+                      aria-hidden="true"
+                    >
+                      +{collapsedImageCount}
+                    </span>
+                  ) : null}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {hiddenImagesWithoutPreviews.length > 0 ? (
+        <div
+          className="text-right text-[11px] text-muted-foreground/70"
+          data-user-message-attachments-without-previews="true"
+        >
+          {hiddenImagesWithoutPreviews.map((image) => image.name).join(", ")}
+        </div>
+      ) : null}
     </div>
   );
 });

--- a/apps/web/src/components/chat/UserMessageAttachments.tsx
+++ b/apps/web/src/components/chat/UserMessageAttachments.tsx
@@ -1,10 +1,7 @@
 import { memo } from "react";
 import type { ChatAttachment } from "../../types";
 import { cn } from "~/lib/utils";
-import {
-  buildExpandedImagePreview,
-  type ExpandedImagePreview,
-} from "./ExpandedImagePreview";
+import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 
 interface UserMessageAttachmentsProps {
   images: ReadonlyArray<ChatAttachment>;
@@ -31,10 +28,8 @@ export const UserMessageAttachments = memo(function UserMessageAttachments(
         "grid w-full max-w-[420px] self-end overflow-hidden rounded-lg border border-border/80 bg-border/80",
         !isMosaic && "grid-cols-1",
         visibleImageCount === 2 && "aspect-[2/1] grid-cols-2 gap-px",
-        visibleImageCount === 3 &&
-          "aspect-[3/2] grid-cols-[2fr_1fr] grid-rows-2 gap-px",
-        visibleImageCount >= 4 &&
-          "aspect-square max-w-[360px] grid-cols-2 grid-rows-2 gap-px",
+        visibleImageCount === 3 && "aspect-[3/2] grid-cols-[2fr_1fr] grid-rows-2 gap-px",
+        visibleImageCount >= 4 && "aspect-square max-w-[360px] grid-cols-2 grid-rows-2 gap-px",
       )}
       data-user-message-attachments="true"
       data-user-message-attachments-collapsed={collapsedImageCount > 0 ? "true" : "false"}

--- a/apps/web/src/components/chat/UserMessageAttachments.tsx
+++ b/apps/web/src/components/chat/UserMessageAttachments.tsx
@@ -1,0 +1,96 @@
+import { memo } from "react";
+import type { ChatAttachment } from "../../types";
+import { cn } from "~/lib/utils";
+import {
+  buildExpandedImagePreview,
+  type ExpandedImagePreview,
+} from "./ExpandedImagePreview";
+
+interface UserMessageAttachmentsProps {
+  images: ReadonlyArray<ChatAttachment>;
+  onImageExpand: (preview: ExpandedImagePreview) => void;
+}
+
+const MAX_VISIBLE_IMAGES = 4;
+
+export const UserMessageAttachments = memo(function UserMessageAttachments(
+  props: UserMessageAttachmentsProps,
+) {
+  if (props.images.length === 0) {
+    return null;
+  }
+
+  const visibleImages = props.images.slice(0, MAX_VISIBLE_IMAGES);
+  const collapsedImageCount = props.images.length - visibleImages.length;
+  const isMosaic = props.images.length > 1;
+
+  return (
+    <div
+      className={cn(
+        "grid w-full max-w-[420px] self-end overflow-hidden rounded-lg border border-border/80 bg-border/80",
+        !isMosaic && "grid-cols-1",
+        isMosaic && "h-[220px] grid-cols-2 gap-px",
+        props.images.length >= 3 && "grid-rows-2",
+      )}
+      data-user-message-attachments="true"
+      data-user-message-attachments-collapsed={collapsedImageCount > 0 ? "true" : "false"}
+    >
+      {visibleImages.map((image, index) => {
+        const isCollapsedTile = collapsedImageCount > 0 && index === visibleImages.length - 1;
+        return (
+          <div
+            key={image.id}
+            className={cn(
+              "relative min-h-0 overflow-hidden bg-background/70",
+              props.images.length === 3 && index === 0 && "row-span-2",
+            )}
+          >
+            {image.previewUrl ? (
+              <button
+                type="button"
+                className="relative h-full w-full cursor-zoom-in"
+                aria-label={
+                  isCollapsedTile
+                    ? `Preview ${image.name} and ${collapsedImageCount} more images`
+                    : `Preview ${image.name}`
+                }
+                onClick={() => {
+                  const preview = buildExpandedImagePreview(props.images, image.id);
+                  if (preview) {
+                    props.onImageExpand(preview);
+                  }
+                }}
+              >
+                <img
+                  src={image.previewUrl}
+                  alt={image.name}
+                  className={cn(
+                    "block w-full object-cover",
+                    isMosaic ? "size-full" : "h-auto max-h-[220px]",
+                  )}
+                />
+                {isCollapsedTile ? (
+                  <span
+                    className="absolute inset-0 flex items-center justify-center bg-black/55 text-lg font-medium text-white backdrop-blur-[1px]"
+                    aria-hidden="true"
+                  >
+                    +{collapsedImageCount}
+                  </span>
+                ) : null}
+              </button>
+            ) : (
+              <div
+                className={cn(
+                  "flex items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70",
+                  isMosaic ? "h-full" : "min-h-[72px]",
+                )}
+              >
+                {image.name}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+});

--- a/apps/web/src/components/chat/UserMessageAttachments.tsx
+++ b/apps/web/src/components/chat/UserMessageAttachments.tsx
@@ -71,7 +71,7 @@ export const UserMessageAttachments = memo(function UserMessageAttachments(
                 />
                 {isCollapsedTile ? (
                   <span
-                    className="absolute inset-0 flex items-center justify-center bg-black/55 text-lg font-medium text-white backdrop-blur-[1px]"
+                    className="absolute inset-0 flex items-center justify-center bg-black/55 text-lg font-medium text-white backdrop-blur-md"
                     aria-hidden="true"
                   >
                     +{collapsedImageCount}

--- a/apps/web/src/components/chat/UserMessageAttachments.tsx
+++ b/apps/web/src/components/chat/UserMessageAttachments.tsx
@@ -30,11 +30,11 @@ export const UserMessageAttachments = memo(function UserMessageAttachments(
       className={cn(
         "grid w-full max-w-[420px] self-end overflow-hidden rounded-lg border border-border/80 bg-border/80",
         !isMosaic && "grid-cols-1",
-        visibleImageCount === 2 && "aspect-[8/5] grid-cols-2 gap-px",
+        visibleImageCount === 2 && "aspect-[2/1] grid-cols-2 gap-px",
         visibleImageCount === 3 &&
-          "aspect-[3/2] grid-cols-[1.15fr_0.85fr] grid-rows-2 gap-px",
+          "aspect-[3/2] grid-cols-[2fr_1fr] grid-rows-2 gap-px",
         visibleImageCount >= 4 &&
-          "aspect-[3/2] grid-cols-[1.15fr_1fr_1fr] grid-rows-2 gap-px",
+          "aspect-square max-w-[360px] grid-cols-2 grid-rows-2 gap-px",
       )}
       data-user-message-attachments="true"
       data-user-message-attachments-collapsed={collapsedImageCount > 0 ? "true" : "false"}
@@ -46,8 +46,7 @@ export const UserMessageAttachments = memo(function UserMessageAttachments(
             key={image.id}
             className={cn(
               "relative min-h-0 overflow-hidden bg-background/70",
-              visibleImageCount >= 3 && index === 0 && "row-span-2",
-              visibleImageCount >= 4 && index === 1 && "col-span-2",
+              visibleImageCount === 3 && index === 0 && "row-span-2",
             )}
           >
             {image.previewUrl ? (

--- a/apps/web/src/lib/userMessage.ts
+++ b/apps/web/src/lib/userMessage.ts
@@ -1,5 +1,7 @@
-export const IMAGE_ONLY_BOOTSTRAP_PROMPT =
-  "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
+const IMAGE_ONLY_BOOTSTRAP_MARKER = "\u2063t3:image-only:v1\u2063";
+
+export const IMAGE_ONLY_BOOTSTRAP_PROMPT = `${IMAGE_ONLY_BOOTSTRAP_MARKER}
+[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]`;
 
 const ULTRATHINK_PREFIX = "Ultrathink:\n";
 

--- a/apps/web/src/lib/userMessage.ts
+++ b/apps/web/src/lib/userMessage.ts
@@ -1,0 +1,20 @@
+export const IMAGE_ONLY_BOOTSTRAP_PROMPT =
+  "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
+
+const ULTRATHINK_PREFIX = "Ultrathink:\n";
+
+export function resolveUserMessageDisplayText(text: string, hasAttachments: boolean): string {
+  if (!hasAttachments) {
+    return text;
+  }
+
+  const trimmed = text.trim();
+  if (
+    trimmed === IMAGE_ONLY_BOOTSTRAP_PROMPT ||
+    trimmed === `${ULTRATHINK_PREFIX}${IMAGE_ONLY_BOOTSTRAP_PROMPT}`
+  ) {
+    return "";
+  }
+
+  return text;
+}


### PR DESCRIPTION
## What changed

- Render normal user image attachments in a dedicated component above the text bubble.
- Omit the text bubble entirely for attachment-only messages.
- Hide the provider-facing image-only fallback prompt from the timeline.
- Use familiar count-specific gallery layouts: two equal squares, one large square with two stacked squares for three images, and a balanced 2×2 square grid for larger sets.
- Collapse sets larger than four behind a +N overlay while keeping every attachment available in the image lightbox.

## Why

Images were rendered inside the same padded message box as text, and image-only turns exposed an internal provider instruction as user-authored content. Larger attachment sets also consumed unnecessary vertical space and flattened every preview into the same shallow proportion.

## Impact

Images and captions now have clear visual separation, image-only turns show only their attachments, and larger sets remain compact without losing access to any image. The gallery changes with image count while keeping square crops and a balanced outer shape. This applies to the web client and the desktop app that wraps it; mobile does not use this web timeline.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: images rendered individually inside the message bubble](https://raw.githubusercontent.com/maria-rcks/t3code/2474794adef69d3d2a63650f5992caafe0c14ab8/.github/pr-assets/5177/before.png) | ![After: balanced square image gallery above a separate text bubble](https://raw.githubusercontent.com/maria-rcks/t3code/2474794adef69d3d2a63650f5992caafe0c14ab8/.github/pr-assets/5177/after.png) |

## Validation

- `vp test run apps/web/src/components/chat/MessagesTimeline.test.tsx` — 18 tests passed
- `vp run typecheck` from `apps/web`
- `vp lint` on the changed files
- Visually verified the balanced gallery against the isolated PR fixture at a 1000×700 viewport

Generated with GPT-5.6 Sol via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chat timeline presentation and display-text filtering only; no auth, API, or persistence changes, with broad test coverage for attachment rendering.
> 
> **Overview**
> User image attachments in the chat timeline are now rendered **above** the text bubble via a new `UserMessageAttachments` mosaic component, instead of inside the same accent bubble as message text.
> 
> **Image-only turns** no longer show the internal provider bootstrap prompt: `IMAGE_ONLY_BOOTSTRAP_PROMPT` moves to `~/lib/userMessage` with a hidden marker, and `resolveUserMessageDisplayText` strips that prompt (including Ultrathink-prefixed variants) when attachments are present. The text bubble is omitted when there is no real caption or other content.
> 
> **Gallery layout** adapts to count (1, 2, 3, or 4+ tiles), collapses sets larger than four behind a **+N** overlay while keeping the full set in the lightbox, and handles missing previews (including picking a previewable overflow image for the collapsed tile). `MessagesTimeline` tests cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41bd9e30f724d4836eba3e474e2032be78098e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate image attachments from message text in user chat messages
> - Adds a new `UserMessageAttachments` component that renders user image attachments as a mosaic grid (1–4+ images), collapsing to four tiles with a "+N" overlay when more are present.
> - Introduces `resolveUserMessageDisplayText` in [`userMessage.ts`](https://github.com/pingdotgg/t3code/pull/5177/files#diff-f15bf0d3c79278769c567b6e5d63c420197e4ea08b33a7190c5cbe34a73d1fab) to suppress the bootstrap prompt text when a message contains only image attachments, returning an empty string in that case.
> - `UserTimelineRow` in [`MessagesTimeline.tsx`](https://github.com/pingdotgg/t3code/pull/5177/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) now renders attachments above the text bubble and hides the text bubble entirely when there is no meaningful message content.
> - Behavioral Change: Image-only messages no longer show the bootstrap prompt text in the chat UI; the text bubble is suppressed when the resolved display text is empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41bd9e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->