### PR TITLE
fix(server): ignore malformed Claude model usage

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1934,7 +1934,7 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("emits Claude context window on result completion usage snapshots", () => {
+  it.effect("ignores malformed Claude model usage entries", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
@@ -1973,10 +1973,12 @@ describe("ClaudeAdapterLive", () => {
           output_tokens: 679,
         },
         modelUsage: {
-          "claude-opus-4-6": {
-            contextWindow: 200000,
-            maxOutputTokens: 64000,
-          },
+          null: null,
+          missing: {},
+          string: { contextWindow: "200000" },
+          infinite: { contextWindow: Number.POSITIVE_INFINITY },
+          zero: { contextWindow: 0 },
+          negative: { contextWindow: -1 },
         },
       } as unknown as SDKMessage);
       harness.query.finish();
@@ -1991,7 +1993,6 @@ describe("ClaudeAdapterLive", () => {
             lastUsedTokens: 24542,
             inputTokens: 23863,
             outputTokens: 679,
-            maxTokens: 200000,
           },
         });
       }

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -18,7 +18,6 @@ import {
   type SDKResultMessage,
   type SettingSource,
   type SDKUserMessage,
-  type ModelUsage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
 import {
@@ -62,6 +61,7 @@ import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
 import * as Path from "effect/Path";
+import * as Predicate from "effect/Predicate";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -322,14 +322,20 @@ function asRuntimeItemId(value: string): RuntimeItemId {
   return RuntimeItemId.make(value);
 }
 
-function maxClaudeContextWindowFromModelUsage(
-  modelUsage: Record<string, ModelUsage> | undefined,
-): number | undefined {
-  if (!modelUsage) return undefined;
+function maxClaudeContextWindowFromModelUsage(modelUsage: unknown): number | undefined {
+  if (!Predicate.isObject(modelUsage)) return undefined;
 
   let maxContextWindow: number | undefined;
   for (const value of Object.values(modelUsage)) {
+    if (!Predicate.isObject(value)) continue;
     const contextWindow = value.contextWindow;
+    if (
+      !Predicate.isNumber(contextWindow) ||
+      !Number.isFinite(contextWindow) ||
+      contextWindow <= 0
+    ) {
+      continue;
+    }
     maxContextWindow = Math.max(maxContextWindow ?? 0, contextWindow);
   }
 


### PR DESCRIPTION
## What changed

Claude result messages are typed by the SDK, but `modelUsage` is runtime provider telemetry. A malformed entry could throw while reading `contextWindow` or produce `NaN`, failing the Claude provider session or degrading token normalization.

The adapter now validates the top-level value and each model entry at runtime, accepting only finite positive numeric context windows. Malformed entries are ignored, while valid token accounting remains unchanged.

## Validation

- `vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts` (62 passed)
- `vp run --filter t3 typecheck`
- `vp lint --report-unused-disable-directives --type-aware --type-check --deny-warnings apps/server/src/provider/Layers/ClaudeAdapter.ts apps/server/src/provider/Layers/ClaudeAdapter.test.ts`
- `vp fmt --check apps/server/src/provider/Layers/ClaudeAdapter.ts apps/server/src/provider/Layers/ClaudeAdapter.test.ts`
- `git diff --check`

Model: OpenAI Codex (GPT-5.6); harness: Codex desktop.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `maxClaudeContextWindowFromModelUsage` to ignore malformed model usage entries
> The `maxClaudeContextWindowFromModelUsage` util in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/5184/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) now accepts `unknown` input and defensively skips invalid `contextWindow` values (non-numeric, non-finite, zero, or negative) instead of propagating `NaN`. Returns `undefined` when no valid entries are found, so `maxTokens` is omitted from the `thread.token-usage.updated` event payload rather than set to a bad value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d64f332.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized defensive parsing in the Claude adapter’s token-usage path; no auth or persistence changes, with test coverage for malformed telemetry.
> 
> **Overview**
> Hardens **`maxClaudeContextWindowFromModelUsage`** in `ClaudeAdapter` so runtime `modelUsage` from Claude result messages cannot crash the session or yield bad **`maxTokens`** on **`thread.token-usage.updated`**.
> 
> The helper now takes **`unknown`**, validates the map and each entry with **`Predicate`**, and only counts **finite positive numeric** `contextWindow` values. Invalid shapes (null entries, missing `contextWindow`, strings, non-finite numbers, zero, or negatives) are skipped. When nothing valid remains, the function returns **`undefined`**, so **`maxTokens`** is omitted from the usage payload while normal token totals still apply.
> 
> A test replaces the happy-path context-window case with malformed **`modelUsage`** fixtures and asserts usage events without **`maxTokens`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d64f3321e3dae01843cfd3f520c459dc384472cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->