### PR TITLE
fix(terminal): protect held Ctrl/Cmd+W close shortcut

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -438,6 +438,51 @@ describe("DesktopWindow", () => {
     }),
   );
 
+  it.effect("blocks only repeated Cmd+W input before it reaches the native window menu", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
+
+        const beforeInput = fakeWindow.webContentsListeners.get("before-input-event");
+        if (!beforeInput) {
+          return yield* Effect.die("before-input-event listener was not registered");
+        }
+
+        let prevented = false;
+        const event = { preventDefault: () => (prevented = true) };
+        const input = {
+          type: "keyDown",
+          isAutoRepeat: true,
+          key: "W",
+          meta: true,
+          control: false,
+          alt: false,
+          shift: false,
+        };
+        beforeInput(event, input);
+        assert.isTrue(prevented);
+
+        prevented = false;
+        beforeInput(event, { ...input, isAutoRepeat: false });
+        assert.isFalse(prevented);
+
+        prevented = false;
+        beforeInput(event, { ...input, meta: false });
+        assert.isFalse(prevented);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
   it.effect("uses the persisted main window bounds when opening the window", () =>
     Effect.gen(function* () {
       const fakeWindow = makeFakeBrowserWindow();

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -514,6 +514,18 @@ export const make = Effect.gen(function* () {
       }
     });
 
+    // Electron's windowMenu close role owns CmdOrCtrl+W. Holding the
+    // close-terminal shortcut can outlive the terminal that handled its first
+    // press, so reject repeats before they reach the native window accelerator.
+    // Deliberate presses still flow through the renderer or native menu.
+    window.webContents.on("before-input-event", (event, input) => {
+      if (input.type !== "keyDown" || !input.isAutoRepeat) return;
+      const modifier = environment.platform === "darwin" ? input.meta : input.control;
+      if (modifier && !input.alt && !input.shift && input.key.toLowerCase() === "w") {
+        event.preventDefault();
+      }
+    });
+
     window.on("page-title-updated", (event) => {
       event.preventDefault();
       window.setTitle(environment.displayName);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -171,6 +171,7 @@ import { useNowMinute } from "../hooks/useNowMinute";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
+import { preventRepeatedTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
 import {
   deriveLogicalProjectKeyFromSettings,
@@ -4354,6 +4355,10 @@ function ChatViewContent(props: ChatViewProps) {
 
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
+      if (preventRepeatedTerminalCloseShortcut(event, keybindings)) {
+        event.stopPropagation();
+        return;
+      }
       if (!activeThreadId || isCommandPaletteOpen()) {
         return;
       }

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -43,7 +43,6 @@ import { isTerminalLinkActivation, resolvePathLinkTarget } from "../terminal-lin
 import {
   isDiffToggleShortcut,
   isTerminalClearShortcut,
-  isTerminalCloseShortcut,
   isTerminalNewShortcut,
   isTerminalSplitShortcut,
   isTerminalSplitVerticalShortcut,
@@ -63,6 +62,7 @@ import { previewEnvironment } from "../state/preview";
 import { terminalEnvironment } from "../state/terminal";
 import { openTerminalLinkInPreview } from "./preview/openTerminalLinkInPreview";
 import { useAtomCommand } from "../state/use-atom-command";
+import { preventTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
 
 const MIN_DRAWER_HEIGHT = 180;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
@@ -527,12 +527,14 @@ export function TerminalViewport({
       function handleBeforeKey(event: KeyboardEvent): boolean {
         const currentKeybindings = keybindingsRef.current;
         const options = { context: { terminalFocus: true, terminalOpen: true } };
+        if (preventTerminalCloseShortcut(event, currentKeybindings)) {
+          return false;
+        }
         if (
           isTerminalToggleShortcut(event, currentKeybindings, options) ||
           isTerminalSplitShortcut(event, currentKeybindings, options) ||
           isTerminalSplitVerticalShortcut(event, currentKeybindings, options) ||
           isTerminalNewShortcut(event, currentKeybindings, options) ||
-          isTerminalCloseShortcut(event, currentKeybindings, options) ||
           isDiffToggleShortcut(event, currentKeybindings, options)
         ) {
           return false;

--- a/apps/web/src/lib/terminalCloseShortcut.test.ts
+++ b/apps/web/src/lib/terminalCloseShortcut.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
+
+import {
+  preventRepeatedTerminalCloseShortcut,
+  preventTerminalCloseShortcut,
+  type TerminalCloseShortcutEvent,
+} from "./terminalCloseShortcut";
+
+const keybindings = [
+  {
+    command: "terminal.close",
+    shortcut: {
+      key: "w",
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      modKey: true,
+    },
+    whenAst: { type: "identifier", name: "terminalFocus" },
+  },
+] satisfies ResolvedKeybindingsConfig;
+
+type KeyboardEventOverrides = Partial<
+  Pick<
+    TerminalCloseShortcutEvent,
+    "key" | "code" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey" | "repeat"
+  >
+>;
+
+function keyboardEvent(
+  overrides: KeyboardEventOverrides = {},
+): TerminalCloseShortcutEvent & { readonly defaultPrevented: boolean } {
+  let defaultPrevented = false;
+  return {
+    key: "w",
+    code: "KeyW",
+    metaKey: false,
+    ctrlKey: true,
+    shiftKey: false,
+    altKey: false,
+    repeat: false,
+    ...overrides,
+    preventDefault: () => {
+      defaultPrevented = true;
+    },
+    get defaultPrevented() {
+      return defaultPrevented;
+    },
+  };
+}
+
+describe("terminal close shortcut guards", () => {
+  it("prevents the browser default for a deliberate terminal close", () => {
+    const event = keyboardEvent();
+
+    expect(preventTerminalCloseShortcut(event, keybindings, "Linux x86_64")).toBe(true);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("keeps held close repeats from closing the browser after the last terminal unmounts", () => {
+    const firstPress = keyboardEvent();
+    expect(preventTerminalCloseShortcut(firstPress, keybindings, "Linux x86_64")).toBe(true);
+
+    let browserCloseCount = 0;
+    for (const repeat of [true, true, true]) {
+      const event = keyboardEvent({ repeat });
+      preventRepeatedTerminalCloseShortcut(event, keybindings, "Linux x86_64");
+      if (!event.defaultPrevented) browserCloseCount += 1;
+    }
+
+    expect(browserCloseCount).toBe(0);
+    expect(preventRepeatedTerminalCloseShortcut(keyboardEvent(), keybindings, "Linux x86_64")).toBe(
+      false,
+    );
+  });
+
+  it("leaves a non-repeated window close and unrelated repeats alone", () => {
+    const deliberateWindowClose = keyboardEvent({ repeat: false });
+    const unrelatedRepeat = keyboardEvent({ key: "q", code: "KeyQ", repeat: true });
+
+    expect(
+      preventRepeatedTerminalCloseShortcut(deliberateWindowClose, keybindings, "Linux x86_64"),
+    ).toBe(false);
+    expect(deliberateWindowClose.defaultPrevented).toBe(false);
+    expect(preventRepeatedTerminalCloseShortcut(unrelatedRepeat, keybindings, "Linux x86_64")).toBe(
+      false,
+    );
+    expect(unrelatedRepeat.defaultPrevented).toBe(false);
+  });
+});

--- a/apps/web/src/lib/terminalCloseShortcut.ts
+++ b/apps/web/src/lib/terminalCloseShortcut.ts
@@ -1,0 +1,36 @@
+import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
+
+import { isTerminalCloseShortcut, type ShortcutEventLike } from "../keybindings";
+
+export interface TerminalCloseShortcutEvent extends ShortcutEventLike {
+  readonly repeat?: boolean;
+  readonly preventDefault: () => void;
+}
+
+function terminalCloseShortcutOptions(platform?: string) {
+  return {
+    ...(platform === undefined ? {} : { platform }),
+    context: { terminalFocus: true, terminalOpen: true },
+  };
+}
+
+export function preventTerminalCloseShortcut(
+  event: TerminalCloseShortcutEvent,
+  keybindings: ResolvedKeybindingsConfig,
+  platform?: string,
+): boolean {
+  if (!isTerminalCloseShortcut(event, keybindings, terminalCloseShortcutOptions(platform))) {
+    return false;
+  }
+  event.preventDefault();
+  return true;
+}
+
+export function preventRepeatedTerminalCloseShortcut(
+  event: TerminalCloseShortcutEvent,
+  keybindings: ResolvedKeybindingsConfig,
+  platform?: string,
+): boolean {
+  if (!event.repeat) return false;
+  return preventTerminalCloseShortcut(event, keybindings, platform);
+}


### PR DESCRIPTION
## Summary

- prevent the terminal key handler from allowing the close shortcut to reach the browser default
- block repeated close-shortcut keydowns at the web window level after the last terminal unmounts
- reject repeated `CmdOrCtrl+W` input before Electron's native window-menu accelerator
- add focused web and desktop regressions

## Root cause

Closing the last terminal unmounts the focused terminal before a held shortcut finishes auto-repeating. Those later repeats no longer resolve the terminal command and could fall through to browser tab-close or Electron window-close behavior.

## Validation

- `pnpm exec vp test run --project unit src/lib/terminalCloseShortcut.test.ts src/components/ThreadTerminalDrawer.test.ts src/keybindings.test.ts`
- `pnpm exec vp test run src/window/DesktopWindow.test.ts`
- `pnpm exec tsgo --noEmit` in `apps/web`
- `pnpm exec tsgo --noEmit` in `apps/desktop`
- formatter check for all touched files

## Visual demo

![Held terminal close protection](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/5f442c04-5722-4fd9-a013-c390512aed09/t3-held-terminal-close-real.gif)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block held Ctrl/Cmd+W from repeatedly closing terminal windows
> - Adds `preventTerminalCloseShortcut` and `preventRepeatedTerminalCloseShortcut` utility functions in [`terminalCloseShortcut.ts`](https://github.com/pingdotgg/t3code/pull/5322/files#diff-2b0d3232944f7ae00479a66e89042bcf3b8e9dfcb687bb323005d4bb8170fb89) to intercept close shortcut key events.
> - Adds a `before-input-event` listener in [`DesktopWindow.ts`](https://github.com/pingdotgg/t3code/pull/5322/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) that blocks auto-repeated Cmd+W (macOS) or Ctrl+W (other platforms) from reaching the native window menu.
> - Updates [`ThreadTerminalDrawer.tsx`](https://github.com/pingdotgg/t3code/pull/5322/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) and [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/5322/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to call these guards, stopping repeated close shortcuts from propagating while leaving deliberate single presses unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3334961.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

closes #2787

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard-input handling only; no auth or data paths. Slight risk of over-blocking if repeat detection diverges from platform behavior, but deliberate closes are explicitly left alone.
> 
> **Overview**
> Fixes a bug where **holding** the terminal close shortcut (`Ctrl/Cmd+W`) could close the browser tab or Electron window after the last terminal unmounts, because auto-repeat key events no longer hit terminal handlers.
> 
> **Web:** Adds `preventTerminalCloseShortcut` / `preventRepeatedTerminalCloseShortcut` in `terminalCloseShortcut.ts`. The terminal drawer calls the deliberate-close guard in its before-key path; `ChatView` stops repeated close shortcuts at the window level when no terminal is focused.
> 
> **Desktop:** Registers a `before-input-event` listener that `preventDefault`s only **auto-repeated** `Cmd+W` (macOS) or `Ctrl+W` (other platforms), so repeats never reach Electron’s native window-menu close accelerator. Single presses are unchanged.
> 
> Regression tests cover the new helpers and the desktop listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3334961830b1c969545f75ba174ec56013b128b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->