### PR TITLE
fix(shared): detect Azure DevOps SSH remotes

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -117,6 +117,7 @@ describe("DesktopShellEnvironment", () => {
             PATH: "/opt/homebrew/bin:/usr/bin",
             SSH_AUTH_SOCK: "/tmp/secretive.sock",
             HOMEBREW_PREFIX: "/opt/homebrew",
+            AZURE_DEVOPS_EXT_PAT: "pat-from-login-shell",
           });
         },
       });
@@ -126,6 +127,7 @@ describe("DesktopShellEnvironment", () => {
       assert.equal(env.PATH, "/opt/homebrew/bin:/usr/bin:/Users/test/.local/bin");
       assert.equal(env.SSH_AUTH_SOCK, "/tmp/secretive.sock");
       assert.equal(env.HOMEBREW_PREFIX, "/opt/homebrew");
+      assert.equal(env.AZURE_DEVOPS_EXT_PAT, "pat-from-login-shell");
     }),
   );
 
@@ -135,6 +137,7 @@ describe("DesktopShellEnvironment", () => {
         SHELL: "/bin/zsh",
         PATH: "/usr/bin",
         SSH_AUTH_SOCK: "/tmp/inherited.sock",
+        AZURE_DEVOPS_EXT_PAT: "inherited-pat",
       };
 
       yield* runShellEnvironment({
@@ -144,11 +147,13 @@ describe("DesktopShellEnvironment", () => {
           envOutput({
             PATH: "/opt/homebrew/bin:/usr/bin",
             SSH_AUTH_SOCK: "/tmp/login-shell.sock",
+            AZURE_DEVOPS_EXT_PAT: "pat-from-login-shell",
           }),
       });
 
       assert.equal(env.PATH, "/opt/homebrew/bin:/usr/bin");
       assert.equal(env.SSH_AUTH_SOCK, "/tmp/inherited.sock");
+      assert.equal(env.AZURE_DEVOPS_EXT_PAT, "inherited-pat");
     }),
   );
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -78,6 +78,9 @@ const LOGIN_SHELL_ENV_NAMES = [
   "XDG_CONFIG_HOME",
   "XDG_CURRENT_DESKTOP",
   "XDG_DATA_HOME",
+  // Azure DevOps CLI commonly receives its PAT from the user's login shell.
+  // Keep it available when the desktop app is launched outside a terminal.
+  "AZURE_DEVOPS_EXT_PAT",
   "XDG_RUNTIME_DIR",
   "XDG_SESSION_DESKTOP",
   "XDG_SESSION_TYPE",
@@ -456,6 +459,7 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
       "HOMEBREW_REPOSITORY",
       "XDG_CONFIG_HOME",
       "XDG_DATA_HOME",
+      "AZURE_DEVOPS_EXT_PAT",
       "XDG_RUNTIME_DIR",
       "WAYLAND_DISPLAY",
     ] as const) {

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -40,6 +40,7 @@ import {
 } from "@t3tools/shared/git";
 import {
   getChangeRequestTerminologyForKind,
+  parseAzureDevOpsRepositoryCoordinates,
   type ChangeRequestTerminology,
 } from "@t3tools/shared/sourceControl";
 
@@ -217,6 +218,32 @@ function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | null): st
     );
   const repositoryNameWithOwner = match?.[1]?.trim() ?? "";
   return repositoryNameWithOwner.length > 0 ? repositoryNameWithOwner : null;
+}
+
+function parseRepositoryIdentityFromRemoteUrl(url: string | null): {
+  readonly repositoryNameWithOwner: string | null;
+  readonly ownerLogin: string | null;
+} {
+  const githubRepositoryNameWithOwner = parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url);
+  if (githubRepositoryNameWithOwner) {
+    return {
+      repositoryNameWithOwner: githubRepositoryNameWithOwner,
+      ownerLogin: parseRepositoryOwnerLogin(githubRepositoryNameWithOwner),
+    };
+  }
+
+  const azureRepository = parseAzureDevOpsRepositoryCoordinates(url);
+  if (azureRepository) {
+    return {
+      repositoryNameWithOwner: `${azureRepository.organization}/${azureRepository.project}/${azureRepository.repository}`,
+      ownerLogin: azureRepository.organization,
+    };
+  }
+
+  return {
+    repositoryNameWithOwner: null,
+    ownerLogin: null,
+  };
 }
 
 function parseRepositoryOwnerLogin(nameWithOwner: string | null): string | null {
@@ -1087,11 +1114,11 @@ export const make = Effect.gen(function* () {
     }
 
     const remoteUrl = yield* readConfigValueNullable(cwd, `remote.${remoteName}.url`);
-    const repositoryNameWithOwner = parseGitHubRepositoryNameWithOwnerFromRemoteUrl(remoteUrl);
+    const repositoryIdentity = parseRepositoryIdentityFromRemoteUrl(remoteUrl);
     return {
       remoteUrlKey: remoteUrl ? normalizeGitRemoteUrl(remoteUrl) : null,
-      repositoryNameWithOwner,
-      ownerLogin: parseRepositoryOwnerLogin(repositoryNameWithOwner),
+      repositoryNameWithOwner: repositoryIdentity.repositoryNameWithOwner,
+      ownerLogin: repositoryIdentity.ownerLogin,
     };
   });
 

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -33,6 +33,18 @@ afterEach(() => {
   mockRun.mockReset();
 });
 
