### PR TITLE
fix(web): blink the terminal cursor again

### DIFF
--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -233,6 +233,7 @@ export class GhosttyTerminalCore {
     this.runtime.free(options, optionsSize);
     this.assertSuccess("ghostty_terminal_new", terminalResult);
     this.terminal = this.runtime.readPointer(this.terminalSlot);
+    this.applyDefaultCursorBlink();
     this.ptyWriter = onPtyData;
     this.ptyWriterId = this.runtime.attachPtyWriter(this.terminal, onPtyData);
 
@@ -302,6 +303,9 @@ export class GhosttyTerminalCore {
   resetAndWrite(data: string): void {
     this.ensureActive();
     this.runtime.call("ghostty_terminal_reset", this.terminal);
+    // RIS returns the cursor to Ghostty's built-in steady default, so the
+    // embedder default has to be applied again before the replay runs.
+    this.applyDefaultCursorBlink();
     this.rows = [];
     if (data.length === 0) return;
     const writer = this.ptyWriter;
@@ -331,6 +335,20 @@ export class GhosttyTerminalCore {
         Math.max(1, Math.round(cellHeight)),
       ),
     );
+  }
+
+  /**
+   * Ghostty's built-in default cursor is steady, while the xterm.js renderer
+   * this replaced ran with `cursorBlink: true`. Option 23 is the embedder's
+   * default blink, which is the state a session starts in and returns to on
+   * DECSCUSR reset (CSI 0 q), so programs that ask for a specific cursor
+   * through DECSCUSR or DEC mode 12 still win.
+   */
+  private applyDefaultCursorBlink(): void {
+    const blink = this.runtime.alloc(1);
+    this.runtime.bytes(blink, 1)[0] = 1;
+    this.runtime.call("ghostty_terminal_set", this.terminal, 23, blink);
+    this.runtime.free(blink, 1);
   }
 
   setTheme(theme: GhosttyTheme): void {

--- a/apps/web/src/terminal/ghostty/renderer.test.ts
+++ b/apps/web/src/terminal/ghostty/renderer.test.ts
@@ -120,6 +120,60 @@ describe("renderGhosttySnapshot", () => {
     ]);
   });
 
