### PR TITLE
fix(client-runtime): tolerate transient foreground probe timeouts

### DIFF
--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -949,6 +949,89 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
+  it.effect("reconnects only after consecutive foreground liveness probe timeouts", () =>
+    Effect.gen(function* () {
+      const firstProbeStarted = yield* Deferred.make<void>();
+      const secondProbeStarted = yield* Deferred.make<void>();
+      const probeCount = yield* Ref.make(0);
+      const harness = yield* makeHarness({
+        probe: () =>
+          Ref.updateAndGet(probeCount, (count) => count + 1).pipe(
+            Effect.tap((count) =>
+              Deferred.succeed(count === 1 ? firstProbeStarted : secondProbeStarted, undefined),
+            ),
+            Effect.andThen(Effect.never),
+          ),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.wake("application-active");
+      yield* Deferred.await(firstProbeStarted);
+      yield* TestClock.adjust("15 seconds");
+      yield* Effect.yieldNow;
+
+      expect((yield* SubscriptionRef.get(supervisor.state)).phase).toBe("connected");
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
+
+      yield* harness.wake("application-active");
+      yield* Deferred.await(secondProbeStarted);
+      yield* TestClock.adjust("15 seconds");
+      yield* awaitState(supervisor.state, (state) => state.phase === "backoff");
+
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("resets the foreground probe timeout count after a successful probe", () =>
+    Effect.gen(function* () {
+      const firstProbeStarted = yield* Deferred.make<void>();
+      const secondProbeStarted = yield* Deferred.make<void>();
+      const thirdProbeStarted = yield* Deferred.make<void>();
+      const probeCount = yield* Ref.make(0);
+      const harness = yield* makeHarness({
+        probe: () =>
+          Ref.updateAndGet(probeCount, (count) => count + 1).pipe(
+            Effect.tap((count) =>
+              count === 1
+                ? Deferred.succeed(firstProbeStarted, undefined)
+                : count === 2
+                  ? Deferred.succeed(secondProbeStarted, undefined)
+                  : count === 3
+                    ? Deferred.succeed(thirdProbeStarted, undefined)
+                    : Effect.void,
+            ),
+            Effect.flatMap((count) => (count === 2 ? Effect.void : Effect.never)),
+          ),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.wake("application-active");
+      yield* Deferred.await(firstProbeStarted);
+      yield* TestClock.adjust("15 seconds");
+
+      yield* harness.wake("application-active");
+      yield* Deferred.await(secondProbeStarted);
+      yield* Effect.yieldNow;
+
+      yield* harness.wake("application-active");
+      yield* Deferred.await(thirdProbeStarted);
+      yield* TestClock.adjust("15 seconds");
+      yield* Effect.yieldNow;
+
+      expect((yield* SubscriptionRef.get(supervisor.state)).phase).toBe("connected");
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
   it.effect("quickly times out a stalled mobile foreground liveness probe", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -33,6 +33,7 @@ const RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 16_000] as const;
 const CONNECTION_ESTABLISHMENT_TIMEOUT = "15 seconds";
 const CONNECTION_PROBE_TIMEOUT = "15 seconds";
 const MOBILE_CONNECTION_PROBE_TIMEOUT = "3 seconds";
+const FOREGROUND_PROBE_TIMEOUTS_BEFORE_RECONNECT = 2;
 const BACKOFF_RESET_AFTER_MS = 30_000;
 
 interface SupervisorIntent {
@@ -392,6 +393,7 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
   const monitorConnectedLease = Effect.fnUntraced(function* (
     lease: ConnectionDriver.EnvironmentConnectionLease,
   ) {
+    let foregroundProbeTimeoutCount = 0;
     for (;;) {
       const next = yield* Queue.take(signals);
       switch (next._tag) {
@@ -415,19 +417,23 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
             return true;
           }
           if (next.reason === "application-active" || next.reason === "application-active-probe") {
+            const tolerateProbeTimeout = next.reason === "application-active";
             const probe = yield* lease.session.probe.pipe(
+              Effect.as(true),
               Effect.timeoutOrElse({
                 duration:
                   next.reason === "application-active-probe"
                     ? MOBILE_CONNECTION_PROBE_TIMEOUT
                     : CONNECTION_PROBE_TIMEOUT,
                 orElse: () =>
-                  Effect.fail(
-                    new ConnectionTransientError({
-                      reason: "timeout",
-                      detail: `${target.label} did not respond to a connection health check.`,
-                    }),
-                  ),
+                  tolerateProbeTimeout
+                    ? Effect.succeed(false)
+                    : Effect.fail(
+                        new ConnectionTransientError({
+                          reason: "timeout",
+                          detail: `${target.label} did not respond to a connection health check.`,
+                        }),
+                      ),
               }),
               Effect.forkChild,
             );
@@ -441,7 +447,26 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
                 ),
               );
               if (probeEvent._tag === "ProbeCompleted") {
-                yield* probeEvent.exit;
+                const responded = yield* probeEvent.exit;
+                if (responded) {
+                  foregroundProbeTimeoutCount = 0;
+                  break;
+                }
+                foregroundProbeTimeoutCount += 1;
+                if (foregroundProbeTimeoutCount >= FOREGROUND_PROBE_TIMEOUTS_BEFORE_RECONNECT) {
+                  return yield* new ConnectionTransientError({
+                    reason: "timeout",
+                    detail: `${target.label} did not respond to a connection health check.`,
+                  });
+                }
+                yield* Effect.logWarning(
+                  "Foreground connection health check timed out; keeping the existing session.",
+                ).pipe(
+                  Effect.annotateLogs({
+                    "environment.id": target.environmentId,
+                    "environment.label": target.label,
+                  }),
+                );
                 break;
               }
               switch (probeEvent.signal._tag) {


### PR DESCRIPTION
## Problem

When the host is temporarily resource constrained, a foreground health probe can time out even though the existing session is still valid. Immediately replacing that session can start a reconnect while the same host is still stalled, leaving the client unusable until it recovers.

## Fix

Keep the existing desktop/web session after the first foreground probe timeout. A successful probe resets the count, while a second consecutive timeout still triggers normal recovery. Definite probe failures and mobile resume behavior are unchanged.

## Testing

- Focused connection supervisor suite: 35 tests passed
- Client-runtime typecheck
- Targeted lint and formatting checks

Model: GPT-5; harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live connection monitoring and reconnect timing in client-runtime; behavior is well-covered by supervisor tests but affects when sessions are replaced under load.
> 
> **Overview**
> **Foreground health probes** on `application-active` no longer tear down the session on a single **15s** timeout when the host is briefly stalled. The supervisor keeps the existing lease, logs a warning, and only triggers normal reconnect recovery after **two consecutive** timeouts (`FOREGROUND_PROBE_TIMEOUTS_BEFORE_RECONNECT`).
> 
> A successful probe resets the counter. **Definite probe failures** and **`application-active-probe`** (mobile, **3s** timeout) behavior are unchanged.
> 
> Tests cover: one timeout stays connected; two timeouts → backoff/release; success between timeouts resets the count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fdbd155b93f90d9b9e24ca89ed010b3ff097887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tolerate transient foreground liveness probe timeouts in `EnvironmentSupervisor`
> - During `application-active` wakeups, a single probe timeout no longer triggers a reconnect; the supervisor only reconnects after 2 consecutive timeouts (`FOREGROUND_PROBE_TIMEOUTS_BEFORE_RECONNECT = 2`).
> - A successful probe resets the timeout counter to 0, so isolated timeouts are always tolerated.
> - `application-active-probe` signals retain the existing fail-fast behavior on timeout.
> - Two new tests cover consecutive timeout reconnection and counter reset after a successful probe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fdbd15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->