### PR TITLE
fix(web): honor autoOpenPreview when running a project action

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -134,6 +134,7 @@ import { closePreviewSession } from "./preview/closePreviewSession";
 import { ThreadPreviewMiniPlayer } from "./preview/ThreadPreviewMiniPlayer";
 import { subscribePreviewAction } from "./preview/previewActionBus";
 import { getConfiguredPreviewUrls } from "./preview/previewEmptyStateLogic";
+import { openUrlInPreview } from "~/browser/openFileInPreview";
 import {
   selectThreadPreviewMiniPlayer,
   usePreviewMiniPlayerStore,
@@ -2880,12 +2881,30 @@ function ChatViewContent(props: ChatViewProps) {
           data: `${script.command}\r`,
         },
       });
-      if (writeResult._tag === "Failure" && !isAtomCommandInterrupted(writeResult)) {
-        const error = squashAtomCommandFailure(writeResult);
-        setThreadError(
-          activeThreadId,
-          error instanceof Error ? error.message : `Failed to run script "${script.name}".`,
-        );
+      if (writeResult._tag === "Failure") {
+        if (!isAtomCommandInterrupted(writeResult)) {
+          const error = squashAtomCommandFailure(writeResult);
+          setThreadError(
+            activeThreadId,
+            error instanceof Error ? error.message : `Failed to run script "${script.name}".`,
+          );
+        }
+        return;
+      }
+
+      if (
+        script.autoOpenPreview &&
+        script.previewUrl &&
+        isPreviewSupportedInRuntime() &&
+        activeThreadRef
+      ) {
+        // Preview failures surface in the panel itself, and the script is
+        // already running — never report one as a failure of the script.
+        await openUrlInPreview({
+          threadRef: activeThreadRef,
+          url: script.previewUrl,
+          openPreview,
+        });
       }
     },
     [
@@ -2894,6 +2913,7 @@ function ChatViewContent(props: ChatViewProps) {
       activeThreadId,
       activeThreadRef,
       gitCwd,
+      openPreview,
       setTerminalOpen,
       setThreadError,
       storeNewTerminal,


### PR DESCRIPTION
The "Open preview automatically when this action runs" toggle in the Add action modal has had no effect since #2978. That rewrite moved `runProjectScript` onto the atom command API and dropped the block that opened the preview panel once the command was written to the terminal. #3842 later restored *persistence* of `previewUrl` / `autoOpenPreview`, so the setting saves and reloads correctly — nothing reads it at run time.

Fixes #5221.

## What Changed

- `runProjectScript` opens the preview again when a script carries both `autoOpenPreview` and `previewUrl`, the runtime supports preview, and a thread ref exists — the same four conditions the original code checked.
- It goes through the existing `openUrlInPreview` helper rather than re-adding the hand-rolled version: that helper already opens the session, applies the snapshot, remembers the URL, and reveals the tab, and the terminal-link and markdown-link paths use it too.
- A failed terminal write now returns instead of falling through, so a script that never started cannot open a preview.

## Why

The setting is currently documented behavior that does nothing. Both schemas promise it — "automatically open the preview panel pointed at `previewUrl` the moment this script starts" (`orchestration.ts`, and the same wording in `t3ProjectFile.ts`) — and the modal's own helper text promises it for the Preview URL field. Since #4317 put both fields in the shared `t3.json` schema, a team can commit `autoOpenPreview` to a repo and get nothing.

Two details worth calling out, since they go slightly beyond reverting:

**The early return on write failure.** Previously that branch set the thread error and then hit the end of the function anyway, so returning was equivalent — it only starts to matter once something is appended after it. Making it explicit keeps "the script never started" from reaching the auto-open, and matches how the `openTerminal` failure directly above is handled.

**The preview result is awaited and ignored.** Preview failures surface in the panel itself, and by that point the script *is* running — reporting one as `Failed to run script` would be wrong. This mirrors the original code's `catch {}` with the comment that said the same thing.

## UI Changes

No visual or layout change: the preview panel, its chrome and its empty state are all untouched. What changes is *when* an existing panel opens — with the toggle on, running the action reveals the preview at the configured URL instead of leaving the panel closed. I don't have a recording to attach; happy to add one if you'd like to see the interaction.

## Validation

- `vp run --filter @t3tools/web typecheck`
- `vp lint apps/web/src/components/ChatView.tsx`
- `vp run --filter @t3tools/web test` — 1765 passed (201 files)
- Built a local macOS arm64 desktop artifact and confirmed the restored call is present in the packaged `app.asar`

No regression test. `runProjectScript` is a `useCallback` inside ChatView with no existing harness, and the only extraction I could make honestly (a `shouldAutoOpenPreview` predicate) would still pass with the call site deleted again — which is the failure mode here. Building a ChatView harness for it seemed well outside "small and focused"; glad to add one if you'd rather have it.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — no visual change; see UI Changes above
- [ ] I included a video for animation/interaction changes — not attached; say the word and I'll record the toggle in action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path UI behavior fix in ChatView with no auth or data-model changes; preview errors are intentionally ignored after the script starts.
> 
> **Overview**
> Restores **auto-open preview** when a project action runs with **Open preview automatically** enabled and a **Preview URL** configured — behavior that stopped working after `runProjectScript` moved to the atom command API.
> 
> After a successful terminal write in `runProjectScript`, the flow calls **`openUrlInPreview`** (same helper as markdown/terminal links) when `autoOpenPreview`, `previewUrl`, preview runtime support, and a thread ref are all present. Preview open failures are awaited but not surfaced as script failures.
> 
> A failed **terminal write** now **returns immediately** so a script that never started cannot trigger preview open; write-failure handling is structured explicitly instead of only setting thread error and falling through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742c1ef71124814d25bc8380c6700907b9fd5696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Honor `autoOpenPreview` when running a project action in `ChatView`
> - When a script has `autoOpenPreview` and a `previewUrl` set, the script-run handler in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/5223/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) now calls `openUrlInPreview` after successfully writing the command to the terminal (in supported runtimes with an active thread).
> - Fixes a bug where a terminal write failure did not exit early, potentially allowing the preview-open logic to run incorrectly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 742c1ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->