### PR TITLE
fix(web): preserve scroll when composer grows

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -87,7 +87,13 @@ import {
   isLatestTurnSettled,
 } from "../session-logic";
 import { type LegendListRef } from "@legendapp/list/react";
-import { getAnchoredTurnMetrics, type TimelineScrollMode } from "./chat/timelineScrollAnchoring";
+import {
+  getAnchoredTurnMetrics,
+  isTimelineLayoutFollowEnabled,
+  reduceTimelineLayoutFollowState,
+  type TimelineLayoutFollowAction,
+  type TimelineScrollMode,
+} from "./chat/timelineScrollAnchoring";
 import {
   buildPendingUserInputAnswers,
   derivePendingUserInputProgress,
@@ -1278,6 +1284,22 @@ function ChatViewContent(props: ChatViewProps) {
   const localComposerRef = useRef<ChatComposerHandle | null>(null);
   const composerRef = useComposerHandleContext() ?? localComposerRef;
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const layoutScrollThreadKeyRef = useRef(routeThreadKey);
+  layoutScrollThreadKeyRef.current = routeThreadKey;
+  const [layoutScrollState, setLayoutScrollState] = useState(() => ({
+    threadKey: routeThreadKey,
+    enabled: true,
+  }));
+  const maintainScrollAtEndOnLayout = isTimelineLayoutFollowEnabled(
+    layoutScrollState,
+    routeThreadKey,
+  );
+  const updateTimelineLayoutFollow = useCallback((action: TimelineLayoutFollowAction) => {
+    setLayoutScrollState((current) => {
+      const threadKey = layoutScrollThreadKeyRef.current;
+      return reduceTimelineLayoutFollowState(current, threadKey, action);
+    });
+  }, []);
   const [expandedImage, setExpandedImage] = useState<ExpandedImagePreview | null>(null);
   const [optimisticUserMessages, setOptimisticUserMessages] = useState<ChatMessage[]>([]);
   const optimisticUserMessagesRef = useRef(optimisticUserMessages);
@@ -3522,6 +3544,10 @@ function ChatViewContent(props: ChatViewProps) {
   } | null>(null);
   const anchorScrollRestoreFrameRef = useRef<number | null>(null);
   const cancelTimelineLiveFollowForUserNavigation = useCallback(() => {
+    updateTimelineLayoutFollow({
+      type: "manual-navigation",
+      isAtEnd: isAtEndRef.current,
+    });
     anchorUserScrollGenerationRef.current += 1;
     timelineScrollModeRef.current = "free-scrolling";
     liveFollowUserScrollGenerationRef.current = null;
@@ -3535,13 +3561,6 @@ function ChatViewContent(props: ChatViewProps) {
       anchorScrollRestoreFrameRef.current = null;
     }
   }, []);
-  const cancelTimelineLiveFollowForUserNavigationRef = useRef(
-    cancelTimelineLiveFollowForUserNavigation,
-  );
-  useEffect(() => {
-    cancelTimelineLiveFollowForUserNavigationRef.current =
-      cancelTimelineLiveFollowForUserNavigation;
-  }, [cancelTimelineLiveFollowForUserNavigation]);
   const getActiveTimelineTurnMetrics = useCallback(
     (list?: LegendListRef | null) => {
       const resolvedList = list ?? legendListRef.current;
@@ -3594,6 +3613,7 @@ function ChatViewContent(props: ChatViewProps) {
   // gesture opts out.
   const scrollToEnd = useCallback((animated = false) => {
     isAtEndRef.current = true;
+    updateTimelineLayoutFollow({ type: "return-to-end" });
     timelineScrollModeRef.current = "following-end";
     liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
     pendingTimelineAnchorRef.current = null;
@@ -3602,38 +3622,6 @@ function ChatViewContent(props: ChatViewProps) {
     setShowScrollToBottom(false);
     void legendListRef.current?.scrollToEnd?.({ animated });
   }, []);
-  useEffect(() => {
-    let removeListeners: (() => void) | null = null;
-    const frame = requestAnimationFrame(() => {
-      const scrollNode = legendListRef.current?.getScrollableNode();
-      if (!scrollNode) {
-        return;
-      }
-      const handleManualNavigation = () => {
-        cancelTimelineLiveFollowForUserNavigationRef.current();
-      };
-      scrollNode.addEventListener("wheel", handleManualNavigation, {
-        passive: true,
-      });
-      scrollNode.addEventListener("touchmove", handleManualNavigation, {
-        passive: true,
-      });
-      scrollNode.addEventListener("pointerdown", handleManualNavigation, {
-        passive: true,
-      });
-      removeListeners = () => {
-        scrollNode.removeEventListener("wheel", handleManualNavigation);
-        scrollNode.removeEventListener("touchmove", handleManualNavigation);
-        scrollNode.removeEventListener("pointerdown", handleManualNavigation);
-      };
-    });
-
-    return () => {
-      cancelAnimationFrame(frame);
-      removeListeners?.();
-    };
-  }, [activeThread?.id]);
-
   const onTimelineAnchorReady = useCallback((messageId: MessageId, anchorIndex: number) => {
     if (pendingTimelineAnchorRef.current === messageId) {
       pendingTimelineAnchorRef.current = null;
@@ -3735,6 +3723,7 @@ function ChatViewContent(props: ChatViewProps) {
       setShowScrollToBottom(false);
       return;
     }
+    updateTimelineLayoutFollow({ type: "at-end-change", isAtEnd });
     if (isAtEndRef.current === isAtEnd) return;
     isAtEndRef.current = isAtEnd;
     if (isAtEnd) {
@@ -3818,6 +3807,7 @@ function ChatViewContent(props: ChatViewProps) {
   useEffect(() => {
     setPullRequestDialogState(null);
     isAtEndRef.current = true;
+    updateTimelineLayoutFollow({ type: "return-to-end" });
     timelineScrollModeRef.current = "following-end";
     liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
     pendingTimelineAnchorRef.current = null;
@@ -4736,6 +4726,7 @@ function ChatViewContent(props: ChatViewProps) {
     // anchored end-space target so it lands near the top while the response
     // streams into the reserved space below it.
     isAtEndRef.current = true;
+    updateTimelineLayoutFollow({ type: "return-to-end" });
     timelineScrollModeRef.current = "anchoring-new-turn";
     liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
     pendingTimelineAnchorRef.current = messageIdForSend;
@@ -5179,6 +5170,7 @@ function ChatViewContent(props: ChatViewProps) {
 
       // Position this sent row once LegendList has measured the anchored tail.
       isAtEndRef.current = true;
+      updateTimelineLayoutFollow({ type: "return-to-end" });
       timelineScrollModeRef.current = "anchoring-new-turn";
       liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
       pendingTimelineAnchorRef.current = messageIdForSend;
@@ -5827,6 +5819,7 @@ function ChatViewContent(props: ChatViewProps) {
                 onAnchorReady={onTimelineAnchorReady}
                 onAnchorSizeChanged={onTimelineAnchorSizeChanged}
                 contentInsetEndAdjustment={composerOverlayHeight}
+                maintainScrollAtEndOnLayout={maintainScrollAtEndOnLayout}
                 onIsAtEndChange={onIsAtEndChange}
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
                 hideEmptyPlaceholder={isDraftHeroState || threadDetailLoading}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -15,6 +15,7 @@ export const TIMELINE_MINIMAP_MIN_ITEMS = 2;
 export const TIMELINE_MINIMAP_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
 export const TIMELINE_CONTENT_MAX_WIDTH = 768;
 export const TIMELINE_MINIMAP_PERSISTENT_GUTTER = 48;
+export const TIMELINE_OVERLAY_SCROLLBAR_HIT_WIDTH = 16;
 
 export interface TimelineEndState {
   readonly isAtEnd?: boolean;
@@ -23,6 +24,31 @@ export interface TimelineEndState {
 
 export function resolveTimelineIsAtEnd(state: TimelineEndState | undefined): boolean | undefined {
   return state?.isNearEnd ?? state?.isAtEnd;
+}
+
+export function isTimelineScrollbarPointerDown(input: {
+  readonly pointerType: string;
+  readonly targetIsCurrentTarget: boolean;
+  readonly clientX: number;
+  readonly viewportRight: number;
+  readonly offsetWidth: number;
+  readonly clientWidth: number;
+  readonly scrollHeight: number;
+  readonly clientHeight: number;
+}): boolean {
+  if (
+    input.pointerType !== "mouse" ||
+    !input.targetIsCurrentTarget ||
+    input.scrollHeight <= input.clientHeight ||
+    !Number.isFinite(input.clientX) ||
+    !Number.isFinite(input.viewportRight)
+  ) {
+    return false;
+  }
+
+  const measuredScrollbarWidth = Math.max(0, input.offsetWidth - input.clientWidth);
+  const hitWidth = Math.max(TIMELINE_OVERLAY_SCROLLBAR_HIT_WIDTH, measuredScrollbarWidth);
+  return input.clientX >= input.viewportRight - hitWidth && input.clientX <= input.viewportRight;
 }
 
 export function resolveTimelineMinimapHeightStyle(itemCount: number): string {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -39,6 +39,9 @@ vi.mock("@legendapp/list/react", async () => {
           size?: boolean;
           shouldRestorePosition?: (item: { id: string }) => boolean;
         };
+    onWheel?: () => void;
+    onTouchMove?: () => void;
+    onPointerDown?: () => void;
     ref?: Ref<LegendListRef>;
   }) => {
     if (props.anchoredEndSpace) {
@@ -90,6 +93,9 @@ vi.mock("@legendapp/list/react", async () => {
             ? props.maintainVisibleContentPosition.size
             : undefined
         }
+        data-manual-navigation-wheel={Boolean(props.onWheel)}
+        data-manual-navigation-touch={Boolean(props.onTouchMove)}
+        data-manual-navigation-pointer={Boolean(props.onPointerDown)}
       >
         {props.ListHeaderComponent}
         {props.data.map((item) => (
@@ -194,6 +200,7 @@ function buildProps() {
     onAnchorReady: () => {},
     onAnchorSizeChanged: () => {},
     contentInsetEndAdjustment: 0,
+    maintainScrollAtEndOnLayout: true,
     onIsAtEndChange: () => {},
     onManualNavigation: () => {},
   };
@@ -357,6 +364,35 @@ describe("MessagesTimeline", () => {
     expect(resolveTimelineMinimapInteractiveWidth(40, true)).toBe("22rem");
   });
 
+  it("only treats a press on the vertical scrollbar as pointer navigation", async () => {
+    const { isTimelineScrollbarPointerDown } = await import("./MessagesTimeline.logic");
+    const scrollbarPointer = {
+      pointerType: "mouse",
+      targetIsCurrentTarget: true,
+      clientX: 994,
+      viewportRight: 1000,
+      offsetWidth: 800,
+      clientWidth: 800,
+      scrollHeight: 1200,
+      clientHeight: 600,
+    };
+
+    expect(isTimelineScrollbarPointerDown(scrollbarPointer)).toBe(true);
+    expect(
+      isTimelineScrollbarPointerDown({ ...scrollbarPointer, targetIsCurrentTarget: false }),
+    ).toBe(false);
+    expect(isTimelineScrollbarPointerDown({ ...scrollbarPointer, clientX: 900 })).toBe(false);
+    expect(isTimelineScrollbarPointerDown({ ...scrollbarPointer, pointerType: "touch" })).toBe(
+      false,
+    );
+    expect(
+      isTimelineScrollbarPointerDown({
+        ...scrollbarPointer,
+        scrollHeight: scrollbarPointer.clientHeight,
+      }),
+    ).toBe(false);
+  });
+
   it("anchors a sent attachment message using its measured height", () => {
     const onAnchorReady = vi.fn();
     const onAnchorSizeChanged = vi.fn();
@@ -422,6 +458,24 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('data-user-message-collapsed="true"');
     expect(markup).toContain('data-user-message-fade="true"');
     expect(markup).toContain('data-user-message-footer="true"');
+  });
+
+  it("preserves the reader's position when the composer resizes away from the live edge", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        maintainScrollAtEndOnLayout={false}
+        timelineEntries={[buildUserTimelineEntry("Earlier message.")]}
+      />,
+    );
+
+    expect(markup).toContain('data-maintain-scroll-at-end="enabled"');
+    expect(markup).toContain('data-maintain-scroll-at-end-data-change="true"');
+    expect(markup).toContain('data-maintain-scroll-at-end-item-layout="true"');
+    expect(markup).toContain('data-maintain-scroll-at-end-layout="false"');
+    expect(markup).toContain('data-manual-navigation-wheel="true"');
+    expect(markup).toContain('data-manual-navigation-touch="true"');
+    expect(markup).toContain('data-manual-navigation-pointer="true"');
   });
 
   it("does not render collapse controls for short user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -19,6 +19,7 @@ import {
   useState,
   type KeyboardEvent,
   type MouseEvent,
+  type PointerEvent,
   type ReactNode,
 } from "react";
 import { flushSync } from "react-dom";
@@ -67,6 +68,7 @@ import { MessageCopyButton } from "./MessageCopyButton";
 import {
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
+  isTimelineScrollbarPointerDown,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
   resolveTimelineIsAtEnd,
@@ -180,6 +182,7 @@ interface MessagesTimelineProps {
   onAnchorReady: (messageId: MessageId, anchorIndex: number) => void;
   onAnchorSizeChanged: (messageId: MessageId, size: number) => void;
   contentInsetEndAdjustment: number;
+  maintainScrollAtEndOnLayout: boolean;
   onIsAtEndChange: (isAtEnd: boolean) => void;
   onManualNavigation: () => void;
   hideEmptyPlaceholder?: boolean;
@@ -215,6 +218,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   onAnchorReady,
   onAnchorSizeChanged,
   contentInsetEndAdjustment,
+  maintainScrollAtEndOnLayout,
   onIsAtEndChange,
   onManualNavigation,
   hideEmptyPlaceholder = false,
@@ -385,6 +389,27 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     }
   }, [listRef, minimapItems, minimapStripMap, onIsAtEndChange]);
 
+  const handlePointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const scrollNode = event.currentTarget;
+      if (
+        isTimelineScrollbarPointerDown({
+          pointerType: event.pointerType,
+          targetIsCurrentTarget: event.target === scrollNode,
+          clientX: event.clientX,
+          viewportRight: scrollNode.getBoundingClientRect().right,
+          offsetWidth: scrollNode.offsetWidth,
+          clientWidth: scrollNode.clientWidth,
+          scrollHeight: scrollNode.scrollHeight,
+          clientHeight: scrollNode.clientHeight,
+        })
+      ) {
+        onManualNavigation();
+      }
+    },
+    [onManualNavigation],
+  );
+
   useEffect(() => {
     const frame = requestAnimationFrame(handleScroll);
     return () => cancelAnimationFrame(frame);
@@ -502,7 +527,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     on: {
                       dataChange: true,
                       itemLayout: true,
-                      layout: true,
+                      layout: maintainScrollAtEndOnLayout,
                     },
                   }
             }
@@ -511,6 +536,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
               size: false,
             }}
             onScroll={handleScroll}
+            onWheel={onManualNavigation}
+            onTouchMove={onManualNavigation}
+            onPointerDown={handlePointerDown}
             className={cn(
               "scrollbar-gutter-both h-full min-h-0 overflow-x-hidden overscroll-y-contain px-3 [overflow-anchor:none] sm:px-5",
               topFadeEnabled && "chat-timeline-scroll-fade",

--- a/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
-import { getAnchoredTurnMetrics, getRowBottom } from "./timelineScrollAnchoring";
+import {
+  getAnchoredTurnMetrics,
+  getRowBottom,
+  isTimelineLayoutFollowEnabled,
+  reduceTimelineLayoutFollowState,
+} from "./timelineScrollAnchoring";
 
 function buildState({
   positions,
@@ -22,6 +27,51 @@ function buildState({
 }
 
 describe("timeline scroll anchoring", () => {
+  it("hands layout following off across scroll-away and return-to-end actions", () => {
+    const threadKey = "environment-local:thread-1";
+    let state = { threadKey, enabled: true };
+
+    state = reduceTimelineLayoutFollowState(state, threadKey, {
+      type: "manual-navigation",
+      isAtEnd: true,
+    });
+    expect(isTimelineLayoutFollowEnabled(state, threadKey)).toBe(true);
+
+    state = reduceTimelineLayoutFollowState(state, threadKey, {
+      type: "at-end-change",
+      isAtEnd: false,
+    });
+    expect(isTimelineLayoutFollowEnabled(state, threadKey)).toBe(false);
+
+    state = reduceTimelineLayoutFollowState(state, threadKey, {
+      type: "at-end-change",
+      isAtEnd: true,
+    });
+    expect(isTimelineLayoutFollowEnabled(state, threadKey)).toBe(true);
+
+    state = reduceTimelineLayoutFollowState(state, threadKey, {
+      type: "at-end-change",
+      isAtEnd: false,
+    });
+    state = reduceTimelineLayoutFollowState(state, threadKey, { type: "return-to-end" });
+    expect(isTimelineLayoutFollowEnabled(state, threadKey)).toBe(true);
+  });
+
+  it("starts a different thread at the live edge on its first render", () => {
+    const previousThreadState = {
+      threadKey: "environment-local:thread-1",
+      enabled: false,
+    };
+    const nextThreadKey = "environment-local:thread-2";
+
+    expect(isTimelineLayoutFollowEnabled(previousThreadState, nextThreadKey)).toBe(true);
+    expect(
+      reduceTimelineLayoutFollowState(previousThreadState, nextThreadKey, {
+        type: "return-to-end",
+      }),
+    ).toEqual({ threadKey: nextThreadKey, enabled: true });
+  });
+
   it("measures row bottoms from LegendList row position and size", () => {
     const state = buildState({
       positions: [0, 120],

--- a/apps/web/src/components/chat/timelineScrollAnchoring.ts
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.ts
@@ -1,5 +1,41 @@
 export type TimelineScrollMode = "following-end" | "anchoring-new-turn" | "free-scrolling";
 
+export interface TimelineLayoutFollowState {
+  readonly threadKey: string;
+  readonly enabled: boolean;
+}
+
+export type TimelineLayoutFollowAction =
+  | { readonly type: "manual-navigation"; readonly isAtEnd: boolean }
+  | { readonly type: "at-end-change"; readonly isAtEnd: boolean }
+  | { readonly type: "return-to-end" };
+
+export function isTimelineLayoutFollowEnabled(
+  state: TimelineLayoutFollowState,
+  threadKey: string,
+): boolean {
+  return state.threadKey === threadKey ? state.enabled : true;
+}
+
+export function reduceTimelineLayoutFollowState(
+  state: TimelineLayoutFollowState,
+  threadKey: string,
+  action: TimelineLayoutFollowAction,
+): TimelineLayoutFollowState {
+  const enabled =
+    action.type === "manual-navigation"
+      ? action.isAtEnd
+        ? isTimelineLayoutFollowEnabled(state, threadKey)
+        : false
+      : action.type === "at-end-change"
+        ? action.isAtEnd
+        : true;
+
+  return state.threadKey === threadKey && state.enabled === enabled
+    ? state
+    : { threadKey, enabled };
+}
+
 export interface TimelineListMeasurementState {
   readonly data: readonly unknown[];
   readonly scroll: number;


### PR DESCRIPTION
## What Changed

- Bind wheel and touch navigation directly to the timeline, and treat only scrollbar presses as pointer navigation, so reader intent cannot be missed without ordinary timeline clicks disabling live follow.
- Disable layout-based end following after the reader leaves the live edge, while preserving existing data-change and item-layout behavior.
- Scope the layout-follow state to the active thread so a scrolled-up thread cannot leak stale state into the next thread.
- Add focused regression coverage for the ChatView state handoff, LegendList configuration, and navigation bindings.

## Why

When manual-navigation listeners miss the timeline during mount, scrolling upward does not cancel live following. Growing the composer with Shift+Enter then updates the timeline's bottom inset and reruns end-following logic, forcing the transcript to the bottom.

The timeline now receives navigation handlers through its normal component lifecycle and only keeps layout-based end following enabled while the reader is at the live edge. Explicit scroll-to-end, thread changes, and sends restore following.

## UI Changes

### Before

Shift+Enter grows the composer and moves the transcript from the reader's earlier position to the live edge.

![Before: Shift+Enter snaps the transcript to the bottom](https://raw.githubusercontent.com/caezium/t3code/pr-assets-preserve-composer-scroll/pr-assets/5234/before.gif)

![Before result at the live edge](https://raw.githubusercontent.com/caezium/t3code/pr-assets-preserve-composer-scroll/pr-assets/5234/before-result.png)

### After

The composer grows while the same earlier transcript position remains in view.

![After: Shift+Enter preserves the transcript position](https://raw.githubusercontent.com/caezium/t3code/pr-assets-preserve-composer-scroll/pr-assets/5234/after.gif)

![After result with the earlier position preserved](https://raw.githubusercontent.com/caezium/t3code/pr-assets-preserve-composer-scroll/pr-assets/5234/after-result.png)

## Validation

- `vp test run apps/web/src/components/chat/MessagesTimeline.test.tsx apps/web/src/components/chat/timelineScrollAnchoring.test.tsx apps/web/src/components/ChatView.logic.test.ts` (59 passed)
- `vp lint --report-unused-disable-directives apps/web/src/components/ChatView.tsx apps/web/src/components/chat/MessagesTimeline.tsx apps/web/src/components/chat/MessagesTimeline.test.tsx`
- `vp run --filter @t3tools/web typecheck`
- Browser regression on untouched `upstream/main`: real Shift+Enter grew the composer from 70px to 90.96px and moved `scrollTop` from 652.08px to the 1252.08px live edge.
- Browser verification on this branch: the same Shift+Enter and composer growth kept `scrollTop` at 652.08px.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with GPT-5.6-Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chat timeline scroll and composer layout behavior only; changes are localized with regression tests and no auth, data, or API impact.
> 
> **Overview**
> Fixes the transcript **jumping to the live edge** when the composer grows (e.g. Shift+Enter) after the user has scrolled up.
> 
> **Layout follow is now gated per thread:** `ChatView` tracks `TimelineLayoutFollowState` and passes `maintainScrollAtEndOnLayout` into `MessagesTimeline`. LegendList still maintains scroll on data/item layout changes, but **layout** end-following is turned off once the reader leaves the bottom; scrolling back, sending, or switching threads restores it. A new thread defaults to follow-at-end so scrolled-up state does not leak across threads.
> 
> **Manual navigation is wired on the timeline list** instead of deferred DOM listeners in `ChatView`: wheel, touchmove, and pointer-down on the scrollbar (via `isTimelineScrollbarPointerDown`) call `onManualNavigation` and update layout-follow state. Ordinary clicks on message content no longer cancel live follow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911cd655735ced73ad5f2d6c8ecef29b1d73f38f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve scroll position in chat timeline when composer grows
> - Introduces per-thread layout-follow state in [ChatViewContent](https://github.com/pingdotgg/t3code/pull/5234/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) that tracks whether the timeline should snap to the end during layout changes (e.g. composer resize).
> - Layout-follow is disabled when the user scrolls away from the end and re-enabled when they return to the end, send a message, or switch threads.
> - Wheel, touchmove, and scrollbar pointerdown events in [MessagesTimeline](https://github.com/pingdotgg/t3code/pull/5234/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) now trigger manual-navigation, which disables layout-follow until the user returns to the end.
> - A new `isTimelineScrollbarPointerDown` utility in [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/5234/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) distinguishes scrollbar drags from content pointer interactions so only scrollbar pointerdowns count as navigation.
> - State transitions are managed by pure reducer functions in [timelineScrollAnchoring.ts](https://github.com/pingdotgg/t3code/pull/5234/files#diff-7d5bb365d2e39e9337a3a31436884ed0c0df1127c2033e30a6c027826c46de67) via `reduceTimelineLayoutFollowState`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 911cd65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat timeline scrolling when navigating between threads.
  * Preserved the correct follow position when new messages or layout changes occur.
  * Prevented automatic scrolling after manually navigating away from the latest messages.
  * Improved scrollbar, wheel, touch, and pointer interactions for manual navigation.
  * Returning to the end of the timeline now reliably restores automatic follow behavior.

* **Tests**
  * Added coverage for thread switching, scrollbar interactions, manual navigation, and layout scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->