### PR TITLE
fix(server): diagnose node-pty startup failures

### DIFF
--- a/apps/server/src/cli/server.test.ts
+++ b/apps/server/src/cli/server.test.ts
@@ -1,0 +1,30 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { vi } from "vite-plus/test";
+
+import * as NodePtyAdapter from "../terminal/NodePtyAdapter.ts";
+import { reportStartupDefect } from "./server.ts";
+
+it.effect("renders native startup diagnostics to stderr and sets a non-zero exit code", () =>
+  Effect.gen(function* () {
+    const previousExitCode = process.exitCode;
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const error = new NodePtyAdapter.NodePtyModuleLoadError({
+      platform: "linux",
+      architecture: "x64",
+      cause: new Error("native binding could not be loaded"),
+    });
+
+    try {
+      yield* reportStartupDefect(error);
+
+      assert.equal(process.exitCode, 1);
+      assert.equal(stderr.mock.calls.length, 1);
+      assert.include(String(stderr.mock.calls[0]?.[0] ?? ""), "native binding could not be loaded");
+      assert.include(String(stderr.mock.calls[0]?.[0] ?? ""), "reinstall t3");
+    } finally {
+      stderr.mockRestore();
+      process.exitCode = previousExitCode;
+    }
+  }),
+);

--- a/apps/server/src/cli/server.ts
+++ b/apps/server/src/cli/server.ts
@@ -5,6 +5,24 @@ import { ServerConfig, type StartupPresentation } from "../config.ts";
 import { runServer } from "../server.ts";
 import { type CliServerFlags, resolveServerConfig, sharedServerCommandFlags } from "./config.ts";
 
