### PR TITLE
fix(codex): inherit environment for personal skills

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -1,10 +1,13 @@
 import * as NodeAssert from "node:assert/strict";
 
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import { describe } from "vite-plus/test";
 import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
+import { ChildProcessSpawner } from "effect/unstable/process";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 
@@ -18,6 +21,7 @@ import {
   buildTurnStartParams,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
+  makeCodexSessionRuntime,
   openCodexThread,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
@@ -37,6 +41,47 @@ describe("CodexSessionRuntimeIdentifierGenerationError", () => {
       "Failed to generate Codex App Server identifier for provider-event.",
     );
   });
+});
+
+it.layer(NodeServices.layer)("CodexSessionRuntime process environment", (it) => {
+  it.effect("inherits host variables when provider environment overrides are present", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let spawnedCommand: unknown;
+        const spawner = ChildProcessSpawner.make((command) => {
+          spawnedCommand = command;
+          return Effect.fail(
+            PlatformError.systemError({
+              _tag: "NotFound",
+              module: "ChildProcess",
+              method: "spawn",
+              description: "expected test spawn failure",
+            }),
+          );
+        });
+
+        yield* makeCodexSessionRuntime({
+          threadId: ThreadId.make("thread-1"),
+          binaryPath: "codex",
+          cwd: "/tmp/project",
+          runtimeMode: "full-access",
+          environment: { T3_TEST_OVERRIDE: "enabled" },
+        }).pipe(
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+          Effect.flip,
+        );
+
+        const command = spawnedCommand as {
+          readonly options?: {
+            readonly env?: NodeJS.ProcessEnv;
+            readonly extendEnv?: boolean;
+          };
+        };
+        NodeAssert.equal(command.options?.extendEnv, true);
+        NodeAssert.equal(command.options?.env?.T3_TEST_OVERRIDE, "enabled");
+      }),
+    ),
+  );
 });
 
 function makeThreadOpenResponse(

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -733,7 +733,10 @@ export const makeCodexSessionRuntime = (
       ...options.environment,
       ...(resolvedHomePath ? { CODEX_HOME: resolvedHomePath } : {}),
     };
-    const extendEnv = options.environment === undefined;
+    // Codex discovers personal skills from `$HOME/.agents/skills`. Provider
+    // environment overrides must not prevent the app-server from inheriting
+    // host variables such as HOME/USERPROFILE.
+    const extendEnv = true;
     const appServerArgs = codexSessionAppServerArgs(options.appServerArgs, options.launchArgs);
     const spawnCommand = yield* resolveSpawnCommand(options.binaryPath, appServerArgs, {
       env,


### PR DESCRIPTION
## What changed

- Always extend the host environment when spawning Codex app-server sessions.
- Preserve explicit provider environment overrides while inheriting host variables such as `HOME` and `USERPROFILE`.
- Add a spawn-boundary regression test for app-server sessions with provider environment overrides.

## Why

Codex discovers personal skills from `$HOME/.agents/skills`. T3 previously set `extendEnv: false` whenever a provider environment object was present, so a partial environment could remove the home-directory variables Codex needs and personal skills would not load.

This is a T3-side workaround for openai/codex#28505.

## Validation

- `vp test run apps/server/src/provider/Layers/CodexSessionRuntime.test.ts` (21 tests)
- `vp fmt --check` on both changed files
- `vp lint --report-unused-disable-directives` on both changed files
- `vp run --filter t3 typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `makeCodexSessionRuntime` to always inherit host environment when spawning Codex
> Previously, `extendEnv` was set to `true` only when no environment override was provided, causing the Codex child process to run in an isolated environment when overrides were present. [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/5257/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) now unconditionally sets `extendEnv=true` so host environment variables are always inherited alongside any provided overrides. Behavioral Change: Codex child processes now always inherit the full host environment, even when an explicit `env` override is passed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f1b3c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->