### PR TITLE
fix(web): offer Update client when the app is behind the server

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -296,9 +296,11 @@ import {
   AlertDialogTitle,
 } from "./ui/alert-dialog";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+import { ClientUpdateAction } from "./ClientUpdateAction";
 import { ServerUpdateAction, ServerUpdateProgress } from "./ServerUpdateAction";
 import {
   buildVersionMismatchDismissalKey,
+  clientUpdateGuidance,
   dismissVersionMismatch,
   isVersionMismatchDismissed,
   resolveServerConfigVersionMismatch,
@@ -1913,7 +1915,10 @@ function ChatViewContent(props: ChatViewProps) {
     // "versions differ". A failed update never folds: its error and retry
     // action must stay visible.
     const reconnectingThroughVersionSkew =
-      serverUpdateState.status === "idle" && environmentReconnecting && versionMismatch !== null;
+      serverUpdateState.status === "idle" &&
+      environmentReconnecting &&
+      versionMismatch !== null &&
+      versionMismatch.outdatedSide !== "client";
     // While an update runs, transient connect blips are expected (the server
     // restarts) and the update banner already shows progress. Hard failure
     // phases still surface so the Reconnect action stays reachable.
@@ -1972,8 +1977,9 @@ function ChatViewContent(props: ChatViewProps) {
       (serverUpdateState.status !== "idle" ||
         (showVersionMismatchBanner && versionMismatch && versionMismatchDismissKey))
     ) {
-      const updateInProgress = serverUpdateState.status === "running";
-      const updateFailed = serverUpdateState.status === "failed";
+      const clientOutdated = versionMismatch?.outdatedSide === "client";
+      const updateInProgress = !clientOutdated && serverUpdateState.status === "running";
+      const updateFailed = !clientOutdated && serverUpdateState.status === "failed";
       items.push({
         id: `server-version:${serverUpdateEnvironmentId}`,
         variant: updateFailed ? "error" : updateInProgress ? "default" : "warning",
@@ -1999,15 +2005,17 @@ function ChatViewContent(props: ChatViewProps) {
             <>
               Client {versionMismatch.clientVersion} is connected to {versionMismatchServerLabel}{" "}
               {versionMismatch.serverVersion}.{" "}
-              {serverUpdateGuidance(versionMismatchSelfUpdate, versionMismatchServerLabel)}
+              {clientOutdated
+                ? clientUpdateGuidance()
+                : serverUpdateGuidance(versionMismatchSelfUpdate, versionMismatchServerLabel)}
             </>
           ) : null,
-        // The desktop-managed guidance is already the description; the action
-        // slot would only repeat it.
+        // Client-behind: Update client via the desktop updater. Server-behind +
+        // desktop-managed: guidance is already the description.
         actions:
-          updateInProgress ||
-          !versionMismatch ||
-          versionMismatchSelfUpdate === "desktop-managed" ? undefined : (
+          updateInProgress || !versionMismatch ? undefined : clientOutdated ? (
+            <ClientUpdateAction />
+          ) : versionMismatchSelfUpdate === "desktop-managed" ? undefined : (
             <ServerUpdateAction
               environmentId={serverUpdateEnvironmentId}
               serverLabel={versionMismatchServerLabel}

--- a/apps/web/src/components/ClientUpdateAction.tsx
+++ b/apps/web/src/components/ClientUpdateAction.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+import type { DesktopUpdateState } from "@t3tools/contracts";
 
 import { isElectron } from "../env";
 import { useDesktopUpdateState } from "../state/desktopUpdate";
@@ -13,6 +14,18 @@ import {
 import { Button } from "./ui/button";
 import { Spinner } from "./ui/spinner";
 import { stackedThreadToast, toastManager } from "./ui/toast";
+
+const CHECK_SETTLE_TIMEOUT_MS = 60_000;
+const CHECK_SETTLE_POLL_MS = 200;
+
+/** Module-scoped so banner dismiss / route changes cannot drop an in-flight check. */
+let clientUpdateCheckInFlight = false;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 
 function downloadDesktopUpdate(): void {
   const bridge = window.desktopBridge;
@@ -49,23 +62,102 @@ function downloadDesktopUpdate(): void {
     });
 }
 
+function handleSettledCheckState(state: DesktopUpdateState): void {
+  const nextAction = resolveDesktopUpdateButtonAction(state);
+  if (nextAction === "download") {
+    downloadDesktopUpdate();
+    return;
+  }
+  if (nextAction === "install") {
+    return;
+  }
+  if (state.status === "up-to-date") {
+    toastManager.add({
+      type: "info",
+      title: "No newer desktop update found",
+      description:
+        "This build may not have a published update yet. Install a newer T3 Code desktop build to match the server.",
+    });
+    return;
+  }
+  if (state.status === "error") {
+    toastManager.add(
+      stackedThreadToast({
+        type: "error",
+        title: "Could not check for updates",
+        description: state.message ?? "Update check failed.",
+      }),
+    );
+  }
+}
+
+/**
+ * Runs check → wait for settled desktop update state → download. Lives outside
+ * React so unmounting ClientUpdateAction (dismiss banner / leave Connections)
+ * cannot cancel the continuation.
+ */
+async function checkThenDownloadDesktopUpdate(baselineCheckedAt: string | null): Promise<void> {
+  const bridge = window.desktopBridge;
+  if (!bridge || typeof bridge.checkForUpdate !== "function") return;
+  if (clientUpdateCheckInFlight) return;
+
+  clientUpdateCheckInFlight = true;
+  try {
+    const result = await bridge.checkForUpdate();
+    if (!result.checked) {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not check for updates",
+          description: result.state.message ?? "Automatic updates are not available in this build.",
+        }),
+      );
+      return;
+    }
+
+    const deadline = Date.now() + CHECK_SETTLE_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const state = await bridge.getUpdateState();
+      const checkAdvanced = state.status === "checking" || state.checkedAt !== baselineCheckedAt;
+      if (!checkAdvanced || state.status === "checking") {
+        await sleep(CHECK_SETTLE_POLL_MS);
+        continue;
+      }
+      handleSettledCheckState(state);
+      return;
+    }
+
+    toastManager.add(
+      stackedThreadToast({
+        type: "error",
+        title: "Could not check for updates",
+        description: "Timed out waiting for the desktop updater to finish checking.",
+      }),
+    );
+  } catch (error: unknown) {
+    toastManager.add(
+      stackedThreadToast({
+        type: "error",
+        title: "Could not check for updates",
+        description: error instanceof Error ? error.message : "Update check failed.",
+      }),
+    );
+  } finally {
+    clientUpdateCheckInFlight = false;
+  }
+}
+
 /**
  * Call-to-action when this client is behind the connected server. On desktop,
  * drives the Electron updater (check → download → install). Elsewhere, only
  * guidance text is shown — there is no server-install path for this case.
- *
- * After `checkForUpdate`, desktop state is applied asynchronously via updater
- * events. We ignore the pre-check snapshot and only continue once `checkedAt`
- * advances (or status becomes `checking`) and then settles to a terminal status.
  */
 export function ClientUpdateAction({ label = "Update client" }: { readonly label?: string }) {
   const updateState = useDesktopUpdateState();
-  const [pendingCheck, setPendingCheck] = useState<{
-    readonly baselineCheckedAt: string | null;
-  } | null>(null);
+  const [localCheckPending, setLocalCheckPending] = useState(false);
 
   const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
-  const checking = updateState?.status === "checking" || pendingCheck !== null;
+  const checking = updateState?.status === "checking" || localCheckPending;
   const downloading = updateState?.status === "downloading";
   const updatesDisabled =
     updateState !== null && (!updateState.enabled || updateState.status === "disabled");
@@ -88,52 +180,6 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
           : checking
             ? "Checking…"
             : label;
-
-  useEffect(() => {
-    if (!pendingCheck || !updateState) {
-      return;
-    }
-
-    const checkAdvanced =
-      updateState.status === "checking" || updateState.checkedAt !== pendingCheck.baselineCheckedAt;
-    if (!checkAdvanced) {
-      // Still looking at the pre-click snapshot; wait for desktop to publish
-      // check-start / check-result state.
-      return;
-    }
-    if (updateState.status === "checking") {
-      return;
-    }
-
-    setPendingCheck(null);
-
-    const nextAction = resolveDesktopUpdateButtonAction(updateState);
-    if (nextAction === "download") {
-      downloadDesktopUpdate();
-      return;
-    }
-    if (nextAction === "install") {
-      return;
-    }
-    if (updateState.status === "up-to-date") {
-      toastManager.add({
-        type: "info",
-        title: "No newer desktop update found",
-        description:
-          "This build may not have a published update yet. Install a newer T3 Code desktop build to match the server.",
-      });
-      return;
-    }
-    if (updateState.status === "error") {
-      toastManager.add(
-        stackedThreadToast({
-          type: "error",
-          title: "Could not check for updates",
-          description: updateState.message ?? "Update check failed.",
-        }),
-      );
-    }
-  }, [pendingCheck, updateState]);
 
   const handleClick = useCallback(() => {
     const bridge = window.desktopBridge;
@@ -178,35 +224,10 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
       return;
     }
 
-    if (typeof bridge.checkForUpdate !== "function") return;
-    setPendingCheck({ baselineCheckedAt: updateState?.checkedAt ?? null });
-    void bridge
-      .checkForUpdate()
-      .then((result) => {
-        if (!result.checked) {
-          setPendingCheck(null);
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not check for updates",
-              description:
-                result.state.message ?? "Automatic updates are not available in this build.",
-            }),
-          );
-        }
-        // Do not download from result.state here — updater events may still be
-        // in flight. The effect above continues once desktop update state settles.
-      })
-      .catch((error: unknown) => {
-        setPendingCheck(null);
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Could not check for updates",
-            description: error instanceof Error ? error.message : "Update check failed.",
-          }),
-        );
-      });
+    setLocalCheckPending(true);
+    void checkThenDownloadDesktopUpdate(updateState?.checkedAt ?? null).finally(() => {
+      setLocalCheckPending(false);
+    });
   }, [action, updateState]);
 
   if (!isElectron) {

--- a/apps/web/src/components/ClientUpdateAction.tsx
+++ b/apps/web/src/components/ClientUpdateAction.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { DesktopUpdateState } from "@t3tools/contracts";
 
 import { isElectron } from "../env";
@@ -25,6 +25,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+async function waitForClientUpdateCheckIdle(): Promise<void> {
+  while (clientUpdateCheckInFlight) {
+    await sleep(CHECK_SETTLE_POLL_MS);
+  }
 }
 
 function downloadDesktopUpdate(): void {
@@ -95,11 +101,16 @@ function handleSettledCheckState(state: DesktopUpdateState): void {
  * Runs check → wait for settled desktop update state → download. Lives outside
  * React so unmounting ClientUpdateAction (dismiss banner / leave Connections)
  * cannot cancel the continuation.
+ *
+ * Returns whether this call owned the in-flight work. Callers must not clear
+ * pending UI on `"skipped"` until `waitForClientUpdateCheckIdle()` resolves.
  */
-async function checkThenDownloadDesktopUpdate(baselineCheckedAt: string | null): Promise<void> {
+async function checkThenDownloadDesktopUpdate(
+  baselineCheckedAt: string | null,
+): Promise<"owned" | "skipped"> {
   const bridge = window.desktopBridge;
-  if (!bridge || typeof bridge.checkForUpdate !== "function") return;
-  if (clientUpdateCheckInFlight) return;
+  if (!bridge || typeof bridge.checkForUpdate !== "function") return "skipped";
+  if (clientUpdateCheckInFlight) return "skipped";
 
   clientUpdateCheckInFlight = true;
   try {
@@ -112,7 +123,7 @@ async function checkThenDownloadDesktopUpdate(baselineCheckedAt: string | null):
           description: result.state.message ?? "Automatic updates are not available in this build.",
         }),
       );
-      return;
+      return "owned";
     }
 
     const deadline = Date.now() + CHECK_SETTLE_TIMEOUT_MS;
@@ -124,7 +135,7 @@ async function checkThenDownloadDesktopUpdate(baselineCheckedAt: string | null):
         continue;
       }
       handleSettledCheckState(state);
-      return;
+      return "owned";
     }
 
     toastManager.add(
@@ -134,6 +145,7 @@ async function checkThenDownloadDesktopUpdate(baselineCheckedAt: string | null):
         description: "Timed out waiting for the desktop updater to finish checking.",
       }),
     );
