### PR TITLE
fix: keep auto-settle policy consistent across clients

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -588,6 +588,16 @@ export function HomeScreen(props: HomeScreenProps) {
     }
     return supported;
   }, [serverConfigs]);
+  const autoSettleAfterDaysByEnvironment = useMemo(
+    () =>
+      new Map(
+        [...serverConfigs].map(
+          ([environmentId, config]) =>
+            [environmentId, config.settings.threadSettlement.autoSettleAfterDays] as const,
+        ),
+      ),
+    [serverConfigs],
+  );
   const snoozeEnvironmentIds = useMemo(() => {
     const supported = new Set<EnvironmentId>();
     for (const [environmentId, config] of serverConfigs) {
@@ -650,6 +660,7 @@ export function HomeScreen(props: HomeScreenProps) {
       matchedThreadKeys,
       changeRequestStateByKey,
       settlementEnvironmentIds,
+      autoSettleAfterDaysByEnvironment,
       snoozeEnvironmentIds,
       settledLimit: settledVisibleCount,
       now: `${nowMinute}:00.000Z`,
@@ -666,6 +677,7 @@ export function HomeScreen(props: HomeScreenProps) {
     settledShelfExpanded,
     settledVisibleCount,
     settlementEnvironmentIds,
+    autoSettleAfterDaysByEnvironment,
     snoozeEnvironmentIds,
     props.searchQuery,
     props.selectedEnvironmentId,

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -478,6 +478,16 @@ function ThreadNavigationSidebarPane(
     }
     return supported;
   }, [serverConfigs]);
+  const autoSettleAfterDaysByEnvironment = useMemo(
+    () =>
+      new Map(
+        [...serverConfigs].map(
+          ([environmentId, config]) =>
+            [environmentId, config.settings.threadSettlement.autoSettleAfterDays] as const,
+        ),
+      ),
+    [serverConfigs],
+  );
   const snoozeEnvironmentIds = useMemo(() => {
     const supported = new Set<EnvironmentId>();
     for (const [environmentId, config] of serverConfigs) {
@@ -537,6 +547,7 @@ function ThreadNavigationSidebarPane(
       matchedThreadKeys,
       changeRequestStateByKey,
       settlementEnvironmentIds,
+      autoSettleAfterDaysByEnvironment,
       snoozeEnvironmentIds,
       settledLimit: settledVisibleCount,
       now: `${nowMinute}:00.000Z`,
@@ -557,6 +568,7 @@ function ThreadNavigationSidebarPane(
     matchedThreadKeys,
     settledVisibleCount,
     settlementEnvironmentIds,
+    autoSettleAfterDaysByEnvironment,
     snoozeEnvironmentIds,
     threadListV2Enabled,
     threads,

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -263,6 +263,70 @@ describe("sortThreadsForListV2", () => {
 });
 
 describe("buildThreadListV2Items", () => {
+  it("uses each thread's environment policy without client drift", () => {
+    const threeDayEnvironment = EnvironmentId.make("environment-three-days");
+    const sevenDayEnvironment = EnvironmentId.make("environment-seven-days");
+    const disabledEnvironment = EnvironmentId.make("environment-disabled");
+    const missingEnvironment = EnvironmentId.make("environment-missing-policy");
+    const sameAge = {
+      createdAt: "2026-06-05T00:00:00.000Z",
+      updatedAt: "2026-06-05T00:00:00.000Z",
+      latestUserMessageAt: "2026-06-05T00:00:00.000Z",
+      latestTurn: {
+        turnId: TurnId.make("same-age-turn"),
+        state: "completed",
+        requestedAt: "2026-06-05T00:00:00.000Z",
+        startedAt: "2026-06-05T00:00:01.000Z",
+        completedAt: "2026-06-05T00:01:00.000Z",
+        assistantMessageId: null,
+      },
+    } as const;
+    const layout = buildThreadListV2Items({
+      threads: [
+        makeThread({
+          ...sameAge,
+          environmentId: threeDayEnvironment,
+          id: ThreadId.make("three-days"),
+          title: "Three days",
+        }),
+        makeThread({
+          ...sameAge,
+          environmentId: sevenDayEnvironment,
+          id: ThreadId.make("seven-days"),
+          title: "Seven days",
+        }),
+        makeThread({
+          ...sameAge,
+          environmentId: disabledEnvironment,
+          id: ThreadId.make("disabled"),
+          title: "Disabled",
+        }),
+        makeThread({
+          ...sameAge,
+          environmentId: missingEnvironment,
+          id: ThreadId.make("missing"),
+          title: "Missing",
+        }),
+      ],
+      environmentId: null,
+      searchQuery: "",
+      autoSettleAfterDaysByEnvironment: new Map([
+        [threeDayEnvironment, 3],
+        [sevenDayEnvironment, 7],
+        [disabledEnvironment, null],
+      ]),
+      now: "2026-06-10T00:00:00.000Z",
+    });
+
+    expect(Object.fromEntries(layout.items.map((item) => [item.thread.id, item.variant]))).toEqual({
+      disabled: "card",
+      "seven-days": "card",
+      missing: "slim",
+      "three-days": "slim",
+    });
+    expect(layout.settledCount).toBe(2);
+  });
+
   it("hides snoozed threads and counts them — visibility parity with web", () => {
     const layout = buildThreadListV2Items({
       threads: [

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -10,7 +10,11 @@ import type { SnoozePreset } from "@t3tools/client-runtime/state/thread-settled"
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
 import { sortPinnedThreadsByOrderKey } from "@t3tools/client-runtime/state/thread-sort";
-import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import {
+  DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS,
+  type EnvironmentId,
+  type ProjectId,
+} from "@t3tools/contracts";
 
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 
@@ -306,9 +310,9 @@ export function buildThreadListV2ListItems(input: {
 
 /**
  * Partitions visible threads into the active card block (creation order) and
- * the settled recency tail, matching the web v2 list. `autoSettleAfterDays`
- * mirrors the web default of 3 — mobile has no client-settings sync yet, so
- * the default is fixed here rather than user-configurable.
+ * the settled recency tail, matching the web v2 list. Inactivity policy is
+ * resolved from each thread's owning environment. Missing policy data keeps
+ * the test-friendly and version-skew-compatible server default of three days.
  */
 export function buildThreadListV2Items(input: {
   readonly threads: ReadonlyArray<EnvironmentThreadShell>;
@@ -328,7 +332,7 @@ export function buildThreadListV2Items(input: {
   /** Environments whose server supports thread.snooze/unsnooze. Same
       contract as settlementEnvironmentIds. */
   readonly snoozeEnvironmentIds?: ReadonlySet<EnvironmentId>;
-  readonly autoSettleAfterDays?: number;
+  readonly autoSettleAfterDaysByEnvironment?: ReadonlyMap<EnvironmentId, number | null>;
   /** Max settled rows to render; the rest are counted, not built. */
   readonly settledLimit?: number;
   /** Injectable for tests; defaults to now. */
@@ -348,7 +352,6 @@ export function buildThreadListV2Items(input: {
 }): ThreadListV2Layout {
   const now = input.now ?? new Date().toISOString();
   const snoozeNow = input.snoozeNow ?? now;
-  const autoSettleAfterDays = input.autoSettleAfterDays ?? 3;
   const query = input.searchQuery.trim().toLocaleLowerCase();
   const projectKeys = input.projectRefs
     ? new Set(input.projectRefs.map((ref) => `${ref.environmentId}:${ref.projectId}`))
@@ -380,6 +383,9 @@ export function buildThreadListV2Items(input: {
     }
     const supportsSettlement = input.settlementEnvironmentIds?.has(thread.environmentId) ?? true;
     const supportsSnooze = input.snoozeEnvironmentIds?.has(thread.environmentId) ?? true;
+    const autoSettleAfterDays = input.autoSettleAfterDaysByEnvironment?.has(thread.environmentId)
+      ? (input.autoSettleAfterDaysByEnvironment.get(thread.environmentId) ?? null)
+      : DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS;
     const changeRequestState =
       input.changeRequestStateByKey?.get(`${thread.environmentId}:${thread.id}`) ?? null;
     // Visibility parity with web: snooze outranks everything, including a

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -144,6 +144,7 @@ export const make = Effect.gen(function* () {
       repositoryIdentity: true,
       connectionProbe: true,
       threadSettlement: true,
+      threadSettlementPolicy: true,
       threadSnooze: true,
       threadPinning: true,
       threadPinReorder: true,

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -116,6 +116,28 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }),
   );
 
+  it.effect("persists thread settlement policy patches", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+
+      const updated = yield* serverSettings.updateSettings({
+        threadSettlement: { autoSettleAfterDays: 14 },
+      });
+      assert.deepEqual(updated.threadSettlement, { autoSettleAfterDays: 14 });
+      assert.include(
+        yield* fileSystem.readFileString(serverConfig.settingsPath),
+        '"threadSettlement": {',
+      );
+
+      const disabled = yield* serverSettings.updateSettings({
+        threadSettlement: { autoSettleAfterDays: null },
+      });
+      assert.isNull(disabled.threadSettlement.autoSettleAfterDays);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect(
     "decodes legacy object-shaped textGenerationModelSelection.options from settings.json",
     () =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4025,7 +4025,7 @@ function ChatViewContent(props: ChatViewProps) {
   // partition (same shell, same capability gate, same PR auto-settle input)
   // so the banner and the sidebar row never disagree.
   const activeThreadShell = useThreadShell(isServerThread ? activeThreadRef : null);
-  const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
+  const autoSettleAfterDays = settings.threadSettlement.autoSettleAfterDays;
   const activeThreadPr = resolveThreadPr({
     threadBranch: activeThread?.branch ?? null,
     gitStatus: gitStatusQuery.data ?? null,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1576,7 +1576,6 @@ export default function Sidebar() {
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
@@ -1891,10 +1890,11 @@ export default function Sidebar() {
       // or descriptor not loaded yet) never classify as settled: the user
       // could neither un-settle nor pin them, so auto-settling them would
       // strand rows in a tail with no working affordances.
-      const supportsSettlement =
-        serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSettlement === true;
-      const supportsSnooze =
-        serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true;
+      const serverConfig = serverConfigs.get(thread.environmentId);
+      const supportsSettlement = serverConfig?.environment.capabilities.threadSettlement === true;
+      const supportsSnooze = serverConfig?.environment.capabilities.threadSnooze === true;
+      const autoSettleAfterDays =
+        serverConfig?.settings.threadSettlement.autoSettleAfterDays ?? null;
       const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
       const changeRequestState = changeRequestStateByKey.get(threadKey) ?? null;
       // Snooze outranks everything, including a pin: "hide until Tuesday"
@@ -1947,7 +1947,6 @@ export default function Sidebar() {
       snoozeNow: preciseNow,
     };
   }, [
-    autoSettleAfterDays,
     changeRequestStateByKey,
     nowMinute,
     scopedProjectKeys,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -18,19 +18,20 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 import {
   DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE,
+  DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS,
   DEFAULT_UNIFIED_SETTINGS,
   type EnvironmentIdentificationMode,
   MAX_CODE_FONT_SIZE,
   MAX_GLASS_OPACITY,
   MAX_INTERFACE_FONT_SIZE,
   MAX_PROMPT_FONT_SIZE,
-  MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+  MAX_THREAD_AUTO_SETTLE_AFTER_DAYS,
   MAX_TERMINAL_FONT_SIZE,
   MIN_CODE_FONT_SIZE,
   MIN_GLASS_OPACITY,
   MIN_INTERFACE_FONT_SIZE,
   MIN_PROMPT_FONT_SIZE,
-  MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+  MIN_THREAD_AUTO_SETTLE_AFTER_DAYS,
   MIN_TERMINAL_FONT_SIZE,
 } from "@t3tools/contracts/settings";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
@@ -78,6 +79,7 @@ import { ensureLocalApi, readLocalApi } from "../../localApi";
 import { isMacPlatform } from "../../lib/utils";
 import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
 import { useProjects } from "../../state/entities";
+import { usePrimaryEnvironment } from "../../state/environments";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel } from "../../timestampFormat";
 import { Button } from "../ui/button";
@@ -461,6 +463,9 @@ export function useSettingsRestore(onRestored?: () => void) {
   } = useTheme();
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
+  const primaryEnvironment = usePrimaryEnvironment();
+  const supportsThreadSettlementPolicy =
+    primaryEnvironment?.serverConfig?.environment.capabilities.threadSettlementPolicy === true;
 
   const isTextGenerationModelDirty = !Equal.equals(
     settings.textGenerationModelSelection ?? null,
@@ -488,8 +493,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode
         ? ["Project Grouping"]
         : []),
-      ...(settings.sidebarAutoSettleAfterDays !==
-      DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays
+      ...(!Equal.equals(settings.threadSettlement, DEFAULT_UNIFIED_SETTINGS.threadSettlement)
         ? ["Auto-settle inactive threads"]
         : []),
       ...(settings.wordWrap !== DEFAULT_UNIFIED_SETTINGS.wordWrap ? ["Word wrap"] : []),
@@ -554,7 +558,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.glassOpacity,
       settings.enableLegacyTokenStreaming,
       settings.enableProviderUpdateChecks,
-      settings.sidebarAutoSettleAfterDays,
+      settings.threadSettlement,
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
       settings.timestampFormat,
@@ -635,7 +639,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
-      sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
+      ...(supportsThreadSettlementPolicy
+        ? { threadSettlement: DEFAULT_UNIFIED_SETTINGS.threadSettlement }
+        : {}),
       enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
       enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
       backgroundActivity: DEFAULT_UNIFIED_SETTINGS.backgroundActivity,
@@ -664,6 +670,7 @@ export function useSettingsRestore(onRestored?: () => void) {
     theme,
     themeHalves,
     updateSettings,
+    supportsThreadSettlementPolicy,
   ]);
 
   return {
@@ -1543,14 +1550,14 @@ function FontFamilySettingsRow({
   );
 }
 
-const AUTO_SETTLE_DEFAULT_DAYS = DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays ?? 3;
-
 function AutoSettleDaysInput({
   value,
   onCommit,
+  disabled,
 }: {
   value: number;
   onCommit: (days: number) => void;
+  disabled: boolean;
 }) {
   // Local draft so the field can be emptied mid-edit; the setting only moves
   // on valid input and snaps back to the persisted value on blur.
@@ -1562,8 +1569,9 @@ function AutoSettleDaysInput({
   return (
     <Input
       type="number"
-      min={MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS}
-      max={MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS}
+      min={MIN_THREAD_AUTO_SETTLE_AFTER_DAYS}
+      max={MAX_THREAD_AUTO_SETTLE_AFTER_DAYS}
+      disabled={disabled}
       className="w-full sm:w-24"
       value={draft}
       onChange={(event) => {
@@ -1574,8 +1582,8 @@ function AutoSettleDaysInput({
         const parsed = Number(event.target.value);
         if (
           Number.isInteger(parsed) &&
-          parsed >= MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS &&
-          parsed <= MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS
+          parsed >= MIN_THREAD_AUTO_SETTLE_AFTER_DAYS &&
+          parsed <= MAX_THREAD_AUTO_SETTLE_AFTER_DAYS
         ) {
           onCommit(parsed);
         }
@@ -1693,6 +1701,10 @@ function LegacyFeaturesSection() {
 export function GeneralSettingsPanel() {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
+  const primaryEnvironment = usePrimaryEnvironment();
+  const supportsThreadSettlementPolicy =
+    primaryEnvironment?.serverConfig?.environment.capabilities.threadSettlementPolicy === true;
+  const autoSettleAfterDays = settings.threadSettlement.autoSettleAfterDays;
   const [backgroundActivityDialogOpen, setBackgroundActivityDialogOpen] = useState(false);
   const lastEnabledProjectGroupingMode = useRef<SidebarProjectGroupingMode>(
     readLastEnabledProjectGroupingMode(),
@@ -1784,15 +1796,18 @@ export function GeneralSettingsPanel() {
 
         <SettingsRow
           {...searchableSetting("auto-settle-inactive-threads")}
-          description="Sidebar threads with no activity for this long settle automatically. Threads on merged or closed PRs always settle."
+          description={
+            supportsThreadSettlementPolicy
+              ? "Inactive threads from this environment appear settled on every connected client. Threads on merged or closed PRs always settle."
+              : "This server version uses the default inactivity policy and cannot change it remotely."
+          }
           resetAction={
-            settings.sidebarAutoSettleAfterDays !==
-            DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays ? (
+            !Equal.equals(settings.threadSettlement, DEFAULT_UNIFIED_SETTINGS.threadSettlement) ? (
               <SettingResetButton
                 label="auto-settle"
                 onClick={() =>
                   updateSettings({
-                    sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
+                    threadSettlement: DEFAULT_UNIFIED_SETTINGS.threadSettlement,
                   })
                 }
               />
@@ -1800,24 +1815,30 @@ export function GeneralSettingsPanel() {
           }
           control={
             <Switch
-              checked={settings.sidebarAutoSettleAfterDays !== null}
+              checked={autoSettleAfterDays !== null}
+              disabled={!supportsThreadSettlementPolicy}
               onCheckedChange={(checked) =>
                 updateSettings({
-                  sidebarAutoSettleAfterDays: checked ? AUTO_SETTLE_DEFAULT_DAYS : null,
+                  threadSettlement: {
+                    autoSettleAfterDays: checked ? DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS : null,
+                  },
                 })
               }
               aria-label="Auto-settle inactive threads"
             />
           }
         />
-        {settings.sidebarAutoSettleAfterDays !== null ? (
+        {autoSettleAfterDays !== null ? (
           <SettingsRow
             title="Days of inactivity before auto-settle"
             description="Any new activity un-settles a thread automatically."
             control={
               <AutoSettleDaysInput
-                value={settings.sidebarAutoSettleAfterDays}
-                onCommit={(days) => updateSettings({ sidebarAutoSettleAfterDays: days })}
+                value={autoSettleAfterDays}
+                disabled={!supportsThreadSettlementPolicy}
+                onCommit={(days) =>
+                  updateSettings({ threadSettlement: { autoSettleAfterDays: days } })
+                }
               />
             }
           />

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -12,6 +12,7 @@ import {
   type ChangeRequestStateLike,
 } from "@t3tools/client-runtime/state/thread-settled";
 import type { ScopedThreadRef } from "@t3tools/contracts";
+import { useAtomValue } from "@effect/atom-react";
 import { useCallback } from "react";
 
 import { resolveSnoozePresets, snoozeWakeDescription } from "../components/Sidebar.snooze";
@@ -30,6 +31,7 @@ import {
   readThreadShell,
 } from "../state/entities";
 import { readLocalApi } from "../localApi";
+import { environmentServerConfigsAtom } from "../state/server";
 import { useUiStateStore } from "../uiStateStore";
 import { useCopyToClipboard } from "./useCopyToClipboard";
 import { useNewThreadHandler } from "./useHandleNewThread";
@@ -79,9 +81,9 @@ export function useThreadActionMenu(input: {
   });
   const handleNewThread = useNewThreadHandler();
   const markThreadUnread = useUiStateStore((s) => s.markThreadUnread);
-  const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
+  const serverConfigs = useAtomValue(environmentServerConfigsAtom);
   const { copyToClipboard: copyPathToClipboard } = useCopyToClipboard<{ path: string }>({
     onCopy: ({ path }) => {
       toastManager.add({ type: "success", title: "Path copied", description: path });
@@ -114,6 +116,9 @@ export function useThreadActionMenu(input: {
           titleRegeneration: readEnvironmentSupportsTitleRegeneration(threadRef.environmentId),
         };
         const isRegeneratingTitle = thread.titleRegeneration != null;
+        const autoSettleAfterDays =
+          serverConfigs.get(threadRef.environmentId)?.settings.threadSettlement
+            .autoSettleAfterDays ?? null;
         const snoozePresets = resolveSnoozePresets(now, timestampFormat);
         const items = buildThreadActionMenuItems({
           branch: thread.branch ?? null,
@@ -274,7 +279,6 @@ export function useThreadActionMenu(input: {
       })();
     },
     [
-      autoSettleAfterDays,
       changeRequestState,
       confirmThreadDelete,
       copyBranchToClipboard,
@@ -285,6 +289,7 @@ export function useThreadActionMenu(input: {
       onStartRename,
       pinThread,
       projectCwd,
+      serverConfigs,
       settleThread,
       snoozeThread,
       threadRef,

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)
+- [Thread settlement](./user/thread-settlement.md)
 - [Background service (Linux)](./user/background-service.md)
 - Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md)
 

--- a/docs/user/thread-settlement.md
+++ b/docs/user/thread-settlement.md
@@ -1,0 +1,13 @@
+# Thread settlement
+
+Settling keeps completed work out of the active thread list without archiving or deleting it. You
+can settle or un-settle a thread explicitly. New activity makes a settled thread active again.
+
+T3 Code can also classify inactive threads as settled after a configurable number of days. This is
+a derived view: crossing the inactivity threshold does not explicitly settle the thread or change
+its stored lifecycle state.
+
+The inactivity policy belongs to the environment that owns the thread. Up-to-date web, desktop,
+and mobile clients connected to that environment use the same value, so switching clients does not
+change which threads appear inactive. In a multi-environment list, each thread uses its owning
+environment's policy. Change the primary environment's policy in **Settings → General**.

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -52,6 +52,9 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
       pre-settlement servers, so clients treat missing as unsupported and
       never send the commands under version skew. */
   threadSettlement: Schema.optionalKey(Schema.Boolean),
+  /** Server owns the per-environment inactivity settlement policy and accepts
+      updates through server settings. Missing means clients must not edit it. */
+  threadSettlementPolicy: Schema.optionalKey(Schema.Boolean),
   /** Server understands thread.snooze / thread.unsnooze commands. Same
       version-skew contract as threadSettlement. */
   threadSnooze: Schema.optionalKey(Schema.Boolean),

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -68,7 +68,7 @@ describe("ClientSettings environment identification", () => {
 });
 
 describe("ClientSettings sidebar", () => {
-  it("defaults to the current sidebar with a three-day auto-settle threshold", () => {
+  it("keeps the legacy auto-settle preference for downgrade compatibility", () => {
     const settings = decodeClientSettings({});
     expect(settings.legacySidebarEnabled).toBe(false);
     expect(settings.sidebarAutoSettleAfterDays).toBe(3);
@@ -100,6 +100,36 @@ describe("ClientSettings sidebar", () => {
   it.each([-1, 0, 91])("rejects an auto-settle threshold outside 1..90: %s", (value) => {
     expect(() => decodeClientSettings({ sidebarAutoSettleAfterDays: value })).toThrow();
     expect(() => decodeClientSettingsPatch({ sidebarAutoSettleAfterDays: value })).toThrow();
+  });
+});
+
+describe("ServerSettings.threadSettlement", () => {
+  it("defaults inactivity classification to three days", () => {
+    expect(decodeServerSettings({}).threadSettlement).toEqual({
+      autoSettleAfterDays: 3,
+    });
+  });
+
+  it("accepts disabling and patching inactivity classification", () => {
+    expect(
+      decodeServerSettings({
+        threadSettlement: { autoSettleAfterDays: null },
+      }).threadSettlement.autoSettleAfterDays,
+    ).toBeNull();
+    expect(
+      decodeServerSettingsPatch({
+        threadSettlement: { autoSettleAfterDays: 14 },
+      }).threadSettlement,
+    ).toEqual({ autoSettleAfterDays: 14 });
+  });
+
+  it.each([-1, 0, 91])("rejects an inactivity threshold outside 1..90: %s", (value) => {
+    expect(() =>
+      decodeServerSettings({ threadSettlement: { autoSettleAfterDays: value } }),
+    ).toThrow();
+    expect(() =>
+      decodeServerSettingsPatch({ threadSettlement: { autoSettleAfterDays: value } }),
+    ).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -43,16 +43,26 @@ export const SidebarThreadPreviewCount = Schema.Int.check(
 );
 export type SidebarThreadPreviewCount = typeof SidebarThreadPreviewCount.Type;
 export const DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT: SidebarThreadPreviewCount = 6;
-export const MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS = 1;
-export const MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS = 90;
-export const SidebarAutoSettleAfterDays = Schema.Number.check(
+export const MIN_THREAD_AUTO_SETTLE_AFTER_DAYS = 1;
+export const MAX_THREAD_AUTO_SETTLE_AFTER_DAYS = 90;
+export const ThreadAutoSettleAfterDays = Schema.Number.check(
   Schema.isBetween({
-    minimum: MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
-    maximum: MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+    minimum: MIN_THREAD_AUTO_SETTLE_AFTER_DAYS,
+    maximum: MAX_THREAD_AUTO_SETTLE_AFTER_DAYS,
   }),
 );
-export type SidebarAutoSettleAfterDays = typeof SidebarAutoSettleAfterDays.Type;
-export const DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS: SidebarAutoSettleAfterDays = 3;
+export type ThreadAutoSettleAfterDays = typeof ThreadAutoSettleAfterDays.Type;
+export const DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS: ThreadAutoSettleAfterDays = 3;
+/** @deprecated Use MIN_THREAD_AUTO_SETTLE_AFTER_DAYS. */
+export const MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS = MIN_THREAD_AUTO_SETTLE_AFTER_DAYS;
+/** @deprecated Use MAX_THREAD_AUTO_SETTLE_AFTER_DAYS. */
+export const MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS = MAX_THREAD_AUTO_SETTLE_AFTER_DAYS;
+/** @deprecated Use ThreadAutoSettleAfterDays. */
+export const SidebarAutoSettleAfterDays = ThreadAutoSettleAfterDays;
+/** @deprecated Use ThreadAutoSettleAfterDays. */
+export type SidebarAutoSettleAfterDays = ThreadAutoSettleAfterDays;
+/** @deprecated Use DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS. */
+export const DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS = DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS;
 export const MIN_GLASS_OPACITY = 40;
 export const MAX_GLASS_OPACITY = 100;
 export const GlassOpacity = Schema.Int.check(
@@ -177,8 +187,10 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
-  sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
+  /** @deprecated Persisted for downgrade compatibility. Auto-settlement is
+      now configured per environment in ServerSettings.threadSettlement. */
+  sidebarAutoSettleAfterDays: Schema.NullOr(ThreadAutoSettleAfterDays).pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS)),
   ),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
@@ -537,6 +549,13 @@ export const BackgroundActivitySettings = Schema.Struct({
 }).pipe(Schema.withDecodingDefault(Effect.succeed({})));
 export type BackgroundActivitySettings = typeof BackgroundActivitySettings.Type;
 
+export const ThreadSettlementSettings = Schema.Struct({
+  autoSettleAfterDays: Schema.NullOr(ThreadAutoSettleAfterDays).pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS)),
+  ),
+}).pipe(Schema.withDecodingDefault(Effect.succeed({})));
+export type ThreadSettlementSettings = typeof ThreadSettlementSettings.Type;
+
 export const ServerSettings = Schema.Struct({
   // Legacy token-by-token assistant output. Deliberately a fresh key (was
   // `enableAssistantStreaming`): decoding drops the old key, so everyone,
@@ -546,6 +565,7 @@ export const ServerSettings = Schema.Struct({
   ),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   backgroundActivity: BackgroundActivitySettings,
+  threadSettlement: ThreadSettlementSettings,
   // Legacy flat fields retained for old settings files and old clients. New
   // consumers should resolve `backgroundActivity` instead.
   automaticGitFetchInterval: Schema.DurationFromMillis.pipe(
@@ -716,6 +736,11 @@ export const ServerSettingsPatch = Schema.Struct({
       overrides: Schema.optionalKey(BackgroundActivityOverrides),
     }),
   ),
+  threadSettlement: Schema.optionalKey(
+    Schema.Struct({
+      autoSettleAfterDays: Schema.optionalKey(Schema.NullOr(ThreadAutoSettleAfterDays)),
+    }),
+  ),
   automaticGitFetchInterval: Schema.optionalKey(Schema.DurationFromMillis),
   providerHealthRefreshInterval: Schema.optionalKey(Schema.DurationFromMillis),
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
@@ -792,7 +817,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
-  sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
+  sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(ThreadAutoSettleAfterDays)),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),


### PR DESCRIPTION
## What Changed

- moved the inactivity auto-settle threshold from device-local client settings into server settings owned by each environment
- made web, desktop, and mobile classify each thread with its owning environment's streamed policy
- kept inactivity classification derived: clients do not send `thread.settle`, and the server does not schedule settlement events
- added version-skew gating, multi-environment regression coverage, and user documentation

## Why

Web/desktop read `sidebarAutoSettleAfterDays` from local client persistence, while mobile hard-coded the default of three days. A desktop configured for seven days and a mobile client connected to the same server could therefore put the same thread in different shelves.

The existing server-settings RPC is already remotely writable and streamed to connected clients, so the policy now lives there. Explicit settle/un-settle remains the durable server lifecycle; crossing the inactivity threshold only changes the derived list classification. This avoids clients racing automatic settle commands and lets a policy change reclassify threads immediately.

The default remains three days. The legacy client field and exported names remain decodable for downgrade/source compatibility, but local values no longer drive upgraded clients; automatically importing whichever client connects first would recreate the same ownership race. In multi-environment lists, each backend owns its own policy rather than one client silently mirroring writes to other environments.

This establishes the ownership boundary that overlaps with #5141. Its proposed additional auto-settle controls should extend the server-owned policy rather than introducing separate web and mobile preferences.

## UI Changes

No layout or interaction changes. The existing General setting now updates the primary environment and is read-only against older servers that do not advertise policy updates, so screenshots/video are not applicable.

## Verification

- `vp test run packages/contracts/src/settings.test.ts apps/server/src/serverSettings.test.ts packages/client-runtime/src/state/threadSettled.test.ts apps/mobile/src/features/threads/threadListV2.test.ts` — 269 passed
- targeted typechecks for contracts, client runtime, server, web, and mobile
- targeted lint and formatting checks for all changed source and documentation files
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because there is no visual layout change
- [x] A video is not applicable because there is no animation or timing interaction change

Model: GPT-5.6-Sol | Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how threads appear in sidebars across clients and introduces server-streamed policy with version-skew gating; behavior can shift when local client thresholds differed from the environment default.
> 
> **Overview**
> Moves **inactive thread auto-settle** from per-device client settings (`sidebarAutoSettleAfterDays`) to **per-environment server settings** (`threadSettlement.autoSettleAfterDays`), streamed to connected clients so web, desktop, and mobile classify the same threads the same way.
> 
> **Contracts & server:** Adds `ThreadSettlementSettings` on `ServerSettings`, renames the day-threshold constants to `THREAD_AUTO_SETTLE_*`, keeps the old client field only for downgrade decoding, and advertises a new `threadSettlementPolicy` capability. The server persists policy patches and tests cover enable/disable.
> 
> **Clients:** Web sidebar, chat view, thread actions, and General settings now read/write the primary environment’s streamed policy (controls disabled when the server lacks `threadSettlementPolicy`). Mobile thread list v2 takes a per-environment map instead of a single hard-coded default; classification still treats inactivity as a **derived** settled view, not a server settle command.
> 
> **Docs:** New user doc on thread settlement and a README link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b6d704ed04180a19e8923fda05999fe1134fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move auto-settle policy from client preferences to per-environment server settings
> - Adds a `threadSettlement` section to server settings with an `autoSettleAfterDays` field (default: 3 days, nullable to disable) and a `threadSettlementPolicy` capability flag so clients can detect support.
> - Updates `buildThreadListV2Items` to accept a per-environment map (`autoSettleAfterDaysByEnvironment`) instead of a single global value; threads fall back to `DEFAULT_THREAD_AUTO_SETTLE_AFTER_DAYS` when no policy is set for their environment.
> - Web sidebar, chat view, and thread action menu all now read auto-settle policy from `serverConfig.settings.threadSettlement` rather than a local client preference.
> - The General settings panel binds auto-settle controls to the server-side policy and disables them when the connected server does not advertise `threadSettlementPolicy` support.
> - Behavioral Change: `sidebarAutoSettleAfterDays` in client settings is deprecated but retained for downgrade compatibility; existing clients on servers without the capability will use the fixed 3-day default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08b6d70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->