### PR TITLE
fix(clients): distinguish projects across environments

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -16,7 +16,10 @@ import { useProjects, useThreadShells } from "../../state/entities";
 import type { WorkspaceState } from "../../state/workspaceModel";
 import { useWorkspaceState } from "../../state/workspace";
 import { useEnvironments } from "../../state/environments";
-import { groupProjectsByRepository } from "../../lib/repositoryGroups";
+import {
+  expandRepositoryGroupProjects,
+  groupProjectsByRepository,
+} from "../../lib/repositoryGroups";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
 
@@ -122,15 +125,11 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
       readonly workspaceRoot: string;
       readonly environmentLabel: string | null;
     }> = [];
-    for (const group of repositoryGroups) {
-      const project = group.projects[0]?.project;
-      if (!project) {
-        continue;
-      }
+    for (const { key, project } of expandRepositoryGroupProjects(repositoryGroups)) {
       nextItems.push({
         environmentId: project.environmentId,
         id: project.id,
-        key: group.key,
+        key,
         title: project.title,
         workspaceRoot: project.workspaceRoot,
         environmentLabel: environmentLabelById.get(project.environmentId) ?? null,

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -1,6 +1,7 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { useIsFocused, useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
+import { buildProjectPickerDescription } from "@t3tools/client-runtime/state/project-grouping";
 import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { useEffect, useMemo, useRef } from "react";
 import { ActivityIndicator, Alert, Platform, Pressable, ScrollView, View } from "react-native";
@@ -14,6 +15,7 @@ import { ProjectFavicon } from "../../components/ProjectFavicon";
 import { useProjects, useThreadShells } from "../../state/entities";
 import type { WorkspaceState } from "../../state/workspaceModel";
 import { useWorkspaceState } from "../../state/workspace";
+import { useEnvironments } from "../../state/environments";
 import { groupProjectsByRepository } from "../../lib/repositoryGroups";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
@@ -81,6 +83,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
   const projects = useProjects();
   const threads = useThreadShells();
   const { state: catalogState } = useWorkspaceState();
+  const { environments } = useEnvironments();
   const navigation = useNavigation();
   const isFocused = useIsFocused();
   const { layout } = useAdaptiveWorkspaceLayout();
@@ -104,6 +107,12 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
     () => groupProjectsByRepository({ projects, threads }),
     [projects, threads],
   );
+  const environmentLabelById = useMemo(
+    () =>
+      new Map(environments.map((environment) => [environment.environmentId, environment.label])),
+    [environments],
+  );
+  const showProjectEnvironmentLabels = environments.length > 1;
   const items = useMemo(() => {
     const nextItems: Array<{
       readonly environmentId: EnvironmentId;
@@ -111,6 +120,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
       readonly key: string;
       readonly title: string;
       readonly workspaceRoot: string;
+      readonly environmentLabel: string | null;
     }> = [];
     for (const group of repositoryGroups) {
       const project = group.projects[0]?.project;
@@ -123,10 +133,11 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
         key: group.key,
         title: project.title,
         workspaceRoot: project.workspaceRoot,
+        environmentLabel: environmentLabelById.get(project.environmentId) ?? null,
       });
     }
     return nextItems;
-  }, [repositoryGroups]);
+  }, [environmentLabelById, repositoryGroups]);
   const projectEmptyState = deriveProjectEmptyState(catalogState);
   const resumedDestinationKeyRef = useRef<string | null>(null);
   const reservedDestinationProject = incomingShare?.destination
@@ -313,6 +324,16 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
                     </View>
                     <View className="flex-1">
                       <Text className="text-base leading-snug font-t3-bold">{item.title}</Text>
+                      <Text
+                        className="text-sm leading-snug text-foreground-muted"
+                        numberOfLines={1}
+                      >
+                        {buildProjectPickerDescription({
+                          workspaceRoot: item.workspaceRoot,
+                          environmentLabel: item.environmentLabel,
+                          showEnvironmentLabel: showProjectEnvironmentLabels,
+                        })}
+                      </Text>
                     </View>
                     <SymbolView
                       name="chevron.right"

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -27,7 +27,10 @@ import {
   groupByProvider,
   resolveSelectableModelSelection,
 } from "../../lib/modelOptions";
