### PR TITLE
fix(composer): detect slash-command trigger mid-prompt, not just at line start

### DIFF
--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -94,6 +94,40 @@ describe("detectComposerTrigger", () => {
     });
   });
 
+  it("detects slash command trigger in the middle of existing text", () => {
+    const text = "Fix the tests /rev";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "rev",
+      rangeStart: "Fix the tests ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("detects a bare slash mid-text as an empty slash command query", () => {
+    const text = "Fix the tests /";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "",
+      rangeStart: "Fix the tests ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("ignores slashes inside a word", () => {
+    const text = "check src/components";
+    expect(detectComposerTrigger(text, text.length)).toBeNull();
+  });
+
+  it("ignores slashes inside URLs", () => {
+    const text = "see https://example.com/docs";
+    expect(detectComposerTrigger(text, text.length)).toBeNull();
+  });
+
   it("detects $skill trigger at cursor", () => {
     const text = "Use $gh-fi";
     const trigger = detectComposerTrigger(text, text.length);

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -242,6 +242,14 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
 
   const tokenStart = tokenStartForCursor(text, cursor);
   const token = text.slice(tokenStart, cursor);
+  if (token.startsWith("/")) {
+    return {
+      kind: "slash-command",
+      query: token.slice(1),
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
+  }
   if (token.startsWith("$")) {
     return {
       kind: "skill",

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { serializeComposerFileLink, serializeComposerMentionPath } from "./composerTrigger.ts";
+import {
+  detectComposerTrigger,
+  serializeComposerFileLink,
+  serializeComposerMentionPath,
+} from "./composerTrigger.ts";
 
 describe("serializeComposerMentionPath", () => {
   it("keeps simple mention paths unquoted", () => {
@@ -13,6 +17,48 @@ describe("serializeComposerMentionPath", () => {
 
   it("escapes quoted mention path content", () => {
     expect(serializeComposerMentionPath('docs/My "File".md')).toBe('"docs/My \\"File\\".md"');
+  });
+});
+
+describe("detectComposerTrigger", () => {
+  it("detects a slash command at the start of the message", () => {
+    const text = "/rev";
+    expect(detectComposerTrigger(text, text.length)).toEqual({
+      kind: "slash-command",
+      query: "rev",
+      rangeStart: 0,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("detects a slash command trigger in the middle of existing text", () => {
+    const text = "Fix the tests /rev";
+    expect(detectComposerTrigger(text, text.length)).toEqual({
+      kind: "slash-command",
+      query: "rev",
+      rangeStart: "Fix the tests ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("detects /model mid-text as the model trigger", () => {
+    const text = "switch it up /model";
+    expect(detectComposerTrigger(text, text.length)).toEqual({
+      kind: "slash-model",
+      query: "",
+      rangeStart: "switch it up ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("ignores slashes inside a word", () => {
+    const text = "check src/components";
+    expect(detectComposerTrigger(text, text.length)).toBeNull();
+  });
+
+  it("ignores slashes inside URLs", () => {
+    const text = "see https://example.com/docs";
+    expect(detectComposerTrigger(text, text.length)).toBeNull();
   });
 });
 

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -104,6 +104,23 @@ export function detectComposerTrigger(
   const tokenStart = tokenIdx + 1;
 
   const token = text.slice(tokenStart, cursor);
+  if (token.startsWith("/")) {
+    const commandQuery = token.slice(1);
+    if (commandQuery.toLowerCase() === "model") {
+      return {
+        kind: "slash-model",
+        query: "",
+        rangeStart: tokenStart,
+        rangeEnd: cursor,
+      };
+    }
+    return {
+      kind: "slash-command",
+      query: commandQuery,
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
+  }
   if (token.startsWith("$")) {
     return {
       kind: "skill",


### PR DESCRIPTION
## What changed

`detectComposerTrigger` only recognized `/` when it was the very first character of the current line (`linePrefix.startsWith("/")`), while `$skill` and `@path` use whitespace-delimited token detection that works anywhere in the text. Typing `/command` in the middle of a prompt therefore never opened the command/skill menu — only starting the message with it did.

This adds a `/` branch to the same token scanner the `$` trigger uses, in both copies of the logic:

- `apps/web/src/composer-logic.ts` (web)
- `packages/shared/src/composerTrigger.ts` (mobile — keeps its `slash-model` special case, so a mid-prompt `/model` opens the model picker just like at line start)

## Why

Slash commands behave inconsistently with the other two composer triggers: `fix the tests $my-skill` autocompletes, while `fix the tests /review` silently does nothing.

## Behavior preserved

- Line-start detection is untouched (the existing line-prefix branch still runs first).
- `/model <args>` on mobile still works via the existing line-prefix branch.
- `"/model spark"` still yields no trigger (existing test unchanged).
- Tokens merely containing slashes (`src/components`, `https://…`) do not trigger, since the token must start with `/`.

## Tests

Added unit tests for mid-prompt `/command`, bare `/`, mid-prompt `/model` (shared), and the non-trigger cases above, in `composer-logic.test.ts` and `composerTrigger.test.ts` (the latter previously had no `detectComposerTrigger` coverage). Full unit suites of `@t3tools/web` (1769 tests) and `@t3tools/shared` (323 tests) pass.
