### PR TITLE
fix(desktop): Preserve Linux workspace icons

### DIFF
--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -107,7 +107,6 @@ describe("DesktopLinuxUrlHandler", () => {
     const entry = DesktopLinuxUrlHandler.renderUrlHandlerDesktopEntry({
       displayName: "T3 Code (Nightly)",
       execTarget: '/home/al ice/Apps/T3 "100%" $HOME\\x.AppImage',
-      wmClass: "t3code",
       scheme: "t3code",
     });
 
@@ -121,7 +120,7 @@ describe("DesktopLinuxUrlHandler", () => {
       'Exec="/home/al ice/Apps/T3 \\\\"100%%\\\\" \\\\$HOME\\\\\\\\x.AppImage" %U',
     );
     assert.include(entry, "NoDisplay=true");
-    assert.include(entry, "StartupWMClass=t3code");
+    assert.notInclude(entry, "StartupWMClass=");
     assert.include(entry, "MimeType=x-scheme-handler/t3code;");
   });
 

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -65,10 +65,11 @@ export function escapeDesktopEntryExecArgument(value: string): string {
   return escapeDesktopEntryString(`"${quoted}"`);
 }
 
+// The AppImage integration entry owns the window identity and icon. This
+// hidden URL-only entry must not compete with it for StartupWMClass matching.
 export function renderUrlHandlerDesktopEntry(input: {
   readonly displayName: string;
   readonly execTarget: string;
-  readonly wmClass: string;
   readonly scheme: string;
 }): string {
   return [
@@ -79,7 +80,6 @@ export function renderUrlHandlerDesktopEntry(input: {
     "Terminal=false",
     "NoDisplay=true",
     "StartupNotify=false",
-    `StartupWMClass=${escapeDesktopEntryString(input.wmClass)}`,
     `MimeType=x-scheme-handler/${input.scheme};`,
     "",
   ].join("\n");
@@ -113,7 +113,6 @@ export const make = Effect.gen(function* () {
       renderUrlHandlerDesktopEntry({
         displayName: environment.displayName,
         execTarget,
-        wmClass: environment.linuxWmClass,
         scheme,
       }),
     );


### PR DESCRIPTION
## Summary

- Keep the hidden Linux URL-handler entry from claiming the app window's identity.
- Let the AppImage integration launcher's icon metadata remain authoritative for taskbars and workspace switchers.

## Problem and Fix

| Problem and Why it Happened | Fix |
| --- | --- |
| The hidden `t3code-url-handler.desktop` entry declared `StartupWMClass=t3code` but had no `Icon`. Desktop shells could match the T3 Code window to that hidden entry instead of the complete launcher installed by an AppImage integration tool, leaving the workspace icon blank. | Omit `StartupWMClass` from the URL-only entry. The visible AppImage launcher continues to own window matching and its extracted icon, while the hidden entry remains responsible only for `t3code://` callbacks. |

## Validation

- `vp test apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts` (6 tests passed)
- `vp run --filter @t3tools/desktop typecheck`
- `vp check apps/desktop/src/app/DesktopLinuxUrlHandler.ts apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts`
- `vp run build:desktop`
- Built an AppImage from current `upstream/main`, #5054 linux-default-scheme-handler, and this commit with the production T3 Connect public configuration.
- Installed the AppImage with Shelly on Arch Linux under Niri. The T3 Code workspace icon appeared correctly.
- Confirmed `gio mime x-scheme-handler/t3code` selected `t3code-url-handler.desktop`; Shelly's full launcher remained registered and recommended.
- Confirmed `gio open 't3code://app/'` opened or foregrounded the running AppImage.
- Completed a Firefox-to-AppImage Google OAuth callback attempt. Firefox launched `t3code-url-handler.desktop`, the AppImage returned to the foreground, and Electron received the expected `t3code://app/` callback path and query intact.
- The authentication result was Clerk `external_account_not_found` because the tested Google identity is not associated with the existing T3 Connect account. No linked Google identity was available for a successful-account test, so validation stopped after confirming callback transport.

Implemented and validated with Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Linux desktop entry metadata for a hidden handler; no auth, data, or URL handling logic changes.
> 
> **Overview**
> Fixes blank workspace/taskbar icons on Linux when the hidden `t3code-url-handler.desktop` entry was winning **StartupWMClass** matching against the visible AppImage integration launcher (which carries icon metadata).
> 
> **`renderUrlHandlerDesktopEntry`** no longer accepts `wmClass` or emits **`StartupWMClass`**. Registration stops passing **`linuxWmClass`**. The URL-only entry still handles **`t3code://`** via **MimeType** and **Exec**; window identity and icons stay with the integration launcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2180d468aecc9de1688a2bfafad328c4ff9ed7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `StartupWMClass` from Linux URL handler desktop entry to preserve workspace icons
> The URL-handler desktop entry was claiming the same `StartupWMClass` as the main app entry, which caused window managers to misattribute windows and lose workspace icon associations. Removes `StartupWMClass` from the generated entry in [`DesktopLinuxUrlHandler.ts`](https://github.com/pingdotgg/t3code/pull/5249/files#diff-504ebe51e9dfd4ae2551fe7de89cc99cac2fc37ae741fb4a2ccace15c8b81187) so only the primary app entry participates in WM class matching.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2180d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->