### PR TITLE
fix(web): allow skill replies to pending questions

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -28,8 +28,33 @@ import {
   resolveSendEnvMode,
   startNewThreadForProject,
   shouldShowBranchMismatchBanner,
+  shouldReconcilePendingUserInputCursor,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
+
+describe("shouldReconcilePendingUserInputCursor", () => {
+  it("does not focus a stale editor snapshot over a controlled replacement", () => {
+    expect(
+      shouldReconcilePendingUserInputCursor({
+        snapshot: { value: "$", cursor: 1, expandedCursor: 1 },
+        value: "$test-t3-app ",
+        cursor: 13,
+        expandedCursor: 13,
+      }),
+    ).toBe(false);
+  });
+
+  it("reconciles cursor drift after the editor has the current value", () => {
+    expect(
+      shouldReconcilePendingUserInputCursor({
+        snapshot: { value: "$test-t3-app ", cursor: 1, expandedCursor: 1 },
+        value: "$test-t3-app ",
+        cursor: 13,
+        expandedCursor: 13,
+      }),
+    ).toBe(true);
+  });
+});
 
 const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -28,6 +28,26 @@ export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 
+export function shouldReconcilePendingUserInputCursor(input: {
+  snapshot:
+    | {
+        value: string;
+        cursor: number;
+        expandedCursor: number;
+      }
+    | null
+    | undefined;
+  value: string;
+  cursor: number;
+  expandedCursor: number;
+}): boolean {
+  return Boolean(
+    input.snapshot?.value === input.value &&
+    (input.snapshot.cursor !== input.cursor ||
+      input.snapshot.expandedCursor !== input.expandedCursor),
+  );
+}
+
 export function startNewThreadForProject(
   projectRef: ScopedProjectRef | null,
   handleNewThread: (projectRef: ScopedProjectRef) => Promise<void>,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -261,6 +261,7 @@ import {
   hasServerAcknowledgedLocalDispatch,
   isBranchMismatchDismissedForSession,
   shouldShowBranchMismatchBanner,
+  shouldReconcilePendingUserInputCursor,
   getStartedThreadModelChangeBlockReason,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
   LastInvokedScriptByProjectSchema,
@@ -5091,10 +5092,16 @@ function ChatViewContent(props: ChatViewProps) {
       }));
       const snapshot = composerRef.current?.readSnapshot();
       if (
-        snapshot?.value !== value ||
-        snapshot.cursor !== nextCursor ||
-        snapshot.expandedCursor !== expandedCursor
+        shouldReconcilePendingUserInputCursor({
+          snapshot,
+          value,
+          cursor: nextCursor,
+          expandedCursor,
+        })
       ) {
+        // A controlled replacement reaches this callback before the editor has
+        // rendered its new value. Focusing that stale snapshot would emit the
+        // previous text and undo the replacement.
         composerRef.current?.focusAt(nextCursor);
       }
     },

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2436,9 +2436,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (text.length === 0 || isConnecting || isComposerApprovalState || projectSelectionRequired) {
       return false;
     }
-    // Pending user-input prompts remain editable: applyPromptReplacement
-    // routes this text into the active custom answer instead of the thread draft.
-    const prompt = promptRef.current;
+    // A pending question replaces the thread draft in the controlled editor,
+    // but promptRef can still contain that draft during the transition.
+    const prompt = activePendingProgress?.activeQuestion
+      ? activePendingProgress.customAnswer
+      : promptRef.current;
+    promptRef.current = prompt;
     const needsLeadingSpace =
       (options?.ensureLeadingBoundary ?? false) && prompt.length > 0 && !/\s$/.test(prompt);
     return applyPromptReplacement(

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2433,15 +2433,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     text: string,
     options?: { ensureLeadingBoundary?: boolean },
   ): boolean => {
-    if (
-      text.length === 0 ||
-      isConnecting ||
-      isComposerApprovalState ||
-      pendingUserInputs.length > 0 ||
-      projectSelectionRequired
-    ) {
+    if (text.length === 0 || isConnecting || isComposerApprovalState || projectSelectionRequired) {
       return false;
     }
+    // Pending user-input prompts remain editable: applyPromptReplacement
+    // routes this text into the active custom answer instead of the thread draft.
     const prompt = promptRef.current;
     const needsLeadingSpace =
       (options?.ensureLeadingBoundary ?? false) && prompt.length > 0 && !/\s$/.test(prompt);
@@ -2645,7 +2641,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       composerReviewComments,
       isConnecting,
       isComposerApprovalState,
-      pendingUserInputs.length,
       projectSelectionRequired,
       applyPromptReplacement,
       isComposerModelPickerOpen,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2631,6 +2631,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }),
     }),
     [
+      activePendingProgress?.activeQuestion,
+      activePendingProgress?.customAnswer,
       activeThread,
       composerDraftTarget,
       composerCursor,


### PR DESCRIPTION
## Problem

When a provider is waiting on structured user input, typing `$` from outside the editor did not reach the pending custom answer. After opening the skill picker, selecting a skill was also rolled back to the raw `$` because cursor reconciliation refocused an editor snapshot that still held the old value.

## Fix

Allow imperative text insertion while user input is pending, then only reconcile the pending-answer cursor when the editor snapshot already contains the controlled value. This preserves skill, file, and command replacements instead of re-emitting stale text.

## Impact

Users can type `$`, choose a skill, and submit it as a free-form answer to a pending provider question without manually focusing or retyping the composer.

## Validation

- `vp run --filter @t3tools/web typecheck`
- targeted lint and formatting checks for the changed web files
- `git diff --check`
- shared-browser verification: type `$` while the pending-answer editor is blurred, click “T3 App Testing,” confirm the picker closes and the skill chip remains focused in the answer

The focused unit test is included, but the local runner currently fails during unchanged `vite-plus/test` setup with `Cannot read properties of undefined (reading config)` before collecting tests.

Built with GPT-5.6 Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat composer and pending-answer focus logic with a small pure helper and tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes composer behavior when the provider is waiting on structured user input so **`$` skill picks and other imperative inserts** work without rolling back the answer.
> 
> **`ChatComposer`** no longer blocks `insertComposerTextAtEnd` while pending questions exist, and during an active question it inserts into **`activePendingProgress.customAnswer`** instead of a stale **`promptRef`** that may still hold the thread draft.
> 
> **`ChatView`** adds **`shouldReconcilePendingUserInputCursor`** and uses it before **`focusAt`** on pending custom answers: focus runs only when the editor snapshot already matches the controlled value but cursor positions drift, avoiding refocus on a stale snapshot that would re-emit old text and undo skill replacements.
> 
> Unit tests cover the reconcile helper for stale vs current snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cfd17f51cda70cb7c98efc4cdd5ea0bfd692441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix skill replies to allow text insertion during pending questions in `ChatComposer`
> - `insertComposerTextAtEnd` in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/5186/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) no longer blocks insertion when pending user inputs are active; it now uses the active question's `customAnswer` as the base prompt instead of the stale draft.
> - Adds `shouldReconcilePendingUserInputCursor` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/5186/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) to isolate the decision of whether to refocus the composer for cursor reconciliation.
> - The composer now only refocuses when the editor value matches the intended value but the cursor has drifted, preventing a stale snapshot from undoing a controlled replacement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cfd17f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->