### PR TITLE
fix(server): strip replayable terminal queries from history

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -991,6 +991,61 @@ it.layer(
     }),
   );
 
+  it.effect("strips replayable CSI and DCS traffic while preserving setters", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("prompt ");
+      // DECRQM/DECRPM, XTVERSION, and kitty-keyboard CSI query/reply traffic.
+      process.emitData("\u001b[?2026$p\u001b[?2026;2$y\u001b[>q\u001b[?u\u001b[?31u");
+      // DECRQSS and XTGETTCAP query/reply traffic in 7-bit DCS form.
+      process.emitData("\u001bP$q m\u001b\\\u001bP1$r0m\u001b\\");
+      process.emitData("\u001bP+q544e\u001b\\\u001bP1+r544e=1b\u001b\\");
+      // The same DCS traffic in 8-bit form.
+      process.emitData("\u0090$q m\u009c\u00901$r0m\u009c");
+      process.emitData("\u0090+q544e\u009c\u00901+r544e=1b\u009c");
+      // Setters and cursor movement share final bytes with query families but
+      // have visible terminal-state value and must survive replay.
+      process.emitData('\u001b[!p\u001b["p\u001b[4 q\u001b[u');
+      process.emitData("done\n");
+
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      assert.equal(reopened.history, 'prompt \u001b[!p\u001b["p\u001b[4 q\u001b[udone\n');
+    }),
+  );
+
+  it.effect("handles CSI and DCS query sequences split across output chunks", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("before ");
+      process.emitData("\u001b[?2026$");
+      process.emitData("pafter ");
+      process.emitData("\u001bP$q ");
+      process.emitData("m\u001b");
+      process.emitData("\\after ");
+      process.emitData("\u009b?3");
+      process.emitData("1uafter ");
+      process.emitData("\u0090+q544e");
+      process.emitData("\u009cafter\n");
+
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      assert.equal(reopened.history, "before after after after after\n");
+    }),
+  );
+
   it.effect(
     "preserves clear and style control sequences while dropping chunk-split query traffic",
     () =>

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -878,7 +878,29 @@ function shouldStripCsiSequence(body: string, finalByte: string): boolean {
   if (finalByte === "c" && /^[>0-9;?]*$/.test(body)) {
     return true;
   }
+  // DECRQM mode queries (…$p) and DECRPM replies (…$y): replaying a stored
+  // query makes the terminal answer again, and the shell echoes the answer as
+  // junk at the prompt. The `$` guard keeps setters like DECSTR (!p) and
+  // DECSCL ("p) intact.
+  if ((finalByte === "p" || finalByte === "y") && /^[0-9;?]*\$$/.test(body)) {
+    return true;
+  }
+  // XTVERSION query (>q). DECSCUSR (space-intermediate q) stays.
+  if (finalByte === "q" && /^>[0-9;]*$/.test(body)) {
+    return true;
+  }
+  // Kitty keyboard protocol query/reply (?u). Restore-cursor (bare u) stays.
+  if (finalByte === "u" && body.startsWith("?")) {
+    return true;
+  }
   return false;
+}
+
+// DECRQSS ($q) and XTGETTCAP (+q) queries plus their replies ([01]$r / [01]+r):
+// pure request/response traffic with no visual value, and replaying a stored
+// query triggers a fresh reply.
+function shouldStripDcsSequence(content: string): boolean {
+  return /^[01]?[$+][qr]/.test(content);
 }
 
 function shouldStripOscSequence(content: string): boolean {
@@ -981,7 +1003,10 @@ function sanitizeTerminalHistoryChunk(
         }
         const sequence = input.slice(index, terminatorIndex);
         const content = stripStringTerminator(input.slice(index + 2, terminatorIndex));
-        if (nextCodePoint !== 0x5d || !shouldStripOscSequence(content)) {
+        const strip =
+          (nextCodePoint === 0x5d && shouldStripOscSequence(content)) ||
+          (nextCodePoint === 0x50 && shouldStripDcsSequence(content));
+        if (!strip) {
           append(sequence);
         }
         index = terminatorIndex;
@@ -1024,7 +1049,10 @@ function sanitizeTerminalHistoryChunk(
       }
       const sequence = input.slice(index, terminatorIndex);
       const content = stripStringTerminator(input.slice(index + 1, terminatorIndex));
-      if (codePoint !== 0x9d || !shouldStripOscSequence(content)) {
+      const strip =
+        (codePoint === 0x9d && shouldStripOscSequence(content)) ||
+        (codePoint === 0x90 && shouldStripDcsSequence(content));
+      if (!strip) {
         append(sequence);
       }
       index = terminatorIndex;


### PR DESCRIPTION
## Summary

- Strip replayable DECRQM/DECRPM, XTVERSION, kitty-keyboard, DECRQSS, and XTGETTCAP traffic from persisted terminal history in both 7-bit and 8-bit forms.
- Preserve legitimate setters and visual control sequences, including DECSTR, DECSCL, DECSCUSR, restore-cursor, styles, and clears.
- Keep live terminal output unchanged and add focused Manager regression coverage for reopen history, chunk splits, setters, and existing OSC behavior.

## Why

Reopening a terminal replays its persisted output. Capability queries in that history can trigger fresh replies, which the shell then displays as visible gibberish at the prompt.

## Validation

- `pnpm exec vitest run --config apps/server/vite.config.ts apps/server/src/terminal/Manager.test.ts --testNamePattern='(strips replay|handles CSI|preserves clear|ESC sequences)'`
- `vp run --filter t3 typecheck`
- `vp fmt --check apps/server/src/terminal/Manager.ts apps/server/src/terminal/Manager.test.ts`

Implemented and validated by Codex (GPT-5.6) in T3 Code.


## Playwright verification

The recording shows query traffic around visible terminal output, a thread reload/reopen, and the same clean output after history reattachment.

![Terminal history sanitizer demo](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/a959b925-b9a5-48f1-9d79-6d802ae1c916/terminal-history-sanitizer.gif)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to terminal history persistence and sanitization logic with regression tests; no auth, data, or live output path changes.
> 
> **Overview**
> Extends **persisted terminal history** sanitization so reopening a session no longer replays capability **queries** that make the terminal answer again and leave junk at the prompt.
> 
> **CSI stripping** now drops DECRQM/DECRPM (`$p`/`$y`), XTVERSION (`>q`), and kitty keyboard (`?u`) traffic, with guards so setters like DECSTR, DECSCL, DECSCUSR, and restore-cursor still stay in history.
> 
> **DCS stripping** is new via `shouldStripDcsSequence` for DECRQSS and XTGETTCAP query/reply pairs (`$q`/`$r` and `+q`/`+r`), in both 7-bit (`ESC P`) and 8-bit (`0x90`) forms. Live PTY output is unchanged; only what gets written to history is filtered.
> 
> **Tests** add reopen scenarios for mixed CSI/DCS traffic, chunk-split sequences, and setter preservation alongside existing OSC behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdb85eed4b9f59e2fcd435f504c515ef6417fbea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip replayable CSI and DCS query sequences from terminal history
> - Extends `shouldStripCsiSequence` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/5319/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e) to also strip DECRQM/DECRPM (`$p`/`$y`), XTVERSION (`>q`), and kitty keyboard (`?u`) query/reply sequences, while preserving setter sequences like DECSTR (`!p`) and restore-cursor (`u`).
> - Adds a new `shouldStripDcsSequence` helper that detects and strips DCS-based query/reply traffic (DECRQSS, XTGETTCAP, and their `[01]$r`/`[01]+r` replies).
> - Updates `sanitizeTerminalHistoryChunk` to apply DCS stripping alongside the existing OSC and CSI filtering, covering both 7-bit and 8-bit encodings and sequences split across output chunks.
> - Adds tests covering split sequences and mixed visible/query output to verify history is clean on terminal reopen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdb85ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

closes #4776
