### PR TITLE
feat(web): attach selected response text

### DIFF
--- a/apps/web/src/chatSelectionAnnotation.test.ts
+++ b/apps/web/src/chatSelectionAnnotation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  appendChatSelectionAnnotationsToPrompt,
+  formatChatSelectionAnnotation,
+  parseChatSelectionMessageSegments,
+  stripAppendedChatSelectionAnnotations,
+  type ChatSelectionAnnotation,
+} from "./chatSelectionAnnotation";
+
+const annotation: ChatSelectionAnnotation = {
+  id: "selection-1",
+  selectedText: "Restart <the> adapter",
+  comment: "Why is this necessary?",
+};
+
+describe("chat selection annotations", () => {
+  it("round-trips selected text and comments without treating markup as tags", () => {
+    const prompt = appendChatSelectionAnnotationsToPrompt("Explain this", [annotation]);
+    const segments = parseChatSelectionMessageSegments(prompt);
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toEqual({
+      kind: "text",
+      id: "chat-selection-text:0",
+      text: "Explain this\n\n",
+    });
+    expect(segments[1]).toEqual({ kind: "selection", annotation });
+  });
+
+  it("supports multiple annotations", () => {
+    const second = {
+      ...annotation,
+      id: "selection-2",
+      comment: "Compare this",
+    };
+    const segments = parseChatSelectionMessageSegments(
+      appendChatSelectionAnnotationsToPrompt("", [annotation, second]),
+    );
+
+    expect(segments.filter((segment) => segment.kind === "selection")).toHaveLength(2);
+  });
+
+  it("keeps user-authored chat selection markup as message text", () => {
+    const userAuthoredMarkup = [
+      '<chat_selection id="example">',
+      "<selected_text>",
+      "this is just an example",
+      "</selected_text>",
+      "<user_comment>",
+      "please explain this format",
+      "</user_comment>",
+      "</chat_selection>",
+    ].join("\n");
+
+    expect(parseChatSelectionMessageSegments(userAuthoredMarkup)).toEqual([
+      { kind: "text", id: "chat-selection-text:0", text: userAuthoredMarkup },
+    ]);
+  });
+
+  it("does not let a user-authored opener swallow a following annotation", () => {
+    const prompt = appendChatSelectionAnnotationsToPrompt("Explain this literal <chat_selection>", [
+      annotation,
+    ]);
+
+    expect(parseChatSelectionMessageSegments(prompt)).toEqual([
+      {
+        kind: "text",
+        id: "chat-selection-text:0",
+        text: "Explain this literal <chat_selection>\n\n",
+      },
+      { kind: "selection", annotation },
+    ]);
+  });
+
+  it("does not emit a block for an empty annotation list", () => {
+    expect(appendChatSelectionAnnotationsToPrompt("Keep this", [])).toBe("Keep this");
+    expect(formatChatSelectionAnnotation(annotation)).toContain("<selected_text>");
+  });
+
+  it("preserves prompt whitespace when appending annotations", () => {
+    const prompt = "  Keep this  ";
+
+    expect(appendChatSelectionAnnotationsToPrompt(prompt, [annotation])).toBe(
+      `${prompt}\n\n${formatChatSelectionAnnotation(annotation)}`,
+    );
+  });
+
+  it("strips app-appended annotations while preserving message text", () => {
+    const prompt = appendChatSelectionAnnotationsToPrompt("Explain this", [annotation]);
+
+    expect(stripAppendedChatSelectionAnnotations(prompt)).toBe("Explain this\n\n");
+  });
+});

