### PR TITLE
fix(marketing): preserve spacing before releases link

### DIFF
--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -79,7 +79,7 @@ import { ANDROID_PLAY_STORE_URL, IOS_APP_STORE_URL } from "../lib/site";
   </div>
 
   <p class="releases-link">
-    Looking for older versions? Check the
+    Looking for older versions? Check the{" "}
     <a href="https://github.com/pingdotgg/t3code/releases" target="_blank" rel="noopener noreferrer">
       GitHub releases page<span aria-hidden="true"> &#8599;</span>
     </a>


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

Adds an explicit whitespace on the bottom of the downloads page between `Check the` and `GitHub releases page` on the bottom of https://t3.codes/download.

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

It is missing and a one line fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line marketing copy markup change with no logic, auth, or data handling impact.
> 
> **Overview**
> On the download page, the “older versions” line now inserts an explicit space between **“Check the”** and the GitHub releases link using `{" "}` in the Astro template.
> 
> That prevents the words and link from running together when adjacent text and markup are rendered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b827b0251f5a20d09e7bdc95a16f82920e7b2419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing space before releases link in download page
> Adds an explicit `{" "}` space token in [download.astro](https://github.com/pingdotgg/t3code/pull/5295/files#diff-9ac8ff1be0976fe42db086d1efaff539e58c29a5da4e782816188ed3cd0c8926) between the text 'Check the' and the GitHub releases anchor, which were rendering without a visible space between them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b827b02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->