### PR TITLE
feat(mobile): keep Android connections alive in the background

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -87,6 +87,28 @@ node ../../scripts/mobile-native-static-check.ts
 
 The native lint task runs SwiftLint for Swift plus ktlint and detekt for Kotlin. Missing native tools are reported as warnings and skipped locally. CI installs the default toolset from `apps/mobile/Brewfile` before running the native checks.
 
+## Android background connection
+
+Android builds expose an opt-in **Keep connected in background** switch in Settings. When enabled,
+the app runs one silent `remoteMessaging` foreground service and one React Native Headless JS task.
+That task keeps the existing connection supervisors, environment shells, active thread details, and
+outbox dispatcher alive; it does not introduce a second WebSocket or synchronization protocol.
+
+Android requires the ongoing `T3 Code · Connected in background` service notification. Granting the
+one-time unrestricted-battery exemption makes recovery more reliable under vendor power management,
+but declining it leaves the feature enabled with a degraded status. A user-initiated Android
+force-stop is the platform boundary: launch the app once before automatic service, update, or boot
+restoration can resume.
+
+The implementation lives in `modules/t3-background-connection`; generated files under `android/`
+are not authoritative. After native changes, regenerate and verify a development project with:
+
+```bash
+APP_VARIANT=development EXPO_NO_GIT_STATUS=1 expo prebuild --clean --platform android
+cd android
+./gradlew :t3-background-connection:compileDebugKotlin lintDebug
+```
+
 ## EAS Builds
 
 CI uses Expo fingerprinting with the `preview:dev` profile to reuse an existing compatible build when possible, or start a new internal EAS build when native runtime inputs change. Production and default local builds continue to use the `appVersion` runtime policy.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -104,6 +104,28 @@ node ../../scripts/mobile-native-static-check.ts
 
 The native lint task runs SwiftLint for Swift plus ktlint and detekt for Kotlin. Missing native tools are reported as warnings and skipped locally. CI installs the default toolset from `apps/mobile/Brewfile` before running the native checks.
 
+## Android background connection
+
+Android builds expose an opt-in **Keep connected in background** switch in Settings. When enabled,
+the app runs one silent `remoteMessaging` foreground service and one React Native Headless JS task.
+That task keeps the existing connection supervisors, environment shells, active thread details, and
+outbox dispatcher alive; it does not introduce a second WebSocket or synchronization protocol.
+
+Android requires the ongoing `T3 Code · Connected in background` service notification. Granting the
+one-time unrestricted-battery exemption makes recovery more reliable under vendor power management,
+but declining it leaves the feature enabled with a degraded status. A user-initiated Android
+force-stop is the platform boundary: launch the app once before automatic service, update, or boot
+restoration can resume.
+
+The implementation lives in `modules/t3-background-connection`; generated files under `android/`
+are not authoritative. After native changes, regenerate and verify a development project with:
+
+```bash
+APP_VARIANT=development EXPO_NO_GIT_STATUS=1 expo prebuild --clean --platform android
+cd android
+./gradlew :t3-background-connection:compileDebugKotlin lintDebug
+```
+
 ## EAS Builds
 
 Preview and production variants use Expo fingerprinting so OTA updates only reach binaries with matching native dependencies, config plugins, and patches. CI uses the `preview:dev` profile to reuse a compatible native build when possible.

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -4,6 +4,7 @@ import { LogBox } from "react-native";
 import { featureFlags } from "react-native-screens";
 
 import App from "./src/App";
+import { registerBackgroundConnectionHeadlessTask } from "./src/features/background-connection/headless-task-registration";
 
 // Required for react-native-screens' iOS FormSheet sizing fix when a nested
 // native stack is rendered inside a non-fitToContents formSheet.
@@ -13,4 +14,5 @@ if (process.env.EXPO_PUBLIC_SHOWCASE === "1") {
   LogBox.ignoreAllLogs();
 }
 
+registerBackgroundConnectionHeadlessTask();
 registerRootComponent(App);

--- a/apps/mobile/modules/t3-background-connection/android/build.gradle
+++ b/apps/mobile/modules/t3-background-connection/android/build.gradle
@@ -1,0 +1,21 @@
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+group = 'com.t3tools.backgroundconnection'
+version = '0.0.0'
+
+android {
+  namespace 'expo.modules.t3backgroundconnection'
+  compileSdk rootProject.ext.compileSdkVersion
+
+  defaultConfig {
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+  }
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+  implementation 'com.facebook.react:react-android'
+  testImplementation 'junit:junit:4.13.2'
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/AndroidManifest.xml
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+  <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+  <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+
+  <application>
+    <service
+      android:name="expo.modules.t3backgroundconnection.T3BackgroundConnectionService"
+      android:exported="false"
+      android:foregroundServiceType="remoteMessaging"
+      android:stopWithTask="false" />
+
+    <receiver
+      android:name="expo.modules.t3backgroundconnection.T3BackgroundConnectionReceiver"
+      android:enabled="true"
+      android:exported="false">
+      <intent-filter>
+        <action android:name="android.intent.action.BOOT_COMPLETED" />
+        <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+      </intent-filter>
+    </receiver>
+  </application>
+</manifest>

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionModule.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionModule.kt
@@ -1,0 +1,107 @@
+package expo.modules.t3backgroundconnection
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import expo.modules.kotlin.functions.Queues
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class T3BackgroundConnectionModule : Module() {
+  private val statusListener: (Map<String, Any>) -> Unit = { status ->
+    sendEvent(T3BackgroundConnectionState.STATUS_EVENT, status)
+  }
+  private val stopRequestListener: () -> Unit = {
+    sendEvent(T3BackgroundConnectionState.STOP_REQUEST_EVENT)
+  }
+
+  override fun definition() = ModuleDefinition {
+    Name("T3BackgroundConnection")
+
+    Events(
+      T3BackgroundConnectionState.STATUS_EVENT,
+      T3BackgroundConnectionState.STOP_REQUEST_EVENT,
+    )
+
+    OnCreate {
+      val context = applicationContext()
+      T3BackgroundConnectionState.initialize(context)
+      T3BackgroundConnectionState.addStatusListener(statusListener)
+      T3BackgroundConnectionState.addStopRequestListener(stopRequestListener)
+    }
+
+    OnDestroy {
+      T3BackgroundConnectionState.removeStatusListener(statusListener)
+      T3BackgroundConnectionState.removeStopRequestListener(stopRequestListener)
+    }
+
+    OnActivityEntersForeground {
+      // The battery-optimization request has no result callback. Refreshing on
+      // resume makes the settings status reflect the user's choice immediately.
+      val context = applicationContext()
+      if (T3BackgroundConnectionState.shouldEnsureStartedOnActivityForeground(context)) {
+        // A visible Activity is an allowed foreground-service start context.
+        // A successful start also cancels any pending recovery alarm.
+        T3BackgroundConnectionController.ensureStarted(context)
+      }
+      T3BackgroundConnectionState.refreshStatus()
+    }
+
+    Function("getStatus") {
+      T3BackgroundConnectionState.status(applicationContext())
+    }
+
+    AsyncFunction("setEnabled") { enabled: Boolean ->
+      val context = applicationContext()
+      T3BackgroundConnectionState.setEnabled(context, enabled)
+      if (enabled) {
+        T3BackgroundConnectionController.ensureStarted(context)
+      } else {
+        T3BackgroundConnectionState.requestOrderlyStop(context)
+      }
+      T3BackgroundConnectionState.status(context)
+    }.runOnQueue(Queues.MAIN)
+
+    Function("ensureStarted") {
+      val context = applicationContext()
+      T3BackgroundConnectionController.ensureStarted(context)
+      T3BackgroundConnectionState.status(context)
+    }
+
+    AsyncFunction("requestBatteryOptimizationExemption") {
+      val context = applicationContext()
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        val intent = Intent(
+          Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+          Uri.parse("package:${context.packageName}"),
+        )
+        val activity = appContext.currentActivity
+        if (activity != null) {
+          activity.startActivity(intent)
+        } else {
+          context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
+      }
+      T3BackgroundConnectionState.status(context)
+    }.runOnQueue(Queues.MAIN)
+
+    Function("setRuntimeReady") { ready: Boolean ->
+      val context = applicationContext()
+      T3BackgroundConnectionState.markRuntimeReady(ready)
+      T3BackgroundConnectionState.status(context)
+    }
+
+    Function("acknowledgeStop") {
+      val context = applicationContext()
+      T3BackgroundConnectionState.acknowledgeStop(context)
+      T3BackgroundConnectionState.status(context)
+    }
+  }
+
+  private fun applicationContext(): Context =
+    requireNotNull(appContext.reactContext?.applicationContext) {
+      "T3BackgroundConnection requires an Android React context"
+    }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionReceiver.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionReceiver.kt
@@ -1,0 +1,26 @@
+package expo.modules.t3backgroundconnection
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.facebook.react.HeadlessJsTaskService
+
+class T3BackgroundConnectionReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context, intent: Intent?) {
+    if (
+      intent?.action != Intent.ACTION_BOOT_COMPLETED &&
+      intent?.action != Intent.ACTION_MY_PACKAGE_REPLACED &&
+      intent?.action != T3BackgroundConnectionState.RESTART_ACTION
+    ) {
+      return
+    }
+    if (!T3BackgroundConnectionState.isEnabled(context)) return
+
+    if (T3BackgroundConnectionController.ensureStarted(context)) {
+      // Acquire before returning from the receiver, but only after Android
+      // accepted the service launch so a rejected FGS cannot leak the static
+      // React Native wake lock.
+      HeadlessJsTaskService.acquireWakeLockNow(context)
+    }
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicy.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicy.kt
@@ -1,0 +1,13 @@
+package expo.modules.t3backgroundconnection
+
+internal object T3BackgroundConnectionRecoveryPolicy {
+  fun shouldScheduleRestartAfterStartFailure(
+    batteryOptimizationIgnored: Boolean,
+  ): Boolean = batteryOptimizationIgnored
+
+  fun shouldEnsureStartedOnActivityForeground(
+    enabled: Boolean,
+    serviceRunning: Boolean,
+    runtimeReady: Boolean,
+  ): Boolean = enabled && (!serviceRunning || !runtimeReady)
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicy.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicy.kt
@@ -2,12 +2,12 @@ package expo.modules.t3backgroundconnection
 
 internal object T3BackgroundConnectionRecoveryPolicy {
   fun shouldScheduleRestartAfterStartFailure(
-    batteryOptimizationIgnored: Boolean,
+    batteryOptimizationIgnored: Boolean
   ): Boolean = batteryOptimizationIgnored
 
   fun shouldEnsureStartedOnActivityForeground(
     enabled: Boolean,
     serviceRunning: Boolean,
-    runtimeReady: Boolean,
+    runtimeReady: Boolean
   ): Boolean = enabled && (!serviceRunning || !runtimeReady)
 }

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoff.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoff.kt
@@ -1,0 +1,12 @@
+package expo.modules.t3backgroundconnection
+
+internal object T3BackgroundConnectionRestartBackoff {
+  private const val INITIAL_DELAY_MS = 1_000L
+  private const val MAX_DELAY_MS = 5 * 60_000L
+
+  fun delayMs(consecutiveFailures: Int): Long {
+    val exponent = consecutiveFailures.coerceIn(0, 20)
+    val exponentialDelay = INITIAL_DELAY_MS * (1L shl exponent)
+    return exponentialDelay.coerceAtMost(MAX_DELAY_MS)
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionService.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionService.kt
@@ -1,0 +1,169 @@
+package expo.modules.t3backgroundconnection
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import com.facebook.react.HeadlessJsTaskService
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.jstasks.HeadlessJsTaskConfig
+
+class T3BackgroundConnectionService : HeadlessJsTaskService() {
+  private var wifiLock: WifiManager.WifiLock? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    T3BackgroundConnectionState.initialize(this)
+    startInForeground()
+    T3BackgroundConnectionState.markServiceRunning(true)
+    acquireWifiLock()
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    if (!T3BackgroundConnectionState.isEnabled(this)) {
+      stopSelf(startId)
+      return Service.START_NOT_STICKY
+    }
+
+    if (T3BackgroundConnectionState.claimTask()) {
+      super.onStartCommand(intent, flags, startId)
+    }
+    return Service.START_STICKY
+  }
+
+  override fun getTaskConfig(intent: Intent?): HeadlessJsTaskConfig =
+    HeadlessJsTaskConfig(
+      T3BackgroundConnectionState.TASK_NAME,
+      Arguments.createMap(),
+      0,
+      true,
+    )
+
+  override fun onHeadlessJsTaskFinish(taskId: Int) {
+    val shouldRestart = T3BackgroundConnectionState.isEnabled(this)
+    T3BackgroundConnectionState.releaseTask()
+    super.onHeadlessJsTaskFinish(taskId)
+    if (shouldRestart) {
+      T3BackgroundConnectionState.scheduleRestartAfterUnexpectedTaskFinish(this)
+    }
+  }
+
+  override fun onDestroy() {
+    releaseWifiLock()
+    T3BackgroundConnectionState.markServiceRunning(false)
+    super.onDestroy()
+  }
+
+  private fun startInForeground() {
+    createNotificationChannel()
+    val notification = createNotification()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      startForeground(
+        NOTIFICATION_ID,
+        notification,
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING,
+      )
+    } else {
+      startForeground(NOTIFICATION_ID, notification)
+    }
+  }
+
+  private fun createNotificationChannel() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+    val channel = NotificationChannel(
+      NOTIFICATION_CHANNEL_ID,
+      "Background connection",
+      NotificationManager.IMPORTANCE_LOW,
+    ).apply {
+      description = "Keeps T3 Code connected while the app is in the background"
+      setSound(null, null)
+      enableLights(false)
+      enableVibration(false)
+      setShowBadge(false)
+      lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+    }
+    getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+  }
+
+  private fun createNotification(): Notification {
+    val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+    val contentIntent = launchIntent?.let {
+      PendingIntent.getActivity(
+        this,
+        0,
+        it,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+      )
+    }
+    val smallIcon = resources.getIdentifier("notification_icon", "drawable", packageName)
+      .takeIf { it != 0 }
+      ?: android.R.drawable.stat_notify_sync_noanim
+
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      Notification.Builder(this, NOTIFICATION_CHANNEL_ID)
+    } else {
+      @Suppress("DEPRECATION")
+      Notification.Builder(this)
+    }.apply {
+      setContentTitle("T3 Code")
+      setContentText("Connected in background")
+      setSmallIcon(smallIcon)
+      setOngoing(true)
+      setOnlyAlertOnce(true)
+      setShowWhen(false)
+      setCategory(Notification.CATEGORY_SERVICE)
+      setVisibility(Notification.VISIBILITY_PRIVATE)
+      contentIntent?.let(::setContentIntent)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+      }
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        @Suppress("DEPRECATION")
+        setPriority(Notification.PRIORITY_LOW)
+        @Suppress("DEPRECATION")
+        setSound(null)
+      }
+    }.build()
+  }
+
+  @SuppressLint("WakelockTimeout")
+  @Suppress("DEPRECATION")
+  private fun acquireWifiLock() {
+    try {
+      val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+      wifiLock = wifiManager.createWifiLock(
+        WifiManager.WIFI_MODE_FULL_HIGH_PERF,
+        "$packageName:t3-background-connection",
+      ).apply {
+        setReferenceCounted(false)
+        acquire()
+      }
+    } catch (_: RuntimeException) {
+      // The lock is best-effort. The foreground task and connection supervisor
+      // remain authoritative on devices that reject or do not expose it.
+      wifiLock = null
+    }
+  }
+
+  private fun releaseWifiLock() {
+    try {
+      wifiLock?.takeIf { it.isHeld }?.release()
+    } catch (_: RuntimeException) {
+      // The system may already have released the lock during process teardown.
+    } finally {
+      wifiLock = null
+    }
+  }
+
+  private companion object {
+    const val NOTIFICATION_CHANNEL_ID = "t3code_background_connection"
+    const val NOTIFICATION_ID = 0x7433
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionState.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionState.kt
@@ -192,6 +192,7 @@ internal object T3BackgroundConnectionState {
     }
   }
 
