### PR TITLE
fix(orchestrator): Prevent redundant delegated completion turns

### DIFF
--- a/apps/mobile/src/features/threads/ThreadQueueControl.tsx
+++ b/apps/mobile/src/features/threads/ThreadQueueControl.tsx
@@ -138,17 +138,15 @@ export function ThreadQueueControl(props: {
                 />
                 <Text className="font-t3-medium text-2xs text-foreground">Steer</Text>
               </Pressable>
-              {controls.automaticCompletion ? (
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={controls.dismissAccessibilityLabel ?? undefined}
-                  disabled={!controls.canDismiss}
-                  onPress={() => void dismiss(run.id)}
-                  className="h-9 w-9 items-center justify-center disabled:opacity-30"
-                >
-                  <SymbolView name="xmark" size={13} tintColor={iconColor} type="monochrome" />
-                </Pressable>
-              ) : null}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={controls.dismissAccessibilityLabel}
+                disabled={!controls.canDismiss}
+                onPress={() => void dismiss(run.id)}
+                className="h-9 w-9 items-center justify-center disabled:opacity-30"
+              >
+                <SymbolView name="xmark" size={13} tintColor={iconColor} type="monochrome" />
+              </Pressable>
             </View>
           );
         })}

--- a/apps/mobile/src/features/threads/ThreadQueueControl.tsx
+++ b/apps/mobile/src/features/threads/ThreadQueueControl.tsx
@@ -12,7 +12,6 @@ import { useAtomCommand } from "../../state/use-atom-command";
 import { useThreadProjection } from "../../state/use-thread-detail";
 import {
   buildCancelQueuedRunCommand,
-  collectAutomaticCompletionMessageIds,
   resolveThreadQueueRowControls,
 } from "./threadQueueControlPresentation";
 
