### PR TITLE
feat(mobile): make archives one-swipe and recoverable

### DIFF
--- a/.github/scripts/prepare-personal-android-preview.mjs
+++ b/.github/scripts/prepare-personal-android-preview.mjs
@@ -1,0 +1,106 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const [sourceRootArgument, versionCodeArgument] = process.argv.slice(2);
+
+if (!sourceRootArgument || !versionCodeArgument) {
+  throw new Error(
+    "Usage: prepare-personal-android-preview.mjs <source-root> <version-code>",
+  );
+}
+
+const sourceRoot = path.resolve(sourceRootArgument);
+const versionCode = Number(versionCodeArgument);
+
+if (
+  !Number.isSafeInteger(versionCode) ||
+  versionCode < 1 ||
+  versionCode > 2_100_000_000
+) {
+  throw new Error(`Invalid Android version code: ${versionCodeArgument}`);
+}
+
+function replaceOnce(contents, search, replacement, label) {
+  const firstIndex = contents.indexOf(search);
+  const lastIndex = contents.lastIndexOf(search);
+
+  if (firstIndex === -1) {
+    throw new Error(`Could not find ${label}`);
+  }
+
+  if (firstIndex !== lastIndex) {
+    throw new Error(`Found ${label} more than once`);
+  }
+
+  return `${contents.slice(0, firstIndex)}${replacement}${contents.slice(firstIndex + search.length)}`;
+}
+
+const manifestPath = path.join(
+  sourceRoot,
+  "apps/mobile/android/app/src/main/AndroidManifest.xml",
+);
+const buildGradlePath = path.join(
+  sourceRoot,
+  "apps/mobile/android/app/build.gradle",
+);
+
+let manifest = await readFile(manifestPath, "utf8");
+manifest = replaceOnce(
+  manifest,
+  '<meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>',
+  '<meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>',
+  "enabled Expo updates metadata",
+);
+await writeFile(manifestPath, manifest);
+
+let buildGradle = await readFile(buildGradlePath, "utf8");
+
+if (
+  !buildGradle.includes("namespace 'com.t3tools.t3code.preview'") ||
+  !buildGradle.includes("applicationId 'com.t3tools.t3code.preview'")
+) {
+  throw new Error("Refusing to sign a build that is not the Android preview variant");
+}
+
+const versionCodeMatches = [...buildGradle.matchAll(/^\s*versionCode \d+$/gm)];
+if (versionCodeMatches.length !== 1) {
+  throw new Error(
+    `Expected one generated versionCode declaration, found ${versionCodeMatches.length}`,
+  );
+}
+buildGradle = buildGradle.replace(
+  versionCodeMatches[0][0],
+  `        versionCode ${versionCode}`,
+);
+
+buildGradle = replaceOnce(
+  buildGradle,
+  "    signingConfigs {\n        debug {",
+  `    signingConfigs {
+        previewRelease {
+            storeFile file(System.getenv("T3CODE_PREVIEW_KEYSTORE_FILE"))
+            storePassword System.getenv("T3CODE_PREVIEW_KEYSTORE_PASSWORD")
+            keyAlias "t3code-preview"
+            keyPassword System.getenv("T3CODE_PREVIEW_KEYSTORE_PASSWORD")
+        }
+        debug {`,
+  "generated Android signingConfigs block",
+);
+
+const releaseBlockIndex = buildGradle.indexOf("        release {");
+const releaseSigning = "            signingConfig signingConfigs.debug";
+const releaseSigningIndex = buildGradle.indexOf(
+  releaseSigning,
+  releaseBlockIndex,
+);
+
+if (releaseBlockIndex === -1 || releaseSigningIndex === -1) {
+  throw new Error("Could not find the generated release signing configuration");
+}
+
+buildGradle = `${buildGradle.slice(0, releaseSigningIndex)}            signingConfig signingConfigs.previewRelease${buildGradle.slice(releaseSigningIndex + releaseSigning.length)}`;
+await writeFile(buildGradlePath, buildGradle);
+
+console.log(
+  `Prepared com.t3tools.t3code.preview versionCode ${versionCode} with private signing and official OTA updates disabled.`,
+);

--- a/.github/systemd/t3code-preview-dispatch.service
+++ b/.github/systemd/t3code-preview-dispatch.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Dispatch the personal T3 Code Android preview build
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+Environment=GH_CONFIG_DIR=/home/admin/.config/gh
+Environment=HOME=/home/admin
+ExecStart=/usr/bin/gh workflow run personal-android-preview.yml --repo Feighery89/t3code --ref main -f force_rebuild=false
+Restart=on-failure
+RestartSec=15min
+TimeoutStartSec=2min
+NoNewPrivileges=true
+PrivateTmp=true

--- a/.github/systemd/t3code-preview-dispatch.timer
+++ b/.github/systemd/t3code-preview-dispatch.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Check daily for a new personal T3 Code Android preview
+
+[Timer]
+OnCalendar=*-*-* 05:47:00 Europe/Dublin
+Persistent=true
+RandomizedDelaySec=20min
+AccuracySec=1min
+Unit=t3code-preview-dispatch.service
+
+[Install]
+WantedBy=timers.target

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -21,6 +21,7 @@ permissions:
 
 env:
   APK_NAME: t3-code-preview.apk
+  APP_VARIANT: preview
   # Pin the reviewed personal feature set while still rebasing it onto current
   # upstream source. Rebase drops patch-equivalent commits as upstream merges
   # them without dropping changes that remain personal to this build.
@@ -193,7 +194,7 @@ jobs:
         run: ./gradlew :app:assembleRelease --no-daemon --stacktrace
 
       - id: apk
-        name: Verify package, version, and signature
+        name: Verify package, embedded config, version, and signature
         if: steps.source.outputs.should_build == 'true'
         env:
           EXPECTED_VERSION_CODE: ${{ steps.source.outputs.version_code }}
@@ -219,6 +220,21 @@ jobs:
 
           if [[ "$version_code" != "$EXPECTED_VERSION_CODE" ]]; then
             echo "::error::Unexpected version code: ${version_code}"
+            exit 1
+          fi
+
+          manifest="$(unzip -p "$apk" assets/app.manifest)"
+          if ! jq -e \
+            --arg package_name "$package_name" \
+            --arg update_api "$T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL" \
+            --arg environment_host "$T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST" \
+            '.name == "T3 Code Preview"
+              and .android.package == $package_name
+              and .extra.appVariant == "preview"
+              and .extra.personalPreviewUpdates.latestReleaseApiUrl == $update_api
+              and .extra.personalPreviewDefaultEnvironmentHost == $environment_host' \
+            <<<"$manifest" >/dev/null; then
+            echo "::error::The embedded app manifest is not the configured personal preview."
             exit 1
           fi
 

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -29,8 +29,8 @@ env:
   FEATURE_BRANCH: feat/mobile-quick-archive
   FEATURE_REPOSITORY: Feighery89/t3code
   NODE_OPTIONS: --max-old-space-size=6144
-  T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST: http://100.97.53.68:7791
-  T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL: https://api.github.com/repos/Feighery89/t3code/releases/latest
+  EXPO_PUBLIC_T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST: http://100.97.53.68:7791
+  EXPO_PUBLIC_T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL: https://api.github.com/repos/Feighery89/t3code/releases/latest
   UPSTREAM_REPOSITORY: pingdotgg/t3code
 
 jobs:
@@ -223,18 +223,11 @@ jobs:
             exit 1
           fi
 
-          manifest="$(unzip -p "$apk" assets/app.manifest)"
-          if ! jq -e \
-            --arg package_name "$package_name" \
-            --arg update_api "$T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL" \
-            --arg environment_host "$T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST" \
-            '.name == "T3 Code Preview"
-              and .android.package == $package_name
-              and .extra.appVariant == "preview"
-              and .extra.personalPreviewUpdates.latestReleaseApiUrl == $update_api
-              and .extra.personalPreviewDefaultEnvironmentHost == $environment_host' \
-            <<<"$manifest" >/dev/null; then
-            echo "::error::The embedded app manifest is not the configured personal preview."
+          bundle="$RUNNER_TEMP/index.android.bundle"
+          unzip -p "$apk" assets/index.android.bundle >"$bundle"
+          if ! grep -aFq "$EXPO_PUBLIC_T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL" "$bundle" || \
+             ! grep -aFq "$EXPO_PUBLIC_T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST" "$bundle"; then
+            echo "::error::The embedded app bundle is missing the personal preview configuration."
             exit 1
           fi
 

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -37,10 +37,15 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 75
     steps:
-      - name: Checkout preview automation
-        uses: actions/checkout@v7
-        with:
-          path: automation
+      - name: Clone preview automation
+        run: >-
+          git clone
+          --filter=blob:none
+          --no-tags
+          --single-branch
+          --branch "$GITHUB_REF_NAME"
+          "https://github.com/${GITHUB_REPOSITORY}.git"
+          automation
 
       - name: Clone latest upstream source
         run: >-
@@ -226,7 +231,10 @@ jobs:
           fi
 
           "$apksigner" verify --verbose --print-certs "$apk"
-          sha256sum "$apk" >"$RUNNER_TEMP/SHA256SUMS.txt"
+          (
+            cd "$RUNNER_TEMP"
+            sha256sum "$APK_NAME" >SHA256SUMS.txt
+          )
 
           echo "apk=${apk}" >>"$GITHUB_OUTPUT"
           echo "package_name=${package_name}" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -42,14 +42,15 @@ jobs:
         with:
           path: automation
 
-      - name: Checkout latest upstream source
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          path: source
-          persist-credentials: false
-          ref: main
-          repository: pingdotgg/t3code
+      - name: Clone latest upstream source
+        run: >-
+          git clone
+          --filter=blob:none
+          --no-tags
+          --single-branch
+          --branch main
+          "https://github.com/${UPSTREAM_REPOSITORY}.git"
+          source
 
       - id: source
         name: Resolve upstream and feature source

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -21,15 +21,15 @@ permissions:
 
 env:
   APK_NAME: t3-code-preview.apk
-  # Keep the personal build on the reviewed archive changes even if concurrent
-  # work is temporarily stacked on the PR branch.
-  ARCHIVE_FEATURE_HEAD: 3e0f9606de3c59e493309eaf185e5fc6f2fb5441
+  # Pin the reviewed personal feature set while still rebasing it onto current
+  # upstream source. Rebase drops patch-equivalent commits as upstream merges
+  # them without dropping changes that remain personal to this build.
+  PERSONAL_FEATURE_HEAD: 3e0f9606de3c59e493309eaf185e5fc6f2fb5441
   FEATURE_BRANCH: feat/mobile-quick-archive
   FEATURE_REPOSITORY: Feighery89/t3code
   NODE_OPTIONS: --max-old-space-size=6144
   T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST: http://100.97.53.68:7791
   T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL: https://api.github.com/repos/Feighery89/t3code/releases/latest
-  UPSTREAM_PR: "5205"
   UPSTREAM_REPOSITORY: pingdotgg/t3code
 
 jobs:
@@ -71,32 +71,24 @@ jobs:
           git -C source checkout --detach origin/main
 
           main_sha="$(git -C source rev-parse HEAD)"
-          pr_json="$(gh api "repos/${UPSTREAM_REPOSITORY}/pulls/${UPSTREAM_PR}")"
-          merged="$(jq -r '.merged' <<<"$pr_json")"
-          pr_state="$(jq -r '.state' <<<"$pr_json")"
+          git -C source fetch --no-tags \
+            "https://github.com/${FEATURE_REPOSITORY}.git" \
+            "+refs/heads/${FEATURE_BRANCH}:refs/remotes/personal/feature"
+          feature_sha="$PERSONAL_FEATURE_HEAD"
 
-          if [[ "$merged" == "true" ]]; then
-            feature_sha="merged"
-          else
-            git -C source fetch --no-tags \
-              "https://github.com/${FEATURE_REPOSITORY}.git" \
-              "+refs/heads/${FEATURE_BRANCH}:refs/remotes/personal/feature"
-            feature_sha="$ARCHIVE_FEATURE_HEAD"
-
-            if ! git -C source merge-base --is-ancestor \
-              "$feature_sha" \
-              refs/remotes/personal/feature; then
-              echo "::error::The curated archive commit is no longer available on the feature branch."
-              exit 1
-            fi
-
-            git -C source config user.name "github-actions[bot]"
-            git -C source config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git -C source checkout --detach "$feature_sha"
-            git -C source rebase origin/main
+          if ! git -C source merge-base --is-ancestor \
+            "$feature_sha" \
+            refs/remotes/personal/feature; then
+            echo "::error::The curated personal feature commit is no longer available on the feature branch."
+            exit 1
           fi
 
-          source_key="${main_sha}:${feature_sha}:${merged}"
+          git -C source config user.name "github-actions[bot]"
+          git -C source config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C source checkout --detach "$feature_sha"
+          git -C source rebase origin/main
+
+          source_key="${main_sha}:${feature_sha}"
           latest_body=""
           if latest_body="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.body')"; then
             :
@@ -114,8 +106,6 @@ jobs:
           echo "build_sha=${build_sha}" >>"$GITHUB_OUTPUT"
           echo "feature_sha=${feature_sha}" >>"$GITHUB_OUTPUT"
           echo "main_sha=${main_sha}" >>"$GITHUB_OUTPUT"
-          echo "merged=${merged}" >>"$GITHUB_OUTPUT"
-          echo "pr_state=${pr_state}" >>"$GITHUB_OUTPUT"
           echo "should_build=${should_build}" >>"$GITHUB_OUTPUT"
           echo "source_key=${source_key}" >>"$GITHUB_OUTPUT"
           echo "version_code=${version_code}" >>"$GITHUB_OUTPUT"
@@ -259,7 +249,7 @@ jobs:
             "- Package: \`${{ steps.apk.outputs.package_name }}\`" \
             "- Android version code: \`${{ steps.apk.outputs.version_code }}\`" \
             "- Upstream main: \`${{ steps.source.outputs.main_sha }}\`" \
-            "- Archive feature: \`${{ steps.source.outputs.feature_sha }}\` (PR #${UPSTREAM_PR}, merged: ${{ steps.source.outputs.merged }})" \
+            "- Personal feature set: \`${{ steps.source.outputs.feature_sha }}\`" \
             "- Official Expo OTA updates: disabled for this custom package" \
             "- Personal updates: checked automatically from this signed GitHub release channel" \
             "" \

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -1,0 +1,267 @@
+name: Personal Android Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_rebuild:
+        description: Build even when the source commits have not changed
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # The VPS timer below is the durable trigger. This is an independent backup.
+    - cron: "17 4 * * *"
+
+concurrency:
+  group: personal-android-preview
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  APK_NAME: t3-code-preview.apk
+  # Keep the personal build on the reviewed archive changes even if concurrent
+  # work is temporarily stacked on the PR branch.
+  ARCHIVE_FEATURE_HEAD: edade0ee6464c661120e15bfd2b188f4f85abfed
+  FEATURE_BRANCH: feat/mobile-quick-archive
+  FEATURE_REPOSITORY: Feighery89/t3code
+  NODE_OPTIONS: --max-old-space-size=6144
+  UPSTREAM_PR: "5205"
+  UPSTREAM_REPOSITORY: pingdotgg/t3code
+
+jobs:
+  build:
+    name: Build signed Android preview
+    if: github.repository == 'Feighery89/t3code'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 75
+    steps:
+      - name: Checkout preview automation
+        uses: actions/checkout@v7
+        with:
+          path: automation
+
+      - name: Checkout latest upstream source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: main
+          repository: pingdotgg/t3code
+
+      - id: source
+        name: Resolve upstream and feature source
+        env:
+          FORCE_REBUILD: ${{ inputs.force_rebuild || false }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          git -C source fetch --no-tags origin main
+          git -C source checkout --detach origin/main
+
+          main_sha="$(git -C source rev-parse HEAD)"
+          pr_json="$(gh api "repos/${UPSTREAM_REPOSITORY}/pulls/${UPSTREAM_PR}")"
+          merged="$(jq -r '.merged' <<<"$pr_json")"
+          pr_state="$(jq -r '.state' <<<"$pr_json")"
+
+          if [[ "$merged" == "true" ]]; then
+            feature_sha="merged"
+          else
+            git -C source fetch --no-tags \
+              "https://github.com/${FEATURE_REPOSITORY}.git" \
+              "+refs/heads/${FEATURE_BRANCH}:refs/remotes/personal/feature"
+            feature_sha="$ARCHIVE_FEATURE_HEAD"
+
+            if ! git -C source merge-base --is-ancestor \
+              "$feature_sha" \
+              refs/remotes/personal/feature; then
+              echo "::error::The curated archive commit is no longer available on the feature branch."
+              exit 1
+            fi
+
+            git -C source config user.name "github-actions[bot]"
+            git -C source config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git -C source checkout --detach "$feature_sha"
+            git -C source rebase origin/main
+          fi
+
+          source_key="${main_sha}:${feature_sha}:${merged}"
+          latest_body=""
+          if latest_body="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.body')"; then
+            :
+          fi
+
+          should_build="true"
+          if [[ "$FORCE_REBUILD" != "true" && "$latest_body" == *"Source key: ${source_key}"* ]]; then
+            should_build="false"
+            echo "Source has not changed since the latest preview release."
+          fi
+
+          version_code="$(date -u +%s)"
+          build_sha="$(git -C source rev-parse HEAD)"
+
+          echo "build_sha=${build_sha}" >>"$GITHUB_OUTPUT"
+          echo "feature_sha=${feature_sha}" >>"$GITHUB_OUTPUT"
+          echo "main_sha=${main_sha}" >>"$GITHUB_OUTPUT"
+          echo "merged=${merged}" >>"$GITHUB_OUTPUT"
+          echo "pr_state=${pr_state}" >>"$GITHUB_OUTPUT"
+          echo "should_build=${should_build}" >>"$GITHUB_OUTPUT"
+          echo "source_key=${source_key}" >>"$GITHUB_OUTPUT"
+          echo "version_code=${version_code}" >>"$GITHUB_OUTPUT"
+
+      - name: Report unchanged source
+        if: steps.source.outputs.should_build != 'true'
+        run: echo "No preview build was needed." >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Set up pnpm
+        if: steps.source.outputs.should_build == 'true'
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+          version: 11.10.0
+
+      - name: Set up Node
+        if: steps.source.outputs.should_build == 'true'
+        uses: actions/setup-node@v7
+        with:
+          cache: pnpm
+          cache-dependency-path: source/pnpm-lock.yaml
+          node-version: 24.13.1
+
+      - name: Set up Java
+        if: steps.source.outputs.should_build == 'true'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle cache
+        if: steps.source.outputs.should_build == 'true'
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Install mobile dependencies
+        if: steps.source.outputs.should_build == 'true'
+        working-directory: source
+        env:
+          CI: "1"
+        run: pnpm install --frozen-lockfile --filter @t3tools/mobile...
+
+      - name: Generate the Android preview project
+        if: steps.source.outputs.should_build == 'true'
+        working-directory: source/apps/mobile
+        env:
+          APP_VARIANT: preview
+          CI: "1"
+          EXPO_NO_DOTENV: "1"
+          EXPO_NO_GIT_STATUS: "1"
+        run: pnpm exec expo prebuild --clean --platform android
+
+      - name: Apply personal preview safeguards
+        if: steps.source.outputs.should_build == 'true'
+        run: >-
+          node automation/.github/scripts/prepare-personal-android-preview.mjs
+          source
+          "${{ steps.source.outputs.version_code }}"
+
+      - name: Restore private signing key
+        if: steps.source.outputs.should_build == 'true'
+        env:
+          KEYSTORE_BASE64: ${{ secrets.T3CODE_PREVIEW_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.T3CODE_PREVIEW_KEYSTORE_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$KEYSTORE_BASE64" || -z "$KEYSTORE_PASSWORD" ]]; then
+            echo "::error::The personal preview signing secrets are missing."
+            exit 1
+          fi
+
+          install -d -m 700 "$RUNNER_TEMP/t3code-preview-signing"
+          printf '%s' "$KEYSTORE_BASE64" \
+            | base64 --decode \
+            >"$RUNNER_TEMP/t3code-preview-signing/t3code-preview.p12"
+          chmod 600 "$RUNNER_TEMP/t3code-preview-signing/t3code-preview.p12"
+
+      - name: Build signed release APK
+        if: steps.source.outputs.should_build == 'true'
+        working-directory: source/apps/mobile/android
+        env:
+          CI: "1"
+          T3CODE_PREVIEW_KEYSTORE_FILE: ${{ runner.temp }}/t3code-preview-signing/t3code-preview.p12
+          T3CODE_PREVIEW_KEYSTORE_PASSWORD: ${{ secrets.T3CODE_PREVIEW_KEYSTORE_PASSWORD }}
+        run: ./gradlew :app:assembleRelease --no-daemon --stacktrace
+
+      - id: apk
+        name: Verify package, version, and signature
+        if: steps.source.outputs.should_build == 'true'
+        env:
+          EXPECTED_VERSION_CODE: ${{ steps.source.outputs.version_code }}
+        run: |
+          set -euo pipefail
+
+          source_apk="source/apps/mobile/android/app/build/outputs/apk/release/app-release.apk"
+          apk="$RUNNER_TEMP/${APK_NAME}"
+          install -m 644 "$source_apk" "$apk"
+
+          build_tools_version="$(find "$ANDROID_HOME/build-tools" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -V | tail -n 1)"
+          aapt="$ANDROID_HOME/build-tools/$build_tools_version/aapt"
+          apksigner="$ANDROID_HOME/build-tools/$build_tools_version/apksigner"
+
+          badging="$($aapt dump badging "$apk" | head -n 1)"
+          package_name="$(sed -n "s/.*name='\([^']*\)'.*/\1/p" <<<"$badging")"
+          version_code="$(sed -n "s/.*versionCode='\([^']*\)'.*/\1/p" <<<"$badging")"
+
+          if [[ "$package_name" != "com.t3tools.t3code.preview" ]]; then
+            echo "::error::Unexpected Android package: ${package_name}"
+            exit 1
+          fi
+
+          if [[ "$version_code" != "$EXPECTED_VERSION_CODE" ]]; then
+            echo "::error::Unexpected version code: ${version_code}"
+            exit 1
+          fi
+
+          "$apksigner" verify --verbose --print-certs "$apk"
+          sha256sum "$apk" >"$RUNNER_TEMP/SHA256SUMS.txt"
+
+          echo "apk=${apk}" >>"$GITHUB_OUTPUT"
+          echo "package_name=${package_name}" >>"$GITHUB_OUTPUT"
+          echo "version_code=${version_code}" >>"$GITHUB_OUTPUT"
+
+      - name: Publish immutable preview release
+        if: steps.source.outputs.should_build == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          tag="mark-mobile-preview-v${{ steps.apk.outputs.version_code }}"
+          release_date="$(date -u +%Y-%m-%d)"
+          notes="$RUNNER_TEMP/release-notes.md"
+
+          printf '%s\n' \
+            "A separately installed Android preview containing Mark's archive workflow and current upstream T3 Code improvements." \
+            "" \
+            "- Package: \`${{ steps.apk.outputs.package_name }}\`" \
+            "- Android version code: \`${{ steps.apk.outputs.version_code }}\`" \
+            "- Upstream main: \`${{ steps.source.outputs.main_sha }}\`" \
+            "- Archive feature: \`${{ steps.source.outputs.feature_sha }}\` (PR #${UPSTREAM_PR}, merged: ${{ steps.source.outputs.merged }})" \
+            "- Official Expo OTA updates: disabled for this custom package" \
+            "" \
+            "Source key: ${{ steps.source.outputs.source_key }}" \
+            >"$notes"
+
+          gh release create "$tag" \
+            "${{ steps.apk.outputs.apk }}#T3 Code Preview APK" \
+            "$RUNNER_TEMP/SHA256SUMS.txt#SHA-256 checksum" \
+            --latest \
+            --notes-file "$notes" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "T3 Code Preview ${release_date}"
+
+          stable_url="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/${APK_NAME}"
+          printf '### Android preview published\n\n[%s](%s)\n' "$APK_NAME" "$stable_url" >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -212,8 +212,8 @@ jobs:
           apksigner="$ANDROID_HOME/build-tools/$build_tools_version/apksigner"
 
           badging="$($aapt dump badging "$apk" | head -n 1)"
-          package_name="$(sed -n "s/.*name='\([^']*\)'.*/\1/p" <<<"$badging")"
-          version_code="$(sed -n "s/.*versionCode='\([^']*\)'.*/\1/p" <<<"$badging")"
+          package_name="$(sed -n "s/^package: name='\([^']*\)'.*/\1/p" <<<"$badging")"
+          version_code="$(sed -n "s/^package: name='[^']*' versionCode='\([^']*\)'.*/\1/p" <<<"$badging")"
 
           if [[ "$package_name" != "com.t3tools.t3code.preview" ]]; then
             echo "::error::Unexpected Android package: ${package_name}"

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -25,7 +25,7 @@ env:
   # Pin the reviewed personal feature set while still rebasing it onto current
   # upstream source. Rebase drops patch-equivalent commits as upstream merges
   # them without dropping changes that remain personal to this build.
-  PERSONAL_FEATURE_HEAD: 3e0f9606de3c59e493309eaf185e5fc6f2fb5441
+  PERSONAL_FEATURE_HEAD: 16601a0c0497c2621ba2ba3152b5ae7e4a48ca0b
   FEATURE_BRANCH: feat/mobile-quick-archive
   FEATURE_REPOSITORY: Feighery89/t3code
   NODE_OPTIONS: --max-old-space-size=6144

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -23,10 +23,12 @@ env:
   APK_NAME: t3-code-preview.apk
   # Keep the personal build on the reviewed archive changes even if concurrent
   # work is temporarily stacked on the PR branch.
-  ARCHIVE_FEATURE_HEAD: edade0ee6464c661120e15bfd2b188f4f85abfed
+  ARCHIVE_FEATURE_HEAD: 3e0f9606de3c59e493309eaf185e5fc6f2fb5441
   FEATURE_BRANCH: feat/mobile-quick-archive
   FEATURE_REPOSITORY: Feighery89/t3code
   NODE_OPTIONS: --max-old-space-size=6144
+  T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST: http://100.97.53.68:7791
+  T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL: https://api.github.com/repos/Feighery89/t3code/releases/latest
   UPSTREAM_PR: "5205"
   UPSTREAM_REPOSITORY: pingdotgg/t3code
 
@@ -252,13 +254,14 @@ jobs:
           notes="$RUNNER_TEMP/release-notes.md"
 
           printf '%s\n' \
-            "A separately installed Android preview containing Mark's archive workflow and current upstream T3 Code improvements." \
+            "A separately installed Android preview containing Mark's archive workflow, local agent notifications, and current upstream T3 Code improvements." \
             "" \
             "- Package: \`${{ steps.apk.outputs.package_name }}\`" \
             "- Android version code: \`${{ steps.apk.outputs.version_code }}\`" \
             "- Upstream main: \`${{ steps.source.outputs.main_sha }}\`" \
             "- Archive feature: \`${{ steps.source.outputs.feature_sha }}\` (PR #${UPSTREAM_PR}, merged: ${{ steps.source.outputs.merged }})" \
             "- Official Expo OTA updates: disabled for this custom package" \
+            "- Personal updates: checked automatically from this signed GitHub release channel" \
             "" \
             "Source key: ${{ steps.source.outputs.source_key }}" \
             >"$notes"

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -232,12 +232,28 @@ jobs:
           echo "package_name=${package_name}" >>"$GITHUB_OUTPUT"
           echo "version_code=${version_code}" >>"$GITHUB_OUTPUT"
 
+      - name: Retain verified preview artifact
+        if: steps.source.outputs.should_build == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: t3-code-preview-${{ steps.apk.outputs.version_code }}
+          path: |
+            ${{ steps.apk.outputs.apk }}
+            ${{ runner.temp }}/SHA256SUMS.txt
+          compression-level: 0
+          retention-days: 3
+
       - name: Publish immutable preview release
         if: steps.source.outputs.should_build == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.T3CODE_PREVIEW_RELEASE_TOKEN }}
         run: |
           set -euo pipefail
+
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error::The personal preview release token is missing."
+            exit 1
+          fi
 
           tag="mark-mobile-preview-v${{ steps.apk.outputs.version_code }}"
           release_date="$(date -u +%Y-%m-%d)"

--- a/.github/workflows/personal-android-preview.yml
+++ b/.github/workflows/personal-android-preview.yml
@@ -25,7 +25,7 @@ env:
   # Pin the reviewed personal feature set while still rebasing it onto current
   # upstream source. Rebase drops patch-equivalent commits as upstream merges
   # them without dropping changes that remain personal to this build.
-  PERSONAL_FEATURE_HEAD: 3e0f9606de3c59e493309eaf185e5fc6f2fb5441
+  PERSONAL_FEATURE_HEAD: 900a62b8e43395ac9d6a8993b129b7f26bb6aee4
   FEATURE_BRANCH: feat/mobile-quick-archive
   FEATURE_REPOSITORY: Feighery89/t3code
   NODE_OPTIONS: --max-old-space-size=6144

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -87,6 +87,28 @@ node ../../scripts/mobile-native-static-check.ts
 
 The native lint task runs SwiftLint for Swift plus ktlint and detekt for Kotlin. Missing native tools are reported as warnings and skipped locally. CI installs the default toolset from `apps/mobile/Brewfile` before running the native checks.
 
+## Android background connection
+
+Android builds expose an opt-in **Keep connected in background** switch in Settings. When enabled,
+the app runs one silent `remoteMessaging` foreground service and one React Native Headless JS task.
+That task keeps the existing connection supervisors, environment shells, active thread details, and
+outbox dispatcher alive; it does not introduce a second WebSocket or synchronization protocol.
+
+Android requires the ongoing `T3 Code · Connected in background` service notification. Granting the
+one-time unrestricted-battery exemption makes recovery more reliable under vendor power management,
+but declining it leaves the feature enabled with a degraded status. A user-initiated Android
+force-stop is the platform boundary: launch the app once before automatic service, update, or boot
+restoration can resume.
+
+The implementation lives in `modules/t3-background-connection`; generated files under `android/`
+are not authoritative. After native changes, regenerate and verify a development project with:
+
+```bash
+APP_VARIANT=development EXPO_NO_GIT_STATUS=1 expo prebuild --clean --platform android
+cd android
+./gradlew :t3-background-connection:compileDebugKotlin lintDebug
+```
+
 ## EAS Builds
 
 CI uses Expo fingerprinting with the `preview:dev` profile to reuse an existing compatible build when possible, or start a new internal EAS build when native runtime inputs change. Production and default local builds continue to use the `appVersion` runtime policy.

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -10,6 +10,9 @@ Object.assign(process.env, repoEnv);
 
 const APP_VARIANT = resolveAppVariant(repoEnv.APP_VARIANT);
 const isIosPersonalTeamBuild = repoEnv.T3CODE_IOS_PERSONAL_TEAM === "1";
+const personalPreviewUpdateApiUrl = repoEnv.T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL?.trim();
+const personalPreviewDefaultEnvironmentHost =
+  repoEnv.T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST?.trim();
 
 const personalTeamBundleIdentifier = repoEnv.T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID?.trim();
 const IOS_BUNDLE_IDENTIFIER_PATTERN = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
@@ -344,6 +347,12 @@ const config: ExpoConfig = {
   extra: {
     appVariant: APP_VARIANT,
     iosPersonalTeamBuild: isIosPersonalTeamBuild,
+    personalPreviewUpdates:
+      APP_VARIANT === "preview" && personalPreviewUpdateApiUrl
+        ? { latestReleaseApiUrl: personalPreviewUpdateApiUrl }
+        : null,
+    personalPreviewDefaultEnvironmentHost:
+      APP_VARIANT === "preview" ? (personalPreviewDefaultEnvironmentHost ?? null) : null,
     relay: {
       url: repoEnv.T3CODE_RELAY_URL ?? null,
     },

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -10,9 +10,14 @@ Object.assign(process.env, repoEnv);
 
 const APP_VARIANT = resolveAppVariant(repoEnv.APP_VARIANT);
 const isIosPersonalTeamBuild = repoEnv.T3CODE_IOS_PERSONAL_TEAM === "1";
-const personalPreviewUpdateApiUrl = repoEnv.T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL?.trim();
-const personalPreviewDefaultEnvironmentHost =
-  repoEnv.T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST?.trim();
+const personalPreviewUpdateApiUrl = (
+  repoEnv.EXPO_PUBLIC_T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL ??
+  repoEnv.T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL
+)?.trim();
+const personalPreviewDefaultEnvironmentHost = (
+  repoEnv.EXPO_PUBLIC_T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST ??
+  repoEnv.T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST
+)?.trim();
 
 const personalTeamBundleIdentifier = repoEnv.T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID?.trim();
 const IOS_BUNDLE_IDENTIFIER_PATTERN = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -10,6 +10,9 @@ Object.assign(process.env, repoEnv);
 
 const APP_VARIANT = resolveAppVariant(repoEnv.APP_VARIANT);
 const isIosPersonalTeamBuild = repoEnv.T3CODE_IOS_PERSONAL_TEAM === "1";
+const personalPreviewUpdateApiUrl = repoEnv.T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL?.trim();
+const personalPreviewDefaultEnvironmentHost =
+  repoEnv.T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST?.trim();
 
 const personalTeamBundleIdentifier = repoEnv.T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID?.trim();
 const IOS_BUNDLE_IDENTIFIER_PATTERN = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
@@ -343,6 +346,12 @@ const config: ExpoConfig = {
   extra: {
     appVariant: APP_VARIANT,
     iosPersonalTeamBuild: isIosPersonalTeamBuild,
+    personalPreviewUpdates:
+      APP_VARIANT === "preview" && personalPreviewUpdateApiUrl
+        ? { latestReleaseApiUrl: personalPreviewUpdateApiUrl }
+        : null,
+    personalPreviewDefaultEnvironmentHost:
+      APP_VARIANT === "preview" ? (personalPreviewDefaultEnvironmentHost ?? null) : null,
     relay: {
       url: repoEnv.T3CODE_RELAY_URL ?? null,
     },

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -4,6 +4,7 @@ import { LogBox } from "react-native";
 import { featureFlags } from "react-native-screens";
 
 import App from "./src/App";
+import { registerBackgroundConnectionHeadlessTask } from "./src/features/background-connection/headless-task-registration";
 
 // Required for react-native-screens' iOS FormSheet sizing fix when a nested
 // native stack is rendered inside a non-fitToContents formSheet.
@@ -13,4 +14,5 @@ if (process.env.EXPO_PUBLIC_SHOWCASE === "1") {
   LogBox.ignoreAllLogs();
 }
 
+registerBackgroundConnectionHeadlessTask();
 registerRootComponent(App);

--- a/apps/mobile/modules/t3-background-connection/android/build.gradle
+++ b/apps/mobile/modules/t3-background-connection/android/build.gradle
@@ -1,0 +1,21 @@
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+group = 'com.t3tools.backgroundconnection'
+version = '0.0.0'
+
+android {
+  namespace 'expo.modules.t3backgroundconnection'
+  compileSdk rootProject.ext.compileSdkVersion
+
+  defaultConfig {
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+  }
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+  implementation 'com.facebook.react:react-android'
+  testImplementation 'junit:junit:4.13.2'
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/AndroidManifest.xml
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+  <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+  <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+
+  <application>
+    <service
+      android:name="expo.modules.t3backgroundconnection.T3BackgroundConnectionService"
+      android:exported="false"
+      android:foregroundServiceType="remoteMessaging"
+      android:stopWithTask="false" />
+
+    <receiver
+      android:name="expo.modules.t3backgroundconnection.T3BackgroundConnectionReceiver"
+      android:enabled="true"
+      android:exported="false">
+      <intent-filter>
+        <action android:name="android.intent.action.BOOT_COMPLETED" />
+        <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+      </intent-filter>
+    </receiver>
+  </application>
+</manifest>

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionModule.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionModule.kt
@@ -1,0 +1,107 @@
+package expo.modules.t3backgroundconnection
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import expo.modules.kotlin.functions.Queues
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class T3BackgroundConnectionModule : Module() {
+  private val statusListener: (Map<String, Any>) -> Unit = { status ->
+    sendEvent(T3BackgroundConnectionState.STATUS_EVENT, status)
+  }
+  private val stopRequestListener: () -> Unit = {
+    sendEvent(T3BackgroundConnectionState.STOP_REQUEST_EVENT)
+  }
+
+  override fun definition() = ModuleDefinition {
+    Name("T3BackgroundConnection")
+
+    Events(
+      T3BackgroundConnectionState.STATUS_EVENT,
+      T3BackgroundConnectionState.STOP_REQUEST_EVENT,
+    )
+
+    OnCreate {
+      val context = applicationContext()
+      T3BackgroundConnectionState.initialize(context)
+      T3BackgroundConnectionState.addStatusListener(statusListener)
+      T3BackgroundConnectionState.addStopRequestListener(stopRequestListener)
+    }
+
+    OnDestroy {
+      T3BackgroundConnectionState.removeStatusListener(statusListener)
+      T3BackgroundConnectionState.removeStopRequestListener(stopRequestListener)
+    }
+
+    OnActivityEntersForeground {
+      // The battery-optimization request has no result callback. Refreshing on
+      // resume makes the settings status reflect the user's choice immediately.
+      val context = applicationContext()
+      if (T3BackgroundConnectionState.shouldEnsureStartedOnActivityForeground(context)) {
+        // A visible Activity is an allowed foreground-service start context.
+        // A successful start also cancels any pending recovery alarm.
+        T3BackgroundConnectionController.ensureStarted(context)
+      }
+      T3BackgroundConnectionState.refreshStatus()
+    }
+
+    Function("getStatus") {
+      T3BackgroundConnectionState.status(applicationContext())
+    }
+
+    AsyncFunction("setEnabled") { enabled: Boolean ->
+      val context = applicationContext()
+      T3BackgroundConnectionState.setEnabled(context, enabled)
+      if (enabled) {
+        T3BackgroundConnectionController.ensureStarted(context)
+      } else {
+        T3BackgroundConnectionState.requestOrderlyStop(context)
+      }
+      T3BackgroundConnectionState.status(context)
+    }.runOnQueue(Queues.MAIN)
+
+    Function("ensureStarted") {
+      val context = applicationContext()
+      T3BackgroundConnectionController.ensureStarted(context)
+      T3BackgroundConnectionState.status(context)
+    }
+
+    AsyncFunction("requestBatteryOptimizationExemption") {
+      val context = applicationContext()
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        val intent = Intent(
+          Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+          Uri.parse("package:${context.packageName}"),
+        )
+        val activity = appContext.currentActivity
+        if (activity != null) {
+          activity.startActivity(intent)
+        } else {
+          context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
+      }
+      T3BackgroundConnectionState.status(context)
+    }.runOnQueue(Queues.MAIN)
+
+    Function("setRuntimeReady") { ready: Boolean ->
+      val context = applicationContext()
+      T3BackgroundConnectionState.markRuntimeReady(ready)
+      T3BackgroundConnectionState.status(context)
+    }
+
+    Function("acknowledgeStop") {
+      val context = applicationContext()
+      T3BackgroundConnectionState.acknowledgeStop(context)
+      T3BackgroundConnectionState.status(context)
+    }
+  }
+
+  private fun applicationContext(): Context =
+    requireNotNull(appContext.reactContext?.applicationContext) {
+      "T3BackgroundConnection requires an Android React context"
+    }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionReceiver.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionReceiver.kt
@@ -1,0 +1,26 @@
+package expo.modules.t3backgroundconnection
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.facebook.react.HeadlessJsTaskService
+
+class T3BackgroundConnectionReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context, intent: Intent?) {
+    if (
+      intent?.action != Intent.ACTION_BOOT_COMPLETED &&
+      intent?.action != Intent.ACTION_MY_PACKAGE_REPLACED &&
+      intent?.action != T3BackgroundConnectionState.RESTART_ACTION
+    ) {
+      return
+    }
+    if (!T3BackgroundConnectionState.isEnabled(context)) return
+
+    if (T3BackgroundConnectionController.ensureStarted(context)) {
+      // Acquire before returning from the receiver, but only after Android
+      // accepted the service launch so a rejected FGS cannot leak the static
+      // React Native wake lock.
+      HeadlessJsTaskService.acquireWakeLockNow(context)
+    }
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicy.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicy.kt
@@ -1,0 +1,13 @@
+package expo.modules.t3backgroundconnection
+
+internal object T3BackgroundConnectionRecoveryPolicy {
+  fun shouldScheduleRestartAfterStartFailure(
+    batteryOptimizationIgnored: Boolean,
+  ): Boolean = batteryOptimizationIgnored
+
+  fun shouldEnsureStartedOnActivityForeground(
+    enabled: Boolean,
+    serviceRunning: Boolean,
+    runtimeReady: Boolean,
+  ): Boolean = enabled && (!serviceRunning || !runtimeReady)
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoff.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoff.kt
@@ -1,0 +1,12 @@
+package expo.modules.t3backgroundconnection
+
+internal object T3BackgroundConnectionRestartBackoff {
+  private const val INITIAL_DELAY_MS = 1_000L
+  private const val MAX_DELAY_MS = 5 * 60_000L
+
+  fun delayMs(consecutiveFailures: Int): Long {
+    val exponent = consecutiveFailures.coerceIn(0, 20)
+    val exponentialDelay = INITIAL_DELAY_MS * (1L shl exponent)
+    return exponentialDelay.coerceAtMost(MAX_DELAY_MS)
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionService.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionService.kt
@@ -1,0 +1,169 @@
+package expo.modules.t3backgroundconnection
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import com.facebook.react.HeadlessJsTaskService
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.jstasks.HeadlessJsTaskConfig
+
+class T3BackgroundConnectionService : HeadlessJsTaskService() {
+  private var wifiLock: WifiManager.WifiLock? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    T3BackgroundConnectionState.initialize(this)
+    startInForeground()
+    T3BackgroundConnectionState.markServiceRunning(true)
+    acquireWifiLock()
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    if (!T3BackgroundConnectionState.isEnabled(this)) {
+      stopSelf(startId)
+      return Service.START_NOT_STICKY
+    }
+
+    if (T3BackgroundConnectionState.claimTask()) {
+      super.onStartCommand(intent, flags, startId)
+    }
+    return Service.START_STICKY
+  }
+
+  override fun getTaskConfig(intent: Intent?): HeadlessJsTaskConfig =
+    HeadlessJsTaskConfig(
+      T3BackgroundConnectionState.TASK_NAME,
+      Arguments.createMap(),
+      0,
+      true,
+    )
+
+  override fun onHeadlessJsTaskFinish(taskId: Int) {
+    val shouldRestart = T3BackgroundConnectionState.isEnabled(this)
+    T3BackgroundConnectionState.releaseTask()
+    super.onHeadlessJsTaskFinish(taskId)
+    if (shouldRestart) {
+      T3BackgroundConnectionState.scheduleRestartAfterUnexpectedTaskFinish(this)
+    }
+  }
+
+  override fun onDestroy() {
+    releaseWifiLock()
+    T3BackgroundConnectionState.markServiceRunning(false)
+    super.onDestroy()
+  }
+
+  private fun startInForeground() {
+    createNotificationChannel()
+    val notification = createNotification()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      startForeground(
+        NOTIFICATION_ID,
+        notification,
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING,
+      )
+    } else {
+      startForeground(NOTIFICATION_ID, notification)
+    }
+  }
+
+  private fun createNotificationChannel() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+    val channel = NotificationChannel(
+      NOTIFICATION_CHANNEL_ID,
+      "Background connection",
+      NotificationManager.IMPORTANCE_LOW,
+    ).apply {
+      description = "Keeps T3 Code connected while the app is in the background"
+      setSound(null, null)
+      enableLights(false)
+      enableVibration(false)
+      setShowBadge(false)
+      lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+    }
+    getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+  }
+
+  private fun createNotification(): Notification {
+    val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+    val contentIntent = launchIntent?.let {
+      PendingIntent.getActivity(
+        this,
+        0,
+        it,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+      )
+    }
+    val smallIcon = resources.getIdentifier("notification_icon", "drawable", packageName)
+      .takeIf { it != 0 }
+      ?: android.R.drawable.stat_notify_sync_noanim
+
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      Notification.Builder(this, NOTIFICATION_CHANNEL_ID)
+    } else {
+      @Suppress("DEPRECATION")
+      Notification.Builder(this)
+    }.apply {
+      setContentTitle("T3 Code")
+      setContentText("Connected in background")
+      setSmallIcon(smallIcon)
+      setOngoing(true)
+      setOnlyAlertOnce(true)
+      setShowWhen(false)
+      setCategory(Notification.CATEGORY_SERVICE)
+      setVisibility(Notification.VISIBILITY_PRIVATE)
+      contentIntent?.let(::setContentIntent)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+      }
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        @Suppress("DEPRECATION")
+        setPriority(Notification.PRIORITY_LOW)
+        @Suppress("DEPRECATION")
+        setSound(null)
+      }
+    }.build()
+  }
+
+  @SuppressLint("WakelockTimeout")
+  @Suppress("DEPRECATION")
+  private fun acquireWifiLock() {
+    try {
+      val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+      wifiLock = wifiManager.createWifiLock(
+        WifiManager.WIFI_MODE_FULL_HIGH_PERF,
+        "$packageName:t3-background-connection",
+      ).apply {
+        setReferenceCounted(false)
+        acquire()
+      }
+    } catch (_: RuntimeException) {
+      // The lock is best-effort. The foreground task and connection supervisor
+      // remain authoritative on devices that reject or do not expose it.
+      wifiLock = null
+    }
+  }
+
+  private fun releaseWifiLock() {
+    try {
+      wifiLock?.takeIf { it.isHeld }?.release()
+    } catch (_: RuntimeException) {
+      // The system may already have released the lock during process teardown.
+    } finally {
+      wifiLock = null
+    }
+  }
+
+  private companion object {
+    const val NOTIFICATION_CHANNEL_ID = "t3code_background_connection"
+    const val NOTIFICATION_ID = 0x7433
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionState.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionState.kt
@@ -1,0 +1,330 @@
+package expo.modules.t3backgroundconnection
+
+import android.annotation.SuppressLint
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.PowerManager
+import android.os.SystemClock
+import android.util.Log
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal object T3BackgroundConnectionState {
+  const val TASK_NAME = "T3BackgroundConnection"
+  const val STATUS_EVENT = "onStatusChange"
+  const val STOP_REQUEST_EVENT = "onStopRequested"
+  const val RESTART_ACTION =
+    "expo.modules.t3backgroundconnection.action.RESTART_BACKGROUND_CONNECTION"
+
+  private const val PREFERENCES_NAME = "t3_background_connection"
+  private const val ENABLED_KEY = "enabled"
+  private const val STOP_FALLBACK_DELAY_MS = 5_000L
+  private const val STABLE_RUNTIME_RESET_DELAY_MS = 60_000L
+
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val serviceRunning = AtomicBoolean(false)
+  private val runtimeReady = AtomicBoolean(false)
+  private val taskStarted = AtomicBoolean(false)
+  private val statusListeners = CopyOnWriteArraySet<(Map<String, Any>) -> Unit>()
+  private val stopRequestListeners = CopyOnWriteArraySet<() -> Unit>()
+
+  @Volatile
+  private var applicationContext: Context? = null
+
+  @Volatile
+  private var stopFallback: Runnable? = null
+
+  @Volatile
+  private var restartFallback: Runnable? = null
+
+  @Volatile
+  private var stableRuntimeReset: Runnable? = null
+
+  private var consecutiveUnexpectedFailures = 0
+
+  fun initialize(context: Context) {
+    applicationContext = context.applicationContext
+  }
+
+  fun isEnabled(context: Context): Boolean =
+    preferences(context).getBoolean(ENABLED_KEY, false)
+
+  @SuppressLint("ApplySharedPref")
+  fun setEnabled(context: Context, enabled: Boolean) {
+    initialize(context)
+    val wasEnabled = isEnabled(context)
+    // Commit before starting the service so a process death cannot start a
+    // sticky service whose boot-time preference still says it is disabled.
+    preferences(context).edit().putBoolean(ENABLED_KEY, enabled).commit()
+    if (enabled) {
+      cancelStopFallback()
+      if (!wasEnabled) {
+        resetUnexpectedRestartBackoff()
+      }
+    } else {
+      resetUnexpectedRestartBackoff()
+    }
+    emitStatus()
+  }
+
+  fun status(context: Context): Map<String, Any> {
+    initialize(context)
+
+    return mapOf(
+      "supported" to true,
+      "enabled" to isEnabled(context),
+      "serviceRunning" to serviceRunning.get(),
+      "runtimeReady" to runtimeReady.get(),
+      "batteryOptimizationIgnored" to isBatteryOptimizationIgnored(context),
+    )
+  }
+
+  fun shouldEnsureStartedOnActivityForeground(context: Context): Boolean =
+    T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+      enabled = isEnabled(context),
+      serviceRunning = serviceRunning.get(),
+      runtimeReady = runtimeReady.get(),
+    )
+
+  fun isBatteryOptimizationIgnored(context: Context): Boolean {
+    val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    return powerManager.isIgnoringBatteryOptimizations(context.packageName)
+  }
+
+  fun addStatusListener(listener: (Map<String, Any>) -> Unit) {
+    statusListeners.add(listener)
+  }
+
+  fun removeStatusListener(listener: (Map<String, Any>) -> Unit) {
+    statusListeners.remove(listener)
+  }
+
+  fun addStopRequestListener(listener: () -> Unit) {
+    stopRequestListeners.add(listener)
+  }
+
+  fun removeStopRequestListener(listener: () -> Unit) {
+    stopRequestListeners.remove(listener)
+  }
+
+  fun refreshStatus() {
+    emitStatus()
+  }
+
+  fun markServiceRunning(running: Boolean) {
+    serviceRunning.set(running)
+    if (!running) {
+      runtimeReady.set(false)
+      taskStarted.set(false)
+      cancelStopFallback()
+      cancelStableRuntimeReset()
+    }
+    emitStatus()
+  }
+
+  fun markRuntimeReady(ready: Boolean) {
+    val appliedReady = ready && serviceRunning.get()
+    runtimeReady.set(appliedReady)
+    if (appliedReady) {
+      scheduleStableRuntimeReset()
+    } else {
+      cancelStableRuntimeReset()
+    }
+    emitStatus()
+  }
+
+  fun claimTask(): Boolean = taskStarted.compareAndSet(false, true)
+
+  fun releaseTask() {
+    taskStarted.set(false)
+    runtimeReady.set(false)
+    cancelStableRuntimeReset()
+    emitStatus()
+  }
+
+  fun requestOrderlyStop(context: Context) {
+    initialize(context)
+    cancelStopFallback()
+    if (!serviceRunning.get()) {
+      stopService(context)
+      return
+    }
+
+    // A claimed task can be creating the React context, or can already own
+    // subscriptions while it bootstraps Clerk and persistence. Keep the
+    // service alive long enough for that task to observe the disabled
+    // preference and unwind; only an idle service is safe to stop immediately.
+    // The bounded fallback below still handles a runtime that never responds.
+    if (!taskStarted.get()) {
+      stopService(context)
+      return
+    }
+
+    mainHandler.post {
+      if (!isEnabled(context)) {
+        stopRequestListeners.forEach { listener -> listener() }
+      }
+    }
+
+    val fallback = Runnable {
+      stopFallback = null
+      if (isEnabled(context)) return@Runnable
+      runtimeReady.set(false)
+      emitStatus()
+      stopService(context)
+    }
+    stopFallback = fallback
+    mainHandler.postDelayed(fallback, STOP_FALLBACK_DELAY_MS)
+  }
+
+  fun acknowledgeStop(context: Context) {
+    initialize(context)
+    cancelStopFallback()
+    runtimeReady.set(false)
+    emitStatus()
+    if (!isEnabled(context)) {
+      stopService(context)
+    }
+  }
+
+  fun scheduleRestartAfterUnexpectedTaskFinish(context: Context) {
+    initialize(context)
+    cancelScheduledRestart(context)
+    val delayMs = T3BackgroundConnectionRestartBackoff.delayMs(consecutiveUnexpectedFailures)
+    consecutiveUnexpectedFailures = (consecutiveUnexpectedFailures + 1).coerceAtMost(20)
+    try {
+      val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+      alarmManager.setAndAllowWhileIdle(
+        AlarmManager.ELAPSED_REALTIME_WAKEUP,
+        SystemClock.elapsedRealtime() + delayMs,
+        checkNotNull(restartPendingIntent(context, PendingIntent.FLAG_UPDATE_CURRENT)),
+      )
+    } catch (error: RuntimeException) {
+      // AlarmManager is the durable path. Keep an in-process fallback for an
+      // unusual vendor failure so recovery still has a best-effort attempt.
+      Log.w("T3BackgroundConnection", "Could not schedule durable restart alarm", error)
+      val restart = Runnable {
+        restartFallback = null
+        if (isEnabled(context)) {
+          T3BackgroundConnectionController.ensureStarted(context)
+        }
+      }
+      restartFallback = restart
+      mainHandler.postDelayed(restart, delayMs)
+    }
+  }
+
+  fun scheduleRestartAfterStartFailure(context: Context) {
+    if (
+      T3BackgroundConnectionRecoveryPolicy.shouldScheduleRestartAfterStartFailure(
+        batteryOptimizationIgnored = isBatteryOptimizationIgnored(context),
+      )
+    ) {
+      scheduleRestartAfterUnexpectedTaskFinish(context)
+      return
+    }
+
+    // An alarm is not a valid exemption from Android's background foreground-
+    // service launch restrictions. Re-arming it here would create an endless
+    // failure ladder on a non-exempt app. Leave the feature enabled and recover
+    // on the next Activity foreground, boot/package update, or sticky restart.
+    cancelScheduledRestart(context)
+  }
+
+  private fun preferences(context: Context) =
+    context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+  private fun emitStatus() {
+    val context = applicationContext ?: return
+    val snapshot = status(context)
+    mainHandler.post {
+      statusListeners.forEach { listener -> listener(snapshot) }
+    }
+  }
+
+  private fun cancelStopFallback() {
+    stopFallback?.let(mainHandler::removeCallbacks)
+    stopFallback = null
+  }
+
+  fun cancelScheduledRestart(context: Context) {
+    restartFallback?.let(mainHandler::removeCallbacks)
+    restartFallback = null
+    val pendingIntent = restartPendingIntent(context, PendingIntent.FLAG_NO_CREATE) ?: return
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    alarmManager.cancel(pendingIntent)
+    pendingIntent.cancel()
+  }
+
+  private fun scheduleStableRuntimeReset() {
+    cancelStableRuntimeReset()
+    val reset = Runnable {
+      stableRuntimeReset = null
+      if (runtimeReady.get() && serviceRunning.get()) {
+        consecutiveUnexpectedFailures = 0
+      }
+    }
+    stableRuntimeReset = reset
+    mainHandler.postDelayed(reset, STABLE_RUNTIME_RESET_DELAY_MS)
+  }
+
+  private fun cancelStableRuntimeReset() {
+    stableRuntimeReset?.let(mainHandler::removeCallbacks)
+    stableRuntimeReset = null
+  }
+
+  private fun resetUnexpectedRestartBackoff() {
+    consecutiveUnexpectedFailures = 0
+    applicationContext?.let(::cancelScheduledRestart)
+    cancelStableRuntimeReset()
+  }
+
+  private fun restartPendingIntent(context: Context, creationFlag: Int): PendingIntent? =
+    PendingIntent.getBroadcast(
+      context.applicationContext,
+      RESTART_REQUEST_CODE,
+      Intent(context.applicationContext, T3BackgroundConnectionReceiver::class.java).apply {
+        action = RESTART_ACTION
+      },
+      creationFlag or PendingIntent.FLAG_IMMUTABLE,
+    )
+
+  private fun stopService(context: Context) {
+    context.applicationContext.stopService(
+      Intent(context.applicationContext, T3BackgroundConnectionService::class.java),
+    )
+  }
+
+  private const val RESTART_REQUEST_CODE = 0x7434
+}
+
+internal object T3BackgroundConnectionController {
+  fun ensureStarted(context: Context): Boolean {
+    val applicationContext = context.applicationContext
+    T3BackgroundConnectionState.initialize(applicationContext)
+    if (!T3BackgroundConnectionState.isEnabled(applicationContext)) return false
+
+    val intent = Intent(applicationContext, T3BackgroundConnectionService::class.java)
+    return try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        applicationContext.startForegroundService(intent)
+      } else {
+        applicationContext.startService(intent)
+      }
+      T3BackgroundConnectionState.cancelScheduledRestart(applicationContext)
+      true
+    } catch (error: RuntimeException) {
+      // Android can reject a background FGS launch. Keep the preference
+      // enabled and let the recovery policy either retry an exempt app or
+      // park until a foreground/OS trigger can legally start the service.
+      Log.w("T3BackgroundConnection", "Could not start foreground service", error)
+      T3BackgroundConnectionState.scheduleRestartAfterStartFailure(applicationContext)
+      false
+    }
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicyTest.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicyTest.kt
@@ -1,0 +1,57 @@
+package expo.modules.t3backgroundconnection
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class T3BackgroundConnectionRecoveryPolicyTest {
+  @Test
+  fun `start failure retries only while battery optimization is ignored`() {
+    assertTrue(
+      T3BackgroundConnectionRecoveryPolicy.shouldScheduleRestartAfterStartFailure(
+        batteryOptimizationIgnored = true,
+      ),
+    )
+    assertFalse(
+      T3BackgroundConnectionRecoveryPolicy.shouldScheduleRestartAfterStartFailure(
+        batteryOptimizationIgnored = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `foreground recovers an enabled service that is stopped or not ready`() {
+    assertTrue(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = true,
+        serviceRunning = false,
+        runtimeReady = false,
+      ),
+    )
+    assertTrue(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = true,
+        serviceRunning = true,
+        runtimeReady = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `foreground leaves a healthy or disabled service alone`() {
+    assertFalse(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = true,
+        serviceRunning = true,
+        runtimeReady = true,
+      ),
+    )
+    assertFalse(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = false,
+        serviceRunning = false,
+        runtimeReady = false,
+      ),
+    )
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoffTest.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoffTest.kt
@@ -1,0 +1,16 @@
+package expo.modules.t3backgroundconnection
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class T3BackgroundConnectionRestartBackoffTest {
+  @Test
+  fun `repeated failures back off and remain bounded`() {
+    assertEquals(1_000L, T3BackgroundConnectionRestartBackoff.delayMs(0))
+    assertEquals(2_000L, T3BackgroundConnectionRestartBackoff.delayMs(1))
+    assertEquals(4_000L, T3BackgroundConnectionRestartBackoff.delayMs(2))
+    assertEquals(256_000L, T3BackgroundConnectionRestartBackoff.delayMs(8))
+    assertEquals(300_000L, T3BackgroundConnectionRestartBackoff.delayMs(9))
+    assertEquals(300_000L, T3BackgroundConnectionRestartBackoff.delayMs(Int.MAX_VALUE))
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/expo-module.config.json
+++ b/apps/mobile/modules/t3-background-connection/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["expo.modules.t3backgroundconnection.T3BackgroundConnectionModule"]
+  }
+}

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -2,7 +2,7 @@ import { BlurTargetView } from "expo-blur";
 import * as Linking from "expo-linking";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
-import { StatusBar, useColorScheme } from "react-native";
+import { Platform, StatusBar, useColorScheme } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -22,6 +22,7 @@ import { appAtomRegistry } from "./state/atom-registry";
 import { OverlayPortalHost } from "./components/OverlayPortal";
 import { appBlurTargetRef } from "./lib/appBlurTarget";
 import { useThemeColor } from "./lib/useThemeColor";
+import { ensureBackgroundConnectionStarted } from "./native/backgroundConnection";
 
 import "../global.css";
 
@@ -57,12 +58,22 @@ function SplashScreenCoordinator() {
   return null;
 }
 
+function BackgroundConnectionServiceCoordinator() {
+  useEffect(() => {
+    if (Platform.OS === "android") {
+      ensureBackgroundConnectionStarted();
+    }
+  }, []);
+  return null;
+}
+
 export default function App() {
   const colorScheme = useColorScheme();
   const statusBarBg = useThemeColor("--color-status-bar");
 
   return (
     <RegistryContext.Provider value={appAtomRegistry}>
+      <BackgroundConnectionServiceCoordinator />
       <CloudAuthProvider>
         <AppearancePreferencesProvider>
           <SplashScreenCoordinator />

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -2,7 +2,7 @@ import { BlurTargetView } from "expo-blur";
 import * as Linking from "expo-linking";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
-import { StatusBar } from "react-native";
+import { Platform, StatusBar } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -23,6 +23,7 @@ import { OverlayPortalHost } from "./components/OverlayPortal";
 import { appBlurTargetRef } from "./lib/appBlurTarget";
 import { useThemeColor } from "./lib/useThemeColor";
 import { useMobileNavigationTheme } from "./lib/useMobileNavigationTheme";
+import { ensureBackgroundConnectionStarted } from "./native/backgroundConnection";
 
 import "../global.css";
 
@@ -58,9 +59,19 @@ function SplashScreenCoordinator() {
   return null;
 }
 
+function BackgroundConnectionServiceCoordinator() {
+  useEffect(() => {
+    if (Platform.OS === "android") {
+      ensureBackgroundConnectionStarted();
+    }
+  }, []);
+  return null;
+}
+
 export default function App() {
   return (
     <RegistryContext.Provider value={appAtomRegistry}>
+      <BackgroundConnectionServiceCoordinator />
       <CloudAuthProvider>
         <AppearancePreferencesProvider>
           <AppContent />

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -23,6 +23,8 @@ import { useConnectOnboardingNavigation } from "./features/cloud/connectOnboardi
 import { ThreadFilesTreeScreen, ThreadFileScreen } from "./features/files/ThreadFilesRouteScreen";
 import { AdaptiveWorkspaceLayout } from "./features/layout/AdaptiveWorkspaceLayout";
 import { HardwareKeyboardCommandProvider } from "./features/keyboard/HardwareKeyboardCommandProvider";
+import { parseActiveThreadPath } from "./features/keyboard/hardwareKeyboardCommands";
+import { saveBackgroundConnectionRetainedThread } from "./features/background-connection/retained-thread";
 import { ReviewCommentComposerSheet } from "./features/review/ReviewCommentComposerSheet";
 import { ReviewSheet } from "./features/review/ReviewSheet";
 import { ThreadTerminalRouteScreen } from "./features/terminal/ThreadTerminalRouteScreen";
@@ -390,6 +392,14 @@ function RootStackLayout(props: {
   const path = getPathFromState(props.state, navigationPathConfig);
   const pathname = path.startsWith("/") ? path : `/${path}`;
   const workspacePathname = workspacePathFromState(props.state);
+  const activeThread = parseActiveThreadPath(workspacePathname);
+
+  useEffect(() => {
+    if (Platform.OS !== "android" || activeThread === null) {
+      return;
+    }
+    void saveBackgroundConnectionRetainedThread(activeThread);
+  }, [activeThread?.environmentId, activeThread?.threadId]);
 
   return (
     <HardwareKeyboardCommandProvider pathname={pathname}>

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -24,6 +24,8 @@ import { useConnectOnboardingNavigation } from "./features/cloud/connectOnboardi
 import { ThreadFilesTreeScreen, ThreadFileScreen } from "./features/files/ThreadFilesRouteScreen";
 import { AdaptiveWorkspaceLayout } from "./features/layout/AdaptiveWorkspaceLayout";
 import { HardwareKeyboardCommandProvider } from "./features/keyboard/HardwareKeyboardCommandProvider";
+import { parseActiveThreadPath } from "./features/keyboard/hardwareKeyboardCommands";
+import { saveBackgroundConnectionRetainedThread } from "./features/background-connection/retained-thread";
 import { ReviewCommentComposerSheet } from "./features/review/ReviewCommentComposerSheet";
 import { ReviewSheet } from "./features/review/ReviewSheet";
 import { ThreadTerminalRouteScreen } from "./features/terminal/ThreadTerminalRouteScreen";
@@ -326,6 +328,14 @@ function RootStackLayout(props: {
   const path = getPathFromState(props.state, navigationPathConfig);
   const pathname = path.startsWith("/") ? path : `/${path}`;
   const workspacePathname = workspacePathFromState(props.state);
+  const activeThread = parseActiveThreadPath(workspacePathname);
+
+  useEffect(() => {
+    if (Platform.OS !== "android" || activeThread === null) {
+      return;
+    }
+    void saveBackgroundConnectionRetainedThread(activeThread);
+  }, [activeThread?.environmentId, activeThread?.threadId]);
 
   return (
     <HardwareKeyboardCommandProvider pathname={pathname}>

--- a/apps/mobile/src/connection/app-state-wakeups.test.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.test.ts
@@ -18,4 +18,34 @@ describe("mobileApplicationActiveWakeup", () => {
       mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS),
     ).toBe("application-active-reconnect");
   });
+
+  it("preserves a protected background connection regardless of elapsed time", () => {
+    const protection = { serviceRunning: true, runtimeReady: true };
+
+    expect(mobileApplicationActiveWakeup(null, 20_000, protection)).toBe(
+      "application-active-preserved",
+    );
+    expect(
+      mobileApplicationActiveWakeup(
+        20_000,
+        20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS * 10,
+        protection,
+      ),
+    ).toBe("application-active-preserved");
+  });
+
+  it("keeps the existing fallback unless both native protection signals are healthy", () => {
+    expect(
+      mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS, {
+        serviceRunning: true,
+        runtimeReady: false,
+      }),
+    ).toBe("application-active-reconnect");
+    expect(
+      mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS, {
+        serviceRunning: false,
+        runtimeReady: true,
+      }),
+    ).toBe("application-active-reconnect");
+  });
 });

--- a/apps/mobile/src/connection/app-state-wakeups.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.ts
@@ -4,13 +4,22 @@ export const MOBILE_BACKGROUND_RECONNECT_AFTER_MS = 10_000;
 
 export type MobileApplicationActiveWakeup = Extract<
   Wakeups.ConnectionWakeup,
-  "application-active-probe" | "application-active-reconnect"
+  "application-active-preserved" | "application-active-probe" | "application-active-reconnect"
 >;
+
+export interface MobileBackgroundConnectionProtection {
+  readonly serviceRunning: boolean;
+  readonly runtimeReady: boolean;
+}
 
 export function mobileApplicationActiveWakeup(
   backgroundedAtMs: number | null,
   activeAtMs: number,
+  protection?: MobileBackgroundConnectionProtection,
 ): MobileApplicationActiveWakeup {
+  if (protection?.serviceRunning === true && protection.runtimeReady === true) {
+    return "application-active-preserved";
+  }
   return backgroundedAtMs !== null &&
     activeAtMs - backgroundedAtMs >= MOBILE_BACKGROUND_RECONNECT_AFTER_MS
     ? "application-active-reconnect"

--- a/apps/mobile/src/connection/platform.ts
+++ b/apps/mobile/src/connection/platform.ts
@@ -26,11 +26,15 @@ import { AppState } from "react-native";
 
 import { authClientMetadata } from "../lib/authClientMetadata";
 import * as Runtime from "../lib/runtime";
+import { getBackgroundConnectionStatus } from "../native/backgroundConnection";
 import * as MobileStorage from "../persistence/mobile-storage";
 import { appAtomRegistry } from "../state/atom-registry";
 import { clearThreadOutboxEnvironment } from "../state/thread-outbox";
 import { clearComposerDraftsEnvironment } from "../state/use-composer-drafts";
-import { mobileApplicationActiveWakeup } from "./app-state-wakeups";
+import {
+  type MobileApplicationActiveWakeup,
+  mobileApplicationActiveWakeup,
+} from "./app-state-wakeups";
 import { connectionStorageLayer } from "./storage";
 
 function networkStatus(state: Network.NetworkState): "unknown" | "offline" | "online" {
@@ -87,7 +91,7 @@ const connectivityLayer = Connectivity.layer({
 
 const wakeupsLayer = Wakeups.layer({
   changes: Stream.merge(
-    Stream.callback<"application-active-probe" | "application-active-reconnect">((queue) =>
+    Stream.callback<MobileApplicationActiveWakeup>((queue) =>
       Effect.acquireRelease(
         Effect.sync(() => {
           let backgroundedAtMs = AppState.currentState === "background" ? Date.now() : null;
@@ -97,7 +101,14 @@ const wakeupsLayer = Wakeups.layer({
               return;
             }
             if (state === "active") {
-              Queue.offerUnsafe(queue, mobileApplicationActiveWakeup(backgroundedAtMs, Date.now()));
+              Queue.offerUnsafe(
+                queue,
+                mobileApplicationActiveWakeup(
+                  backgroundedAtMs,
+                  Date.now(),
+                  getBackgroundConnectionStatus(),
+                ),
+              );
               backgroundedAtMs = null;
             }
           });

--- a/apps/mobile/src/features/agent-awareness/liveActivityPreferences.test.ts
+++ b/apps/mobile/src/features/agent-awareness/liveActivityPreferences.test.ts
@@ -62,6 +62,9 @@ const testLayer = Layer.mergeAll(
       clearAgentAwarenessRegistrationRecord: Effect.void,
       loadRecentThreadShortcuts: Effect.succeed([]),
       saveRecentThreadShortcuts: () => Effect.void,
+      loadBackgroundConnectionRetainedThread: Effect.succeed(null),
+      saveBackgroundConnectionRetainedThread: () => Effect.void,
+      clearBackgroundConnectionRetainedThread: Effect.void,
     }),
   ),
 );

--- a/apps/mobile/src/features/agent-notifications/android-thread-notifications.test.ts
+++ b/apps/mobile/src/features/agent-notifications/android-thread-notifications.test.ts
@@ -1,0 +1,91 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const notifications = vi.hoisted(() => ({
+  setChannel: vi.fn(async () => undefined),
+  getPermissions: vi.fn(async () => ({ granted: true, canAskAgain: true })),
+  requestPermissions: vi.fn(async () => ({ granted: true, canAskAgain: true })),
+  schedule: vi.fn(async () => "notification-id"),
+}));
+
+vi.mock("expo-notifications", () => ({
+  AndroidImportance: { HIGH: 6 },
+  AndroidNotificationPriority: { HIGH: "high" },
+  setNotificationChannelAsync: notifications.setChannel,
+  getPermissionsAsync: notifications.getPermissions,
+  requestPermissionsAsync: notifications.requestPermissions,
+  scheduleNotificationAsync: notifications.schedule,
+}));
+vi.mock("react-native", () => ({
+  AppState: { currentState: "background" },
+  Platform: { OS: "android" },
+}));
+
+import {
+  androidThreadNotificationContent,
+  presentAndroidThreadNotification,
+  requestAndroidAgentNotificationPermission,
+} from "./android-thread-notifications";
+import type {
+  ThreadNotificationEvent,
+  ThreadNotificationKind,
+} from "./thread-notification-reducer";
+
+function event(kind: ThreadNotificationKind): ThreadNotificationEvent {
+  return {
+    id: `event-${kind}`,
+    kind,
+    environmentId: EnvironmentId.make("environment-1"),
+    threadId: ThreadId.make("thread-1"),
+    threadTitle: "Prepare release",
+    occurredAt: "2026-08-02T00:00:00.000Z",
+  };
+}
+
+describe("Android thread notification content", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    ["completed", "Task completed", "Prepare release"],
+    ["failed", "Task failed", "Prepare release needs attention."],
+    ["approval-required", "Approval required", "Prepare release"],
+    ["user-input-required", "Input required", "Prepare release"],
+  ] as const)("maps %s to concise notification copy", (kind, title, body) => {
+    expect(androidThreadNotificationContent(event(kind))).toEqual({ title, body });
+  });
+
+  it("creates the Android channel before requesting permission", async () => {
+    notifications.getPermissions.mockResolvedValueOnce({ granted: false, canAskAgain: true });
+
+    await expect(requestAndroidAgentNotificationPermission()).resolves.toEqual({
+      type: "granted",
+    });
+
+    expect(notifications.setChannel).toHaveBeenCalledOnce();
+    expect(notifications.requestPermissions).toHaveBeenCalledOnce();
+    expect(notifications.setChannel.mock.invocationCallOrder[0]).toBeLessThan(
+      notifications.requestPermissions.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it("posts an immediate notification with stable dedupe and deep-link data", async () => {
+    const notificationEvent = event("completed");
+
+    await presentAndroidThreadNotification(notificationEvent);
+
+    expect(notifications.schedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identifier: notificationEvent.id,
+        content: expect.objectContaining({
+          title: "Task completed",
+          data: expect.objectContaining({
+            deepLink: "/threads/environment-1/thread-1",
+            environmentId: "environment-1",
+            threadId: "thread-1",
+          }),
+        }),
+        trigger: { channelId: "agent-activity" },
+      }),
+    );
+  });
+});

--- a/apps/mobile/src/features/agent-notifications/android-thread-notifications.ts
+++ b/apps/mobile/src/features/agent-notifications/android-thread-notifications.ts
@@ -1,0 +1,85 @@
+import * as Notifications from "expo-notifications";
+import { AppState, Platform } from "react-native";
+
+import type { ThreadNotificationEvent } from "./thread-notification-reducer";
+
+export const ANDROID_AGENT_NOTIFICATION_CHANNEL_ID = "agent-activity";
+
+export type AndroidNotificationPermission =
+  | { readonly type: "unsupported" }
+  | { readonly type: "granted" }
+  | { readonly type: "denied"; readonly canAskAgain: boolean };
+
+export async function ensureAndroidAgentNotificationChannel(): Promise<void> {
+  if (Platform.OS !== "android") return;
+  await Notifications.setNotificationChannelAsync(ANDROID_AGENT_NOTIFICATION_CHANNEL_ID, {
+    name: "Agent activity",
+    description: "Task completions and requests that need your attention",
+    importance: Notifications.AndroidImportance.HIGH,
+    sound: "default",
+    vibrationPattern: [0, 200, 100, 200],
+    enableVibrate: true,
+    showBadge: true,
+  });
+}
+
+export async function getAndroidAgentNotificationPermission(): Promise<AndroidNotificationPermission> {
+  if (Platform.OS !== "android") return { type: "unsupported" };
+  const permission = await Notifications.getPermissionsAsync();
+  return permission.granted
+    ? { type: "granted" }
+    : { type: "denied", canAskAgain: permission.canAskAgain };
+}
+
+export async function requestAndroidAgentNotificationPermission(): Promise<AndroidNotificationPermission> {
+  if (Platform.OS !== "android") return { type: "unsupported" };
+  await ensureAndroidAgentNotificationChannel();
+  const existing = await getAndroidAgentNotificationPermission();
+  if (existing.type !== "denied" || !existing.canAskAgain) return existing;
+  const requested = await Notifications.requestPermissionsAsync();
+  return requested.granted
+    ? { type: "granted" }
+    : { type: "denied", canAskAgain: requested.canAskAgain };
+}
+
+export function androidThreadNotificationContent(event: ThreadNotificationEvent): {
+  readonly title: string;
+  readonly body: string;
+} {
+  switch (event.kind) {
+    case "completed":
+      return { title: "Task completed", body: event.threadTitle };
+    case "failed":
+      return { title: "Task failed", body: `${event.threadTitle} needs attention.` };
+    case "approval-required":
+      return { title: "Approval required", body: event.threadTitle };
+    case "user-input-required":
+      return { title: "Input required", body: event.threadTitle };
+  }
+}
+
+export async function presentAndroidThreadNotification(
+  event: ThreadNotificationEvent,
+): Promise<void> {
+  if (Platform.OS !== "android" || AppState.currentState === "active") return;
+  await ensureAndroidAgentNotificationChannel();
+  const permission = await getAndroidAgentNotificationPermission();
+  if (permission.type !== "granted") return;
+  const content = androidThreadNotificationContent(event);
+  const deepLink = `/threads/${encodeURIComponent(event.environmentId)}/${encodeURIComponent(event.threadId)}`;
+  await Notifications.scheduleNotificationAsync({
+    identifier: event.id,
+    content: {
+      ...content,
+      sound: "default",
+      priority: Notifications.AndroidNotificationPriority.HIGH,
+      data: {
+        deepLink,
+        environmentId: event.environmentId,
+        threadId: event.threadId,
+        eventKind: event.kind,
+      },
+    },
+    trigger: { channelId: ANDROID_AGENT_NOTIFICATION_CHANNEL_ID },
+  });
+}

--- a/apps/mobile/src/features/agent-notifications/thread-notification-reducer.test.ts
+++ b/apps/mobile/src/features/agent-notifications/thread-notification-reducer.test.ts
@@ -1,0 +1,215 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  createThreadNotificationState,
+  reduceThreadNotifications,
+} from "./thread-notification-reducer";
+
+const environmentId = EnvironmentId.make("environment-1");
+const projectId = ProjectId.make("project-1");
+
+function shell(
+  id: string,
+  input: {
+    readonly turnId?: string;
+    readonly turnState?: "pending" | "running" | "completed" | "interrupted" | "error";
+    readonly completedAt?: string | null;
+    readonly sessionStatus?: "starting" | "running" | "ready" | "error";
+    readonly sessionUpdatedAt?: string;
+    readonly hasPendingApprovals?: boolean;
+    readonly hasPendingUserInput?: boolean;
+    readonly updatedAt?: string;
+  } = {},
+): EnvironmentThreadShell {
+  const updatedAt = input.updatedAt ?? "2026-08-02T00:00:00.000Z";
+  return {
+    environmentId,
+    id: ThreadId.make(id),
+    projectId,
+    title: `Thread ${id}`,
+    updatedAt,
+    latestTurn:
+      input.turnId === undefined
+        ? null
+        : {
+            turnId: TurnId.make(input.turnId),
+            state: input.turnState ?? "running",
+            requestedAt: "2026-08-02T00:00:00.000Z",
+            startedAt: "2026-08-02T00:00:01.000Z",
+            completedAt: input.completedAt ?? null,
+            assistantMessageId: null,
+          },
+    session:
+      input.sessionStatus === undefined
+        ? null
+        : {
+            status: input.sessionStatus,
+            updatedAt: input.sessionUpdatedAt ?? updatedAt,
+          },
+    hasPendingApprovals: input.hasPendingApprovals ?? false,
+    hasPendingUserInput: input.hasPendingUserInput ?? false,
+  } as EnvironmentThreadShell;
+}
+
+describe("thread notification reducer", () => {
+  it("seeds initial hydration without notifying for existing terminal or attention states", () => {
+    const result = reduceThreadNotifications(createThreadNotificationState(), [
+      shell("completed", {
+        turnId: "turn-completed",
+        turnState: "completed",
+        completedAt: "2026-08-02T00:00:04.000Z",
+      }),
+      shell("approval", { hasPendingApprovals: true }),
+    ]);
+
+    expect(result.events).toEqual([]);
+  });
+
+  it("emits one completion when an observed turn completes", () => {
+    const seeded = reduceThreadNotifications(createThreadNotificationState(), [
+      shell("task", { turnId: "turn-1", turnState: "running" }),
+    ]).state;
+    const completed = shell("task", {
+      turnId: "turn-1",
+      turnState: "completed",
+      completedAt: "2026-08-02T00:00:04.000Z",
+      updatedAt: "2026-08-02T00:00:04.000Z",
+    });
+
+    const first = reduceThreadNotifications(seeded, [completed]);
+    const repeated = reduceThreadNotifications(first.state, [completed]);
+
+    expect(first.events).toEqual([
+      expect.objectContaining({
+        id: "environment-1:task:completed:turn-1",
+        kind: "completed",
+        environmentId,
+        threadId: ThreadId.make("task"),
+        threadTitle: "Thread task",
+      }),
+    ]);
+    expect(repeated.events).toEqual([]);
+  });
+
+  it("emits failure once and does not duplicate the same failure from session and turn state", () => {
+    const seeded = reduceThreadNotifications(createThreadNotificationState(), [
+      shell("task", { turnId: "turn-1", turnState: "running", sessionStatus: "running" }),
+    ]).state;
+    const failed = shell("task", {
+      turnId: "turn-1",
+      turnState: "error",
+      completedAt: "2026-08-02T00:00:04.000Z",
+      sessionStatus: "error",
+      sessionUpdatedAt: "2026-08-02T00:00:04.000Z",
+      updatedAt: "2026-08-02T00:00:04.000Z",
+    });
+
+    const result = reduceThreadNotifications(seeded, [failed]);
+
+    expect(result.events).toEqual([
+      expect.objectContaining({ id: "environment-1:task:failed:turn-1", kind: "failed" }),
+    ]);
+  });
+
+  it("emits approval and user-input edges without repeating unchanged flags", () => {
+    const seeded = reduceThreadNotifications(createThreadNotificationState(), [
+      shell("task"),
+    ]).state;
+    const approval = reduceThreadNotifications(seeded, [
+      shell("task", { hasPendingApprovals: true, updatedAt: "2026-08-02T00:00:02.000Z" }),
+    ]);
+    const approvalRepeated = reduceThreadNotifications(approval.state, [
+      shell("task", { hasPendingApprovals: true, updatedAt: "2026-08-02T00:00:02.000Z" }),
+    ]);
+    const cleared = reduceThreadNotifications(approvalRepeated.state, [shell("task")]);
+    const input = reduceThreadNotifications(cleared.state, [
+      shell("task", { hasPendingUserInput: true, updatedAt: "2026-08-02T00:00:05.000Z" }),
+    ]);
+
+    expect(approval.events.map((event) => event.kind)).toEqual(["approval-required"]);
+    expect(approvalRepeated.events).toEqual([]);
+    expect(input.events.map((event) => event.kind)).toEqual(["user-input-required"]);
+  });
+
+  it("notifies a newly observed completed turn on a known thread after reconnect catch-up", () => {
+    const seeded = reduceThreadNotifications(createThreadNotificationState(), [
+      shell("task", {
+        turnId: "turn-old",
+        turnState: "completed",
+        completedAt: "2026-08-02T00:00:01.000Z",
+      }),
+    ]).state;
+
+    const result = reduceThreadNotifications(seeded, [
+      shell("task", {
+        turnId: "turn-new",
+        turnState: "completed",
+        completedAt: "2026-08-02T00:00:08.000Z",
+        updatedAt: "2026-08-02T00:00:08.000Z",
+      }),
+    ]);
+
+    expect(result.events.map((event) => event.id)).toEqual([
+      "environment-1:task:completed:turn-new",
+    ]);
+  });
+
+  it("forgets deleted shells without notifying if the identifier is later reused", () => {
+    const seeded = reduceThreadNotifications(createThreadNotificationState(), [
+      shell("task", { turnId: "turn-1", turnState: "running" }),
+    ]).state;
+    const removed = reduceThreadNotifications(seeded, []);
+    const recreated = reduceThreadNotifications(removed.state, [
+      shell("task", {
+        turnId: "turn-2",
+        turnState: "completed",
+        completedAt: "2026-08-02T00:00:08.000Z",
+      }),
+    ]);
+
+    expect(removed.events).toEqual([]);
+    expect(recreated.events).toEqual([]);
+  });
+
+  it("does not duplicate a terminal event after an out-of-order rollback snapshot", () => {
+    const seeded = reduceThreadNotifications(createThreadNotificationState(), [
+      shell("task", { turnId: "turn-1", turnState: "running" }),
+    ]).state;
+    const completedShell = shell("task", {
+      turnId: "turn-1",
+      turnState: "completed",
+      completedAt: "2026-08-02T00:00:04.000Z",
+      updatedAt: "2026-08-02T00:00:04.000Z",
+    });
+    const completed = reduceThreadNotifications(seeded, [completedShell]);
+    const staleRunning = reduceThreadNotifications(completed.state, [
+      shell("task", {
+        turnId: "turn-1",
+        turnState: "running",
+        updatedAt: "2026-08-02T00:00:03.000Z",
+      }),
+    ]);
+    const replayedCompletion = reduceThreadNotifications(staleRunning.state, [completedShell]);
+
+    expect(completed.events).toHaveLength(1);
+    expect(replayedCompletion.events).toEqual([]);
+  });
+
+  it("honors persisted event ids after a process restart", () => {
+    const eventId = "environment-1:task:completed:turn-1";
+    const seeded = reduceThreadNotifications(createThreadNotificationState([eventId]), [
+      shell("task", { turnId: "turn-1", turnState: "running" }),
+    ]).state;
+    const result = reduceThreadNotifications(seeded, [
+      shell("task", {
+        turnId: "turn-1",
+        turnState: "completed",
+        completedAt: "2026-08-02T00:00:04.000Z",
+      }),
+    ]);
+
+    expect(result.events).toEqual([]);
+  });
+});

--- a/apps/mobile/src/features/agent-notifications/thread-notification-reducer.ts
+++ b/apps/mobile/src/features/agent-notifications/thread-notification-reducer.ts
@@ -1,0 +1,181 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+
+export type ThreadNotificationKind =
+  | "completed"
+  | "failed"
+  | "approval-required"
+  | "user-input-required";
+
+export interface ThreadNotificationEvent {
+  readonly id: string;
+  readonly kind: ThreadNotificationKind;
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+  readonly threadTitle: string;
+  readonly occurredAt: string;
+}
+
+interface ThreadNotificationObservation {
+  readonly completionKey: string | null;
+  readonly failureKey: string | null;
+  readonly hasPendingApprovals: boolean;
+  readonly hasPendingUserInput: boolean;
+}
+
+export interface ThreadNotificationState {
+  readonly seeded: boolean;
+  readonly observations: ReadonlyMap<string, ThreadNotificationObservation>;
+  readonly emittedEventIds: ReadonlySet<string>;
+}
+
+export interface ThreadNotificationReduction {
+  readonly state: ThreadNotificationState;
+  readonly events: ReadonlyArray<ThreadNotificationEvent>;
+}
+
+function threadKey(thread: EnvironmentThreadShell): string {
+  return `${thread.environmentId}:${thread.id}`;
+}
+
+function turnCompletionKey(thread: EnvironmentThreadShell): string | null {
+  return thread.latestTurn?.state === "completed" ? String(thread.latestTurn.turnId) : null;
+}
+
+function turnFailureKey(thread: EnvironmentThreadShell): string | null {
+  if (thread.latestTurn?.state === "error") {
+    return `turn:${thread.latestTurn.turnId}`;
+  }
+  if (thread.session?.status === "error") {
+    return `session:${thread.session.updatedAt}`;
+  }
+  return null;
+}
+
+function observe(thread: EnvironmentThreadShell): ThreadNotificationObservation {
+  return {
+    completionKey: turnCompletionKey(thread),
+    failureKey: turnFailureKey(thread),
+    hasPendingApprovals: thread.hasPendingApprovals,
+    hasPendingUserInput: thread.hasPendingUserInput,
+  };
+}
+
+function event(
+  thread: EnvironmentThreadShell,
+  kind: ThreadNotificationKind,
+  identity: string,
+  occurredAt: string,
+): ThreadNotificationEvent {
+  return {
+    id: `${threadKey(thread)}:${kind === "failed" ? "failed" : kind}:${identity}`,
+    kind,
+    environmentId: thread.environmentId,
+    threadId: thread.id,
+    threadTitle: thread.title,
+    occurredAt,
+  };
+}
+
+function transitionEvent(
+  previous: ThreadNotificationObservation,
+  thread: EnvironmentThreadShell,
+  current: ThreadNotificationObservation,
+): ThreadNotificationEvent | null {
+  // Attention outranks terminal status. If one snapshot carries both, the
+  // user needs the actionable alert rather than two notifications for one edge.
+  if (current.hasPendingUserInput && !previous.hasPendingUserInput) {
+    return event(thread, "user-input-required", thread.updatedAt, thread.updatedAt);
+  }
+  if (current.hasPendingApprovals && !previous.hasPendingApprovals) {
+    return event(thread, "approval-required", thread.updatedAt, thread.updatedAt);
+  }
+  if (current.failureKey !== null && current.failureKey !== previous.failureKey) {
+    const identity = current.failureKey.startsWith("turn:")
+      ? current.failureKey.slice("turn:".length)
+      : current.failureKey;
+    return event(
+      thread,
+      "failed",
+      identity,
+      thread.latestTurn?.completedAt ?? thread.session?.updatedAt ?? thread.updatedAt,
+    );
+  }
+  if (current.completionKey !== null && current.completionKey !== previous.completionKey) {
+    return event(
+      thread,
+      "completed",
+      current.completionKey,
+      thread.latestTurn?.completedAt ?? thread.updatedAt,
+    );
+  }
+  return null;
+}
+
+const EMPTY_OBSERVATION: ThreadNotificationObservation = {
+  completionKey: null,
+  failureKey: null,
+  hasPendingApprovals: false,
+  hasPendingUserInput: false,
+};
+
+const MAX_EMITTED_EVENT_IDS = 512;
+
+function rememberEventId(eventIds: Set<string>, eventId: string): void {
+  if (eventIds.has(eventId)) {
+    return;
+  }
+  if (eventIds.size >= MAX_EMITTED_EVENT_IDS) {
+    const oldest = eventIds.values().next().value;
+    if (oldest !== undefined) {
+      eventIds.delete(oldest);
+    }
+  }
+  eventIds.add(eventId);
+}
+
+export function createThreadNotificationState(
+  emittedEventIds: Iterable<string> = [],
+): ThreadNotificationState {
+  const boundedEventIds = new Set<string>();
+  for (const eventId of emittedEventIds) {
+    rememberEventId(boundedEventIds, eventId);
+  }
+  return { seeded: false, observations: new Map(), emittedEventIds: boundedEventIds };
+}
+
+export function reduceThreadNotifications(
+  state: ThreadNotificationState,
+  threads: ReadonlyArray<EnvironmentThreadShell>,
+): ThreadNotificationReduction {
+  const observations = new Map<string, ThreadNotificationObservation>();
+  const emittedEventIds = new Set(state.emittedEventIds);
+  const events: ThreadNotificationEvent[] = [];
+
+  for (const thread of threads) {
+    const key = threadKey(thread);
+    const current = observe(thread);
+    observations.set(key, current);
+    if (!state.seeded) {
+      const existingEvent = transitionEvent(EMPTY_OBSERVATION, thread, current);
+      if (existingEvent !== null) {
+        rememberEventId(emittedEventIds, existingEvent.id);
+      }
+      continue;
+    }
+    const previous = state.observations.get(key);
+    if (previous === undefined) {
+      continue;
+    }
+    const nextEvent = transitionEvent(previous, thread, current);
+    if (nextEvent !== null && !emittedEventIds.has(nextEvent.id)) {
+      events.push(nextEvent);
+      rememberEventId(emittedEventIds, nextEvent.id);
+    }
+  }
+
+  return {
+    state: { seeded: true, observations, emittedEventIds },
+    events,
+  };
+}

--- a/apps/mobile/src/features/agent-notifications/thread-notification-service.test.ts
+++ b/apps/mobile/src/features/agent-notifications/thread-notification-service.test.ts
@@ -1,0 +1,135 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+import { AsyncResult, type AtomRegistry } from "effect/unstable/reactivity";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const atoms = vi.hoisted(() => ({
+  preferences: { name: "preferences" },
+  threads: { name: "threads" },
+}));
+
+vi.mock("../../state/preferences", () => ({ mobilePreferencesAtom: atoms.preferences }));
+vi.mock("../../state/threads", () => ({
+  environmentThreadShells: { threadShellsAtom: atoms.threads },
+}));
+vi.mock("../../persistence/imperative", () => ({ savePreferencesPatch: vi.fn() }));
+vi.mock("./android-thread-notifications", () => ({
+  presentAndroidThreadNotification: vi.fn(),
+}));
+
+import { createThreadNotificationService } from "./thread-notification-service";
+
+const environmentId = EnvironmentId.make("environment-1");
+const projectId = ProjectId.make("project-1");
+
+function shell(turnId: string, state: "running" | "completed"): EnvironmentThreadShell {
+  const completed = state === "completed";
+  return {
+    environmentId,
+    id: ThreadId.make("thread-1"),
+    projectId,
+    title: "Prepare release",
+    updatedAt: completed ? "2026-08-02T00:00:04.000Z" : "2026-08-02T00:00:01.000Z",
+    latestTurn: {
+      turnId: TurnId.make(turnId),
+      state,
+      requestedAt: "2026-08-02T00:00:00.000Z",
+      startedAt: "2026-08-02T00:00:01.000Z",
+      completedAt: completed ? "2026-08-02T00:00:04.000Z" : null,
+      assistantMessageId: null,
+    },
+    session: { status: completed ? "ready" : "running", updatedAt: "2026-08-02T00:00:04.000Z" },
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+  } as EnvironmentThreadShell;
+}
+
+function createRegistry(input: {
+  readonly enabled: boolean;
+  readonly eventIds?: readonly string[];
+}) {
+  let preferences = {
+    androidAgentNotificationsEnabled: input.enabled,
+    androidAgentNotificationEventIds: input.eventIds ?? [],
+  };
+  let threads: ReadonlyArray<EnvironmentThreadShell> = [shell("turn-1", "running")];
+  const callbacks = new Map<unknown, Set<(value: unknown) => void>>();
+  const value = (atom: unknown): unknown =>
+    atom === atoms.preferences ? AsyncResult.success(preferences) : threads;
+  const registry = {
+    get: value,
+    subscribe(
+      atom: unknown,
+      callback: (value: unknown) => void,
+      options?: { readonly immediate?: boolean },
+    ) {
+      const listeners = callbacks.get(atom) ?? new Set();
+      listeners.add(callback);
+      callbacks.set(atom, listeners);
+      if (options?.immediate) callback(value(atom));
+      return () => listeners.delete(callback);
+    },
+  } as unknown as AtomRegistry.AtomRegistry;
+
+  return {
+    registry,
+    setEnabled(enabled: boolean) {
+      preferences = { ...preferences, androidAgentNotificationsEnabled: enabled };
+      for (const callback of callbacks.get(atoms.preferences) ?? []) {
+        callback(AsyncResult.success(preferences));
+      }
+    },
+    setThreads(next: ReadonlyArray<EnvironmentThreadShell>) {
+      threads = next;
+      for (const callback of callbacks.get(atoms.threads) ?? []) callback(threads);
+    },
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("thread notification service", () => {
+  it("delivers and persists one event after the initial shell snapshot", async () => {
+    const harness = createRegistry({ enabled: true });
+    const present = vi.fn(async () => undefined);
+    const persistEventIds = vi.fn(async () => undefined);
+    const service = createThreadNotificationService(harness.registry, {
+      present,
+      persistEventIds,
+    });
+
+    service.start();
+    expect(present).not.toHaveBeenCalled();
+    harness.setThreads([shell("turn-1", "completed")]);
+
+    await vi.waitFor(() => expect(present).toHaveBeenCalledOnce());
+    expect(present).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "environment-1:thread-1:completed:turn-1" }),
+    );
+    expect(persistEventIds).toHaveBeenCalledWith(["environment-1:thread-1:completed:turn-1"]);
+    service.stop();
+  });
+
+  it("tracks transitions while disabled instead of replaying stale alerts when enabled", async () => {
+    const harness = createRegistry({ enabled: false });
+    const present = vi.fn(async () => undefined);
+    const service = createThreadNotificationService(harness.registry, {
+      present,
+      persistEventIds: vi.fn(async () => undefined),
+    });
+
+    service.start();
+    harness.setThreads([shell("turn-1", "completed")]);
+    harness.setEnabled(true);
+    await Promise.resolve();
+    expect(present).not.toHaveBeenCalled();
+
+    harness.setThreads([shell("turn-2", "running")]);
+    harness.setThreads([shell("turn-2", "completed")]);
+    await vi.waitFor(() => expect(present).toHaveBeenCalledOnce());
+    expect(present).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "environment-1:thread-1:completed:turn-2" }),
+    );
+    service.stop();
+  });
+});

--- a/apps/mobile/src/features/agent-notifications/thread-notification-service.ts
+++ b/apps/mobile/src/features/agent-notifications/thread-notification-service.ts
@@ -1,0 +1,106 @@
+import * as Option from "effect/Option";
+import { AsyncResult, type AtomRegistry } from "effect/unstable/reactivity";
+
+import { savePreferencesPatch } from "../../persistence/imperative";
+import type { Preferences } from "../../persistence/mobile-preferences";
+import { mobilePreferencesAtom } from "../../state/preferences";
+import { environmentThreadShells } from "../../state/threads";
+import { presentAndroidThreadNotification } from "./android-thread-notifications";
+import {
+  createThreadNotificationState,
+  reduceThreadNotifications,
+  type ThreadNotificationEvent,
+} from "./thread-notification-reducer";
+
+interface ThreadNotificationService {
+  readonly start: () => void;
+  readonly stop: () => void;
+}
+
+interface ThreadNotificationServiceDependencies {
+  readonly present: (event: ThreadNotificationEvent) => Promise<void>;
+  readonly persistEventIds: (eventIds: readonly string[]) => Promise<unknown>;
+}
+
+const defaultDependencies: ThreadNotificationServiceDependencies = {
+  present: presentAndroidThreadNotification,
+  persistEventIds: (eventIds) =>
+    savePreferencesPatch({ androidAgentNotificationEventIds: eventIds }),
+};
+
+export function createThreadNotificationService(
+  registry: AtomRegistry.AtomRegistry,
+  dependencies: ThreadNotificationServiceDependencies = defaultDependencies,
+): ThreadNotificationService {
+  let started = false;
+  let preferences: Preferences | null = null;
+  let threads = registry.get(environmentThreadShells.threadShellsAtom);
+  let state = createThreadNotificationState();
+  let work = Promise.resolve();
+  let preferencesRelease: (() => void) | null = null;
+  let threadsRelease: (() => void) | null = null;
+
+  const reduce = () => {
+    if (!started || preferences === null) return;
+    const reduction = reduceThreadNotifications(state, threads);
+    state = reduction.state;
+    if (!preferences.androidAgentNotificationsEnabled || reduction.events.length === 0) return;
+
+    const eventIds = [...state.emittedEventIds];
+    work = work
+      .then(async () => {
+        for (const event of reduction.events) {
+          await dependencies.present(event);
+        }
+        await dependencies.persistEventIds(eventIds);
+      })
+      .catch((error) => {
+        console.error("[agent-notifications] failed to deliver Android notification", error);
+      });
+  };
+
+  return {
+    start() {
+      if (started) return;
+      started = true;
+      preferencesRelease = registry.subscribe(
+        mobilePreferencesAtom,
+        (result) => {
+          const nextPreferences = Option.getOrNull(AsyncResult.value(result));
+          if (nextPreferences === null) return;
+          const wasLoaded = preferences !== null;
+          preferences = nextPreferences;
+          if (!wasLoaded) {
+            state = createThreadNotificationState(
+              nextPreferences.androidAgentNotificationEventIds ?? [],
+            );
+          }
+          reduce();
+        },
+        { immediate: true },
+      );
+      threadsRelease = registry.subscribe(
+        environmentThreadShells.threadShellsAtom,
+        (nextThreads) => {
+          threads = nextThreads;
+          reduce();
+        },
+        { immediate: true },
+      );
+    },
+    stop() {
+      if (!started) return;
+      started = false;
+      preferencesRelease?.();
+      preferencesRelease = null;
+      threadsRelease?.();
+      threadsRelease = null;
+    },
+  };
+}
+
+export function acquireThreadNotificationService(registry: AtomRegistry.AtomRegistry): () => void {
+  const service = createThreadNotificationService(registry);
+  service.start();
+  return () => service.stop();
+}

--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -360,7 +360,7 @@ function ArchivedThreadsHeader(props: {
   );
 }
 
-function ProjectGroupLabel(props: {
+export function ArchivedThreadProjectLabel(props: {
   readonly environmentLabel: string | null;
   readonly project: EnvironmentProject;
 }) {
@@ -388,8 +388,14 @@ function ProjectGroupLabel(props: {
   );
 }
 
-function ArchivedThreadRow(props: {
+const ARCHIVED_THREAD_MENU_ACTIONS: MenuAction[] = [
+  { id: "restore", title: "Restore", image: "arrow.uturn.backward" },
+  { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
+];
+
+export function ArchivedThreadRow(props: {
   readonly environmentLabel: string | null;
+  readonly fullSwipeWidth?: number;
   readonly isFirst: boolean;
   readonly isLast: boolean;
   readonly onDelete: () => void;
@@ -409,6 +415,13 @@ function ArchivedThreadRow(props: {
   const subtitle = [props.environmentLabel, props.thread.branch].filter((part): part is string =>
     Boolean(part),
   );
+  const handleMenuAction = useCallback(
+    ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
+      if (nativeEvent.event === "restore") props.onUnarchive();
+      if (nativeEvent.event === "delete") props.onDelete();
+    },
+    [props.onDelete, props.onUnarchive],
+  );
   return (
     <ThreadSwipeable
       backgroundColor={cardColor}
@@ -421,61 +434,79 @@ function ArchivedThreadRow(props: {
         borderBottomRightRadius: props.isLast ? 20 : 0,
         overflow: "hidden",
       }}
-      fullSwipeWidth={windowWidth - 32}
+      fullSwipeAction="primary"
+      fullSwipeWidth={props.fullSwipeWidth ?? windowWidth - 32}
       onDelete={props.onDelete}
       onSwipeableClose={props.onSwipeableClose}
       onSwipeableWillOpen={props.onSwipeableWillOpen}
       primaryAction={{
-        accessibilityLabel: `Unarchive ${props.thread.title}`,
+        accessibilityLabel: `Restore ${props.thread.title}`,
         icon: "arrow.uturn.backward",
-        label: "Unarchive",
+        label: "Restore",
         onPress: props.onUnarchive,
       }}
+      resetKey={`${props.thread.environmentId}:${props.thread.id}`}
       simultaneousWithExternalGesture={props.simultaneousSwipeGesture}
       threadTitle={props.thread.title}
     >
       {() => (
-        <View
-          className="flex-row items-center gap-3 bg-card px-4 py-3"
-          style={{
-            borderBottomColor: separatorColor,
-            borderBottomWidth: props.isLast ? 0 : 1,
-          }}
+        <ControlPillMenu
+          actions={ARCHIVED_THREAD_MENU_ACTIONS}
+          onPressAction={handleMenuAction}
+          shouldOpenOnLongPress
         >
-          <View className="h-[34px] w-[34px] items-center justify-center rounded-[11px] bg-subtle">
-            <SymbolView name="archivebox.fill" size={15} tintColor={iconColor} type="monochrome" />
-          </View>
-
-          <View className="min-w-0 flex-1 gap-1">
-            <View className="flex-row items-center gap-2">
-              <Text
-                className="min-w-0 flex-1 text-base font-t3-bold leading-snug text-foreground"
-                numberOfLines={1}
-              >
-                {props.thread.title}
-              </Text>
-              <Text className="min-w-[30px] text-right text-xs tabular-nums text-foreground-tertiary">
-                {timestamp}
-              </Text>
-            </View>
-            {subtitle.length > 0 ? (
-              <View className="flex-row items-center gap-1.5">
+          <Pressable
+            accessibilityHint="Swipe left to restore, or long press for restore and delete options."
+            accessibilityLabel={props.thread.title}
+          >
+            <View
+              className="flex-row items-center gap-3 bg-card px-4 py-3"
+              style={{
+                borderBottomColor: separatorColor,
+                borderBottomWidth: props.isLast ? 0 : 1,
+              }}
+            >
+              <View className="h-[34px] w-[34px] items-center justify-center rounded-[11px] bg-subtle">
                 <SymbolView
-                  name="arrow.triangle.branch"
-                  size={10}
+                  name="archivebox.fill"
+                  size={15}
                   tintColor={iconColor}
                   type="monochrome"
                 />
-                <Text
-                  className="min-w-0 flex-1 font-mono text-2xs text-foreground-tertiary"
-                  numberOfLines={1}
-                >
-                  {subtitle.join(" · ")}
-                </Text>
               </View>
-            ) : null}
-          </View>
-        </View>
+
+              <View className="min-w-0 flex-1 gap-1">
+                <View className="flex-row items-center gap-2">
+                  <Text
+                    className="min-w-0 flex-1 text-base font-t3-bold leading-snug text-foreground"
+                    numberOfLines={1}
+                  >
+                    {props.thread.title}
+                  </Text>
+                  <Text className="min-w-[30px] text-right text-xs tabular-nums text-foreground-tertiary">
+                    {timestamp}
+                  </Text>
+                </View>
+                {subtitle.length > 0 ? (
+                  <View className="flex-row items-center gap-1.5">
+                    <SymbolView
+                      name="arrow.triangle.branch"
+                      size={10}
+                      tintColor={iconColor}
+                      type="monochrome"
+                    />
+                    <Text
+                      className="min-w-0 flex-1 font-mono text-2xs text-foreground-tertiary"
+                      numberOfLines={1}
+                    >
+                      {subtitle.join(" · ")}
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+            </View>
+          </Pressable>
+        </ControlPillMenu>
       )}
     </ThreadSwipeable>
   );
@@ -563,7 +594,10 @@ export function ArchivedThreadsScreen(props: {
       if (item.kind === "project") {
         return (
           <View className="pt-4">
-            <ProjectGroupLabel environmentLabel={item.environmentLabel} project={item.project} />
+            <ArchivedThreadProjectLabel
+              environmentLabel={item.environmentLabel}
+              project={item.project}
+            />
           </View>
         );
       }

--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -360,7 +360,7 @@ function ArchivedThreadsHeader(props: {
   );
 }
 
-function ProjectGroupLabel(props: {
+export function ArchivedThreadProjectLabel(props: {
   readonly environmentLabel: string | null;
   readonly project: EnvironmentProject;
 }) {
@@ -387,8 +387,14 @@ function ProjectGroupLabel(props: {
   );
 }
 
-function ArchivedThreadRow(props: {
+const ARCHIVED_THREAD_MENU_ACTIONS: MenuAction[] = [
+  { id: "restore", title: "Restore", image: "arrow.uturn.backward" },
+  { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
+];
+
+export function ArchivedThreadRow(props: {
   readonly environmentLabel: string | null;
+  readonly fullSwipeWidth?: number;
   readonly isFirst: boolean;
   readonly isLast: boolean;
   readonly onDelete: () => void;
@@ -408,6 +414,13 @@ function ArchivedThreadRow(props: {
   const subtitle = [props.environmentLabel, props.thread.branch].filter((part): part is string =>
     Boolean(part),
   );
+  const handleMenuAction = useCallback(
+    ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
+      if (nativeEvent.event === "restore") props.onUnarchive();
+      if (nativeEvent.event === "delete") props.onDelete();
+    },
+    [props.onDelete, props.onUnarchive],
+  );
   return (
     <ThreadSwipeable
       backgroundColor={cardColor}
@@ -420,61 +433,79 @@ function ArchivedThreadRow(props: {
         borderBottomRightRadius: props.isLast ? 20 : 0,
         overflow: "hidden",
       }}
-      fullSwipeWidth={windowWidth - 32}
+      fullSwipeAction="primary"
+      fullSwipeWidth={props.fullSwipeWidth ?? windowWidth - 32}
       onDelete={props.onDelete}
       onSwipeableClose={props.onSwipeableClose}
       onSwipeableWillOpen={props.onSwipeableWillOpen}
       primaryAction={{
-        accessibilityLabel: `Unarchive ${props.thread.title}`,
+        accessibilityLabel: `Restore ${props.thread.title}`,
         icon: "arrow.uturn.backward",
-        label: "Unarchive",
+        label: "Restore",
         onPress: props.onUnarchive,
       }}
+      resetKey={`${props.thread.environmentId}:${props.thread.id}`}
       simultaneousWithExternalGesture={props.simultaneousSwipeGesture}
       threadTitle={props.thread.title}
     >
       {() => (
-        <View
-          className="flex-row items-center gap-3 bg-card px-4 py-3"
-          style={{
-            borderBottomColor: separatorColor,
-            borderBottomWidth: props.isLast ? 0 : 1,
-          }}
+        <ControlPillMenu
+          actions={ARCHIVED_THREAD_MENU_ACTIONS}
+          onPressAction={handleMenuAction}
+          shouldOpenOnLongPress
         >
-          <View className="h-[34px] w-[34px] items-center justify-center rounded-[11px] bg-subtle">
-            <SymbolView name="archivebox.fill" size={15} tintColor={iconColor} type="monochrome" />
-          </View>
-
-          <View className="min-w-0 flex-1 gap-1">
-            <View className="flex-row items-center gap-2">
-              <Text
-                className="min-w-0 flex-1 text-base font-t3-bold leading-snug text-foreground"
-                numberOfLines={1}
-              >
-                {props.thread.title}
-              </Text>
-              <Text className="min-w-[30px] text-right text-xs tabular-nums text-foreground-tertiary">
-                {timestamp}
-              </Text>
-            </View>
-            {subtitle.length > 0 ? (
-              <View className="flex-row items-center gap-1.5">
+          <Pressable
+            accessibilityHint="Swipe left to restore, or long press for restore and delete options."
+            accessibilityLabel={props.thread.title}
+          >
+            <View
+              className="flex-row items-center gap-3 bg-card px-4 py-3"
+              style={{
+                borderBottomColor: separatorColor,
+                borderBottomWidth: props.isLast ? 0 : 1,
+              }}
+            >
+              <View className="h-[34px] w-[34px] items-center justify-center rounded-[11px] bg-subtle">
                 <SymbolView
-                  name="arrow.triangle.branch"
-                  size={10}
+                  name="archivebox.fill"
+                  size={15}
                   tintColor={iconColor}
                   type="monochrome"
                 />
-                <Text
-                  className="min-w-0 flex-1 font-mono text-2xs text-foreground-tertiary"
-                  numberOfLines={1}
-                >
-                  {subtitle.join(" · ")}
-                </Text>
               </View>
-            ) : null}
-          </View>
-        </View>
+
+              <View className="min-w-0 flex-1 gap-1">
+                <View className="flex-row items-center gap-2">
+                  <Text
+                    className="min-w-0 flex-1 text-base font-t3-bold leading-snug text-foreground"
+                    numberOfLines={1}
+                  >
+                    {props.thread.title}
+                  </Text>
+                  <Text className="min-w-[30px] text-right text-xs tabular-nums text-foreground-tertiary">
+                    {timestamp}
+                  </Text>
+                </View>
+                {subtitle.length > 0 ? (
+                  <View className="flex-row items-center gap-1.5">
+                    <SymbolView
+                      name="arrow.triangle.branch"
+                      size={10}
+                      tintColor={iconColor}
+                      type="monochrome"
+                    />
+                    <Text
+                      className="min-w-0 flex-1 font-mono text-2xs text-foreground-tertiary"
+                      numberOfLines={1}
+                    >
+                      {subtitle.join(" · ")}
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+            </View>
+          </Pressable>
+        </ControlPillMenu>
       )}
     </ThreadSwipeable>
   );
@@ -562,7 +593,10 @@ export function ArchivedThreadsScreen(props: {
       if (item.kind === "project") {
         return (
           <View className="pt-4">
-            <ProjectGroupLabel environmentLabel={item.environmentLabel} project={item.project} />
+            <ArchivedThreadProjectLabel
+              environmentLabel={item.environmentLabel}
+              project={item.project}
+            />
           </View>
         );
       }

--- a/apps/mobile/src/features/archive/ArchivedThreadsShelf.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsShelf.tsx
@@ -1,0 +1,273 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useCallback, useEffect, useMemo, useState, type ComponentProps } from "react";
+import { ActivityIndicator, Pressable, useColorScheme, View } from "react-native";
+import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
+
+import { SymbolView } from "../../components/AppSymbol";
+import { AppText as Text } from "../../components/AppText";
+import { cn } from "../../lib/cn";
+import { useThemeColor } from "../../lib/useThemeColor";
+import { ThreadSwipeable } from "../home/thread-swipe-actions";
+import { useArchivedThreadListActions } from "../home/useThreadListActions";
+import { ArchivedThreadProjectLabel, ArchivedThreadRow } from "./ArchivedThreadsScreen";
+import { buildArchivedThreadGroups, type ArchivedThreadGroup } from "./archivedThreadList";
+import { useArchivedThreadSnapshots } from "./useArchivedThreadSnapshots";
+
+const INLINE_ARCHIVED_THREAD_LIMIT = 10;
+const ARCHIVE_ACCENT_LIGHT = "#475569";
+const ARCHIVE_ACCENT_DARK = "#cbd5e1";
+
+export interface ArchivedThreadsShelfEnvironment {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+}
+
+export interface ArchivedThreadsShelfData {
+  readonly environmentLabelsById: ReadonlyMap<EnvironmentId, string>;
+  readonly error: string | null;
+  readonly groups: ReadonlyArray<ArchivedThreadGroup>;
+  readonly hasAnyArchivedThreads: boolean;
+  readonly isLoading: boolean;
+  readonly onDeleteThread: (thread: EnvironmentThreadShell) => void;
+  readonly onRestoreThread: (thread: EnvironmentThreadShell) => void;
+  readonly refresh: () => void;
+  readonly threadCount: number;
+}
+
+export function useArchivedThreadsShelfData(input: {
+  readonly environments: ReadonlyArray<ArchivedThreadsShelfEnvironment>;
+  readonly environmentId: EnvironmentId | null;
+  readonly projectKeys: ReadonlySet<string> | null;
+  readonly searchQuery: string;
+}): ArchivedThreadsShelfData {
+  const environmentIds = useMemo(
+    () => input.environments.map((environment) => environment.environmentId),
+    [input.environments],
+  );
+  const environmentLabels = useMemo(
+    () =>
+      Object.fromEntries(
+        input.environments.map((environment) => [environment.environmentId, environment.label]),
+      ),
+    [input.environments],
+  );
+  const environmentLabelsById = useMemo(
+    () =>
+      new Map(
+        input.environments.map(
+          (environment) => [environment.environmentId, environment.label] as const,
+        ),
+      ),
+    [input.environments],
+  );
+  const { error, isLoading, refresh, snapshots } = useArchivedThreadSnapshots(environmentIds);
+  const hasAnyArchivedThreads = useMemo(
+    () =>
+      snapshots.some((entry) =>
+        entry.snapshot.threads.some((thread) => thread.archivedAt !== null),
+      ),
+    [snapshots],
+  );
+  const groups = useMemo(
+    () =>
+      buildArchivedThreadGroups({
+        snapshots,
+        environmentLabels,
+        environmentId: input.environmentId,
+        projectKeys: input.projectKeys,
+        searchQuery: input.searchQuery,
+        sortOrder: "newest",
+      }),
+    [environmentLabels, input.environmentId, input.projectKeys, input.searchQuery, snapshots],
+  );
+  const threadCount = useMemo(
+    () => groups.reduce((count, group) => count + group.threads.length, 0),
+    [groups],
+  );
+  const handleCompleted = useCallback(() => undefined, []);
+  const { confirmDeleteThread, unarchiveThread } = useArchivedThreadListActions(handleCompleted);
+
+  return {
+    environmentLabelsById,
+    error,
+    groups,
+    hasAnyArchivedThreads,
+    isLoading,
+    onDeleteThread: confirmDeleteThread,
+    onRestoreThread: unarchiveThread,
+    refresh,
+    threadCount,
+  };
+}
+
+function limitArchivedThreadGroups(
+  groups: ReadonlyArray<ArchivedThreadGroup>,
+  limit: number,
+): ReadonlyArray<ArchivedThreadGroup> {
+  let remaining = limit;
+  const visibleGroups: ArchivedThreadGroup[] = [];
+  for (const group of groups) {
+    if (remaining === 0) break;
+    const threads = group.threads.slice(0, remaining);
+    if (threads.length > 0) {
+      visibleGroups.push({ ...group, threads });
+      remaining -= threads.length;
+    }
+  }
+  return visibleGroups;
+}
+
+export function ArchivedThreadsShelf(props: {
+  readonly data: ArchivedThreadsShelfData;
+  readonly fullSwipeWidth?: number;
+  readonly onOpenArchive: () => void;
+  readonly onSwipeableClose: (methods: SwipeableMethods) => void;
+  readonly onSwipeableWillOpen: (methods: SwipeableMethods) => void;
+  readonly pane?: "screen" | "sidebar";
+  readonly searchQuery: string;
+  readonly simultaneousSwipeGesture?: ComponentProps<
+    typeof ThreadSwipeable
+  >["simultaneousWithExternalGesture"];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const colorScheme = useColorScheme();
+  const mutedColor = useThemeColor("--color-foreground-muted");
+  const searchActive = props.searchQuery.trim().length > 0;
+  useEffect(() => {
+    if (searchActive) setExpanded(true);
+  }, [searchActive]);
+  const visibleGroups = useMemo(
+    () => limitArchivedThreadGroups(props.data.groups, INLINE_ARCHIVED_THREAD_LIMIT),
+    [props.data.groups],
+  );
+  const visibleThreadCount = useMemo(
+    () => visibleGroups.reduce((count, group) => count + group.threads.length, 0),
+    [visibleGroups],
+  );
+  const hiddenThreadCount = props.data.threadCount - visibleThreadCount;
+
+  if (props.data.threadCount === 0) {
+    if (props.data.error === null || props.data.isLoading) return null;
+    return (
+      <Pressable
+        accessibilityLabel="Archive unavailable. Retry loading archived threads."
+        accessibilityRole="button"
+        className={cn(
+          "mt-4 flex-row items-center gap-2.5 pb-2",
+          props.pane === "sidebar" ? "px-3" : "px-5",
+        )}
+        onPress={props.data.refresh}
+        style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+      >
+        <SymbolView name="exclamationmark.triangle" size={12} tintColor={mutedColor} />
+        <Text className="text-xs font-t3-medium text-foreground-muted">
+          Archive unavailable · Retry
+        </Text>
+      </Pressable>
+    );
+  }
+
+  return (
+    <View className="pb-2">
+      <Pressable
+        accessibilityHint={
+          expanded ? "Collapses the archived threads." : "Expands the archived threads."
+        }
+        accessibilityLabel={
+          props.data.threadCount === 1
+            ? "1 archived thread"
+            : `${props.data.threadCount} archived threads`
+        }
+        accessibilityRole="button"
+        accessibilityState={{ expanded }}
+        className={cn(
+          "mt-4 flex-row items-center gap-2.5 pb-1.5",
+          props.pane === "sidebar" ? "px-3" : "px-5",
+        )}
+        onPress={() => setExpanded((value) => !value)}
+        style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+      >
+        <SymbolView
+          name="archivebox.fill"
+          size={12}
+          tintColor={colorScheme === "dark" ? ARCHIVE_ACCENT_DARK : ARCHIVE_ACCENT_LIGHT}
+          type="monochrome"
+        />
+        <Text className="text-xs font-t3-medium text-foreground-muted">
+          Archived ({props.data.threadCount})
+        </Text>
+        <View className="h-px flex-1 bg-border" />
+        {props.data.isLoading ? (
+          <ActivityIndicator color={String(mutedColor)} size="small" />
+        ) : (
+          <SymbolView
+            name={expanded ? "chevron.up" : "chevron.down"}
+            size={10}
+            tintColor={mutedColor}
+            type="monochrome"
+          />
+        )}
+      </Pressable>
+
+      {expanded ? (
+        <View className={props.pane === "sidebar" ? "px-1" : "px-4"}>
+          {props.data.error ? (
+            <Pressable
+              accessibilityRole="button"
+              className="py-2"
+              onPress={props.data.refresh}
+              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+            >
+              <Text className="text-xs text-danger-foreground">
+                Some archived threads could not be loaded. Tap to retry.
+              </Text>
+            </Pressable>
+          ) : null}
+
+          {visibleGroups.map((group) => {
+            const environmentLabel =
+              props.data.environmentLabelsById.get(group.project.environmentId) ?? null;
+            return (
+              <View className="pt-3" key={group.key}>
+                <ArchivedThreadProjectLabel
+                  environmentLabel={environmentLabel}
+                  project={group.project}
+                />
+                {group.threads.map((thread, index) => (
+                  <ArchivedThreadRow
+                    environmentLabel={environmentLabel}
+                    fullSwipeWidth={props.fullSwipeWidth}
+                    isFirst={index === 0}
+                    isLast={index === group.threads.length - 1}
+                    key={`${thread.environmentId}:${thread.id}`}
+                    onDelete={() => props.data.onDeleteThread(thread)}
+                    onUnarchive={() => props.data.onRestoreThread(thread)}
+                    onSwipeableClose={props.onSwipeableClose}
+                    onSwipeableWillOpen={props.onSwipeableWillOpen}
+                    simultaneousSwipeGesture={props.simultaneousSwipeGesture}
+                    thread={thread}
+                  />
+                ))}
+              </View>
+            );
+          })}
+
+          {hiddenThreadCount > 0 ? (
+            <Pressable
+              accessibilityLabel={`View all ${props.data.threadCount} archived threads`}
+              accessibilityRole="button"
+              className="mt-3 items-center rounded-lg border border-dashed border-border py-2.5"
+              onPress={props.onOpenArchive}
+              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+            >
+              <Text className="text-xs font-t3-medium text-foreground-muted">
+                View all ({hiddenThreadCount} more)
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/features/archive/archivedThreadList.test.ts
+++ b/apps/mobile/src/features/archive/archivedThreadList.test.ts
@@ -3,6 +3,7 @@ import type { OrchestrationProjectShell, OrchestrationThreadShell } from "@t3too
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
+import { scopedProjectKey } from "../../lib/scopedEntities";
 import { buildArchivedThreadGroups } from "./archivedThreadList";
 
 const environmentId = EnvironmentId.make("environment-1");
@@ -142,5 +143,33 @@ describe("buildArchivedThreadGroups", () => {
     });
 
     expect(result).toEqual([]);
+  });
+
+  it("scopes the archive to the selected project", () => {
+    const firstProject = makeProject({ id: ProjectId.make("project-1"), title: "T3 Code" });
+    const secondProject = makeProject({ id: ProjectId.make("project-2"), title: "Website" });
+    const firstThread = makeThread({
+      id: ThreadId.make("thread-1"),
+      projectId: firstProject.id,
+      title: "Keep",
+    });
+    const secondThread = makeThread({
+      id: ThreadId.make("thread-2"),
+      projectId: secondProject.id,
+      title: "Filter out",
+    });
+
+    const result = buildArchivedThreadGroups({
+      snapshots: [makeSnapshot([firstProject, secondProject], [firstThread, secondThread])],
+      environmentLabels: {},
+      environmentId: null,
+      projectKeys: new Set([scopedProjectKey(environmentId, firstProject.id)]),
+      searchQuery: "",
+      sortOrder: "newest",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.project.id).toBe(firstProject.id);
+    expect(result[0]?.threads.map((thread) => thread.id)).toEqual([firstThread.id]);
   });
 });

--- a/apps/mobile/src/features/archive/archivedThreadList.ts
+++ b/apps/mobile/src/features/archive/archivedThreadList.ts
@@ -32,6 +32,7 @@ export function buildArchivedThreadGroups(input: {
   readonly snapshots: ReadonlyArray<ArchivedSnapshotEntry>;
   readonly environmentLabels: Readonly<Record<string, string>>;
   readonly environmentId: EnvironmentId | null;
+  readonly projectKeys?: ReadonlySet<string> | null;
   readonly searchQuery: string;
   readonly sortOrder: ArchivedThreadSortOrder;
 }): ReadonlyArray<ArchivedThreadGroup> {
@@ -56,6 +57,10 @@ export function buildArchivedThreadGroups(input: {
 
     for (const rawProject of entry.snapshot.projects) {
       const project = scopeProject(entry.environmentId, rawProject);
+      const projectKey = scopedProjectKey(project.environmentId, project.id);
+      if (input.projectKeys != null && !input.projectKeys.has(projectKey)) {
+        continue;
+      }
       const projectThreads = threadsByProjectId.get(project.id) ?? [];
       const groupMatches =
         query.length === 0 ||
@@ -74,7 +79,7 @@ export function buildArchivedThreadGroups(input: {
 
       const timestampOrder = input.sortOrder === "newest" ? Order.flip(Order.Number) : Order.Number;
       groups.push({
-        key: scopedProjectKey(project.environmentId, project.id),
+        key: projectKey,
         project,
         threads: Arr.sort(
           matchingThreads,

--- a/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.test.tsx
+++ b/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.test.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { BackgroundConnectionStatus } from "../../native/backgroundConnection";
+
+const native = vi.hoisted(() => ({
+  status: null as BackgroundConnectionStatus | null,
+  setEnabled: vi.fn(),
+  requestExemption: vi.fn(),
+  removeStatusListener: vi.fn(),
+}));
+
+const reactNative = vi.hoisted(() => ({
+  alert: vi.fn(),
+  removeAppStateListener: vi.fn(),
+}));
+
+vi.mock("react", () => ({
+  useCallback: (callback: unknown) => callback,
+  useEffect: (setup: () => void | (() => void)) => {
+    setup();
+  },
+  useState: (initial: unknown) => [
+    typeof initial === "function" ? (initial as () => unknown)() : initial,
+    vi.fn(),
+  ],
+}));
+
+vi.mock("react-native", () => ({
+  Alert: { alert: reactNative.alert },
+  AppState: {
+    addEventListener: vi.fn(() => ({ remove: reactNative.removeAppStateListener })),
+  },
+  Platform: { OS: "android" },
+  Pressable: "Pressable",
+  View: "View",
+}));
+
+vi.mock("../../components/AppText", () => ({ AppText: "Text" }));
+vi.mock("../settings/components/SettingsSection", () => ({
+  SettingsSection: "SettingsSection",
+}));
+vi.mock("../settings/components/SettingsSwitchRow", () => ({
+  SettingsSwitchRow: "SettingsSwitchRow",
+}));
+vi.mock("../../native/backgroundConnection", () => ({
+  addBackgroundConnectionStatusListener: vi.fn(() => ({
+    remove: native.removeStatusListener,
+  })),
+  getBackgroundConnectionStatus: () => native.status,
+  requestBackgroundConnectionBatteryOptimizationExemption: native.requestExemption,
+  setBackgroundConnectionEnabled: native.setEnabled,
+}));
+
+import { BackgroundConnectionSettingsSection } from "./BackgroundConnectionSettingsSection";
+
+interface ElementNode {
+  readonly props?: {
+    readonly children?: unknown;
+    readonly onValueChange?: (enabled: boolean) => void;
+  };
+}
+
+function children(node: unknown): ReadonlyArray<unknown> {
+  const value = (node as ElementNode | null)?.props?.children;
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function renderSwitch(): ElementNode {
+  const root = BackgroundConnectionSettingsSection();
+  const section = children(root)[0];
+  return children(section)[0] as ElementNode;
+}
+
+function status(overrides: Partial<BackgroundConnectionStatus> = {}): BackgroundConnectionStatus {
+  return {
+    supported: true,
+    enabled: false,
+    serviceRunning: false,
+    runtimeReady: false,
+    batteryOptimizationIgnored: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  native.status = status();
+  native.setEnabled.mockImplementation(async (enabled: boolean) =>
+    status({
+      enabled,
+      serviceRunning: enabled,
+      runtimeReady: enabled,
+    }),
+  );
+  native.requestExemption.mockResolvedValue(status({ enabled: true }));
+});
+
+describe("BackgroundConnectionSettingsSection", () => {
+  it("enables the native runtime and keeps it enabled when battery exemption is declined", async () => {
+    native.setEnabled.mockResolvedValue(
+      status({
+        enabled: true,
+        serviceRunning: true,
+        runtimeReady: true,
+        batteryOptimizationIgnored: false,
+      }),
+    );
+    native.requestExemption.mockResolvedValue(
+      status({ enabled: true, batteryOptimizationIgnored: false }),
+    );
+
+    renderSwitch().props?.onValueChange?.(true);
+
+    await vi.waitFor(() => {
+      expect(native.setEnabled).toHaveBeenCalledWith(true);
+      expect(reactNative.alert).toHaveBeenCalledOnce();
+    });
+    const buttons = reactNative.alert.mock.calls[0]?.[2] as
+      | ReadonlyArray<{ readonly text: string; readonly onPress?: () => void }>
+      | undefined;
+    buttons?.find((button) => button.text === "Allow")?.onPress?.();
+    await vi.waitFor(() => expect(native.requestExemption).toHaveBeenCalledOnce());
+
+    expect(native.setEnabled).not.toHaveBeenCalledWith(false);
+  });
+
+  it("disables the native runtime without requesting a battery exemption", async () => {
+    native.status = status({
+      enabled: true,
+      serviceRunning: true,
+      runtimeReady: true,
+    });
+    native.setEnabled.mockResolvedValue(status());
+
+    renderSwitch().props?.onValueChange?.(false);
+
+    await vi.waitFor(() => expect(native.setEnabled).toHaveBeenCalledWith(false));
+    expect(reactNative.alert).not.toHaveBeenCalled();
+    expect(native.requestExemption).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.test.tsx
+++ b/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.test.tsx
@@ -14,6 +14,26 @@ const reactNative = vi.hoisted(() => ({
   removeAppStateListener: vi.fn(),
 }));
 
+const preferences = vi.hoisted(() => ({ save: vi.fn() }));
+const agentNotifications = vi.hoisted(() => ({
+  getPermission: vi.fn(async () => ({ type: "granted" as const })),
+  requestPermission: vi.fn(async () => ({ type: "granted" as const })),
+}));
+
+vi.mock("@effect/atom-react", () => ({
+  useAtomValue: () => ({
+    _tag: "Success",
+    value: { androidAgentNotificationsEnabled: false },
+    waiting: false,
+    timestamp: 0,
+  }),
+  useAtomSet: () => preferences.save,
+}));
+vi.mock("../../state/preferences", () => ({
+  mobilePreferencesAtom: {},
+  updateMobilePreferencesAtom: {},
+}));
+
 vi.mock("react", () => ({
   useCallback: (callback: unknown) => callback,
   useEffect: (setup: () => void | (() => void)) => {
@@ -31,6 +51,7 @@ vi.mock("react-native", () => ({
     addEventListener: vi.fn(() => ({ remove: reactNative.removeAppStateListener })),
   },
   Platform: { OS: "android" },
+  Linking: { openSettings: vi.fn() },
   Pressable: "Pressable",
   View: "View",
 }));
@@ -49,6 +70,10 @@ vi.mock("../../native/backgroundConnection", () => ({
   getBackgroundConnectionStatus: () => native.status,
   requestBackgroundConnectionBatteryOptimizationExemption: native.requestExemption,
   setBackgroundConnectionEnabled: native.setEnabled,
+}));
+vi.mock("../agent-notifications/android-thread-notifications", () => ({
+  getAndroidAgentNotificationPermission: agentNotifications.getPermission,
+  requestAndroidAgentNotificationPermission: agentNotifications.requestPermission,
 }));
 
 import { BackgroundConnectionSettingsSection } from "./BackgroundConnectionSettingsSection";
@@ -70,6 +95,12 @@ function renderSwitch(): ElementNode {
   const root = BackgroundConnectionSettingsSection();
   const section = children(root)[0];
   return children(section)[0] as ElementNode;
+}
+
+function renderNotificationSwitch(): ElementNode {
+  const root = BackgroundConnectionSettingsSection();
+  const section = children(root)[0];
+  return children(section)[1] as ElementNode;
 }
 
 function status(overrides: Partial<BackgroundConnectionStatus> = {}): BackgroundConnectionStatus {
@@ -138,5 +169,16 @@ describe("BackgroundConnectionSettingsSection", () => {
     await vi.waitFor(() => expect(native.setEnabled).toHaveBeenCalledWith(false));
     expect(reactNative.alert).not.toHaveBeenCalled();
     expect(native.requestExemption).not.toHaveBeenCalled();
+    expect(preferences.save).toHaveBeenCalledWith({ androidAgentNotificationsEnabled: false });
+  });
+
+  it("enables notification permission and the required background runtime together", async () => {
+    renderNotificationSwitch().props?.onValueChange?.(true);
+
+    await vi.waitFor(() => {
+      expect(agentNotifications.requestPermission).toHaveBeenCalledOnce();
+      expect(preferences.save).toHaveBeenCalledWith({ androidAgentNotificationsEnabled: true });
+      expect(native.setEnabled).toHaveBeenCalledWith(true);
+    });
   });
 });

--- a/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.tsx
+++ b/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from "react";
+import { Alert, AppState, Platform, Pressable, View } from "react-native";
+
+import { AppText as Text } from "../../components/AppText";
+import {
+  addBackgroundConnectionStatusListener,
+  getBackgroundConnectionStatus,
+  requestBackgroundConnectionBatteryOptimizationExemption,
+  setBackgroundConnectionEnabled,
+  type BackgroundConnectionStatus,
+} from "../../native/backgroundConnection";
+import { SettingsSection } from "../settings/components/SettingsSection";
+import { SettingsSwitchRow } from "../settings/components/SettingsSwitchRow";
+import {
+  backgroundConnectionStatusLabel,
+  shouldRequestBackgroundConnectionBatteryExemption,
+} from "./settings-model";
+
+function promptForBatteryExemption(
+  requestExemption: () => Promise<BackgroundConnectionStatus>,
+): void {
+  Alert.alert(
+    "Allow unrestricted battery use?",
+    "Android can otherwise pause the background connection while T3 Code is locked or another app is open.",
+    [
+      { text: "Not Now", style: "cancel" },
+      { text: "Allow", onPress: () => void requestExemption() },
+    ],
+  );
+}
+
+export function BackgroundConnectionSettingsSection() {
+  const [status, setStatus] = useState(getBackgroundConnectionStatus);
+  const [changing, setChanging] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+    setStatus(getBackgroundConnectionStatus());
+    const nativeSubscription = addBackgroundConnectionStatusListener(setStatus);
+    const appStateSubscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState === "active") {
+        setStatus(getBackgroundConnectionStatus());
+      }
+    });
+    return () => {
+      nativeSubscription.remove();
+      appStateSubscription.remove();
+    };
+  }, []);
+
+  const requestExemption = useCallback(async () => {
+    const next = await requestBackgroundConnectionBatteryOptimizationExemption();
+    setStatus(next);
+    return next;
+  }, []);
+
+  const handleEnabledChange = useCallback(
+    async (enabled: boolean) => {
+      if (changing) {
+        return;
+      }
+      setChanging(true);
+      setStatus((current) => ({ ...current, enabled }));
+      const next = await setBackgroundConnectionEnabled(enabled);
+      setStatus(next);
+      setChanging(false);
+      if (shouldRequestBackgroundConnectionBatteryExemption(next)) {
+        promptForBatteryExemption(requestExemption);
+      }
+    },
+    [changing, requestExemption],
+  );
+
+  if (Platform.OS !== "android") {
+    return null;
+  }
+
+  const statusLabel = backgroundConnectionStatusLabel(status);
+  const canRetryBatteryExemption = shouldRequestBackgroundConnectionBatteryExemption(status);
+
+  return (
+    <View className="gap-3">
+      <SettingsSection title="Background connection">
+        <SettingsSwitchRow
+          disabled={!status.supported || changing}
+          icon="bolt.horizontal.circle"
+          label="Keep connected in background"
+          value={status.enabled}
+          onValueChange={(enabled) => void handleEnabledChange(enabled)}
+        />
+        <View className="border-t border-border px-4 py-3">
+          {canRetryBatteryExemption ? (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => void requestExemption()}
+              className="py-1"
+            >
+              <Text className="text-sm font-t3-medium text-foreground">{statusLabel}</Text>
+              <Text className="mt-1 text-sm text-foreground-muted">
+                Tap to allow unrestricted battery use.
+              </Text>
+            </Pressable>
+          ) : (
+            <Text className="text-sm font-t3-medium text-foreground-muted">{statusLabel}</Text>
+          )}
+        </View>
+      </SettingsSection>
+      <Text className="px-2 text-sm leading-normal text-foreground-muted">
+        Keeps environments and active work synchronized while your phone is locked or another app is
+        open. This can noticeably increase battery use, and Android will show a silent ongoing
+        service status.
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.tsx
+++ b/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.tsx
@@ -1,7 +1,10 @@
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useState } from "react";
-import { Alert, AppState, Platform, Pressable, View } from "react-native";
+import { Alert, AppState, Linking, Platform, Pressable, View } from "react-native";
 
 import { AppText as Text } from "../../components/AppText";
+import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
 import {
   addBackgroundConnectionStatusListener,
   getBackgroundConnectionStatus,
@@ -15,6 +18,11 @@ import {
   backgroundConnectionStatusLabel,
   shouldRequestBackgroundConnectionBatteryExemption,
 } from "./settings-model";
+import {
+  getAndroidAgentNotificationPermission,
+  requestAndroidAgentNotificationPermission,
+  type AndroidNotificationPermission,
+} from "../agent-notifications/android-thread-notifications";
 
 function promptForBatteryExemption(
   requestExemption: () => Promise<BackgroundConnectionStatus>,
@@ -32,16 +40,40 @@ function promptForBatteryExemption(
 export function BackgroundConnectionSettingsSection() {
   const [status, setStatus] = useState(getBackgroundConnectionStatus);
   const [changing, setChanging] = useState(false);
+  const [notificationPermission, setNotificationPermission] =
+    useState<AndroidNotificationPermission>({ type: "unsupported" });
+  const preferencesResult = useAtomValue(mobilePreferencesAtom);
+  const savePreferences = useAtomSet(updateMobilePreferencesAtom);
+  const notificationPreferenceEnabled =
+    AsyncResult.isSuccess(preferencesResult) &&
+    preferencesResult.value.androidAgentNotificationsEnabled === true;
 
   useEffect(() => {
     if (Platform.OS !== "android") {
       return;
     }
     setStatus(getBackgroundConnectionStatus());
+    void getAndroidAgentNotificationPermission()
+      .then(setNotificationPermission)
+      .catch((error) => {
+        console.error(
+          "[agent-notifications] failed to read Android notification permission",
+          error,
+        );
+        setNotificationPermission({ type: "denied", canAskAgain: true });
+      });
     const nativeSubscription = addBackgroundConnectionStatusListener(setStatus);
     const appStateSubscription = AppState.addEventListener("change", (nextState) => {
       if (nextState === "active") {
         setStatus(getBackgroundConnectionStatus());
+        void getAndroidAgentNotificationPermission()
+          .then(setNotificationPermission)
+          .catch((error) => {
+            console.error(
+              "[agent-notifications] failed to refresh Android notification permission",
+              error,
+            );
+          });
       }
     });
     return () => {
@@ -66,11 +98,59 @@ export function BackgroundConnectionSettingsSection() {
       const next = await setBackgroundConnectionEnabled(enabled);
       setStatus(next);
       setChanging(false);
+      if (!enabled) {
+        savePreferences({ androidAgentNotificationsEnabled: false });
+      }
       if (shouldRequestBackgroundConnectionBatteryExemption(next)) {
         promptForBatteryExemption(requestExemption);
       }
     },
-    [changing, requestExemption],
+    [changing, requestExemption, savePreferences],
+  );
+
+  const handleNotificationsChange = useCallback(
+    async (enabled: boolean) => {
+      if (!enabled) {
+        savePreferences({ androidAgentNotificationsEnabled: false });
+        return;
+      }
+      setChanging(true);
+      try {
+        const permission = await requestAndroidAgentNotificationPermission();
+        setNotificationPermission(permission);
+        if (permission.type !== "granted") {
+          savePreferences({ androidAgentNotificationsEnabled: false });
+          if (permission.type === "denied" && !permission.canAskAgain) {
+            Alert.alert(
+              "Notifications disabled",
+              "Notification access was denied for T3 Code. Open Android Settings to enable it.",
+              [
+                { text: "Cancel", style: "cancel" },
+                { text: "Open Settings", onPress: () => void Linking.openSettings() },
+              ],
+            );
+          }
+          return;
+        }
+        savePreferences({ androidAgentNotificationsEnabled: true });
+        if (!status.enabled) {
+          const next = await setBackgroundConnectionEnabled(true);
+          setStatus(next);
+          if (shouldRequestBackgroundConnectionBatteryExemption(next)) {
+            promptForBatteryExemption(requestExemption);
+          }
+        }
+      } catch (error) {
+        savePreferences({ androidAgentNotificationsEnabled: false });
+        Alert.alert(
+          "Notifications unavailable",
+          error instanceof Error ? error.message : "Could not enable Android notifications.",
+        );
+      } finally {
+        setChanging(false);
+      }
+    },
+    [requestExemption, savePreferences, status.enabled],
   );
 
   if (Platform.OS !== "android") {
@@ -89,6 +169,17 @@ export function BackgroundConnectionSettingsSection() {
           label="Keep connected in background"
           value={status.enabled}
           onValueChange={(enabled) => void handleEnabledChange(enabled)}
+        />
+        <SettingsSwitchRow
+          disabled={!status.supported || changing}
+          icon="bell.badge"
+          label="Agent notifications"
+          value={
+            status.enabled &&
+            notificationPreferenceEnabled &&
+            notificationPermission.type === "granted"
+          }
+          onValueChange={(enabled) => void handleNotificationsChange(enabled)}
         />
         <View className="border-t border-border px-4 py-3">
           {canRetryBatteryExemption ? (
@@ -110,7 +201,8 @@ export function BackgroundConnectionSettingsSection() {
       <Text className="px-2 text-sm leading-normal text-foreground-muted">
         Keeps environments and active work synchronized while your phone is locked or another app is
         open. This can noticeably increase battery use, and Android will show a silent ongoing
-        service status.
+        service status. Agent notifications alert you when work completes, fails, or needs your
+        approval or input.
       </Text>
     </View>
   );

--- a/apps/mobile/src/features/background-connection/background-root.test.ts
+++ b/apps/mobile/src/features/background-connection/background-root.test.ts
@@ -3,6 +3,14 @@ import { EnvironmentId, ThreadId, type ScopedThreadRef } from "@t3tools/contract
 import { AsyncResult, type AtomRegistry } from "effect/unstable/reactivity";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 const atoms = vi.hoisted(() => ({
   catalog: { name: "catalog" },
   serverConfigs: { name: "server-configs" },
@@ -22,15 +30,17 @@ const retained = vi.hoisted(() => {
     releaseCount: 0,
   };
   const listeners = new Set<() => void>();
+  const publish = (thread: ScopedThreadRef | null) => {
+    state.snapshot = { loaded: true, thread };
+    for (const listener of listeners) {
+      listener();
+    }
+  };
   return {
     state,
     listeners,
-    clear: vi.fn(async () => {
-      state.snapshot = { loaded: true, thread: null };
-      for (const listener of listeners) {
-        listener();
-      }
-    }),
+    publish,
+    clear: vi.fn(async () => publish(null)),
     ensureLoaded: vi.fn(async () => state.snapshot.thread),
   };
 });
@@ -186,7 +196,8 @@ beforeEach(() => {
   retained.state.subscribeCount = 0;
   retained.state.releaseCount = 0;
   retained.listeners.clear();
-  retained.clear.mockClear();
+  retained.clear.mockReset();
+  retained.clear.mockImplementation(async () => retained.publish(null));
   retained.ensureLoaded.mockClear();
   atoms.shellStates.clear();
   atoms.detailStates.clear();
@@ -265,6 +276,36 @@ describe("background connection root", () => {
     expect(retained.state.snapshot.thread).toBeNull();
     expect(harness.subscribeCount(`detail:${detailKey}`)).toBe(1);
     expect(harness.subscribeReleaseCount(`detail:${detailKey}`)).toBe(1);
+    root.stop();
+  });
+
+  it("re-clears a deleted ref saved while its first clear is pending", async () => {
+    const firstClear = deferred();
+    let clearCount = 0;
+    retained.clear.mockImplementation(() => {
+      retained.publish(null);
+      clearCount += 1;
+      return clearCount === 1 ? firstClear.promise : Promise.resolve();
+    });
+    const detailKey = `${environmentId}:${threadId}`;
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+      deletedThreadKeys: new Set([detailKey]),
+    });
+    const root = createBackgroundConnectionRoot(harness.registry);
+
+    root.start();
+    expect(retained.clear).toHaveBeenCalledOnce();
+
+    retained.publish(retainedThread);
+    expect(retained.clear).toHaveBeenCalledOnce();
+
+    firstClear.resolve();
+    await firstClear.promise;
+    await Promise.resolve();
+
+    expect(retained.clear).toHaveBeenCalledTimes(2);
+    expect(retained.state.snapshot.thread).toBeNull();
     root.stop();
   });
 });

--- a/apps/mobile/src/features/background-connection/background-root.test.ts
+++ b/apps/mobile/src/features/background-connection/background-root.test.ts
@@ -1,0 +1,270 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ThreadId, type ScopedThreadRef } from "@t3tools/contracts";
+import { AsyncResult, type AtomRegistry } from "effect/unstable/reactivity";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const atoms = vi.hoisted(() => ({
+  catalog: { name: "catalog" },
+  serverConfigs: { name: "server-configs" },
+  threadShells: { name: "thread-shells" },
+  shellStates: new Map<string, { readonly name: string }>(),
+  detailStates: new Map<string, { readonly name: string; readonly detailKey: string }>(),
+}));
+
+const retained = vi.hoisted(() => {
+  const state: {
+    snapshot: { loaded: boolean; thread: ScopedThreadRef | null };
+    subscribeCount: number;
+    releaseCount: number;
+  } = {
+    snapshot: { loaded: true, thread: null },
+    subscribeCount: 0,
+    releaseCount: 0,
+  };
+  const listeners = new Set<() => void>();
+  return {
+    state,
+    listeners,
+    clear: vi.fn(async () => {
+      state.snapshot = { loaded: true, thread: null };
+      for (const listener of listeners) {
+        listener();
+      }
+    }),
+    ensureLoaded: vi.fn(async () => state.snapshot.thread),
+  };
+});
+
+vi.mock("../../connection/catalog", () => ({
+  environmentCatalog: { catalogValueAtom: atoms.catalog },
+}));
+
+vi.mock("../../state/server", () => ({
+  environmentServerConfigsAtom: atoms.serverConfigs,
+}));
+
+vi.mock("../../state/shell", () => ({
+  environmentShell: {
+    stateAtom: (environmentId: string) => {
+      let atom = atoms.shellStates.get(environmentId);
+      if (atom === undefined) {
+        atom = { name: `shell:${environmentId}` };
+        atoms.shellStates.set(environmentId, atom);
+      }
+      return atom;
+    },
+  },
+}));
+
+vi.mock("../../state/threads", () => ({
+  environmentThreadShells: { threadShellsAtom: atoms.threadShells },
+  environmentThreads: {
+    stateAtom: (environmentId: string, threadId: string) => {
+      const key = `${environmentId}:${threadId}`;
+      let atom = atoms.detailStates.get(key);
+      if (atom === undefined) {
+        atom = { name: `detail:${key}`, detailKey: key };
+        atoms.detailStates.set(key, atom);
+      }
+      return atom;
+    },
+  },
+}));
+
+vi.mock("./retained-thread", () => ({
+  clearBackgroundConnectionRetainedThread: retained.clear,
+  ensureBackgroundConnectionRetainedThreadLoaded: retained.ensureLoaded,
+  getBackgroundConnectionRetainedThreadSnapshot: () => retained.state.snapshot,
+  subscribeBackgroundConnectionRetainedThread: (listener: () => void) => {
+    retained.state.subscribeCount += 1;
+    retained.listeners.add(listener);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      retained.state.releaseCount += 1;
+      retained.listeners.delete(listener);
+    };
+  },
+}));
+
+import { acquireBackgroundConnectionRoot, createBackgroundConnectionRoot } from "./background-root";
+
+interface CatalogState {
+  readonly isReady: boolean;
+  readonly entries: ReadonlyMap<EnvironmentId, unknown>;
+}
+
+function atomName(atom: unknown): string {
+  return (atom as { readonly name: string }).name;
+}
+
+function createRegistry(options: {
+  readonly catalog: CatalogState;
+  readonly threadShells?: ReadonlyArray<EnvironmentThreadShell>;
+  readonly deletedThreadKeys?: ReadonlySet<string>;
+}) {
+  let catalog = options.catalog;
+  const threadShells = options.threadShells ?? [];
+  const deletedThreadKeys = options.deletedThreadKeys ?? new Set<string>();
+  const callbacks = new Map<unknown, Set<(value: unknown) => void>>();
+  const mountCounts = new Map<string, number>();
+  const mountReleaseCounts = new Map<string, number>();
+  const subscribeCounts = new Map<string, number>();
+  const subscribeReleaseCounts = new Map<string, number>();
+
+  const increment = (counts: Map<string, number>, name: string) =>
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  const read = (atom: unknown): unknown => {
+    if (atom === atoms.catalog) return catalog;
+    if (atom === atoms.threadShells) return threadShells;
+    const detailKey = (atom as { readonly detailKey?: string }).detailKey;
+    if (detailKey !== undefined) {
+      return AsyncResult.success({
+        status: deletedThreadKeys.has(detailKey) ? "deleted" : "live",
+      });
+    }
+    return null;
+  };
+
+  const registry = {
+    get: read,
+    mount(atom: unknown) {
+      const name = atomName(atom);
+      increment(mountCounts, name);
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        increment(mountReleaseCounts, name);
+      };
+    },
+    subscribe(
+      atom: unknown,
+      callback: (value: unknown) => void,
+      subscribeOptions?: { readonly immediate?: boolean },
+    ) {
+      const name = atomName(atom);
+      increment(subscribeCounts, name);
+      const atomCallbacks = callbacks.get(atom) ?? new Set();
+      atomCallbacks.add(callback);
+      callbacks.set(atom, atomCallbacks);
+      if (subscribeOptions?.immediate === true) {
+        callback(read(atom));
+      }
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        increment(subscribeReleaseCounts, name);
+        atomCallbacks.delete(callback);
+      };
+    },
+  } as unknown as AtomRegistry.AtomRegistry;
+
+  return {
+    registry,
+    mountCount: (name: string) => mountCounts.get(name) ?? 0,
+    mountReleaseCount: (name: string) => mountReleaseCounts.get(name) ?? 0,
+    subscribeCount: (name: string) => subscribeCounts.get(name) ?? 0,
+    subscribeReleaseCount: (name: string) => subscribeReleaseCounts.get(name) ?? 0,
+    setCatalog(next: CatalogState) {
+      catalog = next;
+      for (const callback of callbacks.get(atoms.catalog) ?? []) {
+        callback(catalog);
+      }
+    },
+  };
+}
+
+const environmentId = EnvironmentId.make("environment-1");
+const threadId = ThreadId.make("thread-1");
+const retainedThread = { environmentId, threadId };
+
+beforeEach(() => {
+  retained.state.snapshot = { loaded: true, thread: retainedThread };
+  retained.state.subscribeCount = 0;
+  retained.state.releaseCount = 0;
+  retained.listeners.clear();
+  retained.clear.mockClear();
+  retained.ensureLoaded.mockClear();
+  atoms.shellStates.clear();
+  atoms.detailStates.clear();
+});
+
+describe("background connection root", () => {
+  it("starts and stops each lease exactly once", () => {
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+    });
+    const root = createBackgroundConnectionRoot(harness.registry);
+
+    root.start();
+    root.start();
+
+    expect(harness.mountCount("server-configs")).toBe(1);
+    expect(harness.mountCount(`shell:${environmentId}`)).toBe(1);
+    expect(harness.subscribeCount("catalog")).toBe(1);
+    expect(harness.subscribeCount("thread-shells")).toBe(1);
+    expect(harness.subscribeCount(`detail:${environmentId}:${threadId}`)).toBe(1);
+    expect(retained.state.subscribeCount).toBe(1);
+
+    root.stop();
+    root.stop();
+
+    expect(harness.mountReleaseCount("server-configs")).toBe(1);
+    expect(harness.mountReleaseCount(`shell:${environmentId}`)).toBe(1);
+    expect(harness.subscribeReleaseCount("catalog")).toBe(1);
+    expect(harness.subscribeReleaseCount("thread-shells")).toBe(1);
+    expect(harness.subscribeReleaseCount(`detail:${environmentId}:${threadId}`)).toBe(1);
+    expect(retained.state.releaseCount).toBe(1);
+  });
+
+  it("shares one root until the final owner releases it", () => {
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+    });
+
+    const releaseFirst = acquireBackgroundConnectionRoot(harness.registry);
+    const releaseSecond = acquireBackgroundConnectionRoot(harness.registry);
+    expect(harness.mountCount("server-configs")).toBe(1);
+
+    releaseFirst();
+    expect(harness.mountReleaseCount("server-configs")).toBe(0);
+    releaseSecond();
+    releaseSecond();
+    expect(harness.mountReleaseCount("server-configs")).toBe(1);
+  });
+
+  it("clears a retained target when its environment is removed", () => {
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+    });
+    const root = createBackgroundConnectionRoot(harness.registry);
+    root.start();
+
+    harness.setCatalog({ isReady: true, entries: new Map() });
+
+    expect(retained.clear).toHaveBeenCalledOnce();
+    expect(retained.state.snapshot.thread).toBeNull();
+    expect(harness.subscribeReleaseCount(`detail:${environmentId}:${threadId}`)).toBe(1);
+    root.stop();
+  });
+
+  it("clears and releases an immediately deleted retained thread", () => {
+    const detailKey = `${environmentId}:${threadId}`;
+    const harness = createRegistry({
+      catalog: { isReady: true, entries: new Map([[environmentId, {}]]) },
+      deletedThreadKeys: new Set([detailKey]),
+    });
+    const root = createBackgroundConnectionRoot(harness.registry);
+
+    root.start();
+
+    expect(retained.clear).toHaveBeenCalledOnce();
+    expect(retained.state.snapshot.thread).toBeNull();
+    expect(harness.subscribeCount(`detail:${detailKey}`)).toBe(1);
+    expect(harness.subscribeReleaseCount(`detail:${detailKey}`)).toBe(1);
+    root.stop();
+  });
+});

--- a/apps/mobile/src/features/background-connection/background-root.ts
+++ b/apps/mobile/src/features/background-connection/background-root.ts
@@ -1,0 +1,250 @@
+import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { AsyncResult, type AtomRegistry } from "effect/unstable/reactivity";
+
+import { environmentCatalog } from "../../connection/catalog";
+import { environmentServerConfigsAtom } from "../../state/server";
+import { environmentShell } from "../../state/shell";
+import { environmentThreadShells, environmentThreads } from "../../state/threads";
+import {
+  clearBackgroundConnectionRetainedThread,
+  ensureBackgroundConnectionRetainedThreadLoaded,
+  getBackgroundConnectionRetainedThreadSnapshot,
+  subscribeBackgroundConnectionRetainedThread,
+} from "./retained-thread";
+import { selectBackgroundConnectionThreadTargets } from "./target-selection";
+
+interface DetailLease {
+  readonly ref: ScopedThreadRef;
+  readonly release: () => void;
+}
+
+interface BackgroundConnectionRoot {
+  readonly start: () => void;
+  readonly stop: () => void;
+}
+
+function refKey(ref: ScopedThreadRef): string {
+  return JSON.stringify([ref.environmentId, ref.threadId]);
+}
+
+function refsEqual(left: ScopedThreadRef | null, right: ScopedThreadRef): boolean {
+  return (
+    left !== null && left.environmentId === right.environmentId && left.threadId === right.threadId
+  );
+}
+
+function releaseBestEffort(label: string, release: (() => void) | null): void {
+  if (release === null) {
+    return;
+  }
+  try {
+    release();
+  } catch (error) {
+    console.error(`[background-connection] failed to release ${label}`, error);
+  }
+}
+
+export function createBackgroundConnectionRoot(
+  registry: AtomRegistry.AtomRegistry,
+): BackgroundConnectionRoot {
+  let started = false;
+  let retainedThread = getBackgroundConnectionRetainedThreadSnapshot().thread;
+  let catalogReady = false;
+  let catalogEnvironmentIds = new Set<EnvironmentId>();
+  let threadShells = registry.get(environmentThreadShells.threadShellsAtom);
+  let catalogRelease: (() => void) | null = null;
+  let threadShellsRelease: (() => void) | null = null;
+  let serverConfigsRelease: (() => void) | null = null;
+  let retainedThreadRelease: (() => void) | null = null;
+  let clearingDeletedKey: string | null = null;
+  const shellLeases = new Map<EnvironmentId, () => void>();
+  const detailLeases = new Map<string, DetailLease>();
+
+  const clearRetainedIfCurrent = (ref: ScopedThreadRef) => {
+    if (!refsEqual(retainedThread, ref)) {
+      return;
+    }
+    const key = refKey(ref);
+    if (clearingDeletedKey === key) {
+      return;
+    }
+    clearingDeletedKey = key;
+    void clearBackgroundConnectionRetainedThread().finally(() => {
+      if (clearingDeletedKey === key) {
+        clearingDeletedKey = null;
+      }
+    });
+  };
+
+  const syncDetailLeases = () => {
+    if (!started) {
+      return;
+    }
+    const targets = selectBackgroundConnectionThreadTargets(retainedThread, threadShells);
+    const targetKeys = new Set(targets.map(refKey));
+
+    for (const [key, lease] of detailLeases) {
+      if (targetKeys.has(key)) {
+        continue;
+      }
+      detailLeases.delete(key);
+      releaseBestEffort(`thread detail ${key}`, lease.release);
+    }
+
+    for (const ref of targets) {
+      const key = refKey(ref);
+      if (detailLeases.has(key)) {
+        continue;
+      }
+      const atom = environmentThreads.stateAtom(ref.environmentId, ref.threadId);
+      let subscribedRelease: (() => void) | null = null;
+      const lease: DetailLease = {
+        ref,
+        release: () => subscribedRelease?.(),
+      };
+      // Register the lease before subscribing because an immediate deleted
+      // state can synchronously clear the retained target and re-enter this
+      // reconciliation.
+      detailLeases.set(key, lease);
+      subscribedRelease = registry.subscribe(
+        atom,
+        (result) => {
+          const state = Option.getOrNull(AsyncResult.value(result));
+          if (state?.status === "deleted") {
+            clearRetainedIfCurrent(ref);
+          }
+        },
+        { immediate: true },
+      );
+      if (!detailLeases.has(key)) {
+        subscribedRelease();
+      }
+    }
+  };
+
+  const validateRetainedEnvironment = () => {
+    if (
+      catalogReady &&
+      retainedThread !== null &&
+      !catalogEnvironmentIds.has(retainedThread.environmentId)
+    ) {
+      clearRetainedIfCurrent(retainedThread);
+    }
+  };
+
+  const syncRetainedThread = () => {
+    retainedThread = getBackgroundConnectionRetainedThreadSnapshot().thread;
+    validateRetainedEnvironment();
+    syncDetailLeases();
+  };
+
+  return {
+    start() {
+      if (started) {
+        return;
+      }
+      started = true;
+      retainedThreadRelease = subscribeBackgroundConnectionRetainedThread(syncRetainedThread);
+      retainedThread = getBackgroundConnectionRetainedThreadSnapshot().thread;
+      serverConfigsRelease = registry.mount(environmentServerConfigsAtom);
+      catalogRelease = registry.subscribe(
+        environmentCatalog.catalogValueAtom,
+        (catalog) => {
+          catalogReady = catalog.isReady;
+          catalogEnvironmentIds = new Set(catalog.entries.keys());
+
+          for (const [environmentId, release] of shellLeases) {
+            if (catalogEnvironmentIds.has(environmentId)) {
+              continue;
+            }
+            shellLeases.delete(environmentId);
+            releaseBestEffort(`environment shell ${environmentId}`, release);
+          }
+          for (const environmentId of catalogEnvironmentIds) {
+            if (!shellLeases.has(environmentId)) {
+              shellLeases.set(
+                environmentId,
+                registry.mount(environmentShell.stateAtom(environmentId)),
+              );
+            }
+          }
+          validateRetainedEnvironment();
+        },
+        { immediate: true },
+      );
+      threadShellsRelease = registry.subscribe(
+        environmentThreadShells.threadShellsAtom,
+        (nextThreadShells) => {
+          threadShells = nextThreadShells;
+          syncDetailLeases();
+        },
+        { immediate: true },
+      );
+      void ensureBackgroundConnectionRetainedThreadLoaded();
+      syncDetailLeases();
+    },
+    stop() {
+      if (!started) {
+        return;
+      }
+      started = false;
+      releaseBestEffort("retained-thread listener", retainedThreadRelease);
+      retainedThreadRelease = null;
+      releaseBestEffort("thread-shell listener", threadShellsRelease);
+      threadShellsRelease = null;
+      releaseBestEffort("environment catalog", catalogRelease);
+      catalogRelease = null;
+      releaseBestEffort("server configs", serverConfigsRelease);
+      serverConfigsRelease = null;
+      for (const [environmentId, release] of shellLeases) {
+        releaseBestEffort(`environment shell ${environmentId}`, release);
+      }
+      shellLeases.clear();
+      for (const [key, lease] of detailLeases) {
+        releaseBestEffort(`thread detail ${key}`, lease.release);
+      }
+      detailLeases.clear();
+    },
+  };
+}
+
+const roots = new WeakMap<
+  AtomRegistry.AtomRegistry,
+  { readonly root: BackgroundConnectionRoot; owners: number }
+>();
+
+export function acquireBackgroundConnectionRoot(registry: AtomRegistry.AtomRegistry): () => void {
+  let shared = roots.get(registry);
+  if (shared === undefined) {
+    const root = createBackgroundConnectionRoot(registry);
+    shared = { root, owners: 1 };
+    roots.set(registry, shared);
+    try {
+      root.start();
+    } catch (error) {
+      roots.delete(registry);
+      root.stop();
+      throw error;
+    }
+  } else {
+    shared.owners += 1;
+  }
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const current = roots.get(registry);
+    if (current === undefined) {
+      return;
+    }
+    current.owners -= 1;
+    if (current.owners > 0) {
+      return;
+    }
+    current.root.stop();
+    roots.delete(registry);
+  };
+}

--- a/apps/mobile/src/features/background-connection/background-root.ts
+++ b/apps/mobile/src/features/background-connection/background-root.ts
@@ -57,7 +57,7 @@ export function createBackgroundConnectionRoot(
   let threadShellsRelease: (() => void) | null = null;
   let serverConfigsRelease: (() => void) | null = null;
   let retainedThreadRelease: (() => void) | null = null;
-  let clearingDeletedKey: string | null = null;
+  const clearingDeletedKeys = new Set<string>();
   const shellLeases = new Map<EnvironmentId, () => void>();
   const detailLeases = new Map<string, DetailLease>();
 
@@ -66,13 +66,17 @@ export function createBackgroundConnectionRoot(
       return;
     }
     const key = refKey(ref);
-    if (clearingDeletedKey === key) {
+    if (clearingDeletedKeys.has(key)) {
       return;
     }
-    clearingDeletedKey = key;
+    clearingDeletedKeys.add(key);
     void clearBackgroundConnectionRetainedThread().finally(() => {
-      if (clearingDeletedKey === key) {
-        clearingDeletedKey = null;
+      clearingDeletedKeys.delete(key);
+      // Saving publishes before its persistence operation is queued. If the
+      // same deleted ref was saved while this clear was pending, clear it once
+      // more now so the final persistence operation cannot restore it.
+      if (started && refsEqual(retainedThread, ref)) {
+        clearRetainedIfCurrent(ref);
       }
     });
   };

--- a/apps/mobile/src/features/background-connection/background-task.test.ts
+++ b/apps/mobile/src/features/background-connection/background-task.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  acquireRoot: vi.fn(() => vi.fn()),
+  acquireOutbox: vi.fn(() => vi.fn()),
+  relayStop: vi.fn(),
+  setRuntimeReady: vi.fn(),
+  acknowledgeStop: vi.fn(),
+  enabled: true,
+  firstAttempt: Promise.resolve(),
+  stopListener: null as (() => void) | null,
+  removeStopListener: vi.fn(),
+}));
+
+vi.mock("../cloud/backgroundManagedRelayAuth", () => ({
+  startBackgroundManagedRelayAuth: () => ({
+    firstAttempt: mocks.firstAttempt,
+    retryNow: vi.fn(),
+    stop: mocks.relayStop,
+  }),
+}));
+vi.mock("../../native/backgroundConnection", () => ({
+  addBackgroundConnectionStopRequestListener: (listener: () => void) => {
+    mocks.stopListener = listener;
+    return { remove: mocks.removeStopListener };
+  },
+  getBackgroundConnectionStatus: () => ({ enabled: mocks.enabled }),
+  setBackgroundConnectionRuntimeReady: mocks.setRuntimeReady,
+  acknowledgeBackgroundConnectionStop: mocks.acknowledgeStop,
+}));
+vi.mock("../../state/atom-registry", () => ({ appAtomRegistry: {} }));
+vi.mock("../../state/use-thread-outbox-drain", () => ({
+  acquireThreadOutboxDrain: mocks.acquireOutbox,
+}));
+vi.mock("./background-root", () => ({
+  acquireBackgroundConnectionRoot: mocks.acquireRoot,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  mocks.enabled = true;
+  mocks.firstAttempt = Promise.resolve();
+  mocks.stopListener = null;
+});
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+it("shares one runtime across duplicate native task starts and cleans it up once", async () => {
+  const { runBackgroundConnectionHeadlessTask } = await import("./background-task");
+
+  const first = runBackgroundConnectionHeadlessTask();
+  const second = runBackgroundConnectionHeadlessTask();
+  expect(first).toBe(second);
+  await vi.waitFor(() => {
+    expect(mocks.acquireRoot).toHaveBeenCalledOnce();
+    expect(mocks.acquireOutbox).toHaveBeenCalledOnce();
+    expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
+  });
+
+  mocks.stopListener?.();
+  await Promise.all([first, second]);
+
+  expect(mocks.acquireRoot.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.acquireOutbox.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.relayStop).toHaveBeenCalledOnce();
+  expect(mocks.removeStopListener).toHaveBeenCalledOnce();
+  expect(mocks.setRuntimeReady).toHaveBeenLastCalledWith(false);
+  expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
+});
+
+it("cleans up a task that finishes loading after the feature was disabled", async () => {
+  mocks.enabled = false;
+  const { runBackgroundConnectionHeadlessTask } = await import("./background-task");
+
+  await runBackgroundConnectionHeadlessTask();
+
+  expect(mocks.acquireRoot).not.toHaveBeenCalled();
+  expect(mocks.acquireOutbox).not.toHaveBeenCalled();
+  expect(mocks.setRuntimeReady).not.toHaveBeenCalledWith(true);
+  expect(mocks.relayStop).not.toHaveBeenCalled();
+  expect(mocks.removeStopListener).toHaveBeenCalledOnce();
+  expect(mocks.setRuntimeReady).toHaveBeenLastCalledWith(false);
+  expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
+});
+
+it("marks direct connections ready and stops promptly while relay auth is loading", async () => {
+  const authBootstrap = deferred();
+  mocks.firstAttempt = authBootstrap.promise;
+  const { runBackgroundConnectionHeadlessTask } = await import("./background-task");
+
+  const task = runBackgroundConnectionHeadlessTask();
+  await vi.waitFor(() => {
+    expect(mocks.acquireRoot).toHaveBeenCalledOnce();
+    expect(mocks.acquireOutbox).toHaveBeenCalledOnce();
+    expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
+  });
+
+  mocks.stopListener?.();
+  await task;
+
+  expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
+  expect(mocks.acquireRoot.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.acquireOutbox.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.relayStop).toHaveBeenCalledOnce();
+  expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
+
+  authBootstrap.resolve();
+});

--- a/apps/mobile/src/features/background-connection/background-task.test.ts
+++ b/apps/mobile/src/features/background-connection/background-task.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, expect, it, vi } from "vite-plus/test";
 const mocks = vi.hoisted(() => ({
   acquireRoot: vi.fn(() => vi.fn()),
   acquireOutbox: vi.fn(() => vi.fn()),
+  acquireNotifications: vi.fn(() => vi.fn()),
   relayStop: vi.fn(),
   setRuntimeReady: vi.fn(),
   acknowledgeStop: vi.fn(),
@@ -31,6 +32,9 @@ vi.mock("../../native/backgroundConnection", () => ({
 vi.mock("../../state/atom-registry", () => ({ appAtomRegistry: {} }));
 vi.mock("../../state/use-thread-outbox-drain", () => ({
   acquireThreadOutboxDrain: mocks.acquireOutbox,
+}));
+vi.mock("../agent-notifications/thread-notification-service", () => ({
+  acquireThreadNotificationService: mocks.acquireNotifications,
 }));
 vi.mock("./background-root", () => ({
   acquireBackgroundConnectionRoot: mocks.acquireRoot,
@@ -61,6 +65,7 @@ it("shares one runtime across duplicate native task starts and cleans it up once
   await vi.waitFor(() => {
     expect(mocks.acquireRoot).toHaveBeenCalledOnce();
     expect(mocks.acquireOutbox).toHaveBeenCalledOnce();
+    expect(mocks.acquireNotifications).toHaveBeenCalledOnce();
     expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
   });
 
@@ -69,6 +74,7 @@ it("shares one runtime across duplicate native task starts and cleans it up once
 
   expect(mocks.acquireRoot.mock.results[0]?.value).toHaveBeenCalledOnce();
   expect(mocks.acquireOutbox.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.acquireNotifications.mock.results[0]?.value).toHaveBeenCalledOnce();
   expect(mocks.relayStop).toHaveBeenCalledOnce();
   expect(mocks.removeStopListener).toHaveBeenCalledOnce();
   expect(mocks.setRuntimeReady).toHaveBeenLastCalledWith(false);
@@ -83,6 +89,7 @@ it("cleans up a task that finishes loading after the feature was disabled", asyn
 
   expect(mocks.acquireRoot).not.toHaveBeenCalled();
   expect(mocks.acquireOutbox).not.toHaveBeenCalled();
+  expect(mocks.acquireNotifications).not.toHaveBeenCalled();
   expect(mocks.setRuntimeReady).not.toHaveBeenCalledWith(true);
   expect(mocks.relayStop).not.toHaveBeenCalled();
   expect(mocks.removeStopListener).toHaveBeenCalledOnce();
@@ -99,6 +106,7 @@ it("marks direct connections ready and stops promptly while relay auth is loadin
   await vi.waitFor(() => {
     expect(mocks.acquireRoot).toHaveBeenCalledOnce();
     expect(mocks.acquireOutbox).toHaveBeenCalledOnce();
+    expect(mocks.acquireNotifications).toHaveBeenCalledOnce();
     expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
   });
 
@@ -108,6 +116,7 @@ it("marks direct connections ready and stops promptly while relay auth is loadin
   expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
   expect(mocks.acquireRoot.mock.results[0]?.value).toHaveBeenCalledOnce();
   expect(mocks.acquireOutbox.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.acquireNotifications.mock.results[0]?.value).toHaveBeenCalledOnce();
   expect(mocks.relayStop).toHaveBeenCalledOnce();
   expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
 

--- a/apps/mobile/src/features/background-connection/background-task.ts
+++ b/apps/mobile/src/features/background-connection/background-task.ts
@@ -1,0 +1,85 @@
+import { startBackgroundManagedRelayAuth } from "../cloud/backgroundManagedRelayAuth";
+import {
+  acknowledgeBackgroundConnectionStop,
+  addBackgroundConnectionStopRequestListener,
+  getBackgroundConnectionStatus,
+  setBackgroundConnectionRuntimeReady,
+} from "../../native/backgroundConnection";
+import { appAtomRegistry } from "../../state/atom-registry";
+import { acquireThreadOutboxDrain } from "../../state/use-thread-outbox-drain";
+import { acquireBackgroundConnectionRoot } from "./background-root";
+
+let activeTask: Promise<void> | null = null;
+
+function bestEffortCleanup(label: string, cleanup: (() => void) | null): void {
+  if (cleanup === null) {
+    return;
+  }
+  try {
+    cleanup();
+  } catch (error) {
+    console.error(`[background-connection] ${label} cleanup failed`, error);
+  }
+}
+
+async function runTask(): Promise<void> {
+  let hasStopBeenRequested = false;
+  let requestStop!: () => void;
+  const stopRequested = new Promise<void>((resolve) => {
+    requestStop = () => {
+      hasStopBeenRequested = true;
+      resolve();
+    };
+  });
+  // Subscribe before acquiring anything so a disable request cannot race the
+  // cold React runtime bootstrap and leave the service waiting indefinitely.
+  const stopSubscription = addBackgroundConnectionStopRequestListener(requestStop);
+  // Native may have stopped the service before this cold JS runtime finished
+  // loading and installed its listener. Treat the persisted disabled state as
+  // the same stop request so that a late task cannot leak its leases.
+  if (!getBackgroundConnectionStatus().enabled) {
+    requestStop();
+  }
+  let relayAuth: ReturnType<typeof startBackgroundManagedRelayAuth> | null = null;
+  let releaseRoot: (() => void) | null = null;
+  let releaseOutbox: (() => void) | null = null;
+
+  try {
+    if (hasStopBeenRequested) {
+      return;
+    }
+    relayAuth = startBackgroundManagedRelayAuth();
+    releaseRoot = acquireBackgroundConnectionRoot(appAtomRegistry);
+    releaseOutbox = acquireThreadOutboxDrain(appAtomRegistry);
+    // Relay authentication owns its own retry loop. Direct/Tailscale
+    // connections and the shared outbox are fully operational once these
+    // leases are mounted, even if Clerk is slow or temporarily unavailable.
+    setBackgroundConnectionRuntimeReady(true);
+    await stopRequested;
+  } catch (error) {
+    console.error("[background-connection] headless runtime failed", error);
+    // Normal completion lets native release React Native's wake lock and use
+    // its bounded exponential restart ladder for bootstrap defects.
+  } finally {
+    bestEffortCleanup("outbox", releaseOutbox);
+    bestEffortCleanup("root", releaseRoot);
+    bestEffortCleanup("relay authentication", () => relayAuth?.stop());
+    bestEffortCleanup("stop listener", () => stopSubscription.remove());
+    setBackgroundConnectionRuntimeReady(false);
+    acknowledgeBackgroundConnectionStop();
+  }
+}
+
+/** Native guards task creation too; this JS guard protects hot reloads and races. */
+export function runBackgroundConnectionHeadlessTask(): Promise<void> {
+  if (activeTask !== null) {
+    return activeTask;
+  }
+  const task = runTask().finally(() => {
+    if (activeTask === task) {
+      activeTask = null;
+    }
+  });
+  activeTask = task;
+  return task;
+}

--- a/apps/mobile/src/features/background-connection/background-task.ts
+++ b/apps/mobile/src/features/background-connection/background-task.ts
@@ -7,6 +7,7 @@ import {
 } from "../../native/backgroundConnection";
 import { appAtomRegistry } from "../../state/atom-registry";
 import { acquireThreadOutboxDrain } from "../../state/use-thread-outbox-drain";
+import { acquireThreadNotificationService } from "../agent-notifications/thread-notification-service";
 import { acquireBackgroundConnectionRoot } from "./background-root";
 
 let activeTask: Promise<void> | null = null;
@@ -43,6 +44,7 @@ async function runTask(): Promise<void> {
   let relayAuth: ReturnType<typeof startBackgroundManagedRelayAuth> | null = null;
   let releaseRoot: (() => void) | null = null;
   let releaseOutbox: (() => void) | null = null;
+  let releaseNotifications: (() => void) | null = null;
 
   try {
     if (hasStopBeenRequested) {
@@ -51,6 +53,7 @@ async function runTask(): Promise<void> {
     relayAuth = startBackgroundManagedRelayAuth();
     releaseRoot = acquireBackgroundConnectionRoot(appAtomRegistry);
     releaseOutbox = acquireThreadOutboxDrain(appAtomRegistry);
+    releaseNotifications = acquireThreadNotificationService(appAtomRegistry);
     // Relay authentication owns its own retry loop. Direct/Tailscale
     // connections and the shared outbox are fully operational once these
     // leases are mounted, even if Clerk is slow or temporarily unavailable.
@@ -61,6 +64,7 @@ async function runTask(): Promise<void> {
     // Normal completion lets native release React Native's wake lock and use
     // its bounded exponential restart ladder for bootstrap defects.
   } finally {
+    bestEffortCleanup("agent notifications", releaseNotifications);
     bestEffortCleanup("outbox", releaseOutbox);
     bestEffortCleanup("root", releaseRoot);
     bestEffortCleanup("relay authentication", () => relayAuth?.stop());

--- a/apps/mobile/src/features/background-connection/headless-task-registration.test.ts
+++ b/apps/mobile/src/features/background-connection/headless-task-registration.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, expect, it, vi } from "vite-plus/test";
+
+const registerHeadlessTask = vi.hoisted(() => vi.fn());
+
+vi.mock("react-native", () => ({
+  AppRegistry: { registerHeadlessTask },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+it("registers exactly one Android Headless JS task", async () => {
+  const registration = await import("./headless-task-registration");
+
+  registration.registerBackgroundConnectionHeadlessTask();
+  registration.registerBackgroundConnectionHeadlessTask();
+
+  expect(registerHeadlessTask).toHaveBeenCalledOnce();
+  expect(registerHeadlessTask).toHaveBeenCalledWith(
+    registration.BACKGROUND_CONNECTION_HEADLESS_TASK,
+    expect.any(Function),
+  );
+});
+
+it("finishes the native task when its dynamic import fails", async () => {
+  const registration = await import("./headless-task-registration");
+  const error = new Error("bundle chunk unavailable");
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+  await expect(
+    registration.runRegisteredBackgroundConnectionTask(() => Promise.reject(error)),
+  ).resolves.toBeUndefined();
+
+  expect(consoleError).toHaveBeenCalledWith(
+    "[background-connection] registered headless task failed",
+    error,
+  );
+  consoleError.mockRestore();
+});

--- a/apps/mobile/src/features/background-connection/headless-task-registration.ts
+++ b/apps/mobile/src/features/background-connection/headless-task-registration.ts
@@ -1,0 +1,42 @@
+import { AppRegistry } from "react-native";
+
+export const BACKGROUND_CONNECTION_HEADLESS_TASK = "T3BackgroundConnection";
+
+let registered = false;
+
+interface BackgroundConnectionTaskModule {
+  readonly runBackgroundConnectionHeadlessTask: () => Promise<void>;
+}
+
+type BackgroundConnectionTaskLoader = () => Promise<BackgroundConnectionTaskModule>;
+
+const loadBackgroundConnectionTask: BackgroundConnectionTaskLoader = () =>
+  import("./background-task");
+
+/**
+ * React Native does not finish an unlimited Headless JS task when its provider
+ * rejects with a generic error. Convert import/bootstrap defects into normal
+ * completion so native can release its wake lock and apply bounded recovery.
+ */
+export async function runRegisteredBackgroundConnectionTask(
+  loadTask: BackgroundConnectionTaskLoader = loadBackgroundConnectionTask,
+): Promise<void> {
+  try {
+    const { runBackgroundConnectionHeadlessTask } = await loadTask();
+    await runBackgroundConnectionHeadlessTask();
+  } catch (error) {
+    console.error("[background-connection] registered headless task failed", error);
+  }
+}
+
+/** Must run before Expo registers the Activity's root component. */
+export function registerBackgroundConnectionHeadlessTask(): void {
+  if (registered) {
+    return;
+  }
+  registered = true;
+  AppRegistry.registerHeadlessTask(
+    BACKGROUND_CONNECTION_HEADLESS_TASK,
+    () => () => runRegisteredBackgroundConnectionTask(),
+  );
+}

--- a/apps/mobile/src/features/background-connection/retained-thread.test.ts
+++ b/apps/mobile/src/features/background-connection/retained-thread.test.ts
@@ -1,0 +1,98 @@
+import { EnvironmentId, ThreadId, type ScopedThreadRef } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const persistence = vi.hoisted(() => ({
+  load: vi.fn<() => Promise<ScopedThreadRef | null>>(),
+  save: vi.fn<(_thread: ScopedThreadRef) => Promise<void>>(),
+  clear: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("../../persistence/imperative", () => ({
+  loadBackgroundConnectionRetainedThread: persistence.load,
+  saveBackgroundConnectionRetainedThread: persistence.save,
+  clearBackgroundConnectionRetainedThread: persistence.clear,
+}));
+
+function deferred<A>() {
+  let resolve!: (value: A) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<A>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+const firstThread = {
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: ThreadId.make("thread-1"),
+};
+const secondThread = {
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: ThreadId.make("thread-2"),
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  persistence.load.mockReset();
+  persistence.save.mockReset();
+  persistence.clear.mockReset();
+  persistence.load.mockResolvedValue(null);
+  persistence.save.mockResolvedValue(undefined);
+  persistence.clear.mockResolvedValue(undefined);
+});
+
+describe("background retained thread", () => {
+  it("does not let a cold load replace a thread saved during startup", async () => {
+    const coldLoad = deferred<typeof firstThread | null>();
+    persistence.load.mockReturnValueOnce(coldLoad.promise);
+    const retained = await import("./retained-thread");
+
+    const loading = retained.ensureBackgroundConnectionRetainedThreadLoaded();
+    const saving = retained.saveBackgroundConnectionRetainedThread(secondThread);
+    await Promise.resolve();
+    expect(persistence.save).not.toHaveBeenCalled();
+    coldLoad.resolve(firstThread);
+    await Promise.all([loading, saving]);
+
+    expect(retained.getBackgroundConnectionRetainedThreadSnapshot()).toEqual({
+      loaded: true,
+      thread: secondThread,
+    });
+  });
+
+  it("persists rapid thread changes in invocation order", async () => {
+    const firstWrite = deferred<void>();
+    persistence.save.mockReturnValueOnce(firstWrite.promise).mockResolvedValueOnce(undefined);
+    const retained = await import("./retained-thread");
+
+    const savingFirst = retained.saveBackgroundConnectionRetainedThread(firstThread);
+    const savingSecond = retained.saveBackgroundConnectionRetainedThread(secondThread);
+    await Promise.resolve();
+
+    expect(persistence.save).toHaveBeenCalledTimes(1);
+    firstWrite.resolve();
+    await Promise.all([savingFirst, savingSecond]);
+    expect(persistence.save.mock.calls.map(([thread]) => thread)).toEqual([
+      firstThread,
+      secondThread,
+    ]);
+  });
+
+  it("does not let a slow save overwrite a later clear", async () => {
+    const slowSave = deferred<void>();
+    persistence.save.mockReturnValueOnce(slowSave.promise);
+    const retained = await import("./retained-thread");
+
+    const saving = retained.saveBackgroundConnectionRetainedThread(firstThread);
+    const clearing = retained.clearBackgroundConnectionRetainedThread();
+    await Promise.resolve();
+
+    expect(persistence.save).toHaveBeenCalledOnce();
+    expect(persistence.clear).not.toHaveBeenCalled();
+    slowSave.resolve();
+    await Promise.all([saving, clearing]);
+    expect(persistence.clear).toHaveBeenCalledOnce();
+    expect(retained.getBackgroundConnectionRetainedThreadSnapshot().thread).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/background-connection/retained-thread.ts
+++ b/apps/mobile/src/features/background-connection/retained-thread.ts
@@ -1,0 +1,124 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+import {
+  clearBackgroundConnectionRetainedThread as clearPersistedRetainedThread,
+  loadBackgroundConnectionRetainedThread as loadPersistedRetainedThread,
+  saveBackgroundConnectionRetainedThread as savePersistedRetainedThread,
+} from "../../persistence/imperative";
+
+interface RetainedThreadSnapshot {
+  readonly loaded: boolean;
+  readonly thread: ScopedThreadRef | null;
+}
+
+const EMPTY_SNAPSHOT: RetainedThreadSnapshot = Object.freeze({
+  loaded: false,
+  thread: null,
+});
+
+let snapshot = EMPTY_SNAPSHOT;
+let revision = 0;
+let loading: Promise<ScopedThreadRef | null> | null = null;
+let persistenceQueue: Promise<void> = Promise.resolve();
+const listeners = new Set<() => void>();
+
+function threadRefsEqual(left: ScopedThreadRef | null, right: ScopedThreadRef | null): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      left.environmentId === right.environmentId &&
+      left.threadId === right.threadId)
+  );
+}
+
+function publish(next: RetainedThreadSnapshot): void {
+  if (snapshot.loaded === next.loaded && threadRefsEqual(snapshot.thread, next.thread)) {
+    return;
+  }
+  snapshot = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function getBackgroundConnectionRetainedThreadSnapshot(): RetainedThreadSnapshot {
+  return snapshot;
+}
+
+export function subscribeBackgroundConnectionRetainedThread(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function ensureBackgroundConnectionRetainedThreadLoaded(): Promise<ScopedThreadRef | null> {
+  if (snapshot.loaded) {
+    return Promise.resolve(snapshot.thread);
+  }
+  if (loading !== null) {
+    return loading;
+  }
+
+  const loadRevision = revision;
+  const persistedLoad = persistenceQueue.then(
+    loadPersistedRetainedThread,
+    loadPersistedRetainedThread,
+  );
+  // Loading can also remove malformed persisted data. Treat it as part of the
+  // same storage sequence so that cleanup cannot race and delete a newer save.
+  persistenceQueue = persistedLoad.then(
+    () => undefined,
+    () => undefined,
+  );
+  loading = persistedLoad
+    .then((thread) => {
+      if (revision === loadRevision) {
+        publish({ loaded: true, thread });
+      }
+      return snapshot.thread;
+    })
+    .catch((error) => {
+      console.warn("[background-connection] failed to load the retained thread", error);
+      if (revision === loadRevision) {
+        publish({ loaded: true, thread: null });
+      }
+      return snapshot.thread;
+    })
+    .finally(() => {
+      loading = null;
+    });
+  return loading;
+}
+
+function enqueuePersistence(operation: () => Promise<void>): Promise<void> {
+  const queued = persistenceQueue.then(operation, operation);
+  persistenceQueue = queued.catch(() => undefined);
+  return queued;
+}
+
+export async function saveBackgroundConnectionRetainedThread(
+  thread: ScopedThreadRef,
+): Promise<void> {
+  revision += 1;
+  publish({ loaded: true, thread });
+  try {
+    await enqueuePersistence(() => savePersistedRetainedThread(thread));
+  } catch (error) {
+    console.warn("[background-connection] failed to persist the retained thread", error);
+  }
+}
+
+export async function clearBackgroundConnectionRetainedThread(): Promise<void> {
+  revision += 1;
+  publish({ loaded: true, thread: null });
+  try {
+    await enqueuePersistence(clearPersistedRetainedThread);
+  } catch (error) {
+    console.warn("[background-connection] failed to clear the retained thread", error);
+  }
+}
+
+export function clearBackgroundConnectionRetainedThreadInMemory(): void {
+  revision += 1;
+  publish({ loaded: true, thread: null });
+}

--- a/apps/mobile/src/features/background-connection/settings-model.test.ts
+++ b/apps/mobile/src/features/background-connection/settings-model.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { BackgroundConnectionStatus } from "../../native/backgroundConnection";
+import {
+  backgroundConnectionStatusLabel,
+  shouldRequestBackgroundConnectionBatteryExemption,
+} from "./settings-model";
+
+const status = (overrides: Partial<BackgroundConnectionStatus>): BackgroundConnectionStatus => ({
+  supported: true,
+  enabled: true,
+  serviceRunning: true,
+  runtimeReady: true,
+  batteryOptimizationIgnored: true,
+  ...overrides,
+});
+
+describe("backgroundConnectionStatusLabel", () => {
+  it("reports the fully ready runtime", () => {
+    expect(backgroundConnectionStatusLabel(status({}))).toBe("Running");
+  });
+
+  it("reports startup until both native service and JavaScript are ready", () => {
+    expect(backgroundConnectionStatusLabel(status({ runtimeReady: false }))).toBe("Starting");
+    expect(backgroundConnectionStatusLabel(status({ serviceRunning: false }))).toBe("Starting");
+  });
+
+  it("makes degraded battery protection explicit", () => {
+    expect(backgroundConnectionStatusLabel(status({ batteryOptimizationIgnored: false }))).toBe(
+      "Battery optimization enabled",
+    );
+  });
+
+  it("reports disabled and unsupported installations as stopped", () => {
+    expect(backgroundConnectionStatusLabel(status({ enabled: false }))).toBe("Stopped");
+    expect(backgroundConnectionStatusLabel(status({ supported: false }))).toBe("Stopped");
+  });
+
+  it("keeps the feature enabled when the battery exemption is still declined", () => {
+    const declined = status({ batteryOptimizationIgnored: false });
+    expect(shouldRequestBackgroundConnectionBatteryExemption(declined)).toBe(true);
+    expect(declined.enabled).toBe(true);
+  });
+
+  it("does not request an exemption while disabling", () => {
+    expect(
+      shouldRequestBackgroundConnectionBatteryExemption(
+        status({ enabled: false, batteryOptimizationIgnored: false }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/background-connection/settings-model.ts
+++ b/apps/mobile/src/features/background-connection/settings-model.ts
@@ -1,0 +1,25 @@
+import type { BackgroundConnectionStatus } from "../../native/backgroundConnection";
+
+export type BackgroundConnectionStatusLabel =
+  | "Running"
+  | "Starting"
+  | "Stopped"
+  | "Battery optimization enabled";
+
+export function backgroundConnectionStatusLabel(
+  status: BackgroundConnectionStatus,
+): BackgroundConnectionStatusLabel {
+  if (!status.supported || !status.enabled) {
+    return "Stopped";
+  }
+  if (!status.batteryOptimizationIgnored) {
+    return "Battery optimization enabled";
+  }
+  return status.serviceRunning && status.runtimeReady ? "Running" : "Starting";
+}
+
+export function shouldRequestBackgroundConnectionBatteryExemption(
+  status: BackgroundConnectionStatus,
+): boolean {
+  return status.supported && status.enabled && !status.batteryOptimizationIgnored;
+}

--- a/apps/mobile/src/features/background-connection/target-selection.test.ts
+++ b/apps/mobile/src/features/background-connection/target-selection.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ProjectId, ThreadId, type ScopedThreadRef } from "@t3tools/contracts";
+
+import { selectBackgroundConnectionThreadTargets } from "./target-selection";
+
+const environmentId = EnvironmentId.make("environment-1");
+const projectId = ProjectId.make("project-1");
+
+function shell(id: string, status: "starting" | "running" | "ready"): EnvironmentThreadShell {
+  return {
+    environmentId,
+    id: ThreadId.make(id),
+    projectId,
+    title: id,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    session: { status },
+  } as EnvironmentThreadShell;
+}
+
+describe("background connection target selection", () => {
+  it("keeps the retained thread followed by starting and running threads", () => {
+    const retained: ScopedThreadRef = {
+      environmentId,
+      threadId: ThreadId.make("retained"),
+    };
+
+    expect(
+      selectBackgroundConnectionThreadTargets(retained, [
+        shell("settled", "ready"),
+        shell("starting", "starting"),
+        shell("running", "running"),
+      ]),
+    ).toEqual([
+      retained,
+      { environmentId, threadId: ThreadId.make("starting") },
+      { environmentId, threadId: ThreadId.make("running") },
+    ]);
+  });
+
+  it("deduplicates a retained running thread without changing order", () => {
+    const retained = { environmentId, threadId: ThreadId.make("running") };
+    expect(
+      selectBackgroundConnectionThreadTargets(retained, [
+        shell("running", "running"),
+        shell("other", "starting"),
+      ]),
+    ).toEqual([retained, { environmentId, threadId: ThreadId.make("other") }]);
+  });
+
+  it("drops active targets after their shell settles", () => {
+    expect(selectBackgroundConnectionThreadTargets(null, [shell("task", "running")])).toHaveLength(
+      1,
+    );
+    expect(selectBackgroundConnectionThreadTargets(null, [shell("task", "ready")])).toEqual([]);
+  });
+});

--- a/apps/mobile/src/features/background-connection/target-selection.ts
+++ b/apps/mobile/src/features/background-connection/target-selection.ts
@@ -1,0 +1,36 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+function refKey(ref: ScopedThreadRef): string {
+  return JSON.stringify([ref.environmentId, ref.threadId]);
+}
+
+/**
+ * Keep one user-relevant settled thread plus every thread that is currently doing work.
+ * The retained thread is deliberately first and the shell order is preserved.
+ */
+export function selectBackgroundConnectionThreadTargets(
+  retainedThread: ScopedThreadRef | null,
+  threadShells: ReadonlyArray<EnvironmentThreadShell>,
+): ReadonlyArray<ScopedThreadRef> {
+  const targets: ScopedThreadRef[] = [];
+  const seen = new Set<string>();
+  const append = (ref: ScopedThreadRef) => {
+    const key = refKey(ref);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    targets.push(ref);
+  };
+
+  if (retainedThread !== null) {
+    append(retainedThread);
+  }
+  for (const thread of threadShells) {
+    if (thread.session?.status === "starting" || thread.session?.status === "running") {
+      append({ environmentId: thread.environmentId, threadId: thread.id });
+    }
+  }
+  return targets;
+}

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
@@ -89,12 +89,32 @@ describe("CloudAuthProvider relay account isolation", () => {
       readClerkToken: async () => "background-token",
     });
     activateCloudRelayAccount("account-1", async () => "ui-token");
+    vi.mocked(refreshBackgroundManagedRelayAuth).mockClear();
 
     releaseCloudRelayUiAccount();
 
     expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
-    releaseBackground();
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
+    expect(releaseBackground).not.toBeNull();
+    releaseBackground?.();
     expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("waits for account cleanup before refreshing background ownership", async () => {
+    activateCloudRelayAccount("account-1", async () => "ui-token");
+    vi.mocked(refreshBackgroundManagedRelayAuth).mockClear();
+    const cleanup = deferred();
+
+    releaseCloudRelayUiAccount({ refreshAfter: cleanup.promise });
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+    expect(refreshBackgroundManagedRelayAuth).not.toHaveBeenCalled();
+
+    cleanup.resolve();
+    await cleanup.promise;
+    await Promise.resolve();
+
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
   });
 
   it("defers the background refresh for an account switch until cleanup resolves", async () => {

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
@@ -2,8 +2,17 @@ import { managedRelaySessionAtom } from "@t3tools/client-runtime/relay";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { appAtomRegistry } from "../../state/atom-registry";
-import { activateCloudRelayAccount, deactivateCloudRelayAccount } from "./CloudAuthProvider";
 import { setAgentAwarenessRelayTokenProvider } from "../agent-awareness/remoteRegistration";
+import {
+  activateCloudRelayAccount,
+  deactivateCloudRelayAccount,
+  releaseCloudRelayUiAccount,
+} from "./CloudAuthProvider";
+import {
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+import { acquireBackgroundManagedRelaySession } from "./managedRelaySessionOwnership";
 
 vi.mock("@clerk/expo", () => ({
   ClerkProvider: vi.fn(),
@@ -12,6 +21,11 @@ vi.mock("@clerk/expo", () => ({
 
 vi.mock("@clerk/expo/token-cache", () => ({
   tokenCache: {},
+}));
+
+vi.mock("./backgroundManagedRelayAuth", () => ({
+  invalidateBackgroundManagedRelayAuth: vi.fn(),
+  refreshBackgroundManagedRelayAuth: vi.fn(async () => undefined),
 }));
 
 vi.mock("../../lib/runtime", () => ({
@@ -35,9 +49,18 @@ vi.mock("./publicConfig", () => ({
 }));
 
 vi.mock("../agent-awareness/remoteRegistration", () => ({
+  releaseAgentAwarenessRelayTokenProvider: vi.fn(),
   setAgentAwarenessRelayTokenProvider: vi.fn(),
   unregisterAgentAwarenessDeviceForCurrentUser: vi.fn(),
 }));
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 afterEach(() => {
   deactivateCloudRelayAccount();
@@ -49,12 +72,49 @@ describe("CloudAuthProvider relay account isolation", () => {
     const tokenProvider = async () => "account-1-token";
     activateCloudRelayAccount("account-1", tokenProvider);
     expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
 
     deactivateCloudRelayAccount();
     const cleanup = Promise.reject(new Error("Persistence removal failed.")).catch(() => undefined);
 
     expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
     expect(vi.mocked(setAgentAwarenessRelayTokenProvider)).toHaveBeenLastCalledWith(null);
+    expect(invalidateBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
     await cleanup;
+  });
+
+  it("preserves background relay ownership when the UI bridge unmounts", () => {
+    const releaseBackground = acquireBackgroundManagedRelaySession({
+      accountId: "account-1",
+      readClerkToken: async () => "background-token",
+    });
+    activateCloudRelayAccount("account-1", async () => "ui-token");
+
+    releaseCloudRelayUiAccount();
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    releaseBackground();
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("defers the background refresh for an account switch until cleanup resolves", async () => {
+    activateCloudRelayAccount("account-1", async () => "account-1-token");
+    vi.mocked(refreshBackgroundManagedRelayAuth).mockClear();
+
+    const cleanup = deferred();
+    deactivateCloudRelayAccount({ refreshBackground: false });
+    const transition = cleanup.promise.then(() => {
+      activateCloudRelayAccount("account-2", async () => "account-2-token");
+    });
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
+    expect(invalidateBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
+    expect(refreshBackgroundManagedRelayAuth).not.toHaveBeenCalled();
+
+    cleanup.resolve();
+    await transition;
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-2");
+    expect(refreshBackgroundManagedRelayAuth).toHaveBeenCalledOnce();
   });
 });

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
@@ -56,9 +56,20 @@ export function activateCloudRelayAccount(
   void refreshBackgroundManagedRelayAuth();
 }
 
-export function releaseCloudRelayUiAccount(): void {
+export function releaseCloudRelayUiAccount(
+  options: { readonly refreshAfter?: Promise<void> | null } = {},
+): void {
   releaseAgentAwarenessRelayTokenProvider();
   managedRelaySessionOwnership.releaseOwner("ui");
+  const refreshBackground = () => {
+    void refreshBackgroundManagedRelayAuth();
+  };
+  const refreshAfter = options.refreshAfter ?? null;
+  if (refreshAfter === null) {
+    refreshBackground();
+    return;
+  }
+  void refreshAfter.then(refreshBackground, refreshBackground);
 }
 
 function CloudAuthBridge(props: { readonly children: ReactNode }) {
@@ -183,7 +194,7 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       // Unmounting is not a sign-out: the user is usually still signed in, so
       // detach the provider without ending lock-screen activities or wiping the
       // persisted registration (a remount reuses both).
-      releaseCloudRelayUiAccount();
+      releaseCloudRelayUiAccount({ refreshAfter: accountTransitionRef.current });
     },
     [],
   );

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
@@ -1,6 +1,6 @@
 import { ClerkProvider, useAuth } from "@clerk/expo";
 import { tokenCache } from "@clerk/expo/token-cache";
-import { ManagedRelay, setManagedRelaySession } from "@t3tools/client-runtime/relay";
+import { ManagedRelay } from "@t3tools/client-runtime/relay";
 import {
   reportAtomCommandResult,
   settleAsyncResult,
@@ -11,7 +11,6 @@ import { type ReactNode, useEffect, useRef } from "react";
 
 import { environmentCatalog } from "../../connection/catalog";
 import { runtime } from "../../lib/runtime";
-import { appAtomRegistry } from "../../state/atom-registry";
 import { useAtomCommand } from "../../state/use-atom-command";
 import {
   releaseAgentAwarenessRelayTokenProvider,
@@ -19,6 +18,11 @@ import {
   unregisterAgentAwarenessDeviceForCurrentUser,
 } from "../agent-awareness/remoteRegistration";
 import { clearConnectOnboardingRequest, requestConnectOnboarding } from "./connectOnboarding";
+import {
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+import { managedRelaySessionOwnership } from "./managedRelaySessionOwnership";
 import { resolveCloudPublicConfig, resolveRelayClerkTokenOptions } from "./publicConfig";
 
 function resetManagedRelayTokenCache() {
@@ -29,9 +33,15 @@ function resetManagedRelayTokenCache() {
   );
 }
 
-export function deactivateCloudRelayAccount(): void {
+export function deactivateCloudRelayAccount(
+  options: { readonly refreshBackground?: boolean } = {},
+): void {
   setAgentAwarenessRelayTokenProvider(null);
-  setManagedRelaySession(appAtomRegistry, null);
+  invalidateBackgroundManagedRelayAuth();
+  managedRelaySessionOwnership.clear();
+  if (options.refreshBackground !== false) {
+    void refreshBackgroundManagedRelayAuth();
+  }
 }
 
 export function activateCloudRelayAccount(
@@ -39,10 +49,16 @@ export function activateCloudRelayAccount(
   tokenProvider: () => Promise<string | null>,
 ): void {
   setAgentAwarenessRelayTokenProvider(tokenProvider, accountId);
-  setManagedRelaySession(appAtomRegistry, {
+  managedRelaySessionOwnership.setOwner("ui", {
     accountId,
     readClerkToken: tokenProvider,
   });
+  void refreshBackgroundManagedRelayAuth();
+}
+
+export function releaseCloudRelayUiAccount(): void {
+  releaseAgentAwarenessRelayTokenProvider();
+  managedRelaySessionOwnership.releaseOwner("ui");
 }
 
 function CloudAuthBridge(props: { readonly children: ReactNode }) {
@@ -147,7 +163,10 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       previousObservedAccount !== userId
     ) {
       previousTokenProviderRef.current = null;
-      deactivateCloudRelayAccount();
+      // Clerk already exposes the new account here. Keep background auth
+      // invalidated until the previous account's cleanup has completed;
+      // activateCloudRelayAccount refreshes it after the transition settles.
+      deactivateCloudRelayAccount({ refreshBackground: false });
       activateAfterTransition(queueAccountCleanup(previous));
     } else {
       activateAfterTransition(accountTransitionRef.current ?? Promise.resolve());
@@ -164,8 +183,7 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       // Unmounting is not a sign-out: the user is usually still signed in, so
       // detach the provider without ending lock-screen activities or wiping the
       // persisted registration (a remount reuses both).
-      releaseAgentAwarenessRelayTokenProvider();
-      setManagedRelaySession(appAtomRegistry, null);
+      releaseCloudRelayUiAccount();
     },
     [],
   );

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
@@ -94,6 +94,27 @@ describe("background managed relay authentication", () => {
     expect(acquireSession).not.toHaveBeenCalled();
   });
 
+  it("does not report active when a stale background owner is rejected", async () => {
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: true,
+        load: vi.fn(),
+        session: {
+          user: { id: "stale-account" },
+          getToken: vi.fn(async () => "stale-token"),
+        },
+      }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession: vi.fn(() => null),
+    });
+
+    expect(result).toEqual({ state: { status: "superseded" } });
+  });
+
   it("returns immediately for missing public configuration", async () => {
     const createClerk = vi.fn();
     const result = await bootstrapBackgroundManagedRelayAuth({

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  bootstrapBackgroundManagedRelayAuth,
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+  startBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+
+vi.mock("@clerk/expo", () => ({ getClerkInstance: vi.fn() }));
+vi.mock("@clerk/expo/token-cache", () => ({ tokenCache: {} }));
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: {} } },
+}));
+
+const configuredPublicConfig = {
+  clerk: {
+    publishableKey: "pk_test_example",
+    jwtTemplate: "relay-template",
+  },
+  relay: { url: "https://relay.example.com/" },
+  observability: {
+    tracesUrl: null,
+    tracesDataset: null,
+    tracesToken: null,
+  },
+} as const;
+
+function deferred<A>() {
+  let resolve!: (value: A) => void;
+  const promise = new Promise<A>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("background managed relay authentication", () => {
+  it("loads Clerk and acquires a renewable session for the active account", async () => {
+    const load = vi.fn(async () => undefined);
+    const getToken = vi.fn(async () => "relay-token");
+    const release = vi.fn();
+    const acquireSession = vi.fn(
+      (_session: {
+        readonly accountId: string;
+        readonly readClerkToken: () => Promise<string | null>;
+      }) => release,
+    );
+    const resolveTokenOptions = vi.fn(() => ({
+      template: "relay-template",
+      skipCache: true as const,
+    }));
+
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: false,
+        load,
+        session: { user: { id: "account-1" }, getToken },
+      }),
+      resolveTokenOptions,
+      acquireSession,
+    });
+
+    expect(result.state).toEqual({ status: "active", accountId: "account-1" });
+    expect(load).toHaveBeenCalledOnce();
+    const session = acquireSession.mock.calls[0]?.[0];
+    expect(session?.accountId).toBe("account-1");
+    await expect(session?.readClerkToken()).resolves.toBe("relay-token");
+    expect(getToken).toHaveBeenCalledWith({
+      template: "relay-template",
+      skipCache: true,
+    });
+  });
+
+  it("treats a loaded Clerk instance without a session as signed out", async () => {
+    const acquireSession = vi.fn(
+      (_session: {
+        readonly accountId: string;
+        readonly readClerkToken: () => Promise<string | null>;
+      }) => vi.fn(),
+    );
+
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({ loaded: true, load: vi.fn(), session: null }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession,
+    });
+
+    expect(result.state).toEqual({ status: "signed-out" });
+    expect(acquireSession).not.toHaveBeenCalled();
+  });
+
+  it("returns immediately for missing public configuration", async () => {
+    const createClerk = vi.fn();
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => ({
+        ...configuredPublicConfig,
+        clerk: { publishableKey: null, jwtTemplate: null },
+      }),
+      createClerk,
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession: vi.fn(
+        (_session: {
+          readonly accountId: string;
+          readonly readClerkToken: () => Promise<string | null>;
+        }) => vi.fn(),
+      ),
+    });
+
+    expect(result.state).toEqual({ status: "unconfigured" });
+    expect(createClerk).not.toHaveBeenCalled();
+  });
+
+  it("reports transient Clerk initialization failures without throwing", async () => {
+    const error = new Error("Network unavailable");
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => {
+        throw error;
+      },
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession: vi.fn(
+        (_session: {
+          readonly accountId: string;
+          readonly readClerkToken: () => Promise<string | null>;
+        }) => vi.fn(),
+      ),
+    });
+
+    expect(result.state).toEqual({ status: "retrying", error });
+  });
+
+  it("cannot restore a stale account after sign-out invalidates an in-flight load", async () => {
+    const load = deferred<void>();
+    const acquireSession = vi.fn(() => vi.fn());
+    const attempt = bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: false,
+        load: () => load.promise,
+        session: {
+          user: { id: "old-account" },
+          getToken: vi.fn(async () => "old-token"),
+        },
+      }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession,
+    });
+
+    invalidateBackgroundManagedRelayAuth();
+    load.resolve();
+
+    await expect(attempt).resolves.toEqual({ state: { status: "superseded" } });
+    expect(acquireSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps the controller alive and retries transient Clerk failures", async () => {
+    const error = new Error("Clerk is temporarily unavailable");
+    const release = vi.fn();
+    const bootstrap = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({
+        state: { status: "active", accountId: "account-1" },
+        release,
+      });
+    const scheduledRetries: Array<{ retry: () => void; delayMs: number }> = [];
+    const controller = startBackgroundManagedRelayAuth({
+      bootstrap,
+      scheduleRetry: (retry, delayMs) => {
+        scheduledRetries.push({ retry, delayMs });
+        return vi.fn();
+      },
+    });
+
+    await expect(controller.firstAttempt).resolves.toEqual({ status: "retrying", error });
+    expect(scheduledRetries).toHaveLength(1);
+    expect(scheduledRetries[0]?.delayMs).toBe(1_000);
+    await expect(controller.retryNow()).resolves.toEqual({
+      status: "active",
+      accountId: "account-1",
+    });
+
+    controller.stop();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("retries a signed-out bootstrap when UI ownership changes", async () => {
+    const release = vi.fn();
+    const bootstrap = vi
+      .fn()
+      .mockResolvedValueOnce({ state: { status: "signed-out" } })
+      .mockResolvedValueOnce({
+        state: { status: "active", accountId: "account-1" },
+        release,
+      });
+    const controller = startBackgroundManagedRelayAuth({ bootstrap });
+    await expect(controller.firstAttempt).resolves.toEqual({ status: "signed-out" });
+
+    await refreshBackgroundManagedRelayAuth();
+
+    expect(bootstrap).toHaveBeenCalledTimes(2);
+    controller.stop();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("queues a fresh bootstrap when refresh is requested during an in-flight attempt", async () => {
+    const first = deferred<{ state: { status: "superseded" } }>();
+    const bootstrap = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValueOnce({ state: { status: "signed-out" } });
+    const controller = startBackgroundManagedRelayAuth({ bootstrap });
+
+    const refreshed = controller.retryNow();
+    expect(bootstrap).toHaveBeenCalledOnce();
+    first.resolve({ state: { status: "superseded" } });
+
+    await expect(refreshed).resolves.toEqual({ status: "signed-out" });
+    expect(bootstrap).toHaveBeenCalledTimes(2);
+    controller.stop();
+  });
+
+  it("stops retrying and releases ownership idempotently", async () => {
+    const release = vi.fn();
+    const controller = startBackgroundManagedRelayAuth({
+      bootstrap: async () => ({
+        state: { status: "active", accountId: "account-1" },
+        release,
+      }),
+    });
+    await controller.firstAttempt;
+
+    controller.stop();
+    controller.stop();
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
@@ -1,0 +1,216 @@
+import { getClerkInstance } from "@clerk/expo";
+import { tokenCache } from "@clerk/expo/token-cache";
+
+import { acquireBackgroundManagedRelaySession } from "./managedRelaySessionOwnership";
+import { resolveCloudPublicConfig, resolveRelayClerkTokenOptions } from "./publicConfig";
+
+const INITIAL_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 30_000;
+
+export type BackgroundManagedRelayAuthState =
+  | { readonly status: "active"; readonly accountId: string }
+  | { readonly status: "signed-out" }
+  | { readonly status: "unconfigured" }
+  | { readonly status: "superseded" }
+  | { readonly status: "retrying"; readonly error: unknown };
+
+interface BackgroundClerkSession {
+  readonly user: { readonly id: string };
+  readonly getToken: (
+    options: ReturnType<typeof resolveRelayClerkTokenOptions>,
+  ) => Promise<string | null>;
+}
+
+interface BackgroundClerk {
+  readonly loaded: boolean;
+  readonly session: BackgroundClerkSession | null | undefined;
+  readonly load: () => Promise<void>;
+}
+
+interface BackgroundManagedRelayAuthDependencies {
+  readonly resolveConfig: typeof resolveCloudPublicConfig;
+  readonly createClerk: (publishableKey: string) => BackgroundClerk;
+  readonly resolveTokenOptions: typeof resolveRelayClerkTokenOptions;
+  readonly acquireSession: typeof acquireBackgroundManagedRelaySession;
+}
+
+interface BackgroundManagedRelayAuthAttempt {
+  readonly state: BackgroundManagedRelayAuthState;
+  readonly release?: () => void;
+}
+
+const defaultDependencies: BackgroundManagedRelayAuthDependencies = {
+  resolveConfig: resolveCloudPublicConfig,
+  createClerk: (publishableKey) => getClerkInstance({ publishableKey, tokenCache }),
+  resolveTokenOptions: resolveRelayClerkTokenOptions,
+  acquireSession: acquireBackgroundManagedRelaySession,
+};
+
+let authenticationEpoch = 0;
+
+/** Prevent an in-flight Clerk load from restoring ownership after sign-out. */
+export function invalidateBackgroundManagedRelayAuth(): void {
+  authenticationEpoch += 1;
+}
+
+export async function bootstrapBackgroundManagedRelayAuth(
+  dependencies: BackgroundManagedRelayAuthDependencies = defaultDependencies,
+): Promise<BackgroundManagedRelayAuthAttempt> {
+  const attemptEpoch = authenticationEpoch;
+  try {
+    const config = dependencies.resolveConfig();
+    if (!config.clerk.publishableKey || !config.clerk.jwtTemplate || !config.relay.url) {
+      return { state: { status: "unconfigured" } };
+    }
+
+    const clerk = dependencies.createClerk(config.clerk.publishableKey);
+    if (!clerk.loaded) {
+      await clerk.load();
+    }
+    const session = clerk.session;
+    if (!session?.user.id) {
+      return { state: { status: "signed-out" } };
+    }
+
+    // Clerk loading crosses an async boundary. Sign-out or account switching
+    // can invalidate this result while it is in flight; never let that stale
+    // account reacquire the background owner after ownership was cleared.
+    if (attemptEpoch !== authenticationEpoch) {
+      return { state: { status: "superseded" } };
+    }
+
+    const release = dependencies.acquireSession({
+      accountId: session.user.id,
+      readClerkToken: () => session.getToken(dependencies.resolveTokenOptions()),
+    });
+    return {
+      state: { status: "active", accountId: session.user.id },
+      release,
+    };
+  } catch (error) {
+    return { state: { status: "retrying", error } };
+  }
+}
+
+interface BackgroundManagedRelayAuthControllerOptions {
+  readonly bootstrap?: () => Promise<BackgroundManagedRelayAuthAttempt>;
+  readonly scheduleRetry?: (retry: () => void, delayMs: number) => () => void;
+  readonly onStateChange?: (state: BackgroundManagedRelayAuthState) => void;
+}
+
+export interface BackgroundManagedRelayAuthController {
+  readonly firstAttempt: Promise<BackgroundManagedRelayAuthState>;
+  readonly retryNow: () => Promise<BackgroundManagedRelayAuthState>;
+  readonly stop: () => void;
+}
+
+const backgroundManagedRelayAuthRefreshers = new Set<
+  () => Promise<BackgroundManagedRelayAuthState>
+>();
+
+export async function refreshBackgroundManagedRelayAuth(): Promise<void> {
+  await Promise.all([...backgroundManagedRelayAuthRefreshers].map((refresh) => refresh()));
+}
+
+function defaultScheduleRetry(retry: () => void, delayMs: number): () => void {
+  const timeout = setTimeout(retry, delayMs);
+  return () => clearTimeout(timeout);
+}
+
+export function startBackgroundManagedRelayAuth(
+  options: BackgroundManagedRelayAuthControllerOptions = {},
+): BackgroundManagedRelayAuthController {
+  const bootstrap = options.bootstrap ?? (() => bootstrapBackgroundManagedRelayAuth());
+  const scheduleRetry = options.scheduleRetry ?? defaultScheduleRetry;
+  let stopped = false;
+  let failureCount = 0;
+  let releaseSession: (() => void) | null = null;
+  let cancelRetry: (() => void) | null = null;
+  let inFlight: Promise<BackgroundManagedRelayAuthState> | null = null;
+  let refreshRequested = false;
+
+  const cancelScheduledRetry = () => {
+    cancelRetry?.();
+    cancelRetry = null;
+  };
+
+  const runAttempt = (): Promise<BackgroundManagedRelayAuthState> => {
+    if (inFlight) {
+      return inFlight;
+    }
+    cancelScheduledRetry();
+    const operation = (async () => {
+      const attempt = await bootstrap().catch(
+        (error): BackgroundManagedRelayAuthAttempt => ({
+          state: { status: "retrying", error },
+        }),
+      );
+      if (stopped) {
+        attempt.release?.();
+        return attempt.state;
+      }
+
+      if (attempt.state.status === "active") {
+        failureCount = 0;
+        const previousRelease = releaseSession;
+        releaseSession = attempt.release ?? null;
+        previousRelease?.();
+      } else if (attempt.state.status === "retrying") {
+        const retryDelay = Math.min(INITIAL_RETRY_DELAY_MS * 2 ** failureCount, MAX_RETRY_DELAY_MS);
+        failureCount += 1;
+        cancelRetry = scheduleRetry(() => {
+          cancelRetry = null;
+          void runAttempt();
+        }, retryDelay);
+      } else {
+        releaseSession?.();
+        releaseSession = null;
+      }
+
+      options.onStateChange?.(attempt.state);
+      return attempt.state;
+    })();
+    const trackedOperation = operation.finally(() => {
+      if (inFlight === trackedOperation) {
+        inFlight = null;
+      }
+    });
+    inFlight = trackedOperation;
+    return trackedOperation;
+  };
+
+  const requestAttempt = (): Promise<BackgroundManagedRelayAuthState> => {
+    const currentAttempt = inFlight;
+    if (currentAttempt === null) {
+      return runAttempt();
+    }
+    // Coalesce refreshes, but guarantee one fresh bootstrap after the current
+    // attempt. Returning the in-flight promise alone would let a sign-out
+    // invalidation be consumed by the stale attempt without rereading Clerk.
+    refreshRequested = true;
+    return currentAttempt.then((state) => {
+      if (stopped || !refreshRequested) {
+        return state;
+      }
+      refreshRequested = false;
+      return runAttempt();
+    });
+  };
+
+  backgroundManagedRelayAuthRefreshers.add(requestAttempt);
+  const firstAttempt = runAttempt();
+  return {
+    firstAttempt,
+    retryNow: requestAttempt,
+    stop() {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      backgroundManagedRelayAuthRefreshers.delete(requestAttempt);
+      cancelScheduledRetry();
+      releaseSession?.();
+      releaseSession = null;
+    },
+  };
+}

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
@@ -83,6 +83,9 @@ export async function bootstrapBackgroundManagedRelayAuth(
       accountId: session.user.id,
       readClerkToken: () => session.getToken(dependencies.resolveTokenOptions()),
     });
+    if (release === null) {
+      return { state: { status: "superseded" } };
+    }
     return {
       state: { status: "active", accountId: session.user.id },
       release,

--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -96,6 +96,9 @@ function cloudClientLayer() {
         clearAgentAwarenessRegistrationRecord: Effect.void,
         loadRecentThreadShortcuts: Effect.succeed([]),
         saveRecentThreadShortcuts: () => Effect.void,
+        loadBackgroundConnectionRetainedThread: Effect.succeed(null),
+        saveBackgroundConnectionRetainedThread: () => Effect.void,
+        clearBackgroundConnectionRetainedThread: Effect.void,
       }),
     ),
     ManagedRelay.layer({

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
@@ -1,0 +1,108 @@
+import { managedRelaySessionAtom } from "@t3tools/client-runtime/relay";
+import { AtomRegistry } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createManagedRelaySessionOwnership } from "./managedRelaySessionOwnership";
+
+function createHarness() {
+  const registry = AtomRegistry.make();
+  const ownership = createManagedRelaySessionOwnership(registry);
+  const provider = (token: string) => vi.fn(async () => token);
+  return { ownership, provider, registry };
+}
+
+describe("managed relay session ownership", () => {
+  it("keeps the UI owner effective while a background owner is present", () => {
+    const { ownership, provider, registry } = createHarness();
+    const backgroundProvider = provider("background");
+    const uiProvider = provider("ui");
+
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: backgroundProvider,
+    });
+    ownership.setOwner("ui", { accountId: "account-1", readClerkToken: uiProvider });
+
+    const session = registry.get(managedRelaySessionAtom);
+    expect(session?.accountId).toBe("account-1");
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+  });
+
+  it("releasing one owner preserves the other owner", () => {
+    const { ownership, provider, registry } = createHarness();
+    const releaseBackground = ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+    ownership.setOwner("ui", {
+      accountId: "account-1",
+      readClerkToken: provider("ui"),
+    });
+
+    releaseBackground();
+    expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("does not let an obsolete release remove a newer lease", () => {
+    const { ownership, provider, registry } = createHarness();
+    const releaseFirst = ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("first"),
+    });
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("second"),
+    });
+
+    releaseFirst();
+    expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+  });
+
+  it("invalidates a stale background owner on a UI account switch", () => {
+    const { ownership, provider, registry } = createHarness();
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+    ownership.setOwner("ui", {
+      accountId: "account-2",
+      readClerkToken: provider("ui"),
+    });
+
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("rejects a stale background bootstrap that completes after a UI switch", () => {
+    const { ownership, provider, registry } = createHarness();
+    ownership.setOwner("ui", {
+      accountId: "account-2",
+      readClerkToken: provider("ui"),
+    });
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("clears both owners for sign-out", () => {
+    const { ownership, provider, registry } = createHarness();
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+    ownership.setOwner("ui", {
+      accountId: "account-1",
+      readClerkToken: provider("ui"),
+    });
+
+    ownership.clear();
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
@@ -40,7 +40,8 @@ describe("managed relay session ownership", () => {
       readClerkToken: provider("ui"),
     });
 
-    releaseBackground();
+    expect(releaseBackground).not.toBeNull();
+    releaseBackground?.();
     expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
     ownership.releaseOwner("ui");
     expect(registry.get(managedRelaySessionAtom)).toBeNull();
@@ -57,7 +58,8 @@ describe("managed relay session ownership", () => {
       readClerkToken: provider("second"),
     });
 
-    releaseFirst();
+    expect(releaseFirst).not.toBeNull();
+    releaseFirst?.();
     expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
   });
 
@@ -82,11 +84,12 @@ describe("managed relay session ownership", () => {
       accountId: "account-2",
       readClerkToken: provider("ui"),
     });
-    ownership.setOwner("background", {
+    const rejected = ownership.setOwner("background", {
       accountId: "account-1",
       readClerkToken: provider("background"),
     });
 
+    expect(rejected).toBeNull();
     ownership.releaseOwner("ui");
     expect(registry.get(managedRelaySessionAtom)).toBeNull();
   });

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
@@ -16,7 +16,7 @@ export interface ManagedRelaySessionOwnership {
   readonly setOwner: (
     owner: ManagedRelaySessionOwner,
     session: ManagedRelaySessionInput,
-  ) => () => void;
+  ) => (() => void) | null;
   readonly releaseOwner: (owner: ManagedRelaySessionOwner) => void;
   readonly clear: () => void;
 }
@@ -66,7 +66,7 @@ export function createManagedRelaySessionOwnership(
         // A headless bootstrap may finish after the user switches accounts in
         // the UI. Never retain that stale result for a later UI unmount.
         if (ui && ui.accountId !== session.accountId) {
-          return () => undefined;
+          return null;
         }
         background = lease;
       }
@@ -93,6 +93,6 @@ export const managedRelaySessionOwnership = createManagedRelaySessionOwnership(a
 
 export function acquireBackgroundManagedRelaySession(
   session: ManagedRelaySessionInput,
-): () => void {
+): (() => void) | null {
   return managedRelaySessionOwnership.setOwner("background", session);
 }

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
@@ -1,0 +1,98 @@
+import {
+  type ManagedRelaySessionInput,
+  setManagedRelaySession,
+} from "@t3tools/client-runtime/relay";
+import type { AtomRegistry } from "effect/unstable/reactivity";
+
+import { appAtomRegistry } from "../../state/atom-registry";
+
+export type ManagedRelaySessionOwner = "ui" | "background";
+
+interface OwnerLease extends ManagedRelaySessionInput {
+  readonly id: number;
+}
+
+export interface ManagedRelaySessionOwnership {
+  readonly setOwner: (
+    owner: ManagedRelaySessionOwner,
+    session: ManagedRelaySessionInput,
+  ) => () => void;
+  readonly releaseOwner: (owner: ManagedRelaySessionOwner) => void;
+  readonly clear: () => void;
+}
+
+export function createManagedRelaySessionOwnership(
+  registry: AtomRegistry.AtomRegistry,
+): ManagedRelaySessionOwnership {
+  let nextLeaseId = 0;
+  let ui: OwnerLease | null = null;
+  let background: OwnerLease | null = null;
+  let appliedLeaseId: number | null = null;
+
+  const applyEffectiveOwner = () => {
+    const effective = ui ?? background;
+    const effectiveLeaseId = effective?.id ?? null;
+    if (effectiveLeaseId === appliedLeaseId) {
+      return;
+    }
+    appliedLeaseId = effectiveLeaseId;
+    setManagedRelaySession(registry, effective);
+  };
+
+  const releaseLease = (owner: ManagedRelaySessionOwner, leaseId: number) => {
+    if (owner === "ui") {
+      if (ui?.id !== leaseId) {
+        return;
+      }
+      ui = null;
+    } else {
+      if (background?.id !== leaseId) {
+        return;
+      }
+      background = null;
+    }
+    applyEffectiveOwner();
+  };
+
+  return {
+    setOwner(owner, session) {
+      const lease: OwnerLease = { ...session, id: ++nextLeaseId };
+      if (owner === "ui") {
+        ui = lease;
+        if (background?.accountId !== session.accountId) {
+          background = null;
+        }
+      } else {
+        // A headless bootstrap may finish after the user switches accounts in
+        // the UI. Never retain that stale result for a later UI unmount.
+        if (ui && ui.accountId !== session.accountId) {
+          return () => undefined;
+        }
+        background = lease;
+      }
+      applyEffectiveOwner();
+      return () => releaseLease(owner, lease.id);
+    },
+    releaseOwner(owner) {
+      if (owner === "ui") {
+        ui = null;
+      } else {
+        background = null;
+      }
+      applyEffectiveOwner();
+    },
+    clear() {
+      ui = null;
+      background = null;
+      applyEffectiveOwner();
+    },
+  };
+}
+
+export const managedRelaySessionOwnership = createManagedRelaySessionOwnership(appAtomRegistry);
+
+export function acquireBackgroundManagedRelaySession(
+  session: ManagedRelaySessionInput,
+): () => void {
+  return managedRelaySessionOwnership.setOwner("background", session);
+}

--- a/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
@@ -12,6 +12,7 @@ import { AppText as Text, AppTextInput as TextInput } from "../../components/App
 import { ErrorBanner } from "../../components/ErrorBanner";
 import { ConnectionSheetButton } from "./ConnectionSheetButton";
 import { buildPairingUrl, extractPairingUrlFromQrPayload, parsePairingUrl } from "./pairing";
+import { personalPreviewDefaultEnvironmentHost } from "./personal-preview-environment";
 import { useRemoteConnections } from "../../state/use-remote-environment-registry";
 
 type ConnectionsNewRouteParams = {
@@ -46,6 +47,7 @@ export function ConnectionsNewRouteScreen({
   const [cameraPermission, requestCameraPermission] = useCameraPermissions();
   const [scannerLocked, setScannerLocked] = useState(false);
   const attemptedAutoConnectRef = useRef<string | null>(null);
+  const defaultEnvironmentHost = personalPreviewDefaultEnvironmentHost();
 
   const headerIconColor = useThemeColor("--color-icon");
 
@@ -53,9 +55,9 @@ export function ConnectionsNewRouteScreen({
 
   useEffect(() => {
     const { host, code } = parsePairingUrl(connectionPairingUrl);
-    setHostInput(host);
+    setHostInput(host || defaultEnvironmentHost);
     setCodeInput(code);
-  }, [connectionPairingUrl]);
+  }, [connectionPairingUrl, defaultEnvironmentHost]);
 
   useEffect(() => {
     if (routePairingUrl.length === 0) {
@@ -63,9 +65,9 @@ export function ConnectionsNewRouteScreen({
     }
 
     const { host, code } = parsePairingUrl(routePairingUrl);
-    setHostInput(host);
+    setHostInput(host || defaultEnvironmentHost);
     setCodeInput(code);
-  }, [routePairingUrl]);
+  }, [defaultEnvironmentHost, routePairingUrl]);
 
   useEffect(() => {
     if (pairingConnectionError) {

--- a/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
@@ -12,11 +12,13 @@ import { AppText as Text, AppTextInput as TextInput } from "../../components/App
 import { ErrorBanner } from "../../components/ErrorBanner";
 import { ConnectionSheetButton } from "./ConnectionSheetButton";
 import { extractPairingUrlFromQrPayload } from "./pairing";
+import { personalPreviewDefaultEnvironmentHost } from "./personal-preview-environment";
 import { useRemoteConnections } from "../../state/use-remote-environment-registry";
 import { buildPairingUrl, parsePairingUrl } from "./pairing";
 
 type ConnectionsNewRouteParams = {
   readonly mode?: string;
+  readonly pairingUrl?: string;
 };
 
 export function ConnectionsNewRouteScreen({
@@ -37,16 +39,27 @@ export function ConnectionsNewRouteScreen({
   const [showScanner, setShowScanner] = useState(params.mode === "scan_qr");
   const [cameraPermission, requestCameraPermission] = useCameraPermissions();
   const [scannerLocked, setScannerLocked] = useState(false);
+  const defaultEnvironmentHost = personalPreviewDefaultEnvironmentHost();
 
   const headerIconColor = useThemeColor("--color-icon");
 
   const connectDisabled = isSubmitting || hostInput.trim().length === 0;
 
   useEffect(() => {
-    const { host, code } = parsePairingUrl(connectionPairingUrl);
-    setHostInput(host);
+    const routePairingUrl = params.pairingUrl?.trim() ?? "";
+    const pairingUrl = routePairingUrl || connectionPairingUrl;
+    const { host, code } = parsePairingUrl(pairingUrl);
+    setHostInput(host || defaultEnvironmentHost);
     setCodeInput(code);
-  }, [connectionPairingUrl]);
+    if (routePairingUrl && routePairingUrl !== connectionPairingUrl) {
+      onChangeConnectionPairingUrl(routePairingUrl);
+    }
+  }, [
+    connectionPairingUrl,
+    defaultEnvironmentHost,
+    onChangeConnectionPairingUrl,
+    params.pairingUrl,
+  ]);
 
   useEffect(() => {
     if (pairingConnectionError) {

--- a/apps/mobile/src/features/connection/personal-preview-environment.test.ts
+++ b/apps/mobile/src/features/connection/personal-preview-environment.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: {} } },
+}));
+
+import { parsePersonalPreviewDefaultEnvironmentHost } from "./personal-preview-environment";
+
+describe("personal preview default environment", () => {
+  it("accepts a plain HTTP or HTTPS origin", () => {
+    expect(parsePersonalPreviewDefaultEnvironmentHost(" http://100.97.53.68:7791/ ")).toBe(
+      "http://100.97.53.68:7791",
+    );
+    expect(parsePersonalPreviewDefaultEnvironmentHost("https://vps.tailnet.ts.net")).toBe(
+      "https://vps.tailnet.ts.net",
+    );
+  });
+
+  it("rejects credentials, paths, and unsupported schemes", () => {
+    expect(parsePersonalPreviewDefaultEnvironmentHost("https://user:secret@example.test")).toBe("");
+    expect(parsePersonalPreviewDefaultEnvironmentHost("https://example.test/private")).toBe("");
+    expect(parsePersonalPreviewDefaultEnvironmentHost("file:///tmp/environment")).toBe("");
+  });
+});

--- a/apps/mobile/src/features/connection/personal-preview-environment.ts
+++ b/apps/mobile/src/features/connection/personal-preview-environment.ts
@@ -1,5 +1,8 @@
 import Constants from "expo-constants";
 
+const BUILD_DEFAULT_ENVIRONMENT_HOST =
+  process.env.EXPO_PUBLIC_T3CODE_PERSONAL_PREVIEW_DEFAULT_ENVIRONMENT_HOST;
+
 export function parsePersonalPreviewDefaultEnvironmentHost(value: unknown): string {
   if (typeof value !== "string") return "";
   const trimmed = value.trim();
@@ -23,6 +26,7 @@ export function parsePersonalPreviewDefaultEnvironmentHost(value: unknown): stri
 
 export function personalPreviewDefaultEnvironmentHost(): string {
   return parsePersonalPreviewDefaultEnvironmentHost(
-    Constants.expoConfig?.extra?.personalPreviewDefaultEnvironmentHost,
+    BUILD_DEFAULT_ENVIRONMENT_HOST ??
+      Constants.expoConfig?.extra?.personalPreviewDefaultEnvironmentHost,
   );
 }

--- a/apps/mobile/src/features/connection/personal-preview-environment.ts
+++ b/apps/mobile/src/features/connection/personal-preview-environment.ts
@@ -1,0 +1,28 @@
+import Constants from "expo-constants";
+
+export function parsePersonalPreviewDefaultEnvironmentHost(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  try {
+    const url = new URL(trimmed);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username !== "" ||
+      url.password !== "" ||
+      url.pathname !== "/" ||
+      url.search !== "" ||
+      url.hash !== ""
+    ) {
+      return "";
+    }
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return "";
+  }
+}
+
+export function personalPreviewDefaultEnvironmentHost(): string {
+  return parsePersonalPreviewDefaultEnvironmentHost(
+    Constants.expoConfig?.extra?.personalPreviewDefaultEnvironmentHost,
+  );
+}

--- a/apps/mobile/src/features/connection/useConnectionController.ts
+++ b/apps/mobile/src/features/connection/useConnectionController.ts
@@ -10,6 +10,7 @@ import type {
 } from "@t3tools/contracts/relay";
 import * as Option from "effect/Option";
 import { useCallback, useMemo } from "react";
+import { Platform } from "react-native";
 
 import { environmentCatalog } from "../../connection/catalog";
 import {
@@ -20,6 +21,10 @@ import { useEnvironments } from "../../state/environments";
 import { relayEnvironmentDiscovery } from "../../state/relay";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { projectWorkspaceEnvironment, type WorkspaceEnvironment } from "../../state/workspaceModel";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 
 export interface RelayEnvironmentView {
   readonly environment: RelayClientEnvironmentRecord;
@@ -85,7 +90,17 @@ export function useConnectionController() {
     [registerEnvironment],
   );
   const removeEnvironment = useCallback(
-    (environmentId: EnvironmentId) => removeEnvironmentMutation(environmentId),
+    async (environmentId: EnvironmentId) => {
+      const result = await removeEnvironmentMutation(environmentId);
+      if (
+        Platform.OS === "android" &&
+        result._tag === "Success" &&
+        getBackgroundConnectionRetainedThreadSnapshot().thread?.environmentId === environmentId
+      ) {
+        void clearBackgroundConnectionRetainedThread();
+      }
+      return result;
+    },
     [removeEnvironmentMutation],
   );
   const retryEnvironment = useCallback(

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -197,6 +197,12 @@ export function HomeRouteScreen() {
               params: { screen: "Settings" },
             })
           }
+          onOpenArchivedThreads={() =>
+            navigation.navigate("SettingsSheet", {
+              screen: "SettingsContent",
+              params: { screen: "SettingsArchive" },
+            })
+          }
           onProjectSortOrderChange={setProjectSortOrder}
           onSearchQueryChange={setSearchQuery}
           onSelectThread={(thread) => {

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -160,6 +160,9 @@ export function HomeRouteScreen() {
           onOpenEnvironments={() =>
             navigation.navigate("SettingsSheet", { screen: "SettingsEnvironments" })
           }
+          onOpenArchivedThreads={() =>
+            navigation.navigate("SettingsSheet", { screen: "SettingsArchive" })
+          }
           onOpenSettings={() => navigation.navigate("SettingsSheet", { screen: "Settings" })}
           onProjectSortOrderChange={setProjectSortOrder}
           onSearchQueryChange={setSearchQuery}

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -71,6 +71,7 @@ import {
   sortHomeProjectScopes,
   type HomeProjectSortOrder,
 } from "./homeThreadList";
+import { ArchivedThreadsShelf, useArchivedThreadsShelfData } from "../archive/ArchivedThreadsShelf";
 import { SwipeableScrollGateProvider, useSwipeableScrollGate } from "./thread-swipe-actions";
 
 /* ─── Types ──────────────────────────────────────────────────────────── */
@@ -96,6 +97,8 @@ interface HomeScreenProps {
   readonly onProjectSortOrderChange: (sortOrder: HomeProjectSortOrder) => void;
   readonly onThreadSortOrderChange: (sortOrder: SidebarThreadSortOrder) => void;
   readonly onAddConnection: () => void;
+  readonly onOpenEnvironments: () => void;
+  readonly onOpenArchivedThreads: () => void;
   readonly onOpenSettings: () => void;
   readonly onStartNewTask: () => void;
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
@@ -339,6 +342,12 @@ export function HomeScreen(props: HomeScreenProps) {
           ),
     [selectedProjectScope],
   );
+  const archivedThreadsShelfData = useArchivedThreadsShelfData({
+    environments: props.environments,
+    environmentId: props.selectedEnvironmentId,
+    projectKeys: selectedProjectRefKeys,
+    searchQuery: props.searchQuery,
+  });
   const scopedProjects = useMemo(
     () =>
       selectedProjectRefKeys === null
@@ -1039,7 +1048,10 @@ export function HomeScreen(props: HomeScreenProps) {
   // full-page "No threads yet". Settled threads are unarchived live shells,
   // so the v1 check already covers v2.
   const hasAnyThreads =
-    props.threads.some((thread) => thread.archivedAt === null) || props.pendingTasks.length > 0;
+    props.threads.some((thread) => thread.archivedAt === null) ||
+    props.pendingTasks.length > 0 ||
+    archivedThreadsShelfData.hasAnyArchivedThreads ||
+    archivedThreadsShelfData.error !== null;
   const hasResults = projectGroups.length > 0;
   const selectedEnvironmentLabel =
     props.selectedEnvironmentId === null
@@ -1131,19 +1143,28 @@ export function HomeScreen(props: HomeScreenProps) {
             extraData={v2ExtraData}
             ListHeaderComponent={v2ListHeader}
             ListFooterComponent={
-              settledShelfExpanded && threadListV2Layout.hiddenSettledCount > 0 ? (
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={`Show ${Math.min(threadListV2Layout.hiddenSettledCount, THREAD_LIST_V2_SETTLED_PAGE_COUNT)} more settled threads`}
-                  onPress={showMoreSettled}
-                  className="mx-4 mt-2 items-center rounded-lg border border-dashed border-border py-2.5"
-                  style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-                >
-                  <Text className="text-xs font-t3-medium text-foreground-muted">
-                    Show more ({threadListV2Layout.hiddenSettledCount} settled hidden)
-                  </Text>
-                </Pressable>
-              ) : null
+              <>
+                {settledShelfExpanded && threadListV2Layout.hiddenSettledCount > 0 ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={`Show ${Math.min(threadListV2Layout.hiddenSettledCount, THREAD_LIST_V2_SETTLED_PAGE_COUNT)} more settled threads`}
+                    onPress={showMoreSettled}
+                    className="mx-4 mt-2 items-center rounded-lg border border-dashed border-border py-2.5"
+                    style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+                  >
+                    <Text className="text-xs font-t3-medium text-foreground-muted">
+                      Show more ({threadListV2Layout.hiddenSettledCount} settled hidden)
+                    </Text>
+                  </Pressable>
+                ) : null}
+                <ArchivedThreadsShelf
+                  data={archivedThreadsShelfData}
+                  onOpenArchive={props.onOpenArchivedThreads}
+                  onSwipeableClose={handleSwipeableClose}
+                  onSwipeableWillOpen={handleSwipeableWillOpen}
+                  searchQuery={props.searchQuery}
+                />
+              </>
             }
             ListEmptyComponent={v2ListEmpty}
             style={{ flex: 1 }}
@@ -1185,6 +1206,15 @@ export function HomeScreen(props: HomeScreenProps) {
           estimatedItemSize={ESTIMATED_THREAD_ROW_HEIGHT}
           extraData={extraData}
           ListHeaderComponent={listHeader}
+          ListFooterComponent={
+            <ArchivedThreadsShelf
+              data={archivedThreadsShelfData}
+              onOpenArchive={props.onOpenArchivedThreads}
+              onSwipeableClose={handleSwipeableClose}
+              onSwipeableWillOpen={handleSwipeableWillOpen}
+              searchQuery={props.searchQuery}
+            />
+          }
           ListEmptyComponent={listEmpty}
           style={{ flex: 1 }}
           automaticallyAdjustsScrollIndicatorInsets={NATIVE_LIQUID_GLASS_SUPPORTED}

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -68,6 +68,7 @@ import {
 import {
   buildHomeProjectScopes,
   buildHomeThreadGroups,
+  hasVisibleHomeThreadResults,
   sortHomeProjectScopes,
   type HomeProjectSortOrder,
 } from "./homeThreadList";
@@ -1052,7 +1053,14 @@ export function HomeScreen(props: HomeScreenProps) {
     props.pendingTasks.length > 0 ||
     archivedThreadsShelfData.hasAnyArchivedThreads ||
     archivedThreadsShelfData.error !== null;
-  const hasResults = projectGroups.length > 0;
+  const hasVisibleV1Results = hasVisibleHomeThreadResults({
+    activeResultCount: projectGroups.length,
+    archivedResultCount: archivedThreadsShelfData.threadCount,
+  });
+  const hasVisibleV2Results = hasVisibleHomeThreadResults({
+    activeResultCount: threadListV2Items.length,
+    archivedResultCount: archivedThreadsShelfData.threadCount,
+  });
   const selectedEnvironmentLabel =
     props.selectedEnvironmentId === null
       ? null
@@ -1099,7 +1107,7 @@ export function HomeScreen(props: HomeScreenProps) {
   // mobile — the menu is the one filter surface).
   const v2ListHeader = listHeader;
 
-  const listEmpty = !hasResults ? (
+  const listEmpty = !hasVisibleV1Results ? (
     hasSearchQuery && threadSearch.isPending ? null : hasSearchQuery ? (
       <EmptyState title="No results" detail={`No threads matching "${props.searchQuery}".`} />
     ) : selectedProjectScope !== null ? (
@@ -1119,8 +1127,9 @@ export function HomeScreen(props: HomeScreenProps) {
   // Self-contained: v1's listEmpty keys off projectGroups, which ignores the
   // v2 project scope, so it can be null (results elsewhere) while this list
   // is empty. Snoozed threads need no special empty state: their shelf header
-  // is a list row even while collapsed.
-  const v2ListEmpty =
+  // is a list row even while collapsed. Archived matches live in the footer,
+  // so they explicitly suppress the active-list empty state above.
+  const v2ListEmpty = !hasVisibleV2Results ? (
     hasSearchQuery && threadSearch.isPending ? null : hasSearchQuery ? (
       <EmptyState title="No results" detail={`No threads matching "${props.searchQuery}".`} />
     ) : v2ScopedProjectGroup !== null ? (
@@ -1130,7 +1139,8 @@ export function HomeScreen(props: HomeScreenProps) {
       />
     ) : (
       listEmpty
-    );
+    )
+  ) : null;
 
   if (threadListV2Enabled) {
     return (

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -67,6 +67,7 @@ import {
 import {
   buildHomeProjectScopes,
   buildHomeThreadGroups,
+  hasVisibleHomeThreadResults,
   sortHomeProjectScopes,
   type HomeProjectSortOrder,
 } from "./homeThreadList";
@@ -944,7 +945,14 @@ export function HomeScreen(props: HomeScreenProps) {
     props.pendingTasks.length > 0 ||
     archivedThreadsShelfData.hasAnyArchivedThreads ||
     archivedThreadsShelfData.error !== null;
-  const hasResults = projectGroups.length > 0;
+  const hasVisibleV1Results = hasVisibleHomeThreadResults({
+    activeResultCount: projectGroups.length,
+    archivedResultCount: archivedThreadsShelfData.threadCount,
+  });
+  const hasVisibleV2Results = hasVisibleHomeThreadResults({
+    activeResultCount: threadListV2Items.length,
+    archivedResultCount: archivedThreadsShelfData.threadCount,
+  });
   const selectedEnvironmentLabel =
     props.selectedEnvironmentId === null
       ? null
@@ -1022,7 +1030,7 @@ export function HomeScreen(props: HomeScreenProps) {
   // mobile — the menu is the one filter surface).
   const v2ListHeader = listHeader;
 
-  const listEmpty = !hasResults ? (
+  const listEmpty = !hasVisibleV1Results ? (
     hasSearchQuery && threadSearch.isPending ? null : hasSearchQuery ? (
       <EmptyState title="No results" detail={`No threads matching "${props.searchQuery}".`} />
     ) : selectedProjectScope !== null ? (
@@ -1042,8 +1050,9 @@ export function HomeScreen(props: HomeScreenProps) {
   // Self-contained: v1's listEmpty keys off projectGroups, which ignores the
   // v2 project scope, so it can be null (results elsewhere) while this list
   // is empty. Snoozed threads need no special empty state: their shelf header
-  // is a list row even while collapsed.
-  const v2ListEmpty =
+  // is a list row even while collapsed. Archived matches live in the footer,
+  // so they explicitly suppress the active-list empty state above.
+  const v2ListEmpty = !hasVisibleV2Results ? (
     hasSearchQuery && threadSearch.isPending ? null : hasSearchQuery ? (
       <EmptyState title="No results" detail={`No threads matching "${props.searchQuery}".`} />
     ) : v2ScopedProjectGroup !== null ? (
@@ -1053,7 +1062,8 @@ export function HomeScreen(props: HomeScreenProps) {
       />
     ) : (
       listEmpty
-    );
+    )
+  ) : null;
 
   if (threadListV2Enabled) {
     return (

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -73,6 +73,7 @@ import {
 import { SwipeableScrollGateProvider, useSwipeableScrollGate } from "./thread-swipe-actions";
 import { WorkspaceConnectionStatus } from "./WorkspaceConnectionStatus";
 import { shouldShowWorkspaceConnectionStatus } from "./workspace-connection-status";
+import { ArchivedThreadsShelf, useArchivedThreadsShelfData } from "../archive/ArchivedThreadsShelf";
 
 /* ─── Types ──────────────────────────────────────────────────────────── */
 
@@ -98,6 +99,7 @@ interface HomeScreenProps {
   readonly onThreadSortOrderChange: (sortOrder: SidebarThreadSortOrder) => void;
   readonly onAddConnection: () => void;
   readonly onOpenEnvironments: () => void;
+  readonly onOpenArchivedThreads: () => void;
   readonly onOpenSettings: () => void;
   readonly onStartNewTask: () => void;
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
@@ -331,6 +333,12 @@ export function HomeScreen(props: HomeScreenProps) {
           ),
     [selectedProjectScope],
   );
+  const archivedThreadsShelfData = useArchivedThreadsShelfData({
+    environments: props.environments,
+    environmentId: props.selectedEnvironmentId,
+    projectKeys: selectedProjectRefKeys,
+    searchQuery: props.searchQuery,
+  });
   const scopedProjects = useMemo(
     () =>
       selectedProjectRefKeys === null
@@ -932,7 +940,10 @@ export function HomeScreen(props: HomeScreenProps) {
   // full-page "No threads yet". Settled threads are unarchived live shells,
   // so the v1 check already covers v2.
   const hasAnyThreads =
-    props.threads.some((thread) => thread.archivedAt === null) || props.pendingTasks.length > 0;
+    props.threads.some((thread) => thread.archivedAt === null) ||
+    props.pendingTasks.length > 0 ||
+    archivedThreadsShelfData.hasAnyArchivedThreads ||
+    archivedThreadsShelfData.error !== null;
   const hasResults = projectGroups.length > 0;
   const selectedEnvironmentLabel =
     props.selectedEnvironmentId === null
@@ -1055,19 +1066,28 @@ export function HomeScreen(props: HomeScreenProps) {
             extraData={v2ExtraData}
             ListHeaderComponent={v2ListHeader}
             ListFooterComponent={
-              settledShelfExpanded && threadListV2Layout.hiddenSettledCount > 0 ? (
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={`Show ${Math.min(threadListV2Layout.hiddenSettledCount, THREAD_LIST_V2_SETTLED_PAGE_COUNT)} more settled threads`}
-                  onPress={showMoreSettled}
-                  className="mx-4 mt-2 items-center rounded-lg border border-dashed border-border py-2.5"
-                  style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-                >
-                  <Text className="text-xs font-t3-medium text-foreground-muted">
-                    Show more ({threadListV2Layout.hiddenSettledCount} settled hidden)
-                  </Text>
-                </Pressable>
-              ) : null
+              <>
+                {settledShelfExpanded && threadListV2Layout.hiddenSettledCount > 0 ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={`Show ${Math.min(threadListV2Layout.hiddenSettledCount, THREAD_LIST_V2_SETTLED_PAGE_COUNT)} more settled threads`}
+                    onPress={showMoreSettled}
+                    className="mx-4 mt-2 items-center rounded-lg border border-dashed border-border py-2.5"
+                    style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+                  >
+                    <Text className="text-xs font-t3-medium text-foreground-muted">
+                      Show more ({threadListV2Layout.hiddenSettledCount} settled hidden)
+                    </Text>
+                  </Pressable>
+                ) : null}
+                <ArchivedThreadsShelf
+                  data={archivedThreadsShelfData}
+                  onOpenArchive={props.onOpenArchivedThreads}
+                  onSwipeableClose={handleSwipeableClose}
+                  onSwipeableWillOpen={handleSwipeableWillOpen}
+                  searchQuery={props.searchQuery}
+                />
+              </>
             }
             ListEmptyComponent={v2ListEmpty}
             style={{ flex: 1 }}
@@ -1110,6 +1130,15 @@ export function HomeScreen(props: HomeScreenProps) {
           estimatedItemSize={ESTIMATED_THREAD_ROW_HEIGHT}
           extraData={extraData}
           ListHeaderComponent={listHeader}
+          ListFooterComponent={
+            <ArchivedThreadsShelf
+              data={archivedThreadsShelfData}
+              onOpenArchive={props.onOpenArchivedThreads}
+              onSwipeableClose={handleSwipeableClose}
+              onSwipeableWillOpen={handleSwipeableWillOpen}
+              searchQuery={props.searchQuery}
+            />
+          }
           ListEmptyComponent={listEmpty}
           style={{ flex: 1 }}
           automaticallyAdjustsScrollIndicatorInsets={NATIVE_LIQUID_GLASS_SUPPORTED}

--- a/apps/mobile/src/features/home/homeThreadList.test.ts
+++ b/apps/mobile/src/features/home/homeThreadList.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildHomeProjectScopes,
   buildHomeThreadGroups,
+  hasVisibleHomeThreadResults,
   sortHomeProjectScopes,
 } from "./homeThreadList";
 
@@ -52,6 +53,21 @@ function makeThread(
 }
 
 const NOW = Date.parse("2026-06-29T00:00:00.000Z");
+
+describe("hasVisibleHomeThreadResults", () => {
+  it.each([
+    { activeResultCount: 0, archivedResultCount: 0, expected: false },
+    { activeResultCount: 1, archivedResultCount: 0, expected: true },
+    { activeResultCount: 0, archivedResultCount: 1, expected: true },
+  ])(
+    "returns $expected for $activeResultCount active and $archivedResultCount archived results",
+    ({ activeResultCount, archivedResultCount, expected }) => {
+      expect(hasVisibleHomeThreadResults({ activeResultCount, archivedResultCount })).toBe(
+        expected,
+      );
+    },
+  );
+});
 
 function buildGroups(
   projects: ReadonlyArray<EnvironmentProject>,

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -29,6 +29,13 @@ import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 
 export type HomeProjectSortOrder = Exclude<SidebarProjectSortOrder, "manual">;
 
+export function hasVisibleHomeThreadResults(input: {
+  readonly activeResultCount: number;
+  readonly archivedResultCount: number;
+}): boolean {
+  return input.activeResultCount > 0 || input.archivedResultCount > 0;
+}
+
 export interface HomeProjectScope {
   readonly key: string;
   readonly title: string;

--- a/apps/mobile/src/features/home/useThreadListActions.ts
+++ b/apps/mobile/src/features/home/useThreadListActions.ts
@@ -3,7 +3,7 @@ import { canSettle, canSnooze } from "@t3tools/client-runtime/state/thread-settl
 import * as Cause from "effect/Cause";
 import * as Haptics from "expo-haptics";
 import { useCallback, useRef } from "react";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 
 import { showConfirmDialog } from "../../components/ConfirmDialogHost";
 import { scopedThreadKey } from "../../lib/scopedEntities";
@@ -13,6 +13,10 @@ import {
   planPinnedMove,
   sortPinnedThreadsByOrderKey,
 } from "@t3tools/client-runtime/state/thread-sort";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 import { appAtomRegistry } from "../../state/atom-registry";
 import { environmentServerConfigsAtom } from "../../state/server";
 import { environmentThreadShells, threadEnvironment } from "../../state/threads";
@@ -169,6 +173,12 @@ function useThreadActionExecutor(
         // lifecycle still feeds the archived-snapshot surface.
         if (action === "archive" || action === "unarchive" || action === "delete") {
           refreshArchivedThreadsForEnvironment(thread.environmentId);
+        }
+        if (Platform.OS === "android" && action === "delete") {
+          const retained = getBackgroundConnectionRetainedThreadSnapshot().thread;
+          if (retained?.environmentId === thread.environmentId && retained.threadId === thread.id) {
+            void clearBackgroundConnectionRetainedThread();
+          }
         }
         onCompleted?.(action, thread);
         return true;

--- a/apps/mobile/src/features/home/useThreadListActions.ts
+++ b/apps/mobile/src/features/home/useThreadListActions.ts
@@ -3,11 +3,15 @@ import { canSettle, canSnooze } from "@t3tools/client-runtime/state/thread-settl
 import * as Cause from "effect/Cause";
 import * as Haptics from "expo-haptics";
 import { useCallback, useRef } from "react";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 
 import { showConfirmDialog } from "../../components/ConfirmDialogHost";
 import { scopedThreadKey } from "../../lib/scopedEntities";
 import { refreshArchivedThreadsForEnvironment } from "../archive/useArchivedThreadSnapshots";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 import { appAtomRegistry } from "../../state/atom-registry";
 import { environmentServerConfigsAtom } from "../../state/server";
 import { threadEnvironment } from "../../state/threads";
@@ -141,6 +145,12 @@ function useThreadActionExecutor(
         // lifecycle still feeds the archived-snapshot surface.
         if (action === "archive" || action === "unarchive" || action === "delete") {
           refreshArchivedThreadsForEnvironment(thread.environmentId);
+        }
+        if (Platform.OS === "android" && action === "delete") {
+          const retained = getBackgroundConnectionRetainedThreadSnapshot().thread;
+          if (retained?.environmentId === thread.environmentId && retained.threadId === thread.id) {
+            void clearBackgroundConnectionRetainedThread();
+          }
         }
         onCompleted?.(action, thread);
         return true;

--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -435,6 +435,10 @@ function AdaptiveWorkspaceLayoutContent(
     });
   }, [navigation]);
 
+  const handleOpenArchive = useCallback(() => {
+    navigation.navigate("SettingsSheet", { screen: "SettingsArchive" });
+  }, [navigation]);
+
   // Minted here (root stack navigation) so the sidebar pane stays free of
   // navigation hooks — on iOS it renders inside an independent nav tree.
   const handleOpenEnvironmentSettings = useCallback(() => {
@@ -533,6 +537,7 @@ function AdaptiveWorkspaceLayoutContent(
                 visible={panes.primarySidebarVisible}
                 onRequestVisibility={revealPrimarySidebar}
                 selectedThreadKey={selectedThreadKey}
+                onOpenArchive={handleOpenArchive}
                 onOpenSettings={handleOpenSettings}
                 onOpenEnvironmentSettings={handleOpenEnvironmentSettings}
                 onNewThreadInProject={handleNewThreadInProject}

--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -426,6 +426,10 @@ function AdaptiveWorkspaceLayoutContent(
     navigation.navigate("SettingsSheet", { screen: "Settings" });
   }, [navigation]);
 
+  const handleOpenArchive = useCallback(() => {
+    navigation.navigate("SettingsSheet", { screen: "SettingsArchive" });
+  }, [navigation]);
+
   // Minted here (root stack navigation) so the sidebar pane stays free of
   // navigation hooks — on iOS it renders inside an independent nav tree.
   const handleOpenEnvironmentSettings = useCallback(() => {
@@ -521,6 +525,7 @@ function AdaptiveWorkspaceLayoutContent(
                 visible={panes.primarySidebarVisible}
                 onRequestVisibility={revealPrimarySidebar}
                 selectedThreadKey={selectedThreadKey}
+                onOpenArchive={handleOpenArchive}
                 onOpenSettings={handleOpenSettings}
                 onOpenEnvironmentSettings={handleOpenEnvironmentSettings}
                 onNewThreadInProject={handleNewThreadInProject}

--- a/apps/mobile/src/features/settings/SettingsClientStorageRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsClientStorageRouteScreen.tsx
@@ -2,10 +2,14 @@ import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { SymbolView } from "expo-symbols";
 import { useMemo } from "react";
-import { ActivityIndicator, Alert, Pressable, ScrollView, View } from "react-native";
+import { ActivityIndicator, Alert, Platform, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AppText as Text } from "../../components/AppText";
+import {
+  clearBackgroundConnectionRetainedThread,
+  getBackgroundConnectionRetainedThreadSnapshot,
+} from "../background-connection/retained-thread";
 import { useThemeColor } from "../../lib/useThemeColor";
 import {
   clearClientCacheAtom,
@@ -47,8 +51,16 @@ export function SettingsClientStorageRouteScreen() {
         {
           text: "Clear Cache",
           style: "destructive",
-          onPress: () =>
-            clearCache({ type: "environment", environmentId: environment.environmentId }),
+          onPress: () => {
+            const retained = getBackgroundConnectionRetainedThreadSnapshot().thread;
+            if (
+              Platform.OS === "android" &&
+              retained?.environmentId === environment.environmentId
+            ) {
+              void clearBackgroundConnectionRetainedThread();
+            }
+            clearCache({ type: "environment", environmentId: environment.environmentId });
+          },
         },
       ],
     );
@@ -63,7 +75,12 @@ export function SettingsClientStorageRouteScreen() {
         {
           text: "Clear All Caches",
           style: "destructive",
-          onPress: () => clearCache({ type: "all" }),
+          onPress: () => {
+            if (Platform.OS === "android") {
+              void clearBackgroundConnectionRetainedThread();
+            }
+            clearCache({ type: "all" });
+          },
         },
       ],
     );

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -47,6 +47,7 @@ import { SettingsRow } from "./components/SettingsRow";
 import { SettingsSection } from "./components/SettingsSection";
 import { SettingsSwitchRow } from "./components/SettingsSwitchRow";
 import { resolveAgentAwarenessPlatformPresentation } from "./SettingsRouteScreen.logic";
+import { BackgroundConnectionSettingsSection } from "../background-connection/BackgroundConnectionSettingsSection";
 
 type NotificationStatus = "checking" | "enabled" | "disabled" | "unsupported";
 type LiveActivityStatus = "checking" | "enabled" | "disabled" | "signed-out" | "linking";
@@ -126,6 +127,8 @@ function LocalSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />
@@ -512,6 +515,8 @@ function ConfiguredSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -42,6 +42,7 @@ import {
   registerHiddenUpdateTap,
   runAppUpdateCheck,
 } from "../updates/app-updates";
+import { isPersonalPreviewUpdatesEnabled } from "../updates/personal-preview-updates";
 import { useSavedRemoteConnections } from "../../state/use-remote-environment-registry";
 import { SettingsRow } from "./components/SettingsRow";
 import { SettingsSection } from "./components/SettingsSection";
@@ -601,9 +602,15 @@ function AppSettingsSection() {
   const variant = (Constants.expoConfig?.extra?.appVariant as string | undefined) ?? "production";
   const variantLabel = variant === "production" ? "" : capitalize(variant);
   const versionLabel = variantLabel ? `${version} · ${variantLabel}` : version;
-  const updateCheckAvailable = isAppUpdateCheckAvailable();
+  const personalPreviewUpdatesEnabled = isPersonalPreviewUpdatesEnabled();
+  const updateCheckAvailable = personalPreviewUpdatesEnabled || isAppUpdateCheckAvailable();
   const busy =
-    updateState === "checking" || updateState === "downloading" || updateState === "restarting";
+    updateState === "checking" ||
+    updateState === "available" ||
+    updateState === "downloading" ||
+    updateState === "ready" ||
+    updateState === "opening" ||
+    updateState === "restarting";
 
   // "Up to date" is a transient acknowledgement, not a state worth persisting —
   // return the version row to its normal, deliberately quiet state.
@@ -633,27 +640,35 @@ function AppSettingsSection() {
 
   const handleVersionPress = useCallback(() => {
     if (!updateCheckAvailable || updateInFlight.current) return;
+    if (personalPreviewUpdatesEnabled) {
+      void checkForUpdate();
+      return;
+    }
     const tap = registerHiddenUpdateTap(hiddenUpdateTapCount.current);
     hiddenUpdateTapCount.current = tap.nextCount;
     if (tap.shouldCheck) {
       void checkForUpdate();
     }
-  }, [checkForUpdate, updateCheckAvailable]);
+  }, [checkForUpdate, personalPreviewUpdatesEnabled, updateCheckAvailable]);
 
   const statusLabel =
     updateState === "checking"
       ? "Checking…"
-      : updateState === "downloading"
-        ? "Downloading…"
-        : // "ready" appears only when this check joined an in-flight background-mode
-          // check; that download installs at the next backgrounding.
-          updateState === "ready"
-          ? "Update ready"
-          : updateState === "restarting"
-            ? "Restarting…"
-            : updateState === "current"
-              ? "Up to date"
-              : null;
+      : updateState === "available"
+        ? "Update available"
+        : updateState === "downloading"
+          ? "Downloading…"
+          : updateState === "ready"
+            ? "Update ready"
+            : updateState === "opening"
+              ? "Opening download…"
+              : updateState === "restarting"
+                ? "Restarting…"
+                : updateState === "current"
+                  ? "Up to date"
+                  : personalPreviewUpdatesEnabled
+                    ? "Tap to check"
+                    : null;
 
   const versionRow = (
     <View className="flex-row items-center gap-4 p-4">

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -43,6 +43,7 @@ import {
   registerHiddenUpdateTap,
   runAppUpdateCheck,
 } from "../updates/app-updates";
+import { isPersonalPreviewUpdatesEnabled } from "../updates/personal-preview-updates";
 import { useSavedRemoteConnections } from "../../state/use-remote-environment-registry";
 import { SettingsRow } from "./components/SettingsRow";
 import { SettingsSection } from "./components/SettingsSection";
@@ -591,8 +592,14 @@ function AppSettingsSection() {
   const variant = (Constants.expoConfig?.extra?.appVariant as string | undefined) ?? "production";
   const variantLabel = variant === "production" ? "" : capitalize(variant);
   const versionLabel = variantLabel ? `${version} · ${variantLabel}` : version;
+  const personalPreviewUpdatesEnabled = isPersonalPreviewUpdatesEnabled();
+  const updatesEnabled = Updates.isEnabled || personalPreviewUpdatesEnabled;
   const busy =
-    updateState === "checking" || updateState === "downloading" || updateState === "restarting";
+    updateState === "checking" ||
+    updateState === "available" ||
+    updateState === "downloading" ||
+    updateState === "opening" ||
+    updateState === "restarting";
 
   // "Up to date" is a transient acknowledgement, not a state worth persisting —
   // return the version row to its normal, deliberately quiet state.
@@ -618,24 +625,34 @@ function AppSettingsSection() {
   }, []);
 
   const handleVersionPress = useCallback(() => {
-    if (!Updates.isEnabled || updateInFlight.current) return;
+    if (!updatesEnabled || updateInFlight.current) return;
+    if (personalPreviewUpdatesEnabled) {
+      void checkForUpdate();
+      return;
+    }
     const tap = registerHiddenUpdateTap(hiddenUpdateTapCount.current);
     hiddenUpdateTapCount.current = tap.nextCount;
     if (tap.shouldCheck) {
       void checkForUpdate();
     }
-  }, [checkForUpdate]);
+  }, [checkForUpdate, personalPreviewUpdatesEnabled, updatesEnabled]);
 
   const statusLabel =
     updateState === "checking"
       ? "Checking…"
-      : updateState === "downloading"
-        ? "Downloading…"
-        : updateState === "restarting"
-          ? "Restarting…"
-          : updateState === "current"
-            ? "Up to date"
-            : null;
+      : updateState === "available"
+        ? "Update available"
+        : updateState === "downloading"
+          ? "Downloading…"
+          : updateState === "opening"
+            ? "Opening download…"
+            : updateState === "restarting"
+              ? "Restarting…"
+              : updateState === "current"
+                ? "Up to date"
+                : personalPreviewUpdatesEnabled
+                  ? "Tap to check"
+                  : null;
 
   const versionRow = (
     <View className="flex-row items-center gap-4 p-4">
@@ -660,7 +677,7 @@ function AppSettingsSection() {
     <SettingsSection title="App">
       <SettingsRow icon="internaldrive" label="Client Storage" target="SettingsClientStorage" />
       <SettingsRow icon="doc.text" label="Legal" fullScreenTarget="SettingsLegal" />
-      {Updates.isEnabled ? (
+      {updatesEnabled ? (
         <Pressable
           accessibilityLabel={`Version ${versionLabel}`}
           accessibilityRole="text"

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -47,6 +47,7 @@ import { useSavedRemoteConnections } from "../../state/use-remote-environment-re
 import { SettingsRow } from "./components/SettingsRow";
 import { SettingsSection } from "./components/SettingsSection";
 import { SettingsSwitchRow } from "./components/SettingsSwitchRow";
+import { BackgroundConnectionSettingsSection } from "../background-connection/BackgroundConnectionSettingsSection";
 
 type NotificationStatus = "checking" | "enabled" | "disabled" | "unsupported";
 type LiveActivityStatus = "checking" | "enabled" | "disabled" | "signed-out" | "linking";
@@ -126,6 +127,8 @@ function LocalSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />
@@ -514,6 +517,8 @@ function ConfiguredSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -63,6 +63,7 @@ import {
   getConnectionAwareBrandHeaderOptions,
   WorkspaceConnectionTitle,
 } from "../home/WorkspaceConnectionTitle";
+import { ArchivedThreadsShelf, useArchivedThreadsShelfData } from "../archive/ArchivedThreadsShelf";
 import { SidebarHeaderActions } from "./sidebar-header-actions";
 import { SidebarFilterButton } from "./sidebar-filter-button";
 import { createSidebarHeaderItems } from "./sidebar-native-header-items";
@@ -142,6 +143,7 @@ interface ThreadNavigationSidebarProps {
   readonly width: number;
   readonly visible: boolean;
   readonly selectedThreadKey: string | null;
+  readonly onOpenArchive: () => void;
   readonly onOpenSettings: () => void;
   readonly onOpenEnvironmentSettings: () => void;
   readonly onNewThreadInProject: (project: EnvironmentProject) => void;
@@ -327,6 +329,12 @@ function ThreadNavigationSidebarPane(
           ),
     [selectedProjectScope],
   );
+  const archivedThreadsShelfData = useArchivedThreadsShelfData({
+    environments,
+    environmentId: options.selectedEnvironmentId,
+    projectKeys: selectedProjectRefs,
+    searchQuery: props.searchQuery,
+  });
   const scopedProjects = useMemo(
     () =>
       selectedProjectRefs === null
@@ -1272,6 +1280,18 @@ function ThreadNavigationSidebarPane(
                 scrollEventThrottle={16}
                 showsVerticalScrollIndicator={false}
                 style={styles.threadList}
+                ListFooterComponent={
+                  <ArchivedThreadsShelf
+                    data={archivedThreadsShelfData}
+                    fullSwipeWidth={props.width - 20}
+                    onOpenArchive={props.onOpenArchive}
+                    onSwipeableClose={handleSwipeableClose}
+                    onSwipeableWillOpen={handleSwipeableWillOpen}
+                    pane="sidebar"
+                    searchQuery={props.searchQuery}
+                    simultaneousSwipeGesture={sidebarScrollGesture}
+                  />
+                }
                 ListEmptyComponent={listEmpty}
               />
             </GestureDetector>
@@ -1318,6 +1338,18 @@ function ThreadNavigationSidebarPane(
               scrollEventThrottle={16}
               showsVerticalScrollIndicator={false}
               style={styles.threadList}
+              ListFooterComponent={
+                <ArchivedThreadsShelf
+                  data={archivedThreadsShelfData}
+                  fullSwipeWidth={props.width - 20}
+                  onOpenArchive={props.onOpenArchive}
+                  onSwipeableClose={handleSwipeableClose}
+                  onSwipeableWillOpen={handleSwipeableWillOpen}
+                  pane="sidebar"
+                  searchQuery={props.searchQuery}
+                  simultaneousSwipeGesture={sidebarScrollGesture}
+                />
+              }
               ListEmptyComponent={listEmpty}
             />
           </GestureDetector>

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -57,6 +57,7 @@ import { usePendingTaskListActions } from "../home/usePendingTaskListActions";
 import { useThreadListActions } from "../home/useThreadListActions";
 import { WorkspaceConnectionStatus } from "../home/WorkspaceConnectionStatus";
 import { shouldShowWorkspaceConnectionStatus } from "../home/workspace-connection-status";
+import { ArchivedThreadsShelf, useArchivedThreadsShelfData } from "../archive/ArchivedThreadsShelf";
 import { SidebarHeaderActions } from "./sidebar-header-actions";
 import { SidebarFilterButton } from "./sidebar-filter-button";
 import { createSidebarHeaderItems } from "./sidebar-native-header-items";
@@ -136,6 +137,7 @@ interface ThreadNavigationSidebarProps {
   readonly width: number;
   readonly visible: boolean;
   readonly selectedThreadKey: string | null;
+  readonly onOpenArchive: () => void;
   readonly onOpenSettings: () => void;
   readonly onOpenEnvironmentSettings: () => void;
   readonly onNewThreadInProject: (project: EnvironmentProject) => void;
@@ -313,6 +315,12 @@ function ThreadNavigationSidebarPane(
           ),
     [selectedProjectScope],
   );
+  const archivedThreadsShelfData = useArchivedThreadsShelfData({
+    environments,
+    environmentId: options.selectedEnvironmentId,
+    projectKeys: selectedProjectRefs,
+    searchQuery: props.searchQuery,
+  });
   const scopedProjects = useMemo(
     () =>
       selectedProjectRefs === null
@@ -1195,6 +1203,18 @@ function ThreadNavigationSidebarPane(
                     </View>
                   ) : null
                 }
+                ListFooterComponent={
+                  <ArchivedThreadsShelf
+                    data={archivedThreadsShelfData}
+                    fullSwipeWidth={props.width - 20}
+                    onOpenArchive={props.onOpenArchive}
+                    onSwipeableClose={handleSwipeableClose}
+                    onSwipeableWillOpen={handleSwipeableWillOpen}
+                    pane="sidebar"
+                    searchQuery={props.searchQuery}
+                    simultaneousSwipeGesture={sidebarScrollGesture}
+                  />
+                }
                 ListEmptyComponent={listEmpty}
               />
             </GestureDetector>
@@ -1241,6 +1261,18 @@ function ThreadNavigationSidebarPane(
               scrollEventThrottle={16}
               showsVerticalScrollIndicator={false}
               style={styles.threadList}
+              ListFooterComponent={
+                <ArchivedThreadsShelf
+                  data={archivedThreadsShelfData}
+                  fullSwipeWidth={props.width - 20}
+                  onOpenArchive={props.onOpenArchive}
+                  onSwipeableClose={handleSwipeableClose}
+                  onSwipeableWillOpen={handleSwipeableWillOpen}
+                  pane="sidebar"
+                  searchQuery={props.searchQuery}
+                  simultaneousSwipeGesture={sidebarScrollGesture}
+                />
+              }
               ListEmptyComponent={listEmpty}
             />
           </GestureDetector>

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -685,6 +685,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
         compact ? undefined : { borderRadius: SIDEBAR_ROW_RADIUS, overflow: "hidden" }
       }
       enableTrackpadSwipe
+      fullSwipeAction="primary"
       fullSwipeWidth={props.fullSwipeWidth ?? windowWidth - 32}
       onDelete={handleDelete}
       onSwipeableClose={props.onSwipeableClose}

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -654,6 +654,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
         compact ? undefined : { borderRadius: SIDEBAR_ROW_RADIUS, overflow: "hidden" }
       }
       enableTrackpadSwipe
+      fullSwipeAction="primary"
       fullSwipeWidth={props.fullSwipeWidth ?? windowWidth - 32}
       onDelete={handleDelete}
       onSwipeableClose={props.onSwipeableClose}

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -60,20 +60,23 @@ function threadTimeLabel(thread: EnvironmentThreadShell): string {
   return relativeTime(thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt);
 }
 
-// Menus keep lifecycle and title regeneration together. Archive keeps its
-// own surface (thread screen / settings) rather than crowding v2 rows.
+// Menus keep lifecycle, pinning, title regeneration, and archive reachable
+// while Archive remains the consistent full-swipe action.
 const CARD_MENU_ACTIONS: MenuAction[] = [
   { id: "settle", title: "Settle", image: "checkmark" },
+  { id: "archive", title: "Archive", image: "archivebox" },
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
 
 const SLIM_MENU_ACTIONS: MenuAction[] = [
   { id: "unsettle", title: "Un-settle", image: "arrow.uturn.backward" },
+  { id: "archive", title: "Archive", image: "archivebox" },
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
 
 const SNOOZED_MENU_ACTIONS: MenuAction[] = [
   { id: "unsnooze", title: "Wake thread", image: "clock" },
+  { id: "archive", title: "Archive", image: "archivebox" },
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
 
@@ -441,9 +444,9 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   );
   const handleArchive = useCallback(() => onArchiveThread(thread), [onArchiveThread, thread]);
 
-  // Swipe: the v2 primary action is the lifecycle transition. Every settled
-  // row can un-settle — explicit settles clear the override, auto-settled
-  // rows get pinned active until real activity clears the pin.
+  // Archive is the consistent full-swipe action for visible work. Snoozed
+  // rows keep Wake as their primary action because waking is the shelf's
+  // direct inverse; Archive remains in their long-press menu.
   const canUnsettle = variant === "slim";
   const [snoozeGateTick, bumpSnoozeGateTick] = useState(0);
   const snoozeGateExpiryMs = props.snoozeSupported
@@ -456,8 +459,6 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     return () => clearTimeout(id);
   }, [snoozeGateExpiryMs, snoozeGateTick]);
   const swipeActions = resolveThreadListV2SwipeActions({
-    variant,
-    settlementSupported: props.settlementSupported,
     snoozeSupported: props.snoozeSupported,
     snoozable: canSnooze(thread, { now: new Date().toISOString() }),
     snoozed: snoozedRow,
@@ -530,6 +531,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       },
       ...pinMenuItem,
       ...titleRegenerationMenuItems,
+      { id: "archive", title: "Archive", image: "archivebox" },
       { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
     ],
     [pinMenuItem, snoozePresetActions, titleRegenerationMenuItems],
@@ -594,17 +596,6 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     ],
   );
   const primaryAction = useMemo(() => {
-    // Pre-settlement server: archive is the swipe action, as in v1. (Slim
-    // rows cannot occur here — unsupported environments never classify as
-    // settled.)
-    if (swipeActions.primary === "archive") {
-      return {
-        accessibilityLabel: `Archive ${thread.title}`,
-        icon: "archivebox" as const,
-        label: "Archive",
-        onPress: handleArchive,
-      };
-    }
     if (swipeActions.primary === "unsnooze") {
       return {
         accessibilityLabel: `Wake ${thread.title} now`,
@@ -613,27 +604,13 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         onPress: handleUnsnooze,
       };
     }
-    return swipeActions.primary === "unsettle"
-      ? {
-          accessibilityLabel: `Un-settle ${thread.title}`,
-          icon: "arrow.uturn.backward" as const,
-          label: "Un-settle",
-          onPress: handleUnsettle,
-        }
-      : {
-          accessibilityLabel: `Settle ${thread.title}`,
-          icon: "checkmark" as const,
-          label: "Settle",
-          onPress: handleSettle,
-        };
-  }, [
-    handleArchive,
-    handleSettle,
-    handleUnsettle,
-    handleUnsnooze,
-    swipeActions.primary,
-    thread.title,
-  ]);
+    return {
+      accessibilityLabel: `Archive ${thread.title}`,
+      icon: "archivebox" as const,
+      label: "Archive",
+      onPress: handleArchive,
+    };
+  }, [handleArchive, handleUnsnooze, swipeActions.primary, thread.title]);
   const secondaryAction = useMemo(
     () =>
       swipeActions.secondary === "snooze"
@@ -908,8 +885,8 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
           sidebarPane ? { borderRadius: SIDEBAR_V2_ROW_RADIUS, overflow: "hidden" } : undefined
         }
         enableTrackpadSwipe
-        // Full swipe commits the advertised lifecycle action (Settle /
-        // Un-settle), never the secondary snooze action.
+        // Full swipe always commits the advertised primary action, never the
+        // secondary Snooze menu.
         fullSwipeAction="primary"
         fullSwipeWidth={props.fullSwipeWidth ?? windowWidth - 32}
         onDelete={handleDelete}

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -65,20 +65,23 @@ function threadTimeLabel(thread: EnvironmentThreadShell): string {
   return relativeTime(thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt);
 }
 
-// Menus stay lifecycle-focused: settle/un-settle plus delete. Archive keeps
-// its own surface (thread screen / settings) rather than crowding the row.
+// The row menu keeps every lifecycle transition reachable after Archive
+// becomes the consistent full-swipe action.
 const CARD_MENU_ACTIONS: MenuAction[] = [
   { id: "settle", title: "Settle", image: "checkmark" },
+  { id: "archive", title: "Archive", image: "archivebox" },
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
 
 const SLIM_MENU_ACTIONS: MenuAction[] = [
   { id: "unsettle", title: "Un-settle", image: "arrow.uturn.backward" },
+  { id: "archive", title: "Archive", image: "archivebox" },
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
 
 const SNOOZED_MENU_ACTIONS: MenuAction[] = [
   { id: "unsnooze", title: "Wake thread", image: "clock" },
+  { id: "archive", title: "Archive", image: "archivebox" },
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
 
@@ -400,9 +403,9 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   const handleUnsettle = useCallback(() => onUnsettleThread(thread), [onUnsettleThread, thread]);
   const handleArchive = useCallback(() => onArchiveThread(thread), [onArchiveThread, thread]);
 
-  // Swipe: the v2 primary action is the lifecycle transition. Every settled
-  // row can un-settle — explicit settles clear the override, auto-settled
-  // rows get pinned active until real activity clears the pin.
+  // Archive is the consistent full-swipe action for visible work. Snoozed
+  // rows keep Wake as their primary action because waking is the shelf's
+  // direct inverse; Archive remains in their long-press menu.
   const canUnsettle = variant === "slim";
   const [snoozeGateTick, bumpSnoozeGateTick] = useState(0);
   const snoozeGateExpiryMs = props.snoozeSupported
@@ -415,8 +418,6 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     return () => clearTimeout(id);
   }, [snoozeGateExpiryMs, snoozeGateTick]);
   const swipeActions = resolveThreadListV2SwipeActions({
-    variant,
-    settlementSupported: props.settlementSupported,
     snoozeSupported: props.snoozeSupported,
     snoozable: canSnooze(thread, { now: new Date().toISOString() }),
     snoozed: snoozedRow,
@@ -443,6 +444,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         image: "clock",
         subactions: snoozePresetActions,
       },
+      { id: "archive", title: "Archive", image: "archivebox" },
       { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
     ],
     [snoozePresetActions],
@@ -476,17 +478,6 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     ],
   );
   const primaryAction = useMemo(() => {
-    // Pre-settlement server: archive is the swipe action, as in v1. (Slim
-    // rows cannot occur here — unsupported environments never classify as
-    // settled.)
-    if (swipeActions.primary === "archive") {
-      return {
-        accessibilityLabel: `Archive ${thread.title}`,
-        icon: "archivebox" as const,
-        label: "Archive",
-        onPress: handleArchive,
-      };
-    }
     if (swipeActions.primary === "unsnooze") {
       return {
         accessibilityLabel: `Wake ${thread.title} now`,
@@ -495,27 +486,13 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         onPress: handleUnsnooze,
       };
     }
-    return swipeActions.primary === "unsettle"
-      ? {
-          accessibilityLabel: `Un-settle ${thread.title}`,
-          icon: "arrow.uturn.backward" as const,
-          label: "Un-settle",
-          onPress: handleUnsettle,
-        }
-      : {
-          accessibilityLabel: `Settle ${thread.title}`,
-          icon: "checkmark" as const,
-          label: "Settle",
-          onPress: handleSettle,
-        };
-  }, [
-    handleArchive,
-    handleSettle,
-    handleUnsettle,
-    handleUnsnooze,
-    swipeActions.primary,
-    thread.title,
-  ]);
+    return {
+      accessibilityLabel: `Archive ${thread.title}`,
+      icon: "archivebox" as const,
+      label: "Archive",
+      onPress: handleArchive,
+    };
+  }, [handleArchive, handleUnsnooze, swipeActions.primary, thread.title]);
   const secondaryAction = useMemo(
     () =>
       swipeActions.secondary === "snooze"
@@ -781,8 +758,8 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
           sidebarPane ? { borderRadius: SIDEBAR_V2_ROW_RADIUS, overflow: "hidden" } : undefined
         }
         enableTrackpadSwipe
-        // Full swipe commits the advertised lifecycle action (Settle /
-        // Un-settle), never the secondary snooze action.
+        // Full swipe always commits the advertised primary action, never the
+        // secondary Snooze menu.
         fullSwipeAction="primary"
         fullSwipeWidth={props.fullSwipeWidth ?? windowWidth - 32}
         onDelete={handleDelete}

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -153,54 +153,26 @@ describe("resolveThreadListV2Status", () => {
 });
 
 describe("resolveThreadListV2SwipeActions", () => {
-  it("offers settle and snooze for an active snoozable thread", () => {
+  it("offers archive and snooze for an active snoozable thread", () => {
     expect(
       resolveThreadListV2SwipeActions({
-        variant: "card",
-        settlementSupported: true,
         snoozeSupported: true,
         snoozable: true,
       }),
-    ).toEqual({ primary: "settle", secondary: "snooze" });
-  });
-
-  it("offers un-settle and snooze for settled history", () => {
-    expect(
-      resolveThreadListV2SwipeActions({
-        variant: "slim",
-        settlementSupported: true,
-        snoozeSupported: true,
-        snoozable: true,
-      }),
-    ).toEqual({ primary: "unsettle", secondary: "snooze" });
+    ).toEqual({ primary: "archive", secondary: "snooze" });
   });
 
   it("omits snooze when the server or thread does not allow it", () => {
     expect(
       resolveThreadListV2SwipeActions({
-        variant: "card",
-        settlementSupported: true,
         snoozeSupported: false,
         snoozable: true,
       }),
-    ).toEqual({ primary: "settle", secondary: null });
+    ).toEqual({ primary: "archive", secondary: null });
     expect(
       resolveThreadListV2SwipeActions({
-        variant: "card",
-        settlementSupported: true,
         snoozeSupported: true,
         snoozable: false,
-      }),
-    ).toEqual({ primary: "settle", secondary: null });
-  });
-
-  it("falls back to archive only for a pre-lifecycle server", () => {
-    expect(
-      resolveThreadListV2SwipeActions({
-        variant: "card",
-        settlementSupported: false,
-        snoozeSupported: false,
-        snoozable: true,
       }),
     ).toEqual({ primary: "archive", secondary: null });
   });
@@ -208,8 +180,6 @@ describe("resolveThreadListV2SwipeActions", () => {
   it("offers wake and no snooze on a snoozed row", () => {
     expect(
       resolveThreadListV2SwipeActions({
-        variant: "slim",
-        settlementSupported: true,
         snoozeSupported: true,
         snoozable: true,
         snoozed: true,

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -149,54 +149,26 @@ describe("resolveThreadListV2Status", () => {
 });
 
 describe("resolveThreadListV2SwipeActions", () => {
-  it("offers settle and snooze for an active snoozable thread", () => {
+  it("offers archive and snooze for an active snoozable thread", () => {
     expect(
       resolveThreadListV2SwipeActions({
-        variant: "card",
-        settlementSupported: true,
         snoozeSupported: true,
         snoozable: true,
       }),
-    ).toEqual({ primary: "settle", secondary: "snooze" });
-  });
-
-  it("offers un-settle and snooze for settled history", () => {
-    expect(
-      resolveThreadListV2SwipeActions({
-        variant: "slim",
-        settlementSupported: true,
-        snoozeSupported: true,
-        snoozable: true,
-      }),
-    ).toEqual({ primary: "unsettle", secondary: "snooze" });
+    ).toEqual({ primary: "archive", secondary: "snooze" });
   });
 
   it("omits snooze when the server or thread does not allow it", () => {
     expect(
       resolveThreadListV2SwipeActions({
-        variant: "card",
-        settlementSupported: true,
         snoozeSupported: false,
         snoozable: true,
       }),
-    ).toEqual({ primary: "settle", secondary: null });
+    ).toEqual({ primary: "archive", secondary: null });
     expect(
       resolveThreadListV2SwipeActions({
-        variant: "card",
-        settlementSupported: true,
         snoozeSupported: true,
         snoozable: false,
-      }),
-    ).toEqual({ primary: "settle", secondary: null });
-  });
-
-  it("falls back to archive only for a pre-lifecycle server", () => {
-    expect(
-      resolveThreadListV2SwipeActions({
-        variant: "card",
-        settlementSupported: false,
-        snoozeSupported: false,
-        snoozable: true,
       }),
     ).toEqual({ primary: "archive", secondary: null });
   });
@@ -204,8 +176,6 @@ describe("resolveThreadListV2SwipeActions", () => {
   it("offers wake and no snooze on a snoozed row", () => {
     expect(
       resolveThreadListV2SwipeActions({
-        variant: "slim",
-        settlementSupported: true,
         snoozeSupported: true,
         snoozable: true,
         snoozed: true,

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -25,7 +25,7 @@ export { snoozeWakeLabel };
  * unlabeled resting state.
  */
 export type ThreadListV2Status = "approval" | "input" | "working" | "failed" | "ready";
-export type ThreadListV2SwipeAction = "archive" | "settle" | "unsettle" | "snooze" | "unsnooze";
+export type ThreadListV2SwipeAction = "archive" | "snooze" | "unsnooze";
 
 export function resolveThreadListV2SnoozeMenuSelection(input: {
   readonly event: string;
@@ -52,8 +52,6 @@ export function resolveThreadListV2SnoozeMenuSelection(input: {
 }
 
 export function resolveThreadListV2SwipeActions(input: {
-  readonly variant: "card" | "slim";
-  readonly settlementSupported: boolean;
   readonly snoozeSupported: boolean;
   readonly snoozable: boolean;
   /** Row is on the snoozed shelf. */
@@ -65,13 +63,8 @@ export function resolveThreadListV2SwipeActions(input: {
   if (input.snoozed === true) {
     return { primary: "unsnooze", secondary: null };
   }
-  const primary = input.settlementSupported
-    ? input.variant === "slim"
-      ? "unsettle"
-      : "settle"
-    : "archive";
   return {
-    primary,
+    primary: "archive",
     secondary: input.snoozeSupported && input.snoozable ? "snooze" : null,
   };
 }

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -24,7 +24,7 @@ export { snoozeWakeLabel };
  * unlabeled resting state.
  */
 export type ThreadListV2Status = "approval" | "input" | "working" | "failed" | "ready";
-export type ThreadListV2SwipeAction = "archive" | "settle" | "unsettle" | "snooze" | "unsnooze";
+export type ThreadListV2SwipeAction = "archive" | "snooze" | "unsnooze";
 
 export function resolveThreadListV2SnoozeMenuSelection(input: {
   readonly event: string;
@@ -51,8 +51,6 @@ export function resolveThreadListV2SnoozeMenuSelection(input: {
 }
 
 export function resolveThreadListV2SwipeActions(input: {
-  readonly variant: "card" | "slim";
-  readonly settlementSupported: boolean;
   readonly snoozeSupported: boolean;
   readonly snoozable: boolean;
   /** Row is on the snoozed shelf. */
@@ -64,13 +62,8 @@ export function resolveThreadListV2SwipeActions(input: {
   if (input.snoozed === true) {
     return { primary: "unsnooze", secondary: null };
   }
-  const primary = input.settlementSupported
-    ? input.variant === "slim"
-      ? "unsettle"
-      : "settle"
-    : "archive";
   return {
-    primary,
+    primary: "archive",
     secondary: input.snoozeSupported && input.snoozable ? "snooze" : null,
   };
 }

--- a/apps/mobile/src/features/updates/app-updates.test.ts
+++ b/apps/mobile/src/features/updates/app-updates.test.ts
@@ -11,12 +11,23 @@ import {
   type AppUpdateClient,
   type AppUpdateEnvironment,
 } from "./app-updates";
+import type { PersonalPreviewUpdateClient } from "./personal-preview-updates";
 
 vi.mock("expo-updates", () => ({
   isEnabled: true,
   checkForUpdateAsync: vi.fn(),
   fetchUpdateAsync: vi.fn(),
   reloadAsync: vi.fn(),
+}));
+
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: {} }, nativeBuildVersion: "1" },
+}));
+
+vi.mock("react-native", () => ({
+  Alert: { alert: vi.fn() },
+  Linking: { openURL: vi.fn() },
+  Platform: { OS: "android" },
 }));
 
 function makeUpdateClient(overrides: Partial<AppUpdateClient> = {}): AppUpdateClient {
@@ -82,6 +93,50 @@ describe("runAppUpdateCheck", () => {
     }
 
     expect(client.checkForUpdateAsync).not.toHaveBeenCalled();
+  });
+
+  it("uses the signed personal preview release path when configured", async () => {
+    const update = {
+      versionCode: 2,
+      versionName: "T3 Code Preview 2",
+      downloadUrl:
+        "https://github.com/Feighery89/t3code/releases/download/mark-mobile-preview-v2/t3-code-preview.apk",
+    };
+    const previewClient: PersonalPreviewUpdateClient = {
+      isEnabled: true,
+      checkForUpdateAsync: vi.fn(async () => update),
+      presentUpdateAsync: vi.fn(async () => true),
+    };
+    const expoClient = makeUpdateClient();
+    const states: AppUpdateCheckState[] = [];
+
+    await runAppUpdateCheck({
+      client: expoClient,
+      previewClient,
+      onStateChange: (state) => states.push(state),
+    });
+
+    expect(previewClient.checkForUpdateAsync).toHaveBeenCalledOnce();
+    expect(previewClient.presentUpdateAsync).toHaveBeenCalledWith(update);
+    expect(expoClient.checkForUpdateAsync).not.toHaveBeenCalled();
+    expect(states).toEqual(["checking", "available", "opening", "idle"]);
+  });
+
+  it("reports a current personal preview without opening a download", async () => {
+    const previewClient: PersonalPreviewUpdateClient = {
+      isEnabled: true,
+      checkForUpdateAsync: vi.fn(async () => null),
+      presentUpdateAsync: vi.fn(async () => true),
+    };
+    const states: AppUpdateCheckState[] = [];
+
+    await runAppUpdateCheck({
+      previewClient,
+      onStateChange: (state) => states.push(state),
+    });
+
+    expect(previewClient.presentUpdateAsync).not.toHaveBeenCalled();
+    expect(states).toEqual(["checking", "current"]);
   });
 
   it("downloads silently and installs at the next backgrounding", async () => {

--- a/apps/mobile/src/features/updates/app-updates.test.ts
+++ b/apps/mobile/src/features/updates/app-updates.test.ts
@@ -7,12 +7,23 @@ import {
   type AppUpdateCheckState,
   type AppUpdateClient,
 } from "./app-updates";
+import type { PersonalPreviewUpdateClient } from "./personal-preview-updates";
 
 vi.mock("expo-updates", () => ({
   isEnabled: true,
   checkForUpdateAsync: vi.fn(),
   fetchUpdateAsync: vi.fn(),
   reloadAsync: vi.fn(),
+}));
+
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: {} }, nativeBuildVersion: "1" },
+}));
+
+vi.mock("react-native", () => ({
+  Alert: { alert: vi.fn() },
+  Linking: { openURL: vi.fn() },
+  Platform: { OS: "android" },
 }));
 
 function makeUpdateClient(overrides: Partial<AppUpdateClient> = {}): AppUpdateClient {
@@ -32,6 +43,50 @@ function makeUpdateClient(overrides: Partial<AppUpdateClient> = {}): AppUpdateCl
 }
 
 describe("runAppUpdateCheck", () => {
+  it("uses the signed personal preview release path when configured", async () => {
+    const update = {
+      versionCode: 2,
+      versionName: "T3 Code Preview 2",
+      downloadUrl:
+        "https://github.com/Feighery89/t3code/releases/download/mark-mobile-preview-v2/t3-code-preview.apk",
+    };
+    const previewClient: PersonalPreviewUpdateClient = {
+      isEnabled: true,
+      checkForUpdateAsync: vi.fn(async () => update),
+      presentUpdateAsync: vi.fn(async () => true),
+    };
+    const expoClient = makeUpdateClient();
+    const states: AppUpdateCheckState[] = [];
+
+    await runAppUpdateCheck({
+      client: expoClient,
+      previewClient,
+      onStateChange: (state) => states.push(state),
+    });
+
+    expect(previewClient.checkForUpdateAsync).toHaveBeenCalledOnce();
+    expect(previewClient.presentUpdateAsync).toHaveBeenCalledWith(update);
+    expect(expoClient.checkForUpdateAsync).not.toHaveBeenCalled();
+    expect(states).toEqual(["checking", "available", "opening", "idle"]);
+  });
+
+  it("reports a current personal preview without opening a download", async () => {
+    const previewClient: PersonalPreviewUpdateClient = {
+      isEnabled: true,
+      checkForUpdateAsync: vi.fn(async () => null),
+      presentUpdateAsync: vi.fn(async () => true),
+    };
+    const states: AppUpdateCheckState[] = [];
+
+    await runAppUpdateCheck({
+      previewClient,
+      onStateChange: (state) => states.push(state),
+    });
+
+    expect(previewClient.presentUpdateAsync).not.toHaveBeenCalled();
+    expect(states).toEqual(["checking", "current"]);
+  });
+
   it("downloads and restarts when a new update is available", async () => {
     const client = makeUpdateClient({
       checkForUpdateAsync: vi.fn(async () => ({

--- a/apps/mobile/src/features/updates/app-updates.ts
+++ b/apps/mobile/src/features/updates/app-updates.ts
@@ -7,12 +7,18 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import {
+  createPersonalPreviewUpdateClient,
+  type PersonalPreviewUpdateClient,
+} from "./personal-preview-updates";
 
 export type AppUpdateCheckState =
   | "idle"
   | "checking"
+  | "available"
   | "downloading"
   | "ready"
+  | "opening"
   | "restarting"
   | "current";
 
@@ -88,11 +94,12 @@ interface AppUpdateCheckOptions {
    * asking only if the app then stays foregrounded so long that the install
    * never gets its chance. "immediate" restarts as soon as the download
    * lands — reserved for flows where the user explicitly requested the update.
-   */
+  */
   readonly applyMode?: "background" | "immediate";
   readonly client?: AppUpdateClient;
   readonly deferral?: AppUpdateDeferral;
   readonly environment?: AppUpdateEnvironment;
+  readonly previewClient?: PersonalPreviewUpdateClient | null;
   readonly onFailure?: (message: string) => void;
   readonly onStateChange?: (state: AppUpdateCheckState) => void;
 }
@@ -150,7 +157,8 @@ export function registerHiddenUpdateTap(count: number): {
 
 export async function runAppUpdateCheck(options: AppUpdateCheckOptions = {}): Promise<void> {
   const client = options.client ?? Updates;
-  if (!isAppUpdateCheckAvailable(client)) return;
+  const previewClient = options.previewClient ?? createPersonalPreviewUpdateClient();
+  if (!previewClient?.isEnabled && !isAppUpdateCheckAvailable(client)) return;
 
   if (appUpdateCheckInFlight) {
     await observeAppUpdateCheck(appUpdateCheckInFlight, options);
@@ -185,7 +193,7 @@ export async function runAppUpdateCheck(options: AppUpdateCheckOptions = {}): Pr
   // Publish the operation before any state listener can synchronously re-enter.
   appUpdateCheckInFlight = inFlight;
 
-  const execution = performAppUpdateCheck(client, {
+  const progressOptions = {
     applyMode: options.applyMode,
     deferral: options.deferral,
     environment: options.environment,
@@ -197,7 +205,10 @@ export async function runAppUpdateCheck(options: AppUpdateCheckOptions = {}): Pr
       progress.state = state;
       notifyListeners(stateListeners, state);
     },
-  });
+  } satisfies AppUpdateCheckOptions;
+  const execution = previewClient?.isEnabled
+    ? performPersonalPreviewUpdateCheck(previewClient, progressOptions)
+    : performAppUpdateCheck(client, progressOptions);
   void execution.then(deferred.resolve, deferred.reject);
 
   try {
@@ -207,6 +218,34 @@ export async function runAppUpdateCheck(options: AppUpdateCheckOptions = {}): Pr
       appUpdateCheckInFlight = undefined;
     }
   }
+}
+
+async function performPersonalPreviewUpdateCheck(
+  client: PersonalPreviewUpdateClient,
+  options: AppUpdateCheckOptions,
+): Promise<void> {
+  const setState = options.onStateChange ?? (() => {});
+  setState("checking");
+  const check = await settlePromise(() => client.checkForUpdateAsync());
+  if (check._tag === "Failure") {
+    reportUpdateFailure(check, "Could not check for preview updates.", options.onFailure);
+    setState("idle");
+    return;
+  }
+  if (check.value === null) {
+    setState("current");
+    return;
+  }
+
+  setState("available");
+  const presented = await settlePromise(() => client.presentUpdateAsync(check.value));
+  if (presented._tag === "Failure") {
+    reportUpdateFailure(presented, "Could not open the preview update.", options.onFailure);
+    setState("idle");
+    return;
+  }
+  if (presented.value) setState("opening");
+  setState("idle");
 }
 
 function createDeferred(): Deferred {
@@ -559,13 +598,16 @@ function isAppUpdateUnavailableError(error: unknown): boolean {
 
 export function createAppUpdateLaunchCheck(
   client: AppUpdateClient = Updates,
+  previewClient: PersonalPreviewUpdateClient | null = createPersonalPreviewUpdateClient(),
 ): () => Promise<void> | undefined {
   let started = false;
 
   return () => {
-    if (started || !isAppUpdateCheckAvailable(client)) return undefined;
+    if (started || (!previewClient?.isEnabled && !isAppUpdateCheckAvailable(client))) {
+      return undefined;
+    }
     started = true;
-    return runAppUpdateCheck({ client });
+    return runAppUpdateCheck({ client, previewClient });
   };
 }
 

--- a/apps/mobile/src/features/updates/app-updates.ts
+++ b/apps/mobile/src/features/updates/app-updates.ts
@@ -7,8 +7,19 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import {
+  createPersonalPreviewUpdateClient,
+  type PersonalPreviewUpdateClient,
+} from "./personal-preview-updates";
 
-export type AppUpdateCheckState = "idle" | "checking" | "downloading" | "restarting" | "current";
+export type AppUpdateCheckState =
+  | "idle"
+  | "checking"
+  | "available"
+  | "downloading"
+  | "opening"
+  | "restarting"
+  | "current";
 
 export interface AppUpdateClient {
   readonly isEnabled: boolean;
@@ -25,6 +36,7 @@ export interface AppUpdateClient {
 
 interface AppUpdateCheckOptions {
   readonly client?: AppUpdateClient;
+  readonly previewClient?: PersonalPreviewUpdateClient | null;
   readonly onFailure?: (message: string) => void;
   readonly onStateChange?: (state: AppUpdateCheckState) => void;
 }
@@ -73,7 +85,8 @@ export function registerHiddenUpdateTap(count: number): {
 
 export async function runAppUpdateCheck(options: AppUpdateCheckOptions = {}): Promise<void> {
   const client = options.client ?? Updates;
-  if (!client.isEnabled) return;
+  const previewClient = options.previewClient ?? createPersonalPreviewUpdateClient();
+  if (!previewClient?.isEnabled && !client.isEnabled) return;
 
   if (appUpdateCheckInFlight) {
     await observeAppUpdateCheck(appUpdateCheckInFlight, options);
@@ -99,7 +112,7 @@ export async function runAppUpdateCheck(options: AppUpdateCheckOptions = {}): Pr
   // Publish the operation before any state listener can synchronously re-enter.
   appUpdateCheckInFlight = inFlight;
 
-  const execution = performAppUpdateCheck(client, {
+  const progressOptions = {
     onFailure: (message) => {
       progress.failure = message;
       notifyListeners(failureListeners, message);
@@ -108,7 +121,10 @@ export async function runAppUpdateCheck(options: AppUpdateCheckOptions = {}): Pr
       progress.state = state;
       notifyListeners(stateListeners, state);
     },
-  });
+  } satisfies AppUpdateCheckOptions;
+  const execution = previewClient?.isEnabled
+    ? performPersonalPreviewUpdateCheck(previewClient, progressOptions)
+    : performAppUpdateCheck(client, progressOptions);
   void execution.then(deferred.resolve, deferred.reject);
 
   try {
@@ -118,6 +134,34 @@ export async function runAppUpdateCheck(options: AppUpdateCheckOptions = {}): Pr
       appUpdateCheckInFlight = undefined;
     }
   }
+}
+
+async function performPersonalPreviewUpdateCheck(
+  client: PersonalPreviewUpdateClient,
+  options: AppUpdateCheckOptions,
+): Promise<void> {
+  const setState = options.onStateChange ?? (() => {});
+  setState("checking");
+  const check = await settlePromise(() => client.checkForUpdateAsync());
+  if (check._tag === "Failure") {
+    reportUpdateFailure(check, "Could not check for preview updates.", options.onFailure);
+    setState("idle");
+    return;
+  }
+  if (check.value === null) {
+    setState("current");
+    return;
+  }
+
+  setState("available");
+  const presented = await settlePromise(() => client.presentUpdateAsync(check.value));
+  if (presented._tag === "Failure") {
+    reportUpdateFailure(presented, "Could not open the preview update.", options.onFailure);
+    setState("idle");
+    return;
+  }
+  if (presented.value) setState("opening");
+  setState("idle");
 }
 
 function createDeferred(): Deferred {
@@ -215,13 +259,14 @@ function reportUpdateFailure(
 
 export function createAppUpdateLaunchCheck(
   client: AppUpdateClient = Updates,
+  previewClient: PersonalPreviewUpdateClient | null = createPersonalPreviewUpdateClient(),
 ): () => Promise<void> | undefined {
   let started = false;
 
   return () => {
-    if (started || !client.isEnabled) return undefined;
+    if (started || (!previewClient?.isEnabled && !client.isEnabled)) return undefined;
     started = true;
-    return runAppUpdateCheck({ client });
+    return runAppUpdateCheck({ client, previewClient });
   };
 }
 

--- a/apps/mobile/src/features/updates/personal-preview-updates.test.ts
+++ b/apps/mobile/src/features/updates/personal-preview-updates.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: {} }, nativeBuildVersion: "1" },
+}));
+
+vi.mock("react-native", () => ({
+  Alert: { alert: vi.fn() },
+  Linking: { openURL: vi.fn() },
+  Platform: { OS: "android" },
+}));
+
+import {
+  parsePersonalPreviewRelease,
+  parsePersonalPreviewUpdateConfig,
+  selectNewerPersonalPreviewUpdate,
+} from "./personal-preview-updates";
+
+const release = {
+  draft: false,
+  tag_name: "mark-mobile-preview-v1785653285",
+  name: "T3 Code Preview 2026-08-02",
+  assets: [
+    {
+      name: "t3-code-preview.apk",
+      browser_download_url:
+        "https://github.com/Feighery89/t3code/releases/download/mark-mobile-preview-v1785653285/t3-code-preview.apk",
+    },
+  ],
+};
+
+describe("personal preview update parsing", () => {
+  it("accepts only the fork's exact latest-release endpoint", () => {
+    expect(
+      parsePersonalPreviewUpdateConfig({
+        latestReleaseApiUrl: "https://api.github.com/repos/Feighery89/t3code/releases/latest",
+      }),
+    ).toEqual({
+      latestReleaseApiUrl: "https://api.github.com/repos/Feighery89/t3code/releases/latest",
+    });
+    expect(
+      parsePersonalPreviewUpdateConfig({
+        latestReleaseApiUrl: "https://example.test/repos/Feighery89/t3code/releases/latest",
+      }),
+    ).toBeNull();
+    expect(
+      parsePersonalPreviewUpdateConfig({
+        latestReleaseApiUrl: "https://api.github.com/repos/someone-else/t3code/releases/latest",
+      }),
+    ).toBeNull();
+  });
+
+  it("extracts the version and trusted APK asset", () => {
+    expect(parsePersonalPreviewRelease(release)).toEqual({
+      versionCode: 1785653285,
+      versionName: "T3 Code Preview 2026-08-02",
+      downloadUrl:
+        "https://github.com/Feighery89/t3code/releases/download/mark-mobile-preview-v1785653285/t3-code-preview.apk",
+    });
+  });
+
+  it("rejects a release whose APK points outside the fork", () => {
+    expect(() =>
+      parsePersonalPreviewRelease({
+        ...release,
+        assets: [
+          {
+            name: "t3-code-preview.apk",
+            browser_download_url:
+              "https://example.test/mark-mobile-preview-v1785653285/t3-code-preview.apk",
+          },
+        ],
+      }),
+    ).toThrow("download URL was invalid");
+  });
+
+  it("returns only releases newer than the installed build", () => {
+    const parsed = parsePersonalPreviewRelease(release);
+    expect(selectNewerPersonalPreviewUpdate("1785653284", parsed)).toEqual(parsed);
+    expect(selectNewerPersonalPreviewUpdate("1785653285", parsed)).toBeNull();
+    expect(selectNewerPersonalPreviewUpdate("1785653286", parsed)).toBeNull();
+  });
+
+  it("rejects malformed installed and release versions", () => {
+    expect(() =>
+      selectNewerPersonalPreviewUpdate("1.0.1", parsePersonalPreviewRelease(release)),
+    ).toThrow("installed preview version was invalid");
+    expect(() =>
+      parsePersonalPreviewRelease({ ...release, tag_name: "mark-mobile-preview-v1.2.3" }),
+    ).toThrow("release version was invalid");
+  });
+});

--- a/apps/mobile/src/features/updates/personal-preview-updates.ts
+++ b/apps/mobile/src/features/updates/personal-preview-updates.ts
@@ -4,6 +4,7 @@ import { Alert, Linking, Platform } from "react-native";
 const RELEASE_TAG_PREFIX = "mark-mobile-preview-v";
 const PREVIEW_APK_NAME = "t3-code-preview.apk";
 const TRUSTED_REPOSITORY = "Feighery89/t3code";
+const BUILD_UPDATE_API_URL = process.env.EXPO_PUBLIC_T3CODE_PERSONAL_PREVIEW_UPDATE_API_URL;
 
 export interface PersonalPreviewUpdate {
   readonly versionCode: number;
@@ -119,7 +120,11 @@ export function selectNewerPersonalPreviewUpdate(
 
 export function personalPreviewUpdateConfig(): PersonalPreviewUpdateConfig | null {
   if (Platform.OS !== "android") return null;
-  return parsePersonalPreviewUpdateConfig(Constants.expoConfig?.extra?.personalPreviewUpdates);
+  return parsePersonalPreviewUpdateConfig(
+    BUILD_UPDATE_API_URL
+      ? { latestReleaseApiUrl: BUILD_UPDATE_API_URL }
+      : Constants.expoConfig?.extra?.personalPreviewUpdates,
+  );
 }
 
 export function isPersonalPreviewUpdatesEnabled(): boolean {

--- a/apps/mobile/src/features/updates/personal-preview-updates.ts
+++ b/apps/mobile/src/features/updates/personal-preview-updates.ts
@@ -1,0 +1,177 @@
+import Constants from "expo-constants";
+import { Alert, Linking, Platform } from "react-native";
+
+const RELEASE_TAG_PREFIX = "mark-mobile-preview-v";
+const PREVIEW_APK_NAME = "t3-code-preview.apk";
+const TRUSTED_REPOSITORY = "Feighery89/t3code";
+
+export interface PersonalPreviewUpdate {
+  readonly versionCode: number;
+  readonly versionName: string;
+  readonly downloadUrl: string;
+}
+
+export interface PersonalPreviewUpdateClient {
+  readonly isEnabled: boolean;
+  readonly checkForUpdateAsync: () => Promise<PersonalPreviewUpdate | null>;
+  readonly presentUpdateAsync: (update: PersonalPreviewUpdate) => Promise<boolean>;
+}
+
+interface PersonalPreviewUpdateConfig {
+  readonly latestReleaseApiUrl: string;
+}
+
+interface GithubReleaseAsset {
+  readonly name?: unknown;
+  readonly browser_download_url?: unknown;
+}
+
+interface GithubReleasePayload {
+  readonly draft?: unknown;
+  readonly tag_name?: unknown;
+  readonly name?: unknown;
+  readonly assets?: unknown;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parsePersonalPreviewUpdateConfig(
+  value: unknown,
+): PersonalPreviewUpdateConfig | null {
+  if (!isRecord(value) || typeof value.latestReleaseApiUrl !== "string") return null;
+  const latestReleaseApiUrl = value.latestReleaseApiUrl.trim();
+  try {
+    const url = new URL(latestReleaseApiUrl);
+    if (
+      url.protocol !== "https:" ||
+      url.hostname !== "api.github.com" ||
+      url.pathname !== `/repos/${TRUSTED_REPOSITORY}/releases/latest` ||
+      url.search !== "" ||
+      url.hash !== ""
+    ) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  return { latestReleaseApiUrl };
+}
+
+export function parsePersonalPreviewRelease(payload: unknown): PersonalPreviewUpdate {
+  if (!isRecord(payload)) throw new Error("The preview release response was invalid.");
+  const release = payload as GithubReleasePayload;
+  if (release.draft === true || typeof release.tag_name !== "string") {
+    throw new Error("The preview release is unavailable.");
+  }
+
+  const versionText = release.tag_name.startsWith(RELEASE_TAG_PREFIX)
+    ? release.tag_name.slice(RELEASE_TAG_PREFIX.length)
+    : "";
+  const versionCode = Number(versionText);
+  if (!/^\d+$/.test(versionText) || !Number.isSafeInteger(versionCode) || versionCode < 1) {
+    throw new Error("The preview release version was invalid.");
+  }
+
+  if (!Array.isArray(release.assets)) {
+    throw new Error("The preview release did not include an APK.");
+  }
+  const asset = (release.assets as ReadonlyArray<GithubReleaseAsset>).find(
+    (candidate) => candidate.name === PREVIEW_APK_NAME,
+  );
+  if (typeof asset?.browser_download_url !== "string") {
+    throw new Error("The preview release did not include an APK.");
+  }
+
+  const downloadUrl = new URL(asset.browser_download_url);
+  const trustedPathPrefix = `/${TRUSTED_REPOSITORY}/releases/download/${release.tag_name}/`;
+  if (
+    downloadUrl.protocol !== "https:" ||
+    downloadUrl.hostname !== "github.com" ||
+    downloadUrl.pathname !== `${trustedPathPrefix}${PREVIEW_APK_NAME}` ||
+    downloadUrl.search !== "" ||
+    downloadUrl.hash !== ""
+  ) {
+    throw new Error("The preview APK download URL was invalid.");
+  }
+
+  return {
+    versionCode,
+    versionName:
+      typeof release.name === "string" && release.name.trim()
+        ? release.name.trim()
+        : release.tag_name,
+    downloadUrl: downloadUrl.toString(),
+  };
+}
+
+export function selectNewerPersonalPreviewUpdate(
+  currentVersionCode: string | null | undefined,
+  release: PersonalPreviewUpdate,
+): PersonalPreviewUpdate | null {
+  const current = Number(currentVersionCode);
+  if (!/^\d+$/.test(currentVersionCode ?? "") || !Number.isSafeInteger(current)) {
+    throw new Error("The installed preview version was invalid.");
+  }
+  return release.versionCode > current ? release : null;
+}
+
+export function personalPreviewUpdateConfig(): PersonalPreviewUpdateConfig | null {
+  if (Platform.OS !== "android") return null;
+  return parsePersonalPreviewUpdateConfig(Constants.expoConfig?.extra?.personalPreviewUpdates);
+}
+
+export function isPersonalPreviewUpdatesEnabled(): boolean {
+  return personalPreviewUpdateConfig() !== null;
+}
+
+async function checkForUpdate(
+  config: PersonalPreviewUpdateConfig,
+): Promise<PersonalPreviewUpdate | null> {
+  const response = await fetch(config.latestReleaseApiUrl, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Could not check preview updates (${response.status}).`);
+  }
+  const release = parsePersonalPreviewRelease(await response.json());
+  return selectNewerPersonalPreviewUpdate(Constants.nativeBuildVersion, release);
+}
+
+function confirmUpdate(update: PersonalPreviewUpdate): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (accepted: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(accepted);
+    };
+    Alert.alert(
+      "T3 Code Preview update",
+      `${update.versionName} is ready. Android will verify the app signature before installing it.`,
+      [
+        { text: "Later", style: "cancel", onPress: () => finish(false) },
+        { text: "Download", onPress: () => finish(true) },
+      ],
+      { cancelable: true, onDismiss: () => finish(false) },
+    );
+  });
+}
+
+export function createPersonalPreviewUpdateClient(): PersonalPreviewUpdateClient | null {
+  const config = personalPreviewUpdateConfig();
+  if (config === null) return null;
+  return {
+    isEnabled: true,
+    checkForUpdateAsync: () => checkForUpdate(config),
+    presentUpdateAsync: async (update) => {
+      if (!(await confirmUpdate(update))) return false;
+      await Linking.openURL(update.downloadUrl);
+      return true;
+    },
+  };
+}

--- a/apps/mobile/src/native/backgroundConnection.test.ts
+++ b/apps/mobile/src/native/backgroundConnection.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const expoMocks = vi.hoisted(() => ({
+  requireOptionalNativeModule: vi.fn((_name: string): unknown => null),
+}));
+
+vi.mock("expo", () => ({
+  NativeModule: class {
+    readonly __nativeModule = true;
+  },
+  requireOptionalNativeModule: expoMocks.requireOptionalNativeModule,
+}));
+
+const runningStatus = {
+  supported: true,
+  enabled: true,
+  serviceRunning: true,
+  runtimeReady: true,
+  batteryOptimizationIgnored: true,
+} as const;
+
+describe("backgroundConnection native bridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    expoMocks.requireOptionalNativeModule.mockReturnValue(null);
+  });
+
+  it("is safe when the Android native module is unavailable", async () => {
+    const bridge = await import("./backgroundConnection");
+
+    expect(bridge.getBackgroundConnectionStatus()).toEqual({
+      supported: false,
+      enabled: false,
+      serviceRunning: false,
+      runtimeReady: false,
+      batteryOptimizationIgnored: false,
+    });
+    await expect(bridge.setBackgroundConnectionEnabled(true)).resolves.toMatchObject({
+      supported: false,
+    });
+    await expect(
+      bridge.requestBackgroundConnectionBatteryOptimizationExemption(),
+    ).resolves.toMatchObject({ supported: false });
+    expect(bridge.ensureBackgroundConnectionStarted()).toMatchObject({ supported: false });
+    expect(bridge.addBackgroundConnectionStatusListener(vi.fn()).remove).not.toThrow();
+    expect(bridge.addBackgroundConnectionStopRequestListener(vi.fn()).remove).not.toThrow();
+  });
+
+  it("forwards status and lifecycle calls to the installed native module", async () => {
+    const setEnabled = vi.fn(async () => runningStatus);
+    const ensureStarted = vi.fn(() => runningStatus);
+    const requestBatteryOptimizationExemption = vi.fn(async () => runningStatus);
+    const setRuntimeReady = vi.fn(() => runningStatus);
+    const acknowledgeStop = vi.fn(() => runningStatus);
+    expoMocks.requireOptionalNativeModule.mockReturnValue({
+      getStatus: () => runningStatus,
+      setEnabled,
+      ensureStarted,
+      requestBatteryOptimizationExemption,
+      setRuntimeReady,
+      acknowledgeStop,
+    });
+    const bridge = await import("./backgroundConnection");
+
+    expect(bridge.getBackgroundConnectionStatus()).toEqual(runningStatus);
+    await expect(bridge.setBackgroundConnectionEnabled(true)).resolves.toEqual(runningStatus);
+    await expect(bridge.requestBackgroundConnectionBatteryOptimizationExemption()).resolves.toEqual(
+      runningStatus,
+    );
+    expect(bridge.ensureBackgroundConnectionStarted()).toEqual(runningStatus);
+    expect(bridge.setBackgroundConnectionRuntimeReady(true)).toEqual(runningStatus);
+    expect(bridge.acknowledgeBackgroundConnectionStop()).toEqual(runningStatus);
+    expect(setEnabled).toHaveBeenCalledWith(true);
+    expect(requestBatteryOptimizationExemption).toHaveBeenCalledOnce();
+    expect(ensureStarted).toHaveBeenCalledOnce();
+    expect(setRuntimeReady).toHaveBeenCalledWith(true);
+    expect(acknowledgeStop).toHaveBeenCalledOnce();
+  });
+
+  it("normalizes native status events and exposes the stop request", async () => {
+    const listeners = new Map<string, (event?: unknown) => void>();
+    const remove = vi.fn();
+    expoMocks.requireOptionalNativeModule.mockReturnValue({
+      getStatus: () => runningStatus,
+      addListener: (eventName: string, listener: (event?: unknown) => void) => {
+        listeners.set(eventName, listener);
+        return { remove };
+      },
+    });
+    const bridge = await import("./backgroundConnection");
+    const onStatus = vi.fn();
+    const onStop = vi.fn();
+
+    const statusSubscription = bridge.addBackgroundConnectionStatusListener(onStatus);
+    bridge.addBackgroundConnectionStopRequestListener(onStop);
+    listeners.get("onStatusChange")?.({
+      ...runningStatus,
+      runtimeReady: 1,
+    });
+    listeners.get("onStopRequested")?.();
+    statusSubscription.remove();
+
+    expect(onStatus).toHaveBeenCalledWith({ ...runningStatus, runtimeReady: false });
+    expect(onStop).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/native/backgroundConnection.ts
+++ b/apps/mobile/src/native/backgroundConnection.ts
@@ -1,0 +1,141 @@
+import { NativeModule, requireOptionalNativeModule } from "expo";
+
+export interface BackgroundConnectionStatus {
+  readonly supported: boolean;
+  readonly enabled: boolean;
+  readonly serviceRunning: boolean;
+  readonly runtimeReady: boolean;
+  readonly batteryOptimizationIgnored: boolean;
+}
+
+type BackgroundConnectionNativeEvents = {
+  readonly onStatusChange: (status: BackgroundConnectionStatus) => void;
+  readonly onStopRequested: () => void;
+};
+
+declare class BackgroundConnectionNativeModule extends NativeModule<BackgroundConnectionNativeEvents> {
+  readonly getStatus?: () => BackgroundConnectionStatus;
+  readonly setEnabled?: (enabled: boolean) => Promise<BackgroundConnectionStatus>;
+  readonly ensureStarted?: () => BackgroundConnectionStatus;
+  readonly requestBatteryOptimizationExemption?: () => Promise<BackgroundConnectionStatus>;
+  readonly setRuntimeReady?: (ready: boolean) => BackgroundConnectionStatus;
+  readonly acknowledgeStop?: () => BackgroundConnectionStatus;
+}
+
+export interface BackgroundConnectionSubscription {
+  readonly remove: () => void;
+}
+
+const UNSUPPORTED_STATUS: BackgroundConnectionStatus = {
+  supported: false,
+  enabled: false,
+  serviceRunning: false,
+  runtimeReady: false,
+  batteryOptimizationIgnored: false,
+};
+
+let cachedNativeModule: BackgroundConnectionNativeModule | null | undefined;
+
+function getNativeModule(): BackgroundConnectionNativeModule | null {
+  if (cachedNativeModule !== undefined) return cachedNativeModule;
+  try {
+    cachedNativeModule =
+      requireOptionalNativeModule<BackgroundConnectionNativeModule>("T3BackgroundConnection");
+  } catch {
+    cachedNativeModule = null;
+  }
+  return cachedNativeModule;
+}
+
+function normalizeStatus(status: BackgroundConnectionStatus | null | undefined) {
+  if (status?.supported !== true) return UNSUPPORTED_STATUS;
+  return {
+    supported: true,
+    enabled: status.enabled === true,
+    serviceRunning: status.serviceRunning === true,
+    runtimeReady: status.runtimeReady === true,
+    batteryOptimizationIgnored: status.batteryOptimizationIgnored === true,
+  } satisfies BackgroundConnectionStatus;
+}
+
+export function getBackgroundConnectionStatus(): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.getStatus?.());
+  } catch {
+    return UNSUPPORTED_STATUS;
+  }
+}
+
+export async function setBackgroundConnectionEnabled(
+  enabled: boolean,
+): Promise<BackgroundConnectionStatus> {
+  try {
+    const nativeModule = getNativeModule();
+    if (!nativeModule?.setEnabled) return UNSUPPORTED_STATUS;
+    return normalizeStatus(await nativeModule.setEnabled(enabled));
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function ensureBackgroundConnectionStarted(): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.ensureStarted?.());
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export async function requestBackgroundConnectionBatteryOptimizationExemption(): Promise<BackgroundConnectionStatus> {
+  try {
+    const nativeModule = getNativeModule();
+    if (!nativeModule?.requestBatteryOptimizationExemption) return UNSUPPORTED_STATUS;
+    return normalizeStatus(await nativeModule.requestBatteryOptimizationExemption());
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function setBackgroundConnectionRuntimeReady(ready: boolean): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.setRuntimeReady?.(ready));
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function acknowledgeBackgroundConnectionStop(): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.acknowledgeStop?.());
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function addBackgroundConnectionStatusListener(
+  listener: (status: BackgroundConnectionStatus) => void,
+): BackgroundConnectionSubscription {
+  try {
+    const nativeModule = getNativeModule();
+    if (!nativeModule) return NOOP_SUBSCRIPTION;
+    return nativeModule.addListener("onStatusChange", (status) => {
+      listener(normalizeStatus(status));
+    });
+  } catch {
+    return NOOP_SUBSCRIPTION;
+  }
+}
+
+export function addBackgroundConnectionStopRequestListener(
+  listener: () => void,
+): BackgroundConnectionSubscription {
+  try {
+    return getNativeModule()?.addListener("onStopRequested", listener) ?? NOOP_SUBSCRIPTION;
+  } catch {
+    return NOOP_SUBSCRIPTION;
+  }
+}
+
+const NOOP_SUBSCRIPTION: BackgroundConnectionSubscription = {
+  remove() {},
+};

--- a/apps/mobile/src/persistence/imperative.ts
+++ b/apps/mobile/src/persistence/imperative.ts
@@ -51,3 +51,13 @@ export const loadRecentThreadShortcuts = () =>
 export const saveRecentThreadShortcuts = (
   threads: ReadonlyArray<MobileStorage.RecentThreadShortcut>,
 ) => runStorage((storage) => storage.saveRecentThreadShortcuts(threads));
+
+export const loadBackgroundConnectionRetainedThread = () =>
+  runStorage((storage) => storage.loadBackgroundConnectionRetainedThread);
+export const saveBackgroundConnectionRetainedThread = (
+  thread: Parameters<
+    MobileStorage.MobileStorage["Service"]["saveBackgroundConnectionRetainedThread"]
+  >[0],
+) => runStorage((storage) => storage.saveBackgroundConnectionRetainedThread(thread));
+export const clearBackgroundConnectionRetainedThread = () =>
+  runStorage((storage) => storage.clearBackgroundConnectionRetainedThread);

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -21,6 +21,8 @@ export interface Preferences {
   readonly lightThemeId?: MobileThemeId;
   readonly darkThemeId?: MobileThemeId;
   readonly themeMode?: MobileThemeMode;
+  readonly androidAgentNotificationsEnabled?: boolean;
+  readonly androidAgentNotificationEventIds?: readonly string[];
   readonly baseFontSize?: number;
   readonly terminalFontSize?: number | null;
   readonly markdownFontSize?: number;
@@ -88,6 +90,8 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     lightThemeId?: MobileThemeId;
     darkThemeId?: MobileThemeId;
     themeMode?: MobileThemeMode;
+    androidAgentNotificationsEnabled?: boolean;
+    androidAgentNotificationEventIds?: readonly string[];
     baseFontSize?: number;
     terminalFontSize?: number | null;
     markdownFontSize?: number;
@@ -129,6 +133,14 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     parsed.themeMode === "dark"
   ) {
     preferences.themeMode = parsed.themeMode;
+  }
+  if (typeof parsed.androidAgentNotificationsEnabled === "boolean") {
+    preferences.androidAgentNotificationsEnabled = parsed.androidAgentNotificationsEnabled;
+  }
+  if (Array.isArray(parsed.androidAgentNotificationEventIds)) {
+    preferences.androidAgentNotificationEventIds = parsed.androidAgentNotificationEventIds
+      .filter((eventId): eventId is string => typeof eventId === "string" && eventId.length > 0)
+      .slice(-512);
   }
   if (typeof parsed.baseFontSize === "number") preferences.baseFontSize = parsed.baseFontSize;
   if (typeof parsed.terminalFontSize === "number" || parsed.terminalFontSize === null) {

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -15,6 +15,8 @@ const PREFERENCES_FALLBACK_KEY = "t3code.preferences.fallback";
 
 export interface Preferences {
   readonly liveActivitiesEnabled?: boolean;
+  readonly androidAgentNotificationsEnabled?: boolean;
+  readonly androidAgentNotificationEventIds?: readonly string[];
   readonly baseFontSize?: number;
   readonly terminalFontSize?: number | null;
   readonly markdownFontSize?: number;
@@ -72,6 +74,8 @@ export class MobilePreferencesStore extends Context.Service<
 function sanitizePreferences(parsed: Preferences): Preferences {
   const preferences: {
     liveActivitiesEnabled?: boolean;
+    androidAgentNotificationsEnabled?: boolean;
+    androidAgentNotificationEventIds?: readonly string[];
     baseFontSize?: number;
     terminalFontSize?: number | null;
     markdownFontSize?: number;
@@ -85,6 +89,14 @@ function sanitizePreferences(parsed: Preferences): Preferences {
 
   if (typeof parsed.liveActivitiesEnabled === "boolean") {
     preferences.liveActivitiesEnabled = parsed.liveActivitiesEnabled;
+  }
+  if (typeof parsed.androidAgentNotificationsEnabled === "boolean") {
+    preferences.androidAgentNotificationsEnabled = parsed.androidAgentNotificationsEnabled;
+  }
+  if (Array.isArray(parsed.androidAgentNotificationEventIds)) {
+    preferences.androidAgentNotificationEventIds = parsed.androidAgentNotificationEventIds
+      .filter((eventId): eventId is string => typeof eventId === "string" && eventId.length > 0)
+      .slice(-512);
   }
   if (typeof parsed.baseFontSize === "number") preferences.baseFontSize = parsed.baseFontSize;
   if (typeof parsed.terminalFontSize === "number" || parsed.terminalFontSize === null) {

--- a/apps/mobile/src/persistence/mobile-storage.test.ts
+++ b/apps/mobile/src/persistence/mobile-storage.test.ts
@@ -1,0 +1,59 @@
+import { expect, it } from "@effect/vitest";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import { vi } from "vite-plus/test";
+
+const secureStore = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("expo-secure-store", () => ({
+  getItemAsync: vi.fn((key: string) => Promise.resolve(secureStore.get(key) ?? null)),
+  setItemAsync: vi.fn((key: string, value: string) => {
+    secureStore.set(key, value);
+    return Promise.resolve();
+  }),
+  deleteItemAsync: vi.fn((key: string) => {
+    secureStore.delete(key);
+    return Promise.resolve();
+  }),
+}));
+
+vi.mock("react-native", () => ({
+  Platform: { OS: "android" },
+}));
+
+import * as MobileSecureStorage from "./mobile-secure-storage";
+import * as MobileStorage from "./mobile-storage";
+
+const RETAINED_THREAD_KEY = "t3code.background-connection.retained-thread";
+
+const makeStorage = MobileStorage.make().pipe(
+  Effect.provideService(MobileSecureStorage.MobileSecureStorage, MobileSecureStorage.make),
+);
+
+it.effect("round-trips and clears the retained background thread", () =>
+  Effect.gen(function* () {
+    secureStore.clear();
+    const storage = yield* makeStorage;
+    const retained = {
+      environmentId: EnvironmentId.make("environment-1"),
+      threadId: ThreadId.make("thread-1"),
+    };
+
+    yield* storage.saveBackgroundConnectionRetainedThread(retained);
+    expect(yield* storage.loadBackgroundConnectionRetainedThread).toEqual(retained);
+
+    yield* storage.clearBackgroundConnectionRetainedThread;
+    expect(yield* storage.loadBackgroundConnectionRetainedThread).toBeNull();
+  }),
+);
+
+it.effect("removes malformed retained-thread storage", () =>
+  Effect.gen(function* () {
+    secureStore.clear();
+    secureStore.set(RETAINED_THREAD_KEY, JSON.stringify({ environmentId: "environment-1" }));
+    const storage = yield* makeStorage;
+
+    expect(yield* storage.loadBackgroundConnectionRetainedThread).toBeNull();
+    expect(secureStore.has(RETAINED_THREAD_KEY)).toBe(false);
+  }),
+);

--- a/apps/mobile/src/persistence/mobile-storage.ts
+++ b/apps/mobile/src/persistence/mobile-storage.ts
@@ -1,4 +1,8 @@
-import { EnvironmentId } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  ScopedThreadRef,
+  type ScopedThreadRef as ScopedThreadRefType,
+} from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -17,6 +21,15 @@ const CONNECTIONS_KEY = "t3code.connections";
 const AGENT_AWARENESS_DEVICE_ID_KEY = "t3code.agent-awareness.device-id";
 const AGENT_AWARENESS_REGISTRATION_KEY = "t3code.agent-awareness.registration";
 const RECENT_THREAD_SHORTCUTS_KEY = "t3code.recent-thread-shortcuts";
+const BACKGROUND_CONNECTION_RETAINED_THREAD_KEY = "t3code.background-connection.retained-thread";
+
+const BackgroundConnectionRetainedThread = Schema.fromJsonString(ScopedThreadRef);
+const decodeBackgroundConnectionRetainedThread = Schema.decodeUnknownEffect(
+  BackgroundConnectionRetainedThread,
+);
+const encodeBackgroundConnectionRetainedThread = Schema.encodeEffect(
+  BackgroundConnectionRetainedThread,
+);
 
 export class MobileStorageDecodeError extends Schema.TaggedErrorClass<MobileStorageDecodeError>()(
   "MobileStorageDecodeError",
@@ -113,6 +126,20 @@ export class MobileStorage extends Context.Service<
     ) => Effect.Effect<
       void,
       MobileSecureStorage.MobileSecureStorageError | MobileStorageEncodeError
+    >;
+    readonly loadBackgroundConnectionRetainedThread: Effect.Effect<
+      ScopedThreadRefType | null,
+      MobileSecureStorage.MobileSecureStorageError
+    >;
+    readonly saveBackgroundConnectionRetainedThread: (
+      thread: ScopedThreadRefType,
+    ) => Effect.Effect<
+      void,
+      MobileSecureStorage.MobileSecureStorageError | MobileStorageEncodeError
+    >;
+    readonly clearBackgroundConnectionRetainedThread: Effect.Effect<
+      void,
+      MobileSecureStorage.MobileSecureStorageError
     >;
   }
 >()("@t3tools/mobile/persistence/MobileStorage") {}
@@ -245,6 +272,44 @@ export const make = Effect.fn("MobileStorage.make")(function* () {
     ),
   );
 
+  const loadBackgroundConnectionRetainedThread = secureStorage
+    .getItem(BACKGROUND_CONNECTION_RETAINED_THREAD_KEY)
+    .pipe(
+      Effect.flatMap((encoded) => {
+        if (encoded === null || encoded.trim().length === 0) {
+          return Effect.succeed(null);
+        }
+        return decodeBackgroundConnectionRetainedThread(encoded).pipe(
+          Effect.map((thread): ScopedThreadRefType | null => thread),
+          Effect.catch((cause) =>
+            Effect.logWarning("Ignored an invalid retained background thread.").pipe(
+              Effect.annotateLogs({
+                storageKey: BACKGROUND_CONNECTION_RETAINED_THREAD_KEY,
+                cause: String(cause),
+              }),
+              Effect.andThen(secureStorage.removeItem(BACKGROUND_CONNECTION_RETAINED_THREAD_KEY)),
+              Effect.as(null),
+            ),
+          ),
+        );
+      }),
+    );
+
+  const saveBackgroundConnectionRetainedThread = Effect.fn(
+    "MobileStorage.saveBackgroundConnectionRetainedThread",
+  )(function* (thread: ScopedThreadRefType) {
+    const encoded = yield* encodeBackgroundConnectionRetainedThread(thread).pipe(
+      Effect.mapError(
+        (cause) =>
+          new MobileStorageEncodeError({
+            key: BACKGROUND_CONNECTION_RETAINED_THREAD_KEY,
+            cause,
+          }),
+      ),
+    );
+    yield* secureStorage.setItem(BACKGROUND_CONNECTION_RETAINED_THREAD_KEY, encoded);
+  });
+
   return MobileStorage.of({
     loadSavedConnections,
     saveConnection,
@@ -260,6 +325,11 @@ export const make = Effect.fn("MobileStorage.make")(function* () {
     ),
     loadRecentThreadShortcuts,
     saveRecentThreadShortcuts: (threads) => writeJson(RECENT_THREAD_SHORTCUTS_KEY, { threads }),
+    loadBackgroundConnectionRetainedThread,
+    saveBackgroundConnectionRetainedThread,
+    clearBackgroundConnectionRetainedThread: secureStorage.removeItem(
+      BACKGROUND_CONNECTION_RETAINED_THREAD_KEY,
+    ),
   });
 });
 

--- a/apps/mobile/src/state/use-thread-outbox-drain.test.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.test.ts
@@ -1,0 +1,87 @@
+import { AtomRegistry } from "effect/unstable/reactivity";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("../lib/uuid", () => ({
+  randomHex: vi.fn(() => "00"),
+  uuidv4: vi.fn(() => "00000000-0000-4000-8000-000000000000"),
+}));
+
+vi.mock("./presentation", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return { environmentPresentations: { presentationsAtom: Atom.make(new Map()) } };
+});
+
+vi.mock("./projects", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return { environmentProjects: { projectsAtom: Atom.make([]) } };
+});
+
+vi.mock("./threads", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return {
+    environmentThreadShells: { threadShellsAtom: Atom.make([]) },
+    threadEnvironment: {
+      setInteractionMode: {},
+      setRuntimeMode: {},
+      startTurn: {},
+      updateMetadata: {},
+    },
+  };
+});
+
+vi.mock("./use-thread-outbox", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return {
+    editingQueuedMessageIdsAtom: Atom.make({}),
+    threadOutboxShellStatusesAtom: Atom.make(new Map()),
+  };
+});
+
+vi.mock("./thread-outbox", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./thread-outbox")>();
+  return {
+    ...actual,
+    ensureThreadOutboxLoaded: vi.fn(),
+  };
+});
+
+import { ensureThreadOutboxLoaded } from "./thread-outbox";
+import { acquireThreadOutboxDrain } from "./use-thread-outbox-drain";
+
+describe("thread outbox drain ownership", () => {
+  beforeEach(() => {
+    vi.mocked(ensureThreadOutboxLoaded).mockClear();
+  });
+
+  it("shares one dispatcher until the final owner releases", async () => {
+    const registry = AtomRegistry.make();
+    const subscribe = vi.spyOn(registry, "subscribe");
+
+    const releaseUi = acquireThreadOutboxDrain(registry);
+    const subscriptionsPerDispatcher = subscribe.mock.calls.length;
+    expect(subscriptionsPerDispatcher).toBeGreaterThan(0);
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+
+    const releaseBackground = acquireThreadOutboxDrain(registry);
+    expect(subscribe).toHaveBeenCalledTimes(subscriptionsPerDispatcher);
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+
+    releaseUi();
+    releaseUi();
+    const releaseReplacementUi = acquireThreadOutboxDrain(registry);
+    expect(subscribe).toHaveBeenCalledTimes(subscriptionsPerDispatcher);
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+
+    releaseBackground();
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(1);
+    releaseReplacementUi();
+
+    const releaseNextOwner = acquireThreadOutboxDrain(registry);
+    expect(subscribe).toHaveBeenCalledTimes(subscriptionsPerDispatcher * 2);
+    expect(ensureThreadOutboxLoaded).toHaveBeenCalledTimes(2);
+    releaseNextOwner();
+
+    await Promise.resolve();
+    registry.dispose();
+  });
+});

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -1,9 +1,9 @@
-import { useAtomValue } from "@effect/atom-react";
 import type {
   EnvironmentProject,
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
-import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import { RegistryContext } from "@effect/atom-react";
+import { type AtomCommandResult, runAtomCommand } from "@t3tools/client-runtime/state/runtime";
 import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -12,53 +12,53 @@ import {
 } from "@t3tools/contracts";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import * as Cause from "effect/Cause";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { AsyncResult, Atom, type AtomRegistry } from "effect/unstable/reactivity";
+import { useContext, useEffect } from "react";
 
-import { scopedThreadKey } from "../lib/scopedEntities";
-import { buildProjectThreadStartTurnInput } from "../lib/projectThreadStartTurn";
 import { toUploadChatImageAttachments } from "../lib/composerImages";
+import { buildProjectThreadStartTurnInput } from "../lib/projectThreadStartTurn";
+import { scopedThreadKey } from "../lib/scopedEntities";
 import { randomHex } from "../lib/uuid";
-import { appAtomRegistry } from "./atom-registry";
-import { useProjects, useThreadShells } from "./entities";
+import { environmentPresentations } from "./presentation";
+import { environmentProjects } from "./projects";
 import {
   confirmThreadOutboxMessageQueued,
   ensureThreadOutboxLoaded,
   removeThreadOutboxMessage,
+  threadOutboxManager,
 } from "./thread-outbox";
 import {
   isQueuedThreadCreationSendable,
   modelSelectionsEqual,
+  resolveQueuedThreadSettings,
   resolveThreadOutboxDeliveryAction,
   resolveThreadOutboxFailureAction,
-  resolveQueuedThreadSettings,
   threadOutboxRetryDelayMs,
   type QueuedThreadCreation,
   type QueuedThreadMessage,
   type ThreadOutboxCommandStage,
 } from "./thread-outbox-model";
 import { environmentThreadShells, threadEnvironment } from "./threads";
-import { useAtomCommand } from "./use-atom-command";
-import {
-  editingQueuedMessageIdsAtom,
-  useThreadOutboxMessages,
-  useThreadOutboxShellStatuses,
-} from "./use-thread-outbox";
-import { useRemoteConnectionStatus } from "./use-remote-environment-registry";
+import { editingQueuedMessageIdsAtom, threadOutboxShellStatusesAtom } from "./use-thread-outbox";
 
 export const dispatchingQueuedMessageIdAtom = Atom.make<MessageId | null>(null).pipe(
   Atom.keepAlive,
   Atom.withLabel("mobile:thread-outbox:dispatching-message-id"),
 );
 
-function beginDispatchingQueuedMessage(queuedMessageId: MessageId): void {
-  appAtomRegistry.set(dispatchingQueuedMessageIdAtom, queuedMessageId);
+interface ThreadOutboxDrainState {
+  readonly registry: AtomRegistry.AtomRegistry;
+  owners: number;
+  stopped: boolean;
+  drainScheduled: boolean;
+  activeDelivery: Promise<void> | null;
+  readonly retryAttempt: Map<MessageId, number>;
+  readonly retryNotBefore: Map<MessageId, number>;
+  readonly retryTimers: Map<MessageId, ReturnType<typeof setTimeout>>;
+  readonly releases: Array<() => void>;
 }
 
-function finishDispatchingQueuedMessage(queuedMessageId: MessageId): void {
-  const current = appAtomRegistry.get(dispatchingQueuedMessageIdAtom);
-  appAtomRegistry.set(dispatchingQueuedMessageIdAtom, current === queuedMessageId ? null : current);
-}
+const drainStates = new WeakMap<AtomRegistry.AtomRegistry, ThreadOutboxDrainState>();
 
 function findThread(
   threads: ReadonlyArray<EnvironmentThreadShell>,
@@ -85,139 +85,134 @@ function settingsCommandId(message: QueuedThreadMessage, setting: string): Comma
   return CommandId.make(`${message.commandId}:${setting}`);
 }
 
-export function useThreadOutboxDrain(): void {
-  const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
-  const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
-    reportFailure: false,
-  });
-  const setThreadRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
-    reportFailure: false,
-  });
-  const setThreadInteractionMode = useAtomCommand(threadEnvironment.setInteractionMode, {
-    reportFailure: false,
-  });
-  const dispatchingQueuedMessageId = useAtomValue(dispatchingQueuedMessageIdAtom);
-  const editingQueuedMessageIds = useAtomValue(editingQueuedMessageIdsAtom);
-  const queuedMessagesByThreadKey = useThreadOutboxMessages();
-  const shellStatuses = useThreadOutboxShellStatuses();
-  const threads = useThreadShells();
-  const projects = useProjects();
-  const { connectedEnvironments } = useRemoteConnectionStatus();
-  const [retryTick, setRetryTick] = useState(0);
-  const retryAttemptRef = useRef(new Map<MessageId, number>());
-  const retryNotBeforeRef = useRef(new Map<MessageId, number>());
-  const retryTimersRef = useRef(new Map<MessageId, ReturnType<typeof setTimeout>>());
+function makeDeliveryHelpers(queuedMessage: QueuedThreadMessage): {
+  readonly reportFailure: (
+    result: AtomCommandResult<unknown, unknown>,
+    stage: ThreadOutboxCommandStage,
+  ) => boolean;
+  readonly completeDelivery: (result: AtomCommandResult<unknown, unknown>) => Promise<boolean>;
+} {
+  const reportFailure = (
+    commandResult: AtomCommandResult<unknown, unknown>,
+    stage: ThreadOutboxCommandStage,
+  ): boolean => {
+    if (!AsyncResult.isFailure(commandResult)) {
+      return false;
+    }
+    const action = resolveThreadOutboxFailureAction({
+      stage,
+      error: Cause.squash(commandResult.cause),
+      interrupted: Cause.hasInterruptsOnly(commandResult.cause),
+    });
+    const retry = action === "retry";
+    console.warn("[thread-outbox] queued message delivery failed", {
+      environmentId: queuedMessage.environmentId,
+      threadId: queuedMessage.threadId,
+      messageId: queuedMessage.messageId,
+      stage,
+      cause: commandResult.cause,
+      retry,
+    });
+    return retry;
+  };
 
-  useEffect(() => {
-    ensureThreadOutboxLoaded();
-    return () => {
-      for (const timer of retryTimersRef.current.values()) {
-        clearTimeout(timer);
-      }
-      retryTimersRef.current.clear();
-    };
-  }, []);
-
-  const makeDeliveryHelpers = useCallback((queuedMessage: QueuedThreadMessage) => {
-    const reportFailure = (
-      commandResult: AtomCommandResult<unknown, unknown>,
-      stage: ThreadOutboxCommandStage,
-    ): boolean => {
-      if (!AsyncResult.isFailure(commandResult)) {
-        return false;
-      }
-      const action = resolveThreadOutboxFailureAction({
-        stage,
-        error: Cause.squash(commandResult.cause),
-        interrupted: Cause.hasInterruptsOnly(commandResult.cause),
-      });
-      const retry = action === "retry";
-      console.warn("[thread-outbox] queued message delivery failed", {
+  const completeDelivery = async (
+    deliveryResult: AtomCommandResult<unknown, unknown>,
+  ): Promise<boolean> => {
+    if (reportFailure(deliveryResult, "start-turn")) {
+      return false;
+    }
+    try {
+      await removeThreadOutboxMessage(queuedMessage);
+      return true;
+    } catch (error) {
+      console.warn("[thread-outbox] failed to remove delivered queued message", {
         environmentId: queuedMessage.environmentId,
         threadId: queuedMessage.threadId,
         messageId: queuedMessage.messageId,
-        stage,
-        cause: commandResult.cause,
-        retry,
+        error,
       });
-      return retry;
-    };
-    const completeDelivery = async (
-      deliveryResult: AtomCommandResult<unknown, unknown>,
-    ): Promise<boolean> => {
-      if (reportFailure(deliveryResult, "start-turn")) {
-        return false;
-      }
+      return false;
+    }
+  };
+  return { reportFailure, completeDelivery };
+}
 
-      try {
-        await removeThreadOutboxMessage(queuedMessage);
-        return true;
-      } catch (error) {
-        console.warn("[thread-outbox] failed to remove delivered queued message", {
-          environmentId: queuedMessage.environmentId,
+async function sendQueuedMessage(
+  registry: AtomRegistry.AtomRegistry,
+  queuedMessage: QueuedThreadMessage,
+  thread: EnvironmentThreadShell,
+): Promise<boolean> {
+  const settings = resolveQueuedThreadSettings(queuedMessage, thread);
+  const { reportFailure, completeDelivery } = makeDeliveryHelpers(queuedMessage);
+
+  if (!modelSelectionsEqual(settings.modelSelection, thread.modelSelection)) {
+    const updateResult = await runAtomCommand(
+      registry,
+      threadEnvironment.updateMetadata,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "model-selection"),
           threadId: queuedMessage.threadId,
-          messageId: queuedMessage.messageId,
-          error,
-        });
-        return false;
-      }
-    };
-    return { reportFailure, completeDelivery };
-  }, []);
+          modelSelection: settings.modelSelection,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(updateResult)) {
+      reportFailure(updateResult, "settings-sync");
+      return false;
+    }
+  }
 
-  const sendQueuedMessage = useCallback(
-    async (queuedMessage: QueuedThreadMessage, thread: EnvironmentThreadShell) => {
-      const settings = resolveQueuedThreadSettings(queuedMessage, thread);
-      const { reportFailure, completeDelivery } = makeDeliveryHelpers(queuedMessage);
+  if (settings.runtimeMode !== thread.runtimeMode) {
+    const runtimeResult = await runAtomCommand(
+      registry,
+      threadEnvironment.setRuntimeMode,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "runtime-mode"),
+          threadId: queuedMessage.threadId,
+          runtimeMode: settings.runtimeMode,
+          createdAt: queuedMessage.createdAt,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(runtimeResult)) {
+      reportFailure(runtimeResult, "settings-sync");
+      return false;
+    }
+  }
 
-      if (!modelSelectionsEqual(settings.modelSelection, thread.modelSelection)) {
-        const updateResult = await updateThreadMetadata({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "model-selection"),
-            threadId: queuedMessage.threadId,
-            modelSelection: settings.modelSelection,
-          },
-        });
-        if (AsyncResult.isFailure(updateResult)) {
-          reportFailure(updateResult, "settings-sync");
-          return false;
-        }
-      }
+  if (settings.interactionMode !== thread.interactionMode) {
+    const interactionResult = await runAtomCommand(
+      registry,
+      threadEnvironment.setInteractionMode,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "interaction-mode"),
+          threadId: queuedMessage.threadId,
+          interactionMode: settings.interactionMode,
+          createdAt: queuedMessage.createdAt,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(interactionResult)) {
+      reportFailure(interactionResult, "settings-sync");
+      return false;
+    }
+  }
 
-      if (settings.runtimeMode !== thread.runtimeMode) {
-        const runtimeResult = await setThreadRuntimeMode({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "runtime-mode"),
-            threadId: queuedMessage.threadId,
-            runtimeMode: settings.runtimeMode,
-            createdAt: queuedMessage.createdAt,
-          },
-        });
-        if (AsyncResult.isFailure(runtimeResult)) {
-          reportFailure(runtimeResult, "settings-sync");
-          return false;
-        }
-      }
-
-      if (settings.interactionMode !== thread.interactionMode) {
-        const interactionResult = await setThreadInteractionMode({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "interaction-mode"),
-            threadId: queuedMessage.threadId,
-            interactionMode: settings.interactionMode,
-            createdAt: queuedMessage.createdAt,
-          },
-        });
-        if (AsyncResult.isFailure(interactionResult)) {
-          reportFailure(interactionResult, "settings-sync");
-          return false;
-        }
-      }
-
-      const deliveryResult = await startTurn({
+  return completeDelivery(
+    await runAtomCommand(
+      registry,
+      threadEnvironment.startTurn,
+      {
         environmentId: queuedMessage.environmentId,
         input: {
           commandId: queuedMessage.commandId,
@@ -233,203 +228,328 @@ export function useThreadOutboxDrain(): void {
           interactionMode: settings.interactionMode,
           createdAt: queuedMessage.createdAt,
         },
-      });
-      return completeDelivery(deliveryResult);
-    },
-    [
-      makeDeliveryHelpers,
-      setThreadInteractionMode,
-      setThreadRuntimeMode,
-      startTurn,
-      updateThreadMetadata,
-    ],
+      },
+      { reportFailure: false },
+    ),
   );
+}
 
-  const sendQueuedCreation = useCallback(
-    async (
-      queuedMessage: QueuedThreadMessage,
-      creation: QueuedThreadCreation,
-      projectCwd: string,
-    ) => {
-      const modelSelection = queuedMessage.modelSelection;
-      if (modelSelection === undefined) {
-        return false;
-      }
-      const { completeDelivery } = makeDeliveryHelpers(queuedMessage);
-      const deliveryResult = await startTurn({
-        environmentId: queuedMessage.environmentId,
-        input: buildProjectThreadStartTurnInput({
-          projectId: creation.projectId,
-          projectCwd,
-          threadId: queuedMessage.threadId,
-          commandId: queuedMessage.commandId,
-          messageId: queuedMessage.messageId,
-          createdAt: queuedMessage.createdAt,
-          text: queuedMessage.text.trim(),
-          attachments: queuedMessage.attachments,
-          modelSelection,
-          runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
-          interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
-          workspaceMode: creation.workspaceMode,
-          branch: creation.branch,
-          worktreePath: creation.worktreePath,
-          startFromOrigin: creation.startFromOrigin ?? false,
-          worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
-        }),
-      });
-      return completeDelivery(deliveryResult);
+async function sendQueuedCreation(
+  registry: AtomRegistry.AtomRegistry,
+  queuedMessage: QueuedThreadMessage,
+  creation: QueuedThreadCreation,
+  projectCwd: string,
+): Promise<boolean> {
+  const modelSelection = queuedMessage.modelSelection;
+  if (modelSelection === undefined) {
+    return false;
+  }
+  const { completeDelivery } = makeDeliveryHelpers(queuedMessage);
+  const deliveryResult = await runAtomCommand(
+    registry,
+    threadEnvironment.startTurn,
+    {
+      environmentId: queuedMessage.environmentId,
+      input: buildProjectThreadStartTurnInput({
+        projectId: creation.projectId,
+        projectCwd,
+        threadId: queuedMessage.threadId,
+        commandId: queuedMessage.commandId,
+        messageId: queuedMessage.messageId,
+        createdAt: queuedMessage.createdAt,
+        text: queuedMessage.text.trim(),
+        attachments: queuedMessage.attachments,
+        modelSelection,
+        runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+        interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
+        workspaceMode: creation.workspaceMode,
+        branch: creation.branch,
+        worktreePath: creation.worktreePath,
+        startFromOrigin: creation.startFromOrigin ?? false,
+        worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
+      }),
     },
-    [makeDeliveryHelpers, startTurn],
+    { reportFailure: false },
   );
+  return completeDelivery(deliveryResult);
+}
 
-  useEffect(() => {
-    if (dispatchingQueuedMessageId !== null) {
-      return;
+function requestDrain(state: ThreadOutboxDrainState): void {
+  if (state.stopped || state.drainScheduled) {
+    return;
+  }
+  state.drainScheduled = true;
+  queueMicrotask(() => {
+    state.drainScheduled = false;
+    drainOnce(state);
+  });
+}
+
+function clearRetry(state: ThreadOutboxDrainState, messageId: MessageId): void {
+  state.retryAttempt.delete(messageId);
+  state.retryNotBefore.delete(messageId);
+  const timer = state.retryTimers.get(messageId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    state.retryTimers.delete(messageId);
+  }
+}
+
+function scheduleRetry(state: ThreadOutboxDrainState, messageId: MessageId): void {
+  // An in-flight delivery can settle after the final owner releases. Do not
+  // recreate timers that stopDrain already cleared while nobody owns the
+  // dispatcher; a later owner will perform a fresh drain immediately.
+  if (state.stopped) {
+    return;
+  }
+  const retryAttempt = (state.retryAttempt.get(messageId) ?? 0) + 1;
+  state.retryAttempt.set(messageId, retryAttempt);
+  const retryDelayMs = threadOutboxRetryDelayMs(retryAttempt);
+  state.retryNotBefore.set(messageId, Date.now() + retryDelayMs);
+  const pendingTimer = state.retryTimers.get(messageId);
+  if (pendingTimer !== undefined) {
+    clearTimeout(pendingTimer);
+  }
+  const timer = setTimeout(() => {
+    state.retryTimers.delete(messageId);
+    requestDrain(state);
+  }, retryDelayMs);
+  state.retryTimers.set(messageId, timer);
+}
+
+function drainOnce(state: ThreadOutboxDrainState): void {
+  if (
+    state.stopped ||
+    state.activeDelivery !== null ||
+    state.registry.get(dispatchingQueuedMessageIdAtom) !== null
+  ) {
+    return;
+  }
+
+  const queuedMessagesByThreadKey = state.registry.get(
+    threadOutboxManager.queuedMessagesByThreadKeyAtom,
+  );
+  const editingQueuedMessageIds = state.registry.get(editingQueuedMessageIdsAtom);
+  const shellStatuses = state.registry.get(threadOutboxShellStatusesAtom);
+  const threads = state.registry.get(environmentThreadShells.threadShellsAtom);
+  const projects = state.registry.get(environmentProjects.projectsAtom);
+  const presentations = state.registry.get(environmentPresentations.presentationsAtom);
+
+  for (const [threadKey, queuedMessages] of Object.entries(queuedMessagesByThreadKey)) {
+    const nextQueuedMessage = queuedMessages[0];
+    if (!nextQueuedMessage || editingQueuedMessageIds[nextQueuedMessage.messageId]) {
+      continue;
+    }
+    if ((state.retryNotBefore.get(nextQueuedMessage.messageId) ?? 0) > Date.now()) {
+      continue;
     }
 
-    for (const [threadKey, queuedMessages] of Object.entries(queuedMessagesByThreadKey)) {
-      const nextQueuedMessage = queuedMessages[0];
-      if (!nextQueuedMessage) {
-        continue;
-      }
-      if (editingQueuedMessageIds[nextQueuedMessage.messageId]) {
-        continue;
-      }
-      if ((retryNotBeforeRef.current.get(nextQueuedMessage.messageId) ?? 0) > Date.now()) {
-        continue;
-      }
+    const thread = findThread(threads, nextQueuedMessage);
+    if (thread && scopedThreadKey(thread.environmentId, thread.id) !== threadKey) {
+      continue;
+    }
+    const creation = nextQueuedMessage.creation;
+    const shellStatus = shellStatuses.get(nextQueuedMessage.environmentId) ?? "empty";
+    const deliveryAction = resolveThreadOutboxDeliveryAction({
+      isCreation: creation !== undefined,
+      threadExists: thread !== undefined,
+      shellStatus,
+      environmentConnected:
+        presentations.get(nextQueuedMessage.environmentId)?.connection.phase === "connected",
+      threadBusy: thread?.session?.status === "running" || thread?.session?.status === "starting",
+    });
+    if (deliveryAction === "wait") {
+      continue;
+    }
 
-      const thread = findThread(threads, nextQueuedMessage);
-      if (thread && scopedThreadKey(thread.environmentId, thread.id) !== threadKey) {
+    // Prefer the live project shell, but retain the enqueue-time path so a
+    // pending task remains deliverable while its project shell is unloaded.
+    const creationProjectCwd =
+      creation !== undefined
+        ? (findCreationProject(projects, nextQueuedMessage)?.workspaceRoot ??
+          creation.projectCwd ??
+          null)
+        : null;
+    if (deliveryAction === "send" && creation !== undefined) {
+      // Incomplete worktree drafts remain queued until editing finishes.
+      if (!isQueuedThreadCreationSendable(nextQueuedMessage)) {
         continue;
       }
+      if (creationProjectCwd === null && shellStatus !== "live") {
+        continue;
+      }
+    }
 
-      const creation = nextQueuedMessage.creation;
-      const environment = connectedEnvironments.find(
-        (candidate) => candidate.environmentId === nextQueuedMessage.environmentId,
+    state.registry.set(dispatchingQueuedMessageIdAtom, nextQueuedMessage.messageId);
+    const removeQueuedMessage = (warning: string) =>
+      removeThreadOutboxMessage(nextQueuedMessage).then(
+        () => true,
+        (error) => {
+          console.warn(warning, {
+            environmentId: nextQueuedMessage.environmentId,
+            threadId: nextQueuedMessage.threadId,
+            messageId: nextQueuedMessage.messageId,
+            error,
+          });
+          return false;
+        },
       );
-      const shellStatus = shellStatuses.get(nextQueuedMessage.environmentId) ?? "empty";
-      const deliveryAction = resolveThreadOutboxDeliveryAction({
-        isCreation: creation !== undefined,
-        threadExists: thread !== undefined,
-        shellStatus,
-        environmentConnected: environment?.connectionState === "connected",
-        threadBusy: thread?.session?.status === "running" || thread?.session?.status === "starting",
-      });
-      if (deliveryAction === "wait") {
-        continue;
-      }
-      // The live project shell is preferred for the workspace path, with the
-      // snapshot taken at enqueue time as the fallback so a task never dies
-      // just because its project shell is not loaded.
-      const creationProjectCwd =
-        creation !== undefined
-          ? (findCreationProject(projects, nextQueuedMessage)?.workspaceRoot ??
-            creation.projectCwd ??
-            null)
-          : null;
-      // An incomplete pending task (e.g. worktree mode without a branch) stays
-      // queued until the user finishes it in the editor.
-      if (deliveryAction === "send" && creation !== undefined) {
-        if (!isQueuedThreadCreationSendable(nextQueuedMessage)) {
-          continue;
-        }
-        if (creationProjectCwd === null && shellStatus !== "live") {
-          continue;
-        }
-      }
 
-      beginDispatchingQueuedMessage(nextQueuedMessage.messageId);
-      const removeQueuedMessage = (warning: string) =>
-        removeThreadOutboxMessage(nextQueuedMessage).then(
-          () => true,
-          (error) => {
-            console.warn(warning, {
-              environmentId: nextQueuedMessage.environmentId,
-              threadId: nextQueuedMessage.threadId,
-              messageId: nextQueuedMessage.messageId,
-              error,
-            });
-            return false;
-          },
-        );
-      // Enqueues publish optimistically before their durable write settles.
-      // Confirm the write landed (and the message wasn't rolled back) before
-      // sending, so a failed write can never chase an already-delivered turn.
-      const delivery = confirmThreadOutboxMessageQueued(nextQueuedMessage).then((queued) => {
-        if (!queued) {
-          // Rolled back by a failed write; nothing to deliver or retry.
-          return true;
-        }
-        // The guards evaluated before the confirmation await are stale by now:
-        // the thread may have gone busy, or the user may have opened this
-        // message in the editor. Re-read both and defer to the next drain pass
-        // (returning true skips the failure/backoff path) rather than sending
-        // a payload the user is editing or racing an active turn.
-        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]) {
-          return true;
-        }
-        const freshThread = findThread(
-          appAtomRegistry.get(environmentThreadShells.threadShellsAtom),
-          nextQueuedMessage,
-        );
-        const freshThreadBusy =
-          freshThread?.session?.status === "running" || freshThread?.session?.status === "starting";
-        if (deliveryAction === "send" && creation === undefined && freshThreadBusy) {
-          return true;
-        }
-        return deliveryAction === "remove"
-          ? removeQueuedMessage("[thread-outbox] failed to remove message for a missing thread")
-          : creation !== undefined
-            ? creationProjectCwd !== null
-              ? sendQueuedCreation(nextQueuedMessage, creation, creationProjectCwd)
-              : removeQueuedMessage("[thread-outbox] dropped pending task for a missing project")
-            : thread !== undefined
-              ? sendQueuedMessage(nextQueuedMessage, thread)
-              : Promise.resolve(false);
-      });
-      void delivery
-        .then((sent) => {
-          if (sent) {
-            retryAttemptRef.current.delete(nextQueuedMessage.messageId);
-            retryNotBeforeRef.current.delete(nextQueuedMessage.messageId);
-            const pendingTimer = retryTimersRef.current.get(nextQueuedMessage.messageId);
-            if (pendingTimer !== undefined) {
-              clearTimeout(pendingTimer);
-              retryTimersRef.current.delete(nextQueuedMessage.messageId);
-            }
-            return;
-          }
+    // Enqueue publishes optimistically before its durable write settles.
+    // Confirm persistence before dispatch so a rolled-back write cannot send.
+    const delivery = confirmThreadOutboxMessageQueued(nextQueuedMessage).then((queued) => {
+      if (!queued) {
+        return true;
+      }
+      // These guards may have changed while persistence was settling. Re-read
+      // them before sending and let the next atom change restart the drain.
+      if (state.registry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]) {
+        return true;
+      }
+      const freshThread = findThread(
+        state.registry.get(environmentThreadShells.threadShellsAtom),
+        nextQueuedMessage,
+      );
+      const freshThreadBusy =
+        freshThread?.session?.status === "running" || freshThread?.session?.status === "starting";
+      if (deliveryAction === "send" && creation === undefined && freshThreadBusy) {
+        return true;
+      }
+      return deliveryAction === "remove"
+        ? removeQueuedMessage("[thread-outbox] failed to remove message for a missing thread")
+        : creation !== undefined
+          ? creationProjectCwd !== null
+            ? sendQueuedCreation(state.registry, nextQueuedMessage, creation, creationProjectCwd)
+            : removeQueuedMessage("[thread-outbox] dropped pending task for a missing project")
+          : thread !== undefined
+            ? sendQueuedMessage(state.registry, nextQueuedMessage, thread)
+            : Promise.resolve(false);
+    });
 
-          const retryAttempt = (retryAttemptRef.current.get(nextQueuedMessage.messageId) ?? 0) + 1;
-          retryAttemptRef.current.set(nextQueuedMessage.messageId, retryAttempt);
-          const retryDelayMs = threadOutboxRetryDelayMs(retryAttempt);
-          retryNotBeforeRef.current.set(nextQueuedMessage.messageId, Date.now() + retryDelayMs);
-          const pendingTimer = retryTimersRef.current.get(nextQueuedMessage.messageId);
-          if (pendingTimer !== undefined) {
-            clearTimeout(pendingTimer);
-          }
-          const retryTimer = setTimeout(() => {
-            retryTimersRef.current.delete(nextQueuedMessage.messageId);
-            setRetryTick((current) => current + 1);
-          }, retryDelayMs);
-          retryTimersRef.current.set(nextQueuedMessage.messageId, retryTimer);
-        })
-        .finally(() => {
-          finishDispatchingQueuedMessage(nextQueuedMessage.messageId);
+    const completion = delivery
+      .then((sent) => {
+        if (sent) {
+          clearRetry(state, nextQueuedMessage.messageId);
+        } else {
+          scheduleRetry(state, nextQueuedMessage.messageId);
+        }
+      })
+      .catch((error) => {
+        console.warn("[thread-outbox] queued message drain failed", {
+          environmentId: nextQueuedMessage.environmentId,
+          threadId: nextQueuedMessage.threadId,
+          messageId: nextQueuedMessage.messageId,
+          error,
         });
+        scheduleRetry(state, nextQueuedMessage.messageId);
+      })
+      .finally(() => {
+        if (state.registry.get(dispatchingQueuedMessageIdAtom) === nextQueuedMessage.messageId) {
+          state.registry.set(dispatchingQueuedMessageIdAtom, null);
+        }
+        state.activeDelivery = null;
+        requestDrain(state);
+      });
+    state.activeDelivery = completion;
+    return;
+  }
+}
+
+function startDrain(state: ThreadOutboxDrainState): void {
+  if (!state.stopped) {
+    return;
+  }
+  state.stopped = false;
+  try {
+    ensureThreadOutboxLoaded();
+    const request = () => requestDrain(state);
+    // Store each release as it is acquired so a later subscription failure can
+    // still unwind every subscription that was already installed.
+    state.releases.push(
+      state.registry.subscribe(threadOutboxManager.queuedMessagesByThreadKeyAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(editingQueuedMessageIdsAtom, request));
+    state.releases.push(state.registry.subscribe(threadOutboxShellStatusesAtom, request));
+    state.releases.push(
+      state.registry.subscribe(environmentThreadShells.threadShellsAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(environmentProjects.projectsAtom, request));
+    state.releases.push(
+      state.registry.subscribe(environmentPresentations.presentationsAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(dispatchingQueuedMessageIdAtom, request));
+    requestDrain(state);
+  } catch (error) {
+    stopDrain(state);
+    throw error;
+  }
+}
+
+function stopDrain(state: ThreadOutboxDrainState): void {
+  if (state.stopped) {
+    return;
+  }
+  state.stopped = true;
+  for (const release of state.releases.splice(0)) {
+    try {
+      release();
+    } catch (error) {
+      console.warn("[thread-outbox] failed to release drain subscription", error);
+    }
+  }
+  for (const timer of state.retryTimers.values()) {
+    clearTimeout(timer);
+  }
+  state.retryTimers.clear();
+  state.retryAttempt.clear();
+  state.retryNotBefore.clear();
+}
+
+/**
+ * Acquires the one process-wide outbox dispatcher for a registry. UI and
+ * Headless JS owners share this lease, so mounting both cannot double-send.
+ */
+export function acquireThreadOutboxDrain(registry: AtomRegistry.AtomRegistry): () => void {
+  let state = drainStates.get(registry);
+  if (state === undefined) {
+    state = {
+      registry,
+      owners: 0,
+      stopped: true,
+      drainScheduled: false,
+      activeDelivery: null,
+      retryAttempt: new Map(),
+      retryNotBefore: new Map(),
+      retryTimers: new Map(),
+      releases: [],
+    };
+    drainStates.set(registry, state);
+  }
+  state.owners += 1;
+  try {
+    startDrain(state);
+  } catch (error) {
+    state.owners -= 1;
+    if (state.owners === 0) {
+      drainStates.delete(registry);
+    }
+    throw error;
+  }
+
+  let released = false;
+  return () => {
+    if (released) {
       return;
     }
-  }, [
-    connectedEnvironments,
-    dispatchingQueuedMessageId,
-    editingQueuedMessageIds,
-    projects,
-    queuedMessagesByThreadKey,
-    retryTick,
-    sendQueuedCreation,
-    sendQueuedMessage,
-    shellStatuses,
-    threads,
-  ]);
+    released = true;
+    state.owners -= 1;
+    if (state.owners === 0) {
+      stopDrain(state);
+    }
+  };
+}
+
+export function useThreadOutboxDrain(): void {
+  const registry = useContext(RegistryContext);
+  useEffect(() => acquireThreadOutboxDrain(registry), [registry]);
 }

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -1,9 +1,9 @@
-import { useAtomValue } from "@effect/atom-react";
 import type {
   EnvironmentProject,
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
-import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import { RegistryContext } from "@effect/atom-react";
+import { type AtomCommandResult, runAtomCommand } from "@t3tools/client-runtime/state/runtime";
 import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -12,53 +12,53 @@ import {
 } from "@t3tools/contracts";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import * as Cause from "effect/Cause";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { AsyncResult, Atom, type AtomRegistry } from "effect/unstable/reactivity";
+import { useContext, useEffect } from "react";
 
-import { scopedThreadKey } from "../lib/scopedEntities";
-import { buildProjectThreadStartTurnInput } from "../lib/projectThreadStartTurn";
 import { toUploadChatImageAttachments } from "../lib/composerImages";
+import { buildProjectThreadStartTurnInput } from "../lib/projectThreadStartTurn";
+import { scopedThreadKey } from "../lib/scopedEntities";
 import { randomHex } from "../lib/uuid";
-import { appAtomRegistry } from "./atom-registry";
-import { useProjects, useThreadShells } from "./entities";
+import { environmentPresentations } from "./presentation";
+import { environmentProjects } from "./projects";
 import {
   confirmThreadOutboxMessageQueued,
   ensureThreadOutboxLoaded,
   removeThreadOutboxMessage,
+  threadOutboxManager,
 } from "./thread-outbox";
 import {
   isQueuedThreadCreationSendable,
   modelSelectionsEqual,
+  resolveQueuedThreadSettings,
   resolveThreadOutboxDeliveryAction,
   resolveThreadOutboxFailureAction,
-  resolveQueuedThreadSettings,
   threadOutboxRetryDelayMs,
   type QueuedThreadCreation,
   type QueuedThreadMessage,
   type ThreadOutboxCommandStage,
 } from "./thread-outbox-model";
-import { threadEnvironment } from "./threads";
-import { useAtomCommand } from "./use-atom-command";
-import {
-  editingQueuedMessageIdsAtom,
-  useThreadOutboxMessages,
-  useThreadOutboxShellStatuses,
-} from "./use-thread-outbox";
-import { useRemoteConnectionStatus } from "./use-remote-environment-registry";
+import { environmentThreadShells, threadEnvironment } from "./threads";
+import { editingQueuedMessageIdsAtom, threadOutboxShellStatusesAtom } from "./use-thread-outbox";
 
 export const dispatchingQueuedMessageIdAtom = Atom.make<MessageId | null>(null).pipe(
   Atom.keepAlive,
   Atom.withLabel("mobile:thread-outbox:dispatching-message-id"),
 );
 
-function beginDispatchingQueuedMessage(queuedMessageId: MessageId): void {
-  appAtomRegistry.set(dispatchingQueuedMessageIdAtom, queuedMessageId);
+interface ThreadOutboxDrainState {
+  readonly registry: AtomRegistry.AtomRegistry;
+  owners: number;
+  stopped: boolean;
+  drainScheduled: boolean;
+  activeDelivery: Promise<void> | null;
+  readonly retryAttempt: Map<MessageId, number>;
+  readonly retryNotBefore: Map<MessageId, number>;
+  readonly retryTimers: Map<MessageId, ReturnType<typeof setTimeout>>;
+  readonly releases: Array<() => void>;
 }
 
-function finishDispatchingQueuedMessage(queuedMessageId: MessageId): void {
-  const current = appAtomRegistry.get(dispatchingQueuedMessageIdAtom);
-  appAtomRegistry.set(dispatchingQueuedMessageIdAtom, current === queuedMessageId ? null : current);
-}
+const drainStates = new WeakMap<AtomRegistry.AtomRegistry, ThreadOutboxDrainState>();
 
 function findThread(
   threads: ReadonlyArray<EnvironmentThreadShell>,
@@ -85,139 +85,134 @@ function settingsCommandId(message: QueuedThreadMessage, setting: string): Comma
   return CommandId.make(`${message.commandId}:${setting}`);
 }
 
-export function useThreadOutboxDrain(): void {
-  const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
-  const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
-    reportFailure: false,
-  });
-  const setThreadRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
-    reportFailure: false,
-  });
-  const setThreadInteractionMode = useAtomCommand(threadEnvironment.setInteractionMode, {
-    reportFailure: false,
-  });
-  const dispatchingQueuedMessageId = useAtomValue(dispatchingQueuedMessageIdAtom);
-  const editingQueuedMessageIds = useAtomValue(editingQueuedMessageIdsAtom);
-  const queuedMessagesByThreadKey = useThreadOutboxMessages();
-  const shellStatuses = useThreadOutboxShellStatuses();
-  const threads = useThreadShells();
-  const projects = useProjects();
-  const { connectedEnvironments } = useRemoteConnectionStatus();
-  const [retryTick, setRetryTick] = useState(0);
-  const retryAttemptRef = useRef(new Map<MessageId, number>());
-  const retryNotBeforeRef = useRef(new Map<MessageId, number>());
-  const retryTimersRef = useRef(new Map<MessageId, ReturnType<typeof setTimeout>>());
+function makeDeliveryHelpers(queuedMessage: QueuedThreadMessage): {
+  readonly reportFailure: (
+    result: AtomCommandResult<unknown, unknown>,
+    stage: ThreadOutboxCommandStage,
+  ) => boolean;
+  readonly completeDelivery: (result: AtomCommandResult<unknown, unknown>) => Promise<boolean>;
+} {
+  const reportFailure = (
+    commandResult: AtomCommandResult<unknown, unknown>,
+    stage: ThreadOutboxCommandStage,
+  ): boolean => {
+    if (!AsyncResult.isFailure(commandResult)) {
+      return false;
+    }
+    const action = resolveThreadOutboxFailureAction({
+      stage,
+      error: Cause.squash(commandResult.cause),
+      interrupted: Cause.hasInterruptsOnly(commandResult.cause),
+    });
+    const retry = action === "retry";
+    console.warn("[thread-outbox] queued message delivery failed", {
+      environmentId: queuedMessage.environmentId,
+      threadId: queuedMessage.threadId,
+      messageId: queuedMessage.messageId,
+      stage,
+      cause: commandResult.cause,
+      retry,
+    });
+    return retry;
+  };
 
-  useEffect(() => {
-    ensureThreadOutboxLoaded();
-    return () => {
-      for (const timer of retryTimersRef.current.values()) {
-        clearTimeout(timer);
-      }
-      retryTimersRef.current.clear();
-    };
-  }, []);
-
-  const makeDeliveryHelpers = useCallback((queuedMessage: QueuedThreadMessage) => {
-    const reportFailure = (
-      commandResult: AtomCommandResult<unknown, unknown>,
-      stage: ThreadOutboxCommandStage,
-    ): boolean => {
-      if (!AsyncResult.isFailure(commandResult)) {
-        return false;
-      }
-      const action = resolveThreadOutboxFailureAction({
-        stage,
-        error: Cause.squash(commandResult.cause),
-        interrupted: Cause.hasInterruptsOnly(commandResult.cause),
-      });
-      const retry = action === "retry";
-      console.warn("[thread-outbox] queued message delivery failed", {
+  const completeDelivery = async (
+    deliveryResult: AtomCommandResult<unknown, unknown>,
+  ): Promise<boolean> => {
+    if (reportFailure(deliveryResult, "start-turn")) {
+      return false;
+    }
+    try {
+      await removeThreadOutboxMessage(queuedMessage);
+      return true;
+    } catch (error) {
+      console.warn("[thread-outbox] failed to remove delivered queued message", {
         environmentId: queuedMessage.environmentId,
         threadId: queuedMessage.threadId,
         messageId: queuedMessage.messageId,
-        stage,
-        cause: commandResult.cause,
-        retry,
+        error,
       });
-      return retry;
-    };
-    const completeDelivery = async (
-      deliveryResult: AtomCommandResult<unknown, unknown>,
-    ): Promise<boolean> => {
-      if (reportFailure(deliveryResult, "start-turn")) {
-        return false;
-      }
+      return false;
+    }
+  };
+  return { reportFailure, completeDelivery };
+}
 
-      try {
-        await removeThreadOutboxMessage(queuedMessage);
-        return true;
-      } catch (error) {
-        console.warn("[thread-outbox] failed to remove delivered queued message", {
-          environmentId: queuedMessage.environmentId,
+async function sendQueuedMessage(
+  registry: AtomRegistry.AtomRegistry,
+  queuedMessage: QueuedThreadMessage,
+  thread: EnvironmentThreadShell,
+): Promise<boolean> {
+  const settings = resolveQueuedThreadSettings(queuedMessage, thread);
+  const { reportFailure, completeDelivery } = makeDeliveryHelpers(queuedMessage);
+
+  if (!modelSelectionsEqual(settings.modelSelection, thread.modelSelection)) {
+    const updateResult = await runAtomCommand(
+      registry,
+      threadEnvironment.updateMetadata,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "model-selection"),
           threadId: queuedMessage.threadId,
-          messageId: queuedMessage.messageId,
-          error,
-        });
-        return false;
-      }
-    };
-    return { reportFailure, completeDelivery };
-  }, []);
+          modelSelection: settings.modelSelection,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(updateResult)) {
+      reportFailure(updateResult, "settings-sync");
+      return false;
+    }
+  }
 
-  const sendQueuedMessage = useCallback(
-    async (queuedMessage: QueuedThreadMessage, thread: EnvironmentThreadShell) => {
-      const settings = resolveQueuedThreadSettings(queuedMessage, thread);
-      const { reportFailure, completeDelivery } = makeDeliveryHelpers(queuedMessage);
+  if (settings.runtimeMode !== thread.runtimeMode) {
+    const runtimeResult = await runAtomCommand(
+      registry,
+      threadEnvironment.setRuntimeMode,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "runtime-mode"),
+          threadId: queuedMessage.threadId,
+          runtimeMode: settings.runtimeMode,
+          createdAt: queuedMessage.createdAt,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(runtimeResult)) {
+      reportFailure(runtimeResult, "settings-sync");
+      return false;
+    }
+  }
 
-      if (!modelSelectionsEqual(settings.modelSelection, thread.modelSelection)) {
-        const updateResult = await updateThreadMetadata({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "model-selection"),
-            threadId: queuedMessage.threadId,
-            modelSelection: settings.modelSelection,
-          },
-        });
-        if (AsyncResult.isFailure(updateResult)) {
-          reportFailure(updateResult, "settings-sync");
-          return false;
-        }
-      }
+  if (settings.interactionMode !== thread.interactionMode) {
+    const interactionResult = await runAtomCommand(
+      registry,
+      threadEnvironment.setInteractionMode,
+      {
+        environmentId: queuedMessage.environmentId,
+        input: {
+          commandId: settingsCommandId(queuedMessage, "interaction-mode"),
+          threadId: queuedMessage.threadId,
+          interactionMode: settings.interactionMode,
+          createdAt: queuedMessage.createdAt,
+        },
+      },
+      { reportFailure: false },
+    );
+    if (AsyncResult.isFailure(interactionResult)) {
+      reportFailure(interactionResult, "settings-sync");
+      return false;
+    }
+  }
 
-      if (settings.runtimeMode !== thread.runtimeMode) {
-        const runtimeResult = await setThreadRuntimeMode({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "runtime-mode"),
-            threadId: queuedMessage.threadId,
-            runtimeMode: settings.runtimeMode,
-            createdAt: queuedMessage.createdAt,
-          },
-        });
-        if (AsyncResult.isFailure(runtimeResult)) {
-          reportFailure(runtimeResult, "settings-sync");
-          return false;
-        }
-      }
-
-      if (settings.interactionMode !== thread.interactionMode) {
-        const interactionResult = await setThreadInteractionMode({
-          environmentId: queuedMessage.environmentId,
-          input: {
-            commandId: settingsCommandId(queuedMessage, "interaction-mode"),
-            threadId: queuedMessage.threadId,
-            interactionMode: settings.interactionMode,
-            createdAt: queuedMessage.createdAt,
-          },
-        });
-        if (AsyncResult.isFailure(interactionResult)) {
-          reportFailure(interactionResult, "settings-sync");
-          return false;
-        }
-      }
-
-      const deliveryResult = await startTurn({
+  return completeDelivery(
+    await runAtomCommand(
+      registry,
+      threadEnvironment.startTurn,
+      {
         environmentId: queuedMessage.environmentId,
         input: {
           commandId: queuedMessage.commandId,
@@ -233,193 +228,319 @@ export function useThreadOutboxDrain(): void {
           interactionMode: settings.interactionMode,
           createdAt: queuedMessage.createdAt,
         },
-      });
-      return completeDelivery(deliveryResult);
-    },
-    [
-      makeDeliveryHelpers,
-      setThreadInteractionMode,
-      setThreadRuntimeMode,
-      startTurn,
-      updateThreadMetadata,
-    ],
+      },
+      { reportFailure: false },
+    ),
   );
+}
 
-  const sendQueuedCreation = useCallback(
-    async (
-      queuedMessage: QueuedThreadMessage,
-      creation: QueuedThreadCreation,
-      projectCwd: string,
-    ) => {
-      const modelSelection = queuedMessage.modelSelection;
-      if (modelSelection === undefined) {
-        return false;
-      }
-      const { completeDelivery } = makeDeliveryHelpers(queuedMessage);
-      const deliveryResult = await startTurn({
-        environmentId: queuedMessage.environmentId,
-        input: buildProjectThreadStartTurnInput({
-          projectId: creation.projectId,
-          projectCwd,
-          threadId: queuedMessage.threadId,
-          commandId: queuedMessage.commandId,
-          messageId: queuedMessage.messageId,
-          createdAt: queuedMessage.createdAt,
-          text: queuedMessage.text.trim(),
-          attachments: queuedMessage.attachments,
-          modelSelection,
-          runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
-          interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
-          workspaceMode: creation.workspaceMode,
-          branch: creation.branch,
-          worktreePath: creation.worktreePath,
-          startFromOrigin: creation.startFromOrigin ?? false,
-          worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
-        }),
-      });
-      return completeDelivery(deliveryResult);
+async function sendQueuedCreation(
+  registry: AtomRegistry.AtomRegistry,
+  queuedMessage: QueuedThreadMessage,
+  creation: QueuedThreadCreation,
+  projectCwd: string,
+): Promise<boolean> {
+  const modelSelection = queuedMessage.modelSelection;
+  if (modelSelection === undefined) {
+    return false;
+  }
+  const { completeDelivery } = makeDeliveryHelpers(queuedMessage);
+  const deliveryResult = await runAtomCommand(
+    registry,
+    threadEnvironment.startTurn,
+    {
+      environmentId: queuedMessage.environmentId,
+      input: buildProjectThreadStartTurnInput({
+        projectId: creation.projectId,
+        projectCwd,
+        threadId: queuedMessage.threadId,
+        commandId: queuedMessage.commandId,
+        messageId: queuedMessage.messageId,
+        createdAt: queuedMessage.createdAt,
+        text: queuedMessage.text.trim(),
+        attachments: queuedMessage.attachments,
+        modelSelection,
+        runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+        interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
+        workspaceMode: creation.workspaceMode,
+        branch: creation.branch,
+        worktreePath: creation.worktreePath,
+        startFromOrigin: creation.startFromOrigin ?? false,
+        worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
+      }),
     },
-    [makeDeliveryHelpers, startTurn],
+    { reportFailure: false },
   );
+  return completeDelivery(deliveryResult);
+}
 
-  useEffect(() => {
-    if (dispatchingQueuedMessageId !== null) {
-      return;
+function requestDrain(state: ThreadOutboxDrainState): void {
+  if (state.stopped || state.drainScheduled) {
+    return;
+  }
+  state.drainScheduled = true;
+  queueMicrotask(() => {
+    state.drainScheduled = false;
+    drainOnce(state);
+  });
+}
+
+function clearRetry(state: ThreadOutboxDrainState, messageId: MessageId): void {
+  state.retryAttempt.delete(messageId);
+  state.retryNotBefore.delete(messageId);
+  const timer = state.retryTimers.get(messageId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    state.retryTimers.delete(messageId);
+  }
+}
+
+function scheduleRetry(state: ThreadOutboxDrainState, messageId: MessageId): void {
+  // An in-flight delivery can settle after the final owner releases. Do not
+  // recreate timers that stopDrain already cleared while nobody owns the
+  // dispatcher; a later owner will perform a fresh drain immediately.
+  if (state.stopped) {
+    return;
+  }
+  const retryAttempt = (state.retryAttempt.get(messageId) ?? 0) + 1;
+  state.retryAttempt.set(messageId, retryAttempt);
+  const retryDelayMs = threadOutboxRetryDelayMs(retryAttempt);
+  state.retryNotBefore.set(messageId, Date.now() + retryDelayMs);
+  const pendingTimer = state.retryTimers.get(messageId);
+  if (pendingTimer !== undefined) {
+    clearTimeout(pendingTimer);
+  }
+  const timer = setTimeout(() => {
+    state.retryTimers.delete(messageId);
+    requestDrain(state);
+  }, retryDelayMs);
+  state.retryTimers.set(messageId, timer);
+}
+
+function drainOnce(state: ThreadOutboxDrainState): void {
+  if (
+    state.stopped ||
+    state.activeDelivery !== null ||
+    state.registry.get(dispatchingQueuedMessageIdAtom) !== null
+  ) {
+    return;
+  }
+
+  const queuedMessagesByThreadKey = state.registry.get(
+    threadOutboxManager.queuedMessagesByThreadKeyAtom,
+  );
+  const editingQueuedMessageIds = state.registry.get(editingQueuedMessageIdsAtom);
+  const shellStatuses = state.registry.get(threadOutboxShellStatusesAtom);
+  const threads = state.registry.get(environmentThreadShells.threadShellsAtom);
+  const projects = state.registry.get(environmentProjects.projectsAtom);
+  const presentations = state.registry.get(environmentPresentations.presentationsAtom);
+
+  for (const [threadKey, queuedMessages] of Object.entries(queuedMessagesByThreadKey)) {
+    const nextQueuedMessage = queuedMessages[0];
+    if (!nextQueuedMessage || editingQueuedMessageIds[nextQueuedMessage.messageId]) {
+      continue;
+    }
+    if ((state.retryNotBefore.get(nextQueuedMessage.messageId) ?? 0) > Date.now()) {
+      continue;
     }
 
-    for (const [threadKey, queuedMessages] of Object.entries(queuedMessagesByThreadKey)) {
-      const nextQueuedMessage = queuedMessages[0];
-      if (!nextQueuedMessage) {
-        continue;
-      }
-      if (editingQueuedMessageIds[nextQueuedMessage.messageId]) {
-        continue;
-      }
-      if ((retryNotBeforeRef.current.get(nextQueuedMessage.messageId) ?? 0) > Date.now()) {
-        continue;
-      }
+    const thread = findThread(threads, nextQueuedMessage);
+    if (thread && scopedThreadKey(thread.environmentId, thread.id) !== threadKey) {
+      continue;
+    }
+    const creation = nextQueuedMessage.creation;
+    const shellStatus = shellStatuses.get(nextQueuedMessage.environmentId) ?? "empty";
+    const deliveryAction = resolveThreadOutboxDeliveryAction({
+      isCreation: creation !== undefined,
+      threadExists: thread !== undefined,
+      shellStatus,
+      environmentConnected:
+        presentations.get(nextQueuedMessage.environmentId)?.connection.phase === "connected",
+      threadBusy: thread?.session?.status === "running" || thread?.session?.status === "starting",
+    });
+    if (deliveryAction === "wait") {
+      continue;
+    }
 
-      const thread = findThread(threads, nextQueuedMessage);
-      if (thread && scopedThreadKey(thread.environmentId, thread.id) !== threadKey) {
+    // Prefer the live project shell, but retain the enqueue-time path so a
+    // pending task remains deliverable while its project shell is unloaded.
+    const creationProjectCwd =
+      creation !== undefined
+        ? (findCreationProject(projects, nextQueuedMessage)?.workspaceRoot ??
+          creation.projectCwd ??
+          null)
+        : null;
+    if (deliveryAction === "send" && creation !== undefined) {
+      // Incomplete worktree drafts remain queued until editing finishes.
+      if (!isQueuedThreadCreationSendable(nextQueuedMessage)) {
         continue;
       }
+      if (creationProjectCwd === null && shellStatus !== "live") {
+        continue;
+      }
+    }
 
-      const creation = nextQueuedMessage.creation;
-      const environment = connectedEnvironments.find(
-        (candidate) => candidate.environmentId === nextQueuedMessage.environmentId,
+    state.registry.set(dispatchingQueuedMessageIdAtom, nextQueuedMessage.messageId);
+    const removeQueuedMessage = (warning: string) =>
+      removeThreadOutboxMessage(nextQueuedMessage).then(
+        () => true,
+        (error) => {
+          console.warn(warning, {
+            environmentId: nextQueuedMessage.environmentId,
+            threadId: nextQueuedMessage.threadId,
+            messageId: nextQueuedMessage.messageId,
+            error,
+          });
+          return false;
+        },
       );
-      const shellStatus = shellStatuses.get(nextQueuedMessage.environmentId) ?? "empty";
-      const deliveryAction = resolveThreadOutboxDeliveryAction({
-        isCreation: creation !== undefined,
-        threadExists: thread !== undefined,
-        shellStatus,
-        environmentConnected: environment?.connectionState === "connected",
-        threadBusy: thread?.session?.status === "running" || thread?.session?.status === "starting",
-      });
-      if (deliveryAction === "wait") {
-        continue;
-      }
-      // The live project shell is preferred for the workspace path, with the
-      // snapshot taken at enqueue time as the fallback so a task never dies
-      // just because its project shell is not loaded.
-      const creationProjectCwd =
-        creation !== undefined
-          ? (findCreationProject(projects, nextQueuedMessage)?.workspaceRoot ??
-            creation.projectCwd ??
-            null)
-          : null;
-      // An incomplete pending task (e.g. worktree mode without a branch) stays
-      // queued until the user finishes it in the editor.
-      if (deliveryAction === "send" && creation !== undefined) {
-        if (!isQueuedThreadCreationSendable(nextQueuedMessage)) {
-          continue;
-        }
-        if (creationProjectCwd === null && shellStatus !== "live") {
-          continue;
-        }
-      }
 
-      beginDispatchingQueuedMessage(nextQueuedMessage.messageId);
-      const removeQueuedMessage = (warning: string) =>
-        removeThreadOutboxMessage(nextQueuedMessage).then(
-          () => true,
-          (error) => {
-            console.warn(warning, {
-              environmentId: nextQueuedMessage.environmentId,
-              threadId: nextQueuedMessage.threadId,
-              messageId: nextQueuedMessage.messageId,
-              error,
-            });
-            return false;
-          },
-        );
-      // Enqueues publish optimistically before their durable write settles.
-      // Confirm the write landed (and the message wasn't rolled back) before
-      // sending, so a failed write can never chase an already-delivered turn.
-      const delivery = confirmThreadOutboxMessageQueued(nextQueuedMessage).then((queued) => {
-        if (!queued) {
-          // Rolled back by a failed write; nothing to deliver or retry.
-          return true;
-        }
-        // The guards evaluated before the confirmation await are stale by now:
-        // the user may have opened this message in the editor. Re-read that
-        // guard and defer to the next drain pass (returning true skips the
-        // failure/backoff path) rather than sending a payload being edited.
-        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]) {
-          return true;
-        }
-        return deliveryAction === "remove"
-          ? removeQueuedMessage("[thread-outbox] failed to remove message for a missing thread")
-          : creation !== undefined
-            ? creationProjectCwd !== null
-              ? sendQueuedCreation(nextQueuedMessage, creation, creationProjectCwd)
-              : removeQueuedMessage("[thread-outbox] dropped pending task for a missing project")
-            : thread !== undefined
-              ? sendQueuedMessage(nextQueuedMessage, thread)
-              : Promise.resolve(false);
-      });
-      void delivery
-        .then((sent) => {
-          if (sent) {
-            retryAttemptRef.current.delete(nextQueuedMessage.messageId);
-            retryNotBeforeRef.current.delete(nextQueuedMessage.messageId);
-            const pendingTimer = retryTimersRef.current.get(nextQueuedMessage.messageId);
-            if (pendingTimer !== undefined) {
-              clearTimeout(pendingTimer);
-              retryTimersRef.current.delete(nextQueuedMessage.messageId);
-            }
-            return;
-          }
+    // Enqueue publishes optimistically before its durable write settles.
+    // Confirm persistence before dispatch so a rolled-back write cannot send.
+    const delivery = confirmThreadOutboxMessageQueued(nextQueuedMessage).then((queued) => {
+      if (!queued) {
+        return true;
+      }
+      // The editing guard may have changed while persistence was settling.
+      // Re-read it before sending and let the next atom change restart the drain.
+      if (state.registry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]) {
+        return true;
+      }
+      return deliveryAction === "remove"
+        ? removeQueuedMessage("[thread-outbox] failed to remove message for a missing thread")
+        : creation !== undefined
+          ? creationProjectCwd !== null
+            ? sendQueuedCreation(state.registry, nextQueuedMessage, creation, creationProjectCwd)
+            : removeQueuedMessage("[thread-outbox] dropped pending task for a missing project")
+          : thread !== undefined
+            ? sendQueuedMessage(state.registry, nextQueuedMessage, thread)
+            : Promise.resolve(false);
+    });
 
-          const retryAttempt = (retryAttemptRef.current.get(nextQueuedMessage.messageId) ?? 0) + 1;
-          retryAttemptRef.current.set(nextQueuedMessage.messageId, retryAttempt);
-          const retryDelayMs = threadOutboxRetryDelayMs(retryAttempt);
-          retryNotBeforeRef.current.set(nextQueuedMessage.messageId, Date.now() + retryDelayMs);
-          const pendingTimer = retryTimersRef.current.get(nextQueuedMessage.messageId);
-          if (pendingTimer !== undefined) {
-            clearTimeout(pendingTimer);
-          }
-          const retryTimer = setTimeout(() => {
-            retryTimersRef.current.delete(nextQueuedMessage.messageId);
-            setRetryTick((current) => current + 1);
-          }, retryDelayMs);
-          retryTimersRef.current.set(nextQueuedMessage.messageId, retryTimer);
-        })
-        .finally(() => {
-          finishDispatchingQueuedMessage(nextQueuedMessage.messageId);
+    const completion = delivery
+      .then((sent) => {
+        if (sent) {
+          clearRetry(state, nextQueuedMessage.messageId);
+        } else {
+          scheduleRetry(state, nextQueuedMessage.messageId);
+        }
+      })
+      .catch((error) => {
+        console.warn("[thread-outbox] queued message drain failed", {
+          environmentId: nextQueuedMessage.environmentId,
+          threadId: nextQueuedMessage.threadId,
+          messageId: nextQueuedMessage.messageId,
+          error,
         });
+        scheduleRetry(state, nextQueuedMessage.messageId);
+      })
+      .finally(() => {
+        if (state.registry.get(dispatchingQueuedMessageIdAtom) === nextQueuedMessage.messageId) {
+          state.registry.set(dispatchingQueuedMessageIdAtom, null);
+        }
+        state.activeDelivery = null;
+        requestDrain(state);
+      });
+    state.activeDelivery = completion;
+    return;
+  }
+}
+
+function startDrain(state: ThreadOutboxDrainState): void {
+  if (!state.stopped) {
+    return;
+  }
+  state.stopped = false;
+  try {
+    ensureThreadOutboxLoaded();
+    const request = () => requestDrain(state);
+    // Store each release as it is acquired so a later subscription failure can
+    // still unwind every subscription that was already installed.
+    state.releases.push(
+      state.registry.subscribe(threadOutboxManager.queuedMessagesByThreadKeyAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(editingQueuedMessageIdsAtom, request));
+    state.releases.push(state.registry.subscribe(threadOutboxShellStatusesAtom, request));
+    state.releases.push(
+      state.registry.subscribe(environmentThreadShells.threadShellsAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(environmentProjects.projectsAtom, request));
+    state.releases.push(
+      state.registry.subscribe(environmentPresentations.presentationsAtom, request),
+    );
+    state.releases.push(state.registry.subscribe(dispatchingQueuedMessageIdAtom, request));
+    requestDrain(state);
+  } catch (error) {
+    stopDrain(state);
+    throw error;
+  }
+}
+
+function stopDrain(state: ThreadOutboxDrainState): void {
+  if (state.stopped) {
+    return;
+  }
+  state.stopped = true;
+  for (const release of state.releases.splice(0)) {
+    try {
+      release();
+    } catch (error) {
+      console.warn("[thread-outbox] failed to release drain subscription", error);
+    }
+  }
+  for (const timer of state.retryTimers.values()) {
+    clearTimeout(timer);
+  }
+  state.retryTimers.clear();
+  state.retryAttempt.clear();
+  state.retryNotBefore.clear();
+}
+
+/**
+ * Acquires the one process-wide outbox dispatcher for a registry. UI and
+ * Headless JS owners share this lease, so mounting both cannot double-send.
+ */
+export function acquireThreadOutboxDrain(registry: AtomRegistry.AtomRegistry): () => void {
+  let state = drainStates.get(registry);
+  if (state === undefined) {
+    state = {
+      registry,
+      owners: 0,
+      stopped: true,
+      drainScheduled: false,
+      activeDelivery: null,
+      retryAttempt: new Map(),
+      retryNotBefore: new Map(),
+      retryTimers: new Map(),
+      releases: [],
+    };
+    drainStates.set(registry, state);
+  }
+  state.owners += 1;
+  try {
+    startDrain(state);
+  } catch (error) {
+    state.owners -= 1;
+    if (state.owners === 0) {
+      drainStates.delete(registry);
+    }
+    throw error;
+  }
+
+  let released = false;
+  return () => {
+    if (released) {
       return;
     }
-  }, [
-    connectedEnvironments,
-    dispatchingQueuedMessageId,
-    editingQueuedMessageIds,
-    projects,
-    queuedMessagesByThreadKey,
-    retryTick,
-    sendQueuedCreation,
-    sendQueuedMessage,
-    shellStatuses,
-    threads,
-  ]);
+    released = true;
+    state.owners -= 1;
+    if (state.owners === 0) {
+      stopDrain(state);
+    }
+  };
+}
+
+export function useThreadOutboxDrain(): void {
+  const registry = useContext(RegistryContext);
+  useEffect(() => acquireThreadOutboxDrain(registry), [registry]);
 }

--- a/apps/mobile/src/state/use-thread-outbox.ts
+++ b/apps/mobile/src/state/use-thread-outbox.ts
@@ -7,7 +7,7 @@ import { appAtomRegistry } from "./atom-registry";
 import { environmentShell } from "./shell";
 import { threadOutboxManager } from "./thread-outbox";
 
-const threadOutboxShellStatusesAtom = Atom.make(
+export const threadOutboxShellStatusesAtom = Atom.make(
   (get): ReadonlyMap<EnvironmentId, EnvironmentShellStatus> => {
     const statuses = new Map<EnvironmentId, EnvironmentShellStatus>();
     for (const queue of Object.values(get(threadOutboxManager.queuedMessagesByThreadKeyAtom))) {

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -78,8 +78,12 @@ Wakeup handling differs by phase, in [supervisor.ts][supervisor]:
 - Once connected, `monitorConnectedLease` handles plain activation by probing
   the existing session (`lease.session.probe`, with a shorter timeout for
   mobile's `application-active-probe`) rather than reconnecting; a healthy
-  session survives foregrounding. `application-active-reconnect` skips the probe
-  and replaces the lease outright.
+  session survives foregrounding. Android emits `application-active-preserved`
+  when its foreground service and Headless JS runtime both report ready. That
+  reason uses the same bounded mobile probe, preserves the session generation on
+  success, and replaces the lease immediately if the probe fails. It does not
+  force shell or thread subscriptions to restart. `application-active-reconnect`
+  skips the probe and replaces the lease outright.
 
 The UI derives `available`, `offline`, `connecting`, `reconnecting`,
 `connected`, and `error` from supervisor state plus explicit data-sync state.
@@ -156,6 +160,55 @@ ownership.
 Application code must not construct RPC clients, retry loops, or raw
 orchestration commands. Persistence paths belong to the platform registration
 and cache stores, with explicit migration or invalidation policy.
+
+### Android background ownership
+
+Android can add a second application-root owner without adding a second
+connection runtime. The opt-in **Keep connected in background** setting starts a
+`remoteMessaging` foreground service in the normal application process. React
+Native Headless JS cold-starts the existing mobile runtime and acquires
+reference-counted leases against the same process-wide `appAtomRegistry` used by
+the UI. Mounting the UI and background task together therefore still produces
+one supervisor and one transport per saved environment.
+
+The headless root retains:
+
+- the environment catalog, server configurations, and shell state for every
+  saved environment;
+- aggregate thread-shell state;
+- full detail for the last-opened thread and threads whose sessions are
+  `starting` or `running`; and
+- the shared, reference-counted thread-outbox drain worker.
+
+It does not retain every historical thread body. Once running work settles and
+is not the last-opened thread, the existing idle lifetime and persistence rules
+remain authoritative.
+
+T3 Connect authentication has matching `ui` and `background` owners. UI
+ownership wins while the app is visible. A cold headless start loads the
+persisted Clerk session and installs its token provider into the existing
+`managedRelaySessionAtom`; direct and Tailscale startup is not blocked when
+Clerk is signed out, unconfigured, or temporarily unavailable. There is no
+background-only relay transport or authentication path.
+
+The service is deliberately opt-in and defaults off. While enabled, Android
+requires a silent ongoing notification. React Native owns a partial CPU wake
+lock for the headless task, and the native service holds a best-effort
+high-performance Wi-Fi lock. These locks and the continuously active network
+connections have an intentional battery and data cost. A battery-optimization
+exemption improves survival under device power management, but declining it
+does not silently turn the feature off.
+
+The service uses sticky restart behavior and restores an enabled preference
+after package replacement or boot once credential-protected storage is
+available. Android force-stop remains absolute: no receiver or service may
+restart the app until the user launches it again. The app also cannot restart a
+separately stopped Tailscale VPN.
+
+At introduction, the direct/Tailscale path was exercised on a physical Android
+device across lock, Doze, task removal, network transitions, package replacement,
+and reboot. Cold T3 Connect ownership and token refresh have automated coverage,
+but were not live-validated against a configured relay account on that device.
 
 ## Verification
 

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -32,6 +32,33 @@ That gives you:
 - transport security at the network layer
 - less exposure than opening the server to the public internet
 
+## Keeping the Android App Connected
+
+On Android, **Keep connected in background** keeps saved environments and active work synchronized
+while the phone is locked or another app is open. The setting is off by default. Enable it from the
+mobile app under **Settings** → **Background connection**.
+
+This setting keeps the mobile connection runtime running; it does not change how the phone reaches
+an environment. Direct LAN, Tailscale, and T3 Connect environments continue using their existing
+connection methods. If a Tailscale environment depends on the Tailscale Android app, that VPN must
+also remain connected.
+
+Android requires an ongoing foreground-service notification while this mode is enabled. T3 Code's
+notification is silent and contains no thread content, but Android does not allow the app to hide it.
+The service also holds a partial CPU wake lock and, on Wi-Fi, a best-effort high-performance Wi-Fi
+lock. This can increase battery use and mobile-data use compared with the default on-demand
+connection behavior.
+
+When prompted, allowing unrestricted battery use makes the connection more resistant to Android or
+device-vendor power management. If you decline, the feature remains enabled but Settings reports
+**Battery optimization enabled**, and Android may still suspend it. You can tap that status to try
+again.
+
+Android force-stop is the hard boundary. After force-stopping T3 Code, launch it once before
+background connection can run again. A normal task swipe-away, process restart, app update, or reboot
+does not disable an enabled background connection; after a reboot it resumes once Android permits
+the app to start and the device has been unlocked.
+
 ## Enabling Network Access
 
 There are three ways to reach your server from another device: expose the desktop app's backend,

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -873,6 +873,37 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
+  it.effect("probes a preserved mobile session without changing its generation", () =>
+    Effect.gen(function* () {
+      const probeCount = yield* Ref.make(0);
+      const probeCalled = yield* Deferred.make<void>();
+      const harness = yield* makeHarness({
+        probe: () =>
+          Ref.update(probeCount, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.succeed(probeCalled, undefined)),
+          ),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* harness.wake("application-active-preserved");
+      yield* Deferred.await(probeCalled);
+
+      expect(yield* Ref.get(probeCount)).toBe(1);
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
+      expect(yield* SubscriptionRef.get(supervisor.state)).toMatchObject({
+        phase: "connected",
+        generation: 1,
+      });
+    }),
+  );
+
   it.effect("immediately replaces a mobile session after a long background resume", () =>
     Effect.gen(function* () {
       const probeCount = yield* Ref.make(0);
@@ -1016,7 +1047,29 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("quickly times out a stalled mobile foreground liveness probe", () =>
+  it.effect("immediately reconnects when a preserved-session probe fails", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        probe: (attempt) =>
+          attempt === 1 ? Effect.fail(transient("The preserved session is stale.")) : Effect.void,
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.wake("application-active-preserved");
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+
+      expect(yield* Ref.get(harness.sessionCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }),
+  );
+
+  it.effect("quickly times out a stalled preserved-session liveness probe", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({
         probe: (attempt) => (attempt === 1 ? Effect.never : Effect.void),
@@ -1026,7 +1079,7 @@ describe("EnvironmentSupervisor", () => {
       }).pipe(Effect.provide(harness.dependencies));
 
       yield* awaitState(supervisor.state, (state) => state.phase === "connected");
-      yield* harness.wake("application-active-probe");
+      yield* harness.wake("application-active-preserved");
       yield* TestClock.adjust("3 seconds");
       // The timed-out wake probe reconnects immediately without a backoff
       // sleep: no further clock advance is needed.

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -873,6 +873,37 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
+  it.effect("probes a preserved mobile session without changing its generation", () =>
+    Effect.gen(function* () {
+      const probeCount = yield* Ref.make(0);
+      const probeCalled = yield* Deferred.make<void>();
+      const harness = yield* makeHarness({
+        probe: () =>
+          Ref.update(probeCount, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.succeed(probeCalled, undefined)),
+          ),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* harness.wake("application-active-preserved");
+      yield* Deferred.await(probeCalled);
+
+      expect(yield* Ref.get(probeCount)).toBe(1);
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
+      expect(yield* SubscriptionRef.get(supervisor.state)).toMatchObject({
+        phase: "connected",
+        generation: 1,
+      });
+    }),
+  );
+
   it.effect("immediately replaces a mobile session after a long background resume", () =>
     Effect.gen(function* () {
       const probeCount = yield* Ref.make(0);
@@ -949,7 +980,29 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("quickly times out a stalled mobile foreground liveness probe", () =>
+  it.effect("immediately reconnects when a preserved-session probe fails", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        probe: (attempt) =>
+          attempt === 1 ? Effect.fail(transient("The preserved session is stale.")) : Effect.void,
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.wake("application-active-preserved");
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+
+      expect(yield* Ref.get(harness.sessionCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }),
+  );
+
+  it.effect("quickly times out a stalled preserved-session liveness probe", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({
         probe: (attempt) => (attempt === 1 ? Effect.never : Effect.void),
@@ -959,13 +1012,8 @@ describe("EnvironmentSupervisor", () => {
       }).pipe(Effect.provide(harness.dependencies));
 
       yield* awaitState(supervisor.state, (state) => state.phase === "connected");
-      yield* harness.wake("application-active-probe");
+      yield* harness.wake("application-active-preserved");
       yield* TestClock.adjust("3 seconds");
-      yield* awaitState(
-        supervisor.state,
-        (state) => state.phase === "backoff" && state.lastFailure?.reason === "timeout",
-      );
-      yield* TestClock.adjust("1 second");
       yield* eventuallyState(
         supervisor.state,
         (state) => state.phase === "connected" && state.generation === 2,

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -418,10 +418,15 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
             // replaces that lease and starts a fresh attempt without backoff.
             return true;
           }
-          if (next.reason === "application-active" || next.reason === "application-active-probe") {
+          if (
+            next.reason === "application-active" ||
+            next.reason === "application-active-preserved" ||
+            next.reason === "application-active-probe"
+          ) {
             const probe = yield* lease.session.probe.pipe(
               Effect.timeoutOrElse({
                 duration:
+                  next.reason === "application-active-preserved" ||
                   next.reason === "application-active-probe"
                     ? MOBILE_CONNECTION_PROBE_TIMEOUT
                     : CONNECTION_PROBE_TIMEOUT,

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -414,10 +414,15 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
             // replaces that lease and starts a fresh attempt without backoff.
             return true;
           }
-          if (next.reason === "application-active" || next.reason === "application-active-probe") {
+          if (
+            next.reason === "application-active" ||
+            next.reason === "application-active-preserved" ||
+            next.reason === "application-active-probe"
+          ) {
             const probe = yield* lease.session.probe.pipe(
               Effect.timeoutOrElse({
                 duration:
+                  next.reason === "application-active-preserved" ||
                   next.reason === "application-active-probe"
                     ? MOBILE_CONNECTION_PROBE_TIMEOUT
                     : CONNECTION_PROBE_TIMEOUT,
@@ -441,6 +446,16 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
                 ),
               );
               if (probeEvent._tag === "ProbeCompleted") {
+                if (
+                  next.reason === "application-active-preserved" &&
+                  Exit.isFailure(probeEvent.exit)
+                ) {
+                  // Protection means this lease was expected to remain live.
+                  // A failed bounded probe is therefore definitive stale-socket
+                  // evidence: replace it immediately instead of adding the
+                  // ordinary transient-failure backoff to foreground resume.
+                  return true;
+                }
                 yield* probeEvent.exit;
                 break;
               }

--- a/packages/client-runtime/src/connection/wakeups.test.ts
+++ b/packages/client-runtime/src/connection/wakeups.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { isApplicationActiveWakeup, shouldResubscribeAfterWakeup } from "./wakeups.ts";
+
+describe("connection wakeups", () => {
+  it("recognizes preserved resumes as application activation", () => {
+    expect(isApplicationActiveWakeup("application-active-preserved")).toBe(true);
+  });
+
+  it("does not resubscribe snapshots after a preserved resume", () => {
+    expect(shouldResubscribeAfterWakeup("application-active-preserved")).toBe(false);
+    expect(shouldResubscribeAfterWakeup("application-active-probe")).toBe(true);
+  });
+});

--- a/packages/client-runtime/src/connection/wakeups.ts
+++ b/packages/client-runtime/src/connection/wakeups.ts
@@ -4,6 +4,7 @@ import type * as Stream from "effect/Stream";
 
 export type ConnectionWakeup =
   | "application-active"
+  | "application-active-preserved"
   | "application-active-probe"
   | "application-active-reconnect"
   | "credentials-changed";
@@ -11,6 +12,7 @@ export type ConnectionWakeup =
 export function isApplicationActiveWakeup(reason: ConnectionWakeup): boolean {
   return (
     reason === "application-active" ||
+    reason === "application-active-preserved" ||
     reason === "application-active-probe" ||
     reason === "application-active-reconnect"
   );

--- a/scripts/mobile-showcase-environment.ts
+++ b/scripts/mobile-showcase-environment.ts
@@ -255,6 +255,7 @@ export const SHOWCASE_THREADS = [
     title: "Make the OOM killer explain itself",
     branch: "feat/quieter-oom",
     minutesAgo: 2 * 24 * 60,
+    archived: true,
     settled: true,
     request: "Make out-of-memory kills legible without adding a single allocation to the hot path.",
     response:
@@ -347,6 +348,7 @@ function insertThread(
     readonly title: string;
     readonly branch: string;
     readonly minutesAgo: number;
+    readonly archived?: boolean;
     readonly state?: "working" | "approval" | "plan";
     readonly settled?: boolean;
     readonly snoozeMinutes?: number;
@@ -371,7 +373,7 @@ function insertThread(
         branch, worktree_path, latest_turn_id, latest_user_message_at, pending_approval_count,
         pending_user_input_count, has_actionable_proposed_plan, created_at, updated_at,
         archived_at, deleted_at, settled_override, settled_at, snoozed_until, snoozed_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, NULL, ?, ?, ?, ?)`,
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, NULL, ?, ?, ?, ?)`,
     )
     .run(
       input.id,
@@ -388,6 +390,7 @@ function insertThread(
       input.state === "plan" ? 1 : 0,
       minutesBefore(now, input.minutesAgo + 120),
       updatedAt,
+      input.archived ? updatedAt : null,
       input.settled ? "settled" : null,
       input.settled ? updatedAt : null,
       snoozedUntil,

--- a/scripts/mobile-showcase-environment.ts
+++ b/scripts/mobile-showcase-environment.ts
@@ -233,6 +233,7 @@ export const SHOWCASE_THREADS = [
     title: "Make the OOM killer explain itself",
     branch: "feat/quieter-oom",
     minutesAgo: 2 * 24 * 60,
+    archived: true,
     settled: true,
     request: "Make out-of-memory kills legible without adding a single allocation to the hot path.",
     response:
@@ -325,6 +326,7 @@ function insertThread(
     readonly title: string;
     readonly branch: string;
     readonly minutesAgo: number;
+    readonly archived?: boolean;
     readonly state?: "working" | "approval" | "plan";
     readonly settled?: boolean;
     readonly workspaceRoot: string;
@@ -340,7 +342,7 @@ function insertThread(
         branch, worktree_path, latest_turn_id, latest_user_message_at, pending_approval_count,
         pending_user_input_count, has_actionable_proposed_plan, created_at, updated_at,
         archived_at, deleted_at, settled_override, settled_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, NULL, ?, ?)`,
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, NULL, ?, ?)`,
     )
     .run(
       input.id,
@@ -357,6 +359,7 @@ function insertThread(
       input.state === "plan" ? 1 : 0,
       minutesBefore(now, input.minutesAgo + 120),
       updatedAt,
+      input.archived ? updatedAt : null,
       input.settled ? "settled" : null,
       input.settled ? updatedAt : null,
     );

--- a/scripts/mobile-showcase.test.ts
+++ b/scripts/mobile-showcase.test.ts
@@ -325,6 +325,10 @@ it("seeds a playful multi-environment project spectrum", () => {
   }
   const primaryThread = SHOWCASE_THREADS.find((thread) => thread.id === "remote-command-center");
   assert.equal(primaryThread !== undefined && !("snoozeMinutes" in primaryThread), true);
+  assert.equal(
+    SHOWCASE_THREADS.filter((thread) => "archived" in thread && thread.archived).length,
+    1,
+  );
   // Every project contributes to both the active block and the settled tail,
   // so each list scope screenshots with the same two-part structure.
   for (const project of SHOWCASE_PROJECTS) {

--- a/scripts/mobile-showcase.test.ts
+++ b/scripts/mobile-showcase.test.ts
@@ -272,6 +272,10 @@ it("seeds a playful multi-environment project spectrum", () => {
   );
   assert.equal(SHOWCASE_THREADS.length, 8);
   assert.equal(new Set(SHOWCASE_THREADS.map((thread) => thread.projectId)).size, 3);
+  assert.equal(
+    SHOWCASE_THREADS.filter((thread) => "archived" in thread && thread.archived).length,
+    1,
+  );
   // Every project contributes to both the active block and the settled tail,
   // so each list scope screenshots with the same two-part structure.
   for (const project of SHOWCASE_PROJECTS) {


### PR DESCRIPTION
## What Changed

Mobile archiving required a partial swipe plus an action tap, while recovery lived under Settings. This PR makes the archive lifecycle reversible from the thread list:

- Full-swiping an active or settled row archives it; snoozed rows keep full-swipe Wake.
- Long-press menus retain lifecycle actions and expose Archive/Delete.
- An `Archived (N)` shelf sits at the bottom of the list, hidden when empty and collapsed by default.
- Archived rows full-swipe to Restore; partial swipe and long-press expose Restore/Delete.
- The shelf follows the current environment, project, and search filters across home, compact, and sidebar layouts. It shows 10 rows before linking to the existing full archive screen.

The collapsed, empty-hidden shelf provides point-of-use optionality without adding a persistent setting or permanent list clutter.

Closes #5204.

## Why

Archiving should be one deliberate gesture, and mistakes should be recoverable without leaving the thread list. Keeping the complete lifecycle together makes Archive safe enough to be fast.

## UI Changes

| Before: archives only outside the thread list | After: inline collapsed archive shelf |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Feighery89/t3code/refs/heads/pr-assets/mobile-quick-archive/pr-assets/mobile-quick-archive/before.png" width="300" alt="Mobile thread list before the inline archive shelf" /> | <img src="https://raw.githubusercontent.com/Feighery89/t3code/refs/heads/pr-assets/mobile-quick-archive/pr-assets/mobile-quick-archive/after-archive-shelf.png" width="300" alt="Expanded Archived shelf at the bottom of the mobile thread list" /> |

| Archived row partial swipe | Archived row long-press |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Feighery89/t3code/refs/heads/pr-assets/mobile-quick-archive/pr-assets/mobile-quick-archive/archived-row-swipe-actions.png" width="300" alt="Restore and Delete actions revealed by swiping an archived row" /> | <img src="https://raw.githubusercontent.com/Feighery89/t3code/refs/heads/pr-assets/mobile-quick-archive/pr-assets/mobile-quick-archive/archived-row-long-press-menu.png" width="300" alt="Restore and Delete actions in the archived row long-press menu" /> |

[Watch the 33-second Android archive/restore interaction](https://raw.githubusercontent.com/Feighery89/t3code/refs/heads/pr-assets/mobile-quick-archive/pr-assets/mobile-quick-archive/archive-restore-cycle.mp4).

## Verification

- `vp test run scripts/mobile-showcase.test.ts apps/mobile/src/features/threads/threadListV2.test.ts apps/mobile/src/features/archive/archivedThreadList.test.ts apps/mobile/src/features/home/homeThreadList.test.ts` — 76 tests passed
- `vp run --filter @t3tools/mobile typecheck`
- `vp fmt --check`
- Targeted `vp lint --report-unused-disable-directives` on every changed TypeScript file
- Android API 36 emulator: UIAutomator assertions verified full-swipe archive, shelf count/update, partial-swipe Restore/Delete, long-press Restore/Delete, full-swipe restore, and return to the active list

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI changes
- [x] I included a video for the interaction changes

Built with Codex (GPT-5.6) in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large Android native/FGS surface, background Clerk relay ownership, and CI that signs releases with secrets and embeds personal host/update URLs—mistakes affect connectivity, auth, and distributed APK trust.
> 
> **Overview**
> Adds **recoverable archiving on the thread list** via a collapsed **Archived (N)** shelf (filter-aware, up to 10 inline rows), **full-swipe Restore** on archived rows, long-press **Restore/Delete**, and optional **project scoping** in archive grouping.
> 
> On **Android**, introduces opt-in **background connection**: a `remoteMessaging` foreground service + Headless JS task that keeps catalog/shell/thread detail leases, outbox drain, and relay auth alive without forcing reconnect when the app returns. Settings add toggles for background connection and **agent notifications** (thread-state reducer → local notifications when not active). Foreground app resume uses **`application-active-preserved`** when the native runtime reports healthy protection; the active thread is **persisted** for background detail retention.
> 
> **Cloud relay** gains **UI vs background session ownership** so headless Clerk bootstrap cannot restore a stale account after sign-out or UI account switch; UI unmount releases only the UI lease and refreshes background auth.
> 
> **Personal preview** automation adds a GitHub workflow (upstream rebase + signed `com.t3tools.t3code.preview` APK, skip rebuild via release “source key”), a prebuild patch script (disable Expo OTA, private signing), and optional systemd timer dispatch. Preview **app.config** exposes personal update API URL and default environment host in `extra`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ee17537108d152ea6bc238552743e78db2dd22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make archive one-swipe and add Android background connection service
> - Full-swipe on v2 thread rows now always triggers **Archive** (replacing settle/unsettle); archived threads appear in a new inline shelf on the home screen and sidebar with restore/delete via long-press menu.
> - Adds an Android **foreground service** (`T3BackgroundConnectionService`) that runs a headless JS task to maintain relay auth, outbox drain, and thread notifications while the app is in the background; survives reboot and app updates via a `BroadcastReceiver`.
> - Introduces `managedRelaySessionOwnership` to arbitrate between UI and background relay session owners, preventing races during account switches or UI unmount.
> - Adds `thread-notification-service` that observes thread shell state and posts high-priority Android notifications for completions, failures, and attention-required events, with bounded deduplication via persisted event IDs.
> - Adds a **personal preview update** flow for Android preview builds: fetches the latest APK from a trusted GitHub Releases endpoint, validates version, and presents the download.
> - Introduces `application-active-preserved` wakeup reason: when the Android background service is healthy on foreground, the connection supervisor probes rather than reconnects.
> - Risk: the background service, headless task, and ownership arbitration add significant new async coordination paths; ordering bugs (retained thread, relay session ownership, outbox drain) could cause missed messages or stale auth state.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 38ee175. 62 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Built with Codex (GPT-5.6) in T3 Code.
