### PR TITLE
feat(desktop): play completion sound on Linux

### DIFF
--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -2,13 +2,15 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { beforeEach, vi } from "vite-plus/test";
 
-const { openExternalMock, writeTextMock } = vi.hoisted(() => ({
+const { beepMock, openExternalMock, writeTextMock } = vi.hoisted(() => ({
+  beepMock: vi.fn(),
   openExternalMock: vi.fn(),
   writeTextMock: vi.fn(),
 }));
 
 vi.mock("electron", () => ({
   shell: {
+    beep: beepMock,
     openExternal: openExternalMock,
   },
   clipboard: {
@@ -20,9 +22,20 @@ import * as ElectronShell from "./ElectronShell.ts";
 
 describe("ElectronShell", () => {
   beforeEach(() => {
+    beepMock.mockReset();
     openExternalMock.mockReset();
     writeTextMock.mockReset();
   });
+
+  it.effect("plays the native beep", () =>
+    Effect.gen(function* () {
+      const electronShell = yield* ElectronShell.ElectronShell;
+
+      yield* electronShell.beep;
+
+      assert.equal(beepMock.mock.calls.length, 1);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
 
   it.effect("opens safe external URLs", () =>
     Effect.gen(function* () {

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -25,6 +25,7 @@ export class ElectronShell extends Context.Service<
   {
     readonly openExternal: (rawUrl: unknown) => Effect.Effect<boolean>;
     readonly copyText: (text: string) => Effect.Effect<void>;
+    readonly beep: Effect.Effect<void>;
   }
 >()("@t3tools/desktop/electron/ElectronShell") {}
 
@@ -44,6 +45,9 @@ export const make = ElectronShell.of({
     Effect.sync(() => {
       Electron.clipboard.writeText(text);
     }),
+  beep: Effect.sync(() => {
+    Electron.shell.beep();
+  }),
 });
 
 export const layer = Layer.succeed(ElectronShell, make);

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -38,6 +38,7 @@ import {
   getWindowFullscreenState,
   openExternal,
   pickFolder,
+  playTurnCompletionSound,
   setTheme,
   showContextMenu,
 } from "./methods/window.ts";
@@ -83,6 +84,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handle(setTheme);
   yield* ipc.handle(showContextMenu);
   yield* ipc.handle(openExternal);
+  yield* ipc.handle(playTurnCompletionSound);
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);
   yield* ipc.handle(downloadUpdate);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -3,6 +3,7 @@ export const CONFIRM_CHANNEL = "desktop:confirm";
 export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
+export const PLAY_TURN_COMPLETION_SOUND_CHANNEL = "desktop:play-turn-completion-sound";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";
 export const WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:window-fullscreen-state";

--- a/apps/desktop/src/ipc/methods/window.test.ts
+++ b/apps/desktop/src/ipc/methods/window.test.ts
@@ -5,10 +5,16 @@ import * as Option from "effect/Option";
 
 import type * as Electron from "electron";
 
+import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
 import * as DesktopBackendManager from "../../backend/DesktopBackendManager.ts";
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
+import * as ElectronShell from "../../electron/ElectronShell.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
-import { getLocalEnvironmentBootstraps, getWindowFullscreenState } from "./window.ts";
+import {
+  getLocalEnvironmentBootstraps,
+  getWindowFullscreenState,
+  playTurnCompletionSound,
+} from "./window.ts";
 
 const readyWslConfig: DesktopBackendManager.DesktopBackendStartConfig = {
   executablePath: "wsl.exe",
@@ -142,6 +148,52 @@ describe("getWindowFullscreenState", () => {
         Layer.mock(ElectronWindow.ElectronWindow)({
           currentMainOrFirst: Effect.succeed(Option.some(window)),
         }),
+      ),
+    );
+  });
+});
+
+describe("playTurnCompletionSound", () => {
+  it.effect("plays the native beep on Linux", () => {
+    let beepCount = 0;
+
+    return Effect.gen(function* () {
+      yield* playTurnCompletionSound.handler(undefined);
+      assert.equal(beepCount, 1);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
+            platform: "linux",
+          } as DesktopEnvironment.DesktopEnvironment["Service"]),
+          Layer.mock(ElectronShell.ElectronShell)({
+            beep: Effect.sync(() => {
+              beepCount += 1;
+            }),
+          }),
+        ),
+      ),
+    );
+  });
+
+  it.effect("does nothing on other desktop platforms", () => {
+    let beepCount = 0;
+
+    return Effect.gen(function* () {
+      yield* playTurnCompletionSound.handler(undefined);
+      assert.equal(beepCount, 0);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
+            platform: "darwin",
+          } as DesktopEnvironment.DesktopEnvironment["Service"]),
+          Layer.mock(ElectronShell.ElectronShell)({
+            beep: Effect.sync(() => {
+              beepCount += 1;
+            }),
+          }),
+        ),
       ),
     );
   });

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -268,3 +268,18 @@ export const openExternal = DesktopIpc.makeIpcMethod({
     return yield* shell.openExternal(url);
   }),
 });
+
+export const playTurnCompletionSound = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PLAY_TURN_COMPLETION_SOUND_CHANNEL,
+  payload: Schema.Void,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.window.playTurnCompletionSound")(function* () {
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    if (environment.platform !== "linux") {
+      return;
+    }
+
+    const shell = yield* ElectronShell.ElectronShell;
+    yield* shell.beep;
+  }),
+});

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -105,6 +105,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ...(position === undefined ? {} : { position }),
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
+  playTurnCompletionSound: () => ipcRenderer.invoke(IpcChannels.PLAY_TURN_COMPLETION_SOUND_CHANNEL),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
       if (typeof action !== "string") return;

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -256,6 +256,7 @@ function makeTestLayer(input: {
               return true;
             }),
           copyText: () => Effect.void,
+          beep: Effect.void,
         } satisfies ElectronShell.ElectronShell["Service"]),
         electronThemeLayer,
         electronWindowLayer,
