### PR TITLE
fix(server): recover stale Codex approval callbacks

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2566,15 +2566,15 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("surfaces stale provider approval request failures without faking approval resolution", async () => {
+  it("normalizes stale Codex approval callbacks without faking approval resolution", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
     harness.respondToRequest.mockImplementation(() =>
       Effect.fail(
         new ProviderAdapterRequestError({
           provider: ProviderDriverKind.make("codex"),
-          method: "session/request_permission",
-          detail: "Unknown pending permission request: approval-request-1",
+          method: "item/requestApproval/decision",
+          detail: "Unknown pending Codex approval request: approval-request-1",
         }),
       ),
     );

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -187,13 +187,15 @@ function isUnknownPendingApprovalRequestError(cause: Cause.Cause<ProviderService
     const detail = error.detail.toLowerCase();
     return (
       detail.includes("unknown pending approval request") ||
-      detail.includes("unknown pending permission request")
+      detail.includes("unknown pending permission request") ||
+      detail.includes("unknown pending codex approval request")
     );
   }
-  const message = Cause.pretty(cause);
+  const message = Cause.pretty(cause).toLowerCase();
   return (
     message.includes("unknown pending approval request") ||
-    message.includes("unknown pending permission request")
+    message.includes("unknown pending permission request") ||
+    message.includes("unknown pending codex approval request")
   );
 }
 


### PR DESCRIPTION
## What Changed

Normalize Codex's provider-specific missing approval callback error into T3 Code's existing provider-neutral stale approval failure at the provider command reactor boundary.

This keeps web, desktop, mobile, projection counts, and thread settling on the existing shared recovery path without teaching clients about a Codex-specific error string.

## Why

Approval cards are durable, but provider callbacks are in memory. After a Codex session restarts or is recovered, responding to an old card can return `Unknown pending Codex approval request`. That error was not recognized by the approval classifier, so T3 persisted the raw failure and left the impossible approval pending.

The normalized failure clears the stale request without emitting `approval.resolved` or executing the rejected command.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI layout changes require screenshots
- [x] No animation or motion changes require video

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error-string classification in the approval response path; behavior aligns with existing stale-approval recovery and does not alter auth or data handling.
> 
> **Overview**
> Extends the provider command reactor’s **stale approval** classifier so Codex’s in-memory callback errors are treated like existing “unknown pending approval” failures.
> 
> `isUnknownPendingApprovalRequestError` now matches `unknown pending codex approval request` (alongside the generic approval/permission strings), and `Cause.pretty` matching is **case-insensitive** so mixed-case provider details still classify correctly. When matched, failures still surface as the shared `Stale pending approval request: …` activity—not a fake `approval.resolved` and not executing the command.
> 
> The reactor test was updated to simulate Codex’s `item/requestApproval/decision` error shape and asserts that `provider.approval.respond.failed` carries the normalized stale detail and that no `approval.resolved` activity is emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d72a4c6fe61067cdcaf484a58fbf4899340290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isUnknownPendingApprovalRequestError` to recover stale Codex approval callbacks
> Extends the detection logic in `isUnknownPendingApprovalRequestError` in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/5195/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) to match the phrase `'unknown pending codex approval request'` in addition to the existing phrase. The pretty-printed cause message is now lowercased before matching, making all checks case-insensitive.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80d72a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->