### PR TITLE
feat(web): edit and number chat annotations

### DIFF
--- a/apps/web/src/chatSelectionAnnotation.test.ts
+++ b/apps/web/src/chatSelectionAnnotation.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  appendChatSelectionAnnotationsToPrompt,
+  collectChatSelectionAnnotationsByMessageId,
+  countChatSelectionAnnotationsForMessage,
+  deriveChatSelectionIndicators,
+  formatChatSelectionAnnotation,
+  parseChatSelectionMessageSegments,
+  type ChatSelectionAnnotation,
+} from "./chatSelectionAnnotation";
+
+const annotation: ChatSelectionAnnotation = {
+  id: "selection-1",
+  selectedText: "Restart <the> adapter",
+  comment: "Why is this necessary?",
+};
+
+describe("chat selection annotations", () => {
+  it("round-trips selected text and comments without treating markup as tags", () => {
+    const prompt = appendChatSelectionAnnotationsToPrompt("Explain this", [annotation]);
+    const segments = parseChatSelectionMessageSegments(prompt);
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toEqual({
+      kind: "text",
+      id: "chat-selection-text:0",
+      text: "Explain this\n\n",
+    });
+    expect(segments[1]).toEqual({ kind: "selection", annotation });
+  });
+
+  it("supports multiple annotations", () => {
+    const second = {
+      ...annotation,
+      id: "selection-2",
+      comment: "Compare this",
+    };
+    const segments = parseChatSelectionMessageSegments(
+      appendChatSelectionAnnotationsToPrompt("", [annotation, second]),
+    );
+
+    expect(segments.filter((segment) => segment.kind === "selection")).toHaveLength(2);
+
+    expect(countChatSelectionAnnotationsForMessage([annotation, second], "selection-message")).toBe(
+      0,
+    );
+    expect(
+      countChatSelectionAnnotationsForMessage(
+        [{ ...annotation, messageId: "selection-message" }, second],
+        "selection-message",
+      ),
+    ).toBe(1);
+  });
+
+  it("does not emit a block for an empty annotation list", () => {
+    expect(appendChatSelectionAnnotationsToPrompt("Keep this", [])).toBe("Keep this");
+    expect(formatChatSelectionAnnotation(annotation)).toContain("<selected_text>");
+  });
+
+  it("persists the source message id in the sent prompt", () => {
+    const sourceAnnotation = {
+      ...annotation,
+      messageId: "assistant-1",
+      sourceStart: 42,
+      sourceEnd: 63,
+    };
+    const prompt = appendChatSelectionAnnotationsToPrompt("Explain this", [sourceAnnotation]);
+    const segments = parseChatSelectionMessageSegments(prompt);
+
+    expect(segments[1]).toEqual({ kind: "selection", annotation: sourceAnnotation });
+    expect(prompt).toContain('message_id="assistant-1"');
+    expect(prompt).toContain('source_start="42" source_end="63"');
+  });
+
+  it("groups pending annotations by source message", () => {
+    const pending = { ...annotation, messageId: "assistant-1" };
+    const byMessageId = collectChatSelectionAnnotationsByMessageId([pending]);
+
+    expect(byMessageId.get("assistant-1")).toEqual([pending]);
+    expect(deriveChatSelectionIndicators([pending])).toEqual([
+      {
+        id: pending.id,
+        kind: "text-comment",
+        number: 1,
+        annotation: pending,
+      },
+    ]);
+  });
+
+  it("creates one numbered indicator for every annotation in source order", () => {
+    const second = { ...annotation, id: "selection-2", comment: "" };
+
+    expect(deriveChatSelectionIndicators([annotation, second])).toEqual([
+      {
+        id: annotation.id,
+        kind: "text-comment",
+        number: 1,
+        annotation,
+      },
+      {
+        id: second.id,
+        kind: "text-selection",
+        number: 2,
+        annotation: second,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/chatSelectionAnnotation.ts
+++ b/apps/web/src/chatSelectionAnnotation.ts
@@ -1,0 +1,1 @@
+export * from "@t3tools/shared/chatSelectionAnnotation";

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -21,6 +21,7 @@ import React, {
   Suspense,
   type ClipboardEvent as ReactClipboardEvent,
   type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
   isValidElement,
   use,
   useCallback,
@@ -39,6 +40,17 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { renderSkillInlineMarkdownChildren } from "./chat/SkillInlineText";
+import {
+  ChatTextSelectionPopover,
+  type ChatTextSelectionPopoverProps,
+} from "./chat/ChatTextSelectionPopover";
+import { ChatSelectionAnnotationEditor } from "./chat/ChatSelectionAnnotationEditor";
+import { AssistantMessageIndicators } from "./chat/AssistantMessageIndicators";
+import {
+  deriveChatSelectionIndicators,
+  type ChatSelectionAnnotation,
+  type ChatSelectionIndicator,
+} from "../chatSelectionAnnotation";
 import { CHAT_FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 import {
@@ -102,9 +114,342 @@ interface ChatMarkdownProps {
   className?: string;
   /** Treat single newlines as hard breaks — chat-style user input. */
   lineBreaks?: boolean;
+  /** Enables the answer-selection actions used by assistant messages. */
+  onTextSelection?:
+    | ((input: {
+        selectedText: string;
+        comment: string;
+        sourceStart?: number;
+        sourceEnd?: number;
+      }) => void)
+    | undefined;
+  annotations?: ReadonlyArray<ChatSelectionAnnotation>;
+  editableAnnotationIds?: ReadonlySet<string>;
+  onUpdateAnnotation?: ((annotationId: string, comment: string) => void) | undefined;
+  onRemoveAnnotation?: ((annotationId: string) => void) | undefined;
 }
 
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const EMPTY_CHAT_SELECTION_ANNOTATIONS: ReadonlyArray<ChatSelectionAnnotation> = [];
+
+interface ChatMarkdownHighlightRect {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+interface ChatMarkdownIndicatorPlacement {
+  readonly indicator: ChatSelectionIndicator;
+  readonly top: number;
+}
+
+interface ChatMarkdownTextNodeEntry {
+  readonly node: Text;
+  readonly start: number;
+  readonly end: number;
+}
+
+interface ChatMarkdownTextIndex {
+  readonly text: string;
+  readonly nodes: ReadonlyArray<ChatMarkdownTextNodeEntry>;
+}
+
+function readChatMarkdownTextRects(
+  root: HTMLElement,
+  selectionRect: { top: number; left: number; width: number; height: number },
+): ReadonlyArray<{ top: number; left: number; width: number; height: number }> {
+  const rects: Array<{
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  }> = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let current = walker.nextNode();
+  while (current instanceof Text) {
+    const parentRect = current.parentElement?.getBoundingClientRect();
+    const isNearSelection =
+      parentRect &&
+      parentRect.bottom >= selectionRect.top - 80 &&
+      parentRect.top <= selectionRect.top + selectionRect.height + 80;
+    if (current.data.trim().length > 0 && isNearSelection) {
+      const range = document.createRange();
+      range.selectNodeContents(current);
+      for (const rect of range.getClientRects()) {
+        if (rect.width > 0 && rect.height > 0) {
+          rects.push({
+            top: rect.top,
+            left: rect.left,
+            width: rect.width,
+            height: rect.height,
+          });
+        }
+      }
+    }
+    current = walker.nextNode();
+  }
+  return rects;
+}
+
+const CHAT_MARKDOWN_BLOCK_TAGS = new Set([
+  "blockquote",
+  "dd",
+  "div",
+  "dl",
+  "dt",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "li",
+  "ol",
+  "p",
+  "pre",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "tr",
+  "ul",
+]);
+
+function nearestChatMarkdownBlock(node: Text, root: HTMLElement): Element {
+  let current = node.parentElement;
+  while (current && current !== root) {
+    if (CHAT_MARKDOWN_BLOCK_TAGS.has(current.tagName.toLowerCase())) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return root;
+}
+
+function buildChatMarkdownTextIndex(root: HTMLElement): ChatMarkdownTextIndex {
+  const nodes: ChatMarkdownTextNodeEntry[] = [];
+  let text = "";
+  let previousBlock: Element | null = null;
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let current = walker.nextNode();
+
+  while (current instanceof Text) {
+    if (current.data.length > 0) {
+      const block = nearestChatMarkdownBlock(current, root);
+      if (previousBlock && block !== previousBlock) {
+        text += "\n";
+      }
+      const start = text.length;
+      text += current.data;
+      nodes.push({ node: current, start, end: text.length });
+      previousBlock = block;
+    }
+    current = walker.nextNode();
+  }
+
+  return { text, nodes };
+}
+
+function findChatMarkdownBoundaryOffset(
+  index: ChatMarkdownTextIndex,
+  container: Node,
+  offset: number,
+): number | null {
+  if (container instanceof Text) {
+    const entry = index.nodes.find((candidate) => candidate.node === container);
+    return entry ? entry.start + Math.max(0, Math.min(offset, container.data.length)) : null;
+  }
+  if (!(container instanceof Element)) return null;
+
+  const descendants = (candidate: Node) =>
+    index.nodes.filter(
+      (entry) =>
+        candidate === entry.node ||
+        (candidate instanceof Element && candidate.contains(entry.node)),
+    );
+  const child = container.childNodes[offset];
+  if (child) {
+    return descendants(child)[0]?.start ?? null;
+  }
+  const entries = descendants(container);
+  return entries.at(-1)?.end ?? null;
+}
+
+function readChatMarkdownSelectionSourceOffsets(
+  root: HTMLElement,
+  range: Range,
+  selectedText: string,
+): { sourceStart: number; sourceEnd: number } | undefined {
+  const index = buildChatMarkdownTextIndex(root);
+  const rawStart = findChatMarkdownBoundaryOffset(index, range.startContainer, range.startOffset);
+  const rawEnd = findChatMarkdownBoundaryOffset(index, range.endContainer, range.endOffset);
+  if (rawStart === null || rawEnd === null || rawEnd <= rawStart) return undefined;
+
+  const sourceStart = Math.min(rawStart, rawEnd);
+  const sourceEnd = Math.max(rawStart, rawEnd);
+  const rawSelectedText = index.text.slice(sourceStart, sourceEnd);
+  const leadingWhitespace = rawSelectedText.length - rawSelectedText.trimStart().length;
+  const trailingWhitespace = rawSelectedText.length - rawSelectedText.trimEnd().length;
+  const trimmedStart = sourceStart + leadingWhitespace;
+  const trimmedEnd = Math.max(trimmedStart, sourceEnd - trailingWhitespace);
+  const sourceSelection = index.text.slice(trimmedStart, trimmedEnd);
+  if (
+    sourceSelection.trim() !== selectedText.trim() &&
+    normalizeChatMarkdownSearchText(sourceSelection) !==
+      normalizeChatMarkdownSearchText(selectedText)
+  ) {
+    return undefined;
+  }
+  return { sourceStart: trimmedStart, sourceEnd: trimmedEnd };
+}
+
+function normalizeChatMarkdownSearchText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function findChatMarkdownTextMatch(
+  source: string,
+  target: string,
+): { start: number; end: number } | null {
+  const trimmedTarget = target.trim();
+  if (trimmedTarget.length === 0) return null;
+
+  const exactStart = source.indexOf(trimmedTarget);
+  if (exactStart >= 0) {
+    return { start: exactStart, end: exactStart + trimmedTarget.length };
+  }
+
+  const normalizedSource = normalizeChatMarkdownSearchText(source);
+  const normalizedTarget = normalizeChatMarkdownSearchText(trimmedTarget);
+  const normalizedStart = normalizedSource.indexOf(normalizedTarget);
+  if (normalizedStart < 0) return null;
+
+  let sourceIndex = 0;
+  let normalizedIndex = 0;
+  let matchStart = -1;
+  let matchEnd = -1;
+  while (
+    sourceIndex < source.length &&
+    normalizedIndex < normalizedStart + normalizedTarget.length
+  ) {
+    const character = source[sourceIndex]!;
+    if (/\s/.test(character)) {
+      if (normalizedIndex > 0 && normalizedSource[normalizedIndex - 1] !== " ") {
+        if (normalizedIndex === normalizedStart) matchStart = sourceIndex;
+        normalizedIndex += 1;
+        if (normalizedIndex === normalizedStart + normalizedTarget.length) {
+          matchEnd = sourceIndex + 1;
+        }
+      }
+    } else {
+      if (normalizedIndex === normalizedStart) matchStart = sourceIndex;
+      normalizedIndex += 1;
+      if (normalizedIndex === normalizedStart + normalizedTarget.length) {
+        matchEnd = sourceIndex + 1;
+      }
+    }
+    sourceIndex += 1;
+  }
+
+  return matchStart >= 0 && matchEnd > matchStart ? { start: matchStart, end: matchEnd } : null;
+}
+
+function resolveChatMarkdownTextRange(
+  root: HTMLElement,
+  target: string,
+  sourceStart?: number,
+  sourceEnd?: number,
+  index: ChatMarkdownTextIndex = buildChatMarkdownTextIndex(root),
+): Range | null {
+  const validSourceStart = sourceStart;
+  const validSourceEnd = sourceEnd;
+  const hasSourceOffsets =
+    typeof validSourceStart === "number" &&
+    typeof validSourceEnd === "number" &&
+    Number.isSafeInteger(validSourceStart) &&
+    Number.isSafeInteger(validSourceEnd) &&
+    validSourceStart >= 0 &&
+    validSourceEnd > validSourceStart &&
+    validSourceEnd <= index.text.length;
+  const offsetMatch = hasSourceOffsets
+    ? index.text.slice(validSourceStart, validSourceEnd).trim() === target.trim() ||
+      normalizeChatMarkdownSearchText(index.text.slice(validSourceStart, validSourceEnd)) ===
+        normalizeChatMarkdownSearchText(target)
+      ? { start: validSourceStart, end: validSourceEnd }
+      : null
+    : null;
+  const match = offsetMatch ?? findChatMarkdownTextMatch(index.text, target);
+  if (!match) return null;
+  const matchStart = match.start;
+  const matchEnd = match.end;
+  if (matchStart === undefined || matchEnd === undefined) return null;
+
+  const startNode = index.nodes.find(
+    (entry) => matchStart >= entry.start && matchStart < entry.end,
+  );
+  const endNode = index.nodes.find((entry) => matchEnd > entry.start && matchEnd <= entry.end);
+  if (!startNode || !endNode) return null;
+
+  const range = document.createRange();
+  range.setStart(startNode.node, matchStart - startNode.start);
+  range.setEnd(endNode.node, matchEnd - endNode.start);
+  return range;
+}
+
+function resolveChatMarkdownHighlightRects(
+  root: HTMLElement,
+  annotation: ChatSelectionAnnotation,
+  index: ChatMarkdownTextIndex,
+): ReadonlyArray<ChatMarkdownHighlightRect> {
+  const range = resolveChatMarkdownTextRange(
+    root,
+    annotation.selectedText,
+    annotation.sourceStart,
+    annotation.sourceEnd,
+    index,
+  );
+  if (!range) return [];
+
+  const rootRect = root.getBoundingClientRect();
+  return Array.from(range.getClientRects())
+    .filter((rect) => rect.width > 0 && rect.height > 0)
+    .map((rect) => ({
+      left: rect.left - rootRect.left + root.scrollLeft,
+      top: rect.top - rootRect.top + root.scrollTop,
+      width: rect.width,
+      height: rect.height,
+    }));
+}
+
+function resolveChatMarkdownIndicatorPlacements(
+  root: HTMLElement,
+  indicators: ReadonlyArray<ChatSelectionIndicator>,
+  index: ChatMarkdownTextIndex,
+): ReadonlyArray<ChatMarkdownIndicatorPlacement> {
+  const rootRect = root.getBoundingClientRect();
+  const placements: ChatMarkdownIndicatorPlacement[] = [];
+  for (const indicator of indicators) {
+    const range = resolveChatMarkdownTextRange(
+      root,
+      indicator.annotation.selectedText,
+      indicator.annotation.sourceStart,
+      indicator.annotation.sourceEnd,
+      index,
+    );
+    const rects = range ? Array.from(range.getClientRects()) : [];
+    const firstRect = rects[0];
+    if (!firstRect) continue;
+    let top = firstRect.top - rootRect.top + root.scrollTop + firstRect.height / 2;
+    while (placements.some((placement) => Math.abs(placement.top - top) < 28)) {
+      top += 28;
+    }
+    placements.push({ indicator, top });
+  }
+  return placements;
+}
 
 const CODE_FENCE_LANGUAGE_REGEX = /(?:^|\s)language-([^\s]+)/;
 const MAX_HIGHLIGHT_CACHE_ENTRIES = 500;
@@ -286,9 +631,11 @@ function extractCodeBlock(
 
   const onlyChild = childNodes[0];
   if (
-    !isValidElement<{ className?: string; children?: ReactNode; node?: { tagName?: string } }>(
-      onlyChild,
-    )
+    !isValidElement<{
+      className?: string;
+      children?: ReactNode;
+      node?: { tagName?: string };
+    }>(onlyChild)
   ) {
     return null;
   }
@@ -1133,7 +1480,11 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         },
         (error) => {
           reportMarkdownActionFailure(
-            { operation: "copy-file-path", target: targetPath, copyTarget: title },
+            {
+              operation: "copy-file-path",
+              target: targetPath,
+              copyTarget: title,
+            },
             error,
           );
           toastManager.add(
@@ -1162,7 +1513,12 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
           [
             { id: "open", label: "Open in editor" },
             ...(onOpenInBrowser
-              ? ([{ id: "open-in-browser", label: "Open in integrated browser" }] as const)
+              ? ([
+                  {
+                    id: "open-in-browser",
+                    label: "Open in integrated browser",
+                  },
+                ] as const)
               : []),
             { id: "copy-relative", label: "Copy relative path" },
             { id: "copy-full", label: "Copy full path" },
@@ -1260,7 +1616,34 @@ function ChatMarkdown({
   skills = EMPTY_MARKDOWN_SKILLS,
   className,
   lineBreaks = false,
+  onTextSelection,
+  annotations = EMPTY_CHAT_SELECTION_ANNOTATIONS,
+  editableAnnotationIds,
+  onUpdateAnnotation,
+  onRemoveAnnotation,
 }: ChatMarkdownProps) {
+  const markdownRootRef = useRef<HTMLDivElement | null>(null);
+  const selectionPointerControllerRef = useRef<AbortController | null>(null);
+  const [selectionPopover, setSelectionPopover] = useState<
+    | (Pick<ChatTextSelectionPopoverProps, "text" | "rect" | "avoidRects"> & {
+        sourceStart?: number;
+        sourceEnd?: number;
+      })
+    | null
+  >(null);
+  const [highlightRects, setHighlightRects] = useState<ReadonlyArray<ChatMarkdownHighlightRect>>(
+    [],
+  );
+  const [indicatorPlacements, setIndicatorPlacements] = useState<
+    ReadonlyArray<ChatMarkdownIndicatorPlacement>
+  >([]);
+  const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
+  const [editorAnchorRect, setEditorAnchorRect] = useState<
+    ChatTextSelectionPopoverProps["rect"] | null
+  >(null);
+  const indicators = useMemo(() => deriveChatSelectionIndicators(annotations), [annotations]);
+  const activeAnnotation =
+    annotations.find((annotation) => annotation.id === activeAnnotationId) ?? null;
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
     reportFailure: false,
@@ -1443,7 +1826,10 @@ function ChatMarkdown({
                 event.currentTarget.closest("li")?.dataset.taskMarkerOffset,
               );
               if (!Number.isSafeInteger(markerOffset)) return;
-              onTaskListChange({ markerOffset, checked: event.currentTarget.checked });
+              onTaskListChange({
+                markerOffset,
+                checked: event.currentTarget.checked,
+              });
             }}
           />
         );
@@ -1594,13 +1980,191 @@ function ChatMarkdown({
     threadRef,
   ]);
 
+  const readTextSelection = useCallback(() => {
+    if (!onTextSelection) return;
+    const root = markdownRootRef.current;
+    const selection = window.getSelection();
+    if (!root || !selection || selection.isCollapsed || selection.rangeCount === 0) {
+      setSelectionPopover(null);
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    if (!root.contains(range.commonAncestorContainer)) {
+      setSelectionPopover(null);
+      return;
+    }
+    const selectedText = selection.toString().trim();
+    const rect = range.getBoundingClientRect();
+    if (selectedText.length === 0 || (rect.width === 0 && rect.height === 0)) {
+      setSelectionPopover(null);
+      return;
+    }
+    const selectionRect = {
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+    };
+    const sourceOffsets = readChatMarkdownSelectionSourceOffsets(root, range, selectedText);
+    setSelectionPopover({
+      text: selectedText,
+      rect: selectionRect,
+      avoidRects: readChatMarkdownTextRects(root, selectionRect),
+      ...(sourceOffsets
+        ? {
+            sourceStart: sourceOffsets.sourceStart,
+            sourceEnd: sourceOffsets.sourceEnd,
+          }
+        : {}),
+    });
+  }, [onTextSelection]);
+  const selectionActionsEnabled = onTextSelection !== undefined;
+  const scheduleReadTextSelection = useCallback(() => {
+    window.requestAnimationFrame(readTextSelection);
+  }, [readTextSelection]);
+  const handleSelectionPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      selectionPointerControllerRef.current?.abort();
+      const controller = new AbortController();
+      const pointerId = event.pointerId;
+      selectionPointerControllerRef.current = controller;
+      const options = { signal: controller.signal };
+      window.addEventListener(
+        "pointerup",
+        (pointerEvent) => {
+          if (pointerEvent.pointerId !== pointerId) return;
+          controller.abort();
+          scheduleReadTextSelection();
+        },
+        options,
+      );
+      window.addEventListener(
+        "pointercancel",
+        (pointerEvent) => {
+          if (pointerEvent.pointerId === pointerId) controller.abort();
+        },
+        options,
+      );
+    },
+    [scheduleReadTextSelection],
+  );
+
+  useEffect(() => () => selectionPointerControllerRef.current?.abort(), []);
+
+  useEffect(() => {
+    if (!selectionPopover) return;
+    const closeOnOutsidePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && markdownRootRef.current?.contains(target)) return;
+      if (target instanceof Element && target.closest("[data-chat-selection-popover]")) return;
+      setSelectionPopover(null);
+    };
+    document.addEventListener("pointerdown", closeOnOutsidePointerDown, true);
+    return () => document.removeEventListener("pointerdown", closeOnOutsidePointerDown, true);
+  }, [selectionPopover]);
+
+  useEffect(() => {
+    setSelectionPopover(null);
+  }, [text]);
+
+  useEffect(() => {
+    if (activeAnnotationId && !activeAnnotation) {
+      setActiveAnnotationId(null);
+      setEditorAnchorRect(null);
+    }
+  }, [activeAnnotation, activeAnnotationId]);
+
+  useEffect(() => {
+    if (!activeAnnotation?.selectedText.trim()) return;
+    const root = markdownRootRef.current;
+    if (!root) return;
+    const range = resolveChatMarkdownTextRange(
+      root,
+      activeAnnotation.selectedText,
+      activeAnnotation.sourceStart,
+      activeAnnotation.sourceEnd,
+    );
+    range?.startContainer.parentElement?.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [activeAnnotation, text]);
+
+  useEffect(() => {
+    const root = markdownRootRef.current;
+    if (!root || indicators.length === 0) {
+      setHighlightRects((current) => (current.length === 0 ? current : []));
+      setIndicatorPlacements((current) => (current.length === 0 ? current : []));
+      return;
+    }
+
+    let frame: number | null = null;
+    const update = () => {
+      frame = null;
+      const textIndex = buildChatMarkdownTextIndex(root);
+      const nextHighlightRects = activeAnnotation
+        ? resolveChatMarkdownHighlightRects(root, activeAnnotation, textIndex)
+        : [];
+      const nextIndicatorPlacements = resolveChatMarkdownIndicatorPlacements(
+        root,
+        indicators,
+        textIndex,
+      );
+      setHighlightRects((current) =>
+        current.length === nextHighlightRects.length &&
+        current.every((rect, index) => {
+          const next = nextHighlightRects[index];
+          return (
+            next !== undefined &&
+            rect.left === next.left &&
+            rect.top === next.top &&
+            rect.width === next.width &&
+            rect.height === next.height
+          );
+        })
+          ? current
+          : nextHighlightRects,
+      );
+      setIndicatorPlacements((current) =>
+        current.length === nextIndicatorPlacements.length &&
+        current.every((placement, index) => {
+          const next = nextIndicatorPlacements[index];
+          return (
+            next !== undefined &&
+            placement.indicator.id === next.indicator.id &&
+            placement.top === next.top
+          );
+        })
+          ? current
+          : nextIndicatorPlacements,
+      );
+    };
+    const scheduleUpdate = () => {
+      if (frame === null) frame = window.requestAnimationFrame(update);
+    };
+    scheduleUpdate();
+    const observer = new ResizeObserver(scheduleUpdate);
+    observer.observe(root);
+    window.addEventListener("resize", scheduleUpdate);
+    return () => {
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+    };
+  }, [activeAnnotation, indicators, text]);
+
   return (
     <div
+      ref={markdownRootRef}
+      data-chat-selection-annotation-count={annotations.length || undefined}
       className={cn(
-        "chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80",
+        "chat-markdown relative w-full min-w-0 text-sm leading-relaxed text-foreground/80",
+        annotations.length > 0 && "pr-8",
         className,
       )}
       onCopy={handleCopy}
+      onPointerDown={selectionActionsEnabled ? handleSelectionPointerDown : undefined}
+      onKeyUp={selectionActionsEnabled ? scheduleReadTextSelection : undefined}
     >
       <ReactMarkdown
         remarkPlugins={
@@ -1612,6 +2176,75 @@ function ChatMarkdown({
       >
         {text}
       </ReactMarkdown>
+      {highlightRects.length > 0 ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 z-10 overflow-visible"
+          data-chat-selection-highlight-layer
+        >
+          {highlightRects.map((rect) => (
+            <span
+              className="absolute rounded-sm bg-amber-300/35 ring-1 ring-amber-200/60"
+              key={`${rect.left}:${rect.top}:${rect.width}:${rect.height}`}
+              style={rect}
+            />
+          ))}
+        </div>
+      ) : null}
+      <AssistantMessageIndicators
+        placements={indicatorPlacements}
+        activeIndicatorId={activeAnnotationId}
+        onSelect={(indicator, anchorRect) => {
+          setActiveAnnotationId(indicator.id);
+          setEditorAnchorRect(
+            editableAnnotationIds?.has(indicator.id)
+              ? {
+                  top: anchorRect.top,
+                  left: anchorRect.left,
+                  width: anchorRect.width,
+                  height: anchorRect.height,
+                }
+              : null,
+          );
+        }}
+      />
+      {selectionPopover ? (
+        <ChatTextSelectionPopover
+          text={selectionPopover.text}
+          rect={selectionPopover.rect}
+          avoidRects={selectionPopover.avoidRects}
+          onAddAnnotation={(comment) => {
+            onTextSelection?.({
+              selectedText: selectionPopover.text,
+              comment,
+              ...(selectionPopover.sourceStart !== undefined
+                ? { sourceStart: selectionPopover.sourceStart }
+                : {}),
+              ...(selectionPopover.sourceEnd !== undefined
+                ? { sourceEnd: selectionPopover.sourceEnd }
+                : {}),
+            });
+            setSelectionPopover(null);
+          }}
+          onClose={() => setSelectionPopover(null)}
+        />
+      ) : null}
+      {activeAnnotation && editorAnchorRect && onUpdateAnnotation && onRemoveAnnotation ? (
+        <ChatSelectionAnnotationEditor
+          annotation={activeAnnotation}
+          anchorRect={editorAnchorRect}
+          onCancel={() => setEditorAnchorRect(null)}
+          onDelete={() => {
+            onRemoveAnnotation(activeAnnotation.id);
+            setEditorAnchorRect(null);
+            setActiveAnnotationId(null);
+          }}
+          onSave={(comment) => {
+            onUpdateAnnotation(activeAnnotation.id, comment);
+            setEditorAnchorRect(null);
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -28,8 +28,32 @@ import {
   resolveSendEnvMode,
   startNewThreadForProject,
   shouldShowBranchMismatchBanner,
+  shouldRestoreClearedPlanFollowUpDraft,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
+
+describe("shouldRestoreClearedPlanFollowUpDraft", () => {
+  it("restores only while the cleared prompt and annotations remain untouched", () => {
+    expect(
+      shouldRestoreClearedPlanFollowUpDraft({
+        currentPrompt: "",
+        currentChatSelectionAnnotationCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRestoreClearedPlanFollowUpDraft({
+        currentPrompt: "new draft",
+        currentChatSelectionAnnotationCount: 0,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRestoreClearedPlanFollowUpDraft({
+        currentPrompt: "",
+        currentChatSelectionAnnotationCount: 1,
+      }),
+    ).toBe(false);
+  });
+});
 
 const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -28,6 +28,13 @@ export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 
+export function shouldRestoreClearedPlanFollowUpDraft(input: {
+  readonly currentPrompt: string;
+  readonly currentChatSelectionAnnotationCount: number;
+}): boolean {
+  return input.currentPrompt.length === 0 && input.currentChatSelectionAnnotationCount === 0;
+}
+
 export function startNewThreadForProject(
   projectRef: ScopedProjectRef | null,
   handleNewThread: (projectRef: ScopedProjectRef) => Promise<void>,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -152,7 +152,7 @@ import {
   TriangleAlertIcon,
   WifiOffIcon,
 } from "lucide-react";
-import { cn, randomHex } from "~/lib/utils";
+import { cn, randomHex, randomUUID } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
@@ -196,6 +196,10 @@ import {
 } from "../lib/elementContext";
 import { appendPreviewAnnotationPrompt } from "../lib/previewAnnotation";
 import { appendReviewCommentsToPrompt, type ReviewCommentContext } from "../reviewCommentContext";
+import {
+  appendChatSelectionAnnotationsToPrompt,
+  type ChatSelectionAnnotation,
+} from "../chatSelectionAnnotation";
 import { environmentCatalog } from "../connection/catalog";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
@@ -274,6 +278,7 @@ import {
   resolveSendEnvMode,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
+  shouldRestoreClearedPlanFollowUpDraft,
   shouldWriteThreadErrorToCurrentServerThread,
   startNewThreadForProject,
   waitForStartedServerThread,
@@ -309,6 +314,7 @@ import { useAssetUrls } from "../assets/assetUrls";
 
 const IMAGE_ONLY_BOOTSTRAP_PROMPT =
   "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
+const EMPTY_CHAT_SELECTION_ANNOTATIONS: ReadonlyArray<ChatSelectionAnnotation> = [];
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_PROVIDERS: ServerProvider[] = [];
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
@@ -1242,6 +1248,11 @@ function ChatViewContent(props: ChatViewProps) {
   const composerInteractionMode = useComposerDraftStore(
     (store) => store.getComposerDraft(composerDraftTarget)?.interactionMode ?? null,
   );
+  const composerChatSelectionAnnotations = useComposerDraftStore(
+    (store) =>
+      store.getComposerDraft(composerDraftTarget)?.chatSelectionAnnotations ??
+      EMPTY_CHAT_SELECTION_ANNOTATIONS,
+  );
   const composerActiveProvider = useComposerDraftStore(
     (store) => store.getComposerDraft(composerDraftTarget)?.activeProvider ?? null,
   );
@@ -1257,6 +1268,15 @@ function ChatViewContent(props: ChatViewProps) {
     (store) => store.setPreviewAnnotations,
   );
   const setComposerDraftReviewComments = useComposerDraftStore((store) => store.setReviewComments);
+  const addComposerDraftChatSelectionAnnotation = useComposerDraftStore(
+    (store) => store.addChatSelectionAnnotation,
+  );
+  const removeComposerDraftChatSelectionAnnotation = useComposerDraftStore(
+    (store) => store.removeChatSelectionAnnotation,
+  );
+  const setComposerDraftChatSelectionAnnotations = useComposerDraftStore(
+    (store) => store.setChatSelectionAnnotations,
+  );
   const setComposerDraftModelSelection = useComposerDraftStore((store) => store.setModelSelection);
   const setComposerDraftRuntimeMode = useComposerDraftStore((store) => store.setRuntimeMode);
   const setComposerDraftInteractionMode = useComposerDraftStore(
@@ -2626,6 +2646,39 @@ function ChatViewContent(props: ChatViewProps) {
       composerRef.current?.addTerminalContext(selection);
     },
     [composerRef],
+  );
+  const addChatSelectionAnnotation = useCallback(
+    (input: Omit<ChatSelectionAnnotation, "id">) => {
+      addComposerDraftChatSelectionAnnotation(composerDraftTarget, {
+        id: randomUUID(),
+        ...input,
+      });
+      scheduleComposerFocus();
+    },
+    [addComposerDraftChatSelectionAnnotation, composerDraftTarget, scheduleComposerFocus],
+  );
+  const updateChatSelectionAnnotation = useCallback(
+    (annotationId: string, comment: string) => {
+      const annotation = composerChatSelectionAnnotations.find(
+        (candidate) => candidate.id === annotationId,
+      );
+      if (!annotation) return;
+      addComposerDraftChatSelectionAnnotation(composerDraftTarget, {
+        ...annotation,
+        comment,
+      });
+    },
+    [
+      addComposerDraftChatSelectionAnnotation,
+      composerChatSelectionAnnotations,
+      composerDraftTarget,
+    ],
+  );
+  const removeChatSelectionAnnotation = useCallback(
+    (annotationId: string) => {
+      removeComposerDraftChatSelectionAnnotation(composerDraftTarget, annotationId);
+    },
+    [composerDraftTarget, removeComposerDraftChatSelectionAnnotation],
   );
   const setTerminalOpen = useCallback(
     (open: boolean) => {
@@ -4075,7 +4128,8 @@ function ChatViewContent(props: ChatViewProps) {
         draft.terminalContexts.length > 0 ||
         draft.elementContexts.length > 0 ||
         draft.previewAnnotations.length > 0 ||
-        draft.reviewComments.length > 0),
+        draft.reviewComments.length > 0 ||
+        draft.chatSelectionAnnotations.length > 0),
     );
   });
   const activeBranchMismatchKey = branchMismatchKey(
@@ -4579,6 +4633,7 @@ function ChatViewContent(props: ChatViewProps) {
       elementContexts: composerElementContexts,
       previewAnnotations: composerPreviewAnnotations,
       reviewComments: composerReviewComments,
+      chatSelectionAnnotations: composerChatSelectionAnnotations,
       selectedProvider: ctxSelectedProvider,
       selectedModel: ctxSelectedModel,
       selectedProviderModels: ctxSelectedProviderModels,
@@ -4598,19 +4653,21 @@ function ChatViewContent(props: ChatViewProps) {
       elementContextCount:
         composerElementContexts.length +
         composerPreviewAnnotations.length +
-        composerReviewComments.length,
+        composerReviewComments.length +
+        composerChatSelectionAnnotations.length,
     });
     if (showPlanFollowUpPrompt && activeProposedPlan) {
       const followUp = resolvePlanFollowUpSubmission({
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
       });
-      promptRef.current = "";
-      clearComposerDraftContent(composerDraftTarget);
-      composerRef.current?.resetCursorState();
+      const composerChatSelectionAnnotationsSnapshot: ChatSelectionAnnotation[] = [
+        ...composerChatSelectionAnnotations,
+      ];
       await onSubmitPlanFollowUp({
         text: followUp.text,
         interactionMode: followUp.interactionMode,
+        chatSelectionAnnotations: composerChatSelectionAnnotationsSnapshot,
       });
       return;
     }
@@ -4619,7 +4676,8 @@ function ChatViewContent(props: ChatViewProps) {
       sendableComposerTerminalContexts.length === 0 &&
       composerElementContexts.length === 0 &&
       composerPreviewAnnotations.length === 0 &&
-      composerReviewComments.length === 0
+      composerReviewComments.length === 0 &&
+      composerChatSelectionAnnotations.length === 0
         ? parseStandaloneComposerSlashCommand(trimmed)
         : null;
     if (standaloneSlashCommand) {
@@ -4694,8 +4752,18 @@ function ChatViewContent(props: ChatViewProps) {
     const composerElementContextsSnapshot = [...composerElementContexts];
     const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
     const composerReviewCommentsSnapshot: ReviewCommentContext[] = [...composerReviewComments];
+    const composerChatSelectionAnnotationsSnapshot: ChatSelectionAnnotation[] = [
+      ...composerChatSelectionAnnotations,
+    ];
+    const messageTextWithSelectionAnnotations = appendChatSelectionAnnotationsToPrompt(
+      promptForSend,
+      composerChatSelectionAnnotationsSnapshot,
+    );
     const messageTextWithContexts = appendElementContextsToPrompt(
-      appendTerminalContextsToPrompt(promptForSend, composerTerminalContextsSnapshot),
+      appendTerminalContextsToPrompt(
+        messageTextWithSelectionAnnotations,
+        composerTerminalContextsSnapshot,
+      ),
       composerElementContextsSnapshot,
     );
     const messageTextWithPreviewAnnotations = composerPreviewAnnotationsSnapshot.reduce(
@@ -4792,6 +4860,9 @@ function ChatViewContent(props: ChatViewProps) {
         titleSeed = formatTerminalContextLabel(composerTerminalContextsSnapshot[0]!);
       } else if (composerElementContextsSnapshot.length > 0) {
         titleSeed = formatElementContextLabel(composerElementContextsSnapshot[0]!);
+      } else if (composerChatSelectionAnnotationsSnapshot.length > 0) {
+        const firstAnnotation = composerChatSelectionAnnotationsSnapshot[0]!;
+        titleSeed = firstAnnotation.comment.trim() || firstAnnotation.selectedText;
       } else {
         titleSeed = "New thread";
       }
@@ -4906,7 +4977,9 @@ function ChatViewContent(props: ChatViewProps) {
         (useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)?.previewAnnotations
           .length ?? 0) === 0 &&
         (useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)?.reviewComments
-          .length ?? 0) === 0
+          .length ?? 0) === 0 &&
+        (useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)
+          ?.chatSelectionAnnotations.length ?? 0) === 0
       ) {
         setOptimisticUserMessages((existing) => {
           const removed = existing.filter((message) => message.id === messageIdForSend);
@@ -4927,6 +5000,10 @@ function ChatViewContent(props: ChatViewProps) {
         setComposerDraftElementContexts(composerDraftTarget, composerElementContextsSnapshot);
         setComposerDraftPreviewAnnotations(composerDraftTarget, composerPreviewAnnotationsSnapshot);
         setComposerDraftReviewComments(composerDraftTarget, composerReviewCommentsSnapshot);
+        setComposerDraftChatSelectionAnnotations(
+          composerDraftTarget,
+          composerChatSelectionAnnotationsSnapshot,
+        );
         composerRef.current?.resetCursorState({
           cursor: collapseExpandedComposerCursor(promptForSend, promptForSend.length),
           prompt: promptForSend,
@@ -5131,9 +5208,11 @@ function ChatViewContent(props: ChatViewProps) {
     async ({
       text,
       interactionMode: nextInteractionMode,
+      chatSelectionAnnotations = [],
     }: {
       text: string;
       interactionMode: "default" | "plan";
+      chatSelectionAnnotations?: ReadonlyArray<ChatSelectionAnnotation>;
     }) => {
       if (
         !activeThread ||
@@ -5145,7 +5224,7 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
 
-      const trimmed = text.trim();
+      const trimmed = appendChatSelectionAnnotationsToPrompt(text, chatSelectionAnnotations).trim();
       if (!trimmed) {
         return;
       }
@@ -5172,10 +5251,16 @@ function ChatViewContent(props: ChatViewProps) {
         effort: ctxSelectedPromptEffort,
         text: trimmed,
       });
+      const retryChatSelectionAnnotations = chatSelectionAnnotations.map((annotation) => ({
+        ...annotation,
+      }));
 
       sendInFlightRef.current = true;
       beginLocalDispatch({ preparingWorktree: false });
       setThreadError(threadIdForSend, null);
+      promptRef.current = "";
+      clearComposerDraftContent(composerDraftTarget);
+      composerRef.current?.resetCursorState();
 
       // Position this sent row once LegendList has measured the anchored tail.
       isAtEndRef.current = true;
@@ -5269,6 +5354,25 @@ function ChatViewContent(props: ChatViewProps) {
       setOptimisticUserMessages((existing) =>
         existing.filter((message) => message.id !== messageIdForSend),
       );
+      const currentDraft = useComposerDraftStore.getState().getComposerDraft(composerDraftTarget);
+      if (
+        shouldRestoreClearedPlanFollowUpDraft({
+          currentPrompt: promptRef.current,
+          currentChatSelectionAnnotationCount: currentDraft?.chatSelectionAnnotations.length ?? 0,
+        })
+      ) {
+        promptRef.current = text;
+        setComposerDraftPrompt(composerDraftTarget, text);
+        setComposerDraftChatSelectionAnnotations(
+          composerDraftTarget,
+          retryChatSelectionAnnotations,
+        );
+        composerRef.current?.resetCursorState({
+          cursor: collapseExpandedComposerCursor(text, text.length),
+          prompt: text,
+          detectTrigger: true,
+        });
+      }
       if (!isAtomCommandInterrupted(failure)) {
         const error = squashAtomCommandFailure(failure);
         setThreadError(
@@ -5283,6 +5387,9 @@ function ChatViewContent(props: ChatViewProps) {
       activeThread,
       activeProposedPlan,
       beginLocalDispatch,
+      clearComposerDraftContent,
+      composerDraftTarget,
+      composerRef,
       isConnecting,
       isSendBusy,
       isServerThread,
@@ -5290,12 +5397,13 @@ function ChatViewContent(props: ChatViewProps) {
       persistThreadSettingsForNextTurn,
       resetLocalDispatch,
       runtimeMode,
+      setComposerDraftChatSelectionAnnotations,
       setComposerDraftInteractionMode,
+      setComposerDraftPrompt,
       setThreadError,
       startThreadTurn,
       autoOpenPlanSidebar,
       environmentId,
-      composerRef,
     ],
   );
 
@@ -5831,6 +5939,10 @@ function ChatViewContent(props: ChatViewProps) {
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
                 hideEmptyPlaceholder={isDraftHeroState || threadDetailLoading}
                 topFadeEnabled={!hasTimelineTopBanner}
+                onAddChatSelectionAnnotation={addChatSelectionAnnotation}
+                onUpdateChatSelectionAnnotation={updateChatSelectionAnnotation}
+                onRemoveChatSelectionAnnotation={removeChatSelectionAnnotation}
+                chatSelectionAnnotations={composerChatSelectionAnnotations}
               />
 
               {/* scroll to end pill — shown when user has scrolled away from the live edge */}

--- a/apps/web/src/components/chat/AssistantMessageIndicators.tsx
+++ b/apps/web/src/components/chat/AssistantMessageIndicators.tsx
@@ -1,0 +1,62 @@
+import type { ChatSelectionIndicator, ChatSelectionIndicatorKind } from "~/chatSelectionAnnotation";
+import { cn } from "~/lib/utils";
+
+interface IndicatorPresentation {
+  readonly label: string;
+  readonly className: string;
+}
+
+const INDICATOR_PRESENTATION: Record<ChatSelectionIndicatorKind, IndicatorPresentation> = {
+  "text-selection": {
+    label: "selected text",
+    className: "border-blue-400/45 bg-blue-500/90",
+  },
+  "text-comment": {
+    label: "text comment",
+    className: "border-blue-400/45 bg-blue-500/90",
+  },
+};
+
+export function AssistantMessageIndicators({
+  placements,
+  activeIndicatorId,
+  onSelect,
+}: {
+  placements: ReadonlyArray<{
+    indicator: ChatSelectionIndicator;
+    top: number;
+  }>;
+  activeIndicatorId?: string | null;
+  onSelect: (indicator: ChatSelectionIndicator, anchorRect: DOMRect) => void;
+}) {
+  if (placements.length === 0) return null;
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 z-20 overflow-visible"
+      role="group"
+      aria-label="Message annotations"
+    >
+      {placements.map(({ indicator, top }) => {
+        const presentation = INDICATOR_PRESENTATION[indicator.kind];
+        return (
+          <button
+            type="button"
+            key={indicator.id}
+            className={cn(
+              "pointer-events-auto absolute inline-flex size-5 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border border-background text-[10px] font-semibold leading-none text-white shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+              presentation.className,
+              activeIndicatorId === indicator.id && "ring-1 ring-blue-300/80",
+            )}
+            style={{ right: 2, top }}
+            aria-label={`Highlight annotation ${indicator.number}: ${presentation.label}`}
+            aria-pressed={activeIndicatorId === indicator.id}
+            onClick={(event) => onSelect(indicator, event.currentTarget.getBoundingClientRect())}
+          >
+            {indicator.number}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -79,6 +79,7 @@ import { useComposerPathSearch } from "../../lib/composerPathSearchState";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
+import { ComposerPendingChatSelectionAnnotations } from "./ComposerPendingChatSelectionAnnotations";
 import { ComposerPreviewAnnotationCards } from "./ComposerPreviewAnnotationCards";
 import {
   shouldUseCompactComposerPrimaryActions,
@@ -106,6 +107,7 @@ import { ContextWindowMeter } from "./ContextWindowMeter";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
+import type { ChatSelectionAnnotation } from "~/chatSelectionAnnotation";
 import { Separator } from "../ui/separator";
 
 function ComposerCommandMenuLayer(props: { anchor: HTMLElement | null; children: ReactNode }) {
@@ -492,6 +494,7 @@ export interface ChatComposerHandle {
     elementContexts: ElementContextDraft[];
     previewAnnotations: PreviewAnnotationPayload[];
     reviewComments: ReviewCommentContext[];
+    chatSelectionAnnotations: ChatSelectionAnnotation[];
     selectedPromptEffort: string | null;
     selectedModelOptionsForDispatch: unknown;
     selectedModelSelection: ModelSelection;
@@ -704,6 +707,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const composerElementContexts = composerDraft.elementContexts;
   const composerPreviewAnnotations = composerDraft.previewAnnotations;
   const composerReviewComments = composerDraft.reviewComments;
+  const composerChatSelectionAnnotations = composerDraft.chatSelectionAnnotations;
   const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
 
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
@@ -727,6 +731,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   );
   const removeComposerDraftReviewComment = useComposerDraftStore(
     (store) => store.removeReviewComment,
+  );
+  const removeComposerDraftChatSelectionAnnotation = useComposerDraftStore(
+    (store) => store.removeChatSelectionAnnotation,
   );
   const clearComposerDraftPersistedAttachments = useComposerDraftStore(
     (store) => store.clearPersistedAttachments,
@@ -1024,13 +1031,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         elementContextCount:
           composerElementContexts.length +
           composerPreviewAnnotations.length +
-          composerReviewComments.length,
+          composerReviewComments.length +
+          composerChatSelectionAnnotations.length,
       }),
     [
       composerElementContexts.length,
       composerImages.length,
       composerPreviewAnnotations.length,
       composerReviewComments.length,
+      composerChatSelectionAnnotations.length,
       composerTerminalContexts,
       prompt,
     ],
@@ -2622,6 +2631,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         elementContexts: composerElementContextsRef.current,
         previewAnnotations: composerPreviewAnnotations,
         reviewComments: composerReviewComments,
+        chatSelectionAnnotations: composerChatSelectionAnnotations,
         selectedPromptEffort,
         selectedModelOptionsForDispatch,
         selectedModelSelection,
@@ -2643,6 +2653,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       composerElementContextsRef,
       composerPreviewAnnotations,
       composerReviewComments,
+      composerChatSelectionAnnotations,
       isConnecting,
       isComposerApprovalState,
       pendingUserInputs.length,
@@ -2822,6 +2833,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
           {showCollapsedMobilePromptRow ? (
             <div className="flex items-center justify-between gap-2 px-3 py-2">
+              {composerChatSelectionAnnotations.length > 0 ? (
+                <ComposerPendingChatSelectionAnnotations
+                  annotations={composerChatSelectionAnnotations}
+                  onRemove={(annotationId) =>
+                    removeComposerDraftChatSelectionAnnotation(composerDraftTarget, annotationId)
+                  }
+                  compact
+                  className="max-w-[38%] shrink-0"
+                />
+              ) : null}
               <button
                 type="button"
                 className={cn(
@@ -2924,6 +2945,19 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     const preview = buildExpandedImagePreview(composerImages, imageId);
                     if (preview) onExpandImage(preview);
                   }}
+                  className="mb-3"
+                />
+              )}
+
+            {!isComposerCollapsedMobile &&
+              !isComposerApprovalState &&
+              pendingUserInputs.length === 0 &&
+              composerChatSelectionAnnotations.length > 0 && (
+                <ComposerPendingChatSelectionAnnotations
+                  annotations={composerChatSelectionAnnotations}
+                  onRemove={(annotationId) =>
+                    removeComposerDraftChatSelectionAnnotation(composerDraftTarget, annotationId)
+                  }
                   className="mb-3"
                 />
               )}

--- a/apps/web/src/components/chat/ChatSelectionAnnotationEditor.tsx
+++ b/apps/web/src/components/chat/ChatSelectionAnnotationEditor.tsx
@@ -1,0 +1,96 @@
+import { Trash2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import type { ChatSelectionAnnotation } from "~/chatSelectionAnnotation";
+import { Button } from "../ui/button";
+import { Textarea } from "../ui/textarea";
+
+interface ChatSelectionAnnotationEditorProps {
+  annotation: ChatSelectionAnnotation;
+  anchorRect: { top: number; left: number; width: number; height: number };
+  onCancel: () => void;
+  onDelete: () => void;
+  onSave: (comment: string) => void;
+}
+
+function editorPosition(anchorRect: ChatSelectionAnnotationEditorProps["anchorRect"]) {
+  const width = Math.min(320, window.innerWidth - 32);
+  const rightSideLeft = anchorRect.left + anchorRect.width + 12;
+  const left =
+    rightSideLeft + width <= window.innerWidth - 16
+      ? rightSideLeft
+      : Math.max(16, anchorRect.left - width - 12);
+
+  return {
+    left,
+    top: Math.max(16, Math.min(window.innerHeight - 176, anchorRect.top - 24)),
+    width,
+  };
+}
+
+export function ChatSelectionAnnotationEditor({
+  annotation,
+  anchorRect,
+  onCancel,
+  onDelete,
+  onSave,
+}: ChatSelectionAnnotationEditorProps) {
+  const [comment, setComment] = useState(annotation.comment);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setComment(annotation.comment);
+    window.requestAnimationFrame(() => textareaRef.current?.focus());
+  }, [annotation.comment, annotation.id]);
+
+  return createPortal(
+    <form
+      aria-label={`Edit annotation ${annotation.id}`}
+      className="fixed z-[72] rounded-2xl border border-border/80 bg-popover p-3 shadow-xl"
+      data-chat-selection-popover="true"
+      style={editorPosition(anchorRect)}
+      onPointerDown={(event) => event.stopPropagation()}
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSave(comment.trim());
+      }}
+    >
+      <Textarea
+        ref={textareaRef}
+        unstyled
+        value={comment}
+        aria-label="Annotation comment"
+        placeholder="Add an optional comment..."
+        className="block min-h-20 w-full resize-none bg-transparent px-1 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+        onChange={(event) => setComment(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onCancel();
+          }
+        }}
+      />
+      <div className="mt-2 flex items-center justify-between">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Delete annotation"
+          onClick={onDelete}
+        >
+          <Trash2 aria-hidden />
+        </Button>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="submit" size="sm">
+            Save
+          </Button>
+        </div>
+      </div>
+    </form>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/chat/ChatTextSelectionPopover.tsx
+++ b/apps/web/src/components/chat/ChatTextSelectionPopover.tsx
@@ -1,0 +1,187 @@
+import { Check, Plus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "~/lib/utils";
+import { Button } from "../ui/button";
+
+export interface ChatTextSelectionPopoverProps {
+  text: string;
+  rect: { top: number; left: number; width: number; height: number };
+  avoidRects: ReadonlyArray<{
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  }>;
+  onAddAnnotation: (comment: string) => void;
+  onClose: () => void;
+}
+
+function overlapArea(
+  first: { top: number; left: number; width: number; height: number },
+  second: { top: number; left: number; width: number; height: number },
+) {
+  const width = Math.max(
+    0,
+    Math.min(first.left + first.width, second.left + second.width) -
+      Math.max(first.left, second.left),
+  );
+  const height = Math.max(
+    0,
+    Math.min(first.top + first.height, second.top + second.height) -
+      Math.max(first.top, second.top),
+  );
+  return width * height;
+}
+
+function popoverPosition(
+  rect: ChatTextSelectionPopoverProps["rect"],
+  avoidRects: ChatTextSelectionPopoverProps["avoidRects"],
+  mode: "actions" | "comment",
+) {
+  if (mode === "comment") {
+    const edgeGap = 16;
+    const anchorGap = 12;
+    const height = 44;
+    const maxWidth = Math.min(320, Math.max(0, window.innerWidth - edgeGap * 2));
+    const minWidth = Math.min(220, maxWidth);
+    const rightLeft = rect.left + rect.width + anchorGap;
+    const rightAvailable = window.innerWidth - edgeGap - rightLeft;
+    const leftRight = rect.left - anchorGap;
+    const leftAvailable = leftRight - edgeGap;
+    const useRightSide = rightAvailable >= minWidth || rightAvailable >= leftAvailable;
+    const availableWidth = useRightSide ? rightAvailable : leftAvailable;
+    const width = Math.max(minWidth, Math.min(maxWidth, availableWidth));
+    const left = useRightSide ? rightLeft : Math.max(edgeGap, leftRight - width);
+    const clampTop = (top: number) => Math.max(16, Math.min(window.innerHeight - height - 16, top));
+    const centeredTop = rect.top + rect.height / 2 - height / 2;
+    const candidateTops = [
+      centeredTop,
+      rect.top + rect.height + anchorGap,
+      rect.top - height - anchorGap,
+      ...avoidRects.flatMap((avoidRect) => [
+        avoidRect.top + avoidRect.height + anchorGap,
+        avoidRect.top - height - anchorGap,
+      ]),
+    ];
+    const candidates = [...new Set(candidateTops.map(clampTop))].map((top, preference) => ({
+      left,
+      top,
+      width,
+      height,
+      preference,
+    }));
+    const best = candidates.reduce((current, candidate) => {
+      const score = avoidRects.reduce(
+        (total, avoidRect) => total + overlapArea(candidate, avoidRect),
+        0,
+      );
+      const currentScore = avoidRects.reduce(
+        (total, avoidRect) => total + overlapArea(current, avoidRect),
+        0,
+      );
+      if (score === currentScore) {
+        const distance = Math.abs(candidate.top - centeredTop);
+        const currentDistance = Math.abs(current.top - centeredTop);
+        if (distance === currentDistance) {
+          return candidate.preference < current.preference ? candidate : current;
+        }
+        return distance < currentDistance ? candidate : current;
+      }
+      return score < currentScore ? candidate : current;
+    });
+    return { left: best.left, top: best.top, width: best.width };
+  }
+
+  const center = rect.left + rect.width / 2;
+  const preferAbove = rect.top > 96;
+  return {
+    left: Math.max(12, Math.min(window.innerWidth - 12, center)),
+    ...(preferAbove
+      ? { top: Math.max(12, rect.top - 8), transform: "translate(-50%, -100%)" }
+      : { top: rect.top + rect.height + 8, transform: "translateX(-50%)" }),
+  };
+}
+
+export function ChatTextSelectionPopover({
+  rect,
+  avoidRects,
+  onAddAnnotation,
+  onClose,
+}: ChatTextSelectionPopoverProps) {
+  const [isAddingComment, setIsAddingComment] = useState(false);
+  const [comment, setComment] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const position = popoverPosition(rect, avoidRects, isAddingComment ? "comment" : "actions");
+
+  useEffect(() => {
+    if (!isAddingComment) return;
+    inputRef.current?.focus();
+  }, [isAddingComment]);
+
+  const submitAnnotation = () => {
+    onAddAnnotation(comment.trim());
+    setComment("");
+  };
+
+  return createPortal(
+    <div
+      className="pointer-events-auto fixed z-[70]"
+      style={position}
+      role="dialog"
+      aria-label="Selected text actions"
+      data-chat-selection-popover="true"
+      onPointerDown={(event) => event.stopPropagation()}
+      onPointerUp={(event) => event.stopPropagation()}
+      onKeyUp={(event) => event.stopPropagation()}
+    >
+      {isAddingComment ? (
+        <form
+          className="flex w-full items-center gap-1.5 rounded-full border border-border/80 bg-popover px-2.5 py-1.5 shadow-lg"
+          onSubmit={(event) => {
+            event.preventDefault();
+            submitAnnotation();
+          }}
+        >
+          <input
+            ref={inputRef}
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+              }
+            }}
+            placeholder="Add an optional comment..."
+            aria-label="Optional comment for selected text"
+            className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+          />
+          <Button
+            type="submit"
+            size="icon"
+            aria-label="Add text annotation"
+            className="rounded-full"
+          >
+            <Check className="size-4" aria-hidden />
+          </Button>
+        </form>
+      ) : (
+        <div className="flex items-center overflow-hidden rounded-xl border border-border/80 bg-popover p-0.5 shadow-lg">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className={cn("border-0 shadow-none")}
+            onClick={() => setIsAddingComment(true)}
+          >
+            <Plus className="size-3.5" aria-hidden />
+            Add to chat
+          </Button>
+        </div>
+      )}
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/chat/ComposerPendingChatSelectionAnnotations.tsx
+++ b/apps/web/src/components/chat/ComposerPendingChatSelectionAnnotations.tsx
@@ -1,0 +1,116 @@
+import { TextQuote, X } from "lucide-react";
+
+import type { ChatSelectionAnnotation } from "~/chatSelectionAnnotation";
+import {
+  COMPOSER_INLINE_CHIP_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_DISMISS_BUTTON_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_ICON_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME,
+} from "../composerInlineChip";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { cn } from "~/lib/utils";
+
+interface ComposerPendingChatSelectionAnnotationsProps {
+  annotations: ReadonlyArray<ChatSelectionAnnotation>;
+  onRemove: (annotationId: string) => void;
+  className?: string;
+  compact?: boolean;
+}
+
+export function ComposerPendingChatSelectionAnnotations({
+  annotations,
+  onRemove,
+  className,
+  compact = false,
+}: ComposerPendingChatSelectionAnnotationsProps) {
+  if (annotations.length === 0) return null;
+  const label = compact
+    ? `${annotations.length} annotation${annotations.length === 1 ? "" : "s"}`
+    : `${annotations.length} annotation${annotations.length === 1 ? "" : "s"}`;
+
+  return (
+    <div className={cn("flex min-w-0 flex-wrap gap-1.5", className)}>
+      <Popover>
+        <div className={cn(COMPOSER_INLINE_CHIP_CLASS_NAME, "pr-1")}>
+          <PopoverTrigger
+            render={
+              <button
+                type="button"
+                aria-label={label}
+                className="inline-flex min-w-0 cursor-pointer items-center gap-1 rounded-sm bg-transparent py-0.5 text-left outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            }
+          >
+            <TextQuote className={cn(COMPOSER_INLINE_CHIP_ICON_CLASS_NAME, "size-3")} />
+            <span className={COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME}>
+              {compact ? `${annotations.length} selected` : label}
+            </span>
+          </PopoverTrigger>
+          {annotations.length === 1 ? (
+            <button
+              type="button"
+              aria-label="Remove text annotation"
+              className={COMPOSER_INLINE_CHIP_DISMISS_BUTTON_CLASS_NAME}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onRemove(annotations[0]!.id);
+              }}
+            >
+              <X className="size-3" aria-hidden />
+            </button>
+          ) : null}
+        </div>
+        <PopoverPopup
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="w-[min(15rem,calc(100vw-2rem))] border border-border/80 bg-background/72"
+          viewportClassName="p-0.5 [--viewport-inline-padding:--spacing(0.5)]"
+        >
+          <div className="space-y-0.5">
+            {annotations.map((annotation, index) => (
+              <section
+                key={annotation.id}
+                className="relative border-b border-border/30 px-1.5 py-1 pr-6 last:border-b-0"
+              >
+                <div className="flex min-w-0 items-start gap-1.5 text-xs">
+                  <span className="shrink-0 tabular-nums text-muted-foreground/75">
+                    {index + 1}.
+                  </span>
+                  <div className="min-w-0 flex-1 space-y-0.5">
+                    <div className="flex min-w-0 items-start gap-1.5">
+                      <span className="shrink-0 text-muted-foreground">Selected:</span>
+                      <span className="min-w-0 break-words text-muted-foreground/90">
+                        {annotation.selectedText}
+                      </span>
+                    </div>
+                    {annotation.comment.trim() ? (
+                      <div className="flex min-w-0 items-start gap-1.5">
+                        <span className="shrink-0 text-muted-foreground">Comment:</span>
+                        <p className="min-w-0 break-words text-muted-foreground/90">
+                          {annotation.comment}
+                        </p>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  aria-label={`Remove text annotation ${index + 1}`}
+                  className={cn(
+                    COMPOSER_INLINE_CHIP_DISMISS_BUTTON_CLASS_NAME,
+                    "absolute right-1 top-1 size-4",
+                  )}
+                  onClick={() => onRemove(annotation.id)}
+                >
+                  <X className="size-3" aria-hidden />
+                </button>
+              </section>
+            ))}
+          </div>
+        </PopoverPopup>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -3,6 +3,7 @@ import { createRef, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import type { LegendListRef } from "@legendapp/list/react";
+import { appendChatSelectionAnnotationsToPrompt } from "../../chatSelectionAnnotation";
 
 vi.mock("@legendapp/list/react", async () => {
   const legendListTestId = "legend-list";
@@ -196,6 +197,9 @@ function buildProps() {
     contentInsetEndAdjustment: 0,
     onIsAtEndChange: () => {},
     onManualNavigation: () => {},
+    onAddChatSelectionAnnotation: () => {},
+    onUpdateChatSelectionAnnotation: () => {},
+    onRemoveChatSelectionAnnotation: () => {},
   };
 }
 
@@ -294,6 +298,181 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Collapse all folders"');
     expect(markup).toContain('aria-label="Open diff"');
     expect(markup).toContain("1 changed file");
+  });
+
+  it("marks the assistant answer that owns a pending text annotation", () => {
+    const assistantMessageId = MessageId.make("message-assistant-with-selection");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        chatSelectionAnnotations={[
+          {
+            id: "selection-1",
+            messageId: assistantMessageId,
+            selectedText: "Restart the adapter.",
+            comment: "Why?",
+          },
+        ]}
+        timelineEntries={[
+          {
+            id: "entry-assistant-with-selection",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: assistantMessageId,
+              role: "assistant",
+              text: "Restart the adapter.",
+              turnId: null,
+              createdAt: MESSAGE_CREATED_AT,
+              updatedAt: MESSAGE_CREATED_AT,
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('data-chat-selection-annotation-count="1"');
+  });
+
+  it("renders one clickable indicator per annotation in source order", () => {
+    const assistantMessageId = MessageId.make("message-assistant-with-two-selections");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        chatSelectionAnnotations={[
+          {
+            id: "selection-1",
+            messageId: assistantMessageId,
+            selectedText: "first",
+            comment: "",
+          },
+          {
+            id: "selection-2",
+            messageId: assistantMessageId,
+            selectedText: "second",
+            comment: "Add context",
+          },
+        ]}
+        timelineEntries={[
+          {
+            id: "entry-assistant-with-two-selections",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: assistantMessageId,
+              role: "assistant",
+              text: "first and second",
+              turnId: null,
+              createdAt: MESSAGE_CREATED_AT,
+              updatedAt: MESSAGE_CREATED_AT,
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('data-chat-selection-annotation-count="2"');
+  });
+
+  it("removes the editable source indicator after the annotation has been sent", () => {
+    const assistantMessageId = MessageId.make("message-assistant-sent-selection");
+    const sentAnnotation = {
+      id: "selection-sent",
+      messageId: assistantMessageId,
+      selectedText: "Restart the adapter.",
+      comment: "Why?",
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-user-with-selection",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: MessageId.make("message-user-with-selection"),
+              role: "user",
+              text: appendChatSelectionAnnotationsToPrompt("Please explain.", [sentAnnotation]),
+              turnId: null,
+              createdAt: MESSAGE_CREATED_AT,
+              updatedAt: MESSAGE_CREATED_AT,
+              streaming: false,
+            },
+          },
+          {
+            id: "entry-assistant-sent-selection",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: assistantMessageId,
+              role: "assistant",
+              text: "Restart the adapter.",
+              turnId: null,
+              createdAt: MESSAGE_CREATED_AT,
+              updatedAt: MESSAGE_CREATED_AT,
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).not.toContain('data-chat-selection-annotation-count="1"');
+    expect(markup).toContain('data-chat-selection-annotation-summary="true"');
+  });
+
+  it("summarizes sent text annotations without expanding their contents in the user bubble", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          buildUserTimelineEntry(
+            appendChatSelectionAnnotationsToPrompt("Send back this message.", [
+              {
+                id: "selection-summary",
+                messageId: "assistant-source",
+                selectedText: "Hidden selected text",
+                comment: "Hidden annotation comment",
+              },
+            ]),
+          ),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("1 annotation");
+    expect(markup).toContain('data-chat-selection-annotation-summary="true"');
+    expect(markup).toContain("Send back this message.");
+    expect(markup).not.toContain("Hidden selected text");
+    expect(markup).not.toContain("Hidden annotation comment");
+    expect(markup).not.toContain("Selected text");
+  });
+
+  it("does not render an empty user bubble for an annotation-only message", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          buildUserTimelineEntry(
+            appendChatSelectionAnnotationsToPrompt("", [
+              {
+                id: "selection-only-summary",
+                messageId: "assistant-source",
+                selectedText: "Only selected text",
+                comment: "",
+              },
+            ]),
+          ),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('data-chat-selection-annotation-summary="true"');
+    expect(markup).not.toContain('data-user-message-bubble="true"');
+    expect(markup).not.toContain("Only selected text");
   });
 
   it("uses LegendList isNearEnd when deciding whether the live edge is visible", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -108,6 +108,11 @@ import {
 import { SkillInlineText } from "./SkillInlineText";
 import { formatWorkspaceRelativePath } from "../../filePathDisplay";
 import {
+  collectChatSelectionAnnotationsByMessageId,
+  parseChatSelectionMessageSegments,
+  type ChatSelectionAnnotation,
+} from "../../chatSelectionAnnotation";
+import {
   buildReviewCommentRenderablePatch,
   formatReviewCommentFence,
   parseReviewCommentMessageSegments,
@@ -135,6 +140,11 @@ interface TimelineRowSharedState {
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
   onToggleTurnFold: (turnId: TurnId) => void;
   onToggleWorkGroup: (groupId: string, anchorElement?: HTMLElement) => void;
+  onAddChatSelectionAnnotation: (annotation: Omit<ChatSelectionAnnotation, "id">) => void;
+  onUpdateChatSelectionAnnotation: (annotationId: string, comment: string) => void;
+  onRemoveChatSelectionAnnotation: (annotationId: string) => void;
+  pendingChatSelectionAnnotationIds: ReadonlySet<string>;
+  chatSelectionAnnotationsByMessageId: ReadonlyMap<string, ReadonlyArray<ChatSelectionAnnotation>>;
 }
 
 interface TimelineRowActivityState {
@@ -149,6 +159,7 @@ const TimelineRowActivityCtx = createContext<TimelineRowActivityState>(null!);
 const TIMELINE_LIST_HEADER = <div className="h-3 sm:h-4" />;
 const TIMELINE_LIST_FADE_HEADER = <div className="h-10 sm:h-12" />;
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
+const EMPTY_TIMELINE_CHAT_SELECTION_ANNOTATIONS: ReadonlyArray<ChatSelectionAnnotation> = [];
 const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
 
 // ---------------------------------------------------------------------------
@@ -184,6 +195,10 @@ interface MessagesTimelineProps {
   onManualNavigation: () => void;
   hideEmptyPlaceholder?: boolean;
   topFadeEnabled?: boolean;
+  onAddChatSelectionAnnotation: (annotation: Omit<ChatSelectionAnnotation, "id">) => void;
+  onUpdateChatSelectionAnnotation: (annotationId: string, comment: string) => void;
+  onRemoveChatSelectionAnnotation: (annotationId: string) => void;
+  chatSelectionAnnotations?: ReadonlyArray<ChatSelectionAnnotation>;
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +234,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   onManualNavigation,
   hideEmptyPlaceholder = false,
   topFadeEnabled = false,
+  onAddChatSelectionAnnotation,
+  onUpdateChatSelectionAnnotation,
+  onRemoveChatSelectionAnnotation,
+  chatSelectionAnnotations = EMPTY_TIMELINE_CHAT_SELECTION_ANNOTATIONS,
 }: MessagesTimelineProps) {
   const [expandedTurnIds, setExpandedTurnIds] = useState<ReadonlySet<TurnId>>(new Set());
   const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
@@ -322,6 +341,14 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       turnDiffSummaryByAssistantMessageId,
       revertTurnCountByUserMessageId,
     ],
+  );
+  const chatSelectionAnnotationsByMessageId = useMemo(
+    () => collectChatSelectionAnnotationsByMessageId(chatSelectionAnnotations),
+    [chatSelectionAnnotations],
+  );
+  const pendingChatSelectionAnnotationIds = useMemo(
+    () => new Set(chatSelectionAnnotations.map((annotation) => annotation.id)),
+    [chatSelectionAnnotations],
   );
   const rows = useStableRows(rawRows);
   const minimapItems = useMemo(() => deriveTimelineMinimapItems(rows), [rows]);
@@ -430,6 +457,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onOpenTurnDiff,
       onToggleTurnFold,
       onToggleWorkGroup,
+      onAddChatSelectionAnnotation,
+      onUpdateChatSelectionAnnotation,
+      onRemoveChatSelectionAnnotation,
+      pendingChatSelectionAnnotationIds,
+      chatSelectionAnnotationsByMessageId,
     }),
     [
       timestampFormat,
@@ -444,6 +476,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onOpenTurnDiff,
       onToggleTurnFold,
       onToggleWorkGroup,
+      onAddChatSelectionAnnotation,
+      onUpdateChatSelectionAnnotation,
+      onRemoveChatSelectionAnnotation,
+      pendingChatSelectionAnnotationIds,
+      chatSelectionAnnotationsByMessageId,
     ],
   );
   const activityState = useMemo<TimelineRowActivityState>(
@@ -884,70 +921,104 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
     ...displayedUserMessage.elementContexts,
     ...elementContextState.contexts,
   ];
+  const chatSelectionSegments = parseChatSelectionMessageSegments(elementContextState.promptText);
+  const chatSelectionAnnotations = chatSelectionSegments.flatMap((segment) =>
+    segment.kind === "selection" ? [segment.annotation] : [],
+  );
+  const userPromptText =
+    chatSelectionAnnotations.length > 0
+      ? chatSelectionSegments
+          .flatMap((segment) => (segment.kind === "text" ? [segment.text] : []))
+          .join("")
+          .trim()
+      : elementContextState.promptText;
   const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
   const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
+  const hasVisibleUserBubble =
+    regularImages.length > 0 ||
+    previewAnnotations.length > 0 ||
+    elementContexts.length > 0 ||
+    userPromptText.trim().length > 0 ||
+    terminalContexts.length > 0;
 
   return (
     <div className="group flex flex-col items-end gap-1">
-      <div className="relative max-w-[80%] rounded-2xl bg-accent p-3">
-        {regularImages.length > 0 && (
-          <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
-            {regularImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (
-              <div
-                key={image.id}
-                className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
-              >
-                {image.previewUrl ? (
-                  <button
-                    type="button"
-                    className="h-full w-full cursor-zoom-in"
-                    aria-label={`Preview ${image.name}`}
-                    onClick={() => {
-                      const preview = buildExpandedImagePreview(regularImages, image.id);
-                      if (!preview) return;
-                      ctx.onImageExpand(preview);
-                    }}
-                  >
-                    <img
-                      src={image.previewUrl}
-                      alt={image.name}
-                      className="block h-auto max-h-[220px] w-full object-cover"
-                    />
-                  </button>
-                ) : (
-                  <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
-                    {image.name}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-        {previewAnnotations.map((annotation, index) => (
-          <UserMessagePreviewAnnotationCard
-            key={annotation.id}
-            annotation={annotation}
-            image={previewImages[index] ?? null}
+      {chatSelectionAnnotations.length > 0 ? (
+        <div
+          className="mb-0.5 inline-flex h-7 items-center gap-1.5 rounded-full border border-border/80 bg-accent px-2.5 text-xs text-foreground shadow-xs"
+          data-chat-selection-annotation-summary
+        >
+          <MessageCircleIcon className="size-3.5 text-muted-foreground" aria-hidden />
+          <span>
+            {chatSelectionAnnotations.length} annotation
+            {chatSelectionAnnotations.length === 1 ? "" : "s"}
+          </span>
+        </div>
+      ) : null}
+      {hasVisibleUserBubble ? (
+        <div
+          className="relative max-w-[80%] rounded-2xl bg-accent p-3"
+          data-user-message-bubble="true"
+        >
+          {regularImages.length > 0 && (
+            <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
+              {regularImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (
+                <div
+                  key={image.id}
+                  className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
+                >
+                  {image.previewUrl ? (
+                    <button
+                      type="button"
+                      className="h-full w-full cursor-zoom-in"
+                      aria-label={`Preview ${image.name}`}
+                      onClick={() => {
+                        const preview = buildExpandedImagePreview(regularImages, image.id);
+                        if (!preview) return;
+                        ctx.onImageExpand(preview);
+                      }}
+                    >
+                      <img
+                        src={image.previewUrl}
+                        alt={image.name}
+                        className="block h-auto max-h-[220px] w-full object-cover"
+                      />
+                    </button>
+                  ) : (
+                    <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
+                      {image.name}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {previewAnnotations.map((annotation, index) => (
+            <UserMessagePreviewAnnotationCard
+              key={annotation.id}
+              annotation={annotation}
+              image={previewImages[index] ?? null}
+            />
+          ))}
+          {elementContexts.length > 0 ? (
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {elementContexts.map((context) => (
+                <UserMessageElementContextChip
+                  key={`${context.header}:${context.body}`}
+                  context={context}
+                />
+              ))}
+            </div>
+          ) : null}
+          <CollapsibleUserMessageBody
+            text={userPromptText}
+            terminalContexts={terminalContexts}
+            skills={ctx.skills}
+            markdownCwd={ctx.markdownCwd}
           />
-        ))}
-        {elementContexts.length > 0 ? (
-          <div className="mb-2 flex flex-wrap gap-1.5">
-            {elementContexts.map((context) => (
-              <UserMessageElementContextChip
-                key={`${context.header}:${context.body}`}
-                context={context}
-              />
-            ))}
-          </div>
-        ) : null}
-        <CollapsibleUserMessageBody
-          text={elementContextState.promptText}
-          terminalContexts={terminalContexts}
-          skills={ctx.skills}
-          markdownCwd={ctx.markdownCwd}
-        />
-      </div>
+        </div>
+      ) : null}
       <div className="flex w-full max-w-[80%] items-center justify-end pe-1 text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
         <div className="flex shrink-0 items-center gap-2">
           <Tooltip>
@@ -1018,6 +1089,9 @@ function TurnFoldTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "turn-
 function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);
   const messageText = row.message.text || (row.message.streaming ? "" : "(empty response)");
+  const selectionAnnotations =
+    ctx.chatSelectionAnnotationsByMessageId.get(row.message.id) ??
+    EMPTY_TIMELINE_CHAT_SELECTION_ANNOTATIONS;
 
   return (
     <>
@@ -1028,6 +1102,16 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           threadRef={ctx.threadRef ?? undefined}
           isStreaming={Boolean(row.message.streaming)}
           skills={ctx.skills}
+          annotations={selectionAnnotations}
+          editableAnnotationIds={ctx.pendingChatSelectionAnnotationIds}
+          onUpdateAnnotation={ctx.onUpdateChatSelectionAnnotation}
+          onRemoveAnnotation={ctx.onRemoveChatSelectionAnnotation}
+          onTextSelection={(input) =>
+            ctx.onAddChatSelectionAnnotation({
+              ...input,
+              messageId: row.message.id,
+            })
+          }
         />
         <AssistantChangedFilesSection
           turnSummary={row.assistantTurnDiffSummary}

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -679,6 +679,63 @@ describe("composerDraftStore review comments", () => {
   });
 });
 
+describe("composerDraftStore chat selection annotations", () => {
+  const threadId = ThreadId.make("thread-chat-selection");
+  const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+  const annotation = {
+    id: "selection-1",
+    messageId: "assistant-message-1",
+    selectedText: "Restart the adapter, then retry OAuth.",
+    comment: "Why is this needed?",
+  } as const;
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("updates annotations without changing their source order", () => {
+    const store = useComposerDraftStore.getState();
+    store.addChatSelectionAnnotation(threadRef, annotation);
+    store.addChatSelectionAnnotation(threadRef, {
+      ...annotation,
+      id: "selection-2",
+      selectedText: "Retry OAuth.",
+    });
+    store.addChatSelectionAnnotation(threadRef, { ...annotation, comment: "Updated question." });
+
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.chatSelectionAnnotations).toEqual([
+      { ...annotation, comment: "Updated question." },
+      { ...annotation, id: "selection-2", selectedText: "Retry OAuth." },
+    ]);
+
+    store.removeChatSelectionAnnotation(threadRef, annotation.id);
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.chatSelectionAnnotations).toHaveLength(1);
+    store.removeChatSelectionAnnotation(threadRef, "selection-2");
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)).toBeUndefined();
+  });
+
+  it("persists chat selection annotations and clears them with composer content", () => {
+    const store = useComposerDraftStore.getState();
+    store.addChatSelectionAnnotation(threadRef, annotation);
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+      };
+    };
+    const persisted = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+      draftsByThreadKey?: Record<string, { chatSelectionAnnotations?: unknown[] }>;
+    };
+
+    expect(
+      persisted.draftsByThreadKey?.[threadKeyFor(threadId, TEST_ENVIRONMENT_ID)]
+        ?.chatSelectionAnnotations,
+    ).toEqual([annotation]);
+
+    store.clearComposerContent(threadRef);
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)).toBeUndefined();
+  });
+});
+
 describe("composerDraftStore project draft thread mapping", () => {
   const projectId = ProjectId.make("project-a");
   const otherProjectId = ProjectId.make("project-b");

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -45,6 +45,10 @@ import {
   elementContextDedupKey,
   newElementContextId,
 } from "./lib/elementContext";
+import {
+  ChatSelectionAnnotationSchema,
+  type ChatSelectionAnnotation,
+} from "./chatSelectionAnnotation";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
@@ -55,9 +59,10 @@ import { ReviewCommentContextSchema, type ReviewCommentContext } from "./reviewC
 const isRuntimeMode = Schema.is(RuntimeMode);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
 const isReviewCommentContext = Schema.is(ReviewCommentContextSchema);
+const isChatSelectionAnnotation = Schema.is(ChatSelectionAnnotationSchema);
 
 export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
-const COMPOSER_DRAFT_STORAGE_VERSION = 8;
+const COMPOSER_DRAFT_STORAGE_VERSION = 9;
 const DraftThreadEnvModeSchema = Schema.Literals(["local", "worktree"]);
 export type DraftThreadEnvMode = typeof DraftThreadEnvModeSchema.Type;
 
@@ -132,6 +137,7 @@ const PersistedComposerThreadDraftState = Schema.Struct({
   elementContexts: Schema.optionalKey(Schema.Array(PersistedElementContextDraft)),
   previewAnnotations: Schema.optionalKey(Schema.Array(PreviewAnnotationPayloadSchema)),
   reviewComments: Schema.optionalKey(Schema.Array(ReviewCommentContextSchema)),
+  chatSelectionAnnotations: Schema.optionalKey(Schema.Array(ChatSelectionAnnotationSchema)),
   // Keyed by `ProviderInstanceId` (open branded slug) so custom provider
   // instances (e.g. `codex_personal`) round-trip alongside the built-in
   // `codex` / `claudeAgent` / ... entries. Every prior `ProviderDriverKind`
@@ -262,6 +268,7 @@ export interface ComposerThreadDraftState {
   elementContexts: ElementContextDraft[];
   previewAnnotations: PreviewAnnotationPayload[];
   reviewComments: ReviewCommentContext[];
+  chatSelectionAnnotations: ChatSelectionAnnotation[];
   /**
    * Per-instance model selection. Keyed by `ProviderInstanceId` (open
    * branded slug) so a default `codex` instance and a user-authored
@@ -489,6 +496,15 @@ interface ComposerDraftStoreState {
     comments: ReadonlyArray<ReviewCommentContext>,
   ) => void;
   removeReviewComment: (threadRef: ComposerThreadTarget, commentId: string) => void;
+  addChatSelectionAnnotation: (
+    threadRef: ComposerThreadTarget,
+    annotation: ChatSelectionAnnotation,
+  ) => void;
+  setChatSelectionAnnotations: (
+    threadRef: ComposerThreadTarget,
+    annotations: ReadonlyArray<ChatSelectionAnnotation>,
+  ) => void;
+  removeChatSelectionAnnotation: (threadRef: ComposerThreadTarget, annotationId: string) => void;
   clearPersistedAttachments: (threadRef: ComposerThreadTarget) => void;
   syncPersistedAttachments: (
     threadRef: ComposerThreadTarget,
@@ -497,9 +513,10 @@ interface ComposerDraftStoreState {
   clearComposerContent: (threadRef: ComposerThreadTarget) => void;
   /**
    * Clears only the prompt text and image attachments, preserving terminal /
-   * element contexts, preview annotations, and review comments. Used by the
-   * prompt stash, which can only round-trip text + images: clearing the
-   * session-bound contexts would destroy state nothing can restore.
+   * element contexts, preview annotations, review comments, and chat selection
+   * annotations. Used by the prompt stash, which can only round-trip text +
+   * images: clearing the session-bound contexts would destroy state nothing can
+   * restore.
    */
   clearComposerPromptAndImages: (threadRef: ComposerThreadTarget) => void;
 }
@@ -574,12 +591,14 @@ const EMPTY_TERMINAL_CONTEXTS: TerminalContextDraft[] = [];
 const EMPTY_ELEMENT_CONTEXTS: ElementContextDraft[] = [];
 const EMPTY_PREVIEW_ANNOTATIONS: PreviewAnnotationPayload[] = [];
 const EMPTY_REVIEW_COMMENTS: ReviewCommentContext[] = [];
+const EMPTY_CHAT_SELECTION_ANNOTATIONS: ChatSelectionAnnotation[] = [];
 Object.freeze(EMPTY_IMAGES);
 Object.freeze(EMPTY_IDS);
 Object.freeze(EMPTY_PERSISTED_ATTACHMENTS);
 Object.freeze(EMPTY_ELEMENT_CONTEXTS);
 Object.freeze(EMPTY_PREVIEW_ANNOTATIONS);
 Object.freeze(EMPTY_REVIEW_COMMENTS);
+Object.freeze(EMPTY_CHAT_SELECTION_ANNOTATIONS);
 const EMPTY_MODEL_SELECTION_BY_PROVIDER: Partial<Record<ProviderDriverKind, ModelSelection>> =
   Object.freeze({});
 const EMPTY_COMPOSER_DRAFT_MODEL_STATE = Object.freeze<ComposerDraftModelState>({
@@ -596,6 +615,7 @@ const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   elementContexts: EMPTY_ELEMENT_CONTEXTS,
   previewAnnotations: EMPTY_PREVIEW_ANNOTATIONS,
   reviewComments: EMPTY_REVIEW_COMMENTS,
+  chatSelectionAnnotations: EMPTY_CHAT_SELECTION_ANNOTATIONS,
   modelSelectionByProvider: EMPTY_MODEL_SELECTION_BY_PROVIDER,
   activeProvider: null,
   runtimeMode: null,
@@ -618,6 +638,7 @@ export function createEmptyThreadDraft(): ComposerThreadDraftState {
     elementContexts: [],
     previewAnnotations: [],
     reviewComments: [],
+    chatSelectionAnnotations: [],
     modelSelectionByProvider: {},
     activeProvider: null,
     runtimeMode: null,
@@ -691,6 +712,7 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
     draft.elementContexts.length === 0 &&
     draft.previewAnnotations.length === 0 &&
     draft.reviewComments.length === 0 &&
+    draft.chatSelectionAnnotations.length === 0 &&
     Object.keys(draft.modelSelectionByProvider).length === 0 &&
     draft.activeProvider === null &&
     draft.runtimeMode === null &&
@@ -1673,6 +1695,9 @@ function normalizePersistedDraftsByThreadId(
     const reviewComments = Array.isArray(draftCandidate.reviewComments)
       ? draftCandidate.reviewComments.filter(isReviewCommentContext)
       : [];
+    const chatSelectionAnnotations = Array.isArray(draftCandidate.chatSelectionAnnotations)
+      ? draftCandidate.chatSelectionAnnotations.filter(isChatSelectionAnnotation)
+      : [];
     const runtimeMode = isRuntimeMode(draftCandidate.runtimeMode)
       ? draftCandidate.runtimeMode
       : null;
@@ -1738,6 +1763,7 @@ function normalizePersistedDraftsByThreadId(
       terminalContexts.length === 0 &&
       elementContexts.length === 0 &&
       reviewComments.length === 0 &&
+      chatSelectionAnnotations.length === 0 &&
       !hasModelData &&
       !runtimeMode &&
       !interactionMode
@@ -1762,6 +1788,7 @@ function normalizePersistedDraftsByThreadId(
       ...(terminalContexts.length > 0 ? { terminalContexts } : {}),
       ...(elementContexts.length > 0 ? { elementContexts } : {}),
       ...(reviewComments.length > 0 ? { reviewComments } : {}),
+      ...(chatSelectionAnnotations.length > 0 ? { chatSelectionAnnotations } : {}),
       ...(hasModelData
         ? {
             modelSelectionByProvider: compactModelSelectionByProvider(modelSelectionByProvider),
@@ -1847,6 +1874,7 @@ function partializeComposerDraftStoreState(
       draft.elementContexts.length === 0 &&
       draft.previewAnnotations.length === 0 &&
       draft.reviewComments.length === 0 &&
+      draft.chatSelectionAnnotations.length === 0 &&
       !hasModelData &&
       draft.runtimeMode === null &&
       draft.interactionMode === null
@@ -1896,6 +1924,13 @@ function partializeComposerDraftStoreState(
       ...(draft.reviewComments.length > 0
         ? {
             reviewComments: draft.reviewComments.map((comment) => ({ ...comment })),
+          }
+        : {}),
+      ...(draft.chatSelectionAnnotations.length > 0
+        ? {
+            chatSelectionAnnotations: draft.chatSelectionAnnotations.map((annotation) => ({
+              ...annotation,
+            })),
           }
         : {}),
       ...(hasModelData
@@ -2141,6 +2176,8 @@ function toHydratedThreadDraft(
     previewAnnotations:
       persistedDraft.previewAnnotations?.map((annotation) => ({ ...annotation })) ?? [],
     reviewComments: persistedDraft.reviewComments?.map((comment) => ({ ...comment })) ?? [],
+    chatSelectionAnnotations:
+      persistedDraft.chatSelectionAnnotations?.map((annotation) => ({ ...annotation })) ?? [],
     modelSelectionByProvider,
     activeProvider,
     runtimeMode: persistedDraft.runtimeMode ?? null,
@@ -3262,6 +3299,65 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return { draftsByThreadKey: nextDraftsByThreadKey };
           });
         },
+        addChatSelectionAnnotation: (threadRef, annotation) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef);
+          if (!threadKey || !isChatSelectionAnnotation(annotation)) return;
+          set((state) => {
+            const existing = state.draftsByThreadKey[threadKey] ?? createEmptyThreadDraft();
+            const existingIndex = existing.chatSelectionAnnotations.findIndex(
+              (entry) => entry.id === annotation.id,
+            );
+            const chatSelectionAnnotations =
+              existingIndex === -1
+                ? [...existing.chatSelectionAnnotations, { ...annotation }]
+                : existing.chatSelectionAnnotations.map((entry, index) =>
+                    index === existingIndex ? { ...annotation } : entry,
+                  );
+            return {
+              draftsByThreadKey: {
+                ...state.draftsByThreadKey,
+                [threadKey]: {
+                  ...existing,
+                  chatSelectionAnnotations,
+                },
+              },
+            };
+          });
+        },
+        setChatSelectionAnnotations: (threadRef, annotations) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef);
+          if (!threadKey) return;
+          const chatSelectionAnnotations = annotations
+            .filter(isChatSelectionAnnotation)
+            .map((annotation) => ({ ...annotation }));
+          set((state) => {
+            const existing = state.draftsByThreadKey[threadKey] ?? createEmptyThreadDraft();
+            const nextDraft = { ...existing, chatSelectionAnnotations };
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            if (shouldRemoveDraft(nextDraft)) delete nextDraftsByThreadKey[threadKey];
+            else nextDraftsByThreadKey[threadKey] = nextDraft;
+            return { draftsByThreadKey: nextDraftsByThreadKey };
+          });
+        },
+        removeChatSelectionAnnotation: (threadRef, annotationId) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef);
+          if (!threadKey || !annotationId) return;
+          set((state) => {
+            const current = state.draftsByThreadKey[threadKey];
+            if (!current) return state;
+            const chatSelectionAnnotations = current.chatSelectionAnnotations.filter(
+              (entry) => entry.id !== annotationId,
+            );
+            if (chatSelectionAnnotations.length === current.chatSelectionAnnotations.length) {
+              return state;
+            }
+            const nextDraft = { ...current, chatSelectionAnnotations };
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            if (shouldRemoveDraft(nextDraft)) delete nextDraftsByThreadKey[threadKey];
+            else nextDraftsByThreadKey[threadKey] = nextDraft;
+            return { draftsByThreadKey: nextDraftsByThreadKey };
+          });
+        },
         clearPersistedAttachments: (threadRef) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
           if (threadKey.length === 0) {
@@ -3337,6 +3433,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               elementContexts: [],
               previewAnnotations: [],
               reviewComments: [],
+              chatSelectionAnnotations: [],
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {

--- a/docs/user/message-context.md
+++ b/docs/user/message-context.md
@@ -1,0 +1,12 @@
+# Message context
+
+You can attach part of an assistant response to your next message without copying it manually.
+
+In the web and desktop apps, select text in the response, choose **Add to chat**, then add an
+optional comment.
+
+Each annotation gets a numbered indicator beside its source text. Select an indicator to highlight
+the source and edit or delete the annotation before sending.
+
+Attached selections appear in one compact annotation chip in the composer. Open the chip to review
+or remove selections before sending.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -206,6 +206,10 @@
     "./devProxy": {
       "types": "./src/devProxy.ts",
       "import": "./src/devProxy.ts"
+    },
+    "./chatSelectionAnnotation": {
+      "types": "./src/chatSelectionAnnotation.ts",
+      "import": "./src/chatSelectionAnnotation.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/chatSelectionAnnotation.ts
+++ b/packages/shared/src/chatSelectionAnnotation.ts
@@ -1,0 +1,182 @@
+import * as Schema from "effect/Schema";
+
+export const ChatSelectionAnnotationSchema = Schema.Struct({
+  id: Schema.String,
+  messageId: Schema.optionalKey(Schema.String),
+  selectedText: Schema.String,
+  comment: Schema.String,
+  /** UTF-16 offsets in the rendered source message, when available. */
+  sourceStart: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  sourceEnd: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+});
+
+export type ChatSelectionAnnotation = typeof ChatSelectionAnnotationSchema.Type;
+
+export type ChatSelectionIndicatorKind = "text-selection" | "text-comment";
+
+export interface ChatSelectionIndicator {
+  readonly id: string;
+  readonly kind: ChatSelectionIndicatorKind;
+  readonly number: number;
+  readonly annotation: ChatSelectionAnnotation;
+}
+
+export type ChatSelectionMessageSegment =
+  | { readonly kind: "text"; readonly id: string; readonly text: string }
+  | { readonly kind: "selection"; readonly annotation: ChatSelectionAnnotation };
+
+const CHAT_SELECTION_BLOCK_PATTERN =
+  /<chat_selection\b([^>]*)>\s*<selected_text>\s*([\s\S]*?)\s*<\/selected_text>\s*<user_comment>\s*([\s\S]*?)\s*<\/user_comment>\s*<\/chat_selection>/g;
+const CHAT_SELECTION_ATTRIBUTE_PATTERN = /([a-zA-Z][a-zA-Z0-9_-]*)="([^"]*)"/g;
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function unescapeXml(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&");
+}
+
+function readAttribute(rawAttributes: string, name: string): string | undefined {
+  for (const match of rawAttributes.matchAll(CHAT_SELECTION_ATTRIBUTE_PATTERN)) {
+    if (match[1] === name && match[2]) return unescapeXml(match[2]);
+  }
+  return undefined;
+}
+
+function readNonNegativeIntegerAttribute(rawAttributes: string, name: string): number | undefined {
+  const value = readAttribute(rawAttributes, name);
+  if (value === undefined || !/^\d+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function readId(rawAttributes: string, fallback: string): string {
+  return readAttribute(rawAttributes, "id") ?? fallback;
+}
+
+export function formatChatSelectionAnnotation(annotation: ChatSelectionAnnotation): string {
+  const sourceStart = annotation.sourceStart;
+  const sourceEnd = annotation.sourceEnd;
+  const sourceOffsets =
+    typeof sourceStart === "number" &&
+    typeof sourceEnd === "number" &&
+    Number.isSafeInteger(sourceStart) &&
+    Number.isSafeInteger(sourceEnd) &&
+    sourceStart >= 0 &&
+    sourceEnd >= sourceStart
+      ? ` source_start="${sourceStart}" source_end="${sourceEnd}"`
+      : "";
+
+  return [
+    `<chat_selection id="${escapeXml(annotation.id)}"${
+      annotation.messageId ? ` message_id="${escapeXml(annotation.messageId)}"` : ""
+    }${sourceOffsets}>`,
+    "<selected_text>",
+    escapeXml(annotation.selectedText.trim()),
+    "</selected_text>",
+    "<user_comment>",
+    escapeXml(annotation.comment.trim()),
+    "</user_comment>",
+    "</chat_selection>",
+  ].join("\n");
+}
+
+export function appendChatSelectionAnnotationsToPrompt(
+  prompt: string,
+  annotations: ReadonlyArray<ChatSelectionAnnotation>,
+): string {
+  if (annotations.length === 0) return prompt;
+  const blocks = annotations.map(formatChatSelectionAnnotation).join("\n\n");
+  const trimmedPrompt = prompt.trim();
+  return trimmedPrompt.length > 0 ? `${trimmedPrompt}\n\n${blocks}` : blocks;
+}
+
+export function parseChatSelectionMessageSegments(
+  value: string,
+): ReadonlyArray<ChatSelectionMessageSegment> {
+  const segments: ChatSelectionMessageSegment[] = [];
+  let cursor = 0;
+  let parsedIndex = 0;
+
+  for (const match of value.matchAll(CHAT_SELECTION_BLOCK_PATTERN)) {
+    const matchIndex = match.index ?? 0;
+    const beforeText = value.slice(cursor, matchIndex);
+    if (beforeText.length > 0) {
+      segments.push({ kind: "text", id: `chat-selection-text:${cursor}`, text: beforeText });
+    }
+
+    const selectedText = unescapeXml(match[2] ?? "").trim();
+    if (selectedText.length === 0) {
+      segments.push({ kind: "text", id: `chat-selection-invalid:${matchIndex}`, text: match[0] });
+    } else {
+      const rawAttributes = match[1] ?? "";
+      const sourceMessageId =
+        readAttribute(rawAttributes, "message_id") ?? readAttribute(rawAttributes, "messageId");
+      const sourceStart = readNonNegativeIntegerAttribute(rawAttributes, "source_start");
+      const sourceEnd = readNonNegativeIntegerAttribute(rawAttributes, "source_end");
+      segments.push({
+        kind: "selection",
+        annotation: {
+          id: readId(rawAttributes, `chat-selection:${parsedIndex}`),
+          ...(sourceMessageId ? { messageId: sourceMessageId } : {}),
+          selectedText,
+          comment: unescapeXml(match[3] ?? "").trim(),
+          ...(sourceStart !== undefined && sourceEnd !== undefined && sourceEnd >= sourceStart
+            ? { sourceStart, sourceEnd }
+            : {}),
+        },
+      });
+      parsedIndex += 1;
+    }
+    cursor = matchIndex + match[0].length;
+  }
+
+  const rest = value.slice(cursor);
+  if (rest.length > 0) {
+    segments.push({ kind: "text", id: `chat-selection-text:${cursor}`, text: rest });
+  }
+  return segments;
+}
+
+export function hasChatSelectionMessageSegments(value: string): boolean {
+  return parseChatSelectionMessageSegments(value).some((segment) => segment.kind === "selection");
+}
+
+export function countChatSelectionAnnotationsForMessage(
+  annotations: ReadonlyArray<ChatSelectionAnnotation>,
+  messageId: string,
+): number {
+  return annotations.filter((annotation) => annotation.messageId === messageId).length;
+}
+
+export function deriveChatSelectionIndicators(
+  annotations: ReadonlyArray<ChatSelectionAnnotation>,
+): ReadonlyArray<ChatSelectionIndicator> {
+  return annotations.map((annotation, index) => ({
+    id: annotation.id,
+    kind: annotation.comment.trim() ? "text-comment" : "text-selection",
+    number: index + 1,
+    annotation,
+  }));
+}
+
+export function collectChatSelectionAnnotationsByMessageId(
+  pendingAnnotations: ReadonlyArray<ChatSelectionAnnotation>,
+): ReadonlyMap<string, ReadonlyArray<ChatSelectionAnnotation>> {
+  const annotationsByMessageId = new Map<string, ReadonlyArray<ChatSelectionAnnotation>>();
+  for (const annotation of pendingAnnotations) {
+    if (!annotation.messageId) continue;
+    const existing = annotationsByMessageId.get(annotation.messageId) ?? [];
+    annotationsByMessageId.set(annotation.messageId, [...existing, annotation]);
+  }
+  return annotationsByMessageId;
+}


### PR DESCRIPTION
## What Changed

Adds editing and numbered indicators to response-text annotations.

Users can now:

- See numbered markers beside annotated assistant text.
- Distinguish plain selections from selections with comments.
- Click a marker to highlight the source text and edit or delete pending annotations.
- Keep multiple annotations tied to their exact source ranges while reviewing them in the composer.

## Why

The first annotation flow made it possible to attach selected response text, but pending annotations were difficult to locate again and could not be corrected without removing and recreating them. Numbered markers make the relationship between the composer chips and assistant response obvious, while the editor keeps small comment changes fast.

## UI Changes

### Before

The first annotation flow exposed selection and composer actions, but did not show numbered source markers or an edit affordance.

<img width="1456" height="902" alt="Before: response-text annotations without numbered source markers" src="https://github.com/user-attachments/assets/c7357b7f-6fe7-4b69-b359-2a96cea3023a" />

### After

Selecting response text still opens the existing **Add to chat** action.

<!-- SCREENSHOT_SELECTION_POPOVER -->

Pending annotations now show numbered markers beside the source response and a matching composer summary.

<!-- SCREENSHOT_NUMBERED_ANNOTATIONS -->

Clicking a marker highlights the source text and opens an editor for the comment.

<!-- SCREENSHOT_EDIT_ANNOTATION -->

Multiple annotations receive stable sequential numbers and remain visible alongside the prompt.

<!-- SCREENSHOT_MULTIPLE_ANNOTATIONS -->

After sending, the conversation keeps the compact annotation summary without exposing serialized markup.

<!-- SCREENSHOT_SENT_SUMMARY -->

## Validation

- `./node_modules/.bin/vp test run apps/web/src/chatSelectionAnnotation.test.ts apps/web/src/components/ChatView.logic.test.ts apps/web/src/components/chat/MessagesTimeline.test.tsx apps/web/src/composerDraftStore.test.ts apps/web/src/proposedPlan.test.ts` (150 passed)
- `./node_modules/.bin/vp run --filter @t3tools/web typecheck`
- `./node_modules/.bin/vp run --filter @t3tools/shared typecheck`
- Manual verification in an isolated local T3 environment: selection popover, optional comment entry, numbered markers, edit/delete editor, multiple annotations, and sent summary.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI changes
- [x] I included interaction coverage in the validation notes

Model: OpenAI Codex · Harness: Codex desktop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large chat/composer UI and prompt serialization changes affect what users send to providers; DOM text indexing for highlights may misalign on edge-case markdown layouts.
> 
> **Overview**
> Adds **numbered markers** on assistant markdown for pending text selections, with amber highlights and an **edit/delete** flow before send. **`ChatMarkdown`** maps selections to **source offsets** in rendered text so markers stay aligned after layout changes.
> 
> **Composer and send path** store `chatSelectionAnnotations` in drafts (persist v9), show pending chips, and append shared **`chat_selection`** blocks (with optional `message_id` and offsets) to outgoing prompts. **Plan follow-up** can restore cleared prompt + annotations on failed send when the composer was still empty.
> 
> **Timeline** ties pending markers to source assistant messages; sent user turns show a compact **“N annotations”** summary without exposing serialized markup. Shared **`@t3tools/shared/chatSelectionAnnotation`** owns format/parse and indicator derivation; user docs describe the flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f7ad8347d286834318fe7ba313eb87dbf8bc441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add editable, numbered text-selection annotations to chat assistant messages
> - Adds a full annotation flow: selecting text in an assistant message shows a popover to capture an optional comment, which creates a `ChatSelectionAnnotation` stored in the composer draft and serialized into the outgoing message via `<chat_selection>` XML blocks.
> - Numbered indicator buttons render alongside annotated assistant message text; clicking an indicator opens an inline editor (`ChatSelectionAnnotationEditor`) to update or delete the annotation before sending.
> - The composer surfaces pending annotations as a summary chip (`ComposerPendingChatSelectionAnnotations`), counts them toward "has content" checks, and restores them on send failure.
> - Annotation state is persisted in `composerDraftStore` (storage version bumped 8 → 9) and grouped by message id for display in `MessagesTimeline`.
> - Risk: the storage version bump will discard any draft data saved under version 8 for users on the previous version.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5f7ad83. 13 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->