### PR TITLE
fix(web): reconcile terminal opens and closes

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -53,6 +53,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { flushSync } from "react-dom";
 import { useNavigate } from "@tanstack/react-router";
@@ -122,6 +123,7 @@ import {
   selectActiveRightPanelSurface,
   selectThreadRightPanelState,
   type RightPanelSurface,
+  type TerminalSurfaceSnapshot,
   useRightPanelStore,
 } from "../rightPanelStore";
 import {
@@ -197,8 +199,25 @@ import {
 import { appendPreviewAnnotationPrompt } from "../lib/previewAnnotation";
 import { appendReviewCommentsToPrompt, type ReviewCommentContext } from "../reviewCommentContext";
 import { environmentCatalog } from "../connection/catalog";
+import {
+  isTerminalOpenReservationActive,
+  releaseTerminalOpen,
+  reserveTerminalOpen,
+  reservedTerminalOpenIds,
+} from "../lib/terminalOpenReservations";
+import {
+  clearPendingPanelClose,
+  pendingPanelCloseVersion,
+  recordPendingPanelClose,
+  resolvePendingPanelCloses,
+  subscribePendingPanelCloses,
+} from "../lib/terminalPendingPanelCloses";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
-import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
+import {
+  useKnownTerminalSessions,
+  useTerminalMetadataLoaded,
+  useThreadRunningTerminalIds,
+} from "../state/terminalSessions";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import {
@@ -557,45 +576,6 @@ function useLocalDispatchState(input: {
   };
 }
 
-/** Same terminal ids (order ignored) — avoids reconcile when only server session ordering differs. */
-function terminalIdListsEqual(left: readonly string[], right: readonly string[]): boolean {
-  if (left.length !== right.length) {
-    return false;
-  }
-  if (left.length === 0) {
-    return true;
-  }
-  const sortedLeft = left.toSorted((a, b) => a.localeCompare(b));
-  const sortedRight = right.toSorted((a, b) => a.localeCompare(b));
-  for (let index = 0; index < sortedLeft.length; index += 1) {
-    if (sortedLeft[index] !== sortedRight[index]) {
-      return false;
-    }
-  }
-  return true;
-}
-
-/**
- * Server knows about fewer sessions than the client, but every server id still exists locally.
- * Typical right after `terminal.open`: known-session list lags; reconciling would drop the new id
- * and later re-add it as a separate group (no split layout).
- */
-function serverTerminalIdsStrictSubsetOfClient(
-  serverIds: readonly string[],
-  clientIds: readonly string[],
-): boolean {
-  if (serverIds.length >= clientIds.length || clientIds.length === 0) {
-    return false;
-  }
-  const clientSet = new Set(clientIds);
-  for (const id of serverIds) {
-    if (!clientSet.has(id)) {
-      return false;
-    }
-  }
-  return true;
-}
-
 interface PersistentThreadTerminalDrawerProps {
   threadRef: { environmentId: EnvironmentId; threadId: ThreadId };
   threadId: ThreadId;
@@ -704,6 +684,14 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     () => drawerTerminalSessions.map((session) => session.target.terminalId),
     [drawerTerminalSessions],
   );
+  const threadKey = scopedThreadKey(threadRef);
+  const terminalMetadataLoaded = useTerminalMetadataLoaded(threadRef.environmentId);
+  const suppressedTerminalIds = useTerminalUiStateStore(
+    (state) => state.suppressedTerminalIdsByThreadKey[threadKey],
+  );
+  const pendingTerminalIds = useTerminalUiStateStore(
+    (state) => state.pendingTerminalIdsByThreadKey[threadKey],
+  );
   // Every client-side id source participates in allocation: the server list
   // lags fresh opens, and panel terminals are filtered out of the drawer's
   // sessions — an id collision attaches two viewports to one PTY session.
@@ -725,19 +713,22 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const storeNewTerminal = useTerminalUiStateStore((state) => state.newTerminal);
   const storeSetActiveTerminal = useTerminalUiStateStore((state) => state.setActiveTerminal);
   const storeCloseTerminal = useTerminalUiStateStore((state) => state.closeTerminal);
+  const storeUnsuppressTerminal = useTerminalUiStateStore((state) => state.unsuppressTerminal);
+  const storeAbandonPendingTerminal = useTerminalUiStateStore(
+    (state) => state.abandonPendingTerminal,
+  );
   const reconcileTerminalIds = useTerminalUiStateStore((state) => state.reconcileTerminalIds);
 
   useEffect(() => {
-    if (terminalIdListsEqual(serverOrderedTerminalIds, terminalUiState.terminalIds)) {
-      return;
-    }
-    if (
-      serverTerminalIdsStrictSubsetOfClient(serverOrderedTerminalIds, terminalUiState.terminalIds)
-    ) {
-      return;
-    }
-    reconcileTerminalIds(threadRef, serverOrderedTerminalIds);
-  }, [reconcileTerminalIds, serverOrderedTerminalIds, terminalUiState.terminalIds, threadRef]);
+    reconcileTerminalIds(threadRef, serverOrderedTerminalIds, terminalMetadataLoaded);
+  }, [
+    pendingTerminalIds,
+    reconcileTerminalIds,
+    serverOrderedTerminalIds,
+    suppressedTerminalIds,
+    terminalMetadataLoaded,
+    threadRef,
+  ]);
   const [localFocusRequestId, setLocalFocusRequestId] = useState(0);
   const worktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const effectiveWorktreePath = useMemo(() => {
@@ -782,60 +773,86 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     [storeSetTerminalHeight, threadRef],
   );
 
+  const openTerminalSession = useCallback(
+    (terminalId: string, sessionCwd: string) => {
+      const reservation = reserveTerminalOpen(threadKey, terminalId);
+      clearPendingPanelClose(threadKey, terminalId);
+      void (async () => {
+        try {
+          const result = await openTerminal({
+            environmentId: threadRef.environmentId,
+            input: {
+              threadId,
+              terminalId,
+              cwd: sessionCwd,
+              ...(effectiveWorktreePath != null ? { worktreePath: effectiveWorktreePath } : {}),
+              env: runtimeEnv,
+            },
+          });
+          if (
+            result._tag === "Failure" &&
+            isTerminalOpenReservationActive(threadKey, terminalId, reservation)
+          ) {
+            storeAbandonPendingTerminal(threadRef, terminalId);
+          }
+        } catch {
+          if (isTerminalOpenReservationActive(threadKey, terminalId, reservation)) {
+            storeAbandonPendingTerminal(threadRef, terminalId);
+          }
+        } finally {
+          releaseTerminalOpen(threadKey, terminalId, reservation);
+        }
+      })();
+    },
+    [
+      effectiveWorktreePath,
+      openTerminal,
+      runtimeEnv,
+      storeAbandonPendingTerminal,
+      threadId,
+      threadKey,
+      threadRef,
+    ],
+  );
+
   const splitTerminal = useCallback(() => {
     if (!cwd) {
       return;
     }
-    const terminalId = nextTerminalId(allocatableTerminalIds);
+    const terminalId = nextTerminalId([
+      ...allocatableTerminalIds,
+      ...reservedTerminalOpenIds(threadKey),
+    ]);
     storeSplitTerminal(threadRef, terminalId);
     bumpFocusRequestId();
-    void openTerminal({
-      environmentId: threadRef.environmentId,
-      input: {
-        threadId,
-        terminalId,
-        cwd,
-        ...(effectiveWorktreePath != null ? { worktreePath: effectiveWorktreePath } : {}),
-        env: runtimeEnv,
-      },
-    });
+    openTerminalSession(terminalId, cwd);
   }, [
     allocatableTerminalIds,
     bumpFocusRequestId,
     cwd,
-    effectiveWorktreePath,
-    runtimeEnv,
+    openTerminalSession,
     storeSplitTerminal,
-    threadId,
+    threadKey,
     threadRef,
-    openTerminal,
   ]);
   const splitTerminalVertical = useCallback(() => {
     if (!cwd) {
       return;
     }
-    const terminalId = nextTerminalId(allocatableTerminalIds);
+    const terminalId = nextTerminalId([
+      ...allocatableTerminalIds,
+      ...reservedTerminalOpenIds(threadKey),
+    ]);
     storeSplitTerminalVertical(threadRef, terminalId);
     bumpFocusRequestId();
-    void openTerminal({
-      environmentId: threadRef.environmentId,
-      input: {
-        threadId,
-        terminalId,
-        cwd,
-        ...(effectiveWorktreePath != null ? { worktreePath: effectiveWorktreePath } : {}),
-        env: runtimeEnv,
-      },
-    });
+    openTerminalSession(terminalId, cwd);
   }, [
     allocatableTerminalIds,
     bumpFocusRequestId,
     cwd,
-    effectiveWorktreePath,
-    openTerminal,
-    runtimeEnv,
+    openTerminalSession,
     storeSplitTerminalVertical,
-    threadId,
+    threadKey,
     threadRef,
   ]);
 
@@ -843,29 +860,21 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     if (!cwd) {
       return;
     }
-    const terminalId = nextTerminalId(allocatableTerminalIds);
+    const terminalId = nextTerminalId([
+      ...allocatableTerminalIds,
+      ...reservedTerminalOpenIds(threadKey),
+    ]);
     storeNewTerminal(threadRef, terminalId);
     bumpFocusRequestId();
-    void openTerminal({
-      environmentId: threadRef.environmentId,
-      input: {
-        threadId,
-        terminalId,
-        cwd,
-        ...(effectiveWorktreePath != null ? { worktreePath: effectiveWorktreePath } : {}),
-        env: runtimeEnv,
-      },
-    });
+    openTerminalSession(terminalId, cwd);
   }, [
     bumpFocusRequestId,
     cwd,
-    effectiveWorktreePath,
     allocatableTerminalIds,
-    runtimeEnv,
+    openTerminalSession,
     storeNewTerminal,
-    threadId,
+    threadKey,
     threadRef,
-    openTerminal,
   ]);
 
   const activateTerminal = useCallback(
@@ -885,17 +894,31 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         });
 
       void (async () => {
-        const closeResult = await closeTerminalMutation({
-          environmentId: threadRef.environmentId,
-          input: {
-            threadId,
-            terminalId,
-            deleteHistory: true,
-          },
-        });
-        if (closeResult._tag === "Failure" && !isAtomCommandInterrupted(closeResult)) {
-          await fallbackExitWrite();
+        try {
+          const closeResult = await closeTerminalMutation({
+            environmentId: threadRef.environmentId,
+            input: {
+              threadId,
+              terminalId,
+              deleteHistory: true,
+            },
+          });
+          if (closeResult._tag !== "Failure") return;
+          if (isAtomCommandInterrupted(closeResult)) {
+            // Interruption is not confirmation. Roll back the suppression: if
+            // the server did close the session it vanishes from metadata and
+            // reconcile drops the id; if not, the terminal resurfaces.
+            storeUnsuppressTerminal(threadRef, terminalId);
+            return;
+          }
+          const exitResult = await fallbackExitWrite();
+          if (exitResult._tag !== "Failure") return;
+        } catch {
+          // A thrown request is also an unconfirmed close.
         }
+        // Neither path confirmably reached the session. Undo the optimistic
+        // suppression or reconcile would hide a live terminal.
+        storeUnsuppressTerminal(threadRef, terminalId);
       })();
 
       storeCloseTerminal(threadRef, terminalId);
@@ -904,6 +927,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     [
       bumpFocusRequestId,
       storeCloseTerminal,
+      storeUnsuppressTerminal,
       threadId,
       threadRef,
       closeTerminalMutation,
@@ -976,6 +1000,17 @@ interface PersistentThreadTerminalPanelProps {
   splitVerticalShortcutLabel?: string | undefined;
   newShortcutLabel?: string | undefined;
   closeShortcutLabel?: string | undefined;
+}
+
+type TerminalPanelSurface = Extract<RightPanelSurface, { kind: "terminal" }>;
+
+function snapshotTerminalSurface(surface: TerminalPanelSurface): TerminalSurfaceSnapshot {
+  return {
+    surfaceId: surface.id,
+    resourceId: surface.resourceId,
+    terminalIds: [...surface.terminalIds],
+    ...(surface.splitDirection === "vertical" ? { splitDirection: "vertical" as const } : {}),
+  };
 }
 
 const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPanel({
@@ -1374,6 +1409,8 @@ function ChatViewContent(props: ChatViewProps) {
   const storeNewTerminal = useTerminalUiStateStore((s) => s.newTerminal);
   const storeSetActiveTerminal = useTerminalUiStateStore((s) => s.setActiveTerminal);
   const storeCloseTerminal = useTerminalUiStateStore((s) => s.closeTerminal);
+  const storeUnsuppressTerminal = useTerminalUiStateStore((s) => s.unsuppressTerminal);
+  const storeAbandonPendingTerminal = useTerminalUiStateStore((s) => s.abandonPendingTerminal);
   const serverThreadRefs = useThreadRefs();
   const serverThreadKeys = useMemo(() => serverThreadRefs.map(scopedThreadKey), [serverThreadRefs]);
   const draftThreadsByThreadKey = useComposerDraftStore((store) => store.draftThreadsByThreadKey);
@@ -1534,6 +1571,32 @@ function ChatViewContent(props: ChatViewProps) {
       ),
     [rightPanelState.surfaces],
   );
+  const activePendingPanelCloseVersion = useSyncExternalStore(
+    subscribePendingPanelCloses,
+    pendingPanelCloseVersion,
+  );
+  const activeTerminalMetadataLoaded = useTerminalMetadataLoaded(
+    activeThread?.environmentId ?? null,
+  );
+  useEffect(() => {
+    if (!activeThreadRef) return;
+    const restored = resolvePendingPanelCloses(
+      scopedThreadKey(activeThreadRef),
+      activeServerOrderedTerminalIds,
+      Date.now(),
+      activeTerminalMetadataLoaded,
+    );
+    for (const { terminalId, snapshot } of restored) {
+      useRightPanelStore.getState().restoreTerminal(activeThreadRef, snapshot, terminalId);
+      storeUnsuppressTerminal(activeThreadRef, terminalId);
+    }
+  }, [
+    activePendingPanelCloseVersion,
+    activeServerOrderedTerminalIds,
+    activeTerminalMetadataLoaded,
+    activeThreadRef,
+    storeUnsuppressTerminal,
+  ]);
   const allocatableActiveTerminalIds = useMemo(
     () => [...new Set([...activeKnownTerminalIds, ...panelTerminalIds])],
     [activeKnownTerminalIds, panelTerminalIds],
@@ -2634,6 +2697,56 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [activeThreadRef, storeSetTerminalOpen],
   );
+  const openThreadTerminalSession = useCallback(
+    (terminalId: string, sessionCwd: string, workspaceRoot: string, onUncreated?: () => void) => {
+      if (!activeThreadRef || !activeThreadId) return;
+      const threadRef = activeThreadRef;
+      const threadKey = scopedThreadKey(threadRef);
+      const reservation = reserveTerminalOpen(threadKey, terminalId);
+      clearPendingPanelClose(threadKey, terminalId);
+      void (async () => {
+        try {
+          const result = await openTerminal({
+            environmentId,
+            input: {
+              threadId: activeThreadId,
+              terminalId,
+              cwd: sessionCwd,
+              ...(activeThreadWorktreePath != null
+                ? { worktreePath: activeThreadWorktreePath }
+                : {}),
+              env: projectScriptRuntimeEnv({
+                project: { cwd: workspaceRoot },
+                worktreePath: activeThreadWorktreePath,
+              }),
+            },
+          });
+          if (
+            result._tag === "Failure" &&
+            isTerminalOpenReservationActive(threadKey, terminalId, reservation)
+          ) {
+            storeAbandonPendingTerminal(threadRef, terminalId);
+            onUncreated?.();
+          }
+        } catch {
+          if (isTerminalOpenReservationActive(threadKey, terminalId, reservation)) {
+            storeAbandonPendingTerminal(threadRef, terminalId);
+            onUncreated?.();
+          }
+        } finally {
+          releaseTerminalOpen(threadKey, terminalId, reservation);
+        }
+      })();
+    },
+    [
+      activeThreadId,
+      activeThreadRef,
+      activeThreadWorktreePath,
+      environmentId,
+      openTerminal,
+      storeAbandonPendingTerminal,
+    ],
+  );
   const toggleTerminalVisibility = useCallback(() => {
     if (!activeThreadRef) return;
     const nextOpen = !terminalUiState.terminalOpen;
@@ -2645,21 +2758,12 @@ function ChatViewContent(props: ChatViewProps) {
       if (!cwdForOpen) {
         return;
       }
-      const terminalId = nextTerminalId(allocatableActiveTerminalIds);
+      const terminalId = nextTerminalId([
+        ...allocatableActiveTerminalIds,
+        ...reservedTerminalOpenIds(scopedThreadKey(activeThreadRef)),
+      ]);
       storeEnsureTerminal(activeThreadRef, terminalId, { open: true });
-      void openTerminal({
-        environmentId,
-        input: {
-          threadId: activeThreadId,
-          terminalId,
-          cwd: cwdForOpen,
-          ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
-          env: projectScriptRuntimeEnv({
-            project: { cwd: activeProject.workspaceRoot },
-            worktreePath: activeThreadWorktreePath,
-          }),
-        },
-      });
+      openThreadTerminalSession(terminalId, cwdForOpen, activeProject.workspaceRoot);
       return;
     }
     setTerminalOpen(nextOpen);
@@ -2667,11 +2771,9 @@ function ChatViewContent(props: ChatViewProps) {
     activeProject,
     activeThreadId,
     activeThreadRef,
-    activeThreadWorktreePath,
     allocatableActiveTerminalIds,
-    environmentId,
     gitCwd,
-    openTerminal,
+    openThreadTerminalSession,
     setTerminalOpen,
     storeEnsureTerminal,
     terminalUiState.terminalIds.length,
@@ -2686,37 +2788,26 @@ function ChatViewContent(props: ChatViewProps) {
       if (!cwdForOpen) {
         return;
       }
-      const terminalId = nextTerminalId(allocatableActiveTerminalIds);
+      const terminalId = nextTerminalId([
+        ...allocatableActiveTerminalIds,
+        ...reservedTerminalOpenIds(scopedThreadKey(activeThreadRef)),
+      ]);
       if (direction === "vertical") {
         storeSplitTerminalVertical(activeThreadRef, terminalId);
       } else {
         storeSplitTerminal(activeThreadRef, terminalId);
       }
       setTerminalFocusRequestId((value) => value + 1);
-      void openTerminal({
-        environmentId,
-        input: {
-          threadId: activeThreadId,
-          terminalId,
-          cwd: cwdForOpen,
-          ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
-          env: projectScriptRuntimeEnv({
-            project: { cwd: activeProject.workspaceRoot },
-            worktreePath: activeThreadWorktreePath,
-          }),
-        },
-      });
+      openThreadTerminalSession(terminalId, cwdForOpen, activeProject.workspaceRoot);
     },
     [
       activeProject,
       activeThreadId,
       allocatableActiveTerminalIds,
       activeThreadRef,
-      openTerminal,
-      activeThreadWorktreePath,
-      environmentId,
       gitCwd,
       hasReachedSplitLimit,
+      openThreadTerminalSession,
       storeSplitTerminal,
       storeSplitTerminalVertical,
     ],
@@ -2729,31 +2820,20 @@ function ChatViewContent(props: ChatViewProps) {
     if (!cwdForOpen) {
       return;
     }
-    const terminalId = nextTerminalId(allocatableActiveTerminalIds);
+    const terminalId = nextTerminalId([
+      ...allocatableActiveTerminalIds,
+      ...reservedTerminalOpenIds(scopedThreadKey(activeThreadRef)),
+    ]);
     storeNewTerminal(activeThreadRef, terminalId);
     setTerminalFocusRequestId((value) => value + 1);
-    void openTerminal({
-      environmentId,
-      input: {
-        threadId: activeThreadId,
-        terminalId,
-        cwd: cwdForOpen,
-        ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
-        env: projectScriptRuntimeEnv({
-          project: { cwd: activeProject.workspaceRoot },
-          worktreePath: activeThreadWorktreePath,
-        }),
-      },
-    });
+    openThreadTerminalSession(terminalId, cwdForOpen, activeProject.workspaceRoot);
   }, [
     activeProject,
     activeThreadId,
     allocatableActiveTerminalIds,
     activeThreadRef,
-    openTerminal,
-    activeThreadWorktreePath,
-    environmentId,
     gitCwd,
+    openThreadTerminalSession,
     storeNewTerminal,
   ]);
   const closeTerminal = useCallback(
@@ -2765,17 +2845,26 @@ function ChatViewContent(props: ChatViewProps) {
           input: { threadId: activeThreadId, terminalId, data: "exit\n" },
         });
       void (async () => {
-        const closeResult = await closeTerminalMutation({
-          environmentId,
-          input: {
-            threadId: activeThreadId,
-            terminalId,
-            deleteHistory: true,
-          },
-        });
-        if (closeResult._tag === "Failure" && !isAtomCommandInterrupted(closeResult)) {
-          await fallbackExitWrite();
+        try {
+          const closeResult = await closeTerminalMutation({
+            environmentId,
+            input: {
+              threadId: activeThreadId,
+              terminalId,
+              deleteHistory: true,
+            },
+          });
+          if (closeResult._tag !== "Failure") return;
+          if (isAtomCommandInterrupted(closeResult)) {
+            storeUnsuppressTerminal(activeThreadRef, terminalId);
+            return;
+          }
+          const exitResult = await fallbackExitWrite();
+          if (exitResult._tag !== "Failure") return;
+        } catch {
+          // A thrown request is also an unconfirmed close.
         }
+        storeUnsuppressTerminal(activeThreadRef, terminalId);
       })();
       storeCloseTerminal(activeThreadRef, terminalId);
       setTerminalFocusRequestId((value) => value + 1);
@@ -2786,6 +2875,7 @@ function ChatViewContent(props: ChatViewProps) {
       closeTerminalMutation,
       environmentId,
       storeCloseTerminal,
+      storeUnsuppressTerminal,
       writeTerminal,
     ],
   );
@@ -2812,7 +2902,8 @@ function ChatViewContent(props: ChatViewProps) {
         terminalUiState.activeTerminalId || activeKnownTerminalIds[0] || DEFAULT_THREAD_TERMINAL_ID;
       const isBaseTerminalBusy = runningTerminalIds.includes(baseTerminalId);
       const wantsNewTerminal = Boolean(options?.preferNewTerminal) || isBaseTerminalBusy;
-      const shouldCreateNewTerminal = wantsNewTerminal;
+      const shouldCreateNewTerminal =
+        wantsNewTerminal || !allocatableActiveTerminalIds.includes(baseTerminalId);
       const targetWorktreePath = options?.worktreePath ?? activeThread.worktreePath ?? null;
 
       setTerminalUiLaunchContext({
@@ -2833,8 +2924,9 @@ function ChatViewContent(props: ChatViewProps) {
         worktreePath: targetWorktreePath,
         ...(options?.env ? { extraEnv: options.env } : {}),
       });
+      const threadKey = scopedThreadKey(activeThreadRef);
       const targetTerminalId = shouldCreateNewTerminal
-        ? nextTerminalId(allocatableActiveTerminalIds)
+        ? nextTerminalId([...allocatableActiveTerminalIds, ...reservedTerminalOpenIds(threadKey)])
         : baseTerminalId;
       const openTerminalInput: TerminalOpenInput = shouldCreateNewTerminal
         ? {
@@ -2856,11 +2948,38 @@ function ChatViewContent(props: ChatViewProps) {
 
       if (shouldCreateNewTerminal) {
         storeNewTerminal(activeThreadRef, targetTerminalId);
+        clearPendingPanelClose(threadKey, targetTerminalId);
       } else {
         storeSetActiveTerminal(activeThreadRef, targetTerminalId);
       }
 
-      const openResult = await openTerminal({ environmentId, input: openTerminalInput });
+      const reservation = shouldCreateNewTerminal
+        ? reserveTerminalOpen(threadKey, targetTerminalId)
+        : undefined;
+      let openResult: Awaited<ReturnType<typeof openTerminal>>;
+      try {
+        openResult = await openTerminal({ environmentId, input: openTerminalInput });
+        if (
+          openResult._tag === "Failure" &&
+          reservation !== undefined &&
+          isTerminalOpenReservationActive(threadKey, targetTerminalId, reservation)
+        ) {
+          storeAbandonPendingTerminal(activeThreadRef, targetTerminalId);
+        }
+      } catch {
+        if (
+          reservation !== undefined &&
+          isTerminalOpenReservationActive(threadKey, targetTerminalId, reservation)
+        ) {
+          storeAbandonPendingTerminal(activeThreadRef, targetTerminalId);
+        }
+        setThreadError(activeThreadId, `Failed to run script "${script.name}".`);
+        return;
+      } finally {
+        if (reservation !== undefined) {
+          releaseTerminalOpen(threadKey, targetTerminalId, reservation);
+        }
+      }
       if (openResult._tag === "Failure") {
         if (!isAtomCommandInterrupted(openResult)) {
           const error = squashAtomCommandFailure(openResult);
@@ -2897,6 +3016,7 @@ function ChatViewContent(props: ChatViewProps) {
       setTerminalOpen,
       setThreadError,
       storeNewTerminal,
+      storeAbandonPendingTerminal,
       storeSetActiveTerminal,
       setLastInvokedScriptByProjectId,
       environmentId,
@@ -3161,30 +3281,24 @@ function ChatViewContent(props: ChatViewProps) {
   const addTerminalSurface = useCallback(() => {
     if (!activeThreadRef || !activeThreadId || !activeProject) return;
     const cwd = gitCwd ?? activeProject.workspaceRoot;
-    const terminalId = nextTerminalId(allocatableActiveTerminalIds);
-    useRightPanelStore.getState().openTerminal(activeThreadRef, terminalId);
+    const threadRef = activeThreadRef;
+    const threadKey = scopedThreadKey(threadRef);
+    const terminalId = nextTerminalId([
+      ...allocatableActiveTerminalIds,
+      ...reservedTerminalOpenIds(threadKey),
+    ]);
+    useRightPanelStore.getState().openTerminal(threadRef, terminalId);
     setTerminalFocusRequestId((value) => value + 1);
-    void openTerminal({
-      environmentId: activeThreadRef.environmentId,
-      input: {
-        threadId: activeThreadId,
-        terminalId,
-        cwd,
-        ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
-        env: projectScriptRuntimeEnv({
-          project: { cwd: activeProject.workspaceRoot },
-          worktreePath: activeThreadWorktreePath,
-        }),
-      },
+    openThreadTerminalSession(terminalId, cwd, activeProject.workspaceRoot, () => {
+      useRightPanelStore.getState().closeTerminal(threadRef, `terminal:${terminalId}`, terminalId);
     });
   }, [
     activeProject,
     activeThreadId,
     activeThreadRef,
-    activeThreadWorktreePath,
     allocatableActiveTerminalIds,
     gitCwd,
-    openTerminal,
+    openThreadTerminalSession,
   ]);
   const splitPanelTerminal = useCallback(
     (direction: "horizontal" | "vertical" = "horizontal") => {
@@ -3197,24 +3311,18 @@ function ChatViewContent(props: ChatViewProps) {
       ) {
         return;
       }
-      const terminalId = nextTerminalId(allocatableActiveTerminalIds);
+      const threadRef = activeThreadRef;
+      const threadKey = scopedThreadKey(threadRef);
+      const surfaceId = activeRightPanelSurface.id;
+      const terminalId = nextTerminalId([
+        ...allocatableActiveTerminalIds,
+        ...reservedTerminalOpenIds(threadKey),
+      ]);
       const cwd = gitCwd ?? activeProject.workspaceRoot;
-      useRightPanelStore
-        .getState()
-        .splitTerminal(activeThreadRef, activeRightPanelSurface.id, terminalId, direction);
+      useRightPanelStore.getState().splitTerminal(threadRef, surfaceId, terminalId, direction);
       setTerminalFocusRequestId((value) => value + 1);
-      void openTerminal({
-        environmentId: activeThreadRef.environmentId,
-        input: {
-          threadId: activeThreadId,
-          terminalId,
-          cwd,
-          ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
-          env: projectScriptRuntimeEnv({
-            project: { cwd: activeProject.workspaceRoot },
-            worktreePath: activeThreadWorktreePath,
-          }),
-        },
+      openThreadTerminalSession(terminalId, cwd, activeProject.workspaceRoot, () => {
+        useRightPanelStore.getState().closeTerminal(threadRef, surfaceId, terminalId);
       });
     },
     [
@@ -3222,10 +3330,9 @@ function ChatViewContent(props: ChatViewProps) {
       activeRightPanelSurface,
       activeThreadId,
       activeThreadRef,
-      activeThreadWorktreePath,
       allocatableActiveTerminalIds,
       gitCwd,
-      openTerminal,
+      openThreadTerminalSession,
     ],
   );
   const splitPanelTerminalVertical = useCallback(() => {
@@ -3244,17 +3351,46 @@ function ChatViewContent(props: ChatViewProps) {
   const closePanelTerminal = useCallback(
     (terminalId: string) => {
       if (!activeThreadRef || activeRightPanelSurface?.kind !== "terminal") return;
-      void closeTerminalMutation({
-        environmentId: activeThreadRef.environmentId,
-        input: { threadId: activeThreadRef.threadId, terminalId, deleteHistory: true },
-      });
-      storeCloseTerminal(activeThreadRef, terminalId);
+      const threadRef = activeThreadRef;
+      const threadKey = scopedThreadKey(threadRef);
+      const surfaceSnapshot = snapshotTerminalSurface(activeRightPanelSurface);
+      void (async () => {
+        try {
+          const result = await closeTerminalMutation({
+            environmentId: threadRef.environmentId,
+            input: { threadId: threadRef.threadId, terminalId, deleteHistory: true },
+          });
+          if (result._tag !== "Failure") return;
+          if (isAtomCommandInterrupted(result)) {
+            // The optimistic removal stays in place until authoritative
+            // metadata tells us whether the server session survived.
+            recordPendingPanelClose(threadKey, terminalId, surfaceSnapshot);
+            return;
+          }
+        } catch {
+          // A thrown request has an unknown outcome, just like interruption.
+          recordPendingPanelClose(threadKey, terminalId, surfaceSnapshot);
+          return;
+        }
+
+        // A completed failure means the session is still live. Restore it to
+        // the exact surface and pane order it occupied before the close.
+        useRightPanelStore.getState().restoreTerminal(threadRef, surfaceSnapshot, terminalId);
+        storeUnsuppressTerminal(threadRef, terminalId);
+      })();
+      storeCloseTerminal(threadRef, terminalId);
       useRightPanelStore
         .getState()
-        .closeTerminal(activeThreadRef, activeRightPanelSurface.id, terminalId);
+        .closeTerminal(threadRef, activeRightPanelSurface.id, terminalId);
       setTerminalFocusRequestId((value) => value + 1);
     },
-    [activeRightPanelSurface, activeThreadRef, closeTerminalMutation, storeCloseTerminal],
+    [
+      activeRightPanelSurface,
+      activeThreadRef,
+      closeTerminalMutation,
+      storeCloseTerminal,
+      storeUnsuppressTerminal,
+    ],
   );
   const activateRightPanelSurface = useCallback(
     (surface: RightPanelSurface) => {
@@ -3312,12 +3448,38 @@ function ChatViewContent(props: ChatViewProps) {
           });
         }
         if (surface.kind === "terminal") {
+          const surfaceSnapshot = snapshotTerminalSurface(surface);
           for (const terminalId of surface.terminalIds) {
             storeCloseTerminal(activeThreadRef, terminalId);
-            void closeTerminalMutation({
-              environmentId: activeThreadRef.environmentId,
-              input: { threadId: activeThreadRef.threadId, terminalId, deleteHistory: true },
-            });
+            void (async () => {
+              try {
+                const result = await closeTerminalMutation({
+                  environmentId: activeThreadRef.environmentId,
+                  input: { threadId: activeThreadRef.threadId, terminalId, deleteHistory: true },
+                });
+                if (result._tag !== "Failure") return;
+                if (isAtomCommandInterrupted(result)) {
+                  recordPendingPanelClose(
+                    scopedThreadKey(activeThreadRef),
+                    terminalId,
+                    surfaceSnapshot,
+                  );
+                  return;
+                }
+              } catch {
+                recordPendingPanelClose(
+                  scopedThreadKey(activeThreadRef),
+                  terminalId,
+                  surfaceSnapshot,
+                );
+                return;
+              }
+
+              useRightPanelStore
+                .getState()
+                .restoreTerminal(activeThreadRef, surfaceSnapshot, terminalId);
+              storeUnsuppressTerminal(activeThreadRef, terminalId);
+            })();
           }
         }
       }
@@ -3329,6 +3491,7 @@ function ChatViewContent(props: ChatViewProps) {
       closeTerminalMutation,
       dismissPlanSidebarForCurrentTurn,
       storeCloseTerminal,
+      storeUnsuppressTerminal,
     ],
   );
   const syncActivePreviewSurface = useCallback(() => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -713,7 +713,9 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const storeNewTerminal = useTerminalUiStateStore((state) => state.newTerminal);
   const storeSetActiveTerminal = useTerminalUiStateStore((state) => state.setActiveTerminal);
   const storeCloseTerminal = useTerminalUiStateStore((state) => state.closeTerminal);
-  const storeUnsuppressTerminal = useTerminalUiStateStore((state) => state.unsuppressTerminal);
+  const storeRestorePendingTerminal = useTerminalUiStateStore(
+    (state) => state.restorePendingTerminal,
+  );
   const storeAbandonPendingTerminal = useTerminalUiStateStore(
     (state) => state.abandonPendingTerminal,
   );
@@ -908,7 +910,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
             // Interruption is not confirmation. Roll back the suppression: if
             // the server did close the session it vanishes from metadata and
             // reconcile drops the id; if not, the terminal resurfaces.
-            storeUnsuppressTerminal(threadRef, terminalId);
+            storeRestorePendingTerminal(threadRef, terminalId);
             return;
           }
           const exitResult = await fallbackExitWrite();
@@ -918,7 +920,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         }
         // Neither path confirmably reached the session. Undo the optimistic
         // suppression or reconcile would hide a live terminal.
-        storeUnsuppressTerminal(threadRef, terminalId);
+        storeRestorePendingTerminal(threadRef, terminalId);
       })();
 
       storeCloseTerminal(threadRef, terminalId);
@@ -927,7 +929,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     [
       bumpFocusRequestId,
       storeCloseTerminal,
-      storeUnsuppressTerminal,
+      storeRestorePendingTerminal,
       threadId,
       threadRef,
       closeTerminalMutation,
@@ -1414,6 +1416,7 @@ function ChatViewContent(props: ChatViewProps) {
   const storeSetActiveTerminal = useTerminalUiStateStore((s) => s.setActiveTerminal);
   const storeCloseTerminal = useTerminalUiStateStore((s) => s.closeTerminal);
   const storeUnsuppressTerminal = useTerminalUiStateStore((s) => s.unsuppressTerminal);
+  const storeRestorePendingTerminal = useTerminalUiStateStore((s) => s.restorePendingTerminal);
   const storeAbandonPendingTerminal = useTerminalUiStateStore((s) => s.abandonPendingTerminal);
   const serverThreadRefs = useThreadRefs();
   const serverThreadKeys = useMemo(() => serverThreadRefs.map(scopedThreadKey), [serverThreadRefs]);
@@ -2860,7 +2863,7 @@ function ChatViewContent(props: ChatViewProps) {
           });
           if (closeResult._tag !== "Failure") return;
           if (isAtomCommandInterrupted(closeResult)) {
-            storeUnsuppressTerminal(activeThreadRef, terminalId);
+            storeRestorePendingTerminal(activeThreadRef, terminalId);
             return;
           }
           const exitResult = await fallbackExitWrite();
@@ -2868,7 +2871,7 @@ function ChatViewContent(props: ChatViewProps) {
         } catch {
           // A thrown request is also an unconfirmed close.
         }
-        storeUnsuppressTerminal(activeThreadRef, terminalId);
+        storeRestorePendingTerminal(activeThreadRef, terminalId);
       })();
       storeCloseTerminal(activeThreadRef, terminalId);
       setTerminalFocusRequestId((value) => value + 1);
@@ -2879,7 +2882,7 @@ function ChatViewContent(props: ChatViewProps) {
       closeTerminalMutation,
       environmentId,
       storeCloseTerminal,
-      storeUnsuppressTerminal,
+      storeRestorePendingTerminal,
       writeTerminal,
     ],
   );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1004,10 +1004,14 @@ interface PersistentThreadTerminalPanelProps {
 
 type TerminalPanelSurface = Extract<RightPanelSurface, { kind: "terminal" }>;
 
-function snapshotTerminalSurface(surface: TerminalPanelSurface): TerminalSurfaceSnapshot {
+function snapshotTerminalSurface(
+  surface: TerminalPanelSurface,
+  surfaceIndex: number,
+): TerminalSurfaceSnapshot {
   return {
     surfaceId: surface.id,
     resourceId: surface.resourceId,
+    surfaceIndex,
     terminalIds: [...surface.terminalIds],
     ...(surface.splitDirection === "vertical" ? { splitDirection: "vertical" as const } : {}),
   };
@@ -3353,7 +3357,13 @@ function ChatViewContent(props: ChatViewProps) {
       if (!activeThreadRef || activeRightPanelSurface?.kind !== "terminal") return;
       const threadRef = activeThreadRef;
       const threadKey = scopedThreadKey(threadRef);
-      const surfaceSnapshot = snapshotTerminalSurface(activeRightPanelSurface);
+      const surfaceIndex = rightPanelState.surfaces.findIndex(
+        (surface) => surface.id === activeRightPanelSurface.id,
+      );
+      const surfaceSnapshot = snapshotTerminalSurface(
+        activeRightPanelSurface,
+        Math.max(0, surfaceIndex),
+      );
       void (async () => {
         try {
           const result = await closeTerminalMutation({
@@ -3388,6 +3398,7 @@ function ChatViewContent(props: ChatViewProps) {
       activeRightPanelSurface,
       activeThreadRef,
       closeTerminalMutation,
+      rightPanelState.surfaces,
       storeCloseTerminal,
       storeUnsuppressTerminal,
     ],
@@ -3448,7 +3459,10 @@ function ChatViewContent(props: ChatViewProps) {
           });
         }
         if (surface.kind === "terminal") {
-          const surfaceSnapshot = snapshotTerminalSurface(surface);
+          const surfaceIndex = rightPanelState.surfaces.findIndex(
+            (entry) => entry.id === surface.id,
+          );
+          const surfaceSnapshot = snapshotTerminalSurface(surface, Math.max(0, surfaceIndex));
           for (const terminalId of surface.terminalIds) {
             storeCloseTerminal(activeThreadRef, terminalId);
             void (async () => {
@@ -3490,6 +3504,7 @@ function ChatViewContent(props: ChatViewProps) {
       closePreview,
       closeTerminalMutation,
       dismissPlanSidebarForCurrentTurn,
+      rightPanelState.surfaces,
       storeCloseTerminal,
       storeUnsuppressTerminal,
     ],

--- a/apps/web/src/lib/terminalOpenReservations.test.ts
+++ b/apps/web/src/lib/terminalOpenReservations.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  isTerminalOpenReservationActive,
+  releaseTerminalOpen,
+  reserveTerminalOpen,
+  reservedTerminalOpenIds,
+} from "./terminalOpenReservations";
+
+describe("terminalOpenReservations", () => {
+  it("releases ids after an open request settles", () => {
+    const reservation = reserveTerminalOpen("thread-a", "term-2");
+    expect(reservedTerminalOpenIds("thread-a")).toEqual(["term-2"]);
+
+    releaseTerminalOpen("thread-a", "term-2", reservation);
+    expect(reservedTerminalOpenIds("thread-a")).toEqual([]);
+  });
+
+  it("does not let a stale failure release a newer reservation", () => {
+    const stale = reserveTerminalOpen("thread-a", "term-2");
+    const current = reserveTerminalOpen("thread-a", "term-2");
+
+    releaseTerminalOpen("thread-a", "term-2", stale);
+    expect(isTerminalOpenReservationActive("thread-a", "term-2", current)).toBe(true);
+    expect(reservedTerminalOpenIds("thread-a")).toEqual(["term-2"]);
+
+    releaseTerminalOpen("thread-a", "term-2", current);
+    expect(reservedTerminalOpenIds("thread-a")).toEqual([]);
+  });
+
+  it("scopes reservations per thread and tolerates unknown releases", () => {
+    const reservation = reserveTerminalOpen("thread-b", "term-2");
+    releaseTerminalOpen("thread-a", "term-2");
+    releaseTerminalOpen("thread-b", "never-reserved");
+
+    expect(reservedTerminalOpenIds("thread-a")).toEqual([]);
+    expect(reservedTerminalOpenIds("thread-b")).toEqual(["term-2"]);
+    releaseTerminalOpen("thread-b", "term-2", reservation);
+  });
+});

--- a/apps/web/src/lib/terminalOpenReservations.ts
+++ b/apps/web/src/lib/terminalOpenReservations.ts
@@ -1,0 +1,47 @@
+/**
+ * Terminal ids with an open request still in flight, keyed by thread.
+ *
+ * Reservations are deliberately scoped to the request lifetime. They protect
+ * optimistic failure handlers from racing a new allocation without becoming a
+ * history of every terminal id that has ever existed.
+ */
+const inFlightOpenIdsByThreadKey = new Map<string, Map<string, symbol>>();
+
+export type TerminalOpenReservation = symbol;
+
+export function reserveTerminalOpen(
+  threadKey: string,
+  terminalId: string,
+): TerminalOpenReservation {
+  const ids = inFlightOpenIdsByThreadKey.get(threadKey) ?? new Map<string, symbol>();
+  const reservation = Symbol(terminalId);
+  ids.set(terminalId, reservation);
+  inFlightOpenIdsByThreadKey.set(threadKey, ids);
+  return reservation;
+}
+
+export function isTerminalOpenReservationActive(
+  threadKey: string,
+  terminalId: string,
+  reservation: TerminalOpenReservation,
+): boolean {
+  return inFlightOpenIdsByThreadKey.get(threadKey)?.get(terminalId) === reservation;
+}
+
+export function releaseTerminalOpen(
+  threadKey: string,
+  terminalId: string,
+  reservation?: TerminalOpenReservation,
+): void {
+  const ids = inFlightOpenIdsByThreadKey.get(threadKey);
+  if (!ids) return;
+  if (reservation !== undefined && ids.get(terminalId) !== reservation) return;
+  ids.delete(terminalId);
+  if (ids.size === 0) {
+    inFlightOpenIdsByThreadKey.delete(threadKey);
+  }
+}
+
+export function reservedTerminalOpenIds(threadKey: string): string[] {
+  return [...(inFlightOpenIdsByThreadKey.get(threadKey)?.keys() ?? [])];
+}

--- a/apps/web/src/lib/terminalPendingPanelCloses.test.ts
+++ b/apps/web/src/lib/terminalPendingPanelCloses.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  clearPendingPanelClose,
+  clearPendingPanelCloses,
+  pendingPanelCloseVersion,
+  recordPendingPanelClose,
+  resolvePendingPanelCloses,
+  subscribePendingPanelCloses,
+} from "./terminalPendingPanelCloses";
+
+const snapshot = {
+  surfaceId: "terminal:term-1" as const,
+  resourceId: "term-1",
+  terminalIds: ["term-1", "term-2", "term-3"],
+  splitDirection: "vertical" as const,
+};
+
+beforeEach(() => {
+  clearPendingPanelCloses("thread-a");
+  clearPendingPanelCloses("thread-b");
+});
+
+describe("terminalPendingPanelCloses", () => {
+  it("restores a surviving close only after the settle grace", () => {
+    recordPendingPanelClose("thread-a", "term-2", snapshot, 1_000);
+
+    expect(resolvePendingPanelCloses("thread-a", ["term-1", "term-2"], 2_000)).toEqual([]);
+    expect(resolvePendingPanelCloses("thread-a", ["term-1", "term-2"], 3_000)).toEqual([
+      { terminalId: "term-2", snapshot },
+    ]);
+    expect(resolvePendingPanelCloses("thread-a", ["term-1", "term-2"], 3_000)).toEqual([]);
+  });
+
+  it("drops a snapshot when the server confirms the close", () => {
+    recordPendingPanelClose("thread-a", "term-2", snapshot, 1_000);
+
+    expect(resolvePendingPanelCloses("thread-a", ["term-1"], 3_000)).toEqual([]);
+    expect(resolvePendingPanelCloses("thread-a", ["term-1", "term-2"], 3_000)).toEqual([]);
+  });
+
+  it("does not treat an unloaded empty list as authoritative", () => {
+    recordPendingPanelClose("thread-a", "term-2", snapshot, 1_000);
+
+    expect(resolvePendingPanelCloses("thread-a", [], 3_000)).toEqual([]);
+    expect(resolvePendingPanelCloses("thread-a", ["term-1", "term-2"], 3_000)).toEqual([
+      { terminalId: "term-2", snapshot },
+    ]);
+  });
+
+  it("treats an authoritative empty list as a confirmed close", () => {
+    recordPendingPanelClose("thread-a", "term-2", snapshot, 1_000);
+
+    expect(resolvePendingPanelCloses("thread-a", [], 3_000, true)).toEqual([]);
+    expect(resolvePendingPanelCloses("thread-a", ["term-2"], 3_000, true)).toEqual([]);
+  });
+
+  it("restores nested closes in reverse order and allows id reuse to cancel a stale snapshot", () => {
+    recordPendingPanelClose("thread-a", "term-2", snapshot, 1_000);
+    recordPendingPanelClose(
+      "thread-a",
+      "term-3",
+      { ...snapshot, terminalIds: ["term-1", "term-3"] },
+      1_000,
+    );
+
+    expect(
+      resolvePendingPanelCloses("thread-a", ["term-1", "term-2", "term-3"], 3_000, true).map(
+        (entry) => entry.terminalId,
+      ),
+    ).toEqual(["term-3", "term-2"]);
+
+    recordPendingPanelClose("thread-a", "term-2", snapshot, 1_000);
+    clearPendingPanelClose("thread-a", "term-2");
+    expect(resolvePendingPanelCloses("thread-a", ["term-2"], 3_000, true)).toEqual([]);
+  });
+
+  it("notifies subscribers when a close becomes eligible", () => {
+    vi.useFakeTimers();
+    try {
+      let notifications = 0;
+      const unsubscribe = subscribePendingPanelCloses(() => {
+        notifications += 1;
+      });
+      const versionBefore = pendingPanelCloseVersion();
+
+      recordPendingPanelClose("thread-a", "term-2", snapshot);
+      expect(notifications).toBe(0);
+      vi.advanceTimersByTime(1_500);
+      expect(notifications).toBe(1);
+      expect(pendingPanelCloseVersion()).toBeGreaterThan(versionBefore);
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/lib/terminalPendingPanelCloses.test.ts
+++ b/apps/web/src/lib/terminalPendingPanelCloses.test.ts
@@ -12,6 +12,7 @@ import {
 const snapshot = {
   surfaceId: "terminal:term-1" as const,
   resourceId: "term-1",
+  surfaceIndex: 0,
   terminalIds: ["term-1", "term-2", "term-3"],
   splitDirection: "vertical" as const,
 };
@@ -89,6 +90,29 @@ describe("terminalPendingPanelCloses", () => {
       vi.advanceTimersByTime(1_500);
       expect(notifications).toBe(1);
       expect(pendingPanelCloseVersion()).toBeGreaterThan(versionBefore);
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("schedules the earliest interrupted close when closes overlap", () => {
+    vi.useFakeTimers();
+    try {
+      let notifications = 0;
+      const unsubscribe = subscribePendingPanelCloses(() => {
+        notifications += 1;
+      });
+
+      vi.setSystemTime(1_000);
+      recordPendingPanelClose("thread-a", "term-2", snapshot);
+      vi.advanceTimersByTime(1_000);
+      recordPendingPanelClose("thread-a", "term-3", snapshot);
+
+      vi.advanceTimersByTime(499);
+      expect(notifications).toBe(0);
+      vi.advanceTimersByTime(1);
+      expect(notifications).toBe(1);
       unsubscribe();
     } finally {
       vi.useRealTimers();

--- a/apps/web/src/lib/terminalPendingPanelCloses.ts
+++ b/apps/web/src/lib/terminalPendingPanelCloses.ts
@@ -87,7 +87,7 @@ export function recordPendingPanelClose(
   const pending = pendingByThreadKey.get(threadKey) ?? new Map<string, PendingPanelClose>();
   pending.set(terminalId, { snapshot, readyAt: now + SETTLE_GRACE_MS });
   pendingByThreadKey.set(threadKey, pending);
-  scheduleNotification(threadKey, pending, SETTLE_GRACE_MS);
+  scheduleNotification(threadKey, pending);
 }
 
 /**

--- a/apps/web/src/lib/terminalPendingPanelCloses.ts
+++ b/apps/web/src/lib/terminalPendingPanelCloses.ts
@@ -1,0 +1,144 @@
+import type { TerminalSurfaceSnapshot } from "../rightPanelStore";
+
+/**
+ * Right-panel closes whose outcome the server has not confirmed yet.
+ *
+ * An interrupted close is not evidence that the session survived or ended.
+ * Holding the pre-close snapshot until fresh metadata settles the outcome
+ * prevents both a dead pane being resurrected and a live pane being adopted by
+ * the drawer in the wrong layout.
+ */
+interface PendingPanelClose {
+  readonly snapshot: TerminalSurfaceSnapshot;
+  readonly readyAt: number;
+}
+
+const SETTLE_GRACE_MS = 1_500;
+const pendingByThreadKey = new Map<string, Map<string, PendingPanelClose>>();
+const timersByThreadKey = new Map<string, ReturnType<typeof setTimeout>>();
+
+let version = 0;
+const listeners = new Set<() => void>();
+
+function notifyPendingPanelCloses(): void {
+  version += 1;
+  listeners.forEach((listener) => listener());
+}
+
+function clearTimer(threadKey: string): void {
+  const timer = timersByThreadKey.get(threadKey);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  timersByThreadKey.delete(threadKey);
+}
+
+function earliestReadyAt(pending: Map<string, PendingPanelClose>): number {
+  let readyAt = Number.POSITIVE_INFINITY;
+  for (const entry of pending.values()) {
+    readyAt = Math.min(readyAt, entry.readyAt);
+  }
+  return readyAt;
+}
+
+function scheduleNotification(
+  threadKey: string,
+  pending: Map<string, PendingPanelClose>,
+  delayMs?: number,
+): void {
+  clearTimer(threadKey);
+  const nextReadyAt = earliestReadyAt(pending);
+  timersByThreadKey.set(
+    threadKey,
+    setTimeout(
+      () => {
+        timersByThreadKey.delete(threadKey);
+        if (pendingByThreadKey.get(threadKey) === pending) {
+          notifyPendingPanelCloses();
+          if (pending.size > 0) {
+            const nextReadyAt = earliestReadyAt(pending);
+            if (nextReadyAt > Date.now()) {
+              scheduleNotification(threadKey, pending, nextReadyAt - Date.now());
+            }
+          }
+        }
+      },
+      delayMs ?? Math.max(0, nextReadyAt - Date.now()),
+    ),
+  );
+}
+
+export function subscribePendingPanelCloses(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function pendingPanelCloseVersion(): number {
+  return version;
+}
+
+export function recordPendingPanelClose(
+  threadKey: string,
+  terminalId: string,
+  snapshot: TerminalSurfaceSnapshot,
+  now: number = Date.now(),
+): void {
+  const pending = pendingByThreadKey.get(threadKey) ?? new Map<string, PendingPanelClose>();
+  pending.set(terminalId, { snapshot, readyAt: now + SETTLE_GRACE_MS });
+  pendingByThreadKey.set(threadKey, pending);
+  scheduleNotification(threadKey, pending, SETTLE_GRACE_MS);
+}
+
+/**
+ * A newly opened session with the same id supersedes an old interrupted close.
+ * Do not let the old snapshot restore over the new session later.
+ */
+export function clearPendingPanelClose(threadKey: string, terminalId: string): void {
+  const pending = pendingByThreadKey.get(threadKey);
+  if (!pending?.delete(terminalId)) return;
+  if (pending.size === 0) {
+    pendingByThreadKey.delete(threadKey);
+    clearTimer(threadKey);
+    return;
+  }
+  scheduleNotification(threadKey, pending);
+}
+
+/**
+ * Settles eligible entries against authoritative server metadata. Surviving
+ * sessions are returned in reverse close order so nested split closes restore
+ * their original pane order. Sessions absent from metadata are confirmed
+ * closed and are discarded.
+ */
+export function resolvePendingPanelCloses(
+  threadKey: string,
+  serverTerminalIds: readonly string[],
+  now: number = Date.now(),
+  listLoaded: boolean = serverTerminalIds.length > 0,
+): Array<{ terminalId: string; snapshot: TerminalSurfaceSnapshot }> {
+  const pending = pendingByThreadKey.get(threadKey);
+  if (!pending || !listLoaded) return [];
+
+  const serverIds = new Set(serverTerminalIds);
+  const survived: Array<{ terminalId: string; snapshot: TerminalSurfaceSnapshot }> = [];
+  for (const [terminalId, entry] of pending) {
+    if (entry.readyAt > now) continue;
+    pending.delete(terminalId);
+    if (serverIds.has(terminalId)) {
+      survived.push({ terminalId, snapshot: entry.snapshot });
+    }
+  }
+  if (pending.size === 0) {
+    pendingByThreadKey.delete(threadKey);
+    clearTimer(threadKey);
+  } else {
+    scheduleNotification(threadKey, pending);
+  }
+  return survived.toReversed();
+}
+
+export function clearPendingPanelCloses(threadKey: string): void {
+  pendingByThreadKey.delete(threadKey);
+  clearTimer(threadKey);
+}

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -18,6 +18,58 @@ beforeEach(() => {
 });
 
 describe("rightPanelStore", () => {
+  it("restores a failed split close to its original surface and pane order", () => {
+    const store = useRightPanelStore.getState();
+    store.openTerminal(refA, "term-1");
+    store.splitTerminal(refA, "terminal:term-1", "term-2", "vertical");
+    store.splitTerminal(refA, "terminal:term-1", "term-3", "vertical");
+    const snapshot = {
+      surfaceId: "terminal:term-1" as const,
+      resourceId: "term-1",
+      terminalIds: ["term-1", "term-2", "term-3"],
+      splitDirection: "vertical" as const,
+    };
+
+    store.closeTerminal(refA, "terminal:term-1", "term-2");
+    store.restoreTerminal(refA, snapshot, "term-2");
+
+    expect(selectActiveRightPanelSurface(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      id: "terminal:term-1",
+      kind: "terminal",
+      resourceId: "term-1",
+      terminalIds: ["term-1", "term-2", "term-3"],
+      activeTerminalId: "term-2",
+      splitDirection: "vertical",
+    });
+  });
+
+  it("recreates a terminal surface when a failed close removed its last pane", () => {
+    const store = useRightPanelStore.getState();
+    store.openTerminal(refA, "term-1");
+    const snapshot = {
+      surfaceId: "terminal:term-1" as const,
+      resourceId: "term-1",
+      terminalIds: ["term-1"],
+    };
+
+    store.closeTerminal(refA, "terminal:term-1", "term-1");
+    store.restoreTerminal(refA, snapshot, "term-1");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: true,
+      activeSurfaceId: "terminal:term-1",
+      surfaces: [
+        {
+          id: "terminal:term-1",
+          kind: "terminal",
+          resourceId: "term-1",
+          terminalIds: ["term-1"],
+          activeTerminalId: "term-1",
+        },
+      ],
+    });
+  });
+
   it("drops the legacy singleton terminal surface during migration", () => {
     expect(
       migratePersistedRightPanelState({

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -26,6 +26,7 @@ describe("rightPanelStore", () => {
     const snapshot = {
       surfaceId: "terminal:term-1" as const,
       resourceId: "term-1",
+      surfaceIndex: 0,
       terminalIds: ["term-1", "term-2", "term-3"],
       splitDirection: "vertical" as const,
     };
@@ -49,6 +50,7 @@ describe("rightPanelStore", () => {
     const snapshot = {
       surfaceId: "terminal:term-1" as const,
       resourceId: "term-1",
+      surfaceIndex: 0,
       terminalIds: ["term-1"],
     };
 
@@ -68,6 +70,66 @@ describe("rightPanelStore", () => {
         },
       ],
     });
+  });
+
+  it("preserves pane order when concurrent failed closes resolve out of order", () => {
+    const store = useRightPanelStore.getState();
+    store.openTerminal(refA, "term-a");
+    store.splitTerminal(refA, "terminal:term-a", "term-b");
+    store.splitTerminal(refA, "terminal:term-a", "term-c");
+
+    const firstCloseSnapshot = {
+      surfaceId: "terminal:term-a" as const,
+      resourceId: "term-a",
+      surfaceIndex: 0,
+      terminalIds: ["term-a", "term-b", "term-c"],
+    };
+    store.closeTerminal(refA, "terminal:term-a", "term-b");
+
+    const secondCloseSnapshot = {
+      surfaceId: "terminal:term-a" as const,
+      resourceId: "term-a",
+      surfaceIndex: 0,
+      terminalIds: ["term-a", "term-c"],
+    };
+    store.closeTerminal(refA, "terminal:term-a", "term-a");
+
+    store.restoreTerminal(refA, firstCloseSnapshot, "term-b");
+    store.restoreTerminal(refA, secondCloseSnapshot, "term-a");
+
+    expect(
+      selectActiveRightPanelSurface(useRightPanelStore.getState().byThreadKey, refA),
+    ).toMatchObject({ terminalIds: ["term-a", "term-b", "term-c"] });
+  });
+
+  it("restores a removed terminal surface to its original surface position", () => {
+    const store = useRightPanelStore.getState();
+    store.open(refA, "plan");
+    store.openTerminal(refA, "term-1");
+    store.open(refA, "files");
+    const snapshot = {
+      surfaceId: "terminal:term-1" as const,
+      resourceId: "term-1",
+      surfaceIndex: 1,
+      terminalIds: ["term-1"],
+    };
+
+    store.closeTerminal(refA, "terminal:term-1", "term-1");
+    store.restoreTerminal(refA, snapshot, "term-1");
+
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA).surfaces,
+    ).toEqual([
+      { id: "plan", kind: "plan" },
+      {
+        id: "terminal:term-1",
+        kind: "terminal",
+        resourceId: "term-1",
+        terminalIds: ["term-1"],
+        activeTerminalId: "term-1",
+      },
+      { id: "files", kind: "files" },
+    ]);
   });
 
   it("drops the legacy singleton terminal surface during migration", () => {

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -43,6 +43,7 @@ export type RightPanelSurface =
 export interface TerminalSurfaceSnapshot {
   surfaceId: `terminal:${string}`;
   resourceId: string;
+  surfaceIndex: number;
   terminalIds: string[];
   splitDirection?: "horizontal" | "vertical";
 }
@@ -137,13 +138,75 @@ const upsertSurface = (
   current: ThreadRightPanelState,
   surface: RightPanelSurface,
   activate = true,
+  insertAt?: number,
 ): ThreadRightPanelState => ({
   isOpen: true,
   surfaces: current.surfaces.some((entry) => entry.id === surface.id)
     ? current.surfaces
-    : [...current.surfaces, surface],
+    : (() => {
+        const surfaces = [...current.surfaces];
+        const index =
+          insertAt === undefined
+            ? surfaces.length
+            : Math.max(0, Math.min(Math.trunc(insertAt), surfaces.length));
+        surfaces.splice(index, 0, surface);
+        return surfaces;
+      })(),
   activeSurfaceId: activate ? surface.id : current.activeSurfaceId,
 });
+
+function insertTerminalAtSnapshotPosition(
+  currentTerminalIds: readonly string[],
+  snapshotTerminalIds: readonly string[],
+  terminalId: string,
+): string[] {
+  if (currentTerminalIds.includes(terminalId)) {
+    return [...currentTerminalIds];
+  }
+
+  const snapshotIndex = snapshotTerminalIds.indexOf(terminalId);
+  if (snapshotIndex < 0) {
+    return [...currentTerminalIds, terminalId];
+  }
+
+  // Keep the current order of terminals restored by other in-flight closes;
+  // only insert the missing terminal at the closest position described by its
+  // own pre-close snapshot.
+  if (snapshotIndex === 0) {
+    return [terminalId, ...currentTerminalIds];
+  }
+  for (let index = snapshotIndex - 1; index >= 0; index -= 1) {
+    const previousTerminalId = snapshotTerminalIds[index];
+    if (previousTerminalId === undefined) continue;
+    const previousIndex = currentTerminalIds.indexOf(previousTerminalId);
+    if (previousIndex >= 0) {
+      return [
+        ...currentTerminalIds.slice(0, previousIndex + 1),
+        terminalId,
+        ...currentTerminalIds.slice(previousIndex + 1),
+      ];
+    }
+  }
+  for (let index = snapshotIndex + 1; index < snapshotTerminalIds.length; index += 1) {
+    const nextTerminalId = snapshotTerminalIds[index];
+    if (nextTerminalId === undefined) continue;
+    const nextIndex = currentTerminalIds.indexOf(nextTerminalId);
+    if (nextIndex >= 0) {
+      return [
+        ...currentTerminalIds.slice(0, nextIndex),
+        terminalId,
+        ...currentTerminalIds.slice(nextIndex),
+      ];
+    }
+  }
+
+  const insertAt = Math.min(snapshotIndex, currentTerminalIds.length);
+  return [
+    ...currentTerminalIds.slice(0, insertAt),
+    terminalId,
+    ...currentTerminalIds.slice(insertAt),
+  ];
+}
 
 const updateThread = (
   byThreadKey: Record<string, ThreadRightPanelState>,
@@ -313,29 +376,29 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
                 surface.id === snapshot.surfaceId && surface.kind === "terminal",
             );
             if (!existing) {
-              return upsertSurface(current, {
-                id: snapshot.surfaceId,
-                kind: "terminal",
-                resourceId: snapshot.resourceId,
-                terminalIds: [terminalId],
-                activeTerminalId: terminalId,
-                ...(snapshot.splitDirection === "vertical"
-                  ? { splitDirection: "vertical" as const }
-                  : {}),
-              });
+              return upsertSurface(
+                current,
+                {
+                  id: snapshot.surfaceId,
+                  kind: "terminal",
+                  resourceId: snapshot.resourceId,
+                  terminalIds: [terminalId],
+                  activeTerminalId: terminalId,
+                  ...(snapshot.splitDirection === "vertical"
+                    ? { splitDirection: "vertical" as const }
+                    : {}),
+                },
+                true,
+                snapshot.surfaceIndex,
+              );
             }
 
             const existingTerminalIds = [...existing.terminalIds];
-            const snapshotTerminalIdSet = new Set(snapshot.terminalIds);
-            const terminalIds = [
-              ...snapshot.terminalIds.filter(
-                (id) => id === terminalId || existingTerminalIds.includes(id),
-              ),
-              ...existingTerminalIds.filter((id) => !snapshotTerminalIdSet.has(id)),
-            ];
-            if (!terminalIds.includes(terminalId)) {
-              terminalIds.push(terminalId);
-            }
+            const terminalIds = insertTerminalAtSnapshotPosition(
+              existingTerminalIds,
+              snapshot.terminalIds,
+              terminalId,
+            );
 
             return {
               ...current,

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -39,6 +39,14 @@ export type RightPanelSurface =
     }
   | { id: "plan"; kind: "plan" };
 
+/** Pre-close shape of a terminal surface, captured for an optimistic rollback. */
+export interface TerminalSurfaceSnapshot {
+  surfaceId: `terminal:${string}`;
+  resourceId: string;
+  terminalIds: string[];
+  splitDirection?: "horizontal" | "vertical";
+}
+
 const RIGHT_PANEL_STORAGE_KEY = "t3code:right-panel-state:v2";
 const RIGHT_PANEL_STORAGE_VERSION = 7;
 
@@ -54,6 +62,11 @@ interface RightPanelStoreState {
   openBrowser: (ref: ScopedThreadRef, tabId: string | null) => void;
   openFile: (ref: ScopedThreadRef, relativePath: string, line?: number) => void;
   openTerminal: (ref: ScopedThreadRef, terminalId: string) => void;
+  restoreTerminal: (
+    ref: ScopedThreadRef,
+    snapshot: TerminalSurfaceSnapshot,
+    terminalId: string,
+  ) => void;
   splitTerminal: (
     ref: ScopedThreadRef,
     surfaceId: string,
@@ -291,6 +304,61 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
             upsertSurface(current, terminalSurface(terminalId)),
           ),
+        })),
+      restoreTerminal: (ref, snapshot, terminalId) =>
+        set((state) => ({
+          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+            const existing = current.surfaces.find(
+              (surface): surface is Extract<RightPanelSurface, { kind: "terminal" }> =>
+                surface.id === snapshot.surfaceId && surface.kind === "terminal",
+            );
+            if (!existing) {
+              return upsertSurface(current, {
+                id: snapshot.surfaceId,
+                kind: "terminal",
+                resourceId: snapshot.resourceId,
+                terminalIds: [terminalId],
+                activeTerminalId: terminalId,
+                ...(snapshot.splitDirection === "vertical"
+                  ? { splitDirection: "vertical" as const }
+                  : {}),
+              });
+            }
+
+            const existingTerminalIds = [...existing.terminalIds];
+            const snapshotTerminalIdSet = new Set(snapshot.terminalIds);
+            const terminalIds = [
+              ...snapshot.terminalIds.filter(
+                (id) => id === terminalId || existingTerminalIds.includes(id),
+              ),
+              ...existingTerminalIds.filter((id) => !snapshotTerminalIdSet.has(id)),
+            ];
+            if (!terminalIds.includes(terminalId)) {
+              terminalIds.push(terminalId);
+            }
+
+            return {
+              ...current,
+              isOpen: true,
+              activeSurfaceId: snapshot.surfaceId,
+              surfaces: current.surfaces.map((surface) => {
+                if (surface.id !== snapshot.surfaceId || surface.kind !== "terminal") {
+                  return surface;
+                }
+                const restoredSurface = {
+                  ...surface,
+                  terminalIds,
+                  activeTerminalId: terminalId,
+                };
+                if (snapshot.splitDirection === "vertical") {
+                  restoredSurface.splitDirection = "vertical";
+                } else {
+                  delete restoredSurface.splitDirection;
+                }
+                return restoredSurface;
+              }),
+            };
+          }),
         })),
       splitTerminal: (ref, surfaceId, terminalId, direction = "horizontal") =>
         set((state) => ({

--- a/apps/web/src/state/terminalSessions.ts
+++ b/apps/web/src/state/terminalSessions.ts
@@ -48,6 +48,22 @@ export function useAttachedTerminalSession(input: {
   }, [attach.data, attach.error, input.environmentId, input.terminal, metadata.data]);
 }
 
+/**
+ * Whether terminal metadata has loaded at least once. An empty loaded list is
+ * authoritative; an empty list before the first response is not.
+ */
+export function useTerminalMetadataLoaded(environmentId: EnvironmentId | null): boolean {
+  const metadata = useEnvironmentQuery(
+    environmentId === null
+      ? null
+      : terminalEnvironment.metadata({
+          environmentId,
+          input: null,
+        }),
+  );
+  return metadata.data !== null;
+}
+
 export function useKnownTerminalSessions(input: {
   readonly environmentId: EnvironmentId | null;
   readonly threadId: ThreadId | null;

--- a/apps/web/src/terminalUiStateStore.test.ts
+++ b/apps/web/src/terminalUiStateStore.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import {
   migratePersistedTerminalUiStateStoreState,
+  reconcilableServerTerminalIds,
   selectThreadTerminalUiState,
   useTerminalUiStateStore,
 } from "./terminalUiStateStore";
@@ -13,12 +14,68 @@ const THREAD_ID = ThreadId.make("thread-1");
 const THREAD_REF = scopeThreadRef("environment-a" as never, THREAD_ID);
 const OTHER_THREAD_REF = scopeThreadRef("environment-b" as never, THREAD_ID);
 
+describe("reconcilableServerTerminalIds", () => {
+  it("keeps pending opens while server metadata catches up", () => {
+    expect(
+      reconcilableServerTerminalIds(
+        ["terminal-1"],
+        ["terminal-1", "terminal-2"],
+        [],
+        ["terminal-2"],
+      ),
+    ).toBeNull();
+  });
+
+  it("merges unknown server sessions without dropping a pending split", () => {
+    expect(
+      reconcilableServerTerminalIds(
+        ["terminal-1", "terminal-3"],
+        ["terminal-1", "terminal-2"],
+        [],
+        ["terminal-2"],
+      ),
+    ).toEqual(["terminal-1", "terminal-2", "terminal-3"]);
+  });
+
+  it("removes confirmed server-side closures", () => {
+    expect(
+      reconcilableServerTerminalIds(
+        ["terminal-1", "terminal-3"],
+        ["terminal-1", "terminal-2"],
+        [],
+        [],
+      ),
+    ).toEqual(["terminal-1", "terminal-3"]);
+  });
+
+  it("does not clear populated state from an unloaded empty response", () => {
+    expect(reconcilableServerTerminalIds([], ["terminal-1"], [], [])).toBeNull();
+  });
+
+  it("clears confirmed state from an authoritative empty response", () => {
+    expect(reconcilableServerTerminalIds([], ["terminal-1"], [], [], true)).toEqual([]);
+    expect(reconcilableServerTerminalIds([], ["terminal-2"], [], ["terminal-2"], true)).toBeNull();
+  });
+
+  it("filters suppressed stale sessions from both sides of a merge", () => {
+    expect(
+      reconcilableServerTerminalIds(
+        ["terminal-1", "terminal-stale", "terminal-3"],
+        ["terminal-1", "terminal-2", "terminal-stale"],
+        ["terminal-stale"],
+        ["terminal-2"],
+      ),
+    ).toEqual(["terminal-1", "terminal-2", "terminal-3"]);
+  });
+});
+
 describe("terminalUiStateStore actions", () => {
   beforeEach(() => {
     useTerminalUiStateStore.persist.clearStorage();
     useTerminalUiStateStore.setState({
       terminalUiStateByThreadKey: {},
       suppressedTerminalIdsByThreadKey: {},
+      pendingTerminalIdsByThreadKey: {},
     });
   });
 
@@ -243,6 +300,67 @@ describe("terminalUiStateStore actions", () => {
     expect(terminalUiState.terminalGroups).toEqual([
       { id: "group-terminal-2", terminalIds: ["terminal-2"] },
     ]);
+  });
+
+  it("rolls back a failed drawer close", () => {
+    const store = useTerminalUiStateStore.getState();
+    store.setTerminalOpen(THREAD_REF, true);
+    store.splitTerminal(THREAD_REF, "terminal-2");
+    store.closeTerminal(THREAD_REF, "terminal-2");
+
+    store.unsuppressTerminal(THREAD_REF, "terminal-2");
+    store.reconcileTerminalIds(THREAD_REF, [DEFAULT_THREAD_TERMINAL_ID, "terminal-2"]);
+
+    expect(
+      selectThreadTerminalUiState(
+        useTerminalUiStateStore.getState().terminalUiStateByThreadKey,
+        THREAD_REF,
+      ).terminalIds,
+    ).toEqual([DEFAULT_THREAD_TERMINAL_ID, "terminal-2"]);
+  });
+
+  it("preserves a pending split until it is confirmed, then removes a later closure", () => {
+    const store = useTerminalUiStateStore.getState();
+    store.setTerminalOpen(THREAD_REF, true);
+    store.splitTerminal(THREAD_REF, "terminal-2");
+
+    store.reconcileTerminalIds(THREAD_REF, [DEFAULT_THREAD_TERMINAL_ID]);
+    expect(
+      selectThreadTerminalUiState(
+        useTerminalUiStateStore.getState().terminalUiStateByThreadKey,
+        THREAD_REF,
+      ).terminalIds,
+    ).toEqual([DEFAULT_THREAD_TERMINAL_ID, "terminal-2"]);
+
+    store.reconcileTerminalIds(THREAD_REF, [DEFAULT_THREAD_TERMINAL_ID, "terminal-2"]);
+    store.reconcileTerminalIds(THREAD_REF, [DEFAULT_THREAD_TERMINAL_ID]);
+    expect(
+      selectThreadTerminalUiState(
+        useTerminalUiStateStore.getState().terminalUiStateByThreadKey,
+        THREAD_REF,
+      ).terminalIds,
+    ).toEqual([DEFAULT_THREAD_TERMINAL_ID]);
+  });
+
+  it("abandons a failed pending open without leaving a phantom tab", () => {
+    const store = useTerminalUiStateStore.getState();
+    store.setTerminalOpen(THREAD_REF, true);
+    store.splitTerminal(THREAD_REF, "terminal-2");
+    store.abandonPendingTerminal(THREAD_REF, "terminal-2");
+
+    expect(
+      selectThreadTerminalUiState(
+        useTerminalUiStateStore.getState().terminalUiStateByThreadKey,
+        THREAD_REF,
+      ).terminalIds,
+    ).toEqual([DEFAULT_THREAD_TERMINAL_ID]);
+    const threadKey = scopedThreadKey(THREAD_REF);
+    expect(
+      useTerminalUiStateStore.getState().pendingTerminalIdsByThreadKey[threadKey] ?? [],
+    ).not.toContain("terminal-2");
+    expect(
+      useTerminalUiStateStore.getState().suppressedTerminalIdsByThreadKey[threadKey] ?? [],
+    ).not.toContain("terminal-2");
   });
 
   it("reconciles terminal ids from an external ordered list", () => {

--- a/apps/web/src/terminalUiStateStore.test.ts
+++ b/apps/web/src/terminalUiStateStore.test.ts
@@ -1,9 +1,10 @@
 import { scopeThreadRef, scopedThreadKey } from "@t3tools/client-runtime/environment";
 import { ThreadId } from "@t3tools/contracts";
-import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   migratePersistedTerminalUiStateStoreState,
+  PENDING_TERMINAL_OPEN_TIMEOUT_MS,
   reconcilableServerTerminalIds,
   selectThreadTerminalUiState,
   useTerminalUiStateStore,
@@ -76,6 +77,7 @@ describe("terminalUiStateStore actions", () => {
       terminalUiStateByThreadKey: {},
       suppressedTerminalIdsByThreadKey: {},
       pendingTerminalIdsByThreadKey: {},
+      pendingTerminalExpiryByThreadKey: {},
     });
   });
 
@@ -361,6 +363,31 @@ describe("terminalUiStateStore actions", () => {
     expect(
       useTerminalUiStateStore.getState().suppressedTerminalIdsByThreadKey[threadKey] ?? [],
     ).not.toContain("terminal-2");
+  });
+
+  it("expires an unobserved pending terminal after authoritative metadata settles", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      const store = useTerminalUiStateStore.getState();
+      store.setTerminalOpen(THREAD_REF, true);
+      store.splitTerminal(THREAD_REF, "terminal-2");
+
+      now.mockReturnValue(1_000 + PENDING_TERMINAL_OPEN_TIMEOUT_MS + 1);
+      store.reconcileTerminalIds(THREAD_REF, [DEFAULT_THREAD_TERMINAL_ID], true);
+
+      const threadKey = scopedThreadKey(THREAD_REF);
+      expect(
+        selectThreadTerminalUiState(
+          useTerminalUiStateStore.getState().terminalUiStateByThreadKey,
+          THREAD_REF,
+        ).terminalIds,
+      ).toEqual([DEFAULT_THREAD_TERMINAL_ID]);
+      expect(
+        useTerminalUiStateStore.getState().pendingTerminalIdsByThreadKey[threadKey] ?? [],
+      ).toEqual([]);
+    } finally {
+      now.mockRestore();
+    }
   });
 
   it("reconciles terminal ids from an external ordered list", () => {

--- a/apps/web/src/terminalUiStateStore.test.ts
+++ b/apps/web/src/terminalUiStateStore.test.ts
@@ -390,6 +390,28 @@ describe("terminalUiStateStore actions", () => {
     }
   });
 
+  it("restores a pending drawer terminal after a failed close", () => {
+    const store = useTerminalUiStateStore.getState();
+    store.setTerminalOpen(THREAD_REF, true);
+    store.splitTerminal(THREAD_REF, "terminal-2");
+    store.closeTerminal(THREAD_REF, "terminal-2");
+    store.restorePendingTerminal(THREAD_REF, "terminal-2");
+
+    const threadKey = scopedThreadKey(THREAD_REF);
+    expect(
+      selectThreadTerminalUiState(
+        useTerminalUiStateStore.getState().terminalUiStateByThreadKey,
+        THREAD_REF,
+      ).terminalIds,
+    ).toEqual([DEFAULT_THREAD_TERMINAL_ID, "terminal-2"]);
+    expect(
+      useTerminalUiStateStore.getState().pendingTerminalIdsByThreadKey[threadKey] ?? [],
+    ).toContain("terminal-2");
+    expect(
+      useTerminalUiStateStore.getState().suppressedTerminalIdsByThreadKey[threadKey] ?? [],
+    ).not.toContain("terminal-2");
+  });
+
   it("reconciles terminal ids from an external ordered list", () => {
     const store = useTerminalUiStateStore.getState();
     store.setTerminalOpen(THREAD_REF, true);

--- a/apps/web/src/terminalUiStateStore.ts
+++ b/apps/web/src/terminalUiStateStore.ts
@@ -10,6 +10,7 @@ import { type ScopedThreadRef } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { resolveStorage } from "./lib/storage";
+import { clearPendingPanelCloses } from "./lib/terminalPendingPanelCloses";
 import {
   DEFAULT_THREAD_TERMINAL_HEIGHT,
   DEFAULT_THREAD_TERMINAL_ID,
@@ -141,7 +142,7 @@ function normalizeTerminalGroups(
   return nextGroups;
 }
 
-function arraysEqual(a: string[], b: string[]): boolean {
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
   if (a.length !== b.length) return false;
   for (let index = 0; index < a.length; index += 1) {
     if (a[index] !== b[index]) return false;
@@ -489,6 +490,50 @@ export function selectThreadTerminalUiState(
   );
 }
 
+/**
+ * Computes the server ids that can safely reconcile a client surface.
+ *
+ * A client-only id is ambiguous while an optimistic open is catching up: it
+ * may be a fresh local split or a session that ended remotely. Pending ids are
+ * kept until the server confirms them; every other client-only id is removed.
+ * Suppressed ids are excluded from the server side so stale close metadata
+ * cannot resurrect them.
+ *
+ * An empty response is non-authoritative until metadata has loaded. Once a
+ * loaded empty response is known to be real, only still-pending local opens
+ * survive it.
+ */
+export function reconcilableServerTerminalIds(
+  serverTerminalIds: readonly string[],
+  clientTerminalIds: readonly string[],
+  suppressedTerminalIds: readonly string[],
+  pendingTerminalIds: readonly string[],
+  metadataLoaded = false,
+): string[] | null {
+  const suppressed = new Set(suppressedTerminalIds);
+  const pending = new Set(pendingTerminalIds);
+  const visibleServerIds = serverTerminalIds.filter((terminalId) => !suppressed.has(terminalId));
+
+  if (visibleServerIds.length === 0) {
+    if (!metadataLoaded) return null;
+    const nextTerminalIds = clientTerminalIds.filter(
+      (terminalId) => !suppressed.has(terminalId) && pending.has(terminalId),
+    );
+    return arraysEqual(nextTerminalIds, clientTerminalIds) ? null : nextTerminalIds;
+  }
+
+  const visibleServerIdSet = new Set(visibleServerIds);
+  const clientIdSet = new Set(clientTerminalIds);
+  const keptClientIds = clientTerminalIds.filter(
+    (terminalId) =>
+      !suppressed.has(terminalId) &&
+      (visibleServerIdSet.has(terminalId) || pending.has(terminalId)),
+  );
+  const unknownServerIds = visibleServerIds.filter((terminalId) => !clientIdSet.has(terminalId));
+  const nextTerminalIds = [...keptClientIds, ...unknownServerIds];
+  return arraysEqual(nextTerminalIds, clientTerminalIds) ? null : nextTerminalIds;
+}
+
 function updateTerminalUiStateByThreadKey(
   terminalUiStateByThreadKey: Record<string, ThreadTerminalUiState>,
   threadRef: ScopedThreadRef,
@@ -519,25 +564,26 @@ function updateTerminalUiStateByThreadKey(
   };
 }
 
-function updateSuppressedTerminalId(
-  suppressedTerminalIdsByThreadKey: Record<string, string[]>,
+/** Adds or removes one terminal id from a per-thread membership set. */
+function updateThreadTerminalIdSet(
+  idsByThreadKey: Record<string, string[]>,
   threadRef: ScopedThreadRef,
   terminalId: string,
-  suppressed: boolean,
+  member: boolean,
 ): Record<string, string[]> {
   const normalizedTerminalId = terminalId.trim();
   if (normalizedTerminalId.length === 0) {
-    return suppressedTerminalIdsByThreadKey;
+    return idsByThreadKey;
   }
   const threadKey = terminalThreadKey(threadRef);
-  const currentIds = suppressedTerminalIdsByThreadKey[threadKey] ?? [];
-  const currentlySuppressed = currentIds.includes(normalizedTerminalId);
-  if (currentlySuppressed === suppressed) {
-    return suppressedTerminalIdsByThreadKey;
+  const currentIds = idsByThreadKey[threadKey] ?? [];
+  const currentlyMember = currentIds.includes(normalizedTerminalId);
+  if (currentlyMember === member) {
+    return idsByThreadKey;
   }
-  if (suppressed) {
+  if (member) {
     return {
-      ...suppressedTerminalIdsByThreadKey,
+      ...idsByThreadKey,
       [threadKey]: [...currentIds, normalizedTerminalId],
     };
   }
@@ -545,11 +591,11 @@ function updateSuppressedTerminalId(
   const remainingIds = currentIds.filter((id) => id !== normalizedTerminalId);
   if (remainingIds.length > 0) {
     return {
-      ...suppressedTerminalIdsByThreadKey,
+      ...idsByThreadKey,
       [threadKey]: remainingIds,
     };
   }
-  return removeRecordEntry(suppressedTerminalIdsByThreadKey, threadKey);
+  return removeRecordEntry(idsByThreadKey, threadKey);
 }
 
 function removeRecordEntry<T>(record: Record<string, T>, key: string): Record<string, T> {
@@ -564,6 +610,8 @@ interface TerminalUiStateStoreState {
   terminalUiStateByThreadKey: Record<string, ThreadTerminalUiState>;
   /** Closed ids hidden from stale server metadata until that id is explicitly opened again. */
   suppressedTerminalIdsByThreadKey: Record<string, string[]>;
+  /** Locally opened ids not yet confirmed by server metadata. */
+  pendingTerminalIdsByThreadKey: Record<string, string[]>;
   setTerminalOpen: (threadRef: ScopedThreadRef, open: boolean) => void;
   setTerminalHeight: (threadRef: ScopedThreadRef, height: number) => void;
   splitTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
@@ -576,7 +624,13 @@ interface TerminalUiStateStoreState {
   ) => void;
   setActiveTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   closeTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
-  reconcileTerminalIds: (threadRef: ScopedThreadRef, nextIds: string[]) => void;
+  unsuppressTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
+  abandonPendingTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
+  reconcileTerminalIds: (
+    threadRef: ScopedThreadRef,
+    nextIds: string[],
+    metadataLoaded?: boolean,
+  ) => void;
   clearTerminalUiState: (threadRef: ScopedThreadRef) => void;
   removeTerminalUiState: (threadRef: ScopedThreadRef) => void;
   removeOrphanedTerminalUiStates: (activeThreadKeys: Set<string>) => void;
@@ -591,7 +645,7 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
           state: ThreadTerminalUiState,
           suppressedTerminalIds: readonly string[],
         ) => ThreadTerminalUiState,
-        suppression?: { terminalId: string; suppressed: boolean },
+        membership?: { terminalId: string; suppressed: boolean; pending?: boolean },
       ) => {
         set((state) => {
           const threadKey = terminalThreadKey(threadRef);
@@ -601,21 +655,32 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             threadRef,
             (terminalState) => updater(terminalState, suppressedTerminalIds),
           );
-          const nextSuppressedTerminalIdsByThreadKey = suppression
-            ? updateSuppressedTerminalId(
+          const nextSuppressedTerminalIdsByThreadKey = membership
+            ? updateThreadTerminalIdSet(
                 state.suppressedTerminalIdsByThreadKey,
                 threadRef,
-                suppression.terminalId,
-                suppression.suppressed,
+                membership.terminalId,
+                membership.suppressed,
               )
             : state.suppressedTerminalIdsByThreadKey;
+          const nextPendingTerminalIdsByThreadKey =
+            membership?.pending === undefined
+              ? state.pendingTerminalIdsByThreadKey
+              : updateThreadTerminalIdSet(
+                  state.pendingTerminalIdsByThreadKey,
+                  threadRef,
+                  membership.terminalId,
+                  membership.pending,
+                );
           if (
             nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
-            nextSuppressedTerminalIdsByThreadKey === state.suppressedTerminalIdsByThreadKey
+            nextSuppressedTerminalIdsByThreadKey === state.suppressedTerminalIdsByThreadKey &&
+            nextPendingTerminalIdsByThreadKey === state.pendingTerminalIdsByThreadKey
           ) {
             return state;
           }
           return {
+            pendingTerminalIdsByThreadKey: nextPendingTerminalIdsByThreadKey,
             terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
             suppressedTerminalIdsByThreadKey: nextSuppressedTerminalIdsByThreadKey,
           };
@@ -625,6 +690,7 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
       return {
         terminalUiStateByThreadKey: {},
         suppressedTerminalIdsByThreadKey: {},
+        pendingTerminalIdsByThreadKey: {},
         setTerminalOpen: (threadRef, open) => {
           const terminalState = selectThreadTerminalUiState(
             get().terminalUiStateByThreadKey,
@@ -644,16 +710,19 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
           updateTerminal(threadRef, (state) => splitThreadTerminal(state, terminalId), {
             terminalId,
             suppressed: false,
+            pending: true,
           }),
         splitTerminalVertical: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => splitThreadTerminal(state, terminalId, "vertical"), {
             terminalId,
             suppressed: false,
+            pending: true,
           }),
         newTerminal: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => newThreadTerminal(state, terminalId), {
             terminalId,
             suppressed: false,
+            pending: true,
           }),
         ensureTerminal: (threadRef, terminalId, options) =>
           updateTerminal(
@@ -678,7 +747,7 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
               }
               return normalizeThreadTerminalUiState(nextState);
             },
-            { terminalId, suppressed: false },
+            { terminalId, suppressed: false, pending: true },
           ),
         setActiveTerminal: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => setThreadActiveTerminal(state, terminalId)),
@@ -686,19 +755,70 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
           updateTerminal(threadRef, (state) => closeThreadTerminal(state, terminalId), {
             terminalId,
             suppressed: true,
+            pending: false,
           }),
-        reconcileTerminalIds: (threadRef, nextIds) =>
-          updateTerminal(threadRef, (state, suppressedTerminalIds) => {
-            if (suppressedTerminalIds.length === 0) {
-              return reconcileThreadTerminalSessionIds(state, nextIds);
-            }
-            const suppressedIds = new Set(suppressedTerminalIds);
-            return reconcileThreadTerminalSessionIds(
-              state,
-              nextIds.filter((terminalId) => !suppressedIds.has(terminalId)),
+        unsuppressTerminal: (threadRef, terminalId) =>
+          updateTerminal(threadRef, (state) => state, {
+            terminalId,
+            suppressed: false,
+          }),
+        abandonPendingTerminal: (threadRef, terminalId) =>
+          updateTerminal(threadRef, (state) => closeThreadTerminal(state, terminalId), {
+            terminalId,
+            suppressed: false,
+            pending: false,
+          }),
+        reconcileTerminalIds: (threadRef, serverTerminalIds, metadataLoaded = false) =>
+          set((state) => {
+            const threadKey = terminalThreadKey(threadRef);
+            const suppressedTerminalIds = state.suppressedTerminalIdsByThreadKey[threadKey] ?? [];
+            const pendingTerminalIds = state.pendingTerminalIdsByThreadKey[threadKey] ?? [];
+            const serverIdSet = new Set(serverTerminalIds);
+            const remainingPendingTerminalIds = pendingTerminalIds.filter(
+              (terminalId) => !serverIdSet.has(terminalId),
             );
+            const nextPendingTerminalIdsByThreadKey =
+              remainingPendingTerminalIds.length === pendingTerminalIds.length
+                ? state.pendingTerminalIdsByThreadKey
+                : remainingPendingTerminalIds.length > 0
+                  ? {
+                      ...state.pendingTerminalIdsByThreadKey,
+                      [threadKey]: remainingPendingTerminalIds,
+                    }
+                  : removeRecordEntry(state.pendingTerminalIdsByThreadKey, threadKey);
+            const clientTerminalIds = selectThreadTerminalUiState(
+              state.terminalUiStateByThreadKey,
+              threadRef,
+            ).terminalIds;
+            const nextTerminalIds = reconcilableServerTerminalIds(
+              serverTerminalIds,
+              clientTerminalIds,
+              suppressedTerminalIds,
+              remainingPendingTerminalIds,
+              metadataLoaded,
+            );
+            const nextTerminalUiStateByThreadKey =
+              nextTerminalIds === null
+                ? state.terminalUiStateByThreadKey
+                : updateTerminalUiStateByThreadKey(
+                    state.terminalUiStateByThreadKey,
+                    threadRef,
+                    (terminalState) =>
+                      reconcileThreadTerminalSessionIds(terminalState, nextTerminalIds),
+                  );
+            if (
+              nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
+              nextPendingTerminalIdsByThreadKey === state.pendingTerminalIdsByThreadKey
+            ) {
+              return state;
+            }
+            return {
+              terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
+              pendingTerminalIdsByThreadKey: nextPendingTerminalIdsByThreadKey,
+            };
           }),
-        clearTerminalUiState: (threadRef) =>
+        clearTerminalUiState: (threadRef) => {
+          clearPendingPanelCloses(terminalThreadKey(threadRef));
           set((state) => {
             const threadKey = terminalThreadKey(threadRef);
             const nextTerminalUiStateByThreadKey = updateTerminalUiStateByThreadKey(
@@ -708,9 +828,12 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             );
             const hadSuppressedTerminalIds =
               state.suppressedTerminalIdsByThreadKey[threadKey] !== undefined;
+            const hadPendingTerminalIds =
+              state.pendingTerminalIdsByThreadKey[threadKey] !== undefined;
             if (
               nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
-              !hadSuppressedTerminalIds
+              !hadSuppressedTerminalIds &&
+              !hadPendingTerminalIds
             ) {
               return state;
             }
@@ -720,15 +843,23 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
                 state.suppressedTerminalIdsByThreadKey,
                 threadKey,
               ),
+              pendingTerminalIdsByThreadKey: removeRecordEntry(
+                state.pendingTerminalIdsByThreadKey,
+                threadKey,
+              ),
             };
-          }),
-        removeTerminalUiState: (threadRef) =>
+          });
+        },
+        removeTerminalUiState: (threadRef) => {
+          clearPendingPanelCloses(terminalThreadKey(threadRef));
           set((state) => {
             const threadKey = terminalThreadKey(threadRef);
             const hadTerminalUiState = state.terminalUiStateByThreadKey[threadKey] !== undefined;
             const hadSuppressedTerminalIds =
               state.suppressedTerminalIdsByThreadKey[threadKey] !== undefined;
-            if (!hadTerminalUiState && !hadSuppressedTerminalIds) {
+            const hadPendingTerminalIds =
+              state.pendingTerminalIdsByThreadKey[threadKey] !== undefined;
+            if (!hadTerminalUiState && !hadSuppressedTerminalIds && !hadPendingTerminalIds) {
               return state;
             }
             return {
@@ -740,32 +871,44 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
                 state.suppressedTerminalIdsByThreadKey,
                 threadKey,
               ),
+              pendingTerminalIdsByThreadKey: removeRecordEntry(
+                state.pendingTerminalIdsByThreadKey,
+                threadKey,
+              ),
             };
-          }),
-        removeOrphanedTerminalUiStates: (activeThreadKeys) =>
+          });
+        },
+        removeOrphanedTerminalUiStates: (activeThreadKeys) => {
+          const currentState = get();
+          const orphanedIds = new Set(
+            [
+              ...Object.keys(currentState.terminalUiStateByThreadKey),
+              ...Object.keys(currentState.suppressedTerminalIdsByThreadKey),
+              ...Object.keys(currentState.pendingTerminalIdsByThreadKey),
+            ].filter((key) => !activeThreadKeys.has(key)),
+          );
+          if (orphanedIds.size === 0) return;
+          for (const id of orphanedIds) {
+            clearPendingPanelCloses(id);
+          }
           set((state) => {
-            const orphanedIds = new Set(
-              [
-                ...Object.keys(state.terminalUiStateByThreadKey),
-                ...Object.keys(state.suppressedTerminalIdsByThreadKey),
-              ].filter((key) => !activeThreadKeys.has(key)),
-            );
-            if (orphanedIds.size === 0) {
-              return state;
-            }
             const nextTerminalUiStateByThreadKey = { ...state.terminalUiStateByThreadKey };
             const nextSuppressedTerminalIdsByThreadKey = {
               ...state.suppressedTerminalIdsByThreadKey,
             };
+            const nextPendingTerminalIdsByThreadKey = { ...state.pendingTerminalIdsByThreadKey };
             for (const id of orphanedIds) {
               delete nextTerminalUiStateByThreadKey[id];
               delete nextSuppressedTerminalIdsByThreadKey[id];
+              delete nextPendingTerminalIdsByThreadKey[id];
             }
             return {
               terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
               suppressedTerminalIdsByThreadKey: nextSuppressedTerminalIdsByThreadKey,
+              pendingTerminalIdsByThreadKey: nextPendingTerminalIdsByThreadKey,
             };
-          }),
+          });
+        },
       };
     },
     {

--- a/apps/web/src/terminalUiStateStore.ts
+++ b/apps/web/src/terminalUiStateStore.ts
@@ -659,6 +659,7 @@ interface TerminalUiStateStoreState {
   setActiveTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   closeTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   unsuppressTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
+  restorePendingTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   abandonPendingTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   reconcileTerminalIds: (
     threadRef: ScopedThreadRef,
@@ -797,17 +798,41 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
           ),
         setActiveTerminal: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => setThreadActiveTerminal(state, terminalId)),
-        closeTerminal: (threadRef, terminalId) =>
+        closeTerminal: (threadRef, terminalId) => {
+          const threadKey = terminalThreadKey(threadRef);
+          const wasPending =
+            get().pendingTerminalIdsByThreadKey[threadKey]?.includes(terminalId) ?? false;
           updateTerminal(threadRef, (state) => closeThreadTerminal(state, terminalId), {
             terminalId,
             suppressed: true,
-            pending: false,
-          }),
+            // Keep a fresh open distinguishable from a confirmed session while
+            // its close request is in flight. A failed close can then restore
+            // it even if the next metadata list is still stale.
+            pending: wasPending,
+          });
+        },
         unsuppressTerminal: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => state, {
             terminalId,
             suppressed: false,
           }),
+        restorePendingTerminal: (threadRef, terminalId) => {
+          const threadKey = terminalThreadKey(threadRef);
+          const wasPending =
+            get().pendingTerminalIdsByThreadKey[threadKey]?.includes(terminalId) ?? false;
+          updateTerminal(
+            threadRef,
+            (state) =>
+              wasPending && !state.terminalIds.includes(terminalId)
+                ? newThreadTerminal(state, terminalId)
+                : state,
+            {
+              terminalId,
+              suppressed: false,
+              pending: wasPending,
+            },
+          );
+        },
         abandonPendingTerminal: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => closeThreadTerminal(state, terminalId), {
             terminalId,

--- a/apps/web/src/terminalUiStateStore.ts
+++ b/apps/web/src/terminalUiStateStore.ts
@@ -29,6 +29,11 @@ interface ThreadTerminalUiState {
 
 // Keep the old storage key so existing drawer layout preferences migrate.
 const TERMINAL_UI_STATE_STORAGE_KEY = "t3code:terminal-state:v1";
+/**
+ * A local open survives a few stale metadata responses, but not indefinitely.
+ * This bounds the lifetime of a terminal that exits before metadata observes it.
+ */
+export const PENDING_TERMINAL_OPEN_TIMEOUT_MS = 10_000;
 
 interface PersistedTerminalUiStateStoreState {
   terminalUiStateByThreadKey?: Record<string, ThreadTerminalUiState>;
@@ -598,6 +603,34 @@ function updateThreadTerminalIdSet(
   return removeRecordEntry(idsByThreadKey, threadKey);
 }
 
+function updatePendingTerminalExpiry(
+  expiresAtByThreadKey: Record<string, Record<string, number>>,
+  threadRef: ScopedThreadRef,
+  terminalId: string,
+  pending: boolean,
+): Record<string, Record<string, number>> {
+  const normalizedTerminalId = terminalId.trim();
+  if (normalizedTerminalId.length === 0) return expiresAtByThreadKey;
+
+  const threadKey = terminalThreadKey(threadRef);
+  const current = expiresAtByThreadKey[threadKey] ?? {};
+  if (!pending) {
+    if (!(normalizedTerminalId in current)) return expiresAtByThreadKey;
+    const { [normalizedTerminalId]: _removed, ...remaining } = current;
+    return Object.keys(remaining).length > 0
+      ? { ...expiresAtByThreadKey, [threadKey]: remaining }
+      : removeRecordEntry(expiresAtByThreadKey, threadKey);
+  }
+
+  return {
+    ...expiresAtByThreadKey,
+    [threadKey]: {
+      ...current,
+      [normalizedTerminalId]: Date.now() + PENDING_TERMINAL_OPEN_TIMEOUT_MS,
+    },
+  };
+}
+
 function removeRecordEntry<T>(record: Record<string, T>, key: string): Record<string, T> {
   if (record[key] === undefined) {
     return record;
@@ -612,6 +645,7 @@ interface TerminalUiStateStoreState {
   suppressedTerminalIdsByThreadKey: Record<string, string[]>;
   /** Locally opened ids not yet confirmed by server metadata. */
   pendingTerminalIdsByThreadKey: Record<string, string[]>;
+  pendingTerminalExpiryByThreadKey: Record<string, Record<string, number>>;
   setTerminalOpen: (threadRef: ScopedThreadRef, open: boolean) => void;
   setTerminalHeight: (threadRef: ScopedThreadRef, height: number) => void;
   splitTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
@@ -672,15 +706,26 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
                   membership.terminalId,
                   membership.pending,
                 );
+          const nextPendingTerminalExpiryByThreadKey =
+            membership?.pending === undefined
+              ? state.pendingTerminalExpiryByThreadKey
+              : updatePendingTerminalExpiry(
+                  state.pendingTerminalExpiryByThreadKey,
+                  threadRef,
+                  membership.terminalId,
+                  membership.pending,
+                );
           if (
             nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
             nextSuppressedTerminalIdsByThreadKey === state.suppressedTerminalIdsByThreadKey &&
-            nextPendingTerminalIdsByThreadKey === state.pendingTerminalIdsByThreadKey
+            nextPendingTerminalIdsByThreadKey === state.pendingTerminalIdsByThreadKey &&
+            nextPendingTerminalExpiryByThreadKey === state.pendingTerminalExpiryByThreadKey
           ) {
             return state;
           }
           return {
             pendingTerminalIdsByThreadKey: nextPendingTerminalIdsByThreadKey,
+            pendingTerminalExpiryByThreadKey: nextPendingTerminalExpiryByThreadKey,
             terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
             suppressedTerminalIdsByThreadKey: nextSuppressedTerminalIdsByThreadKey,
           };
@@ -691,6 +736,7 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
         terminalUiStateByThreadKey: {},
         suppressedTerminalIdsByThreadKey: {},
         pendingTerminalIdsByThreadKey: {},
+        pendingTerminalExpiryByThreadKey: {},
         setTerminalOpen: (threadRef, open) => {
           const terminalState = selectThreadTerminalUiState(
             get().terminalUiStateByThreadKey,
@@ -773,9 +819,15 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             const threadKey = terminalThreadKey(threadRef);
             const suppressedTerminalIds = state.suppressedTerminalIdsByThreadKey[threadKey] ?? [];
             const pendingTerminalIds = state.pendingTerminalIdsByThreadKey[threadKey] ?? [];
+            const pendingTerminalExpiry = state.pendingTerminalExpiryByThreadKey[threadKey] ?? {};
             const serverIdSet = new Set(serverTerminalIds);
+            const now = Date.now();
             const remainingPendingTerminalIds = pendingTerminalIds.filter(
-              (terminalId) => !serverIdSet.has(terminalId),
+              (terminalId) =>
+                !serverIdSet.has(terminalId) &&
+                (!metadataLoaded ||
+                  (pendingTerminalExpiry[terminalId] !== undefined &&
+                    pendingTerminalExpiry[terminalId] > now)),
             );
             const nextPendingTerminalIdsByThreadKey =
               remainingPendingTerminalIds.length === pendingTerminalIds.length
@@ -786,6 +838,19 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
                       [threadKey]: remainingPendingTerminalIds,
                     }
                   : removeRecordEntry(state.pendingTerminalIdsByThreadKey, threadKey);
+            const remainingPendingTerminalExpiry = Object.fromEntries(
+              remainingPendingTerminalIds.flatMap((terminalId) => {
+                const expiresAt = pendingTerminalExpiry[terminalId];
+                return expiresAt === undefined ? [] : [[terminalId, expiresAt] as const];
+              }),
+            );
+            const nextPendingTerminalExpiryByThreadKey =
+              Object.keys(remainingPendingTerminalExpiry).length > 0
+                ? {
+                    ...state.pendingTerminalExpiryByThreadKey,
+                    [threadKey]: remainingPendingTerminalExpiry,
+                  }
+                : removeRecordEntry(state.pendingTerminalExpiryByThreadKey, threadKey);
             const clientTerminalIds = selectThreadTerminalUiState(
               state.terminalUiStateByThreadKey,
               threadRef,
@@ -808,13 +873,15 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
                   );
             if (
               nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
-              nextPendingTerminalIdsByThreadKey === state.pendingTerminalIdsByThreadKey
+              nextPendingTerminalIdsByThreadKey === state.pendingTerminalIdsByThreadKey &&
+              nextPendingTerminalExpiryByThreadKey === state.pendingTerminalExpiryByThreadKey
             ) {
               return state;
             }
             return {
               terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
               pendingTerminalIdsByThreadKey: nextPendingTerminalIdsByThreadKey,
+              pendingTerminalExpiryByThreadKey: nextPendingTerminalExpiryByThreadKey,
             };
           }),
         clearTerminalUiState: (threadRef) => {
@@ -830,10 +897,13 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
               state.suppressedTerminalIdsByThreadKey[threadKey] !== undefined;
             const hadPendingTerminalIds =
               state.pendingTerminalIdsByThreadKey[threadKey] !== undefined;
+            const hadPendingTerminalExpiry =
+              state.pendingTerminalExpiryByThreadKey[threadKey] !== undefined;
             if (
               nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
               !hadSuppressedTerminalIds &&
-              !hadPendingTerminalIds
+              !hadPendingTerminalIds &&
+              !hadPendingTerminalExpiry
             ) {
               return state;
             }
@@ -845,6 +915,10 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
               ),
               pendingTerminalIdsByThreadKey: removeRecordEntry(
                 state.pendingTerminalIdsByThreadKey,
+                threadKey,
+              ),
+              pendingTerminalExpiryByThreadKey: removeRecordEntry(
+                state.pendingTerminalExpiryByThreadKey,
                 threadKey,
               ),
             };
@@ -859,7 +933,14 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
               state.suppressedTerminalIdsByThreadKey[threadKey] !== undefined;
             const hadPendingTerminalIds =
               state.pendingTerminalIdsByThreadKey[threadKey] !== undefined;
-            if (!hadTerminalUiState && !hadSuppressedTerminalIds && !hadPendingTerminalIds) {
+            const hadPendingTerminalExpiry =
+              state.pendingTerminalExpiryByThreadKey[threadKey] !== undefined;
+            if (
+              !hadTerminalUiState &&
+              !hadSuppressedTerminalIds &&
+              !hadPendingTerminalIds &&
+              !hadPendingTerminalExpiry
+            ) {
               return state;
             }
             return {
@@ -875,6 +956,10 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
                 state.pendingTerminalIdsByThreadKey,
                 threadKey,
               ),
+              pendingTerminalExpiryByThreadKey: removeRecordEntry(
+                state.pendingTerminalExpiryByThreadKey,
+                threadKey,
+              ),
             };
           });
         },
@@ -885,6 +970,7 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
               ...Object.keys(currentState.terminalUiStateByThreadKey),
               ...Object.keys(currentState.suppressedTerminalIdsByThreadKey),
               ...Object.keys(currentState.pendingTerminalIdsByThreadKey),
+              ...Object.keys(currentState.pendingTerminalExpiryByThreadKey),
             ].filter((key) => !activeThreadKeys.has(key)),
           );
           if (orphanedIds.size === 0) return;
@@ -897,15 +983,20 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
               ...state.suppressedTerminalIdsByThreadKey,
             };
             const nextPendingTerminalIdsByThreadKey = { ...state.pendingTerminalIdsByThreadKey };
+            const nextPendingTerminalExpiryByThreadKey = {
+              ...state.pendingTerminalExpiryByThreadKey,
+            };
             for (const id of orphanedIds) {
               delete nextTerminalUiStateByThreadKey[id];
               delete nextSuppressedTerminalIdsByThreadKey[id];
               delete nextPendingTerminalIdsByThreadKey[id];
+              delete nextPendingTerminalExpiryByThreadKey[id];
             }
             return {
               terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
               suppressedTerminalIdsByThreadKey: nextSuppressedTerminalIdsByThreadKey,
               pendingTerminalIdsByThreadKey: nextPendingTerminalIdsByThreadKey,
+              pendingTerminalExpiryByThreadKey: nextPendingTerminalExpiryByThreadKey,
             };
           });
         },


### PR DESCRIPTION
## Summary

- Keep pending local terminal opens separate from suppressed/closed ids while server metadata catches up.
- Reconcile newly discovered and confirmed sessions without stale empty-list resets.
- Make open/close failure handling race-safe and restore interrupted right-panel closes to the original surface, split direction, and pane order.
- Clean transient reservations and pending snapshots on completion and thread cleanup.

## Root cause

Optimistic local terminal state was reconciled against lagging metadata as if it were authoritative. Open/close failures also did not consistently roll back UI state, and late handlers could act on a reused id.

## Validation

- `vp run --filter @t3tools/web typecheck` ✅
- `vp fmt --check` on the touched files ✅
- Targeted lint on the touched files ✅
- Focused test command attempted, but the current Vite Plus/Vitest runner failed before executing tests (`0 test`); unchanged store suites show the same runner error.
- Playwright smoke capture against an isolated T3 environment: terminal drawer open → vertical split → close → split again ✅

## Visual demo

![Real T3 terminal drawer demo](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/1fab63c0-48f3-4c81-a6d8-2bfc66876ee7/terminal-reconciliation-real.gif)

Scope is limited to terminal open/close reconciliation; resize, canvas, and shortcut changes are not included.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile terminal opens and closes to restore terminals after failed or interrupted close operations
> - Introduces a reservation system ([terminalOpenReservations.ts](https://github.com/pingdotgg/t3code/pull/5324/files#diff-e2527a6a50c205986cf667606c4643a7671f490f3fa30186b5d773c00b173c85)) to track in-flight terminal opens per thread, preventing ID collisions when multiple opens are in-flight.
> - Adds a pending panel close system ([terminalPendingPanelCloses.ts](https://github.com/pingdotgg/t3code/pull/5324/files#diff-715cf1c45e9446b17fa56e00e67a8c1cafc1c9ada02d3ead4bd812c12f08e1ab)) that records interrupted closes with a 1.5s grace period, then checks server metadata to determine whether to restore or discard the terminal.
> - Extends `useTerminalUiStateStore` to track pending terminal opens with expiry timestamps and adds `restorePendingTerminal`, `abandonPendingTerminal`, and `unsuppressTerminal` actions for managing optimistic close rollback.
> - Updates `reconcileTerminalIds` to accept terminal metadata load state so pending terminals are preserved across stale metadata and only expired after the server is authoritative.
> - Updates `ChatView` and `PersistentThreadTerminalDrawer` to use reservation and restoration flows for all split, new, open, and close terminal operations.
> - Risk: Terminal open/close flows now have more async state coordination; races between concurrent close and open operations rely on reservation tokens matching correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3316e33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large behavioral change across drawer and right-panel terminal lifecycle with async race handling; scope is UI/state only but regressions could affect split layout, script-run terminals, and panel close flows.
> 
> **Overview**
> Fixes **phantom terminal tabs**, **lost split panes**, and **ID collisions** when optimistic UI races server terminal metadata and interrupted close/open requests.
> 
> **Open path:** Per-thread **open reservations** block stale failure handlers from colliding with newer opens; failed opens **abandon** pending terminals instead of leaving suppression artifacts. Terminal ID allocation includes in-flight reserved ids. **`reconcileTerminalIds`** now treats metadata as authoritative only after load, keeps **pending** local opens across stale lists, merges unknown server sessions, filters **suppressed** closes, and expires unobserved pending opens after a timeout.
> 
> **Close path:** Drawer closes **restore** pending terminals when close/exit cannot be confirmed (including interruption). Right-panel closes record **pending panel close snapshots** (surface index, pane order, split direction); interrupted or thrown closes wait on a settle grace, then **restore** via `restoreTerminal` when metadata shows the session survived; immediate failures restore synchronously.
> 
> `ChatView` centralizes open/close orchestration; `useTerminalMetadataLoaded` distinguishes empty unloaded vs authoritative empty metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3316e332047644ffcc65ef2fea0a9b1339f7babe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->