+    return "owned";
   } catch (error: unknown) {
     toastManager.add(
       stackedThreadToast({
@@ -142,6 +154,7 @@ async function checkThenDownloadDesktopUpdate(baselineCheckedAt: string | null):
         description: error instanceof Error ? error.message : "Update check failed.",
       }),
     );
+    return "owned";
   } finally {
     clientUpdateCheckInFlight = false;
   }
@@ -154,7 +167,17 @@ async function checkThenDownloadDesktopUpdate(baselineCheckedAt: string | null):
  */
 export function ClientUpdateAction({ label = "Update client" }: { readonly label?: string }) {
   const updateState = useDesktopUpdateState();
-  const [localCheckPending, setLocalCheckPending] = useState(false);
+  const [localCheckPending, setLocalCheckPending] = useState(clientUpdateCheckInFlight);
+
+  useEffect(() => {
+    if (!clientUpdateCheckInFlight) {
+      return;
+    }
+    setLocalCheckPending(true);
+    void waitForClientUpdateCheckIdle().then(() => {
+      setLocalCheckPending(false);
+    });
+  }, []);
 
   const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
   const checking = updateState?.status === "checking" || localCheckPending;
@@ -225,7 +248,10 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
     }
 
     setLocalCheckPending(true);
-    void checkThenDownloadDesktopUpdate(updateState?.checkedAt ?? null).finally(() => {
+    void checkThenDownloadDesktopUpdate(updateState?.checkedAt ?? null).then(async (outcome) => {
+      if (outcome === "skipped") {
+        await waitForClientUpdateCheckIdle();
+      }
       setLocalCheckPending(false);
     });
   }, [action, updateState]);

