### PR TITLE
fix(server): stop npx service updates from silently leaving the old server running

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -33,6 +33,7 @@ it("keeps systemd pinned to the stable launcher rather than a versioned server",
 
 const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
   platform: NodeJS.Platform = "linux",
+  usePinnedLauncher = false,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -44,6 +45,10 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
   const runtime = pinnedRuntimePaths(path, baseDir, "1.2.3");
   yield* fs.makeDirectory(path.dirname(runtime.entryPath), { recursive: true });
   yield* fs.writeFileString(runtime.entryPath, "export {};\n");
+  yield* fs.writeFileString(
+    path.join(path.dirname(runtime.entryPath), "service-launcher.mjs"),
+    "export const source = 'pinned runtime';\n",
+  );
   yield* fs.writeFileString(runtime.sentinelPath, "1.2.3\n");
 
   const commands: string[] = [];
@@ -69,8 +74,7 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
     cliVersion: "1.2.3",
     host: {
       execPath: "/usr/bin/node",
-      cliEntryPath: path.join(home, "bin.mjs"),
-      launcherSourcePath: sourceLauncher,
+      ...(usePinnedLauncher ? {} : { launcherSourcePath: sourceLauncher }),
     },
   }).pipe(
     Effect.provideService(ProcessRunner.ProcessRunner, runner),
@@ -106,6 +110,17 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       expect(yield* service.uninstall).toBe(true);
       expect((yield* service.status).installed).toBe(false);
       expect(commands.some((command) => command.startsWith("npm "))).toBe(false);
+    }),
+  );
+
+  it.effect("copies the launcher from the prepared pinned runtime", () =>
+    Effect.gen(function* () {
+      const { service, fs } = yield* makeHarness("linux", true);
+      const plan = yield* service.install;
+
+      expect(yield* fs.readFileString(plan.launcherPath)).toBe(
+        "export const source = 'pinned runtime';\n",
+      );
     }),
   );
 

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -1,8 +1,4 @@
-import {
-  HostProcessArguments,
-  HostProcessExecutablePath,
-  HostProcessPlatform,
-} from "@t3tools/shared/hostProcess";
+import { HostProcessExecutablePath, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -138,7 +134,6 @@ export class BootService extends Context.Service<
 
 export interface BootServiceHost {
   readonly execPath: string;
-  readonly cliEntryPath: string;
   readonly launcherSourcePath?: string;
 }
 
@@ -148,26 +143,23 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   readonly cliVersion: string;
   readonly host?: BootServiceHost;
 }) {
-  const hostArguments = yield* HostProcessArguments;
   const hostExecPath = yield* HostProcessExecutablePath;
   const platform = yield* HostProcessPlatform;
   const homeDir = yield* Config.string("HOME").pipe(Config.withDefault(""));
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const runner = yield* ProcessRunner.ProcessRunner;
-  const host = input.host ?? {
-    execPath: hostExecPath,
-    cliEntryPath: hostArguments[1] ?? "",
-  };
+  const host = input.host ?? { execPath: hostExecPath };
 
   const unitDir = path.join(homeDir, ".config", "systemd", "user");
   const unitPath = path.join(unitDir, BOOT_SERVICE_UNIT_FILE);
   const logPath = path.join(input.logsDir, "boot-service.log");
   const launcherPath = path.join(input.baseDir, "runtime", SERVICE_LAUNCHER_FILE);
   const statePath = path.join(input.baseDir, "runtime", SERVICE_STATE_FILE);
-  const launcherSourcePath =
-    host.launcherSourcePath ?? path.join(path.dirname(host.cliEntryPath), SERVICE_LAUNCHER_FILE);
   const runtimePaths = pinnedRuntimePaths(path, input.baseDir, input.cliVersion);
+  const launcherSourcePath =
+    host.launcherSourcePath ??
+    path.join(path.dirname(runtimePaths.entryPath), SERVICE_LAUNCHER_FILE);
   const writeDurably = (filePath: string, contents: string) =>
     Effect.scoped(
       Effect.gen(function* () {


### PR DESCRIPTION
Updating T3 Code with `npx t3@nightly connect` failed on my machine. It downloaded the new version, then reported "Could not set up the T3 Code background service" and left the old server running. Retrying and rebooting did not help.

The installer looked for `service-launcher.mjs` next to `process.argv[1]`. Under `npx` that path is the `node_modules/.bin/t3` symlink, and Node keeps the symlink path in `argv[1]`, so it searched a bin directory that has no launcher. The read failed before systemd was stopped, so the update aborted with the previous version still serving.

It now reads the launcher from the pinned runtime the installer just prepared and verified, which is the same place the version is staged for every install path.

Verified on bb-1: the repair completed, systemd now runs the launcher with the new server as its child, and the machine came back reachable over the relay.

Made by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time file resolution for the systemd background service on Linux; wrong paths would break updates, but scope is limited to boot service setup and covered by a new test.
> 
> **Overview**
> Fixes background service setup when the CLI runs via **`npx`**, where the installer used to look for **`service-launcher.mjs`** beside **`process.argv[1]`** (often a **`node_modules/.bin`** symlink with no launcher). That read failed before systemd was updated, so updates aborted and the old server kept running.
> 
> **`BootService`** now defaults the launcher source to the **pinned runtime** directory prepared and verified during install—the same staging path used for every install flow. **`cliEntryPath`** and **`HostProcessArguments`** are removed from **`BootServiceHost`**; an explicit **`launcherSourcePath`** override remains.
> 
> A test confirms install copies the launcher from the pinned runtime when no override is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 747860aa93b335555231deb0e5d66bb2492167bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `npx` service updates leaving old server running by resolving launcher from pinned runtime
> When `host.launcherSourcePath` is not provided, the launcher is now copied from the pinned runtime directory (`service-launcher.mjs` alongside the pinned runtime entry) rather than from the host CLI entry path directory. This fixes a bug where `npx` service updates would silently leave the old server running because the wrong launcher was used.
> - Removes `cliEntryPath` from the `BootServiceHost` interface in [bootService.ts](https://github.com/pingdotgg/t3code/pull/5217/files#diff-9ec1426b86c5c9f63a503a0c78a87a5165a6460ca539deb5c365bda9ff0576f0) and stops reading `HostProcessArguments`
> - Adds a test case in [bootService.test.ts](https://github.com/pingdotgg/t3code/pull/5217/files#diff-f019a0d87791b8de337a8eee29f00bca8dbfa55af3ed499337d2790fb3eabf85) that verifies the launcher is copied from the pinned runtime directory during install
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 747860a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->