@@ -350,6 +351,7 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
           Layer.succeed(ElectronShell.ElectronShell, {
             openExternal: () => Effect.succeed(true),
             copyText: () => Effect.void,
+            beep: Effect.void,
           } satisfies ElectronShell.ElectronShell["Service"]),
           electronThemeLayer,
           Layer.succeed(ElectronWindow.ElectronWindow, electronWindowShape),

--- a/apps/web/src/components/desktop/DesktopTurnCompletionSound.test.ts
+++ b/apps/web/src/components/desktop/DesktopTurnCompletionSound.test.ts
@@ -36,6 +36,18 @@ describe("createTurnCompletionTracker", () => {
     expect(tracker.sync([completed])).toBe(0);
   });
 
+  it("does not repeat a completed turn when its completion timestamp changes", () => {
+    const tracker = createTurnCompletionTracker();
+
+    expect(tracker.sync([snapshot()])).toBe(0);
+    expect(
+      tracker.sync([snapshot({ state: "completed", completedAt: "2026-08-03T08:00:00.000Z" })]),
+    ).toBe(1);
+    expect(
+      tracker.sync([snapshot({ state: "completed", completedAt: "2026-08-03T08:00:01.000Z" })]),
+    ).toBe(0);
+  });
+
   it("reports a newer completed turn for an already observed thread", () => {
     const tracker = createTurnCompletionTracker();
 

--- a/apps/web/src/components/desktop/DesktopTurnCompletionSound.test.ts
+++ b/apps/web/src/components/desktop/DesktopTurnCompletionSound.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  createTurnCompletionTracker,
+  type TurnCompletionSnapshot,
+} from "./DesktopTurnCompletionSound";
+
+function snapshot(overrides: Partial<TurnCompletionSnapshot> = {}): TurnCompletionSnapshot {
+  return {
+    threadKey: "environment-1:thread-1",
+    turnId: "turn-1",
+    state: "running",
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+describe("createTurnCompletionTracker", () => {
+  it("reports a turn that transitions from running to completed", () => {
+    const tracker = createTurnCompletionTracker();
+
+    expect(tracker.sync([snapshot()])).toBe(0);
+    expect(
+      tracker.sync([snapshot({ state: "completed", completedAt: "2026-08-03T08:00:00.000Z" })]),
+    ).toBe(1);
+  });
+
+  it("does not report the initial snapshot or repeat a completed turn", () => {
+    const tracker = createTurnCompletionTracker();
+    const completed = snapshot({
+      state: "completed",
+      completedAt: "2026-08-03T08:00:00.000Z",
+    });
+
+    expect(tracker.sync([completed])).toBe(0);
+    expect(tracker.sync([completed])).toBe(0);
+  });
+
+  it("reports a newer completed turn for an already observed thread", () => {
+    const tracker = createTurnCompletionTracker();
+
+    expect(
+      tracker.sync([snapshot({ state: "completed", completedAt: "2026-08-03T08:00:00.000Z" })]),
+    ).toBe(0);
+    expect(
+      tracker.sync([
+        snapshot({
+          turnId: "turn-2",
+          state: "completed",
+          completedAt: "2026-08-03T09:00:00.000Z",
+        }),
+      ]),
+    ).toBe(1);
+  });
+
+  it("ignores interrupted and errored turns", () => {
+    const tracker = createTurnCompletionTracker();
+
+    expect(tracker.sync([snapshot()])).toBe(0);
+    expect(
+      tracker.sync([snapshot({ state: "interrupted", completedAt: "2026-08-03T08:00:00.000Z" })]),
+    ).toBe(0);
+    expect(
+      tracker.sync([
+        snapshot({
+          turnId: "turn-2",
+          state: "error",
+          completedAt: "2026-08-03T09:00:00.000Z",
+        }),
+      ]),
+    ).toBe(0);
+  });
+
+  it("does not report a completed thread that appears after initialization", () => {
+    const tracker = createTurnCompletionTracker();
+
+    expect(tracker.sync([snapshot()])).toBe(0);
+    expect(
+      tracker.sync([
+        snapshot(),
+        snapshot({
+          threadKey: "environment-1:thread-2",
+          turnId: "turn-2",
+          state: "completed",
+          completedAt: "2026-08-03T09:00:00.000Z",
+        }),
+      ]),
+    ).toBe(0);
+  });
+});

--- a/apps/web/src/components/desktop/DesktopTurnCompletionSound.tsx
+++ b/apps/web/src/components/desktop/DesktopTurnCompletionSound.tsx
@@ -1,0 +1,86 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { OrchestrationLatestTurnState } from "@t3tools/contracts";
+import { useEffect, useRef } from "react";
+
+import { useThreadShells } from "../../state/entities";
+
+export interface TurnCompletionSnapshot {
+  readonly threadKey: string;
+  readonly turnId: string | null;
+  readonly state: OrchestrationLatestTurnState | null;
+  readonly completedAt: string | null;
+}
+
+interface ObservedTurn {
+  readonly turnId: string | null;
+  readonly completedAt: string | null;
+}
+
+export interface TurnCompletionTracker {
+  readonly sync: (snapshots: readonly TurnCompletionSnapshot[]) => number;
+}
+
+export function createTurnCompletionTracker(): TurnCompletionTracker {
+  let initialized = false;
+  let observedTurns = new Map<string, ObservedTurn>();
+
+  return {
+    sync: (snapshots) => {
+      const nextObservedTurns = new Map<string, ObservedTurn>();
+      let completedTurnCount = 0;
+
+      for (const snapshot of snapshots) {
+        const currentTurn = {
+          turnId: snapshot.turnId,
+          completedAt: snapshot.completedAt,
+        };
+        nextObservedTurns.set(snapshot.threadKey, currentTurn);
+
+        const previousTurn = observedTurns.get(snapshot.threadKey);
+        if (
+          initialized &&
+          previousTurn !== undefined &&
+          snapshot.state === "completed" &&
+          snapshot.completedAt !== null &&
+          (previousTurn.turnId !== snapshot.turnId ||
+            previousTurn.completedAt !== snapshot.completedAt)
+        ) {
+          completedTurnCount += 1;
+        }
+      }
+
+      observedTurns = nextObservedTurns;
+      initialized = true;
+      return completedTurnCount;
+    },
+  };
+}
+
+function DesktopTurnCompletionObserver({ playSound }: { readonly playSound: () => Promise<void> }) {
+  const threadShells = useThreadShells();
+  const trackerRef = useRef<TurnCompletionTracker | null>(null);
+  trackerRef.current ??= createTurnCompletionTracker();
+
+  useEffect(() => {
+    const snapshots = threadShells.map((thread) => ({
+      threadKey: scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      turnId: thread.latestTurn?.turnId ?? null,
+      state: thread.latestTurn?.state ?? null,
+      completedAt: thread.latestTurn?.completedAt ?? null,
+    }));
+    const completedTurnCount = trackerRef.current?.sync(snapshots) ?? 0;
+
+    for (let index = 0; index < completedTurnCount; index += 1) {
+      void playSound().catch(() => undefined);
+    }
+  }, [playSound, threadShells]);
+
+  return null;
+}
+
+export function DesktopTurnCompletionSound() {
+  const playSound = window.desktopBridge?.playTurnCompletionSound;
+  return typeof playSound === "function" ? (
+    <DesktopTurnCompletionObserver playSound={playSound} />
+  ) : null;
+}

--- a/apps/web/src/components/desktop/DesktopTurnCompletionSound.tsx
+++ b/apps/web/src/components/desktop/DesktopTurnCompletionSound.tsx
@@ -13,7 +13,7 @@ export interface TurnCompletionSnapshot {
 
 interface ObservedTurn {
   readonly turnId: string | null;
-  readonly completedAt: string | null;
+  readonly state: OrchestrationLatestTurnState | null;
 }
 
 export interface TurnCompletionTracker {
@@ -32,7 +32,7 @@ export function createTurnCompletionTracker(): TurnCompletionTracker {
       for (const snapshot of snapshots) {
         const currentTurn = {
           turnId: snapshot.turnId,
-          completedAt: snapshot.completedAt,
+          state: snapshot.state,
         };
         nextObservedTurns.set(snapshot.threadKey, currentTurn);
 
@@ -42,8 +42,7 @@ export function createTurnCompletionTracker(): TurnCompletionTracker {
           previousTurn !== undefined &&
           snapshot.state === "completed" &&
           snapshot.completedAt !== null &&
-          (previousTurn.turnId !== snapshot.turnId ||
-            previousTurn.completedAt !== snapshot.completedAt)
+          (previousTurn.turnId !== snapshot.turnId || previousTurn.state !== "completed")
         ) {
           completedTurnCount += 1;
         }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
 import { ConnectOnboardingDialog } from "../components/cloud/ConnectOnboardingDialog";
 import { RelayClientInstallDialog } from "../components/cloud/RelayClientInstallDialog";
+import { DesktopTurnCompletionSound } from "../components/desktop/DesktopTurnCompletionSound";
 import { SshPasswordPromptDialog } from "../components/desktop/SshPasswordPromptDialog";
 import { ProviderUpdateLaunchNotification } from "../components/ProviderUpdateLaunchNotification";
 import { SlowRpcRequestToastCoordinator } from "../components/SlowRpcRequestToastCoordinator";
@@ -132,6 +133,7 @@ function RootRouteView() {
         <RelayClientInstallDialog />
         <ConnectOnboardingDialog />
         <SshPasswordPromptDialog />
+        <DesktopTurnCompletionSound />
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -41,6 +41,8 @@ Arch Linux:
 yay -S t3code-bin
 ```
 
+On Linux, the desktop app plays the system beep when an agent turn completes.
+
 ## Providers
 
 T3 Code drives provider CLIs; it does not ship them. Install the CLI for each provider you want

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1007,6 +1007,7 @@ export interface DesktopBridge {
     position?: { x: number; y: number },
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
+  playTurnCompletionSound?: () => Promise<void>;
   onMenuAction: (listener: (action: string) => void) => () => void;
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;


### PR DESCRIPTION
## Why

On Ubuntu, an agent can finish while T3 Code is in the background without an audible cue. This adds a lightweight Codex CLI-like completion sound using the platform beep, while leaving web, mobile, and non-Linux desktop behavior unchanged.

## What Changed

- Observe completed agent turns in the desktop renderer without replaying sounds for initial hydration or repeated state updates.
- Route completion notifications through the typed preload/IPC bridge and play Electron's native system beep on Linux only.
- Document the Linux desktop behavior and cover completion tracking, platform gating, and the Electron shell call with focused tests.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because there is no visual UI change
- [x] Video is not applicable because there is no visual animation or interaction change

Built with GPT-5 using Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Play system beep on Linux when an agent turn completes
> - Adds a `DesktopTurnCompletionSound` React component mounted globally in [`__root.tsx`](https://github.com/pingdotgg/t3code/pull/5274/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) that watches thread snapshots and calls `playTurnCompletionSound` via `window.desktopBridge` once per newly completed turn.
> - Adds a `createTurnCompletionTracker` utility that detects transitions to `completed` state, ignoring turns already completed on first observation and deduplicating repeat syncs.
> - Adds a new `desktop:play-turn-completion-sound` IPC channel handled in [`window.ts`](https://github.com/pingdotgg/t3code/pull/5274/files#diff-0da18602882cf6025119591a641faafe1e09c7c4c0a24a8e447278c4a4a55342); on Linux it calls `ElectronShell.beep()`, on other platforms it is a no-op.
> - Exposes `ElectronShell.beep` as an Effect wrapping `Electron.shell.beep()` and adds `playTurnCompletionSound` to the `DesktopBridge` interface as an optional method.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b93fd06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing audio on Linux only, gated in main and renderer; no auth, data, or orchestration changes.
> 
> **Overview**
> Adds an audible cue when agent turns finish on **Linux desktop**, using the platform system beep so background sessions are noticeable without changing web, mobile, or macOS/Windows behavior.
> 
> The web shell mounts **`DesktopTurnCompletionSound`** in the root layout. It watches thread shells via **`createTurnCompletionTracker`**, which only counts turns that **transition** to `completed` after the first sync—skipping hydration, repeated updates, interrupted/error turns, and threads that appear already completed.
> 
> Completion triggers **`window.desktopBridge.playTurnCompletionSound()`** through a new IPC channel; the main process calls **`Electron.shell.beep()`** only when **`DesktopEnvironment.platform === "linux"`**. **`ElectronShell`** gains a **`beep`** effect; **`DesktopBridge`** documents optional **`playTurnCompletionSound`**. Install docs note Linux beep behavior; tests cover tracker logic, platform gating, and shell beep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93fd064451f700f99cc70a6d9f8bff3808e264a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->