+it("parses the Azure DevOps SSH clone URL used by Azure Repos", () => {
+  expect(
+    AzureDevOpsCli.parseAzureDevOpsRemoteUrl(
+      "git@ssh.dev.azure.com:v3/ClubTidy/ClubTidy/ClubTidy.Web.BackOffice",
+    ),
+  ).toEqual({
+    organization: "ClubTidy",
+    project: "ClubTidy",
+    repository: "ClubTidy.Web.BackOffice",
+  });
+});
+
 describe("AzureDevOpsCli.layer", () => {
   it.effect("parses pull request view output", () =>
     Effect.gen(function* () {
@@ -176,6 +188,52 @@ describe("AzureDevOpsCli.layer", () => {
           "feature/merged",
           "--status",
           "completed",
+          "--top",
+          "10",
+          "--only-show-errors",
+          "--output",
+          "json",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("uses explicit repository arguments when Azure cannot detect an SSH remote", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("[]")));
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      yield* az.listPullRequests({
+        cwd: "/repo",
+        headSelector: "t3code/promo-referral-communications",
+        state: "open",
+        limit: 10,
+        repositoryContext: {
+          organization: "ClubTidy",
+          project: "ClubTidy",
+          repository: "ClubTidy.Web.BackOffice",
+        },
+      });
+
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "AzureDevOpsCli.execute",
+        command: "az",
+        args: [
+          "repos",
+          "pr",
+          "list",
+          "--organization",
+          "https://dev.azure.com/ClubTidy",
+          "--project",
+          "ClubTidy",
+          "--repository",
+          "ClubTidy.Web.BackOffice",
+          "--source-branch",
+          "t3code/promo-referral-communications",
+          "--status",
+          "active",
           "--top",
           "10",
           "--only-show-errors",

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -353,6 +353,53 @@ describe("AzureDevOpsCli.layer", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("resolves qualified repository selectors without remote context", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              name: "fork-repo",
+              webUrl: "https://dev.azure.com/acme/fork-project/_git/fork-repo",
+              remoteUrl: "https://dev.azure.com/acme/fork-project/_git/fork-repo",
+              sshUrl: "git@ssh.dev.azure.com:v3/acme/fork-project/fork-repo",
+              project: {
+                name: "fork-project",
+              },
+            }),
+          ),
+        ),
+      );
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      yield* az.getRepositoryCloneUrls({
+        cwd: "/repo",
+        repository: "acme/fork-project/fork-repo",
+      });
+
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "AzureDevOpsCli.execute",
+        command: "az",
+        args: [
+          "repos",
+          "show",
+          "--organization",
+          "https://dev.azure.com/acme",
+          "--project",
+          "fork-project",
+          "--repository",
+          "fork-repo",
+          "--only-show-errors",
+          "--output",
+          "json",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("creates repositories through Azure Repos", () =>
     Effect.gen(function* () {
       mockRun.mockReturnValueOnce(

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -19,6 +19,12 @@ const processOutput = (stdout: string): VcsProcess.VcsProcessOutput => ({
   stderrTruncated: false,
 });
 
+const repositoryContext = {
+  organization: "acme",
+  project: "project",
+  repository: "repo",
+} as const;
+
 const mockRun = vi.fn<VcsProcess.VcsProcess["Service"]["run"]>();
 
 const supportLayer = Layer.mergeAll(
@@ -90,6 +96,56 @@ describe("AzureDevOpsCli.layer", () => {
           "show",
           "--detect",
           "true",
+          "--id",
+          "42",
+          "--only-show-errors",
+          "--output",
+          "json",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("uses explicit organization context when showing an SSH-backed pull request", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              pullRequestId: 42,
+              title: "Add Azure provider",
+              sourceRefName: "refs/heads/feature/source-control",
+              targetRefName: "refs/heads/main",
+              status: "active",
+              _links: {
+                web: {
+                  href: "https://dev.azure.com/acme/project/_git/repo/pullrequest/42",
+                },
+              },
+            }),
+          ),
+        ),
+      );
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      yield* az.getPullRequest({
+        cwd: "/repo",
+        reference: "42",
+        repositoryContext,
+      });
+
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "AzureDevOpsCli.execute",
+        command: "az",
+        args: [
+          "repos",
+          "pr",
+          "show",
+          "--organization",
+          "https://dev.azure.com/acme",
           "--id",
           "42",
           "--only-show-errors",
@@ -267,12 +323,32 @@ describe("AzureDevOpsCli.layer", () => {
       const result = yield* az.getRepositoryCloneUrls({
         cwd: "/repo",
         repository: "repo",
+        repositoryContext,
       });
 
       assert.deepStrictEqual(result, {
         nameWithOwner: "project/repo",
         url: "https://dev.azure.com/acme/project/_git/repo",
         sshUrl: "git@ssh.dev.azure.com:v3/acme/project/repo",
+      });
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "AzureDevOpsCli.execute",
+        command: "az",
+        args: [
+          "repos",
+          "show",
+          "--organization",
+          "https://dev.azure.com/acme",
+          "--project",
+          "project",
+          "--repository",
+          "repo",
+          "--only-show-errors",
+          "--output",
+          "json",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
       });
     }).pipe(Effect.provide(layer)),
   );
@@ -330,6 +406,52 @@ describe("AzureDevOpsCli.layer", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("uses explicit repository context when reading the default branch", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              name: "repo",
+              webUrl: "https://dev.azure.com/acme/project/_git/repo",
+              remoteUrl: "https://dev.azure.com/acme/project/_git/repo",
+              sshUrl: "git@ssh.dev.azure.com:v3/acme/project/repo",
+              defaultBranch: "refs/heads/main",
+            }),
+          ),
+        ),
+      );
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      const branch = yield* az.getDefaultBranch({
+        cwd: "/repo",
+        repositoryContext,
+      });
+
+      assert.strictEqual(branch, "main");
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "AzureDevOpsCli.execute",
+        command: "az",
+        args: [
+          "repos",
+          "show",
+          "--organization",
+          "https://dev.azure.com/acme",
+          "--project",
+          "project",
+          "--repository",
+          "repo",
+          "--only-show-errors",
+          "--output",
+          "json",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("creates pull requests using the body file as the Azure description", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
@@ -342,6 +464,7 @@ describe("AzureDevOpsCli.layer", () => {
         cwd: "/repo",
         baseBranch: "main",
         headSelector: "feature/provider",
+        repositoryContext,
         title: "Provider PR",
         bodyFile,
       });
@@ -350,9 +473,19 @@ describe("AzureDevOpsCli.layer", () => {
         expect.objectContaining({
           command: "az",
           cwd: "/repo",
-          args: expect.arrayContaining(["--description", `@${bodyFile}`]),
+          args: expect.arrayContaining([
+            "--organization",
+            "https://dev.azure.com/acme",
+            "--project",
+            "project",
+            "--repository",
+            "repo",
+            "--description",
+            `@${bodyFile}`,
+          ]),
         }),
       );
+      expect(mockRun.mock.calls[0]?.[0].args).not.toContain("--detect");
       expect(mockRun.mock.calls[0]?.[0].args).not.toContain("--output");
     }).pipe(Effect.provide(layer)),
   );
@@ -375,8 +508,6 @@ describe("AzureDevOpsCli.layer", () => {
           "pr",
           "checkout",
           "--only-show-errors",
-          "--detect",
-          "true",
           "--id",
           "42",
           "--remote-name",
@@ -385,6 +516,80 @@ describe("AzureDevOpsCli.layer", () => {
         cwd: "/repo",
         timeoutMs: 30_000,
       });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("checks out an SSH-backed pull request without Azure remote auto-detection", () =>
+    Effect.gen(function* () {
+      mockRun
+        .mockReturnValueOnce(
+          Effect.succeed(
+            processOutput(
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify({
+                pullRequestId: 42,
+                title: "Add Azure provider",
+                sourceRefName: "refs/heads/feature/source-control",
+                targetRefName: "refs/heads/main",
+                status: "active",
+                _links: {
+                  web: {
+                    href: "https://dev.azure.com/acme/project/_git/repo/pullrequest/42",
+                  },
+                },
+              }),
+            ),
+          ),
+        )
+        .mockReturnValueOnce(Effect.succeed(processOutput("")))
+        .mockReturnValueOnce(Effect.succeed(processOutput("")))
+        .mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      yield* az.checkoutPullRequest({
+        cwd: "/repo",
+        reference: "42",
+        repositoryContext,
+      });
+
+      expect(mockRun.mock.calls.map(([input]) => input)).toEqual([
+        {
+          operation: "AzureDevOpsCli.execute",
+          command: "az",
+          args: [
+            "repos",
+            "pr",
+            "show",
+            "--organization",
+            "https://dev.azure.com/acme",
+            "--id",
+            "42",
+            "--only-show-errors",
+            "--output",
+            "json",
+          ],
+          cwd: "/repo",
+          timeoutMs: 30_000,
+        },
+        {
+          operation: "AzureDevOpsCli.checkoutPullRequest",
+          command: "git",
+          args: ["fetch", "origin", "refs/heads/feature/source-control"],
+          cwd: "/repo",
+        },
+        {
+          operation: "AzureDevOpsCli.checkoutPullRequest",
+          command: "git",
+          args: ["checkout", "feature/source-control"],
+          cwd: "/repo",
+        },
+        {
+          operation: "AzureDevOpsCli.checkoutPullRequest",
+          command: "git",
+          args: ["pull", "origin", "feature/source-control"],
+          cwd: "/repo",
+        },
+      ]);
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -35,13 +35,11 @@ afterEach(() => {
 
 it("parses the Azure DevOps SSH clone URL used by Azure Repos", () => {
   expect(
-    AzureDevOpsCli.parseAzureDevOpsRemoteUrl(
-      "git@ssh.dev.azure.com:v3/ClubTidy/ClubTidy/ClubTidy.Web.BackOffice",
-    ),
+    AzureDevOpsCli.parseAzureDevOpsRemoteUrl("git@ssh.dev.azure.com:v3/acme/project/repo"),
   ).toEqual({
-    organization: "ClubTidy",
-    project: "ClubTidy",
-    repository: "ClubTidy.Web.BackOffice",
+    organization: "acme",
+    project: "project",
+    repository: "repo",
   });
 });
 
@@ -207,13 +205,13 @@ describe("AzureDevOpsCli.layer", () => {
       const az = yield* AzureDevOpsCli.AzureDevOpsCli;
       yield* az.listPullRequests({
         cwd: "/repo",
-        headSelector: "t3code/promo-referral-communications",
+        headSelector: "feature/source-control",
         state: "open",
         limit: 10,
         repositoryContext: {
-          organization: "ClubTidy",
-          project: "ClubTidy",
-          repository: "ClubTidy.Web.BackOffice",
+          organization: "acme",
+          project: "project",
+          repository: "repo",
         },
       });
 
@@ -225,13 +223,13 @@ describe("AzureDevOpsCli.layer", () => {
           "pr",
           "list",
           "--organization",
-          "https://dev.azure.com/ClubTidy",
+          "https://dev.azure.com/acme",
           "--project",
-          "ClubTidy",
+          "project",
           "--repository",
-          "ClubTidy.Web.BackOffice",
+          "repo",
           "--source-branch",
-          "t3code/promo-referral-communications",
+          "feature/source-control",
           "--status",
           "active",
           "--top",

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -623,6 +623,7 @@ describe("AzureDevOpsCli.layer", () => {
         cwd: "/repo",
         reference: "42",
         repositoryContext,
+        remoteUrl: "https://dev.azure.com/acme/project/_git/repo",
       });
 
       expect(mockRun.mock.calls.map(([input]) => input)).toEqual([
@@ -649,7 +650,7 @@ describe("AzureDevOpsCli.layer", () => {
           command: "git",
           args: [
             "fetch",
-            "git@ssh.dev.azure.com:v3/acme/fork-project/fork-repo",
+            "https://dev.azure.com/acme/fork-project/_git/fork-repo",
             "+refs/heads/feature/source-control",
           ],
           cwd: "/repo",

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -322,7 +322,7 @@ describe("AzureDevOpsCli.layer", () => {
       const az = yield* AzureDevOpsCli.AzureDevOpsCli;
       const result = yield* az.getRepositoryCloneUrls({
         cwd: "/repo",
-        repository: "requested-repo",
+        repository: "acme/fork-project/fork-repo",
         repositoryContext: { ...repositoryContext, repository: "working-repo" },
       });
 
@@ -340,9 +340,9 @@ describe("AzureDevOpsCli.layer", () => {
           "--organization",
           "https://dev.azure.com/acme",
           "--project",
-          "project",
+          "fork-project",
           "--repository",
-          "requested-repo",
+          "fork-repo",
           "--only-show-errors",
           "--output",
           "json",

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -322,8 +322,8 @@ describe("AzureDevOpsCli.layer", () => {
       const az = yield* AzureDevOpsCli.AzureDevOpsCli;
       const result = yield* az.getRepositoryCloneUrls({
         cwd: "/repo",
-        repository: "repo",
-        repositoryContext,
+        repository: "requested-repo",
+        repositoryContext: { ...repositoryContext, repository: "working-repo" },
       });
 
       assert.deepStrictEqual(result, {
@@ -342,7 +342,7 @@ describe("AzureDevOpsCli.layer", () => {
           "--project",
           "project",
           "--repository",
-          "repo",
+          "requested-repo",
           "--only-show-errors",
           "--output",
           "json",
@@ -574,19 +574,90 @@ describe("AzureDevOpsCli.layer", () => {
         {
           operation: "AzureDevOpsCli.checkoutPullRequest",
           command: "git",
-          args: ["fetch", "origin", "refs/heads/feature/source-control"],
+          args: ["fetch", "origin", "+refs/heads/feature/source-control"],
           cwd: "/repo",
         },
         {
           operation: "AzureDevOpsCli.checkoutPullRequest",
           command: "git",
-          args: ["checkout", "feature/source-control"],
+          args: ["checkout", "-B", "feature/source-control", "FETCH_HEAD"],
+          cwd: "/repo",
+        },
+      ]);
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("checks out a pull request from an Azure DevOps fork repository", () =>
+    Effect.gen(function* () {
+      mockRun
+        .mockReturnValueOnce(
+          Effect.succeed(
+            processOutput(
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify({
+                pullRequestId: 42,
+                title: "Add Azure provider",
+                sourceRefName: "refs/heads/feature/source-control",
+                targetRefName: "refs/heads/main",
+                status: "active",
+                forkSource: {
+                  repository: {
+                    remoteUrl: "https://dev.azure.com/acme/fork-project/_git/fork-repo",
+                    sshUrl: "git@ssh.dev.azure.com:v3/acme/fork-project/fork-repo",
+                  },
+                },
+                _links: {
+                  web: {
+                    href: "https://dev.azure.com/acme/project/_git/repo/pullrequest/42",
+                  },
+                },
+              }),
+            ),
+          ),
+        )
+        .mockReturnValueOnce(Effect.succeed(processOutput("")))
+        .mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      yield* az.checkoutPullRequest({
+        cwd: "/repo",
+        reference: "42",
+        repositoryContext,
+      });
+
+      expect(mockRun.mock.calls.map(([input]) => input)).toEqual([
+        {
+          operation: "AzureDevOpsCli.execute",
+          command: "az",
+          args: [
+            "repos",
+            "pr",
+            "show",
+            "--organization",
+            "https://dev.azure.com/acme",
+            "--id",
+            "42",
+            "--only-show-errors",
+            "--output",
+            "json",
+          ],
+          cwd: "/repo",
+          timeoutMs: 30_000,
+        },
+        {
+          operation: "AzureDevOpsCli.checkoutPullRequest",
+          command: "git",
+          args: [
+            "fetch",
+            "git@ssh.dev.azure.com:v3/acme/fork-project/fork-repo",
+            "+refs/heads/feature/source-control",
+          ],
           cwd: "/repo",
         },
         {
           operation: "AzureDevOpsCli.checkoutPullRequest",
           command: "git",
-          args: ["pull", "origin", "feature/source-control"],
+          args: ["checkout", "-B", "feature/source-control", "FETCH_HEAD"],
           cwd: "/repo",
         },
       ]);

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -228,6 +228,7 @@ export class AzureDevOpsGitCommandFailedError extends Schema.TaggedErrorClass<Az
   "AzureDevOpsGitCommandFailedError",
   {
     operation: Schema.Literal("checkoutPullRequest"),
+    stage: Schema.Literals(["fetch", "checkout"]),
     command: Schema.Literal("git"),
     cwd: Schema.String,
     argumentCount: NonNegativeInt,
@@ -235,11 +236,11 @@ export class AzureDevOpsGitCommandFailedError extends Schema.TaggedErrorClass<Az
   },
 ) {
   get detail(): string {
-    return "Git checkout command failed.";
+    return `Git ${this.stage} command failed.`;
   }
 
   override get message(): string {
-    return `Azure DevOps Git command failed in ${this.operation}: ${this.detail}`;
+    return `Azure DevOps Git ${this.stage} command failed in ${this.operation}: ${this.detail}`;
   }
 }
 
@@ -503,7 +504,11 @@ export const make = Effect.gen(function* () {
     });
 
   /** Runs one git step of the SSH-safe pull-request checkout flow. */
-  const runGit = (input: { readonly cwd: string; readonly args: ReadonlyArray<string> }) =>
+  const runGit = (input: {
+    readonly cwd: string;
+    readonly stage: "fetch" | "checkout";
+    readonly args: ReadonlyArray<string>;
+  }) =>
     process
       .run({
         operation: "AzureDevOpsCli.checkoutPullRequest",
@@ -516,6 +521,7 @@ export const make = Effect.gen(function* () {
           (cause) =>
             new AzureDevOpsGitCommandFailedError({
               operation: "checkoutPullRequest",
+              stage: input.stage,
               command: "git",
               cwd: input.cwd,
               argumentCount: input.args.length,
@@ -702,13 +708,18 @@ export const make = Effect.gen(function* () {
           return Effect.gen(function* () {
             yield* runGit({
               cwd: input.cwd,
+              stage: "fetch",
               args: [
                 "fetch",
                 pullRequest.sourceRepositoryUrl ?? remoteName,
                 `+refs/heads/${branch}`,
               ],
             });
-            yield* runGit({ cwd: input.cwd, args: ["checkout", "-B", branch, "FETCH_HEAD"] });
+            yield* runGit({
+              cwd: input.cwd,
+              stage: "checkout",
+              args: ["checkout", "-B", branch, "FETCH_HEAD"],
+            });
           });
         }),
       );

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -21,6 +21,86 @@ import * as SourceControlProvider from "./SourceControlProvider.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+export interface AzureDevOpsRepositoryContext {
+  readonly organization: string;
+  readonly project: string;
+  readonly repository: string;
+}
+
+function decodeRemotePathSegment(segment: string): string | null {
+  try {
+    const decoded = decodeURIComponent(segment).trim();
+    return decoded.length > 0 ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseAzureDevOpsRemoteUrl(
+  remoteUrl: string,
+): AzureDevOpsRepositoryContext | undefined {
+  const trimmed = remoteUrl.trim();
+  let segments: ReadonlyArray<string>;
+
+  if (trimmed.startsWith("git@")) {
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex <= "git@".length) {
+      return undefined;
+    }
+
+    const host = trimmed.slice("git@".length, separatorIndex).toLowerCase();
+    if (host !== "ssh.dev.azure.com") {
+      return undefined;
+    }
+
+    segments = trimmed
+      .slice(separatorIndex + 1)
+      .split("/")
+      .filter((segment) => segment.length > 0);
+  } else {
+    try {
+      const url = new URL(trimmed);
+      if (url.hostname.toLowerCase() !== "dev.azure.com") {
+        return undefined;
+      }
+      segments = url.pathname.split("/").filter((segment) => segment.length > 0);
+    } catch {
+      return undefined;
+    }
+  }
+
+  const isSshClonePath = segments[0]?.toLowerCase() === "v3";
+  const isHttpClonePath = segments[2]?.toLowerCase() === "_git";
+  const [organizationSegment, projectSegment, repositorySegment] = isSshClonePath
+    ? [segments[1], segments[2], segments[3]]
+    : isHttpClonePath
+      ? [segments[0], segments[1], segments[3]]
+      : [];
+
+  const organization = organizationSegment ? decodeRemotePathSegment(organizationSegment) : null;
+  const project = projectSegment ? decodeRemotePathSegment(projectSegment) : null;
+  const repository = repositorySegment
+    ? decodeRemotePathSegment(repositorySegment.replace(/\.git$/iu, ""))
+    : null;
+
+  return organization && project && repository ? { organization, project, repository } : undefined;
+}
+
+function repositoryDetectionArgs(
+  repositoryContext: AzureDevOpsRepositoryContext | undefined,
+): ReadonlyArray<string> {
+  return repositoryContext
+    ? [
+        "--organization",
+        `https://dev.azure.com/${repositoryContext.organization}`,
+        "--project",
+        repositoryContext.project,
+        "--repository",
+        repositoryContext.repository,
+      ]
+    : ["--detect", "true"];
+}
+
 const azureDevOpsCommandErrorFields = {
   operation: Schema.Literal("execute"),
   command: Schema.Literal("az"),
@@ -206,6 +286,7 @@ export class AzureDevOpsCli extends Context.Service<
     readonly listPullRequests: (input: {
       readonly cwd: string;
       readonly headSelector: string;
+      readonly repositoryContext?: AzureDevOpsRepositoryContext;
       readonly source?: SourceControlProvider.SourceControlRefSelector;
       readonly state: "open" | "closed" | "merged" | "all";
       readonly limit?: number;
@@ -375,8 +456,7 @@ export const make = Effect.gen(function* () {
           "repos",
           "pr",
           "list",
-          "--detect",
-          "true",
+          ...repositoryDetectionArgs(input.repositoryContext),
           "--source-branch",
           SourceControlProvider.sourceBranch(input),
           "--status",

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -120,7 +120,14 @@ function repositoryShowArgs(
   repository: string,
 ): ReadonlyArray<string> {
   return repositoryContext
-    ? repositoryDetectionArgs(repositoryContext)
+    ? [
+        "--organization",
+        `https://dev.azure.com/${repositoryContext.organization}`,
+        "--project",
+        repositoryContext.project,
+        "--repository",
+        repository,
+      ]
     : ["--detect", "true", "--repository", repository];
 }
 
@@ -232,7 +239,7 @@ export class AzureDevOpsGitCommandFailedError extends Schema.TaggedErrorClass<Az
   }
 
   override get message(): string {
-    return `Azure DevOps CLI failed in ${this.operation}: ${this.detail}`;
+    return `Azure DevOps Git command failed in ${this.operation}: ${this.detail}`;
   }
 }
 
@@ -695,10 +702,13 @@ export const make = Effect.gen(function* () {
           return Effect.gen(function* () {
             yield* runGit({
               cwd: input.cwd,
-              args: ["fetch", remoteName, `refs/heads/${branch}`],
+              args: [
+                "fetch",
+                pullRequest.sourceRepositoryUrl ?? remoteName,
+                `+refs/heads/${branch}`,
+              ],
             });
-            yield* runGit({ cwd: input.cwd, args: ["checkout", branch] });
-            yield* runGit({ cwd: input.cwd, args: ["pull", remoteName, branch] });
+            yield* runGit({ cwd: input.cwd, args: ["checkout", "-B", branch, "FETCH_HEAD"] });
           });
         }),
       );

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -382,6 +382,7 @@ export class AzureDevOpsCli extends Context.Service<
       readonly reference: string;
       readonly repositoryContext?: AzureDevOpsRepositoryContext;
       readonly remoteName?: string;
+      readonly remoteUrl?: string;
     }) => Effect.Effect<void, AzureDevOpsCliError>;
   }
 >()("t3/sourceControl/AzureDevOpsCli") {}
@@ -449,6 +450,29 @@ function parseRepositorySpecifier(repository: string): {
     project: parts.length > 1 ? (parts.at(-2) ?? null) : null,
     name: parts.at(-1) ?? repository.trim(),
   };
+}
+
+/** Returns whether a Git remote uses an SSH transport. */
+function isSshRemoteUrl(remoteUrl: string | undefined): boolean {
+  const trimmed = remoteUrl?.trim() ?? "";
+  return /^git@/iu.test(trimmed) || /^ssh:\/\//iu.test(trimmed);
+}
+
+/** Chooses a fork clone URL that matches the local repository's Git transport. */
+function forkRepositoryRemote(input: {
+  readonly pullRequest: NormalizedAzureDevOpsPullRequestRecord;
+  readonly remoteName: string;
+  readonly remoteUrl?: string;
+}): string {
+  const sshUrl = input.pullRequest.sourceRepositorySshUrl;
+  const httpsUrl = input.pullRequest.sourceRepositoryRemoteUrl;
+  if (isSshRemoteUrl(input.remoteUrl)) {
+    return sshUrl ?? httpsUrl ?? input.remoteName;
+  }
+  if (input.remoteUrl !== undefined) {
+    return httpsUrl ?? sshUrl ?? input.remoteName;
+  }
+  return sshUrl ?? httpsUrl ?? input.remoteName;
 }
 
 function decodeAzureDevOpsJson<S extends Schema.Top>(
@@ -711,7 +735,11 @@ export const make = Effect.gen(function* () {
               stage: "fetch",
               args: [
                 "fetch",
-                pullRequest.sourceRepositoryUrl ?? remoteName,
+                forkRepositoryRemote({
+                  pullRequest,
+                  remoteName,
+                  ...(input.remoteUrl !== undefined ? { remoteUrl: input.remoteUrl } : {}),
+                }),
                 `+refs/heads/${branch}`,
               ],
             });

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -105,6 +105,25 @@ function repositoryDetectionArgs(
     : ["--detect", "true"];
 }
 
+/** Builds the organization argument used by PR commands that do not accept a repository. */
+function repositoryOrganizationArgs(
+  repositoryContext: AzureDevOpsRepositoryContext | undefined,
+): ReadonlyArray<string> {
+  return repositoryContext
+    ? ["--organization", `https://dev.azure.com/${repositoryContext.organization}`]
+    : ["--detect", "true"];
+}
+
+/** Builds repository-show arguments while retaining the CLI's fallback repository selector. */
+function repositoryShowArgs(
+  repositoryContext: AzureDevOpsRepositoryContext | undefined,
+  repository: string,
+): ReadonlyArray<string> {
+  return repositoryContext
+    ? repositoryDetectionArgs(repositoryContext)
+    : ["--detect", "true", "--repository", repository];
+}
+
 const azureDevOpsCommandErrorFields = {
   operation: Schema.Literal("execute"),
   command: Schema.Literal("az"),
@@ -198,6 +217,25 @@ export class AzureDevOpsCommandFailedError extends Schema.TaggedErrorClass<Azure
   }
 }
 
+export class AzureDevOpsGitCommandFailedError extends Schema.TaggedErrorClass<AzureDevOpsGitCommandFailedError>()(
+  "AzureDevOpsGitCommandFailedError",
+  {
+    operation: Schema.Literal("checkoutPullRequest"),
+    command: Schema.Literal("git"),
+    cwd: Schema.String,
+    argumentCount: NonNegativeInt,
+    cause: Schema.Defect(),
+  },
+) {
+  get detail(): string {
+    return "Git checkout command failed.";
+  }
+
+  override get message(): string {
+    return `Azure DevOps CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
 const azureDevOpsDecodeErrorFields = {
   command: Schema.Literal("az"),
   cwd: Schema.String,
@@ -264,6 +302,7 @@ export const AzureDevOpsCliError = Schema.Union([
   AzureDevOpsCliAuthenticationError,
   AzureDevOpsPullRequestNotFoundError,
   AzureDevOpsCommandFailedError,
+  AzureDevOpsGitCommandFailedError,
   AzureDevOpsPullRequestListDecodeError,
   AzureDevOpsPullRequestDecodeError,
   AzureDevOpsRepositoryDecodeError,
@@ -299,11 +338,13 @@ export class AzureDevOpsCli extends Context.Service<
     readonly getPullRequest: (input: {
       readonly cwd: string;
       readonly reference: string;
+      readonly repositoryContext?: AzureDevOpsRepositoryContext;
     }) => Effect.Effect<NormalizedAzureDevOpsPullRequestRecord, AzureDevOpsCliError>;
 
     readonly getRepositoryCloneUrls: (input: {
       readonly cwd: string;
       readonly repository: string;
+      readonly repositoryContext?: AzureDevOpsRepositoryContext;
     }) => Effect.Effect<AzureDevOpsRepositoryCloneUrls, AzureDevOpsCliError>;
 
     readonly createRepository: (input: {
@@ -316,6 +357,7 @@ export class AzureDevOpsCli extends Context.Service<
       readonly cwd: string;
       readonly baseBranch: string;
       readonly headSelector: string;
+      readonly repositoryContext?: AzureDevOpsRepositoryContext;
       readonly source?: SourceControlProvider.SourceControlRefSelector;
       readonly target?: SourceControlProvider.SourceControlRefSelector;
       readonly title: string;
@@ -324,11 +366,13 @@ export class AzureDevOpsCli extends Context.Service<
 
     readonly getDefaultBranch: (input: {
       readonly cwd: string;
+      readonly repositoryContext?: AzureDevOpsRepositoryContext;
     }) => Effect.Effect<string | null, AzureDevOpsCliError>;
 
     readonly checkoutPullRequest: (input: {
       readonly cwd: string;
       readonly reference: string;
+      readonly repositoryContext?: AzureDevOpsRepositoryContext;
       readonly remoteName?: string;
     }) => Effect.Effect<void, AzureDevOpsCliError>;
   }
@@ -451,6 +495,63 @@ export const make = Effect.gen(function* () {
       args: [...input.args, "--only-show-errors", "--output", "json"],
     });
 
+  /** Runs one git step of the SSH-safe pull-request checkout flow. */
+  const runGit = (input: { readonly cwd: string; readonly args: ReadonlyArray<string> }) =>
+    process
+      .run({
+        operation: "AzureDevOpsCli.checkoutPullRequest",
+        command: "git",
+        args: input.args,
+        cwd: input.cwd,
+      })
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new AzureDevOpsGitCommandFailedError({
+              operation: "checkoutPullRequest",
+              command: "git",
+              cwd: input.cwd,
+              argumentCount: input.args.length,
+              cause,
+            }),
+        ),
+      );
+
+  /** Loads a pull request using explicit organization context when available. */
+  const getPullRequest: AzureDevOpsCli["Service"]["getPullRequest"] = (input) =>
+    executeJson({
+      cwd: input.cwd,
+      args: [
+        "repos",
+        "pr",
+        "show",
+        ...repositoryOrganizationArgs(input.repositoryContext),
+        "--id",
+        normalizeChangeRequestId(input.reference),
+      ],
+    }).pipe(
+      Effect.map((result) => result.stdout.trim()),
+      Effect.flatMap((raw) =>
+        Effect.sync(() => decodeAzureDevOpsPullRequestJson(raw)).pipe(
+          Effect.flatMap((decoded) => {
+            if (!Result.isSuccess(decoded)) {
+              return Effect.fail(
+                new AzureDevOpsPullRequestDecodeError({
+                  operation: "getPullRequest",
+                  command: "az",
+                  cwd: input.cwd,
+                  outputLength: raw.length,
+                  cause: decoded.failure,
+                }),
+              );
+            }
+
+            return Effect.succeed(decoded.success);
+          }),
+        ),
+      ),
+    );
+
   return AzureDevOpsCli.of({
     execute,
     listPullRequests: (input) =>
@@ -492,44 +593,11 @@ export const make = Effect.gen(function* () {
               ),
         ),
       ),
-    getPullRequest: (input) =>
-      executeJson({
-        cwd: input.cwd,
-        args: [
-          "repos",
-          "pr",
-          "show",
-          "--detect",
-          "true",
-          "--id",
-          normalizeChangeRequestId(input.reference),
-        ],
-      }).pipe(
-        Effect.map((result) => result.stdout.trim()),
-        Effect.flatMap((raw) =>
-          Effect.sync(() => decodeAzureDevOpsPullRequestJson(raw)).pipe(
-            Effect.flatMap((decoded) => {
-              if (!Result.isSuccess(decoded)) {
-                return Effect.fail(
-                  new AzureDevOpsPullRequestDecodeError({
-                    operation: "getPullRequest",
-                    command: "az",
-                    cwd: input.cwd,
-                    outputLength: raw.length,
-                    cause: decoded.failure,
-                  }),
-                );
-              }
-
-              return Effect.succeed(decoded.success);
-            }),
-          ),
-        ),
-      ),
+    getPullRequest,
     getRepositoryCloneUrls: (input) =>
       executeJson({
         cwd: input.cwd,
-        args: ["repos", "show", "--detect", "true", "--repository", input.repository],
+        args: ["repos", "show", ...repositoryShowArgs(input.repositoryContext, input.repository)],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
@@ -575,8 +643,7 @@ export const make = Effect.gen(function* () {
           "pr",
           "create",
           "--only-show-errors",
-          "--detect",
-          "true",
+          ...repositoryDetectionArgs(input.repositoryContext),
           "--target-branch",
           input.target?.refName ?? input.baseBranch,
           "--source-branch",
@@ -590,7 +657,7 @@ export const make = Effect.gen(function* () {
     getDefaultBranch: (input) =>
       executeJson({
         cwd: input.cwd,
-        args: ["repos", "show", "--detect", "true"],
+        args: ["repos", "show", ...repositoryDetectionArgs(input.repositoryContext)],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
@@ -598,22 +665,44 @@ export const make = Effect.gen(function* () {
         ),
         Effect.map((repo) => normalizeDefaultBranch(repo.defaultBranch)),
       ),
-    checkoutPullRequest: (input) =>
-      execute({
+    checkoutPullRequest: (input) => {
+      const reference = normalizeChangeRequestId(input.reference);
+      const remoteName = input.remoteName ?? "origin";
+
+      if (input.repositoryContext === undefined) {
+        return execute({
+          cwd: input.cwd,
+          args: [
+            "repos",
+            "pr",
+            "checkout",
+            "--only-show-errors",
+            "--id",
+            reference,
+            "--remote-name",
+            remoteName,
+          ],
+        }).pipe(Effect.asVoid);
+      }
+
+      return getPullRequest({
         cwd: input.cwd,
-        args: [
-          "repos",
-          "pr",
-          "checkout",
-          "--only-show-errors",
-          "--detect",
-          "true",
-          "--id",
-          normalizeChangeRequestId(input.reference),
-          "--remote-name",
-          input.remoteName ?? "origin",
-        ],
-      }).pipe(Effect.asVoid),
+        reference,
+        repositoryContext: input.repositoryContext,
+      }).pipe(
+        Effect.flatMap((pullRequest) => {
+          const branch = pullRequest.headRefName;
+          return Effect.gen(function* () {
+            yield* runGit({
+              cwd: input.cwd,
+              args: ["fetch", remoteName, `refs/heads/${branch}`],
+            });
+            yield* runGit({ cwd: input.cwd, args: ["checkout", branch] });
+            yield* runGit({ cwd: input.cwd, args: ["pull", remoteName, branch] });
+          });
+        }),
+      );
+    },
   });
 });
 

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -10,6 +10,10 @@ import {
   type SourceControlRepositoryVisibility,
   type VcsError,
 } from "@t3tools/contracts";
+import {
+  parseAzureDevOpsRepositoryCoordinates,
+  type AzureDevOpsRepositoryCoordinates,
+} from "@t3tools/shared/sourceControl";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import {
@@ -22,71 +26,13 @@ import * as SourceControlProvider from "./SourceControlProvider.ts";
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 /** Identifies the Azure DevOps repository targeted by a CLI request. */
-export interface AzureDevOpsRepositoryContext {
-  readonly organization: string;
-  readonly project: string;
-  readonly repository: string;
-}
-
-/** Decodes one URL path segment, returning null for malformed or empty values. */
-function decodeRemotePathSegment(segment: string): string | null {
-  try {
-    const decoded = decodeURIComponent(segment).trim();
-    return decoded.length > 0 ? decoded : null;
-  } catch {
-    return null;
-  }
-}
+export type AzureDevOpsRepositoryContext = AzureDevOpsRepositoryCoordinates;
 
 /** Extracts repository coordinates from an Azure DevOps SSH or HTTPS clone URL. */
 export function parseAzureDevOpsRemoteUrl(
   remoteUrl: string,
 ): AzureDevOpsRepositoryContext | undefined {
-  const trimmed = remoteUrl.trim();
-  let segments: ReadonlyArray<string>;
-
-  if (trimmed.startsWith("git@")) {
-    const separatorIndex = trimmed.indexOf(":");
-    if (separatorIndex <= "git@".length) {
-      return undefined;
-    }
-
-    const host = trimmed.slice("git@".length, separatorIndex).toLowerCase();
-    if (host !== "ssh.dev.azure.com") {
-      return undefined;
-    }
-
-    segments = trimmed
-      .slice(separatorIndex + 1)
-      .split("/")
-      .filter((segment) => segment.length > 0);
-  } else {
-    try {
-      const url = new URL(trimmed);
-      if (url.hostname.toLowerCase() !== "dev.azure.com") {
-        return undefined;
-      }
-      segments = url.pathname.split("/").filter((segment) => segment.length > 0);
-    } catch {
-      return undefined;
-    }
-  }
-
-  const isSshClonePath = segments[0]?.toLowerCase() === "v3";
-  const isHttpClonePath = segments[2]?.toLowerCase() === "_git";
-  const [organizationSegment, projectSegment, repositorySegment] = isSshClonePath
-    ? [segments[1], segments[2], segments[3]]
-    : isHttpClonePath
-      ? [segments[0], segments[1], segments[3]]
-      : [];
-
-  const organization = organizationSegment ? decodeRemotePathSegment(organizationSegment) : null;
-  const project = projectSegment ? decodeRemotePathSegment(projectSegment) : null;
-  const repository = repositorySegment
-    ? decodeRemotePathSegment(repositorySegment.replace(/\.git$/iu, ""))
-    : null;
-
-  return organization && project && repository ? { organization, project, repository } : undefined;
+  return parseAzureDevOpsRepositoryCoordinates(remoteUrl);
 }
 
 /** Builds explicit Azure CLI repository arguments when remote detection is unreliable. */
@@ -114,21 +60,48 @@ function repositoryOrganizationArgs(
     : ["--detect", "true"];
 }
 
+/** Resolves a repository selector against the current Azure organization and project. */
+function repositorySelectorCoordinates(
+  repositoryContext: AzureDevOpsRepositoryContext,
+  repository: string,
+): AzureDevOpsRepositoryContext {
+  const parts = repository
+    .split("/")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  const repositoryName = parts.at(-1) ?? repositoryContext.repository;
+  const project =
+    parts.length > 1 ? (parts.at(-2) ?? repositoryContext.project) : repositoryContext.project;
+  const organization =
+    parts.length > 2
+      ? (parts.at(-3) ?? repositoryContext.organization)
+      : repositoryContext.organization;
+
+  return {
+    organization,
+    project,
+    repository: repositoryName,
+  };
+}
+
 /** Builds repository-show arguments while retaining the CLI's fallback repository selector. */
 function repositoryShowArgs(
   repositoryContext: AzureDevOpsRepositoryContext | undefined,
   repository: string,
 ): ReadonlyArray<string> {
-  return repositoryContext
-    ? [
-        "--organization",
-        `https://dev.azure.com/${repositoryContext.organization}`,
-        "--project",
-        repositoryContext.project,
-        "--repository",
-        repository,
-      ]
-    : ["--detect", "true", "--repository", repository];
+  if (repositoryContext === undefined) {
+    return ["--detect", "true", "--repository", repository];
+  }
+
+  const selectedRepository = repositorySelectorCoordinates(repositoryContext, repository);
+  return [
+    "--organization",
+    `https://dev.azure.com/${selectedRepository.organization}`,
+    "--project",
+    selectedRepository.project,
+    "--repository",
+    selectedRepository.repository,
+  ];
 }
 
 const azureDevOpsCommandErrorFields = {

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -21,12 +21,14 @@ import * as SourceControlProvider from "./SourceControlProvider.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+/** Identifies the Azure DevOps repository targeted by a CLI request. */
 export interface AzureDevOpsRepositoryContext {
   readonly organization: string;
   readonly project: string;
   readonly repository: string;
 }
 
+/** Decodes one URL path segment, returning null for malformed or empty values. */
 function decodeRemotePathSegment(segment: string): string | null {
   try {
     const decoded = decodeURIComponent(segment).trim();
@@ -36,6 +38,7 @@ function decodeRemotePathSegment(segment: string): string | null {
   }
 }
 
+/** Extracts repository coordinates from an Azure DevOps SSH or HTTPS clone URL. */
 export function parseAzureDevOpsRemoteUrl(
   remoteUrl: string,
 ): AzureDevOpsRepositoryContext | undefined {
@@ -86,6 +89,7 @@ export function parseAzureDevOpsRemoteUrl(
   return organization && project && repository ? { organization, project, repository } : undefined;
 }
 
+/** Builds explicit Azure CLI repository arguments when remote detection is unreliable. */
 function repositoryDetectionArgs(
   repositoryContext: AzureDevOpsRepositoryContext | undefined,
 ): ReadonlyArray<string> {

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -84,16 +84,35 @@ function repositorySelectorCoordinates(
   };
 }
 
+/** Parses an organization/project/repository selector without relying on Git remote detection. */
+function qualifiedRepositorySelectorCoordinates(
+  repository: string,
+): AzureDevOpsRepositoryContext | undefined {
+  const parts = repository
+    .split("/")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  const organization = parts.at(-3);
+  const project = parts.at(-2);
+  const repositoryName = parts.at(-1);
+  return organization && project && repositoryName
+    ? { organization, project, repository: repositoryName }
+    : undefined;
+}
+
 /** Builds repository-show arguments while retaining the CLI's fallback repository selector. */
 function repositoryShowArgs(
   repositoryContext: AzureDevOpsRepositoryContext | undefined,
   repository: string,
 ): ReadonlyArray<string> {
-  if (repositoryContext === undefined) {
+  const selectedRepository =
+    repositoryContext === undefined
+      ? qualifiedRepositorySelectorCoordinates(repository)
+      : repositorySelectorCoordinates(repositoryContext, repository);
+  if (selectedRepository === undefined) {
     return ["--detect", "true", "--repository", repository];
   }
 
-  const selectedRepository = repositorySelectorCoordinates(repositoryContext, repository);
   return [
     "--organization",
     `https://dev.azure.com/${selectedRepository.organization}`,

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
@@ -141,6 +141,7 @@ it.effect("passes the SSH remote repository context to Azure CLI checkout", () =
       repository: "repo",
     });
     assert.strictEqual(checkoutInput?.remoteName, "origin");
+    assert.strictEqual(checkoutInput?.remoteUrl, sshRepositoryContext.remoteUrl);
   }),
 );
 

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
@@ -56,6 +56,45 @@ it.effect("maps Azure DevOps PR summaries into provider-neutral change requests"
   }),
 );
 
+it.effect("preserves Azure DevOps fork identity in change requests", () =>
+  Effect.gen(function* () {
+    const provider = yield* makeProvider({
+      getPullRequest: () =>
+        Effect.succeed({
+          number: 42,
+          title: "Add Azure provider",
+          url: "https://dev.azure.com/acme/project/_git/repo/pullrequest/42",
+          baseRefName: "main",
+          headRefName: "feature/source-control",
+          state: "open",
+          updatedAt: Option.none(),
+          isCrossRepository: true,
+          headRepositoryNameWithOwner: "acme/fork-project/fork-repo",
+          headRepositoryOwnerLogin: "acme",
+        }),
+    });
+
+    const changeRequest = yield* provider.getChangeRequest({
+      cwd: "/repo",
+      reference: "42",
+    });
+
+    assert.deepStrictEqual(changeRequest, {
+      provider: "azure-devops",
+      number: 42,
+      title: "Add Azure provider",
+      url: "https://dev.azure.com/acme/project/_git/repo/pullrequest/42",
+      baseRefName: "main",
+      headRefName: "feature/source-control",
+      state: "open",
+      updatedAt: Option.none(),
+      isCrossRepository: true,
+      headRepositoryNameWithOwner: "acme/fork-project/fork-repo",
+      headRepositoryOwnerLogin: "acme",
+    });
+  }),
+);
+
 it.effect("passes the SSH remote repository context to Azure CLI PR lookup", () =>
   Effect.gen(function* () {
     let getInput:

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
@@ -46,6 +46,41 @@ it.effect("maps Azure DevOps PR summaries into provider-neutral change requests"
   }),
 );
 
+it.effect("passes the SSH remote repository context to Azure CLI PR listing", () =>
+  Effect.gen(function* () {
+    let listInput:
+      | Parameters<AzureDevOpsCli.AzureDevOpsCli["Service"]["listPullRequests"]>[0]
+      | undefined;
+    const provider = yield* makeProvider({
+      listPullRequests: (input) => {
+        listInput = input;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: {
+          kind: "azure-devops",
+          name: "Azure DevOps",
+          baseUrl: "https://dev.azure.com",
+        },
+        remoteName: "origin",
+        remoteUrl: "git@ssh.dev.azure.com:v3/ClubTidy/ClubTidy/ClubTidy.Web.BackOffice",
+      },
+      headSelector: "t3code/promo-referral-communications",
+      state: "open",
+    });
+
+    assert.deepStrictEqual(listInput?.repositoryContext, {
+      organization: "ClubTidy",
+      project: "ClubTidy",
+      repository: "ClubTidy.Web.BackOffice",
+    });
+  }),
+);
+
 it.effect("adds change-request context while retaining Azure CLI causes", () =>
   Effect.gen(function* () {
     const cause = new AzureDevOpsCli.AzureDevOpsCommandFailedError({

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
@@ -12,6 +12,16 @@ function makeProvider(azure: Partial<AzureDevOpsCli.AzureDevOpsCli["Service"]>) 
   );
 }
 
+const sshRepositoryContext = {
+  provider: {
+    kind: "azure-devops",
+    name: "Azure DevOps",
+    baseUrl: "https://dev.azure.com",
+  },
+  remoteName: "origin",
+  remoteUrl: "git@ssh.dev.azure.com:v3/acme/project/repo",
+} as const;
+
 it.effect("maps Azure DevOps PR summaries into provider-neutral change requests", () =>
   Effect.gen(function* () {
     const provider = yield* makeProvider({
@@ -46,6 +56,40 @@ it.effect("maps Azure DevOps PR summaries into provider-neutral change requests"
   }),
 );
 
+it.effect("passes the SSH remote repository context to Azure CLI PR lookup", () =>
+  Effect.gen(function* () {
+    let getInput:
+      | Parameters<AzureDevOpsCli.AzureDevOpsCli["Service"]["getPullRequest"]>[0]
+      | undefined;
+    const provider = yield* makeProvider({
+      getPullRequest: (input) => {
+        getInput = input;
+        return Effect.succeed({
+          number: 42,
+          title: "Azure provider",
+          url: "https://dev.azure.com/acme/project/_git/repo/pullrequest/42",
+          baseRefName: "main",
+          headRefName: "feature/source-control",
+          state: "open",
+          updatedAt: Option.none(),
+        });
+      },
+    });
+
+    yield* provider.getChangeRequest({
+      cwd: "/repo",
+      context: sshRepositoryContext,
+      reference: "42",
+    });
+
+    assert.deepStrictEqual(getInput?.repositoryContext, {
+      organization: "acme",
+      project: "project",
+      repository: "repo",
+    });
+  }),
+);
+
 it.effect("passes the SSH remote repository context to Azure CLI PR listing", () =>
   Effect.gen(function* () {
     let listInput:
@@ -60,15 +104,7 @@ it.effect("passes the SSH remote repository context to Azure CLI PR listing", ()
 
     yield* provider.listChangeRequests({
       cwd: "/repo",
-      context: {
-        provider: {
-          kind: "azure-devops",
-          name: "Azure DevOps",
-          baseUrl: "https://dev.azure.com",
-        },
-        remoteName: "origin",
-        remoteUrl: "git@ssh.dev.azure.com:v3/acme/project/repo",
-      },
+      context: sshRepositoryContext,
       headSelector: "feature/source-control",
       state: "open",
     });
@@ -78,6 +114,33 @@ it.effect("passes the SSH remote repository context to Azure CLI PR listing", ()
       project: "project",
       repository: "repo",
     });
+  }),
+);
+
+it.effect("passes the SSH remote repository context to Azure CLI checkout", () =>
+  Effect.gen(function* () {
+    let checkoutInput:
+      | Parameters<AzureDevOpsCli.AzureDevOpsCli["Service"]["checkoutPullRequest"]>[0]
+      | undefined;
+    const provider = yield* makeProvider({
+      checkoutPullRequest: (input) => {
+        checkoutInput = input;
+        return Effect.void;
+      },
+    });
+
+    yield* provider.checkoutChangeRequest({
+      cwd: "/repo",
+      context: sshRepositoryContext,
+      reference: "42",
+    });
+
+    assert.deepStrictEqual(checkoutInput?.repositoryContext, {
+      organization: "acme",
+      project: "project",
+      repository: "repo",
+    });
+    assert.strictEqual(checkoutInput?.remoteName, "origin");
   }),
 );
 
@@ -135,6 +198,7 @@ it.effect("creates Azure DevOps PRs through provider-neutral input names", () =>
 
     yield* provider.createChangeRequest({
       cwd: "/repo",
+      context: sshRepositoryContext,
       baseRefName: "main",
       headSelector: "feature/provider",
       title: "Provider PR",
@@ -145,6 +209,11 @@ it.effect("creates Azure DevOps PRs through provider-neutral input names", () =>
       cwd: "/repo",
       baseBranch: "main",
       headSelector: "feature/provider",
+      repositoryContext: {
+        organization: "acme",
+        project: "project",
+        repository: "repo",
+      },
       title: "Provider PR",
       bodyFile: "/tmp/body.md",
     });
@@ -153,17 +222,27 @@ it.effect("creates Azure DevOps PRs through provider-neutral input names", () =>
 
 it.effect("uses Azure CLI repository detection for default branch lookup", () =>
   Effect.gen(function* () {
-    let cwdInput: string | null = null;
+    let defaultBranchInput:
+      | Parameters<AzureDevOpsCli.AzureDevOpsCli["Service"]["getDefaultBranch"]>[0]
+      | undefined;
     const provider = yield* makeProvider({
       getDefaultBranch: (input) => {
-        cwdInput = input.cwd;
+        defaultBranchInput = input;
         return Effect.succeed("main");
       },
     });
 
-    const defaultBranch = yield* provider.getDefaultBranch({ cwd: "/repo" });
+    const defaultBranch = yield* provider.getDefaultBranch({
+      cwd: "/repo",
+      context: sshRepositoryContext,
+    });
 
     assert.strictEqual(defaultBranch, "main");
-    assert.strictEqual(cwdInput, "/repo");
+    assert.strictEqual(defaultBranchInput?.cwd, "/repo");
+    assert.deepStrictEqual(defaultBranchInput?.repositoryContext, {
+      organization: "acme",
+      project: "project",
+      repository: "repo",
+    });
   }),
 );

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
@@ -67,16 +67,16 @@ it.effect("passes the SSH remote repository context to Azure CLI PR listing", ()
           baseUrl: "https://dev.azure.com",
         },
         remoteName: "origin",
-        remoteUrl: "git@ssh.dev.azure.com:v3/ClubTidy/ClubTidy/ClubTidy.Web.BackOffice",
+        remoteUrl: "git@ssh.dev.azure.com:v3/acme/project/repo",
       },
-      headSelector: "t3code/promo-referral-communications",
+      headSelector: "feature/source-control",
       state: "open",
     });
 
     assert.deepStrictEqual(listInput?.repositoryContext, {
-      organization: "ClubTidy",
-      project: "ClubTidy",
-      repository: "ClubTidy.Web.BackOffice",
+      organization: "acme",
+      project: "project",
+      repository: "repo",
     });
   }),
 );

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
@@ -58,6 +58,9 @@ function toChangeRequest(summary: {
   readonly headRefName: string;
   readonly state: "open" | "closed" | "merged";
   readonly updatedAt: ChangeRequest["updatedAt"];
+  readonly isCrossRepository?: boolean;
+  readonly headRepositoryNameWithOwner?: string | null;
+  readonly headRepositoryOwnerLogin?: string | null;
 }): ChangeRequest {
   return {
     provider: "azure-devops",
@@ -68,7 +71,13 @@ function toChangeRequest(summary: {
     headRefName: summary.headRefName,
     state: summary.state,
     updatedAt: summary.updatedAt,
-    isCrossRepository: false,
+    isCrossRepository: summary.isCrossRepository ?? false,
+    ...(summary.headRepositoryNameWithOwner !== undefined
+      ? { headRepositoryNameWithOwner: summary.headRepositoryNameWithOwner }
+      : {}),
+    ...(summary.headRepositoryOwnerLogin !== undefined
+      ? { headRepositoryOwnerLogin: summary.headRepositoryOwnerLogin }
+      : {}),
   };
 }
 

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
@@ -58,7 +58,6 @@ function toChangeRequest(summary: {
   readonly headRefName: string;
   readonly state: "open" | "closed" | "merged";
   readonly updatedAt: ChangeRequest["updatedAt"];
-  readonly sourceRepositoryUrl?: string;
 }): ChangeRequest {
   return {
     provider: "azure-devops",
@@ -69,7 +68,7 @@ function toChangeRequest(summary: {
     headRefName: summary.headRefName,
     state: summary.state,
     updatedAt: summary.updatedAt,
-    isCrossRepository: summary.sourceRepositoryUrl !== undefined,
+    isCrossRepository: false,
   };
 }
 
@@ -244,7 +243,9 @@ export const make = Effect.gen(function* () {
           cwd: input.cwd,
           reference: input.reference,
           ...(repositoryContext ? { repositoryContext } : {}),
-          ...(input.context !== undefined ? { remoteName: input.context.remoteName } : {}),
+          ...(input.context !== undefined
+            ? { remoteName: input.context.remoteName, remoteUrl: input.context.remoteUrl }
+            : {}),
         })
         .pipe(
           Effect.mapError(

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
@@ -58,6 +58,7 @@ function toChangeRequest(summary: {
   readonly headRefName: string;
   readonly state: "open" | "closed" | "merged";
   readonly updatedAt: ChangeRequest["updatedAt"];
+  readonly sourceRepositoryUrl?: string;
 }): ChangeRequest {
   return {
     provider: "azure-devops",
@@ -68,7 +69,7 @@ function toChangeRequest(summary: {
     headRefName: summary.headRefName,
     state: summary.state,
     updatedAt: summary.updatedAt,
-    isCrossRepository: false,
+    isCrossRepository: summary.sourceRepositoryUrl !== undefined,
   };
 }
 

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
@@ -72,6 +72,15 @@ function toChangeRequest(summary: {
   };
 }
 
+/** Parses the repository coordinates carried by a provider source-control context. */
+function parseRepositoryContext(input: {
+  readonly context?: SourceControlProvider.SourceControlProviderContext;
+}) {
+  return input.context
+    ? AzureDevOpsCli.parseAzureDevOpsRemoteUrl(input.context.remoteUrl)
+    : undefined;
+}
+
 export const make = Effect.gen(function* () {
   const azure = yield* AzureDevOpsCli.AzureDevOpsCli;
 
@@ -79,9 +88,7 @@ export const make = Effect.gen(function* () {
     kind: "azure-devops",
     listChangeRequests: (input) => {
       const source = SourceControlProvider.sourceControlRefFromInput(input);
-      const repositoryContext = input.context
-        ? AzureDevOpsCli.parseAzureDevOpsRemoteUrl(input.context.remoteUrl)
-        : undefined;
+      const repositoryContext = parseRepositoryContext(input);
       return azure
         .listPullRequests({
           cwd: input.cwd,
@@ -109,31 +116,41 @@ export const make = Effect.gen(function* () {
           ),
         );
     },
-    getChangeRequest: (input) =>
-      azure.getPullRequest(input).pipe(
-        Effect.map(toChangeRequest),
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "azure-devops",
-              operation: "getChangeRequest",
-              command: error.command,
-              cwd: input.cwd,
-              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
-                input.reference,
-              ),
-              detail: error.detail,
-              cause: error,
-            }),
-        ),
-      ),
+    getChangeRequest: (input) => {
+      const repositoryContext = parseRepositoryContext(input);
+      return azure
+        .getPullRequest({
+          cwd: input.cwd,
+          reference: input.reference,
+          ...(repositoryContext ? { repositoryContext } : {}),
+        })
+        .pipe(
+          Effect.map(toChangeRequest),
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "azure-devops",
+                operation: "getChangeRequest",
+                command: error.command,
+                cwd: input.cwd,
+                reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.reference,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
+        );
+    },
     createChangeRequest: (input) => {
       const source = SourceControlProvider.sourceControlRefFromInput(input);
+      const repositoryContext = parseRepositoryContext(input);
       return azure
         .createPullRequest({
           cwd: input.cwd,
           baseBranch: input.baseRefName,
           headSelector: input.headSelector,
+          ...(repositoryContext ? { repositoryContext } : {}),
           ...(source !== undefined ? { source } : {}),
           ...(input.target !== undefined ? { target: input.target } : {}),
           title: input.title,
@@ -156,23 +173,31 @@ export const make = Effect.gen(function* () {
           ),
         );
     },
-    getRepositoryCloneUrls: (input) =>
-      azure.getRepositoryCloneUrls(input).pipe(
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "azure-devops",
-              operation: "getRepositoryCloneUrls",
-              command: error.command,
-              cwd: input.cwd,
-              repository: SourceControlProvider.transportSafeSourceControlErrorValue(
-                input.repository,
-              ),
-              detail: error.detail,
-              cause: error,
-            }),
-        ),
-      ),
+    getRepositoryCloneUrls: (input) => {
+      const repositoryContext = parseRepositoryContext(input);
+      return azure
+        .getRepositoryCloneUrls({
+          cwd: input.cwd,
+          repository: input.repository,
+          ...(repositoryContext ? { repositoryContext } : {}),
+        })
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "azure-devops",
+                operation: "getRepositoryCloneUrls",
+                command: error.command,
+                cwd: input.cwd,
+                repository: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.repository,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
+        );
+    },
     createRepository: (input) =>
       azure.createRepository(input).pipe(
         Effect.mapError(
@@ -190,25 +215,34 @@ export const make = Effect.gen(function* () {
             }),
         ),
       ),
-    getDefaultBranch: (input) =>
-      azure.getDefaultBranch({ cwd: input.cwd }).pipe(
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "azure-devops",
-              operation: "getDefaultBranch",
-              command: error.command,
-              cwd: input.cwd,
-              detail: error.detail,
-              cause: error,
-            }),
-        ),
-      ),
-    checkoutChangeRequest: (input) =>
-      azure
+    getDefaultBranch: (input) => {
+      const repositoryContext = parseRepositoryContext(input);
+      return azure
+        .getDefaultBranch({
+          cwd: input.cwd,
+          ...(repositoryContext ? { repositoryContext } : {}),
+        })
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "azure-devops",
+                operation: "getDefaultBranch",
+                command: error.command,
+                cwd: input.cwd,
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
+        );
+    },
+    checkoutChangeRequest: (input) => {
+      const repositoryContext = parseRepositoryContext(input);
+      return azure
         .checkoutPullRequest({
           cwd: input.cwd,
           reference: input.reference,
+          ...(repositoryContext ? { repositoryContext } : {}),
           ...(input.context !== undefined ? { remoteName: input.context.remoteName } : {}),
         })
         .pipe(
@@ -226,7 +260,8 @@ export const make = Effect.gen(function* () {
                 cause: error,
               }),
           ),
-        ),
+        );
+    },
   });
 });
 

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
@@ -79,10 +79,14 @@ export const make = Effect.gen(function* () {
     kind: "azure-devops",
     listChangeRequests: (input) => {
       const source = SourceControlProvider.sourceControlRefFromInput(input);
+      const repositoryContext = input.context
+        ? AzureDevOpsCli.parseAzureDevOpsRemoteUrl(input.context.remoteUrl)
+        : undefined;
       return azure
         .listPullRequests({
           cwd: input.cwd,
           headSelector: input.headSelector,
+          ...(repositoryContext ? { repositoryContext } : {}),
           ...(source !== undefined ? { source } : {}),
           state: input.state,
           ...(input.limit !== undefined ? { limit: input.limit } : {}),

--- a/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
+++ b/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
@@ -6,6 +6,7 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
 import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
+import { parseAzureDevOpsRepositoryCoordinates } from "@t3tools/shared/sourceControl";
 
 export interface NormalizedAzureDevOpsPullRequestRecord {
   readonly number: number;
@@ -15,6 +16,9 @@ export interface NormalizedAzureDevOpsPullRequestRecord {
   readonly headRefName: string;
   readonly state: "open" | "closed" | "merged";
   readonly updatedAt: Option.Option<DateTime.Utc>;
+  readonly isCrossRepository?: boolean;
+  readonly headRepositoryNameWithOwner?: string | null;
+  readonly headRepositoryOwnerLogin?: string | null;
   /** HTTPS clone URL for a fork source repository, when Azure reports one. */
   readonly sourceRepositoryRemoteUrl?: string;
   /** SSH clone URL for a fork source repository, when Azure reports one. */
@@ -153,6 +157,13 @@ function normalizeAzureDevOpsPullRequestRecord(
   const forkRepository = raw.forkSource?.repository;
   const sourceRepositoryRemoteUrl = trimOptionalString(forkRepository?.remoteUrl);
   const sourceRepositorySshUrl = trimOptionalString(forkRepository?.sshUrl);
+  const sourceRepositoryCoordinates = parseAzureDevOpsRepositoryCoordinates(
+    sourceRepositoryRemoteUrl ?? sourceRepositorySshUrl,
+  );
+  const headRepositoryNameWithOwner = sourceRepositoryCoordinates
+    ? `${sourceRepositoryCoordinates.organization}/${sourceRepositoryCoordinates.project}/${sourceRepositoryCoordinates.repository}`
+    : null;
+  const headRepositoryOwnerLogin = sourceRepositoryCoordinates?.organization ?? null;
 
   return {
     number: raw.pullRequestId,
@@ -164,6 +175,13 @@ function normalizeAzureDevOpsPullRequestRecord(
     updatedAt: (raw.closedDate ?? Option.none()).pipe(
       Option.orElse(() => raw.creationDate ?? Option.none()),
     ),
+    ...(sourceRepositoryCoordinates
+      ? {
+          isCrossRepository: true,
+          headRepositoryNameWithOwner,
+          headRepositoryOwnerLogin,
+        }
+      : {}),
     ...(sourceRepositoryRemoteUrl ? { sourceRepositoryRemoteUrl } : {}),
     ...(sourceRepositorySshUrl ? { sourceRepositorySshUrl } : {}),
   };

--- a/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
+++ b/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
@@ -15,8 +15,10 @@ export interface NormalizedAzureDevOpsPullRequestRecord {
   readonly headRefName: string;
   readonly state: "open" | "closed" | "merged";
   readonly updatedAt: Option.Option<DateTime.Utc>;
-  /** Clone URL for a fork source repository, when Azure reports one. */
-  readonly sourceRepositoryUrl?: string;
+  /** HTTPS clone URL for a fork source repository, when Azure reports one. */
+  readonly sourceRepositoryRemoteUrl?: string;
+  /** SSH clone URL for a fork source repository, when Azure reports one. */
+  readonly sourceRepositorySshUrl?: string;
 }
 
 const AzureDevOpsPullRequestSchema = Schema.Struct({
@@ -149,8 +151,8 @@ function normalizeAzureDevOpsPullRequestRecord(
   raw: Schema.Schema.Type<typeof AzureDevOpsPullRequestSchema>,
 ): NormalizedAzureDevOpsPullRequestRecord {
   const forkRepository = raw.forkSource?.repository;
-  const sourceRepositoryUrl =
-    trimOptionalString(forkRepository?.sshUrl) ?? trimOptionalString(forkRepository?.remoteUrl);
+  const sourceRepositoryRemoteUrl = trimOptionalString(forkRepository?.remoteUrl);
+  const sourceRepositorySshUrl = trimOptionalString(forkRepository?.sshUrl);
 
   return {
     number: raw.pullRequestId,
@@ -162,7 +164,8 @@ function normalizeAzureDevOpsPullRequestRecord(
     updatedAt: (raw.closedDate ?? Option.none()).pipe(
       Option.orElse(() => raw.creationDate ?? Option.none()),
     ),
-    ...(sourceRepositoryUrl ? { sourceRepositoryUrl } : {}),
+    ...(sourceRepositoryRemoteUrl ? { sourceRepositoryRemoteUrl } : {}),
+    ...(sourceRepositorySshUrl ? { sourceRepositorySshUrl } : {}),
   };
 }
 

--- a/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
+++ b/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
@@ -15,6 +15,8 @@ export interface NormalizedAzureDevOpsPullRequestRecord {
   readonly headRefName: string;
   readonly state: "open" | "closed" | "merged";
   readonly updatedAt: Option.Option<DateTime.Utc>;
+  /** Clone URL for a fork source repository, when Azure reports one. */
+  readonly sourceRepositoryUrl?: string;
 }
 
 const AzureDevOpsPullRequestSchema = Schema.Struct({
@@ -31,6 +33,20 @@ const AzureDevOpsPullRequestSchema = Schema.Struct({
         }),
       ),
     }),
+  ),
+  forkSource: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        repository: Schema.optional(
+          Schema.NullOr(
+            Schema.Struct({
+              remoteUrl: Schema.optional(Schema.NullOr(Schema.String)),
+              sshUrl: Schema.optional(Schema.NullOr(Schema.String)),
+            }),
+          ),
+        ),
+      }),
+    ),
   ),
   sourceRefName: TrimmedNonEmptyString,
   targetRefName: TrimmedNonEmptyString,
@@ -132,6 +148,10 @@ function normalizeAzureDevOpsPullRequestUrl(
 function normalizeAzureDevOpsPullRequestRecord(
   raw: Schema.Schema.Type<typeof AzureDevOpsPullRequestSchema>,
 ): NormalizedAzureDevOpsPullRequestRecord {
+  const forkRepository = raw.forkSource?.repository;
+  const sourceRepositoryUrl =
+    trimOptionalString(forkRepository?.sshUrl) ?? trimOptionalString(forkRepository?.remoteUrl);
+
   return {
     number: raw.pullRequestId,
     title: raw.title,
@@ -142,6 +162,7 @@ function normalizeAzureDevOpsPullRequestRecord(
     updatedAt: (raw.closedDate ?? Option.none()).pipe(
       Option.orElse(() => raw.creationDate ?? Option.none()),
     ),
+    ...(sourceRepositoryUrl ? { sourceRepositoryUrl } : {}),
   };
 }
 

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   detectSourceControlProviderFromRemoteUrl,
   getChangeRequestTerminologyForKind,
+  parseAzureDevOpsRepositoryCoordinates,
   resolveChangeRequestPresentation,
 } from "./sourceControl.ts";
 
@@ -80,6 +81,27 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
       kind: "unknown",
       name: "self-hosted.example.test:8443",
       baseUrl: "https://self-hosted.example.test:8443",
+    });
+  });
+});
+
+describe("parseAzureDevOpsRepositoryCoordinates", () => {
+  it("parses SSH and HTTPS Azure Repos clone URLs", () => {
+    expect(
+      parseAzureDevOpsRepositoryCoordinates("git@ssh.dev.azure.com:v3/acme/project/repo"),
+    ).toEqual({
+      organization: "acme",
+      project: "project",
+      repository: "repo",
+    });
+    expect(
+      parseAzureDevOpsRepositoryCoordinates(
+        "https://dev.azure.com/acme/fork-project/_git/fork-repo",
+      ),
+    ).toEqual({
+      organization: "acme",
+      project: "fork-project",
+      repository: "fork-repo",
     });
   });
 });

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -53,6 +53,13 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
       detectSourceControlProviderFromRemoteUrl("https://dev.azure.com/org/project/_git/repo")?.kind,
     ).toBe("azure-devops");
     expect(
+      detectSourceControlProviderFromRemoteUrl("git@ssh.dev.azure.com:v3/org/project/repo"),
+    ).toEqual({
+      kind: "azure-devops",
+      name: "Azure DevOps",
+      baseUrl: "https://dev.azure.com",
+    });
+    expect(
       detectSourceControlProviderFromRemoteUrl("git@bitbucket.org:workspace/repo.git")?.kind,
     ).toBe("bitbucket");
   });

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -133,6 +133,77 @@ export function getChangeRequestTerminologyForKind(
   };
 }
 
+/** Identifies an Azure DevOps organization, project, and repository. */
+export interface AzureDevOpsRepositoryCoordinates {
+  readonly organization: string;
+  readonly project: string;
+  readonly repository: string;
+}
+
+function decodeAzureDevOpsPathSegment(segment: string): string | null {
+  try {
+    const decoded = decodeURIComponent(segment).trim();
+    return decoded.length > 0 ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Extracts organization, project, and repository from an Azure Repos clone URL. */
+export function parseAzureDevOpsRepositoryCoordinates(
+  remoteUrl: string | null | undefined,
+): AzureDevOpsRepositoryCoordinates | undefined {
+  const trimmed = remoteUrl?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  let hostname: string;
+  let segments: ReadonlyArray<string>;
+
+  if (trimmed.startsWith("git@")) {
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex <= "git@".length) {
+      return undefined;
+    }
+    hostname = trimmed.slice("git@".length, separatorIndex).toLowerCase();
+    segments = trimmed
+      .slice(separatorIndex + 1)
+      .split("/")
+      .filter((segment) => segment.length > 0);
+  } else {
+    try {
+      const url = new URL(trimmed);
+      hostname = url.hostname.toLowerCase();
+      segments = url.pathname.split("/").filter((segment) => segment.length > 0);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (hostname !== "dev.azure.com" && hostname !== "ssh.dev.azure.com") {
+    return undefined;
+  }
+
+  const isSshClonePath = segments[0]?.toLowerCase() === "v3";
+  const isHttpClonePath = segments[2]?.toLowerCase() === "_git";
+  const [organizationSegment, projectSegment, repositorySegment] = isSshClonePath
+    ? [segments[1], segments[2], segments[3]]
+    : isHttpClonePath
+      ? [segments[0], segments[1], segments[3]]
+      : [];
+
+  const organization = organizationSegment
+    ? decodeAzureDevOpsPathSegment(organizationSegment)
+    : null;
+  const project = projectSegment ? decodeAzureDevOpsPathSegment(projectSegment) : null;
+  const repository = repositorySegment
+    ? decodeAzureDevOpsPathSegment(repositorySegment.replace(/\.git$/iu, ""))
+    : null;
+
+  return organization && project && repository ? { organization, project, repository } : undefined;
+}
+
 function parseRemoteHost(remoteUrl: string): string | null {
   const trimmed = remoteUrl.trim();
   if (trimmed.length === 0) {

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -176,7 +176,9 @@ function isGitLabHost(host: string): boolean {
 }
 
 function isAzureDevOpsHost(host: string): boolean {
-  return host === "dev.azure.com" || host.endsWith(".visualstudio.com");
+  return (
+    host === "dev.azure.com" || host === "ssh.dev.azure.com" || host.endsWith(".visualstudio.com")
+  );
 }
 
 function isBitbucketHost(host: string): boolean {
@@ -212,7 +214,7 @@ export function detectSourceControlProviderFromRemoteUrl(
     return {
       kind: "azure-devops",
       name: "Azure DevOps",
-      baseUrl: toBaseUrl(host),
+      baseUrl: toBaseUrl(hostname === "ssh.dev.azure.com" ? "dev.azure.com" : host),
     };
   }
 


### PR DESCRIPTION
## Problem

Azure DevOps repositories using standard SSH remotes (`git@ssh.dev.azure.com:v3/...`) were classified as an unknown source-control provider. As a result, T3 Code did not run the Azure DevOps pull-request detection path even when the Azure CLI was available.

## Fix

- Recognize `ssh.dev.azure.com` as an Azure DevOps host.
- Normalize that SSH host to `https://dev.azure.com` for Azure DevOps pull-request URLs and CLI integration.
- Pass explicit Azure repository context through pull-request lookup, creation, clone URL retrieval, default-branch lookup, and checkout.
- Use Git fetch with an exact PR-head checkout for SSH-backed and fork pull requests.
- Add a regression test for the standard Azure DevOps SSH remote format.

## Verification

- Reproduced with a real Azure DevOps-backed repository in a local T3 development environment.
- Verified the existing active pull request appeared in the T3 Code UI after the change.
- Focused source-control tests: 101 passed.
- `@t3tools/shared` typecheck: passed.
- `git diff --check`: passed.

Fixes #5272

Completed by GPT-5.6-Luna via Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Azure DevOps PR listing, checkout, and Git remote identity paths; checkout behavior diverges from `az repos pr checkout` when repository context is present. PAT propagation from login shell touches credential-related environment handling.
> 
> **Overview**
> Fixes Azure DevOps repos that use standard SSH remotes (`git@ssh.dev.azure.com:v3/...`) being treated as unknown providers, which blocked PR detection and Azure CLI workflows.
> 
> **Shared detection** adds `parseAzureDevOpsRepositoryCoordinates` and treats `ssh.dev.azure.com` as Azure DevOps with base URLs normalized to `https://dev.azure.com`. **Git identity** for remotes now resolves Azure org/project/repo (not only GitHub).
> 
> **Azure DevOps CLI integration** passes explicit `--organization`, `--project`, and `--repository` (or org-only for PR show) when context is parsed from the remote, instead of `--detect true`, which fails for SSH clones. **Checkout** with context uses `az repos pr show` plus `git fetch` and `git checkout -B` on the PR head branch, picking fork clone URLs to match SSH vs HTTPS. Fork PRs surface cross-repo metadata in normalized PR records.
> 
> The **desktop app** hydrates `AZURE_DEVOPS_EXT_PAT` from the login shell (with inherited values preserved), so Azure CLI auth works when the app is not launched from a terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f103a6ae41fcd5267bd00de677c8b8f2d31dd5ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Azure DevOps SSH remote detection and explicit repository context to CLI commands
> - Extends `detectSourceControlProviderFromRemoteUrl` and `isAzureDevOpsHost` in [sourceControl.ts](https://github.com/pingdotgg/t3code/pull/5273/files#diff-cb400671e313566c053c016f281d8ebad90db5adcec2fee1dea13d296d8b789d) to recognize `ssh.dev.azure.com` as Azure DevOps, normalizing `baseUrl` to `https://dev.azure.com` for SSH remotes.
> - Adds `parseAzureDevOpsRepositoryCoordinates` to extract organization/project/repository from both SSH (`ssh.dev.azure.com v3`) and HTTPS (`dev.azure.com/_git`) clone URLs.
> - Replaces `--detect true` flags in `AzureDevOpsCli` with explicit org/project/repo args derived from a new `repositoryContext` parameter, reducing reliance on Azure CLI auto-detection.
> - `checkoutPullRequest` now supports SSH-backed and fork PRs by fetching directly via `git fetch`/`git checkout` instead of `az repos pr checkout`, with failures mapped to a new `AzureDevOpsGitCommandFailedError`.
> - Normalized PR records now include fork metadata (`isCrossRepository`, `headRepositoryNameWithOwner`, source clone URLs) when returned by the Azure API.
> - Adds `AZURE_DEVOPS_EXT_PAT` to the login-shell environment variables propagated to the desktop app.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f103a6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure DevOps repository detection for SSH and HTTPS remote URLs.
  * Pull-request listings, lookups, creation, checkout, and branch detection now work reliably with SSH repositories.
  * Azure DevOps SSH remotes now display the correct provider and base URL.
  * Desktop environments now correctly load Azure DevOps authentication settings from the login shell when needed.
* **Tests**
  * Added coverage for SSH remote parsing, repository operations, checkout flows, and authentication environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->