### PR TITLE
fix(web): stop a tall terminal drawer pushing the composer out of the chat area

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -16,6 +16,7 @@ import {
   buildExpiredTerminalContextToastCopy,
   buildLoadingThreadFromShell,
   buildThreadTurnInterruptInput,
+  chatAreaReservedComposerHeight,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
   dismissBranchMismatchForSession,
@@ -28,6 +29,7 @@ import {
   resolveSendEnvMode,
   startNewThreadForProject,
   shouldShowBranchMismatchBanner,
+  shouldShowDraftHeroHeadline,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
 
@@ -676,5 +678,108 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     expect(hasServerAcknowledgedLocalDispatch({ ...common, hasPendingApproval: true })).toBe(true);
     expect(hasServerAcknowledgedLocalDispatch({ ...common, hasPendingUserInput: true })).toBe(true);
     expect(hasServerAcknowledgedLocalDispatch({ ...common, threadError: "failed" })).toBe(true);
+  });
+});
+
+describe("chatAreaReservedComposerHeight", () => {
+  it("reserves the docked composer's height so it cannot spill over the header", () => {
+    expect(
+      chatAreaReservedComposerHeight({
+        isDraftHeroState: false,
+        composerOverlayHeight: 318,
+        composerStackHeight: 310,
+        heroBannerHeight: 0,
+      }),
+    ).toBe(318);
+  });
+
+  it("reserves only the hero composer stack, so the terminal keeps its height", () => {
+    expect(
+      chatAreaReservedComposerHeight({
+        isDraftHeroState: true,
+        composerOverlayHeight: 173,
+        composerStackHeight: 204,
+        heroBannerHeight: 0,
+      }),
+    ).toBe(204);
+  });
+
+  it("reserves twice any hero banner, since centering mirrors it below", () => {
+    expect(
+      chatAreaReservedComposerHeight({
+        isDraftHeroState: true,
+        composerOverlayHeight: 173,
+        composerStackHeight: 204,
+        heroBannerHeight: 40,
+      }),
+    ).toBe(284);
+  });
+
+  it("ignores the hero overlay's own height, which is the chat area's height", () => {
+    expect(
+      chatAreaReservedComposerHeight({
+        isDraftHeroState: true,
+        composerOverlayHeight: 900,
+        composerStackHeight: 204,
+        heroBannerHeight: 0,
+      }),
+    ).toBe(204);
+  });
+
+  it("reserves nothing before the composer has been measured", () => {
+    expect(
+      chatAreaReservedComposerHeight({
+        isDraftHeroState: false,
+        composerOverlayHeight: 0,
+        composerStackHeight: 0,
+        heroBannerHeight: 0,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("shouldShowDraftHeroHeadline", () => {
+  it("shows the headline when the chat area holds it above and below the composer", () => {
+    expect(
+      shouldShowDraftHeroHeadline({
+        chatAreaHeight: 342,
+        composerStackHeight: 204,
+        heroHeadlineHeight: 69,
+        heroBannerHeight: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the headline one pixel short, rather than shrinking the terminal", () => {
+    expect(
+      shouldShowDraftHeroHeadline({
+        chatAreaHeight: 341,
+        composerStackHeight: 204,
+        heroHeadlineHeight: 69,
+        heroBannerHeight: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("counts banners, which keep their space, against the headline's room", () => {
+    expect(
+      shouldShowDraftHeroHeadline({
+        chatAreaHeight: 342,
+        composerStackHeight: 204,
+        heroHeadlineHeight: 69,
+        heroBannerHeight: 40,
+      }),
+    ).toBe(false);
+  });
+
+  it("assumes room before anything has been measured", () => {
+    expect(
+      shouldShowDraftHeroHeadline({
+        chatAreaHeight: 0,
+        composerStackHeight: 0,
+        heroHeadlineHeight: 0,
+        heroBannerHeight: 0,
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -293,6 +293,63 @@ export function deriveComposerSendState(options: {
   };
 }
 
+/**
+ * Height the chat area must reserve for the composer.
+ *
+ * The composer is an overlay, so a chat area shorter than the composer does not
+ * clip it — it spills out instead, across the thread header above and the
+ * terminal drawer below. Reserving its height keeps the drawer from squeezing
+ * the chat area past that point.
+ *
+ * Docked, the composer is pinned to the bottom and the overlay box is the
+ * composer, so its height is the reserve.
+ *
+ * In the draft hero state the overlay instead spans the whole chat area and
+ * centers the composer stack inside it, with the headline and banners hanging
+ * above the stack. Reserving the overlay's own height there would latch the
+ * chat area at whatever size it already had, so the stack is the reserve, plus
+ * twice any banner — centering mirrors a banner's space below the composer, and
+ * banners carry actions that must not be pushed under the header.
+ *
+ * The hero headline is deliberately not reserved. It is decorative, and paying
+ * for it costs the terminal drawer far more height than it is worth; it hides
+ * instead (see {@link shouldShowDraftHeroHeadline}).
+ */
+export function chatAreaReservedComposerHeight(input: {
+  isDraftHeroState: boolean;
+  composerOverlayHeight: number;
+  composerStackHeight: number;
+  heroBannerHeight: number;
+}): number {
+  if (!input.isDraftHeroState) return Math.max(0, input.composerOverlayHeight);
+  return Math.max(0, input.composerStackHeight) + 2 * Math.max(0, input.heroBannerHeight);
+}
+
+/**
+ * Whether the draft hero headline has room to show above the centered composer.
+ *
+ * The composer is centered, so everything above it needs matching space below:
+ * the headline only fits when the chat area holds the composer stack plus twice
+ * the headline and banners. Below that the headline hides rather than forcing
+ * the terminal drawer to give up the height.
+ *
+ * Hidden means `visibility: hidden`, not unmounted — this reads the headline's
+ * measured height, so removing it from layout would make the decision oscillate.
+ */
+export function shouldShowDraftHeroHeadline(input: {
+  chatAreaHeight: number;
+  composerStackHeight: number;
+  heroHeadlineHeight: number;
+  heroBannerHeight: number;
+}): boolean {
+  // Nothing measured yet: show it, matching the roomy case it renders into.
+  if (input.chatAreaHeight <= 0 || input.composerStackHeight <= 0) return true;
+  const needed =
+    input.composerStackHeight +
+    2 * (Math.max(0, input.heroHeadlineHeight) + Math.max(0, input.heroBannerHeight));
+  return input.chatAreaHeight >= needed;
+}
+
 export function buildExpiredTerminalContextToastCopy(
   expiredTerminalContextCount: number,
   variant: "omitted" | "empty",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -254,6 +254,7 @@ import {
   buildLocalDraftThread,
   buildLoadingThreadFromShell,
   buildThreadTurnInterruptInput,
+  chatAreaReservedComposerHeight,
   collectUserMessageBlobPreviewUrls,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
@@ -261,6 +262,7 @@ import {
   hasServerAcknowledgedLocalDispatch,
   isBranchMismatchDismissedForSession,
   shouldShowBranchMismatchBanner,
+  shouldShowDraftHeroHeadline,
   getStartedThreadModelChangeBlockReason,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
   LastInvokedScriptByProjectSchema,
@@ -925,8 +927,10 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     return null;
   }
 
+  // `contents` keeps the drawer itself the flex child of the thread column, so
+  // it is the box that shrinks when the chat area reserves room for the composer.
   return (
-    <div className={visible ? undefined : "hidden"}>
+    <div className={visible ? "contents" : "hidden"}>
       <ThreadTerminalDrawer
         threadRef={threadRef}
         threadId={threadId}
@@ -1331,30 +1335,20 @@ function ChatViewContent(props: ChatViewProps) {
   const legendListRef = useRef<LegendListRef | null>(null);
   const [composerOverlayElement, setComposerOverlayElement] = useState<HTMLDivElement | null>(null);
   const [composerOverlayHeight, setComposerOverlayHeight] = useState(0);
+  // Composer geometry the chat area sizes itself from. The stack, headline and
+  // banners are all content-sized, so none of them tracks the chat area back.
+  const [composerHeroExtent, setComposerHeroExtent] = useState({
+    stack: 0,
+    headline: 0,
+    banners: 0,
+  });
+  const [chatAreaElement, setChatAreaElement] = useState<HTMLDivElement | null>(null);
+  const [chatAreaHeight, setChatAreaHeight] = useState(0);
   const isAtEndRef = useRef(true);
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewPromotionInFlightByMessageIdRef = useRef<Record<string, true>>({});
   const sendInFlightRef = useRef(false);
   const terminalUiOpenByThreadRef = useRef<Record<string, boolean>>({});
-
-  useLayoutEffect(() => {
-    if (!composerOverlayElement) return;
-
-    const updateHeight = () => {
-      const nextHeight = Math.ceil(composerOverlayElement.getBoundingClientRect().height);
-      if (nextHeight <= 0) return;
-      setComposerOverlayHeight((currentHeight) =>
-        currentHeight === nextHeight ? currentHeight : nextHeight,
-      );
-    };
-
-    updateHeight();
-    if (typeof ResizeObserver === "undefined") return;
-
-    const observer = new ResizeObserver(updateHeight);
-    observer.observe(composerOverlayElement);
-    return () => observer.disconnect();
-  }, [composerOverlayElement]);
 
   const terminalUiState = useTerminalUiStateStore((state) =>
     selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef),
@@ -2396,6 +2390,76 @@ function ChatViewContent(props: ChatViewProps) {
     attachDraftHeroComposerAnchorRef,
     captureDraftHeroComposerRect,
   ] = useDraftHeroLayoutTransition(isDraftHeroState);
+
+  useLayoutEffect(() => {
+    if (!composerOverlayElement) return;
+
+    // The hero overlay spans the whole chat area and centers the composer inside
+    // it, so its own height says nothing about how much room the composer needs.
+    // Measure the composer stack, and the headline and banners hanging above it.
+    const stackElement = composerOverlayElement.querySelector<HTMLElement>(
+      "[data-chat-composer-stack]",
+    );
+    const headlineElement = isDraftHeroState
+      ? composerOverlayElement.querySelector<HTMLElement>("[data-chat-composer-hero-headline]")
+      : null;
+    const bannersElement = isDraftHeroState
+      ? composerOverlayElement.querySelector<HTMLElement>("[data-chat-composer-hero-banners]")
+      : null;
+
+    const updateHeight = () => {
+      const nextHeight = Math.ceil(composerOverlayElement.getBoundingClientRect().height);
+      if (nextHeight > 0) {
+        setComposerOverlayHeight((currentHeight) =>
+          currentHeight === nextHeight ? currentHeight : nextHeight,
+        );
+      }
+      const nextStack = stackElement ? Math.ceil(stackElement.getBoundingClientRect().height) : 0;
+      const nextHeadline = headlineElement
+        ? Math.ceil(headlineElement.getBoundingClientRect().height)
+        : 0;
+      const nextBanners = bannersElement
+        ? Math.ceil(bannersElement.getBoundingClientRect().height)
+        : 0;
+      setComposerHeroExtent((current) =>
+        current.stack === nextStack &&
+        current.headline === nextHeadline &&
+        current.banners === nextBanners
+          ? current
+          : { stack: nextStack, headline: nextHeadline, banners: nextBanners },
+      );
+    };
+
+    updateHeight();
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(composerOverlayElement);
+    if (stackElement) observer.observe(stackElement);
+    if (headlineElement) observer.observe(headlineElement);
+    if (bannersElement) observer.observe(bannersElement);
+    return () => observer.disconnect();
+  }, [composerOverlayElement, isDraftHeroState]);
+
+  useLayoutEffect(() => {
+    if (!chatAreaElement) return;
+    const updateChatAreaHeight = () => {
+      const nextHeight = Math.floor(chatAreaElement.getBoundingClientRect().height);
+      setChatAreaHeight((current) => (current === nextHeight ? current : nextHeight));
+    };
+    updateChatAreaHeight();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(updateChatAreaHeight);
+    observer.observe(chatAreaElement);
+    return () => observer.disconnect();
+  }, [chatAreaElement]);
+
+  const showDraftHeroHeadline = shouldShowDraftHeroHeadline({
+    chatAreaHeight,
+    composerStackHeight: composerHeroExtent.stack,
+    heroHeadlineHeight: composerHeroExtent.headline,
+    heroBannerHeight: composerHeroExtent.banners,
+  });
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
   const turnDiffSummaryByAssistantMessageId = useMemo(() => {
@@ -5784,7 +5848,21 @@ function ChatViewContent(props: ChatViewProps) {
           onDismiss={() => setThreadError(activeThread.id, null)}
         />
         {/* Main content area with optional plan sidebar */}
-        <div className="flex min-h-0 min-w-0 flex-1">
+        {/* The composer overlays this row, so it reserves the composer's height:
+            the terminal drawer below shrinks instead of pushing the composer out
+            over the thread header and back down across the terminal. */}
+        <div
+          ref={setChatAreaElement}
+          className="flex min-h-0 min-w-0 flex-1"
+          style={{
+            minHeight: chatAreaReservedComposerHeight({
+              isDraftHeroState,
+              composerOverlayHeight,
+              composerStackHeight: composerHeroExtent.stack,
+              heroBannerHeight: composerHeroExtent.banners,
+            }),
+          }}
+        >
           {/* Chat column */}
           <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
             {/* Provider status overlays the timeline without changing its content height. */}
@@ -5865,13 +5943,22 @@ function ChatViewContent(props: ChatViewProps) {
             >
               <div
                 ref={attachDraftHeroTransitionGroupRef}
+                data-chat-composer-stack="true"
                 className="chat-composer-horizontal-inset w-full"
               >
                 <div className="pointer-events-auto relative z-10">
                   {isDraftHeroState ? (
-                    <div className="absolute inset-x-0 bottom-full z-0">
+                    <div
+                      data-chat-composer-hero-lede="true"
+                      className="absolute inset-x-0 bottom-full z-0"
+                    >
+                      {/* Kept in layout while hidden so its height stays
+                          measurable — the decision to hide it depends on that
+                          height, and unmounting it would oscillate. */}
                       <div
-                        className="pb-8"
+                        data-chat-composer-hero-headline="true"
+                        aria-hidden={showDraftHeroHeadline ? undefined : true}
+                        className={cn("pb-8", !showDraftHeroHeadline && "invisible")}
                         style={
                           forceExpandedMobileComposer
                             ? {
@@ -5885,7 +5972,9 @@ function ChatViewContent(props: ChatViewProps) {
                           activeProjectTitle={activeProject?.title ?? null}
                         />
                       </div>
-                      <ComposerBannerStack className="relative z-0" items={composerBannerItems} />
+                      <div data-chat-composer-hero-banners="true">
+                        <ComposerBannerStack className="relative z-0" items={composerBannerItems} />
+                      </div>
                     </div>
                   ) : (
                     <ComposerBannerStack className="relative z-0" items={composerBannerItems} />

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2439,7 +2439,10 @@ function ChatViewContent(props: ChatViewProps) {
     if (headlineElement) observer.observe(headlineElement);
     if (bannersElement) observer.observe(bannersElement);
     return () => observer.disconnect();
-  }, [composerOverlayElement, isDraftHeroState]);
+    // The overlay node is reused across threads, so the thread key is what
+    // re-measures on navigation. Leaving it to the observer would reserve the
+    // previous thread's composer for a frame, and a taller one would spill.
+  }, [composerOverlayElement, isDraftHeroState, activeThreadKey]);
 
   useLayoutEffect(() => {
     if (!chatAreaElement) return;

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -138,6 +138,18 @@ describe("resolveDrawerResizeStoredHeight", () => {
     ).toBe(600);
   });
 
+  it("keeps the stored height when a drag ends back where it started", () => {
+    // The drag re-anchors on the squeezed height, so a drag that returns to its
+    // starting point still reaches this function — with no net resize.
+    expect(
+      resolveDrawerResizeStoredHeight({
+        draggedHeight: 444,
+        dragStartHeight: 444,
+        storedHeight: 675,
+      }),
+    ).toBe(675);
+  });
+
   it("takes the dragged height when it already exceeds the stored one", () => {
     expect(
       resolveDrawerResizeStoredHeight({

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  resolveDrawerResizeStartHeight,
   resolveTerminalSelectionActionPosition,
   shouldHandleTerminalExit,
   shouldHandleTerminalSelectionMouseUp,
@@ -88,5 +89,17 @@ describe("resolveTerminalSelectionActionPosition", () => {
     expect(shouldHandleTerminalExit("exited", "running", false)).toBe(true);
     expect(shouldHandleTerminalExit("exited", "exited", false)).toBe(false);
     expect(shouldHandleTerminalExit("closed", "running", true)).toBe(false);
+  });
+});
+
+describe("resolveDrawerResizeStartHeight", () => {
+  it("starts the drag from the height the layout granted, not the stored one", () => {
+    expect(resolveDrawerResizeStartHeight(462.4, 700)).toBe(462);
+  });
+
+  it("falls back to the stored height when the drawer has not been measured", () => {
+    expect(resolveDrawerResizeStartHeight(null, 320)).toBe(320);
+    expect(resolveDrawerResizeStartHeight(0, 320)).toBe(320);
+    expect(resolveDrawerResizeStartHeight(Number.NaN, 320)).toBe(320);
   });
 });

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   resolveDrawerResizeStartHeight,
+  resolveDrawerResizeStoredHeight,
   resolveTerminalSelectionActionPosition,
   shouldHandleTerminalExit,
   shouldHandleTerminalSelectionMouseUp,
@@ -101,5 +102,49 @@ describe("resolveDrawerResizeStartHeight", () => {
     expect(resolveDrawerResizeStartHeight(null, 320)).toBe(320);
     expect(resolveDrawerResizeStartHeight(0, 320)).toBe(320);
     expect(resolveDrawerResizeStartHeight(Number.NaN, 320)).toBe(320);
+  });
+});
+
+describe("resolveDrawerResizeStoredHeight", () => {
+  it("persists a drag that shrinks the drawer", () => {
+    expect(
+      resolveDrawerResizeStoredHeight({
+        draggedHeight: 400,
+        dragStartHeight: 444,
+        storedHeight: 675,
+      }),
+    ).toBe(400);
+  });
+
+  it("keeps the taller stored height when a squeezed drag asks for more room", () => {
+    // Divider squeezed to 444 by the composer reserve; nudging it up must not
+    // quietly rewrite the user's 675 preference down to 454.
+    expect(
+      resolveDrawerResizeStoredHeight({
+        draggedHeight: 454,
+        dragStartHeight: 444,
+        storedHeight: 675,
+      }),
+    ).toBe(675);
+  });
+
+  it("grows normally when the drawer was not squeezed", () => {
+    expect(
+      resolveDrawerResizeStoredHeight({
+        draggedHeight: 600,
+        dragStartHeight: 500,
+        storedHeight: 500,
+      }),
+    ).toBe(600);
+  });
+
+  it("takes the dragged height when it already exceeds the stored one", () => {
+    expect(
+      resolveDrawerResizeStoredHeight({
+        draggedHeight: 700,
+        dragStartHeight: 444,
+        storedHeight: 675,
+      }),
+    ).toBe(700);
   });
 });

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -79,6 +79,24 @@ function clampDrawerHeight(height: number): number {
   return Math.min(Math.max(Math.round(safeHeight), MIN_DRAWER_HEIGHT), maxHeight);
 }
 
+/**
+ * Height a divider drag starts from.
+ *
+ * The chat area above the drawer reserves room for the composer, so flex layout
+ * can grant the drawer less than its stored height. Measuring the drag against
+ * the stored value would leave the divider trailing the pointer by the
+ * difference, so start from the height the layout actually granted.
+ */
+export function resolveDrawerResizeStartHeight(
+  renderedHeight: number | null,
+  storedHeight: number,
+): number {
+  if (renderedHeight === null || !Number.isFinite(renderedHeight) || renderedHeight <= 0) {
+    return storedHeight;
+  }
+  return Math.round(renderedHeight);
+}
+
 function writeSystemMessage(terminal: GhosttyTerminalSurface, message: string): void {
   terminal.write(`\r\n[terminal] ${message}\r\n`);
 }
@@ -913,6 +931,7 @@ export default function ThreadTerminalDrawer({
     setDrawerHeight(nextHeight);
   });
   const [resizeEpoch, setResizeEpoch] = useState(0);
+  const drawerElementRef = useRef<HTMLElement | null>(null);
   const drawerHeightRef = useRef(drawerHeight);
   const lastSyncedHeightRef = useRef(controlledDrawerHeight);
   const onHeightChangeRef = useRef(onHeightChange);
@@ -1112,7 +1131,10 @@ export default function ThreadTerminalDrawer({
     resizeStateRef.current = {
       pointerId: event.pointerId,
       startY: event.clientY,
-      startHeight: drawerHeightRef.current,
+      startHeight: resolveDrawerResizeStartHeight(
+        drawerElementRef.current?.getBoundingClientRect().height ?? null,
+        drawerHeightRef.current,
+      ),
     };
   }, []);
 
@@ -1190,12 +1212,18 @@ export default function ThreadTerminalDrawer({
   if (normalizedTerminalIds.length === 0) {
     return (
       <aside
+        ref={drawerElementRef}
         data-terminal-owner={isPanel ? "right-panel" : "drawer"}
         className={cn(
           "thread-terminal-drawer relative flex min-w-0 flex-col overflow-hidden bg-background",
-          isPanel ? "h-full flex-1" : "shrink-0 border-t border-border/80",
+          isPanel ? "h-full flex-1" : "border-t border-border/80",
         )}
-        style={isPanel ? undefined : { height: `${drawerHeight}px` }}
+        style={
+          // Shrinkable so a tall drawer yields to the composer's reserved space
+          // instead of pushing it over the thread header; the floor keeps the
+          // resize handle reachable when it does.
+          isPanel ? undefined : { height: `${drawerHeight}px`, minHeight: `${MIN_DRAWER_HEIGHT}px` }
+        }
       >
         {!isPanel ? (
           <div
@@ -1224,12 +1252,18 @@ export default function ThreadTerminalDrawer({
 
   return (
     <aside
+      ref={drawerElementRef}
       data-terminal-owner={isPanel ? "right-panel" : "drawer"}
       className={cn(
         "thread-terminal-drawer relative flex min-w-0 flex-col overflow-hidden bg-background",
-        isPanel ? "h-full flex-1" : "shrink-0 border-t border-border/80",
+        isPanel ? "h-full flex-1" : "border-t border-border/80",
       )}
-      style={isPanel ? undefined : { height: `${drawerHeight}px` }}
+      style={
+        // Shrinkable so a tall drawer yields to the composer's reserved space
+        // instead of pushing it over the thread header; the floor keeps the
+        // resize handle reachable when it does.
+        isPanel ? undefined : { height: `${drawerHeight}px`, minHeight: `${MIN_DRAWER_HEIGHT}px` }
+      }
     >
       {!isPanel ? (
         <div

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -97,6 +97,25 @@ export function resolveDrawerResizeStartHeight(
   return Math.round(renderedHeight);
 }
 
+/**
+ * Height a finished drag should persist.
+ *
+ * While the chat area's composer reserve squeezes the drawer, the divider sits
+ * below the stored height. A drag that ends above where it started is the user
+ * asking for more room, so persisting the dragged value would quietly discard
+ * the taller height they had already chosen — and they cannot see the
+ * difference, because the squeeze caps what renders either way. Only a drag
+ * that ends below its starting point is a request to shrink.
+ */
+export function resolveDrawerResizeStoredHeight(input: {
+  draggedHeight: number;
+  dragStartHeight: number;
+  storedHeight: number;
+}): number {
+  if (input.draggedHeight <= input.dragStartHeight) return input.draggedHeight;
+  return Math.max(input.draggedHeight, input.storedHeight);
+}
+
 function writeSystemMessage(terminal: GhosttyTerminalSurface, message: string): void {
   terminal.write(`\r\n[terminal] ${message}\r\n`);
 }
@@ -939,6 +958,7 @@ export default function ThreadTerminalDrawer({
     pointerId: number;
     startY: number;
     startHeight: number;
+    storedHeight: number;
   } | null>(null);
   const didResizeDuringDragRef = useRef(false);
 
@@ -1135,6 +1155,7 @@ export default function ThreadTerminalDrawer({
         drawerElementRef.current?.getBoundingClientRect().height ?? null,
         drawerHeightRef.current,
       ),
+      storedHeight: drawerHeightRef.current,
     };
   }, []);
 
@@ -1167,10 +1188,17 @@ export default function ThreadTerminalDrawer({
       if (!didResizeDuringDragRef.current) {
         return;
       }
-      syncHeight(drawerHeightRef.current);
+      const settledHeight = resolveDrawerResizeStoredHeight({
+        draggedHeight: drawerHeightRef.current,
+        dragStartHeight: resizeState.startHeight,
+        storedHeight: resizeState.storedHeight,
+      });
+      drawerHeightRef.current = settledHeight;
+      setDrawerHeight(settledHeight);
+      syncHeight(settledHeight);
       setResizeEpoch((value) => value + 1);
     },
-    [syncHeight],
+    [setDrawerHeight, syncHeight],
   );
 
   useEffect(() => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -105,14 +105,16 @@ export function resolveDrawerResizeStartHeight(
  * asking for more room, so persisting the dragged value would quietly discard
  * the taller height they had already chosen — and they cannot see the
  * difference, because the squeeze caps what renders either way. Only a drag
- * that ends below its starting point is a request to shrink.
+ * that ends strictly below its starting point is a request to shrink — ending
+ * back where it started is no resize at all, and must not rewrite the stored
+ * height down to the squeezed one.
  */
 export function resolveDrawerResizeStoredHeight(input: {
   draggedHeight: number;
   dragStartHeight: number;
   storedHeight: number;
 }): number {
-  if (input.draggedHeight <= input.dragStartHeight) return input.draggedHeight;
+  if (input.draggedHeight < input.dragStartHeight) return input.draggedHeight;
   return Math.max(input.draggedHeight, input.storedHeight);
 }
 


### PR DESCRIPTION
The composer is an overlay, and the chat area it overlays could shrink to nothing (`min-h-0`) while the terminal drawer held an explicit height of up to 75% of the window. Once a tall drawer left the chat area shorter than the composer, nothing clipped the overlay — it spilled out of the area instead.

Docked, it spilled upward over the thread header and off the top of the viewport. On a new thread it is worse: the hero composer is *centred* in the chat area, and a centred flex item that outgrows its container overflows **both** ends — so it covered the header and ran back down across the top of the terminal, with the headline pushed off-screen above. Its glass surface let the header and the terminal read through it either way.

## The fix

The chat area reserves the height the composer actually needs, so flex layout shrinks the drawer rather than the composer's room. Docked that is the overlay's own height; in the hero state the overlay spans the whole area, so the reserve is the composer stack plus twice any banner (centring mirrors a banner's space below the composer, and banners carry actions).

The hero headline is deliberately **not** reserved. It is decorative, and reserving it costs the drawer 138px it should keep — it hides once the area cannot hold it and returns when the drawer shrinks. Hidden means `visibility: hidden`, because the decision reads its measured height and unmounting it would oscillate.

The drawer became shrinkable to allow the reserve — its wrapper is `display: contents` so the drawer itself is the flex child that yields — and it keeps a floor at `MIN_DRAWER_HEIGHT` so the resize handle stays reachable. Drags now start from the height layout actually granted, so the divider keeps tracking the pointer while the drawer is being squeezed.

## What it costs the terminal

A visible composer and an uncapped drawer are mutually exclusive — the bug exists exactly when they don't both fit — so the goal was to make the drawer give up as little as possible:

| window | drawer before | drawer after | cost |
| --- | --- | --- | --- |
| ≥1024px | 75% cap | 75% cap | **none** |
| 900px | 675 | 644 | 31px |
| 900px, typical draft | 675 | **675** | **none** |
| 700px | 525 | 444 | 81px |

Measured live, not derived. At 900px with an ordinary draft the drawer holds its full cap with 6px to spare.

## Before / after

New thread, 1280×700 (the tightest case above), terminal dragged to its cap, long draft in the composer.

| Before | After |
| --- | --- |
| <img width="640" alt="composer over the header and the terminal, headline clipped off-screen" src="https://raw.githubusercontent.com/carlosricojr/t3code/pr-assets/composer-over-thread-header/before.png"> | <img width="640" alt="composer sitting inside the chat area, headline dropped" src="https://raw.githubusercontent.com/carlosricojr/t3code/pr-assets/composer-over-thread-header/after.png"> |

Same run at 1280×900, where the drawer barely moves (675 → 644): [before](https://raw.githubusercontent.com/carlosricojr/t3code/pr-assets/composer-over-thread-header/before-900.png) · [after](https://raw.githubusercontent.com/carlosricojr/t3code/pr-assets/composer-over-thread-header/after-900.png).

Geometry at 1280×700, same 204px composer:

|  | before | after |
| --- | --- | --- |
| composer over the header | **40px** | 0 |
| composer over the terminal | **40px** | 0 |
| headline top | **−57px** (off-screen) | hidden |
| drawer | 525px | 444px |

Reverse state checked: dragging the divider back down brings the headline straight back (drawer 280 → headline shown, 675 → hidden, 203 → shown). The docked case was verified separately — composer top at 52px, bottom exactly on the drawer edge, 0px overlap either side.

## Notes

- Right-panel terminals (`mode="panel"`) are unchanged — they size with `h-full flex-1` and never carried the pixel height.
- `GhosttyTerminalSurface` already observes its own container and refits synchronously, so a drawer shrunk by layout re-fits itself with no extra plumbing.
- The drawer's *stored* height survives a squeeze, so it springs back to what you dragged once the composer shrinks or the thread leaves the hero state. A drag taken while squeezed only lowers it if the drag itself went downward — nudging the divider up cannot quietly rewrite a taller preference.

Verified with `tsgo --noEmit`, `vp lint`, and `vp test run` over the touched files (57 tests), plus the live passes above.

Review round: Bugbot raised three findings. Two were real and are fixed in `466ce94` — the reserve went stale for a frame when switching threads (the overlay node is reused, so the measuring effect never re-ran), and a drag taken while the reserve squeezed the drawer could persist a *smaller* height than the user had stored while they were dragging to make it bigger. The third was already resolved on the current head; replies are inline.

Claude Opus 5 via Claude Code, driven from T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core thread layout flex behavior and persisted terminal drawer height during squeeze; logic is covered by unit tests but regressions could affect composer/terminal coexistence on small viewports.
> 
> **Overview**
> Fixes the composer overlay spilling over the thread header and terminal when a tall drawer left the chat area shorter than the composer.
> 
> The chat row now applies **`minHeight`** from **`chatAreaReservedComposerHeight`** (docked overlay height vs draft-hero stack plus twice banner height). **`ChatView`** measures stack, headline, and banners via **`ResizeObserver`**, tracks chat area height, and hides the draft hero headline with **`visibility: hidden`** when **`shouldShowDraftHeroHeadline`** says there isn’t room—without unmounting, so measurements stay stable.
> 
> The terminal drawer wrapper uses **`display: contents`** when visible so the drawer is the flex child that shrinks; the drawer drops **`shrink-0`**, keeps a **`minHeight`** floor, and resize drags anchor on rendered height (**`resolveDrawerResizeStartHeight`**) and persist height without clobbering a taller stored preference when squeezed (**`resolveDrawerResizeStoredHeight`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 154ad2359b10b577c84ad8535ad15a6400fb5323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tall terminal drawer pushing the composer out of the chat area
> - The chat area now reserves vertical space for the composer via a new `chatAreaReservedComposerHeight` calculation, causing the terminal drawer to shrink under flex layout instead of overlapping the composer.
> - The terminal drawer loses `shrink-0` and gains a `minHeight` style so it can yield space while remaining resizable; its wrapper div uses `contents` when hidden to keep the drawer as the direct flex child.
> - Resize drags now start from the drawer's rendered height (via `resolveDrawerResizeStartHeight`), and height persistence via `resolveDrawerResizeStoredHeight` avoids overwriting a taller stored preference when the drawer is squeezed.
> - The draft hero headline is conditionally hidden (CSS visibility) via `shouldShowDraftHeroHeadline` when the chat area lacks room to display it above and below the composer.
> - Behavioral Change: drawer height can now shrink below its stored value when the composer reserves space; stored height is only updated on explicit drag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 154ad23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