+  it("repaints the cell without an overlay during the blink off phase", () => {
+    const fillTextCalls: unknown[][] = [];
+    const context = {
+      canvas: { width: 200, height: 40 },
+      beginPath: () => {},
+      clip: () => {},
+      fillRect: () => {},
+      fillText: (...args: unknown[]) => fillTextCalls.push(args),
+      rect: () => {},
+      resetTransform: () => {},
+      restore: () => {},
+      save: () => {},
+      set fillStyle(_value: string) {},
+      set font(_value: string) {},
+      set textBaseline(_value: string) {},
+    } as unknown as CanvasRenderingContext2D;
+    const snapshot: GhosttySnapshot = {
+      cols: 3,
+      rows: 1,
+      foreground: { r: 255, g: 255, b: 255 },
+      background: { r: 0, g: 0, b: 0 },
+      cursor: { r: 255, g: 255, b: 255 },
+      cursorX: 2,
+      cursorY: 0,
+      cursorVisible: true,
+      cursorBlinking: true,
+      cursorStyle: 1,
+      dirtyRows: new Set(),
+      rowData: [
+        {
+          cells: [cell("a"), cell("b"), cell("x")],
+          text: "abx",
+          isWrapContinuation: false,
+          wrapsToNext: false,
+        },
+      ],
+    };
+
+    renderGhosttySnapshot({
+      context,
+      snapshot,
+      metrics: { width: 7.2, height: 16, baseline: 11 },
+      fontSize: 12,
+      fontFamily: "monospace",
+      padding: 4,
+      forceFull: false,
+      cursorOn: false,
+    });
+
+    // The cursor row still repaints so the block disappears, but the inverted
+    // glyph the on phase draws over the cell is gone.
+    expect(fillTextCalls).toEqual([["abx", 4, 15, 21.6]]);
+  });
+
   it("repaints the previous cursor row after the cursor moves", () => {
     const clearedRows: number[] = [];
     const context = {

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -83,6 +83,79 @@ describe("vendored libghostty-vt WebAssembly", () => {
     }
   });
 
+  it("blinks the default cursor until a program asks for a steady one", async () => {
+    const result = await WebAssembly.instantiate(
+      decodeWasmDataUrl(wasmDataUrl).buffer as ArrayBuffer,
+      { env: { log: () => {} } },
+    );
+    const instance = result instanceof WebAssembly.Instance ? result : result.instance;
+    const memory = instance.exports.memory as WebAssembly.Memory;
+    const call = (name: string, ...args: number[]) =>
+      (instance.exports[name] as WasmFunction)(...args);
+    const alloc = (size: number) => call("ghostty_wasm_alloc_u8_array", size);
+    const options = alloc(8);
+    const optionsView = new DataView(memory.buffer, options, 8);
+    optionsView.setUint16(0, 80, true);
+    optionsView.setUint16(2, 24, true);
+    const terminalSlot = call("ghostty_wasm_alloc_opaque");
+    expect(call("ghostty_terminal_new", 0, terminalSlot, options)).toBe(0);
+    const terminal = new DataView(memory.buffer).getUint32(terminalSlot, true);
+    const renderStateSlot = call("ghostty_wasm_alloc_opaque");
+    expect(call("ghostty_render_state_new", 0, renderStateSlot)).toBe(0);
+    const renderState = new DataView(memory.buffer).getUint32(renderStateSlot, true);
+    const scratch = alloc(4);
+
+    const blinking = () => {
+      expect(call("ghostty_render_state_update", renderState, terminal)).toBe(0);
+      expect(call("ghostty_render_state_get", renderState, 12, scratch)).toBe(0);
+      return new DataView(memory.buffer, scratch, 4).getUint8(0) !== 0;
+    };
+    const write = (data: string) => {
+      const bytes = new TextEncoder().encode(data);
+      const pointer = alloc(bytes.length);
+      new Uint8Array(memory.buffer, pointer, bytes.length).set(bytes);
+      call("ghostty_terminal_vt_write", terminal, pointer, bytes.length);
+      call("ghostty_wasm_free_u8_array", pointer, bytes.length);
+    };
+    const setDefaultCursorBlink = (blink: boolean) => {
+      const value = alloc(1);
+      new Uint8Array(memory.buffer, value, 1)[0] = blink ? 1 : 0;
+      expect(call("ghostty_terminal_set", terminal, 23, value)).toBe(0);
+      call("ghostty_wasm_free_u8_array", value, 1);
+    };
+
+    // Ghostty's own default is a steady cursor, so the blink the web terminal
+    // inherited from xterm.js only exists because option 23 asks for it.
+    expect(blinking()).toBe(false);
+    setDefaultCursorBlink(true);
+    expect(blinking()).toBe(true);
+
+    // Programs still own the cursor: DECSCUSR steady block and DEC mode 12 both
+    // stop the blink, and DECSCUSR reset returns to the embedder default.
+    write("\u001b[2 q");
+    expect(blinking()).toBe(false);
+    write("\u001b[0 q");
+    expect(blinking()).toBe(true);
+    write("\u001b[?12l");
+    expect(blinking()).toBe(false);
+    write("\u001b[?12h");
+    expect(blinking()).toBe(true);
+
+    // RIS restores Ghostty's built-in steady default rather than the embedder's,
+    // which is why the core reapplies the option around a session replay.
+    call("ghostty_terminal_reset", terminal);
+    expect(blinking()).toBe(false);
+    setDefaultCursorBlink(true);
+    expect(blinking()).toBe(true);
+
+    call("ghostty_wasm_free_u8_array", scratch, 4);
+    call("ghostty_render_state_free", renderState);
+    call("ghostty_wasm_free_opaque", renderStateSlot);
+    call("ghostty_terminal_free", terminal);
+    call("ghostty_wasm_free_opaque", terminalSlot);
+    call("ghostty_wasm_free_u8_array", options, 8);
+  });
+
   it("reports and scrolls the viewport with Ghostty's scrollbar state", async () => {
     const result = await WebAssembly.instantiate(
       decodeWasmDataUrl(wasmDataUrl).buffer as ArrayBuffer,

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -11,6 +11,7 @@ import {
   isTerminalCopyShortcut,
   isTerminalLinkPointerGesture,
   isTerminalPasteShortcut,
+  shouldBlinkTerminalCursor,
   shouldReportTerminalMouse,
   terminalScrollbarGeometry,
   terminalScrollbarOffsetAtPointer,
@@ -51,6 +52,29 @@ describe("isTerminalAltGraphText", () => {
         getModifierState: (modifier) => modifier === "AltGraph",
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldBlinkTerminalCursor", () => {
+  const blinking = {
+    focused: true,
+    cursorBlinking: true,
+    cursorVisible: true,
+    reducedMotion: false,
+  };
+
+  it("blinks a focused visible cursor the terminal asked to blink", () => {
+    expect(shouldBlinkTerminalCursor(blinking)).toBe(true);
+  });
+
+  it("holds the cursor steady when blinking would be unwanted", () => {
+    // Unfocused surfaces draw a steady hollow cursor, DECSCUSR steady styles and
+    // DEC mode 12 turn blinking off, a hidden cursor has nothing to toggle, and
+    // reduced-motion readers get no permanently animating element.
+    expect(shouldBlinkTerminalCursor({ ...blinking, focused: false })).toBe(false);
+    expect(shouldBlinkTerminalCursor({ ...blinking, cursorBlinking: false })).toBe(false);
+    expect(shouldBlinkTerminalCursor({ ...blinking, cursorVisible: false })).toBe(false);
+    expect(shouldBlinkTerminalCursor({ ...blinking, reducedMotion: true })).toBe(false);
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -514,6 +514,9 @@ export class GhosttyTerminalSurface {
   resetAndWrite(data: string): void {
     if (this.disposed) return;
     this.core.resetAndWrite(data);
+    // A replayed session starts from the visible phase like any other write:
+    // reattaching mid-blink must not open on an invisible cursor.
+    this.cursorOn = true;
     this.forceFullRender = true;
     this.scrollbarDirty = true;
     this.requestRender();

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -396,8 +396,8 @@ export class GhosttyTerminalSurface {
   private pasteShortcutToken = 0;
   private wheelRemainder = 0;
   private dprMedia: MediaQueryList | null = null;
-  // Read live on every blink decision, so a preference change during a session
-  // takes effect without a listener.
+  // Read live on every blink decision, and watched so that dropping the
+  // preference restarts a blink cycle that has no timer left to notice it.
   private readonly reducedMotionMedia = window.matchMedia?.("(prefers-reduced-motion: reduce)");
   private inputLeft = -1;
   private inputTop = -1;
@@ -428,6 +428,7 @@ export class GhosttyTerminalSurface {
     this.resizeObserver = new ResizeObserver(() => this.fit());
     this.installEvents();
     this.watchDevicePixelRatio();
+    this.reducedMotionMedia?.addEventListener("change", this.onReducedMotionChange);
     document.fonts.addEventListener("loadingdone", this.onFontsLoaded);
     this.resizeObserver.observe(mount);
   }
@@ -555,6 +556,14 @@ export class GhosttyTerminalSurface {
     this.fit();
     this.requestRender();
   }
+
+  private readonly onReducedMotionChange = () => {
+    if (this.disposed) return;
+    // Nothing else wakes an idle steady cursor: the blink timer only reschedules
+    // from a render, and reduced motion is exactly the state that stopped it.
+    this.cursorOn = true;
+    this.requestRender();
+  };
 
   private readonly onFontsLoaded = () => {
     if (this.disposed) return;
@@ -698,6 +707,7 @@ export class GhosttyTerminalSurface {
     document.fonts.removeEventListener("loadingdone", this.onFontsLoaded);
     this.dprMedia?.removeEventListener("change", this.onDevicePixelRatioChange);
     this.dprMedia = null;
+    this.reducedMotionMedia?.removeEventListener("change", this.onReducedMotionChange);
     if (this.selectionScrollTimer !== null) window.clearInterval(this.selectionScrollTimer);
     if (this.resizeNotifyTimer !== null) {
       window.clearTimeout(this.resizeNotifyTimer);

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -31,6 +31,8 @@ export const DEFAULT_TERMINAL_FONT_FAMILY =
   '"SF Mono", "SFMono-Regular", "JetBrains Mono", ' + TERMINAL_GLYPH_FALLBACKS;
 const CONTENT_PADDING = 4;
 const MIN_SCROLLBAR_THUMB_HEIGHT = 18;
+/** Half a blink cycle: the visible and hidden phases are equally long. */
+const CURSOR_BLINK_INTERVAL_MS = 500;
 
 /** Requested terminal font; omitted fields fall back to the defaults. */
 export interface GhosttyTerminalFont {
@@ -69,6 +71,20 @@ export function terminalFontFamily(family?: string): string {
 export function terminalFontSize(size?: number): number {
   if (size === undefined || !Number.isFinite(size)) return DEFAULT_TERMINAL_FONT_SIZE;
   return Math.max(MIN_TERMINAL_FONT_SIZE, Math.min(MAX_TERMINAL_FONT_SIZE, Math.round(size)));
+}
+
+/**
+ * Whether the cursor should keep toggling. An unfocused surface draws a steady
+ * hollow cursor instead of blinking, and a reduced-motion reader gets a steady
+ * cursor too rather than a permanently animating element.
+ */
+export function shouldBlinkTerminalCursor(state: {
+  readonly focused: boolean;
+  readonly cursorBlinking: boolean;
+  readonly cursorVisible: boolean;
+  readonly reducedMotion: boolean;
+}): boolean {
+  return state.focused && state.cursorBlinking && state.cursorVisible && !state.reducedMotion;
 }
 
 /**
@@ -380,6 +396,9 @@ export class GhosttyTerminalSurface {
   private pasteShortcutToken = 0;
   private wheelRemainder = 0;
   private dprMedia: MediaQueryList | null = null;
+  // Read live on every blink decision, so a preference change during a session
+  // takes effect without a listener.
+  private readonly reducedMotionMedia = window.matchMedia?.("(prefers-reduced-motion: reduce)");
   private inputLeft = -1;
   private inputTop = -1;
 
@@ -1249,7 +1268,9 @@ export class GhosttyTerminalSurface {
       this.frame = 0;
     }
     this.snapshot = this.core.snapshot();
-    if (!this.snapshot.cursorBlinking) this.cursorOn = true;
+    // A cursor that is not blinking right now must be drawn, never caught in an
+    // off phase left behind by a blink that has since been turned off.
+    if (!this.blinkEnabled()) this.cursorOn = true;
     // The origin only moves together with a forced full repaint: partial
     // dirty-row redraws must never composite rows at a shifted origin over
     // rows painted at the previous one. Bottom anchoring starts once
@@ -1299,13 +1320,23 @@ export class GhosttyTerminalSurface {
   private scheduleCursorBlink(): void {
     if (this.cursorTimer !== null) window.clearTimeout(this.cursorTimer);
     this.cursorTimer = null;
-    // An unfocused surface shows a steady hollow cursor instead of blinking.
-    if (!this.focused || !this.snapshot?.cursorBlinking || !this.snapshot.cursorVisible) return;
+    if (!this.blinkEnabled()) return;
     this.cursorTimer = window.setTimeout(() => {
       this.cursorTimer = null;
       this.cursorOn = !this.cursorOn;
       this.requestRender();
-    }, 500);
+    }, CURSOR_BLINK_INTERVAL_MS);
+  }
+
+  private blinkEnabled(): boolean {
+    const snapshot = this.snapshot;
+    if (!snapshot) return false;
+    return shouldBlinkTerminalCursor({
+      focused: this.focused,
+      cursorBlinking: snapshot.cursorBlinking,
+      cursorVisible: snapshot.cursorVisible,
+      reducedMotion: this.reducedMotionMedia?.matches ?? false,
+    });
   }
 
   private positionInput(): void {


### PR DESCRIPTION
## What

The web terminal's cursor stopped blinking when the renderer moved from xterm.js to libghostty-vt. This restores it.

![Terminal cursor blinking again](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/547cf389-65f4-4f57-b2b7-de6de9ec0561/t3code-terminal-cursor-blink.gif)

## Why it broke

The old renderer was constructed with `cursorBlink: true`, so every T3 terminal blinked regardless of what the program inside it wanted. libghostty-vt's built-in default is a steady cursor, and the Canvas renderer only toggles the cursor while the terminal reports `cursorBlinking` — that is, when a program turns blinking on through DECSCUSR (`CSI 5/3/1 q`) or DEC mode 12. A plain shell prompt does neither, so the cursor sat still.

## What changed

- `GhosttyTerminalCore` sets `GHOSTTY_TERMINAL_OPT_DEFAULT_CURSOR_BLINK` when it creates a terminal, so a session starts blinking and returns to blinking on `CSI 0 q`. Programs still own the cursor: a steady DECSCUSR style or `CSI ?12l` turns the blink off, and `CSI ?12h` turns it back on.
- The option is applied again in `resetAndWrite`, because RIS restores Ghostty's built-in steady default. That is the path a reattach to an existing session takes, so without it a reconnected terminal came back steady.
- The blink phase machinery in `GhosttyTerminalSurface` was already in place (500ms half-cycle, reset to the visible phase on write and focus). It now runs through one predicate, `shouldBlinkTerminalCursor`, which also holds the cursor steady when the reader prefers reduced motion, next to the existing unfocused and hidden-cursor cases.

## Tests

- `runtimeAbi.test.ts` exercises the real vendored WASM: the default is steady, option 23 makes it blink, `CSI 2 q` / `CSI ?12l` override it, `CSI 0 q` / `CSI ?12h` restore it, and RIS drops back to steady (the reason for the second apply).
- `renderer.test.ts` covers the off phase repainting the cell without the inverted cursor glyph.
- `surface.test.ts` covers the blink predicate.

Verified in a dev environment — the GIF above is the terminal drawer in that build.

## Note

`apps/mobile`'s Android and iOS terminal views gate on the same `cursorBlinking` flag, so they blink only when a program asks. Matching them to this default is a separate change, not included here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI and embedder default cursor option only; no auth, data, or API surface changes beyond local terminal behavior.
> 
> **Overview**
> Restores **blinking cursor** behavior in the Ghostty web terminal after the move from xterm.js, which always blinked, to libghostty-vt whose default is steady.
> 
> `GhosttyTerminalCore` now sets terminal **option 23** (embedder default cursor blink) when a terminal is created and again after `resetAndWrite`, because RIS resets Ghostty’s built-in steady default—important for session reattach. Programs still override via DECSCUSR and DEC mode 12.
> 
> Blink scheduling in `GhosttyTerminalSurface` goes through **`shouldBlinkTerminalCursor`**, which also keeps the cursor steady when the surface is unfocused, the cursor is hidden, or **`prefers-reduced-motion: reduce`** is set; the surface listens for that media query and resets to the visible phase when it changes.
> 
> Tests cover WASM blink semantics, renderer off-phase repaint, and the blink predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0988f07a9b67cfa1e159263ca3bb5aa5af77e19f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal cursor blinking with reduced-motion and focus awareness
> - Enables cursor blinking by default by setting Ghostty option 23 immediately after terminal creation and after any terminal reset.
> - Adds `shouldBlinkTerminalCursor` to centralize blink logic, requiring the surface to be focused, cursor to be visible and blinking, and `prefers-reduced-motion` to be false.
> - Watches the `prefers-reduced-motion` media query at runtime and restarts the blink cycle on change.
> - Replaces the hardcoded 500ms interval with `CURSOR_BLINK_INTERVAL_MS` and gates blink scheduling through the new `blinkEnabled()` helper.
> - After `resetAndWrite`, forces `cursorOn=true` so the cursor starts visible rather than mid-blink.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0988f07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->