### PR TITLE
fix(server): restore worktree branch naming in the v2 orchestrator

### DIFF
--- a/apps/server/src/orchestration-v2/ThreadLaunchService.test.ts
+++ b/apps/server/src/orchestration-v2/ThreadLaunchService.test.ts
@@ -67,6 +67,7 @@ const adapter = {
 
 interface HarnessOptions {
   readonly createWorktree?: GitWorkflow.GitWorkflowService["Service"]["createWorktree"];
+  readonly renameBranch?: GitWorkflow.GitWorkflowService["Service"]["renameBranch"];
   readonly runSetup?: ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"]["runForThread"];
   readonly generateTitle?: TextGeneration.TextGeneration["Service"]["generateThreadTitle"];
   readonly generateBranchName?: TextGeneration.TextGeneration["Service"]["generateBranchName"];
@@ -87,10 +88,13 @@ function makeHarness(options: HarnessOptions = {}) {
   const outbox = EffectOutbox.layer.pipe(Layer.provide(database));
   const createWorktree = vi.fn(
     options.createWorktree ??
-      (() =>
+      ((input) =>
         Effect.succeed({
-          worktree: { path: "/repo-worktrees/feature", refName: "feature", headSha: "abc" },
+          worktree: { path: "/repo-worktrees/feature", refName: input.newRefName, headSha: "abc" },
         } as never)),
+  );
+  const renameBranch = vi.fn(
+    options.renameBranch ?? ((input) => Effect.succeed({ branch: input.newBranch })),
   );
   const runSetup = vi.fn(
     options.runSetup ?? (() => Effect.succeed({ status: "no-script" as const })),
@@ -113,6 +117,7 @@ function makeHarness(options: HarnessOptions = {}) {
     }),
     Layer.mock(GitWorkflow.GitWorkflowService)({
       createWorktree,
+      renameBranch,
       fetchRemote: () => Effect.void,
       removeWorktree: () => Effect.void,
       resolveRemoteTrackingCommit: () =>
@@ -154,6 +159,7 @@ function makeHarness(options: HarnessOptions = {}) {
   return {
     layer: Layer.mergeAll(launch, threadManagement, titleRegeneration, outbox, database),
     createWorktree,
+    renameBranch,
     generateBranchName,
     generateThreadTitle,
     runSetup,
@@ -717,6 +723,174 @@ it.effect("falls back when the source control writer is unavailable", () =>
         harness.generateBranchName.mock.calls[0]?.[0].modelSelection,
         DEFAULT_SERVER_SETTINGS.textGenerationModelSelection,
       );
+    }).pipe(Effect.provide(harness.layer));
+  }),
+);
+
+it.effect("names the worktree itself when the client provides no branch", () =>
+  Effect.gen(function* () {
+    const harness = makeHarness();
+    yield* Effect.gen(function* () {
+      const launches = yield* ThreadLaunch.ThreadLaunchService;
+      const threads = yield* ThreadManagement.ThreadManagementService;
+      const launched = yield* launches.launch(
+        launchInput({
+          command: "command:launch:server-named-branch",
+          thread: "thread:launch:server-named-branch",
+          message: "Build the feature",
+          workspace: { type: "worktree", baseRef: "main" },
+        }),
+      );
+      yield* waitUntil(() => Effect.sync(() => harness.createWorktree.mock.calls.length === 1));
+      assert.match(
+        harness.createWorktree.mock.calls[0]?.[0].newRefName ?? "",
+        /^t3code\/[0-9a-f]{8}$/u,
+      );
+      yield* waitUntil(() =>
+        threads
+          .getThreadProjection(launched.threadId)
+          .pipe(Effect.map((projection) => projection.thread.branch === "generated-branch")),
+      );
+    }).pipe(Effect.provide(harness.layer));
+  }),
+);
+
+it.effect("renames a temporary t3code/<hash> branch off the provisioning critical path", () =>
+  Effect.gen(function* () {
+    const branchNameStarted = yield* Deferred.make<void>();
+    const allowBranchName = yield* Deferred.make<void>();
+    const harness = makeHarness({
+      createWorktree: (input) =>
+        Effect.succeed({
+          worktree: { path: "/repo-worktrees/temp", refName: input.newRefName, headSha: "abc" },
+        } as never),
+      generateBranchName: () =>
+        Deferred.succeed(branchNameStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(allowBranchName)),
+          Effect.as({ branch: "generated-branch" }),
+        ),
+    });
+    yield* Effect.gen(function* () {
+      const launches = yield* ThreadLaunch.ThreadLaunchService;
+      const threads = yield* ThreadManagement.ThreadManagementService;
+      const launched = yield* launches.launch(
+        launchInput({
+          command: "command:launch:temp-branch",
+          thread: "thread:launch:temp-branch",
+          message: "Build the feature",
+          workspace: { type: "worktree", baseRef: "main", branch: "t3code/abcd1234" },
+        }),
+      );
+      yield* Deferred.await(branchNameStarted);
+      assert.equal(harness.createWorktree.mock.calls[0]?.[0].newRefName, "t3code/abcd1234");
+      yield* waitUntil(() =>
+        threads
+          .getThreadProjection(launched.threadId)
+          .pipe(Effect.map((projection) => projection.runs[0]?.status === "starting")),
+      );
+      assert.equal(
+        (yield* threads.getThreadProjection(launched.threadId)).thread.branch,
+        "t3code/abcd1234",
+      );
+      yield* Deferred.succeed(allowBranchName, undefined);
+      yield* waitUntil(() =>
+        threads
+          .getThreadProjection(launched.threadId)
+          .pipe(Effect.map((projection) => projection.thread.branch === "generated-branch")),
+      );
+      assert.deepEqual(harness.renameBranch.mock.calls[0]?.[0], {
+        cwd: "/repo-worktrees/temp",
+        oldBranch: "t3code/abcd1234",
+        newBranch: "generated-branch",
+      });
+    }).pipe(Effect.provide(harness.layer));
+  }),
+);
+
+it.effect("keeps an explicit branch name instead of generating one", () =>
+  Effect.gen(function* () {
+    const harness = makeHarness();
+    yield* Effect.gen(function* () {
+      const launches = yield* ThreadLaunch.ThreadLaunchService;
+      yield* launches.launch(
+        launchInput({
+          command: "command:launch:explicit-branch",
+          thread: "thread:launch:explicit-branch",
+          message: "Build the feature",
+          workspace: { type: "worktree", baseRef: "main", branch: "my-feature" },
+        }),
+      );
+      yield* waitUntil(() => Effect.sync(() => harness.createWorktree.mock.calls.length === 1));
+      assert.equal(harness.generateBranchName.mock.calls.length, 0);
+      assert.equal(harness.createWorktree.mock.calls[0]?.[0].newRefName, "my-feature");
+    }).pipe(Effect.provide(harness.layer));
+  }),
+);
+
+it.effect("keeps the temporary branch when branch generation fails", () =>
+  Effect.gen(function* () {
+    const harness = makeHarness({
+      createWorktree: (input) =>
+        Effect.succeed({
+          worktree: { path: "/repo-worktrees/temp", refName: input.newRefName, headSha: "abc" },
+        } as never),
+      generateBranchName: () => Effect.die("branch generation is down"),
+    });
+    yield* Effect.gen(function* () {
+      const launches = yield* ThreadLaunch.ThreadLaunchService;
+      const threads = yield* ThreadManagement.ThreadManagementService;
+      const launched = yield* launches.launch(
+        launchInput({
+          command: "command:launch:branch-fallback",
+          thread: "thread:launch:branch-fallback",
+          message: "Build the feature",
+          workspace: { type: "worktree", baseRef: "main", branch: "t3code/abcd1234" },
+        }),
+      );
+      yield* waitUntil(() => Effect.sync(() => harness.generateBranchName.mock.calls.length === 1));
+      assert.equal(harness.createWorktree.mock.calls[0]?.[0].newRefName, "t3code/abcd1234");
+      yield* waitUntil(() =>
+        threads
+          .getThreadProjection(launched.threadId)
+          .pipe(Effect.map((projection) => projection.runs[0]?.status === "starting")),
+      );
+      assert.equal(harness.renameBranch.mock.calls.length, 0);
+      assert.equal(
+        (yield* threads.getThreadProjection(launched.threadId)).thread.branch,
+        "t3code/abcd1234",
+      );
+    }).pipe(Effect.provide(harness.layer));
+  }),
+);
+
+it.effect("renames a temporary branch on an existing worktree to a generated name", () =>
+  Effect.gen(function* () {
+    const harness = makeHarness();
+    yield* Effect.gen(function* () {
+      const launches = yield* ThreadLaunch.ThreadLaunchService;
+      const threads = yield* ThreadManagement.ThreadManagementService;
+      const launched = yield* launches.launch(
+        launchInput({
+          command: "command:launch:existing-worktree-rename",
+          thread: "thread:launch:existing-worktree-rename",
+          message: "Build the feature",
+          workspace: {
+            type: "existing_worktree",
+            worktreePath: "/repo-worktrees/t3code-abcd1234",
+            branch: "t3code/abcd1234",
+          },
+        }),
+      );
+      yield* waitUntil(() =>
+        threads
+          .getThreadProjection(launched.threadId)
+          .pipe(Effect.map((projection) => projection.thread.branch === "generated-branch")),
+      );
+      assert.deepEqual(harness.renameBranch.mock.calls[0]?.[0], {
+        cwd: "/repo-worktrees/t3code-abcd1234",
+        oldBranch: "t3code/abcd1234",
+        newBranch: "generated-branch",
+      });
     }).pipe(Effect.provide(harness.layer));
   }),
 );

--- a/apps/server/src/orchestration-v2/ThreadLaunchService.ts
+++ b/apps/server/src/orchestration-v2/ThreadLaunchService.ts
@@ -21,6 +21,7 @@ import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import { buildTemporaryWorktreeBranchName, isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 
 import * as GitWorkflow from "../git/GitWorkflowService.ts";
 import * as ProjectService from "../project/ProjectService.ts";
@@ -31,6 +32,7 @@ import * as TextGeneration from "../textGeneration/TextGeneration.ts";
 import * as CommandReceiptStore from "./CommandReceiptStore.ts";
 import * as IdAllocator from "./IdAllocator.ts";
 import { makeProviderFailure } from "./ProviderFailure.ts";
+import { randomUuidV4 } from "./RandomUuid.ts";
 import * as ThreadManagement from "./ThreadManagementService.ts";
 
 export type ThreadLaunchWorkspaceStrategy =
@@ -112,16 +114,6 @@ export class ThreadLaunchService extends Context.Service<
 
 const isThreadLaunchError = Schema.is(ThreadLaunchError);
 
-function fallbackBranchName(threadId: ThreadId): string {
-  const suffix = String(threadId)
-    .split(":")
-    .at(-1)
-    ?.replace(/[^a-zA-Z0-9-]+/gu, "-")
-    .replace(/^-+|-+$/gu, "")
-    .slice(0, 16);
-  return `thread-${suffix || "new"}`;
-}
-
 function failureDetail(error: unknown): string {
   if (isThreadLaunchError(error)) {
     const cause = error.cause;
@@ -200,30 +192,37 @@ export const make = Effect.gen(function* () {
     );
 
     const initialMessage = input.initialMessage;
-    let branch =
-      input.workspaceStrategy.type === "worktree" &&
-      input.workspaceStrategy.branch === undefined &&
-      initialMessage !== undefined
-        ? yield* Effect.gen(function* () {
-            const settings = yield* serverSettings.getSettings;
-            const modelSelection =
-              settings.sourceControlWriterModelSelection === null
-                ? settings.textGenerationModelSelection
-                : ServerSettings.resolveSourceControlWriterModelSelection(
-                    settings,
-                    yield* providerRegistry.getProviders,
-                  );
-            return yield* textGeneration
-              .generateBranchName({
-                cwd: project.workspaceRoot,
-                message: initialMessage.text,
-                attachments: initialMessage.attachments,
-                modelSelection,
-              })
-              .pipe(Effect.map((result) => result.branch));
-          }).pipe(Effect.mapError(mapError(input, "generate-metadata", threadId)))
-        : (input.workspaceStrategy.branch ??
-          (input.workspaceStrategy.type === "worktree" ? fallbackBranchName(threadId) : null));
+    const generateBranchNameFor = (cwd: string, message: ThreadLaunchInitialMessage) =>
+      Effect.gen(function* () {
+        const settings = yield* serverSettings.getSettings;
+        const modelSelection =
+          settings.sourceControlWriterModelSelection === null
+            ? settings.textGenerationModelSelection
+            : ServerSettings.resolveSourceControlWriterModelSelection(
+                settings,
+                yield* providerRegistry.getProviders,
+              );
+        return yield* textGeneration
+          .generateBranchName({
+            cwd,
+            message: message.text,
+            attachments: message.attachments,
+            modelSelection,
+          })
+          .pipe(Effect.map((result) => result.branch));
+      });
+
+    // The server owns worktree naming: without an explicit branch, provision
+    // under a temporary `t3code/<hash>` name so the worktree never waits on
+    // name generation, then rename in the background below.
+    const requestedBranch = input.workspaceStrategy.branch;
+    let branch: string | null;
+    if (input.workspaceStrategy.type === "worktree" && requestedBranch === undefined) {
+      const uuid = yield* randomUuidV4;
+      branch = buildTemporaryWorktreeBranchName(() => uuid.replaceAll("-", ""));
+    } else {
+      branch = requestedBranch ?? null;
+    }
     let worktreePath =
       input.workspaceStrategy.type === "existing_worktree"
         ? input.workspaceStrategy.worktreePath
@@ -278,6 +277,41 @@ export const make = Effect.gen(function* () {
         worktreePath,
       })
       .pipe(Effect.mapError(mapError(input, "update-thread", threadId)));
+
+    // Rename temporary branches (server-invented above, or sent by clients
+    // that name worktrees themselves) in the background so generation latency
+    // never delays provisioning or the provider turn. The temporary name
+    // simply sticks if generation or the rename fails.
+    if (
+      worktreePath !== null &&
+      branch !== null &&
+      initialMessage !== undefined &&
+      isTemporaryWorktreeBranch(branch)
+    ) {
+      const oldBranch = branch;
+      const worktreeCwd = worktreePath;
+      yield* generateBranchNameFor(worktreeCwd, initialMessage).pipe(
+        Effect.flatMap((newBranch) => git.renameBranch({ cwd: worktreeCwd, oldBranch, newBranch })),
+        Effect.flatMap((renamed) =>
+          threads.dispatch({
+            type: "thread.metadata.update",
+            commandId: CommandId.make(`${input.commandId}:branch-rename`),
+            threadId,
+            branch: renamed.branch,
+            worktreePath: worktreeCwd,
+          }),
+        ),
+        Effect.catchCause((cause) =>
+          Effect.logWarning("Thread worktree branch rename failed", {
+            commandId: input.commandId,
+            threadId,
+            oldBranch,
+            cause,
+          }),
+        ),
+        Effect.forkIn(preparationScope),
+      );
+    }
 
     const cwd = worktreePath ?? project.workspaceRoot;
     if (runId !== null) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -123,7 +123,6 @@ import {
 import { useTheme } from "../hooks/useTheme";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
-import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { useElementWidth } from "../hooks/useElementWidth";
 import { usePreviewPanelInlineSize } from "../hooks/usePreviewPanelInlineSize";
@@ -167,7 +166,7 @@ import {
   TriangleAlertIcon,
   WifiOffIcon,
 } from "lucide-react";
-import { cn, randomHex } from "~/lib/utils";
+import { cn } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
@@ -5223,7 +5222,6 @@ function ChatViewContent(props: ChatViewProps) {
                     prepareWorktree: {
                       projectCwd: activeProject.workspaceRoot,
                       baseBranch: baseBranchForWorktree,
-                      branch: buildTemporaryWorktreeBranchName(randomHex),
                       ...(startFromOrigin ? { startFromOrigin: true } : {}),
                     },
                     runSetupScript: true,


### PR DESCRIPTION
Stacked on #2829. Complements #5176, which restored title generation — this PR covers the other half of the regression: worktree branch naming.

## Problem

On the v2 orchestrator, threads stay on their temporary `t3code/<hash>` branch forever. `ThreadLaunchService` only generated a branch name when `workspaceStrategy.branch === undefined`, but the web client always passed a temporary `t3code/<hash>` name — so generation never fired, and unlike v1 there was no later rename pass.

## Fix

The server now owns worktree naming:

- Without an explicit branch, the worktree is provisioned **immediately** under a server-invented temporary `t3code/<8hex>` name (`randomUuidV4` + shared `buildTemporaryWorktreeBranchName`).
- After the workspace metadata dispatch, a background fork generates the real name, renames via `git branch -m`, and dispatches a `:branch-rename` metadata update. Name generation never sits on the critical path in front of worktree creation, the setup script, or the provider turn (matching v1's concurrency, where the rename raced the turn). This also removes the previous awaited-generation path, so branchless launches (scheduled tasks, MCP-driven) no longer block provisioning on an LLM call.
- If generation or the rename fails, the temporary name sticks with a logged warning.
- The web client stops inventing temporary branch names. `branch` stays optional in the contract: explicit user-chosen branch names are respected verbatim, and temporary names from clients that still send them (mobile's offline outbox) are renamed server-side the same way.

## Notes

- Generated branch names follow the existing v2 `feature/<slug>` convention rather than v1's `t3code/<slug>` wrapper; happy to align to v1 if the namespace matters downstream.
- Minor UX: the sidebar shows no branch for a beat longer on brand-new threads (until the workspace metadata event lands) since the client no longer has a name to show optimistically; the "Preparing worktree" run phase covers that window.

## Testing

- 5 new `ThreadLaunchService` tests: server-invented temp names, off-critical-path rename (run reaches `starting` while generation is gated behind a deferred), explicit-branch passthrough, generation-failure fallback, existing-worktree rename.
- Full orchestration-v2 suite: 558 passed, 54 files (on top of the merged #5176).
- Typecheck clean for `t3` and `@t3tools/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread launch provisioning and git branch lifecycle on the critical path for new worktrees; failures degrade to temp branch names rather than blocking launch.
> 
> **Overview**
> Restores v2 thread launch behavior where worktrees stayed on client-supplied **`t3code/<hash>`** branches and never got LLM-generated names, because **`ThreadLaunchService`** used that name verbatim and did not run a rename pass like v1.
> 
> **Branch naming** — When no explicit branch is sent, the server provisions immediately under a temporary **`t3code/<8hex>`** name (via **`buildTemporaryWorktreeBranchName`** / **`randomUuidV4`**), instead of awaiting **`generateBranchName`** or using the removed **`thread-<id>`** fallback. After workspace metadata is written, a background fork generates a real branch name, **`git.renameBranch`**, and a **`thread.metadata.update`** with command id **`branch-rename`**; failures are logged and the temp name remains. Explicit user branches are unchanged; client-supplied temp names (legacy/mobile) still get renamed the same way, including **`existing_worktree`** launches.
> 
> **Web client** — **`ChatView`** no longer passes **`branch`** in **`prepareWorktree`** (removed **`buildTemporaryWorktreeBranchName`** / **`randomHex`**); the server owns the initial ref.
> 
> **Tests** — **`ThreadLaunchService.test`** harness mocks **`renameBranch`** and adds cases for server naming, off-critical-path rename, explicit branch, generation failure fallback, and existing-worktree rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7190bf2dd6f7a84faf5cda8ba86787f51a928d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore worktree branch naming to the v2 orchestrator from the client
> - Moves temporary worktree branch name generation (`t3code/<hash>`) from the client ([ChatView.tsx](https://github.com/pingdotgg/t3code/pull/5309/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)) into [ThreadLaunchService.ts](https://github.com/pingdotgg/t3code/pull/5309/files#diff-500dff41e476f8e27a8ab79362d6065acec871cca38910edb6e531bced7f7e3a) using `buildTemporaryWorktreeBranchName` and `randomUuidV4`.
> - After provisioning, the server asynchronously generates a proper branch name and calls `git.renameBranch`, then updates thread metadata; if generation or rename fails, the temporary branch is kept without affecting provisioning.
> - Explicit branches passed by the client are preserved as-is; branch generation only runs for server-assigned temporary branches.
> - Adds tests covering no-branch, deferred rename, explicit branch, failure fallback, and existing-worktree rename scenarios in [ThreadLaunchService.test.ts](https://github.com/pingdotgg/t3code/pull/5309/files#diff-2a283eb9c521d5d800b3fb394b1935e8bc85d08f54632548ca222d9f4279c275).
> - Behavioral Change: clients no longer send a branch when preparing a worktree; the `thread-<suffix>` fallback branch name from the old server path is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7190bf2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->