### PR TITLE
feat(terminal): select installed shell for new sessions

### DIFF
--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -56,6 +56,7 @@ const makeTerminalManagerLayer = (
     resize: () => Effect.void,
     clear: () => Effect.void,
     restart: () => Effect.die(new Error("unused")),
+    resolveAvailableShells: () => Effect.succeed([]),
     close: () => Effect.void,
     subscribe: () => Effect.succeed(() => undefined),
     subscribeMetadata: () => Effect.succeed(() => undefined),

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -736,6 +736,7 @@ const buildAppUnderTest = (options?: {
       ),
       Layer.provide(
         Layer.mock(TerminalManager.TerminalManager)({
+          resolveAvailableShells: () => Effect.succeed([]),
           ...options?.layers?.terminalManager,
         }),
       ),
@@ -3989,7 +3990,13 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
   it.effect("accepts websocket rpc handshake with a bootstrapped browser session cookie", () =>
     Effect.gen(function* () {
-      yield* buildAppUnderTest();
+      yield* buildAppUnderTest({
+        layers: {
+          terminalManager: {
+            resolveAvailableShells: () => Effect.succeed(["zsh", "fish"]),
+          },
+        },
+      });
 
       const { response: bootstrapResponse, cookie } = yield* bootstrapBrowserSession();
 
@@ -4006,6 +4013,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
       assert.equal(response.environment.environmentId, testEnvironmentDescriptor.environmentId);
       assert.equal(response.auth.policy, "desktop-managed-local");
+      assert.deepEqual(response.availableTerminalShells, ["zsh", "fish"]);
       assert.equal(response.shellResumeCompletionMarker, true);
       assert.equal(response.threadResumeCompletionMarker, true);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -102,7 +102,7 @@ const collectQueueUntil = Effect.fn("TransferBudget.collectQueueUntil")(function
 import * as BackgroundPolicy from "./background/BackgroundPolicy.ts";
 import * as ServerConfig from "./config.ts";
 import { makeRoutesLayer } from "./server.ts";
-import { isThreadDetailEvent, resolveAvailableEditorsForConfig } from "./ws.ts";
+import { isThreadDetailEvent, resolveAvailableCapabilitiesForConfig } from "./ws.ts";
 import * as CheckpointDiffQuery from "./checkpointing/CheckpointDiffQuery.ts";
 import * as GitManager from "./git/GitManager.ts";
 import * as Keybindings from "./keybindings.ts";
@@ -4019,10 +4019,10 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
-  it.effect("does not block server config when editor discovery never resolves", () =>
+  it.effect("does not block server config when capability discovery never resolves", () =>
     Effect.gen(function* () {
       const discoveryInterrupted = yield* Deferred.make<void>();
-      const responseFiber = yield* resolveAvailableEditorsForConfig(
+      const responseFiber = yield* resolveAvailableCapabilitiesForConfig(
         Effect.never.pipe(
           Effect.onInterrupt(() => Deferred.succeed(discoveryInterrupted, undefined)),
         ),

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -679,6 +679,7 @@ const buildAppUnderTest = (options?: {
       ),
       Layer.provide(
         Layer.mock(TerminalManager.TerminalManager)({
+          resolveAvailableShells: () => Effect.succeed([]),
           ...options?.layers?.terminalManager,
         }),
       ),
@@ -3910,7 +3911,13 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
   it.effect("accepts websocket rpc handshake with a bootstrapped browser session cookie", () =>
     Effect.gen(function* () {
-      yield* buildAppUnderTest();
+      yield* buildAppUnderTest({
+        layers: {
+          terminalManager: {
+            resolveAvailableShells: () => Effect.succeed(["zsh", "fish"]),
+          },
+        },
+      });
 
       const { response: bootstrapResponse, cookie } = yield* bootstrapBrowserSession();
 
@@ -3927,6 +3934,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
       assert.equal(response.environment.environmentId, testEnvironmentDescriptor.environmentId);
       assert.equal(response.auth.policy, "desktop-managed-local");
+      assert.deepEqual(response.availableTerminalShells, ["zsh", "fish"]);
       assert.equal(response.shellResumeCompletionMarker, true);
       assert.equal(response.threadResumeCompletionMarker, true);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -322,6 +322,7 @@ const PortScannerLayerLive = PortScanner.layer.pipe(Layer.provide(ProcessRunner.
 const TerminalLayerLive = TerminalManager.layer.pipe(
   Layer.provide(PtyAdapterLive),
   Layer.provide(PortScannerLayerLive),
+  Layer.provide(ServerSettingsLayerLive),
 );
 
 const PreviewLayerLive = Layer.empty.pipe(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -298,6 +298,7 @@ const PortScannerLayerLive = PortScanner.layer.pipe(Layer.provide(ProcessRunner.
 const TerminalLayerLive = TerminalManager.layer.pipe(
   Layer.provide(PtyAdapterLive),
   Layer.provide(PortScannerLayerLive),
+  Layer.provide(ServerSettingsLayerLive),
 );
 
 const PreviewLayerLive = Layer.empty.pipe(

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -203,6 +203,7 @@ const multiTerminalHistoryLogPath = (
 
 interface CreateManagerOptions {
   shellResolver?: () => string;
+  terminalShellResolver?: () => Effect.Effect<"system" | "zsh" | "bash" | "fish">;
   env?: NodeJS.ProcessEnv;
   subprocessInspector?: (terminalPid: number) => Effect.Effect<{
     readonly hasRunningSubprocess: boolean;
@@ -243,6 +244,9 @@ const createManager = (
         historyLineLimit,
         ptyAdapter,
         ...(options.shellResolver !== undefined ? { shellResolver: options.shellResolver } : {}),
+        ...(options.terminalShellResolver !== undefined
+          ? { terminalShellResolver: options.terminalShellResolver }
+          : {}),
         ...(options.env !== undefined ? { env: options.env } : {}),
         ...(options.subprocessInspector !== undefined
           ? { subprocessInspector: options.subprocessInspector }
@@ -1487,6 +1491,23 @@ it.layer(
       if (!spawnInput) return;
 
       expect(spawnInput.args).toEqual(["-o", "nopromptsp"]);
+    }),
+  );
+
+  it.effect("uses the configured shell for each new terminal", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") return;
+      let terminalShell: "bash" | "fish" = "bash";
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        env: { SHELL: "/bin/zsh" },
+        terminalShellResolver: () => Effect.succeed(terminalShell),
+      });
+
+      yield* manager.open(openInput({ terminalId: "term-1" }));
+      terminalShell = "fish";
+      yield* manager.open(openInput({ terminalId: "term-2" }));
+
+      expect(ptyAdapter.spawnInputs.map((input) => input.shell)).toEqual(["bash", "fish"]);
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1511,6 +1511,23 @@ it.layer(
     }),
   );
 
+  it.effect("discovers only installed selectable shells", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") return;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-shells-" });
+      for (const shell of ["bash", "fish"] as const) {
+        const executable = path.join(binDir, shell);
+        yield* writeFileString(executable, "#!/bin/sh\n");
+        yield* chmod(executable, 0o755);
+      }
+      const { manager } = yield* createManager(5, { env: { PATH: binDir } });
+
+      expect(yield* manager.resolveAvailableShells()).toEqual(["bash", "fish"]);
+    }),
+  );
+
   it.effect("bridges PTY callbacks back into Effect-managed event streaming", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, getEvents } = yield* createManager(5, {

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -203,6 +203,7 @@ const multiTerminalHistoryLogPath = (
 
 interface CreateManagerOptions {
   shellResolver?: () => string;
+  terminalShellResolver?: () => Effect.Effect<"system" | "zsh" | "bash" | "fish">;
   env?: NodeJS.ProcessEnv;
   subprocessInspector?: (terminalPid: number) => Effect.Effect<{
     readonly hasRunningSubprocess: boolean;
@@ -243,6 +244,9 @@ const createManager = (
         historyLineLimit,
         ptyAdapter,
         ...(options.shellResolver !== undefined ? { shellResolver: options.shellResolver } : {}),
+        ...(options.terminalShellResolver !== undefined
+          ? { terminalShellResolver: options.terminalShellResolver }
+          : {}),
         ...(options.env !== undefined ? { env: options.env } : {}),
         ...(options.subprocessInspector !== undefined
           ? { subprocessInspector: options.subprocessInspector }
@@ -1425,6 +1429,23 @@ it.layer(
       if (!spawnInput) return;
 
       expect(spawnInput.args).toEqual(["-o", "nopromptsp"]);
+    }),
+  );
+
+  it.effect("uses the configured shell for each new terminal", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") return;
+      let terminalShell: "bash" | "fish" = "bash";
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        env: { SHELL: "/bin/zsh" },
+        terminalShellResolver: () => Effect.succeed(terminalShell),
+      });
+
+      yield* manager.open(openInput({ terminalId: "term-1" }));
+      terminalShell = "fish";
+      yield* manager.open(openInput({ terminalId: "term-2" }));
+
+      expect(ptyAdapter.spawnInputs.map((input) => input.shell)).toEqual(["bash", "fish"]);
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1449,6 +1449,23 @@ it.layer(
     }),
   );
 
+  it.effect("discovers only installed selectable shells", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") return;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-shells-" });
+      for (const shell of ["bash", "fish"] as const) {
+        const executable = path.join(binDir, shell);
+        yield* writeFileString(executable, "#!/bin/sh\n");
+        yield* chmod(executable, 0o755);
+      }
+      const { manager } = yield* createManager(5, { env: { PATH: binDir } });
+
+      expect(yield* manager.resolveAvailableShells()).toEqual(["bash", "fish"]);
+    }),
+  );
+
   it.effect("bridges PTY callbacks back into Effect-managed event streaming", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, getEvents } = yield* createManager(5, {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -8,6 +8,8 @@
  */
 import {
   DEFAULT_TERMINAL_ID,
+  INSTALLED_TERMINAL_SHELLS,
+  type InstalledTerminalShell,
   TerminalCwdError,
   TerminalCwdNotDirectoryError,
   TerminalCwdNotFoundError,
@@ -35,6 +37,7 @@ import {
 } from "@t3tools/contracts";
 import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { isCommandAvailable } from "@t3tools/shared/shell";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
@@ -162,6 +165,9 @@ export class TerminalManager extends Context.Service<
     readonly restart: (
       input: TerminalRestartInput,
     ) => Effect.Effect<TerminalSessionSnapshot, TerminalError>;
+
+    /** Discover selectable shells installed on this environment. */
+    readonly resolveAvailableShells: () => Effect.Effect<ReadonlyArray<InstalledTerminalShell>>;
 
     /**
      * Close an active terminal session.
@@ -1275,6 +1281,19 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     options.maxRetainedInactiveSessions ?? DEFAULT_MAX_RETAINED_INACTIVE_SESSIONS;
   const registerTerminalProcesses = options.registerTerminalProcesses ?? (() => Effect.void);
   const unregisterTerminal = options.unregisterTerminal ?? (() => Effect.void);
+
+  const resolveAvailableShells = Effect.fn("terminal.resolveAvailableShells")(function* () {
+    const available: InstalledTerminalShell[] = [];
+    for (const shell of INSTALLED_TERMINAL_SHELLS) {
+      const installed = yield* isCommandAvailable(shell, { env: baseEnv }).pipe(
+        Effect.provideService(HostProcessPlatform, platform),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
+      if (installed) available.push(shell);
+    }
+    return available;
+  });
 
   yield* fileSystem.makeDirectory(logsDir, { recursive: true }).pipe(Effect.orDie);
 
@@ -2734,6 +2753,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     resize,
     clear,
     restart,
+    resolveAvailableShells,
     close,
     subscribe,
     subscribeMetadata,

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -18,6 +18,7 @@ import {
   TerminalResizeError,
   TerminalSessionLookupError,
   TerminalWriteError,
+  type TerminalShell,
   type TerminalAttachInput,
   type TerminalAttachStreamEvent,
   type TerminalClearInput,
@@ -52,6 +53,7 @@ import * as Semaphore from "effect/Semaphore";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import {
   increment,
   terminalRestartsTotal,
@@ -531,12 +533,12 @@ function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellC
 }
 
 function resolveShellCandidates(
-  shellResolver: () => string,
+  requestedShell: string,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
 ): ShellCandidate[] {
   const requested = shellCandidateFromCommand(
-    normalizeShellCommand(shellResolver(), platform),
+    normalizeShellCommand(requestedShell, platform),
     platform,
   );
 
@@ -557,11 +559,24 @@ function resolveShellCandidates(
     shellCandidateFromCommand(normalizeShellCommand(env.SHELL, platform), platform),
     shellCandidateFromCommand("/bin/zsh", platform),
     shellCandidateFromCommand("/bin/bash", platform),
+    shellCandidateFromCommand("/usr/bin/fish", platform),
     shellCandidateFromCommand("/bin/sh", platform),
     shellCandidateFromCommand("zsh", platform),
     shellCandidateFromCommand("bash", platform),
+    shellCandidateFromCommand("fish", platform),
     shellCandidateFromCommand("sh", platform),
   ]);
+}
+
+function configuredShellCommand(
+  preference: TerminalShell,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (preference === "system") {
+    return defaultShellResolver(platform, env);
+  }
+  return preference;
 }
 
 function isRetryableShellSpawnError(error: PtyAdapter.PtySpawnError): boolean {
@@ -1181,6 +1196,7 @@ interface TerminalManagerOptions {
   historyLineLimit?: number;
   ptyAdapter: PtyAdapter.PtyAdapter["Service"];
   shellResolver?: () => string;
+  terminalShellResolver?: () => Effect.Effect<TerminalShell>;
   env?: NodeJS.ProcessEnv;
   subprocessInspector?: TerminalSubprocessInspector;
   subprocessPollIntervalMs?: number;
@@ -1199,11 +1215,21 @@ interface TerminalManagerOptions {
 
 export const make = Effect.fn("TerminalManager.make")(function* () {
   const { terminalLogsDir } = yield* ServerConfig.ServerConfig;
+  const serverSettings = yield* ServerSettings.ServerSettingsService;
   const ptyAdapter = yield* PtyAdapter.PtyAdapter;
   const portDiscovery = yield* PortScanner.PortDiscovery;
   return yield* makeWithOptions({
     logsDir: terminalLogsDir,
     ptyAdapter,
+    terminalShellResolver: () =>
+      serverSettings.getSettings.pipe(
+        Effect.map((settings) => settings.terminalShell),
+        Effect.catch((error) =>
+          Effect.logWarning("failed to read terminal shell setting; using the system shell", {
+            cause: error,
+          }).pipe(Effect.as("system" as const)),
+        ),
+      ),
     registerTerminalProcesses: portDiscovery.registerTerminalProcesses,
     unregisterTerminal: portDiscovery.unregisterTerminal,
   });
@@ -1225,7 +1251,16 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   // things like PSModulePath, DISPLAY, proxies, and toolchain variables.
   // `options.env` is the test seam.
   const baseEnv = options.env ?? process.env;
-  const shellResolver = options.shellResolver ?? (() => defaultShellResolver(platform, baseEnv));
+  const shellResolver = options.shellResolver;
+  const terminalShellResolver = options.terminalShellResolver;
+  const resolveRequestedShell = shellResolver
+    ? () => Effect.sync(shellResolver)
+    : terminalShellResolver
+      ? () =>
+          terminalShellResolver().pipe(
+            Effect.map((preference) => configuredShellCommand(preference, platform, baseEnv)),
+          )
+      : () => Effect.succeed(defaultShellResolver(platform, baseEnv));
   const processRunner = yield* ProcessRunner.ProcessRunner;
   const subprocessInspector =
     options.subprocessInspector ??
@@ -1920,7 +1955,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
         Effect.andThen(
           Effect.gen(function* () {
-            const shellCandidates = resolveShellCandidates(shellResolver, platform, baseEnv);
+            const requestedShell = yield* resolveRequestedShell();
+            const shellCandidates = resolveShellCandidates(requestedShell, platform, baseEnv);
             const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -8,6 +8,8 @@
  */
 import {
   DEFAULT_TERMINAL_ID,
+  INSTALLED_TERMINAL_SHELLS,
+  type InstalledTerminalShell,
   TerminalCwdError,
   TerminalCwdNotDirectoryError,
   TerminalCwdNotFoundError,
@@ -35,6 +37,7 @@ import {
 } from "@t3tools/contracts";
 import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { isCommandAvailable } from "@t3tools/shared/shell";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
@@ -162,6 +165,9 @@ export class TerminalManager extends Context.Service<
     readonly restart: (
       input: TerminalRestartInput,
     ) => Effect.Effect<TerminalSessionSnapshot, TerminalError>;
+
+    /** Discover selectable shells installed on this environment. */
+    readonly resolveAvailableShells: () => Effect.Effect<ReadonlyArray<InstalledTerminalShell>>;
 
     /**
      * Close an active terminal session.
@@ -1238,6 +1244,19 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     options.maxRetainedInactiveSessions ?? DEFAULT_MAX_RETAINED_INACTIVE_SESSIONS;
   const registerTerminalProcesses = options.registerTerminalProcesses ?? (() => Effect.void);
   const unregisterTerminal = options.unregisterTerminal ?? (() => Effect.void);
+
+  const resolveAvailableShells = Effect.fn("terminal.resolveAvailableShells")(function* () {
+    const available: InstalledTerminalShell[] = [];
+    for (const shell of INSTALLED_TERMINAL_SHELLS) {
+      const installed = yield* isCommandAvailable(shell, { env: baseEnv }).pipe(
+        Effect.provideService(HostProcessPlatform, platform),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
+      if (installed) available.push(shell);
+    }
+    return available;
+  });
 
   yield* fileSystem.makeDirectory(logsDir, { recursive: true }).pipe(Effect.orDie);
 
@@ -2697,6 +2716,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     resize,
     clear,
     restart,
+    resolveAvailableShells,
     close,
     subscribe,
     subscribeMetadata,

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -18,6 +18,7 @@ import {
   TerminalResizeError,
   TerminalSessionLookupError,
   TerminalWriteError,
+  type TerminalShell,
   type TerminalAttachInput,
   type TerminalAttachStreamEvent,
   type TerminalClearInput,
@@ -52,6 +53,7 @@ import * as Semaphore from "effect/Semaphore";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import {
   increment,
   terminalRestartsTotal,
@@ -531,12 +533,12 @@ function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellC
 }
 
 function resolveShellCandidates(
-  shellResolver: () => string,
+  requestedShell: string,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
 ): ShellCandidate[] {
   const requested = shellCandidateFromCommand(
-    normalizeShellCommand(shellResolver(), platform),
+    normalizeShellCommand(requestedShell, platform),
     platform,
   );
 
@@ -557,11 +559,24 @@ function resolveShellCandidates(
     shellCandidateFromCommand(normalizeShellCommand(env.SHELL, platform), platform),
     shellCandidateFromCommand("/bin/zsh", platform),
     shellCandidateFromCommand("/bin/bash", platform),
+    shellCandidateFromCommand("/usr/bin/fish", platform),
     shellCandidateFromCommand("/bin/sh", platform),
     shellCandidateFromCommand("zsh", platform),
     shellCandidateFromCommand("bash", platform),
+    shellCandidateFromCommand("fish", platform),
     shellCandidateFromCommand("sh", platform),
   ]);
+}
+
+function configuredShellCommand(
+  preference: TerminalShell,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (preference === "system") {
+    return defaultShellResolver(platform, env);
+  }
+  return preference;
 }
 
 function isRetryableShellSpawnError(error: PtyAdapter.PtySpawnError): boolean {
@@ -1144,6 +1159,7 @@ interface TerminalManagerOptions {
   historyLineLimit?: number;
   ptyAdapter: PtyAdapter.PtyAdapter["Service"];
   shellResolver?: () => string;
+  terminalShellResolver?: () => Effect.Effect<TerminalShell>;
   env?: NodeJS.ProcessEnv;
   subprocessInspector?: TerminalSubprocessInspector;
   subprocessPollIntervalMs?: number;
@@ -1162,11 +1178,21 @@ interface TerminalManagerOptions {
 
 export const make = Effect.fn("TerminalManager.make")(function* () {
   const { terminalLogsDir } = yield* ServerConfig.ServerConfig;
+  const serverSettings = yield* ServerSettings.ServerSettingsService;
   const ptyAdapter = yield* PtyAdapter.PtyAdapter;
   const portDiscovery = yield* PortScanner.PortDiscovery;
   return yield* makeWithOptions({
     logsDir: terminalLogsDir,
     ptyAdapter,
+    terminalShellResolver: () =>
+      serverSettings.getSettings.pipe(
+        Effect.map((settings) => settings.terminalShell),
+        Effect.catch((error) =>
+          Effect.logWarning("failed to read terminal shell setting; using the system shell", {
+            cause: error,
+          }).pipe(Effect.as("system" as const)),
+        ),
+      ),
     registerTerminalProcesses: portDiscovery.registerTerminalProcesses,
     unregisterTerminal: portDiscovery.unregisterTerminal,
   });
@@ -1188,7 +1214,16 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   // things like PSModulePath, DISPLAY, proxies, and toolchain variables.
   // `options.env` is the test seam.
   const baseEnv = options.env ?? process.env;
-  const shellResolver = options.shellResolver ?? (() => defaultShellResolver(platform, baseEnv));
+  const shellResolver = options.shellResolver;
+  const terminalShellResolver = options.terminalShellResolver;
+  const resolveRequestedShell = shellResolver
+    ? () => Effect.sync(shellResolver)
+    : terminalShellResolver
+      ? () =>
+          terminalShellResolver().pipe(
+            Effect.map((preference) => configuredShellCommand(preference, platform, baseEnv)),
+          )
+      : () => Effect.succeed(defaultShellResolver(platform, baseEnv));
   const processRunner = yield* ProcessRunner.ProcessRunner;
   const subprocessInspector =
     options.subprocessInspector ??
@@ -1883,7 +1918,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
         Effect.andThen(
           Effect.gen(function* () {
-            const shellCandidates = resolveShellCandidates(shellResolver, platform, baseEnv);
+            const requestedShell = yield* resolveRequestedShell();
+            const shellCandidates = resolveShellCandidates(requestedShell, platform, baseEnv);
             const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -126,15 +126,17 @@ import * as RelayClient from "@t3tools/shared/relayClient";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
-const EDITOR_DISCOVERY_TIMEOUT = Duration.seconds(5);
+const SYSTEM_CAPABILITY_DISCOVERY_TIMEOUT = Duration.seconds(5);
 
-export const resolveAvailableEditorsForConfig = <A, E, R>(
+export const resolveAvailableCapabilitiesForConfig = <A, E, R>(
   discovery: Effect.Effect<ReadonlyArray<A>, E, R>,
 ) =>
   discovery.pipe(
-    Effect.timeoutOption(EDITOR_DISCOVERY_TIMEOUT),
+    Effect.timeoutOption(SYSTEM_CAPABILITY_DISCOVERY_TIMEOUT),
     Effect.map(Option.getOrElse(() => [])),
   );
+
+export const resolveAvailableEditorsForConfig = resolveAvailableCapabilitiesForConfig;
 
 function unexpectedCompatibilityError(error: never): never {
   throw new Error(`Unhandled compatibility error: ${String(error)}`);
@@ -998,6 +1000,13 @@ const makeWsRpcLayer = (
         );
         const environment = yield* serverEnvironment.getDescriptor;
         const auth = yield* serverAuth.getDescriptor();
+        const [availableEditors, availableTerminalShells] = yield* Effect.all(
+          [
+            resolveAvailableCapabilitiesForConfig(externalLauncher.resolveAvailableEditors()),
+            resolveAvailableCapabilitiesForConfig(terminalManager.resolveAvailableShells()),
+          ],
+          { concurrency: "unbounded" },
+        );
 
         return {
           environment,
@@ -1007,9 +1016,8 @@ const makeWsRpcLayer = (
           keybindings: keybindingsConfig.keybindings,
           issues: keybindingsConfig.issues,
           providers,
-          availableEditors: yield* resolveAvailableEditorsForConfig(
-            externalLauncher.resolveAvailableEditors(),
-          ),
+          availableEditors,
+          availableTerminalShells,
           observability: {
             logsDirectoryPath: config.logsDir,
             localTracingEnabled: true,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -136,8 +136,6 @@ export const resolveAvailableCapabilitiesForConfig = <A, E, R>(
     Effect.map(Option.getOrElse(() => [])),
   );
 
-export const resolveAvailableEditorsForConfig = resolveAvailableCapabilitiesForConfig;
-
 function unexpectedCompatibilityError(error: never): never {
   throw new Error(`Unhandled compatibility error: ${String(error)}`);
 }

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -123,15 +123,17 @@ import * as RelayClient from "@t3tools/shared/relayClient";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
-const EDITOR_DISCOVERY_TIMEOUT = Duration.seconds(5);
+const SYSTEM_CAPABILITY_DISCOVERY_TIMEOUT = Duration.seconds(5);
 
-export const resolveAvailableEditorsForConfig = <A, E, R>(
+export const resolveAvailableCapabilitiesForConfig = <A, E, R>(
   discovery: Effect.Effect<ReadonlyArray<A>, E, R>,
 ) =>
   discovery.pipe(
-    Effect.timeoutOption(EDITOR_DISCOVERY_TIMEOUT),
+    Effect.timeoutOption(SYSTEM_CAPABILITY_DISCOVERY_TIMEOUT),
     Effect.map(Option.getOrElse(() => [])),
   );
+
+export const resolveAvailableEditorsForConfig = resolveAvailableCapabilitiesForConfig;
 
 function unexpectedCompatibilityError(error: never): never {
   throw new Error(`Unhandled compatibility error: ${String(error)}`);
@@ -984,6 +986,13 @@ const makeWsRpcLayer = (
         );
         const environment = yield* serverEnvironment.getDescriptor;
         const auth = yield* serverAuth.getDescriptor();
+        const [availableEditors, availableTerminalShells] = yield* Effect.all(
+          [
+            resolveAvailableCapabilitiesForConfig(externalLauncher.resolveAvailableEditors()),
+            resolveAvailableCapabilitiesForConfig(terminalManager.resolveAvailableShells()),
+          ],
+          { concurrency: "unbounded" },
+        );
 
         return {
           environment,
@@ -993,9 +1002,8 @@ const makeWsRpcLayer = (
           keybindings: keybindingsConfig.keybindings,
           issues: keybindingsConfig.issues,
           providers,
-          availableEditors: yield* resolveAvailableEditorsForConfig(
-            externalLauncher.resolveAvailableEditors(),
-          ),
+          availableEditors,
+          availableTerminalShells,
           observability: {
             logsDirectoryPath: config.logsDir,
             localTracingEnabled: true,

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -17,6 +17,7 @@ import {
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
   resolveBackgroundActivityProfileOption,
+  resolveTerminalShellOptions,
 } from "./SettingsPanels.logic";
 
 describe("typography settings restore", () => {
@@ -29,6 +30,26 @@ describe("typography settings restore", () => {
         fontFamilyCode: "Fira Code",
       }),
     ).toEqual(["Interface font", "Code font"]);
+  });
+});
+
+describe("terminal shell options", () => {
+  it("shows only shells installed on the connected environment", () => {
+    expect(
+      resolveTerminalShellOptions({ installed: ["bash", "fish"], selected: "system" }),
+    ).toEqual([
+      { value: "system", installed: true },
+      { value: "bash", installed: true },
+      { value: "fish", installed: true },
+    ]);
+  });
+
+  it("keeps an unavailable current selection visible but disabled", () => {
+    expect(resolveTerminalShellOptions({ installed: ["bash"], selected: "fish" })).toEqual([
+      { value: "system", installed: true },
+      { value: "bash", installed: true },
+      { value: "fish", installed: false },
+    ]);
   });
 });
 

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -16,7 +16,28 @@ import {
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
   resolveBackgroundActivityProfileOption,
+  resolveTerminalShellOptions,
 } from "./SettingsPanels.logic";
+
+describe("terminal shell options", () => {
+  it("shows only shells installed on the connected environment", () => {
+    expect(
+      resolveTerminalShellOptions({ installed: ["bash", "fish"], selected: "system" }),
+    ).toEqual([
+      { value: "system", installed: true },
+      { value: "bash", installed: true },
+      { value: "fish", installed: true },
+    ]);
+  });
+
+  it("keeps an unavailable current selection visible but disabled", () => {
+    expect(resolveTerminalShellOptions({ installed: ["bash"], selected: "fish" })).toEqual([
+      { value: "system", installed: true },
+      { value: "bash", installed: true },
+      { value: "fish", installed: false },
+    ]);
+  });
+});
 
 describe("background activity settings restore", () => {
   it("detects legacy interval values even when the structured setting is at its default", () => {

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,11 +1,13 @@
 import type {
   BackgroundActivityProfile,
   BackgroundActivitySettings,
+  InstalledTerminalShell,
   ProviderDriverKind,
   ProviderInstanceConfig,
   ProviderInstanceId,
   ServerSettings,
   SidebarProjectGroupingMode,
+  TerminalShell,
   UnifiedSettings,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
@@ -28,6 +30,23 @@ export function projectGroupingModeFromToggle(
 ): SidebarProjectGroupingMode {
   if (!enabled) return "separate";
   return lastEnabledMode === "repository_path" ? "repository_path" : "repository";
+}
+
+const TERMINAL_SHELL_ORDER = [
+  "system",
+  "zsh",
+  "bash",
+  "fish",
+] as const satisfies ReadonlyArray<TerminalShell>;
+
+export function resolveTerminalShellOptions(input: {
+  readonly installed: ReadonlyArray<InstalledTerminalShell>;
+  readonly selected: TerminalShell;
+}): ReadonlyArray<{ readonly value: TerminalShell; readonly installed: boolean }> {
+  const installed = new Set<TerminalShell>(["system", ...input.installed]);
+  return TERMINAL_SHELL_ORDER.filter(
+    (value) => installed.has(value) || value === input.selected,
+  ).map((value) => ({ value, installed: installed.has(value) }));
 }
 
 const LAST_ENABLED_PROJECT_GROUPING_MODE_KEY = "t3code:last-enabled-project-grouping-mode";

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,11 +1,13 @@
 import type {
   BackgroundActivityProfile,
   BackgroundActivitySettings,
+  InstalledTerminalShell,
   ProviderDriverKind,
   ProviderInstanceConfig,
   ProviderInstanceId,
   ServerSettings,
   SidebarProjectGroupingMode,
+  TerminalShell,
   UnifiedSettings,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
@@ -26,6 +28,23 @@ export function projectGroupingModeFromToggle(
 ): SidebarProjectGroupingMode {
   if (!enabled) return "separate";
   return lastEnabledMode === "repository_path" ? "repository_path" : "repository";
+}
+
+const TERMINAL_SHELL_ORDER = [
+  "system",
+  "zsh",
+  "bash",
+  "fish",
+] as const satisfies ReadonlyArray<TerminalShell>;
+
+export function resolveTerminalShellOptions(input: {
+  readonly installed: ReadonlyArray<InstalledTerminalShell>;
+  readonly selected: TerminalShell;
+}): ReadonlyArray<{ readonly value: TerminalShell; readonly installed: boolean }> {
+  const installed = new Set<TerminalShell>(["system", ...input.installed]);
+  return TERMINAL_SHELL_ORDER.filter(
+    (value) => installed.has(value) || value === input.selected,
+  ).map((value) => ({ value, installed: installed.has(value) }));
 }
 
 const LAST_ENABLED_PROJECT_GROUPING_MODE_KEY = "t3code:last-enabled-project-grouping-mode";

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -77,7 +77,11 @@ import {
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
 import { isMacPlatform } from "../../lib/utils";
-import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
+import {
+  primaryServerConfigAtom,
+  primaryServerObservabilityAtom,
+  primaryServerProvidersAtom,
+} from "../../state/server";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel } from "../../timestampFormat";
@@ -132,6 +136,7 @@ import {
   readLastEnabledProjectGroupingMode,
   rememberEnabledProjectGroupingMode,
   resolveBackgroundActivityProfileOption,
+  resolveTerminalShellOptions,
 } from "./SettingsPanels.logic";
 import {
   PolicyTooltip,
@@ -1753,6 +1758,11 @@ export function GeneralSettingsPanel() {
   );
   const observability = useAtomValue(primaryServerObservabilityAtom);
   const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const serverConfig = useAtomValue(primaryServerConfigAtom);
+  const terminalShellOptions = resolveTerminalShellOptions({
+    installed: serverConfig?.availableTerminalShells ?? [],
+    selected: settings.terminalShell,
+  });
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
     otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
@@ -1942,16 +1952,27 @@ export function GeneralSettingsPanel() {
               }}
             >
               <SelectTrigger className="w-full sm:w-40" aria-label="Terminal shell">
-                <SelectValue>{TERMINAL_SHELL_LABELS[settings.terminalShell]}</SelectValue>
+                <SelectValue>
+                  {TERMINAL_SHELL_LABELS[settings.terminalShell]}
+                  {terminalShellOptions.some(
+                    (option) => option.value === settings.terminalShell && !option.installed,
+                  )
+                    ? " (not installed)"
+                    : ""}
+                </SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
-                {(Object.entries(TERMINAL_SHELL_LABELS) as Array<[TerminalShell, string]>).map(
-                  ([value, label]) => (
-                    <SelectItem hideIndicator key={value} value={value}>
-                      {label}
-                    </SelectItem>
-                  ),
-                )}
+                {terminalShellOptions.map((option) => (
+                  <SelectItem
+                    disabled={!option.installed}
+                    hideIndicator
+                    key={option.value}
+                    value={option.value}
+                  >
+                    {TERMINAL_SHELL_LABELS[option.value]}
+                    {!option.installed ? " (not installed)" : ""}
+                  </SelectItem>
+                ))}
               </SelectPopup>
             </Select>
           }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -523,6 +523,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
         ? ["New thread mode"]
         : []),
+      ...(settings.terminalShell !== DEFAULT_UNIFIED_SETTINGS.terminalShell
+        ? ["Terminal shell"]
+        : []),
       ...(settings.newWorktreesStartFromOrigin !==
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
@@ -545,6 +548,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
+      settings.terminalShell,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
       settings.environmentIdentificationMode,
@@ -648,6 +652,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+      terminalShell: DEFAULT_UNIFIED_SETTINGS.terminalShell,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -9,6 +9,7 @@ import {
   ProviderDriverKind,
   type ScopedThreadRef,
   type SidebarProjectGroupingMode,
+  type TerminalShell,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import {
@@ -154,6 +155,13 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const TERMINAL_SHELL_LABELS: Record<TerminalShell, string> = {
+  system: "System default",
+  zsh: "Zsh",
+  bash: "Bash",
+  fish: "Fish",
+};
 
 const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<BackgroundActivityProfile, string> = {
   balanced: "Balanced",
@@ -1906,6 +1914,44 @@ export function GeneralSettingsPanel() {
                 <SelectItem hideIndicator value="24-hour">
                   {TIMESTAMP_FORMAT_LABELS["24-hour"]}
                 </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("terminal-shell")}
+          description="Shell used by new and restarted terminals on this environment. System default uses the environment's configured shell."
+          resetAction={
+            settings.terminalShell !== DEFAULT_UNIFIED_SETTINGS.terminalShell ? (
+              <SettingResetButton
+                label="terminal shell"
+                onClick={() =>
+                  updateSettings({ terminalShell: DEFAULT_UNIFIED_SETTINGS.terminalShell })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.terminalShell}
+              onValueChange={(value) => {
+                if (value === "system" || value === "zsh" || value === "bash" || value === "fish") {
+                  updateSettings({ terminalShell: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Terminal shell">
+                <SelectValue>{TERMINAL_SHELL_LABELS[settings.terminalShell]}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                {(Object.entries(TERMINAL_SHELL_LABELS) as Array<[TerminalShell, string]>).map(
+                  ([value, label]) => (
+                    <SelectItem hideIndicator key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ),
+                )}
               </SelectPopup>
             </Select>
           }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -22,6 +22,7 @@ import {
   type ProviderInstanceId,
   type ScopedThreadRef,
   type SidebarProjectGroupingMode,
+  type TerminalShell,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
@@ -166,6 +167,13 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const TERMINAL_SHELL_LABELS: Record<TerminalShell, string> = {
+  system: "System default",
+  zsh: "Zsh",
+  bash: "Bash",
+  fish: "Fish",
+};
 
 const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<BackgroundActivityProfile, string> = {
   balanced: "Balanced",
@@ -1243,6 +1251,44 @@ export function GeneralSettingsPanel() {
                 <SelectItem hideIndicator value="24-hour">
                   {TIMESTAMP_FORMAT_LABELS["24-hour"]}
                 </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("terminal-shell")}
+          description="Shell used by new and restarted terminals on this environment. System default uses the environment's configured shell."
+          resetAction={
+            settings.terminalShell !== DEFAULT_UNIFIED_SETTINGS.terminalShell ? (
+              <SettingResetButton
+                label="terminal shell"
+                onClick={() =>
+                  updateSettings({ terminalShell: DEFAULT_UNIFIED_SETTINGS.terminalShell })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.terminalShell}
+              onValueChange={(value) => {
+                if (value === "system" || value === "zsh" || value === "bash" || value === "fish") {
+                  updateSettings({ terminalShell: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Terminal shell">
+                <SelectValue>{TERMINAL_SHELL_LABELS[settings.terminalShell]}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                {(Object.entries(TERMINAL_SHELL_LABELS) as Array<[TerminalShell, string]>).map(
+                  ([value, label]) => (
+                    <SelectItem hideIndicator key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ),
+                )}
               </SelectPopup>
             </Select>
           }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -79,6 +79,7 @@ import {
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
 import {
+  primaryServerConfigAtom,
   primaryServerObservabilityAtom,
   primaryServerProvidersAtom,
   serverEnvironment,
@@ -129,6 +130,7 @@ import {
   readLastEnabledProjectGroupingMode,
   rememberEnabledProjectGroupingMode,
   resolveBackgroundActivityProfileOption,
+  resolveTerminalShellOptions,
 } from "./SettingsPanels.logic";
 import {
   SettingResetButton,
@@ -1131,6 +1133,11 @@ export function GeneralSettingsPanel() {
   );
   const observability = useAtomValue(primaryServerObservabilityAtom);
   const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const serverConfig = useAtomValue(primaryServerConfigAtom);
+  const terminalShellOptions = resolveTerminalShellOptions({
+    installed: serverConfig?.availableTerminalShells ?? [],
+    selected: settings.terminalShell,
+  });
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
     otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
@@ -1279,16 +1286,27 @@ export function GeneralSettingsPanel() {
               }}
             >
               <SelectTrigger className="w-full sm:w-40" aria-label="Terminal shell">
-                <SelectValue>{TERMINAL_SHELL_LABELS[settings.terminalShell]}</SelectValue>
+                <SelectValue>
+                  {TERMINAL_SHELL_LABELS[settings.terminalShell]}
+                  {terminalShellOptions.some(
+                    (option) => option.value === settings.terminalShell && !option.installed,
+                  )
+                    ? " (not installed)"
+                    : ""}
+                </SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
-                {(Object.entries(TERMINAL_SHELL_LABELS) as Array<[TerminalShell, string]>).map(
-                  ([value, label]) => (
-                    <SelectItem hideIndicator key={value} value={value}>
-                      {label}
-                    </SelectItem>
-                  ),
-                )}
+                {terminalShellOptions.map((option) => (
+                  <SelectItem
+                    disabled={!option.installed}
+                    hideIndicator
+                    key={option.value}
+                    value={option.value}
+                  >
+                    {TERMINAL_SHELL_LABELS[option.value]}
+                    {!option.installed ? " (not installed)" : ""}
+                  </SelectItem>
+                ))}
               </SelectPopup>
             </Select>
           }

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -85,4 +85,11 @@ describe("searchSettings", () => {
       targetId: "appearance",
     });
   });
+
+  it("routes terminal shell to General settings", () => {
+    expect(searchSettings("terminal shell")[0]).toMatchObject({
+      id: "terminal-shell",
+      to: "/settings/general",
+    });
+  });
 });

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -84,4 +84,11 @@ describe("searchSettings", () => {
       targetId: "appearance",
     });
   });
+
+  it("routes terminal shell to General settings", () => {
+    expect(searchSettings("terminal shell")[0]).toMatchObject({
+      id: "terminal-shell",
+      to: "/settings/general",
+    });
+  });
 });

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -109,6 +109,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "terminal-shell",
+    title: "Terminal shell",
+    to: "/settings/general",
+  },
+  {
     id: "hide-whitespace-changes",
     title: "Hide whitespace changes",
     to: "/settings/general",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -71,6 +71,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "terminal-shell",
+    title: "Terminal shell",
+    to: "/settings/general",
+  },
+  {
     id: "hide-whitespace-changes",
     title: "Hide whitespace changes",
     to: "/settings/general",

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - [Organizing threads](./user/thread-sidebar.md)
 - [Review usage](./user/usage.md)
 - [Customize a project icon](./user/project-settings.md)
+- [Terminal](./user/terminal.md)
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Install and first run](./user/install.md)
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
+- [Terminal](./user/terminal.md)
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)

--- a/docs/user/terminal.md
+++ b/docs/user/terminal.md
@@ -8,11 +8,14 @@ directory.
 Open **Settings → General → Terminal shell** and choose one of these options:
 
 - **System default** uses the connected environment's configured shell.
-- **Zsh**, **Bash**, or **Fish** explicitly starts that shell.
+- **Zsh**, **Bash**, or **Fish** explicitly starts that shell. Only shells discovered on the
+  connected environment are offered.
 
 The choice is saved on the environment, so it also applies when a web, desktop, or mobile client
 opens a terminal there. It affects new and restarted terminals; shells that are already running
 continue unchanged.
 
-The selected shell must be installed and available on the environment's `PATH`. If it cannot be
-started, T3 Code tries another available shell so the terminal remains usable.
+T3 Code probes the connected environment's `PATH`, so remote environments can show different
+choices. If a previously selected shell is later removed, it appears as unavailable until you
+choose another option. T3 Code still tries another available shell when opening a terminal so the
+terminal remains usable.

--- a/docs/user/terminal.md
+++ b/docs/user/terminal.md
@@ -1,0 +1,18 @@
+# Terminal
+
+T3 Code opens terminal sessions on the connected environment, in the active project's working
+directory.
+
+## Choose a shell
+
+Open **Settings → General → Terminal shell** and choose one of these options:
+
+- **System default** uses the connected environment's configured shell.
+- **Zsh**, **Bash**, or **Fish** explicitly starts that shell.
+
+The choice is saved on the environment, so it also applies when a web, desktop, or mobile client
+opens a terminal there. It affects new and restarted terminals; shells that are already running
+continue unchanged.
+
+The selected shell must be installed and available on the environment's `PATH`. If it cannot be
+started, T3 Code tries another available shell so the terminal remains usable.

--- a/packages/client-runtime/src/rpc/session.test.ts
+++ b/packages/client-runtime/src/rpc/session.test.ts
@@ -124,6 +124,7 @@ const SERVER_CONFIG: ServerConfigType = {
   issues: [],
   providers: [],
   availableEditors: [],
+  availableTerminalShells: [],
   observability: {
     logsDirectoryPath: "/tmp/logs",
     localTracingEnabled: false,

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -45,6 +45,7 @@ import {
 
 const CONFIG = {
   availableEditors: [],
+  availableTerminalShells: [],
   issues: [],
   keybindings: {},
   keybindingsConfigPath: null,

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -40,6 +40,7 @@ import {
 
 const CONFIG = {
   availableEditors: [],
+  availableTerminalShells: [],
   issues: [],
   keybindings: {},
   keybindingsConfigPath: null,

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -12,6 +12,9 @@ const decodeServerProvider = Schema.decodeUnknownSync(ServerProvider);
 const decodeServerProviders = Schema.decodeUnknownSync(ServerProviders);
 const decodeUpsertKeybindingResult = Schema.decodeUnknownSync(ServerUpsertKeybindingResult);
 const decodeAvailableEditors = Schema.decodeUnknownSync(ServerConfig.fields.availableEditors);
+const decodeAvailableTerminalShells = Schema.decodeUnknownSync(
+  ServerConfig.fields.availableTerminalShells,
+);
 
 const baseProviderSnapshot = {
   instanceId: "codex",
@@ -153,5 +156,10 @@ describe("server config forward compatibility", () => {
     ]);
 
     expect(parsed).toEqual([decodedBase]);
+  });
+
+  it("defaults and forward-filters available terminal shells", () => {
+    expect(decodeAvailableTerminalShells(undefined)).toEqual([]);
+    expect(decodeAvailableTerminalShells(["zsh", "nu", "fish"])).toEqual(["zsh", "fish"]);
   });
 });

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -6,6 +6,9 @@ import { ServerConfig, ServerProvider, ServerUpsertKeybindingResult } from "./se
 const decodeServerProvider = Schema.decodeUnknownSync(ServerProvider);
 const decodeUpsertKeybindingResult = Schema.decodeUnknownSync(ServerUpsertKeybindingResult);
 const decodeAvailableEditors = Schema.decodeUnknownSync(ServerConfig.fields.availableEditors);
+const decodeAvailableTerminalShells = Schema.decodeUnknownSync(
+  ServerConfig.fields.availableTerminalShells,
+);
 
 describe("ServerProvider", () => {
   it("defaults capability arrays when decoding provider snapshots", () => {
@@ -118,5 +121,10 @@ describe("server config forward compatibility", () => {
     const parsed = decodeAvailableEditors(["zed", "some-future-editor", "vscode"]);
 
     expect(parsed).toEqual(["zed", "vscode"]);
+  });
+
+  it("defaults and forward-filters available terminal shells", () => {
+    expect(decodeAvailableTerminalShells(undefined)).toEqual([]);
+    expect(decodeAvailableTerminalShells(["zsh", "nu", "fish"])).toEqual(["zsh", "fish"]);
   });
 });

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -20,7 +20,7 @@ import {
 import { EditorId } from "./editor.ts";
 import { ModelCapabilities } from "./model.ts";
 import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
-import { ServerSettings } from "./settings.ts";
+import { InstalledTerminalShell, ServerSettings } from "./settings.ts";
 
 const KeybindingsMalformedConfigIssue = Schema.Struct({
   kind: Schema.Literal("keybindings.malformed-config"),
@@ -428,6 +428,11 @@ export const ServerConfig = Schema.Struct({
   // Editor ids grow over time; drop ones this build does not know rather than
   // failing the whole config decode.
   availableEditors: ForwardCompatibleArray(EditorId),
+  // Shell ids can also grow over time. Defaulting preserves config decoding
+  // when a newer client connects to a server that predates shell discovery.
+  availableTerminalShells: ForwardCompatibleArray(InstalledTerminalShell).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
   observability: ServerObservability,
   settings: ServerSettings,
   /** Whether shell subscriptions can emit an opt-in catch-up completion marker. */

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -20,7 +20,7 @@ import {
 import { EditorId } from "./editor.ts";
 import { ModelCapabilities } from "./model.ts";
 import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
-import { ServerSettings } from "./settings.ts";
+import { InstalledTerminalShell, ServerSettings } from "./settings.ts";
 
 const KeybindingsMalformedConfigIssue = Schema.Struct({
   kind: Schema.Literal("keybindings.malformed-config"),
@@ -424,6 +424,11 @@ export const ServerConfig = Schema.Struct({
   // Editor ids grow over time; drop ones this build does not know rather than
   // failing the whole config decode.
   availableEditors: ForwardCompatibleArray(EditorId),
+  // Shell ids can also grow over time. Defaulting preserves config decoding
+  // when a newer client connects to a server that predates shell discovery.
+  availableTerminalShells: ForwardCompatibleArray(InstalledTerminalShell).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
   observability: ServerObservability,
   settings: ServerSettings,
   /** Whether shell subscriptions can emit an opt-in catch-up completion marker. */

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -179,6 +179,23 @@ describe("ServerSettings worktree defaults", () => {
   });
 });
 
+describe("ServerSettings terminal shell", () => {
+  it("preserves the host shell for legacy configs", () => {
+    expect(decodeServerSettings({}).terminalShell).toBe("system");
+  });
+
+  it.each(["system", "zsh", "bash", "fish"] as const)(
+    "accepts the supported terminal shell: %s",
+    (terminalShell) => {
+      expect(decodeServerSettingsPatch({ terminalShell }).terminalShell).toBe(terminalShell);
+    },
+  );
+
+  it("rejects unsupported terminal shells", () => {
+    expect(() => decodeServerSettingsPatch({ terminalShell: "nu" })).toThrow();
+  });
+});
+
 describe("ServerSettings.sourceControlWritingStyle", () => {
   it("defaults all style settings for legacy configs", () => {
     const settings = decodeServerSettings({});

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -191,6 +191,10 @@ describe("ServerSettings terminal shell", () => {
     },
   );
 
+  it("falls back to the system shell when decoding a future server value", () => {
+    expect(decodeServerSettings({ terminalShell: "nu" }).terminalShell).toBe("system");
+  });
+
   it("rejects unsupported terminal shells", () => {
     expect(() => decodeServerSettingsPatch({ terminalShell: "nu" })).toThrow();
   });

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -211,7 +211,10 @@ export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientS
 // import cycle; re-exported here for compatibility with deep imports.
 export { ThreadEnvMode } from "./environment.ts";
 
-export const TerminalShell = Schema.Literals(["system", "zsh", "bash", "fish"]);
+export const INSTALLED_TERMINAL_SHELLS = ["zsh", "bash", "fish"] as const;
+export const InstalledTerminalShell = Schema.Literals(INSTALLED_TERMINAL_SHELLS);
+export type InstalledTerminalShell = typeof InstalledTerminalShell.Type;
+export const TerminalShell = Schema.Literals(["system", ...INSTALLED_TERMINAL_SHELLS]);
 export type TerminalShell = typeof TerminalShell.Type;
 export const DEFAULT_TERMINAL_SHELL: TerminalShell = "system";
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -217,6 +217,16 @@ export type InstalledTerminalShell = typeof InstalledTerminalShell.Type;
 export const TerminalShell = Schema.Literals(["system", ...INSTALLED_TERMINAL_SHELLS]);
 export type TerminalShell = typeof TerminalShell.Type;
 export const DEFAULT_TERMINAL_SHELL: TerminalShell = "system";
+const isTerminalShell = Schema.is(TerminalShell);
+const ForwardCompatibleTerminalShell = Schema.String.pipe(
+  Schema.decodeTo(
+    TerminalShell,
+    SchemaTransformation.transform({
+      decode: (value) => (isTerminalShell(value) ? value : DEFAULT_TERMINAL_SHELL),
+      encode: (value) => value,
+    }),
+  ),
+);
 
 const makeBinaryPathSetting = (fallback: string) =>
   TrimmedString.pipe(
@@ -571,7 +581,7 @@ export const ServerSettings = Schema.Struct({
   defaultThreadEnvMode: ThreadEnvMode.pipe(
     Schema.withDecodingDefault(Effect.succeed("local" as const satisfies ThreadEnvMode)),
   ),
-  terminalShell: TerminalShell.pipe(
+  terminalShell: ForwardCompatibleTerminalShell.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TERMINAL_SHELL)),
   ),
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -211,6 +211,10 @@ export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientS
 // import cycle; re-exported here for compatibility with deep imports.
 export { ThreadEnvMode } from "./environment.ts";
 
+export const TerminalShell = Schema.Literals(["system", "zsh", "bash", "fish"]);
+export type TerminalShell = typeof TerminalShell.Type;
+export const DEFAULT_TERMINAL_SHELL: TerminalShell = "system";
+
 const makeBinaryPathSetting = (fallback: string) =>
   TrimmedString.pipe(
     Schema.decodeTo(
@@ -564,6 +568,9 @@ export const ServerSettings = Schema.Struct({
   defaultThreadEnvMode: ThreadEnvMode.pipe(
     Schema.withDecodingDefault(Effect.succeed("local" as const satisfies ThreadEnvMode)),
   ),
+  terminalShell: TerminalShell.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_TERMINAL_SHELL)),
+  ),
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
@@ -720,6 +727,7 @@ export const ServerSettingsPatch = Schema.Struct({
   providerHealthRefreshInterval: Schema.optionalKey(Schema.DurationFromMillis),
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
+  terminalShell: Schema.optionalKey(TerminalShell),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -141,7 +141,10 @@ export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientS
 export const ThreadEnvMode = Schema.Literals(["local", "worktree"]);
 export type ThreadEnvMode = typeof ThreadEnvMode.Type;
 
-export const TerminalShell = Schema.Literals(["system", "zsh", "bash", "fish"]);
+export const INSTALLED_TERMINAL_SHELLS = ["zsh", "bash", "fish"] as const;
+export const InstalledTerminalShell = Schema.Literals(INSTALLED_TERMINAL_SHELLS);
+export type InstalledTerminalShell = typeof InstalledTerminalShell.Type;
+export const TerminalShell = Schema.Literals(["system", ...INSTALLED_TERMINAL_SHELLS]);
 export type TerminalShell = typeof TerminalShell.Type;
 export const DEFAULT_TERMINAL_SHELL: TerminalShell = "system";
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -141,6 +141,10 @@ export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientS
 export const ThreadEnvMode = Schema.Literals(["local", "worktree"]);
 export type ThreadEnvMode = typeof ThreadEnvMode.Type;
 
+export const TerminalShell = Schema.Literals(["system", "zsh", "bash", "fish"]);
+export type TerminalShell = typeof TerminalShell.Type;
+export const DEFAULT_TERMINAL_SHELL: TerminalShell = "system";
+
 const makeBinaryPathSetting = (fallback: string) =>
   TrimmedString.pipe(
     Schema.decodeTo(
@@ -489,6 +493,9 @@ export const ServerSettings = Schema.Struct({
   defaultThreadEnvMode: ThreadEnvMode.pipe(
     Schema.withDecodingDefault(Effect.succeed("local" as const satisfies ThreadEnvMode)),
   ),
+  terminalShell: TerminalShell.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_TERMINAL_SHELL)),
+  ),
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
@@ -639,6 +646,7 @@ export const ServerSettingsPatch = Schema.Struct({
   providerHealthRefreshInterval: Schema.optionalKey(Schema.DurationFromMillis),
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
+  terminalShell: Schema.optionalKey(TerminalShell),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),


### PR DESCRIPTION
## Problem

The integrated terminal follows the environment shell without giving users an explicit choice, and the settings UI cannot tell which supported shells are actually installed on the connected machine.

## Changes

- add an environment-scoped terminal shell setting with System default, Zsh, Bash, and Fish
- probe the connected environment's `PATH` for installed shells and publish those capabilities in server config
- filter the settings dropdown to installed shells while preserving an unavailable prior selection as disabled
- resolve the setting at spawn time so new and restarted terminals use the latest choice across web, desktop, and mobile clients
- retain fallback shell behavior when the selected executable cannot start

## Validation

- 133 focused contract, terminal manager, settings, and client-runtime tests
- focused WebSocket handshake integration test
- contracts, client-runtime, server, and web typechecks
- targeted lint, formatting, and diff checks

This is a draft because the settings UI has not yet received a manual browser pass or screenshots.

Implemented with GPT-5.6 Codex in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add terminal shell selection to settings with per-platform shell discovery
> - Adds a `terminalShell` preference to `ServerSettings` and `ServerSettingsPatch` with forward-compatible decoding that defaults to `"system"`.
> - Extends `TerminalManager` with `resolveAvailableShells`, which probes installed shells (including fish) and returns the available ones.
> - Includes `availableTerminalShells` in the `serverGetConfig` RPC response so the client knows which shells are installed.
> - Adds a Terminal Shell selector to the General settings panel in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/5268/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18), showing only installed shells and marking unavailable selections.
> - Adds terminal shell as a searchable settings item routing to `/settings/general`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be9a495.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PTY spawn behavior and server config RPC; mistakes could break terminals or misreport installed shells, though existing fallback spawn logic is retained.
> 
> **Overview**
> Adds an environment-scoped **terminal shell** preference (`system`, `zsh`, `bash`, `fish`) and wires it through contracts, server spawn logic, and the web **Settings → General** UI.
> 
> **Server:** `TerminalManager` reads `terminalShell` from server settings when opening or restarting PTYs (with fallback to the system shell if settings read fails). It exposes `resolveAvailableShells()` by probing `PATH` for installed shells; **fish** is included in spawn fallbacks. `serverGetConfig` returns `availableTerminalShells` alongside editors, with both discoveries sharing a renamed 5s timeout helper so config does not block indefinitely.
> 
> **Web:** General settings shows a shell selector built from installed shells; a previously selected shell that is no longer installed stays visible but disabled. Reset/search/dirty-state handling and user docs for the terminal setting are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be9a4953b12faf4f245d2241b50330cd64dd9b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->