-import { groupProjectsByRepository } from "../../lib/repositoryGroups";
+import {
+  expandRepositoryGroupProjects,
+  groupProjectsByRepository,
+} from "../../lib/repositoryGroups";
 import { scopedProjectKey } from "../../lib/scopedEntities";
 import { appAtomRegistry } from "../../state/atom-registry";
 import {
@@ -181,25 +184,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     [projects, threads],
   );
   const logicalProjects = useMemo(
-    () =>
-      pipe(
-        repositoryGroups,
-        Arr.map((group) => {
-          const primaryProject = group.projects[0]?.project;
-          if (!primaryProject) {
-            return null;
-          }
-          return { key: group.key, project: primaryProject };
-        }),
-        Arr.filter(
-          (
-            entry,
-          ): entry is {
-            readonly key: string;
-            readonly project: EnvironmentProject;
-          } => entry !== null,
-        ),
-      ),
+    () => expandRepositoryGroupProjects(repositoryGroups),
     [repositoryGroups],
   );
 

--- a/apps/mobile/src/lib/repositoryGroups.test.ts
+++ b/apps/mobile/src/lib/repositoryGroups.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 
-import { groupProjectsByRepository } from "./repositoryGroups";
+import { expandRepositoryGroupProjects, groupProjectsByRepository } from "./repositoryGroups";
 import { EnvironmentProject, EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 
 function makeProject(
@@ -44,6 +44,68 @@ function makeThread(
 }
 
 describe("groupProjectsByRepository", () => {
+  it("expands identical repository workspaces into scoped projects for every environment", () => {
+    const repositoryIdentity = {
+      canonicalKey: "github.com/t3tools/t3code",
+      locator: {
+        source: "git-remote" as const,
+        remoteName: "origin",
+        remoteUrl: "git@github.com:t3tools/t3code.git",
+      },
+      provider: "github",
+      owner: "t3tools",
+      name: "t3code",
+      displayName: "T3 Code",
+    };
+    const projects = [
+      makeProject({
+        environmentId: EnvironmentId.make("env-macbook"),
+        id: ProjectId.make("project-t3code"),
+        title: "T3 Code",
+        workspaceRoot: "/Users/henry/Desktop/t3code",
+        repositoryIdentity,
+      }),
+      makeProject({
+        environmentId: EnvironmentId.make("env-studio"),
+        id: ProjectId.make("project-t3code"),
+        title: "T3 Code",
+        workspaceRoot: "/Users/henry/Desktop/t3code",
+        repositoryIdentity,
+      }),
+    ];
+
+    const expanded = expandRepositoryGroupProjects(
+      groupProjectsByRepository({ projects, threads: [] }),
+    );
+
+    expect(
+      expanded
+        .map(({ key, project }) => ({
+          key,
+          environmentId: project.environmentId,
+          projectId: project.id,
+          title: project.title,
+          workspaceRoot: project.workspaceRoot,
+        }))
+        .sort((left, right) => left.key.localeCompare(right.key)),
+    ).toEqual([
+      {
+        key: "env-macbook:project-t3code",
+        environmentId: "env-macbook",
+        projectId: "project-t3code",
+        title: "T3 Code",
+        workspaceRoot: "/Users/henry/Desktop/t3code",
+      },
+      {
+        key: "env-studio:project-t3code",
+        environmentId: "env-studio",
+        projectId: "project-t3code",
+        title: "T3 Code",
+        workspaceRoot: "/Users/henry/Desktop/t3code",
+      },
+    ]);
+  });
+
   it("groups projects across environments by repository identity", () => {
     const repoIdentity = {
       canonicalKey: "github.com/t3tools/t3code",

--- a/apps/mobile/src/lib/repositoryGroups.ts
+++ b/apps/mobile/src/lib/repositoryGroups.ts
@@ -25,6 +25,12 @@ export interface RepositoryGroup {
   readonly projects: ReadonlyArray<RepositoryProjectGroup>;
 }
 
+export function expandRepositoryGroupProjects(
+  groups: ReadonlyArray<RepositoryGroup>,
+): ReadonlyArray<RepositoryProjectGroup> {
+  return Arr.flatMap(groups, (group) => group.projects);
+}
+
 function compareIsoDateDescending(left: string, right: string): number {
   return new Date(right).getTime() - new Date(left).getTime();
 }

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -17,6 +17,7 @@ import {
   resolvePreviousWorktreeLabel,
   resolvePreviousWorktreeSeed,
   shouldIncludeBranchPickerItem,
+  shouldShowComposerContextStrip,
   shouldShowEnvironmentIndicator,
 } from "./BranchToolbar.logic";
 
@@ -415,6 +416,41 @@ describe("shouldShowEnvironmentIndicator", () => {
     expect(
       shouldShowEnvironmentIndicator({
         activeEnvironment: null,
+        canPickEnvironment: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldShowComposerContextStrip", () => {
+  it("keeps machine identity visible for a remote non-git project", () => {
+    expect(
+      shouldShowComposerContextStrip({
+        hasActiveProject: true,
+        isGitRepo: false,
+        activeEnvironment: { isPrimary: false },
+        canPickEnvironment: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the existing git controls for a primary project", () => {
+    expect(
+      shouldShowComposerContextStrip({
+        hasActiveProject: true,
+        isGitRepo: true,
+        activeEnvironment: { isPrimary: true },
+        canPickEnvironment: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the strip for a sole primary non-git project", () => {
+    expect(
+      shouldShowComposerContextStrip({
+        hasActiveProject: true,
+        isGitRepo: false,
+        activeEnvironment: { isPrimary: true },
         canPickEnvironment: false,
       }),
     ).toBe(false);

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -54,6 +54,17 @@ export function shouldShowEnvironmentIndicator(input: {
   return input.activeEnvironment !== null && !input.activeEnvironment.isPrimary;
 }
 
+export function shouldShowComposerContextStrip(input: {
+  hasActiveProject: boolean;
+  isGitRepo: boolean;
+  activeEnvironment: Pick<EnvironmentOption, "isPrimary"> | null;
+  canPickEnvironment: boolean;
+}): boolean {
+  if (!input.hasActiveProject) return false;
+  if (input.isGitRepo) return true;
+  return shouldShowEnvironmentIndicator(input);
+}
+
 export function resolveEnvModeLabel(mode: EnvMode): string {
   return mode === "worktree" ? "New worktree" : "Current checkout";
 }

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -56,6 +56,7 @@ interface BranchToolbarProps {
   onComposerFocusRequest?: () => void;
   availableEnvironments?: readonly EnvironmentOption[];
   onEnvironmentChange?: (environmentId: EnvironmentId) => void;
+  showWorkspaceControls?: boolean;
 }
 
 interface MobileRunContextSelectorProps {
@@ -229,6 +230,7 @@ export const BranchToolbar = memo(function BranchToolbar({
   onComposerFocusRequest,
   availableEnvironments,
   onEnvironmentChange,
+  showWorkspaceControls = true,
 }: BranchToolbarProps) {
   const threadRef = useMemo(
     () => scopeThreadRef(environmentId, threadId),
@@ -301,11 +303,24 @@ export const BranchToolbar = memo(function BranchToolbar({
   });
   const isMobile = useIsMobile();
 
-  if (!hasActiveThread || !activeProject) return null;
+  if (!hasActiveThread || !activeProject || (!showWorkspaceControls && !showEnvironmentIndicator)) {
+    return null;
+  }
 
   return (
     <div className="chat-composer-context-strip -mt-4 mx-auto flex w-[calc(100%-2.75rem)] max-w-[calc(48rem-2.75rem)] items-center gap-2 px-1 pt-5 pb-1">
-      {isMobile ? (
+      {!showWorkspaceControls ? (
+        <div className="flex min-w-0 flex-1 items-center">
+          {availableEnvironments ? (
+            <BranchToolbarEnvironmentSelector
+              envLocked={envLocked}
+              environmentId={environmentId}
+              availableEnvironments={availableEnvironments}
+              {...(showEnvironmentPicker && onEnvironmentChange ? { onEnvironmentChange } : {})}
+            />
+          ) : null}
+        </div>
+      ) : isMobile ? (
         <MobileRunContextSelector
           envLocked={envLocked}
           envModeLocked={envModeLocked}
@@ -344,20 +359,22 @@ export const BranchToolbar = memo(function BranchToolbar({
         </div>
       )}
 
-      <BranchToolbarBranchSelector
-        className="min-w-0 flex-1 justify-end md:ml-auto md:flex-none"
-        environmentId={environmentId}
-        threadId={threadId}
-        {...(draftId ? { draftId } : {})}
-        envLocked={envLocked}
-        {...(effectiveEnvModeOverride ? { effectiveEnvModeOverride } : {})}
-        {...(activeThreadBranchOverride !== undefined ? { activeThreadBranchOverride } : {})}
-        {...(onActiveThreadBranchOverrideChange ? { onActiveThreadBranchOverrideChange } : {})}
-        startFromOrigin={startFromOrigin}
-        onStartFromOriginChange={onStartFromOriginChange}
-        {...(onCheckoutPullRequestRequest ? { onCheckoutPullRequestRequest } : {})}
-        {...(onComposerFocusRequest ? { onComposerFocusRequest } : {})}
-      />
+      {showWorkspaceControls ? (
+        <BranchToolbarBranchSelector
+          className="min-w-0 flex-1 justify-end md:ml-auto md:flex-none"
+          environmentId={environmentId}
+          threadId={threadId}
+          {...(draftId ? { draftId } : {})}
+          envLocked={envLocked}
+          {...(effectiveEnvModeOverride ? { effectiveEnvModeOverride } : {})}
+          {...(activeThreadBranchOverride !== undefined ? { activeThreadBranchOverride } : {})}
+          {...(onActiveThreadBranchOverrideChange ? { onActiveThreadBranchOverrideChange } : {})}
+          startFromOrigin={startFromOrigin}
+          onStartFromOriginChange={onStartFromOriginChange}
+          {...(onCheckoutPullRequestRequest ? { onCheckoutPullRequestRequest } : {})}
+          {...(onComposerFocusRequest ? { onComposerFocusRequest } : {})}
+        />
+      ) : null}
     </div>
   );
 });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -229,7 +229,11 @@ import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
-import { resolveEffectiveEnvMode, resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
+import {
+  resolveEffectiveEnvMode,
+  resolveLocalCheckoutBranchMismatch,
+  shouldShowComposerContextStrip,
+} from "./BranchToolbar.logic";
 import {
   getProviderStatusBannerKey,
   ProviderStatusBanner,
@@ -2501,7 +2505,17 @@ function ChatViewContent(props: ChatViewProps) {
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.
   const isGitRepo = gitStatusQuery.data?.isRepo ?? true;
-  const showComposerContextStrip = isGitRepo && activeProject !== null;
+  const activeProjectEnvironment = activeThread
+    ? (logicalProjectEnvironments.find(
+        (environment) => environment.environmentId === activeThread.environmentId,
+      ) ?? null)
+    : null;
+  const showComposerContextStrip = shouldShowComposerContextStrip({
+    hasActiveProject: activeProject !== null,
+    isGitRepo,
+    activeEnvironment: activeProjectEnvironment,
+    canPickEnvironment: hasMultipleEnvironments,
+  });
   const initialDiffPanelGitScope =
     gitStatusQuery.data?.hasWorkingTreeChanges === true ? "unstaged" : "branch";
   const diffPanelGitStatusResolutionKey = gitStatusQuery.data ? "resolved" : "pending";
@@ -6020,6 +6034,7 @@ function ChatViewContent(props: ChatViewProps) {
                                   : {})}
                                 {...(hasMultipleEnvironments ? { onEnvironmentChange } : {})}
                                 availableEnvironments={logicalProjectEnvironments}
+                                showWorkspaceControls={isGitRepo}
                               />
                             </div>
                           )}

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -3,6 +3,7 @@ import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools
 import type { Thread } from "../types";
 import {
   buildBrowseGroups,
+  buildProjectActionItems,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
@@ -110,6 +111,32 @@ describe("enumerateCommandPaletteItems", () => {
 
 const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
 const PROJECT_ID = ProjectId.make("project-1");
+
+describe("buildProjectActionItems", () => {
+  it("uses the caller-provided machine-aware description", () => {
+    const project = {
+      id: PROJECT_ID,
+      environmentId: LOCAL_ENVIRONMENT_ID,
+      title: "Desktop",
+      workspaceRoot: "/Users/henry/Desktop",
+      repositoryIdentity: null,
+      defaultModelSelection: null,
+      scripts: [],
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    };
+
+    const [item] = buildProjectActionItems({
+      projects: [project],
+      valuePrefix: "new-thread-in",
+      description: (candidate) => `${candidate.workspaceRoot} · Henry's Mac Studio`,
+      icon: () => null,
+      runProject: async () => undefined,
+    });
+
+    expect(item?.description).toBe("/Users/henry/Desktop · Henry's Mac Studio");
+  });
+});
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -130,12 +130,13 @@ export function normalizeSearchText(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
-export function buildProjectActionItems(input: {
-  projects: ReadonlyArray<Project>;
+export function buildProjectActionItems<TProject extends Project>(input: {
+  projects: ReadonlyArray<TProject>;
   valuePrefix: string;
-  icon: (project: Project) => ReactNode;
-  runProject: (project: Project) => Promise<void>;
-  searchTerms?: (project: Project) => ReadonlyArray<string>;
+  icon: (project: TProject) => ReactNode;
+  runProject: (project: TProject) => Promise<void>;
+  description?: (project: TProject) => ReactNode;
+  searchTerms?: (project: TProject) => ReadonlyArray<string>;
   shortcutCommand?: KeybindingCommand;
 }): CommandPaletteActionItem[] {
   return input.projects.map((project) => ({
@@ -143,7 +144,7 @@ export function buildProjectActionItems(input: {
     value: `${input.valuePrefix}:${project.environmentId}:${project.id}`,
     searchTerms: [project.title, project.workspaceRoot, ...(input.searchTerms?.(project) ?? [])],
     title: project.title,
-    description: project.workspaceRoot,
+    description: input.description?.(project) ?? project.workspaceRoot,
     icon: input.icon(project),
     ...(input.shortcutCommand !== undefined ? { shortcutCommand: input.shortcutCommand } : {}),
     run: async () => {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@
 
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { canCreateProjectInEnvironment } from "@t3tools/client-runtime/operations/projects";
+import { buildProjectPickerDescription } from "@t3tools/client-runtime/state/project-grouping";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
 import {
@@ -602,10 +603,21 @@ function OpenCommandPaletteDialog(props: {
   const environmentLabelById = useMemo(
     () =>
       new Map(
-        environments.map((environment) => [environment.environmentId, environment.label] as const),
+        environments.map(
+          (environment) =>
+            [
+              environment.environmentId,
+              resolveEnvironmentOptionLabel({
+                isPrimary: environment.environmentId === primaryEnvironmentId,
+                environmentId: environment.environmentId,
+                runtimeLabel: environment.label,
+              }),
+            ] as const,
+        ),
       ),
-    [environments],
+    [environments, primaryEnvironmentId],
   );
+  const showProjectEnvironmentLabels = environments.length > 1;
   const orderedProjects = useMemo(
     () =>
       orderItemsByPreferredIds({
@@ -918,10 +930,20 @@ function OpenCommandPaletteDialog(props: {
       buildProjectActionItems({
         projects: pickerProjects,
         valuePrefix: "project",
+        description: (project) =>
+          buildProjectPickerDescription({
+            workspaceRoot: project.workspaceRoot,
+            environmentLabel: project.environmentLabel,
+            showEnvironmentLabel: showProjectEnvironmentLabels,
+          }),
         searchTerms: (project) => {
           const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
           return (
-            group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
+            group?.memberProjects.flatMap((member) => [
+              member.title,
+              member.workspaceRoot,
+              member.environmentLabel ?? "",
+            ]) ?? []
           );
         },
         icon: (project) => (
@@ -933,7 +955,7 @@ function OpenCommandPaletteDialog(props: {
         ),
         runProject: openProjectFromSearch,
       }),
-    [openProjectFromSearch, pickerProjects, projectGroupByTargetKey],
+    [openProjectFromSearch, pickerProjects, projectGroupByTargetKey, showProjectEnvironmentLabels],
   );
 
   const projectThreadItems = useMemo(
@@ -942,10 +964,20 @@ function OpenCommandPaletteDialog(props: {
         buildProjectActionItems({
           projects: pickerProjects,
           valuePrefix: "new-thread-in",
+          description: (project) =>
+            buildProjectPickerDescription({
+              workspaceRoot: project.workspaceRoot,
+              environmentLabel: project.environmentLabel,
+              showEnvironmentLabel: showProjectEnvironmentLabels,
+            }),
           searchTerms: (project) => {
             const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
             return (
-              group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
+              group?.memberProjects.flatMap((member) => [
+                member.title,
+                member.workspaceRoot,
+                member.environmentLabel ?? "",
+              ]) ?? []
             );
           },
           icon: (project) => (
@@ -972,7 +1004,13 @@ function OpenCommandPaletteDialog(props: {
           },
         }),
       ),
-    [contextualProjectRef, handleNewThread, pickerProjects, projectGroupByTargetKey],
+    [
+      contextualProjectRef,
+      handleNewThread,
+      pickerProjects,
+      projectGroupByTargetKey,
+      showProjectEnvironmentLabels,
+    ],
   );
 
   const allThreadItems = useMemo(
@@ -1355,9 +1393,18 @@ function OpenCommandPaletteDialog(props: {
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
 
   if (projects.length > 0) {
+    const activeProjectEntry = projectPickerEntries.find((entry) => entry.isPreferred) ?? null;
     const activeProjectTitle =
-      projectPickerEntries.find((entry) => entry.isPreferred)?.group.displayName ??
+      activeProjectEntry?.group.displayName ??
       (currentProjectId ? (projectTitleById.get(currentProjectId) ?? null) : null);
+    const activeProjectDescription =
+      showProjectEnvironmentLabels && activeProjectEntry
+        ? buildProjectPickerDescription({
+            workspaceRoot: activeProjectEntry.targetProject.workspaceRoot,
+            environmentLabel: activeProjectEntry.targetProject.environmentLabel,
+            showEnvironmentLabel: true,
+          })
+        : null;
 
     if (activeProjectTitle) {
       actionItems.push({
@@ -1369,6 +1416,7 @@ function OpenCommandPaletteDialog(props: {
             New thread in <span className="font-semibold">{activeProjectTitle}</span>
           </>
         ),
+        ...(activeProjectDescription ? { description: activeProjectDescription } : {}),
         icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
         shortcutCommand: "chat.new",
         run: async () => {

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -1,5 +1,6 @@
 import type { ScopedProjectRef } from "@t3tools/contracts";
 import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
+import { buildProjectPickerDescription } from "@t3tools/client-runtime/state/project-grouping";
 import { FolderPlusIcon } from "lucide-react";
 import { useCallback, useMemo } from "react";
 
@@ -13,6 +14,7 @@ import {
 } from "~/sidebarProjectGrouping";
 import { useProjects, useThreadShells } from "~/state/entities";
 import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
+import { resolveEnvironmentOptionLabel } from "../BranchToolbar.logic";
 import { sortLogicalProjectsForSidebar } from "../Sidebar.logic";
 import {
   Menu,
@@ -45,10 +47,21 @@ export function DraftHeroHeadline({
   const environmentLabelById = useMemo(
     () =>
       new Map(
-        environments.map((environment) => [environment.environmentId, environment.label] as const),
+        environments.map(
+          (environment) =>
+            [
+              environment.environmentId,
+              resolveEnvironmentOptionLabel({
+                isPrimary: environment.environmentId === primaryEnvironmentId,
+                environmentId: environment.environmentId,
+                runtimeLabel: environment.label,
+              }),
+            ] as const,
+        ),
       ),
-    [environments],
+    [environments, primaryEnvironmentId],
   );
+  const showProjectEnvironmentLabels = environments.length > 1;
   const projectGroups = useMemo(
     () =>
       sortLogicalProjectsForSidebar(
@@ -119,10 +132,21 @@ export function DraftHeroHeadline({
             });
           }}
         >
-          {projectPickerEntries.map(({ group }) => {
+          {projectPickerEntries.map(({ group, targetProject }) => {
             return (
               <MenuRadioItem key={group.projectKey} value={group.projectKey} closeOnClick>
-                <span className="min-w-0 truncate">{group.displayName}</span>
+                <span className="flex min-w-0 flex-col">
+                  <span className="truncate">{group.displayName}</span>
+                  {showProjectEnvironmentLabels ? (
+                    <span className="truncate text-muted-foreground text-xs">
+                      {buildProjectPickerDescription({
+                        workspaceRoot: targetProject.workspaceRoot,
+                        environmentLabel: targetProject.environmentLabel,
+                        showEnvironmentLabel: true,
+                      })}
+                    </span>
+                  ) : null}
+                </span>
               </MenuRadioItem>
             );
           })}

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -121,6 +121,9 @@ npx t3 serve --tailscale-serve --tailscale-serve-port 8443
 
 Once paired, add projects normally: open the Command Palette and choose **Add Project**, then pick
 the environment the project lives on. Every saved environment is offered, not only the local one.
+When multiple environments are connected, project choosers show the environment name beside each
+workspace path. In the web and desktop clients, remote conversations keep that environment visible
+below the composer.
 
 ### Option 3: Desktop-Managed SSH Launch
 

--- a/packages/client-runtime/src/state/projectGrouping.test.ts
+++ b/packages/client-runtime/src/state/projectGrouping.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildProjectPickerDescription } from "./projectGrouping.ts";
+
+describe("buildProjectPickerDescription", () => {
+  it("adds the selected environment when several environments are visible", () => {
+    expect(
+      buildProjectPickerDescription({
+        workspaceRoot: "/Users/henry/Desktop",
+        environmentLabel: "Henry's Mac Studio",
+        showEnvironmentLabel: true,
+      }),
+    ).toBe("/Users/henry/Desktop · Henry's Mac Studio");
+  });
+
+  it("keeps the workspace path compact for a single environment", () => {
+    expect(
+      buildProjectPickerDescription({
+        workspaceRoot: "/Users/henry/Desktop",
+        environmentLabel: "Henry's MacBook",
+        showEnvironmentLabel: false,
+      }),
+    ).toBe("/Users/henry/Desktop");
+  });
+});

--- a/packages/client-runtime/src/state/projectGrouping.ts
+++ b/packages/client-runtime/src/state/projectGrouping.ts
@@ -12,6 +12,16 @@ export interface ProjectGroupingSettings {
 
 export type ProjectGroupingMode = SidebarProjectGroupingMode;
 
+export function buildProjectPickerDescription(input: {
+  readonly workspaceRoot: string;
+  readonly environmentLabel: string | null;
+  readonly showEnvironmentLabel: boolean;
+}): string {
+  return input.showEnvironmentLabel && input.environmentLabel
+    ? `${input.workspaceRoot} · ${input.environmentLabel}`
+    : input.workspaceRoot;
+}
+
 export function selectProjectGroupingSettings(settings: ClientSettings): ProjectGroupingSettings {
   return {
     sidebarProjectGroupingMode: settings.sidebarProjectGroupingMode,


### PR DESCRIPTION
## What Changed

- show `workspace path · environment` when project choosers span multiple environments
- apply the same identity to command-palette project search/new-thread actions, the draft project menu, and the mobile new-task chooser
- keep the remote environment visible below the web/desktop composer for non-Git projects without showing irrelevant workspace or branch controls
- centralize the project description formatter, add focused regression coverage, and document the behavior

## Why

When two connected environments expose the same workspace path, rows such as `/Users/henry/Desktop` were visually identical. A new thread could therefore be started on the wrong machine with no way to tell before selection.

The missing composer identity had a separate cause: the entire context strip was gated on `isGitRepo`, so remote non-Git projects hid their environment. It was unrelated to interrupting the thread.

## UI Changes

The captures use two isolated servers that both expose `/Users/henry/Desktop`; `Remote Mac` is the neutral test-only label for the second server.

### Project chooser

| Before | After |
| --- | --- |
| ![Two identical Desktop project rows](https://raw.githubusercontent.com/caezium/t3code/pr-assets-machine-aware-project-labels/.github/pr-assets/machine-aware-project-labels/before-project-picker.png) | ![Desktop rows identified by environment](https://raw.githubusercontent.com/caezium/t3code/pr-assets-machine-aware-project-labels/.github/pr-assets/machine-aware-project-labels/after-project-picker.png) |

### Remote non-Git composer

| Before | After |
| --- | --- |
| ![Remote non-Git composer without environment identity](https://raw.githubusercontent.com/caezium/t3code/pr-assets-machine-aware-project-labels/.github/pr-assets/machine-aware-project-labels/before-remote-context.png) | ![Remote non-Git composer with environment identity](https://raw.githubusercontent.com/caezium/t3code/pr-assets-machine-aware-project-labels/.github/pr-assets/machine-aware-project-labels/after-remote-context.png) |

## Verification

- `vp test run packages/client-runtime/src/state/projectGrouping.test.ts apps/web/src/components/CommandPalette.logic.test.ts apps/web/src/environmentGrouping.test.ts apps/web/src/components/BranchToolbar.logic.test.ts` (83 tests)
- scoped typechecks for client runtime, web, and mobile
- touched-file lint and `git diff --check`
- integrated desktop pass with paired local/remote environments sharing the same project path

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI changes
- [x] Video is not applicable; there are no animation or timing changes

Created by `gpt-5.6-sol` using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI labeling and visibility rules with unit tests; no auth or data-path changes. Composer strip gating is the only behavioral surface worth a quick manual check on remote non-Git projects.
> 
> **Overview**
> When several environments expose the **same workspace path or repo**, project pickers now show **`path · environment`** so users can pick the right machine. Shared **`buildProjectPickerDescription`** drives command palette search, “new thread in project”, the draft project menu, and the mobile new-task list.
> 
> Mobile project lists use **`expandRepositoryGroupProjects`** so grouped repos still surface **one row per environment**, not only the first member of each repository group.
> 
> On web/desktop, **`shouldShowComposerContextStrip`** and **`showWorkspaceControls`** keep the composer context strip for remote **non-Git** projects (environment only) while hiding branch/worktree controls that do not apply. Docs note the chooser and composer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb58657f16b69099eaebd9e9101f9504483c1b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show environment labels in project pickers when multiple environments are connected
> - Adds `buildProjectPickerDescription` to generate environment-aware project description strings, used across the command palette, draft hero, and mobile project picker.
> - Expands `expandRepositoryGroupProjects` to flatten all scoped projects from repository groups rather than selecting only the first, so all per-environment entries appear in selection lists.
> - `BranchToolbar` gains a `showWorkspaceControls` prop (default `true`) to hide branch/workspace controls for non-git projects while still rendering the environment selector.
> - `shouldShowComposerContextStrip` is added to control whether the composer context strip renders for non-git projects based on environment indicator visibility.
> - Behavioral Change: `logicalProjects` in `NewTaskFlowProvider` now includes all projects per repository group instead of only the first, which may affect downstream project selection and context resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb58657.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project pickers now show environment names alongside workspace paths when multiple environments are connected.
  * Remote conversations display the active environment below the composer.
  * Environment selection remains available when workspace and branch controls are hidden.
  * Project search and “New thread” actions include environment details for clearer identification.
  * Mobile project pickers now include projects from all connected environments.

* **Documentation**
  * Updated remote access guidance to explain environment labels in project selectors and conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->