--- a/apps/web/src/components/ClientUpdateAction.tsx
+++ b/apps/web/src/components/ClientUpdateAction.tsx
@@ -55,15 +55,17 @@ function downloadDesktopUpdate(): void {
  * guidance text is shown — there is no server-install path for this case.
  *
  * After `checkForUpdate`, desktop state is applied asynchronously via updater
- * events. We wait for that settled state (not the immediate return value)
- * before downloading or reporting "up to date".
+ * events. We ignore the pre-check snapshot and only continue once `checkedAt`
+ * advances (or status becomes `checking`) and then settles to a terminal status.
  */
 export function ClientUpdateAction({ label = "Update client" }: { readonly label?: string }) {
   const updateState = useDesktopUpdateState();
-  const [awaitingCheckResult, setAwaitingCheckResult] = useState(false);
+  const [pendingCheck, setPendingCheck] = useState<{
+    readonly baselineCheckedAt: string | null;
+  } | null>(null);
 
   const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
-  const checking = updateState?.status === "checking" || awaitingCheckResult;
+  const checking = updateState?.status === "checking" || pendingCheck !== null;
   const downloading = updateState?.status === "downloading";
   const updatesDisabled =
     updateState !== null && (!updateState.enabled || updateState.status === "disabled");
@@ -88,16 +90,22 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
             : label;
 
   useEffect(() => {
-    if (!awaitingCheckResult || !updateState) {
+    if (!pendingCheck || !updateState) {
       return;
     }
-    // Desktop applies update-available / up-to-date asynchronously after
-    // checkForUpdate resolves; stay pending until status leaves "checking".
+
+    const checkAdvanced =
+      updateState.status === "checking" || updateState.checkedAt !== pendingCheck.baselineCheckedAt;
+    if (!checkAdvanced) {
+      // Still looking at the pre-click snapshot; wait for desktop to publish
+      // check-start / check-result state.
+      return;
+    }
     if (updateState.status === "checking") {
       return;
     }
 
-    setAwaitingCheckResult(false);
+    setPendingCheck(null);
 
     const nextAction = resolveDesktopUpdateButtonAction(updateState);
     if (nextAction === "download") {
@@ -125,7 +133,7 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
         }),
       );
     }
-  }, [awaitingCheckResult, updateState]);
+  }, [pendingCheck, updateState]);
 
   const handleClick = useCallback(() => {
     const bridge = window.desktopBridge;
@@ -171,12 +179,12 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
     }
 
     if (typeof bridge.checkForUpdate !== "function") return;
-    setAwaitingCheckResult(true);
+    setPendingCheck({ baselineCheckedAt: updateState?.checkedAt ?? null });
     void bridge
       .checkForUpdate()
       .then((result) => {
         if (!result.checked) {
-          setAwaitingCheckResult(false);
+          setPendingCheck(null);
           toastManager.add(
             stackedThreadToast({
               type: "error",
@@ -190,7 +198,7 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
         // in flight. The effect above continues once desktop update state settles.
       })
       .catch((error: unknown) => {
-        setAwaitingCheckResult(false);
+        setPendingCheck(null);
         toastManager.add(
           stackedThreadToast({
             type: "error",

--- a/apps/web/src/components/ClientUpdateAction.tsx
+++ b/apps/web/src/components/ClientUpdateAction.tsx
@@ -1,0 +1,191 @@
+import { useCallback } from "react";
+
+import { isElectron } from "../env";
+import { useDesktopUpdateState } from "../state/desktopUpdate";
+import {
+  canCheckForUpdate,
+  getDesktopUpdateActionError,
+  getDesktopUpdateInstallConfirmationMessage,
+  isDesktopUpdateButtonDisabled,
+  resolveDesktopUpdateButtonAction,
+  shouldToastDesktopUpdateActionResult,
+} from "./desktopUpdate.logic";
+import { Button } from "./ui/button";
+import { Spinner } from "./ui/spinner";
+import { stackedThreadToast, toastManager } from "./ui/toast";
+
+/**
+ * Call-to-action when this client is behind the connected server. On desktop,
+ * drives the Electron updater (check → download → install). Elsewhere, only
+ * guidance text is shown — there is no server-install path for this case.
+ */
+export function ClientUpdateAction({ label = "Update client" }: { readonly label?: string }) {
+  const updateState = useDesktopUpdateState();
+
+  const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
+  const checking = updateState?.status === "checking";
+  const downloading = updateState?.status === "downloading";
+  const buttonDisabled =
+    checking ||
+    downloading ||
+    (action === "none"
+      ? !canCheckForUpdate(updateState)
+      : isDesktopUpdateButtonDisabled(updateState));
+
+  const buttonLabel =
+    action === "install"
+      ? "Restart to update"
+      : action === "download"
+        ? label
+        : downloading
+          ? typeof updateState?.downloadPercent === "number"
+            ? `Downloading (${Math.floor(updateState.downloadPercent)}%)`
+            : "Downloading…"
+          : checking
+            ? "Checking…"
+            : label;
+
+  const handleClick = useCallback(() => {
+    const bridge = window.desktopBridge;
+    if (!bridge) return;
+
+    if (action === "download") {
+      void bridge
+        .downloadUpdate()
+        .then((result) => {
+          if (result.completed) {
+            toastManager.add({
+              type: "success",
+              title: "Update downloaded",
+              description: "Restart the app from the update button to install it.",
+            });
+          }
+          if (!shouldToastDesktopUpdateActionResult(result)) return;
+          const actionError = getDesktopUpdateActionError(result);
+          if (!actionError) return;
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not download update",
+              description: actionError,
+            }),
+          );
+        })
+        .catch((error: unknown) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not start update download",
+              description: error instanceof Error ? error.message : "An unexpected error occurred.",
+            }),
+          );
+        });
+      return;
+    }
+
+    if (action === "install") {
+      const confirmed = window.confirm(
+        getDesktopUpdateInstallConfirmationMessage(
+          updateState ?? { availableVersion: null, downloadedVersion: null },
+          navigator.platform,
+        ),
+      );
+      if (!confirmed) return;
+      void bridge
+        .installUpdate()
+        .then((result) => {
+          if (!shouldToastDesktopUpdateActionResult(result)) return;
+          const actionError = getDesktopUpdateActionError(result);
+          if (!actionError) return;
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not install update",
+              description: actionError,
+            }),
+          );
+        })
+        .catch((error: unknown) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not install update",
+              description: error instanceof Error ? error.message : "An unexpected error occurred.",
+            }),
+          );
+        });
+      return;
+    }
+
+    if (typeof bridge.checkForUpdate !== "function") return;
+    void bridge
+      .checkForUpdate()
+      .then((result) => {
+        if (!result.checked) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not check for updates",
+              description:
+                result.state.message ?? "Automatic updates are not available in this build.",
+            }),
+          );
+          return;
+        }
+        const nextAction = resolveDesktopUpdateButtonAction(result.state);
+        if (nextAction === "download") {
+          return bridge.downloadUpdate().then((downloadResult) => {
+            if (downloadResult.completed) {
+              toastManager.add({
+                type: "success",
+                title: "Update downloaded",
+                description: "Restart the app from the update button to install it.",
+              });
+            }
+            if (!shouldToastDesktopUpdateActionResult(downloadResult)) return;
+            const actionError = getDesktopUpdateActionError(downloadResult);
+            if (!actionError) return;
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Could not download update",
+                description: actionError,
+              }),
+            );
+          });
+        }
+        if (nextAction === "none" && result.state.status === "up-to-date") {
+          toastManager.add({
+            type: "info",
+            title: "No newer desktop update found",
+            description:
+              "This build may not have a published update yet. Install a newer T3 Code desktop build to match the server.",
+          });
+        }
+      })
+      .catch((error: unknown) => {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not check for updates",
+            description: error instanceof Error ? error.message : "Update check failed.",
+          }),
+        );
+      });
+  }, [action, updateState]);
+
+  if (!isElectron) {
+    return (
+      <span className="text-muted-foreground text-xs">
+        Update or reload this client to match the server.
+      </span>
+    );
+  }
+
+  return (
+    <Button size="xs" disabled={buttonDisabled} onClick={handleClick}>
+      {checking || downloading ? <Spinner className="size-3.5" /> : null}
+      {buttonLabel}
+    </Button>
+  );
+}

