### PR TITLE
fix: open Windows file links in chat

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -128,6 +128,10 @@ const highlightedCodeCache = new LRUCache<string>(
   MAX_HIGHLIGHT_CACHE_MEMORY_BYTES,
 );
 
+const WINDOWS_DRIVE_LINK_PROTOCOLS = Array.from(
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+);
+
 function findTaskListMarkerOffset(markdown: string, listItemStart: number): number | null {
   const firstLineEnd = markdown.indexOf("\n", listItemStart);
   const firstLine = markdown.slice(
@@ -147,7 +151,10 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   },
   protocols: {
     ...defaultSchema.protocols,
-    href: [...(defaultSchema.protocols?.href ?? []), "file"],
+    // rehype-sanitize runs before react-markdown's urlTransform. A Windows
+    // drive letter looks like a protocol (`C:`), so allow drive letters here;
+    // urlTransform only preserves values with a drive-path shape afterward.
+    href: [...(defaultSchema.protocols?.href ?? []), "file", ...WINDOWS_DRIVE_LINK_PROTOCOLS],
   },
 } satisfies Parameters<typeof rehypeSanitize>[0];
 

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -21,17 +21,39 @@ describe("rewriteMarkdownFileUriHref", () => {
   });
 
   it("normalizes file uri hrefs for windows drive paths", () => {
+    const canonicalHref = "/D:/Programme/t3code/apps/web/src/components/chat/OpenInPicker.tsx#L69";
     expect(
       rewriteMarkdownFileUriHref(
         "file:///D:/Programme/t3code/apps/web/src/components/chat/OpenInPicker.tsx#L69",
       ),
-    ).toBe("D:/Programme/t3code/apps/web/src/components/chat/OpenInPicker.tsx#L69");
+    ).toBe(canonicalHref);
+    expect(rewriteMarkdownFileUriHref(canonicalHref)).toBe(canonicalHref);
   });
 
   it("unwraps angle-bracketed file uri hrefs", () => {
     expect(
       rewriteMarkdownFileUriHref(" <file:///D:/Programme/t3code/apps/web/src/markdown-links.ts> "),
-    ).toBe("D:/Programme/t3code/apps/web/src/markdown-links.ts");
+    ).toBe("/D:/Programme/t3code/apps/web/src/markdown-links.ts");
+  });
+
+  it("canonicalizes windows drive hrefs for the custom markdown file renderer", () => {
+    expect(rewriteMarkdownFileUriHref("C:/Users/mike/project/src/main.ts:42")).toBe(
+      "/C:/Users/mike/project/src/main.ts:42",
+    );
+    expect(rewriteMarkdownFileUriHref("C:\\Users\\mike\\project\\src\\main.ts:42")).toBe(
+      "/C:/Users/mike/project/src/main.ts:42",
+    );
+    expect(rewriteMarkdownFileUriHref("C:%5CUsers%5Cmike%5Cproject%5Csrc%5Cmain.ts:42")).toBe(
+      "/C:/Users/mike/project/src/main.ts:42",
+    );
+    expect(rewriteMarkdownFileUriHref("C://Users/mike/project/src/main.ts:42")).toBe(
+      "/C:/Users/mike/project/src/main.ts:42",
+    );
+  });
+
+  it("ignores non-file hrefs", () => {
+    expect(rewriteMarkdownFileUriHref("https://example.com/docs")).toBeNull();
+    expect(rewriteMarkdownFileUriHref("x:command")).toBeNull();
   });
 });
 

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -103,9 +103,18 @@ function parseFileUrlHref(
 export function rewriteMarkdownFileUriHref(href: string | undefined): string | null {
   if (!href) return null;
   const normalizedHref = normalizeMarkdownLinkDestination(href);
+  // Markdown parsing can encode backslashes or duplicate the drive separator.
+  const windowsDriveHref = normalizedHref
+    .replaceAll(/%5c/gi, "/")
+    .replaceAll(/\\/g, "/")
+    .replace(/^\/?([A-Za-z]):\/+/, "/$1:/");
+  // A leading slash keeps the drive letter from being treated as a URL scheme.
+  if (/^\/[A-Za-z]:\//.test(windowsDriveHref)) return windowsDriveHref;
+
   const target = parseFileUrlHref(normalizedHref, { decodePath: false });
   if (!target) return null;
-  return `${target.path}${target.hash}`;
+  const path = WINDOWS_DRIVE_PATH_PATTERN.test(target.path) ? `/${target.path}` : target.path;
+  return `${path}${target.hash}`;
 }
 
 function looksLikePosixFilesystemPath(path: string): boolean {


### PR DESCRIPTION
### Summary

Make chat file links in Windows native app clickable
Clicking opens sidebar with the file
Adds a relevant file icon too

### Why

Chat file links in Windows native apps look clickable, act clickable, but arent, its confusing, would be nice to add clickable behavior

### Validation

Have AI reply to you with file links in chat on Windows app:

Before:

<img width="791" height="376" alt="image" src="https://github.com/user-attachments/assets/5d4fa5e4-a3fe-4dd2-a912-657ed9fc6ec7" />


https://github.com/user-attachments/assets/95980b0c-60e0-450c-8876-1d3dfe7da907



After ( clickable, opens sidebar with file ):

<img width="2015" height="482" alt="image" src="https://github.com/user-attachments/assets/561284d4-2ee6-43b8-b352-3a6e98e5c54a" />


https://github.com/user-attachments/assets/6670d6aa-207a-46a4-8e07-591756de2fb9

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized markdown link normalization and sanitize allowlist for chat rendering; no auth or server changes, with added unit tests.
> 
> **Overview**
> **Windows drive-letter paths in chat markdown** (e.g. `C:/Users/...` or `file:///D:/...`) now survive sanitization and are normalized so the existing file-link UI can treat them as workspace files instead of broken or external links.
> 
> `rehype-sanitize` is extended so single-letter `href` protocols are allowed before `urlTransform` runs—otherwise `C:` is stripped as an unknown scheme. `rewriteMarkdownFileUriHref` then canonicalizes backslashes, encoded `%5C`, and duplicate slashes to a leading-slash form like `/C:/path`, which keeps the drive letter from being parsed as a URL scheme downstream.
> 
> Tests cover `file://` Windows URIs, angle-bracketed destinations, and several slash/encoding variants; non-file hrefs like `https://` and `x:command` stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76625dadfda27c3111ac251d7b1bda0998390dd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows drive letter file links opening in chat
> - Extends the rehype-sanitize schema in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/5283/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to allow Windows drive-letter pseudo-protocols (e.g. `C:`) so they are not stripped before `urlTransform` runs.
> - Updates `rewriteMarkdownFileUriHref` in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/5283/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) to canonicalize Windows drive-style hrefs (including backslash, URL-encoded backslash, and duplicate-slash variants) to a leading-slash form like `/C:/path`.
> - Adds tests in [markdown-links.test.ts](https://github.com/pingdotgg/t3code/pull/5283/files#diff-2ea1038bc159e3aef9f742e8defd5d4b19ae4bbab3b6658b3ad82a8229968a51) covering normalization of `file://` URIs, angle-bracketed paths, and various slash/encoding variants.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76625da.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->