### PR TITLE
feat: fold legacy models into separate menus

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -43,7 +43,7 @@ import {
   type ComposerDraft,
 } from "../../state/use-composer-drafts";
 import { useEnvironmentServerConfig, useProjects } from "../../state/entities";
-import { resolveSelectableModelSelection } from "../../lib/modelOptions";
+import { buildModelMenuActions, resolveSelectableModelSelection } from "../../lib/modelOptions";
 import { deriveThreadTitleFromPrompt } from "../../lib/projectThreadStartTurn";
 import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/remoteRegistration";
 import { enqueueThreadOutboxMessage, removeThreadOutboxMessage } from "../../state/thread-outbox";
@@ -543,27 +543,7 @@ export function NewTaskDraftScreen(props: {
   );
 
   const modelMenuActions = useMemo(
-    () =>
-      flow.providerGroups.map((group) => ({
-        id: `provider:${group.providerKey}`,
-        title: group.providerLabel,
-        subtitle: group.models.find(
-          (model) =>
-            flow.selectedModel &&
-            model.selection.instanceId === flow.selectedModel.instanceId &&
-            model.selection.model === flow.selectedModel.model,
-        )?.label,
-        subactions: group.models.map((option) => ({
-          id: `model:${option.key}`,
-          title: option.label,
-          state:
-            flow.selectedModel &&
-            option.selection.instanceId === flow.selectedModel.instanceId &&
-            option.selection.model === flow.selectedModel.model
-              ? ("on" as const)
-              : undefined,
-        })),
-      })),
+    () => buildModelMenuActions(flow.providerGroups, flow.selectedModel),
     [flow.providerGroups, flow.selectedModel],
   );
   const providerOptionDescriptors = useMemo(

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -53,7 +53,7 @@ import {
 import { ControlPill, ControlPillMenu } from "../../components/ControlPill";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
-import { buildModelOptions, groupByProvider } from "../../lib/modelOptions";
+import { buildModelMenuActions, buildModelOptions, groupByProvider } from "../../lib/modelOptions";
 import { useScaledTextRole } from "../settings/appearance/useScaledTextRole";
 import type { RemoteClientConnectionState } from "../../lib/connection";
 import {
@@ -606,25 +606,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     [providerOptionDescriptors],
   );
   const modelMenuActions = useMemo(
-    () =>
-      providerGroups.map((group) => ({
-        id: `provider:${group.providerKey}`,
-        title: group.providerLabel,
-        subtitle: group.models.find(
-          (model) =>
-            model.selection.instanceId === currentModelSelection.instanceId &&
-            model.selection.model === currentModelSelection.model,
-        )?.label,
-        subactions: group.models.map((option) => ({
-          id: `model:${option.key}`,
-          title: option.label,
-          state:
-            option.selection.instanceId === currentModelSelection.instanceId &&
-            option.selection.model === currentModelSelection.model
-              ? ("on" as const)
-              : undefined,
-        })),
-      })),
+    () => buildModelMenuActions(providerGroups, currentModelSelection),
     [providerGroups, currentModelSelection],
   );
 

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -2,9 +2,58 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { ProviderInstanceId, type ServerConfig } from "@t3tools/contracts";
 
-import { buildModelOptions, resolveSelectableModelSelection } from "./modelOptions";
+import {
+  buildModelMenuActions,
+  buildModelOptions,
+  groupByProvider,
+  resolveSelectableModelSelection,
+} from "./modelOptions";
 
 describe("mobile model options", () => {
+  it("folds legacy models into a provider-scoped menu", () => {
+    const config = {
+      providers: [
+        {
+          instanceId: "codex",
+          driver: "codex",
+          displayName: "Codex",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          models: [
+            {
+              slug: "gpt-5.6-sol",
+              name: "GPT-5.6 Sol",
+              isCustom: false,
+              capabilities: null,
+            },
+            {
+              slug: "gpt-5.4",
+              name: "GPT-5.4",
+              isCustom: false,
+              isLegacy: true,
+              capabilities: null,
+            },
+          ],
+        },
+      ],
+    } as unknown as ServerConfig;
+
+    const actions = buildModelMenuActions(groupByProvider(buildModelOptions(config, null)), null);
+
+    expect(actions).toMatchObject([
+      {
+        title: "Codex",
+        subactions: [{ id: "model:codex:gpt-5.6-sol", title: "GPT-5.6 Sol" }],
+      },
+      {
+        id: "legacy-models:codex",
+        title: "Codex legacy models",
+        subactions: [{ id: "model:codex:gpt-5.4", title: "GPT-5.4" }],
+      },
+    ]);
+  });
+
   it("normalizes a legacy fallback selection against current capabilities", () => {
     const config = {
       providers: [

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -54,6 +54,40 @@ describe("mobile model options", () => {
     ]);
   });
 
+  it("omits an empty provider menu when every model is legacy", () => {
+    const config = {
+      providers: [
+        {
+          instanceId: "codex",
+          driver: "codex",
+          displayName: "Codex",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          models: [
+            {
+              slug: "gpt-5.4",
+              name: "GPT-5.4",
+              isCustom: false,
+              isLegacy: true,
+              capabilities: null,
+            },
+          ],
+        },
+      ],
+    } as unknown as ServerConfig;
+
+    expect(
+      buildModelMenuActions(groupByProvider(buildModelOptions(config, null)), null),
+    ).toMatchObject([
+      {
+        id: "legacy-models:codex",
+        title: "Codex legacy models",
+        subactions: [{ id: "model:codex:gpt-5.4" }],
+      },
+    ]);
+  });
+
   it("normalizes a legacy fallback selection against current capabilities", () => {
     const config = {
       providers: [

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -195,12 +195,16 @@ export function buildModelMenuActions(
     );
 
     return [
-      {
-        id: `provider:${group.providerKey}`,
-        title: group.providerLabel,
-        subtitle: selected && !selected.isLegacy ? selected.label : undefined,
-        subactions: currentModels.map((option) => modelMenuAction(option, selectedModel)),
-      },
+      ...(currentModels.length > 0
+        ? [
+            {
+              id: `provider:${group.providerKey}`,
+              title: group.providerLabel,
+              subtitle: selected && !selected.isLegacy ? selected.label : undefined,
+              subactions: currentModels.map((option) => modelMenuAction(option, selectedModel)),
+            },
+          ]
+        : []),
       ...(legacyModels.length > 0
         ? [
             {

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -3,6 +3,7 @@ import type {
   ModelSelection,
   ServerConfig as T3ServerConfig,
 } from "@t3tools/contracts";
+import type { MenuAction } from "@react-native-menu/menu";
 import {
   buildProviderOptionSelectionsFromDescriptors,
   getProviderOptionDescriptors,
@@ -16,6 +17,7 @@ export type ModelOption = {
   readonly providerLabel: string;
   readonly providerDriver: string;
   readonly isDefault: boolean;
+  readonly isLegacy: boolean;
   readonly capabilities: ModelCapabilities | null;
   readonly selection: ModelSelection;
 };
@@ -105,6 +107,7 @@ export function buildModelOptions(
         providerLabel,
         providerDriver: provider.driver,
         isDefault: model.isDefault === true,
+        isLegacy: model.isLegacy === true,
         capabilities: model.capabilities,
         selection: normalizeSelectionOptions(
           {
@@ -135,6 +138,7 @@ export function buildModelOptions(
         providerLabel,
         providerDriver: fallbackModelSelection.instanceId,
         isDefault: false,
+        isLegacy: false,
         capabilities: null,
         selection: fallbackModelSelection,
       });
@@ -163,4 +167,50 @@ export function groupByProvider(options: ReadonlyArray<ModelOption>): ReadonlyAr
     providerLabel: group.providerLabel,
     models: group.models,
   }));
+}
+
+function modelMenuAction(option: ModelOption, selectedModel: ModelSelection | null): MenuAction {
+  return {
+    id: `model:${option.key}`,
+    title: option.label,
+    state:
+      option.selection.instanceId === selectedModel?.instanceId &&
+      option.selection.model === selectedModel.model
+        ? "on"
+        : undefined,
+  };
+}
+
+export function buildModelMenuActions(
+  groups: ReadonlyArray<ProviderGroup>,
+  selectedModel: ModelSelection | null,
+): MenuAction[] {
+  return groups.flatMap((group) => {
+    const currentModels = group.models.filter((model) => !model.isLegacy);
+    const legacyModels = group.models.filter((model) => model.isLegacy);
+    const selected = group.models.find(
+      (model) =>
+        model.selection.instanceId === selectedModel?.instanceId &&
+        model.selection.model === selectedModel.model,
+    );
+
+    return [
+      {
+        id: `provider:${group.providerKey}`,
+        title: group.providerLabel,
+        subtitle: selected && !selected.isLegacy ? selected.label : undefined,
+        subactions: currentModels.map((option) => modelMenuAction(option, selectedModel)),
+      },
+      ...(legacyModels.length > 0
+        ? [
+            {
+              id: `legacy-models:${group.providerKey}`,
+              title: `${group.providerLabel} legacy models`,
+              subtitle: selected?.isLegacy ? selected.label : undefined,
+              subactions: legacyModels.map((option) => modelMenuAction(option, selectedModel)),
+            },
+          ]
+        : []),
+    ];
+  });
 }

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -9,10 +9,26 @@ import * as Schema from "effect/Schema";
 import {
   buildClaudeCapabilitiesProbeQueryOptions,
   CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES,
+  isLegacyClaudeModel,
   probeClaudeCapabilities,
 } from "./ClaudeProvider.ts";
 
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
+
+it("keeps only the Claude 5 family out of legacy models", () => {
+  assert.deepStrictEqual(
+    ["claude-fable-5", "claude-opus-5", "claude-sonnet-5", "claude-opus-4-8"].map((model) => [
+      model,
+      isLegacyClaudeModel(model),
+    ]),
+    [
+      ["claude-fable-5", false],
+      ["claude-opus-5", false],
+      ["claude-sonnet-5", false],
+      ["claude-opus-4-8", true],
+    ],
+  );
+});
 
 it("isolates Claude capability probes without dropping workspace setting sources", () => {
   const abortController = new AbortController();

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -56,7 +56,13 @@ const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";
 const MINIMUM_CLAUDE_OPUS_4_7_VERSION = "2.1.111";
 
-const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+const CURRENT_CLAUDE_MODELS = new Set(["claude-fable-5", "claude-opus-5", "claude-sonnet-5"]);
+
+export function isLegacyClaudeModel(model: string): boolean {
+  return !CURRENT_CLAUDE_MODELS.has(model);
+}
+
+const CLAUDE_MODEL_CATALOG: ReadonlyArray<ServerProviderModel> = [
   {
     slug: "claude-fable-5",
     name: "Claude Fable 5",
@@ -308,6 +314,10 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
     }),
   },
 ];
+
+const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = CLAUDE_MODEL_CATALOG.map((model) =>
+  isLegacyClaudeModel(model.slug) ? { ...model, isLegacy: true } : model,
+);
 
 function supportsClaudeOpus5(version: string | null | undefined): boolean {
   return version ? compareSemverVersions(version, MINIMUM_CLAUDE_OPUS_5_VERSION) >= 0 : false;

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,25 @@
 import { assert, it } from "@effect/vitest";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  isLegacyCodexModel,
+  mapCodexModelCapabilities,
+} from "./CodexProvider.ts";
+
+it("keeps only the GPT-5.6 Codex family out of legacy models", () => {
+  assert.deepStrictEqual(
+    ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.4"].map((model) => [
+      model,
+      isLegacyCodexModel(model),
+    ]),
+    [
+      ["gpt-5.6-luna", false],
+      ["gpt-5.6-terra", false],
+      ["gpt-5.6-sol", false],
+      ["gpt-5.4", true],
+    ],
+  );
+});
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -62,6 +62,11 @@ const REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
 };
 
 const DEFAULT_SERVICE_TIER_ID = "default";
+const CURRENT_CODEX_MODELS = new Set(["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]);
+
+export function isLegacyCodexModel(model: string): boolean {
+  return !CURRENT_CODEX_MODELS.has(model);
+}
 
 function reasoningEffortLabel(reasoningEffort: string): string {
   return REASONING_EFFORT_LABELS[reasoningEffort] ?? reasoningEffort;
@@ -190,6 +195,7 @@ function parseCodexModelListResponse(
     name: toDisplayName(model),
     isCustom: false,
     ...(model.isDefault ? { isDefault: true } : {}),
+    ...(isLegacyCodexModel(model.model) ? { isLegacy: true } : {}),
     capabilities: mapCodexModelCapabilities(model),
   }));
 }

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -12,6 +12,7 @@ import { Button } from "../ui/button";
 import { Kbd } from "../ui/kbd";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "~/lib/utils";
+import { modelPickerModelKey } from "./modelPickerKeys";
 
 export const ModelListRow = memo(function ModelListRow(props: {
   index: number;
@@ -46,7 +47,7 @@ export const ModelListRow = memo(function ModelListRow(props: {
     <ComboboxItem
       hideIndicator
       index={props.index}
-      value={`${props.instanceId}:${props.model.slug}`}
+      value={modelPickerModelKey(props.instanceId, props.model.slug)}
       disabled={Boolean(props.disabledReason)}
       contentClassName="flex w-full items-center gap-3"
       className={cn(

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -6,12 +6,18 @@ import {
 import { resolveSelectableModel } from "@t3tools/shared/model";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { memo, useMemo, useState, useCallback, useEffect, useLayoutEffect, useRef } from "react";
-import { SearchIcon } from "lucide-react";
+import { ChevronRightIcon, SearchIcon } from "lucide-react";
 import { ModelListRow } from "./ModelListRow";
 import { ModelPickerSidebar } from "./ModelPickerSidebar";
 import { isModelPickerNewModel } from "./modelPickerModelHighlights";
 import { buildModelPickerSearchText, scoreModelPickerSearch } from "./modelPickerSearch";
-import { Combobox, ComboboxEmpty, ComboboxInput, ComboboxListVirtualized } from "../ui/combobox";
+import {
+  Combobox,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxListVirtualized,
+} from "../ui/combobox";
 import { ModelEsque } from "./providerIconUtils";
 import {
   modelPickerJumpCommandForIndex,
@@ -39,12 +45,24 @@ type ModelPickerItem = {
   instanceDisplayName: string;
   instanceAccentColor?: string | undefined;
   continuationGroupKey?: string | undefined;
+  isLegacy?: boolean | undefined;
 };
 
 const EMPTY_MODEL_JUMP_LABELS = new Map<string, string>();
+const LEGACY_SECTION_KEY_PREFIX = "legacy-models:";
 
 function ModelListSeparator() {
   return <div className="h-0.5" />;
+}
+
+function legacySectionKey(instanceId: ProviderInstanceId): string {
+  return `${LEGACY_SECTION_KEY_PREFIX}${instanceId}`;
+}
+
+function legacySectionInstanceId(key: string): ProviderInstanceId | null {
+  return key.startsWith(LEGACY_SECTION_KEY_PREFIX)
+    ? (key.slice(LEGACY_SECTION_KEY_PREFIX.length) as ProviderInstanceId)
+    : null;
 }
 
 // Split a `${instanceId}:${slug}` combobox key back into its pieces. Slugs
@@ -116,6 +134,16 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       }
       return favorites.length > 0 ? "favorites" : props.activeInstanceId;
     },
+  );
+  const [expandedLegacyInstances, setExpandedLegacyInstances] = useState(
+    () =>
+      new Set<ProviderInstanceId>(
+        modelOptionsByInstance
+          .get(props.activeInstanceId)
+          ?.some((model) => model.slug === props.model && model.isLegacy)
+          ? [props.activeInstanceId]
+          : [],
+      ),
   );
   const keybindings = useMemo<ResolvedKeybindingsConfig>(
     () => providedKeybindings ?? [],
@@ -211,6 +239,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
           name: model.name,
           ...(model.shortName ? { shortName: model.shortName } : {}),
           ...(model.subProvider ? { subProvider: model.subProvider } : {}),
+          ...(model.isLegacy ? { isLegacy: true } : {}),
           instanceId,
           driverKind: entry.driverKind,
           instanceDisplayName: entry.displayName,
@@ -366,6 +395,45 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     selectedInstanceId,
   ]);
 
+  const legacySection = useMemo(() => {
+    if (isSearching || selectedInstanceId === "favorites") {
+      return null;
+    }
+    const currentModels = filteredModels.filter((model) => !model.isLegacy);
+    const legacyModels = filteredModels.filter((model) => model.isLegacy);
+    if (legacyModels.length === 0) {
+      return null;
+    }
+    return {
+      key: legacySectionKey(selectedInstanceId),
+      currentModels,
+      legacyModels,
+      isExpanded: expandedLegacyInstances.has(selectedInstanceId),
+    };
+  }, [expandedLegacyInstances, filteredModels, isSearching, selectedInstanceId]);
+
+  const visibleModels = useMemo(() => {
+    if (!legacySection) {
+      return filteredModels;
+    }
+    return [
+      ...legacySection.currentModels,
+      ...(legacySection.isExpanded ? legacySection.legacyModels : []),
+    ];
+  }, [filteredModels, legacySection]);
+
+  const toggleLegacySection = useCallback((instanceId: ProviderInstanceId) => {
+    setExpandedLegacyInstances((expanded) => {
+      const next = new Set(expanded);
+      if (next.has(instanceId)) {
+        next.delete(instanceId);
+      } else {
+        next.add(instanceId);
+      }
+      return next;
+    });
+  }, []);
+
   const handleModelSelect = useCallback(
     (modelSlug: string, instanceId: ProviderInstanceId) => {
       if (getModelDisabledReason?.(instanceId, modelSlug)) {
@@ -410,7 +478,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       NonNullable<ReturnType<typeof modelPickerJumpCommandForIndex>>
     >();
     let selectableModelIndex = 0;
-    for (const model of filteredModels) {
+    for (const model of visibleModels) {
       if (getModelDisabledReason?.(model.instanceId, model.slug)) {
         continue;
       }
@@ -422,23 +490,34 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       selectableModelIndex += 1;
     }
     return mapping;
-  }, [filteredModels, getModelDisabledReason]);
+  }, [getModelDisabledReason, visibleModels]);
   const modelJumpModelKeys = useMemo(
     () => [...modelJumpCommandByKey.keys()],
     [modelJumpCommandByKey],
   );
-  const allModelKeys = useMemo(
-    (): string[] => flatModels.map((model) => `${model.instanceId}:${model.slug}`),
+  const allItemKeys = useMemo(
+    (): string[] => [
+      ...flatModels.map((model) => `${model.instanceId}:${model.slug}`),
+      ...new Set(
+        flatModels
+          .filter((model) => model.isLegacy)
+          .map((model) => legacySectionKey(model.instanceId)),
+      ),
+    ],
     [flatModels],
   );
-  const filteredModelKeys = useMemo(
-    (): string[] => filteredModels.map((model) => `${model.instanceId}:${model.slug}`),
-    [filteredModels],
-  );
+  const filteredItemKeys = useMemo((): string[] => {
+    const modelKeys = visibleModels.map((model) => `${model.instanceId}:${model.slug}`);
+    if (!legacySection) {
+      return modelKeys;
+    }
+    modelKeys.splice(legacySection.currentModels.length, 0, legacySection.key);
+    return modelKeys;
+  }, [legacySection, visibleModels]);
   const filteredModelByKey = useMemo(
     (): ReadonlyMap<string, ModelPickerItem> =>
-      new Map(filteredModels.map((model) => [`${model.instanceId}:${model.slug}`, model] as const)),
-    [filteredModels],
+      new Map(visibleModels.map((model) => [`${model.instanceId}:${model.slug}`, model] as const)),
+    [visibleModels],
   );
   const updateModelListScrollFades = useCallback(() => {
     const scrollElement = modelListRef.current?.getScrollableNode();
@@ -510,7 +589,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
 
   useLayoutEffect(() => {
     setShowTopScrollFade(false);
-    setShowBottomScrollFade(filteredModelKeys.length > 5);
+    setShowBottomScrollFade(filteredItemKeys.length > 5);
     let nestedFrame = 0;
     const frame = window.requestAnimationFrame(() => {
       updateModelListScrollFades();
@@ -520,7 +599,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       window.cancelAnimationFrame(frame);
       window.cancelAnimationFrame(nestedFrame);
     };
-  }, [filteredModelKeys, updateModelListScrollFades]);
+  }, [filteredItemKeys, updateModelListScrollFades]);
 
   return (
     <TooltipProvider delay={0}>
@@ -548,8 +627,8 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
         {/* Main content area */}
         <Combobox
           inline
-          items={allModelKeys}
-          filteredItems={filteredModelKeys}
+          items={allItemKeys}
+          filteredItems={filteredItemKeys}
           filter={null}
           autoHighlight
           open
@@ -566,6 +645,11 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
           }}
           onValueChange={(modelKey) => {
             if (typeof modelKey !== "string") {
+              return;
+            }
+            const legacyInstanceId = legacySectionInstanceId(modelKey);
+            if (legacyInstanceId) {
+              toggleLegacySection(legacyInstanceId);
               return;
             }
             const { instanceId, slug } = splitInstanceModelKey(modelKey);
@@ -605,6 +689,13 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                       ).preventBaseUIHandler?.();
                       e.preventDefault();
                       e.stopPropagation();
+                      const legacyInstanceId = legacySectionInstanceId(
+                        highlightedModelKeyRef.current,
+                      );
+                      if (legacyInstanceId) {
+                        toggleLegacySection(legacyInstanceId);
+                        return;
+                      }
                       const { instanceId, slug } = splitInstanceModelKey(
                         highlightedModelKeyRef.current,
                       );
@@ -626,10 +717,35 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
               <ComboboxListVirtualized className="size-full min-w-0 p-0 not-empty:p-0">
                 <LegendList<string>
                   ref={modelListRef}
-                  data={filteredModelKeys}
+                  data={filteredItemKeys}
                   extraData={favoritesSet}
                   keyExtractor={(modelKey) => modelKey}
                   renderItem={({ item: modelKey, index }) => {
+                    if (legacySection?.key === modelKey) {
+                      return (
+                        <ComboboxItem
+                          hideIndicator
+                          index={index}
+                          value={modelKey}
+                          aria-expanded={legacySection.isExpanded}
+                          className="group w-full cursor-pointer rounded-md px-2 py-2"
+                          contentClassName="flex w-full items-center gap-3"
+                        >
+                          <div className="min-w-0 flex-1 text-left">
+                            <div className="text-xs font-medium leading-snug">Legacy models</div>
+                            <div className="mt-1 text-xs font-normal leading-snug text-muted-foreground/70">
+                              {legacySection.legacyModels.length} models
+                            </div>
+                          </div>
+                          <ChevronRightIcon
+                            className={cn(
+                              "size-4 transition-transform",
+                              legacySection.isExpanded && "rotate-90",
+                            )}
+                          />
+                        </ComboboxItem>
+                      );
+                    }
                     const model = filteredModelByKey.get(modelKey);
                     if (!model) {
                       return null;
@@ -657,7 +773,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                       />
                     );
                   }}
-                  estimatedItemSize={60}
+                  estimatedItemSize={52}
                   drawDistance={480}
                   recycleItems
                   contentContainerClassName="pl-2 pr-px"

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -9,6 +9,12 @@ import { memo, useMemo, useState, useCallback, useEffect, useLayoutEffect, useRe
 import { ChevronRightIcon, SearchIcon } from "lucide-react";
 import { ModelListRow } from "./ModelListRow";
 import { ModelPickerSidebar } from "./ModelPickerSidebar";
+import {
+  modelPickerLegacySectionKey,
+  modelPickerModelKey,
+  parseModelPickerLegacySectionKey,
+  parseModelPickerModelKey,
+} from "./modelPickerKeys";
 import { isModelPickerNewModel } from "./modelPickerModelHighlights";
 import { buildModelPickerSearchText, scoreModelPickerSearch } from "./modelPickerSearch";
 import {
@@ -49,34 +55,9 @@ type ModelPickerItem = {
 };
 
 const EMPTY_MODEL_JUMP_LABELS = new Map<string, string>();
-const LEGACY_SECTION_KEY_PREFIX = "legacy-models:";
 
 function ModelListSeparator() {
   return <div className="h-0.5" />;
-}
-
-function legacySectionKey(instanceId: ProviderInstanceId): string {
-  return `${LEGACY_SECTION_KEY_PREFIX}${instanceId}`;
-}
-
-function legacySectionInstanceId(key: string): ProviderInstanceId | null {
-  return key.startsWith(LEGACY_SECTION_KEY_PREFIX)
-    ? (key.slice(LEGACY_SECTION_KEY_PREFIX.length) as ProviderInstanceId)
-    : null;
-}
-
-// Split a `${instanceId}:${slug}` combobox key back into its pieces. Slugs
-// can contain colons (e.g. some vendor model ids), so we only split on the
-// first colon — anything after that is the slug.
-function splitInstanceModelKey(key: string): { instanceId: ProviderInstanceId; slug: string } {
-  const colonIndex = key.indexOf(":");
-  if (colonIndex === -1) {
-    return { instanceId: key as ProviderInstanceId, slug: "" };
-  }
-  return {
-    instanceId: key.slice(0, colonIndex) as ProviderInstanceId,
-    slug: key.slice(colonIndex + 1),
-  };
 }
 
 export const ModelPickerContent = memo(function ModelPickerContent(props: {
@@ -405,7 +386,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       return null;
     }
     return {
-      key: legacySectionKey(selectedInstanceId),
+      key: modelPickerLegacySectionKey(selectedInstanceId),
       currentModels,
       legacyModels,
       isExpanded: expandedLegacyInstances.has(selectedInstanceId),
@@ -486,7 +467,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       if (!jumpCommand) {
         return mapping;
       }
-      mapping.set(`${model.instanceId}:${model.slug}`, jumpCommand);
+      mapping.set(modelPickerModelKey(model.instanceId, model.slug), jumpCommand);
       selectableModelIndex += 1;
     }
     return mapping;
@@ -497,17 +478,19 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   );
   const allItemKeys = useMemo(
     (): string[] => [
-      ...flatModels.map((model) => `${model.instanceId}:${model.slug}`),
+      ...flatModels.map((model) => modelPickerModelKey(model.instanceId, model.slug)),
       ...new Set(
         flatModels
           .filter((model) => model.isLegacy)
-          .map((model) => legacySectionKey(model.instanceId)),
+          .map((model) => modelPickerLegacySectionKey(model.instanceId)),
       ),
     ],
     [flatModels],
   );
   const filteredItemKeys = useMemo((): string[] => {
-    const modelKeys = visibleModels.map((model) => `${model.instanceId}:${model.slug}`);
+    const modelKeys = visibleModels.map((model) =>
+      modelPickerModelKey(model.instanceId, model.slug),
+    );
     if (!legacySection) {
       return modelKeys;
     }
@@ -516,7 +499,11 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   }, [legacySection, visibleModels]);
   const filteredModelByKey = useMemo(
     (): ReadonlyMap<string, ModelPickerItem> =>
-      new Map(visibleModels.map((model) => [`${model.instanceId}:${model.slug}`, model] as const)),
+      new Map(
+        visibleModels.map(
+          (model) => [modelPickerModelKey(model.instanceId, model.slug), model] as const,
+        ),
+      ),
     [visibleModels],
   );
   const updateModelListScrollFades = useCallback(() => {
@@ -574,10 +561,13 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       if (!targetModelKey) {
         return;
       }
-      const { instanceId, slug } = splitInstanceModelKey(targetModelKey);
+      const model = parseModelPickerModelKey(targetModelKey);
+      if (!model) {
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
-      handleModelSelect(slug, instanceId);
+      handleModelSelect(model.slug, model.instanceId);
     };
 
     window.addEventListener("keydown", onWindowKeyDown, true);
@@ -633,7 +623,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
           autoHighlight
           open
           virtualized
-          value={`${props.activeInstanceId}:${props.model}`}
+          value={modelPickerModelKey(props.activeInstanceId, props.model)}
           onItemHighlighted={(modelKey, eventDetails) => {
             highlightedModelKeyRef.current = typeof modelKey === "string" ? modelKey : null;
             if (eventDetails.reason === "keyboard" && eventDetails.index >= 0) {
@@ -647,13 +637,15 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
             if (typeof modelKey !== "string") {
               return;
             }
-            const legacyInstanceId = legacySectionInstanceId(modelKey);
+            const legacyInstanceId = parseModelPickerLegacySectionKey(modelKey);
             if (legacyInstanceId) {
               toggleLegacySection(legacyInstanceId);
               return;
             }
-            const { instanceId, slug } = splitInstanceModelKey(modelKey);
-            handleModelSelect(slug, instanceId);
+            const model = parseModelPickerModelKey(modelKey);
+            if (model) {
+              handleModelSelect(model.slug, model.instanceId);
+            }
           }}
         >
           <div
@@ -689,17 +681,17 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                       ).preventBaseUIHandler?.();
                       e.preventDefault();
                       e.stopPropagation();
-                      const legacyInstanceId = legacySectionInstanceId(
+                      const legacyInstanceId = parseModelPickerLegacySectionKey(
                         highlightedModelKeyRef.current,
                       );
                       if (legacyInstanceId) {
                         toggleLegacySection(legacyInstanceId);
                         return;
                       }
-                      const { instanceId, slug } = splitInstanceModelKey(
-                        highlightedModelKeyRef.current,
-                      );
-                      handleModelSelect(slug, instanceId);
+                      const model = parseModelPickerModelKey(highlightedModelKeyRef.current);
+                      if (model) {
+                        handleModelSelect(model.slug, model.instanceId);
+                      }
                       return;
                     }
                     e.stopPropagation();
@@ -761,8 +753,12 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                         driverKind={model.driverKind}
                         providerDisplayName={model.instanceDisplayName}
                         providerAccentColor={model.instanceAccentColor}
-                        isFavorite={favoritesSet.has(modelKey)}
-                        isSelected={modelKey === `${props.activeInstanceId}:${props.model}`}
+                        isFavorite={favoritesSet.has(
+                          providerModelKey(model.instanceId, model.slug),
+                        )}
+                        isSelected={
+                          modelKey === modelPickerModelKey(props.activeInstanceId, props.model)
+                        }
                         showProvider
                         preferShortName={!isLocked}
                         useTriggerLabel={false}

--- a/apps/web/src/components/chat/modelPickerKeys.test.ts
+++ b/apps/web/src/components/chat/modelPickerKeys.test.ts
@@ -1,0 +1,22 @@
+import { ProviderInstanceId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  modelPickerLegacySectionKey,
+  modelPickerModelKey,
+  parseModelPickerLegacySectionKey,
+  parseModelPickerModelKey,
+} from "./modelPickerKeys";
+
+describe("model picker item keys", () => {
+  it("keeps model and legacy section keys distinct for colliding instance names", () => {
+    const modelKey = modelPickerModelKey(ProviderInstanceId.make("legacy-models"), "codex");
+    const sectionKey = modelPickerLegacySectionKey(ProviderInstanceId.make("codex"));
+
+    expect(modelKey).not.toBe(sectionKey);
+    expect(parseModelPickerLegacySectionKey(modelKey)).toBeNull();
+    expect(parseModelPickerModelKey(modelKey)).toEqual({
+      instanceId: "legacy-models",
+      slug: "codex",
+    });
+  });
+});

--- a/apps/web/src/components/chat/modelPickerKeys.test.ts
+++ b/apps/web/src/components/chat/modelPickerKeys.test.ts
@@ -19,4 +19,13 @@ describe("model picker item keys", () => {
       slug: "codex",
     });
   });
+
+  it("round-trips arbitrary strings without throwing", () => {
+    const instanceId = ProviderInstanceId.make("custom");
+    const slug = "model:\udfff";
+
+    const key = modelPickerModelKey(instanceId, slug);
+
+    expect(parseModelPickerModelKey(key)).toEqual({ instanceId, slug });
+  });
 });

--- a/apps/web/src/components/chat/modelPickerKeys.ts
+++ b/apps/web/src/components/chat/modelPickerKeys.ts
@@ -1,0 +1,39 @@
+import type { ProviderInstanceId } from "@t3tools/contracts";
+
+const MODEL_KEY_PREFIX = "model:";
+const LEGACY_SECTION_KEY_PREFIX = "legacy-models:";
+
+export function modelPickerModelKey(instanceId: ProviderInstanceId, slug: string): string {
+  return `${MODEL_KEY_PREFIX}${encodeURIComponent(instanceId)}:${encodeURIComponent(slug)}`;
+}
+
+export function parseModelPickerModelKey(
+  key: string,
+): { instanceId: ProviderInstanceId; slug: string } | null {
+  if (!key.startsWith(MODEL_KEY_PREFIX)) {
+    return null;
+  }
+  const encoded = key.slice(MODEL_KEY_PREFIX.length);
+  const separatorIndex = encoded.indexOf(":");
+  if (separatorIndex === -1) {
+    return null;
+  }
+  try {
+    return {
+      instanceId: decodeURIComponent(encoded.slice(0, separatorIndex)) as ProviderInstanceId,
+      slug: decodeURIComponent(encoded.slice(separatorIndex + 1)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function modelPickerLegacySectionKey(instanceId: ProviderInstanceId): string {
+  return `${LEGACY_SECTION_KEY_PREFIX}${instanceId}`;
+}
+
+export function parseModelPickerLegacySectionKey(key: string): ProviderInstanceId | null {
+  return key.startsWith(LEGACY_SECTION_KEY_PREFIX)
+    ? (key.slice(LEGACY_SECTION_KEY_PREFIX.length) as ProviderInstanceId)
+    : null;
+}

--- a/apps/web/src/components/chat/modelPickerKeys.ts
+++ b/apps/web/src/components/chat/modelPickerKeys.ts
@@ -4,7 +4,7 @@ const MODEL_KEY_PREFIX = "model:";
 const LEGACY_SECTION_KEY_PREFIX = "legacy-models:";
 
 export function modelPickerModelKey(instanceId: ProviderInstanceId, slug: string): string {
-  return `${MODEL_KEY_PREFIX}${encodeURIComponent(instanceId)}:${encodeURIComponent(slug)}`;
+  return `${MODEL_KEY_PREFIX}${instanceId.length}:${instanceId}${slug}`;
 }
 
 export function parseModelPickerModelKey(
@@ -18,14 +18,22 @@ export function parseModelPickerModelKey(
   if (separatorIndex === -1) {
     return null;
   }
-  try {
-    return {
-      instanceId: decodeURIComponent(encoded.slice(0, separatorIndex)) as ProviderInstanceId,
-      slug: decodeURIComponent(encoded.slice(separatorIndex + 1)),
-    };
-  } catch {
+
+  const instanceIdLengthText = encoded.slice(0, separatorIndex);
+  if (!/^\d+$/.test(instanceIdLengthText)) {
     return null;
   }
+
+  const instanceIdLength = Number(instanceIdLengthText);
+  const value = encoded.slice(separatorIndex + 1);
+  if (!Number.isSafeInteger(instanceIdLength) || instanceIdLength > value.length) {
+    return null;
+  }
+
+  return {
+    instanceId: value.slice(0, instanceIdLength) as ProviderInstanceId,
+    slug: value.slice(instanceIdLength),
+  };
 }
 
 export function modelPickerLegacySectionKey(instanceId: ProviderInstanceId): string {

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -26,6 +26,7 @@ export type ModelEsque = {
   name: string;
   shortName?: string | undefined;
   subProvider?: string | undefined;
+  isLegacy?: boolean | undefined;
 };
 
 function escapeRegExp(value: string): string {

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -55,6 +55,24 @@ function settingsWithProviderInstances(): UnifiedSettings {
 }
 
 describe("instance-scoped model selection", () => {
+  it("preserves server-provided legacy model metadata", () => {
+    const baseProvider = provider({
+      instanceId: "claudeAgent",
+      models: ["claude-opus-4-8"],
+    });
+    const providers = [
+      {
+        ...baseProvider,
+        models: [{ ...baseProvider.models[0]!, isLegacy: true }],
+      },
+    ];
+    const stock = deriveProviderInstanceEntries(providers)[0]!;
+
+    expect(getAppModelOptionsForInstance(settingsWithProviderInstances(), stock)[0]?.isLegacy).toBe(
+      true,
+    );
+  });
+
   it("keeps custom models on the provider instance that declared them", () => {
     const providers = [
       provider({

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -76,6 +76,7 @@ export interface AppModelOption {
   subProvider?: string;
   isCustom: boolean;
   isDefault?: boolean;
+  isLegacy?: boolean;
 }
 
 function toAppModelOption(model: ServerProvider["models"][number]): AppModelOption {
@@ -87,6 +88,7 @@ function toAppModelOption(model: ServerProvider["models"][number]): AppModelOpti
   if (model.shortName) option.shortName = model.shortName;
   if (model.subProvider) option.subProvider = model.subProvider;
   if (model.isDefault) option.isDefault = true;
+  if (model.isLegacy) option.isLegacy = true;
   return option;
 }
 

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -73,6 +73,30 @@ describe("ServerProvider", () => {
 
     expect(parsed.continuation?.groupKey).toBe("codex:home:/Users/julius/.codex");
   });
+
+  it("decodes optional legacy model metadata", () => {
+    const parsed = decodeServerProvider({
+      instanceId: "codex",
+      driver: "codex",
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready",
+      auth: { status: "authenticated" },
+      checkedAt: "2026-04-10T00:00:00.000Z",
+      models: [
+        {
+          slug: "gpt-5.4",
+          name: "GPT-5.4",
+          isCustom: false,
+          isLegacy: true,
+          capabilities: null,
+        },
+      ],
+    });
+
+    expect(parsed.models[0]?.isLegacy).toBe(true);
+  });
 });
 
 describe("server config forward compatibility", () => {

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -68,6 +68,7 @@ export const ServerProviderModel = Schema.Struct({
   subProvider: Schema.optional(TrimmedNonEmptyString),
   isCustom: Schema.Boolean,
   isDefault: Schema.optional(Schema.Boolean),
+  isLegacy: Schema.optional(Schema.Boolean),
   capabilities: Schema.NullOr(ModelCapabilities),
 });
 export type ServerProviderModel = typeof ServerProviderModel.Type;


### PR DESCRIPTION
Older provider models crowd the model picker and make the current families harder to scan.

This marks legacy models in provider snapshots so every client receives the same classification. Web and desktop now place them in an inline collapsed section, while mobile places a provider-scoped legacy submenu immediately after each provider. Search, favorites, existing selections, and custom models remain directly usable.

## Screenshots

### Before

![Flat model menu](https://files.tslop.org/2026/08/legacy-models-before-e297497c.png)

### After, collapsed

![Collapsed legacy models section](https://files.tslop.org/2026/08/legacy-models-after-collapsed-b06d3b69.png)

### After, expanded

![Expanded legacy models section](https://files.tslop.org/2026/08/legacy-models-after-expanded-05173170.png)

## Verification

- `vp test run packages/contracts/src/server.test.ts apps/server/src/provider/Layers/CodexProvider.test.ts apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts apps/web/src/modelSelection.test.ts apps/mobile/src/lib/modelOptions.test.ts`
- Scoped typechecks for contracts, server, web, and mobile
- Touched-file lint
- Real web client pass for collapse, expand, search, selection, and legacy-selection reopen behavior

Created by `gpt-5.6-sol` using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared contracts and model-picker combobox key format; behavior is user-visible across web and mobile but scoped to picker UX with tests for classification and key round-trips.
> 
> **Overview**
> Adds an optional **`isLegacy`** flag on provider model snapshots (contracts schema, Claude/Codex classification) so clients can tuck older models out of the main list while keeping search, favorites, and existing selections working.
> 
> **Mobile** centralizes model menu building in **`buildModelMenuActions`**, splitting current vs legacy models into per-provider submenus (including a dedicated “legacy models” group when only legacy models exist).
> 
> **Web** adds a collapsible **Legacy models** row per provider instance in **`ModelPickerContent`**, auto-expands when the active model is legacy, and switches combobox keys to **`modelPickerKeys`** so model rows and legacy section toggles cannot collide (replacing naive `instanceId:slug` parsing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ccc746b6061994f136328162527be546fa0d39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fold legacy models into collapsible sections in the model picker UI
> - Adds an `isLegacy` flag to `ServerProviderModel` in [server.ts](https://github.com/pingdotgg/t3code/pull/5190/files#diff-e575e7eac4053ca860f2d99f4f5bf09331b4e959961ac7bfed0562e916fc5dbb), propagated from Claude and Codex providers through to `AppModelOption` and `ModelOption` on web and mobile.
> - On web, [ModelPickerContent.tsx](https://github.com/pingdotgg/t3code/pull/5190/files#diff-af6ec8809b715e3718ef62e155f706b7bfc2b5331a509865043ed81e0f10f50c) groups legacy models under a collapsible "Legacy models" section per provider instance, with collision-safe item keys via the new [modelPickerKeys.ts](https://github.com/pingdotgg/t3code/pull/5190/files#diff-956294f5c3900cd424a1286d24bf23e07c34937756e8e4118a735bdcb75be3ad) module.
> - On mobile, a new `buildModelMenuActions` utility in [modelOptions.ts](https://github.com/pingdotgg/t3code/pull/5190/files#diff-e728e5b82529c8d8d8ae7017fbd0ee4021eea3e722dc156b9f3b209951cc7dea) separates legacy models into a provider-scoped submenu; providers whose only models are legacy may be omitted.
> - Behavioral Change: model picker keyboard navigation and `onValueChange` handlers now parse the new prefixed key format; existing stored keys would not match the new scheme.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6ccc74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->