+  @Suppress("TooGenericExceptionCaught")
   fun scheduleRestartAfterUnexpectedTaskFinish(context: Context) {
     initialize(context)
     cancelScheduledRestart(context)
@@ -304,6 +305,7 @@ internal object T3BackgroundConnectionState {
 }
 
 internal object T3BackgroundConnectionController {
+  @Suppress("TooGenericExceptionCaught")
   fun ensureStarted(context: Context): Boolean {
     val applicationContext = context.applicationContext
     T3BackgroundConnectionState.initialize(applicationContext)

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionState.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionState.kt
@@ -1,0 +1,330 @@
+package expo.modules.t3backgroundconnection
+
+import android.annotation.SuppressLint
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.PowerManager
+import android.os.SystemClock
+import android.util.Log
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal object T3BackgroundConnectionState {
+  const val TASK_NAME = "T3BackgroundConnection"
+  const val STATUS_EVENT = "onStatusChange"
+  const val STOP_REQUEST_EVENT = "onStopRequested"
+  const val RESTART_ACTION =
+    "expo.modules.t3backgroundconnection.action.RESTART_BACKGROUND_CONNECTION"
+
+  private const val PREFERENCES_NAME = "t3_background_connection"
+  private const val ENABLED_KEY = "enabled"
+  private const val STOP_FALLBACK_DELAY_MS = 5_000L
+  private const val STABLE_RUNTIME_RESET_DELAY_MS = 60_000L
+
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val serviceRunning = AtomicBoolean(false)
+  private val runtimeReady = AtomicBoolean(false)
+  private val taskStarted = AtomicBoolean(false)
+  private val statusListeners = CopyOnWriteArraySet<(Map<String, Any>) -> Unit>()
+  private val stopRequestListeners = CopyOnWriteArraySet<() -> Unit>()
+
+  @Volatile
+  private var applicationContext: Context? = null
+
+  @Volatile
+  private var stopFallback: Runnable? = null
+
+  @Volatile
+  private var restartFallback: Runnable? = null
+
+  @Volatile
+  private var stableRuntimeReset: Runnable? = null
+
+  private var consecutiveUnexpectedFailures = 0
+
+  fun initialize(context: Context) {
+    applicationContext = context.applicationContext
+  }
+
+  fun isEnabled(context: Context): Boolean =
+    preferences(context).getBoolean(ENABLED_KEY, false)
+
+  @SuppressLint("ApplySharedPref")
+  fun setEnabled(context: Context, enabled: Boolean) {
+    initialize(context)
+    val wasEnabled = isEnabled(context)
+    // Commit before starting the service so a process death cannot start a
+    // sticky service whose boot-time preference still says it is disabled.
+    preferences(context).edit().putBoolean(ENABLED_KEY, enabled).commit()
+    if (enabled) {
+      cancelStopFallback()
+      if (!wasEnabled) {
+        resetUnexpectedRestartBackoff()
+      }
+    } else {
+      resetUnexpectedRestartBackoff()
+    }
+    emitStatus()
+  }
+
+  fun status(context: Context): Map<String, Any> {
+    initialize(context)
+
+    return mapOf(
+      "supported" to true,
+      "enabled" to isEnabled(context),
+      "serviceRunning" to serviceRunning.get(),
+      "runtimeReady" to runtimeReady.get(),
+      "batteryOptimizationIgnored" to isBatteryOptimizationIgnored(context),
+    )
+  }
+
+  fun shouldEnsureStartedOnActivityForeground(context: Context): Boolean =
+    T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+      enabled = isEnabled(context),
+      serviceRunning = serviceRunning.get(),
+      runtimeReady = runtimeReady.get(),
+    )
+
+  fun isBatteryOptimizationIgnored(context: Context): Boolean {
+    val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    return powerManager.isIgnoringBatteryOptimizations(context.packageName)
+  }
+
+  fun addStatusListener(listener: (Map<String, Any>) -> Unit) {
+    statusListeners.add(listener)
+  }
+
+  fun removeStatusListener(listener: (Map<String, Any>) -> Unit) {
+    statusListeners.remove(listener)
+  }
+
+  fun addStopRequestListener(listener: () -> Unit) {
+    stopRequestListeners.add(listener)
+  }
+
+  fun removeStopRequestListener(listener: () -> Unit) {
+    stopRequestListeners.remove(listener)
+  }
+
+  fun refreshStatus() {
+    emitStatus()
+  }
+
+  fun markServiceRunning(running: Boolean) {
+    serviceRunning.set(running)
+    if (!running) {
+      runtimeReady.set(false)
+      taskStarted.set(false)
+      cancelStopFallback()
+      cancelStableRuntimeReset()
+    }
+    emitStatus()
+  }
+
+  fun markRuntimeReady(ready: Boolean) {
+    val appliedReady = ready && serviceRunning.get()
+    runtimeReady.set(appliedReady)
+    if (appliedReady) {
+      scheduleStableRuntimeReset()
+    } else {
+      cancelStableRuntimeReset()
+    }
+    emitStatus()
+  }
+
+  fun claimTask(): Boolean = taskStarted.compareAndSet(false, true)
+
+  fun releaseTask() {
+    taskStarted.set(false)
+    runtimeReady.set(false)
+    cancelStableRuntimeReset()
+    emitStatus()
+  }
+
+  fun requestOrderlyStop(context: Context) {
+    initialize(context)
+    cancelStopFallback()
+    if (!serviceRunning.get()) {
+      stopService(context)
+      return
+    }
+
+    // A claimed task can be creating the React context, or can already own
+    // subscriptions while it bootstraps Clerk and persistence. Keep the
+    // service alive long enough for that task to observe the disabled
+    // preference and unwind; only an idle service is safe to stop immediately.
+    // The bounded fallback below still handles a runtime that never responds.
+    if (!taskStarted.get()) {
+      stopService(context)
+      return
+    }
+
+    mainHandler.post {
+      if (!isEnabled(context)) {
+        stopRequestListeners.forEach { listener -> listener() }
+      }
+    }
+
+    val fallback = Runnable {
+      stopFallback = null
+      if (isEnabled(context)) return@Runnable
+      runtimeReady.set(false)
+      emitStatus()
+      stopService(context)
+    }
+    stopFallback = fallback
+    mainHandler.postDelayed(fallback, STOP_FALLBACK_DELAY_MS)
+  }
+
+  fun acknowledgeStop(context: Context) {
+    initialize(context)
+    cancelStopFallback()
+    runtimeReady.set(false)
+    emitStatus()
+    if (!isEnabled(context)) {
+      stopService(context)
+    }
+  }
+
+  fun scheduleRestartAfterUnexpectedTaskFinish(context: Context) {
+    initialize(context)
+    cancelScheduledRestart(context)
+    val delayMs = T3BackgroundConnectionRestartBackoff.delayMs(consecutiveUnexpectedFailures)
+    consecutiveUnexpectedFailures = (consecutiveUnexpectedFailures + 1).coerceAtMost(20)
+    try {
+      val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+      alarmManager.setAndAllowWhileIdle(
+        AlarmManager.ELAPSED_REALTIME_WAKEUP,
+        SystemClock.elapsedRealtime() + delayMs,
+        checkNotNull(restartPendingIntent(context, PendingIntent.FLAG_UPDATE_CURRENT)),
+      )
+    } catch (error: RuntimeException) {
+      // AlarmManager is the durable path. Keep an in-process fallback for an
+      // unusual vendor failure so recovery still has a best-effort attempt.
+      Log.w("T3BackgroundConnection", "Could not schedule durable restart alarm", error)
+      val restart = Runnable {
+        restartFallback = null
+        if (isEnabled(context)) {
+          T3BackgroundConnectionController.ensureStarted(context)
+        }
+      }
+      restartFallback = restart
+      mainHandler.postDelayed(restart, delayMs)
+    }
+  }
+
+  fun scheduleRestartAfterStartFailure(context: Context) {
+    if (
+      T3BackgroundConnectionRecoveryPolicy.shouldScheduleRestartAfterStartFailure(
+        batteryOptimizationIgnored = isBatteryOptimizationIgnored(context),
+      )
+    ) {
+      scheduleRestartAfterUnexpectedTaskFinish(context)
+      return
+    }
+
+    // An alarm is not a valid exemption from Android's background foreground-
+    // service launch restrictions. Re-arming it here would create an endless
+    // failure ladder on a non-exempt app. Leave the feature enabled and recover
+    // on the next Activity foreground, boot/package update, or sticky restart.
+    cancelScheduledRestart(context)
+  }
+
+  private fun preferences(context: Context) =
+    context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+  private fun emitStatus() {
+    val context = applicationContext ?: return
+    val snapshot = status(context)
+    mainHandler.post {
+      statusListeners.forEach { listener -> listener(snapshot) }
+    }
+  }
+
+  private fun cancelStopFallback() {
+    stopFallback?.let(mainHandler::removeCallbacks)
+    stopFallback = null
+  }
+
+  fun cancelScheduledRestart(context: Context) {
+    restartFallback?.let(mainHandler::removeCallbacks)
+    restartFallback = null
+    val pendingIntent = restartPendingIntent(context, PendingIntent.FLAG_NO_CREATE) ?: return
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    alarmManager.cancel(pendingIntent)
+    pendingIntent.cancel()
+  }
+
+  private fun scheduleStableRuntimeReset() {
+    cancelStableRuntimeReset()
+    val reset = Runnable {
+      stableRuntimeReset = null
+      if (runtimeReady.get() && serviceRunning.get()) {
+        consecutiveUnexpectedFailures = 0
+      }
+    }
+    stableRuntimeReset = reset
+    mainHandler.postDelayed(reset, STABLE_RUNTIME_RESET_DELAY_MS)
+  }
+
+  private fun cancelStableRuntimeReset() {
+    stableRuntimeReset?.let(mainHandler::removeCallbacks)
+    stableRuntimeReset = null
+  }
+
+  private fun resetUnexpectedRestartBackoff() {
+    consecutiveUnexpectedFailures = 0
+    applicationContext?.let(::cancelScheduledRestart)
+    cancelStableRuntimeReset()
+  }
+
+  private fun restartPendingIntent(context: Context, creationFlag: Int): PendingIntent? =
+    PendingIntent.getBroadcast(
+      context.applicationContext,
+      RESTART_REQUEST_CODE,
+      Intent(context.applicationContext, T3BackgroundConnectionReceiver::class.java).apply {
+        action = RESTART_ACTION
+      },
+      creationFlag or PendingIntent.FLAG_IMMUTABLE,
+    )
+
+  private fun stopService(context: Context) {
+    context.applicationContext.stopService(
+      Intent(context.applicationContext, T3BackgroundConnectionService::class.java),
+    )
+  }
+
+  private const val RESTART_REQUEST_CODE = 0x7434
+}
+
+internal object T3BackgroundConnectionController {
+  fun ensureStarted(context: Context): Boolean {
+    val applicationContext = context.applicationContext
+    T3BackgroundConnectionState.initialize(applicationContext)
+    if (!T3BackgroundConnectionState.isEnabled(applicationContext)) return false
+
+    val intent = Intent(applicationContext, T3BackgroundConnectionService::class.java)
+    return try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        applicationContext.startForegroundService(intent)
+      } else {
+        applicationContext.startService(intent)
+      }
+      T3BackgroundConnectionState.cancelScheduledRestart(applicationContext)
+      true
+    } catch (error: RuntimeException) {
+      // Android can reject a background FGS launch. Keep the preference
+      // enabled and let the recovery policy either retry an exempt app or
+      // park until a foreground/OS trigger can legally start the service.
+      Log.w("T3BackgroundConnection", "Could not start foreground service", error)
+      T3BackgroundConnectionState.scheduleRestartAfterStartFailure(applicationContext)
+      false
+    }
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicyTest.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicyTest.kt
@@ -1,0 +1,57 @@
+package expo.modules.t3backgroundconnection
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class T3BackgroundConnectionRecoveryPolicyTest {
+  @Test
+  fun `start failure retries only while battery optimization is ignored`() {
+    assertTrue(
+      T3BackgroundConnectionRecoveryPolicy.shouldScheduleRestartAfterStartFailure(
+        batteryOptimizationIgnored = true,
+      ),
+    )
+    assertFalse(
+      T3BackgroundConnectionRecoveryPolicy.shouldScheduleRestartAfterStartFailure(
+        batteryOptimizationIgnored = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `foreground recovers an enabled service that is stopped or not ready`() {
+    assertTrue(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = true,
+        serviceRunning = false,
+        runtimeReady = false,
+      ),
+    )
+    assertTrue(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = true,
+        serviceRunning = true,
+        runtimeReady = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `foreground leaves a healthy or disabled service alone`() {
+    assertFalse(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = true,
+        serviceRunning = true,
+        runtimeReady = true,
+      ),
+    )
+    assertFalse(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = false,
+        serviceRunning = false,
+        runtimeReady = false,
+      ),
+    )
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoffTest.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoffTest.kt
@@ -1,0 +1,16 @@
+package expo.modules.t3backgroundconnection
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class T3BackgroundConnectionRestartBackoffTest {
+  @Test
+  fun `repeated failures back off and remain bounded`() {
+    assertEquals(1_000L, T3BackgroundConnectionRestartBackoff.delayMs(0))
+    assertEquals(2_000L, T3BackgroundConnectionRestartBackoff.delayMs(1))
+    assertEquals(4_000L, T3BackgroundConnectionRestartBackoff.delayMs(2))
+    assertEquals(256_000L, T3BackgroundConnectionRestartBackoff.delayMs(8))
+    assertEquals(300_000L, T3BackgroundConnectionRestartBackoff.delayMs(9))
+    assertEquals(300_000L, T3BackgroundConnectionRestartBackoff.delayMs(Int.MAX_VALUE))
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/expo-module.config.json
+++ b/apps/mobile/modules/t3-background-connection/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["expo.modules.t3backgroundconnection.T3BackgroundConnectionModule"]
+  }
+}

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -2,7 +2,7 @@ import { BlurTargetView } from "expo-blur";
 import * as Linking from "expo-linking";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
-import { StatusBar, useColorScheme } from "react-native";
+import { Platform, StatusBar, useColorScheme } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -22,6 +22,7 @@ import { appAtomRegistry } from "./state/atom-registry";
 import { OverlayPortalHost } from "./components/OverlayPortal";
 import { appBlurTargetRef } from "./lib/appBlurTarget";
 import { useThemeColor } from "./lib/useThemeColor";
+import { ensureBackgroundConnectionStarted } from "./native/backgroundConnection";
 
 import "../global.css";
 
@@ -57,12 +58,22 @@ function SplashScreenCoordinator() {
   return null;
 }
 
+function BackgroundConnectionServiceCoordinator() {
+  useEffect(() => {
+    if (Platform.OS === "android") {
+      ensureBackgroundConnectionStarted();
+    }
+  }, []);
+  return null;
+}
+
 export default function App() {
   const colorScheme = useColorScheme();
   const statusBarBg = useThemeColor("--color-status-bar");
 
   return (
     <RegistryContext.Provider value={appAtomRegistry}>
+      <BackgroundConnectionServiceCoordinator />
       <CloudAuthProvider>
         <AppearancePreferencesProvider>
           <SplashScreenCoordinator />

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -2,7 +2,7 @@ import { BlurTargetView } from "expo-blur";
 import * as Linking from "expo-linking";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
-import { StatusBar } from "react-native";
+import { Platform, StatusBar } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -22,6 +22,7 @@ import { appAtomRegistry } from "./state/atom-registry";
 import { OverlayPortalHost } from "./components/OverlayPortal";
 import { appBlurTargetRef } from "./lib/appBlurTarget";
 import { useMobileNavigationTheme } from "./lib/useMobileNavigationTheme";
+import { ensureBackgroundConnectionStarted } from "./native/backgroundConnection";
 
 import "../global.css";
 
@@ -57,9 +58,19 @@ function SplashScreenCoordinator() {
   return null;
 }
 
+function BackgroundConnectionServiceCoordinator() {
+  useEffect(() => {
+    if (Platform.OS === "android") {
+      ensureBackgroundConnectionStarted();
+    }
+  }, []);
+  return null;
+}
+
 export default function App() {
   return (
     <RegistryContext.Provider value={appAtomRegistry}>
+      <BackgroundConnectionServiceCoordinator />
       <CloudAuthProvider>
         <AppearancePreferencesProvider>
           <AppContent />

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -24,6 +24,8 @@ import { useConnectOnboardingNavigation } from "./features/cloud/connectOnboardi
 import { ThreadFilesTreeScreen, ThreadFileScreen } from "./features/files/ThreadFilesRouteScreen";
 import { AdaptiveWorkspaceLayout } from "./features/layout/AdaptiveWorkspaceLayout";
 import { HardwareKeyboardCommandProvider } from "./features/keyboard/HardwareKeyboardCommandProvider";
+import { parseActiveThreadPath } from "./features/keyboard/hardwareKeyboardCommands";
+import { saveBackgroundConnectionRetainedThread } from "./features/background-connection/retained-thread";
 import { ReviewCommentComposerSheet } from "./features/review/ReviewCommentComposerSheet";
 import { ReviewSheet } from "./features/review/ReviewSheet";
 import { ThreadTerminalRouteScreen } from "./features/terminal/ThreadTerminalRouteScreen";
@@ -342,6 +344,14 @@ function RootStackLayout(props: {
   const path = getPathFromState(props.state, navigationPathConfig);
   const pathname = path.startsWith("/") ? path : `/${path}`;
   const workspacePathname = workspacePathFromState(props.state);
+  const activeThread = parseActiveThreadPath(workspacePathname);
+
+  useEffect(() => {
+    if (Platform.OS !== "android" || activeThread === null) {
+      return;
+    }
+    void saveBackgroundConnectionRetainedThread(activeThread);
+  }, [activeThread?.environmentId, activeThread?.threadId]);
 
   return (
     <HardwareKeyboardCommandProvider pathname={pathname}>

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -23,6 +23,8 @@ import { useConnectOnboardingNavigation } from "./features/cloud/connectOnboardi
 import { ThreadFilesTreeScreen, ThreadFileScreen } from "./features/files/ThreadFilesRouteScreen";
 import { AdaptiveWorkspaceLayout } from "./features/layout/AdaptiveWorkspaceLayout";
 import { HardwareKeyboardCommandProvider } from "./features/keyboard/HardwareKeyboardCommandProvider";
+import { parseActiveThreadPath } from "./features/keyboard/hardwareKeyboardCommands";
+import { saveBackgroundConnectionRetainedThread } from "./features/background-connection/retained-thread";
 import { ReviewCommentComposerSheet } from "./features/review/ReviewCommentComposerSheet";
 import { ReviewSheet } from "./features/review/ReviewSheet";
 import { ThreadTerminalRouteScreen } from "./features/terminal/ThreadTerminalRouteScreen";
@@ -392,6 +394,14 @@ function RootStackLayout(props: {
   const path = getPathFromState(props.state, navigationPathConfig);
   const pathname = path.startsWith("/") ? path : `/${path}`;
   const workspacePathname = workspacePathFromState(props.state);
+  const activeThread = parseActiveThreadPath(workspacePathname);
+
+  useEffect(() => {
+    if (Platform.OS !== "android" || activeThread === null) {
+      return;
+    }
+    void saveBackgroundConnectionRetainedThread(activeThread);
+  }, [activeThread?.environmentId, activeThread?.threadId]);
 
   return (
     <HardwareKeyboardCommandProvider pathname={pathname}>

--- a/apps/mobile/src/connection/app-state-wakeups.test.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.test.ts
@@ -18,4 +18,34 @@ describe("mobileApplicationActiveWakeup", () => {
       mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS),
     ).toBe("application-active-reconnect");
   });
+
+  it("preserves a protected background connection regardless of elapsed time", () => {
+    const protection = { serviceRunning: true, runtimeReady: true };
+
+    expect(mobileApplicationActiveWakeup(null, 20_000, protection)).toBe(
+      "application-active-preserved",
+    );
+    expect(
+      mobileApplicationActiveWakeup(
+        20_000,
+        20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS * 10,
+        protection,
+      ),
+    ).toBe("application-active-preserved");
+  });
+
+  it("keeps the existing fallback unless both native protection signals are healthy", () => {
+    expect(
+      mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS, {
+        serviceRunning: true,
+        runtimeReady: false,
+      }),
+    ).toBe("application-active-reconnect");
+    expect(
+      mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS, {
+        serviceRunning: false,
+        runtimeReady: true,
+      }),
+    ).toBe("application-active-reconnect");
+  });
 });

--- a/apps/mobile/src/connection/app-state-wakeups.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.ts
@@ -4,13 +4,22 @@ export const MOBILE_BACKGROUND_RECONNECT_AFTER_MS = 10_000;
 
 export type MobileApplicationActiveWakeup = Extract<
   Wakeups.ConnectionWakeup,
-  "application-active-probe" | "application-active-reconnect"
+  "application-active-preserved" | "application-active-probe" | "application-active-reconnect"
 >;
+
+export interface MobileBackgroundConnectionProtection {
+  readonly serviceRunning: boolean;
+  readonly runtimeReady: boolean;
+}
 
 export function mobileApplicationActiveWakeup(
   backgroundedAtMs: number | null,
   activeAtMs: number,
+  protection?: MobileBackgroundConnectionProtection,
 ): MobileApplicationActiveWakeup {
+  if (protection?.serviceRunning === true && protection.runtimeReady === true) {
+    return "application-active-preserved";
+  }
   return backgroundedAtMs !== null &&
     activeAtMs - backgroundedAtMs >= MOBILE_BACKGROUND_RECONNECT_AFTER_MS
     ? "application-active-reconnect"

--- a/apps/mobile/src/connection/platform.ts
+++ b/apps/mobile/src/connection/platform.ts
@@ -26,11 +26,15 @@ import { AppState } from "react-native";
 
 import { authClientMetadata } from "../lib/authClientMetadata";
 import * as Runtime from "../lib/runtime";
+import { getBackgroundConnectionStatus } from "../native/backgroundConnection";
 import * as MobileStorage from "../persistence/mobile-storage";
 import { appAtomRegistry } from "../state/atom-registry";
 import { clearThreadOutboxEnvironment } from "../state/thread-outbox";
 import { clearComposerDraftsEnvironment } from "../state/use-composer-drafts";
-import { mobileApplicationActiveWakeup } from "./app-state-wakeups";
+import {
+  type MobileApplicationActiveWakeup,
+  mobileApplicationActiveWakeup,
+} from "./app-state-wakeups";
 import { connectionStorageLayer } from "./storage";
 
 function networkStatus(state: Network.NetworkState): "unknown" | "offline" | "online" {
@@ -87,7 +91,7 @@ const connectivityLayer = Connectivity.layer({
 
 const wakeupsLayer = Wakeups.layer({
   changes: Stream.merge(
-    Stream.callback<"application-active-probe" | "application-active-reconnect">((queue) =>
+    Stream.callback<MobileApplicationActiveWakeup>((queue) =>
       Effect.acquireRelease(
         Effect.sync(() => {
           let backgroundedAtMs = AppState.currentState === "background" ? Date.now() : null;
@@ -97,7 +101,14 @@ const wakeupsLayer = Wakeups.layer({
               return;
             }
             if (state === "active") {
-              Queue.offerUnsafe(queue, mobileApplicationActiveWakeup(backgroundedAtMs, Date.now()));
+              Queue.offerUnsafe(
+                queue,
+                mobileApplicationActiveWakeup(
+                  backgroundedAtMs,
+                  Date.now(),
+                  getBackgroundConnectionStatus(),
+                ),
+              );
               backgroundedAtMs = null;
             }
           });

--- a/apps/mobile/src/connection/platform.ts
+++ b/apps/mobile/src/connection/platform.ts
@@ -27,11 +27,15 @@ import { AppState } from "react-native";
 
 import { authClientMetadata } from "../lib/authClientMetadata";
 import * as Runtime from "../lib/runtime";
+import { getBackgroundConnectionStatus } from "../native/backgroundConnection";
 import * as MobileStorage from "../persistence/mobile-storage";
 import { appAtomRegistry } from "../state/atom-registry";
 import { clearThreadOutboxEnvironment } from "../state/thread-outbox-removal";
 import { clearComposerDraftsEnvironment } from "../state/use-composer-drafts";
-import { mobileApplicationActiveWakeup } from "./app-state-wakeups";
+import {
+  type MobileApplicationActiveWakeup,
+  mobileApplicationActiveWakeup,
+} from "./app-state-wakeups";
 import { connectionStorageLayer } from "./storage";
 
 function networkStatus(state: Network.NetworkState): "unknown" | "offline" | "online" {
@@ -88,7 +92,7 @@ const connectivityLayer = Connectivity.layer({
 
 const wakeupsLayer = Wakeups.layer({
   changes: Stream.merge(
-    Stream.callback<"application-active-probe" | "application-active-reconnect">((queue) =>
+    Stream.callback<MobileApplicationActiveWakeup>((queue) =>
       Effect.acquireRelease(
         Effect.sync(() => {
           let backgroundedAtMs = AppState.currentState === "background" ? Date.now() : null;
@@ -98,7 +102,14 @@ const wakeupsLayer = Wakeups.layer({
               return;
             }
             if (state === "active") {
-              Queue.offerUnsafe(queue, mobileApplicationActiveWakeup(backgroundedAtMs, Date.now()));
+              Queue.offerUnsafe(
+                queue,
+                mobileApplicationActiveWakeup(
+                  backgroundedAtMs,
+                  Date.now(),
+                  getBackgroundConnectionStatus(),
+                ),
+              );
               backgroundedAtMs = null;
             }
           });

--- a/apps/mobile/src/features/agent-awareness/liveActivityPreferences.test.ts
+++ b/apps/mobile/src/features/agent-awareness/liveActivityPreferences.test.ts
@@ -62,6 +62,9 @@ const testLayer = Layer.mergeAll(
       clearAgentAwarenessRegistrationRecord: Effect.void,
       loadRecentThreadShortcuts: Effect.succeed([]),
       saveRecentThreadShortcuts: () => Effect.void,
+      loadBackgroundConnectionRetainedThread: Effect.succeed(null),
+      saveBackgroundConnectionRetainedThread: () => Effect.void,
+      clearBackgroundConnectionRetainedThread: Effect.void,
     }),
   ),
 );

--- a/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.test.tsx
+++ b/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.test.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { BackgroundConnectionStatus } from "../../native/backgroundConnection";
+
+const native = vi.hoisted(() => ({
+  status: null as BackgroundConnectionStatus | null,
+  setEnabled: vi.fn(),
+  requestExemption: vi.fn(),
+  removeStatusListener: vi.fn(),
+}));
+
+const reactNative = vi.hoisted(() => ({
+  alert: vi.fn(),
+  removeAppStateListener: vi.fn(),
+}));
+
+vi.mock("react", () => ({
+  useCallback: (callback: unknown) => callback,
+  useEffect: (setup: () => void | (() => void)) => {
+    setup();
+  },
+  useState: (initial: unknown) => [
+    typeof initial === "function" ? (initial as () => unknown)() : initial,
+    vi.fn(),
+  ],
+}));
+
+vi.mock("react-native", () => ({
+  Alert: { alert: reactNative.alert },
+  AppState: {
+    addEventListener: vi.fn(() => ({ remove: reactNative.removeAppStateListener })),
+  },
+  Platform: { OS: "android" },
+  Pressable: "Pressable",
+  View: "View",
+}));
+
+vi.mock("../../components/AppText", () => ({ AppText: "Text" }));
+vi.mock("../settings/components/SettingsSection", () => ({
+  SettingsSection: "SettingsSection",
+}));
+vi.mock("../settings/components/SettingsSwitchRow", () => ({
+  SettingsSwitchRow: "SettingsSwitchRow",
+}));
+vi.mock("../../native/backgroundConnection", () => ({
+  addBackgroundConnectionStatusListener: vi.fn(() => ({
+    remove: native.removeStatusListener,
+  })),
+  getBackgroundConnectionStatus: () => native.status,
+  requestBackgroundConnectionBatteryOptimizationExemption: native.requestExemption,
+  setBackgroundConnectionEnabled: native.setEnabled,
+}));
+
+import { BackgroundConnectionSettingsSection } from "./BackgroundConnectionSettingsSection";
+
+interface ElementNode {
+  readonly props?: {
+    readonly children?: unknown;
+    readonly onValueChange?: (enabled: boolean) => void;
+  };
+}
+
+function children(node: unknown): ReadonlyArray<unknown> {
+  const value = (node as ElementNode | null)?.props?.children;
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function renderSwitch(): ElementNode {
+  const root = BackgroundConnectionSettingsSection();
+  const section = children(root)[0];
+  return children(section)[0] as ElementNode;
+}
+
+function status(overrides: Partial<BackgroundConnectionStatus> = {}): BackgroundConnectionStatus {
+  return {
+    supported: true,
+    enabled: false,
+    serviceRunning: false,
+    runtimeReady: false,
+    batteryOptimizationIgnored: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  native.status = status();
+  native.setEnabled.mockImplementation(async (enabled: boolean) =>
+    status({
+      enabled,
+      serviceRunning: enabled,
+      runtimeReady: enabled,
+    }),
+  );
+  native.requestExemption.mockResolvedValue(status({ enabled: true }));
+});
+
+describe("BackgroundConnectionSettingsSection", () => {
+  it("enables the native runtime and keeps it enabled when battery exemption is declined", async () => {
+    native.setEnabled.mockResolvedValue(
+      status({
+        enabled: true,
+        serviceRunning: true,
+        runtimeReady: true,
+        batteryOptimizationIgnored: false,
+      }),
+    );
+    native.requestExemption.mockResolvedValue(
+      status({ enabled: true, batteryOptimizationIgnored: false }),
+    );
+
+    renderSwitch().props?.onValueChange?.(true);
+
+    await vi.waitFor(() => {
+      expect(native.setEnabled).toHaveBeenCalledWith(true);
+      expect(reactNative.alert).toHaveBeenCalledOnce();
+    });
+    const buttons = reactNative.alert.mock.calls[0]?.[2] as
+      | ReadonlyArray<{ readonly text: string; readonly onPress?: () => void }>
+      | undefined;
+    buttons?.find((button) => button.text === "Allow")?.onPress?.();
+    await vi.waitFor(() => expect(native.requestExemption).toHaveBeenCalledOnce());
+
+    expect(native.setEnabled).not.toHaveBeenCalledWith(false);
+  });
+
+  it("disables the native runtime without requesting a battery exemption", async () => {
+    native.status = status({
+      enabled: true,
+      serviceRunning: true,
+      runtimeReady: true,
+    });
+    native.setEnabled.mockResolvedValue(status());
+
+    renderSwitch().props?.onValueChange?.(false);
+
+    await vi.waitFor(() => expect(native.setEnabled).toHaveBeenCalledWith(false));
+    expect(reactNative.alert).not.toHaveBeenCalled();
+    expect(native.requestExemption).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.tsx
+++ b/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from "react";
+import { Alert, AppState, Platform, Pressable, View } from "react-native";
+
+import { AppText as Text } from "../../components/AppText";
+import {
+  addBackgroundConnectionStatusListener,
+  getBackgroundConnectionStatus,
+  requestBackgroundConnectionBatteryOptimizationExemption,
+  setBackgroundConnectionEnabled,
+  type BackgroundConnectionStatus,
+} from "../../native/backgroundConnection";
+import { SettingsSection } from "../settings/components/SettingsSection";
+import { SettingsSwitchRow } from "../settings/components/SettingsSwitchRow";
+import {
+  backgroundConnectionStatusLabel,
+  shouldRequestBackgroundConnectionBatteryExemption,
+} from "./settings-model";
+
+function promptForBatteryExemption(
+  requestExemption: () => Promise<BackgroundConnectionStatus>,
+): void {
+  Alert.alert(
+    "Allow unrestricted battery use?",
+    "Android can otherwise pause the background connection while T3 Code is locked or another app is open.",
+    [
+      { text: "Not Now", style: "cancel" },
+      { text: "Allow", onPress: () => void requestExemption() },
+    ],
+  );
+}
+
+export function BackgroundConnectionSettingsSection() {
+  const [status, setStatus] = useState(getBackgroundConnectionStatus);
+  const [changing, setChanging] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+    setStatus(getBackgroundConnectionStatus());
+    const nativeSubscription = addBackgroundConnectionStatusListener(setStatus);
+    const appStateSubscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState === "active") {
+        setStatus(getBackgroundConnectionStatus());
+      }
+    });
+    return () => {
+      nativeSubscription.remove();
+      appStateSubscription.remove();
+    };
+  }, []);
+
+  const requestExemption = useCallback(async () => {
+    const next = await requestBackgroundConnectionBatteryOptimizationExemption();
+    setStatus(next);
+    return next;
+  }, []);
+
+  const handleEnabledChange = useCallback(
+    async (enabled: boolean) => {
+      if (changing) {
+        return;
+      }
+      setChanging(true);
+      setStatus((current) => ({ ...current, enabled }));
+      const next = await setBackgroundConnectionEnabled(enabled);
+      setStatus(next);
+      setChanging(false);
+      if (shouldRequestBackgroundConnectionBatteryExemption(next)) {
+        promptForBatteryExemption(requestExemption);
+      }
+    },
+    [changing, requestExemption],
+  );
+
+  if (Platform.OS !== "android") {
+    return null;
+  }
+
+  const statusLabel = backgroundConnectionStatusLabel(status);
+  const canRetryBatteryExemption = shouldRequestBackgroundConnectionBatteryExemption(status);
+
+  return (
+    <View className="gap-3">
+      <SettingsSection title="Background connection">
+        <SettingsSwitchRow
+          disabled={!status.supported || changing}
+          icon="bolt.horizontal.circle"
+          label="Keep connected in background"
+          value={status.enabled}
+          onValueChange={(enabled) => void handleEnabledChange(enabled)}
+        />
+        <View className="border-t border-border px-4 py-3">
+          {canRetryBatteryExemption ? (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => void requestExemption()}
+              className="py-1"
+            >
+              <Text className="text-sm font-t3-medium text-foreground">{statusLabel}</Text>
+              <Text className="mt-1 text-sm text-foreground-muted">
+                Tap to allow unrestricted battery use.
+              </Text>
+            </Pressable>
+          ) : (
+            <Text className="text-sm font-t3-medium text-foreground-muted">{statusLabel}</Text>
+          )}
+        </View>
+      </SettingsSection>
+      <Text className="px-2 text-sm leading-normal text-foreground-muted">
+        Keeps environments and active work synchronized while your phone is locked or another app is
+        open. This can noticeably increase battery use, and Android will show a silent ongoing
+        service status.
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/background-connection/background-root.test.ts
+++ b/apps/mobile/src/features/background-connection/background-root.test.ts
@@ -3,6 +3,14 @@ import { EnvironmentId, ThreadId, type ScopedThreadRef } from "@t3tools/contract
 import { AsyncResult, type AtomRegistry } from "effect/unstable/reactivity";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 const atoms = vi.hoisted(() => ({
   catalog: { name: "catalog" },
   serverConfigs: { name: "server-configs" },
@@ -22,15 +30,17 @@ const retained = vi.hoisted(() => {
     releaseCount: 0,
   };
   const listeners = new Set<() => void>();
+  const publish = (thread: ScopedThreadRef | null) => {
+    state.snapshot = { loaded: true, thread };
+    for (const listener of listeners) {
+      listener();
+    }
+  };
   return {
     state,
     listeners,
-    clear: vi.fn(async () => {
-      state.snapshot = { loaded: true, thread: null };
-      for (const listener of listeners) {
-        listener();
-      }
-    }),
+    publish,
+    clear: vi.fn(async () => publish(null)),
     ensureLoaded: vi.fn(async () => state.snapshot.thread),
   };
 });
@@ -186,7 +196,8 @@ beforeEach(() => {
   retained.state.subscribeCount = 0;
   retained.state.releaseCount = 0;
   retained.listeners.clear();
-  retained.clear.mockClear();
+  retained.clear.mockReset();
+  retained.clear.mockImplementation(async () => retained.publish(null));
   retained.ensureLoaded.mockClear();
   atoms.shellStates.clear();
   atoms.detailStates.clear();
@@ -265,6 +276,36 @@ describe("background connection root", () => {
     expect(retained.state.snapshot.thread).toBeNull();
     expect(harness.subscribeCount(`detail:${detailKey}`)).toBe(1);
     expect(harness.subscribeReleaseCount(`detail:${detailKey}`)).toBe(1);
+    root.stop();
+  });
+
+  it("re-clears a deleted ref saved while its first clear is pending", async () => {
+    const firstClear = deferred();
+    let clearCount = 0;
+    retained.clear.mockImplementation(() => {
+      retained.publish(null);
+      clearCount += 1;
+      return clearCount === 1 ? firstClear.promise : Promise.resolve();
+    });
+    const detailKey = `${environmentId}:${threadId}`;
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+      deletedThreadKeys: new Set([detailKey]),
+    });
+    const root = createBackgroundConnectionRoot(harness.registry);
+
+    root.start();
+    expect(retained.clear).toHaveBeenCalledOnce();
+
+    retained.publish(retainedThread);
+    expect(retained.clear).toHaveBeenCalledOnce();
+
+    firstClear.resolve();
+    await firstClear.promise;
+    await Promise.resolve();
+
+    expect(retained.clear).toHaveBeenCalledTimes(2);
+    expect(retained.state.snapshot.thread).toBeNull();
     root.stop();
   });
 });

--- a/apps/mobile/src/features/background-connection/background-root.test.ts
+++ b/apps/mobile/src/features/background-connection/background-root.test.ts
@@ -1,0 +1,270 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ThreadId, type ScopedThreadRef } from "@t3tools/contracts";
+import { AsyncResult, type AtomRegistry } from "effect/unstable/reactivity";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const atoms = vi.hoisted(() => ({
+  catalog: { name: "catalog" },
+  serverConfigs: { name: "server-configs" },
+  threadShells: { name: "thread-shells" },
+  shellStates: new Map<string, { readonly name: string }>(),
+  detailStates: new Map<string, { readonly name: string; readonly detailKey: string }>(),
+}));
+
+const retained = vi.hoisted(() => {
+  const state: {
+    snapshot: { loaded: boolean; thread: ScopedThreadRef | null };
+    subscribeCount: number;
+    releaseCount: number;
+  } = {
+    snapshot: { loaded: true, thread: null },
+    subscribeCount: 0,
+    releaseCount: 0,
+  };
+  const listeners = new Set<() => void>();
+  return {
+    state,
+    listeners,
+    clear: vi.fn(async () => {
+      state.snapshot = { loaded: true, thread: null };
+      for (const listener of listeners) {
+        listener();
+      }
+    }),
+    ensureLoaded: vi.fn(async () => state.snapshot.thread),
+  };
+});
+
+vi.mock("../../connection/catalog", () => ({
+  environmentCatalog: { catalogValueAtom: atoms.catalog },
+}));
+
+vi.mock("../../state/server", () => ({
+  environmentServerConfigsAtom: atoms.serverConfigs,
+}));
+
+vi.mock("../../state/shell", () => ({
+  environmentShell: {
+    stateAtom: (environmentId: string) => {
+      let atom = atoms.shellStates.get(environmentId);
+      if (atom === undefined) {
+        atom = { name: `shell:${environmentId}` };
+        atoms.shellStates.set(environmentId, atom);
+      }
+      return atom;
+    },
+  },
+}));
+
+vi.mock("../../state/threads", () => ({
+  environmentThreadShells: { threadShellsAtom: atoms.threadShells },
+  environmentThreads: {
+    stateAtom: (environmentId: string, threadId: string) => {
+      const key = `${environmentId}:${threadId}`;
+      let atom = atoms.detailStates.get(key);
+      if (atom === undefined) {
+        atom = { name: `detail:${key}`, detailKey: key };
+        atoms.detailStates.set(key, atom);
+      }
+      return atom;
+    },
+  },
+}));
+
+vi.mock("./retained-thread", () => ({
+  clearBackgroundConnectionRetainedThread: retained.clear,
+  ensureBackgroundConnectionRetainedThreadLoaded: retained.ensureLoaded,
+  getBackgroundConnectionRetainedThreadSnapshot: () => retained.state.snapshot,
+  subscribeBackgroundConnectionRetainedThread: (listener: () => void) => {
+    retained.state.subscribeCount += 1;
+    retained.listeners.add(listener);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      retained.state.releaseCount += 1;
+      retained.listeners.delete(listener);
+    };
+  },
+}));
+
+import { acquireBackgroundConnectionRoot, createBackgroundConnectionRoot } from "./background-root";
+
+interface CatalogState {
+  readonly isReady: boolean;
+  readonly entries: ReadonlyMap<EnvironmentId, unknown>;
+}
+
+function atomName(atom: unknown): string {
+  return (atom as { readonly name: string }).name;
+}
+
+function createRegistry(options: {
+  readonly catalog: CatalogState;
+  readonly threadShells?: ReadonlyArray<EnvironmentThreadShell>;
+  readonly deletedThreadKeys?: ReadonlySet<string>;
+}) {
+  let catalog = options.catalog;
+  const threadShells = options.threadShells ?? [];
+  const deletedThreadKeys = options.deletedThreadKeys ?? new Set<string>();
+  const callbacks = new Map<unknown, Set<(value: unknown) => void>>();
+  const mountCounts = new Map<string, number>();
+  const mountReleaseCounts = new Map<string, number>();
+  const subscribeCounts = new Map<string, number>();
+  const subscribeReleaseCounts = new Map<string, number>();
+
+  const increment = (counts: Map<string, number>, name: string) =>
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  const read = (atom: unknown): unknown => {
+    if (atom === atoms.catalog) return catalog;
+    if (atom === atoms.threadShells) return threadShells;
+    const detailKey = (atom as { readonly detailKey?: string }).detailKey;
+    if (detailKey !== undefined) {
+      return AsyncResult.success({
+        status: deletedThreadKeys.has(detailKey) ? "deleted" : "live",
+      });
+    }
+    return null;
+  };
+
+  const registry = {
+    get: read,
+    mount(atom: unknown) {
+      const name = atomName(atom);
+      increment(mountCounts, name);
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        increment(mountReleaseCounts, name);
+      };
+    },
+    subscribe(
+      atom: unknown,
+      callback: (value: unknown) => void,
+      subscribeOptions?: { readonly immediate?: boolean },
+    ) {
+      const name = atomName(atom);
+      increment(subscribeCounts, name);
+      const atomCallbacks = callbacks.get(atom) ?? new Set();
+      atomCallbacks.add(callback);
+      callbacks.set(atom, atomCallbacks);
+      if (subscribeOptions?.immediate === true) {
+        callback(read(atom));
+      }
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        increment(subscribeReleaseCounts, name);
+        atomCallbacks.delete(callback);
+      };
+    },
+  } as unknown as AtomRegistry.AtomRegistry;
+
+  return {
+    registry,
+    mountCount: (name: string) => mountCounts.get(name) ?? 0,
+    mountReleaseCount: (name: string) => mountReleaseCounts.get(name) ?? 0,
+    subscribeCount: (name: string) => subscribeCounts.get(name) ?? 0,
+    subscribeReleaseCount: (name: string) => subscribeReleaseCounts.get(name) ?? 0,
+    setCatalog(next: CatalogState) {
+      catalog = next;
+      for (const callback of callbacks.get(atoms.catalog) ?? []) {
+        callback(catalog);
+      }
+    },
+  };
+}
+
+const environmentId = EnvironmentId.make("environment-1");
+const threadId = ThreadId.make("thread-1");
+const retainedThread = { environmentId, threadId };
+
+beforeEach(() => {
+  retained.state.snapshot = { loaded: true, thread: retainedThread };
+  retained.state.subscribeCount = 0;
+  retained.state.releaseCount = 0;
+  retained.listeners.clear();
+  retained.clear.mockClear();
+  retained.ensureLoaded.mockClear();
+  atoms.shellStates.clear();
+  atoms.detailStates.clear();
+});
+
+describe("background connection root", () => {
+  it("starts and stops each lease exactly once", () => {
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+    });
+    const root = createBackgroundConnectionRoot(harness.registry);
+
+    root.start();
+    root.start();
+
+    expect(harness.mountCount("server-configs")).toBe(1);
+    expect(harness.mountCount(`shell:${environmentId}`)).toBe(1);
+    expect(harness.subscribeCount("catalog")).toBe(1);
+    expect(harness.subscribeCount("thread-shells")).toBe(1);
+    expect(harness.subscribeCount(`detail:${environmentId}:${threadId}`)).toBe(1);
+    expect(retained.state.subscribeCount).toBe(1);
+
+    root.stop();
+    root.stop();
+
+    expect(harness.mountReleaseCount("server-configs")).toBe(1);
+    expect(harness.mountReleaseCount(`shell:${environmentId}`)).toBe(1);
+    expect(harness.subscribeReleaseCount("catalog")).toBe(1);
+    expect(harness.subscribeReleaseCount("thread-shells")).toBe(1);
+    expect(harness.subscribeReleaseCount(`detail:${environmentId}:${threadId}`)).toBe(1);
+    expect(retained.state.releaseCount).toBe(1);
+  });
+
+  it("shares one root until the final owner releases it", () => {
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+    });
+
+    const releaseFirst = acquireBackgroundConnectionRoot(harness.registry);
+    const releaseSecond = acquireBackgroundConnectionRoot(harness.registry);
+    expect(harness.mountCount("server-configs")).toBe(1);
+
+    releaseFirst();
+    expect(harness.mountReleaseCount("server-configs")).toBe(0);
+    releaseSecond();
+    releaseSecond();
+    expect(harness.mountReleaseCount("server-configs")).toBe(1);
+  });
+
+  it("clears a retained target when its environment is removed", () => {
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+    });
+    const root = createBackgroundConnectionRoot(harness.registry);
+    root.start();
+
+    harness.setCatalog({ isReady: true, entries: new Map() });
+
+    expect(retained.clear).toHaveBeenCalledOnce();
+    expect(retained.state.snapshot.thread).toBeNull();
+    expect(harness.subscribeReleaseCount(`detail:${environmentId}:${threadId}`)).toBe(1);
+    root.stop();
+  });
+
+  it("clears and releases an immediately deleted retained thread", () => {
+    const detailKey = `${environmentId}:${threadId}`;
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+      deletedThreadKeys: new Set([detailKey]),
+    });
+    const root = createBackgroundConnectionRoot(harness.registry);
+
+    root.start();
+
+    expect(retained.clear).toHaveBeenCalledOnce();
+    expect(retained.state.snapshot.thread).toBeNull();
+    expect(harness.subscribeCount(`detail:${detailKey}`)).toBe(1);
+    expect(harness.subscribeReleaseCount(`detail:${detailKey}`)).toBe(1);
+    root.stop();
+  });
+});

--- a/apps/mobile/src/features/background-connection/background-root.ts
+++ b/apps/mobile/src/features/background-connection/background-root.ts
@@ -1,0 +1,250 @@
+import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { AsyncResult, type AtomRegistry } from "effect/unstable/reactivity";
+
+import { environmentCatalog } from "../../connection/catalog";
+import { environmentServerConfigsAtom } from "../../state/server";
+import { environmentShell } from "../../state/shell";
+import { environmentThreadShells, environmentThreads } from "../../state/threads";
+import {
+  clearBackgroundConnectionRetainedThread,
+  ensureBackgroundConnectionRetainedThreadLoaded,
+  getBackgroundConnectionRetainedThreadSnapshot,
+  subscribeBackgroundConnectionRetainedThread,
+} from "./retained-thread";
+import { selectBackgroundConnectionThreadTargets } from "./target-selection";
+
+interface DetailLease {
+  readonly ref: ScopedThreadRef;
+  readonly release: () => void;
+}
+
+interface BackgroundConnectionRoot {
+  readonly start: () => void;
+  readonly stop: () => void;
+}
+
+function refKey(ref: ScopedThreadRef): string {
+  return JSON.stringify([ref.environmentId, ref.threadId]);
+}
+
+function refsEqual(left: ScopedThreadRef | null, right: ScopedThreadRef): boolean {
+  return (
+    left !== null && left.environmentId === right.environmentId && left.threadId === right.threadId
+  );
+}
+
+function releaseBestEffort(label: string, release: (() => void) | null): void {
+  if (release === null) {
+    return;
+  }
+  try {
+    release();
+  } catch (error) {
+    console.error(`[background-connection] failed to release ${label}`, error);
+  }
+}
+
+export function createBackgroundConnectionRoot(
+  registry: AtomRegistry.AtomRegistry,
+): BackgroundConnectionRoot {
+  let started = false;
+  let retainedThread = getBackgroundConnectionRetainedThreadSnapshot().thread;
+  let catalogReady = false;
+  let catalogEnvironmentIds = new Set<EnvironmentId>();
+  let threadShells = registry.get(environmentThreadShells.threadShellsAtom);
+  let catalogRelease: (() => void) | null = null;
+  let threadShellsRelease: (() => void) | null = null;
+  let serverConfigsRelease: (() => void) | null = null;
+  let retainedThreadRelease: (() => void) | null = null;
+  let clearingDeletedKey: string | null = null;
+  const shellLeases = new Map<EnvironmentId, () => void>();
+  const detailLeases = new Map<string, DetailLease>();
+
+  const clearRetainedIfCurrent = (ref: ScopedThreadRef) => {
+    if (!refsEqual(retainedThread, ref)) {
+      return;
+    }
+    const key = refKey(ref);
+    if (clearingDeletedKey === key) {
+      return;
+    }
+    clearingDeletedKey = key;
+    void clearBackgroundConnectionRetainedThread().finally(() => {
+      if (clearingDeletedKey === key) {
+        clearingDeletedKey = null;
+      }
+    });
+  };
+
+  const syncDetailLeases = () => {
+    if (!started) {
+      return;
+    }
+    const targets = selectBackgroundConnectionThreadTargets(retainedThread, threadShells);
+    const targetKeys = new Set(targets.map(refKey));
+
+    for (const [key, lease] of detailLeases) {
+      if (targetKeys.has(key)) {
+        continue;
+      }
+      detailLeases.delete(key);
+      releaseBestEffort(`thread detail ${key}`, lease.release);
+    }
+
+    for (const ref of targets) {
+      const key = refKey(ref);
+      if (detailLeases.has(key)) {
+        continue;
+      }
+      const atom = environmentThreads.stateAtom(ref.environmentId, ref.threadId);
+      let subscribedRelease: (() => void) | null = null;
+      const lease: DetailLease = {
+        ref,
+        release: () => subscribedRelease?.(),
+      };
+      // Register the lease before subscribing because an immediate deleted
+      // state can synchronously clear the retained target and re-enter this
+      // reconciliation.
+      detailLeases.set(key, lease);
+      subscribedRelease = registry.subscribe(
+        atom,
+        (result) => {
+          const state = Option.getOrNull(AsyncResult.value(result));
+          if (state?.status === "deleted") {
+            clearRetainedIfCurrent(ref);
+          }
+        },
+        { immediate: true },
+      );
+      if (!detailLeases.has(key)) {
+        subscribedRelease();
+      }
+    }
+  };
+
+  const validateRetainedEnvironment = () => {
+    if (
+      catalogReady &&
+      retainedThread !== null &&
+      !catalogEnvironmentIds.has(retainedThread.environmentId)
+    ) {
+      clearRetainedIfCurrent(retainedThread);
+    }
+  };
+
+  const syncRetainedThread = () => {
+    retainedThread = getBackgroundConnectionRetainedThreadSnapshot().thread;
+    validateRetainedEnvironment();
+    syncDetailLeases();
+  };
+
+  return {
+    start() {
+      if (started) {
+        return;
+      }
+      started = true;
+      retainedThreadRelease = subscribeBackgroundConnectionRetainedThread(syncRetainedThread);
+      retainedThread = getBackgroundConnectionRetainedThreadSnapshot().thread;
+      serverConfigsRelease = registry.mount(environmentServerConfigsAtom);
+      catalogRelease = registry.subscribe(
+        environmentCatalog.catalogValueAtom,
+        (catalog) => {
+          catalogReady = catalog.isReady;
+          catalogEnvironmentIds = new Set(catalog.entries.keys());
+
+          for (const [environmentId, release] of shellLeases) {
+            if (catalogEnvironmentIds.has(environmentId)) {
+              continue;
+            }
+            shellLeases.delete(environmentId);
+            releaseBestEffort(`environment shell ${environmentId}`, release);
+          }
+          for (const environmentId of catalogEnvironmentIds) {
+            if (!shellLeases.has(environmentId)) {
+              shellLeases.set(
+                environmentId,
+                registry.mount(environmentShell.stateAtom(environmentId)),
+              );
+            }
+          }
+          validateRetainedEnvironment();
+        },
+        { immediate: true },
+      );
+      threadShellsRelease = registry.subscribe(
+        environmentThreadShells.threadShellsAtom,
+        (nextThreadShells) => {
+          threadShells = nextThreadShells;
+          syncDetailLeases();
+        },
+        { immediate: true },
+      );
+      void ensureBackgroundConnectionRetainedThreadLoaded();
+      syncDetailLeases();
+    },
+    stop() {
+      if (!started) {
+        return;
+      }
+      started = false;
+      releaseBestEffort("retained-thread listener", retainedThreadRelease);
+      retainedThreadRelease = null;
+      releaseBestEffort("thread-shell listener", threadShellsRelease);
+      threadShellsRelease = null;
+      releaseBestEffort("environment catalog", catalogRelease);
+      catalogRelease = null;
+      releaseBestEffort("server configs", serverConfigsRelease);
+      serverConfigsRelease = null;
+      for (const [environmentId, release] of shellLeases) {
+        releaseBestEffort(`environment shell ${environmentId}`, release);
+      }
+      shellLeases.clear();
+      for (const [key, lease] of detailLeases) {
+        releaseBestEffort(`thread detail ${key}`, lease.release);
+      }
+      detailLeases.clear();
+    },
+  };
+}
+
+const roots = new WeakMap<
+  AtomRegistry.AtomRegistry,
+  { readonly root: BackgroundConnectionRoot; owners: number }
+>();
+
+export function acquireBackgroundConnectionRoot(registry: AtomRegistry.AtomRegistry): () => void {
+  let shared = roots.get(registry);
+  if (shared === undefined) {
+    const root = createBackgroundConnectionRoot(registry);
+    shared = { root, owners: 1 };
+    roots.set(registry, shared);
+    try {
+      root.start();
+    } catch (error) {
+      roots.delete(registry);
+      root.stop();
+      throw error;
+    }
+  } else {
+    shared.owners += 1;
+  }
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const current = roots.get(registry);
+    if (current === undefined) {
+      return;
+    }
+    current.owners -= 1;
+    if (current.owners > 0) {
+      return;
+    }
+    current.root.stop();
+    roots.delete(registry);
+  };
+}

--- a/apps/mobile/src/features/background-connection/background-root.ts
+++ b/apps/mobile/src/features/background-connection/background-root.ts
@@ -57,7 +57,7 @@ export function createBackgroundConnectionRoot(
   let threadShellsRelease: (() => void) | null = null;
   let serverConfigsRelease: (() => void) | null = null;
   let retainedThreadRelease: (() => void) | null = null;
-  let clearingDeletedKey: string | null = null;
+  const clearingDeletedKeys = new Set<string>();
   const shellLeases = new Map<EnvironmentId, () => void>();
   const detailLeases = new Map<string, DetailLease>();
 
@@ -66,13 +66,17 @@ export function createBackgroundConnectionRoot(
       return;
     }
     const key = refKey(ref);
-    if (clearingDeletedKey === key) {
+    if (clearingDeletedKeys.has(key)) {
       return;
     }
-    clearingDeletedKey = key;
+    clearingDeletedKeys.add(key);
     void clearBackgroundConnectionRetainedThread().finally(() => {
-      if (clearingDeletedKey === key) {
-        clearingDeletedKey = null;
+      clearingDeletedKeys.delete(key);
+      // Saving publishes before its persistence operation is queued. If the
+      // same deleted ref was saved while this clear was pending, clear it once
+      // more now so the final persistence operation cannot restore it.
+      if (started && refsEqual(retainedThread, ref)) {
+        clearRetainedIfCurrent(ref);
       }
     });
   };

--- a/apps/mobile/src/features/background-connection/background-task.test.ts
+++ b/apps/mobile/src/features/background-connection/background-task.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  acquireRoot: vi.fn(() => vi.fn()),
+  acquireOutbox: vi.fn(() => vi.fn()),
+  relayStop: vi.fn(),
+  setRuntimeReady: vi.fn(),
+  acknowledgeStop: vi.fn(),
+  enabled: true,
+  firstAttempt: Promise.resolve(),
+  stopListener: null as (() => void) | null,
+  removeStopListener: vi.fn(),
+}));
+
+vi.mock("../cloud/backgroundManagedRelayAuth", () => ({
+  startBackgroundManagedRelayAuth: () => ({
+    firstAttempt: mocks.firstAttempt,
+    retryNow: vi.fn(),
+    stop: mocks.relayStop,
+  }),
+}));
+vi.mock("../../native/backgroundConnection", () => ({
+  addBackgroundConnectionStopRequestListener: (listener: () => void) => {
+    mocks.stopListener = listener;
+    return { remove: mocks.removeStopListener };
+  },
+  getBackgroundConnectionStatus: () => ({ enabled: mocks.enabled }),
+  setBackgroundConnectionRuntimeReady: mocks.setRuntimeReady,
+  acknowledgeBackgroundConnectionStop: mocks.acknowledgeStop,
+}));
+vi.mock("../../state/atom-registry", () => ({ appAtomRegistry: {} }));
+vi.mock("../../state/use-thread-outbox-drain", () => ({
+  acquireThreadOutboxDrain: mocks.acquireOutbox,
+}));
+vi.mock("./background-root", () => ({
+  acquireBackgroundConnectionRoot: mocks.acquireRoot,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  mocks.enabled = true;
+  mocks.firstAttempt = Promise.resolve();
+  mocks.stopListener = null;
+});
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+it("shares one runtime across duplicate native task starts and cleans it up once", async () => {
+  const { runBackgroundConnectionHeadlessTask } = await import("./background-task");
+
+  const first = runBackgroundConnectionHeadlessTask();
+  const second = runBackgroundConnectionHeadlessTask();
+  expect(first).toBe(second);
+  await vi.waitFor(() => {
+    expect(mocks.acquireRoot).toHaveBeenCalledOnce();
+    expect(mocks.acquireOutbox).toHaveBeenCalledOnce();
+    expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
+  });
+
+  mocks.stopListener?.();
+  await Promise.all([first, second]);
+
+  expect(mocks.acquireRoot.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.acquireOutbox.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.relayStop).toHaveBeenCalledOnce();
+  expect(mocks.removeStopListener).toHaveBeenCalledOnce();
+  expect(mocks.setRuntimeReady).toHaveBeenLastCalledWith(false);
+  expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
+});
+
+it("cleans up a task that finishes loading after the feature was disabled", async () => {
+  mocks.enabled = false;
+  const { runBackgroundConnectionHeadlessTask } = await import("./background-task");
+
+  await runBackgroundConnectionHeadlessTask();
+
+  expect(mocks.acquireRoot).not.toHaveBeenCalled();
+  expect(mocks.acquireOutbox).not.toHaveBeenCalled();
+  expect(mocks.setRuntimeReady).not.toHaveBeenCalledWith(true);
+  expect(mocks.relayStop).not.toHaveBeenCalled();
+  expect(mocks.removeStopListener).toHaveBeenCalledOnce();
+  expect(mocks.setRuntimeReady).toHaveBeenLastCalledWith(false);
+  expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
+});
+
+it("marks direct connections ready and stops promptly while relay auth is loading", async () => {
+  const authBootstrap = deferred();
+  mocks.firstAttempt = authBootstrap.promise;
+  const { runBackgroundConnectionHeadlessTask } = await import("./background-task");
+
+  const task = runBackgroundConnectionHeadlessTask();
+  await vi.waitFor(() => {
+    expect(mocks.acquireRoot).toHaveBeenCalledOnce();
+    expect(mocks.acquireOutbox).toHaveBeenCalledOnce();
+    expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
+  });
+
+  mocks.stopListener?.();
+  await task;
+
+  expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
+  expect(mocks.acquireRoot.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.acquireOutbox.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.relayStop).toHaveBeenCalledOnce();
+  expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
+
+  authBootstrap.resolve();
+});

--- a/apps/mobile/src/features/background-connection/background-task.ts
+++ b/apps/mobile/src/features/background-connection/background-task.ts
@@ -1,0 +1,85 @@
+import { startBackgroundManagedRelayAuth } from "../cloud/backgroundManagedRelayAuth";
+import {
+  acknowledgeBackgroundConnectionStop,
+  addBackgroundConnectionStopRequestListener,
+  getBackgroundConnectionStatus,
+  setBackgroundConnectionRuntimeReady,
+} from "../../native/backgroundConnection";
+import { appAtomRegistry } from "../../state/atom-registry";
+import { acquireThreadOutboxDrain } from "../../state/use-thread-outbox-drain";
+import { acquireBackgroundConnectionRoot } from "./background-root";
+
+let activeTask: Promise<void> | null = null;
+
+function bestEffortCleanup(label: string, cleanup: (() => void) | null): void {
+  if (cleanup === null) {
+    return;
+  }
+  try {
+    cleanup();
+  } catch (error) {
+    console.error(`[background-connection] ${label} cleanup failed`, error);
+  }
+}
+
+async function runTask(): Promise<void> {
+  let hasStopBeenRequested = false;
+  let requestStop!: () => void;
+  const stopRequested = new Promise<void>((resolve) => {
+    requestStop = () => {
+      hasStopBeenRequested = true;
+      resolve();
+    };
+  });
+  // Subscribe before acquiring anything so a disable request cannot race the
+  // cold React runtime bootstrap and leave the service waiting indefinitely.
+  const stopSubscription = addBackgroundConnectionStopRequestListener(requestStop);
+  // Native may have stopped the service before this cold JS runtime finished
+  // loading and installed its listener. Treat the persisted disabled state as
+  // the same stop request so that a late task cannot leak its leases.
+  if (!getBackgroundConnectionStatus().enabled) {
+    requestStop();
+  }
+  let relayAuth: ReturnType<typeof startBackgroundManagedRelayAuth> | null = null;
+  let releaseRoot: (() => void) | null = null;
+  let releaseOutbox: (() => void) | null = null;
+
+  try {
+    if (hasStopBeenRequested) {
+      return;
+    }
+    relayAuth = startBackgroundManagedRelayAuth();
+    releaseRoot = acquireBackgroundConnectionRoot(appAtomRegistry);
+    releaseOutbox = acquireThreadOutboxDrain(appAtomRegistry);
+    // Relay authentication owns its own retry loop. Direct/Tailscale
+    // connections and the shared outbox are fully operational once these
+    // leases are mounted, even if Clerk is slow or temporarily unavailable.
+    setBackgroundConnectionRuntimeReady(true);
+    await stopRequested;
+  } catch (error) {
+    console.error("[background-connection] headless runtime failed", error);
+    // Normal completion lets native release React Native's wake lock and use
+    // its bounded exponential restart ladder for bootstrap defects.
+  } finally {
+    bestEffortCleanup("outbox", releaseOutbox);
+    bestEffortCleanup("root", releaseRoot);
+    bestEffortCleanup("relay authentication", () => relayAuth?.stop());
+    bestEffortCleanup("stop listener", () => stopSubscription.remove());
+    setBackgroundConnectionRuntimeReady(false);
+    acknowledgeBackgroundConnectionStop();
+  }
+}
+
+/** Native guards task creation too; this JS guard protects hot reloads and races. */
+export function runBackgroundConnectionHeadlessTask(): Promise<void> {
+  if (activeTask !== null) {
+    return activeTask;
+  }
+  const task = runTask().finally(() => {
+    if (activeTask === task) {
+      activeTask = null;
+    }
+  });
+  activeTask = task;
+  return task;
+}

--- a/apps/mobile/src/features/background-connection/headless-task-registration.test.ts
+++ b/apps/mobile/src/features/background-connection/headless-task-registration.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, expect, it, vi } from "vite-plus/test";
+
+const registerHeadlessTask = vi.hoisted(() => vi.fn());
+
+vi.mock("react-native", () => ({
+  AppRegistry: { registerHeadlessTask },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+it("registers exactly one Android Headless JS task", async () => {
+  const registration = await import("./headless-task-registration");
+
+  registration.registerBackgroundConnectionHeadlessTask();
+  registration.registerBackgroundConnectionHeadlessTask();
+
+  expect(registerHeadlessTask).toHaveBeenCalledOnce();
+  expect(registerHeadlessTask).toHaveBeenCalledWith(
+    registration.BACKGROUND_CONNECTION_HEADLESS_TASK,
+    expect.any(Function),
+  );
+});
+
+it("finishes the native task when its dynamic import fails", async () => {
+  const registration = await import("./headless-task-registration");
+  const error = new Error("bundle chunk unavailable");
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+  await expect(
+    registration.runRegisteredBackgroundConnectionTask(() => Promise.reject(error)),
+  ).resolves.toBeUndefined();
+
+  expect(consoleError).toHaveBeenCalledWith(
+    "[background-connection] registered headless task failed",
+    error,
+  );
+  consoleError.mockRestore();
+});

--- a/apps/mobile/src/features/background-connection/headless-task-registration.ts
+++ b/apps/mobile/src/features/background-connection/headless-task-registration.ts
@@ -1,0 +1,42 @@
+import { AppRegistry } from "react-native";
+
+export const BACKGROUND_CONNECTION_HEADLESS_TASK = "T3BackgroundConnection";
+
+let registered = false;
+
+interface BackgroundConnectionTaskModule {
+  readonly runBackgroundConnectionHeadlessTask: () => Promise<void>;
+}
+
+type BackgroundConnectionTaskLoader = () => Promise<BackgroundConnectionTaskModule>;
+
+const loadBackgroundConnectionTask: BackgroundConnectionTaskLoader = () =>
+  import("./background-task");
+
+/**
+ * React Native does not finish an unlimited Headless JS task when its provider
+ * rejects with a generic error. Convert import/bootstrap defects into normal
+ * completion so native can release its wake lock and apply bounded recovery.
+ */
+export async function runRegisteredBackgroundConnectionTask(
+  loadTask: BackgroundConnectionTaskLoader = loadBackgroundConnectionTask,
+): Promise<void> {
+  try {
+    const { runBackgroundConnectionHeadlessTask } = await loadTask();
+    await runBackgroundConnectionHeadlessTask();
+  } catch (error) {
+    console.error("[background-connection] registered headless task failed", error);
+  }
+}
+
+/** Must run before Expo registers the Activity's root component. */
+export function registerBackgroundConnectionHeadlessTask(): void {
+  if (registered) {
+    return;
+  }
+  registered = true;
+  AppRegistry.registerHeadlessTask(
+    BACKGROUND_CONNECTION_HEADLESS_TASK,
+    () => () => runRegisteredBackgroundConnectionTask(),
+  );
+}

--- a/apps/mobile/src/features/background-connection/retained-thread.test.ts
+++ b/apps/mobile/src/features/background-connection/retained-thread.test.ts
@@ -1,0 +1,98 @@
+import { EnvironmentId, ThreadId, type ScopedThreadRef } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const persistence = vi.hoisted(() => ({
+  load: vi.fn<() => Promise<ScopedThreadRef | null>>(),
+  save: vi.fn<(_thread: ScopedThreadRef) => Promise<void>>(),
+  clear: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("../../persistence/imperative", () => ({
+  loadBackgroundConnectionRetainedThread: persistence.load,
+  saveBackgroundConnectionRetainedThread: persistence.save,
+  clearBackgroundConnectionRetainedThread: persistence.clear,
+}));
+
+function deferred<A>() {
+  let resolve!: (value: A) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<A>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+const firstThread = {
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: ThreadId.make("thread-1"),
+};
+const secondThread = {
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: ThreadId.make("thread-2"),
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  persistence.load.mockReset();
+  persistence.save.mockReset();
+  persistence.clear.mockReset();
+  persistence.load.mockResolvedValue(null);
+  persistence.save.mockResolvedValue(undefined);
+  persistence.clear.mockResolvedValue(undefined);
+});
+
+describe("background retained thread", () => {
+  it("does not let a cold load replace a thread saved during startup", async () => {
+    const coldLoad = deferred<typeof firstThread | null>();
+    persistence.load.mockReturnValueOnce(coldLoad.promise);
+    const retained = await import("./retained-thread");
+
+    const loading = retained.ensureBackgroundConnectionRetainedThreadLoaded();
+    const saving = retained.saveBackgroundConnectionRetainedThread(secondThread);
+    await Promise.resolve();
+    expect(persistence.save).not.toHaveBeenCalled();
+    coldLoad.resolve(firstThread);
+    await Promise.all([loading, saving]);
+
+    expect(retained.getBackgroundConnectionRetainedThreadSnapshot()).toEqual({
+      loaded: true,
+      thread: secondThread,
+    });
+  });
+
+  it("persists rapid thread changes in invocation order", async () => {
+    const firstWrite = deferred<void>();
+    persistence.save.mockReturnValueOnce(firstWrite.promise).mockResolvedValueOnce(undefined);
+    const retained = await import("./retained-thread");
+
+    const savingFirst = retained.saveBackgroundConnectionRetainedThread(firstThread);
+    const savingSecond = retained.saveBackgroundConnectionRetainedThread(secondThread);
+    await Promise.resolve();
+
+    expect(persistence.save).toHaveBeenCalledTimes(1);
+    firstWrite.resolve();
+    await Promise.all([savingFirst, savingSecond]);
+    expect(persistence.save.mock.calls.map(([thread]) => thread)).toEqual([
+      firstThread,
+      secondThread,
+    ]);
+  });
+
+  it("does not let a slow save overwrite a later clear", async () => {
+    const slowSave = deferred<void>();
+    persistence.save.mockReturnValueOnce(slowSave.promise);
+    const retained = await import("./retained-thread");
+
+    const saving = retained.saveBackgroundConnectionRetainedThread(firstThread);
+    const clearing = retained.clearBackgroundConnectionRetainedThread();
+    await Promise.resolve();
+
+    expect(persistence.save).toHaveBeenCalledOnce();
+    expect(persistence.clear).not.toHaveBeenCalled();
+    slowSave.resolve();
+    await Promise.all([saving, clearing]);
+    expect(persistence.clear).toHaveBeenCalledOnce();
+    expect(retained.getBackgroundConnectionRetainedThreadSnapshot().thread).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/background-connection/retained-thread.test.ts
+++ b/apps/mobile/src/features/background-connection/retained-thread.test.ts
@@ -43,6 +43,32 @@ beforeEach(() => {
 });
 
 describe("background retained thread", () => {
+  it("retries a transient cold-load failure", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    persistence.load.mockRejectedValueOnce(new Error("storage unavailable"));
+    persistence.load.mockResolvedValueOnce(firstThread);
+    const retained = await import("./retained-thread");
+
+    try {
+      await expect(retained.ensureBackgroundConnectionRetainedThreadLoaded()).resolves.toBeNull();
+      expect(retained.getBackgroundConnectionRetainedThreadSnapshot()).toEqual({
+        loaded: false,
+        thread: null,
+      });
+
+      await expect(retained.ensureBackgroundConnectionRetainedThreadLoaded()).resolves.toEqual(
+        firstThread,
+      );
+      expect(persistence.load).toHaveBeenCalledTimes(2);
+      expect(retained.getBackgroundConnectionRetainedThreadSnapshot()).toEqual({
+        loaded: true,
+        thread: firstThread,
+      });
+    } finally {
+      warning.mockRestore();
+    }
+  });
+
   it("does not let a cold load replace a thread saved during startup", async () => {
     const coldLoad = deferred<typeof firstThread | null>();
     persistence.load.mockReturnValueOnce(coldLoad.promise);

--- a/apps/mobile/src/features/background-connection/retained-thread.ts
+++ b/apps/mobile/src/features/background-connection/retained-thread.ts
@@ -79,9 +79,9 @@ export function ensureBackgroundConnectionRetainedThreadLoaded(): Promise<Scoped
     })
     .catch((error) => {
       console.warn("[background-connection] failed to load the retained thread", error);
-      if (revision === loadRevision) {
-        publish({ loaded: true, thread: null });
-      }
+      // Keep a cold snapshot retryable. A transient secure-storage/runtime
+      // failure must not suppress the persisted retained thread for the rest
+      // of this JS process.
       return snapshot.thread;
     })
     .finally(() => {

--- a/apps/mobile/src/features/background-connection/retained-thread.ts
+++ b/apps/mobile/src/features/background-connection/retained-thread.ts
@@ -1,0 +1,124 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+import {
+  clearBackgroundConnectionRetainedThread as clearPersistedRetainedThread,
+  loadBackgroundConnectionRetainedThread as loadPersistedRetainedThread,
+  saveBackgroundConnectionRetainedThread as savePersistedRetainedThread,
+} from "../../persistence/imperative";
+
+interface RetainedThreadSnapshot {
+  readonly loaded: boolean;
+  readonly thread: ScopedThreadRef | null;
+}
+
+const EMPTY_SNAPSHOT: RetainedThreadSnapshot = Object.freeze({
+  loaded: false,
+  thread: null,
+});
+
+let snapshot = EMPTY_SNAPSHOT;
+let revision = 0;
+let loading: Promise<ScopedThreadRef | null> | null = null;
+let persistenceQueue: Promise<void> = Promise.resolve();
+const listeners = new Set<() => void>();
+
+function threadRefsEqual(left: ScopedThreadRef | null, right: ScopedThreadRef | null): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      left.environmentId === right.environmentId &&
+      left.threadId === right.threadId)
+  );
+}
+
+function publish(next: RetainedThreadSnapshot): void {
+  if (snapshot.loaded === next.loaded && threadRefsEqual(snapshot.thread, next.thread)) {
+    return;
+  }
+  snapshot = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function getBackgroundConnectionRetainedThreadSnapshot(): RetainedThreadSnapshot {
+  return snapshot;
+}
+
+export function subscribeBackgroundConnectionRetainedThread(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function ensureBackgroundConnectionRetainedThreadLoaded(): Promise<ScopedThreadRef | null> {
+  if (snapshot.loaded) {
+    return Promise.resolve(snapshot.thread);
+  }
+  if (loading !== null) {
+    return loading;
+  }
+
+  const loadRevision = revision;
+  const persistedLoad = persistenceQueue.then(
+    loadPersistedRetainedThread,
+    loadPersistedRetainedThread,
+  );
+  // Loading can also remove malformed persisted data. Treat it as part of the
+  // same storage sequence so that cleanup cannot race and delete a newer save.
+  persistenceQueue = persistedLoad.then(
+    () => undefined,
+    () => undefined,
+  );
+  loading = persistedLoad
+    .then((thread) => {
+      if (revision === loadRevision) {
+        publish({ loaded: true, thread });
+      }
+      return snapshot.thread;
+    })
+    .catch((error) => {
+      console.warn("[background-connection] failed to load the retained thread", error);
+      if (revision === loadRevision) {
+        publish({ loaded: true, thread: null });
+      }
+      return snapshot.thread;
+    })
+    .finally(() => {
+      loading = null;
+    });
+  return loading;
+}
+
+function enqueuePersistence(operation: () => Promise<void>): Promise<void> {
+  const queued = persistenceQueue.then(operation, operation);
+  persistenceQueue = queued.catch(() => undefined);
+  return queued;
+}
+
+export async function saveBackgroundConnectionRetainedThread(
+  thread: ScopedThreadRef,
+): Promise<void> {
+  revision += 1;
+  publish({ loaded: true, thread });
+  try {
+    await enqueuePersistence(() => savePersistedRetainedThread(thread));
+  } catch (error) {
+    console.warn("[background-connection] failed to persist the retained thread", error);
+  }
+}
+
+export async function clearBackgroundConnectionRetainedThread(): Promise<void> {
+  revision += 1;
+  publish({ loaded: true, thread: null });
+  try {
+    await enqueuePersistence(clearPersistedRetainedThread);
+  } catch (error) {
+    console.warn("[background-connection] failed to clear the retained thread", error);
+  }
+}
+
+export function clearBackgroundConnectionRetainedThreadInMemory(): void {
+  revision += 1;
+  publish({ loaded: true, thread: null });
+}

--- a/apps/mobile/src/features/background-connection/settings-model.test.ts
+++ b/apps/mobile/src/features/background-connection/settings-model.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { BackgroundConnectionStatus } from "../../native/backgroundConnection";
+import {
+  backgroundConnectionStatusLabel,
+  shouldRequestBackgroundConnectionBatteryExemption,
+} from "./settings-model";
+
+const status = (overrides: Partial<BackgroundConnectionStatus>): BackgroundConnectionStatus => ({
+  supported: true,
+  enabled: true,
+  serviceRunning: true,
+  runtimeReady: true,
+  batteryOptimizationIgnored: true,
+  ...overrides,
+});
+
+describe("backgroundConnectionStatusLabel", () => {
+  it("reports the fully ready runtime", () => {
+    expect(backgroundConnectionStatusLabel(status({}))).toBe("Running");
+  });
+
+  it("reports startup until both native service and JavaScript are ready", () => {
+    expect(backgroundConnectionStatusLabel(status({ runtimeReady: false }))).toBe("Starting");
+    expect(backgroundConnectionStatusLabel(status({ serviceRunning: false }))).toBe("Starting");
+  });
+
+  it("makes degraded battery protection explicit", () => {
+    expect(backgroundConnectionStatusLabel(status({ batteryOptimizationIgnored: false }))).toBe(
+      "Battery optimization enabled",
+    );
+  });
+
+  it("reports disabled and unsupported installations as stopped", () => {
+    expect(backgroundConnectionStatusLabel(status({ enabled: false }))).toBe("Stopped");
+    expect(backgroundConnectionStatusLabel(status({ supported: false }))).toBe("Stopped");
+  });
+
+  it("keeps the feature enabled when the battery exemption is still declined", () => {
+    const declined = status({ batteryOptimizationIgnored: false });
+    expect(shouldRequestBackgroundConnectionBatteryExemption(declined)).toBe(true);
+    expect(declined.enabled).toBe(true);
+  });
+
+  it("does not request an exemption while disabling", () => {
+    expect(
+      shouldRequestBackgroundConnectionBatteryExemption(
+        status({ enabled: false, batteryOptimizationIgnored: false }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/background-connection/settings-model.ts
+++ b/apps/mobile/src/features/background-connection/settings-model.ts
@@ -1,0 +1,25 @@
+import type { BackgroundConnectionStatus } from "../../native/backgroundConnection";
+
+export type BackgroundConnectionStatusLabel =
+  | "Running"
+  | "Starting"
+  | "Stopped"
+  | "Battery optimization enabled";
+
+export function backgroundConnectionStatusLabel(
+  status: BackgroundConnectionStatus,
+): BackgroundConnectionStatusLabel {
+  if (!status.supported || !status.enabled) {
+    return "Stopped";
+  }
+  if (!status.batteryOptimizationIgnored) {
+    return "Battery optimization enabled";
+  }
+  return status.serviceRunning && status.runtimeReady ? "Running" : "Starting";
+}
+
+export function shouldRequestBackgroundConnectionBatteryExemption(
+  status: BackgroundConnectionStatus,
+): boolean {
+  return status.supported && status.enabled && !status.batteryOptimizationIgnored;
+}

--- a/apps/mobile/src/features/background-connection/target-selection.test.ts
+++ b/apps/mobile/src/features/background-connection/target-selection.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ProjectId, ThreadId, type ScopedThreadRef } from "@t3tools/contracts";
+
+import { selectBackgroundConnectionThreadTargets } from "./target-selection";
+
+const environmentId = EnvironmentId.make("environment-1");
+const projectId = ProjectId.make("project-1");
+
+function shell(id: string, status: "starting" | "running" | "ready"): EnvironmentThreadShell {
+  return {
+    environmentId,
+    id: ThreadId.make(id),
+    projectId,
+    title: id,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    session: { status },
+  } as EnvironmentThreadShell;
+}
+
+describe("background connection target selection", () => {
+  it("keeps the retained thread followed by starting and running threads", () => {
+    const retained: ScopedThreadRef = {
+      environmentId,
+      threadId: ThreadId.make("retained"),
+    };
+
+    expect(
+      selectBackgroundConnectionThreadTargets(retained, [
+        shell("settled", "ready"),
+        shell("starting", "starting"),
+        shell("running", "running"),
+      ]),
+    ).toEqual([
+      retained,
+      { environmentId, threadId: ThreadId.make("starting") },
+      { environmentId, threadId: ThreadId.make("running") },
+    ]);
+  });
+
+  it("deduplicates a retained running thread without changing order", () => {
+    const retained = { environmentId, threadId: ThreadId.make("running") };
+    expect(
+      selectBackgroundConnectionThreadTargets(retained, [
+        shell("running", "running"),
+        shell("other", "starting"),
+      ]),
+    ).toEqual([retained, { environmentId, threadId: ThreadId.make("other") }]);
+  });
+
+  it("drops active targets after their shell settles", () => {
+    expect(selectBackgroundConnectionThreadTargets(null, [shell("task", "running")])).toHaveLength(
+      1,
+    );
+    expect(selectBackgroundConnectionThreadTargets(null, [shell("task", "ready")])).toEqual([]);
+  });
+});

--- a/apps/mobile/src/features/background-connection/target-selection.ts
+++ b/apps/mobile/src/features/background-connection/target-selection.ts
@@ -1,0 +1,36 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+function refKey(ref: ScopedThreadRef): string {
+  return JSON.stringify([ref.environmentId, ref.threadId]);
+}
+
+/**
+ * Keep one user-relevant settled thread plus every thread that is currently doing work.
+ * The retained thread is deliberately first and the shell order is preserved.
+ */
+export function selectBackgroundConnectionThreadTargets(
+  retainedThread: ScopedThreadRef | null,
+  threadShells: ReadonlyArray<EnvironmentThreadShell>,
+): ReadonlyArray<ScopedThreadRef> {
+  const targets: ScopedThreadRef[] = [];
+  const seen = new Set<string>();
+  const append = (ref: ScopedThreadRef) => {
+    const key = refKey(ref);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    targets.push(ref);
+  };
+
+  if (retainedThread !== null) {
+    append(retainedThread);
+  }
+  for (const thread of threadShells) {
+    if (thread.session?.status === "starting" || thread.session?.status === "running") {
+      append({ environmentId: thread.environmentId, threadId: thread.id });
+    }
+  }
+  return targets;
+}

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
@@ -89,12 +89,32 @@ describe("CloudAuthProvider relay account isolation", () => {
       readClerkToken: async () => "background-token",
     });
     activateCloudRelayAccount("account-1", async () => "ui-token");
+    vi.mocked(refreshBackgroundManagedRelayAuth).mockClear();
 
     releaseCloudRelayUiAccount();
 
     expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
-    releaseBackground();
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
+    expect(releaseBackground).not.toBeNull();
+    releaseBackground?.();
     expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("waits for account cleanup before refreshing background ownership", async () => {
+    activateCloudRelayAccount("account-1", async () => "ui-token");
+    vi.mocked(refreshBackgroundManagedRelayAuth).mockClear();
+    const cleanup = deferred();
+
+    releaseCloudRelayUiAccount({ refreshAfter: cleanup.promise });
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+    expect(refreshBackgroundManagedRelayAuth).not.toHaveBeenCalled();
+
+    cleanup.resolve();
+    await cleanup.promise;
+    await Promise.resolve();
+
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
   });
 
   it("defers the background refresh for an account switch until cleanup resolves", async () => {

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
@@ -2,8 +2,17 @@ import { managedRelaySessionAtom } from "@t3tools/client-runtime/relay";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { appAtomRegistry } from "../../state/atom-registry";
-import { activateCloudRelayAccount, deactivateCloudRelayAccount } from "./CloudAuthProvider";
 import { setAgentAwarenessRelayTokenProvider } from "../agent-awareness/remoteRegistration";
+import {
+  activateCloudRelayAccount,
+  deactivateCloudRelayAccount,
+  releaseCloudRelayUiAccount,
+} from "./CloudAuthProvider";
+import {
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+import { acquireBackgroundManagedRelaySession } from "./managedRelaySessionOwnership";
 
 vi.mock("@clerk/expo", () => ({
   ClerkProvider: vi.fn(),
@@ -12,6 +21,11 @@ vi.mock("@clerk/expo", () => ({
 
 vi.mock("@clerk/expo/token-cache", () => ({
   tokenCache: {},
+}));
+
+vi.mock("./backgroundManagedRelayAuth", () => ({
+  invalidateBackgroundManagedRelayAuth: vi.fn(),
+  refreshBackgroundManagedRelayAuth: vi.fn(async () => undefined),
 }));
 
 vi.mock("../../lib/runtime", () => ({
@@ -35,9 +49,18 @@ vi.mock("./publicConfig", () => ({
 }));
 
 vi.mock("../agent-awareness/remoteRegistration", () => ({
+  releaseAgentAwarenessRelayTokenProvider: vi.fn(),
   setAgentAwarenessRelayTokenProvider: vi.fn(),
   unregisterAgentAwarenessDeviceForCurrentUser: vi.fn(),
 }));
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 afterEach(() => {
   deactivateCloudRelayAccount();
@@ -49,12 +72,49 @@ describe("CloudAuthProvider relay account isolation", () => {
     const tokenProvider = async () => "account-1-token";
     activateCloudRelayAccount("account-1", tokenProvider);
     expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
 
     deactivateCloudRelayAccount();
     const cleanup = Promise.reject(new Error("Persistence removal failed.")).catch(() => undefined);
 
     expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
     expect(vi.mocked(setAgentAwarenessRelayTokenProvider)).toHaveBeenLastCalledWith(null);
+    expect(invalidateBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
     await cleanup;
+  });
+
+  it("preserves background relay ownership when the UI bridge unmounts", () => {
+    const releaseBackground = acquireBackgroundManagedRelaySession({
+      accountId: "account-1",
+      readClerkToken: async () => "background-token",
+    });
+    activateCloudRelayAccount("account-1", async () => "ui-token");
+
+    releaseCloudRelayUiAccount();
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    releaseBackground();
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("defers the background refresh for an account switch until cleanup resolves", async () => {
+    activateCloudRelayAccount("account-1", async () => "account-1-token");
+    vi.mocked(refreshBackgroundManagedRelayAuth).mockClear();
+
+    const cleanup = deferred();
+    deactivateCloudRelayAccount({ refreshBackground: false });
+    const transition = cleanup.promise.then(() => {
+      activateCloudRelayAccount("account-2", async () => "account-2-token");
+    });
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+    expect(invalidateBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
+    expect(refreshBackgroundManagedRelayAuth).not.toHaveBeenCalled();
+
+    cleanup.resolve();
+    await transition;
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-2");
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
   });
 });

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
@@ -2,8 +2,17 @@ import { managedRelaySessionAtom } from "@t3tools/client-runtime/relay";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { appAtomRegistry } from "../../state/atom-registry";
-import { activateCloudRelayAccount, deactivateCloudRelayAccount } from "./CloudAuthProvider";
 import { setAgentAwarenessRelayTokenProvider } from "../agent-awareness/remoteRegistration";
+import {
+  activateCloudRelayAccount,
+  deactivateCloudRelayAccount,
+  releaseCloudRelayUiAccount,
+} from "./CloudAuthProvider";
+import {
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+import { acquireBackgroundManagedRelaySession } from "./managedRelaySessionOwnership";
 
 vi.mock("@clerk/expo", () => ({
   ClerkProvider: vi.fn(),
@@ -12,6 +21,11 @@ vi.mock("@clerk/expo", () => ({
 
 vi.mock("@clerk/expo/token-cache", () => ({
   tokenCache: {},
+}));
+
+vi.mock("./backgroundManagedRelayAuth", () => ({
+  invalidateBackgroundManagedRelayAuth: vi.fn(),
+  refreshBackgroundManagedRelayAuth: vi.fn(async () => undefined),
 }));
 
 vi.mock("../../lib/runtime", () => ({
@@ -41,9 +55,18 @@ vi.mock("./publicConfig", () => ({
 }));
 
 vi.mock("../agent-awareness/remoteRegistration", () => ({
+  releaseAgentAwarenessRelayTokenProvider: vi.fn(),
   setAgentAwarenessRelayTokenProvider: vi.fn(),
   unregisterAgentAwarenessDeviceForCurrentUser: vi.fn(),
 }));
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 afterEach(() => {
   deactivateCloudRelayAccount();
@@ -55,12 +78,49 @@ describe("CloudAuthProvider relay account isolation", () => {
     const tokenProvider = async () => "account-1-token";
     activateCloudRelayAccount("account-1", tokenProvider);
     expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
 
     deactivateCloudRelayAccount();
     const cleanup = Promise.reject(new Error("Persistence removal failed.")).catch(() => undefined);
 
     expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
     expect(vi.mocked(setAgentAwarenessRelayTokenProvider)).toHaveBeenLastCalledWith(null);
+    expect(invalidateBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
     await cleanup;
+  });
+
+  it("preserves background relay ownership when the UI bridge unmounts", () => {
+    const releaseBackground = acquireBackgroundManagedRelaySession({
+      accountId: "account-1",
+      readClerkToken: async () => "background-token",
+    });
+    activateCloudRelayAccount("account-1", async () => "ui-token");
+
+    releaseCloudRelayUiAccount();
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    releaseBackground();
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("defers the background refresh for an account switch until cleanup resolves", async () => {
+    activateCloudRelayAccount("account-1", async () => "account-1-token");
+    vi.mocked(refreshBackgroundManagedRelayAuth).mockClear();
+
+    const cleanup = deferred();
+    deactivateCloudRelayAccount({ refreshBackground: false });
+    const transition = cleanup.promise.then(() => {
+      activateCloudRelayAccount("account-2", async () => "account-2-token");
+    });
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+    expect(invalidateBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
+    expect(refreshBackgroundManagedRelayAuth).not.toHaveBeenCalled();
+
+    cleanup.resolve();
+    await transition;
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-2");
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
   });
 });

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
@@ -95,12 +95,32 @@ describe("CloudAuthProvider relay account isolation", () => {
       readClerkToken: async () => "background-token",
     });
     activateCloudRelayAccount("account-1", async () => "ui-token");
+    vi.mocked(refreshBackgroundManagedRelayAuth).mockClear();
 
     releaseCloudRelayUiAccount();
 
     expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
-    releaseBackground();
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
+    expect(releaseBackground).not.toBeNull();
+    releaseBackground?.();
     expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("waits for account cleanup before refreshing background ownership", async () => {
+    activateCloudRelayAccount("account-1", async () => "ui-token");
+    vi.mocked(refreshBackgroundManagedRelayAuth).mockClear();
+    const cleanup = deferred();
+
+    releaseCloudRelayUiAccount({ refreshAfter: cleanup.promise });
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+    expect(refreshBackgroundManagedRelayAuth).not.toHaveBeenCalled();
+
+    cleanup.resolve();
+    await cleanup.promise;
+    await Promise.resolve();
+
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
   });
 
   it("defers the background refresh for an account switch until cleanup resolves", async () => {

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
@@ -24,6 +24,7 @@ vi.mock("@clerk/expo/token-cache", () => ({
 }));
 
 vi.mock("./backgroundManagedRelayAuth", () => ({
+  holdBackgroundManagedRelayAuth: vi.fn(),
   invalidateBackgroundManagedRelayAuth: vi.fn(),
   refreshBackgroundManagedRelayAuth: vi.fn(async () => undefined),
 }));

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
@@ -56,9 +56,20 @@ export function activateCloudRelayAccount(
   void refreshBackgroundManagedRelayAuth();
 }
 
-export function releaseCloudRelayUiAccount(): void {
+export function releaseCloudRelayUiAccount(
+  options: { readonly refreshAfter?: Promise<void> | null } = {},
+): void {
   releaseAgentAwarenessRelayTokenProvider();
   managedRelaySessionOwnership.releaseOwner("ui");
+  const refreshBackground = () => {
+    void refreshBackgroundManagedRelayAuth();
+  };
+  const refreshAfter = options.refreshAfter ?? null;
+  if (refreshAfter === null) {
+    refreshBackground();
+    return;
+  }
+  void refreshAfter.then(refreshBackground, refreshBackground);
 }
 
 function CloudAuthBridge(props: { readonly children: ReactNode }) {
@@ -183,7 +194,7 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       // Unmounting is not a sign-out: the user is usually still signed in, so
       // detach the provider without ending lock-screen activities or wiping the
       // persisted registration (a remount reuses both).
-      releaseCloudRelayUiAccount();
+      releaseCloudRelayUiAccount({ refreshAfter: accountTransitionRef.current });
     },
     [],
   );

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
@@ -1,6 +1,6 @@
 import { ClerkProvider, useAuth } from "@clerk/expo";
 import { tokenCache } from "@clerk/expo/token-cache";
-import { ManagedRelay, setManagedRelaySession } from "@t3tools/client-runtime/relay";
+import { ManagedRelay } from "@t3tools/client-runtime/relay";
 import {
   reportAtomCommandResult,
   settleAsyncResult,
@@ -11,7 +11,6 @@ import { type ReactNode, useEffect, useRef } from "react";
 
 import { environmentCatalog } from "../../connection/catalog";
 import { runtime } from "../../lib/runtime";
-import { appAtomRegistry } from "../../state/atom-registry";
 import { useAtomCommand } from "../../state/use-atom-command";
 import {
   releaseAgentAwarenessRelayTokenProvider,
@@ -19,6 +18,11 @@ import {
   unregisterAgentAwarenessDeviceForCurrentUser,
 } from "../agent-awareness/remoteRegistration";
 import { clearConnectOnboardingRequest, requestConnectOnboarding } from "./connectOnboarding";
+import {
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+import { managedRelaySessionOwnership } from "./managedRelaySessionOwnership";
 import { resolveCloudPublicConfig, resolveRelayClerkTokenOptions } from "./publicConfig";
 
 function resetManagedRelayTokenCache() {
@@ -29,9 +33,15 @@ function resetManagedRelayTokenCache() {
   );
 }
 
-export function deactivateCloudRelayAccount(): void {
+export function deactivateCloudRelayAccount(
+  options: { readonly refreshBackground?: boolean } = {},
+): void {
   setAgentAwarenessRelayTokenProvider(null);
-  setManagedRelaySession(appAtomRegistry, null);
+  invalidateBackgroundManagedRelayAuth();
+  managedRelaySessionOwnership.clear();
+  if (options.refreshBackground !== false) {
+    void refreshBackgroundManagedRelayAuth();
+  }
 }
 
 export function activateCloudRelayAccount(
@@ -39,10 +49,16 @@ export function activateCloudRelayAccount(
   tokenProvider: () => Promise<string | null>,
 ): void {
   setAgentAwarenessRelayTokenProvider(tokenProvider, accountId);
-  setManagedRelaySession(appAtomRegistry, {
+  managedRelaySessionOwnership.setOwner("ui", {
     accountId,
     readClerkToken: tokenProvider,
   });
+  void refreshBackgroundManagedRelayAuth();
+}
+
+export function releaseCloudRelayUiAccount(): void {
+  releaseAgentAwarenessRelayTokenProvider();
+  managedRelaySessionOwnership.releaseOwner("ui");
 }
 
 function CloudAuthBridge(props: { readonly children: ReactNode }) {
@@ -147,7 +163,10 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       previousObservedAccount !== userId
     ) {
       previousTokenProviderRef.current = null;
-      deactivateCloudRelayAccount();
+      // Clerk already exposes the new account here. Keep background auth
+      // invalidated until the previous account's cleanup has completed;
+      // activateCloudRelayAccount refreshes it after the transition settles.
+      deactivateCloudRelayAccount({ refreshBackground: false });
       activateAfterTransition(queueAccountCleanup(previous));
     } else {
       activateAfterTransition(accountTransitionRef.current ?? Promise.resolve());
@@ -164,8 +183,7 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       // Unmounting is not a sign-out: the user is usually still signed in, so
       // detach the provider without ending lock-screen activities or wiping the
       // persisted registration (a remount reuses both).
-      releaseAgentAwarenessRelayTokenProvider();
-      setManagedRelaySession(appAtomRegistry, null);
+      releaseCloudRelayUiAccount();
     },
     [],
   );

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
@@ -61,9 +61,20 @@ export function activateCloudRelayAccount(
   void refreshBackgroundManagedRelayAuth();
 }
 
-export function releaseCloudRelayUiAccount(): void {
+export function releaseCloudRelayUiAccount(
+  options: { readonly refreshAfter?: Promise<void> | null } = {},
+): void {
   releaseAgentAwarenessRelayTokenProvider();
   managedRelaySessionOwnership.releaseOwner("ui");
+  const refreshBackground = () => {
+    void refreshBackgroundManagedRelayAuth();
+  };
+  const refreshAfter = options.refreshAfter ?? null;
+  if (refreshAfter === null) {
+    refreshBackground();
+    return;
+  }
+  void refreshAfter.then(refreshBackground, refreshBackground);
 }
 
 function CloudAuthBridge(props: { readonly children: ReactNode }) {
@@ -205,7 +216,7 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       // Unmounting is not a sign-out: the user is usually still signed in, so
       // detach the provider without ending lock-screen activities or wiping the
       // persisted registration (a remount reuses both).
-      releaseCloudRelayUiAccount();
+      releaseCloudRelayUiAccount({ refreshAfter: accountTransitionRef.current });
     },
     [],
   );

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
@@ -1,6 +1,6 @@
 import { ClerkProvider, useAuth } from "@clerk/expo";
 import { tokenCache } from "@clerk/expo/token-cache";
-import { ManagedRelay, setManagedRelaySession } from "@t3tools/client-runtime/relay";
+import { ManagedRelay } from "@t3tools/client-runtime/relay";
 import {
   reportAtomCommandResult,
   settleAsyncResult,
@@ -11,7 +11,6 @@ import * as Effect from "effect/Effect";
 import { type ReactNode, useEffect, useRef } from "react";
 
 import { runtime } from "../../lib/runtime";
-import { appAtomRegistry } from "../../state/atom-registry";
 import { useAtomCommand } from "../../state/use-atom-command";
 import {
   getComposerCloudAccountId,
@@ -23,6 +22,11 @@ import {
   unregisterAgentAwarenessDeviceForCurrentUser,
 } from "../agent-awareness/remoteRegistration";
 import { clearConnectOnboardingRequest, requestConnectOnboarding } from "./connectOnboarding";
+import {
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+import { managedRelaySessionOwnership } from "./managedRelaySessionOwnership";
 import { resolveCloudPublicConfig, resolveRelayClerkTokenOptions } from "./publicConfig";
 import { removeCloudEnvironments } from "./cloud-drafts";
 
@@ -34,9 +38,15 @@ function resetManagedRelayTokenCache() {
   );
 }
 
-export function deactivateCloudRelayAccount(): void {
+export function deactivateCloudRelayAccount(
+  options: { readonly refreshBackground?: boolean } = {},
+): void {
   setAgentAwarenessRelayTokenProvider(null);
-  setManagedRelaySession(appAtomRegistry, null);
+  invalidateBackgroundManagedRelayAuth();
+  managedRelaySessionOwnership.clear();
+  if (options.refreshBackground !== false) {
+    void refreshBackgroundManagedRelayAuth();
+  }
 }
 
 export function activateCloudRelayAccount(
@@ -44,10 +54,16 @@ export function activateCloudRelayAccount(
   tokenProvider: () => Promise<string | null>,
 ): void {
   setAgentAwarenessRelayTokenProvider(tokenProvider, accountId);
-  setManagedRelaySession(appAtomRegistry, {
+  managedRelaySessionOwnership.setOwner("ui", {
     accountId,
     readClerkToken: tokenProvider,
   });
+  void refreshBackgroundManagedRelayAuth();
+}
+
+export function releaseCloudRelayUiAccount(): void {
+  releaseAgentAwarenessRelayTokenProvider();
+  managedRelaySessionOwnership.releaseOwner("ui");
 }
 
 function CloudAuthBridge(props: { readonly children: ReactNode }) {
@@ -167,7 +183,10 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       previousObservedAccount !== userId
     ) {
       previousTokenProviderRef.current = null;
-      deactivateCloudRelayAccount();
+      // Clerk already exposes the new account here. Keep background auth
+      // invalidated until the previous account's cleanup has completed;
+      // activateCloudRelayAccount refreshes it after the transition settles.
+      deactivateCloudRelayAccount({ refreshBackground: false });
       activateAfterTransition(queueAccountCleanup(previous));
     } else {
       // A failed disk write can be retried. The persisted account check above
@@ -186,8 +205,7 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       // Unmounting is not a sign-out: the user is usually still signed in, so
       // detach the provider without ending lock-screen activities or wiping the
       // persisted registration (a remount reuses both).
-      releaseAgentAwarenessRelayTokenProvider();
-      setManagedRelaySession(appAtomRegistry, null);
+      releaseCloudRelayUiAccount();
     },
     [],
   );

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
@@ -23,6 +23,7 @@ import {
 } from "../agent-awareness/remoteRegistration";
 import { clearConnectOnboardingRequest, requestConnectOnboarding } from "./connectOnboarding";
 import {
+  holdBackgroundManagedRelayAuth,
   invalidateBackgroundManagedRelayAuth,
   refreshBackgroundManagedRelayAuth,
 } from "./backgroundManagedRelayAuth";
@@ -152,7 +153,11 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       previousTokenProviderRef.current = null;
       deactivateCloudRelayAccount();
       if (previousObservedAccount !== null) {
-        void settlePromise(() => queueAccountCleanup(previous)).then((result) => {
+        const cleanup = queueAccountCleanup(previous);
+        // A sign-in that follows before this cleanup settles must not let a
+        // background retry publish the next account's relay session early.
+        holdBackgroundManagedRelayAuth(cleanup);
+        void settlePromise(() => cleanup).then((result) => {
           reportAtomCommandResult(result, { label: "cloud account cleanup" });
         });
       }
@@ -184,6 +189,11 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
         activateSession();
       })();
       accountTransitionRef.current = activation;
+      // Refresh requests already wait for the transition, but a scheduled
+      // retry or a cold headless start does not. Hold every background
+      // bootstrap until the previous account's cleanup and this activation
+      // settle; the refresh issued by activateSession resumes them.
+      holdBackgroundManagedRelayAuth(activation);
       void settlePromise(() => activation).then((result) => {
         reportAtomCommandResult(result, { label: "cloud account activation" });
       });

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
@@ -94,6 +94,27 @@ describe("background managed relay authentication", () => {
     expect(acquireSession).not.toHaveBeenCalled();
   });
 
+  it("does not report active when a stale background owner is rejected", async () => {
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: true,
+        load: vi.fn(),
+        session: {
+          user: { id: "stale-account" },
+          getToken: vi.fn(async () => "stale-token"),
+        },
+      }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession: vi.fn(() => null),
+    });
+
+    expect(result).toEqual({ state: { status: "superseded" } });
+  });
+
   it("returns immediately for missing public configuration", async () => {
     const createClerk = vi.fn();
     const result = await bootstrapBackgroundManagedRelayAuth({

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  bootstrapBackgroundManagedRelayAuth,
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+  startBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+
+vi.mock("@clerk/expo", () => ({ getClerkInstance: vi.fn() }));
+vi.mock("@clerk/expo/token-cache", () => ({ tokenCache: {} }));
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: {} } },
+}));
+
+const configuredPublicConfig = {
+  clerk: {
+    publishableKey: "pk_test_example",
+    jwtTemplate: "relay-template",
+  },
+  relay: { url: "https://relay.example.com/" },
+  observability: {
+    tracesUrl: null,
+    tracesDataset: null,
+    tracesToken: null,
+  },
+} as const;
+
+function deferred<A>() {
+  let resolve!: (value: A) => void;
+  const promise = new Promise<A>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("background managed relay authentication", () => {
+  it("loads Clerk and acquires a renewable session for the active account", async () => {
+    const load = vi.fn(async () => undefined);
+    const getToken = vi.fn(async () => "relay-token");
+    const release = vi.fn();
+    const acquireSession = vi.fn(
+      (_session: {
+        readonly accountId: string;
+        readonly readClerkToken: () => Promise<string | null>;
+      }) => release,
+    );
+    const resolveTokenOptions = vi.fn(() => ({
+      template: "relay-template",
+      skipCache: true as const,
+    }));
+
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: false,
+        load,
+        session: { user: { id: "account-1" }, getToken },
+      }),
+      resolveTokenOptions,
+      acquireSession,
+    });
+
+    expect(result.state).toEqual({ status: "active", accountId: "account-1" });
+    expect(load).toHaveBeenCalledOnce();
+    const session = acquireSession.mock.calls[0]?.[0];
+    expect(session?.accountId).toBe("account-1");
+    await expect(session?.readClerkToken()).resolves.toBe("relay-token");
+    expect(getToken).toHaveBeenCalledWith({
+      template: "relay-template",
+      skipCache: true,
+    });
+  });
+
+  it("treats a loaded Clerk instance without a session as signed out", async () => {
+    const acquireSession = vi.fn(
+      (_session: {
+        readonly accountId: string;
+        readonly readClerkToken: () => Promise<string | null>;
+      }) => vi.fn(),
+    );
+
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({ loaded: true, load: vi.fn(), session: null }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession,
+    });
+
+    expect(result.state).toEqual({ status: "signed-out" });
+    expect(acquireSession).not.toHaveBeenCalled();
+  });
+
+  it("returns immediately for missing public configuration", async () => {
+    const createClerk = vi.fn();
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => ({
+        ...configuredPublicConfig,
+        clerk: { publishableKey: null, jwtTemplate: null },
+      }),
+      createClerk,
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession: vi.fn(
+        (_session: {
+          readonly accountId: string;
+          readonly readClerkToken: () => Promise<string | null>;
+        }) => vi.fn(),
+      ),
+    });
+
+    expect(result.state).toEqual({ status: "unconfigured" });
+    expect(createClerk).not.toHaveBeenCalled();
+  });
+
+  it("reports transient Clerk initialization failures without throwing", async () => {
+    const error = new Error("Network unavailable");
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => {
+        throw error;
+      },
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession: vi.fn(
+        (_session: {
+          readonly accountId: string;
+          readonly readClerkToken: () => Promise<string | null>;
+        }) => vi.fn(),
+      ),
+    });
+
+    expect(result.state).toEqual({ status: "retrying", error });
+  });
+
+  it("cannot restore a stale account after sign-out invalidates an in-flight load", async () => {
+    const load = deferred<void>();
+    const acquireSession = vi.fn(() => vi.fn());
+    const attempt = bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: false,
+        load: () => load.promise,
+        session: {
+          user: { id: "old-account" },
+          getToken: vi.fn(async () => "old-token"),
+        },
+      }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession,
+    });
+
+    invalidateBackgroundManagedRelayAuth();
+    load.resolve();
+
+    await expect(attempt).resolves.toEqual({ state: { status: "superseded" } });
+    expect(acquireSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps the controller alive and retries transient Clerk failures", async () => {
+    const error = new Error("Clerk is temporarily unavailable");
+    const release = vi.fn();
+    const bootstrap = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({
+        state: { status: "active", accountId: "account-1" },
+        release,
+      });
+    const scheduledRetries: Array<{ retry: () => void; delayMs: number }> = [];
+    const controller = startBackgroundManagedRelayAuth({
+      bootstrap,
+      scheduleRetry: (retry, delayMs) => {
+        scheduledRetries.push({ retry, delayMs });
+        return vi.fn();
+      },
+    });
+
+    await expect(controller.firstAttempt).resolves.toEqual({ status: "retrying", error });
+    expect(scheduledRetries).toHaveLength(1);
+    expect(scheduledRetries[0]?.delayMs).toBe(1_000);
+    await expect(controller.retryNow()).resolves.toEqual({
+      status: "active",
+      accountId: "account-1",
+    });
+
+    controller.stop();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("retries a signed-out bootstrap when UI ownership changes", async () => {
+    const release = vi.fn();
+    const bootstrap = vi
+      .fn()
+      .mockResolvedValueOnce({ state: { status: "signed-out" } })
+      .mockResolvedValueOnce({
+        state: { status: "active", accountId: "account-1" },
+        release,
+      });
+    const controller = startBackgroundManagedRelayAuth({ bootstrap });
+    await expect(controller.firstAttempt).resolves.toEqual({ status: "signed-out" });
+
+    await refreshBackgroundManagedRelayAuth();
+
+    expect(bootstrap).toHaveBeenCalledTimes(2);
+    controller.stop();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("queues a fresh bootstrap when refresh is requested during an in-flight attempt", async () => {
+    const first = deferred<{ state: { status: "superseded" } }>();
+    const bootstrap = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValueOnce({ state: { status: "signed-out" } });
+    const controller = startBackgroundManagedRelayAuth({ bootstrap });
+
+    const refreshed = controller.retryNow();
+    expect(bootstrap).toHaveBeenCalledOnce();
+    first.resolve({ state: { status: "superseded" } });
+
+    await expect(refreshed).resolves.toEqual({ status: "signed-out" });
+    expect(bootstrap).toHaveBeenCalledTimes(2);
+    controller.stop();
+  });
+
+  it("stops retrying and releases ownership idempotently", async () => {
+    const release = vi.fn();
+    const controller = startBackgroundManagedRelayAuth({
+      bootstrap: async () => ({
+        state: { status: "active", accountId: "account-1" },
+        release,
+      }),
+    });
+    await controller.firstAttempt;
+
+    controller.stop();
+    controller.stop();
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   bootstrapBackgroundManagedRelayAuth,
+  holdBackgroundManagedRelayAuth,
   invalidateBackgroundManagedRelayAuth,
   refreshBackgroundManagedRelayAuth,
   startBackgroundManagedRelayAuth,
@@ -186,6 +187,63 @@ describe("background managed relay authentication", () => {
 
     await expect(attempt).resolves.toEqual({ state: { status: "superseded" } });
     expect(acquireSession).not.toHaveBeenCalled();
+  });
+
+  it("holds bootstrap attempts until an account transition settles", async () => {
+    const transition = deferred<void>();
+    const release = vi.fn();
+    const acquireSession = vi.fn(() => release);
+    const load = vi.fn(async () => undefined);
+    holdBackgroundManagedRelayAuth(transition.promise);
+
+    // A retry timer or cold headless start that fires mid-transition must not
+    // publish the new account's relay session before the old account's
+    // cleanup has finished.
+    const attempt = bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: false,
+        load,
+        session: {
+          user: { id: "new-account" },
+          getToken: vi.fn(async () => "new-token"),
+        },
+      }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(load).not.toHaveBeenCalled();
+    expect(acquireSession).not.toHaveBeenCalled();
+
+    transition.resolve();
+
+    await expect(attempt).resolves.toEqual({
+      state: { status: "active", accountId: "new-account" },
+      release,
+    });
+    expect(acquireSession).toHaveBeenCalledOnce();
+  });
+
+  it("releases a hold whose transition fails", async () => {
+    const failed = Promise.reject(new Error("cleanup failed"));
+    holdBackgroundManagedRelayAuth(failed);
+
+    await expect(
+      bootstrapBackgroundManagedRelayAuth({
+        resolveConfig: () => configuredPublicConfig,
+        createClerk: () => ({ loaded: true, load: async () => undefined, session: null }),
+        resolveTokenOptions: vi.fn(() => ({
+          template: "relay-template",
+          skipCache: true as const,
+        })),
+        acquireSession: vi.fn(() => vi.fn()),
+      }),
+    ).resolves.toEqual({ state: { status: "signed-out" } });
   });
 
   it("keeps the controller alive and retries transient Clerk failures", async () => {

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
@@ -1,0 +1,216 @@
+import { getClerkInstance } from "@clerk/expo";
+import { tokenCache } from "@clerk/expo/token-cache";
+
+import { acquireBackgroundManagedRelaySession } from "./managedRelaySessionOwnership";
+import { resolveCloudPublicConfig, resolveRelayClerkTokenOptions } from "./publicConfig";
+
+const INITIAL_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 30_000;
+
+export type BackgroundManagedRelayAuthState =
+  | { readonly status: "active"; readonly accountId: string }
+  | { readonly status: "signed-out" }
+  | { readonly status: "unconfigured" }
+  | { readonly status: "superseded" }
+  | { readonly status: "retrying"; readonly error: unknown };
+
+interface BackgroundClerkSession {
+  readonly user: { readonly id: string };
+  readonly getToken: (
+    options: ReturnType<typeof resolveRelayClerkTokenOptions>,
+  ) => Promise<string | null>;
+}
+
+interface BackgroundClerk {
+  readonly loaded: boolean;
+  readonly session: BackgroundClerkSession | null | undefined;
+  readonly load: () => Promise<void>;
+}
+
+interface BackgroundManagedRelayAuthDependencies {
+  readonly resolveConfig: typeof resolveCloudPublicConfig;
+  readonly createClerk: (publishableKey: string) => BackgroundClerk;
+  readonly resolveTokenOptions: typeof resolveRelayClerkTokenOptions;
+  readonly acquireSession: typeof acquireBackgroundManagedRelaySession;
+}
+
+interface BackgroundManagedRelayAuthAttempt {
+  readonly state: BackgroundManagedRelayAuthState;
+  readonly release?: () => void;
+}
+
+const defaultDependencies: BackgroundManagedRelayAuthDependencies = {
+  resolveConfig: resolveCloudPublicConfig,
+  createClerk: (publishableKey) => getClerkInstance({ publishableKey, tokenCache }),
+  resolveTokenOptions: resolveRelayClerkTokenOptions,
+  acquireSession: acquireBackgroundManagedRelaySession,
+};
+
+let authenticationEpoch = 0;
+
+/** Prevent an in-flight Clerk load from restoring ownership after sign-out. */
+export function invalidateBackgroundManagedRelayAuth(): void {
+  authenticationEpoch += 1;
+}
+
+export async function bootstrapBackgroundManagedRelayAuth(
+  dependencies: BackgroundManagedRelayAuthDependencies = defaultDependencies,
+): Promise<BackgroundManagedRelayAuthAttempt> {
+  const attemptEpoch = authenticationEpoch;
+  try {
+    const config = dependencies.resolveConfig();
+    if (!config.clerk.publishableKey || !config.clerk.jwtTemplate || !config.relay.url) {
+      return { state: { status: "unconfigured" } };
+    }
+
+    const clerk = dependencies.createClerk(config.clerk.publishableKey);
+    if (!clerk.loaded) {
+      await clerk.load();
+    }
+    const session = clerk.session;
+    if (!session?.user.id) {
+      return { state: { status: "signed-out" } };
+    }
+
+    // Clerk loading crosses an async boundary. Sign-out or account switching
+    // can invalidate this result while it is in flight; never let that stale
+    // account reacquire the background owner after ownership was cleared.
+    if (attemptEpoch !== authenticationEpoch) {
+      return { state: { status: "superseded" } };
+    }
+
+    const release = dependencies.acquireSession({
+      accountId: session.user.id,
+      readClerkToken: () => session.getToken(dependencies.resolveTokenOptions()),
+    });
+    return {
+      state: { status: "active", accountId: session.user.id },
+      release,
+    };
+  } catch (error) {
+    return { state: { status: "retrying", error } };
+  }
+}
+
+interface BackgroundManagedRelayAuthControllerOptions {
+  readonly bootstrap?: () => Promise<BackgroundManagedRelayAuthAttempt>;
+  readonly scheduleRetry?: (retry: () => void, delayMs: number) => () => void;
+  readonly onStateChange?: (state: BackgroundManagedRelayAuthState) => void;
+}
+
+export interface BackgroundManagedRelayAuthController {
+  readonly firstAttempt: Promise<BackgroundManagedRelayAuthState>;
+  readonly retryNow: () => Promise<BackgroundManagedRelayAuthState>;
+  readonly stop: () => void;
+}
+
+const backgroundManagedRelayAuthRefreshers = new Set<
+  () => Promise<BackgroundManagedRelayAuthState>
+>();
+
+export async function refreshBackgroundManagedRelayAuth(): Promise<void> {
+  await Promise.all([...backgroundManagedRelayAuthRefreshers].map((refresh) => refresh()));
+}
+
+function defaultScheduleRetry(retry: () => void, delayMs: number): () => void {
+  const timeout = setTimeout(retry, delayMs);
+  return () => clearTimeout(timeout);
+}
+
+export function startBackgroundManagedRelayAuth(
+  options: BackgroundManagedRelayAuthControllerOptions = {},
+): BackgroundManagedRelayAuthController {
+  const bootstrap = options.bootstrap ?? (() => bootstrapBackgroundManagedRelayAuth());
+  const scheduleRetry = options.scheduleRetry ?? defaultScheduleRetry;
+  let stopped = false;
+  let failureCount = 0;
+  let releaseSession: (() => void) | null = null;
+  let cancelRetry: (() => void) | null = null;
+  let inFlight: Promise<BackgroundManagedRelayAuthState> | null = null;
+  let refreshRequested = false;
+
+  const cancelScheduledRetry = () => {
+    cancelRetry?.();
+    cancelRetry = null;
+  };
+
+  const runAttempt = (): Promise<BackgroundManagedRelayAuthState> => {
+    if (inFlight) {
+      return inFlight;
+    }
+    cancelScheduledRetry();
+    const operation = (async () => {
+      const attempt = await bootstrap().catch(
+        (error): BackgroundManagedRelayAuthAttempt => ({
+          state: { status: "retrying", error },
+        }),
+      );
+      if (stopped) {
+        attempt.release?.();
+        return attempt.state;
+      }
+
+      if (attempt.state.status === "active") {
+        failureCount = 0;
+        const previousRelease = releaseSession;
+        releaseSession = attempt.release ?? null;
+        previousRelease?.();
+      } else if (attempt.state.status === "retrying") {
+        const retryDelay = Math.min(INITIAL_RETRY_DELAY_MS * 2 ** failureCount, MAX_RETRY_DELAY_MS);
+        failureCount += 1;
+        cancelRetry = scheduleRetry(() => {
+          cancelRetry = null;
+          void runAttempt();
+        }, retryDelay);
+      } else {
+        releaseSession?.();
+        releaseSession = null;
+      }
+
+      options.onStateChange?.(attempt.state);
+      return attempt.state;
+    })();
+    const trackedOperation = operation.finally(() => {
+      if (inFlight === trackedOperation) {
+        inFlight = null;
+      }
+    });
+    inFlight = trackedOperation;
+    return trackedOperation;
+  };
+
+  const requestAttempt = (): Promise<BackgroundManagedRelayAuthState> => {
+    const currentAttempt = inFlight;
+    if (currentAttempt === null) {
+      return runAttempt();
+    }
+    // Coalesce refreshes, but guarantee one fresh bootstrap after the current
+    // attempt. Returning the in-flight promise alone would let a sign-out
+    // invalidation be consumed by the stale attempt without rereading Clerk.
+    refreshRequested = true;
+    return currentAttempt.then((state) => {
+      if (stopped || !refreshRequested) {
+        return state;
+      }
+      refreshRequested = false;
+      return runAttempt();
+    });
+  };
+
+  backgroundManagedRelayAuthRefreshers.add(requestAttempt);
+  const firstAttempt = runAttempt();
+  return {
+    firstAttempt,
+    retryNow: requestAttempt,
+    stop() {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      backgroundManagedRelayAuthRefreshers.delete(requestAttempt);
+      cancelScheduledRetry();
+      releaseSession?.();
+      releaseSession = null;
+    },
+  };
+}

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
@@ -83,6 +83,9 @@ export async function bootstrapBackgroundManagedRelayAuth(
       accountId: session.user.id,
       readClerkToken: () => session.getToken(dependencies.resolveTokenOptions()),
     });
+    if (release === null) {
+      return { state: { status: "superseded" } };
+    }
     return {
       state: { status: "active", accountId: session.user.id },
       release,

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
@@ -47,17 +47,49 @@ const defaultDependencies: BackgroundManagedRelayAuthDependencies = {
 };
 
 let authenticationEpoch = 0;
+const pendingHolds = new Set<Promise<void>>();
 
 /** Prevent an in-flight Clerk load from restoring ownership after sign-out. */
 export function invalidateBackgroundManagedRelayAuth(): void {
   authenticationEpoch += 1;
 }
 
+/**
+ * Defers every background bootstrap until `transition` settles. Account
+ * switches invalidate the epoch, but that only stops attempts already in
+ * flight; a scheduled retry or a cold headless start would otherwise read the
+ * new Clerk account and publish its relay session before the previous
+ * account's environment removal and token-cache reset have finished.
+ */
+export function holdBackgroundManagedRelayAuth(transition: Promise<void>): void {
+  const hold: Promise<void> = transition
+    .then(
+      () => undefined,
+      () => undefined,
+    )
+    .finally(() => {
+      pendingHolds.delete(hold);
+    });
+  pendingHolds.add(hold);
+}
+
+async function awaitBackgroundManagedRelayAuthHolds(): Promise<void> {
+  while (pendingHolds.size > 0) {
+    await Promise.all(pendingHolds);
+  }
+}
+
 export async function bootstrapBackgroundManagedRelayAuth(
   dependencies: BackgroundManagedRelayAuthDependencies = defaultDependencies,
 ): Promise<BackgroundManagedRelayAuthAttempt> {
+  // Capture the epoch before yielding so an invalidation issued right after
+  // this attempt started still supersedes it, then wait out any transition.
   const attemptEpoch = authenticationEpoch;
   try {
+    await awaitBackgroundManagedRelayAuthHolds();
+    if (attemptEpoch !== authenticationEpoch) {
+      return { state: { status: "superseded" } };
+    }
     const config = dependencies.resolveConfig();
     if (!config.clerk.publishableKey || !config.clerk.jwtTemplate || !config.relay.url) {
       return { state: { status: "unconfigured" } };

--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -96,6 +96,9 @@ function cloudClientLayer() {
         clearAgentAwarenessRegistrationRecord: Effect.void,
         loadRecentThreadShortcuts: Effect.succeed([]),
         saveRecentThreadShortcuts: () => Effect.void,
+        loadBackgroundConnectionRetainedThread: Effect.succeed(null),
+        saveBackgroundConnectionRetainedThread: () => Effect.void,
+        clearBackgroundConnectionRetainedThread: Effect.void,
       }),
     ),
     ManagedRelay.layer({

--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -109,6 +109,9 @@ function cloudClientLayer() {
         clearAgentAwarenessRegistrationRecord: Effect.void,
         loadRecentThreadShortcuts: Effect.succeed([]),
         saveRecentThreadShortcuts: () => Effect.void,
+        loadBackgroundConnectionRetainedThread: Effect.succeed(null),
+        saveBackgroundConnectionRetainedThread: () => Effect.void,
+        clearBackgroundConnectionRetainedThread: Effect.void,
       }),
     ),
     ManagedRelay.layer({

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
@@ -1,0 +1,108 @@
+import { managedRelaySessionAtom } from "@t3tools/client-runtime/relay";
+import { AtomRegistry } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createManagedRelaySessionOwnership } from "./managedRelaySessionOwnership";
+
+function createHarness() {
+  const registry = AtomRegistry.make();
+  const ownership = createManagedRelaySessionOwnership(registry);
+  const provider = (token: string) => vi.fn(async () => token);
+  return { ownership, provider, registry };
+}
+
+describe("managed relay session ownership", () => {
+  it("keeps the UI owner effective while a background owner is present", () => {
+    const { ownership, provider, registry } = createHarness();
+    const backgroundProvider = provider("background");
+    const uiProvider = provider("ui");
+
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: backgroundProvider,
+    });
+    ownership.setOwner("ui", { accountId: "account-1", readClerkToken: uiProvider });
+
+    const session = registry.get(managedRelaySessionAtom);
+    expect(session?.accountId).toBe("account-1");
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+  });
+
+  it("releasing one owner preserves the other owner", () => {
+    const { ownership, provider, registry } = createHarness();
+    const releaseBackground = ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+    ownership.setOwner("ui", {
+      accountId: "account-1",
+      readClerkToken: provider("ui"),
+    });
+
+    releaseBackground();
+    expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("does not let an obsolete release remove a newer lease", () => {
+    const { ownership, provider, registry } = createHarness();
+    const releaseFirst = ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("first"),
+    });
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("second"),
+    });
+
+    releaseFirst();
+    expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+  });
+
+  it("invalidates a stale background owner on a UI account switch", () => {
+    const { ownership, provider, registry } = createHarness();
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+    ownership.setOwner("ui", {
+      accountId: "account-2",
+      readClerkToken: provider("ui"),
+    });
+
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("rejects a stale background bootstrap that completes after a UI switch", () => {
+    const { ownership, provider, registry } = createHarness();
+    ownership.setOwner("ui", {
+      accountId: "account-2",
+      readClerkToken: provider("ui"),
+    });
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("clears both owners for sign-out", () => {
+    const { ownership, provider, registry } = createHarness();
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+    ownership.setOwner("ui", {
+      accountId: "account-1",
+      readClerkToken: provider("ui"),
+    });
+
+    ownership.clear();
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
@@ -40,7 +40,8 @@ describe("managed relay session ownership", () => {
       readClerkToken: provider("ui"),
     });
 
-    releaseBackground();
+    expect(releaseBackground).not.toBeNull();
+    releaseBackground?.();
     expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
     ownership.releaseOwner("ui");
     expect(registry.get(managedRelaySessionAtom)).toBeNull();
@@ -57,7 +58,8 @@ describe("managed relay session ownership", () => {
       readClerkToken: provider("second"),
     });
 
-    releaseFirst();
+    expect(releaseFirst).not.toBeNull();
+    releaseFirst?.();
     expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
   });
 
@@ -82,11 +84,12 @@ describe("managed relay session ownership", () => {
       accountId: "account-2",
       readClerkToken: provider("ui"),
     });
-    ownership.setOwner("background", {
+    const rejected = ownership.setOwner("background", {
       accountId: "account-1",
       readClerkToken: provider("background"),
     });
 
+    expect(rejected).toBeNull();
     ownership.releaseOwner("ui");
     expect(registry.get(managedRelaySessionAtom)).toBeNull();
   });

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
@@ -16,7 +16,7 @@ export interface ManagedRelaySessionOwnership {
   readonly setOwner: (
     owner: ManagedRelaySessionOwner,
     session: ManagedRelaySessionInput,
-  ) => () => void;
+  ) => (() => void) | null;
   readonly releaseOwner: (owner: ManagedRelaySessionOwner) => void;
   readonly clear: () => void;
 }
@@ -66,7 +66,7 @@ export function createManagedRelaySessionOwnership(
         // A headless bootstrap may finish after the user switches accounts in
         // the UI. Never retain that stale result for a later UI unmount.
         if (ui && ui.accountId !== session.accountId) {
-          return () => undefined;
+          return null;
         }
         background = lease;
       }
@@ -93,6 +93,6 @@ export const managedRelaySessionOwnership = createManagedRelaySessionOwnership(a
 
 export function acquireBackgroundManagedRelaySession(
   session: ManagedRelaySessionInput,
-): () => void {
+): (() => void) | null {
   return managedRelaySessionOwnership.setOwner("background", session);
 }

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
@@ -1,0 +1,98 @@
+import {
+  type ManagedRelaySessionInput,
+  setManagedRelaySession,
+} from "@t3tools/client-runtime/relay";
+import type { AtomRegistry } from "effect/unstable/reactivity";
+
+import { appAtomRegistry } from "../../state/atom-registry";
+
+export type ManagedRelaySessionOwner = "ui" | "background";
+
+interface OwnerLease extends ManagedRelaySessionInput {
+  readonly id: number;
+}
+
+export interface ManagedRelaySessionOwnership {
+  readonly setOwner: (
+    owner: ManagedRelaySessionOwner,
+    session: ManagedRelaySessionInput,
+  ) => () => void;
+  readonly releaseOwner: (owner: ManagedRelaySessionOwner) => void;
+  readonly clear: () => void;
+}
+
+export function createManagedRelaySessionOwnership(
+  registry: AtomRegistry.AtomRegistry,
+): ManagedRelaySessionOwnership {
+  let nextLeaseId = 0;
+  let ui: OwnerLease | null = null;
+  let background: OwnerLease | null = null;
+  let appliedLeaseId: number | null = null;
+
+  const applyEffectiveOwner = () => {
+    const effective = ui ?? background;
+    const effectiveLeaseId = effective?.id ?? null;
+    if (effectiveLeaseId === appliedLeaseId) {
+      return;
+    }
+    appliedLeaseId = effectiveLeaseId;
+    setManagedRelaySession(registry, effective);
+  };
+
+  const releaseLease = (owner: ManagedRelaySessionOwner, leaseId: number) => {
+    if (owner === "ui") {
+      if (ui?.id !== leaseId) {
+        return;
+      }
+      ui = null;
+    } else {
+      if (background?.id !== leaseId) {
+        return;
+      }
+      background = null;
+    }
+    applyEffectiveOwner();
+  };
+
+  return {
+    setOwner(owner, session) {
+      const lease: OwnerLease = { ...session, id: ++nextLeaseId };
+      if (owner === "ui") {
+        ui = lease;
+        if (background?.accountId !== session.accountId) {
+          background = null;
+        }
+      } else {
+        // A headless bootstrap may finish after the user switches accounts in
+        // the UI. Never retain that stale result for a later UI unmount.
+        if (ui && ui.accountId !== session.accountId) {
+          return () => undefined;
+        }
+        background = lease;
+      }
+      applyEffectiveOwner();
+      return () => releaseLease(owner, lease.id);
+    },
+    releaseOwner(owner) {
+      if (owner === "ui") {
+        ui = null;
+      } else {
+        background = null;
+      }
+      applyEffectiveOwner();
+    },
+    clear() {
+      ui = null;
+      background = null;
+      applyEffectiveOwner();
+    },
+  };
+}
+
+export const managedRelaySessionOwnership = createManagedRelaySessionOwnership(appAtomRegistry);
+
+export function acquireBackgroundManagedRelaySession(
+  session: ManagedRelaySessionInput,
+): () => void {
+  return managedRelaySessionOwnership.setOwner("background", session);
+}

--- a/apps/mobile/src/features/connection/useConnectionController.ts
+++ b/apps/mobile/src/features/connection/useConnectionController.ts
@@ -10,6 +10,7 @@ import type {
 } from "@t3tools/contracts/relay";
 import * as Option from "effect/Option";
 import { useCallback, useMemo } from "react";
+import { Platform } from "react-native";
 
 import { environmentCatalog } from "../../connection/catalog";
 import {
@@ -20,6 +21,10 @@ import { useEnvironments } from "../../state/environments";
 import { relayEnvironmentDiscovery } from "../../state/relay";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { projectWorkspaceEnvironment, type WorkspaceEnvironment } from "../../state/workspaceModel";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 
 export interface RelayEnvironmentView {
   readonly environment: RelayClientEnvironmentRecord;
@@ -85,7 +90,17 @@ export function useConnectionController() {
     [registerEnvironment],
   );
   const removeEnvironment = useCallback(
-    (environmentId: EnvironmentId) => removeEnvironmentMutation(environmentId),
+    async (environmentId: EnvironmentId) => {
+      const result = await removeEnvironmentMutation(environmentId);
+      if (
+        Platform.OS === "android" &&
+        result._tag === "Success" &&
+        getBackgroundConnectionRetainedThreadSnapshot().thread?.environmentId === environmentId
+      ) {
+        void clearBackgroundConnectionRetainedThread();
+      }
+      return result;
+    },
     [removeEnvironmentMutation],
   );
   const retryEnvironment = useCallback(

--- a/apps/mobile/src/features/connection/useConnectionController.ts
+++ b/apps/mobile/src/features/connection/useConnectionController.ts
@@ -10,6 +10,7 @@ import type {
 } from "@t3tools/contracts/relay";
 import * as Option from "effect/Option";
 import { useCallback, useMemo } from "react";
+import { Platform } from "react-native";
 
 import { environmentCatalog } from "../../connection/catalog";
 import {
@@ -20,6 +21,10 @@ import { useEnvironments } from "../../state/environments";
 import { relayEnvironmentDiscovery } from "../../state/relay";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { projectWorkspaceEnvironment, type WorkspaceEnvironment } from "../../state/workspaceModel";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 import { relayManagedEnvironmentIds } from "./environmentSections";
 
 export interface RelayEnvironmentView {
@@ -86,7 +91,17 @@ export function useConnectionController() {
     [registerEnvironment],
   );
   const removeEnvironment = useCallback(
-    (environmentId: EnvironmentId) => removeEnvironmentMutation(environmentId),
+    async (environmentId: EnvironmentId) => {
+      const result = await removeEnvironmentMutation(environmentId);
+      if (
+        Platform.OS === "android" &&
+        result._tag === "Success" &&
+        getBackgroundConnectionRetainedThreadSnapshot().thread?.environmentId === environmentId
+      ) {
+        void clearBackgroundConnectionRetainedThread();
+      }
+      return result;
+    },
     [removeEnvironmentMutation],
   );
   const retryEnvironment = useCallback(

--- a/apps/mobile/src/features/home/useThreadListActions.ts
+++ b/apps/mobile/src/features/home/useThreadListActions.ts
@@ -3,7 +3,7 @@ import { canSettle, canSnooze } from "@t3tools/client-runtime/state/thread-settl
 import * as Cause from "effect/Cause";
 import * as Haptics from "expo-haptics";
 import { useCallback, useRef } from "react";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 
 import { showConfirmDialog } from "../../components/ConfirmDialogHost";
 import { scopedThreadKey } from "../../lib/scopedEntities";
@@ -13,6 +13,10 @@ import {
   planPinnedMove,
   sortPinnedThreadsByOrderKey,
 } from "@t3tools/client-runtime/state/thread-sort";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 import { appAtomRegistry } from "../../state/atom-registry";
 import { environmentServerConfigsAtom } from "../../state/server";
 import { environmentThreadShells, threadEnvironment } from "../../state/threads";
@@ -160,6 +164,12 @@ function useThreadActionExecutor(
         // lifecycle still feeds the archived-snapshot surface.
         if (action === "archive" || action === "unarchive" || action === "delete") {
           refreshArchivedThreadsForEnvironment(thread.environmentId);
+        }
+        if (Platform.OS === "android" && action === "delete") {
+          const retained = getBackgroundConnectionRetainedThreadSnapshot().thread;
+          if (retained?.environmentId === thread.environmentId && retained.threadId === thread.id) {
+            void clearBackgroundConnectionRetainedThread();
+          }
         }
         onCompleted?.(action, thread);
         return true;

--- a/apps/mobile/src/features/home/useThreadListActions.ts
+++ b/apps/mobile/src/features/home/useThreadListActions.ts
@@ -3,7 +3,7 @@ import { canSnooze } from "@t3tools/client-runtime/state/thread-settled";
 import * as Cause from "effect/Cause";
 import * as Haptics from "expo-haptics";
 import { useCallback, useRef } from "react";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 
 import { showConfirmDialog } from "../../components/ConfirmDialogHost";
 import { scopedThreadKey } from "../../lib/scopedEntities";
@@ -13,6 +13,10 @@ import {
   planPinnedMove,
   sortPinnedThreadsByOrderKey,
 } from "@t3tools/client-runtime/state/thread-sort";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 import { appAtomRegistry } from "../../state/atom-registry";
 import { environmentServerConfigsAtom } from "../../state/server";
 import { environmentThreadShells, threadEnvironment } from "../../state/threads";
@@ -159,6 +163,12 @@ function useThreadActionExecutor(
         // lifecycle still feeds the archived-snapshot surface.
         if (action === "archive" || action === "unarchive" || action === "delete") {
           refreshArchivedThreadsForEnvironment(thread.environmentId);
+        }
+        if (Platform.OS === "android" && action === "delete") {
+          const retained = getBackgroundConnectionRetainedThreadSnapshot().thread;
+          if (retained?.environmentId === thread.environmentId && retained.threadId === thread.id) {
+            void clearBackgroundConnectionRetainedThread();
+          }
         }
         onCompleted?.(action, thread);
         return true;

--- a/apps/mobile/src/features/settings/SettingsClientStorageRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsClientStorageRouteScreen.tsx
@@ -2,10 +2,14 @@ import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { SymbolView } from "expo-symbols";
 import { useMemo } from "react";
-import { ActivityIndicator, Alert, Pressable, ScrollView, View } from "react-native";
+import { ActivityIndicator, Alert, Platform, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AppText as Text } from "../../components/AppText";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 import { useThemeColor } from "../../lib/useThemeColor";
 import {
   clearClientCacheAtom,
@@ -47,8 +51,16 @@ export function SettingsClientStorageRouteScreen() {
         {
           text: "Clear Cache",
           style: "destructive",
-          onPress: () =>
-            clearCache({ type: "environment", environmentId: environment.environmentId }),
+          onPress: () => {
+            const retained = getBackgroundConnectionRetainedThreadSnapshot().thread;
+            if (
+              Platform.OS === "android" &&
+              retained?.environmentId === environment.environmentId
+            ) {
+              void clearBackgroundConnectionRetainedThread();
+            }
+            clearCache({ type: "environment", environmentId: environment.environmentId });
+          },
         },
       ],
     );
@@ -63,7 +75,12 @@ export function SettingsClientStorageRouteScreen() {
         {
           text: "Clear All Caches",
           style: "destructive",
-          onPress: () => clearCache({ type: "all" }),
+          onPress: () => {
+            if (Platform.OS === "android") {
+              void clearBackgroundConnectionRetainedThread();
+            }
+            clearCache({ type: "all" });
+          },
         },
       ],
     );

--- a/apps/mobile/src/features/settings/SettingsClientStorageRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsClientStorageRouteScreen.tsx
@@ -1,11 +1,15 @@
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useMemo } from "react";
-import { ActivityIndicator, Alert, Pressable, ScrollView, View } from "react-native";
+import { ActivityIndicator, Alert, Platform, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AppText as Text } from "../../components/AppText";
 import { SymbolView } from "../../components/AppSymbol";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 import {
   clearClientCacheAtom,
   clientCacheSummaryAtom,
@@ -44,8 +48,16 @@ export function SettingsClientStorageRouteScreen() {
         {
           text: "Clear Cache",
           style: "destructive",
-          onPress: () =>
-            clearCache({ type: "environment", environmentId: environment.environmentId }),
+          onPress: () => {
+            const retained = getBackgroundConnectionRetainedThreadSnapshot().thread;
+            if (
+              Platform.OS === "android" &&
+              retained?.environmentId === environment.environmentId
+            ) {
+              void clearBackgroundConnectionRetainedThread();
+            }
+            clearCache({ type: "environment", environmentId: environment.environmentId });
+          },
         },
       ],
     );
@@ -60,7 +72,12 @@ export function SettingsClientStorageRouteScreen() {
         {
           text: "Clear All Caches",
           style: "destructive",
-          onPress: () => clearCache({ type: "all" }),
+          onPress: () => {
+            if (Platform.OS === "android") {
+              void clearBackgroundConnectionRetainedThread();
+            }
+            clearCache({ type: "all" });
+          },
         },
       ],
     );

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -58,6 +58,7 @@ import { useSavedRemoteConnections } from "../../state/use-remote-environment-re
 import { SettingsRow } from "./components/SettingsRow";
 import { SettingsSection } from "./components/SettingsSection";
 import { SettingsSwitchRow } from "./components/SettingsSwitchRow";
+import { BackgroundConnectionSettingsSection } from "../background-connection/BackgroundConnectionSettingsSection";
 import { resolveAgentAwarenessPlatformPresentation } from "./SettingsRouteScreen.logic";
 
 type NotificationStatus = "checking" | "enabled" | "disabled" | "unsupported";
@@ -138,6 +139,8 @@ function LocalSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />
@@ -524,6 +527,8 @@ function ConfiguredSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -47,6 +47,7 @@ import { useSavedRemoteConnections } from "../../state/use-remote-environment-re
 import { SettingsRow } from "./components/SettingsRow";
 import { SettingsSection } from "./components/SettingsSection";
 import { SettingsSwitchRow } from "./components/SettingsSwitchRow";
+import { BackgroundConnectionSettingsSection } from "../background-connection/BackgroundConnectionSettingsSection";
 
 type NotificationStatus = "checking" | "enabled" | "disabled" | "unsupported";
 type LiveActivityStatus = "checking" | "enabled" | "disabled" | "signed-out" | "linking";
@@ -126,6 +127,8 @@ function LocalSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />
@@ -514,6 +517,8 @@ function ConfiguredSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />

--- a/apps/mobile/src/native/backgroundConnection.test.ts
+++ b/apps/mobile/src/native/backgroundConnection.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const expoMocks = vi.hoisted(() => ({
+  requireOptionalNativeModule: vi.fn((_name: string): unknown => null),
+}));
+
+vi.mock("expo", () => ({
+  NativeModule: class {
+    readonly __nativeModule = true;
+  },
+  requireOptionalNativeModule: expoMocks.requireOptionalNativeModule,
+}));
+
+const runningStatus = {
+  supported: true,
+  enabled: true,
+  serviceRunning: true,
+  runtimeReady: true,
+  batteryOptimizationIgnored: true,
+} as const;
+
+describe("backgroundConnection native bridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    expoMocks.requireOptionalNativeModule.mockReturnValue(null);
+  });
+
+  it("is safe when the Android native module is unavailable", async () => {
+    const bridge = await import("./backgroundConnection");
+
+    expect(bridge.getBackgroundConnectionStatus()).toEqual({
+      supported: false,
+      enabled: false,
+      serviceRunning: false,
+      runtimeReady: false,
+      batteryOptimizationIgnored: false,
+    });
+    await expect(bridge.setBackgroundConnectionEnabled(true)).resolves.toMatchObject({
+      supported: false,
+    });
+    await expect(
+      bridge.requestBackgroundConnectionBatteryOptimizationExemption(),
+    ).resolves.toMatchObject({ supported: false });
+    expect(bridge.ensureBackgroundConnectionStarted()).toMatchObject({ supported: false });
+    expect(bridge.addBackgroundConnectionStatusListener(vi.fn()).remove).not.toThrow();
+    expect(bridge.addBackgroundConnectionStopRequestListener(vi.fn()).remove).not.toThrow();
+  });
+
+  it("forwards status and lifecycle calls to the installed native module", async () => {
+    const setEnabled = vi.fn(async () => runningStatus);
+    const ensureStarted = vi.fn(() => runningStatus);
+    const requestBatteryOptimizationExemption = vi.fn(async () => runningStatus);
+    const setRuntimeReady = vi.fn(() => runningStatus);
+    const acknowledgeStop = vi.fn(() => runningStatus);
+    expoMocks.requireOptionalNativeModule.mockReturnValue({
+      getStatus: () => runningStatus,
+      setEnabled,
+      ensureStarted,
+      requestBatteryOptimizationExemption,
+      setRuntimeReady,
+      acknowledgeStop,
+    });
+    const bridge = await import("./backgroundConnection");
+
+    expect(bridge.getBackgroundConnectionStatus()).toEqual(runningStatus);
+    await expect(bridge.setBackgroundConnectionEnabled(true)).resolves.toEqual(runningStatus);
+    await expect(bridge.requestBackgroundConnectionBatteryOptimizationExemption()).resolves.toEqual(
+      runningStatus,
+    );
+    expect(bridge.ensureBackgroundConnectionStarted()).toEqual(runningStatus);
+    expect(bridge.setBackgroundConnectionRuntimeReady(true)).toEqual(runningStatus);
+    expect(bridge.acknowledgeBackgroundConnectionStop()).toEqual(runningStatus);
+    expect(setEnabled).toHaveBeenCalledWith(true);
+    expect(requestBatteryOptimizationExemption).toHaveBeenCalledOnce();
+    expect(ensureStarted).toHaveBeenCalledOnce();
+    expect(setRuntimeReady).toHaveBeenCalledWith(true);
+    expect(acknowledgeStop).toHaveBeenCalledOnce();
+  });
+
+  it("normalizes native status events and exposes the stop request", async () => {
+    const listeners = new Map<string, (event?: unknown) => void>();
+    const remove = vi.fn();
+    expoMocks.requireOptionalNativeModule.mockReturnValue({
+      getStatus: () => runningStatus,
+      addListener: (eventName: string, listener: (event?: unknown) => void) => {
+        listeners.set(eventName, listener);
+        return { remove };
+      },
+    });
+    const bridge = await import("./backgroundConnection");
+    const onStatus = vi.fn();
+    const onStop = vi.fn();
+
+    const statusSubscription = bridge.addBackgroundConnectionStatusListener(onStatus);
+    bridge.addBackgroundConnectionStopRequestListener(onStop);
+    listeners.get("onStatusChange")?.({
+      ...runningStatus,
+      runtimeReady: 1,
+    });
+    listeners.get("onStopRequested")?.();
+    statusSubscription.remove();
+
+    expect(onStatus).toHaveBeenCalledWith({ ...runningStatus, runtimeReady: false });
+    expect(onStop).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/native/backgroundConnection.ts
+++ b/apps/mobile/src/native/backgroundConnection.ts
@@ -1,0 +1,141 @@
+import { NativeModule, requireOptionalNativeModule } from "expo";
+
+export interface BackgroundConnectionStatus {
+  readonly supported: boolean;
+  readonly enabled: boolean;
+  readonly serviceRunning: boolean;
+  readonly runtimeReady: boolean;
+  readonly batteryOptimizationIgnored: boolean;
+}
+
+type BackgroundConnectionNativeEvents = {
+  readonly onStatusChange: (status: BackgroundConnectionStatus) => void;
+  readonly onStopRequested: () => void;
+};
+
+declare class BackgroundConnectionNativeModule extends NativeModule<BackgroundConnectionNativeEvents> {
+  readonly getStatus?: () => BackgroundConnectionStatus;
+  readonly setEnabled?: (enabled: boolean) => Promise<BackgroundConnectionStatus>;
+  readonly ensureStarted?: () => BackgroundConnectionStatus;
+  readonly requestBatteryOptimizationExemption?: () => Promise<BackgroundConnectionStatus>;
+  readonly setRuntimeReady?: (ready: boolean) => BackgroundConnectionStatus;
+  readonly acknowledgeStop?: () => BackgroundConnectionStatus;
+}
+
+export interface BackgroundConnectionSubscription {
+  readonly remove: () => void;
+}
+
+const UNSUPPORTED_STATUS: BackgroundConnectionStatus = {
+  supported: false,
+  enabled: false,
+  serviceRunning: false,
+  runtimeReady: false,
+  batteryOptimizationIgnored: false,
+};
+
+let cachedNativeModule: BackgroundConnectionNativeModule | null | undefined;
+
+function getNativeModule(): BackgroundConnectionNativeModule | null {
+  if (cachedNativeModule !== undefined) return cachedNativeModule;
+  try {
+    cachedNativeModule =
+      requireOptionalNativeModule<BackgroundConnectionNativeModule>("T3BackgroundConnection");
+  } catch {
+    cachedNativeModule = null;
+  }
+  return cachedNativeModule;
+}
+
+function normalizeStatus(status: BackgroundConnectionStatus | null | undefined) {
+  if (status?.supported !== true) return UNSUPPORTED_STATUS;
+  return {
+    supported: true,
+    enabled: status.enabled === true,
+    serviceRunning: status.serviceRunning === true,
+    runtimeReady: status.runtimeReady === true,
+    batteryOptimizationIgnored: status.batteryOptimizationIgnored === true,
+  } satisfies BackgroundConnectionStatus;
+}
+
+export function getBackgroundConnectionStatus(): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.getStatus?.());
+  } catch {
+    return UNSUPPORTED_STATUS;
+  }
+}
+
+export async function setBackgroundConnectionEnabled(
+  enabled: boolean,
+): Promise<BackgroundConnectionStatus> {
+  try {
+    const nativeModule = getNativeModule();
+    if (!nativeModule?.setEnabled) return UNSUPPORTED_STATUS;
+    return normalizeStatus(await nativeModule.setEnabled(enabled));
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function ensureBackgroundConnectionStarted(): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.ensureStarted?.());
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export async function requestBackgroundConnectionBatteryOptimizationExemption(): Promise<BackgroundConnectionStatus> {
+  try {
+    const nativeModule = getNativeModule();
+    if (!nativeModule?.requestBatteryOptimizationExemption) return UNSUPPORTED_STATUS;
+    return normalizeStatus(await nativeModule.requestBatteryOptimizationExemption());
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function setBackgroundConnectionRuntimeReady(ready: boolean): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.setRuntimeReady?.(ready));
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function acknowledgeBackgroundConnectionStop(): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.acknowledgeStop?.());
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function addBackgroundConnectionStatusListener(
+  listener: (status: BackgroundConnectionStatus) => void,
+): BackgroundConnectionSubscription {
+  try {
+    const nativeModule = getNativeModule();
+    if (!nativeModule) return NOOP_SUBSCRIPTION;
+    return nativeModule.addListener("onStatusChange", (status) => {
+      listener(normalizeStatus(status));
+    });
+  } catch {
+    return NOOP_SUBSCRIPTION;
+  }
+}
+
+export function addBackgroundConnectionStopRequestListener(
+  listener: () => void,
+): BackgroundConnectionSubscription {
+  try {
+    return getNativeModule()?.addListener("onStopRequested", listener) ?? NOOP_SUBSCRIPTION;
+  } catch {
+    return NOOP_SUBSCRIPTION;
+  }
+}
+
+const NOOP_SUBSCRIPTION: BackgroundConnectionSubscription = {
+  remove() {},
+};

--- a/apps/mobile/src/persistence/imperative.ts
+++ b/apps/mobile/src/persistence/imperative.ts
@@ -51,3 +51,13 @@ export const loadRecentThreadShortcuts = () =>
 export const saveRecentThreadShortcuts = (
   threads: ReadonlyArray<MobileStorage.RecentThreadShortcut>,
 ) => runStorage((storage) => storage.saveRecentThreadShortcuts(threads));
+
+export const loadBackgroundConnectionRetainedThread = () =>
+  runStorage((storage) => storage.loadBackgroundConnectionRetainedThread);
+export const saveBackgroundConnectionRetainedThread = (
+  thread: Parameters<
+    MobileStorage.MobileStorage["Service"]["saveBackgroundConnectionRetainedThread"]
+  >[0],
+) => runStorage((storage) => storage.saveBackgroundConnectionRetainedThread(thread));
+export const clearBackgroundConnectionRetainedThread = () =>
+  runStorage((storage) => storage.clearBackgroundConnectionRetainedThread);

--- a/apps/mobile/src/persistence/mobile-storage.test.ts
+++ b/apps/mobile/src/persistence/mobile-storage.test.ts
@@ -1,0 +1,59 @@
+import { expect, it } from "@effect/vitest";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import { vi } from "vite-plus/test";
+
+const secureStore = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("expo-secure-store", () => ({
+  getItemAsync: vi.fn((key: string) => Promise.resolve(secureStore.get(key) ?? null)),
+  setItemAsync: vi.fn((key: string, value: string) => {
+    secureStore.set(key, value);
+    return Promise.resolve();
+  }),
+  deleteItemAsync: vi.fn((key: string) => {
+    secureStore.delete(key);
+    return Promise.resolve();
+  }),
+}));
+
+vi.mock("react-native", () => ({
+  Platform: { OS: "android" },
+}));
+
+import * as MobileSecureStorage from "./mobile-secure-storage";
+import * as MobileStorage from "./mobile-storage";
+
+const RETAINED_THREAD_KEY = "t3code.background-connection.retained-thread";
+
+const makeStorage = MobileStorage.make().pipe(
+  Effect.provideService(MobileSecureStorage.MobileSecureStorage, MobileSecureStorage.make),
+);
+
+it.effect("round-trips and clears the retained background thread", () =>
+  Effect.gen(function* () {
+    secureStore.clear();
+    const storage = yield* makeStorage;
+    const retained = {
+      environmentId: EnvironmentId.make("environment-1"),
+      threadId: ThreadId.make("thread-1"),
+    };
+
+    yield* storage.saveBackgroundConnectionRetainedThread(retained);
+    expect(yield* storage.loadBackgroundConnectionRetainedThread).toEqual(retained);
+
+    yield* storage.clearBackgroundConnectionRetainedThread;
+    expect(yield* storage.loadBackgroundConnectionRetainedThread).toBeNull();
+  }),
+);
+
+it.effect("removes malformed retained-thread storage", () =>
+  Effect.gen(function* () {
+    secureStore.clear();
+    secureStore.set(RETAINED_THREAD_KEY, JSON.stringify({ environmentId: "environment-1" }));
+    const storage = yield* makeStorage;
+
+    expect(yield* storage.loadBackgroundConnectionRetainedThread).toBeNull();
+    expect(secureStore.has(RETAINED_THREAD_KEY)).toBe(false);
+  }),
+);

--- a/apps/mobile/src/persistence/mobile-storage.ts
+++ b/apps/mobile/src/persistence/mobile-storage.ts
@@ -285,7 +285,7 @@ export const make = Effect.fn("MobileStorage.make")(function* () {
             Effect.logWarning("Ignored an invalid retained background thread.").pipe(
               Effect.annotateLogs({
                 storageKey: BACKGROUND_CONNECTION_RETAINED_THREAD_KEY,
-                cause: String(cause),
+                cause,
               }),
               Effect.andThen(secureStorage.removeItem(BACKGROUND_CONNECTION_RETAINED_THREAD_KEY)),
               Effect.as(null),

--- a/apps/mobile/src/persistence/mobile-storage.ts
+++ b/apps/mobile/src/persistence/mobile-storage.ts
@@ -1,4 +1,8 @@
-import { EnvironmentId } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  ScopedThreadRef,
+  type ScopedThreadRef as ScopedThreadRefType,
+} from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -17,6 +21,15 @@ const CONNECTIONS_KEY = "t3code.connections";
 const AGENT_AWARENESS_DEVICE_ID_KEY = "t3code.agent-awareness.device-id";
 const AGENT_AWARENESS_REGISTRATION_KEY = "t3code.agent-awareness.registration";
 const RECENT_THREAD_SHORTCUTS_KEY = "t3code.recent-thread-shortcuts";
+const BACKGROUND_CONNECTION_RETAINED_THREAD_KEY = "t3code.background-connection.retained-thread";
+
+const BackgroundConnectionRetainedThread = Schema.fromJsonString(ScopedThreadRef);
+const decodeBackgroundConnectionRetainedThread = Schema.decodeUnknownEffect(
+  BackgroundConnectionRetainedThread,
+);
+const encodeBackgroundConnectionRetainedThread = Schema.encodeEffect(
+  BackgroundConnectionRetainedThread,
+);
 
 export class MobileStorageDecodeError extends Schema.TaggedErrorClass<MobileStorageDecodeError>()(
   "MobileStorageDecodeError",
@@ -113,6 +126,20 @@ export class MobileStorage extends Context.Service<
     ) => Effect.Effect<
       void,
       MobileSecureStorage.MobileSecureStorageError | MobileStorageEncodeError
+    >;
+    readonly loadBackgroundConnectionRetainedThread: Effect.Effect<
+      ScopedThreadRefType | null,
+      MobileSecureStorage.MobileSecureStorageError
+    >;
+    readonly saveBackgroundConnectionRetainedThread: (
+      thread: ScopedThreadRefType,
+    ) => Effect.Effect<
+      void,
+      MobileSecureStorage.MobileSecureStorageError | MobileStorageEncodeError
+    >;
+    readonly clearBackgroundConnectionRetainedThread: Effect.Effect<
+      void,
+      MobileSecureStorage.MobileSecureStorageError
     >;
   }
 >()("@t3tools/mobile/persistence/MobileStorage") {}
@@ -245,6 +272,44 @@ export const make = Effect.fn("MobileStorage.make")(function* () {
     ),
   );
 
+  const loadBackgroundConnectionRetainedThread = secureStorage
+    .getItem(BACKGROUND_CONNECTION_RETAINED_THREAD_KEY)
+    .pipe(
+      Effect.flatMap((encoded) => {
+        if (encoded === null || encoded.trim().length === 0) {
+          return Effect.succeed(null);
+        }
+        return decodeBackgroundConnectionRetainedThread(encoded).pipe(
+          Effect.map((thread): ScopedThreadRefType | null => thread),
+          Effect.catch((cause) =>
+            Effect.logWarning("Ignored an invalid retained background thread.").pipe(
+              Effect.annotateLogs({
+                storageKey: BACKGROUND_CONNECTION_RETAINED_THREAD_KEY,
+                cause: String(cause),
+              }),
+              Effect.andThen(secureStorage.removeItem(BACKGROUND_CONNECTION_RETAINED_THREAD_KEY)),
+              Effect.as(null),
+            ),
+          ),
+        );
+      }),
+    );
+
+  const saveBackgroundConnectionRetainedThread = Effect.fn(
+    "MobileStorage.saveBackgroundConnectionRetainedThread",
+  )(function* (thread: ScopedThreadRefType) {
+    const encoded = yield* encodeBackgroundConnectionRetainedThread(thread).pipe(
+      Effect.mapError(
+        (cause) =>
+          new MobileStorageEncodeError({
+            key: BACKGROUND_CONNECTION_RETAINED_THREAD_KEY,
+            cause,
+          }),
+      ),
+    );
+    yield* secureStorage.setItem(BACKGROUND_CONNECTION_RETAINED_THREAD_KEY, encoded);
+  });
+
   return MobileStorage.of({
     loadSavedConnections,
     saveConnection,
@@ -260,6 +325,11 @@ export const make = Effect.fn("MobileStorage.make")(function* () {
     ),
     loadRecentThreadShortcuts,
     saveRecentThreadShortcuts: (threads) => writeJson(RECENT_THREAD_SHORTCUTS_KEY, { threads }),
+    loadBackgroundConnectionRetainedThread,
+    saveBackgroundConnectionRetainedThread,
+    clearBackgroundConnectionRetainedThread: secureStorage.removeItem(
+      BACKGROUND_CONNECTION_RETAINED_THREAD_KEY,
+    ),
   });
 });
 

--- a/apps/mobile/src/state/use-thread-outbox-drain.test.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.test.ts
@@ -1,0 +1,87 @@
+import { AtomRegistry } from "effect/unstable/reactivity";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("../lib/uuid", () => ({
+  randomHex: vi.fn(() => "00"),
+  uuidv4: vi.fn(() => "00000000-0000-4000-8000-000000000000"),
+}));
+
+vi.mock("./presentation", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return { environmentPresentations: { presentationsAtom: Atom.make(new Map()) } };
+});
+
+vi.mock("./projects", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return { environmentProjects: { projectsAtom: Atom.make([]) } };
+});
+
+vi.mock("./threads", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return {
+    environmentThreadShells: { threadShellsAtom: Atom.make([]) },
+    threadEnvironment: {
+      setInteractionMode: {},
+      setRuntimeMode: {},
+      startTurn: {},
+      updateMetadata: {},
+    },
+  };
+});
+
+vi.mock("./use-thread-outbox", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return {
+    editingQueuedMessageIdsAtom: Atom.make({}),
+    threadOutboxShellStatusesAtom: Atom.make(new Map()),
+  };
+});
+
+vi.mock("./thread-outbox", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./thread-outbox")>();
+  return {
+    ...actual,
+    ensureThreadOutboxLoaded: vi.fn(),
+  };
+});
+
+import { ensureThreadOutboxLoaded } from "./thread-outbox";
+import { acquireThreadOutboxDrain } from "./use-thread-outbox-drain";
+
+describe("thread outbox drain ownership", () => {
+  beforeEach(() => {
+    vi.mocked(ensureThreadOutboxLoaded).mockClear();
+  });
+
+  it("shares one dispatcher until the final owner releases", async () => {
+    const registry = AtomRegistry.make();
+    const subscribe = vi.spyOn(registry, "subscribe");
+
+    const releaseUi = acquireThreadOutboxDrain(registry);
+    const subscriptionsPerDispatcher = subscribe.mock.calls.length;
+    expect(subscriptionsPerDispatcher).toBeGreaterThan(0);
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+
+    const releaseBackground = acquireThreadOutboxDrain(registry);
+    expect(subscribe).toHaveBeenCalledTimes(subscriptionsPerDispatcher);
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+
+    releaseUi();
+    releaseUi();
+    const releaseReplacementUi = acquireThreadOutboxDrain(registry);
+    expect(subscribe).toHaveBeenCalledTimes(subscriptionsPerDispatcher);
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+
+    releaseBackground();
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+    releaseReplacementUi();
+
+    const releaseNextOwner = acquireThreadOutboxDrain(registry);
+    expect(subscribe).toHaveBeenCalledTimes(subscriptionsPerDispatcher * 2);
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(2);
+    releaseNextOwner();
+
+    await Promise.resolve();
+    registry.dispose();
+  });
+});

--- a/apps/mobile/src/state/use-thread-outbox-drain.test.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.test.ts
@@ -6,6 +6,7 @@ import {
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
+import { AtomRegistry } from "effect/unstable/reactivity";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { PreparedTurnAttachments } from "../lib/attachmentUpload";
@@ -14,6 +15,7 @@ const harness = vi.hoisted(() => ({
   manager: null as unknown as ReturnType<
     typeof import("./thread-outbox-manager").createThreadOutboxManager
   >,
+  ensureThreadOutboxLoaded: vi.fn(),
   removePersistedFile: vi.fn(async () => undefined),
   removeOutboxMessage: vi.fn(async (_message: QueuedThreadMessage) => undefined),
   prepareTurnAttachments: vi.fn<typeof import("../lib/attachmentUpload").prepareTurnAttachments>(),
@@ -74,24 +76,34 @@ vi.mock("../lib/attachmentUpload", () => ({
   prepareTurnAttachments: harness.prepareTurnAttachments,
 }));
 
-vi.mock("./entities", () => ({
-  useProjects: () => [],
-  useServerConfigs: () => new Map(),
-  useThreadShells: () => [],
-}));
+vi.mock("./presentation", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return { environmentPresentations: { presentationsAtom: Atom.make(new Map()) } };
+});
 
-vi.mock("./threads", () => ({
-  threadEnvironment: {},
-}));
+vi.mock("./projects", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return { environmentProjects: { projectsAtom: Atom.make([]) } };
+});
 
-vi.mock("./use-atom-command", () => ({
-  useAtomCommand: () => async () => undefined,
-}));
+vi.mock("./server", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return { environmentServerConfigsAtom: Atom.make(new Map()) };
+});
+
+vi.mock("./threads", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return {
+    environmentThreadShells: { threadShellsAtom: Atom.make([]) },
+    threadEnvironment: {},
+  };
+});
 
 vi.mock("./use-thread-outbox", async () => {
   const { Atom } = await import("effect/unstable/reactivity");
   return {
     editingQueuedMessageIdsAtom: Atom.make<Record<string, boolean>>({}).pipe(Atom.keepAlive),
+    threadOutboxShellStatusesAtom: Atom.make(new Map()),
     useThreadOutboxMessages: () => ({}),
     useThreadOutboxShellStatuses: () => new Map(),
   };
@@ -117,7 +129,7 @@ vi.mock("./thread-outbox", async () => {
   return {
     threadOutboxManager: manager,
     flushThreadOutbox: async () => undefined,
-    ensureThreadOutboxLoaded: () => undefined,
+    ensureThreadOutboxLoaded: harness.ensureThreadOutboxLoaded,
     confirmThreadOutboxMessageQueued: (message: never) => manager.confirmQueued(message),
     updateThreadOutboxMessage: (message: never, expectedRevision?: number) =>
       manager.update(message, expectedRevision),
@@ -130,6 +142,7 @@ import type { QueuedThreadMessage } from "./thread-outbox-model";
 import * as composerDrafts from "./use-composer-drafts";
 import { editingQueuedMessageIdsAtom } from "./use-thread-outbox";
 import {
+  acquireThreadOutboxDrain,
   completeQueuedMessageDelivery,
   prepareQueuedMessageAttachments,
   recoverEditedCreationAfterDelivery,
@@ -200,6 +213,41 @@ afterEach(() => {
   harness.removeOutboxMessage.mockClear();
   harness.prepareTurnAttachments.mockReset();
   harness.setPendingConnectionError.mockClear();
+  harness.ensureThreadOutboxLoaded.mockClear();
+});
+
+describe("thread outbox drain ownership", () => {
+  it("shares one dispatcher until the final owner releases", async () => {
+    const registry = AtomRegistry.make();
+    const subscribe = vi.spyOn(registry, "subscribe");
+
+    const releaseUi = acquireThreadOutboxDrain(registry);
+    const subscriptionsPerDispatcher = subscribe.mock.calls.length;
+    expect(subscriptionsPerDispatcher).toBeGreaterThan(0);
+    expect(harness.ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+
+    const releaseBackground = acquireThreadOutboxDrain(registry);
+    expect(subscribe).toHaveBeenCalledTimes(subscriptionsPerDispatcher);
+    expect(harness.ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+
+    releaseUi();
+    releaseUi();
+    const releaseReplacementUi = acquireThreadOutboxDrain(registry);
+    expect(subscribe).toHaveBeenCalledTimes(subscriptionsPerDispatcher);
+    expect(harness.ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+
+    releaseBackground();
+    expect(harness.ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+    releaseReplacementUi();
+
+    const releaseNextOwner = acquireThreadOutboxDrain(registry);
+    expect(subscribe).toHaveBeenCalledTimes(subscriptionsPerDispatcher * 2);
+    expect(harness.ensureThreadOutboxLoaded).toHaveBeenCalledTimes(2);
+    releaseNextOwner();
+
+    await Promise.resolve();
+    registry.dispose();
+  });
 });
 
 describe("thread outbox attachment preparation", () => {

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -1,9 +1,9 @@
-import { useAtomValue } from "@effect/atom-react";
 import type {
   EnvironmentProject,
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
-import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import { RegistryContext } from "@effect/atom-react";
+import { type AtomCommandResult, runAtomCommand } from "@t3tools/client-runtime/state/runtime";
 import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -12,53 +12,53 @@ import {
 } from "@t3tools/contracts";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import * as Cause from "effect/Cause";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { AsyncResult, Atom, type AtomRegistry } from "effect/unstable/reactivity";
+import { useContext, useEffect } from "react";
 
-import { scopedThreadKey } from "../lib/scopedEntities";
-import { buildProjectThreadStartTurnInput } from "../lib/projectThreadStartTurn";
 import { toUploadChatImageAttachments } from "../lib/composerImages";
+import { buildProjectThreadStartTurnInput } from "../lib/projectThreadStartTurn";
+import { scopedThreadKey } from "../lib/scopedEntities";
 import { randomHex } from "../lib/uuid";
-import { appAtomRegistry } from "./atom-registry";
-import { useProjects, useThreadShells } from "./entities";
+import { environmentPresentations } from "./presentation";
+import { environmentProjects } from "./projects";
 import {
   confirmThreadOutboxMessageQueued,
   ensureThreadOutboxLoaded,
   removeThreadOutboxMessage,
+  threadOutboxManager,
 } from "./thread-outbox";
 import {
   isQueuedThreadCreationSendable,
   modelSelectionsEqual,
+  resolveQueuedThreadSettings,
   resolveThreadOutboxDeliveryAction,
   resolveThreadOutboxFailureAction,
-  resolveQueuedThreadSettings,
   threadOutboxRetryDelayMs,
   type QueuedThreadCreation,
   type QueuedThreadMessage,
   type ThreadOutboxCommandStage,
 } from "./thread-outbox-model";
 import { environmentThreadShells, threadEnvironment } from "./threads";
-import { useAtomCommand } from "./use-atom-command";
-import {
-  editingQueuedMessageIdsAtom,
-  useThreadOutboxMessages,
-  useThreadOutboxShellStatuses,
-} from "./use-thread-outbox";
-import { useRemoteConnectionStatus } from "./use-remote-environment-registry";
+import { editingQueuedMessageIdsAtom, threadOutboxShellStatusesAtom } from "./use-thread-outbox";
 
 export const dispatchingQueuedMessageIdAtom = Atom.make<MessageId | null>(null).pipe(
   Atom.keepAlive,
   Atom.withLabel("mobile:thread-outbox:dispatching-message-id"),
 );
 
-function beginDispatchingQueuedMessage(queuedMessageId: MessageId): void {
-  appAtomRegistry.set(dispatchingQueuedMessageIdAtom, queuedMessageId);
+interface ThreadOutboxDrainState {
+  readonly registry: AtomRegistry.AtomRegistry;
+  owners: number;
+  stopped: boolean;
+  drainScheduled: boolean;
+  activeDelivery: Promise<void> | null;
+  readonly retryAttempt: Map<MessageId, number>;
+  readonly retryNotBefore: Map<MessageId, number>;
+  readonly retryTimers: Map<MessageId, ReturnType<typeof setTimeout>>;
+  readonly releases: Array<() => void>;
 }
 
-function finishDispatchingQueuedMessage(queuedMessageId: MessageId): void {
-  const current = appAtomRegistry.get(dispatchingQueuedMessageIdAtom);
-  appAtomRegistry.set(dispatchingQueuedMessageIdAtom, current === queuedMessageId ? null : current);
-}
+const drainStates = new WeakMap<AtomRegistry.AtomRegistry, ThreadOutboxDrainState>();
 
 function findThread(
   threads: ReadonlyArray<EnvironmentThreadShell>,
@@ -85,139 +85,134 @@ function settingsCommandId(message: QueuedThreadMessage, setting: string): Comma
   return CommandId.make(`${message.commandId}:${setting}`);
 }
 
-export function useThreadOutboxDrain(): void {
-  const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
-  const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
-    reportFailure: false,
-  });
-  const setThreadRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
-    reportFailure: false,
-  });
-  const setThreadInteractionMode = useAtomCommand(threadEnvironment.setInteractionMode, {
-    reportFailure: false,
-  });
-  const dispatchingQueuedMessageId = useAtomValue(dispatchingQueuedMessageIdAtom);
-  const editingQueuedMessageIds = useAtomValue(editingQueuedMessageIdsAtom);
-  const queuedMessagesByThreadKey = useThreadOutboxMessages();
-  const shellStatuses = useThreadOutboxShellStatuses();
-  const threads = useThreadShells();
-  const projects = useProjects();
-  const { connectedEnvironments } = useRemoteConnectionStatus();
-  const [retryTick, setRetryTick] = useState(0);
-  const retryAttemptRef = useRef(new Map<MessageId, number>());
-  const retryNotBeforeRef = useRef(new Map<MessageId, number>());
-  const retryTimersRef = useRef(new Map<MessageId, ReturnType<typeof setTimeout>>());
+function makeDeliveryHelpers(queuedMessage: QueuedThreadMessage): {
+  readonly reportFailure: (
+    result: AtomCommandResult<unknown, unknown>,
+    stage: ThreadOutboxCommandStage,
+  ) => boolean;
+  readonly completeDelivery: (result: AtomCommandResult<unknown, unknown>) => Promise<boolean>;
+} {
+  const reportFailure = (
+    commandResult: AtomCommandResult<unknown, unknown>,
+    stage: ThreadOutboxCommandStage,
+  ): boolean => {
+    if (!AsyncResult.isFailure(commandResult)) {
+      return false;
+    }
+    const action = resolveThreadOutboxFailureAction({
+      stage,
+      error: Cause.squash(commandResult.cause),
+      interrupted: Cause.hasInterruptsOnly(commandResult.cause),
+    });
+    const retry = action === "retry";
+    console.warn("[thread-outbox] queued message delivery failed", {
+      environmentId: queuedMessage.environmentId,
+      threadId: queuedMessage.threadId,
+      messageId: queuedMessage.messageId,
+      stage,
+      cause: commandResult.cause,
+      retry,
+    });
+    return retry;
+  };
 
-  useEffect(() => {
-    ensureThreadOutboxLoaded();
-    return () => {
-      for (const timer of retryTimersRef.current.values()) {
-        clearTimeout(timer);
-      }
-      retryTimersRef.current.clear();
-    };
-  }, []);
-
-  const makeDeliveryHelpers = useCallback((queuedMessage: QueuedThreadMessage) => {
-    const reportFailure = (
-      commandResult: AtomCommandResult<unknown, unknown>,
-      stage: ThreadOutboxCommandStage,
-    ): boolean => {
-      if (!AsyncResult.isFailure(commandResult)) {
-        return false;
-      }
-      const action = resolveThreadOutboxFailureAction({
-        stage,
-        error: Cause.squash(commandResult.cause),
-        interrupted: Cause.hasInterruptsOnly(commandResult.cause),
-      });
-      const retry = action === "retry";
-      console.warn("[thread-outbox] queued message delivery failed", {
+  const completeDelivery = async (
+    deliveryResult: AtomCommandResult<unknown, unknown>,
+  ): Promise<boolean> => {
+    if (reportFailure(deliveryResult, "start-turn")) {
+      return false;
+    }
+    try {
+      await removeThreadOutboxMessage(queuedMessage);
+      return true;
+    } catch (error) {
+      console.warn("[thread-outbox] failed to remove delivered queued message", {
         environmentId: queuedMessage.environmentId,
         threadId: queuedMessage.threadId,
         messageId: queuedMessage.messageId,
-        stage,
-        cause: commandResult.cause,
-        retry,
+        error,
       });
-      return retry;
-    };
-    const completeDelivery = async (
-      deliveryResult: AtomCommandResult<unknown, unknown>,
-    ): Promise<boolean> => {
-      if (reportFailure(deliveryResult, "start-turn")) {
-        return false;
-      }
+      return false;
+    }
+  };
+  return { reportFailure, completeDelivery };
+}
 
-      try {
-        await removeThreadOutboxMessage(queuedMessage);
-        return true;
-      } catch (error) {
-        console.warn("[thread-outbox] failed to remove delivered queued message", {
-          environmentId: queuedMessage.environmentId,
+async function sendQueuedMessage(
+  registry: AtomRegistry.AtomRegistry,
+  queuedMessage: QueuedThreadMessage,
+  thread: EnvironmentThreadShell,
+): Promise<boolean> {
+  const settings = resolveQueuedThreadSettings(queuedMessage, thread);
+  const { reportFailure, completeDelivery } = makeDeliveryHelpers(queuedMessage);
+
+  if (!modelSelectionsEqual(settings.modelSelection, thread.modelSelection)) {
+    const updateResult = await runAtomCommand(
+      registry,
+      threadEnvironment.updateMetadata,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "model-selection"),
           threadId: queuedMessage.threadId,
-          messageId: queuedMessage.messageId,
-          error,
-        });
-        return false;
-      }
-    };
-    return { reportFailure, completeDelivery };
-  }, []);
+          modelSelection: settings.modelSelection,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(updateResult)) {
+      reportFailure(updateResult, "settings-sync");
+      return false;
+    }
+  }
 
-  const sendQueuedMessage = useCallback(
-    async (queuedMessage: QueuedThreadMessage, thread: EnvironmentThreadShell) => {
-      const settings = resolveQueuedThreadSettings(queuedMessage, thread);
-      const { reportFailure, completeDelivery } = makeDeliveryHelpers(queuedMessage);
+  if (settings.runtimeMode !== thread.runtimeMode) {
+    const runtimeResult = await runAtomCommand(
+      registry,
+      threadEnvironment.setRuntimeMode,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "runtime-mode"),
+          threadId: queuedMessage.threadId,
+          runtimeMode: settings.runtimeMode,
+          createdAt: queuedMessage.createdAt,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(runtimeResult)) {
+      reportFailure(runtimeResult, "settings-sync");
+      return false;
+    }
+  }
 
-      if (!modelSelectionsEqual(settings.modelSelection, thread.modelSelection)) {
-        const updateResult = await updateThreadMetadata({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "model-selection"),
-            threadId: queuedMessage.threadId,
-            modelSelection: settings.modelSelection,
-          },
-        });
-        if (AsyncResult.isFailure(updateResult)) {
-          reportFailure(updateResult, "settings-sync");
-          return false;
-        }
-      }
+  if (settings.interactionMode !== thread.interactionMode) {
+    const interactionResult = await runAtomCommand(
+      registry,
+      threadEnvironment.setInteractionMode,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "interaction-mode"),
+          threadId: queuedMessage.threadId,
+          interactionMode: settings.interactionMode,
+          createdAt: queuedMessage.createdAt,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(interactionResult)) {
+      reportFailure(interactionResult, "settings-sync");
+      return false;
+    }
+  }
 
-      if (settings.runtimeMode !== thread.runtimeMode) {
-        const runtimeResult = await setThreadRuntimeMode({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "runtime-mode"),
-            threadId: queuedMessage.threadId,
-            runtimeMode: settings.runtimeMode,
-            createdAt: queuedMessage.createdAt,
-          },
-        });
-        if (AsyncResult.isFailure(runtimeResult)) {
-          reportFailure(runtimeResult, "settings-sync");
-          return false;
-        }
-      }
-
-      if (settings.interactionMode !== thread.interactionMode) {
-        const interactionResult = await setThreadInteractionMode({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "interaction-mode"),
-            threadId: queuedMessage.threadId,
-            interactionMode: settings.interactionMode,
-            createdAt: queuedMessage.createdAt,
-          },
-        });
-        if (AsyncResult.isFailure(interactionResult)) {
-          reportFailure(interactionResult, "settings-sync");
-          return false;
-        }
-      }
-
-      const deliveryResult = await startTurn({
+  return completeDelivery(
+    await runAtomCommand(
+      registry,
+      threadEnvironment.startTurn,
+      {
         environmentId: queuedMessage.environmentId,
         input: {
           commandId: queuedMessage.commandId,
@@ -233,203 +228,328 @@ export function useThreadOutboxDrain(): void {
           interactionMode: settings.interactionMode,
           createdAt: queuedMessage.createdAt,
         },
-      });
-      return completeDelivery(deliveryResult);
-    },
-    [
-      makeDeliveryHelpers,
-      setThreadInteractionMode,
-      setThreadRuntimeMode,
-      startTurn,
-      updateThreadMetadata,
-    ],
+      },
+      { reportFailure: false },
+    ),
   );
+}
 
-  const sendQueuedCreation = useCallback(
-    async (
-      queuedMessage: QueuedThreadMessage,
-      creation: QueuedThreadCreation,
-      projectCwd: string,
-    ) => {
-      const modelSelection = queuedMessage.modelSelection;
-      if (modelSelection === undefined) {
-        return false;
-      }
-      const { completeDelivery } = makeDeliveryHelpers(queuedMessage);
-      const deliveryResult = await startTurn({
-        environmentId: queuedMessage.environmentId,
-        input: buildProjectThreadStartTurnInput({
-          projectId: creation.projectId,
-          projectCwd,
-          threadId: queuedMessage.threadId,
-          commandId: queuedMessage.commandId,
-          messageId: queuedMessage.messageId,
-          createdAt: queuedMessage.createdAt,
-          text: queuedMessage.text.trim(),
-          attachments: queuedMessage.attachments,
-          modelSelection,
-          runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
-          interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
-          workspaceMode: creation.workspaceMode,
-          branch: creation.branch,
-          worktreePath: creation.worktreePath,
-          startFromOrigin: creation.startFromOrigin ?? false,
-          worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
-        }),
-      });
-      return completeDelivery(deliveryResult);
+async function sendQueuedCreation(
+  registry: AtomRegistry.AtomRegistry,
+  queuedMessage: QueuedThreadMessage,
+  creation: QueuedThreadCreation,
+  projectCwd: string,
+): Promise<boolean> {
+  const modelSelection = queuedMessage.modelSelection;
+  if (modelSelection === undefined) {
+    return false;
+  }
+  const { completeDelivery } = makeDeliveryHelpers(queuedMessage);
+  const deliveryResult = await runAtomCommand(
+    registry,
+    threadEnvironment.startTurn,
+    {
+      environmentId: queuedMessage.environmentId,
+      input: buildProjectThreadStartTurnInput({
+        projectId: creation.projectId,
+        projectCwd,
+        threadId: queuedMessage.threadId,
+        commandId: queuedMessage.commandId,
+        messageId: queuedMessage.messageId,
+        createdAt: queuedMessage.createdAt,
+        text: queuedMessage.text.trim(),
+        attachments: queuedMessage.attachments,
+        modelSelection,
+        runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+        interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
+        workspaceMode: creation.workspaceMode,
+        branch: creation.branch,
+        worktreePath: creation.worktreePath,
+        startFromOrigin: creation.startFromOrigin ?? false,
+        worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
+      }),
     },
-    [makeDeliveryHelpers, startTurn],
+    { reportFailure: false },
   );
+  return completeDelivery(deliveryResult);
+}
 
-  useEffect(() => {
-    if (dispatchingQueuedMessageId !== null) {
-      return;
+function requestDrain(state: ThreadOutboxDrainState): void {
+  if (state.stopped || state.drainScheduled) {
+    return;
+  }
+  state.drainScheduled = true;
+  queueMicrotask(() => {
+    state.drainScheduled = false;
+    drainOnce(state);
+  });
+}
+
+function clearRetry(state: ThreadOutboxDrainState, messageId: MessageId): void {
+  state.retryAttempt.delete(messageId);
+  state.retryNotBefore.delete(messageId);
+  const timer = state.retryTimers.get(messageId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    state.retryTimers.delete(messageId);
+  }
+}
+
+function scheduleRetry(state: ThreadOutboxDrainState, messageId: MessageId): void {
+  // An in-flight delivery can settle after the final owner releases. Do not
+  // recreate timers that stopDrain already cleared while nobody owns the
+  // dispatcher; a later owner will perform a fresh drain immediately.
+  if (state.stopped) {
+    return;
+  }
+  const retryAttempt = (state.retryAttempt.get(messageId) ?? 0) + 1;
+  state.retryAttempt.set(messageId, retryAttempt);
+  const retryDelayMs = threadOutboxRetryDelayMs(retryAttempt);
+  state.retryNotBefore.set(messageId, Date.now() + retryDelayMs);
+  const pendingTimer = state.retryTimers.get(messageId);
+  if (pendingTimer !== undefined) {
+    clearTimeout(pendingTimer);
+  }
+  const timer = setTimeout(() => {
+    state.retryTimers.delete(messageId);
+    requestDrain(state);
+  }, retryDelayMs);
+  state.retryTimers.set(messageId, timer);
+}
+
+function drainOnce(state: ThreadOutboxDrainState): void {
+  if (
+    state.stopped ||
+    state.activeDelivery !== null ||
+    state.registry.get(dispatchingQueuedMessageIdAtom) !== null
+  ) {
+    return;
+  }
+
+  const queuedMessagesByThreadKey = state.registry.get(
+    threadOutboxManager.queuedMessagesByThreadKeyAtom,
+  );
+  const editingQueuedMessageIds = state.registry.get(editingQueuedMessageIdsAtom);
+  const shellStatuses = state.registry.get(threadOutboxShellStatusesAtom);
+  const threads = state.registry.get(environmentThreadShells.threadShellsAtom);
+  const projects = state.registry.get(environmentProjects.projectsAtom);
+  const presentations = state.registry.get(environmentPresentations.presentationsAtom);
+
+  for (const [threadKey, queuedMessages] of Object.entries(queuedMessagesByThreadKey)) {
+    const nextQueuedMessage = queuedMessages[0];
+    if (!nextQueuedMessage || editingQueuedMessageIds[nextQueuedMessage.messageId]) {
+      continue;
+    }
+    if ((state.retryNotBefore.get(nextQueuedMessage.messageId) ?? 0) > Date.now()) {
+      continue;
     }
 
-    for (const [threadKey, queuedMessages] of Object.entries(queuedMessagesByThreadKey)) {
-      const nextQueuedMessage = queuedMessages[0];
-      if (!nextQueuedMessage) {
-        continue;
-      }
-      if (editingQueuedMessageIds[nextQueuedMessage.messageId]) {
-        continue;
-      }
-      if ((retryNotBeforeRef.current.get(nextQueuedMessage.messageId) ?? 0) > Date.now()) {
-        continue;
-      }
+    const thread = findThread(threads, nextQueuedMessage);
+    if (thread && scopedThreadKey(thread.environmentId, thread.id) !== threadKey) {
+      continue;
+    }
+    const creation = nextQueuedMessage.creation;
+    const shellStatus = shellStatuses.get(nextQueuedMessage.environmentId) ?? "empty";
+    const deliveryAction = resolveThreadOutboxDeliveryAction({
+      isCreation: creation !== undefined,
+      threadExists: thread !== undefined,
+      shellStatus,
+      environmentConnected:
+        presentations.get(nextQueuedMessage.environmentId)?.connection.phase === "connected",
+      threadBusy: thread?.session?.status === "running" || thread?.session?.status === "starting",
+    });
+    if (deliveryAction === "wait") {
+      continue;
+    }
 
-      const thread = findThread(threads, nextQueuedMessage);
-      if (thread && scopedThreadKey(thread.environmentId, thread.id) !== threadKey) {
+    // Prefer the live project shell, but retain the enqueue-time path so a
+    // pending task remains deliverable while its project shell is unloaded.
+    const creationProjectCwd =
+      creation !== undefined
+        ? (findCreationProject(projects, nextQueuedMessage)?.workspaceRoot ??
+          creation.projectCwd ??
+          null)
+        : null;
+    if (deliveryAction === "send" && creation !== undefined) {
+      // Incomplete worktree drafts remain queued until editing finishes.
+      if (!isQueuedThreadCreationSendable(nextQueuedMessage)) {
         continue;
       }
+      if (creationProjectCwd === null && shellStatus !== "live") {
+        continue;
+      }
+    }
 
-      const creation = nextQueuedMessage.creation;
-      const environment = connectedEnvironments.find(
-        (candidate) => candidate.environmentId === nextQueuedMessage.environmentId,
+    state.registry.set(dispatchingQueuedMessageIdAtom, nextQueuedMessage.messageId);
+    const removeQueuedMessage = (warning: string) =>
+      removeThreadOutboxMessage(nextQueuedMessage).then(
+        () => true,
+        (error) => {
+          console.warn(warning, {
+            environmentId: nextQueuedMessage.environmentId,
+            threadId: nextQueuedMessage.threadId,
+            messageId: nextQueuedMessage.messageId,
+            error,
+          });
+          return false;
+        },
       );
-      const shellStatus = shellStatuses.get(nextQueuedMessage.environmentId) ?? "empty";
-      const deliveryAction = resolveThreadOutboxDeliveryAction({
-        isCreation: creation !== undefined,
-        threadExists: thread !== undefined,
-        shellStatus,
-        environmentConnected: environment?.connectionState === "connected",
-        threadBusy: thread?.session?.status === "running" || thread?.session?.status === "starting",
-      });
-      if (deliveryAction === "wait") {
-        continue;
-      }
-      // The live project shell is preferred for the workspace path, with the
-      // snapshot taken at enqueue time as the fallback so a task never dies
-      // just because its project shell is not loaded.
-      const creationProjectCwd =
-        creation !== undefined
-          ? (findCreationProject(projects, nextQueuedMessage)?.workspaceRoot ??
-            creation.projectCwd ??
-            null)
-          : null;
-      // An incomplete pending task (e.g. worktree mode without a branch) stays
-      // queued until the user finishes it in the editor.
-      if (deliveryAction === "send" && creation !== undefined) {
-        if (!isQueuedThreadCreationSendable(nextQueuedMessage)) {
-          continue;
-        }
-        if (creationProjectCwd === null && shellStatus !== "live") {
-          continue;
-        }
-      }
 
-      beginDispatchingQueuedMessage(nextQueuedMessage.messageId);
-      const removeQueuedMessage = (warning: string) =>
-        removeThreadOutboxMessage(nextQueuedMessage).then(
-          () => true,
-          (error) => {
-            console.warn(warning, {
-              environmentId: nextQueuedMessage.environmentId,
-              threadId: nextQueuedMessage.threadId,
-              messageId: nextQueuedMessage.messageId,
-              error,
-            });
-            return false;
-          },
-        );
-      // Enqueues publish optimistically before their durable write settles.
-      // Confirm the write landed (and the message wasn't rolled back) before
-      // sending, so a failed write can never chase an already-delivered turn.
-      const delivery = confirmThreadOutboxMessageQueued(nextQueuedMessage).then((queued) => {
-        if (!queued) {
-          // Rolled back by a failed write; nothing to deliver or retry.
-          return true;
-        }
-        // The guards evaluated before the confirmation await are stale by now:
-        // the thread may have gone busy, or the user may have opened this
-        // message in the editor. Re-read both and defer to the next drain pass
-        // (returning true skips the failure/backoff path) rather than sending
-        // a payload the user is editing or racing an active turn.
-        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]) {
-          return true;
-        }
-        const freshThread = findThread(
-          appAtomRegistry.get(environmentThreadShells.threadShellsAtom),
-          nextQueuedMessage,
-        );
-        const freshThreadBusy =
-          freshThread?.session?.status === "running" || freshThread?.session?.status === "starting";
-        if (deliveryAction === "send" && creation === undefined && freshThreadBusy) {
-          return true;
-        }
-        return deliveryAction === "remove"
-          ? removeQueuedMessage("[thread-outbox] failed to remove message for a missing thread")
-          : creation !== undefined
-            ? creationProjectCwd !== null
-              ? sendQueuedCreation(nextQueuedMessage, creation, creationProjectCwd)
-              : removeQueuedMessage("[thread-outbox] dropped pending task for a missing project")
-            : thread !== undefined
-              ? sendQueuedMessage(nextQueuedMessage, thread)
-              : Promise.resolve(false);
-      });
-      void delivery
-        .then((sent) => {
-          if (sent) {
-            retryAttemptRef.current.delete(nextQueuedMessage.messageId);
-            retryNotBeforeRef.current.delete(nextQueuedMessage.messageId);
-            const pendingTimer = retryTimersRef.current.get(nextQueuedMessage.messageId);
-            if (pendingTimer !== undefined) {
-              clearTimeout(pendingTimer);
-              retryTimersRef.current.delete(nextQueuedMessage.messageId);
-            }
-            return;
-          }
+    // Enqueue publishes optimistically before its durable write settles.
+    // Confirm persistence before dispatch so a rolled-back write cannot send.
+    const delivery = confirmThreadOutboxMessageQueued(nextQueuedMessage).then((queued) => {
+      if (!queued) {
+        return true;
+      }
+      // These guards may have changed while persistence was settling. Re-read
+      // them before sending and let the next atom change restart the drain.
+      if (state.registry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]) {
+        return true;
+      }
+      const freshThread = findThread(
+        state.registry.get(environmentThreadShells.threadShellsAtom),
+        nextQueuedMessage,
+      );
+      const freshThreadBusy =
+        freshThread?.session?.status === "running" || freshThread?.session?.status === "starting";
+      if (deliveryAction === "send" && creation === undefined && freshThreadBusy) {
+        return true;
+      }
+      return deliveryAction === "remove"
+        ? removeQueuedMessage("[thread-outbox] failed to remove message for a missing thread")
+        : creation !== undefined
+          ? creationProjectCwd !== null
+            ? sendQueuedCreation(state.registry, nextQueuedMessage, creation, creationProjectCwd)
+            : removeQueuedMessage("[thread-outbox] dropped pending task for a missing project")
+          : thread !== undefined
+            ? sendQueuedMessage(state.registry, nextQueuedMessage, thread)
+            : Promise.resolve(false);
+    });
 
-          const retryAttempt = (retryAttemptRef.current.get(nextQueuedMessage.messageId) ?? 0) + 1;
-          retryAttemptRef.current.set(nextQueuedMessage.messageId, retryAttempt);
-          const retryDelayMs = threadOutboxRetryDelayMs(retryAttempt);
-          retryNotBeforeRef.current.set(nextQueuedMessage.messageId, Date.now() + retryDelayMs);
-          const pendingTimer = retryTimersRef.current.get(nextQueuedMessage.messageId);
-          if (pendingTimer !== undefined) {
-            clearTimeout(pendingTimer);
-          }
-          const retryTimer = setTimeout(() => {
-            retryTimersRef.current.delete(nextQueuedMessage.messageId);
-            setRetryTick((current) => current + 1);
-          }, retryDelayMs);
-          retryTimersRef.current.set(nextQueuedMessage.messageId, retryTimer);
-        })
-        .finally(() => {
-          finishDispatchingQueuedMessage(nextQueuedMessage.messageId);
+    const completion = delivery
+      .then((sent) => {
+        if (sent) {
+          clearRetry(state, nextQueuedMessage.messageId);
+        } else {
+          scheduleRetry(state, nextQueuedMessage.messageId);
+        }
+      })
+      .catch((error) => {
+        console.warn("[thread-outbox] queued message drain failed", {
+          environmentId: nextQueuedMessage.environmentId,
+          threadId: nextQueuedMessage.threadId,
+          messageId: nextQueuedMessage.messageId,
+          error,
         });
+        scheduleRetry(state, nextQueuedMessage.messageId);
+      })
+      .finally(() => {
+        if (state.registry.get(dispatchingQueuedMessageIdAtom) === nextQueuedMessage.messageId) {
+          state.registry.set(dispatchingQueuedMessageIdAtom, null);
+        }
+        state.activeDelivery = null;
+        requestDrain(state);
+      });
+    state.activeDelivery = completion;
+    return;
+  }
+}
+
+function startDrain(state: ThreadOutboxDrainState): void {
+  if (!state.stopped) {
+    return;
+  }
+  state.stopped = false;
+  try {
+    ensureThreadOutboxLoaded();
+    const request = () => requestDrain(state);
+    // Store each release as it is acquired so a later subscription failure can
+    // still unwind every subscription that was already installed.
+    state.releases.push(
+      state.registry.subscribe(threadOutboxManager.queuedMessagesByThreadKeyAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(editingQueuedMessageIdsAtom, request));
+    state.releases.push(state.registry.subscribe(threadOutboxShellStatusesAtom, request));
+    state.releases.push(
+      state.registry.subscribe(environmentThreadShells.threadShellsAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(environmentProjects.projectsAtom, request));
+    state.releases.push(
+      state.registry.subscribe(environmentPresentations.presentationsAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(dispatchingQueuedMessageIdAtom, request));
+    requestDrain(state);
+  } catch (error) {
+    stopDrain(state);
+    throw error;
+  }
+}
+
+function stopDrain(state: ThreadOutboxDrainState): void {
+  if (state.stopped) {
+    return;
+  }
+  state.stopped = true;
+  for (const release of state.releases.splice(0)) {
+    try {
+      release();
+    } catch (error) {
+      console.warn("[thread-outbox] failed to release drain subscription", error);
+    }
+  }
+  for (const timer of state.retryTimers.values()) {
+    clearTimeout(timer);
+  }
+  state.retryTimers.clear();
+  state.retryAttempt.clear();
+  state.retryNotBefore.clear();
+}
+
+/**
+ * Acquires the one process-wide outbox dispatcher for a registry. UI and
+ * Headless JS owners share this lease, so mounting both cannot double-send.
+ */
+export function acquireThreadOutboxDrain(registry: AtomRegistry.AtomRegistry): () => void {
+  let state = drainStates.get(registry);
+  if (state === undefined) {
+    state = {
+      registry,
+      owners: 0,
+      stopped: true,
+      drainScheduled: false,
+      activeDelivery: null,
+      retryAttempt: new Map(),
+      retryNotBefore: new Map(),
+      retryTimers: new Map(),
+      releases: [],
+    };
+    drainStates.set(registry, state);
+  }
+  state.owners += 1;
+  try {
+    startDrain(state);
+  } catch (error) {
+    state.owners -= 1;
+    if (state.owners === 0) {
+      drainStates.delete(registry);
+    }
+    throw error;
+  }
+
+  let released = false;
+  return () => {
+    if (released) {
       return;
     }
-  }, [
-    connectedEnvironments,
-    dispatchingQueuedMessageId,
-    editingQueuedMessageIds,
-    projects,
-    queuedMessagesByThreadKey,
-    retryTick,
-    sendQueuedCreation,
-    sendQueuedMessage,
-    shellStatuses,
-    threads,
-  ]);
+    released = true;
+    state.owners -= 1;
+    if (state.owners === 0) {
+      stopDrain(state);
+    }
+  };
+}
+
+export function useThreadOutboxDrain(): void {
+  const registry = useContext(RegistryContext);
+  useEffect(() => acquireThreadOutboxDrain(registry), [registry]);
 }

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -1,9 +1,9 @@
-import { useAtomValue } from "@effect/atom-react";
+import { RegistryContext } from "@effect/atom-react";
 import type {
   EnvironmentProject,
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
-import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import { type AtomCommandResult, runAtomCommand } from "@t3tools/client-runtime/state/runtime";
 import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -13,15 +13,17 @@ import {
 } from "@t3tools/contracts";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import * as Cause from "effect/Cause";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { AsyncResult, Atom, type AtomRegistry } from "effect/unstable/reactivity";
+import { useContext, useEffect } from "react";
 
 import { scopedProjectKey, scopedThreadKey } from "../lib/scopedEntities";
 import { buildProjectThreadStartTurnInput } from "../lib/projectThreadStartTurn";
 import { prepareTurnAttachments, type PreparedTurnAttachments } from "../lib/attachmentUpload";
 import { randomHex } from "../lib/uuid";
 import { appAtomRegistry } from "./atom-registry";
-import { useProjects, useServerConfigs, useThreadShells } from "./entities";
+import { environmentPresentations } from "./presentation";
+import { environmentProjects } from "./projects";
+import { environmentServerConfigsAtom } from "./server";
 import {
   confirmThreadOutboxMessageQueued,
   ensureThreadOutboxLoaded,
@@ -57,30 +59,13 @@ import {
   updateComposerDraftSettings,
   waitForComposerDraftsLoaded,
 } from "./use-composer-drafts";
-import { useAtomCommand } from "./use-atom-command";
-import {
-  editingQueuedMessageIdsAtom,
-  useThreadOutboxMessages,
-  useThreadOutboxShellStatuses,
-} from "./use-thread-outbox";
-import {
-  setPendingConnectionError,
-  useRemoteConnectionStatus,
-} from "./use-remote-environment-registry";
+import { editingQueuedMessageIdsAtom, threadOutboxShellStatusesAtom } from "./use-thread-outbox";
+import { setPendingConnectionError } from "./use-remote-environment-registry";
 
 export const dispatchingQueuedMessageIdAtom = Atom.make<MessageId | null>(null).pipe(
   Atom.keepAlive,
   Atom.withLabel("mobile:thread-outbox:dispatching-message-id"),
 );
-
-function beginDispatchingQueuedMessage(queuedMessageId: MessageId): void {
-  appAtomRegistry.set(dispatchingQueuedMessageIdAtom, queuedMessageId);
-}
-
-function finishDispatchingQueuedMessage(queuedMessageId: MessageId): void {
-  const current = appAtomRegistry.get(dispatchingQueuedMessageIdAtom);
-  appAtomRegistry.set(dispatchingQueuedMessageIdAtom, current === queuedMessageId ? null : current);
-}
 
 function findThread(
   threads: ReadonlyArray<EnvironmentThreadShell>,
@@ -496,622 +481,769 @@ async function preserveUploadedAttachmentsForEditor(
   }
 }
 
-export function useThreadOutboxDrain(): void {
-  const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
-  const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
-    reportFailure: false,
-  });
-  const setThreadRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
-    reportFailure: false,
-  });
-  const setThreadInteractionMode = useAtomCommand(threadEnvironment.setInteractionMode, {
-    reportFailure: false,
-  });
-  const dispatchingQueuedMessageId = useAtomValue(dispatchingQueuedMessageIdAtom);
-  const editingQueuedMessageIds = useAtomValue(editingQueuedMessageIdsAtom);
-  const queuedMessagesByThreadKey = useThreadOutboxMessages();
-  const shellStatuses = useThreadOutboxShellStatuses();
-  const threads = useThreadShells();
-  const projects = useProjects();
-  const serverConfigs = useServerConfigs();
-  const { connectedEnvironments } = useRemoteConnectionStatus();
-  const [retryTick, setRetryTick] = useState(0);
-  const retryAttemptRef = useRef(new Map<MessageId, number>());
-  const retryNotBeforeRef = useRef(new Map<MessageId, number>());
-  const retryTimersRef = useRef(new Map<MessageId, ReturnType<typeof setTimeout>>());
-  const acknowledgedExistingThreadMessageIdsRef = useRef(new Set<MessageId>());
-  const blockedRecoverySubscriptionsRef = useRef(
-    new Map<
-      MessageId,
-      { readonly message: QueuedThreadMessage; readonly unsubscribe: () => void }
-    >(),
-  );
+interface BlockedRecoverySubscription {
+  readonly message: QueuedThreadMessage;
+  readonly unsubscribe: () => void;
+}
 
-  const scheduleQueuedMessageRetry = useCallback((messageId: MessageId) => {
-    const retryAttempt = (retryAttemptRef.current.get(messageId) ?? 0) + 1;
-    retryAttemptRef.current.set(messageId, retryAttempt);
-    const retryDelayMs = threadOutboxRetryDelayMs(retryAttempt);
-    retryNotBeforeRef.current.set(messageId, Date.now() + retryDelayMs);
-    const pendingTimer = retryTimersRef.current.get(messageId);
-    if (pendingTimer !== undefined) {
-      clearTimeout(pendingTimer);
+interface ThreadOutboxDrainState {
+  readonly registry: AtomRegistry.AtomRegistry;
+  owners: number;
+  stopped: boolean;
+  drainScheduled: boolean;
+  activeDelivery: Promise<void> | null;
+  readonly retryAttempt: Map<MessageId, number>;
+  readonly retryNotBefore: Map<MessageId, number>;
+  readonly retryTimers: Map<MessageId, ReturnType<typeof setTimeout>>;
+  /**
+   * Existing-thread sends whose startTurn was acknowledged but whose local
+   * removal has not completed. Kept across owner changes so a later owner
+   * retries only the cleanup instead of re-sending the delivered turn.
+   */
+  readonly acknowledgedExistingThreadMessageIds: Set<MessageId>;
+  readonly blockedRecoverySubscriptions: Map<MessageId, BlockedRecoverySubscription>;
+  readonly releases: Array<() => void>;
+}
+
+const drainStates = new WeakMap<AtomRegistry.AtomRegistry, ThreadOutboxDrainState>();
+
+function requestDrain(state: ThreadOutboxDrainState): void {
+  if (state.stopped || state.drainScheduled) {
+    return;
+  }
+  state.drainScheduled = true;
+  queueMicrotask(() => {
+    state.drainScheduled = false;
+    drainOnce(state);
+  });
+}
+
+function clearRetry(state: ThreadOutboxDrainState, messageId: MessageId): void {
+  state.retryAttempt.delete(messageId);
+  state.retryNotBefore.delete(messageId);
+  const timer = state.retryTimers.get(messageId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    state.retryTimers.delete(messageId);
+  }
+}
+
+function scheduleRetry(state: ThreadOutboxDrainState, messageId: MessageId): void {
+  // An in-flight delivery can settle after the final owner releases. Do not
+  // recreate timers that stopDrain already cleared while nobody owns the
+  // dispatcher; a later owner will perform a fresh drain immediately.
+  if (state.stopped) {
+    return;
+  }
+  const retryAttempt = (state.retryAttempt.get(messageId) ?? 0) + 1;
+  state.retryAttempt.set(messageId, retryAttempt);
+  const retryDelayMs = threadOutboxRetryDelayMs(retryAttempt);
+  state.retryNotBefore.set(messageId, Date.now() + retryDelayMs);
+  const pendingTimer = state.retryTimers.get(messageId);
+  if (pendingTimer !== undefined) {
+    clearTimeout(pendingTimer);
+  }
+  const timer = setTimeout(() => {
+    state.retryTimers.delete(messageId);
+    requestDrain(state);
+  }, retryDelayMs);
+  state.retryTimers.set(messageId, timer);
+}
+
+function releaseBlockedRecovery(state: ThreadOutboxDrainState, messageId: MessageId): void {
+  const blocked = state.blockedRecoverySubscriptions.get(messageId);
+  if (!blocked) {
+    return;
+  }
+  state.blockedRecoverySubscriptions.delete(messageId);
+  blocked.unsubscribe();
+}
+
+function supportsImageUploads(
+  state: ThreadOutboxDrainState,
+  queuedMessage: QueuedThreadMessage,
+): boolean {
+  return (
+    state.registry.get(environmentServerConfigsAtom).get(queuedMessage.environmentId)?.environment
+      .capabilities.attachmentUploads === true
+  );
+}
+
+/**
+ * Runs one dispatch for `messageId`. The dispatching atom and `activeDelivery`
+ * keep every owner off the queue until the work settles, after which the next
+ * drain pass is requested.
+ */
+function dispatch(
+  state: ThreadOutboxDrainState,
+  messageId: MessageId,
+  work: () => Promise<void>,
+): void {
+  state.registry.set(dispatchingQueuedMessageIdAtom, messageId);
+  const completion = work()
+    .catch((error) => {
+      console.warn("[thread-outbox] queued message drain failed", { messageId, error });
+      scheduleRetry(state, messageId);
+    })
+    .finally(() => {
+      if (state.registry.get(dispatchingQueuedMessageIdAtom) === messageId) {
+        state.registry.set(dispatchingQueuedMessageIdAtom, null);
+      }
+      state.activeDelivery = null;
+      requestDrain(state);
+    });
+  state.activeDelivery = completion;
+}
+
+function makeDeliveryHelpers(queuedMessage: QueuedThreadMessage) {
+  const reportFailure = (
+    commandResult: AtomCommandResult<unknown, unknown>,
+    stage: ThreadOutboxCommandStage,
+  ): { readonly action: "retry" | "restore"; readonly message: string } | null => {
+    if (!AsyncResult.isFailure(commandResult)) {
+      return null;
     }
-    const retryTimer = setTimeout(() => {
-      retryTimersRef.current.delete(messageId);
-      setRetryTick((current) => current + 1);
-    }, retryDelayMs);
-    retryTimersRef.current.set(messageId, retryTimer);
-  }, []);
-
-  const restoreQueuedMessage = useCallback(
-    async (queuedMessage: QueuedThreadMessage, message: string): Promise<boolean> => {
-      const result = await restoreRejectedQueuedMessage(queuedMessage, message);
-      if (result !== "blocked") {
-        return result !== "retry";
-      }
-
-      if (!blockedRecoverySubscriptionsRef.current.has(queuedMessage.messageId)) {
-        const draftKey = recoveryDraftKey(queuedMessage);
-        const editorDraftKey = queuedMessage.creation
-          ? `pending-task:${queuedMessage.messageId}`
-          : null;
-        const currentDrafts = appAtomRegistry.get(composerDraftsAtom);
-        const blockedAttachments = currentDrafts[draftKey]?.attachments;
-        const editorAttachments =
-          editorDraftKey === null ? undefined : currentDrafts[editorDraftKey]?.attachments;
-        const unsubscribe = appAtomRegistry.subscribe(composerDraftsAtom, (drafts) => {
-          if (
-            drafts[draftKey]?.attachments === blockedAttachments &&
-            (editorDraftKey === null || drafts[editorDraftKey]?.attachments === editorAttachments)
-          ) {
-            return;
-          }
-          const active = blockedRecoverySubscriptionsRef.current.get(queuedMessage.messageId);
-          if (!active) {
-            return;
-          }
-          blockedRecoverySubscriptionsRef.current.delete(queuedMessage.messageId);
-          active.unsubscribe();
-          setRetryTick((current) => current + 1);
-        });
-        blockedRecoverySubscriptionsRef.current.set(queuedMessage.messageId, {
-          message: queuedMessage,
-          unsubscribe,
-        });
-      }
-      return true;
-    },
-    [],
-  );
-
-  useEffect(() => {
-    ensureThreadOutboxLoaded();
-    return () => {
-      for (const timer of retryTimersRef.current.values()) {
-        clearTimeout(timer);
-      }
-      retryTimersRef.current.clear();
-      for (const blocked of blockedRecoverySubscriptionsRef.current.values()) {
-        blocked.unsubscribe();
-      }
-      blockedRecoverySubscriptionsRef.current.clear();
+    const error = Cause.squash(commandResult.cause);
+    const action = resolveThreadOutboxFailureAction({
+      stage,
+      error,
+      interrupted: Cause.hasInterruptsOnly(commandResult.cause),
+    });
+    console.warn("[thread-outbox] queued message delivery failed", {
+      environmentId: queuedMessage.environmentId,
+      threadId: queuedMessage.threadId,
+      messageId: queuedMessage.messageId,
+      stage,
+      cause: commandResult.cause,
+      action,
+    });
+    return {
+      action,
+      message: error instanceof Error ? error.message : "The message could not be sent.",
     };
-  }, []);
+  };
+  return { reportFailure };
+}
 
-  const makeDeliveryHelpers = useCallback((queuedMessage: QueuedThreadMessage) => {
-    const reportFailure = (
-      commandResult: AtomCommandResult<unknown, unknown>,
-      stage: ThreadOutboxCommandStage,
-    ): { readonly action: "retry" | "restore"; readonly message: string } | null => {
-      if (!AsyncResult.isFailure(commandResult)) {
-        return null;
-      }
-      const error = Cause.squash(commandResult.cause);
-      const action = resolveThreadOutboxFailureAction({
-        stage,
-        error,
-        interrupted: Cause.hasInterruptsOnly(commandResult.cause),
-      });
-      console.warn("[thread-outbox] queued message delivery failed", {
-        environmentId: queuedMessage.environmentId,
-        threadId: queuedMessage.threadId,
-        messageId: queuedMessage.messageId,
-        stage,
-        cause: commandResult.cause,
-        action,
-      });
-      return {
-        action,
-        message: error instanceof Error ? error.message : "The message could not be sent.",
-      };
-    };
-    return { reportFailure };
-  }, []);
+async function restoreQueuedMessage(
+  state: ThreadOutboxDrainState,
+  queuedMessage: QueuedThreadMessage,
+  message: string,
+): Promise<boolean> {
+  const result = await restoreRejectedQueuedMessage(queuedMessage, message);
+  if (result !== "blocked") {
+    return result !== "retry";
+  }
+  if (state.stopped || state.blockedRecoverySubscriptions.has(queuedMessage.messageId)) {
+    return true;
+  }
 
-  const sendQueuedMessage = useCallback(
-    async (queuedMessage: QueuedThreadMessage, thread: EnvironmentThreadShell) => {
-      const settings = resolveQueuedThreadSettings(queuedMessage, thread);
-      const { reportFailure } = makeDeliveryHelpers(queuedMessage);
+  const draftKey = recoveryDraftKey(queuedMessage);
+  const editorDraftKey = queuedMessage.creation ? `pending-task:${queuedMessage.messageId}` : null;
+  const currentDrafts = state.registry.get(composerDraftsAtom);
+  const blockedAttachments = currentDrafts[draftKey]?.attachments;
+  const editorAttachments =
+    editorDraftKey === null ? undefined : currentDrafts[editorDraftKey]?.attachments;
+  const unsubscribe = state.registry.subscribe(composerDraftsAtom, (drafts) => {
+    if (
+      drafts[draftKey]?.attachments === blockedAttachments &&
+      (editorDraftKey === null || drafts[editorDraftKey]?.attachments === editorAttachments)
+    ) {
+      return;
+    }
+    if (!state.blockedRecoverySubscriptions.has(queuedMessage.messageId)) {
+      return;
+    }
+    releaseBlockedRecovery(state, queuedMessage.messageId);
+    requestDrain(state);
+  });
+  state.blockedRecoverySubscriptions.set(queuedMessage.messageId, {
+    message: queuedMessage,
+    unsubscribe,
+  });
+  return true;
+}
 
-      if (!modelSelectionsEqual(settings.modelSelection, thread.modelSelection)) {
-        const updateResult = await updateThreadMetadata({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "model-selection"),
-            threadId: queuedMessage.threadId,
-            modelSelection: settings.modelSelection,
-          },
-        });
-        if (AsyncResult.isFailure(updateResult)) {
-          reportFailure(updateResult, "settings-sync");
-          return false;
-        }
-      }
+async function sendQueuedMessage(
+  state: ThreadOutboxDrainState,
+  queuedMessage: QueuedThreadMessage,
+  thread: EnvironmentThreadShell,
+): Promise<boolean> {
+  const settings = resolveQueuedThreadSettings(queuedMessage, thread);
+  const { reportFailure } = makeDeliveryHelpers(queuedMessage);
 
-      if (settings.runtimeMode !== thread.runtimeMode) {
-        const runtimeResult = await setThreadRuntimeMode({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "runtime-mode"),
-            threadId: queuedMessage.threadId,
-            runtimeMode: settings.runtimeMode,
-            createdAt: queuedMessage.createdAt,
-          },
-        });
-        if (AsyncResult.isFailure(runtimeResult)) {
-          reportFailure(runtimeResult, "settings-sync");
-          return false;
-        }
-      }
-
-      if (settings.interactionMode !== thread.interactionMode) {
-        const interactionResult = await setThreadInteractionMode({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "interaction-mode"),
-            threadId: queuedMessage.threadId,
-            interactionMode: settings.interactionMode,
-            createdAt: queuedMessage.createdAt,
-          },
-        });
-        if (AsyncResult.isFailure(interactionResult)) {
-          reportFailure(interactionResult, "settings-sync");
-          return false;
-        }
-      }
-
-      let prepared: PreparedTurnAttachments;
-      let persistedMessage: QueuedThreadMessage;
-      let deliveryRevision: number;
-      try {
-        const preparedResult = await prepareQueuedMessageAttachments(
-          queuedMessage,
-          serverConfigs.get(queuedMessage.environmentId)?.environment.capabilities
-            .attachmentUploads === true,
-        );
-        if (preparedResult.status === "abandoned") {
-          return true;
-        }
-        prepared = preparedResult.prepared;
-        persistedMessage = preparedResult.persistedMessage;
-        deliveryRevision = preparedResult.deliveryRevision;
-        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]) {
-          await preserveUploadedAttachmentsForEditor(
-            queuedMessage,
-            preparedResult.persistedMessage,
-          );
-          return true;
-        }
-      } catch (error) {
-        console.warn("[thread-outbox] failed to upload attachments", error);
-        if (!shouldRetryThreadOutboxDelivery(error)) {
-          return restoreQueuedMessage(
-            queuedMessage,
-            error instanceof Error ? error.message : "An attachment could not upload.",
-          );
-        }
-        return false;
-      }
-      if (!isQueuedMessagePayloadCurrent(persistedMessage, deliveryRevision)) {
-        return true;
-      }
-      const deliveryResult = await startTurn({
+  if (!modelSelectionsEqual(settings.modelSelection, thread.modelSelection)) {
+    const updateResult = await runAtomCommand(
+      state.registry,
+      threadEnvironment.updateMetadata,
+      {
         environmentId: queuedMessage.environmentId,
         input: {
-          commandId: queuedMessage.commandId,
+          commandId: settingsCommandId(queuedMessage, "model-selection"),
           threadId: queuedMessage.threadId,
-          message: {
-            messageId: queuedMessage.messageId,
-            role: "user",
-            text: queuedMessage.text,
-            attachments: prepared.attachments,
-          },
           modelSelection: settings.modelSelection,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(updateResult)) {
+      reportFailure(updateResult, "settings-sync");
+      return false;
+    }
+  }
+
+  if (settings.runtimeMode !== thread.runtimeMode) {
+    const runtimeResult = await runAtomCommand(
+      state.registry,
+      threadEnvironment.setRuntimeMode,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "runtime-mode"),
+          threadId: queuedMessage.threadId,
           runtimeMode: settings.runtimeMode,
+          createdAt: queuedMessage.createdAt,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(runtimeResult)) {
+      reportFailure(runtimeResult, "settings-sync");
+      return false;
+    }
+  }
+
+  if (settings.interactionMode !== thread.interactionMode) {
+    const interactionResult = await runAtomCommand(
+      state.registry,
+      threadEnvironment.setInteractionMode,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "interaction-mode"),
+          threadId: queuedMessage.threadId,
           interactionMode: settings.interactionMode,
           createdAt: queuedMessage.createdAt,
         },
-      });
-      const failure = reportFailure(deliveryResult, "start-turn");
-      if (failure?.action === "retry") {
-        return false;
-      }
-      if (failure?.action === "restore") {
-        return restoreQueuedMessage(persistedMessage, failure.message);
-      }
-      acknowledgedExistingThreadMessageIdsRef.current.add(persistedMessage.messageId);
-      const delivered =
-        (await completeQueuedMessageDelivery(persistedMessage, deliveryRevision)) === "removed";
-      if (delivered) {
-        acknowledgedExistingThreadMessageIdsRef.current.delete(persistedMessage.messageId);
-        // The delivered turn holds its own copy of the bytes. A failed delete
-        // is surfaced (never fails the delivered turn); the server also
-        // expires leaked pending uploads.
-        await prepared.releaseUploads().catch((error) => {
-          console.warn("[thread-outbox] could not delete consumed pending uploads", error);
-        });
-      }
-      return delivered;
-    },
-    [
-      makeDeliveryHelpers,
-      setThreadInteractionMode,
-      setThreadRuntimeMode,
-      startTurn,
-      updateThreadMetadata,
-      restoreQueuedMessage,
-      serverConfigs,
-    ],
-  );
-
-  const sendQueuedCreation = useCallback(
-    async (
-      queuedMessage: QueuedThreadMessage,
-      creation: QueuedThreadCreation,
-      projectCwd: string,
-    ) => {
-      const modelSelection = queuedMessage.modelSelection;
-      if (modelSelection === undefined) {
-        return false;
-      }
-      let prepared: PreparedTurnAttachments;
-      let persistedMessage: QueuedThreadMessage;
-      let deliveryRevision: number;
-      try {
-        const preparedResult = await prepareQueuedMessageAttachments(
-          queuedMessage,
-          serverConfigs.get(queuedMessage.environmentId)?.environment.capabilities
-            .attachmentUploads === true,
-        );
-        if (preparedResult.status === "abandoned") {
-          return true;
-        }
-        prepared = preparedResult.prepared;
-        persistedMessage = preparedResult.persistedMessage;
-        deliveryRevision = preparedResult.deliveryRevision;
-        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]) {
-          await preserveUploadedAttachmentsForEditor(
-            queuedMessage,
-            preparedResult.persistedMessage,
-          );
-          return true;
-        }
-      } catch (error) {
-        console.warn("[thread-outbox] failed to upload attachments", error);
-        if (!shouldRetryThreadOutboxDelivery(error)) {
-          return restoreQueuedMessage(
-            queuedMessage,
-            error instanceof Error ? error.message : "An attachment could not upload.",
-          );
-        }
-        return false;
-      }
-      if (!isQueuedMessagePayloadCurrent(persistedMessage, deliveryRevision)) {
-        return true;
-      }
-      const deliveryResult = await startTurn({
-        environmentId: queuedMessage.environmentId,
-        input: buildProjectThreadStartTurnInput({
-          projectId: creation.projectId,
-          projectCwd,
-          threadId: queuedMessage.threadId,
-          commandId: queuedMessage.commandId,
-          messageId: queuedMessage.messageId,
-          createdAt: queuedMessage.createdAt,
-          text: queuedMessage.text.trim(),
-          attachments: queuedMessage.attachments,
-          uploadedAttachments: prepared.attachments,
-          modelSelection,
-          runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
-          interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
-          workspaceMode: creation.workspaceMode,
-          branch: creation.branch,
-          worktreePath: creation.worktreePath,
-          startFromOrigin: creation.startFromOrigin ?? false,
-          worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
-        }),
-      });
-      const { reportFailure } = makeDeliveryHelpers(queuedMessage);
-      const failure = reportFailure(deliveryResult, "start-turn");
-      if (failure?.action === "retry") {
-        return false;
-      }
-      if (failure?.action === "restore") {
-        return restoreQueuedMessage(persistedMessage, failure.message);
-      }
-      const outcome = await completeQueuedMessageDelivery(persistedMessage, deliveryRevision);
-      if (outcome === "edited") {
-        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]) {
-          // The editor holds the entry with unsaved edits; merging the queue
-          // payload now would duplicate the delivered turn. Once the editor
-          // saves, the duplicate-creation removal below recovers the edits.
-          return true;
-        }
-        // The thread exists now, so the next drain would remove the edited
-        // payload as a duplicate creation. Hand it to the thread's composer.
-        return recoverEditedCreationAfterDelivery(persistedMessage);
-      }
-      if (outcome === "removed") {
-        await prepared.releaseUploads().catch((error) => {
-          console.warn("[thread-outbox] could not delete consumed pending uploads", error);
-        });
-        return true;
-      }
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(interactionResult)) {
+      reportFailure(interactionResult, "settings-sync");
       return false;
-    },
-    [makeDeliveryHelpers, restoreQueuedMessage, serverConfigs, startTurn],
-  );
+    }
+  }
 
-  useEffect(() => {
-    if (dispatchingQueuedMessageId !== null) {
+  let prepared: PreparedTurnAttachments;
+  let persistedMessage: QueuedThreadMessage;
+  let deliveryRevision: number;
+  try {
+    const preparedResult = await prepareQueuedMessageAttachments(
+      queuedMessage,
+      supportsImageUploads(state, queuedMessage),
+    );
+    if (preparedResult.status === "abandoned") {
+      return true;
+    }
+    prepared = preparedResult.prepared;
+    persistedMessage = preparedResult.persistedMessage;
+    deliveryRevision = preparedResult.deliveryRevision;
+    if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]) {
+      await preserveUploadedAttachmentsForEditor(queuedMessage, preparedResult.persistedMessage);
+      return true;
+    }
+  } catch (error) {
+    console.warn("[thread-outbox] failed to upload attachments", error);
+    if (!shouldRetryThreadOutboxDelivery(error)) {
+      return restoreQueuedMessage(
+        state,
+        queuedMessage,
+        error instanceof Error ? error.message : "An attachment could not upload.",
+      );
+    }
+    return false;
+  }
+  if (!isQueuedMessagePayloadCurrent(persistedMessage, deliveryRevision)) {
+    return true;
+  }
+  const deliveryResult = await runAtomCommand(
+    state.registry,
+    threadEnvironment.startTurn,
+    {
+      environmentId: queuedMessage.environmentId,
+      input: {
+        commandId: queuedMessage.commandId,
+        threadId: queuedMessage.threadId,
+        message: {
+          messageId: queuedMessage.messageId,
+          role: "user",
+          text: queuedMessage.text,
+          attachments: prepared.attachments,
+        },
+        modelSelection: settings.modelSelection,
+        runtimeMode: settings.runtimeMode,
+        interactionMode: settings.interactionMode,
+        createdAt: queuedMessage.createdAt,
+      },
+    },
+    { reportFailure: false },
+  );
+  const failure = reportFailure(deliveryResult, "start-turn");
+  if (failure?.action === "retry") {
+    return false;
+  }
+  if (failure?.action === "restore") {
+    return restoreQueuedMessage(state, persistedMessage, failure.message);
+  }
+  state.acknowledgedExistingThreadMessageIds.add(persistedMessage.messageId);
+  const delivered =
+    (await completeQueuedMessageDelivery(persistedMessage, deliveryRevision)) === "removed";
+  if (delivered) {
+    state.acknowledgedExistingThreadMessageIds.delete(persistedMessage.messageId);
+    // The delivered turn holds its own copy of the bytes. A failed delete
+    // is surfaced (never fails the delivered turn); the server also
+    // expires leaked pending uploads.
+    await prepared.releaseUploads().catch((error) => {
+      console.warn("[thread-outbox] could not delete consumed pending uploads", error);
+    });
+  }
+  return delivered;
+}
+
+async function sendQueuedCreation(
+  state: ThreadOutboxDrainState,
+  queuedMessage: QueuedThreadMessage,
+  creation: QueuedThreadCreation,
+  projectCwd: string,
+): Promise<boolean> {
+  const modelSelection = queuedMessage.modelSelection;
+  if (modelSelection === undefined) {
+    return false;
+  }
+  let prepared: PreparedTurnAttachments;
+  let persistedMessage: QueuedThreadMessage;
+  let deliveryRevision: number;
+  try {
+    const preparedResult = await prepareQueuedMessageAttachments(
+      queuedMessage,
+      supportsImageUploads(state, queuedMessage),
+    );
+    if (preparedResult.status === "abandoned") {
+      return true;
+    }
+    prepared = preparedResult.prepared;
+    persistedMessage = preparedResult.persistedMessage;
+    deliveryRevision = preparedResult.deliveryRevision;
+    if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]) {
+      await preserveUploadedAttachmentsForEditor(queuedMessage, preparedResult.persistedMessage);
+      return true;
+    }
+  } catch (error) {
+    console.warn("[thread-outbox] failed to upload attachments", error);
+    if (!shouldRetryThreadOutboxDelivery(error)) {
+      return restoreQueuedMessage(
+        state,
+        queuedMessage,
+        error instanceof Error ? error.message : "An attachment could not upload.",
+      );
+    }
+    return false;
+  }
+  if (!isQueuedMessagePayloadCurrent(persistedMessage, deliveryRevision)) {
+    return true;
+  }
+  const deliveryResult = await runAtomCommand(
+    state.registry,
+    threadEnvironment.startTurn,
+    {
+      environmentId: queuedMessage.environmentId,
+      input: buildProjectThreadStartTurnInput({
+        projectId: creation.projectId,
+        projectCwd,
+        threadId: queuedMessage.threadId,
+        commandId: queuedMessage.commandId,
+        messageId: queuedMessage.messageId,
+        createdAt: queuedMessage.createdAt,
+        text: queuedMessage.text.trim(),
+        attachments: queuedMessage.attachments,
+        uploadedAttachments: prepared.attachments,
+        modelSelection,
+        runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+        interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
+        workspaceMode: creation.workspaceMode,
+        branch: creation.branch,
+        worktreePath: creation.worktreePath,
+        startFromOrigin: creation.startFromOrigin ?? false,
+        worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
+      }),
+    },
+    { reportFailure: false },
+  );
+  const { reportFailure } = makeDeliveryHelpers(queuedMessage);
+  const failure = reportFailure(deliveryResult, "start-turn");
+  if (failure?.action === "retry") {
+    return false;
+  }
+  if (failure?.action === "restore") {
+    return restoreQueuedMessage(state, persistedMessage, failure.message);
+  }
+  const outcome = await completeQueuedMessageDelivery(persistedMessage, deliveryRevision);
+  if (outcome === "edited") {
+    if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]) {
+      // The editor holds the entry with unsaved edits; merging the queue
+      // payload now would duplicate the delivered turn. Once the editor
+      // saves, the duplicate-creation removal below recovers the edits.
+      return true;
+    }
+    // The thread exists now, so the next drain would remove the edited
+    // payload as a duplicate creation. Hand it to the thread's composer.
+    return recoverEditedCreationAfterDelivery(persistedMessage);
+  }
+  if (outcome === "removed") {
+    await prepared.releaseUploads().catch((error) => {
+      console.warn("[thread-outbox] could not delete consumed pending uploads", error);
+    });
+    return true;
+  }
+  return false;
+}
+
+function drainOnce(state: ThreadOutboxDrainState): void {
+  if (
+    state.stopped ||
+    state.activeDelivery !== null ||
+    state.registry.get(dispatchingQueuedMessageIdAtom) !== null
+  ) {
+    return;
+  }
+
+  const registry = state.registry;
+  const queuedMessagesByThreadKey = registry.get(threadOutboxManager.queuedMessagesByThreadKeyAtom);
+  const editingQueuedMessageIds = registry.get(editingQueuedMessageIdsAtom);
+  const shellStatuses = registry.get(threadOutboxShellStatusesAtom);
+  const threads = registry.get(environmentThreadShells.threadShellsAtom);
+  const projects = registry.get(environmentProjects.projectsAtom);
+  const serverConfigs = registry.get(environmentServerConfigsAtom);
+  const presentations = registry.get(environmentPresentations.presentationsAtom);
+
+  const queuedMessageIds = new Set(
+    Object.values(queuedMessagesByThreadKey)
+      .flat()
+      .map((message) => message.messageId),
+  );
+  for (const messageId of state.acknowledgedExistingThreadMessageIds) {
+    if (!queuedMessageIds.has(messageId)) {
+      state.acknowledgedExistingThreadMessageIds.delete(messageId);
+    }
+  }
+
+  for (const [threadKey, queuedMessages] of Object.entries(queuedMessagesByThreadKey)) {
+    const nextQueuedMessage = queuedMessages[0];
+    if (!nextQueuedMessage) {
+      continue;
+    }
+    const messageId = nextQueuedMessage.messageId;
+    if (
+      nextQueuedMessage.creation === undefined &&
+      state.acknowledgedExistingThreadMessageIds.has(messageId)
+    ) {
+      if ((state.retryNotBefore.get(messageId) ?? 0) > Date.now()) {
+        continue;
+      }
+      dispatch(state, messageId, async () => {
+        const removed = await removeAcknowledgedExistingThreadMessage(
+          nextQueuedMessage,
+          state.acknowledgedExistingThreadMessageIds,
+        );
+        if (removed) {
+          clearRetry(state, messageId);
+        } else {
+          scheduleRetry(state, messageId);
+        }
+      });
       return;
     }
+    if (editingQueuedMessageIds[messageId]) {
+      continue;
+    }
+    const blockedRecovery = state.blockedRecoverySubscriptions.get(messageId);
+    if (blockedRecovery) {
+      if (blockedRecovery.message === nextQueuedMessage) {
+        continue;
+      }
+      releaseBlockedRecovery(state, messageId);
+    }
+    if ((state.retryNotBefore.get(messageId) ?? 0) > Date.now()) {
+      continue;
+    }
 
-    const queuedMessageIds = new Set(
-      Object.values(queuedMessagesByThreadKey)
-        .flat()
-        .map((message) => message.messageId),
-    );
-    for (const messageId of acknowledgedExistingThreadMessageIdsRef.current) {
-      if (!queuedMessageIds.has(messageId)) {
-        acknowledgedExistingThreadMessageIdsRef.current.delete(messageId);
+    const thread = findThread(threads, nextQueuedMessage);
+    if (thread && scopedThreadKey(thread.environmentId, thread.id) !== threadKey) {
+      continue;
+    }
+
+    const creation = nextQueuedMessage.creation;
+    const environmentConnected =
+      presentations.get(nextQueuedMessage.environmentId)?.connection.phase === "connected";
+    const shellStatus = shellStatuses.get(nextQueuedMessage.environmentId) ?? "empty";
+    const deliveryAction = resolveThreadOutboxDeliveryAction({
+      isCreation: creation !== undefined,
+      threadExists: thread !== undefined,
+      shellStatus,
+      environmentConnected,
+      threadBusy: thread?.session?.status === "running" || thread?.session?.status === "starting",
+    });
+    // The delivery action resolves first; the file-capability gate applies
+    // only to a message that will send. Gating earlier would restore a
+    // creation whose startTurn already made the thread as a duplicate draft
+    // instead of removing it.
+    const serverConfig = serverConfigs.get(nextQueuedMessage.environmentId);
+    const dispatchStep = resolveThreadOutboxDispatchStep({
+      deliveryAction,
+      fileAttachments: nextQueuedMessage.attachments.filter(
+        (attachment) => attachment.type === "file",
+      ),
+      serverConfig: serverConfig
+        ? {
+            maxFileUploadBytes:
+              serverConfig.environment.capabilities.fileAttachments?.maxUploadBytes,
+          }
+        : null,
+    });
+    if (dispatchStep.step === "wait") {
+      continue;
+    }
+    if (dispatchStep.step === "retry") {
+      // The environment is connected but its config has not synced yet.
+      // Back off and retry instead of parking the message forever.
+      scheduleRetry(state, messageId);
+      continue;
+    }
+    if (dispatchStep.step === "restore") {
+      const attachmentError = dispatchStep.reason;
+      dispatch(state, messageId, async () => {
+        const queued = await confirmThreadOutboxMessageQueued(nextQueuedMessage);
+        const restored =
+          !queued || registry.get(editingQueuedMessageIdsAtom)[messageId]
+            ? true
+            : await restoreQueuedMessage(state, nextQueuedMessage, attachmentError);
+        if (!restored) {
+          scheduleRetry(state, messageId);
+        }
+      });
+      return;
+    }
+    // The live project shell is preferred for the workspace path, with the
+    // snapshot taken at enqueue time as the fallback so a task never dies
+    // just because its project shell is not loaded.
+    const creationProjectCwd =
+      creation !== undefined
+        ? (findCreationProject(projects, nextQueuedMessage)?.workspaceRoot ??
+          creation.projectCwd ??
+          null)
+        : null;
+    // An incomplete pending task (e.g. worktree mode without a branch) stays
+    // queued until the user finishes it in the editor.
+    if (deliveryAction === "send" && creation !== undefined) {
+      if (!isQueuedThreadCreationSendable(nextQueuedMessage)) {
+        continue;
+      }
+      if (creationProjectCwd === null && shellStatus !== "live") {
+        continue;
       }
     }
 
-    for (const [threadKey, queuedMessages] of Object.entries(queuedMessagesByThreadKey)) {
-      const nextQueuedMessage = queuedMessages[0];
-      if (!nextQueuedMessage) {
-        continue;
-      }
-      if (
-        nextQueuedMessage.creation === undefined &&
-        acknowledgedExistingThreadMessageIdsRef.current.has(nextQueuedMessage.messageId)
-      ) {
-        if ((retryNotBeforeRef.current.get(nextQueuedMessage.messageId) ?? 0) > Date.now()) {
-          continue;
-        }
-        beginDispatchingQueuedMessage(nextQueuedMessage.messageId);
-        void removeAcknowledgedExistingThreadMessage(
-          nextQueuedMessage,
-          acknowledgedExistingThreadMessageIdsRef.current,
-        )
-          .then((removed) => {
-            if (!removed) {
-              scheduleQueuedMessageRetry(nextQueuedMessage.messageId);
-              return;
-            }
-            retryAttemptRef.current.delete(nextQueuedMessage.messageId);
-            retryNotBeforeRef.current.delete(nextQueuedMessage.messageId);
-            const pendingTimer = retryTimersRef.current.get(nextQueuedMessage.messageId);
-            if (pendingTimer !== undefined) {
-              clearTimeout(pendingTimer);
-              retryTimersRef.current.delete(nextQueuedMessage.messageId);
-            }
-          })
-          .finally(() => finishDispatchingQueuedMessage(nextQueuedMessage.messageId));
-        return;
-      }
-      if (editingQueuedMessageIds[nextQueuedMessage.messageId]) {
-        continue;
-      }
-      const blockedRecovery = blockedRecoverySubscriptionsRef.current.get(
-        nextQueuedMessage.messageId,
+    const removeQueuedMessage = (warning: string) =>
+      removeThreadOutboxMessage(nextQueuedMessage).then(
+        () => true,
+        (error) => {
+          console.warn(warning, {
+            environmentId: nextQueuedMessage.environmentId,
+            threadId: nextQueuedMessage.threadId,
+            messageId,
+            error,
+          });
+          return false;
+        },
       );
-      if (blockedRecovery) {
-        if (blockedRecovery.message === nextQueuedMessage) {
-          continue;
-        }
-        blockedRecoverySubscriptionsRef.current.delete(nextQueuedMessage.messageId);
-        blockedRecovery.unsubscribe();
-      }
-      if ((retryNotBeforeRef.current.get(nextQueuedMessage.messageId) ?? 0) > Date.now()) {
-        continue;
-      }
-
-      const thread = findThread(threads, nextQueuedMessage);
-      if (thread && scopedThreadKey(thread.environmentId, thread.id) !== threadKey) {
-        continue;
-      }
-
-      const creation = nextQueuedMessage.creation;
-      const environment = connectedEnvironments.find(
-        (candidate) => candidate.environmentId === nextQueuedMessage.environmentId,
-      );
-      const shellStatus = shellStatuses.get(nextQueuedMessage.environmentId) ?? "empty";
-      const deliveryAction = resolveThreadOutboxDeliveryAction({
-        isCreation: creation !== undefined,
-        threadExists: thread !== undefined,
-        shellStatus,
-        environmentConnected: environment?.connectionState === "connected",
-        threadBusy: thread?.session?.status === "running" || thread?.session?.status === "starting",
-      });
-      // The delivery action resolves first; the file-capability gate applies
-      // only to a message that will send. Gating earlier would restore a
-      // creation whose startTurn already made the thread as a duplicate draft
-      // instead of removing it.
-      const serverConfig = serverConfigs.get(nextQueuedMessage.environmentId);
-      const dispatchStep = resolveThreadOutboxDispatchStep({
-        deliveryAction,
-        fileAttachments: nextQueuedMessage.attachments.filter(
-          (attachment) => attachment.type === "file",
-        ),
-        serverConfig: serverConfig
-          ? {
-              maxFileUploadBytes:
-                serverConfig.environment.capabilities.fileAttachments?.maxUploadBytes,
-            }
-          : null,
-      });
-      if (dispatchStep.step === "wait") {
-        continue;
-      }
-      if (dispatchStep.step === "retry") {
-        // The environment is connected but its config has not synced yet.
-        // Back off and retry instead of parking the message forever.
-        scheduleQueuedMessageRetry(nextQueuedMessage.messageId);
-        continue;
-      }
-      if (dispatchStep.step === "restore") {
-        const attachmentError = dispatchStep.reason;
-        beginDispatchingQueuedMessage(nextQueuedMessage.messageId);
-        void confirmThreadOutboxMessageQueued(nextQueuedMessage)
-          .then((queued) => {
-            if (
-              !queued ||
-              appAtomRegistry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]
-            ) {
-              return true;
-            }
-            return restoreQueuedMessage(nextQueuedMessage, attachmentError);
-          })
-          .then((restored) => {
-            if (!restored) {
-              scheduleQueuedMessageRetry(nextQueuedMessage.messageId);
-            }
-          })
-          .finally(() => finishDispatchingQueuedMessage(nextQueuedMessage.messageId));
-        return;
-      }
-      // The live project shell is preferred for the workspace path, with the
-      // snapshot taken at enqueue time as the fallback so a task never dies
-      // just because its project shell is not loaded.
-      const creationProjectCwd =
-        creation !== undefined
-          ? (findCreationProject(projects, nextQueuedMessage)?.workspaceRoot ??
-            creation.projectCwd ??
-            null)
-          : null;
-      // An incomplete pending task (e.g. worktree mode without a branch) stays
-      // queued until the user finishes it in the editor.
-      if (deliveryAction === "send" && creation !== undefined) {
-        if (!isQueuedThreadCreationSendable(nextQueuedMessage)) {
-          continue;
-        }
-        if (creationProjectCwd === null && shellStatus !== "live") {
-          continue;
-        }
-      }
-
-      beginDispatchingQueuedMessage(nextQueuedMessage.messageId);
-      const removeQueuedMessage = (warning: string) =>
-        removeThreadOutboxMessage(nextQueuedMessage).then(
-          () => true,
-          (error) => {
-            console.warn(warning, {
-              environmentId: nextQueuedMessage.environmentId,
-              threadId: nextQueuedMessage.threadId,
-              messageId: nextQueuedMessage.messageId,
-              error,
-            });
-            return false;
-          },
-        );
+    dispatch(state, messageId, async () => {
       // Enqueues publish optimistically before their durable write settles.
       // Confirm the write landed (and the message wasn't rolled back) before
       // sending, so a failed write can never chase an already-delivered turn.
-      const delivery = confirmThreadOutboxMessageQueued(nextQueuedMessage).then((queued) => {
-        if (!queued) {
-          // Rolled back by a failed write; nothing to deliver or retry.
-          return true;
-        }
+      const queued = await confirmThreadOutboxMessageQueued(nextQueuedMessage);
+      let sent: boolean;
+      if (!queued) {
+        // Rolled back by a failed write; nothing to deliver or retry.
+        sent = true;
+      } else if (registry.get(editingQueuedMessageIdsAtom)[messageId]) {
         // The guards evaluated before the confirmation await are stale by now:
-        // the user may have opened this message in the editor. Re-read that
-        // guard and defer to the next drain pass (returning true skips the
-        // failure/backoff path) rather than sending a payload being edited.
-        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]) {
-          return true;
-        }
+        // the user may have opened this message in the editor. Defer to the
+        // next drain pass rather than sending a payload being edited.
+        sent = true;
+      } else {
         // The shell state is equally stale. Re-run the same delivery policy
         // against the live thread snapshot so a vanished thread or newly
         // created target defers, while busy existing threads can still steer.
+        let liveDeliveryAction = deliveryAction;
         if (deliveryAction === "send") {
           const liveThread = findThread(
-            appAtomRegistry.get(environmentThreadShells.threadShellsAtom),
+            registry.get(environmentThreadShells.threadShellsAtom),
             nextQueuedMessage,
           );
-          const liveThreadBusy =
-            liveThread?.session?.status === "running" || liveThread?.session?.status === "starting";
-          const liveDeliveryAction = resolveThreadOutboxDeliveryAction({
+          liveDeliveryAction = resolveThreadOutboxDeliveryAction({
             isCreation: creation !== undefined,
             threadExists: liveThread !== undefined,
             shellStatus,
-            environmentConnected: environment?.connectionState === "connected",
-            threadBusy: liveThreadBusy,
+            environmentConnected,
+            threadBusy:
+              liveThread?.session?.status === "running" ||
+              liveThread?.session?.status === "starting",
           });
-          if (liveDeliveryAction !== "send") {
-            return true;
-          }
         }
-        return deliveryAction === "remove"
-          ? creation !== undefined
-            ? // A creation entry that survived its delivery cleanup either
-              // holds edits (recover them) or the delivered payload (a
-              // recovered duplicate the user can delete). Restart loses any
-              // in-memory distinction, and losing edits is the worse failure,
-              // so recovery is unconditional here.
-              recoverEditedCreationAfterDelivery(nextQueuedMessage)
-            : removeQueuedMessage("[thread-outbox] failed to remove message for a missing thread")
-          : creation !== undefined
-            ? creationProjectCwd !== null
-              ? sendQueuedCreation(nextQueuedMessage, creation, creationProjectCwd)
-              : removeQueuedMessage("[thread-outbox] dropped pending task for a missing project")
-            : thread !== undefined
-              ? sendQueuedMessage(nextQueuedMessage, thread)
-              : Promise.resolve(false);
-      });
-      void delivery
-        .then((sent) => {
-          if (sent) {
-            retryAttemptRef.current.delete(nextQueuedMessage.messageId);
-            retryNotBeforeRef.current.delete(nextQueuedMessage.messageId);
-            const pendingTimer = retryTimersRef.current.get(nextQueuedMessage.messageId);
-            if (pendingTimer !== undefined) {
-              clearTimeout(pendingTimer);
-              retryTimersRef.current.delete(nextQueuedMessage.messageId);
-            }
-            return;
-          }
+        if (deliveryAction === "send" && liveDeliveryAction !== "send") {
+          sent = true;
+        } else if (deliveryAction === "remove") {
+          sent =
+            creation !== undefined
+              ? // A creation entry that survived its delivery cleanup either
+                // holds edits (recover them) or the delivered payload (a
+                // recovered duplicate the user can delete). Restart loses any
+                // in-memory distinction, and losing edits is the worse failure,
+                // so recovery is unconditional here.
+                await recoverEditedCreationAfterDelivery(nextQueuedMessage)
+              : await removeQueuedMessage(
+                  "[thread-outbox] failed to remove message for a missing thread",
+                );
+        } else if (creation !== undefined) {
+          sent =
+            creationProjectCwd !== null
+              ? await sendQueuedCreation(state, nextQueuedMessage, creation, creationProjectCwd)
+              : await removeQueuedMessage(
+                  "[thread-outbox] dropped pending task for a missing project",
+                );
+        } else {
+          sent =
+            thread !== undefined
+              ? await sendQueuedMessage(state, nextQueuedMessage, thread)
+              : false;
+        }
+      }
+      if (sent) {
+        clearRetry(state, messageId);
+      } else {
+        scheduleRetry(state, messageId);
+      }
+    });
+    return;
+  }
+}
 
-          scheduleQueuedMessageRetry(nextQueuedMessage.messageId);
-        })
-        .finally(() => {
-          finishDispatchingQueuedMessage(nextQueuedMessage.messageId);
-        });
+function startDrain(state: ThreadOutboxDrainState): void {
+  if (!state.stopped) {
+    return;
+  }
+  state.stopped = false;
+  try {
+    ensureThreadOutboxLoaded();
+    const request = () => requestDrain(state);
+    // Store each release as it is acquired so a later subscription failure can
+    // still unwind every subscription that was already installed.
+    state.releases.push(
+      state.registry.subscribe(threadOutboxManager.queuedMessagesByThreadKeyAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(editingQueuedMessageIdsAtom, request));
+    state.releases.push(state.registry.subscribe(threadOutboxShellStatusesAtom, request));
+    state.releases.push(
+      state.registry.subscribe(environmentThreadShells.threadShellsAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(environmentProjects.projectsAtom, request));
+    state.releases.push(state.registry.subscribe(environmentServerConfigsAtom, request));
+    state.releases.push(
+      state.registry.subscribe(environmentPresentations.presentationsAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(dispatchingQueuedMessageIdAtom, request));
+    requestDrain(state);
+  } catch (error) {
+    stopDrain(state);
+    throw error;
+  }
+}
+
+function stopDrain(state: ThreadOutboxDrainState): void {
+  if (state.stopped) {
+    return;
+  }
+  state.stopped = true;
+  for (const release of state.releases.splice(0)) {
+    try {
+      release();
+    } catch (error) {
+      console.warn("[thread-outbox] failed to release drain subscription", error);
+    }
+  }
+  for (const timer of state.retryTimers.values()) {
+    clearTimeout(timer);
+  }
+  state.retryTimers.clear();
+  state.retryAttempt.clear();
+  state.retryNotBefore.clear();
+  for (const blocked of state.blockedRecoverySubscriptions.values()) {
+    try {
+      blocked.unsubscribe();
+    } catch (error) {
+      console.warn("[thread-outbox] failed to release blocked recovery subscription", error);
+    }
+  }
+  state.blockedRecoverySubscriptions.clear();
+}
+
+/**
+ * Acquires the one process-wide outbox dispatcher for a registry. UI and
+ * Headless JS owners share this lease, so mounting both cannot double-send.
+ */
+export function acquireThreadOutboxDrain(registry: AtomRegistry.AtomRegistry): () => void {
+  let state = drainStates.get(registry);
+  if (state === undefined) {
+    state = {
+      registry,
+      owners: 0,
+      stopped: true,
+      drainScheduled: false,
+      activeDelivery: null,
+      retryAttempt: new Map(),
+      retryNotBefore: new Map(),
+      retryTimers: new Map(),
+      acknowledgedExistingThreadMessageIds: new Set(),
+      blockedRecoverySubscriptions: new Map(),
+      releases: [],
+    };
+    drainStates.set(registry, state);
+  }
+  state.owners += 1;
+  try {
+    startDrain(state);
+  } catch (error) {
+    state.owners -= 1;
+    if (state.owners === 0) {
+      drainStates.delete(registry);
+    }
+    throw error;
+  }
+
+  let released = false;
+  return () => {
+    if (released) {
       return;
     }
-  }, [
-    connectedEnvironments,
-    dispatchingQueuedMessageId,
-    editingQueuedMessageIds,
-    projects,
-    queuedMessagesByThreadKey,
-    retryTick,
-    restoreQueuedMessage,
-    scheduleQueuedMessageRetry,
-    sendQueuedCreation,
-    sendQueuedMessage,
-    serverConfigs,
-    shellStatuses,
-    threads,
-  ]);
+    released = true;
+    state.owners -= 1;
+    if (state.owners === 0) {
+      stopDrain(state);
+    }
+  };
+}
+
+export function useThreadOutboxDrain(): void {
+  const registry = useContext(RegistryContext);
+  useEffect(() => acquireThreadOutboxDrain(registry), [registry]);
 }

--- a/apps/mobile/src/state/use-thread-outbox.ts
+++ b/apps/mobile/src/state/use-thread-outbox.ts
@@ -7,7 +7,7 @@ import { appAtomRegistry } from "./atom-registry";
 import { environmentShell } from "./shell";
 import { threadOutboxManager } from "./thread-outbox";
 
-const threadOutboxShellStatusesAtom = Atom.make(
+export const threadOutboxShellStatusesAtom = Atom.make(
   (get): ReadonlyMap<EnvironmentId, EnvironmentShellStatus> => {
     const statuses = new Map<EnvironmentId, EnvironmentShellStatus>();
     for (const queue of Object.values(get(threadOutboxManager.queuedMessagesByThreadKeyAtom))) {

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -78,8 +78,12 @@ Wakeup handling differs by phase, in [supervisor.ts][supervisor]:
 - Once connected, `monitorConnectedLease` handles plain activation by probing
   the existing session (`lease.session.probe`, with a shorter timeout for
   mobile's `application-active-probe`) rather than reconnecting; a healthy
-  session survives foregrounding. `application-active-reconnect` skips the probe
-  and replaces the lease outright.
+  session survives foregrounding. Android emits `application-active-preserved`
+  when its foreground service and Headless JS runtime both report ready. That
+  reason uses the same bounded mobile probe, preserves the session generation on
+  success, and replaces the lease immediately if the probe fails. It does not
+  force shell or thread subscriptions to restart. `application-active-reconnect`
+  skips the probe and replaces the lease outright.
 
 The UI derives `available`, `offline`, `connecting`, `reconnecting`,
 `connected`, and `error` from supervisor state plus explicit data-sync state.
@@ -156,6 +160,55 @@ ownership.
 Application code must not construct RPC clients, retry loops, or raw
 orchestration commands. Persistence paths belong to the platform registration
 and cache stores, with explicit migration or invalidation policy.
+
+### Android background ownership
+
+Android can add a second application-root owner without adding a second
+connection runtime. The opt-in **Keep connected in background** setting starts a
+`remoteMessaging` foreground service in the normal application process. React
+Native Headless JS cold-starts the existing mobile runtime and acquires
+reference-counted leases against the same process-wide `appAtomRegistry` used by
+the UI. Mounting the UI and background task together therefore still produces
+one supervisor and one transport per saved environment.
+
+The headless root retains:
+
+- the environment catalog, server configurations, and shell state for every
+  saved environment;
+- aggregate thread-shell state;
+- full detail for the last-opened thread and threads whose sessions are
+  `starting` or `running`; and
+- the shared, reference-counted thread-outbox drain worker.
+
+It does not retain every historical thread body. Once running work settles and
+is not the last-opened thread, the existing idle lifetime and persistence rules
+remain authoritative.
+
+T3 Connect authentication has matching `ui` and `background` owners. UI
+ownership wins while the app is visible. A cold headless start loads the
+persisted Clerk session and installs its token provider into the existing
+`managedRelaySessionAtom`; direct and Tailscale startup is not blocked when
+Clerk is signed out, unconfigured, or temporarily unavailable. There is no
+background-only relay transport or authentication path.
+
+The service is deliberately opt-in and defaults off. While enabled, Android
+requires a silent ongoing notification. React Native owns a partial CPU wake
+lock for the headless task, and the native service holds a best-effort
+high-performance Wi-Fi lock. These locks and the continuously active network
+connections have an intentional battery and data cost. A battery-optimization
+exemption improves survival under device power management, but declining it
+does not silently turn the feature off.
+
+The service uses sticky restart behavior and restores an enabled preference
+after package replacement or boot once credential-protected storage is
+available. Android force-stop remains absolute: no receiver or service may
+restart the app until the user launches it again. The app also cannot restart a
+separately stopped Tailscale VPN.
+
+At introduction, the direct/Tailscale path was exercised on a physical Android
+device across lock, Doze, task removal, network transitions, package replacement,
+and reboot. Cold T3 Connect ownership and token refresh have automated coverage,
+but were not live-validated against a configured relay account on that device.
 
 ## Verification
 

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -78,8 +78,12 @@ Wakeup handling differs by phase, in [supervisor.ts][supervisor]:
 - Once connected, `monitorConnectedLease` handles plain activation by probing
   the existing session (`lease.session.probe`, with a shorter timeout for
   mobile's `application-active-probe`) rather than reconnecting; a healthy
-  session survives foregrounding. `application-active-reconnect` skips the probe
-  and replaces the lease outright.
+  session survives foregrounding. Android emits `application-active-preserved`
+  when its foreground service and Headless JS runtime both report ready. That
+  reason uses the same bounded mobile probe, preserves the session generation on
+  success, and replaces the lease immediately if the probe fails. It does not
+  force shell or thread subscriptions to restart. `application-active-reconnect`
+  skips the probe and replaces the lease outright.
 
 The UI derives `available`, `offline`, `connecting`, `reconnecting`,
 `connected`, and `error` from supervisor state plus explicit data-sync state.
@@ -169,6 +173,55 @@ ownership.
 Application code must not construct RPC clients, retry loops, or raw
 orchestration commands. Persistence paths belong to the platform registration
 and cache stores, with explicit migration or invalidation policy.
+
+### Android background ownership
+
+Android can add a second application-root owner without adding a second
+connection runtime. The opt-in **Keep connected in background** setting starts a
+`remoteMessaging` foreground service in the normal application process. React
+Native Headless JS cold-starts the existing mobile runtime and acquires
+reference-counted leases against the same process-wide `appAtomRegistry` used by
+the UI. Mounting the UI and background task together therefore still produces
+one supervisor and one transport per saved environment.
+
+The headless root retains:
+
+- the environment catalog, server configurations, and shell state for every
+  saved environment;
+- aggregate thread-shell state;
+- full detail for the last-opened thread and threads whose sessions are
+  `starting` or `running`; and
+- the shared, reference-counted thread-outbox drain worker.
+
+It does not retain every historical thread body. Once running work settles and
+is not the last-opened thread, the existing idle lifetime and persistence rules
+remain authoritative.
+
+T3 Connect authentication has matching `ui` and `background` owners. UI
+ownership wins while the app is visible. A cold headless start loads the
+persisted Clerk session and installs its token provider into the existing
+`managedRelaySessionAtom`; direct and Tailscale startup is not blocked when
+Clerk is signed out, unconfigured, or temporarily unavailable. There is no
+background-only relay transport or authentication path.
+
+The service is deliberately opt-in and defaults off. While enabled, Android
+requires a silent ongoing notification. React Native owns a partial CPU wake
+lock for the headless task, and the native service holds a best-effort
+high-performance Wi-Fi lock. These locks and the continuously active network
+connections have an intentional battery and data cost. A battery-optimization
+exemption improves survival under device power management, but declining it
+does not silently turn the feature off.
+
+The service uses sticky restart behavior and restores an enabled preference
+after package replacement or boot once credential-protected storage is
+available. Android force-stop remains absolute: no receiver or service may
+restart the app until the user launches it again. The app also cannot restart a
+separately stopped Tailscale VPN.
+
+At introduction, the direct/Tailscale path was exercised on a physical Android
+device across lock, Doze, task removal, network transitions, package replacement,
+and reboot. Cold T3 Connect ownership and token refresh have automated coverage,
+but were not live-validated against a configured relay account on that device.
 
 ## Verification
 

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -201,8 +201,11 @@ T3 Connect authentication has matching `ui` and `background` owners. UI
 ownership wins while the app is visible. A cold headless start loads the
 persisted Clerk session and installs its token provider into the existing
 `managedRelaySessionAtom`; direct and Tailscale startup is not blocked when
-Clerk is signed out, unconfigured, or temporarily unavailable. There is no
-background-only relay transport or authentication path.
+Clerk is signed out, unconfigured, or temporarily unavailable. Sign-out and
+account switches hold every background bootstrap, including scheduled retries
+and cold headless starts, until the previous account's cleanup settles, so the
+next account's relay session is never published before that cleanup finishes.
+There is no background-only relay transport or authentication path.
 
 The service is deliberately opt-in and defaults off. While enabled, Android
 requires a silent ongoing notification. React Native owns a partial CPU wake

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -32,6 +32,33 @@ That gives you:
 - transport security at the network layer
 - less exposure than opening the server to the public internet
 
+## Keeping the Android App Connected
+
+On Android, **Keep connected in background** keeps saved environments and active work synchronized
+while the phone is locked or another app is open. The setting is off by default. Enable it from the
+mobile app under **Settings** → **Background connection**.
+
+This setting keeps the mobile connection runtime running; it does not change how the phone reaches
+an environment. Direct LAN, Tailscale, and T3 Connect environments continue using their existing
+connection methods. If a Tailscale environment depends on the Tailscale Android app, that VPN must
+also remain connected.
+
+Android requires an ongoing foreground-service notification while this mode is enabled. T3 Code's
+notification is silent and contains no thread content, but Android does not allow the app to hide it.
+The service also holds a partial CPU wake lock and, on Wi-Fi, a best-effort high-performance Wi-Fi
+lock. This can increase battery use and mobile-data use compared with the default on-demand
+connection behavior.
+
+When prompted, allowing unrestricted battery use makes the connection more resistant to Android or
+device-vendor power management. If you decline, the feature remains enabled but Settings reports
+**Battery optimization enabled**, and Android may still suspend it. You can tap that status to try
+again.
+
+Android force-stop is the hard boundary. After force-stopping T3 Code, launch it once before
+background connection can run again. A normal task swipe-away, process restart, app update, or reboot
+does not disable an enabled background connection; after a reboot it resumes once Android permits
+the app to start and the device has been unlocked.
+
 ## Enabling Network Access
 
 There are three ways to reach your server from another device: expose the desktop app's backend,

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -569,7 +569,7 @@ describe("EnvironmentSupervisor", () => {
         supervisor.state,
         (state) => state.phase === "backoff" && state.attempt === 1,
       );
-      yield* TestClock.adjust("1 second");
+      yield* TestClock.adjust("3 seconds");
       yield* eventuallyState(
         supervisor.state,
         (state) => state.phase === "backoff" && state.attempt === 2,

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -873,6 +873,37 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
+  it.effect("probes a preserved mobile session without changing its generation", () =>
+    Effect.gen(function* () {
+      const probeCount = yield* Ref.make(0);
+      const probeCalled = yield* Deferred.make<void>();
+      const harness = yield* makeHarness({
+        probe: () =>
+          Ref.update(probeCount, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.succeed(probeCalled, undefined)),
+          ),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* harness.wake("application-active-preserved");
+      yield* Deferred.await(probeCalled);
+
+      expect(yield* Ref.get(probeCount)).toBe(1);
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
+      expect(yield* SubscriptionRef.get(supervisor.state)).toMatchObject({
+        phase: "connected",
+        generation: 1,
+      });
+    }),
+  );
+
   it.effect("immediately replaces a mobile session after a long background resume", () =>
     Effect.gen(function* () {
       const probeCount = yield* Ref.make(0);
@@ -1016,7 +1047,29 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("quickly times out a stalled mobile foreground liveness probe", () =>
+  it.effect("immediately reconnects when a preserved-session probe fails", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        probe: (attempt) =>
+          attempt === 1 ? Effect.fail(transient("The preserved session is stale.")) : Effect.void,
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.wake("application-active-preserved");
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+
+      expect(yield* Ref.get(harness.sessionCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }),
+  );
+
+  it.effect("quickly times out a stalled preserved-session liveness probe", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({
         probe: (attempt) => (attempt === 1 ? Effect.never : Effect.void),
@@ -1026,7 +1079,7 @@ describe("EnvironmentSupervisor", () => {
       }).pipe(Effect.provide(harness.dependencies));
 
       yield* awaitState(supervisor.state, (state) => state.phase === "connected");
-      yield* harness.wake("application-active-probe");
+      yield* harness.wake("application-active-preserved");
       yield* TestClock.adjust("3 seconds");
       // The timed-out wake probe reconnects immediately without a backoff
       // sleep: no further clock advance is needed.

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -550,6 +550,44 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
+  it.effect("preserved activation interrupts reconnect backoff and resets retries", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        prepare: (attempt) =>
+          attempt === 2 ? Effect.fail(transient()) : Effect.succeed(PREPARED_CONNECTION),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* harness.closeLatestSession();
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      yield* TestClock.adjust("1 second");
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 2,
+      );
+
+      yield* harness.wake("application-active-preserved");
+      const reconnected = yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+
+      expect(reconnected).toMatchObject({ phase: "connected", attempt: 1, generation: 2 });
+      expect(yield* Ref.get(harness.prepareCount)).toBe(3);
+      expect(yield* Ref.get(harness.sessionCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
   it.effect("keeps blocked failures idle until an external signal requests another attempt", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -551,6 +551,44 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
+  it.effect("preserved activation interrupts reconnect backoff and resets retries", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        prepare: (attempt) =>
+          attempt === 2 ? Effect.fail(transient()) : Effect.succeed(PREPARED_CONNECTION),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* harness.closeLatestSession();
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      yield* TestClock.adjust("1 second");
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 2,
+      );
+
+      yield* harness.wake("application-active-preserved");
+      const reconnected = yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+
+      expect(reconnected).toMatchObject({ phase: "connected", attempt: 1, generation: 2 });
+      expect(yield* Ref.get(harness.prepareCount)).toBe(3);
+      expect(yield* Ref.get(harness.sessionCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
   it.effect("keeps blocked failures idle until an external signal requests another attempt", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -570,7 +570,7 @@ describe("EnvironmentSupervisor", () => {
         supervisor.state,
         (state) => state.phase === "backoff" && state.attempt === 1,
       );
-      yield* TestClock.adjust("1 second");
+      yield* TestClock.adjust("3 seconds");
       yield* eventuallyState(
         supervisor.state,
         (state) => state.phase === "backoff" && state.attempt === 2,

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -874,6 +874,37 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
+  it.effect("probes a preserved mobile session without changing its generation", () =>
+    Effect.gen(function* () {
+      const probeCount = yield* Ref.make(0);
+      const probeCalled = yield* Deferred.make<void>();
+      const harness = yield* makeHarness({
+        probe: () =>
+          Ref.update(probeCount, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.succeed(probeCalled, undefined)),
+          ),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* harness.wake("application-active-preserved");
+      yield* Deferred.await(probeCalled);
+
+      expect(yield* Ref.get(probeCount)).toBe(1);
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
+      expect(yield* SubscriptionRef.get(supervisor.state)).toMatchObject({
+        phase: "connected",
+        generation: 1,
+      });
+    }),
+  );
+
   it.effect("immediately replaces a mobile session after a long background resume", () =>
     Effect.gen(function* () {
       const probeCount = yield* Ref.make(0);
@@ -1017,7 +1048,29 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("quickly times out a stalled mobile foreground liveness probe", () =>
+  it.effect("immediately reconnects when a preserved-session probe fails", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        probe: (attempt) =>
+          attempt === 1 ? Effect.fail(transient("The preserved session is stale.")) : Effect.void,
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.wake("application-active-preserved");
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+
+      expect(yield* Ref.get(harness.sessionCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }),
+  );
+
+  it.effect("quickly times out a stalled preserved-session liveness probe", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({
         probe: (attempt) => (attempt === 1 ? Effect.never : Effect.void),
@@ -1027,7 +1080,7 @@ describe("EnvironmentSupervisor", () => {
       }).pipe(Effect.provide(harness.dependencies));
 
       yield* awaitState(supervisor.state, (state) => state.phase === "connected");
-      yield* harness.wake("application-active-probe");
+      yield* harness.wake("application-active-preserved");
       yield* TestClock.adjust("3 seconds");
       // The timed-out wake probe reconnects immediately without a backoff
       // sleep: no further clock advance is needed.

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -418,10 +418,15 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
             // replaces that lease and starts a fresh attempt without backoff.
             return true;
           }
-          if (next.reason === "application-active" || next.reason === "application-active-probe") {
+          if (
+            next.reason === "application-active" ||
+            next.reason === "application-active-preserved" ||
+            next.reason === "application-active-probe"
+          ) {
             const probe = yield* lease.session.probe.pipe(
               Effect.timeoutOrElse({
                 duration:
+                  next.reason === "application-active-preserved" ||
                   next.reason === "application-active-probe"
                     ? MOBILE_CONNECTION_PROBE_TIMEOUT
                     : CONNECTION_PROBE_TIMEOUT,

--- a/packages/client-runtime/src/connection/wakeups.test.ts
+++ b/packages/client-runtime/src/connection/wakeups.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { isApplicationActiveWakeup, shouldResubscribeAfterWakeup } from "./wakeups.ts";
+
+describe("connection wakeups", () => {
+  it("recognizes preserved resumes as application activation", () => {
+    expect(isApplicationActiveWakeup("application-active-preserved")).toBe(true);
+  });
+
+  it("does not resubscribe snapshots after a preserved resume", () => {
+    expect(shouldResubscribeAfterWakeup("application-active-preserved")).toBe(false);
+    expect(shouldResubscribeAfterWakeup("application-active-probe")).toBe(true);
+  });
+});

--- a/packages/client-runtime/src/connection/wakeups.ts
+++ b/packages/client-runtime/src/connection/wakeups.ts
@@ -4,6 +4,7 @@ import type * as Stream from "effect/Stream";
 
 export type ConnectionWakeup =
   | "application-active"
+  | "application-active-preserved"
   | "application-active-probe"
   | "application-active-reconnect"
   | "credentials-changed";
@@ -11,6 +12,7 @@ export type ConnectionWakeup =
 export function isApplicationActiveWakeup(reason: ConnectionWakeup): boolean {
   return (
     reason === "application-active" ||
+    reason === "application-active-preserved" ||
     reason === "application-active-probe" ||
     reason === "application-active-reconnect"
   );

--- a/packages/client-runtime/src/state/threads-sync.test.ts
+++ b/packages/client-runtime/src/state/threads-sync.test.ts
@@ -674,6 +674,9 @@ describe("EnvironmentThreads", () => {
           value.data.value.title === "Latest title",
       );
 
+      expect(yield* Ref.get(harness.loaderCalls)).toBe(0);
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(1);
+
       yield* Queue.offer(harness.wakeups, "application-active");
       const synchronizing = yield* awaitThreadState(
         harness.observed,

--- a/packages/client-runtime/src/state/threads-sync.test.ts
+++ b/packages/client-runtime/src/state/threads-sync.test.ts
@@ -675,6 +675,9 @@ describe("EnvironmentThreads", () => {
           value.data.value.title === "Latest title",
       );
 
+      expect(yield* Ref.get(harness.loaderCalls)).toBe(0);
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(1);
+
       yield* Queue.offer(harness.wakeups, "application-active");
       const synchronizing = yield* awaitThreadState(
         harness.observed,


### PR DESCRIPTION
## What Changed

Android currently suspends the JavaScript connection runtime when T3 Code is backgrounded or the phone is locked. Reopening the app can therefore require a full reconnect and synchronization before current thread state appears.

This PR adds an Android-only, opt-in background connection mode that:

- runs the existing client runtime from a foreground service backed by React Native Headless JS
- shares the existing atom registry, connection supervisors, subscriptions, and outbox dispatcher instead of creating a second WebSocket stack
- keeps every saved environment's shell state current while retaining full detail only for the last-opened and `starting`/`running` threads
- preserves managed-relay authentication for cold T3 Connect startup
- probes healthy sessions on resume without forcing reconnects or resubscriptions
- restores the service after ordinary process reclamation, task swipe-away, package replacement, and reboot after unlock
- exposes an Android setting and the platform-required silent foreground-service notification

This does not change the WebSocket protocol, synchronization reducer, server contracts, or server behavior.

The recovery work in #5154 improves what happens after Android has suspended the client. This PR addresses the preceding problem: while the setting is enabled, it prevents Android suspension from stopping the connection runtime in the first place. The approaches remain compatible.

## Why

Mobile is commonly used to monitor or continue work running on another machine through a direct connection, Tailscale, or T3 Connect. Keeping the existing runtime alive means events can arrive while the app is backgrounded, outgoing messages continue draining, and reopening can render current state immediately rather than beginning a reconnect cycle.

The feature defaults off. Android force-stop remains an unavoidable boundary, and users must launch the app once afterward.

## Verification

- 18 focused test files passed (114 tests)
- mobile and client-runtime typechecks passed
- mobile lint passed
- native module unit tests and Android release lint passed
- arm64 production release APK built successfully, matched the expected signing certificate, and installed with replacement semantics without clearing app data
- physical Android validation covered direct/Tailscale operation while backgrounded and locked, forced Doze, task swipe-away, Wi-Fi/cellular recovery, package replacement, and reboot restoration
- T3 Connect ownership and cold-bootstrap paths are covered by focused tests; live T3 Connect validation was intentionally skipped
- a clean emulator was used for UI evidence; it contains no account or personal data

## UI Changes

Before:

![Settings before](https://raw.githubusercontent.com/snipemanmike/t3code/pr-evidence-android-background-connection/before.png)

After:

![Settings after](https://raw.githubusercontent.com/snipemanmike/t3code/pr-evidence-android-background-connection/after.png)

[Interaction video (sanitized emulator)](https://github.com/snipemanmike/t3code/blob/pr-evidence-android-background-connection/interaction.mp4)

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

This is one focused Android runtime concern, but it is not a small diff; the native lifecycle, shared runtime ownership, relay authentication, resume semantics, tests, and documentation must land together to avoid partial behavior.

Implemented with GPT-5.6-sol through the Codex harness. Reviewed with Claude Fable through the Claude Code CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting change to Android FGS lifecycle, shared connection/outbox state, and managed-relay auth across UI unmount and account switches—regressions could affect credentials, reconnect behavior, or background message delivery.
> 
> **Overview**
> Adds an **opt-in Android “Keep connected in background”** mode that keeps the existing mobile client runtime alive via a `remoteMessaging` foreground service and a single React Native Headless JS task—no second WebSocket or sync stack.
> 
> The new **`t3-background-connection`** Expo module owns native lifecycle: persistent enablement, ongoing notification, Wi‑Fi lock, boot/package-replace recovery, exponential restart backoff (only when battery optimization is ignored), and orderly stop when the user turns the feature off. JS registers the headless task at startup and coordinates **`background-root`** leases (environment catalog/shells, server configs, thread detail for the retained + active threads) plus **`acquireThreadOutboxDrain`** so queued messages still drain without a mounted UI.
> 
> **T3 Connect / relay** gains separate **UI vs background** managed-relay session ownership and **`backgroundManagedRelayAuth`** (cold Clerk bootstrap, holds during account transitions, retries). **`CloudAuthProvider`** no longer clears relay on UI unmount when background still owns the session. Returning to the app uses **`application-active-preserved`** when the native service and JS runtime are both ready, avoiding forced reconnects.
> 
> Settings expose the toggle, status, and optional battery-exemption prompt; the active thread is **persisted** as the retained target and cleared when environments/threads are removed or caches are wiped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36b040a2016508348d5770483b11ff1c742e0b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Android background connection with foreground service and shared outbox dispatcher
> - Adds the `t3-background-connection` Expo native module with a sticky foreground service, headless JS task, broadcast receiver (boot/package-replace/restart), state manager, exponential restart backoff (1s–5min), and battery-optimization exemption support
> - Adds JS background infrastructure: background task lifecycle, retained-thread persistence (single-flight load, serialized saves/clears), target selection, background relay-auth bootstrap with epoch invalidation and transition holds, and lease-based UI/background managed-relay session ownership
> - Refactors the thread outbox drain from React hooks to a registry-backed shared dispatcher (`acquireThreadOutboxDrain`) that reference-counts owners, coalesces drain requests, and retries through state-backed timers
> - Adds `application-active-preserved` wakeup type so `EnvironmentSupervisor` probes the connected session instead of reconnecting when both the native service and runtime are ready
> - Integrates into the app entrypoint, `App.tsx` startup coordinator, `RootStackLayout` retained-thread tracking, and Android-only settings UI with battery-exemption prompting
> - Risk: `CloudAuthProvider` account deactivation now invalidates background relay auth and clears both UI and background ownership; account switches suppress intermediate refresh. The outbox drain lifecycle changed from per-component to registry-scoped shared leases — multiple hook mounts share one dispatcher, and the final release stops drains, cancels retries, and unsubscribes listeners
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b36b040.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->