+/**
+ * Startup defects can otherwise be swallowed by headless logging. The CLI owns
+ * process-exit policy, so render an adapter-provided diagnosis to stderr and
+ * make sure a broken native install cannot exit successfully.
+ */
+const hasDiagnostic = (defect: unknown): defect is { readonly diagnostic: string } =>
+  typeof defect === "object" &&
+  defect !== null &&
+  typeof (defect as { readonly diagnostic?: unknown }).diagnostic === "string";
+
+export const reportStartupDefect = (defect: unknown) =>
+  Effect.sync(() => {
+    process.exitCode = 1;
+    if (hasDiagnostic(defect)) {
+      process.stderr.write(`${defect.diagnostic}\n`);
+    }
+  });
+
 export const runServerCommand = (
   flags: CliServerFlags,
   options?: {
@@ -15,7 +33,10 @@ export const runServerCommand = (
   Effect.gen(function* () {
     const logLevel = yield* GlobalFlag.LogLevel;
     const config = yield* resolveServerConfig(flags, logLevel, options);
-    return yield* runServer.pipe(Effect.provideService(ServerConfig, config));
+    return yield* runServer.pipe(
+      Effect.provideService(ServerConfig, config),
+      Effect.tapDefect(reportStartupDefect),
+    );
   });
 
 export const startCommand = Command.make("start", { ...sharedServerCommandFlags }).pipe(

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1260,6 +1260,28 @@ it.layer(
     }),
   );
 
+  it.effect("does not retry other shells when spawn-helper is not executable", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, getEvents } = yield* createManager();
+      ptyAdapter.spawnFailures.push(
+        new PtyAdapter.SpawnHelperNotExecutableError({
+          helperPath: "/pkg/spawn-helper",
+          cause: new Error("posix_spawnp failed."),
+        }),
+      );
+
+      const snapshot = yield* manager.open(openInput());
+
+      assert.equal(snapshot.status, "error");
+      expect(ptyAdapter.spawnInputs).toHaveLength(1);
+
+      const events = yield* getEvents;
+      const errorEvent = events.find((event) => event.type === "error");
+      assert.isDefined(errorEvent);
+      assert.include(errorEvent?.message ?? "", 'chmod +x "/pkg/spawn-helper"');
+    }),
+  );
+
   it.effect("prefers PowerShell over ComSpec for Windows terminals", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager(5, {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -565,6 +565,12 @@ function resolveShellCandidates(
 }
 
 function isRetryableShellSpawnError(error: PtyAdapter.PtySpawnError): boolean {
+  // A non-executable node-pty spawn-helper fails identically for every shell;
+  // use the structured tag to preserve the actionable diagnosis.
+  if (PtyAdapter.hasSpawnHelperNotExecutableCause(error)) {
+    return false;
+  }
+
   const queue: unknown[] = [error];
   const seen = new Set<unknown>();
   const messages: string[] = [];
@@ -1959,7 +1965,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
       yield* evictInactiveSessionsIfNeeded();
 
-      const message = error.message;
+      const message = (PtyAdapter.findSpawnHelperNotExecutableCause(error) ?? error).message;
       yield* publishEvent({
         type: "error",
         threadId: session.threadId,

--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -75,6 +75,11 @@ it.effect("reports native module load failures as structured startup defects", (
         architecture: "x64",
       });
       assert.equal(error.message, "Failed to load node-pty for win32-x64.");
+      // The CLI entrypoint renders this; a broken install must never exit
+      // cleanly with no output.
+      assert.include(error.diagnostic, "Failed to load node-pty for win32-x64.");
+      assert.include(error.diagnostic, "native binding could not be loaded");
+      assert.include(error.diagnostic, "reinstall t3");
     }
   }).pipe(
     Effect.provide(
@@ -86,3 +91,158 @@ it.effect("reports native module load failures as structured startup defects", (
     ),
   ),
 );
+
+it("resolves helper executability against the calling process, not any exec bit", () => {
+  const owned = { ownerUid: 501, ownerGid: 20 };
+
+  // Owner-only binary: executable for its owner, not for anyone else.
+  assert.isTrue(
+    NodePtyAdapter.modeIsExecutableFor({
+      mode: 0o100,
+      ...owned,
+      processUid: 501,
+      processGids: [20],
+    }),
+  );
+  assert.isFalse(
+    NodePtyAdapter.modeIsExecutableFor({
+      mode: 0o100,
+      ...owned,
+      processUid: 502,
+      processGids: [21],
+    }),
+  );
+
+  // Group and other bits are honoured independently of the owner bit.
+  assert.isTrue(
+    NodePtyAdapter.modeIsExecutableFor({
+      mode: 0o010,
+      ...owned,
+      processUid: 502,
+      processGids: [20],
+    }),
+  );
+  assert.isFalse(
+    NodePtyAdapter.modeIsExecutableFor({
+      mode: 0o600,
+      ...owned,
+      processUid: 501,
+      processGids: [20],
+    }),
+  );
+  assert.isTrue(
+    NodePtyAdapter.modeIsExecutableFor({
+      mode: 0o001,
+      ...owned,
+      processUid: 502,
+      processGids: [21],
+    }),
+  );
+
+  // Root and unknown identities fall back to whether any execute bit exists.
+  assert.isTrue(
+    NodePtyAdapter.modeIsExecutableFor({ mode: 0o100, ...owned, processUid: 0, processGids: [0] }),
+  );
+  assert.isFalse(
+    NodePtyAdapter.modeIsExecutableFor({ mode: 0o644, ...owned, processUid: 0, processGids: [0] }),
+  );
+  assert.isTrue(
+    NodePtyAdapter.modeIsExecutableFor({
+      mode: 0o100,
+      ownerUid: null,
+      ownerGid: null,
+      processUid: null,
+      processGids: [],
+    }),
+  );
+
+  // The reported bug: a 0644 helper is never executable for anyone.
+  assert.isFalse(
+    NodePtyAdapter.modeIsExecutableFor({
+      mode: 0o644,
+      ...owned,
+      processUid: 501,
+      processGids: [20],
+    }),
+  );
+});
+
+it("leaves non-posix_spawnp failures untouched", () => {
+  const cause = new Error("cwd does not exist");
+  const described = NodePtyAdapter.describeSpawnFailure({
+    cause,
+    platform: "darwin",
+    helperPath: "/pkg/node-pty/build/Release/spawn-helper",
+    helperIsExecutable: false,
+  });
+  assert.equal(described, cause);
+});
+
+it("explains posix_spawnp failures caused by a non-executable spawn-helper", () => {
+  const cause = new Error("posix_spawnp failed.");
+  const described = NodePtyAdapter.describeSpawnFailure({
+    cause,
+    platform: "darwin",
+    helperPath: "/pkg/node-pty/build/Release/spawn-helper",
+    helperIsExecutable: false,
+  });
+  assert.instanceOf(described, PtyAdapter.SpawnHelperNotExecutableError);
+  const error = described as PtyAdapter.SpawnHelperNotExecutableError;
+  assert.equal(error.helperPath, "/pkg/node-pty/build/Release/spawn-helper");
+  assert.include(error.message, 'chmod +x "/pkg/node-pty/build/Release/spawn-helper"');
+  assert.equal(error.cause, cause);
+  // The terminal manager keys its retry decision off the tag, not the wording.
+  assert.isTrue(PtyAdapter.hasSpawnHelperNotExecutableCause(error));
+  assert.isTrue(
+    PtyAdapter.hasSpawnHelperNotExecutableCause(
+      new PtyAdapter.PtySpawnError({ adapter: "node-pty", shell: "/bin/zsh", cause: error }),
+    ),
+  );
+  assert.isFalse(PtyAdapter.hasSpawnHelperNotExecutableCause(cause));
+});
+
+it("keeps posix_spawnp failures as-is when the helper is executable or missing", () => {
+  const cause = new Error("posix_spawnp failed.");
+  assert.equal(
+    NodePtyAdapter.describeSpawnFailure({
+      cause,
+      platform: "darwin",
+      helperPath: "/pkg/node-pty/build/Release/spawn-helper",
+      helperIsExecutable: true,
+    }),
+    cause,
+  );
+  assert.equal(
+    NodePtyAdapter.describeSpawnFailure({
+      cause,
+      platform: "darwin",
+      helperPath: null,
+      helperIsExecutable: false,
+    }),
+    cause,
+  );
+  assert.equal(
+    NodePtyAdapter.describeSpawnFailure({
+      cause,
+      platform: "win32",
+      helperPath: "/pkg/node-pty/build/Release/spawn-helper",
+      helperIsExecutable: false,
+    }),
+    cause,
+  );
+});
+
+it("finds posix_spawnp mentions through nested error causes", () => {
+  const nested = new Error("outer wrapper", {
+    cause: new Error("posix_spawnp failed."),
+  });
+  const described = NodePtyAdapter.describeSpawnFailure({
+    cause: nested,
+    platform: "darwin",
+    helperPath: "/pkg/spawn-helper",
+    helperIsExecutable: false,
+  });
+  assert.instanceOf(described, PtyAdapter.SpawnHelperNotExecutableError);
+  const error = described as PtyAdapter.SpawnHelperNotExecutableError;
+  assert.equal(error.cause, nested);
+});

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -3,6 +3,7 @@ import * as NodeModule from "node:module";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
@@ -20,11 +21,33 @@ export class NodePtyModuleLoadError extends Schema.TaggedErrorClass<NodePtyModul
   override get message(): string {
     return `Failed to load node-pty for ${this.platform}-${this.architecture}.`;
   }
+
+  /**
+   * Full, user-facing explanation for the CLI to render on stderr. The
+   * adapter keeps the failure typed; process-exit policy belongs to the CLI.
+   */
+  get diagnostic(): string {
+    const causeMessage = this.cause instanceof Error ? this.cause.message : String(this.cause);
+    return [
+      this.message,
+      `Caused by: ${causeMessage}`,
+      "",
+      "node-pty is the native module that powers t3 terminals. It is compiled (or a",
+      "prebuild is unpacked) when t3 is installed, so this usually means the install",
+      "could not produce a working binary for this machine:",
+      "  - the machine is missing a C/C++ toolchain (macOS: `xcode-select --install`,",
+      "    Debian/Ubuntu: `sudo apt-get install -y build-essential python3`), or",
+      "  - t3 was installed with a different Node.js version or architecture than the",
+      "    one running now.",
+      "Fix the toolchain, then reinstall t3 (`npm install -g t3`, or clear the npx",
+      "cache with `rm -rf ~/.npm/_npx` and re-run `npx t3`).",
+    ].join("\n");
+  }
 }
 
 type NodePtyModuleLoader = () => Promise<typeof import("node-pty")>;
 
-let didEnsureSpawnHelperExecutable = false;
+let ensuredSpawnHelperPath: string | null = null;
 
 const resolveNodePtySpawnHelperPath = Effect.gen(function* () {
   const requireForNodePty = NodeModule.createRequire(import.meta.url);
@@ -49,23 +72,143 @@ const resolveNodePtySpawnHelperPath = Effect.gen(function* () {
   return null;
 }).pipe(Effect.orElseSucceed(() => null));
 
+/**
+ * Whether `mode` grants execute permission to the identified process.
+ *
+ * `FileSystem.access` cannot test `X_OK`, and checking only `mode & 0o111`
+ * treats an owner-only helper as executable for unrelated users. Match the
+ * POSIX owner/group/other class against the calling process instead.
+ */
+export const modeIsExecutableFor = (input: {
+  mode: number;
+  ownerUid: number | null;
+  ownerGid: number | null;
+  processUid: number | null;
+  processGids: readonly number[];
+}): boolean => {
+  const anyExecuteBit = (input.mode & 0o111) !== 0;
+  // Unknown identity, or root, which can execute a file with any execute bit.
+  if (input.processUid === null || input.processUid === 0) return anyExecuteBit;
+  if (input.ownerUid !== null && input.ownerUid === input.processUid) {
+    return (input.mode & 0o100) !== 0;
+  }
+  if (input.ownerGid !== null && input.processGids.includes(input.ownerGid)) {
+    return (input.mode & 0o010) !== 0;
+  }
+  return (input.mode & 0o001) !== 0;
+};
+
+const currentProcessIdentity = (): {
+  processUid: number | null;
+  processGids: readonly number[];
+} => {
+  const processUid = process.getuid?.() ?? null;
+  const primaryGid = process.getgid?.() ?? null;
+  // getgroups() omits the primary gid on some platforms, so add it explicitly.
+  const supplementaryGids = process.getgroups?.() ?? [];
+  return {
+    processUid,
+    processGids: primaryGid === null ? supplementaryGids : [primaryGid, ...supplementaryGids],
+  };
+};
+
+/** `null` means metadata could not be read, not that the helper is executable. */
+const readSpawnHelperExecutable = Effect.fn(function* (helperPath: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const identity = currentProcessIdentity();
+  return yield* fs.stat(helperPath).pipe(
+    Effect.map((info) =>
+      modeIsExecutableFor({
+        mode: info.mode,
+        ownerUid: Option.getOrNull(info.uid),
+        ownerGid: Option.getOrNull(info.gid),
+        ...identity,
+      }),
+    ),
+    Effect.orElseSucceed(() => null),
+  );
+});
+
 const ensureNodePtySpawnHelperExecutable = Effect.fn(function* () {
   const fs = yield* FileSystem.FileSystem;
   const platform = yield* HostProcessPlatform;
   if (platform === "win32") return;
-  if (didEnsureSpawnHelperExecutable) return;
 
+  // Resolution and chmod can fail transiently. Only cache a successful repair
+  // (or a confirmed executable helper) so the next spawn retries after failure.
   const helperPath = yield* resolveNodePtySpawnHelperPath;
   if (!helperPath) return;
-  didEnsureSpawnHelperExecutable = true;
 
-  if (!(yield* fs.exists(helperPath))) {
+  if (ensuredSpawnHelperPath === helperPath) return;
+
+  // Avoid chmod and its warning entirely when the current process can execute
+  // the helper. This matters for read-only package stores.
+  if ((yield* readSpawnHelperExecutable(helperPath)) === true) {
+    ensuredSpawnHelperPath = helperPath;
     return;
   }
 
-  // Best-effort: avoid FileSystem.stat in packaged mode where some fs metadata can be missing.
-  yield* fs.chmod(helperPath, 0o755).pipe(Effect.orElseSucceed(() => undefined));
+  const chmodResult = yield* Effect.result(fs.chmod(helperPath, 0o755));
+  if (chmodResult._tag === "Success") {
+    ensuredSpawnHelperPath = helperPath;
+    return;
+  }
+
+  yield* Effect.logWarning("failed to mark node-pty spawn-helper executable", {
+    helperPath,
+    error: chmodResult.failure,
+    remedy: `chmod +x "${helperPath}"`,
+  });
 });
+
+const causeMentionsPosixSpawnFailure = (cause: unknown): boolean => {
+  let current: unknown = cause;
+  const seen = new Set<unknown>();
+  while (current !== null && current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    if (typeof current === "string") {
+      return current.toLowerCase().includes("posix_spawnp failed");
+    }
+    if (current instanceof Error) {
+      if (current.message.toLowerCase().includes("posix_spawnp failed")) return true;
+      current = current.cause;
+      continue;
+    }
+    if (typeof current === "object") {
+      const value = current as { readonly message?: unknown; readonly cause?: unknown };
+      if (
+        typeof value.message === "string" &&
+        value.message.toLowerCase().includes("posix_spawnp failed")
+      ) {
+        return true;
+      }
+      current = value.cause;
+      continue;
+    }
+    return false;
+  }
+  return false;
+};
+
+/**
+ * Turn the low-level node-pty failure into a structured diagnosis only when
+ * the helper is known to be the cause. Other platforms and spawn failures stay
+ * unchanged.
+ */
+export const describeSpawnFailure = (input: {
+  cause: unknown;
+  platform: string;
+  helperPath: string | null;
+  helperIsExecutable: boolean;
+}): unknown => {
+  if (input.platform === "win32") return input.cause;
+  if (!causeMentionsPosixSpawnFailure(input.cause)) return input.cause;
+  if (input.helperPath === null || input.helperIsExecutable) return input.cause;
+  return new PtyAdapter.SpawnHelperNotExecutableError({
+    helperPath: input.helperPath,
+    cause: input.cause,
+  });
+};
 
 class NodePtyProcess implements PtyAdapter.PtyProcess {
   private readonly process: import("node-pty").IPty;
@@ -128,36 +271,71 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
       }),
   }).pipe(Effect.orDie);
 
-  const ensureNodePtySpawnHelperExecutableCached = yield* Effect.cached(
-    ensureNodePtySpawnHelperExecutable().pipe(
-      Effect.provideService(FileSystem.FileSystem, fs),
-      Effect.provideService(Path.Path, path),
-      Effect.provideService(HostProcessPlatform, platform),
-      Effect.provideService(HostProcessArchitecture, architecture),
-      Effect.orElseSucceed(() => undefined),
-    ),
+  const ensureSpawnHelperExecutable = ensureNodePtySpawnHelperExecutable().pipe(
+    Effect.provideService(FileSystem.FileSystem, fs),
+    Effect.provideService(Path.Path, path),
+    Effect.provideService(HostProcessPlatform, platform),
+    Effect.provideService(HostProcessArchitecture, architecture),
   );
+  const resolveSpawnHelperPath = resolveNodePtySpawnHelperPath.pipe(
+    Effect.provideService(FileSystem.FileSystem, fs),
+    Effect.provideService(Path.Path, path),
+    Effect.provideService(HostProcessPlatform, platform),
+    Effect.provideService(HostProcessArchitecture, architecture),
+  );
+  const spawnHelperIsExecutable = (helperPath: string) =>
+    readSpawnHelperExecutable(helperPath).pipe(
+      // Unknown metadata must not point users at a chmod that may not help.
+      Effect.map((isExecutable) => isExecutable !== false),
+      Effect.provideService(FileSystem.FileSystem, fs),
+    );
 
   return PtyAdapter.PtyAdapter.of({
     spawn: Effect.fn("NodePtyAdapter.spawn")(function* (input) {
-      yield* ensureNodePtySpawnHelperExecutableCached;
-      const ptyProcess = yield* Effect.try({
-        try: () =>
-          nodePty.spawn(input.shell, input.args ?? [], {
-            cwd: input.cwd,
-            cols: input.cols,
-            rows: input.rows,
-            env: input.env,
-            name: platform === "win32" ? "xterm-color" : "xterm-256color",
-          }),
-        catch: (cause) =>
-          new PtyAdapter.PtySpawnError({
-            adapter: "node-pty",
-            shell: input.shell,
-            cause,
-          }),
+      yield* ensureSpawnHelperExecutable;
+      const attempt = yield* Effect.result(
+        Effect.try({
+          try: () =>
+            nodePty.spawn(input.shell, input.args ?? [], {
+              cwd: input.cwd,
+              cols: input.cols,
+              rows: input.rows,
+              env: input.env,
+              name: platform === "win32" ? "xterm-color" : "xterm-256color",
+            }),
+          catch: (cause) =>
+            new PtyAdapter.PtySpawnError({
+              adapter: "node-pty",
+              shell: input.shell,
+              cause,
+            }),
+        }),
+      );
+      if (attempt._tag === "Success") {
+        return new NodePtyProcess(attempt.success);
+      }
+
+      const spawnCause = attempt.failure.cause;
+      if (platform === "win32" || !causeMentionsPosixSpawnFailure(spawnCause)) {
+        return yield* attempt.failure;
+      }
+
+      const helperPath = yield* resolveSpawnHelperPath;
+      const helperIsExecutable =
+        helperPath === null ? true : yield* spawnHelperIsExecutable(helperPath);
+      if (helperPath === null || helperIsExecutable) {
+        return yield* attempt.failure;
+      }
+      return yield* new PtyAdapter.PtySpawnError({
+        adapter: "node-pty",
+        shell: input.shell,
+        cause: describeSpawnFailure({
+          cause: spawnCause,
+          platform,
+          helperPath,
+          helperIsExecutable,
+        }),
       });
-      return new NodePtyProcess(ptyProcess);
     }),
   });
 });

--- a/apps/server/src/terminal/PtyAdapter.ts
+++ b/apps/server/src/terminal/PtyAdapter.ts
@@ -29,6 +29,44 @@ export class PtySpawnError extends Schema.TaggedErrorClass<PtySpawnError>()("Pty
   }
 }
 
+/**
+ * A spawn failure whose real culprit is node-pty's `spawn-helper` missing its
+ * exec bit. It fails identically for every shell, so the terminal manager must
+ * not bury it under the shell-candidate fallback.
+ */
+export class SpawnHelperNotExecutableError extends Schema.TaggedErrorClass<SpawnHelperNotExecutableError>()(
+  "SpawnHelperNotExecutableError",
+  {
+    helperPath: Schema.String,
+    // Keep the originating failure available for diagnostics and logging.
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `node-pty's spawn-helper at ${this.helperPath} is not executable, so every shell fails with "posix_spawnp failed". Fix it with: chmod +x "${this.helperPath}"`;
+  }
+}
+
+const isSpawnHelperNotExecutableError = Schema.is(SpawnHelperNotExecutableError);
+
+/** Walk the cause chain so wrappers cannot hide the structured diagnosis. */
+export const findSpawnHelperNotExecutableCause = (
+  error: unknown,
+): SpawnHelperNotExecutableError | null => {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current !== null && current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    if (isSpawnHelperNotExecutableError(current)) return current;
+    if (typeof current !== "object") return null;
+    current = (current as { readonly cause?: unknown }).cause;
+  }
+  return null;
+};
+
+export const hasSpawnHelperNotExecutableCause = (error: unknown): boolean =>
+  findSpawnHelperNotExecutableCause(error) !== null;
+
 export interface PtyExitEvent {
   exitCode: number;
   signal: number | null;


### PR DESCRIPTION
## What changed

- Render actionable node-pty native-load diagnostics from the CLI, set a non-zero exit code, and keep the adapter failure typed.
- Repair `spawn-helper` permissions on non-Windows hosts with retries after transient path/chmod failures, while skipping chmod for helpers executable by the current uid/gids.
- Surface non-executable helpers as a structured error with `helperPath` and the underlying `cause`; stop shell fallback and publish the chmod remedy.
- Add focused regressions for startup output, permission modes, nested causes, platform behavior, shell fallback, and terminal error events.

## Why

Broken native installs previously exited without an actionable diagnosis, and a non-executable `spawn-helper` made every shell candidate fail with a misleading generic error. The structured diagnosis preserves the original failure while making the remediation visible at the correct boundary.

## Validation

- `vp run --filter t3 typecheck`
- Targeted `vp lint` and `vp fmt --check` for the seven touched files
- Focused Vitest runs for `NodePtyAdapter.test.ts`, the new CLI test, the new helper-error manager test, and the existing generic shell-fallback test

No resize handling or terminal-history sanitization changes are included.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Diagnose node-pty spawn-helper failures with actionable stderr output
> - Adds `SpawnHelperNotExecutableError` in [`PtyAdapter.ts`](https://github.com/pingdotgg/t3code/pull/5280/files#diff-9f4dcf0ef754999ffd83969b17c335fbfccec1192e006620e7c1977456e9e557) to represent non-executable spawn-helper failures with a direct `chmod` remediation message.
> - `NodePtyAdapter` now detects `posix_spawnp` failures caused by a non-executable spawn-helper, wraps them as `SpawnHelperNotExecutableError`, and attempts `chmod 0755` on the helper path before spawning.
> - `NodePtyModuleLoadError` gains a `diagnostic` getter that returns a multi-line user-facing explanation with remediation steps, suitable for writing to stderr.
> - `reportStartupDefect` in [`server.ts`](https://github.com/pingdotgg/t3code/pull/5280/files#diff-88c61edd2116c0c0ad1ede92854c2e4a3b4605f101921c8457b1532a490cb055) writes any defect's `diagnostic` string to stderr and sets `process.exitCode = 1` on startup failure.
> - Shell retry logic in `TerminalManager` is short-circuited when the cause is a non-executable spawn-helper, and error events surface the specific chmod advisory instead of a generic message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8da7562.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal spawn path and CLI exit behavior on startup failures; changes are localized to node-pty adapter and server CLI with strong test coverage, but terminal startup is user-critical.
> 
> **Overview**
> Improves **node-pty** failure handling so broken installs and bad **spawn-helper** permissions surface clear remediation instead of silent or misleading errors.
> 
> The CLI now hooks **startup defects** via `reportStartupDefect`: writes adapter `diagnostic` text to **stderr**, sets **exit code 1**, so native load failures (e.g. `NodePtyModuleLoadError`) are visible in headless `serve` runs.
> 
> On Unix, **spawn-helper** repair checks **POSIX execute bits for the current uid/gids** (not just any exec bit), skips **chmod** when already executable or on read-only stores, and maps **`posix_spawnp`** failures to **`SpawnHelperNotExecutableError`** with a **`chmod +x`** message. **Terminal manager** stops **shell fallback** for that case and publishes the structured error to terminal events.
> 
> Adds focused tests for CLI stderr output, permission modes, spawn failure classification, and manager retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da75622b88a465a5fa7bfe34496e7793bbeefb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

closes #4924
