### PR TITLE
feat(relay): provision the Vitess database ahead of the Postgres cutover

### DIFF
--- a/infra/relay/migrations/mysql/20260803221318_baseline/migration.sql
+++ b/infra/relay/migrations/mysql/20260803221318_baseline/migration.sql
@@ -1,0 +1,127 @@
+CREATE TABLE `relay_agent_activity_rows` (
+	`environment_id` varchar(191) NOT NULL,
+	`environment_public_key` varchar(255) NOT NULL,
+	`thread_id` varchar(191) NOT NULL,
+	`state_json` json NOT NULL,
+	`updated_at` varchar(64) NOT NULL,
+	`created_at` varchar(64) NOT NULL,
+	CONSTRAINT PRIMARY KEY(`environment_id`,`environment_public_key`,`thread_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `relay_delivery_attempts` (
+	`id` varchar(36) PRIMARY KEY,
+	`created_at` varchar(64) NOT NULL,
+	`user_id` varchar(255),
+	`environment_id` varchar(191),
+	`thread_id` varchar(191),
+	`device_id` varchar(255),
+	`kind` varchar(64) NOT NULL,
+	`source_job_id` varchar(64),
+	`token_suffix` varchar(16),
+	`apns_status` int,
+	`apns_reason` text,
+	`apns_id` varchar(128),
+	`transport_error` text,
+	CONSTRAINT `idx_relay_delivery_attempts_source_job` UNIQUE INDEX(`source_job_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `relay_dpop_proofs` (
+	`thumbprint` varchar(128) NOT NULL,
+	`jti` varchar(255) NOT NULL,
+	`iat` int NOT NULL,
+	`expires_at` varchar(64) NOT NULL,
+	`created_at` varchar(64) NOT NULL,
+	CONSTRAINT PRIMARY KEY(`thumbprint`,`jti`)
+);
+--> statement-breakpoint
+CREATE TABLE `relay_environment_credentials` (
+	`credential_id` varchar(64) PRIMARY KEY,
+	`environment_id` varchar(191) NOT NULL,
+	`environment_public_key` varchar(255) NOT NULL,
+	`credential_hash` varchar(191) NOT NULL,
+	`revoked_at` varchar(64),
+	`created_at` varchar(64) NOT NULL,
+	`updated_at` varchar(64) NOT NULL,
+	CONSTRAINT `idx_relay_environment_credentials_hash` UNIQUE INDEX(`credential_hash`)
+);
+--> statement-breakpoint
+CREATE TABLE `relay_environment_links` (
+	`user_id` varchar(191) NOT NULL,
+	`environment_id` varchar(191) NOT NULL,
+	`environment_label` text NOT NULL DEFAULT ('T3 Environment'),
+	`environment_public_key` varchar(255) NOT NULL,
+	`endpoint_http_base_url` text NOT NULL,
+	`endpoint_ws_base_url` text NOT NULL,
+	`endpoint_provider_kind` varchar(32) NOT NULL,
+	`notifications_enabled` boolean NOT NULL DEFAULT true,
+	`live_activities_enabled` boolean NOT NULL DEFAULT true,
+	`managed_tunnels_enabled` boolean NOT NULL DEFAULT false,
+	`created_by_device_id` varchar(191),
+	`revoked_at` varchar(64),
+	`created_at` varchar(64) NOT NULL,
+	`updated_at` varchar(64) NOT NULL,
+	CONSTRAINT PRIMARY KEY(`user_id`,`environment_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `relay_live_activities` (
+	`user_id` varchar(255) NOT NULL,
+	`device_id` varchar(255) NOT NULL,
+	`activity_push_token` varchar(255),
+	`remote_start_queued_at` varchar(64),
+	`remote_started_at` varchar(64),
+	`ended_at` varchar(64),
+	`last_aggregate_json` json,
+	`last_live_activity_delivery_at` varchar(64),
+	`created_at` varchar(64) NOT NULL,
+	`updated_at` varchar(64) NOT NULL,
+	CONSTRAINT PRIMARY KEY(`user_id`,`device_id`),
+	CONSTRAINT `idx_relay_live_activities_activity_push_token` UNIQUE INDEX(`activity_push_token`)
+);
+--> statement-breakpoint
+CREATE TABLE `relay_managed_endpoint_allocations` (
+	`user_id` varchar(191) NOT NULL,
+	`environment_id` varchar(191) NOT NULL,
+	`hostname` varchar(255) NOT NULL,
+	`tunnel_id` varchar(191),
+	`tunnel_name` varchar(255) NOT NULL,
+	`dns_record_id` varchar(191),
+	`ready_at` varchar(64),
+	`created_at` varchar(64) NOT NULL,
+	`updated_at` varchar(64) NOT NULL,
+	CONSTRAINT PRIMARY KEY(`user_id`,`environment_id`),
+	CONSTRAINT `idx_relay_managed_endpoint_allocations_hostname` UNIQUE INDEX(`hostname`),
+	CONSTRAINT `idx_relay_managed_endpoint_allocations_tunnel_name` UNIQUE INDEX(`tunnel_name`)
+);
+--> statement-breakpoint
+CREATE TABLE `relay_managed_tunnel_limits` (
+	`user_id` varchar(191) PRIMARY KEY,
+	`max_tunnels` int NOT NULL,
+	`created_at` varchar(64) NOT NULL,
+	`updated_at` varchar(64) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `relay_mobile_devices` (
+	`user_id` varchar(255) NOT NULL,
+	`device_id` varchar(255) NOT NULL,
+	`label` text NOT NULL DEFAULT ('iOS device'),
+	`platform` varchar(16) NOT NULL,
+	`ios_major_version` int NOT NULL,
+	`app_version` varchar(64),
+	`bundle_id` varchar(255),
+	`aps_environment` varchar(16),
+	`push_token` varchar(255),
+	`push_to_start_token` varchar(255),
+	`preferences_json` json NOT NULL,
+	`created_at` varchar(64) NOT NULL,
+	`updated_at` varchar(64) NOT NULL,
+	CONSTRAINT PRIMARY KEY(`user_id`,`device_id`),
+	CONSTRAINT `idx_relay_mobile_devices_push_token` UNIQUE INDEX(`push_token`),
+	CONSTRAINT `idx_relay_mobile_devices_push_to_start_token` UNIQUE INDEX(`push_to_start_token`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_relay_agent_activity_rows_updated` ON `relay_agent_activity_rows` (`updated_at`);--> statement-breakpoint
+CREATE INDEX `idx_relay_delivery_attempts_environment` ON `relay_delivery_attempts` (`environment_id`,`thread_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_relay_dpop_proofs_expires_at` ON `relay_dpop_proofs` (`expires_at`);--> statement-breakpoint
+CREATE INDEX `idx_relay_environment_credentials_environment` ON `relay_environment_credentials` (`environment_id`,`revoked_at`);--> statement-breakpoint
+CREATE INDEX `idx_relay_environment_credentials_environment_key` ON `relay_environment_credentials` (`environment_id`,`environment_public_key`,`revoked_at`);--> statement-breakpoint
+CREATE INDEX `idx_relay_environment_links_environment` ON `relay_environment_links` (`environment_id`,`revoked_at`);

--- a/infra/relay/migrations/mysql/20260803221318_baseline/snapshot.json
+++ b/infra/relay/migrations/mysql/20260803221318_baseline/snapshot.json
@@ -1,0 +1,1465 @@
+{
+  "version": "6",
+  "dialect": "mysql",
+  "id": "a76d909d-778c-4001-b57f-e5125535fa3a",
+  "prevIds": ["00000000-0000-0000-0000-000000000000"],
+  "ddl": [
+    {
+      "name": "relay_agent_activity_rows",
+      "entityType": "tables"
+    },
+    {
+      "name": "relay_delivery_attempts",
+      "entityType": "tables"
+    },
+    {
+      "name": "relay_dpop_proofs",
+      "entityType": "tables"
+    },
+    {
+      "name": "relay_environment_credentials",
+      "entityType": "tables"
+    },
+    {
+      "name": "relay_environment_links",
+      "entityType": "tables"
+    },
+    {
+      "name": "relay_live_activities",
+      "entityType": "tables"
+    },
+    {
+      "name": "relay_managed_endpoint_allocations",
+      "entityType": "tables"
+    },
+    {
+      "name": "relay_managed_tunnel_limits",
+      "entityType": "tables"
+    },
+    {
+      "name": "relay_mobile_devices",
+      "entityType": "tables"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "environment_id",
+      "entityType": "columns",
+      "table": "relay_agent_activity_rows"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "environment_public_key",
+      "entityType": "columns",
+      "table": "relay_agent_activity_rows"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "thread_id",
+      "entityType": "columns",
+      "table": "relay_agent_activity_rows"
+    },
+    {
+      "type": "json",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "state_json",
+      "entityType": "columns",
+      "table": "relay_agent_activity_rows"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "relay_agent_activity_rows"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "relay_agent_activity_rows"
+    },
+    {
+      "type": "varchar(36)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "environment_id",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "thread_id",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "device_id",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "source_job_id",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(16)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "token_suffix",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "int",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "apns_status",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "apns_reason",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(128)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "apns_id",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "transport_error",
+      "entityType": "columns",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "type": "varchar(128)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "thumbprint",
+      "entityType": "columns",
+      "table": "relay_dpop_proofs"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "jti",
+      "entityType": "columns",
+      "table": "relay_dpop_proofs"
+    },
+    {
+      "type": "int",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "iat",
+      "entityType": "columns",
+      "table": "relay_dpop_proofs"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "relay_dpop_proofs"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "relay_dpop_proofs"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "environment_id",
+      "entityType": "columns",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "environment_public_key",
+      "entityType": "columns",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "credential_hash",
+      "entityType": "columns",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "environment_id",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": "('T3 Environment')",
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "environment_label",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "environment_public_key",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "endpoint_http_base_url",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "endpoint_ws_base_url",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "varchar(32)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "endpoint_provider_kind",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "boolean",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": "true",
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "notifications_enabled",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "boolean",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": "true",
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "live_activities_enabled",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "boolean",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": "false",
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "managed_tunnels_enabled",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_by_device_id",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "relay_environment_links"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "device_id",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "activity_push_token",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "remote_start_queued_at",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "remote_started_at",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "json",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "last_aggregate_json",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "last_live_activity_delivery_at",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "relay_live_activities"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "environment_id",
+      "entityType": "columns",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "hostname",
+      "entityType": "columns",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "tunnel_id",
+      "entityType": "columns",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "tunnel_name",
+      "entityType": "columns",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "dns_record_id",
+      "entityType": "columns",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "ready_at",
+      "entityType": "columns",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "type": "varchar(191)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "relay_managed_tunnel_limits"
+    },
+    {
+      "type": "int",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "max_tunnels",
+      "entityType": "columns",
+      "table": "relay_managed_tunnel_limits"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "relay_managed_tunnel_limits"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "relay_managed_tunnel_limits"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "device_id",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": "('iOS device')",
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "label",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "varchar(16)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "platform",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "int",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "ios_major_version",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "app_version",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "bundle_id",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "varchar(16)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "aps_environment",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "push_token",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "varchar(255)",
+      "notNull": false,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "push_to_start_token",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "json",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "preferences_json",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "type": "varchar(64)",
+      "notNull": true,
+      "autoIncrement": false,
+      "default": null,
+      "onUpdateNow": false,
+      "onUpdateNowFsp": null,
+      "charSet": null,
+      "collation": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "columns": ["environment_id", "environment_public_key", "thread_id"],
+      "name": "PRIMARY",
+      "table": "relay_agent_activity_rows",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["thumbprint", "jti"],
+      "name": "PRIMARY",
+      "table": "relay_dpop_proofs",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["user_id", "environment_id"],
+      "name": "PRIMARY",
+      "table": "relay_environment_links",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["user_id", "device_id"],
+      "name": "PRIMARY",
+      "table": "relay_live_activities",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["user_id", "environment_id"],
+      "name": "PRIMARY",
+      "table": "relay_managed_endpoint_allocations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["user_id", "device_id"],
+      "name": "PRIMARY",
+      "table": "relay_mobile_devices",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "name": "PRIMARY",
+      "table": "relay_delivery_attempts",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["credential_id"],
+      "name": "PRIMARY",
+      "table": "relay_environment_credentials",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["user_id"],
+      "name": "PRIMARY",
+      "table": "relay_managed_tunnel_limits",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "updated_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_agent_activity_rows_updated",
+      "entityType": "indexes",
+      "table": "relay_agent_activity_rows"
+    },
+    {
+      "columns": [
+        {
+          "value": "environment_id",
+          "isExpression": false
+        },
+        {
+          "value": "thread_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_delivery_attempts_environment",
+      "entityType": "indexes",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "columns": [
+        {
+          "value": "source_job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_delivery_attempts_source_job",
+      "entityType": "indexes",
+      "table": "relay_delivery_attempts"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_dpop_proofs_expires_at",
+      "entityType": "indexes",
+      "table": "relay_dpop_proofs"
+    },
+    {
+      "columns": [
+        {
+          "value": "credential_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_environment_credentials_hash",
+      "entityType": "indexes",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "columns": [
+        {
+          "value": "environment_id",
+          "isExpression": false
+        },
+        {
+          "value": "revoked_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_environment_credentials_environment",
+      "entityType": "indexes",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "columns": [
+        {
+          "value": "environment_id",
+          "isExpression": false
+        },
+        {
+          "value": "environment_public_key",
+          "isExpression": false
+        },
+        {
+          "value": "revoked_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_environment_credentials_environment_key",
+      "entityType": "indexes",
+      "table": "relay_environment_credentials"
+    },
+    {
+      "columns": [
+        {
+          "value": "environment_id",
+          "isExpression": false
+        },
+        {
+          "value": "revoked_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_environment_links_environment",
+      "entityType": "indexes",
+      "table": "relay_environment_links"
+    },
+    {
+      "columns": [
+        {
+          "value": "activity_push_token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_live_activities_activity_push_token",
+      "entityType": "indexes",
+      "table": "relay_live_activities"
+    },
+    {
+      "columns": [
+        {
+          "value": "hostname",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_managed_endpoint_allocations_hostname",
+      "entityType": "indexes",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "columns": [
+        {
+          "value": "tunnel_name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_managed_endpoint_allocations_tunnel_name",
+      "entityType": "indexes",
+      "table": "relay_managed_endpoint_allocations"
+    },
+    {
+      "columns": [
+        {
+          "value": "push_token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_mobile_devices_push_token",
+      "entityType": "indexes",
+      "table": "relay_mobile_devices"
+    },
+    {
+      "columns": [
+        {
+          "value": "push_to_start_token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "using": null,
+      "algorithm": null,
+      "lock": null,
+      "nameExplicit": true,
+      "name": "idx_relay_mobile_devices_push_to_start_token",
+      "entityType": "indexes",
+      "table": "relay_mobile_devices"
+    }
+  ],
+  "renames": []
+}

--- a/infra/relay/src/db.ts
+++ b/infra/relay/src/db.ts
@@ -44,6 +44,26 @@ export const PlanetscaleDatabase = Effect.gen(function* () {
   });
 
   const mode = relayDatabaseMode(stage);
+
+  // Phase 1 of the Vitess migration
+  // (docs/operations/relay-postgres-to-vitess-migration.md): provision the
+  // MySQL target and apply its checked-in baseline schema while the worker
+  // still runs on Postgres, so DMS can replicate data into it ahead of the
+  // cutover deploy. Deliberately prod-only: nothing speaks MySQL until the
+  // cutover PR, which takes over this resource id and adds the per-stage
+  // MySQLBranch/MySQLPassword mirror of the Postgres branch-per-stage
+  // setup below for developer stages.
+  if (mode === "shared-database") {
+    yield* Planetscale.MySQLDatabase("RelayMysqlDatabase", {
+      name: "t3coderelay-vitess",
+      region: { slug: "us-west" },
+      clusterSize: "PS_20",
+      migrationsDir: "migrations/mysql",
+      migrationsTable: "relay_migrations",
+      replicas: 2,
+    }).pipe(RemovalPolicy.retain());
+  }
+
   const database =
     mode === "shared-database"
       ? yield* Planetscale.PostgresDatabase("RelayPostgresDatabase", {


### PR DESCRIPTION
Phase 1 of the relay Postgres → Vitess migration (see the stacked cutover PR for the full picture and runbook).

Adds `RelayMysqlDatabase` (`t3coderelay-vitess`, us-west, PS_20) to the prod stack with the checked-in `migrations/mysql` baseline. Deploying this creates the empty Vitess database and applies the schema via the alchemy migration runner — `relay_migrations` bookkeeping included — while the worker keeps running on Postgres. That lets AWS DMS replicate production data into the target before the cutover PR flips Hyperdrive.

No worker or runtime changes; Postgres remains the live database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prod infra now provisions an additional live database and applies schema on deploy; misconfiguration could affect migration bookkeeping or DMS target readiness, but runtime traffic stays on Postgres until cutover.
> 
> **Overview**
> **Phase 1** of the relay Postgres → Vitess migration: prod deploys now also provision PlanetScale MySQL (`t3coderelay-vitess`, us-west, PS_20) when `relayDatabaseMode` is `shared-database`, alongside the existing Postgres database.
> 
> A new checked-in **MySQL baseline** in `migrations/mysql` creates all `relay_*` tables and indexes (mirroring Postgres) and is applied via `relay_migrations` on deploy. The worker and Hyperdrive still use Postgres; nothing reads or writes MySQL until the cutover PR.
> 
> Adds the Drizzle **snapshot** for the MySQL baseline migration metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 394dead4323b923f2008703c8f01c3ac3760b0d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Provision Vitess MySQL database ahead of Postgres cutover for relay service
> - Adds a Planetscale MySQL database resource (`t3coderelay-vitess`, us-west, PS_20, 2 replicas) in [db.ts](https://github.com/pingdotgg/t3code/pull/5305/files#diff-93331c5b023bb7bc3e26bcfe696278f8d53eeb2fc66488a2351b7506cd58a4e6) when `relayDatabaseMode` returns `"shared-database"`.
> - Adds a baseline MySQL migration in [migration.sql](https://github.com/pingdotgg/t3code/pull/5305/files#diff-afc91b1bc6376d5ad28df2c665da439d258f23c87a669d822d9b03e34531f7eb) that creates all `relay_*` tables, indexes, and schema matching the existing Postgres structure.
> - The Postgres database continues to be provisioned and used; the MySQL resource is additive at this stage.
> - Behavioral Change: `shared-database` deployments now provision an additional database resource with `RemovalPolicy.retain()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 394dead.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->