### PR TITLE
fix(server): transcode HEIC attachments instead of failing the turn

### DIFF
--- a/apps/server/src/imageTranscode.test.ts
+++ b/apps/server/src/imageTranscode.test.ts
@@ -1,0 +1,91 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  isTranscodableImageMimeType,
+  TRANSCODED_IMAGE_MIME_TYPE,
+  transcodeImageToJpeg,
+} from "./imageTranscode.ts";
+
+// 8x8 RGB PNG, used as the source for the HEIC fixture below.
+const SAMPLE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAbElEQVR4nA3JQQEAMAgDMZRUCUqqpEpQgoh7o2jLN1WFii5cpJhiiyuqhEQLi4gRK04/GjXduEkzzTbXP4xMG5uYMWvOP4JCB4eECRsuPwYNPXjIMMMONz8WLb14yTLLLrc/Dh19+Mgxxx53PKaVZoFj4h8/AAAAAElFTkSuQmCC";
+
+const JPEG_START_OF_IMAGE = [0xff, 0xd8, 0xff];
+
+function runSips(args: Array<string>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    NodeChildProcess.execFile("sips", args, (error) =>
+      error === null ? resolve() : reject(error),
+    );
+  });
+}
+
+// `sips` is the macOS transcoder, and also the only way to build a real HEIC
+// fixture without shipping a binary in the repo. Probing for it keeps this
+// suite green on hosts that do not have it.
+const SIPS_AVAILABLE = await runSips(["--version"]).then(
+  () => true,
+  () => false,
+);
+
+async function makeHeicFixture(): Promise<Uint8Array> {
+  const workingDir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-heic-fixture-"));
+  const pngPath = NodePath.join(workingDir, "source.png");
+  const heicPath = NodePath.join(workingDir, "source.heic");
+
+  try {
+    await NodeFSP.writeFile(pngPath, Buffer.from(SAMPLE_PNG_BASE64, "base64"));
+    await runSips(["-s", "format", "heic", pngPath, "--out", heicPath]);
+    return new Uint8Array(await NodeFSP.readFile(heicPath));
+  } finally {
+    await NodeFSP.rm(workingDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+describe("imageTranscode", () => {
+  it("recognizes the mime types Claude cannot ingest", () => {
+    expect(isTranscodableImageMimeType("image/heic")).toBe(true);
+    expect(isTranscodableImageMimeType("image/heif")).toBe(true);
+    expect(isTranscodableImageMimeType("IMAGE/HEIC")).toBe(true);
+    expect(isTranscodableImageMimeType(" image/heic ")).toBe(true);
+  });
+
+  it("leaves natively supported mime types alone", () => {
+    for (const mimeType of ["image/jpeg", "image/png", "image/gif", "image/webp"]) {
+      expect(isTranscodableImageMimeType(mimeType)).toBe(false);
+    }
+  });
+
+  it("targets jpeg, which every provider accepts", () => {
+    expect(TRANSCODED_IMAGE_MIME_TYPE).toBe("image/jpeg");
+  });
+
+  it.skipIf(!SIPS_AVAILABLE)("converts HEIC bytes into JPEG bytes", async () => {
+    const heic = await makeHeicFixture();
+    // Guards against the fixture silently degrading into a non-HEIC file.
+    expect(Buffer.from(heic.subarray(4, 12)).toString("ascii")).toBe("ftypheic");
+
+    const jpeg = await transcodeImageToJpeg({
+      bytes: heic,
+      platform: "darwin",
+    });
+
+    expect(jpeg.byteLength).toBeGreaterThan(0);
+    expect([...jpeg.subarray(0, 3)]).toEqual(JPEG_START_OF_IMAGE);
+  });
+
+  it.skipIf(!SIPS_AVAILABLE)("rejects bytes that are not a decodable image", async () => {
+    await expect(
+      transcodeImageToJpeg({
+        bytes: new TextEncoder().encode("not an image"),
+        platform: "darwin",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/server/src/imageTranscode.ts
+++ b/apps/server/src/imageTranscode.ts
@@ -1,0 +1,116 @@
+// @effect-diagnostics nodeBuiltinImport:off
+/**
+ * Transcodes image formats the model providers cannot ingest (HEIC/HEIF) into
+ * JPEG, which every provider accepts.
+ *
+ * iPhones capture HEIC by default, so pasting or attaching a photo straight
+ * from an Apple device otherwise fails at the provider boundary even though the
+ * attachment itself was stored just fine.
+ *
+ * Transcoding shells out to a tool that ships with the host rather than pulling
+ * in a HEIC decoder dependency: `sips` on macOS (always present) and
+ * `heif-convert` from libheif elsewhere (packaged on most desktop Linux). When
+ * neither is available the caller surfaces the original "unsupported type"
+ * failure, so this is strictly additive.
+ *
+ * @module imageTranscode
+ */
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+export const TRANSCODABLE_IMAGE_MIME_TYPES: ReadonlySet<string> = new Set([
+  "image/heic",
+  "image/heic-sequence",
+  "image/heif",
+  "image/heif-sequence",
+]);
+
+export const TRANSCODED_IMAGE_MIME_TYPE = "image/jpeg";
+
+/** Whether `mimeType` is one we can convert into a provider-supported format. */
+export function isTranscodableImageMimeType(mimeType: string): boolean {
+  return TRANSCODABLE_IMAGE_MIME_TYPES.has(mimeType.trim().toLowerCase());
+}
+
+interface Transcoder {
+  readonly command: string;
+  readonly args: (input: {
+    readonly inputPath: string;
+    readonly outputPath: string;
+  }) => Array<string>;
+}
+
+const SIPS_TRANSCODER: Transcoder = {
+  command: "sips",
+  args: ({ inputPath, outputPath }) => ["-s", "format", "jpeg", inputPath, "--out", outputPath],
+};
+
+const HEIF_CONVERT_TRANSCODER: Transcoder = {
+  command: "heif-convert",
+  args: ({ inputPath, outputPath }) => [inputPath, outputPath],
+};
+
+function transcodersFor(platform: NodeJS.Platform): ReadonlyArray<Transcoder> {
+  return platform === "darwin" ? [SIPS_TRANSCODER] : [HEIF_CONVERT_TRANSCODER];
+}
+
+function runTranscoder(input: {
+  readonly transcoder: Transcoder;
+  readonly inputPath: string;
+  readonly outputPath: string;
+}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    NodeChildProcess.execFile(
+      input.transcoder.command,
+      input.transcoder.args({
+        inputPath: input.inputPath,
+        outputPath: input.outputPath,
+      }),
+      // A photo is a bounded workload; the cap only guards against a wedged
+      // helper process holding the turn open forever.
+      { timeout: 30_000, maxBuffer: 1024 * 1024 },
+      (error) => (error === null ? resolve() : reject(error)),
+    );
+  });
+}
+
+/**
+ * Converts HEIC/HEIF bytes to JPEG bytes.
+ *
+ * Rejects when no transcoder is available on the host or the conversion fails,
+ * so callers can fall back to reporting the attachment as unsupported.
+ */
+export async function transcodeImageToJpeg(input: {
+  readonly bytes: Uint8Array;
+  readonly platform: NodeJS.Platform;
+}): Promise<Uint8Array> {
+  const workingDir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-image-transcode-"));
+  const inputPath = NodePath.join(workingDir, "input");
+  const outputPath = NodePath.join(workingDir, "output.jpg");
+
+  try {
+    await NodeFSP.writeFile(inputPath, input.bytes);
+
+    let lastError: unknown = new Error("No image transcoder is available on this host.");
+    for (const transcoder of transcodersFor(input.platform)) {
+      try {
+        await runTranscoder({ transcoder, inputPath, outputPath });
+        const converted = await NodeFSP.readFile(outputPath);
+        if (converted.byteLength === 0) {
+          // Some builds of `sips` exit 0 after writing nothing when the input
+          // is not decodable, so an empty result has to count as a failure.
+          throw new Error(`${transcoder.command} produced an empty image.`);
+        }
+        return new Uint8Array(converted);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError;
+  } finally {
+    await NodeFSP.rm(workingDir, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -21,6 +21,7 @@ import {
   type ModelUsage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import {
   ApprovalRequestId,
   type CanonicalItemType,
@@ -69,6 +70,11 @@ import * as Stream from "effect/Stream";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
+import {
+  isTranscodableImageMimeType,
+  TRANSCODED_IMAGE_MIME_TYPE,
+  transcodeImageToJpeg,
+} from "../../imageTranscode.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
@@ -951,7 +957,11 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
       continue;
     }
 
-    if (!SUPPORTED_CLAUDE_IMAGE_MIME_TYPES.has(attachment.mimeType)) {
+    // HEIC/HEIF is the default capture format on Apple devices, so it arrives
+    // constantly via paste and the mobile composer. Convert it instead of
+    // failing the turn.
+    const needsTranscode = isTranscodableImageMimeType(attachment.mimeType);
+    if (!needsTranscode && !SUPPORTED_CLAUDE_IMAGE_MIME_TYPES.has(attachment.mimeType)) {
       return yield* new ProviderAdapterRequestError({
         provider: PROVIDER,
         method: "turn/start",
@@ -982,6 +992,28 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
           }),
       ),
     );
+
+    if (needsTranscode) {
+      const hostPlatform = yield* HostProcessPlatform;
+      const converted = yield* Effect.tryPromise({
+        try: () => transcodeImageToJpeg({ bytes, platform: hostPlatform }),
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "turn/start",
+            detail: `Unsupported Claude image attachment type '${attachment.mimeType}' and converting it to JPEG failed.`,
+            cause,
+          }),
+      });
+
+      sdkContent.push(
+        buildClaudeImageContentBlock({
+          mimeType: TRANSCODED_IMAGE_MIME_TYPE,
+          bytes: converted,
+        }),
+      );
+      continue;
+    }
 
     sdkContent.push(
       buildClaudeImageContentBlock({


### PR DESCRIPTION
## What Changed

`ClaudeAdapter` now converts HEIC/HEIF image attachments to JPEG instead of failing the turn with `Unsupported Claude image attachment type 'image/heic'`.

- New `apps/server/src/imageTranscode.ts` exposing `isTranscodableImageMimeType` and `transcodeImageToJpeg`.
- `buildUserMessageEffect` converts a transcodable attachment after reading its bytes and pushes the JPEG content block. Everything else is untouched.
- Unit tests covering mime detection plus a real HEIC to JPEG round trip.

No new dependencies, and no `package.json` change.

## Why

Fixes #4579.

HEIC is the default capture format on every recent iPhone, so this fires constantly: attaching a photo from the mobile composer, or pasting an iPhone screenshot on desktop. The attachment pipeline already handles HEIC end to end (`imageMime.ts` lists it in `SAFE_IMAGE_FILE_EXTENSIONS`, and `apps/mobile/src/lib/composerImages.ts` labels it `image/heic`), so the file is stored correctly and only the provider hand-off rejects it. The issue asks for exactly this: "the image should be converted automagically to a supported format".

### Why shelling out rather than a decoder dependency

A HEIC decoder (`heic-convert`, `sharp`) would be a new runtime dependency for a narrow edge case. Instead this uses what the host already has: `sips` on macOS, which is part of the OS and always present, and `heif-convert` from libheif elsewhere. When neither exists the conversion fails and the caller reports the attachment as unsupported exactly as it does today, so the change cannot regress any current behaviour.

### Note on #2829

#4200 was closed in favour of the orchestration-v2 rewrite because it built on `apps/server/src/orchestration/**` and `provider/Layers/*Adapter.ts`. This PR keeps all the logic in a standalone module with no orchestration imports, so it survives that move. The adapter call site is a single `yield*` that can be dropped into wherever the attachment loop lands in v2.

## Verification

Run on macOS 15, Node 24:

- `pnpm exec vp test run src/imageTranscode.test.ts src/provider/Layers/ClaudeAdapter.test.ts` — 67 passed, including the HEIC to JPEG round trip
- `pnpm exec tsgo --noEmit` — clean
- `pnpm exec vp lint` — no new findings
- `pnpm exec vp fmt` — applied

The round-trip test builds a genuine HEIC fixture with `sips`, asserts the `ftypheic` box is present, converts it, and checks the output starts with the JPEG SOI marker. It skips itself on hosts without `sips`.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a, no UI change)
- [x] I included a video for animation/interaction changes (n/a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turn-start path now shells out to host transcoding tools with temp files and a 30s timeout; failure modes are handled but behavior depends on OS tooling (especially Linux without libheif).
> 
> **Overview**
> **HEIC/HEIF image attachments** no longer fail Claude turns with an unsupported MIME error. The adapter now **transcodes** those formats to **JPEG** before building the SDK image block.
> 
> A new **`imageTranscode`** module detects transcodable MIME types (HEIC/HEIF and sequence variants), writes bytes to a temp dir, and runs **`sips`** on macOS or **`heif-convert`** elsewhere—no new npm HEIC decoder. If conversion fails, the turn still errors with a message that includes the original type.
> 
> **`ClaudeAdapter.buildUserMessageEffect`** branches after reading attachment bytes: transcodable images go through `transcodeImageToJpeg` with `HostProcessPlatform`; others keep the existing supported-type check. Tests cover MIME detection and a real HEIC→JPEG round trip when `sips` is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b43c309c4c65717367918056eff3be5030f1eed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Transcode HEIC/HEIF image attachments to JPEG before sending to Claude
> - Adds [imageTranscode.ts](https://github.com/pingdotgg/t3code/pull/5229/files#diff-bb49ddece36a9903166783eae35a0f80ebc8a8b4a291e3553a273b9c6c500707) with `transcodeImageToJpeg`, which writes the input to a temp file, runs `sips` on macOS or `heif-convert` elsewhere, and returns the JPEG bytes.
> - Updates [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/5229/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) to detect HEIC/HEIF mime types via `isTranscodableImageMimeType` and transcode before building the image content block; throws `ProviderAdapterRequestError` if transcoding fails.
> - Risk: transcoding depends on `sips` (macOS) or `heif-convert` (Linux) being available on the host; missing tools cause the request to error rather than silently skip the attachment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b43c309.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->