--- a/apps/web/src/components/ClientUpdateAction.tsx
+++ b/apps/web/src/components/ClientUpdateAction.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import type { DesktopUpdateState } from "@t3tools/contracts";
 
 import { isElectron } from "../env";
@@ -20,17 +20,39 @@ const CHECK_SETTLE_POLL_MS = 200;
 
 /** Module-scoped so banner dismiss / route changes cannot drop an in-flight check. */
 let clientUpdateCheckInFlight = false;
+const clientUpdateCheckListeners = new Set<() => void>();
+
+function setClientUpdateCheckInFlight(next: boolean): void {
+  if (clientUpdateCheckInFlight === next) return;
+  clientUpdateCheckInFlight = next;
+  for (const listener of clientUpdateCheckListeners) {
+    listener();
+  }
+}
+
+function subscribeClientUpdateCheckInFlight(listener: () => void): () => void {
+  clientUpdateCheckListeners.add(listener);
+  return () => {
+    clientUpdateCheckListeners.delete(listener);
+  };
+}
+
+function getClientUpdateCheckInFlightSnapshot(): boolean {
+  return clientUpdateCheckInFlight;
+}
+
+function useClientUpdateCheckInFlight(): boolean {
+  return useSyncExternalStore(
+    subscribeClientUpdateCheckInFlight,
+    getClientUpdateCheckInFlightSnapshot,
+    () => false,
+  );
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-}
-
-async function waitForClientUpdateCheckIdle(): Promise<void> {
-  while (clientUpdateCheckInFlight) {
-    await sleep(CHECK_SETTLE_POLL_MS);
-  }
 }
 
 function downloadDesktopUpdate(): void {
@@ -102,8 +124,7 @@ function handleSettledCheckState(state: DesktopUpdateState): void {
  * React so unmounting ClientUpdateAction (dismiss banner / leave Connections)
  * cannot cancel the continuation.
  *
- * Returns whether this call owned the in-flight work. Callers must not clear
- * pending UI on `"skipped"` until `waitForClientUpdateCheckIdle()` resolves.
+ * Returns whether this call owned the in-flight work.
  */
 async function checkThenDownloadDesktopUpdate(
   baselineCheckedAt: string | null,
@@ -112,7 +133,7 @@ async function checkThenDownloadDesktopUpdate(
   if (!bridge || typeof bridge.checkForUpdate !== "function") return "skipped";
   if (clientUpdateCheckInFlight) return "skipped";
 
-  clientUpdateCheckInFlight = true;
+  setClientUpdateCheckInFlight(true);
   try {
     const result = await bridge.checkForUpdate();
     if (!result.checked) {
@@ -156,7 +177,7 @@ async function checkThenDownloadDesktopUpdate(
     );
     return "owned";
   } finally {
-    clientUpdateCheckInFlight = false;
+    setClientUpdateCheckInFlight(false);
   }
 }
 
@@ -167,20 +188,10 @@ async function checkThenDownloadDesktopUpdate(
  */
 export function ClientUpdateAction({ label = "Update client" }: { readonly label?: string }) {
   const updateState = useDesktopUpdateState();
-  const [localCheckPending, setLocalCheckPending] = useState(clientUpdateCheckInFlight);
-
-  useEffect(() => {
-    if (!clientUpdateCheckInFlight) {
-      return;
-    }
-    setLocalCheckPending(true);
-    void waitForClientUpdateCheckIdle().then(() => {
-      setLocalCheckPending(false);
-    });
-  }, []);
+  const checkInFlight = useClientUpdateCheckInFlight();
 
   const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
-  const checking = updateState?.status === "checking" || localCheckPending;
+  const checking = updateState?.status === "checking" || checkInFlight;
   const downloading = updateState?.status === "downloading";
   const updatesDisabled =
     updateState !== null && (!updateState.enabled || updateState.status === "disabled");
@@ -247,13 +258,7 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
       return;
     }
 
-    setLocalCheckPending(true);
-    void checkThenDownloadDesktopUpdate(updateState?.checkedAt ?? null).then(async (outcome) => {
-      if (outcome === "skipped") {
-        await waitForClientUpdateCheckIdle();
-      }
-      setLocalCheckPending(false);
-    });
+    void checkThenDownloadDesktopUpdate(updateState?.checkedAt ?? null);
   }, [action, updateState]);
 
   if (!isElectron) {

--- a/apps/web/src/components/ClientUpdateAction.tsx
+++ b/apps/web/src/components/ClientUpdateAction.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { isElectron } from "../env";
 import { useDesktopUpdateState } from "../state/desktopUpdate";
@@ -14,17 +14,59 @@ import { Button } from "./ui/button";
 import { Spinner } from "./ui/spinner";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 
+function downloadDesktopUpdate(): void {
+  const bridge = window.desktopBridge;
+  if (!bridge) return;
+  void bridge
+    .downloadUpdate()
+    .then((result) => {
+      if (result.completed) {
+        toastManager.add({
+          type: "success",
+          title: "Update downloaded",
+          description: "Restart the app from the update button to install it.",
+        });
+      }
+      if (!shouldToastDesktopUpdateActionResult(result)) return;
+      const actionError = getDesktopUpdateActionError(result);
+      if (!actionError) return;
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not download update",
+          description: actionError,
+        }),
+      );
+    })
+    .catch((error: unknown) => {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not start update download",
+          description: error instanceof Error ? error.message : "An unexpected error occurred.",
+        }),
+      );
+    });
+}
+
 /**
  * Call-to-action when this client is behind the connected server. On desktop,
  * drives the Electron updater (check → download → install). Elsewhere, only
  * guidance text is shown — there is no server-install path for this case.
+ *
+ * After `checkForUpdate`, desktop state is applied asynchronously via updater
+ * events. We wait for that settled state (not the immediate return value)
+ * before downloading or reporting "up to date".
  */
 export function ClientUpdateAction({ label = "Update client" }: { readonly label?: string }) {
   const updateState = useDesktopUpdateState();
+  const [awaitingCheckResult, setAwaitingCheckResult] = useState(false);
 
   const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
-  const checking = updateState?.status === "checking";
+  const checking = updateState?.status === "checking" || awaitingCheckResult;
   const downloading = updateState?.status === "downloading";
+  const updatesDisabled =
+    updateState !== null && (!updateState.enabled || updateState.status === "disabled");
   const buttonDisabled =
     checking ||
     downloading ||
@@ -45,41 +87,52 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
             ? "Checking…"
             : label;
 
+  useEffect(() => {
+    if (!awaitingCheckResult || !updateState) {
+      return;
+    }
+    // Desktop applies update-available / up-to-date asynchronously after
+    // checkForUpdate resolves; stay pending until status leaves "checking".
+    if (updateState.status === "checking") {
+      return;
+    }
+
+    setAwaitingCheckResult(false);
+
+    const nextAction = resolveDesktopUpdateButtonAction(updateState);
+    if (nextAction === "download") {
+      downloadDesktopUpdate();
+      return;
+    }
+    if (nextAction === "install") {
+      return;
+    }
+    if (updateState.status === "up-to-date") {
+      toastManager.add({
+        type: "info",
+        title: "No newer desktop update found",
+        description:
+          "This build may not have a published update yet. Install a newer T3 Code desktop build to match the server.",
+      });
+      return;
+    }
+    if (updateState.status === "error") {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not check for updates",
+          description: updateState.message ?? "Update check failed.",
+        }),
+      );
+    }
+  }, [awaitingCheckResult, updateState]);
+
   const handleClick = useCallback(() => {
     const bridge = window.desktopBridge;
     if (!bridge) return;
 
     if (action === "download") {
-      void bridge
-        .downloadUpdate()
-        .then((result) => {
-          if (result.completed) {
-            toastManager.add({
-              type: "success",
-              title: "Update downloaded",
-              description: "Restart the app from the update button to install it.",
-            });
-          }
-          if (!shouldToastDesktopUpdateActionResult(result)) return;
-          const actionError = getDesktopUpdateActionError(result);
-          if (!actionError) return;
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not download update",
-              description: actionError,
-            }),
-          );
-        })
-        .catch((error: unknown) => {
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not start update download",
-              description: error instanceof Error ? error.message : "An unexpected error occurred.",
-            }),
-          );
-        });
+      downloadDesktopUpdate();
       return;
     }
 
