### PR TITLE
fix(mobile): keep pending input card below the navigation header

### DIFF
--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -2,6 +2,7 @@ import { type EnvironmentConnectionPhase } from "@t3tools/client-runtime/connect
 import type { EnvironmentThreadStatus } from "@t3tools/client-runtime/state/threads";
 import { useKeyboardChatComposerInset, useKeyboardScrollToEnd } from "@legendapp/list/keyboard";
 import type { LegendListRef } from "@legendapp/list/react-native";
+import { HeaderHeightContext } from "@react-navigation/elements";
 import type {
   ApprovalRequestId,
   EnvironmentId,
@@ -15,8 +16,23 @@ import type {
   ThreadId,
 } from "@t3tools/contracts";
 import * as Haptics from "expo-haptics";
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Platform, View, type GestureResponderEvent } from "react-native";
+import {
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Platform,
+  ScrollView,
+  useWindowDimensions,
+  View,
+  type GestureResponderEvent,
+} from "react-native";
 import { KeyboardController, KeyboardStickyView } from "react-native-keyboard-controller";
 import Animated, { FadeInDown, FadeOut } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -202,6 +218,21 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const selectedThreadFeed = props.selectedThreadFeed;
   const composerChrome = composerExpanded ? COMPOSER_EXPANDED_CHROME : COMPOSER_COLLAPSED_CHROME;
   const composerOverlapHeight = composerChrome + composerBottomInset;
+  const windowDimensions = useWindowDimensions();
+  // The pending approval/user-input cards live in the bottom-anchored composer
+  // overlay, so a card with many questions grows upward past the navigation
+  // header. Cap the card stack to the space between the header and the
+  // composer and let it scroll instead. Read the context directly
+  // (useHeaderHeight throws outside a header-providing screen) and fall back
+  // to the standard iOS bar height.
+  const navigationHeaderHeight = useContext(HeaderHeightContext);
+  const pendingCardsMaxHeight = Math.max(
+    120,
+    windowDimensions.height -
+      (navigationHeaderHeight || insets.top + 44) -
+      composerOverlapHeight -
+      12,
+  );
   const estimatedOverlayHeight = composerOverlapHeight;
   // The overlay's measured height includes the home-indicator inset (the
   // composer pads it), but contentInsetAdjustmentBehavior="automatic" makes
@@ -390,28 +421,35 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
             <View className="w-full self-center" style={{ maxWidth: contentMaxWidth }}>
               {props.activePendingApproval || props.activePendingUserInput ? (
                 <Animated.View
-                  className="shrink-0 gap-3 px-4 pb-3"
+                  className="shrink-0 px-4 pb-3"
+                  style={{ maxHeight: pendingCardsMaxHeight }}
                   entering={FadeInDown.duration(220)}
                   exiting={FadeOut.duration(140)}
                 >
-                  {props.activePendingApproval ? (
-                    <PendingApprovalCard
-                      approval={props.activePendingApproval}
-                      respondingApprovalId={props.respondingApprovalId}
-                      onRespond={props.onRespondToApproval}
-                    />
-                  ) : null}
-                  {props.activePendingUserInput ? (
-                    <PendingUserInputCard
-                      pendingUserInput={props.activePendingUserInput}
-                      drafts={props.activePendingUserInputDrafts}
-                      answers={props.activePendingUserInputAnswers}
-                      respondingUserInputId={props.respondingUserInputId}
-                      onSelectOption={props.onSelectUserInputOption}
-                      onChangeCustomAnswer={props.onChangeUserInputCustomAnswer}
-                      onSubmit={props.onSubmitUserInput}
-                    />
-                  ) : null}
+                  <ScrollView
+                    contentContainerClassName="gap-3"
+                    showsVerticalScrollIndicator={false}
+                    keyboardShouldPersistTaps="handled"
+                  >
+                    {props.activePendingApproval ? (
+                      <PendingApprovalCard
+                        approval={props.activePendingApproval}
+                        respondingApprovalId={props.respondingApprovalId}
+                        onRespond={props.onRespondToApproval}
+                      />
+                    ) : null}
+                    {props.activePendingUserInput ? (
+                      <PendingUserInputCard
+                        pendingUserInput={props.activePendingUserInput}
+                        drafts={props.activePendingUserInputDrafts}
+                        answers={props.activePendingUserInputAnswers}
+                        respondingUserInputId={props.respondingUserInputId}
+                        onSelectOption={props.onSelectUserInputOption}
+                        onChangeCustomAnswer={props.onChangeUserInputCustomAnswer}
+                        onSubmit={props.onSubmitUserInput}
+                      />
+                    ) : null}
+                  </ScrollView>
                 </Animated.View>
               ) : null}
             </View>


### PR DESCRIPTION
## What changed

`PendingApprovalCard` / `PendingUserInputCard` render inside the bottom-anchored composer overlay (`KeyboardStickyView`) in `ThreadDetailScreen` with no height cap. When an agent asks several questions (each with option pills plus a custom-answer input), the card grows upward past the top of the screen and renders underneath the transparent navigation header — the card's "User input needed / Fill in the pending answers" heading collides with the header title and back button.

This caps the pending-card stack at the space between the navigation header and the composer (`window height − header height − composer chrome − 12`), and wraps the cards in a `ScrollView` so overflowing questions scroll inside the card area instead of growing under the header. Header height is read from `HeaderHeightContext` with the same `insets.top + 44` fallback `ThreadFeed` already uses. No visual change for short cards — the cap only engages when the card would otherwise underlap the header.

## Why

With a two-question user-input request on an iPhone, the card covers the entire screen and overlaps the header, making the header unreadable and the top of the card unreachable behind it.

## Before / After

Captured on an iPhone 17 Pro simulator (iOS 26.2), dev client paired to a local backend, with a Claude thread raising a two-question `AskUserQuestion`.

| Before (main) | After (this PR) | After — scrolled |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/KyleKincer/t3code/assets/pending-input-overlap/before.png) | ![after](https://raw.githubusercontent.com/KyleKincer/t3code/assets/pending-input-overlap/after.png) | ![after scrolled](https://raw.githubusercontent.com/KyleKincer/t3code/assets/pending-input-overlap/after-scrolled.png) |

Before: the card's heading renders on top of the nav header title and back chevron. After: the card stops below the header and scrolls internally; the Submit answers button stays reachable.

Verified with `pnpm typecheck` (mobile), `pnpm lint`, `pnpm fmt:check`, and live on the simulator as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)