@@ -23,10 +22,6 @@ export function ThreadQueueControl(props: {
   const scoped = useThreadProjection(props);
   const workflow = useMemo(
     () => (scoped ? deriveThreadQueueWorkflowState(scoped.projection) : null),
-    [scoped],
-  );
-  const automaticCompletionMessageIds = useMemo(
-    () => collectAutomaticCompletionMessageIds(scoped?.projection.messages ?? []),
     [scoped],
   );
   const reorder = useAtomCommand(threadEnvironment.reorderQueuedRun, "reorder queued message");
@@ -87,14 +82,12 @@ export function ThreadQueueControl(props: {
       <ScrollView style={{ maxHeight: 156 }} contentContainerStyle={{ paddingVertical: 4 }}>
         {workflow.queuedRuns.map(({ run, text }, index) => {
           const controls = resolveThreadQueueRowControls({
-            automaticCompletionMessageIds,
             busy: busyRunId !== null,
             canPromoteToSteer: workflow.canPromoteToSteer,
             canReorder: workflow.canReorder,
             index,
             queuedCount: workflow.queuedRuns.length,
             text,
-            userMessageId: run.userMessageId,
           });
 
           return (

--- a/apps/mobile/src/features/threads/ThreadQueueControl.tsx
+++ b/apps/mobile/src/features/threads/ThreadQueueControl.tsx
@@ -10,6 +10,11 @@ import { useThemeColor } from "../../lib/useThemeColor";
 import { threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { useThreadProjection } from "../../state/use-thread-detail";
+import {
+  buildCancelQueuedRunCommand,
+  collectAutomaticCompletionMessageIds,
+  resolveThreadQueueRowControls,
+} from "./threadQueueControlPresentation";
 
 export function ThreadQueueControl(props: {
   readonly environmentId: EnvironmentId;
@@ -20,8 +25,13 @@ export function ThreadQueueControl(props: {
     () => (scoped ? deriveThreadQueueWorkflowState(scoped.projection) : null),
     [scoped],
   );
+  const automaticCompletionMessageIds = useMemo(
+    () => collectAutomaticCompletionMessageIds(scoped?.projection.messages ?? []),
+    [scoped],
+  );
   const reorder = useAtomCommand(threadEnvironment.reorderQueuedRun, "reorder queued message");
   const promote = useAtomCommand(threadEnvironment.promoteQueuedRun, "promote queued message");
+  const cancel = useAtomCommand(threadEnvironment.cancelQueuedRun, "cancel queued message");
   const [busyRunId, setBusyRunId] = useState<RunId | null>(null);
   const iconColor = useThemeColor("--color-icon-subtle");
 
@@ -52,6 +62,19 @@ export function ThreadQueueControl(props: {
     setBusyRunId(null);
   };
 
+  const dismiss = async (runId: RunId) => {
+    setBusyRunId(runId);
+    void Haptics.selectionAsync();
+    await cancel(
+      buildCancelQueuedRunCommand({
+        environmentId: props.environmentId,
+        runId,
+        threadId: props.threadId,
+      }),
+    );
+    setBusyRunId(null);
+  };
+
   return (
     <View className="mx-4 mb-3 overflow-hidden rounded-2xl border border-neutral-300/60 bg-card dark:border-white/[0.1]">
       <View className="flex-row items-center gap-2 border-b border-neutral-300/50 px-3 py-2 dark:border-white/[0.08]">
@@ -62,53 +85,73 @@ export function ThreadQueueControl(props: {
         </Text>
       </View>
       <ScrollView style={{ maxHeight: 156 }} contentContainerStyle={{ paddingVertical: 4 }}>
-        {workflow.queuedRuns.map(({ run, text }, index) => (
-          <View key={run.id} className="min-h-11 flex-row items-center gap-1.5 px-2">
-            <Text className="w-5 text-right text-3xs tabular-nums text-foreground-muted">
-              {index + 1}
-            </Text>
-            <Text className="min-w-0 flex-1 text-xs text-foreground" numberOfLines={1}>
-              {text}
-            </Text>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Move queued message up"
-              disabled={busyRunId !== null || !workflow.canReorder || index === 0}
-              onPress={() => void move(run.id, workflow.queuedRuns[index - 1]?.run.id ?? null)}
-              className="h-9 w-9 items-center justify-center disabled:opacity-30"
-            >
-              <SymbolView name="arrow.up" size={13} tintColor={iconColor} type="monochrome" />
-            </Pressable>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Move queued message down"
-              disabled={
-                busyRunId !== null ||
-                !workflow.canReorder ||
-                index === workflow.queuedRuns.length - 1
-              }
-              onPress={() => void move(run.id, workflow.queuedRuns[index + 2]?.run.id ?? null)}
-              className="h-9 w-9 items-center justify-center disabled:opacity-30"
-            >
-              <SymbolView name="arrow.down" size={13} tintColor={iconColor} type="monochrome" />
-            </Pressable>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Promote queued message to steer"
-              disabled={busyRunId !== null || !workflow.canPromoteToSteer}
-              onPress={() => void steer(run.id)}
-              className="min-h-8 flex-row items-center gap-1 rounded-lg border border-neutral-300/60 px-2 disabled:opacity-30 dark:border-white/[0.1]"
-            >
-              <SymbolView
-                name="arrow.turn.left.up"
-                size={12}
-                tintColor={iconColor}
-                type="monochrome"
-              />
-              <Text className="font-t3-medium text-2xs text-foreground">Steer</Text>
-            </Pressable>
-          </View>
-        ))}
+        {workflow.queuedRuns.map(({ run, text }, index) => {
+          const controls = resolveThreadQueueRowControls({
+            automaticCompletionMessageIds,
+            busy: busyRunId !== null,
+            canPromoteToSteer: workflow.canPromoteToSteer,
+            canReorder: workflow.canReorder,
+            index,
+            queuedCount: workflow.queuedRuns.length,
+            text,
+            userMessageId: run.userMessageId,
+          });
+
+          return (
+            <View key={run.id} className="min-h-11 flex-row items-center gap-1.5 px-2">
+              <Text className="w-5 text-right text-3xs tabular-nums text-foreground-muted">
+                {index + 1}
+              </Text>
+              <Text className="min-w-0 flex-1 text-xs text-foreground" numberOfLines={1}>
+                {controls.displayText}
+              </Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Move queued message up"
+                disabled={!controls.canMoveUp}
+                onPress={() => void move(run.id, workflow.queuedRuns[index - 1]?.run.id ?? null)}
+                className="h-9 w-9 items-center justify-center disabled:opacity-30"
+              >
+                <SymbolView name="arrow.up" size={13} tintColor={iconColor} type="monochrome" />
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Move queued message down"
+                disabled={!controls.canMoveDown}
+                onPress={() => void move(run.id, workflow.queuedRuns[index + 2]?.run.id ?? null)}
+                className="h-9 w-9 items-center justify-center disabled:opacity-30"
+              >
+                <SymbolView name="arrow.down" size={13} tintColor={iconColor} type="monochrome" />
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Promote queued message to steer"
+                disabled={!controls.canSteer}
+                onPress={() => void steer(run.id)}
+                className="min-h-8 flex-row items-center gap-1 rounded-lg border border-neutral-300/60 px-2 disabled:opacity-30 dark:border-white/[0.1]"
+              >
+                <SymbolView
+                  name="arrow.turn.left.up"
+                  size={12}
+                  tintColor={iconColor}
+                  type="monochrome"
+                />
+                <Text className="font-t3-medium text-2xs text-foreground">Steer</Text>
+              </Pressable>
+              {controls.automaticCompletion ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={controls.dismissAccessibilityLabel ?? undefined}
+                  disabled={!controls.canDismiss}
+                  onPress={() => void dismiss(run.id)}
+                  className="h-9 w-9 items-center justify-center disabled:opacity-30"
+                >
+                  <SymbolView name="xmark" size={13} tintColor={iconColor} type="monochrome" />
+                </Pressable>
+              ) : null}
+            </View>
+          );
+        })}
       </ScrollView>
     </View>
   );

--- a/apps/mobile/src/features/threads/threadQueueControlPresentation.test.ts
+++ b/apps/mobile/src/features/threads/threadQueueControlPresentation.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  AUTOMATIC_COMPLETION_DELIVERY_LABEL,
+  DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL,
+  buildCancelQueuedRunCommand,
+  collectAutomaticCompletionMessageIds,
+  resolveThreadQueueRowControls,
+} from "./threadQueueControlPresentation";
+
+const automaticIds = collectAutomaticCompletionMessageIds([
+  {
+    delegatedCompletion: {
+      generation: 1,
+      parentRunId: "run:parent",
+      taskIds: ["task:child"],
+    },
+    id: "message:completion",
+  },
+  {
+    id: "message:ordinary",
+  },
+]);
+
+describe("threadQueueControlPresentation", () => {
+  it("detects automatic completion message ownership", () => {
+    expect(automaticIds.has("message:completion")).toBe(true);
+    expect(automaticIds.has("message:ordinary")).toBe(false);
+  });
+
+  it("locks mutation controls for automatic completion rows while enabling dismissal", () => {
+    const controls = resolveThreadQueueRowControls({
+      automaticCompletionMessageIds: automaticIds,
+      busy: false,
+      canPromoteToSteer: true,
+      canReorder: true,
+      index: 1,
+      queuedCount: 3,
+      text: "A delegated task reached a terminal state.",
+      userMessageId: "message:completion",
+    });
+
+    expect(controls.automaticCompletion).toBe(true);
+    expect(controls.displayText).toBe(AUTOMATIC_COMPLETION_DELIVERY_LABEL);
+    expect(controls.canMoveUp).toBe(false);
+    expect(controls.canMoveDown).toBe(false);
+    expect(controls.canSteer).toBe(false);
+    expect(controls.canDismiss).toBe(true);
+    expect(controls.dismissAccessibilityLabel).toBe(
+      DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL,
+    );
+  });
+
+  it("preserves ordinary queue reorder and steer controls without dismissal", () => {
+    const controls = resolveThreadQueueRowControls({
+      automaticCompletionMessageIds: automaticIds,
+      busy: false,
+      canPromoteToSteer: true,
+      canReorder: true,
+      index: 1,
+      queuedCount: 3,
+      text: "Please review the follow-up change.",
+      userMessageId: "message:ordinary",
+    });
+
+    expect(controls.automaticCompletion).toBe(false);
+    expect(controls.displayText).toBe("Please review the follow-up change.");
+    expect(controls.canMoveUp).toBe(true);
+    expect(controls.canMoveDown).toBe(true);
+    expect(controls.canSteer).toBe(true);
+    expect(controls.canDismiss).toBe(false);
+    expect(controls.dismissAccessibilityLabel).toBeNull();
+  });
+
+  it("disables edge reorder controls and busy dismissal", () => {
+    const firstOrdinary = resolveThreadQueueRowControls({
+      automaticCompletionMessageIds: automaticIds,
+      busy: false,
+      canPromoteToSteer: false,
+      canReorder: true,
+      index: 0,
+      queuedCount: 2,
+      text: "First",
+      userMessageId: "message:ordinary",
+    });
+    const busyAutomatic = resolveThreadQueueRowControls({
+      automaticCompletionMessageIds: automaticIds,
+      busy: true,
+      canPromoteToSteer: true,
+      canReorder: true,
+      index: 0,
+      queuedCount: 1,
+      text: "A delegated task reached a terminal state.",
+      userMessageId: "message:completion",
+    });
+
+    expect(firstOrdinary.canMoveUp).toBe(false);
+    expect(firstOrdinary.canMoveDown).toBe(true);
+    expect(firstOrdinary.canSteer).toBe(false);
+    expect(busyAutomatic.canDismiss).toBe(false);
+    expect(busyAutomatic.canMoveUp).toBe(false);
+    expect(busyAutomatic.canSteer).toBe(false);
+  });
+
+  it("builds cancelQueuedRun command arguments for dismissal", () => {
+    expect(
+      buildCancelQueuedRunCommand({
+        environmentId: "environment:test" as never,
+        runId: "run:completion" as never,
+        threadId: "thread:test" as never,
+      }),
+    ).toEqual({
+      environmentId: "environment:test",
+      input: {
+        runId: "run:completion",
+        threadId: "thread:test",
+      },
+    });
+  });
+});

--- a/apps/mobile/src/features/threads/threadQueueControlPresentation.test.ts
+++ b/apps/mobile/src/features/threads/threadQueueControlPresentation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   AUTOMATIC_COMPLETION_DELIVERY_LABEL,
   DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL,
+  REMOVE_QUEUED_MESSAGE_ACCESSIBILITY_LABEL,
   buildCancelQueuedRunCommand,
   collectAutomaticCompletionMessageIds,
   resolveThreadQueueRowControls,
@@ -51,7 +52,7 @@ describe("threadQueueControlPresentation", () => {
     );
   });
 
-  it("preserves ordinary queue reorder and steer controls without dismissal", () => {
+  it("preserves ordinary queue reorder and steer controls with removal", () => {
     const controls = resolveThreadQueueRowControls({
       automaticCompletionMessageIds: automaticIds,
       busy: false,
@@ -68,8 +69,8 @@ describe("threadQueueControlPresentation", () => {
     expect(controls.canMoveUp).toBe(true);
     expect(controls.canMoveDown).toBe(true);
     expect(controls.canSteer).toBe(true);
-    expect(controls.canDismiss).toBe(false);
-    expect(controls.dismissAccessibilityLabel).toBeNull();
+    expect(controls.canDismiss).toBe(true);
+    expect(controls.dismissAccessibilityLabel).toBe(REMOVE_QUEUED_MESSAGE_ACCESSIBILITY_LABEL);
   });
 
   it("disables edge reorder controls and busy dismissal", () => {

--- a/apps/mobile/src/features/threads/threadQueueControlPresentation.test.ts
+++ b/apps/mobile/src/features/threads/threadQueueControlPresentation.test.ts
@@ -1,70 +1,22 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  AUTOMATIC_COMPLETION_DELIVERY_LABEL,
-  DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL,
   REMOVE_QUEUED_MESSAGE_ACCESSIBILITY_LABEL,
   buildCancelQueuedRunCommand,
-  collectAutomaticCompletionMessageIds,
   resolveThreadQueueRowControls,
 } from "./threadQueueControlPresentation";
 
-const automaticIds = collectAutomaticCompletionMessageIds([
-  {
-    delegatedCompletion: {
-      generation: 1,
-      parentRunId: "run:parent",
-      taskIds: ["task:child"],
-    },
-    id: "message:completion",
-  },
-  {
-    id: "message:ordinary",
-  },
-]);
-
 describe("threadQueueControlPresentation", () => {
-  it("detects automatic completion message ownership", () => {
-    expect(automaticIds.has("message:completion")).toBe(true);
-    expect(automaticIds.has("message:ordinary")).toBe(false);
-  });
-
-  it("locks mutation controls for automatic completion rows while enabling dismissal", () => {
+  it("preserves queue reorder and steer controls with removal", () => {
     const controls = resolveThreadQueueRowControls({
-      automaticCompletionMessageIds: automaticIds,
-      busy: false,
-      canPromoteToSteer: true,
-      canReorder: true,
-      index: 1,
-      queuedCount: 3,
-      text: "A delegated task reached a terminal state.",
-      userMessageId: "message:completion",
-    });
-
-    expect(controls.automaticCompletion).toBe(true);
-    expect(controls.displayText).toBe(AUTOMATIC_COMPLETION_DELIVERY_LABEL);
-    expect(controls.canMoveUp).toBe(false);
-    expect(controls.canMoveDown).toBe(false);
-    expect(controls.canSteer).toBe(false);
-    expect(controls.canDismiss).toBe(true);
-    expect(controls.dismissAccessibilityLabel).toBe(
-      DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL,
-    );
-  });
-
-  it("preserves ordinary queue reorder and steer controls with removal", () => {
-    const controls = resolveThreadQueueRowControls({
-      automaticCompletionMessageIds: automaticIds,
       busy: false,
       canPromoteToSteer: true,
       canReorder: true,
       index: 1,
       queuedCount: 3,
       text: "Please review the follow-up change.",
-      userMessageId: "message:ordinary",
     });
 
-    expect(controls.automaticCompletion).toBe(false);
     expect(controls.displayText).toBe("Please review the follow-up change.");
     expect(controls.canMoveUp).toBe(true);
     expect(controls.canMoveDown).toBe(true);
@@ -74,46 +26,42 @@ describe("threadQueueControlPresentation", () => {
   });
 
   it("disables edge reorder controls and busy dismissal", () => {
-    const firstOrdinary = resolveThreadQueueRowControls({
-      automaticCompletionMessageIds: automaticIds,
+    const first = resolveThreadQueueRowControls({
       busy: false,
       canPromoteToSteer: false,
       canReorder: true,
       index: 0,
       queuedCount: 2,
       text: "First",
-      userMessageId: "message:ordinary",
     });
-    const busyAutomatic = resolveThreadQueueRowControls({
-      automaticCompletionMessageIds: automaticIds,
+    const busy = resolveThreadQueueRowControls({
       busy: true,
       canPromoteToSteer: true,
       canReorder: true,
       index: 0,
       queuedCount: 1,
-      text: "A delegated task reached a terminal state.",
-      userMessageId: "message:completion",
+      text: "Queued message",
     });
 
-    expect(firstOrdinary.canMoveUp).toBe(false);
-    expect(firstOrdinary.canMoveDown).toBe(true);
-    expect(firstOrdinary.canSteer).toBe(false);
-    expect(busyAutomatic.canDismiss).toBe(false);
-    expect(busyAutomatic.canMoveUp).toBe(false);
-    expect(busyAutomatic.canSteer).toBe(false);
+    expect(first.canMoveUp).toBe(false);
+    expect(first.canMoveDown).toBe(true);
+    expect(first.canSteer).toBe(false);
+    expect(busy.canDismiss).toBe(false);
+    expect(busy.canMoveUp).toBe(false);
+    expect(busy.canSteer).toBe(false);
   });
 
-  it("builds cancelQueuedRun command arguments for dismissal", () => {
+  it("builds cancelQueuedRun command arguments for removal", () => {
     expect(
       buildCancelQueuedRunCommand({
         environmentId: "environment:test" as never,
-        runId: "run:completion" as never,
+        runId: "run:queued" as never,
         threadId: "thread:test" as never,
       }),
     ).toEqual({
       environmentId: "environment:test",
       input: {
-        runId: "run:completion",
+        runId: "run:queued",
         threadId: "thread:test",
       },
     });

--- a/apps/mobile/src/features/threads/threadQueueControlPresentation.ts
+++ b/apps/mobile/src/features/threads/threadQueueControlPresentation.ts
@@ -3,6 +3,7 @@ import type { EnvironmentId, RunId, ThreadId } from "@t3tools/contracts";
 export const AUTOMATIC_COMPLETION_DELIVERY_LABEL = "Automatic completion delivery";
 export const DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL =
   "Dismiss automatic completion delivery";
+export const REMOVE_QUEUED_MESSAGE_ACCESSIBILITY_LABEL = "Remove queued message";
 
 export function collectAutomaticCompletionMessageIds(
   messages: ReadonlyArray<{
@@ -23,7 +24,7 @@ export interface ThreadQueueRowControls {
   readonly canMoveDown: boolean;
   readonly canMoveUp: boolean;
   readonly canSteer: boolean;
-  readonly dismissAccessibilityLabel: string | null;
+  readonly dismissAccessibilityLabel: string;
   readonly displayText: string;
 }
 
@@ -42,13 +43,13 @@ export function resolveThreadQueueRowControls(input: {
 
   return {
     automaticCompletion,
-    canDismiss: automaticCompletion && !input.busy,
+    canDismiss: !input.busy,
     canMoveDown: mutationEnabled && input.canReorder && input.index < input.queuedCount - 1,
     canMoveUp: mutationEnabled && input.canReorder && input.index > 0,
     canSteer: mutationEnabled && input.canPromoteToSteer,
     dismissAccessibilityLabel: automaticCompletion
       ? DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL
-      : null,
+      : REMOVE_QUEUED_MESSAGE_ACCESSIBILITY_LABEL,
     displayText: automaticCompletion ? AUTOMATIC_COMPLETION_DELIVERY_LABEL : input.text,
   };
 }

--- a/apps/mobile/src/features/threads/threadQueueControlPresentation.ts
+++ b/apps/mobile/src/features/threads/threadQueueControlPresentation.ts
@@ -1,0 +1,74 @@
+import type { EnvironmentId, RunId, ThreadId } from "@t3tools/contracts";
+
+export const AUTOMATIC_COMPLETION_DELIVERY_LABEL = "Automatic completion delivery";
+export const DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL =
+  "Dismiss automatic completion delivery";
+
+export function collectAutomaticCompletionMessageIds(
+  messages: ReadonlyArray<{
+    readonly id: string;
+    readonly delegatedCompletion?: unknown;
+  }>,
+): ReadonlySet<string> {
+  return new Set(
+    messages
+      .filter((message) => message.delegatedCompletion !== undefined)
+      .map((message) => message.id),
+  );
+}
+
+export interface ThreadQueueRowControls {
+  readonly automaticCompletion: boolean;
+  readonly canDismiss: boolean;
+  readonly canMoveDown: boolean;
+  readonly canMoveUp: boolean;
+  readonly canSteer: boolean;
+  readonly dismissAccessibilityLabel: string | null;
+  readonly displayText: string;
+}
+
+export function resolveThreadQueueRowControls(input: {
+  readonly automaticCompletionMessageIds: ReadonlySet<string>;
+  readonly busy: boolean;
+  readonly canPromoteToSteer: boolean;
+  readonly canReorder: boolean;
+  readonly index: number;
+  readonly queuedCount: number;
+  readonly text: string;
+  readonly userMessageId: string;
+}): ThreadQueueRowControls {
+  const automaticCompletion = input.automaticCompletionMessageIds.has(input.userMessageId);
+  const mutationEnabled = !input.busy && !automaticCompletion;
+
+  return {
+    automaticCompletion,
+    canDismiss: automaticCompletion && !input.busy,
+    canMoveDown: mutationEnabled && input.canReorder && input.index < input.queuedCount - 1,
+    canMoveUp: mutationEnabled && input.canReorder && input.index > 0,
+    canSteer: mutationEnabled && input.canPromoteToSteer,
+    dismissAccessibilityLabel: automaticCompletion
+      ? DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL
+      : null,
+    displayText: automaticCompletion ? AUTOMATIC_COMPLETION_DELIVERY_LABEL : input.text,
+  };
+}
+
+export function buildCancelQueuedRunCommand(input: {
+  readonly environmentId: EnvironmentId;
+  readonly runId: RunId;
+  readonly threadId: ThreadId;
+}): {
+  readonly environmentId: EnvironmentId;
+  readonly input: {
+    readonly runId: RunId;
+    readonly threadId: ThreadId;
+  };
+} {
+  return {
+    environmentId: input.environmentId,
+    input: {
+      runId: input.runId,
+      threadId: input.threadId,
+    },
+  };
+}

--- a/apps/mobile/src/features/threads/threadQueueControlPresentation.ts
+++ b/apps/mobile/src/features/threads/threadQueueControlPresentation.ts
@@ -1,25 +1,8 @@
 import type { EnvironmentId, RunId, ThreadId } from "@t3tools/contracts";
 
-export const AUTOMATIC_COMPLETION_DELIVERY_LABEL = "Automatic completion delivery";
-export const DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL =
-  "Dismiss automatic completion delivery";
 export const REMOVE_QUEUED_MESSAGE_ACCESSIBILITY_LABEL = "Remove queued message";
 
-export function collectAutomaticCompletionMessageIds(
-  messages: ReadonlyArray<{
-    readonly id: string;
-    readonly delegatedCompletion?: unknown;
-  }>,
-): ReadonlySet<string> {
-  return new Set(
-    messages
-      .filter((message) => message.delegatedCompletion !== undefined)
-      .map((message) => message.id),
-  );
-}
-
 export interface ThreadQueueRowControls {
-  readonly automaticCompletion: boolean;
   readonly canDismiss: boolean;
   readonly canMoveDown: boolean;
   readonly canMoveUp: boolean;
@@ -29,28 +12,22 @@ export interface ThreadQueueRowControls {
 }
 
 export function resolveThreadQueueRowControls(input: {
-  readonly automaticCompletionMessageIds: ReadonlySet<string>;
   readonly busy: boolean;
   readonly canPromoteToSteer: boolean;
   readonly canReorder: boolean;
   readonly index: number;
   readonly queuedCount: number;
   readonly text: string;
-  readonly userMessageId: string;
 }): ThreadQueueRowControls {
-  const automaticCompletion = input.automaticCompletionMessageIds.has(input.userMessageId);
-  const mutationEnabled = !input.busy && !automaticCompletion;
+  const mutationEnabled = !input.busy;
 
   return {
-    automaticCompletion,
     canDismiss: !input.busy,
     canMoveDown: mutationEnabled && input.canReorder && input.index < input.queuedCount - 1,
     canMoveUp: mutationEnabled && input.canReorder && input.index > 0,
     canSteer: mutationEnabled && input.canPromoteToSteer,
-    dismissAccessibilityLabel: automaticCompletion
-      ? DISMISS_AUTOMATIC_COMPLETION_ACCESSIBILITY_LABEL
-      : REMOVE_QUEUED_MESSAGE_ACCESSIBILITY_LABEL,
-    displayText: automaticCompletion ? AUTOMATIC_COMPLETION_DELIVERY_LABEL : input.text,
+    dismissAccessibilityLabel: REMOVE_QUEUED_MESSAGE_ACCESSIBILITY_LABEL,
+    displayText: input.text,
   };
 }
 

--- a/apps/server/src/mcp/OrchestratorMcpService.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.test.ts
@@ -1,0 +1,217 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import {
+  EnvironmentId,
+  NodeId,
+  ProviderInstanceId,
+  RunId,
+  ThreadId,
+  type OrchestrationV2ThreadProjection,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
+import { ThreadManagementService } from "../orchestration-v2/ThreadManagementService.ts";
+import { ProviderRegistry } from "../provider/Services/ProviderRegistry.ts";
+import { ScheduledTaskService } from "../scheduledTasks/ScheduledTaskService.ts";
+import type { McpInvocationScope } from "./McpInvocationContext.ts";
+import { layer, OrchestratorMcpService } from "./OrchestratorMcpService.ts";
+
+describe("OrchestratorMcpService", () => {
+  it.effect("does not dispose delivery when a nonterminal task has no active child run", () =>
+    Effect.gen(function* () {
+      const parentThreadId = ThreadId.make("thread:mcp-cancel-parent");
+      const childThreadId = ThreadId.make("thread:mcp-cancel-child");
+      const taskId = NodeId.make("node:mcp-cancel-task");
+      const dispatched = yield* Ref.make<ReadonlyArray<unknown>>([]);
+      const parentProjection = {
+        thread: { id: parentThreadId },
+        runs: [],
+        contextTransfers: [],
+        subagents: [
+          {
+            id: taskId,
+            threadId: parentThreadId,
+            origin: "app_owned",
+            childThreadId,
+            driver: "codex",
+            model: "gpt-5.6-terra",
+            result: null,
+            completionDelivery: { state: "pending" },
+          },
+        ],
+      } as unknown as OrchestrationV2ThreadProjection;
+      const childProjection = {
+        thread: { id: childThreadId },
+        runs: [],
+        contextTransfers: [],
+      } as unknown as OrchestrationV2ThreadProjection;
+      const dependencies = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(ThreadManagementService)({
+          getThreadProjection: (threadId) =>
+            Effect.succeed(threadId === parentThreadId ? parentProjection : childProjection),
+          dispatch: (command) =>
+            Ref.update(dispatched, (commands) => [...commands, command]).pipe(
+              Effect.as({} as never),
+            ),
+        }),
+        Layer.mock(ProviderRegistry)({ getProviders: Effect.succeed([]) }),
+        Layer.mock(ScheduledTaskService)({}),
+      );
+      const scope: McpInvocationScope = {
+        environmentId: EnvironmentId.make("environment:mcp-cancel"),
+        threadId: parentThreadId,
+        providerSessionId: "provider-session:mcp-cancel",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(["orchestration"]),
+        issuedAt: 1,
+      };
+
+      yield* Effect.gen(function* () {
+        const service = yield* OrchestratorMcpService;
+        const error = yield* service
+          .cancelTask(scope, { taskId, clientRequestId: "cancel-unstarted-task" })
+          .pipe(Effect.flip);
+        assert.equal(error.code, "task_not_cancellable");
+        assert.deepEqual(yield* Ref.get(dispatched), []);
+      }).pipe(Effect.provide(layer.pipe(Layer.provide(dependencies))));
+    }),
+  );
+
+  it.effect("does not dispose delivery when the child interrupt fails", () =>
+    Effect.gen(function* () {
+      const parentThreadId = ThreadId.make("thread:mcp-cancel-failed-parent");
+      const childThreadId = ThreadId.make("thread:mcp-cancel-failed-child");
+      const childRunId = RunId.make("run:mcp-cancel-failed-child");
+      const taskId = NodeId.make("node:mcp-cancel-failed-task");
+      const dispatched = yield* Ref.make<ReadonlyArray<unknown>>([]);
+      const parentProjection = {
+        thread: { id: parentThreadId },
+        runs: [],
+        contextTransfers: [],
+        subagents: [
+          {
+            id: taskId,
+            threadId: parentThreadId,
+            origin: "app_owned",
+            childThreadId,
+            driver: "codex",
+            model: "gpt-5.6-terra",
+            result: null,
+            completionDelivery: { state: "pending" },
+          },
+        ],
+      } as unknown as OrchestrationV2ThreadProjection;
+      const childProjection = {
+        thread: { id: childThreadId },
+        runs: [{ id: childRunId, status: "running" }],
+        contextTransfers: [],
+      } as unknown as OrchestrationV2ThreadProjection;
+      const dependencies = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(ThreadManagementService)({
+          getThreadProjection: (threadId) =>
+            Effect.succeed(threadId === parentThreadId ? parentProjection : childProjection),
+          dispatch: (command) =>
+            Ref.update(dispatched, (commands) => [...commands, command]).pipe(
+              Effect.andThen(Effect.fail(new Error("simulated interrupt failure") as never)),
+            ),
+        }),
+        Layer.mock(ProviderRegistry)({ getProviders: Effect.succeed([]) }),
+        Layer.mock(ScheduledTaskService)({}),
+      );
+      const scope: McpInvocationScope = {
+        environmentId: EnvironmentId.make("environment:mcp-cancel-failed"),
+        threadId: parentThreadId,
+        providerSessionId: "provider-session:mcp-cancel-failed",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(["orchestration"]),
+        issuedAt: 1,
+      };
+
+      yield* Effect.gen(function* () {
+        const service = yield* OrchestratorMcpService;
+        const error = yield* service
+          .cancelTask(scope, { taskId, clientRequestId: "cancel-failed-task" })
+          .pipe(Effect.flip);
+        assert.equal(error.code, "task_not_cancellable");
+        assert.deepEqual(
+          (yield* Ref.get(dispatched)).map((command) => (command as { type: string }).type),
+          ["run.interrupt"],
+        );
+      }).pipe(Effect.provide(layer.pipe(Layer.provide(dependencies))));
+    }),
+  );
+
+  it.effect("returns cancel requested when post-interrupt disposal fails", () =>
+    Effect.gen(function* () {
+      const parentThreadId = ThreadId.make("thread:mcp-cancel-dispose-failed-parent");
+      const childThreadId = ThreadId.make("thread:mcp-cancel-dispose-failed-child");
+      const childRunId = RunId.make("run:mcp-cancel-dispose-failed-child");
+      const taskId = NodeId.make("node:mcp-cancel-dispose-failed-task");
+      const dispatched = yield* Ref.make<ReadonlyArray<unknown>>([]);
+      const parentProjection = {
+        thread: { id: parentThreadId },
+        runs: [],
+        contextTransfers: [],
+        subagents: [
+          {
+            id: taskId,
+            threadId: parentThreadId,
+            origin: "app_owned",
+            childThreadId,
+            driver: "codex",
+            model: "gpt-5.6-terra",
+            result: null,
+            completionDelivery: { state: "pending" },
+          },
+        ],
+      } as unknown as OrchestrationV2ThreadProjection;
+      const childProjection = {
+        thread: { id: childThreadId },
+        runs: [{ id: childRunId, status: "running" }],
+        contextTransfers: [],
+      } as unknown as OrchestrationV2ThreadProjection;
+      const dependencies = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(ThreadManagementService)({
+          getThreadProjection: (threadId) =>
+            Effect.succeed(threadId === parentThreadId ? parentProjection : childProjection),
+          dispatch: (command) =>
+            Ref.update(dispatched, (commands) => [...commands, command]).pipe(
+              Effect.andThen(
+                command.type === "delegated_task.completion-delivery.dispose"
+                  ? Effect.fail(new Error("simulated disposal failure") as never)
+                  : Effect.succeed({} as never),
+              ),
+            ),
+        }),
+        Layer.mock(ProviderRegistry)({ getProviders: Effect.succeed([]) }),
+        Layer.mock(ScheduledTaskService)({}),
+      );
+      const scope: McpInvocationScope = {
+        environmentId: EnvironmentId.make("environment:mcp-cancel-dispose-failed"),
+        threadId: parentThreadId,
+        providerSessionId: "provider-session:mcp-cancel-dispose-failed",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(["orchestration"]),
+        issuedAt: 1,
+      };
+
+      yield* Effect.gen(function* () {
+        const service = yield* OrchestratorMcpService;
+        const result = yield* service.cancelTask(scope, {
+          taskId,
+          clientRequestId: "cancel-dispose-failed-task",
+        });
+        assert.equal(result.status, "cancel_requested");
+        assert.deepEqual(
+          (yield* Ref.get(dispatched)).map((command) => (command as { type: string }).type),
+          ["run.interrupt", "delegated_task.completion-delivery.dispose"],
+        );
+      }).pipe(Effect.provide(layer.pipe(Layer.provide(dependencies))));
+    }),
+  );
+});

--- a/apps/server/src/mcp/OrchestratorMcpService.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.test.ts
@@ -16,9 +16,84 @@ import { ThreadManagementService } from "../orchestration-v2/ThreadManagementSer
 import { ProviderRegistry } from "../provider/Services/ProviderRegistry.ts";
 import { ScheduledTaskService } from "../scheduledTasks/ScheduledTaskService.ts";
 import type { McpInvocationScope } from "./McpInvocationContext.ts";
-import { layer, OrchestratorMcpService } from "./OrchestratorMcpService.ts";
+import * as OrchestratorMcpService from "./OrchestratorMcpService.ts";
 
 describe("OrchestratorMcpService", () => {
+  it.effect("retries terminal acknowledgement with a fresh command id", () =>
+    Effect.gen(function* () {
+      const parentThreadId = ThreadId.make("thread:mcp-ack-parent");
+      const childThreadId = ThreadId.make("thread:mcp-ack-child");
+      const childRunId = RunId.make("run:mcp-ack-child");
+      const taskId = NodeId.make("node:mcp-ack-task");
+      const acknowledgementCommandIds = yield* Ref.make<ReadonlyArray<string>>([]);
+      const acknowledgementAttempts = yield* Ref.make(0);
+      const parentProjection = {
+        thread: { id: parentThreadId },
+        runs: [],
+        contextTransfers: [],
+        subagents: [
+          {
+            id: taskId,
+            threadId: parentThreadId,
+            origin: "app_owned",
+            childThreadId,
+            driver: "codex",
+            model: "gpt-5.6-terra",
+            result: "terminal result",
+            completionDelivery: { state: "pending" },
+          },
+        ],
+      } as unknown as OrchestrationV2ThreadProjection;
+      const childProjection = {
+        thread: { id: childThreadId },
+        runs: [{ id: childRunId, ordinal: 1, status: "completed" }],
+        contextTransfers: [],
+      } as unknown as OrchestrationV2ThreadProjection;
+      const dependencies = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(ThreadManagementService)({
+          getThreadProjection: (threadId) =>
+            Effect.succeed(threadId === parentThreadId ? parentProjection : childProjection),
+          dispatch: (command) =>
+            Ref.update(acknowledgementCommandIds, (commandIds) => [
+              ...commandIds,
+              String(command.commandId),
+            ]).pipe(
+              Effect.andThen(Ref.updateAndGet(acknowledgementAttempts, (count) => count + 1)),
+              Effect.flatMap((attempt) =>
+                attempt === 1
+                  ? Effect.fail(new Error("simulated acknowledgement failure") as never)
+                  : Effect.succeed({} as never),
+              ),
+            ),
+        }),
+        Layer.mock(ProviderRegistry)({ getProviders: Effect.succeed([]) }),
+        Layer.mock(ScheduledTaskService)({}),
+      );
+      const scope: McpInvocationScope = {
+        environmentId: EnvironmentId.make("environment:mcp-ack"),
+        threadId: parentThreadId,
+        providerSessionId: "provider-session:mcp-ack",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(["orchestration"]),
+        issuedAt: 1,
+      };
+
+      yield* Effect.gen(function* () {
+        const service = yield* OrchestratorMcpService.OrchestratorMcpService;
+        const error = yield* service.taskStatus(scope, taskId).pipe(Effect.flip);
+        assert.equal(error.code, "orchestration_error");
+
+        const result = yield* service.taskStatus(scope, taskId);
+        assert.equal(result.status, "completed");
+        assert.equal(result.summary, "terminal result");
+        const commandIds = yield* Ref.get(acknowledgementCommandIds);
+        assert.equal(commandIds.length, 2);
+        assert.notEqual(commandIds[0], commandIds[1]);
+      }).pipe(Effect.provide(OrchestratorMcpService.layer.pipe(Layer.provide(dependencies))));
+    }),
+  );
+
   it.effect("does not dispose delivery when a nonterminal task has no active child run", () =>
     Effect.gen(function* () {
       const parentThreadId = ThreadId.make("thread:mcp-cancel-parent");
@@ -70,13 +145,13 @@ describe("OrchestratorMcpService", () => {
       };
 
       yield* Effect.gen(function* () {
-        const service = yield* OrchestratorMcpService;
+        const service = yield* OrchestratorMcpService.OrchestratorMcpService;
         const error = yield* service
           .cancelTask(scope, { taskId, clientRequestId: "cancel-unstarted-task" })
           .pipe(Effect.flip);
         assert.equal(error.code, "task_not_cancellable");
         assert.deepEqual(yield* Ref.get(dispatched), []);
-      }).pipe(Effect.provide(layer.pipe(Layer.provide(dependencies))));
+      }).pipe(Effect.provide(OrchestratorMcpService.layer.pipe(Layer.provide(dependencies))));
     }),
   );
 
@@ -132,7 +207,7 @@ describe("OrchestratorMcpService", () => {
       };
 
       yield* Effect.gen(function* () {
-        const service = yield* OrchestratorMcpService;
+        const service = yield* OrchestratorMcpService.OrchestratorMcpService;
         const error = yield* service
           .cancelTask(scope, { taskId, clientRequestId: "cancel-failed-task" })
           .pipe(Effect.flip);
@@ -141,7 +216,7 @@ describe("OrchestratorMcpService", () => {
           (yield* Ref.get(dispatched)).map((command) => (command as { type: string }).type),
           ["run.interrupt"],
         );
-      }).pipe(Effect.provide(layer.pipe(Layer.provide(dependencies))));
+      }).pipe(Effect.provide(OrchestratorMcpService.layer.pipe(Layer.provide(dependencies))));
     }),
   );
 
@@ -201,7 +276,7 @@ describe("OrchestratorMcpService", () => {
       };
 
       yield* Effect.gen(function* () {
-        const service = yield* OrchestratorMcpService;
+        const service = yield* OrchestratorMcpService.OrchestratorMcpService;
         const result = yield* service.cancelTask(scope, {
           taskId,
           clientRequestId: "cancel-dispose-failed-task",
@@ -211,7 +286,7 @@ describe("OrchestratorMcpService", () => {
           (yield* Ref.get(dispatched)).map((command) => (command as { type: string }).type),
           ["run.interrupt", "delegated_task.completion-delivery.dispose"],
         );
-      }).pipe(Effect.provide(layer.pipe(Layer.provide(dependencies))));
+      }).pipe(Effect.provide(OrchestratorMcpService.layer.pipe(Layer.provide(dependencies))));
     }),
   );
 });

--- a/apps/server/src/mcp/OrchestratorMcpService.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.ts
@@ -889,12 +889,13 @@ const make = Effect.gen(function* () {
         task.completionDelivery?.state !== "disposed"
       ) {
         const observingRun = latestActiveRun(parentProjection);
+        const acknowledgementRequestKey = yield* requestKey(undefined);
         yield* threadManagement
           .dispatch({
             type: "delegated_task.completion-delivery.acknowledge",
             commandId: stableCommandId({
               scope,
-              requestKey: String(taskId),
+              requestKey: acknowledgementRequestKey,
               operation: acknowledgementOperation,
             }),
             parentThreadId: scope.threadId,

--- a/apps/server/src/mcp/OrchestratorMcpService.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.ts
@@ -328,6 +328,50 @@ function isTerminalTaskStatus(
   );
 }
 
+function directAppOwnedChildTask(
+  parent: OrchestrationV2ThreadProjection,
+  target: OrchestrationV2ThreadProjection,
+): OrchestrationV2Subagent | undefined {
+  if (
+    target.thread.lineage.parentThreadId !== parent.thread.id ||
+    target.thread.lineage.relationshipToParent !== "subagent"
+  ) {
+    return undefined;
+  }
+  return parent.subagents.find(
+    (task) =>
+      task.origin === "app_owned" &&
+      task.threadId === parent.thread.id &&
+      task.childThreadId === target.thread.id,
+  );
+}
+
+function pageIncludesTerminalTaskResult(input: {
+  readonly page: ReadonlyArray<OrchestrationV2ThreadProjection["visibleTurnItems"][number]>;
+  readonly task: OrchestrationV2Subagent;
+  readonly target: OrchestrationV2ThreadProjection;
+  readonly maxChars: number;
+}): boolean {
+  const run = delegatedTaskRun(input.target, input.task);
+  if (run === undefined || !isTerminalTaskStatus(taskStatusForRun(run))) return false;
+
+  const result = subagentResultForRun(input.target, run);
+  if (result.messageId === null && result.turnItemId === null) return false;
+
+  return input.page.some((row) => {
+    if (row.sourceThreadId !== input.target.thread.id) return false;
+    const matchesResult =
+      (result.turnItemId !== null && row.sourceItemId === result.turnItemId) ||
+      (result.messageId !== null &&
+        row.item.type === "assistant_message" &&
+        row.item.messageId === result.messageId);
+    if (!matchesResult) return false;
+
+    const text = turnItemText(row.item);
+    return text !== null && text.length <= input.maxChars;
+  });
+}
+
 function runtimeModeRank(mode: RuntimeMode): number {
   switch (mode) {
     case "approval-required":
@@ -792,6 +836,8 @@ const make = Effect.gen(function* () {
     scope: McpInvocationScope,
     taskId: NodeId,
     waitTimedOut = false,
+    acknowledgeTerminal = false,
+    acknowledgementOperation = "task-status-acknowledge",
   ): Effect.Effect<OrchestratorMcpDelegateTaskResult, OrchestratorMcpFailure> =>
     Effect.gen(function* () {
       yield* requireCapability(scope);
@@ -824,7 +870,7 @@ const make = Effect.gen(function* () {
             transfer.sourceThreadId === task.childThreadId &&
             transfer.targetThreadId === scope.threadId,
         ) ?? null;
-      return {
+      const response = {
         taskId: task.id,
         childThreadId: task.childThreadId,
         childRunId: childRun?.id ?? null,
@@ -835,13 +881,45 @@ const make = Effect.gen(function* () {
         summary: derivedResult,
         resultContextTransferId: resultTransfer?.id ?? null,
         waitTimedOut,
-      };
+      } satisfies OrchestratorMcpDelegateTaskResult;
+      if (
+        acknowledgeTerminal &&
+        isTerminalTaskStatus(status) &&
+        task.completionDelivery?.state !== "acknowledged" &&
+        task.completionDelivery?.state !== "disposed"
+      ) {
+        const observingRun = latestActiveRun(parentProjection);
+        yield* threadManagement
+          .dispatch({
+            type: "delegated_task.completion-delivery.acknowledge",
+            commandId: stableCommandId({
+              scope,
+              requestKey: String(taskId),
+              operation: acknowledgementOperation,
+            }),
+            parentThreadId: scope.threadId,
+            taskId,
+            observedByRunId:
+              observingRun?.providerInstanceId === scope.providerInstanceId
+                ? observingRun.id
+                : null,
+          })
+          .pipe(
+            Effect.mapError((error) =>
+              failure(
+                "orchestration_error",
+                `Unable to acknowledge delegated task ${taskId}: ${errorMessage(error)}`,
+              ),
+            ),
+          );
+      }
+      return response;
     });
 
   const waitForTask = (scope: McpInvocationScope, taskId: NodeId, timeoutMs: number) =>
     Effect.gen(function* () {
       while (true) {
-        const result = yield* readTask(scope, taskId);
+        const result = yield* readTask(scope, taskId, false, true);
         if (isTerminalTaskStatus(result.status)) return result;
         yield* Effect.sleep(Duration.millis(TASK_POLL_INTERVAL_MS));
       }
@@ -1113,7 +1191,7 @@ const make = Effect.gen(function* () {
         const taskId = taskEvent.event.payload.id;
 
         if (input.mode !== "wait") {
-          return yield* readTask(scope, taskId);
+          return yield* readTask(scope, taskId, false, true);
         }
         const timeoutMs = Math.min(
           MAX_WAIT_TIMEOUT_MS,
@@ -1162,13 +1240,42 @@ const make = Effect.gen(function* () {
               }),
             ),
           );
-        return yield* readTask(scope, taskId, true);
+        return yield* readTask(scope, taskId, true, true);
       }),
-    taskStatus: (scope, taskId) => readTask(scope, taskId),
+    taskStatus: (scope, taskId) => readTask(scope, taskId, false, true),
     cancelTask: (scope, input) =>
       Effect.gen(function* () {
         const current = yield* readTask(scope, input.taskId);
+        const key = yield* requestKey(input.clientRequestId);
+        const parentProjection = yield* loadProjection(scope.threadId);
+        const parentTask = parentProjection.subagents.find(
+          (task) => task.id === input.taskId && task.origin === "app_owned",
+        );
+        const disposeCompletionDelivery =
+          parentTask?.completionDelivery?.state === "disposed"
+            ? Effect.void
+            : threadManagement
+                .dispatch({
+                  type: "delegated_task.completion-delivery.dispose",
+                  commandId: stableCommandId({
+                    scope,
+                    requestKey: key,
+                    operation: "cancel-task-completion-delivery",
+                  }),
+                  parentThreadId: scope.threadId,
+                  taskId: input.taskId,
+                })
+                .pipe(
+                  Effect.asVoid,
+                  Effect.mapError((error) =>
+                    failure(
+                      "orchestration_error",
+                      `Unable to dispose delegated task ${input.taskId} completion delivery: ${errorMessage(error)}`,
+                    ),
+                  ),
+                );
         if (isTerminalTaskStatus(current.status)) {
+          yield* disposeCompletionDelivery;
           return {
             taskId: input.taskId,
             status: current.status,
@@ -1184,7 +1291,6 @@ const make = Effect.gen(function* () {
             `Delegated task ${input.taskId} has no interruptible child run.`,
           );
         }
-        const key = yield* requestKey(input.clientRequestId);
         yield* threadManagement
           .dispatch({
             type: "run.interrupt",
@@ -1205,6 +1311,14 @@ const make = Effect.gen(function* () {
               ),
             ),
           );
+        yield* disposeCompletionDelivery.pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("orchestrator-mcp.cancel-task.delivery-dispose-failed", {
+              taskId: input.taskId,
+              cause,
+            }),
+          ),
+        );
         return {
           taskId: input.taskId,
           status: "cancel_requested",
@@ -1393,7 +1507,7 @@ const make = Effect.gen(function* () {
       }),
     readThread: (scope, input) =>
       Effect.gen(function* () {
-        const { target } = yield* loadScopedThread(scope, input.threadId);
+        const { parent, target } = yield* loadScopedThread(scope, input.threadId);
         const view = input.view ?? "messages";
         const afterPosition = input.afterPosition ?? -1;
         const limit = input.limit ?? DEFAULT_THREAD_READ_LIMIT;
@@ -1429,6 +1543,13 @@ const make = Effect.gen(function* () {
             (projection) => [projection.thread.id, projection.messages] as const,
           ),
         ]);
+        const task = directAppOwnedChildTask(parent, target);
+        if (
+          task !== undefined &&
+          pageIncludesTerminalTaskResult({ page, task, target, maxChars })
+        ) {
+          yield* readTask(scope, task.id, false, true, "thread-read-acknowledge");
+        }
         return {
           thread: threadDetail(target),
           recentRuns: target.runs

--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -33,6 +33,7 @@ import {
   TurnItemId,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as PubSub from "effect/PubSub";
@@ -144,6 +145,7 @@ function makeDeterministicAdapter(input: {
   readonly capabilities: OrchestrationV2ProviderCapabilities;
   readonly capturedTurns: Ref.Ref<ReadonlyArray<CapturedTurn>>;
   readonly shouldComplete: (turn: ProviderAdapterV2TurnInput) => boolean;
+  readonly terminalGate?: (turn: ProviderAdapterV2TurnInput) => Deferred.Deferred<void> | undefined;
   readonly response: (turn: ProviderAdapterV2TurnInput) => string;
 }): ProviderAdapterV2Shape {
   return {
@@ -173,6 +175,7 @@ function makeDeterministicAdapter(input: {
             discard: true,
           });
         const runOrdinals = new Map<ProviderTurnId, number>();
+        const turnInputs = new Map<ProviderTurnId, ProviderAdapterV2TurnInput>();
 
         return {
           instanceId: input.instanceId,
@@ -222,6 +225,7 @@ function makeDeterministicAdapter(input: {
                 `provider-turn:${input.instanceId}:${turnInput.threadId}:${turnInput.runOrdinal}`,
               );
               runOrdinals.set(providerTurnId, turnInput.runOrdinal);
+              turnInputs.set(providerTurnId, turnInput);
               yield* publish([
                 {
                   type: "provider_turn.updated",
@@ -243,7 +247,10 @@ function makeDeterministicAdapter(input: {
                   },
                 },
               ]);
-              if (!input.shouldComplete(turnInput)) {
+              const terminalGate = input.terminalGate?.(turnInput);
+              if (terminalGate !== undefined) {
+                yield* Deferred.await(terminalGate);
+              } else if (!input.shouldComplete(turnInput)) {
                 return;
               }
               const response = input.response(turnInput);
@@ -309,16 +316,45 @@ function makeDeterministicAdapter(input: {
             }),
           steerTurn: () => Effect.void,
           interruptTurn: ({ providerThread, providerTurnId }) =>
-            PubSub.publish(events, {
-              type: "turn.terminal",
-              driver: input.driver,
-              providerThreadId: providerThread.id,
-              providerTurnId,
-              runOrdinal: runOrdinals.get(providerTurnId) ?? 1,
-              status: "interrupted",
-              failure: null,
-              threadDisposition: "reusable",
-            }).pipe(Effect.asVoid),
+            Effect.gen(function* () {
+              const turnInput = turnInputs.get(providerTurnId);
+              const completedAt = yield* DateTime.now;
+              if (turnInput !== undefined) {
+                yield* publish([
+                  {
+                    type: "provider_turn.updated",
+                    driver: input.driver,
+                    providerTurn: {
+                      id: providerTurnId,
+                      providerThreadId: providerThread.id,
+                      nodeId: turnInput.rootNodeId,
+                      runAttemptId: turnInput.attemptId,
+                      nativeTurnRef: {
+                        driver: input.driver,
+                        nativeId: `native-turn:${turnInput.threadId}:${turnInput.runOrdinal}`,
+                        strength: "strong",
+                      },
+                      ordinal: turnInput.providerTurnOrdinal,
+                      status: "interrupted",
+                      startedAt: completedAt,
+                      completedAt,
+                    },
+                  },
+                ]);
+              }
+              yield* publish([
+                {
+                  type: "turn.terminal",
+                  driver: input.driver,
+                  providerThreadId: providerThread.id,
+                  providerTurnId,
+                  runOrdinal: runOrdinals.get(providerTurnId) ?? 1,
+                  status: "interrupted",
+                  failure: null,
+                  threadDisposition: "reusable",
+                },
+              ]);
+            }),
           respondToRuntimeRequest: () => Effect.void,
           readThreadSnapshot: () =>
             unsupported(input.driver, "readThreadSnapshot is unused in this test"),
@@ -394,6 +430,8 @@ describe("orchestrator MCP toolkit", () => {
         Effect.gen(function* () {
           const cwd = yield* checkpointWorkspace("orchestrator-mcp-toolkit");
           const capturedTurns = yield* Ref.make<ReadonlyArray<CapturedTurn>>([]);
+          const parentTerminalGates = new Map<ThreadId, Deferred.Deferred<void>>();
+          const deliveryTerminalGates = new Map<ThreadId, Deferred.Deferred<void>>();
           const registryLayer = makeProviderAdapterRegistryLayer([
             makeDeterministicAdapter({
               instanceId: codexInstanceId,
@@ -402,6 +440,11 @@ describe("orchestrator MCP toolkit", () => {
               capturedTurns,
               shouldComplete: (turn) =>
                 turn.threadId !== parentThreadId && turn.message.text !== cancellationPrompt,
+              terminalGate: (turn) =>
+                turn.message.text.startsWith("Delegated task") ||
+                turn.message.text.startsWith("Delegated tasks")
+                  ? deliveryTerminalGates.get(turn.threadId)
+                  : parentTerminalGates.get(turn.threadId),
               response: (turn) => `Codex completed: ${turn.message.text}`,
             }),
             makeDeterministicAdapter({
@@ -410,6 +453,11 @@ describe("orchestrator MCP toolkit", () => {
               capabilities: ClaudeProviderCapabilitiesV2,
               capturedTurns,
               shouldComplete: (turn) => turn.message.text !== cancellationPrompt,
+              terminalGate: (turn) =>
+                turn.message.text.startsWith("Delegated task") ||
+                turn.message.text.startsWith("Delegated tasks")
+                  ? deliveryTerminalGates.get(turn.threadId)
+                  : parentTerminalGates.get(turn.threadId),
               response: (turn) =>
                 turn.message.text === delegatedPrompt
                   ? delegatedResult
@@ -586,6 +634,496 @@ describe("orchestrator MCP toolkit", () => {
                   Effect.provideService(McpSchema.McpServerClient, client),
                 );
 
+            if (parentRun === undefined || parentRun.rootNodeId === null) {
+              return yield* Effect.die(new Error("Parent run missing."));
+            }
+            let parentRootNodeId = parentRun.rootNodeId;
+            const queueAutomaticCompletion = (suffix: string, taskText: string) =>
+              Effect.gen(function* () {
+                const delegated = yield* orchestrator.dispatch({
+                  type: "delegated_task.request",
+                  createdBy: "agent",
+                  creationSource: "mcp",
+                  commandId: CommandId.make(`command:mcp-parent:${suffix}:delegate`),
+                  parentThreadId,
+                  parentRunId: parentRun.id,
+                  parentNodeId: parentRootNodeId,
+                  task: taskText,
+                  modelSelection: claudeSelection,
+                  runtimeMode: "full-access",
+                  interactionMode: "default",
+                  completionWake: "always",
+                });
+                const taskEvent = delegated.storedEvents.find(
+                  (stored) =>
+                    stored.event.type === "subagent.updated" &&
+                    stored.event.payload.origin === "app_owned",
+                );
+                if (taskEvent?.event.type !== "subagent.updated") {
+                  return yield* Effect.die(
+                    new Error(`Automatic completion task ${suffix} was not created.`),
+                  );
+                }
+                const task = taskEvent.event.payload;
+                const reserved = yield* waitForProjection(
+                  orchestrator,
+                  parentThreadId,
+                  (projection) => {
+                    const delivery = projection.runs.find((run) => run.id === parentRun.id)
+                      ?.delegatedCompletion?.delivery;
+                    return (
+                      projection.subagents.find((candidate) => candidate.id === task.id)?.status ===
+                        "completed" &&
+                      delivery !== undefined &&
+                      delivery !== null &&
+                      delivery.taskIds.includes(task.id)
+                    );
+                  },
+                );
+                const delivery = reserved.runs.find((run) => run.id === parentRun.id)
+                  ?.delegatedCompletion?.delivery;
+                if (delivery === undefined || delivery === null) {
+                  return yield* Effect.die(
+                    new Error(`Automatic completion delivery ${suffix} was not reserved.`),
+                  );
+                }
+                yield* orchestrator.dispatch({
+                  type: "message.dispatch",
+                  createdBy: "agent",
+                  creationSource: "server",
+                  commandId: CommandId.make(`command:mcp-parent:${suffix}:dispatch`),
+                  threadId: parentThreadId,
+                  messageId: delivery.messageId,
+                  text: "Delegated task reached a terminal state.",
+                  attachments: [],
+                  modelSelection: codexSelection,
+                  dispatchMode: { type: "queue_after_active" },
+                  delegatedCompletion: {
+                    parentRunId: parentRun.id,
+                    generation: delivery.generation,
+                    taskIds: delivery.taskIds,
+                  },
+                });
+                const queued = yield* waitForProjection(
+                  orchestrator,
+                  parentThreadId,
+                  (projection) =>
+                    projection.runs.some(
+                      (run) => run.userMessageId === delivery.messageId && run.status === "queued",
+                    ),
+                );
+                const queuedRun = queued.runs.find(
+                  (run) => run.userMessageId === delivery.messageId,
+                );
+                if (queuedRun === undefined) {
+                  return yield* Effect.die(
+                    new Error(`Automatic completion delivery ${suffix} was not queued.`),
+                  );
+                }
+                return { task, delivery, queuedRun };
+              });
+
+            // Several async terminals belonging to one parent run reserve one
+            // durable delivery. The continuation worker owns the later
+            // message.dispatch, so use the same metadata here while the test
+            // probe records the offers instead of starting a worker.
+            const coalescedTask = (suffix: string) =>
+              orchestrator.dispatch({
+                type: "delegated_task.request",
+                createdBy: "agent",
+                creationSource: "mcp",
+                commandId: CommandId.make(`command:mcp-parent:coalesced-${suffix}`),
+                parentThreadId,
+                parentRunId: parentRun.id,
+                parentNodeId: parentRootNodeId,
+                task: `Complete coalesced task ${suffix}.`,
+                modelSelection: claudeSelection,
+                runtimeMode: "full-access",
+                interactionMode: "default",
+                completionWake: "always",
+              });
+            const firstCoalesced = yield* coalescedTask("one");
+            const secondCoalesced = yield* coalescedTask("two");
+            const coalescedTaskIds = [firstCoalesced, secondCoalesced].map((result) => {
+              const taskEvent = result.storedEvents.find(
+                (stored) =>
+                  stored.event.type === "subagent.updated" &&
+                  stored.event.payload.origin === "app_owned",
+              );
+              if (taskEvent?.event.type !== "subagent.updated") {
+                throw new Error("Coalesced delegated task projection missing.");
+              }
+              return taskEvent.event.payload.id;
+            });
+            const coalescedProjection = yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                coalescedTaskIds.every(
+                  (taskId) =>
+                    projection.subagents.find((task) => task.id === taskId)?.status === "completed",
+                ) &&
+                projection.runs.find((run) => run.id === parentRun.id)?.delegatedCompletion !==
+                  undefined,
+            );
+            const coalescedCohort = coalescedProjection.runs.find(
+              (run) => run.id === parentRun.id,
+            )?.delegatedCompletion;
+            expect(coalescedCohort?.delivery?.taskIds).toEqual(
+              expect.arrayContaining(coalescedTaskIds),
+            );
+            expect(coalescedCohort?.delivery?.taskIds).toHaveLength(2);
+            const coalescedOffers = yield* waitForContinuationOffers(1);
+            expect(coalescedOffers).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  delegatedCompletion: expect.objectContaining({
+                    parentRunId: parentRun.id,
+                    messageId: coalescedCohort?.delivery?.messageId,
+                  }),
+                }),
+              ]),
+            );
+            if (coalescedCohort?.delivery === undefined || coalescedCohort.delivery === null) {
+              return yield* Effect.die(new Error("Coalesced delivery reservation missing."));
+            }
+            const coalescedDelivery = coalescedCohort.delivery;
+            yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "agent",
+              creationSource: "server",
+              commandId: CommandId.make("command:mcp-parent:dispatch-coalesced-delivery"),
+              threadId: parentThreadId,
+              messageId: coalescedDelivery.messageId,
+              text: "Delegated tasks reached terminal states.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "queue_after_active" },
+              delegatedCompletion: {
+                parentRunId: parentRun.id,
+                generation: coalescedDelivery.generation,
+                taskIds: coalescedDelivery.taskIds,
+              },
+            });
+            const queuedCoalesced = yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                projection.runs.some(
+                  (run) =>
+                    run.userMessageId === coalescedDelivery.messageId && run.status === "queued",
+                ),
+            );
+            const queuedCoalescedRun = queuedCoalesced.runs.find(
+              (run) => run.userMessageId === coalescedDelivery.messageId,
+            );
+            expect(queuedCoalescedRun?.status).toBe("queued");
+            if (queuedCoalescedRun === undefined) {
+              return yield* Effect.die(new Error("Queued coalesced delivery missing."));
+            }
+
+            // Server-owned delivery ownership is authoritative even if a
+            // stale client tries to mutate the queue directly.
+            const completionEditError = yield* orchestrator
+              .dispatch({
+                type: "queued-run.edit",
+                commandId: CommandId.make("command:mcp-parent:edit-coalesced-delivery"),
+                threadId: parentThreadId,
+                runId: queuedCoalescedRun.id,
+                text: "Rewrite the automatic delivery.",
+              })
+              .pipe(Effect.flip);
+            expect(completionEditError._tag).toBe("OrchestratorDispatchError");
+            const completionReorderError = yield* orchestrator
+              .dispatch({
+                type: "queued-run.reorder",
+                commandId: CommandId.make("command:mcp-parent:reorder-coalesced-delivery"),
+                threadId: parentThreadId,
+                runId: queuedCoalescedRun.id,
+                beforeRunId: null,
+              })
+              .pipe(Effect.flip);
+            expect(completionReorderError._tag).toBe("OrchestratorDispatchError");
+            const completionSteerError = yield* orchestrator
+              .dispatch({
+                type: "queued-message.promote-to-steer",
+                commandId: CommandId.make("command:mcp-parent:steer-coalesced-delivery"),
+                threadId: parentThreadId,
+                queuedRunId: queuedCoalescedRun.id,
+                targetRunId: parentRun.id,
+              })
+              .pipe(Effect.flip);
+            expect(completionSteerError._tag).toBe("OrchestratorDispatchError");
+
+            for (const taskId of coalescedTaskIds) {
+              const statusCall = yield* invoke("task_status", { taskId });
+              expect(statusCall.isError).toBe(false);
+            }
+            const acknowledgedCoalesced = yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                projection.runs.find((run) => run.id === queuedCoalescedRun.id)?.status ===
+                  "cancelled" &&
+                coalescedTaskIds.every(
+                  (taskId) =>
+                    projection.subagents.find((task) => task.id === taskId)?.completionDelivery
+                      ?.state === "acknowledged",
+                ),
+            );
+            expect(
+              acknowledgedCoalesced.runs.find((run) => run.id === parentRun.id)?.delegatedCompletion
+                ?.delivery,
+            ).toBeNull();
+            yield* Ref.set(continuationOffers, []);
+
+            // Waiting only observes the child run's status. A direct parent
+            // read acknowledges delivery only after the terminal result is
+            // returned untruncated, never from the child prompt or a partial
+            // result page.
+            const directRead = yield* queueAutomaticCompletion(
+              "direct-child-read",
+              "Complete before a parent reads this child result directly.",
+            );
+            if (directRead.task.childThreadId === null) {
+              return yield* Effect.die(new Error("Direct-read child thread missing."));
+            }
+            const directChildThreadId = directRead.task.childThreadId;
+            const directChildWaitCall = yield* invoke("t3_thread_wait", {
+              threadId: directChildThreadId,
+              timeoutMs: 10_000,
+            });
+            const directChildWait = yield* decodeThreadWaitResult(
+              directChildWaitCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(directChildWait).toMatchObject({
+              threadId: directChildThreadId,
+              status: "completed",
+              timedOut: false,
+            });
+            const pendingAfterWait = yield* orchestrator.getThreadProjection(parentThreadId);
+            expect(
+              pendingAfterWait.subagents.find((task) => task.id === directRead.task.id)
+                ?.completionDelivery?.state,
+            ).toBe("claimed");
+            expect(
+              pendingAfterWait.runs.find((run) => run.id === directRead.queuedRun.id)?.status,
+            ).toBe("queued");
+
+            const childPromptReadCall = yield* invoke("t3_thread_read", {
+              threadId: directChildThreadId,
+              limit: 1,
+            });
+            const childPromptRead = yield* decodeThreadReadResult(
+              childPromptReadCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(childPromptRead.items.map((item) => item.type)).toEqual(["user_message"]);
+            if (childPromptRead.nextPosition === null) {
+              return yield* Effect.die(new Error("Direct-read child prompt position missing."));
+            }
+            expect(
+              (yield* orchestrator.getThreadProjection(parentThreadId)).subagents.find(
+                (task) => task.id === directRead.task.id,
+              )?.completionDelivery?.state,
+            ).toBe("claimed");
+
+            const truncatedResultReadCall = yield* invoke("t3_thread_read", {
+              threadId: directChildThreadId,
+              afterPosition: childPromptRead.nextPosition,
+              limit: 1,
+              maxCharsPerItem: 1,
+            });
+            const truncatedResultRead = yield* decodeThreadReadResult(
+              truncatedResultReadCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(truncatedResultRead.items).toMatchObject([
+              { type: "assistant_message", textTruncated: true },
+            ]);
+            expect(
+              (yield* orchestrator.getThreadProjection(parentThreadId)).subagents.find(
+                (task) => task.id === directRead.task.id,
+              )?.completionDelivery?.state,
+            ).toBe("claimed");
+
+            const terminalResultReadCall = yield* invoke("t3_thread_read", {
+              threadId: directChildThreadId,
+              afterPosition: childPromptRead.nextPosition,
+              limit: 1,
+            });
+            const terminalResultRead = yield* decodeThreadReadResult(
+              terminalResultReadCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(terminalResultRead.items).toMatchObject([
+              {
+                type: "assistant_message",
+                text: "Claude completed: Complete before a parent reads this child result directly.",
+                textTruncated: false,
+              },
+            ]);
+            const acknowledgedByDirectRead = yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                projection.runs.find((run) => run.id === directRead.queuedRun.id)?.status ===
+                  "cancelled" &&
+                projection.subagents.find((task) => task.id === directRead.task.id)
+                  ?.completionDelivery?.state === "acknowledged",
+            );
+            expect(
+              acknowledgedByDirectRead.subagents.find((task) => task.id === directRead.task.id)
+                ?.completionDelivery,
+            ).toMatchObject({ state: "acknowledged", observedByRunId: parentRun.id });
+            yield* Ref.set(continuationOffers, []);
+
+            // New user work retains its own queue entry while an explicit
+            // observation disposes the stale automatic one.
+            const queueRace = yield* queueAutomaticCompletion(
+              "queue-race",
+              "Complete before a user queues follow-up work.",
+            );
+            const queuedUserMessageId = MessageId.make("message:mcp-parent:queue-race:user");
+            yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "user",
+              creationSource: "web",
+              commandId: CommandId.make("command:mcp-parent:queue-race:user"),
+              threadId: parentThreadId,
+              messageId: queuedUserMessageId,
+              text: "Queue user follow-up work.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "queue_after_active" },
+            });
+            const queueRaceQueued = yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                projection.runs.some((run) => run.id === queueRace.queuedRun.id) &&
+                projection.runs.some(
+                  (run) => run.userMessageId === queuedUserMessageId && run.status === "queued",
+                ),
+            );
+            const queuedUserRun = queueRaceQueued.runs.find(
+              (run) => run.userMessageId === queuedUserMessageId,
+            );
+            if (queuedUserRun === undefined) {
+              return yield* Effect.die(new Error("Queued user follow-up missing."));
+            }
+            const queueRaceStatus = yield* invoke("task_status", { taskId: queueRace.task.id });
+            expect(queueRaceStatus.isError).toBe(false);
+            yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                projection.runs.find((run) => run.id === queueRace.queuedRun.id)?.status ===
+                  "cancelled" &&
+                projection.runs.find((run) => run.id === queuedUserRun.id)?.status === "queued" &&
+                projection.subagents.find((task) => task.id === queueRace.task.id)
+                  ?.completionDelivery?.state === "acknowledged",
+            );
+            yield* orchestrator.dispatch({
+              type: "queued-run.cancel",
+              commandId: CommandId.make("command:mcp-parent:queue-race:cleanup"),
+              threadId: parentThreadId,
+              runId: queuedUserRun.id,
+            });
+
+            // A native in-place Steer keeps the parent active. Once the
+            // parent observes the child result, its queued delivery is stale.
+            const steerRace = yield* queueAutomaticCompletion(
+              "steer-race",
+              "Complete before a user steers the parent.",
+            );
+            const steerMessageId = MessageId.make("message:mcp-parent:steer-race:user");
+            yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "user",
+              creationSource: "web",
+              commandId: CommandId.make("command:mcp-parent:steer-race:user"),
+              threadId: parentThreadId,
+              messageId: steerMessageId,
+              text: "Steer the active parent after receiving the result.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "steer_active", targetRunId: parentRun.id },
+            });
+            const steerRaceStatus = yield* invoke("task_status", { taskId: steerRace.task.id });
+            expect(steerRaceStatus.isError).toBe(false);
+            const acknowledgedSteerRace = yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                projection.messages.some((message) => message.id === steerMessageId) &&
+                projection.runs.find((run) => run.id === parentRun.id)?.status === "running" &&
+                projection.runs.find((run) => run.id === steerRace.queuedRun.id)?.status ===
+                  "cancelled" &&
+                projection.subagents.find((task) => task.id === steerRace.task.id)
+                  ?.completionDelivery?.state === "acknowledged",
+            );
+            expect(
+              acknowledgedSteerRace.runs.find((run) => run.id === parentRun.id)?.delegatedCompletion
+                ?.delivery,
+            ).toBeNull();
+
+            // Restart creates a new attempt for the same parent cohort. The
+            // old terminal must not turn that continuation into a Stop
+            // barrier, and an acknowledged result cancels the stale delivery.
+            const restartRace = yield* queueAutomaticCompletion(
+              "restart-race",
+              "Complete before a user restarts the parent.",
+            );
+            const attemptBeforeRestart = (yield* orchestrator.getThreadProjection(
+              parentThreadId,
+            )).runs.find((run) => run.id === parentRun.id)?.activeAttemptId;
+            const restartMessageId = MessageId.make("message:mcp-parent:restart-race:user");
+            yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "user",
+              creationSource: "web",
+              commandId: CommandId.make("command:mcp-parent:restart-race:user"),
+              threadId: parentThreadId,
+              messageId: restartMessageId,
+              text: "Restart the active parent after receiving the result.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "restart_active", targetRunId: parentRun.id },
+            });
+            const restartedParent = yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) => {
+                const run = projection.runs.find((candidate) => candidate.id === parentRun.id);
+                return (
+                  run?.status === "running" &&
+                  run.activeAttemptId !== attemptBeforeRestart &&
+                  run.rootNodeId !== null
+                );
+              },
+            );
+            const currentParentRun = restartedParent.runs.find((run) => run.id === parentRun.id);
+            if (currentParentRun?.rootNodeId === null || currentParentRun === undefined) {
+              return yield* Effect.die(new Error("Restarted parent run missing."));
+            }
+            parentRootNodeId = currentParentRun.rootNodeId;
+            expect(currentParentRun.delegatedCompletion?.disposition).toBe("open");
+            const restartRaceStatus = yield* invoke("task_status", {
+              taskId: restartRace.task.id,
+            });
+            expect(restartRaceStatus.isError).toBe(false);
+            yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                projection.messages.some((message) => message.id === restartMessageId) &&
+                projection.runs.find((run) => run.id === restartRace.queuedRun.id)?.status ===
+                  "cancelled" &&
+                projection.subagents.find((task) => task.id === restartRace.task.id)
+                  ?.completionDelivery?.state === "acknowledged" &&
+                projection.runs.find((run) => run.id === parentRun.id)?.delegatedCompletion
+                  ?.disposition === "open",
+            );
+            yield* Ref.set(continuationOffers, []);
+
             const capabilitiesTool = server.tools.find(
               ({ tool }) => tool.name === "orchestrator_capabilities",
             );
@@ -594,6 +1132,9 @@ describe("orchestrator MCP toolkit", () => {
             const delegateTool = server.tools.find(({ tool }) => tool.name === "delegate_task");
             expect(delegateTool?.tool.annotations?.destructiveHint).toBe(true);
             expect(delegateTool?.tool.annotations?.openWorldHint).toBe(true);
+            const taskStatusTool = server.tools.find(({ tool }) => tool.name === "task_status");
+            expect(taskStatusTool?.tool.annotations?.readOnlyHint).toBe(false);
+            expect(taskStatusTool?.tool.annotations?.idempotentHint).toBe(true);
             const createThreadsTool = server.tools.find(
               ({ tool }) => tool.name === "create_threads",
             );
@@ -602,7 +1143,7 @@ describe("orchestrator MCP toolkit", () => {
             expect(threadListTool?.tool.annotations?.readOnlyHint).toBe(true);
             expect(threadListTool?.tool.annotations?.idempotentHint).toBe(true);
             const threadReadTool = server.tools.find(({ tool }) => tool.name === "t3_thread_read");
-            expect(threadReadTool?.tool.annotations?.readOnlyHint).toBe(true);
+            expect(threadReadTool?.tool.annotations?.readOnlyHint).toBe(false);
             const threadSendTool = server.tools.find(({ tool }) => tool.name === "t3_thread_send");
             expect(threadSendTool?.tool.annotations?.destructiveHint).toBe(true);
             const threadWaitTool = server.tools.find(({ tool }) => tool.name === "t3_thread_wait");
@@ -1010,17 +1551,15 @@ describe("orchestrator MCP toolkit", () => {
             ).pipe(Effect.orDie);
             expect(cancelledStatus.status).toBe("interrupted");
 
-            // The cancelled async child carries completionWake "always", so
-            // its terminal offers a wake even though the parent run is live;
-            // queue_after_active sequences the continuation behind it.
-            const offersAfterCancel = yield* waitForContinuationOffers(1);
-            expect(offersAfterCancel).toHaveLength(1);
-            expect(offersAfterCancel[0]).toMatchObject({
-              threadId: parentThreadId,
-              delivery: "message_text",
-            });
-            expect(offersAfterCancel[0]?.detail).toContain(cancellable.taskId);
-            expect(offersAfterCancel[0]?.detail).toContain("interrupted");
+            // Explicit task_cancel disposes automatic delivery after the child
+            // interrupt succeeds. The interrupted result remains readable,
+            // but it cannot create a parent continuation.
+            expect(
+              (yield* orchestrator.getThreadProjection(parentThreadId)).subagents.find(
+                (task) => task.id === cancellable.taskId,
+              )?.completionDelivery,
+            ).toMatchObject({ state: "disposed" });
+            yield* expectOffersToStay(0);
 
             const createInput = {
               clientRequestId: "create-thread-batch-1",
@@ -1405,13 +1944,12 @@ describe("orchestrator MCP toolkit", () => {
                 (task) => task.id === upgradedDelegated.taskId && task.status === "interrupted",
               ),
             );
-            const offersAfterUpgrade = yield* waitForContinuationOffers(2);
-            expect(offersAfterUpgrade).toHaveLength(2);
-            expect(offersAfterUpgrade[1]).toMatchObject({
-              threadId: parentThreadId,
-              delivery: "message_text",
-            });
-            expect(offersAfterUpgrade[1]?.detail).toContain(upgradedDelegated.taskId);
+            expect(
+              (yield* orchestrator.getThreadProjection(parentThreadId)).subagents.find(
+                (task) => task.id === upgradedDelegated.taskId,
+              )?.completionDelivery,
+            ).toMatchObject({ state: "disposed" });
+            yield* expectOffersToStay(0);
 
             // The MCP tool cannot force the reverse interleaving (child
             // terminal before the upgrade lands), so dispatch the command
@@ -1439,20 +1977,13 @@ describe("orchestrator MCP toolkit", () => {
                 (task) => task.id === delegated.taskId,
               )?.completionWake,
             ).toBe("always");
-            const offersAfterTerminalUpgrade = yield* waitForContinuationOffers(3);
-            expect(offersAfterTerminalUpgrade).toHaveLength(3);
-            expect(offersAfterTerminalUpgrade[2]).toMatchObject({
-              threadId: parentThreadId,
-              delivery: "message_text",
-            });
-            expect(offersAfterTerminalUpgrade[2]?.detail).toContain(delegated.taskId);
+            // task_status above acknowledged this terminal result, so making
+            // its policy eager later cannot re-arm a stale parent wake.
+            yield* expectOffersToStay(0);
 
             // Legacy records omit completionWake and stay settled_only. The
             // MCP service always sets the field now, so dispatch the request
             // directly to cover the legacy shape.
-            if (parentRun === undefined || parentRun.rootNodeId === null) {
-              return yield* Effect.die(new Error("Parent run missing."));
-            }
             const legacyDispatch = yield* orchestrator.dispatch({
               type: "delegated_task.request",
               createdBy: "agent",
@@ -1460,7 +1991,7 @@ describe("orchestrator MCP toolkit", () => {
               commandId: CommandId.make("command:mcp-parent:delegate-legacy"),
               parentThreadId,
               parentRunId: parentRun.id,
-              parentNodeId: parentRun.rootNodeId,
+              parentNodeId: parentRootNodeId,
               task: cancellationPrompt,
               modelSelection: codexSelection,
               runtimeMode: "full-access",
@@ -1484,9 +2015,88 @@ describe("orchestrator MCP toolkit", () => {
               projection.providerTurns.some((turn) => turn.status === "running"),
             );
             // Nothing terminalized here, so the offer count must hold.
-            yield* expectOffersToStay(3);
+            yield* expectOffersToStay(0);
 
+            // Stop cancels a queued server-owned delivery for this cohort and
+            // records a barrier before any still-running child reaches a
+            // terminal state.
+            const stopQueuedDispatch = yield* orchestrator.dispatch({
+              type: "delegated_task.request",
+              createdBy: "agent",
+              creationSource: "mcp",
+              commandId: CommandId.make("command:mcp-parent:stop-queued-delivery"),
+              parentThreadId,
+              parentRunId: parentRun.id,
+              parentNodeId: parentRootNodeId,
+              task: "Complete the stop barrier delivery task.",
+              modelSelection: claudeSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              completionWake: "always",
+            });
+            const stopQueuedTaskEvent = stopQueuedDispatch.storedEvents.find(
+              (stored) =>
+                stored.event.type === "subagent.updated" &&
+                stored.event.payload.origin === "app_owned",
+            );
+            if (stopQueuedTaskEvent?.event.type !== "subagent.updated") {
+              return yield* Effect.die(
+                new Error("Stop barrier delegated task projection missing."),
+              );
+            }
+            const stopQueuedTaskId = stopQueuedTaskEvent.event.payload.id;
+            const stopQueuedProjection = yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                projection.subagents.find((task) => task.id === stopQueuedTaskId)?.status ===
+                  "completed" &&
+                projection.runs.find((run) => run.id === parentRun.id)?.delegatedCompletion
+                  ?.delivery !== null &&
+                projection.runs.find((run) => run.id === parentRun.id)?.delegatedCompletion
+                  ?.delivery !== undefined,
+            );
+            const stopQueuedDelivery = stopQueuedProjection.runs.find(
+              (run) => run.id === parentRun.id,
+            )?.delegatedCompletion?.delivery;
+            if (stopQueuedDelivery === undefined || stopQueuedDelivery === null) {
+              return yield* Effect.die(new Error("Stop barrier delivery reservation missing."));
+            }
             yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "agent",
+              creationSource: "server",
+              commandId: CommandId.make("command:mcp-parent:dispatch-stop-queued-delivery"),
+              threadId: parentThreadId,
+              messageId: stopQueuedDelivery.messageId,
+              text: "Delegated task reached a terminal state.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "queue_after_active" },
+              delegatedCompletion: {
+                parentRunId: parentRun.id,
+                generation: stopQueuedDelivery.generation,
+                taskIds: stopQueuedDelivery.taskIds,
+              },
+            });
+            const queuedStopDelivery = yield* waitForProjection(
+              orchestrator,
+              parentThreadId,
+              (projection) =>
+                projection.runs.some(
+                  (run) =>
+                    run.userMessageId === stopQueuedDelivery.messageId && run.status === "queued",
+                ),
+            );
+            const queuedStopDeliveryRun = queuedStopDelivery.runs.find(
+              (run) => run.userMessageId === stopQueuedDelivery.messageId,
+            );
+            if (queuedStopDeliveryRun === undefined) {
+              return yield* Effect.die(new Error("Queued stop barrier delivery missing."));
+            }
+            yield* Ref.set(continuationOffers, []);
+
+            const parentStop = yield* orchestrator.dispatch({
               type: "run.interrupt",
               commandId: CommandId.make("command:mcp-parent:interrupt-wake"),
               threadId: parentThreadId,
@@ -1501,20 +2111,49 @@ describe("orchestrator MCP toolkit", () => {
                   run.status !== "running",
               ),
             );
-            const legacyCancelCall = yield* invoke("task_cancel", {
-              taskId: legacyTask.id,
-              reason: "Terminalize the legacy child after the parent settled.",
-              clientRequestId: "cancel-legacy-1",
+            const stoppedParent = yield* orchestrator.getThreadProjection(parentThreadId);
+            expect(stoppedParent.runs.some((run) => run.id === parentRun.id)).toBe(true);
+            expect(
+              parentStop.storedEvents.some(
+                (stored) =>
+                  stored.event.type === "run.updated" &&
+                  stored.event.payload.id === parentRun.id &&
+                  stored.event.payload.delegatedCompletion?.disposition === "stopped",
+              ),
+            ).toBe(true);
+            expect(
+              stoppedParent.runs.find((run) => run.id === parentRun.id)?.delegatedCompletion,
+            ).toMatchObject({ disposition: "stopped", delivery: null });
+            expect(
+              stoppedParent.runs.find((run) => run.id === queuedStopDeliveryRun.id)?.status,
+            ).toBe("cancelled");
+            expect(
+              stoppedParent.subagents.find((task) => task.id === legacyTask.id)?.completionDelivery,
+            ).toMatchObject({ state: "disposed" });
+            const legacyChildRun = (yield* orchestrator.getThreadProjection(
+              legacyChildThreadId,
+            )).runs.find((run) => run.status === "running");
+            if (legacyChildRun === undefined) {
+              return yield* Effect.die(
+                new Error("Still-running child was missing after parent Stop."),
+              );
+            }
+            yield* orchestrator.dispatch({
+              type: "run.interrupt",
+              commandId: CommandId.make("command:mcp-parent:interrupt-legacy-after-parent-stop"),
+              threadId: legacyChildThreadId,
+              runId: legacyChildRun.id,
+              reason: "Terminalize after the parent Stop barrier.",
             });
-            expect(legacyCancelCall.isError).toBe(false);
             yield* waitForProjection(orchestrator, legacyChildThreadId, (projection) =>
               projection.runs.some((run) => run.status === "interrupted"),
             );
-            const offers = yield* waitForContinuationOffers(4);
-            expect(offers).toHaveLength(4);
-            expect(offers[3]).toMatchObject({ threadId: parentThreadId, delivery: "message_text" });
-            expect(offers[3]?.detail).toContain(legacyTask.id);
-            expect(offers[3]?.detail).toContain("task_status");
+            expect(
+              (yield* orchestrator.getThreadProjection(parentThreadId)).subagents.find(
+                (task) => task.id === legacyTask.id,
+              )?.completionDelivery,
+            ).toMatchObject({ state: "disposed" });
+            yield* expectOffersToStay(0);
 
             // Same command against a terminal task whose finalize already
             // offered (the parent was settled then, and still is): the policy
@@ -1539,7 +2178,441 @@ describe("orchestrator MCP toolkit", () => {
                 (task) => task.id === legacyTask.id,
               )?.completionWake,
             ).toBe("always");
-            yield* expectOffersToStay(4);
+            yield* expectOffersToStay(0);
+
+            // A child that terminalizes after the coalesced delivery started
+            // is held for one successor. It must not fan out into a second
+            // concurrent delivery for the same parent run.
+            const lateParentThreadId = ThreadId.make("thread:mcp-late-completion-parent");
+            const lateParentGate = yield* Deferred.make<void>();
+            const lateDeliveryGate = yield* Deferred.make<void>();
+            parentTerminalGates.set(lateParentThreadId, lateParentGate);
+            deliveryTerminalGates.set(lateParentThreadId, lateDeliveryGate);
+            yield* Ref.set(continuationOffers, []);
+            yield* orchestrator.dispatch({
+              type: "thread.create",
+              createdBy: "user",
+              creationSource: "web",
+              commandId: CommandId.make("command:mcp-late-parent:create"),
+              threadId: lateParentThreadId,
+              projectId,
+              title: "Late completion parent",
+              modelSelection: codexSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              branch: null,
+              worktreePath: cwd,
+            });
+            yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "user",
+              creationSource: "web",
+              commandId: CommandId.make("command:mcp-late-parent:start"),
+              threadId: lateParentThreadId,
+              messageId: MessageId.make("message:mcp-late-parent:start"),
+              text: "Hold this parent until its completion delivery is queued.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "start_immediately" },
+            });
+            const lateParentProjection = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.runs.some((run) => run.status === "running") &&
+                projection.providerTurns.some((turn) => turn.status === "running"),
+            );
+            const lateParentRun = lateParentProjection.runs.find((run) => run.status === "running");
+            if (lateParentRun?.rootNodeId === null || lateParentRun === undefined) {
+              return yield* Effect.die(new Error("Late completion parent run missing."));
+            }
+            const earlyLateDelivery = yield* orchestrator.dispatch({
+              type: "delegated_task.request",
+              createdBy: "agent",
+              creationSource: "mcp",
+              commandId: CommandId.make("command:mcp-late-parent:early-task"),
+              parentThreadId: lateParentThreadId,
+              parentRunId: lateParentRun.id,
+              parentNodeId: lateParentRun.rootNodeId,
+              task: "Complete before the first delivery starts.",
+              modelSelection: claudeSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              completionWake: "always",
+            });
+            const lateChild = yield* orchestrator.dispatch({
+              type: "delegated_task.request",
+              createdBy: "agent",
+              creationSource: "mcp",
+              commandId: CommandId.make("command:mcp-late-parent:late-task"),
+              parentThreadId: lateParentThreadId,
+              parentRunId: lateParentRun.id,
+              parentNodeId: lateParentRun.rootNodeId,
+              task: cancellationPrompt,
+              modelSelection: codexSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              completionWake: "always",
+            });
+            const taskFromDispatch = (result: typeof earlyLateDelivery) => {
+              const taskEvent = result.storedEvents.find(
+                (stored) =>
+                  stored.event.type === "subagent.updated" &&
+                  stored.event.payload.origin === "app_owned",
+              );
+              if (taskEvent?.event.type !== "subagent.updated") {
+                throw new Error("Late completion delegated task projection missing.");
+              }
+              return taskEvent.event.payload;
+            };
+            const earlyLateTask = taskFromDispatch(earlyLateDelivery);
+            const lateTask = taskFromDispatch(lateChild);
+            const thirdLateChild = yield* orchestrator.dispatch({
+              type: "delegated_task.request",
+              createdBy: "agent",
+              creationSource: "mcp",
+              commandId: CommandId.make("command:mcp-late-parent:third-late-task"),
+              parentThreadId: lateParentThreadId,
+              parentRunId: lateParentRun.id,
+              parentNodeId: lateParentRun.rootNodeId,
+              task: cancellationPrompt,
+              modelSelection: codexSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              completionWake: "always",
+            });
+            const thirdLateTask = taskFromDispatch(thirdLateChild);
+            if (lateTask.childThreadId === null || thirdLateTask.childThreadId === null) {
+              return yield* Effect.die(new Error("Late completion child thread missing."));
+            }
+            const beforeFirstDelivery = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.subagents.find((task) => task.id === earlyLateTask.id)?.status ===
+                  "completed" &&
+                projection.subagents.find((task) => task.id === lateTask.id)?.status ===
+                  "running" &&
+                projection.runs.find((run) => run.id === lateParentRun.id)?.delegatedCompletion
+                  ?.delivery !== null &&
+                projection.runs.find((run) => run.id === lateParentRun.id)?.delegatedCompletion
+                  ?.delivery !== undefined,
+            );
+            const firstLateDelivery = beforeFirstDelivery.runs.find(
+              (run) => run.id === lateParentRun.id,
+            )?.delegatedCompletion?.delivery;
+            if (firstLateDelivery === undefined || firstLateDelivery === null) {
+              return yield* Effect.die(new Error("First late completion delivery missing."));
+            }
+            yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "agent",
+              creationSource: "server",
+              commandId: CommandId.make("command:mcp-late-parent:dispatch-first-delivery"),
+              threadId: lateParentThreadId,
+              messageId: firstLateDelivery.messageId,
+              text: "Delegated task reached a terminal state.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "queue_after_active" },
+              delegatedCompletion: {
+                parentRunId: lateParentRun.id,
+                generation: firstLateDelivery.generation,
+                taskIds: firstLateDelivery.taskIds,
+              },
+            });
+            yield* Deferred.succeed(lateParentGate, undefined);
+            const activeFirstDelivery = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.runs.some(
+                  (run) =>
+                    run.userMessageId === firstLateDelivery.messageId && run.status === "running",
+                ),
+            );
+            const activeFirstDeliveryRun = activeFirstDelivery.runs.find(
+              (run) => run.userMessageId === firstLateDelivery.messageId,
+            );
+            if (activeFirstDeliveryRun === undefined) {
+              return yield* Effect.die(new Error("First late completion delivery did not start."));
+            }
+            const lateChildProjection = yield* orchestrator.getThreadProjection(
+              lateTask.childThreadId,
+            );
+            const lateChildRun = lateChildProjection.runs[0];
+            if (lateChildRun === undefined) {
+              return yield* Effect.die(new Error("Late completion child run missing."));
+            }
+            yield* orchestrator.dispatch({
+              type: "run.interrupt",
+              commandId: CommandId.make("command:mcp-late-parent:interrupt-late-child"),
+              threadId: lateTask.childThreadId,
+              runId: lateChildRun.id,
+              reason: "Terminalize after the first completion delivery started.",
+            });
+            yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.subagents.find((task) => task.id === lateTask.id)?.completionDelivery
+                  ?.state === "pending",
+            );
+            yield* Deferred.succeed(lateDeliveryGate, undefined);
+            const successorReserved = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) => {
+                const delivery = projection.runs.find((run) => run.id === lateParentRun.id)
+                  ?.delegatedCompletion?.delivery;
+                return (
+                  delivery !== undefined &&
+                  delivery !== null &&
+                  delivery.generation === firstLateDelivery.generation + 1 &&
+                  delivery.taskIds.length === 1 &&
+                  delivery.taskIds[0] === lateTask.id
+                );
+              },
+            );
+            const successorDelivery = successorReserved.runs.find(
+              (run) => run.id === lateParentRun.id,
+            )?.delegatedCompletion?.delivery;
+            expect(successorDelivery).toMatchObject({
+              generation: firstLateDelivery.generation + 1,
+              taskIds: [lateTask.id],
+            });
+            const lateOffers = yield* waitForContinuationOffers(2);
+            expect(lateOffers).toHaveLength(2);
+            expect(
+              successorReserved.runs.filter((run) => {
+                const message = successorReserved.messages.find(
+                  (candidate) => candidate.id === run.userMessageId,
+                );
+                return message?.delegatedCompletion?.parentRunId === lateParentRun.id;
+              }),
+            ).toHaveLength(1);
+            if (successorDelivery === undefined || successorDelivery === null) {
+              return yield* Effect.die(new Error("Late completion successor delivery missing."));
+            }
+
+            // The bounded successor can coalesce a late result only once. A
+            // third terminal after that successor has started remains
+            // inspectable, but cannot recursively create a third parent run.
+            const successorGate = yield* Deferred.make<void>();
+            deliveryTerminalGates.set(lateParentThreadId, successorGate);
+            yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "agent",
+              creationSource: "server",
+              commandId: CommandId.make("command:mcp-late-parent:dispatch-successor-delivery"),
+              threadId: lateParentThreadId,
+              messageId: successorDelivery.messageId,
+              text: "Delegated task reached a terminal state.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "queue_after_active" },
+              delegatedCompletion: {
+                parentRunId: lateParentRun.id,
+                generation: successorDelivery.generation,
+                taskIds: successorDelivery.taskIds,
+              },
+            });
+            const activeSuccessor = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.runs.some(
+                  (run) =>
+                    run.userMessageId === successorDelivery.messageId && run.status === "running",
+                ),
+            );
+            const activeSuccessorRun = activeSuccessor.runs.find(
+              (run) => run.userMessageId === successorDelivery.messageId,
+            );
+            if (activeSuccessorRun === undefined) {
+              return yield* Effect.die(new Error("Late completion successor did not start."));
+            }
+            const thirdLateChildProjection = yield* waitForProjection(
+              orchestrator,
+              thirdLateTask.childThreadId,
+              (projection) =>
+                projection.runs.some((run) => run.status === "running") &&
+                projection.providerTurns.some((turn) => turn.status === "running"),
+            );
+            const thirdLateChildRun = thirdLateChildProjection.runs.find(
+              (run) => run.status === "running",
+            );
+            if (thirdLateChildRun === undefined) {
+              return yield* Effect.die(new Error("Third late completion child run missing."));
+            }
+            yield* orchestrator.dispatch({
+              type: "run.interrupt",
+              commandId: CommandId.make("command:mcp-late-parent:interrupt-third-late-child"),
+              threadId: thirdLateTask.childThreadId,
+              runId: thirdLateChildRun.id,
+              reason: "Terminalize after the bounded successor started.",
+            });
+            yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.subagents.find((task) => task.id === thirdLateTask.id)
+                  ?.completionDelivery?.state === "pending",
+            );
+            yield* Deferred.succeed(successorGate, undefined);
+            const exhaustedCohort = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) => {
+                const cohort = projection.runs.find(
+                  (run) => run.id === lateParentRun.id,
+                )?.delegatedCompletion;
+                return (
+                  cohort?.settledDeliveryCount === 2 &&
+                  cohort.delivery === null &&
+                  projection.runs.find((run) => run.id === activeSuccessorRun.id)?.status ===
+                    "completed" &&
+                  projection.subagents.find((task) => task.id === thirdLateTask.id)
+                    ?.completionDelivery?.state === "pending"
+                );
+              },
+            );
+            expect(
+              exhaustedCohort.runs.find((run) => run.id === lateParentRun.id)?.delegatedCompletion,
+            ).toMatchObject({ settledDeliveryCount: 2, delivery: null });
+            yield* expectOffersToStay(2);
+
+            // Queue Remove is a durable disposal action, not a local queue
+            // edit. Start a fresh parent-run cohort so removing this delivery
+            // cannot interfere with the bounded late-delivery assertions.
+            const removeParentGate = yield* Deferred.make<void>();
+            parentTerminalGates.set(lateParentThreadId, removeParentGate);
+            const removeParentMessageId = MessageId.make("message:mcp-late-parent:remove-start");
+            yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "user",
+              creationSource: "web",
+              commandId: CommandId.make("command:mcp-late-parent:remove-start"),
+              threadId: lateParentThreadId,
+              messageId: removeParentMessageId,
+              text: "Keep the parent active while removing automatic delivery.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "start_immediately" },
+            });
+            const removeParentProjection = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.runs.some(
+                  (run) => run.userMessageId === removeParentMessageId && run.status === "running",
+                ),
+            );
+            const removeParentRun = removeParentProjection.runs.find(
+              (run) => run.userMessageId === removeParentMessageId,
+            );
+            if (removeParentRun?.rootNodeId === null || removeParentRun === undefined) {
+              return yield* Effect.die(new Error("Queue Remove parent run missing."));
+            }
+            const removeDelegation = yield* orchestrator.dispatch({
+              type: "delegated_task.request",
+              createdBy: "agent",
+              creationSource: "mcp",
+              commandId: CommandId.make("command:mcp-late-parent:remove-delegate"),
+              parentThreadId: lateParentThreadId,
+              parentRunId: removeParentRun.id,
+              parentNodeId: removeParentRun.rootNodeId,
+              task: "Complete before Queue Remove disposes this automatic delivery.",
+              modelSelection: claudeSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              completionWake: "always",
+            });
+            const removeTaskEvent = removeDelegation.storedEvents.find(
+              (stored) =>
+                stored.event.type === "subagent.updated" &&
+                stored.event.payload.origin === "app_owned",
+            );
+            if (removeTaskEvent?.event.type !== "subagent.updated") {
+              return yield* Effect.die(
+                new Error("Queue Remove delegated task projection missing."),
+              );
+            }
+            const removeTask = removeTaskEvent.event.payload;
+            const removeReserved = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.subagents.find((task) => task.id === removeTask.id)?.status ===
+                  "completed" &&
+                projection.runs.find((run) => run.id === removeParentRun.id)?.delegatedCompletion
+                  ?.delivery !== null &&
+                projection.runs.find((run) => run.id === removeParentRun.id)?.delegatedCompletion
+                  ?.delivery !== undefined,
+            );
+            const removeDelivery = removeReserved.runs.find((run) => run.id === removeParentRun.id)
+              ?.delegatedCompletion?.delivery;
+            if (removeDelivery === undefined || removeDelivery === null) {
+              return yield* Effect.die(new Error("Queue Remove delivery reservation missing."));
+            }
+            yield* orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "agent",
+              creationSource: "server",
+              commandId: CommandId.make("command:mcp-late-parent:remove-dispatch"),
+              threadId: lateParentThreadId,
+              messageId: removeDelivery.messageId,
+              text: "Delegated task reached a terminal state.",
+              attachments: [],
+              modelSelection: codexSelection,
+              dispatchMode: { type: "queue_after_active" },
+              delegatedCompletion: {
+                parentRunId: removeParentRun.id,
+                generation: removeDelivery.generation,
+                taskIds: removeDelivery.taskIds,
+              },
+            });
+            const removeQueued = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.runs.some(
+                  (run) =>
+                    run.userMessageId === removeDelivery.messageId && run.status === "queued",
+                ),
+            );
+            const removeQueuedRun = removeQueued.runs.find(
+              (run) => run.userMessageId === removeDelivery.messageId,
+            );
+            if (removeQueuedRun === undefined) {
+              return yield* Effect.die(new Error("Queue Remove delivery did not queue."));
+            }
+            yield* Ref.set(continuationOffers, []);
+            yield* orchestrator.dispatch({
+              type: "queued-run.cancel",
+              commandId: CommandId.make("command:mcp-late-parent:remove-queued-delivery"),
+              threadId: lateParentThreadId,
+              runId: removeQueuedRun.id,
+            });
+            const removedDelivery = yield* waitForProjection(
+              orchestrator,
+              lateParentThreadId,
+              (projection) =>
+                projection.runs.find((run) => run.id === removeParentRun.id)?.delegatedCompletion
+                  ?.disposition === "disposed" &&
+                projection.runs.find((run) => run.id === removeQueuedRun.id)?.status ===
+                  "cancelled" &&
+                projection.subagents.find((task) => task.id === removeTask.id)?.completionDelivery
+                  ?.state === "disposed",
+            );
+            expect(
+              removedDelivery.runs.find((run) => run.id === removeParentRun.id)
+                ?.delegatedCompletion,
+            ).toMatchObject({ disposition: "disposed", delivery: null });
+            expect(
+              removedDelivery.subagents.find((task) => task.id === removeTask.id),
+            ).toMatchObject({ result: expect.any(String), status: "completed" });
+            yield* expectOffersToStay(0);
           }).pipe(Effect.provide(testLayer));
         }),
       ),

--- a/apps/server/src/mcp/toolkits/orchestrator/tools.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/tools.ts
@@ -62,7 +62,7 @@ export const DelegateTaskTool = Tool.make("delegate_task", {
 
 export const TaskStatusTool = Tool.make("task_status", {
   description:
-    "Read the latest durable state and final summary for a T3-owned delegated task created by this parent thread.",
+    "Read the latest durable state and final summary for a T3-owned delegated task created by this parent thread. Reading a terminal result acknowledges its automatic parent delivery.",
   parameters: OrchestratorMcpTaskStatusInput,
   success: OrchestratorMcpDelegateTaskResult,
   failure: OrchestratorMcpFailure,
@@ -70,13 +70,13 @@ export const TaskStatusTool = Tool.make("task_status", {
   dependencies,
 })
   .annotate(Tool.Title, "Get delegated task status")
-  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Readonly, false)
   .annotate(Tool.Destructive, false)
   .annotate(Tool.Idempotent, true);
 
 export const TaskCancelTool = Tool.make("task_cancel", {
   description:
-    "Request interruption of an active T3-owned delegated task. Completed tasks are returned unchanged.",
+    "Request interruption of an active T3-owned delegated task and dispose its automatic parent delivery. Completed task results remain available.",
   parameters: OrchestratorMcpTaskCancelInput,
   success: OrchestratorMcpTaskCancelResult,
   failure: OrchestratorMcpFailure,
@@ -178,7 +178,7 @@ export const ThreadListTool = Tool.make("t3_thread_list", {
 
 export const ThreadReadTool = Tool.make("t3_thread_read", {
   description:
-    "Read durable state and a paginated timeline from a T3 thread in the calling project. The default messages view returns user messages, assistant messages, and proposed plans; activity returns all summarized timeline items. Continue with afterPosition=nextPosition.",
+    "Read durable state and a paginated timeline from a T3 thread in the calling project. The default messages view returns user messages, assistant messages, and proposed plans; activity returns all summarized timeline items. Reading an untruncated terminal assistant result from this parent thread's direct app-owned child acknowledges that child's automatic completion delivery. Continue with afterPosition=nextPosition.",
   parameters: OrchestratorMcpThreadReadInput,
   success: OrchestratorMcpThreadReadResult,
   failure: OrchestratorMcpFailure,
@@ -186,7 +186,7 @@ export const ThreadReadTool = Tool.make("t3_thread_read", {
   dependencies,
 })
   .annotate(Tool.Title, "Read a T3 thread")
-  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Readonly, false)
   .annotate(Tool.Destructive, false)
   .annotate(Tool.Idempotent, true);
 
@@ -205,7 +205,7 @@ export const ThreadSendTool = Tool.make("t3_thread_send", {
 
 export const ThreadWaitTool = Tool.make("t3_thread_wait", {
   description:
-    "Wait for a T3 thread run to reach a terminal durable state. Without runId, the latest run at call time is selected; an idle thread returns immediately. Timeout does not interrupt work, so call again or use t3_thread_read/list after timedOut=true.",
+    "Wait for a T3 thread run to reach a terminal durable state. Without runId, the latest run at call time is selected; an idle thread returns immediately. Timeout does not interrupt work, so call again or use t3_thread_read/list after timedOut=true. Waiting reports status only and does not acknowledge a delegated result.",
   parameters: OrchestratorMcpThreadWaitInput,
   success: OrchestratorMcpThreadWaitResult,
   failure: OrchestratorMcpFailure,

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -712,10 +712,8 @@ export const CLAUDE_T3_MCP_TOOL_WILDCARD = "mcp__t3-code__*";
 // ClaudeAdapterV2.test.ts cross-checks this list against the toolkit.
 export const CLAUDE_READ_ONLY_T3_MCP_ALLOWED_TOOLS: ReadonlyArray<string> = [
   "mcp__t3-code__orchestrator_capabilities",
-  "mcp__t3-code__task_status",
   "mcp__t3-code__list_scheduled_tasks",
   "mcp__t3-code__t3_thread_list",
-  "mcp__t3-code__t3_thread_read",
   "mcp__t3-code__t3_thread_wait",
 ];
 

--- a/apps/server/src/orchestration-v2/CheckpointCaptureService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointCaptureService.test.ts
@@ -1,0 +1,330 @@
+import { assert, it } from "@effect/vitest";
+import {
+  CheckpointId,
+  CheckpointRef,
+  CheckpointScopeId,
+  EventId,
+  MessageId,
+  NodeId,
+  type OrchestrationV2DomainEvent,
+  type OrchestrationV2Run,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ProviderThreadId,
+  RunId,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import { CheckpointServiceV2 } from "./CheckpointService.ts";
+import {
+  CheckpointCaptureServiceV2,
+  layer as checkpointCaptureServiceLayer,
+} from "./CheckpointCaptureService.ts";
+import { EventSinkV2 } from "./EventSink.ts";
+import { layer as idAllocatorLayer } from "./IdAllocator.ts";
+import { ProjectionStoreV2, layer as projectionStoreLayer } from "./ProjectionStore.ts";
+
+const ProjectionStoreTestLayer = Layer.mergeAll(
+  projectionStoreLayer.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+  SqlitePersistenceMemory,
+);
+
+const threadId = ThreadId.make("thread:checkpoint-capture-delegated");
+const projectId = ProjectId.make("project:checkpoint-capture-delegated");
+const runId = RunId.make("run:checkpoint-capture-delegated");
+const scopeId = CheckpointScopeId.make("scope:checkpoint-capture-delegated");
+const rootNodeId = NodeId.make("node:checkpoint-capture-delegated-root");
+const taskId = NodeId.make("node:checkpoint-capture-task");
+const deliveryMessageId = MessageId.make("message:checkpoint-capture-delivery");
+const providerThreadId = ProviderThreadId.make("provider-thread:checkpoint-capture-delegated");
+const providerInstanceId = ProviderInstanceId.make("codex");
+const driver = ProviderDriverKind.make("codex");
+const modelSelection = {
+  instanceId: providerInstanceId,
+  model: "gpt-5.4",
+} as const;
+
+it.layer(ProjectionStoreTestLayer)("CheckpointCaptureServiceV2", (it) => {
+  it.effect(
+    "preserves a newer delegatedCompletion cohort when checkpoint run.updated is applied after it",
+    () =>
+      Effect.gen(function* () {
+        const projectionStore = yield* ProjectionStoreV2;
+        const now = yield* DateTime.now;
+        const later = DateTime.add(now, { seconds: 1 });
+
+        const staleDelegatedCompletion = {
+          disposition: "open" as const,
+          nextGeneration: 1,
+          settledDeliveryCount: 0,
+          delivery: null,
+        };
+        const newerCohort = {
+          disposition: "open" as const,
+          nextGeneration: 2,
+          settledDeliveryCount: 1,
+          delivery: {
+            generation: 1,
+            messageId: deliveryMessageId,
+            taskIds: [taskId],
+          },
+        };
+        const staleRun: OrchestrationV2Run = {
+          id: runId,
+          threadId,
+          ordinal: 1,
+          providerInstanceId,
+          modelSelection,
+          providerThreadId,
+          userMessageId: MessageId.make("message:checkpoint-capture-user"),
+          rootNodeId,
+          activeAttemptId: null,
+          status: "waiting",
+          requestedAt: now,
+          startedAt: now,
+          completedAt: null,
+          checkpointId: null,
+          contextHandoffId: null,
+          // Snapshot taken before a concurrent cohort advanced during capture work.
+          delegatedCompletion: staleDelegatedCompletion,
+        };
+        const rootNode = {
+          id: rootNodeId,
+          threadId,
+          runId,
+          parentNodeId: null,
+          rootNodeId,
+          kind: "root_turn" as const,
+          status: "waiting" as const,
+          countsForRun: true,
+          providerThreadId,
+          providerTurnId: null,
+          nativeItemRef: null,
+          runtimeRequestId: null,
+          checkpointScopeId: scopeId,
+          startedAt: now,
+          completedAt: null,
+        };
+        const scope = {
+          id: scopeId,
+          threadId,
+          runId,
+          nodeId: rootNodeId,
+          parentScopeId: null,
+          providerThreadId,
+          kind: "root_run" as const,
+          ordinalWithinParent: 0,
+          advancesAppRunCount: true,
+          cwd: "/repo",
+          createdAt: now,
+        };
+        const providerThread = {
+          id: providerThreadId,
+          driver,
+          providerInstanceId,
+          providerSessionId: null,
+          appThreadId: threadId,
+          ownerNodeId: rootNodeId,
+          nativeThreadRef: null,
+          nativeConversationHeadRef: null,
+          status: "idle" as const,
+          firstRunOrdinal: 1,
+          lastRunOrdinal: 1,
+          handoffIds: [],
+          forkedFrom: null,
+          createdAt: now,
+          updatedAt: now,
+        };
+        const readyBaseline = {
+          id: CheckpointId.make("checkpoint:baseline-0"),
+          threadId,
+          scopeId,
+          runId: null,
+          nodeId: rootNodeId,
+          parentCheckpointId: null,
+          ordinalWithinScope: 0,
+          appRunOrdinal: null,
+          ref: CheckpointRef.make("checkpoint-ref:baseline-0"),
+          status: "ready" as const,
+          files: [],
+          capturedAt: now,
+        };
+        const captured = {
+          id: CheckpointId.make("checkpoint:captured-1"),
+          threadId,
+          scopeId,
+          runId,
+          nodeId: rootNodeId,
+          parentCheckpointId: readyBaseline.id,
+          ordinalWithinScope: 1,
+          appRunOrdinal: 1,
+          ref: CheckpointRef.make("checkpoint-ref:captured-1"),
+          status: "ready" as const,
+          files: [],
+          capturedAt: now,
+        };
+
+        yield* projectionStore.apply({
+          id: EventId.make("event:checkpoint-capture:thread"),
+          type: "thread.created",
+          threadId,
+          occurredAt: now,
+          payload: {
+            createdBy: "user",
+            creationSource: "web",
+            id: threadId,
+            projectId,
+            title: "Checkpoint capture delegated completion",
+            providerInstanceId,
+            modelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            activeProviderThreadId: null,
+            lineage: {
+              parentThreadId: null,
+              relationshipToParent: null,
+              rootThreadId: threadId,
+            },
+            forkedFrom: null,
+            createdAt: now,
+            updatedAt: now,
+            archivedAt: null,
+            settledOverride: null,
+            settledAt: null,
+            lastVisitedAt: null,
+            deletedAt: null,
+          },
+        });
+        yield* projectionStore.apply({
+          id: EventId.make("event:checkpoint-capture:run-stale"),
+          type: "run.updated",
+          threadId,
+          runId,
+          nodeId: rootNodeId,
+          providerInstanceId,
+          occurredAt: now,
+          payload: staleRun,
+        });
+        yield* projectionStore.apply({
+          id: EventId.make("event:checkpoint-capture:node"),
+          type: "node.updated",
+          threadId,
+          runId,
+          nodeId: rootNodeId,
+          providerInstanceId,
+          occurredAt: now,
+          payload: rootNode,
+        });
+        yield* projectionStore.apply({
+          id: EventId.make("event:checkpoint-capture:provider-thread"),
+          type: "provider-thread.updated",
+          threadId,
+          nodeId: rootNodeId,
+          driver,
+          providerInstanceId,
+          occurredAt: now,
+          payload: providerThread,
+        });
+        yield* projectionStore.apply({
+          id: EventId.make("event:checkpoint-capture:scope"),
+          type: "checkpoint-scope.created",
+          threadId,
+          runId,
+          nodeId: rootNodeId,
+          occurredAt: now,
+          payload: scope,
+        });
+        yield* projectionStore.apply({
+          id: EventId.make("event:checkpoint-capture:baseline"),
+          type: "checkpoint.captured",
+          threadId,
+          nodeId: rootNodeId,
+          driver,
+          providerInstanceId,
+          occurredAt: now,
+          payload: readyBaseline,
+        });
+
+        const committed = yield* Ref.make<ReadonlyArray<OrchestrationV2DomainEvent>>([]);
+        const captureLayer = checkpointCaptureServiceLayer.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              idAllocatorLayer,
+              Layer.mock(CheckpointServiceV2)({
+                materializeBaselineCheckpoint: () =>
+                  Effect.die("baseline materialization must be skipped when ordinal 0 is ready"),
+                capture: () => Effect.succeed(captured),
+              }),
+              Layer.mock(EventSinkV2)({
+                commitCommand: (input) =>
+                  Ref.set(committed, input.events).pipe(
+                    Effect.as({
+                      commandId: input.commandId,
+                      committed: true,
+                      sequence: 1,
+                      events: input.events,
+                      effects: [],
+                    } as never),
+                  ),
+              }),
+            ),
+          ),
+        );
+
+        yield* Effect.gen(function* () {
+          const service = yield* CheckpointCaptureServiceV2;
+          // Capture reads the waiting run while the projection still holds the stale cohort.
+          yield* service.execute({ threadId, runId, scopeId });
+
+          const events = yield* Ref.get(committed);
+          const runUpdated = events.find((event) => event.type === "run.updated");
+          assert.isDefined(runUpdated);
+          if (runUpdated?.type !== "run.updated") {
+            return;
+          }
+          assert.equal(runUpdated.payload.status, "completed");
+          assert.equal(runUpdated.payload.checkpointId, captured.id);
+          assert.isUndefined(
+            runUpdated.payload.delegatedCompletion,
+            "checkpoint capture must omit delegatedCompletion so ProjectionStore can keep a newer cohort",
+          );
+
+          // Race: a newer cohort lands on the projection after capture read the stale
+          // waiting run and before the capture command's run.updated is applied.
+          yield* projectionStore.apply({
+            id: EventId.make("event:checkpoint-capture:newer-cohort"),
+            type: "run.updated",
+            threadId,
+            runId,
+            nodeId: rootNodeId,
+            providerInstanceId,
+            occurredAt: later,
+            payload: {
+              ...staleRun,
+              delegatedCompletion: newerCohort,
+            },
+          });
+
+          // Apply the real capture-emitted run.updated through ProjectionStore.
+          yield* projectionStore.apply(runUpdated);
+
+          const projection = yield* projectionStore.getThreadProjection(threadId);
+          const projectedRun = projection.runs[0];
+          assert.isDefined(projectedRun);
+          assert.equal(projectedRun?.status, "completed");
+          assert.equal(projectedRun?.checkpointId, captured.id);
+          assert.deepEqual(projectedRun?.delegatedCompletion, newerCohort);
+          assert.equal(projectedRun?.delegatedCompletion?.delivery?.messageId, deliveryMessageId);
+          assert.deepEqual(projectedRun?.delegatedCompletion?.delivery?.taskIds, [taskId]);
+        }).pipe(Effect.provide(captureLayer));
+      }),
+  );
+});

--- a/apps/server/src/orchestration-v2/CheckpointCaptureService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointCaptureService.test.ts
@@ -22,16 +22,13 @@ import * as Ref from "effect/Ref";
 
 import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
 import { CheckpointServiceV2 } from "./CheckpointService.ts";
-import {
-  CheckpointCaptureServiceV2,
-  layer as checkpointCaptureServiceLayer,
-} from "./CheckpointCaptureService.ts";
+import * as CheckpointCaptureService from "./CheckpointCaptureService.ts";
 import { EventSinkV2 } from "./EventSink.ts";
-import { layer as idAllocatorLayer } from "./IdAllocator.ts";
-import { ProjectionStoreV2, layer as projectionStoreLayer } from "./ProjectionStore.ts";
+import * as IdAllocator from "./IdAllocator.ts";
+import * as ProjectionStore from "./ProjectionStore.ts";
 
 const ProjectionStoreTestLayer = Layer.mergeAll(
-  projectionStoreLayer.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+  ProjectionStore.layer.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
   SqlitePersistenceMemory,
 );
 
@@ -55,7 +52,7 @@ it.layer(ProjectionStoreTestLayer)("CheckpointCaptureServiceV2", (it) => {
     "preserves a newer delegatedCompletion cohort when checkpoint run.updated is applied after it",
     () =>
       Effect.gen(function* () {
-        const projectionStore = yield* ProjectionStoreV2;
+        const projectionStore = yield* ProjectionStore.ProjectionStoreV2;
         const now = yield* DateTime.now;
         const later = DateTime.add(now, { seconds: 1 });
 
@@ -254,10 +251,10 @@ it.layer(ProjectionStoreTestLayer)("CheckpointCaptureServiceV2", (it) => {
         });
 
         const committed = yield* Ref.make<ReadonlyArray<OrchestrationV2DomainEvent>>([]);
-        const captureLayer = checkpointCaptureServiceLayer.pipe(
+        const captureLayer = CheckpointCaptureService.layer.pipe(
           Layer.provide(
             Layer.mergeAll(
-              idAllocatorLayer,
+              IdAllocator.layer,
               Layer.mock(CheckpointServiceV2)({
                 materializeBaselineCheckpoint: () =>
                   Effect.die("baseline materialization must be skipped when ordinal 0 is ready"),
@@ -280,7 +277,7 @@ it.layer(ProjectionStoreTestLayer)("CheckpointCaptureServiceV2", (it) => {
         );
 
         yield* Effect.gen(function* () {
-          const service = yield* CheckpointCaptureServiceV2;
+          const service = yield* CheckpointCaptureService.CheckpointCaptureServiceV2;
           // Capture reads the waiting run while the projection still holds the stale cohort.
           yield* service.execute({ threadId, runId, scopeId });
 

--- a/apps/server/src/orchestration-v2/CheckpointCaptureService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointCaptureService.ts
@@ -122,6 +122,11 @@ export const layer: Layer.Layer<
         appRunOrdinal: run.ordinal,
         capturedAt,
       });
+      // Match RunExecutionService: capture loaded the waiting run before
+      // materializing baselines. Omit delegatedCompletion so a newer cohort
+      // write during capture is not overwritten by this stale snapshot
+      // (ProjectionStore preserves the field when absent from the payload).
+      const { delegatedCompletion: _delegatedCompletion, ...runWithoutDelegatedCompletion } = run;
       const commandId = CommandId.make(`command:effect:checkpoint.capture:${run.id}`);
       yield* eventSink.commitCommand({
         commandId,
@@ -196,7 +201,7 @@ export const layer: Layer.Layer<
             providerInstanceId: run.providerInstanceId,
             occurredAt: capturedAt,
             payload: {
-              ...run,
+              ...runWithoutDelegatedCompletion,
               status: "completed",
               completedAt: capturedAt,
               checkpointId: checkpoint.id,

--- a/apps/server/src/orchestration-v2/DelegatedCompletionDelivery.test.ts
+++ b/apps/server/src/orchestration-v2/DelegatedCompletionDelivery.test.ts
@@ -21,7 +21,10 @@ import * as Stream from "effect/Stream";
 import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
 import { ServerConfig } from "../config.ts";
 import { layer as mcpSessionRegistryTestLayer } from "../mcp/McpSessionRegistry.testkit.ts";
+import { OrchestrationEngineService } from "../orchestration/Services/OrchestrationEngine.ts";
+import { OrchestrationLayerLive } from "../orchestration/runtimeLayer.ts";
 import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import { ProjectEnrichmentService } from "../project/ProjectEnrichmentService.ts";
 import type { ProviderInstance } from "../provider/ProviderDriver.ts";
 import { ProviderInstanceRegistry } from "../provider/Services/ProviderInstanceRegistry.ts";
 import { ServerSettingsService } from "../serverSettings.ts";
@@ -83,7 +86,30 @@ const TestProviderInstanceRegistry = Layer.succeed(ProviderInstanceRegistry, {
   subscribeChanges: Effect.never,
 });
 
-const TestLayer = Layer.merge(OrchestrationV2LayerLive, OrchestrationV2EventSinkLayerLive).pipe(
+const TestLayer = Layer.mergeAll(
+  OrchestrationLayerLive,
+  OrchestrationV2LayerLive,
+  OrchestrationV2EventSinkLayerLive,
+).pipe(
+  Layer.provide(
+    Layer.succeed(ProjectEnrichmentService, {
+      peek: () =>
+        Effect.succeed({
+          repositoryIdentity: null,
+          faviconPath: null,
+          repositoryIdentityResolved: false,
+        }),
+      request: () => Effect.void,
+      getAvailable: () =>
+        Effect.succeed({
+          repositoryIdentity: null,
+          faviconPath: null,
+          repositoryIdentityResolved: false,
+        }),
+      invalidate: () => Effect.void,
+      subscribeChanges: Effect.never,
+    }),
+  ),
   Layer.provide(mcpSessionRegistryTestLayer),
   Layer.provide(SqlitePersistenceMemory),
   Layer.provide(CheckpointStoreTestLayer),
@@ -101,14 +127,27 @@ const seedParentWithTerminalTask = (input: {
   readonly taskId: NodeId;
   readonly deliveryState: "delivered" | "claimed" | "acknowledged" | "disposed";
   readonly completionWake?: "always" | "settled_only";
+  readonly deliveryTaskIds?: ReadonlyArray<NodeId>;
   readonly now: DateTime.Utc;
 }) =>
   Effect.gen(function* () {
+    const applicationEngine = yield* OrchestrationEngineService;
     const orchestrator = yield* OrchestratorV2;
     const eventSink = yield* EventSinkV2;
     const providerThreadId = ProviderThreadId.make(
       `provider-thread:${String(input.threadId).replace("thread:", "")}`,
     );
+
+    yield* applicationEngine.dispatch({
+      type: "project.create",
+      commandId: CommandId.make(`command:seed-project:${input.threadId}`),
+      projectId: input.projectId,
+      title: "Delegated completion delivery",
+      workspaceRoot: `/workspace/${input.projectId}`,
+      defaultModelSelection: modelSelection,
+      scripts: [],
+      createdAt: DateTime.formatIso(input.now),
+    });
 
     yield* orchestrator.dispatch({
       type: "thread.create",
@@ -185,7 +224,14 @@ const seedParentWithTerminalTask = (input: {
               disposition: "open",
               nextGeneration: 2,
               settledDeliveryCount: 1,
-              delivery: null,
+              delivery:
+                input.deliveryTaskIds === undefined
+                  ? null
+                  : {
+                      generation: 1,
+                      messageId: MessageId.make(`message:delegated-delivery:${input.threadId}`),
+                      taskIds: input.deliveryTaskIds,
+                    },
             },
           },
         },
@@ -230,6 +276,56 @@ const seedParentWithTerminalTask = (input: {
   });
 
 it.layer(TestLayer)("delegated completion delivery repairs", (it) => {
+  it.effect("builds completion text and metadata from the same live cohort", () =>
+    Effect.gen(function* () {
+      const orchestrator = yield* OrchestratorV2;
+      const now = yield* DateTime.now;
+      const threadId = ThreadId.make("thread:delegated-delivery-live-cohort");
+      const projectId = ProjectId.make("project:delegated-delivery-live-cohort");
+      const runId = RunId.make("run:delegated-delivery-live-cohort");
+      const rootNodeId = NodeId.make("node:delegated-delivery-live-cohort-root");
+      const firstTaskId = NodeId.make("node:delegated-delivery-live-cohort-first");
+      const secondTaskId = NodeId.make("node:delegated-delivery-live-cohort-second");
+      const messageId = MessageId.make(`message:delegated-delivery:${threadId}`);
+
+      yield* seedParentWithTerminalTask({
+        threadId,
+        projectId,
+        runId,
+        rootNodeId,
+        taskId: firstTaskId,
+        deliveryState: "claimed",
+        completionWake: "always",
+        deliveryTaskIds: [firstTaskId, secondTaskId],
+        now,
+      });
+
+      yield* orchestrator.dispatch({
+        type: "message.dispatch",
+        commandId: CommandId.make("command:delegated-delivery-live-cohort"),
+        threadId,
+        messageId,
+        text: `Delegated task ${firstTaskId} reached a terminal state.`,
+        attachments: [],
+        dispatchMode: { type: "queue_after_active" },
+        createdBy: "agent",
+        creationSource: "server",
+        delegatedCompletion: {
+          parentRunId: runId,
+          generation: 1,
+          taskIds: [firstTaskId],
+        },
+      });
+
+      const projection = yield* orchestrator.getThreadProjection(threadId);
+      const message = projection.messages.find((candidate) => candidate.id === messageId);
+      assert.deepEqual(message?.delegatedCompletion?.taskIds, [firstTaskId, secondTaskId]);
+      assert.include(message?.text ?? "", String(firstTaskId));
+      assert.include(message?.text ?? "", String(secondTaskId));
+      assert.include(message?.text ?? "", "task_status");
+    }),
+  );
+
   it.effect("does not re-offer when wake-policy upgrades after delivered ownership settled", () =>
     Effect.gen(function* () {
       const orchestrator = yield* OrchestratorV2;
@@ -412,6 +508,35 @@ it.layer(TestLayer)("delegated completion delivery repairs", (it) => {
         const afterDispose = yield* orchestrator.getThreadProjection(threadId);
         assert.deepEqual(
           afterDispose.subagents.find((candidate) => candidate.id === taskId)?.completionDelivery,
+          {
+            state: "disposed",
+            observedByRunId: null,
+          },
+        );
+
+        const acknowledgeAfterDispose = yield* orchestrator.dispatch({
+          type: "delegated_task.completion-delivery.acknowledge",
+          commandId: CommandId.make("command:delegated-delivery-a2:ack-after-dispose"),
+          parentThreadId: threadId,
+          taskId,
+          observedByRunId: runId,
+        });
+        const acknowledgedTask = acknowledgeAfterDispose.storedEvents.find(
+          (stored) => stored.event.type === "subagent.updated",
+        );
+        if (acknowledgedTask?.event.type !== "subagent.updated") {
+          return yield* Effect.die(new Error("Acknowledge-after-dispose event missing."));
+        }
+        assert.deepEqual(acknowledgedTask.event.payload.completionDelivery, {
+          state: "disposed",
+          observedByRunId: null,
+        });
+        assert.equal(acknowledgeAfterDispose.storedEvents.length, 1);
+
+        const afterStaleAcknowledge = yield* orchestrator.getThreadProjection(threadId);
+        assert.deepEqual(
+          afterStaleAcknowledge.subagents.find((candidate) => candidate.id === taskId)
+            ?.completionDelivery,
           {
             state: "disposed",
             observedByRunId: null,

--- a/apps/server/src/orchestration-v2/DelegatedCompletionDelivery.test.ts
+++ b/apps/server/src/orchestration-v2/DelegatedCompletionDelivery.test.ts
@@ -1,0 +1,422 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import {
+  CommandId,
+  EventId,
+  MessageId,
+  type ModelSelection,
+  NodeId,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ProviderThreadId,
+  RunId,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+
+import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
+import { ServerConfig } from "../config.ts";
+import { layer as mcpSessionRegistryTestLayer } from "../mcp/McpSessionRegistry.testkit.ts";
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import type { ProviderInstance } from "../provider/ProviderDriver.ts";
+import { ProviderInstanceRegistry } from "../provider/Services/ProviderInstanceRegistry.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import { CodexProviderCapabilitiesV2 } from "./Adapters/CodexAdapterV2.ts";
+import { EventSinkV2 } from "./EventSink.ts";
+import { OrchestratorV2 } from "./Orchestrator.ts";
+import type { ProviderAdapterV2Shape } from "./ProviderAdapter.ts";
+import { OrchestrationV2EventSinkLayerLive, OrchestrationV2LayerLive } from "./runtimeLayer.ts";
+
+const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3-orchestration-v2-delegated-completion-",
+});
+
+const modelSelection = {
+  instanceId: ProviderInstanceId.make("codex"),
+  model: "gpt-5.4",
+} satisfies ModelSelection;
+
+const VcsDriverRegistryTestLayer = VcsDriverRegistry.layer.pipe(
+  Layer.provide(VcsProcess.layer),
+  Layer.provide(ServerConfigLayer),
+  Layer.provide(NodeServices.layer),
+);
+
+const CheckpointStoreTestLayer = CheckpointStore.layer.pipe(
+  Layer.provide(VcsDriverRegistryTestLayer),
+);
+
+const driver = ProviderDriverKind.make("codex");
+const orchestrationAdapter = {
+  instanceId: modelSelection.instanceId,
+  driver,
+  getCapabilities: () => Effect.succeed(CodexProviderCapabilitiesV2),
+  planSelectionTransition: () => Effect.succeed({ type: "apply_on_next_turn" }),
+  openSession: () => Effect.die("sessions are not used by delegated completion tests"),
+} as ProviderAdapterV2Shape;
+const providerInstance = {
+  instanceId: modelSelection.instanceId,
+  driverKind: driver,
+  continuationIdentity: {
+    driverKind: driver,
+    continuationKey: "codex:test",
+  },
+  displayName: "Codex test",
+  enabled: true,
+  snapshot: {} as ProviderInstance["snapshot"],
+  orchestrationAdapter,
+  textGeneration: {} as ProviderInstance["textGeneration"],
+} satisfies ProviderInstance;
+
+const TestProviderInstanceRegistry = Layer.succeed(ProviderInstanceRegistry, {
+  getInstance: (instanceId) =>
+    Effect.succeed(instanceId === providerInstance.instanceId ? providerInstance : undefined),
+  listInstances: Effect.succeed([providerInstance]),
+  listUnavailable: Effect.succeed([]),
+  streamChanges: Stream.empty,
+  subscribeChanges: Effect.never,
+});
+
+const TestLayer = Layer.merge(OrchestrationV2LayerLive, OrchestrationV2EventSinkLayerLive).pipe(
+  Layer.provide(mcpSessionRegistryTestLayer),
+  Layer.provide(SqlitePersistenceMemory),
+  Layer.provide(CheckpointStoreTestLayer),
+  Layer.provide(ServerConfigLayer),
+  Layer.provide(ServerSettingsService.layerTest()),
+  Layer.provide(TestProviderInstanceRegistry),
+  Layer.provide(NodeServices.layer),
+);
+
+const seedParentWithTerminalTask = (input: {
+  readonly threadId: ThreadId;
+  readonly projectId: ProjectId;
+  readonly runId: RunId;
+  readonly rootNodeId: NodeId;
+  readonly taskId: NodeId;
+  readonly deliveryState: "delivered" | "claimed" | "acknowledged" | "disposed";
+  readonly completionWake?: "always" | "settled_only";
+  readonly now: DateTime.Utc;
+}) =>
+  Effect.gen(function* () {
+    const orchestrator = yield* OrchestratorV2;
+    const eventSink = yield* EventSinkV2;
+    const providerThreadId = ProviderThreadId.make(
+      `provider-thread:${String(input.threadId).replace("thread:", "")}`,
+    );
+
+    yield* orchestrator.dispatch({
+      type: "thread.create",
+      createdBy: "user",
+      creationSource: "web",
+      commandId: CommandId.make(`command:seed-create:${input.threadId}`),
+      threadId: input.threadId,
+      projectId: input.projectId,
+      title: "Delegated completion delivery",
+      modelSelection,
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      branch: null,
+      worktreePath: null,
+    });
+
+    yield* eventSink.write({
+      commandId: CommandId.make(`command:seed-projection:${input.threadId}`),
+      events: [
+        {
+          id: EventId.make(`event:seed-provider-thread:${input.threadId}`),
+          type: "provider-thread.updated",
+          threadId: input.threadId,
+          driver,
+          providerInstanceId: modelSelection.instanceId,
+          occurredAt: input.now,
+          payload: {
+            id: providerThreadId,
+            driver,
+            providerInstanceId: modelSelection.instanceId,
+            providerSessionId: null,
+            appThreadId: input.threadId,
+            ownerNodeId: input.rootNodeId,
+            nativeThreadRef: {
+              driver,
+              nativeId: `native:${input.threadId}`,
+              strength: "strong",
+            },
+            nativeConversationHeadRef: null,
+            status: "active",
+            firstRunOrdinal: 1,
+            lastRunOrdinal: 1,
+            handoffIds: [],
+            forkedFrom: null,
+            createdAt: input.now,
+            updatedAt: input.now,
+          },
+        },
+        {
+          id: EventId.make(`event:seed-run:${input.threadId}`),
+          type: "run.updated",
+          threadId: input.threadId,
+          runId: input.runId,
+          nodeId: input.rootNodeId,
+          providerInstanceId: modelSelection.instanceId,
+          occurredAt: input.now,
+          payload: {
+            id: input.runId,
+            threadId: input.threadId,
+            ordinal: 1,
+            providerInstanceId: modelSelection.instanceId,
+            modelSelection,
+            providerThreadId,
+            userMessageId: MessageId.make(`message:seed-user:${input.threadId}`),
+            rootNodeId: input.rootNodeId,
+            activeAttemptId: null,
+            status: "running",
+            requestedAt: input.now,
+            startedAt: input.now,
+            completedAt: null,
+            checkpointId: null,
+            contextHandoffId: null,
+            delegatedCompletion: {
+              disposition: "open",
+              nextGeneration: 2,
+              settledDeliveryCount: 1,
+              delivery: null,
+            },
+          },
+        },
+        {
+          id: EventId.make(`event:seed-task:${input.threadId}`),
+          type: "subagent.updated",
+          threadId: input.threadId,
+          runId: input.runId,
+          nodeId: input.taskId,
+          driver,
+          providerInstanceId: modelSelection.instanceId,
+          occurredAt: input.now,
+          payload: {
+            id: input.taskId,
+            threadId: input.threadId,
+            runId: input.runId,
+            parentNodeId: input.rootNodeId,
+            origin: "app_owned",
+            createdBy: "agent",
+            driver,
+            providerInstanceId: modelSelection.instanceId,
+            providerThreadId: null,
+            childThreadId: null,
+            nativeTaskRef: null,
+            prompt: "Inspect the delivered ownership edge.",
+            title: null,
+            model: null,
+            completionWake: input.completionWake ?? "settled_only",
+            completionDelivery: {
+              state: input.deliveryState,
+              observedByRunId: input.deliveryState === "acknowledged" ? input.runId : null,
+            },
+            status: "completed",
+            result: "child finished",
+            startedAt: input.now,
+            completedAt: input.now,
+            updatedAt: input.now,
+          },
+        },
+      ],
+    });
+  });
+
+it.layer(TestLayer)("delegated completion delivery repairs", (it) => {
+  it.effect("does not re-offer when wake-policy upgrades after delivered ownership settled", () =>
+    Effect.gen(function* () {
+      const orchestrator = yield* OrchestratorV2;
+      const now = yield* DateTime.now;
+      const threadId = ThreadId.make("thread:delegated-delivery-a1");
+      const projectId = ProjectId.make("project:delegated-delivery-a1");
+      const runId = RunId.make("run:delegated-delivery-a1");
+      const rootNodeId = NodeId.make("node:delegated-delivery-a1-root");
+      const taskId = NodeId.make("node:delegated-delivery-a1-task");
+
+      yield* seedParentWithTerminalTask({
+        threadId,
+        projectId,
+        runId,
+        rootNodeId,
+        taskId,
+        deliveryState: "delivered",
+        completionWake: "settled_only",
+        now,
+      });
+
+      const upgrade = yield* orchestrator.dispatch({
+        type: "delegated_task.wake-policy",
+        commandId: CommandId.make("command:delegated-delivery-a1:wake-policy"),
+        parentThreadId: threadId,
+        taskId,
+        completionWake: "always",
+      });
+
+      const projection = yield* orchestrator.getThreadProjection(threadId);
+      const task = projection.subagents.find((candidate) => candidate.id === taskId);
+      const parentRun = projection.runs.find((candidate) => candidate.id === runId);
+
+      assert.equal(task?.completionWake, "always");
+      assert.deepEqual(task?.completionDelivery, {
+        state: "delivered",
+        observedByRunId: null,
+      });
+      assert.deepEqual(parentRun?.delegatedCompletion, {
+        disposition: "open",
+        nextGeneration: 2,
+        settledDeliveryCount: 1,
+        delivery: null,
+      });
+      assert.isFalse(
+        upgrade.storedEvents.some(
+          (stored) =>
+            stored.event.type === "subagent.updated" &&
+            stored.event.payload.id === taskId &&
+            stored.event.payload.completionDelivery?.state === "claimed",
+        ),
+      );
+      assert.isFalse(
+        upgrade.storedEvents.some(
+          (stored) =>
+            stored.event.type === "run.updated" &&
+            stored.event.payload.id === runId &&
+            stored.event.payload.delegatedCompletion?.delivery !== null &&
+            stored.event.payload.delegatedCompletion?.delivery !== undefined,
+        ),
+      );
+    }),
+  );
+
+  it.effect(
+    "treats repeated acknowledge and dispose with distinct command IDs as successful no-ops",
+    () =>
+      Effect.gen(function* () {
+        const orchestrator = yield* OrchestratorV2;
+        const now = yield* DateTime.now;
+        const threadId = ThreadId.make("thread:delegated-delivery-a2");
+        const projectId = ProjectId.make("project:delegated-delivery-a2");
+        const runId = RunId.make("run:delegated-delivery-a2");
+        const rootNodeId = NodeId.make("node:delegated-delivery-a2-root");
+        const taskId = NodeId.make("node:delegated-delivery-a2-task");
+
+        yield* seedParentWithTerminalTask({
+          threadId,
+          projectId,
+          runId,
+          rootNodeId,
+          taskId,
+          deliveryState: "delivered",
+          completionWake: "always",
+          now,
+        });
+
+        // Distinct command IDs mirror task_status vs t3_thread_read racing after
+        // their shared read preflight saw delivered ownership.
+        const firstAck = yield* orchestrator.dispatch({
+          type: "delegated_task.completion-delivery.acknowledge",
+          commandId: CommandId.make("command:delegated-delivery-a2:ack-task-status"),
+          parentThreadId: threadId,
+          taskId,
+          observedByRunId: runId,
+        });
+        const secondAck = yield* orchestrator.dispatch({
+          type: "delegated_task.completion-delivery.acknowledge",
+          commandId: CommandId.make("command:delegated-delivery-a2:ack-thread-read"),
+          parentThreadId: threadId,
+          taskId,
+          observedByRunId: runId,
+        });
+
+        const firstAckTask = firstAck.storedEvents.find(
+          (stored) =>
+            stored.event.type === "subagent.updated" && stored.event.payload.id === taskId,
+        );
+        const secondAckTask = secondAck.storedEvents.find(
+          (stored) =>
+            stored.event.type === "subagent.updated" && stored.event.payload.id === taskId,
+        );
+        assert.isDefined(firstAckTask);
+        assert.isDefined(secondAckTask);
+        if (
+          firstAckTask?.event.type !== "subagent.updated" ||
+          secondAckTask?.event.type !== "subagent.updated"
+        ) {
+          return yield* Effect.die(new Error("Acknowledge events missing."));
+        }
+        assert.equal(firstAckTask.event.payload.completionDelivery?.state, "acknowledged");
+        assert.equal(secondAckTask.event.payload.completionDelivery?.state, "acknowledged");
+        // Idempotent replay keeps the first observation's ownership and timestamp.
+        assert.deepEqual(
+          secondAckTask.event.payload.completionDelivery,
+          firstAckTask.event.payload.completionDelivery,
+        );
+        assert.deepEqual(
+          secondAckTask.event.payload.updatedAt,
+          firstAckTask.event.payload.updatedAt,
+        );
+        assert.equal(secondAck.storedEvents.length, 1);
+
+        const afterAck = yield* orchestrator.getThreadProjection(threadId);
+        assert.deepEqual(
+          afterAck.subagents.find((candidate) => candidate.id === taskId)?.completionDelivery,
+          {
+            state: "acknowledged",
+            observedByRunId: runId,
+          },
+        );
+
+        const firstDispose = yield* orchestrator.dispatch({
+          type: "delegated_task.completion-delivery.dispose",
+          commandId: CommandId.make("command:delegated-delivery-a2:dispose-task-status"),
+          parentThreadId: threadId,
+          taskId,
+        });
+        const secondDispose = yield* orchestrator.dispatch({
+          type: "delegated_task.completion-delivery.dispose",
+          commandId: CommandId.make("command:delegated-delivery-a2:dispose-thread-read"),
+          parentThreadId: threadId,
+          taskId,
+        });
+
+        const firstDisposeTask = firstDispose.storedEvents.find(
+          (stored) =>
+            stored.event.type === "subagent.updated" && stored.event.payload.id === taskId,
+        );
+        const secondDisposeTask = secondDispose.storedEvents.find(
+          (stored) =>
+            stored.event.type === "subagent.updated" && stored.event.payload.id === taskId,
+        );
+        assert.isDefined(firstDisposeTask);
+        assert.isDefined(secondDisposeTask);
+        if (
+          firstDisposeTask?.event.type !== "subagent.updated" ||
+          secondDisposeTask?.event.type !== "subagent.updated"
+        ) {
+          return yield* Effect.die(new Error("Dispose events missing."));
+        }
+        assert.equal(firstDisposeTask.event.payload.completionDelivery?.state, "disposed");
+        assert.equal(secondDisposeTask.event.payload.completionDelivery?.state, "disposed");
+        assert.deepEqual(
+          secondDisposeTask.event.payload.completionDelivery,
+          firstDisposeTask.event.payload.completionDelivery,
+        );
+        assert.equal(secondDispose.storedEvents.length, 1);
+
+        const afterDispose = yield* orchestrator.getThreadProjection(threadId);
+        assert.deepEqual(
+          afterDispose.subagents.find((candidate) => candidate.id === taskId)?.completionDelivery,
+          {
+            state: "disposed",
+            observedByRunId: null,
+          },
+        );
+      }),
+  );
+});

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -1050,15 +1050,25 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         command.type === "delegated_task.completion-delivery.acknowledge"
           ? "acknowledged"
           : "disposed";
-      if (task.completionDelivery?.state === state) {
-        return yield* new OrchestratorDispatchError({
-          commandId: command.commandId,
-          commandType: command.type,
-          cause: `Delegated task ${command.taskId} completion delivery is already ${state}.`,
-        });
-      }
       const now = yield* DateTime.now;
       const emitEvent = emit(events, command);
+      // task_status and t3_thread_read use distinct command IDs, so two
+      // valid observations can race after their read preflight. Re-emit the
+      // existing task row so the second dispatch is a successful idempotent
+      // no-op rather than "already acknowledged/disposed" or empty-events.
+      if (task.completionDelivery?.state === state) {
+        yield* emitEvent({
+          type: "subagent.updated",
+          threadId: command.parentThreadId,
+          ...(task.runId === null ? {} : { runId: task.runId }),
+          nodeId: task.id,
+          driver: task.driver,
+          providerInstanceId: task.providerInstanceId,
+          occurredAt: now,
+          payload: task,
+        });
+        return;
+      }
       const updatedTask: OrchestrationV2Subagent = {
         ...task,
         completionDelivery: {
@@ -5998,7 +6008,13 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
     readonly now: DateTime.Utc;
   }) {
     const taskDelivery = input.updatedTask.completionDelivery;
-    if (taskDelivery?.state === "acknowledged" || taskDelivery?.state === "disposed") {
+    // delivered ownership has already settled through a completed wake run.
+    // A later wake-policy upgrade must not re-claim the task or offer again.
+    if (
+      taskDelivery?.state === "acknowledged" ||
+      taskDelivery?.state === "delivered" ||
+      taskDelivery?.state === "disposed"
+    ) {
       return {
         task: input.updatedTask,
         parentRun: undefined,

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -10,6 +10,8 @@ import {
   type OrchestrationV2ContextTransfer,
   type OrchestrationV2ContextTransferResolution,
   type OrchestrationV2ConversationMessage,
+  type OrchestrationV2DelegatedCompletionCohort,
+  type OrchestrationV2DelegatedCompletionDelivery,
   type OrchestrationV2DomainEvent,
   type OrchestrationV2ExecutionNode,
   type OrchestrationV2ProviderThread,
@@ -24,6 +26,7 @@ import {
   type OrchestrationV2TurnItem,
   ProviderInstanceId,
   type ProviderSessionId,
+  RunId,
   ThreadId,
 } from "@t3tools/contracts";
 import { modelSelectionsEqual } from "@t3tools/shared/model";
@@ -52,10 +55,7 @@ import {
 } from "./ProjectionStore.ts";
 import type { ProviderAdapterV2Shape } from "./ProviderAdapter.ts";
 import { ProviderAdapterRegistryV2 } from "./ProviderAdapterRegistry.ts";
-import {
-  type ProviderContinuationRequest,
-  ProviderContinuationRequests,
-} from "./ProviderContinuationRequests.ts";
+import { ProviderContinuationRequests } from "./ProviderContinuationRequests.ts";
 import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
 import { ProviderSwitchServiceV2 } from "./ProviderSwitchService.ts";
 import { RuntimePolicyV2 } from "./RuntimePolicy.ts";
@@ -217,6 +217,8 @@ function commandThreadId(command: OrchestrationV2Command): ThreadId {
       return command.threadId;
     case "delegated_task.request":
     case "delegated_task.wake-policy":
+    case "delegated_task.completion-delivery.acknowledge":
+    case "delegated_task.completion-delivery.dispose":
     case "thread.created.record":
       return command.parentThreadId;
     case "thread.fork":
@@ -266,38 +268,11 @@ function hasLiveRun(projection: OrchestrationV2ThreadProjection): boolean {
   );
 }
 
-function delegatedTaskWakeDetail(
-  task: Pick<OrchestrationV2Subagent, "id" | "title" | "status">,
-): string {
-  const label = task.title === null ? task.id : `"${task.title}"`;
-  return task.status === "completed"
-    ? `Delegated task ${label} completed. Use task_status with taskId ${task.id} to read the result.`
-    : `Delegated task ${label} ended with status ${task.status}. Use task_status with taskId ${task.id} for details.`;
-}
-
-/**
- * Both app-owned wake producers must go through this. An app-owned child leaves
- * nothing buffered in the adapter, so the detail text is the entire wake and has
- * to reach the provider as a real prompt. Omitting `delivery` here would mark
- * the dispatch as an adapter-buffered wake, which ClaudeAdapterV2 and
- * AcpAdapterV2 both answer by discarding the text and settling the turn against
- * an empty buffer.
- */
-function delegatedTaskWakeRequest(input: {
-  readonly threadId: ThreadId;
-  readonly providerThread: Pick<
-    OrchestrationV2ThreadProjection["providerThreads"][number],
-    "id" | "driver"
-  >;
-  readonly task: Pick<OrchestrationV2Subagent, "id" | "title" | "status">;
-}): ProviderContinuationRequest {
-  return {
-    threadId: input.threadId,
-    providerThreadId: input.providerThread.id,
-    driver: input.providerThread.driver,
-    detail: delegatedTaskWakeDetail(input.task),
-    delivery: "message_text",
-  };
+function delegatedCompletionWakeDetail(taskIds: ReadonlyArray<string>): string {
+  const taskList = taskIds.join(", ");
+  return taskIds.length === 1
+    ? `Delegated task ${taskList} reached a terminal state. Use task_status with taskId ${taskList} to read the result.`
+    : `Delegated tasks ${taskList} reached terminal states. Use task_status with each taskId to read the results.`;
 }
 
 function isTerminalDelegatedTaskStatus(status: OrchestrationV2Subagent["status"]): boolean {
@@ -537,6 +512,18 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         ),
       );
 
+  const mapDelegatedCompletionError = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.mapError(
+        (cause) =>
+          new OrchestratorDispatchError({
+            commandId: CommandId.make("command:system:delegated-completion-delivery"),
+            commandType: "delegated_task.completion-delivery",
+            cause,
+          }),
+      ),
+    );
+
   const providerSessionIdFor = (input: {
     readonly adapter: ProviderAdapterV2Shape;
     readonly providerInstanceId: ProviderInstanceId;
@@ -650,6 +637,141 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         makeSystemEvent(event as Omit<OrchestrationV2DomainEvent, "id">),
       );
       yield* eventSink.writeWithEffects({ events: withIds, effects });
+    });
+
+  const completionDeliveryRun = (
+    projection: OrchestrationV2ThreadProjection,
+    delivery: OrchestrationV2DelegatedCompletionDelivery | null | undefined,
+  ) =>
+    delivery === null || delivery === undefined
+      ? undefined
+      : projection.runs.find((candidate) => candidate.userMessageId === delivery.messageId);
+
+  const completionDeliveryMessage = (
+    projection: OrchestrationV2ThreadProjection,
+    delivery: OrchestrationV2DelegatedCompletionDelivery | null | undefined,
+  ) =>
+    delivery === null || delivery === undefined
+      ? undefined
+      : projection.messages.find((candidate) => candidate.id === delivery.messageId);
+
+  const offerDelegatedCompletionDelivery = (threadId: ThreadId, parentRunId: RunId) =>
+    Effect.gen(function* () {
+      const projection = yield* projectionStore.getThreadProjection(threadId);
+      const parentRun = projection.runs.find((candidate) => candidate.id === parentRunId);
+      const cohort = parentRun?.delegatedCompletion;
+      const delivery = cohort?.delivery;
+      if (
+        parentRun === undefined ||
+        cohort?.disposition !== "open" ||
+        delivery === null ||
+        delivery === undefined ||
+        delivery.taskIds.length === 0 ||
+        projection.thread.archivedAt !== null ||
+        projection.thread.deletedAt !== null ||
+        completionDeliveryMessage(projection, delivery) !== undefined
+      ) {
+        return;
+      }
+      const providerThread =
+        parentRun.providerThreadId === null
+          ? undefined
+          : projection.providerThreads.find(
+              (candidate) => candidate.id === parentRun.providerThreadId,
+            );
+      if (providerThread === undefined) {
+        return;
+      }
+      yield* continuationRequests.offer({
+        threadId,
+        providerThreadId: providerThread.id,
+        driver: providerThread.driver,
+        detail: null,
+        delivery: "message_text",
+        delegatedCompletion: {
+          parentRunId,
+          generation: delivery.generation,
+          messageId: delivery.messageId,
+        },
+      });
+    });
+
+  const offerDelegatedCompletionDeliveries = (threadId: ThreadId) =>
+    Effect.gen(function* () {
+      const projection = yield* projectionStore.getThreadProjection(threadId);
+      for (const run of projection.runs) {
+        if (
+          run.delegatedCompletion?.delivery !== undefined &&
+          run.delegatedCompletion.delivery !== null
+        ) {
+          yield* offerDelegatedCompletionDelivery(threadId, run.id);
+        }
+      }
+    });
+
+  const emitQueuedRunCancellation = (input: {
+    readonly command: OrchestrationV2Command;
+    readonly events: Ref.Ref<Array<OrchestrationV2DomainEvent>>;
+    readonly projection: OrchestrationV2ThreadProjection;
+    readonly run: OrchestrationV2Run;
+    readonly now: DateTime.Utc;
+  }) =>
+    Effect.gen(function* () {
+      const rootNode =
+        input.run.rootNodeId === null
+          ? undefined
+          : input.projection.nodes.find((candidate) => candidate.id === input.run.rootNodeId);
+      const attempt =
+        input.run.activeAttemptId === null
+          ? undefined
+          : input.projection.attempts.find(
+              (candidate) => candidate.id === input.run.activeAttemptId,
+            );
+      const emitEvent = emit(input.events, input.command);
+      yield* emitEvent({
+        type: "run.updated",
+        threadId: input.run.threadId,
+        runId: input.run.id,
+        ...(input.run.rootNodeId === null ? {} : { nodeId: input.run.rootNodeId }),
+        providerInstanceId: input.run.providerInstanceId,
+        occurredAt: input.now,
+        payload: {
+          ...input.run,
+          status: "cancelled",
+          queuePosition: null,
+          completedAt: input.now,
+        },
+      });
+      if (attempt !== undefined && rootNode !== undefined) {
+        yield* emitEvent({
+          type: "run-attempt.updated",
+          threadId: input.run.threadId,
+          runId: input.run.id,
+          nodeId: rootNode.id,
+          providerInstanceId: input.run.providerInstanceId,
+          occurredAt: input.now,
+          payload: {
+            ...attempt,
+            status: "cancelled",
+            completedAt: input.now,
+          },
+        });
+      }
+      if (rootNode !== undefined) {
+        yield* emitEvent({
+          type: "node.updated",
+          threadId: input.run.threadId,
+          runId: input.run.id,
+          nodeId: rootNode.id,
+          providerInstanceId: input.run.providerInstanceId,
+          occurredAt: input.now,
+          payload: {
+            ...rootNode,
+            status: "cancelled",
+            completedAt: input.now,
+          },
+        });
+      }
     });
 
   const startNextQueuedRun = (threadId: ThreadId) =>
@@ -892,6 +1014,260 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         }),
     ),
   );
+
+  const dispatchDelegatedTaskCompletionDeliveryResolution = (
+    command: Extract<
+      OrchestrationV2Command,
+      {
+        readonly type:
+          | "delegated_task.completion-delivery.acknowledge"
+          | "delegated_task.completion-delivery.dispose";
+      }
+    >,
+    events: Ref.Ref<Array<OrchestrationV2DomainEvent>>,
+  ) =>
+    Effect.gen(function* () {
+      const projection = yield* projectionStore.getThreadProjection(command.parentThreadId).pipe(
+        Effect.mapError(
+          (cause) =>
+            new OrchestratorProjectionError({
+              threadId: command.parentThreadId,
+              cause,
+            }),
+        ),
+      );
+      const task = projection.subagents.find(
+        (candidate) => candidate.id === command.taskId && candidate.origin === "app_owned",
+      );
+      if (task === undefined) {
+        return yield* new OrchestratorDispatchError({
+          commandId: command.commandId,
+          commandType: command.type,
+          cause: `Delegated task ${command.taskId} is not an app-owned task of thread ${command.parentThreadId}.`,
+        });
+      }
+      const state =
+        command.type === "delegated_task.completion-delivery.acknowledge"
+          ? "acknowledged"
+          : "disposed";
+      if (task.completionDelivery?.state === state) {
+        return yield* new OrchestratorDispatchError({
+          commandId: command.commandId,
+          commandType: command.type,
+          cause: `Delegated task ${command.taskId} completion delivery is already ${state}.`,
+        });
+      }
+      const now = yield* DateTime.now;
+      const emitEvent = emit(events, command);
+      const updatedTask: OrchestrationV2Subagent = {
+        ...task,
+        completionDelivery: {
+          state,
+          observedByRunId:
+            command.type === "delegated_task.completion-delivery.acknowledge"
+              ? command.observedByRunId
+              : null,
+        },
+        updatedAt: now,
+      };
+      yield* emitEvent({
+        type: "subagent.updated",
+        threadId: command.parentThreadId,
+        ...(task.runId === null ? {} : { runId: task.runId }),
+        nodeId: task.id,
+        driver: task.driver,
+        providerInstanceId: task.providerInstanceId,
+        occurredAt: now,
+        payload: updatedTask,
+      });
+
+      const parentRun =
+        task.runId === null
+          ? undefined
+          : projection.runs.find((candidate) => candidate.id === task.runId);
+      const cohort = parentRun?.delegatedCompletion;
+      const delivery = cohort?.delivery;
+      if (
+        parentRun === undefined ||
+        cohort === undefined ||
+        delivery === null ||
+        delivery === undefined
+      ) {
+        return;
+      }
+      if (!delivery.taskIds.includes(task.id)) {
+        return;
+      }
+
+      const remainingTaskIds = delivery.taskIds.filter((taskId) => taskId !== task.id);
+      const deliveryRun = completionDeliveryRun(projection, delivery);
+      const clearDelivery =
+        remainingTaskIds.length === 0 &&
+        (deliveryRun === undefined || deliveryRun.status === "queued");
+      const updatedCohort: OrchestrationV2DelegatedCompletionCohort = {
+        ...cohort,
+        delivery: clearDelivery
+          ? null
+          : {
+              ...delivery,
+              taskIds: remainingTaskIds,
+            },
+      };
+      yield* emitEvent({
+        type: "run.updated",
+        threadId: command.parentThreadId,
+        runId: parentRun.id,
+        ...(parentRun.rootNodeId === null ? {} : { nodeId: parentRun.rootNodeId }),
+        providerInstanceId: parentRun.providerInstanceId,
+        occurredAt: now,
+        payload: {
+          ...parentRun,
+          delegatedCompletion: updatedCohort,
+        },
+      });
+
+      if (deliveryRun?.status === "queued") {
+        if (remainingTaskIds.length === 0) {
+          yield* emitQueuedRunCancellation({
+            command,
+            events,
+            projection,
+            run: deliveryRun,
+            now,
+          });
+          return;
+        }
+        const message = completionDeliveryMessage(projection, delivery);
+        if (message !== undefined) {
+          yield* emitEvent({
+            type: "message.updated",
+            threadId: command.parentThreadId,
+            runId: deliveryRun.id,
+            ...(deliveryRun.rootNodeId === null ? {} : { nodeId: deliveryRun.rootNodeId }),
+            providerInstanceId: deliveryRun.providerInstanceId,
+            occurredAt: now,
+            payload: {
+              ...message,
+              text: delegatedCompletionWakeDetail(remainingTaskIds),
+              delegatedCompletion: {
+                parentRunId: parentRun.id,
+                generation: delivery.generation,
+                taskIds: remainingTaskIds,
+              },
+              updatedAt: now,
+            },
+          });
+        }
+      }
+    });
+
+  const disposeDelegatedCompletionCohort = (input: {
+    readonly command: OrchestrationV2Command;
+    readonly events: Ref.Ref<Array<OrchestrationV2DomainEvent>>;
+    readonly projection: OrchestrationV2ThreadProjection;
+    readonly parentRunId: RunId;
+    readonly disposition: "stopped" | "disposed";
+    readonly now: DateTime.Utc;
+    readonly cancelQueuedDelivery?: boolean;
+  }) =>
+    Effect.gen(function* () {
+      const parentRun = input.projection.runs.find(
+        (candidate) => candidate.id === input.parentRunId,
+      );
+      if (parentRun === undefined) {
+        return;
+      }
+      const cohort = parentRun.delegatedCompletion;
+      const tasks = input.projection.subagents.filter(
+        (candidate) => candidate.origin === "app_owned" && candidate.runId === input.parentRunId,
+      );
+      if (cohort === undefined && tasks.length === 0) {
+        return;
+      }
+      const emitEvent = emit(input.events, input.command);
+      const nextDisposition = cohort?.disposition === "disposed" ? "disposed" : input.disposition;
+      const nextCohort = {
+        disposition: nextDisposition,
+        nextGeneration: cohort?.nextGeneration ?? 1,
+        settledDeliveryCount: cohort?.settledDeliveryCount ?? 0,
+        delivery: null,
+      } as const;
+      yield* emitEvent({
+        type: "run.updated",
+        threadId: parentRun.threadId,
+        runId: parentRun.id,
+        ...(parentRun.rootNodeId === null ? {} : { nodeId: parentRun.rootNodeId }),
+        providerInstanceId: parentRun.providerInstanceId,
+        occurredAt: input.now,
+        payload: {
+          ...parentRun,
+          delegatedCompletion: nextCohort,
+        },
+      });
+      for (const task of tasks) {
+        if (
+          task.completionDelivery?.state === "acknowledged" ||
+          task.completionDelivery?.state === "delivered" ||
+          task.completionDelivery?.state === "disposed"
+        ) {
+          continue;
+        }
+        yield* emitEvent({
+          type: "subagent.updated",
+          threadId: parentRun.threadId,
+          ...(task.runId === null ? {} : { runId: task.runId }),
+          nodeId: task.id,
+          driver: task.driver,
+          providerInstanceId: task.providerInstanceId,
+          occurredAt: input.now,
+          payload: {
+            ...task,
+            completionDelivery: {
+              state: "disposed",
+              observedByRunId: null,
+            },
+            updatedAt: input.now,
+          },
+        });
+      }
+      const deliveryRun = completionDeliveryRun(input.projection, cohort?.delivery ?? null);
+      if (input.cancelQueuedDelivery !== false && deliveryRun?.status === "queued") {
+        yield* emitQueuedRunCancellation({
+          command: input.command,
+          events: input.events,
+          projection: input.projection,
+          run: deliveryRun,
+          now: input.now,
+        });
+      }
+    });
+
+  const disposeAllDelegatedCompletionCohorts = (input: {
+    readonly command: OrchestrationV2Command;
+    readonly events: Ref.Ref<Array<OrchestrationV2DomainEvent>>;
+    readonly projection: OrchestrationV2ThreadProjection;
+    readonly now: DateTime.Utc;
+    readonly cancelQueuedDelivery?: boolean;
+  }) =>
+    Effect.forEach(
+      Array.from(
+        new Set([
+          ...input.projection.runs
+            .filter((run) => run.delegatedCompletion !== undefined)
+            .map((run) => run.id),
+          ...input.projection.subagents
+            .filter((task) => task.origin === "app_owned" && task.runId !== null)
+            .map((task) => task.runId!),
+        ]),
+      ),
+      (parentRunId) =>
+        disposeDelegatedCompletionCohort({
+          ...input,
+          parentRunId,
+          disposition: "disposed",
+        }),
+      { concurrency: 1, discard: true },
+    );
 
   const dispatchThreadCreate = Effect.fn("orchestrationV2.dispatch.threadCreate")(function* (
     command: Extract<OrchestrationV2Command, { readonly type: "thread.create" }>,
@@ -1348,6 +1724,14 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           });
         }
       }
+
+      yield* disposeAllDelegatedCompletionCohorts({
+        command,
+        events,
+        projection: yield* getProjectionWithPendingEvents(command.threadId, events),
+        now,
+        cancelQueuedDelivery: false,
+      });
     }
 
     const detachSessionIds = new Set(
@@ -2414,6 +2798,46 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
       }
       const modelSelection = command.modelSelection ?? projection.thread.modelSelection;
       const dispatchMode = command.dispatchMode;
+      let delegatedCompletion:
+        | OrchestrationV2ConversationMessage["delegatedCompletion"]
+        | undefined;
+      if (command.delegatedCompletion !== undefined) {
+        const requestedCompletion = command.delegatedCompletion;
+        if (
+          command.createdBy !== "agent" ||
+          command.creationSource !== "server" ||
+          dispatchMode.type !== "queue_after_active"
+        ) {
+          return yield* new OrchestratorDispatchError({
+            commandId: command.commandId,
+            commandType: command.type,
+            cause: "Delegated completion delivery must be a server-created queued message.",
+          });
+        }
+        const parentRun = projection.runs.find(
+          (candidate) => candidate.id === requestedCompletion.parentRunId,
+        );
+        const delivery = parentRun?.delegatedCompletion?.delivery;
+        if (
+          parentRun?.delegatedCompletion?.disposition !== "open" ||
+          delivery === null ||
+          delivery === undefined ||
+          delivery.generation !== requestedCompletion.generation ||
+          delivery.messageId !== command.messageId ||
+          projection.messages.some((candidate) => candidate.id === command.messageId)
+        ) {
+          return yield* new OrchestratorDispatchError({
+            commandId: command.commandId,
+            commandType: command.type,
+            cause: "Delegated completion delivery is no longer dispatchable.",
+          });
+        }
+        delegatedCompletion = {
+          parentRunId: requestedCompletion.parentRunId,
+          generation: delivery.generation,
+          taskIds: delivery.taskIds,
+        };
+      }
       const sourcePlanProjection =
         command.sourcePlanRef === undefined
           ? null
@@ -2635,6 +3059,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           streaming: false,
           createdAt: now,
           updatedAt: now,
+          ...(delegatedCompletion === undefined ? {} : { delegatedCompletion }),
         };
         const emitEvent = emit(events, command);
         yield* emitEvent({
@@ -2887,6 +3312,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           streaming: false,
           createdAt: now,
           updatedAt: now,
+          ...(delegatedCompletion === undefined ? {} : { delegatedCompletion }),
         };
         const turnItem: OrchestrationV2TurnItem = {
           createdBy: command.createdBy,
@@ -3545,6 +3971,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         streaming: false,
         createdAt: now,
         updatedAt: now,
+        ...(delegatedCompletion === undefined ? {} : { delegatedCompletion }),
       };
       const turnItem: OrchestrationV2TurnItem = {
         createdBy: command.createdBy,
@@ -4220,6 +4647,38 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
     }
     const now = yield* DateTime.now;
     const emitEvent = emit(events, command);
+    const updatedTask: OrchestrationV2Subagent = {
+      ...task,
+      completionWake: command.completionWake,
+      updatedAt: now,
+    };
+    // A non-terminal task needs no offer here: finalize reads the upgraded
+    // policy when the child terminalizes. Both writers hold this parent lock,
+    // so a terminal task means finalize already committed the terminal row and
+    // already made its offer decision under the pre-upgrade policy: under
+    // settled_only it offered iff the parent had no live run. Plan a delivery
+    // only when the parent has a live run now, which is precisely the case
+    // where finalize skipped. Queue-after-active then sequences it behind that
+    // run. When the parent is not live, finalize already offered and a second
+    // offer would wake the parent twice. (If the parent settled in between,
+    // this skips a wake that finalize also skipped; a missed wake is cheaper
+    // than a duplicate one, and the result is already in the projection.)
+    const parentRun =
+      task.runId === null
+        ? undefined
+        : parentProjection.runs.find((candidate) => candidate.id === task.runId);
+    const completionPlan =
+      command.completionWake === "always" &&
+      isTerminalDelegatedTaskStatus(task.status) &&
+      hasLiveRun(parentProjection)
+        ? yield* planDelegatedCompletionDelivery({
+            parentProjection,
+            parentRun,
+            task: updatedTask,
+            updatedTask,
+            now,
+          })
+        : undefined;
     yield* emitEvent({
       type: "subagent.updated",
       threadId: command.parentThreadId,
@@ -4228,45 +4687,39 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
       driver: task.driver,
       providerInstanceId: task.providerInstanceId,
       occurredAt: now,
-      payload: { ...task, completionWake: command.completionWake, updatedAt: now },
+      payload: completionPlan?.task ?? updatedTask,
     });
-    // A non-terminal task needs no offer here: finalize reads the upgraded
-    // policy when the child terminalizes. Both writers hold this parent lock,
-    // so a terminal task means finalize already committed the terminal row and
-    // already made its offer decision under the pre-upgrade policy: under
-    // settled_only it offered iff the parent had no live run. Offer here only
-    // when the parent has a live run now, which is precisely the case where
-    // finalize skipped; queue_after_active then sequences the wake behind that
-    // run. When the parent is not live, finalize already offered and a second
-    // offer would wake the parent twice. (If the parent settled in between,
-    // this skips a wake that finalize also skipped; a missed wake is cheaper
-    // than a duplicate one, and the result is already in the projection.)
-    if (command.completionWake !== "always" || !isTerminalDelegatedTaskStatus(task.status)) {
+    if (completionPlan === undefined) {
       return;
     }
-    if (!hasLiveRun(parentProjection)) {
-      return;
-    }
-    const parentRun =
-      task.runId === null
-        ? undefined
-        : parentProjection.runs.find((candidate) => candidate.id === task.runId);
-    const parentProviderThread =
-      parentRun?.providerThreadId === null || parentRun?.providerThreadId === undefined
-        ? undefined
-        : parentProjection.providerThreads.find(
-            (candidate) => candidate.id === parentRun.providerThreadId,
-          );
-    if (parentProviderThread === undefined) {
-      return;
-    }
-    yield* continuationRequests.offer(
-      delegatedTaskWakeRequest({
+    if (completionPlan.parentRun !== undefined) {
+      yield* emitEvent({
+        type: "run.updated",
         threadId: command.parentThreadId,
-        providerThread: parentProviderThread,
-        task,
-      }),
-    );
+        runId: completionPlan.parentRun.id,
+        ...(completionPlan.parentRun.rootNodeId === null
+          ? {}
+          : { nodeId: completionPlan.parentRun.rootNodeId }),
+        providerInstanceId: completionPlan.parentRun.providerInstanceId,
+        occurredAt: now,
+        payload: completionPlan.parentRun,
+      });
+    }
+    if (completionPlan.message !== undefined) {
+      yield* emitEvent({
+        type: "message.updated",
+        threadId: command.parentThreadId,
+        ...(completionPlan.message.runId === null ? {} : { runId: completionPlan.message.runId }),
+        ...(completionPlan.message.nodeId === null
+          ? {}
+          : { nodeId: completionPlan.message.nodeId }),
+        providerInstanceId:
+          completionPlan.parentRun?.providerInstanceId ??
+          parentProjection.thread.providerInstanceId,
+        occurredAt: now,
+        payload: completionPlan.message,
+      });
+    }
   });
 
   const dispatchCreatedThreadRecord = Effect.fn("orchestrationV2.dispatch.createdThreadRecord")(
@@ -4545,6 +4998,13 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           cause: `Queued run ${queuedRun.id} is missing message or execution state.`,
         });
       }
+      if (queuedMessage.delegatedCompletion !== undefined) {
+        return yield* new OrchestratorDispatchError({
+          commandId: command.commandId,
+          commandType: command.type,
+          cause: "Automatic completion deliveries cannot be promoted to Steer.",
+        });
+      }
 
       const now = yield* DateTime.now;
       const emitEvent = emit(events, command);
@@ -4630,6 +5090,16 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           cause: `Run ${command.runId} is not queued.`,
         });
       }
+      const movingMessage = projection.messages.find(
+        (candidate) => candidate.id === moving.userMessageId,
+      );
+      if (movingMessage?.delegatedCompletion !== undefined) {
+        return yield* new OrchestratorDispatchError({
+          commandId: command.commandId,
+          commandType: command.type,
+          cause: "Automatic completion deliveries cannot be reordered.",
+        });
+      }
       const withoutMoving = queuedRuns.filter((run) => run.id !== command.runId);
       const beforeIndex =
         command.beforeRunId === null
@@ -4691,6 +5161,21 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           commandType: command.type,
           cause: `Run ${command.runId} is not queued.`,
         });
+      }
+      const queuedMessage = projection.messages.find(
+        (candidate) => candidate.id === queuedRun.userMessageId,
+      );
+      if (queuedMessage?.delegatedCompletion !== undefined) {
+        const now = yield* DateTime.now;
+        yield* disposeDelegatedCompletionCohort({
+          command,
+          events,
+          projection,
+          parentRunId: queuedMessage.delegatedCompletion.parentRunId,
+          disposition: "disposed",
+          now,
+        });
+        return;
       }
       const queuedRootNode =
         queuedRun.rootNodeId === null
@@ -4782,6 +5267,13 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           commandId: command.commandId,
           commandType: command.type,
           cause: `Queued run ${queuedRun.id} has no user message.`,
+        });
+      }
+      if (queuedMessage.delegatedCompletion !== undefined) {
+        return yield* new OrchestratorDispatchError({
+          commandId: command.commandId,
+          commandType: command.type,
+          cause: "Automatic completion deliveries cannot be edited.",
         });
       }
       const queuedTurnItem = projection.turnItems.find(
@@ -5101,8 +5593,23 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           cause: `Run ${command.runId} is not interruptible.`,
         });
       }
-
       const now = yield* DateTime.now;
+      const completionMessage = projection.messages.find(
+        (candidate) => candidate.id === run.userMessageId,
+      );
+      const completionCohortRunId = completionMessage?.delegatedCompletion?.parentRunId ?? run.id;
+      const stopCompletionCohort = () =>
+        Effect.gen(function* () {
+          yield* disposeDelegatedCompletionCohort({
+            command,
+            events,
+            projection: yield* getProjectionWithPendingEvents(command.threadId, events),
+            parentRunId: completionCohortRunId,
+            disposition: "stopped",
+            now,
+          });
+        });
+
       const emitEvent = emit(events, command);
       const interruptRequestItem: OrchestrationV2TurnItem = {
         id: idAllocator.derive.runSignalTurnItem({
@@ -5236,6 +5743,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           occurredAt: now,
           payload: { ...run, status: "interrupted", completedAt: now },
         });
+        yield* stopCompletionCohort();
         return {
           effectTypes: ["provider-turn.start", "provider-turn.restart"],
           reason: `Run ${run.id} was interrupted before its provider turn started.`,
@@ -5321,6 +5829,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         occurredAt: now,
         payload: interruptRequestItem,
       });
+      yield* stopCompletionCohort();
       yield* Ref.update(effects, (existing) => [
         ...existing,
         {
@@ -5479,6 +5988,205 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         : undefined;
     });
 
+  const planDelegatedCompletionDelivery = Effect.fn(
+    "orchestrationV2.planDelegatedCompletionDelivery",
+  )(function* (input: {
+    readonly parentProjection: OrchestrationV2ThreadProjection;
+    readonly parentRun: OrchestrationV2Run | undefined;
+    readonly task: OrchestrationV2Subagent;
+    readonly updatedTask: OrchestrationV2Subagent;
+    readonly now: DateTime.Utc;
+  }) {
+    const taskDelivery = input.updatedTask.completionDelivery;
+    if (taskDelivery?.state === "acknowledged" || taskDelivery?.state === "disposed") {
+      return {
+        task: input.updatedTask,
+        parentRun: undefined,
+        message: undefined,
+        offer: false,
+      };
+    }
+    const cohort = input.parentRun?.delegatedCompletion;
+    if (
+      input.parentRun === undefined ||
+      input.parentProjection.thread.archivedAt !== null ||
+      input.parentProjection.thread.deletedAt !== null ||
+      (cohort !== undefined && cohort.disposition !== "open")
+    ) {
+      return {
+        task: {
+          ...input.updatedTask,
+          completionDelivery: {
+            state: "disposed" as const,
+            observedByRunId: null,
+          },
+        },
+        parentRun: undefined,
+        message: undefined,
+        offer: false,
+      };
+    }
+    if (
+      (input.task.completionWake ?? "settled_only") === "settled_only" &&
+      hasLiveRun(input.parentProjection)
+    ) {
+      return {
+        task: input.updatedTask,
+        parentRun: undefined,
+        message: undefined,
+        offer: false,
+      };
+    }
+
+    const delivery = cohort?.delivery ?? null;
+    const deliveryRun = completionDeliveryRun(input.parentProjection, delivery);
+    if (delivery !== null) {
+      if (deliveryRun?.status === "queued") {
+        const taskIds = Array.from(new Set([...delivery.taskIds, input.task.id]));
+        const message = completionDeliveryMessage(input.parentProjection, delivery);
+        const nextCohort = {
+          ...cohort!,
+          delivery: {
+            ...delivery,
+            taskIds,
+          },
+        };
+        return {
+          task: {
+            ...input.updatedTask,
+            completionDelivery: {
+              state: "claimed" as const,
+              observedByRunId: null,
+            },
+          },
+          parentRun: {
+            ...input.parentRun,
+            delegatedCompletion: nextCohort,
+          },
+          message:
+            message === undefined
+              ? undefined
+              : {
+                  ...message,
+                  text: delegatedCompletionWakeDetail(taskIds),
+                  delegatedCompletion: {
+                    parentRunId: input.parentRun.id,
+                    generation: delivery.generation,
+                    taskIds,
+                  },
+                  updatedAt: input.now,
+                },
+          offer: false,
+        };
+      }
+      if (deliveryRun !== undefined && isBlockingRun(deliveryRun)) {
+        return {
+          task: {
+            ...input.updatedTask,
+            completionDelivery: {
+              state: "pending" as const,
+              observedByRunId: null,
+            },
+          },
+          parentRun: undefined,
+          message: undefined,
+          offer: false,
+        };
+      }
+      if (deliveryRun !== undefined) {
+        // The terminal-run listener owns reconciliation of a completed wake.
+        // A sibling that wins the parent lock first remains pending for its
+        // one successor rather than creating a competing delivery.
+        return {
+          task: {
+            ...input.updatedTask,
+            completionDelivery: {
+              state: "pending" as const,
+              observedByRunId: null,
+            },
+          },
+          parentRun: undefined,
+          message: undefined,
+          offer: false,
+        };
+      }
+      const taskIds = Array.from(new Set([...delivery.taskIds, input.task.id]));
+      const nextCohort = {
+        ...cohort!,
+        delivery: {
+          ...delivery,
+          taskIds,
+        },
+      };
+      return {
+        task: {
+          ...input.updatedTask,
+          completionDelivery: {
+            state: "claimed" as const,
+            observedByRunId: null,
+          },
+        },
+        parentRun: {
+          ...input.parentRun,
+          delegatedCompletion: nextCohort,
+        },
+        message: undefined,
+        offer: true,
+      };
+    }
+
+    const settledDeliveryCount = cohort?.settledDeliveryCount ?? 0;
+    if (settledDeliveryCount >= 2) {
+      // A cohort permits one initial delivery and one successor. Keep the
+      // result pending and inspectable instead of recursively re-arming the
+      // parent for every child that finishes after that bounded handoff.
+      return {
+        task: {
+          ...input.updatedTask,
+          completionDelivery: {
+            state: "pending" as const,
+            observedByRunId: null,
+          },
+        },
+        parentRun: undefined,
+        message: undefined,
+        offer: false,
+      };
+    }
+    const generation = cohort?.nextGeneration ?? 1;
+    const messageId = yield* mapDelegatedCompletionError(
+      idAllocator.allocate.message({
+        threadId: input.parentRun.threadId,
+        ordinal: input.parentProjection.messages.length + 1,
+      }),
+    );
+    const nextCohort = {
+      disposition: "open" as const,
+      nextGeneration: generation + 1,
+      settledDeliveryCount,
+      delivery: {
+        generation,
+        messageId,
+        taskIds: [input.task.id],
+      },
+    };
+    return {
+      task: {
+        ...input.updatedTask,
+        completionDelivery: {
+          state: "claimed" as const,
+          observedByRunId: null,
+        },
+      },
+      parentRun: {
+        ...input.parentRun,
+        delegatedCompletion: nextCohort,
+      },
+      message: undefined,
+      offer: true,
+    };
+  });
+
   /**
    * Transfers a terminal child's result into its parent and offers the parent
    * wake. Every mutation here targets the PARENT thread, so callers must hold
@@ -5547,6 +6255,13 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         completedAt: now,
         updatedAt: now,
       };
+      const completionPlan = yield* planDelegatedCompletionDelivery({
+        parentProjection,
+        parentRun,
+        task,
+        updatedTask,
+        now,
+      });
       const resultTransferId = yield* idAllocator.allocate.contextTransfer({
         sourceThreadId: childThreadId,
         targetThreadId: parentThreadId,
@@ -5629,8 +6344,42 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           nodeId: task.id,
           driver: task.driver,
           occurredAt: now,
-          payload: updatedTask,
+          payload: completionPlan.task,
         },
+        ...(completionPlan.parentRun === undefined
+          ? []
+          : [
+              {
+                type: "run.updated" as const,
+                threadId: parentThreadId,
+                runId: completionPlan.parentRun.id,
+                ...(completionPlan.parentRun.rootNodeId === null
+                  ? {}
+                  : { nodeId: completionPlan.parentRun.rootNodeId }),
+                providerInstanceId: completionPlan.parentRun.providerInstanceId,
+                occurredAt: now,
+                payload: completionPlan.parentRun,
+              },
+            ]),
+        ...(completionPlan.message === undefined
+          ? []
+          : [
+              {
+                type: "message.updated" as const,
+                threadId: parentThreadId,
+                ...(completionPlan.message.runId === null
+                  ? {}
+                  : { runId: completionPlan.message.runId }),
+                ...(completionPlan.message.nodeId === null
+                  ? {}
+                  : { nodeId: completionPlan.message.nodeId }),
+                providerInstanceId:
+                  completionPlan.parentRun?.providerInstanceId ??
+                  parentProjection.thread.providerInstanceId,
+                occurredAt: now,
+                payload: completionPlan.message,
+              },
+            ]),
         ...(parentNode === undefined
           ? []
           : [
@@ -5690,36 +6439,141 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         },
       ]);
 
-      // Nothing else re-invokes a parent that already settled: the child's
-      // result lands in the projection above, but no parent run starts to let
-      // the agent act on it. Offer a continuation (dispatched
-      // queue_after_active) so the parent wakes and collects the result.
-      // Policy comes from the task's completionWake: "always" (async
-      // delegations) offers on every terminal, sequencing behind a live
-      // parent run like a provider task notification; "settled_only" (wait
-      // delegations, and legacy records without the field) skips while the
-      // parent has a run in preparing/starting/running, because the blocking
-      // tool call already returns the result there. A run parked at
-      // "waiting" is post-terminal drain, so its agent turn is over and the
-      // wake is still needed. The result-transfer guard above makes this a
-      // single offer per child, replay included.
-      if (parentProviderThread === undefined) {
+      if (completionPlan.offer && completionPlan.parentRun !== undefined) {
+        yield* offerDelegatedCompletionDelivery(parentThreadId, completionPlan.parentRun.id);
+      }
+    });
+
+  const finalizeDelegatedCompletionDelivery = (threadId: ThreadId, runId: RunId) =>
+    Effect.gen(function* () {
+      const projection = yield* projectionStore.getThreadProjection(threadId);
+      const deliveryRun = projection.runs.find((candidate) => candidate.id === runId);
+      const deliveryMessage =
+        deliveryRun === undefined
+          ? undefined
+          : projection.messages.find((candidate) => candidate.id === deliveryRun.userMessageId);
+      const messageOwnership = deliveryMessage?.delegatedCompletion;
+      if (deliveryRun === undefined || messageOwnership === undefined) {
         return;
       }
-      if ((task.completionWake ?? "settled_only") === "settled_only") {
-        // Re-read under the parent lock so the gate sees the run states left
-        // by the writes above rather than the pre-write snapshot.
-        if (hasLiveRun(yield* projectionStore.getThreadProjection(parentThreadId))) {
-          return;
+      const parentRun = projection.runs.find(
+        (candidate) => candidate.id === messageOwnership.parentRunId,
+      );
+      const cohort = parentRun?.delegatedCompletion;
+      const delivery = cohort?.delivery;
+      if (
+        parentRun === undefined ||
+        cohort === undefined ||
+        delivery === null ||
+        delivery === undefined ||
+        delivery.messageId !== deliveryRun.userMessageId ||
+        delivery.generation !== messageOwnership.generation
+      ) {
+        return;
+      }
+
+      const now = yield* DateTime.now;
+      const nextTaskStates = new Map<
+        OrchestrationV2Subagent["id"],
+        OrchestrationV2Subagent["completionDelivery"]
+      >();
+      for (const task of projection.subagents) {
+        if (
+          task.origin !== "app_owned" ||
+          task.runId !== parentRun.id ||
+          !delivery.taskIds.includes(task.id) ||
+          task.completionDelivery?.state !== "claimed"
+        ) {
+          continue;
+        }
+        nextTaskStates.set(task.id, {
+          state: deliveryRun.status === "cancelled" ? "pending" : "delivered",
+          observedByRunId: null,
+        });
+      }
+      const pendingTaskIds = projection.subagents
+        .filter(
+          (task) =>
+            task.origin === "app_owned" &&
+            task.runId === parentRun.id &&
+            isTerminalDelegatedTaskStatus(task.status) &&
+            (task.completionDelivery?.state === "pending" ||
+              nextTaskStates.get(task.id)?.state === "pending"),
+        )
+        .map((task) => task.id);
+      const settledDeliveryCount = (cohort.settledDeliveryCount ?? 0) + 1;
+      const canReserveFollowUp =
+        cohort.disposition === "open" &&
+        projection.thread.archivedAt === null &&
+        projection.thread.deletedAt === null &&
+        settledDeliveryCount < 2 &&
+        pendingTaskIds.length > 0;
+      const nextDelivery = canReserveFollowUp
+        ? {
+            generation: cohort.nextGeneration,
+            messageId: yield* mapDelegatedCompletionError(
+              idAllocator.allocate.message({
+                threadId,
+                ordinal: projection.messages.length + 1,
+              }),
+            ),
+            taskIds: pendingTaskIds,
+          }
+        : null;
+      if (nextDelivery !== null) {
+        for (const taskId of pendingTaskIds) {
+          nextTaskStates.set(taskId, {
+            state: "claimed",
+            observedByRunId: null,
+          });
         }
       }
-      yield* continuationRequests.offer(
-        delegatedTaskWakeRequest({
-          threadId: parentThreadId,
-          providerThread: parentProviderThread,
-          task: updatedTask,
-        }),
-      );
+      const updatedParentRun: OrchestrationV2Run = {
+        ...parentRun,
+        delegatedCompletion: {
+          ...cohort,
+          settledDeliveryCount,
+          nextGeneration: nextDelivery === null ? cohort.nextGeneration : cohort.nextGeneration + 1,
+          delivery: nextDelivery,
+        },
+      };
+      const taskEvents = projection.subagents.flatMap((task) => {
+        const completionDelivery = nextTaskStates.get(task.id);
+        if (completionDelivery === undefined) {
+          return [];
+        }
+        return [
+          {
+            type: "subagent.updated" as const,
+            threadId,
+            ...(task.runId === null ? {} : { runId: task.runId }),
+            nodeId: task.id,
+            driver: task.driver,
+            providerInstanceId: task.providerInstanceId,
+            occurredAt: now,
+            payload: {
+              ...task,
+              completionDelivery,
+              updatedAt: now,
+            },
+          },
+        ];
+      });
+      yield* writeSystemEvents([
+        ...taskEvents,
+        {
+          type: "run.updated",
+          threadId,
+          runId: updatedParentRun.id,
+          ...(updatedParentRun.rootNodeId === null ? {} : { nodeId: updatedParentRun.rootNodeId }),
+          providerInstanceId: updatedParentRun.providerInstanceId,
+          occurredAt: now,
+          payload: updatedParentRun,
+        },
+      ]);
+      if (nextDelivery !== null) {
+        yield* offerDelegatedCompletionDelivery(threadId, parentRun.id);
+      }
     });
 
   const dispatchUnsupported = (command: OrchestrationV2Command) =>
@@ -5825,6 +6679,10 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         break;
       case "delegated_task.wake-policy":
         yield* dispatchDelegatedTaskWakePolicy(command, events);
+        break;
+      case "delegated_task.completion-delivery.acknowledge":
+      case "delegated_task.completion-delivery.dispose":
+        yield* dispatchDelegatedTaskCompletionDeliveryResolution(command, events);
         break;
       case "thread.created.record":
         yield* dispatchCreatedThreadRecord(command, events);
@@ -5955,6 +6813,9 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         detail: committed.receipt.error ?? "Previously rejected.",
       });
     }
+    if (command.type === "delegated_task.wake-policy") {
+      yield* mapDispatchError(command)(offerDelegatedCompletionDeliveries(command.parentThreadId));
+    }
 
     return {
       sequence: committed.receipt.resultSequence,
@@ -5977,6 +6838,12 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
       const parentThreadId = yield* appOwnedSubagentParentThreadId(threadId);
       if (parentThreadId !== undefined) {
         yield* threadDispatch.withLock(parentThreadId, finalizeAppOwnedSubagent(threadId));
+      }
+      if (stored.event.type === "run.updated") {
+        yield* threadDispatch.withLock(
+          threadId,
+          finalizeDelegatedCompletionDelivery(threadId, stored.event.payload.id),
+        );
       }
       yield* threadDispatch.withLock(threadId, startNextQueuedRun(threadId));
     }).pipe(
@@ -6054,6 +6921,57 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
     ),
     Effect.catchCause((cause) =>
       Effect.logWarning("Failed to inspect app-owned subagents during recovery", {
+        cause,
+      }),
+    ),
+  );
+  yield* projectionStore.getShellSnapshot().pipe(
+    Effect.flatMap((shell) =>
+      Effect.forEach(
+        [...shell.threads, ...shell.archivedThreads],
+        (thread) =>
+          threadDispatch
+            .withLock(
+              thread.id,
+              Effect.gen(function* () {
+                const projection = yield* projectionStore.getThreadProjection(thread.id);
+                const terminalDeliveryRunIds = projection.runs
+                  .filter((run) => delegatedTaskTerminalStatus(run.status) !== null)
+                  .filter((run) =>
+                    projection.messages.some(
+                      (message) =>
+                        message.id === run.userMessageId &&
+                        message.delegatedCompletion !== undefined,
+                    ),
+                  )
+                  .map((run) => run.id);
+                for (const runId of terminalDeliveryRunIds) {
+                  yield* finalizeDelegatedCompletionDelivery(thread.id, runId);
+                }
+                const refreshed = yield* projectionStore.getThreadProjection(thread.id);
+                for (const run of refreshed.runs) {
+                  if (
+                    run.delegatedCompletion?.delivery !== null &&
+                    run.delegatedCompletion !== undefined
+                  ) {
+                    yield* offerDelegatedCompletionDelivery(thread.id, run.id);
+                  }
+                }
+              }),
+            )
+            .pipe(
+              Effect.catchCause((cause) =>
+                Effect.logWarning("Failed to recover delegated completion delivery", {
+                  threadId: thread.id,
+                  cause,
+                }),
+              ),
+            ),
+        { concurrency: 8, discard: true },
+      ),
+    ),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("Failed to inspect delegated completion delivery during recovery", {
         cause,
       }),
     ),

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -58,6 +58,7 @@ import { ProviderAdapterRegistryV2 } from "./ProviderAdapterRegistry.ts";
 import { ProviderContinuationRequests } from "./ProviderContinuationRequests.ts";
 import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
 import { ProviderSwitchServiceV2 } from "./ProviderSwitchService.ts";
+import { isAutomaticCompletionRun, queuedRunsInDeliveryOrder } from "./QueuedRunOrder.ts";
 import { RuntimePolicyV2 } from "./RuntimePolicy.ts";
 import {
   makeSubagentChildThread,
@@ -307,13 +308,7 @@ function delegatedTaskTerminalStatus(
 function nextQueuedRun(
   projection: OrchestrationV2ThreadProjection,
 ): OrchestrationV2Run | undefined {
-  return projection.runs
-    .filter((run) => run.status === "queued")
-    .toSorted(
-      (left, right) =>
-        (left.queuePosition ?? left.ordinal) - (right.queuePosition ?? right.ordinal) ||
-        left.ordinal - right.ordinal,
-    )[0];
+  return queuedRunsInDeliveryOrder(projection)[0];
 }
 
 function latestStableRun(projection: OrchestrationV2ThreadProjection): OrchestrationV2Run | null {
@@ -1056,7 +1051,11 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
       // valid observations can race after their read preflight. Re-emit the
       // existing task row so the second dispatch is a successful idempotent
       // no-op rather than "already acknowledged/disposed" or empty-events.
-      if (task.completionDelivery?.state === state) {
+      if (
+        task.completionDelivery?.state === state ||
+        (command.type === "delegated_task.completion-delivery.acknowledge" &&
+          task.completionDelivery?.state === "disposed")
+      ) {
         yield* emitEvent({
           type: "subagent.updated",
           threadId: command.parentThreadId,
@@ -2848,6 +2847,10 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           taskIds: delivery.taskIds,
         };
       }
+      const dispatchText =
+        delegatedCompletion === undefined
+          ? command.text
+          : delegatedCompletionWakeDetail(delegatedCompletion.taskIds);
       const sourcePlanProjection =
         command.sourcePlanRef === undefined
           ? null
@@ -2906,7 +2909,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           modelSelection,
           targetRunId: dispatchMode.targetRunId,
           messageId: command.messageId,
-          text: command.text,
+          text: dispatchText,
           attachments: command.attachments,
           createdBy: command.createdBy,
           creationSource: command.creationSource,
@@ -3064,7 +3067,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           runId,
           nodeId: rootNodeId,
           role: "user",
-          text: command.text,
+          text: dispatchText,
           attachments: command.attachments,
           streaming: false,
           createdAt: now,
@@ -3317,7 +3320,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           runId,
           nodeId: rootNodeId,
           role: "user",
-          text: command.text,
+          text: dispatchText,
           attachments: command.attachments,
           streaming: false,
           createdAt: now,
@@ -3344,7 +3347,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           type: "user_message",
           messageId: command.messageId,
           inputIntent: "turn_start",
-          text: command.text,
+          text: dispatchText,
           attachments: command.attachments,
         };
         const preparationTurnItem: OrchestrationV2TurnItem | null =
@@ -3976,7 +3979,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         runId,
         nodeId: rootNodeId,
         role: "user",
-        text: command.text,
+        text: dispatchText,
         attachments: command.attachments,
         streaming: false,
         createdAt: now,
@@ -4003,7 +4006,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         type: "user_message",
         messageId: command.messageId,
         inputIntent: "turn_start",
-        text: command.text,
+        text: dispatchText,
         attachments: command.attachments,
       };
       const activeHandoff = portableForkHandoff ?? mergeBackHandoff ?? providerSwitchHandoff;
@@ -5085,13 +5088,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         .pipe(
           Effect.mapError(() => new OrchestratorProjectionError({ threadId: command.threadId })),
         );
-      const queuedRuns = projection.runs
-        .filter((run) => run.status === "queued")
-        .toSorted(
-          (left, right) =>
-            (left.queuePosition ?? left.ordinal) - (right.queuePosition ?? right.ordinal) ||
-            left.ordinal - right.ordinal,
-        );
+      const queuedRuns = queuedRunsInDeliveryOrder(projection);
       const moving = queuedRuns.find((run) => run.id === command.runId);
       if (moving === undefined) {
         return yield* new OrchestratorDispatchError({
@@ -5110,7 +5107,21 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           cause: "Automatic completion deliveries cannot be reordered.",
         });
       }
-      const withoutMoving = queuedRuns.filter((run) => run.id !== command.runId);
+      const automaticRuns = queuedRuns.filter((run) => isAutomaticCompletionRun(projection, run));
+      if (
+        command.beforeRunId !== null &&
+        automaticRuns.some((run) => run.id === command.beforeRunId)
+      ) {
+        return yield* new OrchestratorDispatchError({
+          commandId: command.commandId,
+          commandType: command.type,
+          cause: "Queued messages cannot be reordered ahead of automatic completion delivery.",
+        });
+      }
+      const reorderableRuns = queuedRuns.filter(
+        (run) => !isAutomaticCompletionRun(projection, run),
+      );
+      const withoutMoving = reorderableRuns.filter((run) => run.id !== command.runId);
       const beforeIndex =
         command.beforeRunId === null
           ? withoutMoving.length
@@ -5123,6 +5134,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         });
       }
       const reordered = [
+        ...automaticRuns,
         ...withoutMoving.slice(0, beforeIndex),
         moving,
         ...withoutMoving.slice(beforeIndex),

--- a/apps/server/src/orchestration-v2/ProjectionStore.test.ts
+++ b/apps/server/src/orchestration-v2/ProjectionStore.test.ts
@@ -153,6 +153,156 @@ it.layer(TestLayer)("ProjectionStoreV2", (it) => {
     }),
   );
 
+  it.effect("preserves delegated completion ownership across stale run and task updates", () =>
+    Effect.gen(function* () {
+      const projectionStore = yield* ProjectionStoreV2;
+      const now = yield* DateTime.now;
+      const later = DateTime.add(now, { seconds: 1 });
+      const threadId = ThreadId.make("thread:projection-delegated-completion");
+      const projectId = ProjectId.make("project:projection-delegated-completion");
+      const runId = RunId.make("run:projection-delegated-completion");
+      const rootNodeId = NodeId.make("node:projection-delegated-completion-root");
+      const taskId = NodeId.make("node:projection-delegated-completion-task");
+      const thread = {
+        createdBy: "user" as const,
+        creationSource: "web" as const,
+        id: threadId,
+        projectId,
+        title: "Delegated completion projection",
+        providerInstanceId,
+        modelSelection,
+        runtimeMode: "full-access" as const,
+        interactionMode: "default" as const,
+        branch: null,
+        worktreePath: null,
+        activeProviderThreadId: null,
+        lineage: {
+          parentThreadId: null,
+          relationshipToParent: null,
+          rootThreadId: threadId,
+        },
+        forkedFrom: null,
+        createdAt: now,
+        updatedAt: now,
+        archivedAt: null,
+        settledOverride: null,
+        settledAt: null,
+        lastVisitedAt: null,
+        deletedAt: null,
+      };
+      const run = {
+        id: runId,
+        threadId,
+        ordinal: 1,
+        providerInstanceId,
+        modelSelection,
+        providerThreadId: null,
+        userMessageId: MessageId.make("message:projection-delegated-completion"),
+        rootNodeId,
+        activeAttemptId: null,
+        status: "running" as const,
+        requestedAt: now,
+        startedAt: now,
+        completedAt: null,
+        checkpointId: null,
+        contextHandoffId: null,
+        delegatedCompletion: {
+          disposition: "stopped" as const,
+          nextGeneration: 2,
+          delivery: null,
+        },
+      };
+      const task = {
+        id: taskId,
+        threadId,
+        runId,
+        parentNodeId: rootNodeId,
+        origin: "app_owned" as const,
+        createdBy: "agent" as const,
+        driver,
+        providerInstanceId,
+        providerThreadId: null,
+        childThreadId: null,
+        nativeTaskRef: null,
+        prompt: "Inspect the stop barrier.",
+        title: null,
+        model: null,
+        completionWake: "always" as const,
+        completionDelivery: {
+          state: "disposed" as const,
+          observedByRunId: null,
+        },
+        status: "running" as const,
+        result: null,
+        startedAt: now,
+        completedAt: null,
+        updatedAt: now,
+      };
+
+      yield* projectionStore.apply({
+        id: EventId.make("event:projection-delegated-completion:thread"),
+        type: "thread.created",
+        threadId,
+        occurredAt: now,
+        payload: thread,
+      });
+      yield* projectionStore.apply({
+        id: EventId.make("event:projection-delegated-completion:run"),
+        type: "run.updated",
+        threadId,
+        runId,
+        nodeId: rootNodeId,
+        providerInstanceId,
+        occurredAt: now,
+        payload: run,
+      });
+      yield* projectionStore.apply({
+        id: EventId.make("event:projection-delegated-completion:task"),
+        type: "subagent.updated",
+        threadId,
+        runId,
+        nodeId: taskId,
+        driver,
+        providerInstanceId,
+        occurredAt: now,
+        payload: task,
+      });
+
+      const { delegatedCompletion: _delegatedCompletion, ...staleRun } = run;
+      const { completionDelivery: _completionDelivery, ...staleTask } = task;
+      yield* projectionStore.apply({
+        id: EventId.make("event:projection-delegated-completion:stale-run"),
+        type: "run.updated",
+        threadId,
+        runId,
+        nodeId: rootNodeId,
+        providerInstanceId,
+        occurredAt: later,
+        payload: { ...staleRun, status: "interrupted", completedAt: later },
+      });
+      yield* projectionStore.apply({
+        id: EventId.make("event:projection-delegated-completion:stale-task"),
+        type: "subagent.updated",
+        threadId,
+        runId,
+        nodeId: taskId,
+        driver,
+        providerInstanceId,
+        occurredAt: later,
+        payload: {
+          ...staleTask,
+          status: "interrupted",
+          completedAt: later,
+          updatedAt: later,
+        },
+      });
+
+      const projection = yield* projectionStore.getThreadProjection(threadId);
+      assert.deepEqual(projection.runs[0]?.delegatedCompletion, run.delegatedCompletion);
+      assert.deepEqual(projection.subagents[0]?.completionDelivery, task.completionDelivery);
+    }),
+  );
+
   it.effect("only exposes interruptible runs through the shell activeRunId", () =>
     Effect.gen(function* () {
       const projectionStore = yield* ProjectionStoreV2;

--- a/apps/server/src/orchestration-v2/ProjectionStore.ts
+++ b/apps/server/src/orchestration-v2/ProjectionStore.ts
@@ -2,6 +2,8 @@ import type {
   OrchestrationV2ConversationMessage,
   OrchestrationV2DomainEvent,
   OrchestrationV2ProjectedTurnItem,
+  OrchestrationV2Run,
+  OrchestrationV2Subagent,
   OrchestrationV2ThreadShellSnapshot,
   OrchestrationV2ShellThreadStatus,
   OrchestrationV2ThreadShell,
@@ -137,6 +139,26 @@ function upsertById<T extends { readonly id: string }>(items: ReadonlyArray<T>, 
   return updated;
 }
 
+function preserveDelegatedCompletion(
+  current: OrchestrationV2Run | undefined,
+  next: OrchestrationV2Run,
+): OrchestrationV2Run {
+  if (next.delegatedCompletion !== undefined || current?.delegatedCompletion === undefined) {
+    return next;
+  }
+  return { ...next, delegatedCompletion: current.delegatedCompletion };
+}
+
+function preserveCompletionDelivery(
+  current: OrchestrationV2Subagent | undefined,
+  next: OrchestrationV2Subagent,
+): OrchestrationV2Subagent {
+  if (next.completionDelivery !== undefined || current?.completionDelivery === undefined) {
+    return next;
+  }
+  return { ...next, completionDelivery: current.completionDelivery };
+}
+
 export function emptyProjection(
   event: Extract<OrchestrationV2DomainEvent, { readonly type: "thread.created" }>,
 ): OrchestrationV2ThreadProjection {
@@ -205,7 +227,13 @@ export function applyToProjection(
     case "run.updated":
       return withLocalVisibleTurnItems({
         ...base,
-        runs: upsertById(base.runs, event.payload),
+        runs: upsertById(
+          base.runs,
+          preserveDelegatedCompletion(
+            base.runs.find((run) => run.id === event.payload.id),
+            event.payload,
+          ),
+        ),
       });
     case "run-attempt.created":
     case "run-attempt.updated":
@@ -221,7 +249,13 @@ export function applyToProjection(
     case "subagent.updated":
       return {
         ...base,
-        subagents: upsertById(base.subagents, event.payload),
+        subagents: upsertById(
+          base.subagents,
+          preserveCompletionDelivery(
+            base.subagents.find((task) => task.id === event.payload.id),
+            event.payload,
+          ),
+        ),
       };
     case "provider-session.attached":
     case "provider-session.updated":
@@ -1149,7 +1183,19 @@ export const layer: Layer.Layer<ProjectionStoreV2, never, SqlClient.SqlClient> =
                 status = excluded.status,
                 requested_at = excluded.requested_at,
                 completed_at = excluded.completed_at,
-                payload_json = excluded.payload_json
+                payload_json = CASE
+                  WHEN json_type(excluded.payload_json, '$.delegatedCompletion') IS NULL
+                    AND json_type(orchestration_v2_projection_runs.payload_json, '$.delegatedCompletion') IS NOT NULL
+                  THEN json_set(
+                    excluded.payload_json,
+                    '$.delegatedCompletion',
+                    json_extract(
+                      orchestration_v2_projection_runs.payload_json,
+                      '$.delegatedCompletion'
+                    )
+                  )
+                  ELSE excluded.payload_json
+                END
             `;
             break;
           }
@@ -1305,7 +1351,19 @@ export const layer: Layer.Layer<ProjectionStoreV2, never, SqlClient.SqlClient> =
                 started_at = excluded.started_at,
                 completed_at = excluded.completed_at,
                 updated_at = excluded.updated_at,
-                payload_json = excluded.payload_json
+                payload_json = CASE
+                  WHEN json_type(excluded.payload_json, '$.completionDelivery') IS NULL
+                    AND json_type(orchestration_v2_projection_subagents.payload_json, '$.completionDelivery') IS NOT NULL
+                  THEN json_set(
+                    excluded.payload_json,
+                    '$.completionDelivery',
+                    json_extract(
+                      orchestration_v2_projection_subagents.payload_json,
+                      '$.completionDelivery'
+                    )
+                  )
+                  ELSE excluded.payload_json
+                END
             `;
             break;
           }

--- a/apps/server/src/orchestration-v2/ProviderContinuationRequests.ts
+++ b/apps/server/src/orchestration-v2/ProviderContinuationRequests.ts
@@ -1,4 +1,10 @@
-import { ProviderDriverKind, ProviderThreadId, ThreadId } from "@t3tools/contracts";
+import {
+  MessageId,
+  ProviderDriverKind,
+  ProviderThreadId,
+  RunId,
+  ThreadId,
+} from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -10,6 +16,16 @@ export interface ProviderContinuationRequest {
   readonly providerThreadId: ProviderThreadId;
   readonly driver: ProviderDriverKind;
   readonly detail: string | null;
+  /**
+   * Durable ownership for an app-owned delegated-task completion delivery.
+   * The continuation worker re-reads the cohort before dispatching so a later
+   * task can join a queued wake and a stopped or acknowledged cohort is dropped.
+   */
+  readonly delegatedCompletion?: {
+    readonly parentRunId: RunId;
+    readonly generation: number;
+    readonly messageId: MessageId;
+  };
   /**
    * How the continuation turn gets its content.
    *

--- a/apps/server/src/orchestration-v2/ProviderContinuationService.test.ts
+++ b/apps/server/src/orchestration-v2/ProviderContinuationService.test.ts
@@ -303,6 +303,85 @@ describe("ProviderContinuationService", () => {
     });
   });
 
+  it.effect("resets delegated completion retry backoff after archive or deletion", () => {
+    return Effect.gen(function* () {
+      for (const barrier of ["archivedAt", "deletedAt"] as const) {
+        const attempts = yield* Ref.make(0);
+        const blockedProjectionReads = yield* Ref.make(0);
+        const blockedRequestDropped = yield* Deferred.make<void>();
+        const state = yield* Ref.make<"open" | "blocked" | "disposed">("open");
+        const threads = Layer.mock(ThreadManagementService)({
+          getThreadProjection: () =>
+            Effect.gen(function* () {
+              const currentState = yield* Ref.get(state);
+              if (currentState === "blocked") {
+                const reads = yield* Ref.updateAndGet(blockedProjectionReads, (count) => count + 1);
+                if (reads === 2) {
+                  yield* Deferred.succeed(blockedRequestDropped, undefined);
+                }
+              }
+              return {
+                ...delegatedProjection(currentState === "disposed" ? "disposed" : "open"),
+                thread: {
+                  ...projection.thread,
+                  [barrier]:
+                    currentState === "blocked"
+                      ? DateTime.makeUnsafe("2026-08-05T00:00:00.000Z")
+                      : null,
+                },
+              };
+            }),
+          dispatch: () =>
+            Ref.update(attempts, (count) => count + 1).pipe(
+              Effect.andThen(Effect.fail(new Error("simulated persistent failure") as never)),
+            ),
+        });
+        const worker = workerLive.pipe(
+          Layer.provide(Layer.mergeAll(idAllocatorLayer, continuationRequestsLayer, threads)),
+        );
+        const completionRequest = {
+          threadId,
+          providerThreadId,
+          driver,
+          detail: null,
+          delivery: "message_text" as const,
+          delegatedCompletion: {
+            parentRunId,
+            generation: 1,
+            messageId: delegatedMessageId,
+          },
+        };
+
+        yield* Effect.gen(function* () {
+          const requests = yield* ProviderContinuationRequests;
+          yield* requests.offer(completionRequest);
+          yield* Effect.yieldNow;
+          assert.equal(yield* Ref.get(attempts), 1);
+
+          yield* Ref.set(state, "blocked");
+          yield* TestClock.adjust("100 millis");
+          yield* Deferred.await(blockedRequestDropped);
+          yield* Effect.yieldNow;
+          assert.equal(yield* Ref.get(attempts), 1);
+
+          yield* Ref.set(state, "open");
+          yield* requests.offer(completionRequest);
+          yield* Effect.yieldNow;
+          assert.equal(yield* Ref.get(attempts), 2);
+          yield* TestClock.adjust("99 millis");
+          yield* Effect.yieldNow;
+          assert.equal(yield* Ref.get(attempts), 2);
+          yield* TestClock.adjust("1 millis");
+          yield* Effect.yieldNow;
+          assert.equal(yield* Ref.get(attempts), 3);
+
+          yield* Ref.set(state, "disposed");
+          yield* TestClock.adjust("200 millis");
+        }).pipe(Effect.provide(Layer.merge(continuationRequestsLayer, worker)), Effect.scoped);
+      }
+    });
+  });
+
   it.effect("drops a delegated completion retry after its delivery closes", () => {
     return Effect.gen(function* () {
       const attempts = yield* Ref.make(0);

--- a/apps/server/src/orchestration-v2/ProviderContinuationService.test.ts
+++ b/apps/server/src/orchestration-v2/ProviderContinuationService.test.ts
@@ -1,7 +1,9 @@
 import { assert, describe, it } from "@effect/vitest";
 import {
+  MessageId,
   ProviderDriverKind,
   ProviderThreadId,
+  RunId,
   ThreadId,
   type OrchestrationV2ThreadProjection,
 } from "@t3tools/contracts";
@@ -13,6 +15,7 @@ import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Semaphore from "effect/Semaphore";
+import * as TestClock from "effect/testing/TestClock";
 
 import { layer as idAllocatorLayer } from "./IdAllocator.ts";
 import {
@@ -26,8 +29,10 @@ import { ThreadManagementService } from "./ThreadManagementService.ts";
 const threadId = ThreadId.make("thread-provider-continuation");
 const providerThreadId = ProviderThreadId.make("provider-thread-continuation");
 const driver = ProviderDriverKind.make("continuation-test");
+const parentRunId = RunId.make("run-provider-continuation-parent");
+const delegatedMessageId = MessageId.make("message-provider-continuation-delegated");
 const projection = {
-  thread: { archivedAt: null },
+  thread: { archivedAt: null, deletedAt: null },
   messages: [],
 } as unknown as OrchestrationV2ThreadProjection;
 
@@ -41,6 +46,25 @@ const request = (
   detail,
   ...(dispatchIfCurrent === undefined ? {} : { dispatchIfCurrent }),
 });
+
+const delegatedProjection = (disposition: "open" | "stopped" | "disposed" = "open") =>
+  ({
+    ...projection,
+    runs: [
+      {
+        id: parentRunId,
+        delegatedCompletion: {
+          disposition,
+          nextGeneration: 2,
+          delivery: {
+            generation: 1,
+            messageId: delegatedMessageId,
+            taskIds: ["node-provider-continuation-first", "node-provider-continuation-second"],
+          },
+        },
+      },
+    ],
+  }) as unknown as OrchestrationV2ThreadProjection;
 
 const makeGuard = Effect.fnUntraced(function* (completed?: Deferred.Deferred<void>) {
   const generation = yield* Ref.make(0);
@@ -128,6 +152,342 @@ describe("ProviderContinuationService", () => {
         ),
         Effect.scoped,
       );
+    });
+  });
+
+  it.effect("dispatches a current delegated completion as one server-owned queued message", () => {
+    return Effect.gen(function* () {
+      const dispatched = yield* Queue.unbounded<unknown>();
+      yield* Effect.gen(function* () {
+        const requests = yield* ProviderContinuationRequests;
+        yield* requests.offer({
+          threadId,
+          providerThreadId,
+          driver,
+          detail: null,
+          delivery: "message_text",
+          delegatedCompletion: {
+            parentRunId,
+            generation: 1,
+            messageId: delegatedMessageId,
+          },
+        });
+        const command = (yield* Queue.take(dispatched)) as {
+          readonly createdBy: string;
+          readonly creationSource: string;
+          readonly delegatedCompletion: {
+            readonly generation: number;
+            readonly parentRunId: RunId;
+            readonly taskIds: ReadonlyArray<string>;
+          };
+          readonly dispatchMode: { readonly type: string };
+          readonly messageId: MessageId;
+          readonly text: string;
+        };
+        assert.equal(command.createdBy, "agent");
+        assert.equal(command.creationSource, "server");
+        assert.deepEqual(command.dispatchMode, { type: "queue_after_active" });
+        assert.equal(command.messageId, delegatedMessageId);
+        assert.equal(command.delegatedCompletion.parentRunId, parentRunId);
+        assert.equal(command.delegatedCompletion.generation, 1);
+        assert.deepEqual(command.delegatedCompletion.taskIds, [
+          "node-provider-continuation-first",
+          "node-provider-continuation-second",
+        ]);
+        assert.include(command.text, "task_status");
+      }).pipe(
+        Effect.provide(
+          testLayer({
+            dispatched,
+            getThreadProjection: () => Effect.succeed(delegatedProjection()),
+          }),
+        ),
+        Effect.scoped,
+      );
+    });
+  });
+
+  it.effect("retries a delegated completion after a transient dispatch failure", () => {
+    return Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const dispatched = yield* Queue.unbounded<unknown>();
+      const threads = Layer.mock(ThreadManagementService)({
+        getThreadProjection: () => Effect.succeed(delegatedProjection()),
+        dispatch: (command) =>
+          Ref.getAndUpdate(attempts, (count) => count + 1).pipe(
+            Effect.flatMap((attempt) =>
+              attempt === 0
+                ? Effect.fail(new Error("simulated transient dispatch failure") as never)
+                : Queue.offer(dispatched, command).pipe(Effect.as({} as never)),
+            ),
+          ),
+      });
+      const worker = workerLive.pipe(
+        Layer.provide(Layer.mergeAll(idAllocatorLayer, continuationRequestsLayer, threads)),
+      );
+
+      yield* Effect.gen(function* () {
+        const requests = yield* ProviderContinuationRequests;
+        yield* requests.offer({
+          threadId,
+          providerThreadId,
+          driver,
+          detail: null,
+          delivery: "message_text",
+          delegatedCompletion: {
+            parentRunId,
+            generation: 1,
+            messageId: delegatedMessageId,
+          },
+        });
+        yield* Effect.yieldNow;
+        assert.equal(yield* Ref.get(attempts), 1);
+        assert.isTrue(Option.isNone(yield* Queue.poll(dispatched)));
+
+        yield* TestClock.adjust("100 millis");
+        const command = (yield* Queue.take(dispatched)) as {
+          readonly messageId: MessageId;
+        };
+        assert.equal(command.messageId, delegatedMessageId);
+        assert.equal(yield* Ref.get(attempts), 2);
+      }).pipe(Effect.provide(Layer.merge(continuationRequestsLayer, worker)), Effect.scoped);
+    });
+  });
+
+  it.effect("backs off repeated delegated completion dispatch failures", () => {
+    return Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const disposition = yield* Ref.make<"open" | "disposed">("open");
+      const threads = Layer.mock(ThreadManagementService)({
+        getThreadProjection: () =>
+          Ref.get(disposition).pipe(Effect.map((state) => delegatedProjection(state))),
+        dispatch: () =>
+          Ref.update(attempts, (count) => count + 1).pipe(
+            Effect.andThen(Effect.fail(new Error("simulated persistent failure") as never)),
+          ),
+      });
+      const worker = workerLive.pipe(
+        Layer.provide(Layer.mergeAll(idAllocatorLayer, continuationRequestsLayer, threads)),
+      );
+
+      yield* Effect.gen(function* () {
+        const requests = yield* ProviderContinuationRequests;
+        yield* requests.offer({
+          threadId,
+          providerThreadId,
+          driver,
+          detail: null,
+          delivery: "message_text",
+          delegatedCompletion: {
+            parentRunId,
+            generation: 1,
+            messageId: delegatedMessageId,
+          },
+        });
+        yield* Effect.yieldNow;
+        assert.equal(yield* Ref.get(attempts), 1);
+
+        yield* TestClock.adjust("100 millis");
+        yield* Effect.yieldNow;
+        assert.equal(yield* Ref.get(attempts), 2);
+        yield* TestClock.adjust("199 millis");
+        yield* Effect.yieldNow;
+        assert.equal(yield* Ref.get(attempts), 2);
+        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
+        assert.equal(yield* Ref.get(attempts), 3);
+
+        yield* Ref.set(disposition, "disposed");
+        yield* TestClock.adjust("400 millis");
+      }).pipe(Effect.provide(Layer.merge(continuationRequestsLayer, worker)), Effect.scoped);
+    });
+  });
+
+  it.effect("drops a delegated completion retry after its delivery closes", () => {
+    return Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const disposition = yield* Ref.make<"open" | "disposed">("open");
+      const threads = Layer.mock(ThreadManagementService)({
+        getThreadProjection: () =>
+          Ref.get(disposition).pipe(Effect.map((state) => delegatedProjection(state))),
+        dispatch: () =>
+          Ref.update(attempts, (count) => count + 1).pipe(
+            Effect.andThen(Effect.fail(new Error("simulated dispatch failure") as never)),
+          ),
+      });
+      const worker = workerLive.pipe(
+        Layer.provide(Layer.mergeAll(idAllocatorLayer, continuationRequestsLayer, threads)),
+      );
+
+      yield* Effect.gen(function* () {
+        const requests = yield* ProviderContinuationRequests;
+        yield* requests.offer({
+          threadId,
+          providerThreadId,
+          driver,
+          detail: null,
+          delivery: "message_text",
+          delegatedCompletion: {
+            parentRunId,
+            generation: 1,
+            messageId: delegatedMessageId,
+          },
+        });
+        yield* Effect.yieldNow;
+        assert.equal(yield* Ref.get(attempts), 1);
+
+        yield* Ref.set(disposition, "disposed");
+        yield* TestClock.adjust("100 millis");
+        yield* Effect.yieldNow;
+        assert.equal(yield* Ref.get(attempts), 1);
+      }).pipe(Effect.provide(Layer.merge(continuationRequestsLayer, worker)), Effect.scoped);
+    });
+  });
+
+  it.effect("keeps a Grok delegated completion queued instead of restarting active work", () => {
+    return Effect.gen(function* () {
+      const dispatched = yield* Queue.unbounded<unknown>();
+      yield* Effect.gen(function* () {
+        const requests = yield* ProviderContinuationRequests;
+        yield* requests.offer({
+          threadId,
+          providerThreadId,
+          driver: ProviderDriverKind.make("grok"),
+          detail: null,
+          delivery: "message_text",
+          delegatedCompletion: {
+            parentRunId,
+            generation: 1,
+            messageId: delegatedMessageId,
+          },
+        });
+        const command = (yield* Queue.take(dispatched)) as {
+          readonly dispatchMode: { readonly type: string };
+        };
+        assert.deepEqual(command.dispatchMode, { type: "queue_after_active" });
+      }).pipe(
+        Effect.provide(
+          testLayer({
+            dispatched,
+            getThreadProjection: () => Effect.succeed(delegatedProjection()),
+          }),
+        ),
+        Effect.scoped,
+      );
+    });
+  });
+
+  it.effect(
+    "drops stopped and disposed delegated completions instead of reviving them after recovery",
+    () => {
+      return Effect.gen(function* () {
+        for (const disposition of ["stopped", "disposed"] as const) {
+          const dispatched = yield* Queue.unbounded<unknown>();
+          yield* Effect.gen(function* () {
+            const requests = yield* ProviderContinuationRequests;
+            yield* requests.offer({
+              threadId,
+              providerThreadId,
+              driver,
+              detail: null,
+              delivery: "message_text",
+              delegatedCompletion: {
+                parentRunId,
+                generation: 1,
+                messageId: delegatedMessageId,
+              },
+            });
+            yield* Effect.yieldNow;
+            yield* Effect.yieldNow;
+            assert.isTrue(Option.isNone(yield* Queue.poll(dispatched)));
+          }).pipe(
+            Effect.provide(
+              testLayer({
+                dispatched,
+                getThreadProjection: () => Effect.succeed(delegatedProjection(disposition)),
+              }),
+            ),
+            Effect.scoped,
+          );
+        }
+      });
+    },
+  );
+
+  it.effect("does not redispatch a persisted delegated completion message during recovery", () => {
+    return Effect.gen(function* () {
+      const dispatched = yield* Queue.unbounded<unknown>();
+      yield* Effect.gen(function* () {
+        const requests = yield* ProviderContinuationRequests;
+        yield* requests.offer({
+          threadId,
+          providerThreadId,
+          driver,
+          detail: null,
+          delivery: "message_text",
+          delegatedCompletion: {
+            parentRunId,
+            generation: 1,
+            messageId: delegatedMessageId,
+          },
+        });
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        assert.isTrue(Option.isNone(yield* Queue.poll(dispatched)));
+      }).pipe(
+        Effect.provide(
+          testLayer({
+            dispatched,
+            getThreadProjection: () =>
+              Effect.succeed({
+                ...delegatedProjection(),
+                messages: [{ id: delegatedMessageId }],
+              } as unknown as OrchestrationV2ThreadProjection),
+          }),
+        ),
+        Effect.scoped,
+      );
+    });
+  });
+
+  it.effect("drops archived and deleted delegated completions during recovery", () => {
+    return Effect.gen(function* () {
+      for (const barrier of ["archivedAt", "deletedAt"] as const) {
+        const dispatched = yield* Queue.unbounded<unknown>();
+        yield* Effect.gen(function* () {
+          const requests = yield* ProviderContinuationRequests;
+          yield* requests.offer({
+            threadId,
+            providerThreadId,
+            driver,
+            detail: null,
+            delivery: "message_text",
+            delegatedCompletion: {
+              parentRunId,
+              generation: 1,
+              messageId: delegatedMessageId,
+            },
+          });
+          yield* Effect.yieldNow;
+          yield* Effect.yieldNow;
+          assert.isTrue(Option.isNone(yield* Queue.poll(dispatched)));
+        }).pipe(
+          Effect.provide(
+            testLayer({
+              dispatched,
+              getThreadProjection: () =>
+                Effect.succeed({
+                  ...delegatedProjection(),
+                  thread: {
+                    ...projection.thread,
+                    [barrier]: DateTime.makeUnsafe("2026-08-03T00:00:00.000Z"),
+                  },
+                } as unknown as OrchestrationV2ThreadProjection),
+            }),
+          ),
+          Effect.scoped,
+        );
+      }
     });
   });
 

--- a/apps/server/src/orchestration-v2/ProviderContinuationService.ts
+++ b/apps/server/src/orchestration-v2/ProviderContinuationService.ts
@@ -86,6 +86,11 @@ export const workerLive = Layer.effectDiscard(
             threadId: request.threadId,
             providerThreadId: request.providerThreadId,
           });
+          if (request.delegatedCompletion !== undefined) {
+            yield* clearRetryAttempt(
+              delegatedCompletionRetryKey(request, request.delegatedCompletion),
+            );
+          }
           // No continuation turn will start to clear the adapter's sticky offer.
           if (request.clearIfCurrent !== undefined) {
             yield* request.clearIfCurrent();

--- a/apps/server/src/orchestration-v2/ProviderContinuationService.ts
+++ b/apps/server/src/orchestration-v2/ProviderContinuationService.ts
@@ -1,6 +1,7 @@
-import { CommandId } from "@t3tools/contracts";
+import { CommandId, type OrchestrationV2ThreadProjection } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
 
 import { IdAllocatorV2 } from "./IdAllocator.ts";
 import {
@@ -10,6 +11,42 @@ import {
 import { ThreadManagementService } from "./ThreadManagementService.ts";
 
 const CONTINUATION_MESSAGE_TEXT = "Background task completed.";
+
+function delegatedCompletionText(taskIds: ReadonlyArray<string>): string {
+  const taskList = taskIds.join(", ");
+  return taskIds.length === 1
+    ? `Delegated task ${taskList} reached a terminal state. Use task_status with taskId ${taskList} to read the result.`
+    : `Delegated tasks ${taskList} reached terminal states. Use task_status with each taskId to read the results.`;
+}
+
+function currentDelegatedCompletionDelivery(
+  projection: OrchestrationV2ThreadProjection,
+  completion: NonNullable<ProviderContinuationRequest["delegatedCompletion"]>,
+) {
+  const sourceRun = projection.runs.find((candidate) => candidate.id === completion.parentRunId);
+  const delivery = sourceRun?.delegatedCompletion?.delivery;
+  const alreadyDispatched = projection.messages.some(
+    (message) => message.id === completion.messageId,
+  );
+  if (
+    sourceRun?.delegatedCompletion?.disposition !== "open" ||
+    delivery === null ||
+    delivery === undefined ||
+    delivery.generation !== completion.generation ||
+    delivery.messageId !== completion.messageId ||
+    alreadyDispatched
+  ) {
+    return undefined;
+  }
+  return delivery;
+}
+
+function delegatedCompletionRetryKey(
+  request: ProviderContinuationRequest,
+  completion: NonNullable<ProviderContinuationRequest["delegatedCompletion"]>,
+): string {
+  return `${request.threadId}:${completion.parentRunId}:${completion.generation}:${completion.messageId}`;
+}
 
 /**
  * Drains ProviderContinuationRequests and dispatches an internal
@@ -23,11 +60,28 @@ export const workerLive = Layer.effectDiscard(
     const ids = yield* IdAllocatorV2;
     const requests = yield* ProviderContinuationRequests;
     const threads = yield* ThreadManagementService;
+    const retryAttempts = yield* Ref.make(new Map<string, number>());
+
+    const clearRetryAttempt = (key: string) =>
+      Ref.update(retryAttempts, (current) => {
+        if (!current.has(key)) return current;
+        const updated = new Map(current);
+        updated.delete(key);
+        return updated;
+      });
+
+    const nextRetryDelay = (key: string) =>
+      Ref.modify(retryAttempts, (current) => {
+        const attempt = current.get(key) ?? 0;
+        const updated = new Map(current);
+        updated.set(key, attempt + 1);
+        return [Math.min(100 * 2 ** Math.min(attempt, 6), 5_000), updated] as const;
+      });
 
     const dispatchContinuation = Effect.fn("ProviderContinuationService.dispatchContinuation")(
       function* (request: ProviderContinuationRequest) {
         const projection = yield* threads.getThreadProjection(request.threadId);
-        if (projection.thread.archivedAt !== null) {
+        if (projection.thread.archivedAt !== null || projection.thread.deletedAt !== null) {
           yield* Effect.logInfo("orchestration-v2.provider-continuation.thread-archived", {
             threadId: request.threadId,
             providerThreadId: request.providerThreadId,
@@ -40,6 +94,39 @@ export const workerLive = Layer.effectDiscard(
             // drop callback.
             yield* request.dispatchIfCurrent(Effect.void);
           }
+          return;
+        }
+        if (request.delegatedCompletion !== undefined) {
+          const retryKey = delegatedCompletionRetryKey(request, request.delegatedCompletion);
+          const delivery = currentDelegatedCompletionDelivery(
+            projection,
+            request.delegatedCompletion,
+          );
+          if (delivery === undefined) {
+            yield* clearRetryAttempt(retryKey);
+            return;
+          }
+          const commandId = yield* ids.allocate.command({
+            fixtureName: "delegated-completion",
+            commandName: "dispatch",
+          });
+          yield* threads.dispatch({
+            type: "message.dispatch",
+            commandId,
+            threadId: request.threadId,
+            messageId: delivery.messageId,
+            text: delegatedCompletionText(delivery.taskIds),
+            attachments: [],
+            dispatchMode: { type: "queue_after_active" },
+            createdBy: "agent",
+            creationSource: "server",
+            delegatedCompletion: {
+              parentRunId: request.delegatedCompletion.parentRunId,
+              generation: delivery.generation,
+              taskIds: delivery.taskIds,
+            },
+          });
+          yield* clearRetryAttempt(retryKey);
           return;
         }
         // The ordinal is display metadata only: allocate.message appends a
@@ -76,10 +163,35 @@ export const workerLive = Layer.effectDiscard(
       Effect.flatMap((request) =>
         dispatchContinuation(request).pipe(
           Effect.catchCause((cause) =>
-            Effect.logWarning("orchestration-v2.provider-continuation.dispatch-failed", {
-              threadId: request.threadId,
-              providerThreadId: request.providerThreadId,
-              cause,
+            Effect.gen(function* () {
+              yield* Effect.logWarning("orchestration-v2.provider-continuation.dispatch-failed", {
+                threadId: request.threadId,
+                providerThreadId: request.providerThreadId,
+                cause,
+              });
+              if (request.delegatedCompletion !== undefined) {
+                const completion = request.delegatedCompletion;
+                const retryKey = delegatedCompletionRetryKey(request, completion);
+                const retryDelay = yield* nextRetryDelay(retryKey);
+                yield* Effect.gen(function* () {
+                  yield* Effect.sleep(`${retryDelay} millis`);
+                  const projection = yield* threads.getThreadProjection(request.threadId);
+                  if (currentDelegatedCompletionDelivery(projection, completion) !== undefined) {
+                    yield* requests.offer(request);
+                  } else {
+                    yield* clearRetryAttempt(retryKey);
+                  }
+                }).pipe(
+                  Effect.catchCause((retryCause) =>
+                    Effect.logWarning("orchestration-v2.provider-continuation.retry-check-failed", {
+                      threadId: request.threadId,
+                      providerThreadId: request.providerThreadId,
+                      cause: retryCause,
+                    }).pipe(Effect.andThen(requests.offer(request))),
+                  ),
+                  Effect.forkScoped,
+                );
+              }
             }),
           ),
         ),

--- a/apps/server/src/orchestration-v2/QueuedRunOrder.test.ts
+++ b/apps/server/src/orchestration-v2/QueuedRunOrder.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { queuedRunsInDeliveryOrder } from "./QueuedRunOrder.ts";
+
+describe("queued run delivery order", () => {
+  it("keeps automatic completion delivery ahead of visible queued messages", () => {
+    const projection = {
+      messages: [
+        { id: "message:visible-first" },
+        {
+          id: "message:automatic",
+          delegatedCompletion: {
+            generation: 1,
+            parentRunId: "run:parent",
+            taskIds: ["task:child"],
+          },
+        },
+        { id: "message:visible-second" },
+      ],
+      runs: [
+        {
+          id: "run:visible-first",
+          ordinal: 2,
+          queuePosition: 1,
+          status: "queued",
+          userMessageId: "message:visible-first",
+        },
+        {
+          id: "run:automatic",
+          ordinal: 4,
+          queuePosition: 3,
+          status: "queued",
+          userMessageId: "message:automatic",
+        },
+        {
+          id: "run:visible-second",
+          ordinal: 3,
+          queuePosition: 2,
+          status: "queued",
+          userMessageId: "message:visible-second",
+        },
+      ],
+    } as never;
+
+    expect(queuedRunsInDeliveryOrder(projection).map((run) => run.id)).toEqual([
+      "run:automatic",
+      "run:visible-first",
+      "run:visible-second",
+    ]);
+  });
+});

--- a/apps/server/src/orchestration-v2/QueuedRunOrder.ts
+++ b/apps/server/src/orchestration-v2/QueuedRunOrder.ts
@@ -1,0 +1,32 @@
+import type { OrchestrationV2Run, OrchestrationV2ThreadProjection } from "@t3tools/contracts";
+
+export function isAutomaticCompletionRun(
+  projection: OrchestrationV2ThreadProjection,
+  run: OrchestrationV2Run,
+): boolean {
+  return projection.messages.some(
+    (message) => message.id === run.userMessageId && message.delegatedCompletion !== undefined,
+  );
+}
+
+export function queuedRunsInDeliveryOrder(
+  projection: OrchestrationV2ThreadProjection,
+): ReadonlyArray<OrchestrationV2Run> {
+  const automaticCompletionMessageIds = new Set(
+    projection.messages
+      .filter((message) => message.delegatedCompletion !== undefined)
+      .map((message) => message.id),
+  );
+  return projection.runs
+    .filter((run) => run.status === "queued")
+    .toSorted((left, right) => {
+      const deliveryPriority =
+        Number(automaticCompletionMessageIds.has(right.userMessageId)) -
+        Number(automaticCompletionMessageIds.has(left.userMessageId));
+      return (
+        deliveryPriority ||
+        (left.queuePosition ?? left.ordinal) - (right.queuePosition ?? right.ordinal) ||
+        left.ordinal - right.ordinal
+      );
+    });
+}

--- a/apps/server/src/orchestration-v2/RunExecutionService.ts
+++ b/apps/server/src/orchestration-v2/RunExecutionService.ts
@@ -564,8 +564,13 @@ export const layer: Layer.Layer<
             : [];
         const persistedStatus =
           input.terminal.status === "completed" ? "waiting" : input.terminal.status;
+        // Completion cohorts are advanced by Orchestrator while a provider
+        // turn is in flight. Do not replay the run snapshot captured at start
+        // over a newer acknowledgement, successor, or Stop barrier.
+        const { delegatedCompletion: _delegatedCompletion, ...runWithoutDelegatedCompletion } =
+          input.run;
         const finalizedRun: OrchestrationV2Run = {
-          ...input.run,
+          ...runWithoutDelegatedCompletion,
           status: persistedStatus,
           completedAt: input.terminal.status === "completed" ? null : completedAt,
         };

--- a/apps/server/src/orchestration-v2/ThreadManagementService.ts
+++ b/apps/server/src/orchestration-v2/ThreadManagementService.ts
@@ -80,6 +80,8 @@ export function existingThreadIdsForCommand(
         : [command.sourceThreadId, command.targetThreadId];
     case "delegated_task.request":
     case "delegated_task.wake-policy":
+    case "delegated_task.completion-delivery.acknowledge":
+    case "delegated_task.completion-delivery.dispose":
       return [command.parentThreadId];
     case "thread.created.record":
       return command.parentThreadId === command.targetThreadId

--- a/apps/server/src/orchestration-v2/testkit/OrchestratorScenario.ts
+++ b/apps/server/src/orchestration-v2/testkit/OrchestratorScenario.ts
@@ -128,6 +128,8 @@ function commandThreadIds(command: OrchestrationV2Command): ReadonlyArray<Thread
       return [command.threadId];
     case "delegated_task.request":
     case "delegated_task.wake-policy":
+    case "delegated_task.completion-delivery.acknowledge":
+    case "delegated_task.completion-delivery.dispose":
     case "thread.created.record":
       return [command.parentThreadId];
     case "thread.fork":

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1044,6 +1044,8 @@ const makeWsRpcLayer = (
                   ? command.targetThreadId
                   : command.type === "delegated_task.request" ||
                       command.type === "delegated_task.wake-policy" ||
+                      command.type === "delegated_task.completion-delivery.acknowledge" ||
+                      command.type === "delegated_task.completion-delivery.dispose" ||
                       command.type === "thread.created.record"
                     ? command.parentThreadId
                     : command.threadId,

--- a/apps/web/src/components/chat/QueuedRunsControl.test.tsx
+++ b/apps/web/src/components/chat/QueuedRunsControl.test.tsx
@@ -1,0 +1,96 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const state = vi.hoisted(() => ({
+  projection: null as unknown,
+  workflow: null as unknown,
+}));
+
+vi.mock("@t3tools/client-runtime/environment", () => ({
+  scopeThreadRef: () => ({}) as never,
+}));
+
+vi.mock("@t3tools/client-runtime/state/thread-workflows", () => ({
+  deriveThreadQueueWorkflowState: () => state.workflow,
+}));
+
+vi.mock("../../state/entities", () => ({
+  useThreadProjection: () => state.projection,
+}));
+
+vi.mock("../../state/threads", () => ({
+  threadEnvironment: {
+    cancelQueuedRun: Symbol("cancelQueuedRun"),
+    editQueuedRun: Symbol("editQueuedRun"),
+    promoteQueuedRun: Symbol("promoteQueuedRun"),
+    reorderQueuedRun: Symbol("reorderQueuedRun"),
+  },
+}));
+
+vi.mock("../../state/use-atom-command", () => ({
+  useAtomCommand: () => async () => undefined,
+}));
+
+import { QueuedRunsControl } from "./QueuedRunsControl";
+
+function buttonTag(html: string, ariaLabel: string) {
+  return html.match(new RegExp(`<button[^>]*aria-label="${ariaLabel}"[^>]*>`))?.[0];
+}
+
+function buttonWithText(html: string, text: string) {
+  return html.match(new RegExp(`<button[^>]*>[\\s\\S]*?${text}</button>`))?.[0];
+}
+
+function expectDisabled(button: string | undefined) {
+  expect(button).toMatch(/\sdisabled(?:=|\s|>)/);
+}
+
+function expectEnabled(button: string | undefined) {
+  expect(button).not.toMatch(/\sdisabled(?:=|\s|>)/);
+}
+
+describe("QueuedRunsControl automatic completion delivery", () => {
+  it("locks server-owned delivery controls while keeping dismissal available", () => {
+    state.projection = {
+      projection: {
+        messages: [
+          {
+            delegatedCompletion: {
+              parentRunId: "run:parent",
+              generation: 1,
+              taskIds: ["task:child"],
+            },
+            id: "message:completion",
+          },
+        ],
+      },
+    };
+    state.workflow = {
+      activeRun: { id: "run:active" },
+      canPromoteToSteer: true,
+      canReorder: true,
+      queuedRuns: [
+        {
+          run: { id: "run:completion", userMessageId: "message:completion" },
+          text: "A delegated task reached a terminal state.",
+        },
+      ],
+    };
+
+    const html = renderToStaticMarkup(
+      <QueuedRunsControl
+        environmentId={"environment:test" as never}
+        optimisticMessages={[]}
+        threadId={"thread:test" as never}
+      />,
+    );
+
+    expect(html).toContain("Automatic completion delivery");
+    expectDisabled(buttonTag(html, "Edit queued message"));
+    expectDisabled(buttonTag(html, "Move queued message up"));
+    expectDisabled(buttonTag(html, "Move queued message down"));
+    expectDisabled(buttonWithText(html, "Steer"));
+    expect(html).toContain("Automatic completion deliveries are always queued");
+    expectEnabled(buttonTag(html, "Dismiss automatic completion delivery"));
+  });
+});

--- a/apps/web/src/components/chat/QueuedRunsControl.test.tsx
+++ b/apps/web/src/components/chat/QueuedRunsControl.test.tsx
@@ -33,24 +33,8 @@ vi.mock("../../state/use-atom-command", () => ({
 
 import { QueuedRunsControl } from "./QueuedRunsControl";
 
-function buttonTag(html: string, ariaLabel: string) {
-  return html.match(new RegExp(`<button[^>]*aria-label="${ariaLabel}"[^>]*>`))?.[0];
-}
-
-function buttonWithText(html: string, text: string) {
-  return html.match(new RegExp(`<button[^>]*>[\\s\\S]*?${text}</button>`))?.[0];
-}
-
-function expectDisabled(button: string | undefined) {
-  expect(button).toMatch(/\sdisabled(?:=|\s|>)/);
-}
-
-function expectEnabled(button: string | undefined) {
-  expect(button).not.toMatch(/\sdisabled(?:=|\s|>)/);
-}
-
 describe("QueuedRunsControl automatic completion delivery", () => {
-  it("locks server-owned delivery controls while keeping dismissal available", () => {
+  it("does not render a queue control when only hidden delivery remains", () => {
     state.projection = {
       projection: {
         messages: [
@@ -69,12 +53,7 @@ describe("QueuedRunsControl automatic completion delivery", () => {
       activeRun: { id: "run:active" },
       canPromoteToSteer: true,
       canReorder: true,
-      queuedRuns: [
-        {
-          run: { id: "run:completion", userMessageId: "message:completion" },
-          text: "A delegated task reached a terminal state.",
-        },
-      ],
+      queuedRuns: [],
     };
 
     const html = renderToStaticMarkup(
@@ -85,12 +64,6 @@ describe("QueuedRunsControl automatic completion delivery", () => {
       />,
     );
 
-    expect(html).toContain("Automatic completion delivery");
-    expectDisabled(buttonTag(html, "Edit queued message"));
-    expectDisabled(buttonTag(html, "Move queued message up"));
-    expectDisabled(buttonTag(html, "Move queued message down"));
-    expectDisabled(buttonWithText(html, "Steer"));
-    expect(html).toContain("Automatic completion deliveries are always queued");
-    expectEnabled(buttonTag(html, "Dismiss automatic completion delivery"));
+    expect(html).toBe("");
   });
 });

--- a/apps/web/src/components/chat/QueuedRunsControl.tsx
+++ b/apps/web/src/components/chat/QueuedRunsControl.tsx
@@ -39,11 +39,6 @@ export function QueuedRunsControl(props: {
   );
   const queued = workflow?.queuedRuns ?? [];
   const activeRun = workflow?.activeRun ?? null;
-  const automaticCompletionMessageIds = new Set(
-    projection?.messages
-      .filter((message) => message.delegatedCompletion !== undefined)
-      .map((message) => message.id) ?? [],
-  );
   const committedQueuedMessageIds = new Set(queued.map(({ run }) => run.userMessageId));
   const optimisticQueued = props.optimisticMessages.filter(
     (message) =>
@@ -56,7 +51,6 @@ export function QueuedRunsControl(props: {
       serverIndex,
       text,
       pending: false,
-      automaticCompletion: automaticCompletionMessageIds.has(run.userMessageId),
     })),
     ...optimisticQueued.map((message) => ({
       key: message.id,
@@ -64,7 +58,6 @@ export function QueuedRunsControl(props: {
       serverIndex: null,
       text: message.text,
       pending: true,
-      automaticCompletion: false,
     })),
   ];
 
@@ -209,16 +202,16 @@ export function QueuedRunsControl(props: {
               ) : (
                 <>
                   <span className="min-w-0 flex-1 truncate text-xs" title={item.text}>
-                    {item.automaticCompletion ? "Automatic completion delivery" : item.text}
+                    {item.text}
                   </span>
                   <Button
                     size="icon-xs"
                     variant="ghost"
                     aria-label="Edit queued message"
                     className="size-6 text-muted-foreground"
-                    disabled={item.runId === null || item.automaticCompletion || busyRunId !== null}
+                    disabled={item.runId === null || busyRunId !== null}
                     onClick={() => {
-                      if (item.runId !== null && !item.automaticCompletion) {
+                      if (item.runId !== null) {
                         setEditing({ runId: item.runId, draft: item.text });
                       }
                     }}
@@ -232,18 +225,13 @@ export function QueuedRunsControl(props: {
                     className="size-6 text-muted-foreground"
                     disabled={
                       item.runId === null ||
-                      item.automaticCompletion ||
                       item.serverIndex === null ||
                       busyRunId !== null ||
                       !workflow?.canReorder ||
                       item.serverIndex === 0
                     }
                     onClick={() => {
-                      if (
-                        item.runId === null ||
-                        item.serverIndex === null ||
-                        item.automaticCompletion
-                      ) {
+                      if (item.runId === null || item.serverIndex === null) {
                         return;
                       }
                       void move(item.runId, queued[item.serverIndex - 1]?.run.id ?? null);
@@ -258,18 +246,13 @@ export function QueuedRunsControl(props: {
                     className="size-6 text-muted-foreground"
                     disabled={
                       item.runId === null ||
-                      item.automaticCompletion ||
                       item.serverIndex === null ||
                       busyRunId !== null ||
                       !workflow?.canReorder ||
                       item.serverIndex === queued.length - 1
                     }
                     onClick={() => {
-                      if (
-                        item.runId === null ||
-                        item.serverIndex === null ||
-                        item.automaticCompletion
-                      ) {
+                      if (item.runId === null || item.serverIndex === null) {
                         return;
                       }
                       void move(item.runId, queued[item.serverIndex + 2]?.run.id ?? null);
@@ -282,20 +265,15 @@ export function QueuedRunsControl(props: {
                     variant="ghost"
                     className="h-6 gap-1 px-1.5 text-[11px] text-muted-foreground"
                     disabled={
-                      item.runId === null ||
-                      item.automaticCompletion ||
-                      busyRunId !== null ||
-                      !workflow?.canPromoteToSteer
+                      item.runId === null || busyRunId !== null || !workflow?.canPromoteToSteer
                     }
                     title={
-                      item.automaticCompletion
-                        ? "Automatic completion deliveries are always queued"
-                        : activeRun === null
-                          ? "There is no active run to steer"
-                          : "Send as a steer instead"
+                      activeRun === null
+                        ? "There is no active run to steer"
+                        : "Send as a steer instead"
                     }
                     onClick={() => {
-                      if (item.runId !== null && !item.automaticCompletion) {
+                      if (item.runId !== null) {
                         void steer(item.runId);
                       }
                     }}
@@ -306,18 +284,10 @@ export function QueuedRunsControl(props: {
                   <Button
                     size="icon-xs"
                     variant="ghost"
-                    aria-label={
-                      item.automaticCompletion
-                        ? "Dismiss automatic completion delivery"
-                        : "Remove queued message"
-                    }
+                    aria-label="Remove queued message"
                     className="size-6 text-muted-foreground"
                     disabled={item.runId === null || busyRunId !== null}
-                    title={
-                      item.automaticCompletion
-                        ? "Dismiss automatic completion delivery"
-                        : "Remove from queue"
-                    }
+                    title="Remove from queue"
                     onClick={() => {
                       if (item.runId !== null) void remove(item.runId);
                     }}

--- a/apps/web/src/components/chat/QueuedRunsControl.tsx
+++ b/apps/web/src/components/chat/QueuedRunsControl.tsx
@@ -39,6 +39,11 @@ export function QueuedRunsControl(props: {
   );
   const queued = workflow?.queuedRuns ?? [];
   const activeRun = workflow?.activeRun ?? null;
+  const automaticCompletionMessageIds = new Set(
+    projection?.messages
+      .filter((message) => message.delegatedCompletion !== undefined)
+      .map((message) => message.id) ?? [],
+  );
   const committedQueuedMessageIds = new Set(queued.map(({ run }) => run.userMessageId));
   const optimisticQueued = props.optimisticMessages.filter(
     (message) =>
@@ -51,6 +56,7 @@ export function QueuedRunsControl(props: {
       serverIndex,
       text,
       pending: false,
+      automaticCompletion: automaticCompletionMessageIds.has(run.userMessageId),
     })),
     ...optimisticQueued.map((message) => ({
       key: message.id,
@@ -58,6 +64,7 @@ export function QueuedRunsControl(props: {
       serverIndex: null,
       text: message.text,
       pending: true,
+      automaticCompletion: false,
     })),
   ];
 
@@ -202,16 +209,18 @@ export function QueuedRunsControl(props: {
               ) : (
                 <>
                   <span className="min-w-0 flex-1 truncate text-xs" title={item.text}>
-                    {item.text}
+                    {item.automaticCompletion ? "Automatic completion delivery" : item.text}
                   </span>
                   <Button
                     size="icon-xs"
                     variant="ghost"
                     aria-label="Edit queued message"
                     className="size-6 text-muted-foreground"
-                    disabled={item.runId === null || busyRunId !== null}
+                    disabled={item.runId === null || item.automaticCompletion || busyRunId !== null}
                     onClick={() => {
-                      if (item.runId !== null) setEditing({ runId: item.runId, draft: item.text });
+                      if (item.runId !== null && !item.automaticCompletion) {
+                        setEditing({ runId: item.runId, draft: item.text });
+                      }
                     }}
                   >
                     <PencilIcon className="size-3" />
@@ -223,13 +232,20 @@ export function QueuedRunsControl(props: {
                     className="size-6 text-muted-foreground"
                     disabled={
                       item.runId === null ||
+                      item.automaticCompletion ||
                       item.serverIndex === null ||
                       busyRunId !== null ||
                       !workflow?.canReorder ||
                       item.serverIndex === 0
                     }
                     onClick={() => {
-                      if (item.runId === null || item.serverIndex === null) return;
+                      if (
+                        item.runId === null ||
+                        item.serverIndex === null ||
+                        item.automaticCompletion
+                      ) {
+                        return;
+                      }
                       void move(item.runId, queued[item.serverIndex - 1]?.run.id ?? null);
                     }}
                   >
@@ -242,13 +258,20 @@ export function QueuedRunsControl(props: {
                     className="size-6 text-muted-foreground"
                     disabled={
                       item.runId === null ||
+                      item.automaticCompletion ||
                       item.serverIndex === null ||
                       busyRunId !== null ||
                       !workflow?.canReorder ||
                       item.serverIndex === queued.length - 1
                     }
                     onClick={() => {
-                      if (item.runId === null || item.serverIndex === null) return;
+                      if (
+                        item.runId === null ||
+                        item.serverIndex === null ||
+                        item.automaticCompletion
+                      ) {
+                        return;
+                      }
                       void move(item.runId, queued[item.serverIndex + 2]?.run.id ?? null);
                     }}
                   >
@@ -259,15 +282,22 @@ export function QueuedRunsControl(props: {
                     variant="ghost"
                     className="h-6 gap-1 px-1.5 text-[11px] text-muted-foreground"
                     disabled={
-                      item.runId === null || busyRunId !== null || !workflow?.canPromoteToSteer
+                      item.runId === null ||
+                      item.automaticCompletion ||
+                      busyRunId !== null ||
+                      !workflow?.canPromoteToSteer
                     }
                     title={
-                      activeRun === null
-                        ? "There is no active run to steer"
-                        : "Send as a steer instead"
+                      item.automaticCompletion
+                        ? "Automatic completion deliveries are always queued"
+                        : activeRun === null
+                          ? "There is no active run to steer"
+                          : "Send as a steer instead"
                     }
                     onClick={() => {
-                      if (item.runId !== null) void steer(item.runId);
+                      if (item.runId !== null && !item.automaticCompletion) {
+                        void steer(item.runId);
+                      }
                     }}
                   >
                     <CornerUpRightIcon className="size-3" />
@@ -276,10 +306,18 @@ export function QueuedRunsControl(props: {
                   <Button
                     size="icon-xs"
                     variant="ghost"
-                    aria-label="Remove queued message"
+                    aria-label={
+                      item.automaticCompletion
+                        ? "Dismiss automatic completion delivery"
+                        : "Remove queued message"
+                    }
                     className="size-6 text-muted-foreground"
                     disabled={item.runId === null || busyRunId !== null}
-                    title="Remove from queue"
+                    title={
+                      item.automaticCompletion
+                        ? "Dismiss automatic completion delivery"
+                        : "Remove from queue"
+                    }
                     onClick={() => {
                       if (item.runId !== null) void remove(item.runId);
                     }}

--- a/packages/client-runtime/src/state/threadWorkflows.test.ts
+++ b/packages/client-runtime/src/state/threadWorkflows.test.ts
@@ -85,6 +85,47 @@ describe("thread workflows", () => {
     expect(state.canPromoteToSteer).toBe(true);
   });
 
+  it("hides automatic completion delivery from the visible queue", () => {
+    const state = deriveThreadQueueWorkflowState({
+      thread: { id: "thread", activeProviderThreadId: null },
+      runs: [
+        {
+          id: "automatic",
+          status: "queued",
+          userMessageId: "message-automatic",
+          ordinal: 2,
+          queuePosition: 1,
+        },
+        {
+          id: "visible",
+          status: "queued",
+          userMessageId: "message-visible",
+          ordinal: 3,
+          queuePosition: 2,
+        },
+      ],
+      messages: [
+        {
+          id: "message-automatic",
+          text: "A delegated task reached a terminal state.",
+          delegatedCompletion: {
+            generation: 1,
+            parentRunId: "run:parent",
+            taskIds: ["task:child"],
+          },
+        },
+        { id: "message-visible", text: "Visible queued message" },
+      ],
+      providerTurns: [],
+      providerThreads: [],
+      providerSessions: [],
+    } as never);
+
+    expect(state.queuedRuns.map(({ run, text }) => [run.id, text])).toEqual([
+      ["visible", "Visible queued message"],
+    ]);
+  });
+
   it("removes only the promoted head from the visible queue", () => {
     const state = deriveThreadQueueWorkflowState({
       thread: { id: "thread", activeProviderThreadId: "provider-thread" },

--- a/packages/client-runtime/src/state/threadWorkflows.ts
+++ b/packages/client-runtime/src/state/threadWorkflows.ts
@@ -90,8 +90,15 @@ export function deriveThreadQueueWorkflowState(projection: Projection): ThreadQu
     projection.providerTurns.some(
       (turn) => turn.runAttemptId === activeRun.activeAttemptId && turn.status === "running",
     );
+  const automaticCompletionMessageIds = new Set(
+    projection.messages
+      .filter((message) => message.delegatedCompletion !== undefined)
+      .map((message) => message.id),
+  );
   const queuedRuns = copySorted(
-    projection.runs.filter((run) => run.status === "queued"),
+    projection.runs.filter(
+      (run) => run.status === "queued" && !automaticCompletionMessageIds.has(run.userMessageId),
+    ),
     (left, right) =>
       (left.queuePosition ?? left.ordinal) - (right.queuePosition ?? right.ordinal) ||
       left.ordinal - right.ordinal,

--- a/packages/contracts/src/orchestrationV2.ts
+++ b/packages/contracts/src/orchestrationV2.ts
@@ -354,6 +354,42 @@ export const OrchestrationV2RunStatus = Schema.Literals([
 ]);
 export type OrchestrationV2RunStatus = typeof OrchestrationV2RunStatus.Type;
 
+export const OrchestrationV2DelegatedCompletionTaskDeliveryState = Schema.Literals([
+  "pending",
+  "claimed",
+  "acknowledged",
+  "delivered",
+  "disposed",
+]);
+export type OrchestrationV2DelegatedCompletionTaskDeliveryState =
+  typeof OrchestrationV2DelegatedCompletionTaskDeliveryState.Type;
+
+export const OrchestrationV2DelegatedCompletionTaskDelivery = Schema.Struct({
+  state: OrchestrationV2DelegatedCompletionTaskDeliveryState,
+  observedByRunId: Schema.NullOr(RunId),
+});
+export type OrchestrationV2DelegatedCompletionTaskDelivery =
+  typeof OrchestrationV2DelegatedCompletionTaskDelivery.Type;
+
+export const OrchestrationV2DelegatedCompletionDelivery = Schema.Struct({
+  generation: PositiveInt,
+  messageId: MessageId,
+  taskIds: Schema.Array(NodeId),
+});
+export type OrchestrationV2DelegatedCompletionDelivery =
+  typeof OrchestrationV2DelegatedCompletionDelivery.Type;
+
+export const OrchestrationV2DelegatedCompletionCohort = Schema.Struct({
+  disposition: Schema.Literals(["open", "stopped", "disposed"]),
+  nextGeneration: PositiveInt,
+  // Optional for compatibility with cohorts persisted before bounded
+  // follow-up delivery was introduced. Missing means no delivery has settled.
+  settledDeliveryCount: Schema.optional(NonNegativeInt),
+  delivery: Schema.NullOr(OrchestrationV2DelegatedCompletionDelivery),
+});
+export type OrchestrationV2DelegatedCompletionCohort =
+  typeof OrchestrationV2DelegatedCompletionCohort.Type;
+
 export const OrchestrationV2Run = Schema.Struct({
   id: RunId,
   threadId: ThreadId,
@@ -377,6 +413,7 @@ export const OrchestrationV2Run = Schema.Struct({
       planId: PlanId,
     }),
   ),
+  delegatedCompletion: Schema.optional(OrchestrationV2DelegatedCompletionCohort),
 });
 export type OrchestrationV2Run = typeof OrchestrationV2Run.Type;
 
@@ -464,6 +501,7 @@ export const OrchestrationV2Subagent = Schema.Struct({
   // live run (wait-mode delegations, whose result returns through the
   // blocking tool call). Absent on legacy records; treated as settled_only.
   completionWake: Schema.optional(Schema.Literals(["always", "settled_only"])),
+  completionDelivery: Schema.optional(OrchestrationV2DelegatedCompletionTaskDelivery),
   status: Schema.Literals([
     "pending",
     "running",
@@ -621,6 +659,13 @@ export const OrchestrationV2ConversationMessage = Schema.Struct({
   streaming: Schema.Boolean,
   createdAt: Schema.DateTimeUtc,
   updatedAt: Schema.DateTimeUtc,
+  delegatedCompletion: Schema.optional(
+    Schema.Struct({
+      parentRunId: RunId,
+      generation: PositiveInt,
+      taskIds: Schema.Array(NodeId),
+    }),
+  ),
 });
 export type OrchestrationV2ConversationMessage = typeof OrchestrationV2ConversationMessage.Type;
 
@@ -1983,6 +2028,13 @@ export const OrchestrationV2Command = Schema.Union([
     titleSeed: Schema.optional(TrimmedNonEmptyString),
     modelSelection: Schema.optional(ModelSelection),
     sourcePlanRef: Schema.optional(Schema.Struct({ threadId: ThreadId, planId: PlanId })),
+    delegatedCompletion: Schema.optional(
+      Schema.Struct({
+        parentRunId: RunId,
+        generation: PositiveInt,
+        taskIds: Schema.Array(NodeId),
+      }),
+    ),
     dispatchMode: Schema.Union([
       Schema.Struct({ type: Schema.Literal("defer_start") }),
       Schema.Struct({ type: Schema.Literal("steer_active"), targetRunId: RunId }),
@@ -2102,6 +2154,19 @@ export const OrchestrationV2Command = Schema.Union([
     parentThreadId: ThreadId,
     taskId: NodeId,
     completionWake: Schema.Literals(["always", "settled_only"]),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("delegated_task.completion-delivery.acknowledge"),
+    commandId: CommandId,
+    parentThreadId: ThreadId,
+    taskId: NodeId,
+    observedByRunId: Schema.NullOr(RunId),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("delegated_task.completion-delivery.dispose"),
+    commandId: CommandId,
+    parentThreadId: ThreadId,
+    taskId: NodeId,
   }),
   Schema.Struct({
     type: Schema.Literal("thread.created.record"),


### PR DESCRIPTION
## Summary

- [Decision brief](https://xudl9al0nyl8.postplan.dev): evidence, product
  tradeoffs, and the final durable-delivery design.
- Coalesce app-owned delegated child terminals into one durable, queued
  completion delivery per parent-run cohort, with at most one successor for
  results that arrive after the first delivery starts.
- Let a parent acknowledge a terminal result through `task_status` or an
  untruncated direct-child read, then cancel its unstarted stale delivery
  without deleting the result.
- Hide automatic completion deliveries from web and mobile queue controls while
  preserving their scheduler priority and allowing their prompt to appear if
  the delivery enters the conversation.
- Add durable Stop, task-cancel, Queue Remove, archive, delete, and recovery
  barriers around server-owned completion delivery.

## Problem and Fix

| Problem and Why it Happened | Fix |
| --------------------------- | --- |
| #4499 delegated-task-parent-wake deliberately created one real queued parent continuation for every async child terminal. Sibling completions therefore fanned out into repeated parent turns and timeline output. | A parent-run cohort reserves one delivery that terminal siblings join before it starts. A late result gets at most one bounded successor instead of recursively re-arming the parent. |
| A parent could read a result through `task_status` or its direct child timeline, but the scheduler had no durable observation signal, so its queued completion still ran later. | Terminal `task_status` reads and untruncated direct-child terminal-result reads durably acknowledge the task and remove it from the queued delivery. Status-only waits, prompt-only reads, and truncated results do not acknowledge. When no owned task remains, the queued run is cancelled. |
| Stop, Queue Remove, archive, and delete cancelled transient work but did not own or dispose future completion delivery. | Durable cohort and task-delivery states make these actions replay-safe barriers. Results remain inspectable even when their automatic delivery is disposed. |
| Server-created completion messages looked like normal queue entries and exposed Edit, Reorder, and Steer controls. In particular, a Grok wake could be converted into interrupt-and-restart steering. | Server commands reject those mutations, while web and mobile omit automatic completion entries from visible queue controls. The scheduler still gives every surviving hidden delivery priority over ordinary queued messages, and the prompt remains visible once it enters the conversation. |

## Defensive Fixes

| Problem and Why it Happened | Fix |
| --------------------------- | --- |
| Provider lifecycle updates can persist a full run or subagent row captured before a later acknowledgement or Stop barrier. | Projection storage preserves newer delivery state when a stale provider row omits it, and run finalization intentionally excludes its old cohort snapshot. |
| A continuation offer can survive in memory while a cohort is acknowledged, disposed, archived, deleted, or replaced by a later generation. | The worker rereads durable projection ownership immediately before dispatch and drops an offer that is no longer current. |

## Validation

- Focused MCP, continuation-worker, projection, Claude allowlist,
  scheduler-priority, and hidden queue presentation tests pass.
- Direct-child read coverage proves that only the complete terminal result,
  rather than `t3_thread_wait`, a prompt-only page, or a truncated result,
  acknowledges delivery.
- Isolated real-provider verification proved one durable delivery for one child,
  coalescing for two async Grok children, acknowledgement persistence, and
  durable acknowledgement and retraction before a queued delivery starts.
- `vp check` passes with no warnings or lint errors, all 15 typecheck tasks pass,
  and the desktop production build succeeds.
- The current source tip was integrated into the v2.1 trial, where focused
  queue and delegated-completion coverage and guarded Nightly AppImage package
  verification pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes orchestration scheduling, MCP tool semantics, and durable completion-delivery state across server projection, continuation workers, and clients—incorrect acknowledgement or disposal could drop or duplicate parent work.
> 
> **Overview**
> Stops **one parent continuation per async child terminal** by coalescing app-owned delegated results into a **single durable queued delivery per parent-run cohort**, with at most one bounded successor when a terminal arrives after the first delivery has already started.
> 
> **MCP observation now owns delivery lifecycle:** `task_status`, delegate/wait paths, and an **untruncated** direct-child `t3_thread_read` of the terminal assistant result dispatch `completion-delivery.acknowledge` and cancel the stale queued run when no tasks remain. `t3_thread_wait`, prompt-only reads, and truncated pages do **not** acknowledge. `task_cancel` interrupts the child when possible and **disposes** automatic delivery (including on already-terminal tasks) without hiding the result. Tool metadata marks `task_status` and `t3_thread_read` as non-read-only; Claude’s read-only MCP allowlist drops those tools accordingly.
> 
> **Race-safety:** checkpoint capture and related run finalization **omit `delegatedCompletion`** from stale run snapshots so newer cohort state is not overwritten; tests cover acknowledge/dispose idempotency and wake-policy upgrades after delivery settled.
> 
> **Mobile** queue rows gain a **Remove** control wired to `queued-run.cancel`, with shared presentation helpers for enablement and command building. **Integration tests** expand heavily around coalescing, Stop barriers, server-owned queue mutation rejects, late completions, and queue remove.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60f38e6d39a10455ee192126662e9ae6aaadc6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent redundant delegated completion turns by tracking delivery state across runs
> - Adds a `delegatedCompletion` cohort to runs and `completionDelivery` to subagents in the contract schema, enabling generation-tracked, durable ownership of delegated task completion delivery.
> - `ProviderContinuationService` now dispatches delegated completions as server-owned queued messages with capped exponential backoff retries and revalidation before re-offer; drops on `archivedAt`/`deletedAt`.
> - `ProjectionStore` preserves `delegatedCompletion` on runs and `completionDelivery` on subagents when newer events omit those fields, both in-memory and in SQL upserts.
> - `CheckpointCaptureService` and `RunExecutionService` strip `delegatedCompletion` from finalized run snapshots to avoid overwriting a newer cohort.
> - MCP tool handlers (`readTask`, `waitForTask`, `taskStatus`, `cancelTask`, `readThread`) now dispatch `delegated_task.completion-delivery.acknowledge` or `dispose` commands at the appropriate points in the task lifecycle.
> - Automatic completion delivery runs are hidden from the visible queue in both web and mobile clients via `deriveThreadQueueWorkflowState` and `queuedRunsInDeliveryOrder`.
> - Risk: `ProjectionStore` SQL upsert behavior changes for any row that previously stored `delegatedCompletion`/`completionDelivery`; stale events no longer overwrite those fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a60f38e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->