--- a/apps/web/src/chatSelectionAnnotation.ts
+++ b/apps/web/src/chatSelectionAnnotation.ts
@@ -1,0 +1,128 @@
+import * as Schema from "effect/Schema";
+
+export const ChatSelectionAnnotationSchema = Schema.Struct({
+  id: Schema.String,
+  selectedText: Schema.String,
+  comment: Schema.String,
+});
+
+export type ChatSelectionAnnotation = typeof ChatSelectionAnnotationSchema.Type;
+
+export type ChatSelectionMessageSegment =
+  | { readonly kind: "text"; readonly id: string; readonly text: string }
+  | { readonly kind: "selection"; readonly annotation: ChatSelectionAnnotation };
+
+const CHAT_SELECTION_BLOCK_PATTERN =
+  /<chat_selection\b([^<>\n]*)>\s*<selected_text>\s*([\s\S]*?)\s*<\/selected_text>\s*<user_comment>\s*([\s\S]*?)\s*<\/user_comment>\s*<\/chat_selection>/g;
+const CHAT_SELECTION_ATTRIBUTE_PATTERN = /([a-zA-Z][a-zA-Z0-9_-]*)="([^"]*)"/g;
+const CHAT_SELECTION_APP_MARKER_NAME = "data-t3code-appended";
+const CHAT_SELECTION_APP_MARKER_VALUE = "true";
+const CHAT_SELECTION_APP_MARKER = `${CHAT_SELECTION_APP_MARKER_NAME}="${CHAT_SELECTION_APP_MARKER_VALUE}"`;
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function unescapeXml(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&");
+}
+
+function readId(rawAttributes: string, fallback: string): string {
+  for (const match of rawAttributes.matchAll(CHAT_SELECTION_ATTRIBUTE_PATTERN)) {
+    if (match[1] === "id" && match[2]) return unescapeXml(match[2]);
+  }
+  return fallback;
+}
+
+function isAppendedChatSelection(rawAttributes: string): boolean {
+  for (const match of rawAttributes.matchAll(CHAT_SELECTION_ATTRIBUTE_PATTERN)) {
+    if (
+      match[1] === CHAT_SELECTION_APP_MARKER_NAME &&
+      match[2] === CHAT_SELECTION_APP_MARKER_VALUE
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function formatChatSelectionAnnotation(annotation: ChatSelectionAnnotation): string {
+  return [
+    `<chat_selection id="${escapeXml(annotation.id)}" ${CHAT_SELECTION_APP_MARKER}>`,
+    "<selected_text>",
+    escapeXml(annotation.selectedText.trim()),
+    "</selected_text>",
+    "<user_comment>",
+    escapeXml(annotation.comment.trim()),
+    "</user_comment>",
+    "</chat_selection>",
+  ].join("\n");
+}
+
+export function appendChatSelectionAnnotationsToPrompt(
+  prompt: string,
+  annotations: ReadonlyArray<ChatSelectionAnnotation>,
+): string {
+  if (annotations.length === 0) return prompt;
+  const blocks = annotations.map(formatChatSelectionAnnotation).join("\n\n");
+  const trimmedPrompt = prompt.trim();
+  return trimmedPrompt.length > 0 ? `${prompt}\n\n${blocks}` : blocks;
+}
+
+export function parseChatSelectionMessageSegments(
+  value: string,
+): ReadonlyArray<ChatSelectionMessageSegment> {
+  const segments: ChatSelectionMessageSegment[] = [];
+  let cursor = 0;
+  let parsedIndex = 0;
+
+  for (const match of value.matchAll(CHAT_SELECTION_BLOCK_PATTERN)) {
+    const matchIndex = match.index ?? 0;
+    const beforeText = value.slice(cursor, matchIndex);
+    if (beforeText.length > 0) {
+      segments.push({ kind: "text", id: `chat-selection-text:${cursor}`, text: beforeText });
+    }
+
+    if (!isAppendedChatSelection(match[1] ?? "")) {
+      segments.push({ kind: "text", id: `chat-selection-text:${matchIndex}`, text: match[0] });
+      cursor = matchIndex + match[0].length;
+      continue;
+    }
+
+    const selectedText = unescapeXml(match[2] ?? "").trim();
+    if (selectedText.length === 0) {
+      segments.push({ kind: "text", id: `chat-selection-invalid:${matchIndex}`, text: match[0] });
+    } else {
+      segments.push({
+        kind: "selection",
+        annotation: {
+          id: readId(match[1] ?? "", `chat-selection:${parsedIndex}`),
+          selectedText,
+          comment: unescapeXml(match[3] ?? "").trim(),
+        },
+      });
+      parsedIndex += 1;
+    }
+    cursor = matchIndex + match[0].length;
+  }
+
+  const rest = value.slice(cursor);
+  if (rest.length > 0) {
+    segments.push({ kind: "text", id: `chat-selection-text:${cursor}`, text: rest });
+  }
+  return segments;
+}
+
+export function stripAppendedChatSelectionAnnotations(value: string): string {
+  return parseChatSelectionMessageSegments(value)
+    .flatMap((segment) => (segment.kind === "text" ? [segment.text] : []))
+    .join("");
+}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -21,6 +21,7 @@ import React, {
   Suspense,
   type ClipboardEvent as ReactClipboardEvent,
   type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
   isValidElement,
   use,
   useCallback,
@@ -39,6 +40,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { renderSkillInlineMarkdownChildren } from "./chat/SkillInlineText";
+import { ChatTextSelectionPopover } from "./chat/ChatTextSelectionPopover";
 import { CHAT_FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 import {
@@ -102,6 +104,8 @@ interface ChatMarkdownProps {
   className?: string;
   /** Treat single newlines as hard breaks — chat-style user input. */
   lineBreaks?: boolean;
+  /** Enables attaching selected response text to the next chat message. */
+  onTextSelection?: ((input: { selectedText: string; comment: string }) => void) | undefined;
 }
 
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
@@ -1260,7 +1264,16 @@ function ChatMarkdown({
   skills = EMPTY_MARKDOWN_SKILLS,
   className,
   lineBreaks = false,
+  onTextSelection,
 }: ChatMarkdownProps) {
+  const markdownRootRef = useRef<HTMLDivElement | null>(null);
+  const selectionPointerControllerRef = useRef<AbortController | null>(null);
+  const selectionReadFrameRef = useRef<number | null>(null);
+  const [selectionPopover, setSelectionPopover] = useState<{
+    text: string;
+    rect: { top: number; left: number; width: number; height: number };
+  } | null>(null);
+  const [selectionPopoverHasDraft, setSelectionPopoverHasDraft] = useState(false);
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
     reportFailure: false,
@@ -1594,13 +1607,121 @@ function ChatMarkdown({
     threadRef,
   ]);
 
+  const readTextSelection = useCallback(() => {
+    if (!onTextSelection) return;
+    const root = markdownRootRef.current;
+    const selection = window.getSelection();
+    if (!root || !selection || selection.isCollapsed || selection.rangeCount === 0) {
+      if (!selectionPopoverHasDraft) setSelectionPopover(null);
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    if (!root.contains(range.commonAncestorContainer)) {
+      if (!selectionPopoverHasDraft) setSelectionPopover(null);
+      return;
+    }
+    const selectedText = selection.toString().trim();
+    const rect = range.getBoundingClientRect();
+    if (selectedText.length === 0 || (rect.width === 0 && rect.height === 0)) {
+      if (!selectionPopoverHasDraft) setSelectionPopover(null);
+      return;
+    }
+    if (selectionPopoverHasDraft) return;
+    setSelectionPopover({
+      text: selectedText,
+      rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height },
+    });
+  }, [onTextSelection, selectionPopoverHasDraft]);
+  const scheduleReadTextSelection = useCallback(() => {
+    if (selectionReadFrameRef.current !== null) {
+      window.cancelAnimationFrame(selectionReadFrameRef.current);
+    }
+    selectionReadFrameRef.current = window.requestAnimationFrame(() => {
+      selectionReadFrameRef.current = null;
+      readTextSelection();
+    });
+  }, [readTextSelection]);
+  const handleSelectionPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      selectionPointerControllerRef.current?.abort();
+      const controller = new AbortController();
+      const pointerId = event.pointerId;
+      selectionPointerControllerRef.current = controller;
+      const options = { signal: controller.signal };
+      window.addEventListener(
+        "pointerup",
+        (pointerEvent) => {
+          if (pointerEvent.pointerId !== pointerId) return;
+          controller.abort();
+          scheduleReadTextSelection();
+        },
+        options,
+      );
+      window.addEventListener(
+        "pointercancel",
+        (pointerEvent) => {
+          if (pointerEvent.pointerId === pointerId) controller.abort();
+        },
+        options,
+      );
+    },
+    [scheduleReadTextSelection],
+  );
+
+  useEffect(
+    () => () => {
+      selectionPointerControllerRef.current?.abort();
+      if (selectionReadFrameRef.current !== null) {
+        window.cancelAnimationFrame(selectionReadFrameRef.current);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!onTextSelection) return;
+    document.addEventListener("selectionchange", scheduleReadTextSelection);
+    return () => document.removeEventListener("selectionchange", scheduleReadTextSelection);
+  }, [onTextSelection, scheduleReadTextSelection]);
+
+  useEffect(() => {
+    if (!selectionPopover) return;
+    const closeOnOutsidePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Element && target.closest("[data-chat-selection-popover]")) return;
+      if (target instanceof Node && markdownRootRef.current?.contains(target)) {
+        if (selectionPopoverHasDraft) return;
+        setSelectionPopover(null);
+        return;
+      }
+      setSelectionPopover(null);
+    };
+    document.addEventListener("pointerdown", closeOnOutsidePointerDown, true);
+    return () => document.removeEventListener("pointerdown", closeOnOutsidePointerDown, true);
+  }, [selectionPopover, selectionPopoverHasDraft]);
+
+  useEffect(() => {
+    if (!selectionPopover) return;
+    const closeOnViewportChange = () => {
+      if (!selectionPopoverHasDraft) setSelectionPopover(null);
+    };
+    window.addEventListener("scroll", closeOnViewportChange, true);
+    window.addEventListener("resize", closeOnViewportChange);
+    return () => {
+      window.removeEventListener("scroll", closeOnViewportChange, true);
+      window.removeEventListener("resize", closeOnViewportChange);
+    };
+  }, [selectionPopover, selectionPopoverHasDraft]);
+
   return (
     <div
+      ref={markdownRootRef}
       className={cn(
         "chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80",
         className,
       )}
       onCopy={handleCopy}
+      onPointerDown={onTextSelection ? handleSelectionPointerDown : undefined}
     >
       <ReactMarkdown
         remarkPlugins={
@@ -1612,6 +1733,21 @@ function ChatMarkdown({
       >
         {text}
       </ReactMarkdown>
+      {selectionPopover ? (
+        <ChatTextSelectionPopover
+          rect={selectionPopover.rect}
+          onAddAnnotation={(comment) => {
+            onTextSelection?.({ selectedText: selectionPopover.text, comment });
+            setSelectionPopover(null);
+            setSelectionPopoverHasDraft(false);
+          }}
+          onCommentStateChange={setSelectionPopoverHasDraft}
+          onClose={() => {
+            setSelectionPopover(null);
+            setSelectionPopoverHasDraft(false);
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -28,8 +28,32 @@ import {
   resolveSendEnvMode,
   startNewThreadForProject,
   shouldShowBranchMismatchBanner,
+  shouldRestoreClearedPlanFollowUpDraft,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
+
+describe("shouldRestoreClearedPlanFollowUpDraft", () => {
+  it("restores only while the cleared prompt and annotations remain untouched", () => {
+    expect(
+      shouldRestoreClearedPlanFollowUpDraft({
+        currentPrompt: "",
+        currentChatSelectionAnnotationCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRestoreClearedPlanFollowUpDraft({
+        currentPrompt: "new draft",
+        currentChatSelectionAnnotationCount: 0,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRestoreClearedPlanFollowUpDraft({
+        currentPrompt: "",
+        currentChatSelectionAnnotationCount: 1,
+      }),
+    ).toBe(false);
+  });
+});
 
 const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -28,6 +28,13 @@ export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 
+export function shouldRestoreClearedPlanFollowUpDraft(input: {
+  readonly currentPrompt: string;
+  readonly currentChatSelectionAnnotationCount: number;
+}): boolean {
+  return input.currentPrompt.length === 0 && input.currentChatSelectionAnnotationCount === 0;
+}
+
 export function startNewThreadForProject(
   projectRef: ScopedProjectRef | null,
   handleNewThread: (projectRef: ScopedProjectRef) => Promise<void>,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -152,7 +152,7 @@ import {
   TriangleAlertIcon,
   WifiOffIcon,
 } from "lucide-react";
-import { cn, randomHex } from "~/lib/utils";
+import { cn, randomHex, randomUUID } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
@@ -196,6 +196,10 @@ import {
 } from "../lib/elementContext";
 import { appendPreviewAnnotationPrompt } from "../lib/previewAnnotation";
 import { appendReviewCommentsToPrompt, type ReviewCommentContext } from "../reviewCommentContext";
+import {
+  appendChatSelectionAnnotationsToPrompt,
+  type ChatSelectionAnnotation,
+} from "../chatSelectionAnnotation";
 import { environmentCatalog } from "../connection/catalog";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
@@ -274,6 +278,7 @@ import {
   resolveSendEnvMode,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
+  shouldRestoreClearedPlanFollowUpDraft,
   shouldWriteThreadErrorToCurrentServerThread,
   startNewThreadForProject,
   waitForStartedServerThread,
@@ -1257,6 +1262,12 @@ function ChatViewContent(props: ChatViewProps) {
     (store) => store.setPreviewAnnotations,
   );
   const setComposerDraftReviewComments = useComposerDraftStore((store) => store.setReviewComments);
+  const addComposerDraftChatSelectionAnnotation = useComposerDraftStore(
+    (store) => store.addChatSelectionAnnotation,
+  );
+  const setComposerDraftChatSelectionAnnotations = useComposerDraftStore(
+    (store) => store.setChatSelectionAnnotations,
+  );
   const setComposerDraftModelSelection = useComposerDraftStore((store) => store.setModelSelection);
   const setComposerDraftRuntimeMode = useComposerDraftStore((store) => store.setRuntimeMode);
   const setComposerDraftInteractionMode = useComposerDraftStore(
@@ -2626,6 +2637,16 @@ function ChatViewContent(props: ChatViewProps) {
       composerRef.current?.addTerminalContext(selection);
     },
     [composerRef],
+  );
+  const addChatSelectionAnnotation = useCallback(
+    (input: Omit<ChatSelectionAnnotation, "id">) => {
+      addComposerDraftChatSelectionAnnotation(composerDraftTarget, {
+        id: randomUUID(),
+        ...input,
+      });
+      scheduleComposerFocus();
+    },
+    [addComposerDraftChatSelectionAnnotation, composerDraftTarget, scheduleComposerFocus],
   );
   const setTerminalOpen = useCallback(
     (open: boolean) => {
@@ -4075,7 +4096,8 @@ function ChatViewContent(props: ChatViewProps) {
         draft.terminalContexts.length > 0 ||
         draft.elementContexts.length > 0 ||
         draft.previewAnnotations.length > 0 ||
-        draft.reviewComments.length > 0),
+        draft.reviewComments.length > 0 ||
+        draft.chatSelectionAnnotations.length > 0),
     );
   });
   const activeBranchMismatchKey = branchMismatchKey(
@@ -4579,6 +4601,7 @@ function ChatViewContent(props: ChatViewProps) {
       elementContexts: composerElementContexts,
       previewAnnotations: composerPreviewAnnotations,
       reviewComments: composerReviewComments,
+      chatSelectionAnnotations: composerChatSelectionAnnotations,
       selectedProvider: ctxSelectedProvider,
       selectedModel: ctxSelectedModel,
       selectedProviderModels: ctxSelectedProviderModels,
@@ -4598,19 +4621,23 @@ function ChatViewContent(props: ChatViewProps) {
       elementContextCount:
         composerElementContexts.length +
         composerPreviewAnnotations.length +
-        composerReviewComments.length,
+        composerReviewComments.length +
+        composerChatSelectionAnnotations.length,
     });
     if (showPlanFollowUpPrompt && activeProposedPlan) {
       const followUp = resolvePlanFollowUpSubmission({
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
+        hasChatSelectionAnnotations: composerChatSelectionAnnotations.length > 0,
       });
-      promptRef.current = "";
-      clearComposerDraftContent(composerDraftTarget);
-      composerRef.current?.resetCursorState();
+      const composerChatSelectionAnnotationsSnapshot: ChatSelectionAnnotation[] = [
+        ...composerChatSelectionAnnotations,
+      ];
       await onSubmitPlanFollowUp({
         text: followUp.text,
         interactionMode: followUp.interactionMode,
+        draftText: followUp.draftText,
+        chatSelectionAnnotations: composerChatSelectionAnnotationsSnapshot,
       });
       return;
     }
@@ -4619,7 +4646,8 @@ function ChatViewContent(props: ChatViewProps) {
       sendableComposerTerminalContexts.length === 0 &&
       composerElementContexts.length === 0 &&
       composerPreviewAnnotations.length === 0 &&
-      composerReviewComments.length === 0
+      composerReviewComments.length === 0 &&
+      composerChatSelectionAnnotations.length === 0
         ? parseStandaloneComposerSlashCommand(trimmed)
         : null;
     if (standaloneSlashCommand) {
@@ -4694,8 +4722,18 @@ function ChatViewContent(props: ChatViewProps) {
     const composerElementContextsSnapshot = [...composerElementContexts];
     const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
     const composerReviewCommentsSnapshot: ReviewCommentContext[] = [...composerReviewComments];
+    const composerChatSelectionAnnotationsSnapshot: ChatSelectionAnnotation[] = [
+      ...composerChatSelectionAnnotations,
+    ];
+    const messageTextWithSelectionAnnotations = appendChatSelectionAnnotationsToPrompt(
+      promptForSend,
+      composerChatSelectionAnnotationsSnapshot,
+    );
     const messageTextWithContexts = appendElementContextsToPrompt(
-      appendTerminalContextsToPrompt(promptForSend, composerTerminalContextsSnapshot),
+      appendTerminalContextsToPrompt(
+        messageTextWithSelectionAnnotations,
+        composerTerminalContextsSnapshot,
+      ),
       composerElementContextsSnapshot,
     );
     const messageTextWithPreviewAnnotations = composerPreviewAnnotationsSnapshot.reduce(
@@ -4792,6 +4830,9 @@ function ChatViewContent(props: ChatViewProps) {
         titleSeed = formatTerminalContextLabel(composerTerminalContextsSnapshot[0]!);
       } else if (composerElementContextsSnapshot.length > 0) {
         titleSeed = formatElementContextLabel(composerElementContextsSnapshot[0]!);
+      } else if (composerChatSelectionAnnotationsSnapshot.length > 0) {
+        const firstAnnotation = composerChatSelectionAnnotationsSnapshot[0]!;
+        titleSeed = firstAnnotation.comment.trim() || firstAnnotation.selectedText;
       } else {
         titleSeed = "New thread";
       }
@@ -4906,7 +4947,9 @@ function ChatViewContent(props: ChatViewProps) {
         (useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)?.previewAnnotations
           .length ?? 0) === 0 &&
         (useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)?.reviewComments
-          .length ?? 0) === 0
+          .length ?? 0) === 0 &&
+        (useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)
+          ?.chatSelectionAnnotations.length ?? 0) === 0
       ) {
         setOptimisticUserMessages((existing) => {
           const removed = existing.filter((message) => message.id === messageIdForSend);
@@ -4927,6 +4970,10 @@ function ChatViewContent(props: ChatViewProps) {
         setComposerDraftElementContexts(composerDraftTarget, composerElementContextsSnapshot);
         setComposerDraftPreviewAnnotations(composerDraftTarget, composerPreviewAnnotationsSnapshot);
         setComposerDraftReviewComments(composerDraftTarget, composerReviewCommentsSnapshot);
+        setComposerDraftChatSelectionAnnotations(
+          composerDraftTarget,
+          composerChatSelectionAnnotationsSnapshot,
+        );
         composerRef.current?.resetCursorState({
           cursor: collapseExpandedComposerCursor(promptForSend, promptForSend.length),
           prompt: promptForSend,
@@ -5131,9 +5178,13 @@ function ChatViewContent(props: ChatViewProps) {
     async ({
       text,
       interactionMode: nextInteractionMode,
+      draftText: draftTextToRestore,
+      chatSelectionAnnotations = [],
     }: {
       text: string;
       interactionMode: "default" | "plan";
+      draftText: string;
+      chatSelectionAnnotations?: ReadonlyArray<ChatSelectionAnnotation>;
     }) => {
       if (
         !activeThread ||
@@ -5145,7 +5196,7 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
 
-      const trimmed = text.trim();
+      const trimmed = appendChatSelectionAnnotationsToPrompt(text, chatSelectionAnnotations).trim();
       if (!trimmed) {
         return;
       }
@@ -5172,10 +5223,16 @@ function ChatViewContent(props: ChatViewProps) {
         effort: ctxSelectedPromptEffort,
         text: trimmed,
       });
+      const retryChatSelectionAnnotations = chatSelectionAnnotations.map((annotation) => ({
+        ...annotation,
+      }));
 
       sendInFlightRef.current = true;
       beginLocalDispatch({ preparingWorktree: false });
       setThreadError(threadIdForSend, null);
+      promptRef.current = "";
+      clearComposerDraftContent(composerDraftTarget);
+      composerRef.current?.resetCursorState();
 
       // Position this sent row once LegendList has measured the anchored tail.
       isAtEndRef.current = true;
@@ -5269,6 +5326,25 @@ function ChatViewContent(props: ChatViewProps) {
       setOptimisticUserMessages((existing) =>
         existing.filter((message) => message.id !== messageIdForSend),
       );
+      const currentDraft = useComposerDraftStore.getState().getComposerDraft(composerDraftTarget);
+      if (
+        shouldRestoreClearedPlanFollowUpDraft({
+          currentPrompt: promptRef.current,
+          currentChatSelectionAnnotationCount: currentDraft?.chatSelectionAnnotations.length ?? 0,
+        })
+      ) {
+        promptRef.current = draftTextToRestore;
+        setComposerDraftPrompt(composerDraftTarget, draftTextToRestore);
+        setComposerDraftChatSelectionAnnotations(
+          composerDraftTarget,
+          retryChatSelectionAnnotations,
+        );
+        composerRef.current?.resetCursorState({
+          cursor: collapseExpandedComposerCursor(draftTextToRestore, draftTextToRestore.length),
+          prompt: draftTextToRestore,
+          detectTrigger: true,
+        });
+      }
       if (!isAtomCommandInterrupted(failure)) {
         const error = squashAtomCommandFailure(failure);
         setThreadError(
@@ -5283,6 +5359,9 @@ function ChatViewContent(props: ChatViewProps) {
       activeThread,
       activeProposedPlan,
       beginLocalDispatch,
+      clearComposerDraftContent,
+      composerDraftTarget,
+      composerRef,
       isConnecting,
       isSendBusy,
       isServerThread,
@@ -5290,12 +5369,13 @@ function ChatViewContent(props: ChatViewProps) {
       persistThreadSettingsForNextTurn,
       resetLocalDispatch,
       runtimeMode,
+      setComposerDraftChatSelectionAnnotations,
       setComposerDraftInteractionMode,
+      setComposerDraftPrompt,
       setThreadError,
       startThreadTurn,
       autoOpenPlanSidebar,
       environmentId,
-      composerRef,
     ],
   );
 
@@ -5831,6 +5911,7 @@ function ChatViewContent(props: ChatViewProps) {
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
                 hideEmptyPlaceholder={isDraftHeroState || threadDetailLoading}
                 topFadeEnabled={!hasTimelineTopBanner}
+                onAddChatSelectionAnnotation={addChatSelectionAnnotation}
               />
 
               {/* scroll to end pill — shown when user has scrolled away from the live edge */}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -79,6 +79,7 @@ import { useComposerPathSearch } from "../../lib/composerPathSearchState";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
+import { ComposerPendingChatSelectionAnnotations } from "./ComposerPendingChatSelectionAnnotations";
 import { ComposerPreviewAnnotationCards } from "./ComposerPreviewAnnotationCards";
 import {
   shouldUseCompactComposerPrimaryActions,
@@ -106,6 +107,7 @@ import { ContextWindowMeter } from "./ContextWindowMeter";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
+import type { ChatSelectionAnnotation } from "~/chatSelectionAnnotation";
 import { Separator } from "../ui/separator";
 
 function ComposerCommandMenuLayer(props: { anchor: HTMLElement | null; children: ReactNode }) {
@@ -492,6 +494,7 @@ export interface ChatComposerHandle {
     elementContexts: ElementContextDraft[];
     previewAnnotations: PreviewAnnotationPayload[];
     reviewComments: ReviewCommentContext[];
+    chatSelectionAnnotations: ChatSelectionAnnotation[];
     selectedPromptEffort: string | null;
     selectedModelOptionsForDispatch: unknown;
     selectedModelSelection: ModelSelection;
@@ -704,6 +707,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const composerElementContexts = composerDraft.elementContexts;
   const composerPreviewAnnotations = composerDraft.previewAnnotations;
   const composerReviewComments = composerDraft.reviewComments;
+  const composerChatSelectionAnnotations = composerDraft.chatSelectionAnnotations;
+  const hasComposerPromptText =
+    prompt.trim().length > 0 || composerChatSelectionAnnotations.length > 0;
   const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
 
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
@@ -727,6 +733,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   );
   const removeComposerDraftReviewComment = useComposerDraftStore(
     (store) => store.removeReviewComment,
+  );
+  const removeComposerDraftChatSelectionAnnotation = useComposerDraftStore(
+    (store) => store.removeChatSelectionAnnotation,
   );
   const clearComposerDraftPersistedAttachments = useComposerDraftStore(
     (store) => store.clearPersistedAttachments,
@@ -1024,13 +1033,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         elementContextCount:
           composerElementContexts.length +
           composerPreviewAnnotations.length +
-          composerReviewComments.length,
+          composerReviewComments.length +
+          composerChatSelectionAnnotations.length,
       }),
     [
       composerElementContexts.length,
       composerImages.length,
       composerPreviewAnnotations.length,
       composerReviewComments.length,
+      composerChatSelectionAnnotations.length,
       composerTerminalContexts,
       prompt,
     ],
@@ -1166,7 +1177,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return "running";
     }
     if (showPlanFollowUpPrompt) {
-      return prompt.trim().length > 0 ? "plan:refine" : "plan:implement";
+      return hasComposerPromptText ? "plan:refine" : "plan:implement";
     }
     return `idle:${composerSendState.hasSendableContent}:${isSendBusy}:${isConnecting}:${isPreparingWorktree}`;
   }, [
@@ -1176,8 +1187,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     isConnecting,
     isPreparingWorktree,
     isSendBusy,
+    hasComposerPromptText,
     phase,
-    prompt,
     showPlanFollowUpPrompt,
   ]);
 
@@ -2622,6 +2633,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         elementContexts: composerElementContextsRef.current,
         previewAnnotations: composerPreviewAnnotations,
         reviewComments: composerReviewComments,
+        chatSelectionAnnotations: composerChatSelectionAnnotations,
         selectedPromptEffort,
         selectedModelOptionsForDispatch,
         selectedModelSelection,
@@ -2643,6 +2655,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       composerElementContextsRef,
       composerPreviewAnnotations,
       composerReviewComments,
+      composerChatSelectionAnnotations,
       isConnecting,
       isComposerApprovalState,
       pendingUserInputs.length,
@@ -2822,6 +2835,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
           {showCollapsedMobilePromptRow ? (
             <div className="flex items-center justify-between gap-2 px-3 py-2">
+              {composerChatSelectionAnnotations.length > 0 ? (
+                <ComposerPendingChatSelectionAnnotations
+                  annotations={composerChatSelectionAnnotations}
+                  onRemove={(annotationId) =>
+                    removeComposerDraftChatSelectionAnnotation(composerDraftTarget, annotationId)
+                  }
+                  compact
+                  className="max-w-[38%] shrink-0"
+                />
+              ) : null}
               <button
                 type="button"
                 className={cn(
@@ -2924,6 +2947,19 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     const preview = buildExpandedImagePreview(composerImages, imageId);
                     if (preview) onExpandImage(preview);
                   }}
+                  className="mb-3"
+                />
+              )}
+
+            {!isComposerCollapsedMobile &&
+              !isComposerApprovalState &&
+              pendingUserInputs.length === 0 &&
+              composerChatSelectionAnnotations.length > 0 && (
+                <ComposerPendingChatSelectionAnnotations
+                  annotations={composerChatSelectionAnnotations}
+                  onRemove={(annotationId) =>
+                    removeComposerDraftChatSelectionAnnotation(composerDraftTarget, annotationId)
+                  }
                   className="mb-3"
                 />
               )}
@@ -3212,7 +3248,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   pendingAction={pendingPrimaryAction}
                   isRunning={phase === "running"}
                   showPlanFollowUpPrompt={pendingUserInputs.length === 0 && showPlanFollowUpPrompt}
-                  promptHasText={prompt.trim().length > 0}
+                  promptHasText={hasComposerPromptText}
                   isSendBusy={isSendBusy}
                   sendDisabledReason={sendDisabledReason}
                   isConnecting={isConnecting}

--- a/apps/web/src/components/chat/ChatTextSelectionPopover.tsx
+++ b/apps/web/src/components/chat/ChatTextSelectionPopover.tsx
@@ -1,0 +1,127 @@
+import { Check, Plus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { Button } from "../ui/button";
+
+export interface ChatTextSelectionPopoverProps {
+  rect: { top: number; left: number; width: number; height: number };
+  onAddAnnotation: (comment: string) => void;
+  onCommentStateChange: (isAddingComment: boolean) => void;
+  onClose: () => void;
+}
+
+function popoverPosition(rect: ChatTextSelectionPopoverProps["rect"], isAddingComment: boolean) {
+  const viewportGap = 12;
+  const popoverGap = 8;
+  const estimatedPopoverHeight = isAddingComment ? 48 : 36;
+  const width = isAddingComment ? Math.min(320, window.innerWidth - viewportGap * 2) : undefined;
+  const halfWidth = width ? width / 2 : 60;
+  const minimumCenter = viewportGap + halfWidth;
+  const maximumCenter = window.innerWidth - viewportGap - halfWidth;
+  const center =
+    maximumCenter < minimumCenter
+      ? window.innerWidth / 2
+      : Math.max(minimumCenter, Math.min(maximumCenter, rect.left + rect.width / 2));
+  const selectionBottom = rect.top + rect.height;
+  const preferAbove =
+    rect.top > 96 ||
+    selectionBottom + popoverGap + estimatedPopoverHeight > window.innerHeight - viewportGap;
+  const minimumTop = viewportGap + estimatedPopoverHeight;
+  const maximumTop = Math.max(minimumTop, window.innerHeight - viewportGap);
+
+  return {
+    left: center,
+    ...(preferAbove
+      ? {
+          top: Math.max(minimumTop, Math.min(maximumTop, rect.top - popoverGap)),
+          transform: "translate(-50%, -100%)",
+        }
+      : {
+          top: Math.max(
+            viewportGap,
+            Math.min(
+              selectionBottom + popoverGap,
+              window.innerHeight - viewportGap - estimatedPopoverHeight,
+            ),
+          ),
+          transform: "translateX(-50%)",
+        }),
+    ...(width ? { width } : {}),
+  };
+}
+
+export function ChatTextSelectionPopover({
+  rect,
+  onAddAnnotation,
+  onCommentStateChange,
+  onClose,
+}: ChatTextSelectionPopoverProps) {
+  const [isAddingComment, setIsAddingComment] = useState(false);
+  const [comment, setComment] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    onCommentStateChange(isAddingComment);
+    return () => onCommentStateChange(false);
+  }, [isAddingComment, onCommentStateChange]);
+
+  useEffect(() => {
+    if (isAddingComment) inputRef.current?.focus();
+  }, [isAddingComment]);
+
+  return createPortal(
+    <div
+      className="pointer-events-auto fixed z-[70]"
+      style={popoverPosition(rect, isAddingComment)}
+      role="dialog"
+      aria-label="Selected text actions"
+      data-chat-selection-popover="true"
+      onPointerDown={(event) => event.stopPropagation()}
+      onPointerUp={(event) => event.stopPropagation()}
+      onKeyUp={(event) => event.stopPropagation()}
+    >
+      {isAddingComment ? (
+        <form
+          className="flex w-full items-center gap-1.5 rounded-full border border-border/80 bg-popover px-2.5 py-1.5 shadow-lg"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onAddAnnotation(comment.trim());
+          }}
+        >
+          <input
+            ref={inputRef}
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+              }
+            }}
+            placeholder="Add an optional comment..."
+            aria-label="Optional comment for selected text"
+            className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+          />
+          <Button type="submit" size="icon" aria-label="Add selected text" className="rounded-full">
+            <Check className="size-4" aria-hidden />
+          </Button>
+        </form>
+      ) : (
+        <div className="flex items-center overflow-hidden rounded-xl border border-border/80 bg-popover p-0.5 shadow-lg">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onPointerDown={(event) => event.preventDefault()}
+            onClick={() => setIsAddingComment(true)}
+          >
+            <Plus className="size-3.5" aria-hidden />
+            Add to chat
+          </Button>
+        </div>
+      )}
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/chat/ComposerPendingChatSelectionAnnotations.tsx
+++ b/apps/web/src/components/chat/ComposerPendingChatSelectionAnnotations.tsx
@@ -1,0 +1,116 @@
+import { TextQuote, X } from "lucide-react";
+
+import type { ChatSelectionAnnotation } from "~/chatSelectionAnnotation";
+import {
+  COMPOSER_INLINE_CHIP_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_DISMISS_BUTTON_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_ICON_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME,
+} from "../composerInlineChip";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { cn } from "~/lib/utils";
+
+interface ComposerPendingChatSelectionAnnotationsProps {
+  annotations: ReadonlyArray<ChatSelectionAnnotation>;
+  onRemove: (annotationId: string) => void;
+  className?: string;
+  compact?: boolean;
+}
+
+export function ComposerPendingChatSelectionAnnotations({
+  annotations,
+  onRemove,
+  className,
+  compact = false,
+}: ComposerPendingChatSelectionAnnotationsProps) {
+  if (annotations.length === 0) return null;
+  const label = compact
+    ? `${annotations.length} annotation${annotations.length === 1 ? "" : "s"}`
+    : `${annotations.length} annotation${annotations.length === 1 ? "" : "s"}`;
+
+  return (
+    <div className={cn("flex min-w-0 flex-wrap gap-1.5", className)}>
+      <Popover>
+        <div className={cn(COMPOSER_INLINE_CHIP_CLASS_NAME, "pr-1")}>
+          <PopoverTrigger
+            render={
+              <button
+                type="button"
+                aria-label={label}
+                className="inline-flex min-w-0 cursor-pointer items-center gap-1 rounded-sm bg-transparent py-0.5 text-left outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            }
+          >
+            <TextQuote className={cn(COMPOSER_INLINE_CHIP_ICON_CLASS_NAME, "size-3")} />
+            <span className={COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME}>
+              {compact ? `${annotations.length} selected` : label}
+            </span>
+          </PopoverTrigger>
+          {annotations.length === 1 ? (
+            <button
+              type="button"
+              aria-label="Remove text annotation"
+              className={COMPOSER_INLINE_CHIP_DISMISS_BUTTON_CLASS_NAME}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onRemove(annotations[0]!.id);
+              }}
+            >
+              <X className="size-3" aria-hidden />
+            </button>
+          ) : null}
+        </div>
+        <PopoverPopup
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="w-[min(22rem,calc(100vw-2rem))] border border-border/80 bg-background/95 shadow-lg"
+          viewportClassName="p-1 [--viewport-inline-padding:--spacing(1)]"
+        >
+          <div>
+            {annotations.map((annotation, index) => (
+              <section
+                key={annotation.id}
+                className="relative border-b border-border/40 px-2.5 py-2.5 pr-8 last:border-b-0"
+              >
+                <div className="flex min-w-0 items-start gap-2">
+                  <span className="mt-0.5 shrink-0 text-xs tabular-nums text-muted-foreground/75">
+                    {index + 1}.
+                  </span>
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <div>
+                      <div className="text-xs font-medium text-muted-foreground">Selected text</div>
+                      <p className="mt-0.5 break-words text-sm leading-5 text-foreground/90">
+                        {annotation.selectedText}
+                      </p>
+                    </div>
+                    {annotation.comment.trim() ? (
+                      <div>
+                        <div className="text-xs font-medium text-muted-foreground">Comment</div>
+                        <p className="mt-0.5 break-words text-sm leading-5 text-foreground/90">
+                          {annotation.comment}
+                        </p>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  aria-label={`Remove text annotation ${index + 1}`}
+                  className={cn(
+                    COMPOSER_INLINE_CHIP_DISMISS_BUTTON_CLASS_NAME,
+                    "absolute right-2 top-2 size-5",
+                  )}
+                  onClick={() => onRemove(annotation.id)}
+                >
+                  <X className="size-3" aria-hidden />
+                </button>
+              </section>
+            ))}
+          </div>
+        </PopoverPopup>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -3,6 +3,7 @@ import { createRef, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import type { LegendListRef } from "@legendapp/list/react";
+import { appendChatSelectionAnnotationsToPrompt } from "../../chatSelectionAnnotation";
 
 vi.mock("@legendapp/list/react", async () => {
   const legendListTestId = "legend-list";
@@ -196,6 +197,7 @@ function buildProps() {
     contentInsetEndAdjustment: 0,
     onIsAtEndChange: () => {},
     onManualNavigation: () => {},
+    onAddChatSelectionAnnotation: () => {},
   };
 }
 
@@ -628,6 +630,76 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Clarify this.");
     expect(markup).toContain("# Plan");
     expect(markup).not.toContain('data-testid="file-diff"');
+  });
+
+  it("summarizes attached response text without exposing its prompt markup", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          buildUserTimelineEntry(
+            appendChatSelectionAnnotationsToPrompt("Please explain.", [
+              {
+                id: "selection-1",
+                selectedText: "Retry the request.",
+                comment: "Why is this safe?",
+              },
+            ]),
+          ),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("1 annotation");
+    expect(markup).toContain('data-chat-selection-annotation-summary="true"');
+    expect(markup).toContain("lucide-text-quote");
+    expect(markup).toContain("Please explain.");
+    expect(markup).not.toContain("Retry the request.");
+    expect(markup).not.toContain("Why is this safe?");
+    expect(markup).not.toContain("&lt;chat_selection");
+  });
+
+  it("preserves user-authored chat selection markup in the message bubble", () => {
+    const userAuthoredMarkup = [
+      "I am discussing this format:",
+      '<chat_selection id="example">',
+      "<selected_text>",
+      "this is just an example",
+      "</selected_text>",
+      "<user_comment>",
+      "please explain this format",
+      "</user_comment>",
+      "</chat_selection>",
+    ].join("\n");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[buildUserTimelineEntry(userAuthoredMarkup)]}
+      />,
+    );
+
+    expect(markup).not.toContain('data-chat-selection-annotation-summary="true"');
+    expect(markup).toContain("this is just an example");
+    expect(markup).toContain("please explain this format");
+  });
+
+  it("does not render an empty user bubble for an annotation-only message", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          buildUserTimelineEntry(
+            appendChatSelectionAnnotationsToPrompt("", [
+              { id: "selection-1", selectedText: "Retry the request.", comment: "" },
+            ]),
+          ),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('data-chat-selection-annotation-summary="true"');
+    expect(markup).not.toContain('data-user-message-bubble="true"');
+    expect(markup).not.toContain('aria-label="Copy link"');
   });
 
   it("renders a failure marker for failed tool lifecycle entries", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -53,6 +53,7 @@ import {
   MinusIcon,
   SquarePenIcon,
   TerminalIcon,
+  TextQuote,
   Undo2Icon,
   WrenchIcon,
   XIcon,
@@ -108,6 +109,11 @@ import {
 import { SkillInlineText } from "./SkillInlineText";
 import { formatWorkspaceRelativePath } from "../../filePathDisplay";
 import {
+  parseChatSelectionMessageSegments,
+  stripAppendedChatSelectionAnnotations,
+  type ChatSelectionAnnotation,
+} from "../../chatSelectionAnnotation";
+import {
   buildReviewCommentRenderablePatch,
   formatReviewCommentFence,
   parseReviewCommentMessageSegments,
@@ -135,6 +141,7 @@ interface TimelineRowSharedState {
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
   onToggleTurnFold: (turnId: TurnId) => void;
   onToggleWorkGroup: (groupId: string, anchorElement?: HTMLElement) => void;
+  onAddChatSelectionAnnotation: (annotation: Omit<ChatSelectionAnnotation, "id">) => void;
 }
 
 interface TimelineRowActivityState {
@@ -184,6 +191,7 @@ interface MessagesTimelineProps {
   onManualNavigation: () => void;
   hideEmptyPlaceholder?: boolean;
   topFadeEnabled?: boolean;
+  onAddChatSelectionAnnotation: (annotation: Omit<ChatSelectionAnnotation, "id">) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +227,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   onManualNavigation,
   hideEmptyPlaceholder = false,
   topFadeEnabled = false,
+  onAddChatSelectionAnnotation,
 }: MessagesTimelineProps) {
   const [expandedTurnIds, setExpandedTurnIds] = useState<ReadonlySet<TurnId>>(new Set());
   const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
@@ -430,6 +439,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onOpenTurnDiff,
       onToggleTurnFold,
       onToggleWorkGroup,
+      onAddChatSelectionAnnotation,
     }),
     [
       timestampFormat,
@@ -444,6 +454,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onOpenTurnDiff,
       onToggleTurnFold,
       onToggleWorkGroup,
+      onAddChatSelectionAnnotation,
     ],
   );
   const activityState = useMemo<TimelineRowActivityState>(
@@ -884,70 +895,108 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
     ...displayedUserMessage.elementContexts,
     ...elementContextState.contexts,
   ];
+  const chatSelectionSegments = parseChatSelectionMessageSegments(elementContextState.promptText);
+  const chatSelectionAnnotations = chatSelectionSegments.flatMap((segment) =>
+    segment.kind === "selection" ? [segment.annotation] : [],
+  );
+  const userPromptText =
+    chatSelectionAnnotations.length > 0
+      ? chatSelectionSegments
+          .flatMap((segment) => (segment.kind === "text" ? [segment.text] : []))
+          .join("")
+          .trim()
+      : elementContextState.promptText;
+  const userCopyText =
+    chatSelectionAnnotations.length > 0
+      ? stripAppendedChatSelectionAnnotations(displayedUserMessage.copyText)
+      : displayedUserMessage.copyText;
   const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
   const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
+  const hasVisibleUserBubble =
+    regularImages.length > 0 ||
+    previewAnnotations.length > 0 ||
+    elementContexts.length > 0 ||
+    userPromptText.trim().length > 0 ||
+    terminalContexts.length > 0;
 
   return (
     <div className="group flex flex-col items-end gap-1">
-      <div className="relative max-w-[80%] rounded-2xl bg-accent p-3">
-        {regularImages.length > 0 && (
-          <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
-            {regularImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (
-              <div
-                key={image.id}
-                className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
-              >
-                {image.previewUrl ? (
-                  <button
-                    type="button"
-                    className="h-full w-full cursor-zoom-in"
-                    aria-label={`Preview ${image.name}`}
-                    onClick={() => {
-                      const preview = buildExpandedImagePreview(regularImages, image.id);
-                      if (!preview) return;
-                      ctx.onImageExpand(preview);
-                    }}
-                  >
-                    <img
-                      src={image.previewUrl}
-                      alt={image.name}
-                      className="block h-auto max-h-[220px] w-full object-cover"
-                    />
-                  </button>
-                ) : (
-                  <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
-                    {image.name}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-        {previewAnnotations.map((annotation, index) => (
-          <UserMessagePreviewAnnotationCard
-            key={annotation.id}
-            annotation={annotation}
-            image={previewImages[index] ?? null}
+      {chatSelectionAnnotations.length > 0 ? (
+        <div
+          className="mb-0.5 inline-flex h-7 items-center gap-1.5 rounded-full border border-border/80 bg-accent px-2.5 text-xs text-foreground shadow-xs"
+          data-chat-selection-annotation-summary
+        >
+          <TextQuote className="size-3.5 text-muted-foreground" aria-hidden />
+          <span>
+            {chatSelectionAnnotations.length} annotation
+            {chatSelectionAnnotations.length === 1 ? "" : "s"}
+          </span>
+        </div>
+      ) : null}
+      {hasVisibleUserBubble ? (
+        <div
+          className="relative max-w-[80%] rounded-2xl bg-accent p-3"
+          data-user-message-bubble="true"
+        >
+          {regularImages.length > 0 && (
+            <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
+              {regularImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (
+                <div
+                  key={image.id}
+                  className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
+                >
+                  {image.previewUrl ? (
+                    <button
+                      type="button"
+                      className="h-full w-full cursor-zoom-in"
+                      aria-label={`Preview ${image.name}`}
+                      onClick={() => {
+                        const preview = buildExpandedImagePreview(regularImages, image.id);
+                        if (!preview) return;
+                        ctx.onImageExpand(preview);
+                      }}
+                    >
+                      <img
+                        src={image.previewUrl}
+                        alt={image.name}
+                        className="block h-auto max-h-[220px] w-full object-cover"
+                      />
+                    </button>
+                  ) : (
+                    <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
+                      {image.name}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {previewAnnotations.map((annotation, index) => (
+            <UserMessagePreviewAnnotationCard
+              key={annotation.id}
+              annotation={annotation}
+              image={previewImages[index] ?? null}
+            />
+          ))}
+          {elementContexts.length > 0 ? (
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {elementContexts.map((context) => (
+                <UserMessageElementContextChip
+                  key={`${context.header}:${context.body}`}
+                  context={context}
+                />
+              ))}
+            </div>
+          ) : null}
+          <CollapsibleUserMessageBody
+            text={userPromptText}
+            terminalContexts={terminalContexts}
+            skills={ctx.skills}
+            markdownCwd={ctx.markdownCwd}
           />
-        ))}
-        {elementContexts.length > 0 ? (
-          <div className="mb-2 flex flex-wrap gap-1.5">
-            {elementContexts.map((context) => (
-              <UserMessageElementContextChip
-                key={`${context.header}:${context.body}`}
-                context={context}
-              />
-            ))}
-          </div>
-        ) : null}
-        <CollapsibleUserMessageBody
-          text={elementContextState.promptText}
-          terminalContexts={terminalContexts}
-          skills={ctx.skills}
-          markdownCwd={ctx.markdownCwd}
-        />
-      </div>
+        </div>
+      ) : null}
       <div className="flex w-full max-w-[80%] items-center justify-end pe-1 text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
         <div className="flex shrink-0 items-center gap-2">
           <Tooltip>
@@ -960,8 +1009,8 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
           </Tooltip>
           <div className="flex items-center gap-0.5">
             {canRevertAgentWork && <RevertUserMessageButton messageId={row.message.id} />}
-            {displayedUserMessage.copyText && (
-              <MessageCopyButton text={displayedUserMessage.copyText} variant="ghost" />
+            {userCopyText.trim().length > 0 && (
+              <MessageCopyButton text={userCopyText} variant="ghost" />
             )}
           </div>
         </div>
@@ -1028,6 +1077,7 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           threadRef={ctx.threadRef ?? undefined}
           isStreaming={Boolean(row.message.streaming)}
           skills={ctx.skills}
+          onTextSelection={ctx.onAddChatSelectionAnnotation}
         />
         <AssistantChangedFilesSection
           turnSummary={row.assistantTurnDiffSummary}

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -345,6 +345,52 @@ describe("composerDraftStore syncPersistedAttachments", () => {
   });
 });
 
+describe("composerDraftStore persisted preview annotations", () => {
+  const threadId = ThreadId.make("thread-preview-annotation");
+
+  it("preserves preview-only drafts while normalizing legacy storage", () => {
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const previewAnnotation = {
+      id: "preview-1",
+      pageUrl: "https://example.com",
+      pageTitle: "Example",
+      comment: "Move this button.",
+      elements: [],
+      regions: [],
+      strokes: [],
+      styleChanges: [],
+      screenshot: null,
+      createdAt: "2026-03-13T12:00:00.000Z",
+    };
+
+    const mergedState = persistApi.getOptions().merge(
+      {
+        draftsByThreadId: {
+          [threadId]: {
+            prompt: "",
+            attachments: [],
+            previewAnnotations: [previewAnnotation],
+          },
+        },
+        draftThreadsByThreadId: {},
+        projectDraftThreadIdByProjectKey: {},
+      },
+      useComposerDraftStore.getInitialState(),
+    );
+
+    expect(mergedState.draftsByThreadKey[threadId]?.previewAnnotations).toEqual([
+      previewAnnotation,
+    ]);
+  });
+});
+
 describe("composerDraftStore terminal contexts", () => {
   const threadId = ThreadId.make("thread-dedupe");
   const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
@@ -676,6 +722,61 @@ describe("composerDraftStore review comments", () => {
     expect(useComposerDraftStore.getState().getComposerDraft(draftId)?.reviewComments).toEqual([
       comment,
     ]);
+  });
+});
+
+describe("composerDraftStore chat selection annotations", () => {
+  const threadId = ThreadId.make("thread-chat-selection");
+  const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+  const annotation = {
+    id: "selection-1",
+    selectedText: "Restart the adapter, then retry OAuth.",
+    comment: "Why is this needed?",
+  } as const;
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("adds and removes annotations in source order", () => {
+    const store = useComposerDraftStore.getState();
+    store.addChatSelectionAnnotation(threadRef, annotation);
+    store.addChatSelectionAnnotation(threadRef, {
+      ...annotation,
+      id: "selection-2",
+      selectedText: "Retry OAuth.",
+    });
+
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.chatSelectionAnnotations).toEqual([
+      annotation,
+      { ...annotation, id: "selection-2", selectedText: "Retry OAuth." },
+    ]);
+
+    store.removeChatSelectionAnnotation(threadRef, annotation.id);
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.chatSelectionAnnotations).toHaveLength(1);
+    store.removeChatSelectionAnnotation(threadRef, "selection-2");
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)).toBeUndefined();
+  });
+
+  it("persists chat selection annotations and clears them with composer content", () => {
+    const store = useComposerDraftStore.getState();
+    store.addChatSelectionAnnotation(threadRef, annotation);
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+      };
+    };
+    const persisted = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+      draftsByThreadKey?: Record<string, { chatSelectionAnnotations?: unknown[] }>;
+    };
+
+    expect(
+      persisted.draftsByThreadKey?.[threadKeyFor(threadId, TEST_ENVIRONMENT_ID)]
+        ?.chatSelectionAnnotations,
+    ).toEqual([annotation]);
+
+    store.clearComposerContent(threadRef);
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)).toBeUndefined();
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -45,6 +45,10 @@ import {
   elementContextDedupKey,
   newElementContextId,
 } from "./lib/elementContext";
+import {
+  ChatSelectionAnnotationSchema,
+  type ChatSelectionAnnotation,
+} from "./chatSelectionAnnotation";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
@@ -54,10 +58,12 @@ import { UnifiedSettings } from "@t3tools/contracts/settings";
 import { ReviewCommentContextSchema, type ReviewCommentContext } from "./reviewCommentContext";
 const isRuntimeMode = Schema.is(RuntimeMode);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
+const isPreviewAnnotationPayload = Schema.is(PreviewAnnotationPayloadSchema);
 const isReviewCommentContext = Schema.is(ReviewCommentContextSchema);
+const isChatSelectionAnnotation = Schema.is(ChatSelectionAnnotationSchema);
 
 export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
-const COMPOSER_DRAFT_STORAGE_VERSION = 8;
+const COMPOSER_DRAFT_STORAGE_VERSION = 9;
 const DraftThreadEnvModeSchema = Schema.Literals(["local", "worktree"]);
 export type DraftThreadEnvMode = typeof DraftThreadEnvModeSchema.Type;
 
@@ -132,6 +138,7 @@ const PersistedComposerThreadDraftState = Schema.Struct({
   elementContexts: Schema.optionalKey(Schema.Array(PersistedElementContextDraft)),
   previewAnnotations: Schema.optionalKey(Schema.Array(PreviewAnnotationPayloadSchema)),
   reviewComments: Schema.optionalKey(Schema.Array(ReviewCommentContextSchema)),
+  chatSelectionAnnotations: Schema.optionalKey(Schema.Array(ChatSelectionAnnotationSchema)),
   // Keyed by `ProviderInstanceId` (open branded slug) so custom provider
   // instances (e.g. `codex_personal`) round-trip alongside the built-in
   // `codex` / `claudeAgent` / ... entries. Every prior `ProviderDriverKind`
@@ -262,6 +269,7 @@ export interface ComposerThreadDraftState {
   elementContexts: ElementContextDraft[];
   previewAnnotations: PreviewAnnotationPayload[];
   reviewComments: ReviewCommentContext[];
+  chatSelectionAnnotations: ChatSelectionAnnotation[];
   /**
    * Per-instance model selection. Keyed by `ProviderInstanceId` (open
    * branded slug) so a default `codex` instance and a user-authored
@@ -489,6 +497,15 @@ interface ComposerDraftStoreState {
     comments: ReadonlyArray<ReviewCommentContext>,
   ) => void;
   removeReviewComment: (threadRef: ComposerThreadTarget, commentId: string) => void;
+  addChatSelectionAnnotation: (
+    threadRef: ComposerThreadTarget,
+    annotation: ChatSelectionAnnotation,
+  ) => void;
+  setChatSelectionAnnotations: (
+    threadRef: ComposerThreadTarget,
+    annotations: ReadonlyArray<ChatSelectionAnnotation>,
+  ) => void;
+  removeChatSelectionAnnotation: (threadRef: ComposerThreadTarget, annotationId: string) => void;
   clearPersistedAttachments: (threadRef: ComposerThreadTarget) => void;
   syncPersistedAttachments: (
     threadRef: ComposerThreadTarget,
@@ -497,9 +514,10 @@ interface ComposerDraftStoreState {
   clearComposerContent: (threadRef: ComposerThreadTarget) => void;
   /**
    * Clears only the prompt text and image attachments, preserving terminal /
-   * element contexts, preview annotations, and review comments. Used by the
-   * prompt stash, which can only round-trip text + images: clearing the
-   * session-bound contexts would destroy state nothing can restore.
+   * element contexts, preview annotations, review comments, and chat selection
+   * annotations. Used by the prompt stash, which can only round-trip text +
+   * images: clearing the session-bound contexts would destroy state nothing can
+   * restore.
    */
   clearComposerPromptAndImages: (threadRef: ComposerThreadTarget) => void;
 }
@@ -574,12 +592,14 @@ const EMPTY_TERMINAL_CONTEXTS: TerminalContextDraft[] = [];
 const EMPTY_ELEMENT_CONTEXTS: ElementContextDraft[] = [];
 const EMPTY_PREVIEW_ANNOTATIONS: PreviewAnnotationPayload[] = [];
 const EMPTY_REVIEW_COMMENTS: ReviewCommentContext[] = [];
+const EMPTY_CHAT_SELECTION_ANNOTATIONS: ChatSelectionAnnotation[] = [];
 Object.freeze(EMPTY_IMAGES);
 Object.freeze(EMPTY_IDS);
 Object.freeze(EMPTY_PERSISTED_ATTACHMENTS);
 Object.freeze(EMPTY_ELEMENT_CONTEXTS);
 Object.freeze(EMPTY_PREVIEW_ANNOTATIONS);
 Object.freeze(EMPTY_REVIEW_COMMENTS);
+Object.freeze(EMPTY_CHAT_SELECTION_ANNOTATIONS);
 const EMPTY_MODEL_SELECTION_BY_PROVIDER: Partial<Record<ProviderDriverKind, ModelSelection>> =
   Object.freeze({});
 const EMPTY_COMPOSER_DRAFT_MODEL_STATE = Object.freeze<ComposerDraftModelState>({
@@ -596,6 +616,7 @@ const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   elementContexts: EMPTY_ELEMENT_CONTEXTS,
   previewAnnotations: EMPTY_PREVIEW_ANNOTATIONS,
   reviewComments: EMPTY_REVIEW_COMMENTS,
+  chatSelectionAnnotations: EMPTY_CHAT_SELECTION_ANNOTATIONS,
   modelSelectionByProvider: EMPTY_MODEL_SELECTION_BY_PROVIDER,
   activeProvider: null,
   runtimeMode: null,
@@ -618,6 +639,7 @@ export function createEmptyThreadDraft(): ComposerThreadDraftState {
     elementContexts: [],
     previewAnnotations: [],
     reviewComments: [],
+    chatSelectionAnnotations: [],
     modelSelectionByProvider: {},
     activeProvider: null,
     runtimeMode: null,
@@ -691,6 +713,7 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
     draft.elementContexts.length === 0 &&
     draft.previewAnnotations.length === 0 &&
     draft.reviewComments.length === 0 &&
+    draft.chatSelectionAnnotations.length === 0 &&
     Object.keys(draft.modelSelectionByProvider).length === 0 &&
     draft.activeProvider === null &&
     draft.runtimeMode === null &&
@@ -1670,8 +1693,14 @@ function normalizePersistedDraftsByThreadId(
           return normalized ? [normalized] : [];
         })
       : [];
+    const previewAnnotations = Array.isArray(draftCandidate.previewAnnotations)
+      ? draftCandidate.previewAnnotations.filter(isPreviewAnnotationPayload)
+      : [];
     const reviewComments = Array.isArray(draftCandidate.reviewComments)
       ? draftCandidate.reviewComments.filter(isReviewCommentContext)
+      : [];
+    const chatSelectionAnnotations = Array.isArray(draftCandidate.chatSelectionAnnotations)
+      ? draftCandidate.chatSelectionAnnotations.filter(isChatSelectionAnnotation)
       : [];
     const runtimeMode = isRuntimeMode(draftCandidate.runtimeMode)
       ? draftCandidate.runtimeMode
@@ -1737,7 +1766,9 @@ function normalizePersistedDraftsByThreadId(
       attachments.length === 0 &&
       terminalContexts.length === 0 &&
       elementContexts.length === 0 &&
+      previewAnnotations.length === 0 &&
       reviewComments.length === 0 &&
+      chatSelectionAnnotations.length === 0 &&
       !hasModelData &&
       !runtimeMode &&
       !interactionMode
@@ -1761,7 +1792,9 @@ function normalizePersistedDraftsByThreadId(
       attachments,
       ...(terminalContexts.length > 0 ? { terminalContexts } : {}),
       ...(elementContexts.length > 0 ? { elementContexts } : {}),
+      ...(previewAnnotations.length > 0 ? { previewAnnotations } : {}),
       ...(reviewComments.length > 0 ? { reviewComments } : {}),
+      ...(chatSelectionAnnotations.length > 0 ? { chatSelectionAnnotations } : {}),
       ...(hasModelData
         ? {
             modelSelectionByProvider: compactModelSelectionByProvider(modelSelectionByProvider),
@@ -1847,6 +1880,7 @@ function partializeComposerDraftStoreState(
       draft.elementContexts.length === 0 &&
       draft.previewAnnotations.length === 0 &&
       draft.reviewComments.length === 0 &&
+      draft.chatSelectionAnnotations.length === 0 &&
       !hasModelData &&
       draft.runtimeMode === null &&
       draft.interactionMode === null
@@ -1896,6 +1930,13 @@ function partializeComposerDraftStoreState(
       ...(draft.reviewComments.length > 0
         ? {
             reviewComments: draft.reviewComments.map((comment) => ({ ...comment })),
+          }
+        : {}),
+      ...(draft.chatSelectionAnnotations.length > 0
+        ? {
+            chatSelectionAnnotations: draft.chatSelectionAnnotations.map((annotation) => ({
+              ...annotation,
+            })),
           }
         : {}),
       ...(hasModelData
@@ -2141,6 +2182,8 @@ function toHydratedThreadDraft(
     previewAnnotations:
       persistedDraft.previewAnnotations?.map((annotation) => ({ ...annotation })) ?? [],
     reviewComments: persistedDraft.reviewComments?.map((comment) => ({ ...comment })) ?? [],
+    chatSelectionAnnotations:
+      persistedDraft.chatSelectionAnnotations?.map((annotation) => ({ ...annotation })) ?? [],
     modelSelectionByProvider,
     activeProvider,
     runtimeMode: persistedDraft.runtimeMode ?? null,
@@ -3262,6 +3305,62 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return { draftsByThreadKey: nextDraftsByThreadKey };
           });
         },
+        addChatSelectionAnnotation: (threadRef, annotation) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef);
+          if (!threadKey || !isChatSelectionAnnotation(annotation)) return;
+          set((state) => {
+            const existing = state.draftsByThreadKey[threadKey] ?? createEmptyThreadDraft();
+            if (existing.chatSelectionAnnotations.some((entry) => entry.id === annotation.id)) {
+              return state;
+            }
+            return {
+              draftsByThreadKey: {
+                ...state.draftsByThreadKey,
+                [threadKey]: {
+                  ...existing,
+                  chatSelectionAnnotations: [
+                    ...existing.chatSelectionAnnotations,
+                    { ...annotation },
+                  ],
+                },
+              },
+            };
+          });
+        },
+        setChatSelectionAnnotations: (threadRef, annotations) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef);
+          if (!threadKey) return;
+          const chatSelectionAnnotations = annotations
+            .filter(isChatSelectionAnnotation)
+            .map((annotation) => ({ ...annotation }));
+          set((state) => {
+            const existing = state.draftsByThreadKey[threadKey] ?? createEmptyThreadDraft();
+            const nextDraft = { ...existing, chatSelectionAnnotations };
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            if (shouldRemoveDraft(nextDraft)) delete nextDraftsByThreadKey[threadKey];
+            else nextDraftsByThreadKey[threadKey] = nextDraft;
+            return { draftsByThreadKey: nextDraftsByThreadKey };
+          });
+        },
+        removeChatSelectionAnnotation: (threadRef, annotationId) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef);
+          if (!threadKey || !annotationId) return;
+          set((state) => {
+            const current = state.draftsByThreadKey[threadKey];
+            if (!current) return state;
+            const chatSelectionAnnotations = current.chatSelectionAnnotations.filter(
+              (entry) => entry.id !== annotationId,
+            );
+            if (chatSelectionAnnotations.length === current.chatSelectionAnnotations.length) {
+              return state;
+            }
+            const nextDraft = { ...current, chatSelectionAnnotations };
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            if (shouldRemoveDraft(nextDraft)) delete nextDraftsByThreadKey[threadKey];
+            else nextDraftsByThreadKey[threadKey] = nextDraft;
+            return { draftsByThreadKey: nextDraftsByThreadKey };
+          });
+        },
         clearPersistedAttachments: (threadRef) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
           if (threadKey.length === 0) {
@@ -3337,6 +3436,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               elementContexts: [],
               previewAnnotations: [],
               reviewComments: [],
+              chatSelectionAnnotations: [],
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {

--- a/apps/web/src/proposedPlan.test.ts
+++ b/apps/web/src/proposedPlan.test.ts
@@ -73,6 +73,21 @@ describe("resolvePlanFollowUpSubmission", () => {
     ).toEqual({
       text: "PLEASE IMPLEMENT THIS PLAN:\n## Ship it\n\n- step 1",
       interactionMode: "default",
+      draftText: "",
+    });
+  });
+
+  it("keeps annotation-only follow-ups in plan mode", () => {
+    expect(
+      resolvePlanFollowUpSubmission({
+        draftText: "   ",
+        planMarkdown: "## Ship it\n\n- step 1\n",
+        hasChatSelectionAnnotations: true,
+      }),
+    ).toEqual({
+      text: "",
+      interactionMode: "plan",
+      draftText: "",
     });
   });
 
@@ -85,6 +100,7 @@ describe("resolvePlanFollowUpSubmission", () => {
     ).toEqual({
       text: "Refine step 2 first",
       interactionMode: "plan",
+      draftText: "Refine step 2 first",
     });
   });
 });

--- a/apps/web/src/proposedPlan.ts
+++ b/apps/web/src/proposedPlan.ts
@@ -74,21 +74,28 @@ export function buildPlanImplementationPrompt(planMarkdown: string): string {
   return `PLEASE IMPLEMENT THIS PLAN:\n${planMarkdown.trim()}`;
 }
 
-export function resolvePlanFollowUpSubmission(input: { draftText: string; planMarkdown: string }): {
+export function resolvePlanFollowUpSubmission(input: {
+  draftText: string;
+  planMarkdown: string;
+  hasChatSelectionAnnotations?: boolean;
+}): {
   text: string;
   interactionMode: "default" | "plan";
+  draftText: string;
 } {
   const trimmedDraftText = input.draftText.trim();
-  if (trimmedDraftText.length > 0) {
+  if (trimmedDraftText.length > 0 || input.hasChatSelectionAnnotations) {
     return {
       text: trimmedDraftText,
       interactionMode: "plan",
+      draftText: trimmedDraftText,
     };
   }
 
   return {
     text: buildPlanImplementationPrompt(input.planMarkdown),
     interactionMode: "default",
+    draftText: trimmedDraftText,
   };
 }
 

--- a/docs/user/message-context.md
+++ b/docs/user/message-context.md
@@ -1,0 +1,9 @@
+# Message context
+
+You can attach part of an assistant response to your next message without copying it manually.
+
+In the web and desktop apps, select text in the response, choose **Add to chat**, then add an
+optional comment.
+
+Attached selections appear in one compact annotation chip in the composer. Open the chip to review
+or remove selections before sending.


### PR DESCRIPTION
## What Changed

Adds response-text annotations to web and desktop chat.

Users can select text from an assistant response, choose **Add to chat**, and include an optional comment. Pending selections are grouped in a composer chip where they can be reviewed or removed before sending.

Selections are sent as structured prompt context and displayed as a compact annotation summary instead of exposing the serialized markup in the conversation.

## Why

Referencing part of an assistant response currently requires manually copying and pasting it into the composer. This makes the excerpt and the user’s instruction harder to distinguish.

Attaching the exact selection keeps that context explicit while leaving the composer and conversation readable.

## UI Changes

### Before

Selecting text in an assistant response did not provide an action for attaching it to the next message.

<img width="1456" height="902" alt="image" src="https://github.com/user-attachments/assets/c7357b7f-6fe7-4b69-b359-2a96cea3023a" />


### After

Selecting response text opens an **Add to chat** action.

<img width="1456" height="902" alt="image" src="https://github.com/user-attachments/assets/c306480a-484e-480d-ac34-e74246651e9b" />

An optional comment can be added to explain why the text is relevant.

<img width="1456" height="902" alt="image" src="https://github.com/user-attachments/assets/fdee606b-2c29-40bd-ba45-64acba087d6c" />

Multiple selections are grouped and can be reviewed or removed individually.

<img width="1456" height="902" alt="image" src="https://github.com/user-attachments/assets/445459d7-68e1-45e7-ba12-11074ee0b50a" />

Sent messages display a compact annotation summary without showing the underlying prompt markup.

<img width="1456" height="902" alt="image" src="https://github.com/user-attachments/assets/3fc58d60-7eea-4a07-ac1b-808a2708686e" />


<img width="1456" height="902" alt="image" src="https://github.com/user-attachments/assets/026d3507-a1ed-4d96-aa93-fad7c0438341" />


### Interaction video

https://github.com/user-attachments/assets/19be3ed2-9f34-446e-a294-11ef4363c082


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: OpenAI Codex · Harness: Codex desktop

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add selected response text attachment to the chat composer
> - Users can select text in assistant messages to open a popover ([ChatTextSelectionPopover](https://github.com/pingdotgg/t3code/pull/5224/files#diff-3bab87103d692126e4ed15c6ed1ef0cde01638b7a6b8f2cea000e67e191aeae1)) that lets them add the selection (with an optional comment) to the composer draft as a chat selection annotation.
> - Annotations are serialized as XML blocks and appended to the outgoing prompt via `appendChatSelectionAnnotationsToPrompt`; the composer shows a summary chip ([ComposerPendingChatSelectionAnnotations](https://github.com/pingdotgg/t3code/pull/5224/files#diff-a7dde8652c94c26b20afa15a86f17c084f7ddb7d4166ad0b4334b37cb720cf5c)) to review or remove pending annotations before sending.
> - The [composerDraftStore](https://github.com/pingdotgg/t3code/pull/5224/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a) persists chat selection annotations alongside other draft content (storage version bumped to 9), restores them on send failure, and treats their presence as sendable content.
> - User message bubbles in the timeline parse and hide raw annotation markup, displaying a summary chip instead; annotation-only messages suppress the empty bubble.
> - Behavioral Change: `resolvePlanFollowUpSubmission` now stays in plan mode when chat selection annotations are present even if draft text is empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6163c32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches composer send/rollback, draft persistence, and prompt serialization for outbound messages, but changes are localized to chat UI with tests for round-trip and markup edge cases.
> 
> **Overview**
> Adds **response-text annotations** so users can quote assistant output in the next message without copy-paste.
> 
> Selecting text in an assistant markdown response opens an **Add to chat** popover (optional comment). Pending selections live in the composer as reviewable chips, persist in the draft store (storage version bump), and count toward sendable content and plan follow-up mode.
> 
> On send, annotations are appended as structured `chat_selection` XML blocks marked `data-t3code-appended`; only app-generated blocks are parsed as annotations—user-authored similar markup stays plain text. The timeline shows a compact **N annotation(s)** summary instead of raw markup; annotation-only messages skip an empty user bubble. Failed sends and plan follow-ups restore cleared drafts when the composer was not edited mid-flight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6163c328e7e4e45773729876b184bc1827899a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->