@@ -118,10 +171,12 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
     }
 
     if (typeof bridge.checkForUpdate !== "function") return;
+    setAwaitingCheckResult(true);
     void bridge
       .checkForUpdate()
       .then((result) => {
         if (!result.checked) {
+          setAwaitingCheckResult(false);
           toastManager.add(
             stackedThreadToast({
               type: "error",
@@ -130,40 +185,12 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
                 result.state.message ?? "Automatic updates are not available in this build.",
             }),
           );
-          return;
         }
-        const nextAction = resolveDesktopUpdateButtonAction(result.state);
-        if (nextAction === "download") {
-          return bridge.downloadUpdate().then((downloadResult) => {
-            if (downloadResult.completed) {
-              toastManager.add({
-                type: "success",
-                title: "Update downloaded",
-                description: "Restart the app from the update button to install it.",
-              });
-            }
-            if (!shouldToastDesktopUpdateActionResult(downloadResult)) return;
-            const actionError = getDesktopUpdateActionError(downloadResult);
-            if (!actionError) return;
-            toastManager.add(
-              stackedThreadToast({
-                type: "error",
-                title: "Could not download update",
-                description: actionError,
-              }),
-            );
-          });
-        }
-        if (nextAction === "none" && result.state.status === "up-to-date") {
-          toastManager.add({
-            type: "info",
-            title: "No newer desktop update found",
-            description:
-              "This build may not have a published update yet. Install a newer T3 Code desktop build to match the server.",
-          });
-        }
+        // Do not download from result.state here — updater events may still be
+        // in flight. The effect above continues once desktop update state settles.
       })
       .catch((error: unknown) => {
+        setAwaitingCheckResult(false);
         toastManager.add(
           stackedThreadToast({
             type: "error",
@@ -178,6 +205,15 @@ export function ClientUpdateAction({ label = "Update client" }: { readonly label
     return (
       <span className="text-muted-foreground text-xs">
         Update or reload this client to match the server.
+      </span>
+    );
+  }
+
+  if (updatesDisabled) {
+    return (
+      <span className="text-muted-foreground text-xs">
+        Automatic updates are unavailable in this build. Install a newer T3 Code desktop build to
+        match the server.
       </span>
     );
   }

--- a/apps/web/src/components/ClientUpdateAction.tsx
+++ b/apps/web/src/components/ClientUpdateAction.tsx
@@ -137,14 +137,31 @@ async function checkThenDownloadDesktopUpdate(
   try {
     const result = await bridge.checkForUpdate();
     if (!result.checked) {
-      toastManager.add(
-        stackedThreadToast({
-          type: "error",
-          title: "Could not check for updates",
-          description: result.state.message ?? "Automatic updates are not available in this build.",
-        }),
-      );
-      return "owned";
+      // `checked: false` is not always a hard failure — desktop skips starting a
+      // second check while one is already in flight (or while download/install is
+      // active). Join the in-flight check via polling; otherwise act on current state.
+      if (result.state.status === "checking") {
+        // fall through to the settle poll below
+      } else {
+        handleSettledCheckState(result.state);
+        const nextAction = resolveDesktopUpdateButtonAction(result.state);
+        if (
+          nextAction === "none" &&
+          result.state.status !== "downloading" &&
+          result.state.status !== "up-to-date" &&
+          result.state.status !== "error"
+        ) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not check for updates",
+              description:
+                result.state.message ?? "Automatic updates are not available in this build.",
+            }),
+          );
+        }
+        return "owned";
+      }
     }
 
     const deadline = Date.now() + CHECK_SETTLE_TIMEOUT_MS;

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -109,6 +109,7 @@ import {
 import { isDesktopLocalConnectionTarget } from "~/connection/desktopLocal";
 import { useUiStateStore } from "~/uiStateStore";
 import {
+  clientUpdateGuidance,
   resolveServerConfigVersionMismatch,
   resolveServerSelfUpdateCapability,
 } from "~/versionSkew";
@@ -135,6 +136,7 @@ import {
 import { useAtomCommand } from "../../state/use-atom-command";
 import { serverEnvironment } from "~/state/server";
 import { ConnectionStatusDot } from "../ConnectionStatusDot";
+import { ClientUpdateAction } from "../ClientUpdateAction";
 import { ServerUpdateAction, ServerUpdateProgress } from "../ServerUpdateAction";
 import { CloudEnvironmentConnectRows } from "../cloud/CloudEnvironmentConnectList";
 import { ITEM_ROW_CLASSNAME, ITEM_ROW_INNER_CLASSNAME } from "./itemRows";
@@ -1431,7 +1433,7 @@ function SavedBackendListRow({
           {metadataBits.length > 0 ? (
             <p className="text-xs text-muted-foreground">{metadataBits.join(" · ")}</p>
           ) : null}
-          {serverUpdateState.status !== "idle" ? (
+          {versionMismatch?.outdatedSide !== "client" && serverUpdateState.status !== "idle" ? (
             <div className="max-w-md">
               <ServerUpdateProgress
                 fromVersion={serverUpdateState.fromVersion}
@@ -1443,6 +1445,7 @@ function SavedBackendListRow({
               <TriangleAlertIcon className="size-3.5 shrink-0" />
               Version drift: client {versionMismatch.clientVersion}, server{" "}
               {versionMismatch.serverVersion}.
+              {versionMismatch.outdatedSide === "client" ? ` ${clientUpdateGuidance()}` : null}
             </p>
           ) : null}
           {environment.connection.error && !resumingServerUpdate ? (
@@ -1461,8 +1464,10 @@ function SavedBackendListRow({
           ) : null}
         </div>
         <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
-          {versionMismatch &&
-          (serverUpdateState.status === "idle" || serverUpdateState.status === "failed") ? (
+          {versionMismatch?.outdatedSide === "client" ? (
+            <ClientUpdateAction />
+          ) : versionMismatch &&
+            (serverUpdateState.status === "idle" || serverUpdateState.status === "failed") ? (
             <ServerUpdateAction
               environmentId={environmentId}
               serverLabel={`${environment.label} server`}
@@ -3001,13 +3006,16 @@ export function ConnectionsSettings() {
             {primaryVersionMismatch || primaryServerUpdateState.status !== "idle" ? (
               <SettingsRow
                 title={
+                  primaryVersionMismatch?.outdatedSide !== "client" &&
                   primaryServerUpdateState.status === "failed"
                     ? "Update failed"
-                    : primaryServerUpdateState.status === "running"
+                    : primaryVersionMismatch?.outdatedSide !== "client" &&
+                        primaryServerUpdateState.status === "running"
                       ? "Updating server"
                       : "Version drift"
                 }
                 description={
+                  primaryVersionMismatch?.outdatedSide !== "client" &&
                   primaryServerUpdateState.status !== "idle" ? (
                     <ServerUpdateProgress
                       fromVersion={primaryServerUpdateState.fromVersion}
@@ -3017,15 +3025,19 @@ export function ConnectionsSettings() {
                     <span className="flex items-center gap-1 text-warning">
                       <TriangleAlertIcon className="size-3.5 shrink-0" />
                       Client {primaryVersionMismatch.clientVersion}, server{" "}
-                      {primaryVersionMismatch.serverVersion}. Sync them if RPC calls or reconnects
-                      fail.
+                      {primaryVersionMismatch.serverVersion}.{" "}
+                      {primaryVersionMismatch.outdatedSide === "client"
+                        ? clientUpdateGuidance()
+                        : "Sync them if RPC calls or reconnects fail."}
                     </span>
                   ) : null
                 }
                 control={
-                  primaryVersionMismatch &&
-                  primaryEnvironmentId !== null &&
-                  primaryServerUpdateState.status !== "running" ? (
+                  primaryVersionMismatch?.outdatedSide === "client" ? (
+                    <ClientUpdateAction />
+                  ) : primaryVersionMismatch &&
+                    primaryEnvironmentId !== null &&
+                    primaryServerUpdateState.status !== "running" ? (
                     <ServerUpdateAction
                       environmentId={primaryEnvironmentId}
                       serverLabel={primaryEnvironment?.label ?? "this server"}

--- a/apps/web/src/versionSkew.test.ts
+++ b/apps/web/src/versionSkew.test.ts
@@ -5,11 +5,13 @@ import { APP_VERSION } from "./branding";
 import {
   appendVersionMismatchHint,
   buildVersionMismatchDismissalKey,
+  clientUpdateGuidance,
   dismissVersionMismatch,
   isVersionMismatchDismissed,
   resolveServerConfigVersionMismatch,
   resolveServerSelfUpdateCapability,
   resolveVersionMismatch,
+  resolveVersionOutdatedSide,
   serverUpdateGuidance,
 } from "./versionSkew";
 
@@ -19,11 +21,30 @@ describe("versionSkew", () => {
   });
 
   it("returns a mismatch when the server version differs from the client", () => {
+    const outdatedSide = resolveVersionOutdatedSide(APP_VERSION, "9.9.9");
     expect(resolveVersionMismatch("9.9.9")).toEqual({
       clientVersion: APP_VERSION,
       serverVersion: "9.9.9",
-      hint: "Version mismatch. Try syncing the client and server to the same T3 Code version.",
+      outdatedSide,
+      hint:
+        outdatedSide === "client"
+          ? "Version mismatch. Update the client to the same T3 Code version as the server."
+          : outdatedSide === "server"
+            ? "Version mismatch. Update the server to the same T3 Code version as the client."
+            : "Version mismatch. Try syncing the client and server to the same T3 Code version.",
     });
+  });
+
+  it("marks the client outdated when the server nightly is newer", () => {
+    expect(
+      resolveVersionOutdatedSide("0.0.32-nightly.20260802.980", "0.0.32-nightly.20260803.985"),
+    ).toBe("client");
+  });
+
+  it("marks the server outdated when the client nightly is newer", () => {
+    expect(
+      resolveVersionOutdatedSide("0.0.32-nightly.20260803.985", "0.0.32-nightly.20260802.980"),
+    ).toBe("server");
   });
 
   it("reads the server version from config descriptors", () => {
@@ -70,11 +91,11 @@ describe("versionSkew", () => {
     ).toBe(false);
   });
 
-  it("appends a hint to connection errors when versions differ", () => {
+  it("appends a direction-aware hint to connection errors when versions differ", () => {
     const mismatch = resolveVersionMismatch("9.9.9");
 
     expect(appendVersionMismatchHint("Socket closed.", mismatch)).toBe(
-      "Socket closed. Hint: Version mismatch. Try syncing the client and server to the same T3 Code version.",
+      `Socket closed. Hint: ${mismatch?.hint}`,
     );
   });
 
@@ -106,5 +127,6 @@ describe("versionSkew", () => {
     expect(serverUpdateGuidance(null, "Local server")).toBe(
       "Relaunch the Local server with the copied command to sync them.",
     );
+    expect(clientUpdateGuidance()).toBe("Update this client so they stay in sync.");
   });
 });

--- a/apps/web/src/versionSkew.ts
+++ b/apps/web/src/versionSkew.ts
@@ -1,12 +1,17 @@
 import type { EnvironmentId, ServerConfig, ServerSelfUpdateCapability } from "@t3tools/contracts";
+import { compareSemverVersions } from "@t3tools/shared/semver";
 import * as Schema from "effect/Schema";
 
 import { APP_VERSION } from "./branding";
 import { getLocalStorageItem, setLocalStorageItem } from "./hooks/useLocalStorage";
 
+/** Which side of a version mismatch is behind, or unknown when ordering is inconclusive. */
+export type VersionOutdatedSide = "client" | "server" | "unknown";
+
 export interface VersionMismatch {
   readonly clientVersion: string;
   readonly serverVersion: string;
+  readonly outdatedSide: VersionOutdatedSide;
   readonly hint: string;
 }
 
@@ -23,6 +28,31 @@ function normalizeVersion(version: string | null | undefined): string | null {
   return trimmed && trimmed.length > 0 ? trimmed : null;
 }
 
+export function resolveVersionOutdatedSide(
+  clientVersion: string,
+  serverVersion: string,
+): VersionOutdatedSide {
+  const comparison = compareSemverVersions(clientVersion, serverVersion);
+  if (comparison < 0) {
+    return "client";
+  }
+  if (comparison > 0) {
+    return "server";
+  }
+  return "unknown";
+}
+
+function versionMismatchHint(outdatedSide: VersionOutdatedSide): string {
+  switch (outdatedSide) {
+    case "client":
+      return "Version mismatch. Update the client to the same T3 Code version as the server.";
+    case "server":
+      return "Version mismatch. Update the server to the same T3 Code version as the client.";
+    default:
+      return "Version mismatch. Try syncing the client and server to the same T3 Code version.";
+  }
+}
+
 export function resolveVersionMismatch(
   serverVersion: string | null | undefined,
 ): VersionMismatch | null {
@@ -36,10 +66,13 @@ export function resolveVersionMismatch(
     return null;
   }
 
+  const outdatedSide = resolveVersionOutdatedSide(normalizedClientVersion, normalizedServerVersion);
+
   return {
     clientVersion: normalizedClientVersion,
     serverVersion: normalizedServerVersion,
-    hint: "Version mismatch. Try syncing the client and server to the same T3 Code version.",
+    outdatedSide,
+    hint: versionMismatchHint(outdatedSide),
   };
 }
 
@@ -77,6 +110,11 @@ export function serverUpdateGuidance(
     default:
       return `Relaunch the ${serverLabel} with the copied command to sync them.`;
   }
+}
+
+/** One sentence telling the user to update this client when it is behind the server. */
+export function clientUpdateGuidance(): string {
+  return "Update this client so they stay in sync.";
 }
 
 export function buildVersionMismatchDismissalKey(

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -1,7 +1,8 @@
 # Keeping T3 Code in Sync
 
 The T3 Code web or desktop app and the server it connects to work best when they use the same
-version. If they do not match, T3 Code shows a warning with the right update option for that server.
+version. If they do not match, T3 Code shows a warning with the right update option for whichever
+side is behind.
 
 ## Where to Find the Update
 
@@ -11,25 +12,30 @@ You may see the warning in either of these places:
 - **Settings** → **Connections**, beside the affected connection
 
 Dismissing the conversation warning only hides that reminder for those two versions. It does not
-update the server, and the version difference remains visible in Connections.
+update either side, and the version difference remains visible in Connections.
 
 ## Before You Update
 
-Let active agent work and terminal commands finish first. Updating restarts the server, so the
-connection will disappear briefly and work that is still running may be interrupted.
+If the warning asks you to update the **server**, let active agent work and terminal commands finish
+first. Updating restarts the server, so the connection will disappear briefly and work that is still
+running may be interrupted.
+
+If the warning asks you to update this **client**, finish local work you care about before
+restarting the desktop app.
 
 The update does not remove saved threads, settings, or project files.
 
 ## Choose the Action You See
 
-| Action                     | What to do                                                                                                                                                                  |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Update server**          | Available for the T3 Code Linux background service. Select the button and leave T3 Code open while it prepares, tests, restarts, and reconnects.                            |
-| **Update the desktop app** | Open the T3 Code desktop app on the machine that runs the server and install the app update there. Reopen it if needed.                                                     |
-| **Copy update command**    | Copy the command, open a terminal on the server machine, stop the current T3 Code server, and relaunch it with the copied command and any startup options you normally use. |
+| Action                     | What to do                                                                                                                                                                            |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Update client**          | Shown when this app is older than the connected server. On the desktop app, select the button to check for, download, and install the newer client build.                             |
+| **Update server**          | Shown when the connected server is older than this client. Available for the T3 Code Linux background service. Leave T3 Code open while it prepares, tests, restarts, and reconnects. |
+| **Update the desktop app** | Shown for a server managed by a desktop app on another machine. Open T3 Code there and install the app update. Reopen it if needed.                                                   |
+| **Copy update command**    | Copy the command, open a terminal on the server machine, stop the current T3 Code server, and relaunch it with the copied command and any startup options you normally use.           |
 
-The available action depends on how that server was started. T3 Code does not update connected
-servers silently in the background.
+The available action depends on which side is behind and how that server was started. T3 Code does
+not update connected servers silently in the background.
 
 If the requested version includes a database update, remote installation stops before restart and
 asks you to run the exact `npx t3@<version> service update` command on the server machine. This is


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Fixes #5253
- Compare client/server versions with semver and expose `outdatedSide` from `resolveVersionMismatch`
- When the client is behind, show **Update client** and drive the desktop updater (`checkForUpdate` → `downloadUpdate` → `installUpdate`)
- When the server is behind, keep the existing **Update server** / copy-command paths
- Update `docs/user/updating.md` for the client-behind case

## Why

The version-drift UI treated the client as canonical and always offered a server update targeting the client version. When a newer server connected to an older macOS/desktop client, that CTA was inverted and could downgrade the server. Direction-aware skew fixes the CTA and routes client-behind cases through the existing Electron updater.

## UI Changes

### Before
Client behind server, but the banner still offers **Update server**:

![Before: Update server CTA](https://raw.githubusercontent.com/matheustimbo/t3code/pr-5254-media/version-skew-before.jpg)

### After
Same mismatch offers **Update client**, which drives the desktop updater:

![After: Update client CTA](https://raw.githubusercontent.com/matheustimbo/t3code/pr-5254-media/version-skew-after.jpg)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes _(N/A — no motion/interaction choreography)_

## Test plan

- [ ] `vp test run apps/web/src/versionSkew.test.ts`
- [ ] macOS desktop on an older nightly connected to a newer server: banner says update this client; **Update client** checks/downloads/installs
- [ ] Newer client connected to an older self-updating server: still shows **Update server**
- [ ] Web (non-Electron) client behind a server: guidance text only, no Update server button

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes version-mismatch CTAs and desktop update orchestration; fixes a prior path that could push server updates toward the client version when the client was actually behind.
> 
> **Overview**
> Version mismatch handling now compares client and server with semver and records **which side is behind** (`outdatedSide`), instead of always treating the client version as the update target.
> 
> When the **client** is older, the chat banner and **Connections** show **Update client** and `clientUpdateGuidance()` text. On Electron, the new `ClientUpdateAction` runs the desktop updater (check → download → install) with in-flight state kept outside React so dismiss/navigation does not cancel checks. Non-desktop clients get guidance only—no server update button.
> 
> When the **server** is older, behavior stays on **Update server** / copy-command paths. Server update progress and failure UI are hidden when the client is the outdated side. Reconnect banners no longer fold into “server restarting” messaging when skew is client-behind.
> 
> User docs in `docs/user/updating.md` describe client-behind vs server-behind actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caff1cec67529092742fb383da0fe53405c2f318. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show client update controls in chat banner and settings when client is behind the server
> - Adds a new `ClientUpdateAction` component ([ClientUpdateAction.tsx](https://github.com/pingdotgg/t3code/pull/5254/files#diff-ed4ad61a04edec2b136510784b2b827a5cf433f8b948b832de3a63f4b069333c)) that on Electron can check, download, and install updates with progress feedback via toasts; on non-Electron it renders static guidance text.
> - Extends `versionSkew.ts` with `resolveVersionOutdatedSide` and an `outdatedSide` field on `VersionMismatch`, so the UI can distinguish whether the client or server needs updating.
> - Updates the chat banner ([ChatView.tsx](https://github.com/pingdotgg/t3code/pull/5254/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)) and connections settings ([ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/5254/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9)) to show client-focused guidance and `ClientUpdateAction` when the client is behind, suppressing server update controls and progress in that case.
> - Reconnect-folding in the chat banner no longer applies when the version skew is due to an outdated client.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized caff1ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->