### PR TITLE
fix(web): preserve shifted terminal input

### DIFF
--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -1,5 +1,6 @@
 import {
   type GhosttyKeyboardLayoutMap,
+  ghosttyConsumedMods,
   ghosttyKeyForCode,
   ghosttyUnshiftedCodepoint,
   loadGhosttyKeyboardLayoutMap,
@@ -445,13 +446,18 @@ export class GhosttyTerminalCore {
       (event.metaKey ? 1 << 3 : 0) |
       (event.getModifierState("CapsLock") ? 1 << 4 : 0) |
       (event.getModifierState("NumLock") ? 1 << 5 : 0);
+    const unshiftedCodepoint = ghosttyUnshiftedCodepoint(event, this.keyboardLayoutMap);
     this.runtime.call("ghostty_key_event_set_mods", this.keyEvent, mods);
-    this.runtime.call("ghostty_key_event_set_consumed_mods", this.keyEvent, 0);
+    this.runtime.call(
+      "ghostty_key_event_set_consumed_mods",
+      this.keyEvent,
+      ghosttyConsumedMods(event, unshiftedCodepoint),
+    );
     this.runtime.call("ghostty_key_event_set_composing", this.keyEvent, event.isComposing ? 1 : 0);
     this.runtime.call(
       "ghostty_key_event_set_unshifted_codepoint",
       this.keyEvent,
-      ghosttyUnshiftedCodepoint(event, this.keyboardLayoutMap),
+      unshiftedCodepoint,
     );
 
     const text = event.key.length === 1 ? event.key : "";

--- a/apps/web/src/terminal/ghostty/keyCodes.test.ts
+++ b/apps/web/src/terminal/ghostty/keyCodes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { ghosttyKeyForCode, ghosttyUnshiftedCodepoint } from "./keyCodes";
+import { ghosttyConsumedMods, ghosttyKeyForCode, ghosttyUnshiftedCodepoint } from "./keyCodes";
 
 describe("ghosttyKeyForCode", () => {
   it("keeps the tail of the pinned Ghostty key enum in order", () => {
@@ -49,5 +49,24 @@ describe("ghosttyUnshiftedCodepoint", () => {
     expect(ghosttyUnshiftedCodepoint({ code: "KeyC", key: "J", shiftKey: true }, layoutMap)).toBe(
       "j".codePointAt(0),
     );
+  });
+});
+
+describe("ghosttyConsumedMods", () => {
+  it("marks Shift consumed when it produces a different printable character", () => {
+    expect(ghosttyConsumedMods({ key: ":", shiftKey: true }, ";".codePointAt(0)!)).toBe(1);
+    expect(ghosttyConsumedMods({ key: "C", shiftKey: true }, "c".codePointAt(0)!)).toBe(1);
+  });
+
+  it("uses the active layout's unshifted character", () => {
+    const event = { code: "Period", key: ":", shiftKey: true };
+    const unshiftedCodepoint = ghosttyUnshiftedCodepoint(event, new Map([["Period", "."]]));
+    expect(ghosttyConsumedMods(event, unshiftedCodepoint)).toBe(1);
+  });
+
+  it("preserves Shift when it did not transform printable text", () => {
+    expect(ghosttyConsumedMods({ key: " ", shiftKey: true }, " ".codePointAt(0)!)).toBe(0);
+    expect(ghosttyConsumedMods({ key: "Tab", shiftKey: true }, 0)).toBe(0);
+    expect(ghosttyConsumedMods({ key: ":", shiftKey: false }, ":".codePointAt(0)!)).toBe(0);
   });
 });

--- a/apps/web/src/terminal/ghostty/keyCodes.ts
+++ b/apps/web/src/terminal/ghostty/keyCodes.ts
@@ -184,6 +184,8 @@ const codeToGhosttyKey = new Map<string, number>(
   ghosttyKeyboardCodes.map((code, index) => [code, index]),
 );
 
+const GHOSTTY_MOD_SHIFT = 1 << 0;
+
 export function ghosttyKeyForCode(code: string): number {
   return codeToGhosttyKey.get(code) ?? 0;
 }
@@ -255,4 +257,12 @@ export function ghosttyUnshiftedCodepoint(
     return 0;
   }
   return event.key.codePointAt(0) ?? 0;
+}
+
+export function ghosttyConsumedMods(
+  event: Pick<KeyboardEvent, "key" | "shiftKey">,
+  unshiftedCodepoint: number,
+): number {
+  if (!event.shiftKey || unshiftedCodepoint === 0 || [...event.key].length !== 1) return 0;
+  return event.key.codePointAt(0) !== unshiftedCodepoint ? GHOSTTY_MOD_SHIFT : 0;
 }

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import wasmDataUrl from "./vendor/ghostty-vt.wasm?inline";
 import writePtyWasmDataUrl from "./vendor/ghostty-write-pty.wasm?inline";
 import pinnedVersion from "../../../../../native/libghostty-vt/VERSION?raw";
-import { ghosttyKeyForCode } from "./keyCodes";
+import { ghosttyConsumedMods, ghosttyKeyForCode } from "./keyCodes";
 
 type WasmFunction = (...args: number[]) => number;
 
@@ -519,8 +519,46 @@ describe("vendored libghostty-vt WebAssembly", () => {
       new TextDecoder().decode(new Uint8Array(memory.buffer, remappedOutput, remappedOutputLength)),
     ).toBe("\u001b[106;5u");
 
+    const unshiftedColon = ";".codePointAt(0)!;
+    const colonText = new TextEncoder().encode(":");
+    const colonTextPointer = alloc(colonText.length);
+    new Uint8Array(memory.buffer, colonTextPointer, colonText.length).set(colonText);
+    call("ghostty_key_event_set_key", keyEvent, ghosttyKeyForCode("Semicolon"));
+    call("ghostty_key_event_set_mods", keyEvent, 1);
+    call(
+      "ghostty_key_event_set_consumed_mods",
+      keyEvent,
+      ghosttyConsumedMods({ key: ":", shiftKey: true }, unshiftedColon),
+    );
+    call("ghostty_key_event_set_unshifted_codepoint", keyEvent, unshiftedColon);
+    call("ghostty_key_event_set_utf8", keyEvent, colonTextPointer, colonText.length);
+    expect(call("ghostty_key_encoder_encode", keyEncoder, keyEvent, 0, 0, written)).toBe(-3);
+    const colonOutputSize = new DataView(memory.buffer, written, 4).getUint32(0, true);
+    const colonOutput = alloc(colonOutputSize);
+    expect(
+      call(
+        "ghostty_key_encoder_encode",
+        keyEncoder,
+        keyEvent,
+        colonOutput,
+        colonOutputSize,
+        written,
+      ),
+    ).toBe(0);
+    const colonOutputLength = new DataView(memory.buffer, written, 4).getUint32(0, true);
+    expect(
+      new TextDecoder().decode(new Uint8Array(memory.buffer, colonOutput, colonOutputLength)),
+    ).toBe(":");
+    free(colonOutput, colonOutputSize);
+    free(colonTextPointer, colonText.length);
+
     // Without the Kitty report-event-types flag a release encodes nothing, so
     // the surface's keyup handler stays silent for legacy sessions.
+    call("ghostty_key_event_set_key", keyEvent, ghosttyKeyForCode("KeyC"));
+    call("ghostty_key_event_set_mods", keyEvent, 1 << 1);
+    call("ghostty_key_event_set_consumed_mods", keyEvent, 0);
+    call("ghostty_key_event_set_unshifted_codepoint", keyEvent, "j".codePointAt(0)!);
+    call("ghostty_key_event_set_utf8", keyEvent, remappedTextPointer, remappedText.length);
     call("ghostty_key_event_set_action", keyEvent, 0);
     expect(call("ghostty_key_encoder_encode", keyEncoder, keyEvent, 0, 0, written)).toBe(0);
     expect(new DataView(memory.buffer, written, 4).getUint32(0, true)).toBe(0);


### PR DESCRIPTION
## Problem

Fixes #5276

Neovim enables Kitty keyboard disambiguation when it starts in the built-in terminal. Pressing Shift+`;` should produce `:` and open the Neovim command line, but T3 Code encoded it as `ESC[59;2u`, so Neovim handled it as `;` instead.

This appeared specific to Neovim because a regular shell uses the legacy keyboard path, where the browser-provided `:` text was already emitted correctly.

## Root cause

The web Ghostty bridge passed `0` to `ghostty_key_event_set_consumed_mods` for every key event. That told the Kitty encoder that Shift was still an effective modifier even when the browser had already consumed Shift to translate the layout base character `;` into `:`.

The encoder therefore emitted a modified unshifted codepoint instead of the translated printable text.

## Fix

- Derive the unshifted codepoint once from the active browser keyboard layout, retaining the existing US-layout fallback.
- Mark Shift as consumed only when Shift is pressed, the event produced one Unicode codepoint, a valid unshifted codepoint exists, and the produced character differs from that base codepoint.
- Pass that consumed-modifier mask and the same unshifted codepoint into the Ghostty WASM encoder.

This is deliberately a general shifted-printable fix rather than a colon special case. Shift remains effective for functional keys and for printable keys it does not transform, such as Shift+Space.

## Behavior before and after

| Input | Before | After |
| --- | --- | --- |
| Shift+`;` in a normal shell | `:` | `:` |
| Shift+`;` after Neovim enables Kitty disambiguation | `ESC[59;2u` and Neovim sees `;` | literal `:` and the command line opens |
| Shift+Space / Shift+Tab | Shift remains distinguishable | unchanged |
| Shifted printable keys on a non-US layout | could be encoded as a modified base key | browser-translated character is preserved |

## Scope and risk

- Limited to browser-to-PTY key encoding in `apps/web/src/terminal/ghostty`.
- Covers local web, hosted web, and desktop because they share this terminal implementation.
- Does not change server or WebSocket contracts, terminal session state, mobile native input, or visual rendering.
- Falls back to the prior behavior when the browser cannot provide a trustworthy unshifted codepoint.

Screenshots are not applicable because this has no visual UI change; the user-visible difference is the terminal byte sequence shown above.

## Verification

- `cd apps/web && vp test run src/terminal/ghostty/keyCodes.test.ts src/terminal/ghostty/runtimeAbi.test.ts --project unit` — 14 tests passed.
- The helper tests cover shifted punctuation, shifted letters, a non-US layout map, Shift+Space, Shift+Tab, and unmodified text.
- The pinned Ghostty WASM ABI test enables Kitty disambiguation with `CSI > 1 u` and verifies Shift+`;` emits exactly `:`.
- Targeted `vp lint` passed for all four changed files.
- `vp run --filter @t3tools/web typecheck` passed.

Implemented with GPT-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only browser-to-PTY key encoding for the Ghostty web terminal; behavior shifts for Shift+printable keys under Kitty modes, with tests but limited surface area outside terminal input.
> 
> **Overview**
> Fixes **shifted printable input** in the web Ghostty bridge when apps use Kitty keyboard disambiguation (e.g. Neovim in the built-in terminal). The bridge always sent **zero consumed modifiers**, so Shift+`;` was encoded like a modified `;` instead of plain `:`.
> 
> Adds **`ghosttyConsumedMods`**, which marks Shift consumed when the pressed character differs from the layout-aware **unshifted codepoint** (reuses the same unshifted value already passed to the encoder). **`encodeKey`** in `core.ts` passes that value to `ghostty_key_event_set_consumed_mods` instead of `0`. Shift stays visible for keys where it does not change the character (space, Tab, etc.).
> 
> Unit tests cover the helper; the vendored WASM ABI test asserts Shift+`;` encodes as `:` in Kitty mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ecfbc395dc1e710f86316d222e45b0c5c6b738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix shifted terminal input by marking Shift as a consumed modifier when it transforms a printable character
> - Adds `ghosttyConsumedMods` in [`keyCodes.ts`](https://github.com/pingdotgg/t3code/pull/5277/files#diff-93221f3e8e496f52536eb4798a536a527b2174d696e963f02a246d1601794687) to compute consumed modifier bits: returns the Shift bit when Shift produces a different printable character than the unshifted codepoint, otherwise returns 0.
> - Updates the key event handler in [`core.ts`](https://github.com/pingdotgg/t3code/pull/5277/files#diff-40345426232e3feaf88713623c1f6cc40b4c1730f13cd935fbda4032577864fa) to pass the result of `ghosttyConsumedMods` to `ghostty_key_event_set_consumed_mods` instead of the previous hardcoded `0`.
> - Behavioral Change: keys like `:` (Shift+Semicolon) now correctly report Shift as consumed, fixing shifted character input that was previously broken.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4ecfbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->