### PR TITLE
fix(terminal): keep PTY and Ghostty resize ordering in lockstep

### DIFF
--- a/apps/mobile/src/features/terminal/terminalMenu.test.ts
+++ b/apps/mobile/src/features/terminal/terminalMenu.test.ts
@@ -61,6 +61,7 @@ function makeKnownSession(input: {
       error: null,
       hasRunningSubprocess: false,
       updatedAt: input.updatedAt ?? "2026-04-15T20:00:00.000Z",
+      sequence: 0,
       version: 1,
     },
   };

--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -53,7 +53,7 @@ const makeTerminalManagerLayer = (
   Layer.succeed(TerminalManager.TerminalManager, {
     ...overrides,
     attachStream: () => Effect.die(new Error("unused")),
-    resize: () => Effect.void,
+    resize: () => Effect.succeed({ sequence: 0 }),
     clear: () => Effect.void,
     restart: () => Effect.die(new Error("unused")),
     close: () => Effect.void,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7581,7 +7581,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           terminalManager: {
             open: () => Effect.succeed(snapshot),
             write: () => Effect.void,
-            resize: () => Effect.void,
+            resize: () => Effect.succeed({ sequence: 0 }),
             clear: () => Effect.void,
             restart: () => Effect.succeed(snapshot),
             close: () => Effect.void,

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -553,7 +553,7 @@ it.layer(
       // The data callback queues output synchronously, while its Effect drain
       // runs independently. The resize acknowledgement must wait behind it.
       process.emitData("old-width bytes\n");
-      yield* manager.resize({
+      const resizeResult = yield* manager.resize({
         threadId: "thread-1",
         terminalId: DEFAULT_TERMINAL_ID,
         cols: 42,
@@ -563,6 +563,7 @@ it.layer(
       const events = yield* getEvents;
       const outputEvent = events.find((event) => event.type === "output");
       expect(outputEvent).toBeDefined();
+      expect(resizeResult.sequence).toBe(outputEvent?.sequence);
       expect(process.resizeCalls).toEqual([{ cols: 42, rows: 20 }]);
     }),
   );

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -567,6 +567,35 @@ it.layer(
     }),
   );
 
+  it.effect("does not deadlock when an output listener resizes synchronously", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      const resizeFinished = yield* Deferred.make<void>();
+      const unsubscribe = yield* manager.subscribe((event) =>
+        event.type === "output"
+          ? manager
+              .resize({
+                threadId: "thread-1",
+                terminalId: DEFAULT_TERMINAL_ID,
+                cols: 42,
+                rows: 20,
+              })
+              .pipe(Effect.tap(() => Deferred.succeed(resizeFinished, undefined)))
+          : Effect.void,
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("listener-triggered resize\n");
+      yield* Deferred.await(resizeFinished);
+      expect(process.resizeCalls).toEqual([{ cols: 42, rows: 20 }]);
+    }),
+  );
+
   it.effect("releases a resize flush when exit disposes the pending queue", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, getEvents } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -580,7 +580,10 @@ it.layer(
                 cols: 42,
                 rows: 20,
               })
-              .pipe(Effect.tap(() => Deferred.succeed(resizeFinished, undefined)))
+              .pipe(
+                Effect.tap(() => Deferred.succeed(resizeFinished, undefined)),
+                Effect.ignore,
+              )
           : Effect.void,
       );
       yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Data from "effect/Data";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
@@ -538,6 +539,75 @@ it.layer(
 
       expect(process.writes).toEqual(["ls\n"]);
       expect(process.resizeCalls).toEqual([{ cols: 120, rows: 30 }]);
+    }),
+  );
+
+  it.effect("publishes old-width output before acknowledging a resize", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, getEvents } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      // The data callback queues output synchronously, while its Effect drain
+      // runs independently. The resize acknowledgement must wait behind it.
+      process.emitData("old-width bytes\n");
+      yield* manager.resize({
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+        cols: 42,
+        rows: 20,
+      });
+
+      const events = yield* getEvents;
+      const outputEvent = events.find((event) => event.type === "output");
+      expect(outputEvent).toBeDefined();
+      expect(process.resizeCalls).toEqual([{ cols: 42, rows: 20 }]);
+    }),
+  );
+
+  it.effect("releases a resize flush when exit disposes the pending queue", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, getEvents } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      const outputEntered = yield* Deferred.make<void>();
+      const releaseOutput = yield* Deferred.make<void>();
+      const unsubscribe = yield* manager.subscribe((event) =>
+        event.type === "output"
+          ? Effect.gen(function* () {
+              yield* Deferred.succeed(outputEntered, undefined);
+              yield* Deferred.await(releaseOutput);
+            })
+          : Effect.void,
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      process.emitData("output being published\n");
+      yield* Deferred.await(outputEntered);
+
+      // Queue the exit before the resize sentinel. Once the blocked output is
+      // released, exit cleanup must dispose the sentinel instead of leaving
+      // the resize fiber suspended forever.
+      process.emitExit({ exitCode: 0, signal: 0 });
+      const resizeFiber = yield* manager
+        .resize({
+          threadId: "thread-1",
+          terminalId: DEFAULT_TERMINAL_ID,
+          cols: 42,
+          rows: 20,
+        })
+        .pipe(Effect.forkChild);
+      yield* waitFor(Effect.sync(() => process.resizeCalls.length === 1));
+      yield* Deferred.succeed(releaseOutput, undefined);
+      yield* Fiber.join(resizeFiber);
+      yield* waitFor(
+        Effect.map(getEvents, (events) => events.some((event) => event.type === "exited")),
+      );
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -37,6 +37,7 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as Equal from "effect/Equal";
@@ -263,10 +264,26 @@ interface PersistHistoryRequest {
 
 type PendingProcessEvent =
   | { type: "output"; data: string }
-  | { type: "exit"; event: PtyAdapter.PtyExitEvent };
+  | { type: "exit"; event: PtyAdapter.PtyExitEvent }
+  // Drain-ordering sentinel: completes once every event queued before it has
+  // been published. Resize replies use it without adding a wire-protocol
+  // marker that clients would need to understand.
+  | { type: "flush"; deferred: Deferred.Deferred<void> };
+
+/** Queue disposal must release flush sentinels or their awaiters hang forever. */
+function discardPendingProcessEvents(session: TerminalSessionState): void {
+  for (const event of session.pendingProcessEvents) {
+    if (event.type === "flush") {
+      Deferred.doneUnsafe(event.deferred, Effect.void);
+    }
+  }
+  session.pendingProcessEvents = [];
+  session.pendingProcessEventIndex = 0;
+}
 
 type DrainProcessEventAction =
   | { type: "idle" }
+  | { type: "flush"; deferred: Deferred.Deferred<void> }
   | {
       type: "output";
       threadId: string;
@@ -1678,7 +1695,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     while (true) {
       const action: DrainProcessEventAction = yield* Effect.sync(() => {
         if (session.pid !== expectedPid || !session.process || session.status !== "running") {
-          session.pendingProcessEvents = [];
+          discardPendingProcessEvents(session);
           session.pendingProcessEventIndex = 0;
           session.processEventDrainRunning = false;
           return { type: "idle" } as const;
@@ -1686,7 +1703,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
         const nextEvent = session.pendingProcessEvents[session.pendingProcessEventIndex];
         if (!nextEvent) {
-          session.pendingProcessEvents = [];
+          discardPendingProcessEvents(session);
           session.pendingProcessEventIndex = 0;
           session.processEventDrainRunning = false;
           return { type: "idle" } as const;
@@ -1694,8 +1711,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
         session.pendingProcessEventIndex += 1;
         if (session.pendingProcessEventIndex >= session.pendingProcessEvents.length) {
-          session.pendingProcessEvents = [];
-          session.pendingProcessEventIndex = 0;
+          discardPendingProcessEvents(session);
+        }
+
+        if (nextEvent.type === "flush") {
+          return { type: "flush", deferred: nextEvent.deferred } as const;
         }
 
         if (nextEvent.type === "output") {
@@ -1730,7 +1750,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.childCommandLabel = null;
         session.status = "exited";
         session.pendingHistoryControlSequence = "";
-        session.pendingProcessEvents = [];
+        discardPendingProcessEvents(session);
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
         session.exitCode = Number.isInteger(nextEvent.event.exitCode)
@@ -1754,6 +1774,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
       if (action.type === "idle") {
         return;
+      }
+
+      if (action.type === "flush") {
+        yield* Deferred.succeed(action.deferred, undefined);
+        continue;
       }
 
       if (action.type === "output") {
@@ -1802,7 +1827,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       session.childCommandLabel = null;
       session.status = "exited";
       session.pendingHistoryControlSequence = "";
-      session.pendingProcessEvents = [];
+      discardPendingProcessEvents(session);
       session.pendingProcessEventIndex = 0;
       session.processEventDrainRunning = false;
       session.updatedAt = updatedAt;
@@ -1897,7 +1922,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       session.exitSignal = null;
       session.hasRunningSubprocess = false;
       session.childCommandLabel = null;
-      session.pendingProcessEvents = [];
+      discardPendingProcessEvents(session);
       session.pendingProcessEventIndex = 0;
       session.processEventDrainRunning = false;
       session.updatedAt = startingAt;
@@ -1974,7 +1999,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.process = null;
         session.hasRunningSubprocess = false;
         session.childCommandLabel = null;
-        session.pendingProcessEvents = [];
+        discardPendingProcessEvents(session);
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
         advanceEventSequence(session);
@@ -2252,7 +2277,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.history = "";
       liveSession.pendingHistoryControlSequence = "";
-      liveSession.pendingProcessEvents = [];
+      discardPendingProcessEvents(liveSession);
       liveSession.pendingProcessEventIndex = 0;
       liveSession.processEventDrainRunning = false;
       yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
@@ -2261,7 +2286,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.worktreePath = nextWorktreePath;
       liveSession.history = "";
       liveSession.pendingHistoryControlSequence = "";
-      liveSession.pendingProcessEvents = [];
+      discardPendingProcessEvents(liveSession);
       liveSession.pendingProcessEventIndex = 0;
       liveSession.processEventDrainRunning = false;
       yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
@@ -2553,6 +2578,25 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     session.value.cols = input.cols;
     session.value.rows = input.rows;
     session.value.updatedAt = yield* nowIso;
+
+    // The client applies its grid when this reply lands. Publish every output
+    // queued before the resize first so those bytes are still interpreted at
+    // the width that produced them. The drain flag matters even when the
+    // queue is momentarily empty: the active drain may already be publishing
+    // a dequeued chunk.
+    const pid = session.value.pid;
+    if (
+      pid !== null &&
+      (session.value.pendingProcessEvents.length > 0 || session.value.processEventDrainRunning)
+    ) {
+      const flushed = yield* Deferred.make<void>();
+      session.value.pendingProcessEvents.push({ type: "flush", deferred: flushed });
+      if (!session.value.processEventDrainRunning) {
+        session.value.processEventDrainRunning = true;
+        runFork(drainProcessEvents(session.value, pid));
+      }
+      yield* Deferred.await(flushed);
+    }
   });
 
   const resize: TerminalManager["Service"]["resize"] = (input) =>
@@ -2566,7 +2610,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const session = yield* requireSession(input.threadId, terminalId);
         session.history = "";
         session.pendingHistoryControlSequence = "";
-        session.pendingProcessEvents = [];
+        discardPendingProcessEvents(session);
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
         const eventStamp = advanceEventSequence(session);
@@ -2639,7 +2683,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
         session.history = "";
         session.pendingHistoryControlSequence = "";
-        session.pendingProcessEvents = [];
+        discardPendingProcessEvents(session);
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
         yield* persistHistory(input.threadId, terminalId, session.history);

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -26,6 +26,7 @@ import {
   type TerminalMetadataStreamEvent,
   type TerminalOpenInput,
   type TerminalResizeInput,
+  type TerminalResizeResult,
   type TerminalRestartInput,
   type TerminalSessionSnapshot,
   type TerminalSessionStatus,
@@ -146,7 +147,9 @@ export class TerminalManager extends Context.Service<
     /**
      * Resize the PTY backing a terminal session.
      */
-    readonly resize: (input: TerminalResizeInput) => Effect.Effect<void, TerminalError>;
+    readonly resize: (
+      input: TerminalResizeInput,
+    ) => Effect.Effect<TerminalResizeResult, TerminalError>;
 
     /**
      * Clear terminal output history.
@@ -2583,11 +2586,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const session = yield* getSession(input.threadId, input.terminalId);
     // ResizeObserver traffic can already be in flight when the UI closes the session.
     if (Option.isNone(session)) {
-      return;
+      return { sequence: 0 };
     }
     const process = session.value.process;
     if (!process || session.value.status !== "running") {
-      return;
+      return { sequence: session.value.eventSequence };
     }
     yield* resizePtyProcess(session.value, process, input.cols, input.rows);
     session.value.cols = input.cols;
@@ -2619,6 +2622,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         yield* Deferred.await(flushed);
       }
     }
+    return { sequence: session.value.eventSequence };
   });
 
   const resize: TerminalManager["Service"]["resize"] = (input) =>

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -242,6 +242,7 @@ export interface TerminalSessionState {
   pendingProcessEvents: Array<PendingProcessEvent>;
   pendingProcessEventIndex: number;
   processEventDrainRunning: boolean;
+  processEventPublishFiberIds: Set<number>;
   exitCode: number | null;
   exitSignal: number | null;
   updatedAt: string;
@@ -1267,6 +1268,19 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
     });
 
+  const publishProcessEvent = (session: TerminalSessionState, event: TerminalEvent) =>
+    Effect.gen(function* () {
+      const fiberId = yield* Effect.fiberId;
+      session.processEventPublishFiberIds.add(fiberId);
+      yield* publishEvent(event).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            session.processEventPublishFiberIds.delete(fiberId);
+          }),
+        ),
+      );
+    });
+
   const historyPath = (threadId: string, terminalId: string) => {
     const threadPart = toSafeThreadId(threadId);
     if (terminalId === DEFAULT_TERMINAL_ID) {
@@ -1786,7 +1800,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           yield* queuePersist(action.threadId, action.terminalId, action.history);
         }
 
-        yield* publishEvent({
+        yield* publishProcessEvent(session, {
           type: "output",
           threadId: action.threadId,
           terminalId: action.terminalId,
@@ -1801,7 +1815,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         threadId: action.threadId,
         terminalId: action.terminalId,
       });
-      yield* publishEvent({
+      yield* publishProcessEvent(session, {
         type: "exited",
         threadId: action.threadId,
         terminalId: action.terminalId,
@@ -2219,6 +2233,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         pendingProcessEvents: [],
         pendingProcessEventIndex: 0,
         processEventDrainRunning: false,
+        processEventPublishFiberIds: new Set(),
         exitCode: null,
         exitSignal: null,
         updatedAt: yield* nowIso,
@@ -2589,13 +2604,20 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       pid !== null &&
       (session.value.pendingProcessEvents.length > 0 || session.value.processEventDrainRunning)
     ) {
+      const currentFiberId = yield* Effect.fiberId;
       const flushed = yield* Deferred.make<void>();
       session.value.pendingProcessEvents.push({ type: "flush", deferred: flushed });
       if (!session.value.processEventDrainRunning) {
         session.value.processEventDrainRunning = true;
         runFork(drainProcessEvents(session.value, pid));
       }
-      yield* Deferred.await(flushed);
+      // A listener may synchronously call resize while the drain is delivering
+      // this output. Waiting here would make the listener wait for the drain
+      // while the drain waits for that listener. The sentinel remains queued
+      // and the drain releases it as soon as listener delivery resumes.
+      if (!session.value.processEventPublishFiberIds.has(currentFiberId)) {
+        yield* Deferred.await(flushed);
+      }
     }
   });
 
@@ -2650,6 +2672,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             pendingProcessEvents: [],
             pendingProcessEventIndex: 0,
             processEventDrainRunning: false,
+            processEventPublishFiberIds: new Set(),
             exitCode: null,
             exitSignal: null,
             updatedAt: yield* nowIso,

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -4,9 +4,42 @@ import {
   resolveTerminalSelectionActionPosition,
   shouldHandleTerminalExit,
   shouldHandleTerminalSelectionMouseUp,
+  TerminalWriteBarrier,
   terminalSelectionActionDelayForClickCount,
   terminalSelectionLineRange,
 } from "./ThreadTerminalDrawer";
+
+describe("TerminalWriteBarrier", () => {
+  it("holds a resize until the matching output version is applied", async () => {
+    const barrier = new TerminalWriteBarrier();
+    let released = false;
+    const waiting = barrier.waitFor(2).then(() => {
+      released = true;
+    });
+
+    await Promise.resolve();
+    expect(released).toBe(false);
+    barrier.markApplied(1);
+    await Promise.resolve();
+    expect(released).toBe(false);
+    barrier.markApplied(2);
+    await waiting;
+    expect(released).toBe(true);
+  });
+
+  it("releases an in-flight waiter when the terminal is disposed", async () => {
+    const barrier = new TerminalWriteBarrier();
+    let released = false;
+    const waiting = barrier.waitFor(1).then(() => {
+      released = true;
+    });
+
+    barrier.release();
+    await waiting;
+    expect(released).toBe(true);
+    expect(await barrier.waitFor(1)).toBe(false);
+  });
+});
 
 describe("resolveTerminalSelectionActionPosition", () => {
   it("prefers the selection rect over the last pointer position", () => {

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -27,6 +27,13 @@ describe("TerminalWriteBarrier", () => {
     expect(released).toBe(true);
   });
 
+  it("can seed a recreated barrier with output already applied", async () => {
+    const barrier = new TerminalWriteBarrier();
+    barrier.markApplied(4);
+
+    expect(await barrier.waitFor(4)).toBe(true);
+  });
+
   it("releases an in-flight waiter when the terminal is disposed", async () => {
     const barrier = new TerminalWriteBarrier();
     let released = false;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -68,6 +68,42 @@ const MIN_DRAWER_HEIGHT = 180;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
 const MULTI_CLICK_SELECTION_ACTION_DELAY_MS = 260;
 
+/**
+ * Keeps PTY resize acknowledgements behind terminal output already committed
+ * to Ghostty. The server orders the wire messages, but React may commit the
+ * stream update one render after the resize RPC resolves.
+ */
+export class TerminalWriteBarrier {
+  private settledVersion = 0;
+  private released = false;
+  private waiters: Array<{
+    readonly version: number;
+    readonly resolve: (applied: boolean) => void;
+  }> = [];
+
+  waitFor(version: number): Promise<boolean> {
+    if (this.released) return Promise.resolve(false);
+    if (version <= this.settledVersion) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      this.waiters.push({ version, resolve });
+    });
+  }
+
+  markApplied(version: number): void {
+    this.settledVersion = Math.max(this.settledVersion, version);
+    const ready = this.waiters.filter((waiter) => waiter.version <= this.settledVersion);
+    this.waiters = this.waiters.filter((waiter) => waiter.version > this.settledVersion);
+    for (const waiter of ready) waiter.resolve(true);
+  }
+
+  release(): void {
+    this.released = true;
+    const waiters = this.waiters;
+    this.waiters = [];
+    for (const waiter of waiters) waiter.resolve(false);
+  }
+}
+
 function maxDrawerHeight(): number {
   if (typeof window === "undefined") return DEFAULT_THREAD_TERMINAL_HEIGHT;
   return Math.max(MIN_DRAWER_HEIGHT, Math.floor(window.innerHeight * MAX_DRAWER_HEIGHT_RATIO));
@@ -321,15 +357,6 @@ export function TerminalViewport({
       input: { threadId, terminalId, data },
     }),
   );
-  const resizeTerminal = useEffectEvent(async (cols: number, rows: number) => {
-    const result = await runTerminalResize({
-      environmentId,
-      input: { threadId, terminalId, cols, rows },
-    });
-    // A failed request leaves the PTY at its previous dimensions, so the
-    // surface must keep its old grid and retry instead of guessing.
-    return result._tag === "Success";
-  });
   const terminalBuffer = terminalSession.buffer;
   const terminalError = terminalSession.error;
   const terminalStatus = terminalSession.status;
@@ -365,6 +392,28 @@ export function TerminalViewport({
     status: terminalStatus,
     version: terminalVersion,
   };
+  const terminalWriteBarrierRef = useRef<TerminalWriteBarrier | null>(null);
+  const waitForTerminalWrites = useEffectEvent(async () => {
+    const barrier = terminalWriteBarrierRef.current;
+    if (barrier === null) return false;
+    return await barrier.waitFor(latestSessionRef.current.version);
+  });
+  const resizeTerminal = useEffectEvent(async (cols: number, rows: number) => {
+    // The attach stream and the resize RPC share a transport, but the stream
+    // state reaches Ghostty through a React effect. Drain that effect before
+    // sending the resize so old-width bytes cannot be reinterpreted later.
+    if (!(await waitForTerminalWrites())) return false;
+    const result = await runTerminalResize({
+      environmentId,
+      input: { threadId, terminalId, cols, rows },
+    });
+    // The server publishes queued output before resolving this request. Wait
+    // for React to commit that output before the surface applies the new grid.
+    if (result._tag === "Success" && !(await waitForTerminalWrites())) return false;
+    // A failed request leaves the PTY at its previous dimensions, so the
+    // surface must keep its old grid and retry instead of guessing.
+    return result._tag === "Success";
+  });
 
   useEffect(() => {
     keybindingsRef.current = keybindings;
@@ -379,6 +428,8 @@ export function TerminalViewport({
     let teardown: (() => void) | null = null;
     let setupTerminal: GhosttyTerminalSurface | null = null;
     let setupCleanups: Array<() => void> = [];
+    const terminalWriteBarrier = new TerminalWriteBarrier();
+    terminalWriteBarrierRef.current = terminalWriteBarrier;
 
     const setup = async (): Promise<(() => void) | null> => {
       const terminalOptions: GhosttyTerminalSurfaceOptions = {
@@ -721,6 +772,10 @@ export function TerminalViewport({
     return () => {
       cancelled = true;
       teardown?.();
+      terminalWriteBarrier.release();
+      if (terminalWriteBarrierRef.current === terminalWriteBarrier) {
+        terminalWriteBarrierRef.current = null;
+      }
     };
     // autoFocus is intentionally omitted;
     // it is only read at mount time and must not trigger terminal teardown/recreation.
@@ -736,6 +791,7 @@ export function TerminalViewport({
     };
     if (!terminal) {
       previousSessionRef.current = current;
+      terminalWriteBarrierRef.current?.markApplied(current.version);
       return;
     }
 
@@ -765,6 +821,7 @@ export function TerminalViewport({
       });
     }
     previousSessionRef.current = current;
+    terminalWriteBarrierRef.current?.markApplied(current.version);
   }, [autoFocus, terminalBuffer, terminalError, terminalStatus, terminalVersion]);
 
   useEffect(() => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -414,7 +414,12 @@ export function TerminalViewport({
     });
     // The server publishes queued output before resolving this request. Wait
     // for React to commit that output before the surface applies the new grid.
-    if (result._tag === "Success" && !(await waitForTerminalWrites(result.value.sequence))) {
+    if (
+      result._tag === "Success" &&
+      !(await waitForTerminalWrites(
+        Math.max(result.value.sequence, latestSessionRef.current.sequence),
+      ))
+    ) {
       return false;
     }
     // A failed request leaves the PTY at its previous dimensions, so the
@@ -436,6 +441,7 @@ export function TerminalViewport({
     let setupTerminal: GhosttyTerminalSurface | null = null;
     let setupCleanups: Array<() => void> = [];
     const terminalWriteBarrier = new TerminalWriteBarrier();
+    terminalWriteBarrier.markApplied(latestSessionRef.current.sequence);
     terminalWriteBarrierRef.current = terminalWriteBarrier;
 
     const setup = async (): Promise<(() => void) | null> => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -74,25 +74,25 @@ const MULTI_CLICK_SELECTION_ACTION_DELAY_MS = 260;
  * stream update one render after the resize RPC resolves.
  */
 export class TerminalWriteBarrier {
-  private settledVersion = 0;
+  private settledSequence = 0;
   private released = false;
   private waiters: Array<{
-    readonly version: number;
+    readonly sequence: number;
     readonly resolve: (applied: boolean) => void;
   }> = [];
 
-  waitFor(version: number): Promise<boolean> {
+  waitFor(sequence: number): Promise<boolean> {
     if (this.released) return Promise.resolve(false);
-    if (version <= this.settledVersion) return Promise.resolve(true);
+    if (sequence <= this.settledSequence) return Promise.resolve(true);
     return new Promise((resolve) => {
-      this.waiters.push({ version, resolve });
+      this.waiters.push({ sequence, resolve });
     });
   }
 
-  markApplied(version: number): void {
-    this.settledVersion = Math.max(this.settledVersion, version);
-    const ready = this.waiters.filter((waiter) => waiter.version <= this.settledVersion);
-    this.waiters = this.waiters.filter((waiter) => waiter.version > this.settledVersion);
+  markApplied(sequence: number): void {
+    this.settledSequence = Math.max(this.settledSequence, sequence);
+    const ready = this.waiters.filter((waiter) => waiter.sequence <= this.settledSequence);
+    this.waiters = this.waiters.filter((waiter) => waiter.sequence > this.settledSequence);
     for (const waiter of ready) waiter.resolve(true);
   }
 
@@ -379,10 +379,12 @@ export function TerminalViewport({
     },
   );
   const terminalVersion = terminalSession.version;
+  const terminalSequence = terminalSession.sequence;
   const previousSessionRef = useRef({
     buffer: terminalBuffer,
     error: terminalError,
     status: terminalStatus,
+    sequence: terminalSequence,
     version: terminalVersion,
   });
   const latestSessionRef = useRef(previousSessionRef.current);
@@ -390,14 +392,17 @@ export function TerminalViewport({
     buffer: terminalBuffer,
     error: terminalError,
     status: terminalStatus,
+    sequence: terminalSequence,
     version: terminalVersion,
   };
   const terminalWriteBarrierRef = useRef<TerminalWriteBarrier | null>(null);
-  const waitForTerminalWrites = useEffectEvent(async () => {
-    const barrier = terminalWriteBarrierRef.current;
-    if (barrier === null) return false;
-    return await barrier.waitFor(latestSessionRef.current.version);
-  });
+  const waitForTerminalWrites = useEffectEvent(
+    async (sequence = latestSessionRef.current.sequence) => {
+      const barrier = terminalWriteBarrierRef.current;
+      if (barrier === null) return false;
+      return await barrier.waitFor(sequence);
+    },
+  );
   const resizeTerminal = useEffectEvent(async (cols: number, rows: number) => {
     // The attach stream and the resize RPC share a transport, but the stream
     // state reaches Ghostty through a React effect. Drain that effect before
@@ -409,7 +414,9 @@ export function TerminalViewport({
     });
     // The server publishes queued output before resolving this request. Wait
     // for React to commit that output before the surface applies the new grid.
-    if (result._tag === "Success" && !(await waitForTerminalWrites())) return false;
+    if (result._tag === "Success" && !(await waitForTerminalWrites(result.value.sequence))) {
+      return false;
+    }
     // A failed request leaves the PTY at its previous dimensions, so the
     // surface must keep its old grid and retry instead of guessing.
     return result._tag === "Success";
@@ -787,17 +794,20 @@ export function TerminalViewport({
       buffer: terminalBuffer,
       error: terminalError,
       status: terminalStatus,
+      sequence: terminalSequence,
       version: terminalVersion,
     };
     if (!terminal) {
       previousSessionRef.current = current;
-      terminalWriteBarrierRef.current?.markApplied(current.version);
+      terminalWriteBarrierRef.current?.markApplied(current.sequence);
       return;
     }
 
     const previous = previousSessionRef.current;
     synchronizeTerminalStatus(terminal, current.status);
     if (current.version === previous.version) {
+      previousSessionRef.current = current;
+      terminalWriteBarrierRef.current?.markApplied(current.sequence);
       return;
     }
 
@@ -821,8 +831,8 @@ export function TerminalViewport({
       });
     }
     previousSessionRef.current = current;
-    terminalWriteBarrierRef.current?.markApplied(current.version);
-  }, [autoFocus, terminalBuffer, terminalError, terminalStatus, terminalVersion]);
+    terminalWriteBarrierRef.current?.markApplied(current.sequence);
+  }, [autoFocus, terminalBuffer, terminalError, terminalSequence, terminalStatus, terminalVersion]);
 
   useEffect(() => {
     if (!autoFocus) return;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -321,12 +321,15 @@ export function TerminalViewport({
       input: { threadId, terminalId, data },
     }),
   );
-  const resizeTerminal = useEffectEvent((cols: number, rows: number) =>
-    runTerminalResize({
+  const resizeTerminal = useEffectEvent(async (cols: number, rows: number) => {
+    const result = await runTerminalResize({
       environmentId,
       input: { threadId, terminalId, cols, rows },
-    }),
-  );
+    });
+    // A failed request leaves the PTY at its previous dimensions, so the
+    // surface must keep its old grid and retry instead of guessing.
+    return result._tag === "Success";
+  });
   const terminalBuffer = terminalSession.buffer;
   const terminalError = terminalSession.error;
   const terminalStatus = terminalSession.status;
@@ -381,7 +384,7 @@ export function TerminalViewport({
       const terminalOptions: GhosttyTerminalSurfaceOptions = {
         theme: terminalThemeFromApp(mount),
         onData: (data) => handleData(data),
-        onResize: (cols, rows) => void resizeTerminal(cols, rows),
+        onResize: (cols, rows) => resizeTerminal(cols, rows),
         onSelectionChange: () => handleSelectionChange(),
         onCopy: (text) => handleCopy(text),
         beforeKey: (event) => handleBeforeKey(event),

--- a/apps/web/src/terminal/ghostty/renderer.ts
+++ b/apps/web/src/terminal/ghostty/renderer.ts
@@ -14,7 +14,7 @@ export interface GhosttyCellMetrics {
 
 const DEFAULT_SELECTION_BACKGROUND = "rgba(72, 122, 191, 0.35)";
 
-function cssColor(color: GhosttyColor): string {
+export function cssColor(color: GhosttyColor): string {
   return `rgb(${color.r}, ${color.g}, ${color.b})`;
 }
 

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_TERMINAL_FONT_FAMILY,
   DEFAULT_TERMINAL_FONT_SIZE,
   advanceTerminalSelectionClickSequence,
+  flushPendingTerminalInput,
   ghosttyMouseButton,
   isTerminalAltGraphText,
   isTerminalCompositionCommitInput,
@@ -320,6 +321,20 @@ describe("terminal canvas prefill", () => {
     });
 
     expect(fillStyle).toBe("rgb(14, 18, 24)");
+  });
+});
+
+describe("initial terminal input", () => {
+  it("replays history before streamed output after the grid is acknowledged", () => {
+    const calls: string[] = [];
+
+    flushPendingTerminalInput(
+      { reset: "history", writes: ["output-1", "output-2"] },
+      (data) => calls.push(`reset:${data}`),
+      (data) => calls.push(`write:${data}`),
+    );
+
+    expect(calls).toEqual(["reset:history", "write:output-1", "write:output-2"]);
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -11,6 +11,8 @@ import {
   isTerminalCopyShortcut,
   isTerminalLinkPointerGesture,
   isTerminalPasteShortcut,
+  prefillTerminalCanvas,
+  settleGhosttyResize,
   shouldBlinkTerminalCursor,
   shouldReportTerminalMouse,
   terminalScrollbarGeometry,
@@ -262,6 +264,62 @@ describe("terminal font resolution", () => {
     expect(terminalFontSize(13.4)).toBe(13);
     expect(terminalFontSize(2)).toBe(6);
     expect(terminalFontSize(90)).toBe(32);
+  });
+});
+
+describe("ghostty resize acknowledgements", () => {
+  it("applies only accepted dimensions and retries an unchanged failure", () => {
+    expect(
+      settleGhosttyResize({
+        request: { cols: 80, rows: 24 },
+        desired: { cols: 80, rows: 24 },
+        accepted: false,
+      }),
+    ).toEqual({ apply: false, requestNext: false, retry: true });
+    expect(
+      settleGhosttyResize({
+        request: { cols: 80, rows: 24 },
+        desired: { cols: 100, rows: 30 },
+        accepted: false,
+      }),
+    ).toEqual({ apply: false, requestNext: true, retry: false });
+  });
+
+  it("applies the acknowledged request before asking for a newer measurement", () => {
+    expect(
+      settleGhosttyResize({
+        request: { cols: 80, rows: 24 },
+        desired: { cols: 100, rows: 30 },
+        accepted: true,
+      }),
+    ).toEqual({ apply: true, requestNext: true, retry: false });
+  });
+});
+
+describe("terminal canvas prefill", () => {
+  it("fills the opaque backing store with the theme background", () => {
+    let fillStyle = "";
+    const fillRect = (left: number, top: number, width: number, height: number) => {
+      expect([left, top, width, height]).toEqual([0, 0, 320, 180]);
+    };
+    const context = {
+      canvas: { width: 320, height: 180 },
+      fillRect,
+      get fillStyle() {
+        return fillStyle;
+      },
+      set fillStyle(value: string) {
+        fillStyle = value;
+      },
+    } as unknown as CanvasRenderingContext2D;
+
+    prefillTerminalCanvas(context, {
+      background: { r: 14, g: 18, b: 24 },
+      foreground: { r: 237, g: 241, b: 247 },
+      cursor: { r: 237, g: 241, b: 247 },
+    });
+
+    expect(fillStyle).toBe("rgb(14, 18, 24)");
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -18,6 +18,8 @@ import symbolsFontUrl from "./fonts/SymbolsNerdFontMono-Regular.woff2?url";
 export const DEFAULT_TERMINAL_FONT_SIZE = 12;
 const MIN_TERMINAL_FONT_SIZE = 6;
 const MAX_TERMINAL_FONT_SIZE = 32;
+const INITIAL_TERMINAL_COLS = 1;
+const INITIAL_TERMINAL_ROWS = 1;
 // The glyph fallbacks only supply symbols the text faces are missing (powerline
 // separators, devicons, and other private-use prompt symbols), so shells
 // configured for a locally installed Nerd Font keep their prompt glyphs no
@@ -527,10 +529,9 @@ export class GhosttyTerminalSurface {
       // Metrics fall back to whichever faces are already available.
     }
     const metrics = measureGhosttyCell(context, fontSize, fontFamily);
-    const grid = terminalGridSize(mount.clientWidth, mount.clientHeight, metrics, CONTENT_PADDING);
     const core = await GhosttyTerminalCore.create(
-      grid.cols,
-      grid.rows,
+      INITIAL_TERMINAL_COLS,
+      INITIAL_TERMINAL_ROWS,
       metrics.width,
       metrics.height,
       options.theme,
@@ -600,6 +601,8 @@ export class GhosttyTerminalSurface {
   }
 
   private applyFontMetrics(): void {
+    // Keep the core on the last PTY-acknowledged grid while a newer resize is
+    // in flight. The initial sentinel is also the core's initial dimensions.
     this.metrics = measureGhosttyCell(this.context, this.fontSize, this.fontFamily);
     this.core.resize(this.cols, this.rows, this.metrics.width, this.metrics.height);
     // Cached IME textarea coordinates are stale in the new cell geometry.

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -106,6 +106,21 @@ export function settleGhosttyResize(input: {
   };
 }
 
+export interface PendingTerminalInput {
+  readonly reset: string | null;
+  readonly writes: readonly string[];
+}
+
+/** Replay input collected before the first accepted PTY dimensions. */
+export function flushPendingTerminalInput(
+  input: PendingTerminalInput,
+  resetAndWrite: (data: string) => void,
+  write: (data: string) => void,
+): void {
+  if (input.reset !== null) resetAndWrite(input.reset);
+  for (const data of input.writes) write(data);
+}
+
 /** Fill an opaque canvas before asynchronous font/WASM initialization yields. */
 export function prefillTerminalCanvas(
   context: CanvasRenderingContext2D,
@@ -437,6 +452,9 @@ export class GhosttyTerminalSurface {
   private focused = false;
   private resizeRequestedOnce = false;
   private resizeRequestActive = false;
+  private resizeReady = false;
+  private pendingInitialReset: string | null = null;
+  private pendingInitialWrites: string[] = [];
   private desiredCols = 0;
   private desiredRows = 0;
   private canvasConfigured = false;
@@ -555,7 +573,11 @@ export class GhosttyTerminalSurface {
 
   write(data: string): void {
     if (this.disposed) return;
-    this.core.write(data);
+    if (!this.resizeReady) {
+      if (data.length > 0) this.pendingInitialWrites.push(data);
+    } else {
+      this.core.write(data);
+    }
     // Restart the blink cycle from the visible phase so the cursor never sits
     // invisible through a stream of output or a burst of typing echo.
     this.cursorOn = true;
@@ -565,7 +587,12 @@ export class GhosttyTerminalSurface {
 
   resetAndWrite(data: string): void {
     if (this.disposed) return;
-    this.core.resetAndWrite(data);
+    if (!this.resizeReady) {
+      this.pendingInitialReset = data;
+      this.pendingInitialWrites = [];
+    } else {
+      this.core.resetAndWrite(data);
+    }
     // A replayed session starts from the visible phase like any other write:
     // reattaching mid-blink must not open on an invisible cursor.
     this.cursorOn = true;
@@ -741,10 +768,29 @@ export class GhosttyTerminalSurface {
   }
 
   private applyGridSize(cols: number, rows: number): void {
-    if (cols === this.cols && rows === this.rows) return;
-    this.cols = cols;
-    this.rows = rows;
-    this.core.resize(cols, rows, this.metrics.width, this.metrics.height);
+    const wasResizeReady = this.resizeReady;
+    const dimensionsChanged = cols !== this.cols || rows !== this.rows;
+    if (dimensionsChanged) {
+      this.cols = cols;
+      this.rows = rows;
+      this.core.resize(cols, rows, this.metrics.width, this.metrics.height);
+    }
+    if (!this.resizeReady) {
+      this.resizeReady = true;
+      const pendingInput = {
+        reset: this.pendingInitialReset,
+        writes: this.pendingInitialWrites,
+      };
+      this.pendingInitialReset = null;
+      this.pendingInitialWrites = [];
+      flushPendingTerminalInput(
+        pendingInput,
+        (data) => this.core.resetAndWrite(data),
+        (data) => this.core.write(data),
+      );
+      this.cursorOn = true;
+    }
+    if (!dimensionsChanged && wasResizeReady) return;
     this.forceFullRender = true;
     this.scrollbarDirty = true;
     this.renderFrame();
@@ -826,6 +872,8 @@ export class GhosttyTerminalSurface {
     if (this.compositionSuppressionTimer !== null) {
       window.clearTimeout(this.compositionSuppressionTimer);
     }
+    this.pendingInitialReset = null;
+    this.pendingInitialWrites = [];
     this.removeEvents();
     this.core.dispose();
     if (

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -7,6 +7,7 @@ import {
   type GhosttyTheme,
 } from "./core";
 import {
+  cssColor,
   measureGhosttyCell,
   renderGhosttySnapshot,
   terminalGridSize,
@@ -71,6 +72,45 @@ export function terminalFontFamily(family?: string): string {
 export function terminalFontSize(size?: number): number {
   if (size === undefined || !Number.isFinite(size)) return DEFAULT_TERMINAL_FONT_SIZE;
   return Math.max(MIN_TERMINAL_FONT_SIZE, Math.min(MAX_TERMINAL_FONT_SIZE, Math.round(size)));
+}
+
+export interface GhosttyResizeDimensions {
+  readonly cols: number;
+  readonly rows: number;
+}
+
+export interface GhosttyResizeSettlement {
+  readonly apply: boolean;
+  readonly requestNext: boolean;
+  readonly retry: boolean;
+}
+
+/**
+ * Decide how one PTY resize acknowledgement changes the surface state. A
+ * rejected request never moves the grid; a newer measurement is sent after
+ * the current request settles, while an unchanged rejection is retried.
+ */
+export function settleGhosttyResize(input: {
+  readonly request: GhosttyResizeDimensions;
+  readonly desired: GhosttyResizeDimensions;
+  readonly accepted: boolean;
+}): GhosttyResizeSettlement {
+  const requestNext =
+    input.request.cols !== input.desired.cols || input.request.rows !== input.desired.rows;
+  return {
+    apply: input.accepted,
+    requestNext,
+    retry: !input.accepted && !requestNext,
+  };
+}
+
+/** Fill an opaque canvas before asynchronous font/WASM initialization yields. */
+export function prefillTerminalCanvas(
+  context: CanvasRenderingContext2D,
+  theme: GhosttyTheme,
+): void {
+  context.fillStyle = cssColor(theme.background);
+  context.fillRect(0, 0, context.canvas.width, context.canvas.height);
 }
 
 /**
@@ -329,7 +369,11 @@ export interface GhosttyTerminalSurfaceOptions {
   readonly theme: GhosttyTheme;
   readonly font?: GhosttyTerminalFont;
   readonly onData: (data: string) => void;
-  readonly onResize: (cols: number, rows: number) => void;
+  /**
+   * Requests a PTY resize. When it returns a promise, the grid is resized only
+   * once it settles; resolving false means the PTY kept its old size.
+   */
+  readonly onResize: (cols: number, rows: number) => Promise<boolean> | void;
   readonly onSelectionChange: () => void;
   readonly onCopy: (text: string) => void;
   readonly beforeKey: (event: KeyboardEvent) => boolean;
@@ -366,7 +410,7 @@ export class GhosttyTerminalSurface {
   private scrollbarPointerId: number | null = null;
   private scrollbarPointerOffset = 0;
   private disposed = false;
-  private resizeNotifyTimer: number | null = null;
+  private resizeRetryTimer: number | null = null;
   private originY = CONTENT_PADDING;
   private mountHeight = 0;
   private selectionEnd: { x: number; y: number } | null = null;
@@ -389,7 +433,10 @@ export class GhosttyTerminalSurface {
   private selectionMoved = false;
   private composing = false;
   private focused = false;
-  private resizeNotified = false;
+  private resizeRequestedOnce = false;
+  private resizeRequestActive = false;
+  private desiredCols = 0;
+  private desiredRows = 0;
   private canvasConfigured = false;
   private theme: GhosttyTheme;
   private readonly suppressedKeyCodes = new Set<string>();
@@ -465,6 +512,10 @@ export class GhosttyTerminalSurface {
 
     const context = canvas.getContext("2d", { alpha: false });
     if (!context) throw new Error("Canvas 2D is unavailable");
+    // An opaque backing store starts black and remains visible through the
+    // font and WASM awaits below. Prefill it with the theme background before
+    // any asynchronous initialization can yield to the browser.
+    prefillTerminalCanvas(context, options.theme);
     const fontFamily = terminalFontFamily(options.font?.family);
     const fontSize = terminalFontSize(options.font?.size);
     try {
@@ -610,13 +661,19 @@ export class GhosttyTerminalSurface {
     }
     const grid = terminalGridSize(width, height, this.metrics, CONTENT_PADDING);
     this.mountHeight = height;
-    // onResize is the only PTY resize channel, so the first successful fit must
-    // notify even when the measured grid equals the 1x1 construction sentinel.
-    if (grid.cols !== this.cols || grid.rows !== this.rows || !this.resizeNotified) {
-      this.cols = grid.cols;
-      this.rows = grid.rows;
-      this.core.resize(grid.cols, grid.rows, this.metrics.width, this.metrics.height);
-      this.notifyResize();
+    // The PTY and the grid must agree on width for every byte, or shell redraw
+    // sequences get interpreted at a width they were not generated for. A
+    // single in-flight request keeps resize acknowledgements ordered; if the
+    // mount moves again while it is active, the newest desired size is sent
+    // after the current request settles.
+    if (
+      grid.cols !== this.desiredCols ||
+      grid.rows !== this.desiredRows ||
+      !this.resizeRequestedOnce
+    ) {
+      this.desiredCols = grid.cols;
+      this.desiredRows = grid.rows;
+      this.requestResize();
       this.forceFullRender = true;
       this.scrollbarDirty = true;
       shouldRender = true;
@@ -628,18 +685,66 @@ export class GhosttyTerminalSurface {
     return true;
   }
 
-  /**
-   * The local grid reflows immediately, but the PTY only hears about settled
-   * dimensions: notifying on every drag step makes the shell reprint its
-   * prompt mid-drag, which reads as jitter.
-   */
-  private notifyResize(): void {
-    this.resizeNotified = true;
-    if (this.resizeNotifyTimer !== null) window.clearTimeout(this.resizeNotifyTimer);
-    this.resizeNotifyTimer = window.setTimeout(() => {
-      this.resizeNotifyTimer = null;
-      if (!this.disposed) this.options.onResize(this.cols, this.rows);
-    }, 150);
+  private requestResize(): void {
+    if (this.disposed || this.resizeRequestActive) return;
+    if (this.resizeRetryTimer !== null) {
+      window.clearTimeout(this.resizeRetryTimer);
+      this.resizeRetryTimer = null;
+    }
+    this.resizeRequestActive = true;
+    this.resizeRequestedOnce = true;
+    const cols = this.desiredCols;
+    const rows = this.desiredRows;
+    const settle = (granted: boolean) => {
+      if (this.disposed) return;
+      this.resizeRequestActive = false;
+      const settlement = settleGhosttyResize({
+        request: { cols, rows },
+        desired: { cols: this.desiredCols, rows: this.desiredRows },
+        accepted: granted,
+      });
+      if (settlement.apply) {
+        this.applyGridSize(cols, rows);
+      }
+      if (settlement.requestNext) {
+        this.requestResize();
+      } else if (settlement.retry) {
+        this.scheduleResizeRetry();
+      }
+    };
+    let acknowledgement: Promise<boolean> | void;
+    try {
+      acknowledgement = this.options.onResize(cols, rows);
+    } catch {
+      settle(false);
+      return;
+    }
+    if (acknowledgement && typeof acknowledgement.then === "function") {
+      void acknowledgement.then(
+        (granted) => settle(granted !== false),
+        () => settle(false),
+      );
+    } else {
+      settle(true);
+    }
+  }
+
+  private scheduleResizeRetry(): void {
+    if (this.disposed || this.resizeRetryTimer !== null) return;
+    this.resizeRetryTimer = window.setTimeout(() => {
+      this.resizeRetryTimer = null;
+      if (!this.disposed) this.requestResize();
+    }, 1000);
+  }
+
+  private applyGridSize(cols: number, rows: number): void {
+    if (cols === this.cols && rows === this.rows) return;
+    this.cols = cols;
+    this.rows = rows;
+    this.core.resize(cols, rows, this.metrics.width, this.metrics.height);
+    this.forceFullRender = true;
+    this.scrollbarDirty = true;
+    this.renderFrame();
   }
 
   focus(): void {
@@ -712,13 +817,7 @@ export class GhosttyTerminalSurface {
     this.dprMedia = null;
     this.reducedMotionMedia?.removeEventListener("change", this.onReducedMotionChange);
     if (this.selectionScrollTimer !== null) window.clearInterval(this.selectionScrollTimer);
-    if (this.resizeNotifyTimer !== null) {
-      window.clearTimeout(this.resizeNotifyTimer);
-      this.resizeNotifyTimer = null;
-      // Flush the settled dimensions so the PTY keeps the final size even when
-      // the surface unmounts inside the debounce window.
-      this.options.onResize(this.cols, this.rows);
-    }
+    if (this.resizeRetryTimer !== null) window.clearTimeout(this.resizeRetryTimer);
     if (this.frame !== 0) window.cancelAnimationFrame(this.frame);
     if (this.cursorTimer !== null) window.clearTimeout(this.cursorTimer);
     if (this.compositionSuppressionTimer !== null) {

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -28,6 +28,7 @@ const BASE_SNAPSHOT: TerminalSessionSnapshot = {
   exitSignal: null,
   label: "Terminal 1",
   updatedAt: "2026-04-01T00:00:00.000Z",
+  sequence: 7,
 };
 
 describe("terminal session reducers", () => {
@@ -121,6 +122,7 @@ describe("terminal session reducers", () => {
         threadId: TARGET.threadId,
         terminalId: TARGET.terminalId,
         data: " world",
+        sequence: 8,
       },
       8,
     );
@@ -129,6 +131,7 @@ describe("terminal session reducers", () => {
       buffer: "lo world",
       status: "running",
       error: null,
+      sequence: 8,
       version: 2,
     });
   });

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -14,6 +14,7 @@ export interface TerminalSessionState {
   readonly error: string | null;
   readonly hasRunningSubprocess: boolean;
   readonly updatedAt: string | null;
+  readonly sequence: number;
   readonly version: number;
 }
 
@@ -22,6 +23,7 @@ export interface TerminalBufferState {
   readonly status: TerminalSessionSnapshot["status"] | "closed";
   readonly error: string | null;
   readonly updatedAt: string | null;
+  readonly sequence: number;
   readonly version: number;
 }
 
@@ -49,6 +51,7 @@ export const EMPTY_TERMINAL_BUFFER_STATE = Object.freeze<TerminalBufferState>({
   status: "closed",
   error: null,
   updatedAt: null,
+  sequence: 0,
   version: 0,
 });
 
@@ -59,6 +62,7 @@ export const EMPTY_TERMINAL_SESSION_STATE = Object.freeze<TerminalSessionState>(
   error: null,
   hasRunningSubprocess: false,
   updatedAt: null,
+  sequence: 0,
   version: 0,
 });
 
@@ -97,8 +101,17 @@ export function terminalBufferStateFromSnapshot(
     status: snapshot.status,
     error: null,
     updatedAt: snapshot.updatedAt,
+    sequence: snapshot.sequence ?? 0,
     version: 1,
   };
+}
+
+function nextTerminalSequence(
+  current: TerminalBufferState,
+  event: TerminalAttachStreamEvent,
+): number {
+  if (event.type === "snapshot") return current.sequence + 1;
+  return event.sequence ?? current.sequence + 1;
 }
 
 function latestTimestamp(left: string | null, right: string | null): string | null {
@@ -118,6 +131,7 @@ export function combineTerminalSessionState(
     error: buffer.error,
     hasRunningSubprocess: summary?.hasRunningSubprocess ?? false,
     updatedAt: latestTimestamp(summary?.updatedAt ?? null, buffer.updatedAt),
+    sequence: buffer.sequence,
     version: buffer.version,
   };
 }
@@ -137,6 +151,7 @@ export function applyTerminalAttachStreamEvent(
         buffer: trimBufferToBytes(`${current.buffer}${event.data}`, maxBufferBytes),
         status: current.status === "closed" ? "running" : current.status,
         error: null,
+        sequence: nextTerminalSequence(current, event),
         version: current.version + 1,
       };
     case "cleared":
@@ -144,6 +159,7 @@ export function applyTerminalAttachStreamEvent(
         ...current,
         buffer: "",
         error: null,
+        sequence: nextTerminalSequence(current, event),
         version: current.version + 1,
       };
     case "exited":
@@ -151,6 +167,7 @@ export function applyTerminalAttachStreamEvent(
         ...current,
         status: "exited",
         error: null,
+        sequence: nextTerminalSequence(current, event),
         version: current.version + 1,
       };
     case "closed":
@@ -158,6 +175,7 @@ export function applyTerminalAttachStreamEvent(
         ...current,
         status: "closed",
         error: null,
+        sequence: nextTerminalSequence(current, event),
         version: current.version + 1,
       };
     case "error":
@@ -165,10 +183,11 @@ export function applyTerminalAttachStreamEvent(
         ...current,
         status: "error",
         error: event.message,
+        sequence: nextTerminalSequence(current, event),
         version: current.version + 1,
       };
     case "activity":
-      return current;
+      return { ...current, sequence: nextTerminalSequence(current, event) };
   }
 }
 

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -39,6 +39,7 @@ import type {
   TerminalMetadataStreamEvent,
   TerminalOpenInput,
   TerminalResizeInput,
+  TerminalResizeResult,
   TerminalRestartInput,
   TerminalSessionSnapshot,
   TerminalWriteInput,
@@ -1144,7 +1145,7 @@ export interface EnvironmentApi {
       },
     ) => () => void;
     write: (input: typeof TerminalWriteInput.Encoded) => Promise<void>;
-    resize: (input: typeof TerminalResizeInput.Encoded) => Promise<void>;
+    resize: (input: typeof TerminalResizeInput.Encoded) => Promise<TerminalResizeResult>;
     clear: (input: typeof TerminalClearInput.Encoded) => Promise<void>;
     restart: (input: typeof TerminalRestartInput.Encoded) => Promise<TerminalSessionSnapshot>;
     close: (input: typeof TerminalCloseInput.Encoded) => Promise<void>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -96,6 +96,7 @@ import {
   TerminalMetadataStreamEvent,
   TerminalOpenInput,
   TerminalResizeInput,
+  TerminalResizeResult,
   TerminalRestartInput,
   TerminalSessionSnapshot,
   TerminalWriteInput,
@@ -586,6 +587,7 @@ export const WsTerminalWriteRpc = Rpc.make(WS_METHODS.terminalWrite, {
 
 export const WsTerminalResizeRpc = Rpc.make(WS_METHODS.terminalResize, {
   payload: TerminalResizeInput,
+  success: TerminalResizeResult,
   error: Schema.Union([TerminalError, EnvironmentAuthorizationError]),
 });
 

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -9,6 +9,7 @@ import {
   TerminalEvent,
   TerminalOpenInput,
   TerminalResizeInput,
+  TerminalResizeResult,
   TerminalSessionSnapshot,
   TerminalThreadInput,
   TerminalWriteInput,
@@ -181,6 +182,13 @@ describe("TerminalResizeInput", () => {
         rows: 24,
       }),
     ).toBe(false);
+  });
+});
+
+describe("TerminalResizeResult", () => {
+  it("carries the attach-stream sequence covered by the acknowledgement", () => {
+    expect(decodes(TerminalResizeResult, { sequence: 12 })).toBe(true);
+    expect(decodes(TerminalResizeResult, { sequence: -1 })).toBe(false);
   });
 });
 

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -70,6 +70,12 @@ export const TerminalResizeInput = Schema.Struct({
 });
 export type TerminalResizeInput = Schema.Codec.Encoded<typeof TerminalResizeInput>;
 
+/** Event sequence visible to an attach stream when a resize is acknowledged. */
+export const TerminalResizeResult = Schema.Struct({
+  sequence: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+});
+export type TerminalResizeResult = Schema.Schema.Type<typeof TerminalResizeResult>;
+
 export const TerminalClearInput = TerminalSessionInput;
 export type TerminalClearInput = Schema.Codec.Encoded<typeof TerminalClearInput>;
 


### PR DESCRIPTION
## Summary

- Queue a server-side flush sentinel so resize acknowledgements follow all previously queued PTY output.
- Return the covered attach-stream sequence in each resize acknowledgement, and wait for that exact sequence before applying Ghostty dimensions.
- Gate Ghostty grid changes on accepted PTY dimensions with single-flight desired-size retries and safe disposal.
- Hold initial terminal history/output until the first accepted grid so old-width bytes cannot be replayed as duplicate lines during resize.
- Prefill the opaque terminal canvas with the theme background before font/WASM initialization.

## Validation

- Server ordering tests: 3 passed.
- Focused web terminal tests: 46 passed.
- Contract tests: 23 passed; client-runtime terminal state tests: 6 passed.
- Server, contracts, client-runtime, and web typechecks: passed.
- Focused lint for touched terminal files: passed.

## Actual T3 preview

The GIF below is captured from the real T3 Code UI and terminal drawer on this branch while resizing wide → narrow → wide. It contains no synthetic frame or added border:

![T3 terminal resize proof](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/a0d9d44e-7a65-45fc-8538-4695a4c3d647/t3-terminal-resize-proof.gif)

This intentionally does not include terminal open/close reconciliation or Ctrl+W handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Resize RPCs now block until output drains, and synchronous resize-from-listener paths are sensitive; changes touch core terminal I/O ordering across server and web renderer.
> 
> **Overview**
> Terminal resize is now **ordered end-to-end** so PTY width and Ghostty grid stay aligned during drawer resize and streaming output.
> 
> **Contracts & client state:** `resize` returns **`TerminalResizeResult`** with an attach-stream **`sequence`** instead of `void`. Terminal session/buffer state tracks **`sequence`** alongside **`version`** so the UI knows which output events have been applied.
> 
> **Server (`TerminalManager`):** Before acknowledging a resize, the manager queues a **flush sentinel** on the PTY output drain, publishes all prior queued output, and returns the covered **`eventSequence`**. Flush sentinels are released on queue disposal (including exit) to avoid hangs; tests cover ordering, listener-triggered resize deadlock, and exit during a blocked drain.
> 
> **Web UI:** **`TerminalWriteBarrier`** waits until React has applied output up to the resize acknowledgement’s sequence before and after **`runTerminalResize`**. **`GhosttyTerminalSurface`** starts at a 1×1 grid, **buffers** initial history/output until the first **accepted** PTY resize, uses **async `onResize`** with single-flight requests and retries, and **prefills** the opaque canvas with the theme background during async init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f52f5e65ca4da485ad394f8af6e06e867b3cc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep PTY and Ghostty resize ordering in lockstep by sequencing resize acknowledgements
> - Introduces `TerminalResizeResult` (with a `sequence` field) as the return type for resize RPCs, replacing `void`, so callers know which output event the PTY had processed at acknowledgement time.
> - The server's `TerminalManager.resize` now queues a flush sentinel and waits for all in-flight output to be published before returning, ensuring the sequence number reflects output order.
> - The Ghostty surface (`GhosttyTerminalSurface`) buffers writes until the first resize is acknowledged, applies grid changes only on accepted PTY resizes, and retries on unchanged-dimension rejection to avoid jitter.
> - A new client-side `TerminalWriteBarrier` in `ThreadTerminalDrawer` gates grid changes until the corresponding output sequence has been applied to the terminal buffer.
> - Sequence numbers are now tracked end-to-end in `TerminalSessionState` and `TerminalBufferState` via `nextTerminalSequence`.
> - Risk: `resize` no longer returns immediately — it suspends until queued output drains, which could block callers if the drain stalls (guarded by deadlock detection for synchronous resize-from-listener patterns).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55f52f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->