### PR TITLE
feat(github): render pull request checks in threads

### DIFF
--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -1,6 +1,18 @@
 import * as Haptics from "expo-haptics";
 import { type AppSymbolName, SymbolView } from "../../components/AppSymbol";
-import { LayoutAnimation, Pressable, ScrollView, useColorScheme, View } from "react-native";
+import {
+  LayoutAnimation,
+  Linking,
+  Pressable,
+  ScrollView,
+  useColorScheme,
+  View,
+} from "react-native";
+import {
+  summarizeGitHubActions,
+  type GitHubActionsSnapshot,
+  type GitHubCheckBucket,
+} from "@t3tools/shared/githubActions";
 
 import { AppText as Text } from "../../components/AppText";
 import { scaledTypographyLineHeight } from "../../lib/appearancePreferences";
@@ -83,7 +95,9 @@ function isFreshRow(createdAt: string): boolean {
 export function visibleWorkLogActivities(
   activities: ReadonlyArray<ThreadFeedActivity>,
 ): ReadonlyArray<ThreadFeedActivity> {
-  return activities.filter((activity) => !(activity.toolLike && activity.status === "neutral"));
+  return activities.filter(
+    (activity) => activity.githubActions || !(activity.toolLike && activity.status === "neutral"),
+  );
 }
 
 // Pre-measurement heights for the feed's getFixedItemSize. Collapsed work-log
@@ -97,6 +111,18 @@ const WORK_ROW_HEIGHT = 32; // min-h-8
 const WORK_ROW_GAP = 1; // gap-px
 const WORK_LOG_HEADER_PADDING = 2; // pb-0.5 under the "work log" label
 const WORK_LOG_BOTTOM_MARGIN = 4; // mb-1
+const GITHUB_ACTIONS_HEADER_HEIGHT = 52;
+const GITHUB_ACTIONS_CHECK_HEIGHT = 40;
+const GITHUB_ACTIONS_MORE_HEIGHT = 32;
+
+function githubActionsCardHeight(snapshot: GitHubActionsSnapshot): number {
+  const visibleChecks = Math.max(1, Math.min(snapshot.checks.length, 6));
+  return (
+    GITHUB_ACTIONS_HEADER_HEIGHT +
+    visibleChecks * GITHUB_ACTIONS_CHECK_HEIGHT +
+    (snapshot.checks.length > visibleChecks ? GITHUB_ACTIONS_MORE_HEIGHT : 0)
+  );
+}
 
 export const WORK_GROUP_TOGGLE_HEIGHT = 36; // min-h-8 (32) + mb-1 (4)
 
@@ -114,8 +140,121 @@ export function collapsedWorkLogHeight(
   return (
     WORK_LOG_BOTTOM_MARGIN +
     (onlyToolRows ? 0 : headerHeight) +
-    rows.length * WORK_ROW_HEIGHT +
+    rows.reduce(
+      (height, row) =>
+        height + (row.githubActions ? githubActionsCardHeight(row.githubActions) : WORK_ROW_HEIGHT),
+      0,
+    ) +
     (rows.length - 1) * WORK_ROW_GAP
+  );
+}
+
+function githubActionsStatus(activity: ThreadFeedActivity): string {
+  const snapshot = activity.githubActions!;
+  const summary = summarizeGitHubActions(snapshot);
+  if (summary.total === 0) {
+    return activity.status === "neutral" ? "Watching · Waiting for checks" : "No checks reported";
+  }
+  if (summary.failed > 0) {
+    return `${summary.failed} ${summary.failed === 1 ? "check" : "checks"} failed`;
+  }
+  if (summary.pending > 0) return `${summary.total - summary.pending} of ${summary.total} complete`;
+  const outcomes = [
+    ...(summary.passed > 0 ? [`${summary.passed} passed`] : []),
+    ...(summary.skipped > 0 ? [`${summary.skipped} skipped`] : []),
+    ...(summary.cancelled > 0 ? [`${summary.cancelled} cancelled`] : []),
+  ];
+  return outcomes.join(" · ");
+}
+
+function gitHubCheckSymbol(bucket: GitHubCheckBucket): AppSymbolName {
+  if (bucket === "pass") return { ios: "checkmark.circle", android: "check_circle" };
+  if (bucket === "fail") return { ios: "xmark.circle.fill", android: "cancel" };
+  if (bucket === "pending") return { ios: "clock", android: "schedule" };
+  return { ios: "minus", android: "remove" };
+}
+
+function GitHubActionsCard(props: {
+  readonly activity: ThreadFeedActivity;
+  readonly iconSubtleColor: import("react-native").ColorValue;
+}) {
+  const snapshot = props.activity.githubActions!;
+  const visibleChecks = snapshot.checks.slice(0, 6);
+  const hiddenCount = snapshot.checks.length - visibleChecks.length;
+
+  return (
+    <View className="overflow-hidden rounded-lg border border-neutral-200/80 bg-background dark:border-white/[0.12]">
+      <View className="h-[52px] flex-row items-center gap-2 border-b border-neutral-200/70 px-3 dark:border-white/[0.1]">
+        <SymbolView
+          name={{ ios: "bolt.circle", android: "bolt" }}
+          size={17}
+          tintColor={props.iconSubtleColor}
+          type="monochrome"
+        />
+        <View className="min-w-0 flex-1">
+          <Text className="font-t3-medium text-xs text-foreground">GitHub Actions</Text>
+          <Text className="text-2xs text-foreground-muted">
+            {githubActionsStatus(props.activity)}
+          </Text>
+        </View>
+      </View>
+      {visibleChecks.length > 0 ? (
+        visibleChecks.map((check) => {
+          const failed = check.bucket === "fail";
+          return (
+            <Pressable
+              key={check.link ?? check.name}
+              accessibilityRole={check.link ? "link" : undefined}
+              accessibilityLabel={`${check.name}, ${check.bucket}`}
+              disabled={!check.link}
+              onPress={() => {
+                if (check.link) void Linking.openURL(check.link).catch(() => undefined);
+              }}
+              className="h-10 flex-row items-center gap-2 border-b border-neutral-200/60 px-3 dark:border-white/[0.08]"
+            >
+              <SymbolView
+                name={gitHubCheckSymbol(check.bucket)}
+                size={14}
+                tintColor={failed ? "#e11d48" : props.iconSubtleColor}
+                type="monochrome"
+              />
+              <View className="min-w-0 flex-1">
+                <Text className="font-t3-medium text-xs text-foreground" numberOfLines={1}>
+                  {check.name}
+                </Text>
+                {check.workflow || check.description ? (
+                  <Text className="text-3xs text-foreground-muted" numberOfLines={1}>
+                    {check.workflow || check.description}
+                  </Text>
+                ) : null}
+              </View>
+              {check.duration ? (
+                <Text className="text-2xs text-foreground-muted">{check.duration}</Text>
+              ) : null}
+              {check.link ? (
+                <SymbolView
+                  name={{ ios: "safari", android: "open_in_new" }}
+                  size={12}
+                  tintColor={props.iconSubtleColor}
+                  type="monochrome"
+                />
+              ) : null}
+            </Pressable>
+          );
+        })
+      ) : (
+        <View className="h-10 justify-center px-3">
+          <Text className="text-xs text-foreground-muted">Checks have not reported yet.</Text>
+        </View>
+      )}
+      {hiddenCount > 0 ? (
+        <View className="h-8 justify-center px-3">
+          <Text className="font-t3-medium text-2xs text-foreground-muted">
+            {hiddenCount} more {hiddenCount === 1 ? "check" : "checks"}
+          </Text>
+        </View>
+      ) : null}
+    </View>
   );
 }
 
@@ -150,6 +289,16 @@ export function ThreadWorkLog(props: {
 
       <View className="gap-px">
         {rows.map((row) => {
+          if (row.githubActions) {
+            return (
+              <Animated.View
+                key={row.id}
+                {...(isFreshRow(row.createdAt) ? { entering: FadeIn.duration(200) } : {})}
+              >
+                <GitHubActionsCard activity={row} iconSubtleColor={props.iconSubtleColor} />
+              </Animated.View>
+            );
+          }
           const expanded = props.expandedRows[row.id] ?? false;
           const canExpand = row.canExpand;
           const fullDetail = expanded ? row.getFullDetail() : null;

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -56,6 +56,74 @@ function makeThread(
 }
 
 describe("buildThreadFeed", () => {
+  it("keeps GitHub Actions watch progress visible after a settled turn folds", () => {
+    const turnId = TurnId.make("turn-github");
+    const thread = makeThread({
+      id: ThreadId.make("thread-github"),
+      projectId: ProjectId.make("project-1"),
+      title: "GitHub Actions",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:10.000Z",
+        assistantMessageId: MessageId.make("assistant-final"),
+      },
+      messages: [
+        {
+          id: MessageId.make("assistant-final"),
+          role: "assistant",
+          text: "Checks passed.",
+          turnId,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:09.000Z",
+          updatedAt: "2026-04-01T00:00:10.000Z",
+        },
+      ],
+      activities: [
+        makeActivity({
+          id: EventId.make("github-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Ran command",
+          createdAt: "2026-04-01T00:00:05.000Z",
+          turnId,
+          payload: {
+            itemType: "command_execution",
+            title: "Ran command",
+            detail: "gh pr checks 42 --watch",
+            status: "completed",
+            data: {
+              githubActions: {
+                kind: "pr-checks",
+                watching: true,
+                checks: [{ name: "Test", bucket: "pass", duration: "1m2s" }],
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const group = feed.find((entry) => entry.type === "activity-group");
+    expect(group).toMatchObject({
+      type: "activity-group",
+      activities: [
+        {
+          githubActions: {
+            watching: true,
+            checks: [{ name: "Test", bucket: "pass", duration: "1m2s" }],
+          },
+        },
+      ],
+    });
+
+    const collapsed = deriveThreadFeedPresentation(feed, thread.latestTurn, new Set());
+    expect(collapsed.map((entry) => entry.id)).toContain("github-completed");
+  });
+
   it("keeps historic work entries attributed to their turns", () => {
     const thread = makeThread({
       id: ThreadId.make("thread-1"),

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -124,6 +124,84 @@ describe("buildThreadFeed", () => {
     expect(collapsed.map((entry) => entry.id)).toContain("github-completed");
   });
 
+  it("shows started GitHub Actions progress while folding adjacent tools", () => {
+    const turnId = TurnId.make("turn-github-started");
+    const thread = makeThread({
+      id: ThreadId.make("thread-github-started"),
+      projectId: ProjectId.make("project-1"),
+      title: "GitHub Actions started",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:10.000Z",
+        assistantMessageId: MessageId.make("assistant-final"),
+      },
+      messages: [
+        {
+          id: MessageId.make("assistant-final"),
+          role: "assistant",
+          text: "Still watching.",
+          turnId,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:09.000Z",
+          updatedAt: "2026-04-01T00:00:10.000Z",
+        },
+      ],
+      activities: [
+        makeActivity({
+          id: EventId.make("tool-before"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Read files",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId,
+          payload: { itemType: "command_execution", status: "completed" },
+        }),
+        makeActivity({
+          id: EventId.make("github-started"),
+          kind: "tool.started",
+          tone: "tool",
+          summary: "Watching checks",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          turnId,
+          payload: {
+            itemType: "command_execution",
+            status: "inProgress",
+            data: {
+              githubActions: {
+                kind: "pr-checks",
+                watching: true,
+                checks: [{ name: "Test", bucket: "pending" }],
+              },
+            },
+          },
+        }),
+        makeActivity({
+          id: EventId.make("tool-after"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Read logs",
+          createdAt: "2026-04-01T00:00:04.000Z",
+          turnId,
+          payload: { itemType: "command_execution", status: "completed" },
+        }),
+      ],
+    });
+
+    const presented = deriveThreadFeedPresentation(
+      buildThreadFeed(thread),
+      thread.latestTurn,
+      new Set(),
+    );
+    const ids = presented.map((entry) => entry.id);
+    expect(ids).toContain("github-started");
+    expect(ids).not.toContain("tool-before");
+    expect(ids).not.toContain("tool-after");
+    expect(ids.some((id) => id.startsWith("work-toggle:"))).toBe(false);
+  });
+
   it("keeps historic work entries attributed to their turns", () => {
     const thread = makeThread({
       id: ThreadId.make("thread-1"),

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -83,6 +83,27 @@ describe("buildThreadFeed", () => {
       ],
       activities: [
         makeActivity({
+          id: EventId.make("github-started"),
+          kind: "tool.started",
+          tone: "tool",
+          summary: "Ran command started",
+          createdAt: "2026-04-01T00:00:04.000Z",
+          turnId,
+          payload: {
+            itemType: "command_execution",
+            detail: "gh pr checks 42 --watch",
+            status: "inProgress",
+            data: {
+              item: { command: "gh pr checks 42 --watch" },
+              githubActions: {
+                kind: "pr-checks",
+                watching: true,
+                checks: [{ name: "Test", bucket: "pending" }],
+              },
+            },
+          },
+        }),
+        makeActivity({
           id: EventId.make("github-completed"),
           kind: "tool.completed",
           tone: "tool",
@@ -95,6 +116,7 @@ describe("buildThreadFeed", () => {
             detail: "gh pr checks 42 --watch",
             status: "completed",
             data: {
+              item: { command: "gh pr checks 42 --watch" },
               githubActions: {
                 kind: "pr-checks",
                 watching: true,

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -450,6 +450,10 @@ function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | un
   ) {
     return undefined;
   }
+  const githubCommand = (entry.rawCommand ?? entry.command)?.trim();
+  if (entry.githubActions && githubCommand) {
+    return `github-actions:${githubCommand}`;
+  }
   const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
   const detail = entry.detail?.trim() ?? "";
   const itemType = entry.itemType ?? "";

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1001,6 +1001,19 @@ function groupAdjacentActivities(entries: ReadonlyArray<RawThreadFeedEntry>): Th
       continue;
     }
 
+    if (entry.activity.githubActions) {
+      grouped.push({
+        type: "activity-group",
+        id: entry.id,
+        createdAt: entry.createdAt,
+        turnId: entry.turnId,
+        activities: [entry.activity],
+      });
+      openGroupActivities = null;
+      openGroupTurnId = null;
+      continue;
+    }
+
     if (openGroupActivities !== null && openGroupTurnId === entry.turnId) {
       openGroupActivities.push(entry.activity);
       continue;
@@ -1225,7 +1238,7 @@ function appendPresentedFeedEntry(
   }
 
   const activities = entry.activities.filter(
-    (activity) => !(activity.toolLike && activity.status === "neutral"),
+    (activity) => !(activity.toolLike && activity.status === "neutral" && !activity.githubActions),
   );
   if (activities.length === 0) {
     return;

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -8,6 +8,10 @@ import type {
   UserInputQuestion,
 } from "@t3tools/contracts";
 import { formatDuration } from "@t3tools/shared/orchestrationTiming";
+import {
+  readGitHubActionsSnapshot,
+  type GitHubActionsSnapshot,
+} from "@t3tools/shared/githubActions";
 
 import * as Arr from "effect/Array";
 import * as Order from "effect/Order";
@@ -54,6 +58,7 @@ export interface ThreadFeedActivity {
     | "zap";
   readonly toolLike: boolean;
   readonly status: "success" | "failure" | "neutral" | null;
+  readonly githubActions?: GitHubActionsSnapshot;
 }
 
 const MAX_VISIBLE_WORK_LOG_ENTRIES = 1;
@@ -75,6 +80,7 @@ interface WorkLogEntry {
   requestKind?: PendingApproval["requestKind"];
   toolLifecycleStatus?: WorkLogToolLifecycleStatus;
   toolData?: unknown;
+  githubActions?: GitHubActionsSnapshot;
 }
 
 interface DerivedWorkLogEntry extends WorkLogEntry {
@@ -241,7 +247,7 @@ function deriveWorkLogEntries(
   const ordered = Arr.sort(activities, activityOrder);
   const entries: DerivedWorkLogEntry[] = [];
   for (const activity of ordered) {
-    if (activity.kind === "tool.started") continue;
+    if (activity.kind === "tool.started" && !extractGitHubActions(activity.payload)) continue;
     if (activity.kind === "task.started") continue;
     if (activity.kind === "context-window.updated") continue;
     if (activity.summary === "Checkpoint captured") continue;
@@ -249,6 +255,12 @@ function deriveWorkLogEntries(
     entries.push(toDerivedWorkLogEntry(activity));
   }
   return collapseDerivedWorkLogEntries(entries);
+}
+
+function extractGitHubActions(payload: unknown): GitHubActionsSnapshot | null {
+  const payloadRecord = asRecord(payload);
+  const data = asRecord(payloadRecord?.data);
+  return readGitHubActionsSnapshot(data?.githubActions);
 }
 
 function isPlanBoundaryToolActivity(activity: OrchestrationThreadActivity): boolean {
@@ -328,6 +340,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       entry.toolData = data.item;
     }
   }
+  const githubActions = extractGitHubActions(payload);
+  if (githubActions) {
+    entry.githubActions = githubActions;
+  }
   if (itemType) {
     entry.itemType = itemType;
   }
@@ -367,7 +383,11 @@ function shouldCollapseToolLifecycleEntries(
   previous: DerivedWorkLogEntry,
   next: DerivedWorkLogEntry,
 ): boolean {
-  if (previous.activityKind !== "tool.updated" && previous.activityKind !== "tool.completed") {
+  if (
+    previous.activityKind !== "tool.started" &&
+    previous.activityKind !== "tool.updated" &&
+    previous.activityKind !== "tool.completed"
+  ) {
     return false;
   }
   if (next.activityKind !== "tool.updated" && next.activityKind !== "tool.completed") {
@@ -393,6 +413,7 @@ function mergeDerivedWorkLogEntries(
   const collapseKey = next.collapseKey ?? previous.collapseKey;
   const toolLifecycleStatus = next.toolLifecycleStatus ?? previous.toolLifecycleStatus;
   const toolData = next.toolData ?? previous.toolData;
+  const githubActions = next.githubActions ?? previous.githubActions;
   return {
     ...previous,
     ...next,
@@ -406,6 +427,7 @@ function mergeDerivedWorkLogEntries(
     ...(collapseKey ? { collapseKey } : {}),
     ...(toolLifecycleStatus ? { toolLifecycleStatus } : {}),
     ...(toolData !== undefined ? { toolData } : {}),
+    ...(githubActions !== undefined ? { githubActions } : {}),
   };
 }
 
@@ -421,7 +443,11 @@ function mergeChangedFiles(
 }
 
 function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | undefined {
-  if (entry.activityKind !== "tool.updated" && entry.activityKind !== "tool.completed") {
+  if (
+    entry.activityKind !== "tool.started" &&
+    entry.activityKind !== "tool.updated" &&
+    entry.activityKind !== "tool.completed"
+  ) {
     return undefined;
   }
   const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
@@ -1084,7 +1110,16 @@ function deriveThreadFeedTurnFolds(
 
     const terminalAssistantMessageId = terminalAssistantMessageIdByTurn.get(turnId);
     const hiddenEntryIds = new Set(
-      entries.filter((entry) => entry.id !== terminalAssistantMessageId).map((entry) => entry.id),
+      entries
+        .filter(
+          (entry) =>
+            entry.id !== terminalAssistantMessageId &&
+            !(
+              entry.type === "activity-group" &&
+              entry.activities.some((activity) => activity.githubActions !== undefined)
+            ),
+        )
+        .map((entry) => entry.id),
     );
     if (hiddenEntryIds.size === 0) {
       continue;
@@ -1414,6 +1449,7 @@ export function buildThreadFeed(
               icon: workEntryIcon(entry),
               toolLike: workLogEntryIsToolLike(entry),
               status: workEntryStatus(entry),
+              ...(entry.githubActions ? { githubActions: entry.githubActions } : {}),
             },
           };
         }),

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -3,6 +3,7 @@ import type {
   OrchestrationThreadActivity,
   OrchestrationThreadDetailSnapshot,
 } from "@t3tools/contracts";
+import { parseGitHubActionsSnapshot } from "@t3tools/shared/githubActions";
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -151,6 +152,17 @@ function projectRawOutput(value: unknown): Record<string, unknown> | undefined {
   return undefined;
 }
 
+function githubActionsSnapshot(data: Record<string, unknown>) {
+  const item = asRecord(data.item);
+  const input = asRecord(item?.input);
+  const result = asRecord(item?.result);
+  const rawOutput = asRecord(data.rawOutput);
+  const command = item?.command ?? input?.command ?? result?.command ?? data.command;
+  const output =
+    item?.aggregatedOutput ?? result?.aggregatedOutput ?? rawOutput?.content ?? rawOutput?.stdout;
+  return parseGitHubActionsSnapshot({ command, output });
+}
+
 /**
  * Removes activity payload fields that no current client reads while retaining
  * the full payload in persistence and the event store.
@@ -185,6 +197,11 @@ export function projectActivityPayload(
   }
   if ("kind" in data) {
     projectedData.kind = data.kind;
+  }
+
+  const githubActions = githubActionsSnapshot(data);
+  if (githubActions) {
+    projectedData.githubActions = githubActions;
   }
 
   const rawOutput = projectRawOutput(data.rawOutput);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2734,9 +2734,14 @@ describe("ProviderRuntimeIngestion", () => {
       turnId: asTurnId("turn-9"),
       payload: {
         itemType: "command_execution",
-        status: "in_progress",
-        title: "Read file",
-        detail: "/tmp/file.ts",
+        status: "inProgress",
+        title: "Ran command",
+        detail: "gh pr checks 42 --watch",
+        data: {
+          item: {
+            command: "gh pr checks 42 --watch",
+          },
+        },
       },
     });
 
@@ -2756,6 +2761,20 @@ describe("ProviderRuntimeIngestion", () => {
         (activity: ProviderRuntimeTestActivity) => activity.kind === "tool.started",
       ),
     ).toBe(true);
+    expect(
+      thread.activities.find(
+        (activity: ProviderRuntimeTestActivity) => activity.kind === "tool.started",
+      )?.payload,
+    ).toMatchObject({
+      status: "inProgress",
+      data: {
+        githubActions: {
+          kind: "pr-checks",
+          watching: true,
+          checks: [],
+        },
+      },
+    });
   });
 
   it("consumes P1 runtime events into thread metadata, diff checkpoints, and activities", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -24,8 +24,10 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { parseGitHubActionsSnapshot } from "@t3tools/shared/githubActions";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
@@ -123,6 +125,20 @@ function sameId(left: string | null | undefined, right: string | null | undefine
     return false;
   }
   return left === right;
+}
+
+function githubActionsStartedData(value: unknown): Record<string, unknown> | undefined {
+  const data = Predicate.isObject(value) ? value : null;
+  const item = Predicate.isObject(data?.item) ? data.item : null;
+  const input = Predicate.isObject(item?.input) ? item.input : null;
+  const result = Predicate.isObject(item?.result) ? item.result : null;
+  const command = item?.command ?? input?.command ?? result?.command ?? data?.command;
+  const githubActions = parseGitHubActionsSnapshot({ command });
+  if (!githubActions) return undefined;
+  return {
+    githubActions,
+    ...(command !== undefined ? { item: { command } } : {}),
+  };
 }
 
 function hasAssistantMessageForTurn(
@@ -663,6 +679,7 @@ export function runtimeEventToActivities(
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];
       }
+      const githubActionsData = githubActionsStartedData(event.payload.data);
       return [
         {
           id: event.eventId,
@@ -672,7 +689,9 @@ export function runtimeEventToActivities(
           summary: `${event.payload.title ?? "Tool"} started`,
           payload: {
             itemType: event.payload.itemType,
+            ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(githubActionsData ? { data: githubActionsData } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -188,6 +188,41 @@ describe("projectActivityPayload", () => {
     expect(projectActivityPayload(fixtures[4]!)).toBe(fixtures[4]);
   });
 
+  it("retains a bounded GitHub Actions snapshot instead of command output", () => {
+    const activity = makeActivity("github-checks", "command_execution", {
+      item: {
+        command: "gh pr checks 42 --watch",
+        aggregatedOutput: [
+          "Test\tpending\t0\thttps://github.com/acme/repo/actions/runs/1",
+          "Lint\tpass\t12s\thttps://github.com/acme/repo/actions/runs/2",
+        ].join("\n"),
+      },
+      toolCallId: "github-checks",
+    });
+
+    expect(projectActivityPayload(activity).payload).toMatchObject({
+      data: {
+        githubActions: {
+          kind: "pr-checks",
+          watching: true,
+          checks: [
+            {
+              name: "Test",
+              bucket: "pending",
+              link: "https://github.com/acme/repo/actions/runs/1",
+            },
+            {
+              name: "Lint",
+              bucket: "pass",
+              duration: "12s",
+              link: "https://github.com/acme/repo/actions/runs/2",
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it("keeps current web and mobile derived output identical for every tool item type", () => {
     for (const activity of fixtures) {
       const projected = projectActivityPayload(activity);

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -352,7 +352,10 @@ function deriveTurnFolds(input: {
     }
     const hiddenEntryIds = new Set<string>();
     for (const entry of group.entries) {
-      if (entry.id !== group.terminalEntry?.id) {
+      if (
+        entry.id !== group.terminalEntry?.id &&
+        !(entry.kind === "work" && entry.entry.githubActions !== undefined)
+      ) {
         hiddenEntryIds.add(entry.id);
       }
     }
@@ -476,7 +479,7 @@ export function deriveMessagesTimelineRows(input: {
         cursor += 1;
       }
       const visibleGroupedEntries = groupedEntries.filter(
-        (entry) => !workEntryIndicatesToolNeutralStatus(entry),
+        (entry) => entry.githubActions || !workEntryIndicatesToolNeutralStatus(entry),
       );
       if (visibleGroupedEntries.length > 0) {
         if (visibleGroupedEntries.length <= MAX_VISIBLE_WORK_LOG_ENTRIES) {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -223,6 +223,51 @@ function buildUserTimelineEntry(text: string) {
 }
 
 describe("MessagesTimeline", () => {
+  it("renders GitHub Actions watch progress as a check list", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        activeTurnInProgress
+        timelineEntries={[
+          buildUserTimelineEntry("Watch CI"),
+          {
+            id: "github-checks",
+            kind: "work",
+            createdAt: MESSAGE_CREATED_AT,
+            entry: {
+              id: "github-checks",
+              createdAt: MESSAGE_CREATED_AT,
+              label: "Ran command",
+              tone: "tool",
+              command: "gh pr checks 42 --watch",
+              itemType: "command_execution",
+              toolLifecycleStatus: "inProgress",
+              githubActions: {
+                kind: "pr-checks",
+                watching: true,
+                checks: [
+                  { name: "Lint", bucket: "pass", duration: "12s" },
+                  {
+                    name: "Test",
+                    bucket: "pending",
+                    link: "https://github.com/acme/repo/actions/runs/1",
+                    workflow: "CI",
+                  },
+                ],
+              },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("GitHub Actions");
+    expect(markup).toContain("Watching · 1 of 2 complete");
+    expect(markup).toContain("Lint");
+    expect(markup).toContain("Test");
+    expect(markup).toContain('href="https://github.com/acme/repo/actions/runs/1"');
+  });
+
   it("uses the larger leading inset only when the top fade is enabled", () => {
     const timelineEntries = [buildUserTimelineEntry("Hello")];
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -7,6 +7,7 @@ import {
 } from "@t3tools/contracts";
 import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import { resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
+import { summarizeGitHubActions, type GitHubCheckBucket } from "@t3tools/shared/githubActions";
 import {
   createContext,
   Fragment,
@@ -45,9 +46,12 @@ import {
   ChevronRightIcon,
   CircleAlertIcon,
   EyeIcon,
+  ExternalLinkIcon,
+  GithubIcon,
   GlobeIcon,
   HammerIcon,
   MessageCircleIcon,
+  CircleDotIcon,
   MousePointerClickIcon,
   PaintbrushIcon,
   MinusIcon,
@@ -1155,7 +1159,10 @@ const WorkGroupSection = memo(function WorkGroupSection({
 }) {
   const { workspaceRoot } = use(TimelineRowCtx);
   const nonEmptyEntries = useMemo(
-    () => groupedEntries.filter((entry) => !workEntryIndicatesToolNeutralStatus(entry)),
+    () =>
+      groupedEntries.filter(
+        (entry) => entry.githubActions || !workEntryIndicatesToolNeutralStatus(entry),
+      ),
     [groupedEntries],
   );
   const onlyToolEntries = nonEmptyEntries.every((entry) => workLogEntryIsToolLike(entry));
@@ -1176,11 +1183,13 @@ const WorkGroupSection = memo(function WorkGroupSection({
       )}
       <div className="space-y-px">
         {nonEmptyEntries.map((workEntry) => (
-          <SimpleWorkEntryRow
-            key={workEntry.id}
-            workEntry={workEntry}
-            workspaceRoot={workspaceRoot}
-          />
+          <Fragment key={workEntry.id}>
+            {workEntry.githubActions ? (
+              <GitHubActionsWorkEntry workEntry={workEntry} />
+            ) : (
+              <SimpleWorkEntryRow workEntry={workEntry} workspaceRoot={workspaceRoot} />
+            )}
+          </Fragment>
         ))}
       </div>
     </section>
@@ -2077,5 +2086,131 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
         </div>
       ) : null}
     </div>
+  );
+});
+
+function gitHubCheckIcon(bucket: GitHubCheckBucket) {
+  if (bucket === "pass") {
+    return <CheckIcon className="size-3.5 text-success" aria-hidden />;
+  }
+  if (bucket === "fail") {
+    return <XIcon className="size-3.5 text-destructive" aria-hidden />;
+  }
+  if (bucket === "pending") {
+    return <CircleDotIcon className="size-3.5 text-warning" aria-hidden />;
+  }
+  return <MinusIcon className="size-3.5 text-muted-foreground/60" aria-hidden />;
+}
+
+function gitHubActionsStatus(workEntry: TimelineWorkEntry): string {
+  const snapshot = workEntry.githubActions!;
+  const summary = summarizeGitHubActions(snapshot);
+  if (summary.total === 0) {
+    return workEntry.toolLifecycleStatus === "inProgress"
+      ? "Waiting for checks"
+      : "No checks reported";
+  }
+  if (summary.failed > 0) {
+    return `${summary.failed} ${summary.failed === 1 ? "check" : "checks"} failed`;
+  }
+  if (summary.pending > 0) {
+    return `${summary.total - summary.pending} of ${summary.total} complete`;
+  }
+  const outcomes = [
+    ...(summary.passed > 0 ? [`${summary.passed} passed`] : []),
+    ...(summary.skipped > 0 ? [`${summary.skipped} skipped`] : []),
+    ...(summary.cancelled > 0 ? [`${summary.cancelled} cancelled`] : []),
+  ];
+  return outcomes.join(" · ");
+}
+
+const GitHubActionsWorkEntry = memo(function GitHubActionsWorkEntry({
+  workEntry,
+}: {
+  workEntry: TimelineWorkEntry;
+}) {
+  const [showAll, setShowAll] = useState(false);
+  const snapshot = workEntry.githubActions!;
+  const visibleChecks = showAll ? snapshot.checks : snapshot.checks.slice(0, 6);
+  const hiddenCount = snapshot.checks.length - visibleChecks.length;
+
+  return (
+    <section
+      className="overflow-hidden rounded-lg border border-border/70 bg-background/70"
+      aria-label="GitHub Actions checks"
+      aria-live="polite"
+    >
+      <header className="flex items-center gap-2 border-b border-border/55 px-3 py-2.5">
+        <GithubIcon className="size-4 shrink-0 text-foreground" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium text-foreground">GitHub Actions</p>
+          <p className="text-[11px] text-muted-foreground">
+            {snapshot.watching && workEntry.toolLifecycleStatus === "inProgress"
+              ? `Watching · ${gitHubActionsStatus(workEntry)}`
+              : gitHubActionsStatus(workEntry)}
+          </p>
+        </div>
+      </header>
+      {visibleChecks.length > 0 ? (
+        <div className="divide-y divide-border/45">
+          {visibleChecks.map((check) => {
+            const content = (
+              <>
+                <span className="flex size-5 shrink-0 items-center justify-center">
+                  {gitHubCheckIcon(check.bucket)}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-xs font-medium text-foreground/90">
+                    {check.name}
+                  </span>
+                  {(check.workflow || check.description) && (
+                    <span className="block truncate text-[11px] text-muted-foreground/65">
+                      {check.workflow || check.description}
+                    </span>
+                  )}
+                </span>
+                {check.duration && (
+                  <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/65">
+                    {check.duration}
+                  </span>
+                )}
+                {check.link && (
+                  <ExternalLinkIcon
+                    className="size-3 shrink-0 text-muted-foreground/55"
+                    aria-hidden
+                  />
+                )}
+              </>
+            );
+            return check.link ? (
+              <a
+                key={check.link}
+                href={check.link}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-2 px-3 py-2 transition-colors hover:bg-accent/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
+              >
+                {content}
+              </a>
+            ) : (
+              <div key={check.name} className="flex items-center gap-2 px-3 py-2">
+                {content}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="px-3 py-3 text-xs text-muted-foreground">Checks have not reported yet.</p>
+      )}
+      {(hiddenCount > 0 || showAll) && snapshot.checks.length > 6 ? (
+        <button
+          type="button"
+          className="w-full border-t border-border/45 px-3 py-2 text-left text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent/25 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
+          onClick={() => setShowAll((value) => !value)}
+        >
+          {showAll ? "Show fewer checks" : `Show ${hiddenCount} more checks`}
+        </button>
+      ) : null}
+    </section>
   );
 });

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -701,12 +701,15 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "github-started",
         kind: "tool.started",
+        summary: "Ran command started",
         payload: {
           itemType: "command_execution",
-          title: "Ran command",
           detail: "gh pr checks 42 --watch",
           status: "inProgress",
-          data: { toolCallId: "github-watch", githubActions },
+          data: {
+            item: { command: "gh pr checks 42 --watch" },
+            githubActions,
+          },
         },
       }),
       makeActivity({
@@ -718,7 +721,7 @@ describe("deriveWorkLogEntries", () => {
           detail: "gh pr checks 42 --watch",
           status: "completed",
           data: {
-            toolCallId: "github-watch",
+            item: { command: "gh pr checks 42 --watch" },
             githubActions: {
               ...githubActions,
               checks: [{ name: "Test", bucket: "pass", duration: "1m2s" }],

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -691,6 +691,53 @@ describe("workEntryIndicatesToolFailure", () => {
 });
 
 describe("deriveWorkLogEntries", () => {
+  it("keeps and collapses GitHub Actions watch lifecycle entries", () => {
+    const githubActions = {
+      kind: "pr-checks",
+      watching: true,
+      checks: [{ name: "Test", bucket: "pending" }],
+    };
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "github-started",
+        kind: "tool.started",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "gh pr checks 42 --watch",
+          status: "inProgress",
+          data: { toolCallId: "github-watch", githubActions },
+        },
+      }),
+      makeActivity({
+        id: "github-completed",
+        kind: "tool.completed",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "gh pr checks 42 --watch",
+          status: "completed",
+          data: {
+            toolCallId: "github-watch",
+            githubActions: {
+              ...githubActions,
+              checks: [{ name: "Test", bucket: "pass", duration: "1m2s" }],
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "github-completed",
+      toolLifecycleStatus: "completed",
+      githubActions: {
+        watching: true,
+        checks: [{ name: "Test", bucket: "pass", duration: "1m2s" }],
+      },
+    });
+  });
   it("omits tool started entries and keeps completed entries", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -12,6 +12,10 @@ import {
   type ThreadId,
   type TurnId,
 } from "@t3tools/contracts";
+import {
+  readGitHubActionsSnapshot,
+  type GitHubActionsSnapshot,
+} from "@t3tools/shared/githubActions";
 
 import type {
   ChatMessage,
@@ -72,6 +76,7 @@ export interface WorkLogEntry {
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
   toolData?: unknown;
+  githubActions?: GitHubActionsSnapshot;
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];
   /** From runtime item / task payload `status` when present (e.g. tool.updated). */
@@ -630,7 +635,7 @@ export function deriveWorkLogEntries(
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   const entries: DerivedWorkLogEntry[] = [];
   for (const activity of ordered) {
-    if (activity.kind === "tool.started") continue;
+    if (activity.kind === "tool.started" && !extractGitHubActions(activity.payload)) continue;
     if (activity.kind === "task.started") continue;
     if (activity.kind === "context-window.updated") continue;
     if (activity.summary === "Checkpoint captured") continue;
@@ -641,6 +646,12 @@ export function deriveWorkLogEntries(
     const { activityKind, collapseKey: _collapseKey, ...rest } = entry;
     return Object.assign(rest, { sourceActivityKind: activityKind });
   });
+}
+
+function extractGitHubActions(payload: unknown): GitHubActionsSnapshot | null {
+  const payloadRecord = asRecord(payload);
+  const data = asRecord(payloadRecord?.data);
+  return readGitHubActionsSnapshot(data?.githubActions);
 }
 
 function isPlanBoundaryToolActivity(activity: OrchestrationThreadActivity): boolean {
@@ -740,6 +751,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       entry.toolData = data.item;
     }
   }
+  const githubActions = extractGitHubActions(payload);
+  if (githubActions) {
+    entry.githubActions = githubActions;
+  }
   if (itemType) {
     entry.itemType = itemType;
   }
@@ -782,7 +797,11 @@ function shouldCollapseToolLifecycleEntries(
   previous: DerivedWorkLogEntry,
   next: DerivedWorkLogEntry,
 ): boolean {
-  if (previous.activityKind !== "tool.updated" && previous.activityKind !== "tool.completed") {
+  if (
+    previous.activityKind !== "tool.started" &&
+    previous.activityKind !== "tool.updated" &&
+    previous.activityKind !== "tool.completed"
+  ) {
     return false;
   }
   if (next.activityKind !== "tool.updated" && next.activityKind !== "tool.completed") {
@@ -818,6 +837,7 @@ function mergeDerivedWorkLogEntries(
   const toolCallId = next.toolCallId ?? previous.toolCallId;
   const toolLifecycleStatus = next.toolLifecycleStatus ?? previous.toolLifecycleStatus;
   const toolData = next.toolData ?? previous.toolData;
+  const githubActions = next.githubActions ?? previous.githubActions;
   return {
     ...previous,
     ...next,
@@ -832,6 +852,7 @@ function mergeDerivedWorkLogEntries(
     ...(toolCallId ? { toolCallId } : {}),
     ...(toolLifecycleStatus !== undefined ? { toolLifecycleStatus } : {}),
     ...(toolData !== undefined ? { toolData } : {}),
+    ...(githubActions !== undefined ? { githubActions } : {}),
   };
 }
 
@@ -847,7 +868,11 @@ function mergeChangedFiles(
 }
 
 function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | undefined {
-  if (entry.activityKind !== "tool.updated" && entry.activityKind !== "tool.completed") {
+  if (
+    entry.activityKind !== "tool.started" &&
+    entry.activityKind !== "tool.updated" &&
+    entry.activityKind !== "tool.completed"
+  ) {
     return undefined;
   }
   if (entry.toolCallId) {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -878,6 +878,10 @@ function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | un
   if (entry.toolCallId) {
     return `tool:${entry.toolCallId}`;
   }
+  const githubCommand = (entry.rawCommand ?? entry.command)?.trim();
+  if (entry.githubActions && githubCommand) {
+    return `github-actions:${githubCommand}`;
+  }
   const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
   const detail = entry.detail?.trim() ?? "";
   const itemType = entry.itemType ?? "";

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -41,6 +41,16 @@ T3 Code works with the platforms your team already uses:
 - Open the review directly in your browser with one click
 - Check out a teammate's branch to review code locally
 
+**Follow GitHub Actions in the thread**
+
+When an agent runs `gh pr checks` or `gh pr checks --watch`, T3 Code shows the result as a GitHub
+Actions check list in the thread. Pending, passed, failed, skipped, and cancelled checks remain easy
+to scan, and links open the corresponding check on GitHub. The completed check list stays visible
+after the rest of the turn's work log folds.
+
+This uses the GitHub CLI authentication on the machine running T3 Code. T3 Code does not start or
+continue monitoring independently of the agent command.
+
 ### Know Your Setup at a Glance
 
 The **Source Control settings** page shows you exactly what's connected:

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,6 +23,10 @@
       "types": "./src/git.ts",
       "import": "./src/git.ts"
     },
+    "./githubActions": {
+      "types": "./src/githubActions.ts",
+      "import": "./src/githubActions.ts"
+    },
     "./sourceControl": {
       "types": "./src/sourceControl.ts",
       "import": "./src/sourceControl.ts"

--- a/packages/shared/src/githubActions.test.ts
+++ b/packages/shared/src/githubActions.test.ts
@@ -5,6 +5,8 @@ describe("GitHub Actions snapshots", () => {
   it("recognizes direct and shell-wrapped PR check commands", () => {
     expect(isGitHubPrChecksCommand("gh pr checks 42 --watch")).toBe(true);
     expect(isGitHubPrChecksCommand(["/bin/zsh", "-lc", "gh pr checks --watch"])).toBe(true);
+    expect(isGitHubPrChecksCommand("echo gh pr checks 42 --watch")).toBe(false);
+    expect(isGitHubPrChecksCommand("grep 'gh pr checks' commands.txt")).toBe(false);
     expect(isGitHubPrChecksCommand("gh run list")).toBe(false);
   });
 

--- a/packages/shared/src/githubActions.test.ts
+++ b/packages/shared/src/githubActions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isGitHubPrChecksCommand, parseGitHubActionsSnapshot } from "./githubActions.ts";
+
+describe("GitHub Actions snapshots", () => {
+  it("recognizes direct and shell-wrapped PR check commands", () => {
+    expect(isGitHubPrChecksCommand("gh pr checks 42 --watch")).toBe(true);
+    expect(isGitHubPrChecksCommand(["/bin/zsh", "-lc", "gh pr checks --watch"])).toBe(true);
+    expect(isGitHubPrChecksCommand("gh run list")).toBe(false);
+  });
+
+  it("parses and deduplicates the latest watched table", () => {
+    const snapshot = parseGitHubActionsSnapshot({
+      command: "gh pr checks 42 --watch",
+      output: [
+        "Test\tpending\t0\thttps://github.com/acme/repo/actions/runs/1",
+        "Lint\tpass\t12s\thttps://github.com/acme/repo/actions/runs/2",
+        "Test\tpass\t1m2s\thttps://github.com/acme/repo/actions/runs/1",
+      ].join("\n"),
+    });
+
+    expect(snapshot).toEqual({
+      kind: "pr-checks",
+      watching: true,
+      checks: [
+        {
+          name: "Lint",
+          bucket: "pass",
+          duration: "12s",
+          link: "https://github.com/acme/repo/actions/runs/2",
+        },
+        {
+          name: "Test",
+          bucket: "pass",
+          duration: "1m2s",
+          link: "https://github.com/acme/repo/actions/runs/1",
+        },
+      ],
+    });
+  });
+
+  it("parses gh JSON output", () => {
+    const snapshot = parseGitHubActionsSnapshot({
+      command: "gh pr checks --json bucket,name,link,workflow",
+      output: JSON.stringify([
+        {
+          bucket: "pending",
+          name: "Test",
+          link: "https://github.com/acme/repo/actions/runs/1",
+          workflow: "CI",
+        },
+      ]),
+    });
+
+    expect(snapshot?.checks).toEqual([
+      {
+        name: "Test",
+        bucket: "pending",
+        link: "https://github.com/acme/repo/actions/runs/1",
+        workflow: "CI",
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/githubActions.ts
+++ b/packages/shared/src/githubActions.ts
@@ -97,16 +97,27 @@ export function summarizeGitHubActions(snapshot: GitHubActionsSnapshot): GitHubA
 }
 
 function commandText(command: unknown): string | null {
-  if (typeof command === "string") return command;
+  if (typeof command === "string") return command.trim() || null;
   if (!Array.isArray(command)) return null;
   const parts = command.filter((part): part is string => typeof part === "string");
-  return parts.length > 0 ? parts.join(" ") : null;
+  if (parts.length === 0) return null;
+
+  const executable = parts[0]
+    ?.replace(/^['"]|['"]$/g, "")
+    .split(/[\\/]/)
+    .at(-1);
+  if (executable && /^(?:ba|z|k)?sh$/i.test(executable)) {
+    const commandFlagIndex = parts.findIndex((part) => /^-[a-z]*c[a-z]*$/i.test(part));
+    const script = commandFlagIndex >= 0 ? parts[commandFlagIndex + 1]?.trim() : undefined;
+    if (script) return script;
+  }
+  return parts.join(" ").trim() || null;
 }
 
 export function isGitHubPrChecksCommand(command: unknown): boolean {
   const value = commandText(command);
   if (!value) return false;
-  return /(?:^|[\s;&|])(?:["'][^"']*[\\/])?gh["']?\s+pr\s+checks(?:\s|$)/i.test(value);
+  return /^(?:["']?[^"'\s]*[\\/])?gh["']?\s+pr\s+checks(?:\s|$)/i.test(value);
 }
 
 function parseJsonChecks(output: string): GitHubCheck[] | null {

--- a/packages/shared/src/githubActions.ts
+++ b/packages/shared/src/githubActions.ts
@@ -1,0 +1,185 @@
+export type GitHubCheckBucket = "pass" | "fail" | "pending" | "skipping" | "cancel";
+
+export interface GitHubCheck {
+  readonly name: string;
+  readonly bucket: GitHubCheckBucket;
+  readonly duration?: string;
+  readonly link?: string;
+  readonly description?: string;
+  readonly workflow?: string;
+}
+
+export interface GitHubActionsSnapshot {
+  readonly kind: "pr-checks";
+  readonly watching: boolean;
+  readonly checks: ReadonlyArray<GitHubCheck>;
+}
+
+export interface GitHubActionsSummary {
+  readonly total: number;
+  readonly passed: number;
+  readonly failed: number;
+  readonly pending: number;
+  readonly skipped: number;
+  readonly cancelled: number;
+}
+
+const MAX_CHECKS = 50;
+const MAX_OUTPUT_LENGTH = 200_000;
+const ANSI_ESCAPE_CHAR = String.fromCharCode(27);
+const ANSI_CSI_SEQUENCE = new RegExp(`${ANSI_ESCAPE_CHAR}\\[[0-?]*[ -/]*[@-~]`, "g");
+const CHECK_BUCKETS = new Set<GitHubCheckBucket>(["pass", "fail", "pending", "skipping", "cancel"]);
+
+function trimmed(value: unknown, maxLength = 500): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const result = value.trim();
+  if (result.length === 0) return undefined;
+  return result.slice(0, maxLength);
+}
+
+function bucket(value: unknown): GitHubCheckBucket | undefined {
+  const result = trimmed(value)?.toLowerCase() as GitHubCheckBucket | undefined;
+  return result && CHECK_BUCKETS.has(result) ? result : undefined;
+}
+
+function externalLink(value: unknown): string | undefined {
+  const link = trimmed(value);
+  return link && /^https:\/\//i.test(link) ? link : undefined;
+}
+
+export function readGitHubActionsSnapshot(value: unknown): GitHubActionsSnapshot | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (record.kind !== "pr-checks" || typeof record.watching !== "boolean") return null;
+  if (!Array.isArray(record.checks)) return null;
+
+  const checks: GitHubCheck[] = [];
+  for (const value of record.checks.slice(0, MAX_CHECKS)) {
+    if (!value || typeof value !== "object") continue;
+    const check = value as Record<string, unknown>;
+    const name = trimmed(check.name, 200);
+    const checkBucket = bucket(check.bucket);
+    if (!name || !checkBucket) continue;
+    const link = externalLink(check.link);
+    checks.push({
+      name,
+      bucket: checkBucket,
+      ...(trimmed(check.duration, 40) ? { duration: trimmed(check.duration, 40)! } : {}),
+      ...(link ? { link } : {}),
+      ...(trimmed(check.description) ? { description: trimmed(check.description)! } : {}),
+      ...(trimmed(check.workflow, 200) ? { workflow: trimmed(check.workflow, 200)! } : {}),
+    });
+  }
+  return { kind: "pr-checks", watching: record.watching, checks };
+}
+
+export function summarizeGitHubActions(snapshot: GitHubActionsSnapshot): GitHubActionsSummary {
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+  let skipped = 0;
+  let cancelled = 0;
+  for (const check of snapshot.checks) {
+    if (check.bucket === "pass") passed += 1;
+    if (check.bucket === "fail") failed += 1;
+    if (check.bucket === "pending") pending += 1;
+    if (check.bucket === "skipping") skipped += 1;
+    if (check.bucket === "cancel") cancelled += 1;
+  }
+  return {
+    total: snapshot.checks.length,
+    passed,
+    failed,
+    pending,
+    skipped,
+    cancelled,
+  };
+}
+
+function commandText(command: unknown): string | null {
+  if (typeof command === "string") return command;
+  if (!Array.isArray(command)) return null;
+  const parts = command.filter((part): part is string => typeof part === "string");
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+export function isGitHubPrChecksCommand(command: unknown): boolean {
+  const value = commandText(command);
+  if (!value) return false;
+  return /(?:^|[\s;&|])(?:["'][^"']*[\\/])?gh["']?\s+pr\s+checks(?:\s|$)/i.test(value);
+}
+
+function parseJsonChecks(output: string): GitHubCheck[] | null {
+  const start = output.indexOf("[");
+  const end = output.lastIndexOf("]");
+  if (start < 0 || end <= start) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+
+  const checks: GitHubCheck[] = [];
+  for (const value of parsed) {
+    if (!value || typeof value !== "object") continue;
+    const record = value as Record<string, unknown>;
+    const name = trimmed(record.name, 200);
+    const checkBucket = bucket(record.bucket);
+    if (!name || !checkBucket) continue;
+    const link = externalLink(record.link);
+    checks.push({
+      name,
+      bucket: checkBucket,
+      ...(link ? { link } : {}),
+      ...(trimmed(record.description) ? { description: trimmed(record.description)! } : {}),
+      ...(trimmed(record.workflow, 200) ? { workflow: trimmed(record.workflow, 200)! } : {}),
+    });
+    if (checks.length >= MAX_CHECKS) break;
+  }
+  return checks;
+}
+
+function parseTableChecks(output: string): GitHubCheck[] {
+  const byIdentity = new Map<string, GitHubCheck>();
+  for (const line of output.split(/\r?\n/u)) {
+    const columns = line.split("\t");
+    if (columns.length < 2) continue;
+    const name = trimmed(columns[0], 200);
+    const checkBucket = bucket(columns[1]);
+    if (!name || !checkBucket) continue;
+    const duration = trimmed(columns[2], 40);
+    const link = externalLink(columns[3]);
+    const description = trimmed(columns[4]);
+    const check = {
+      name,
+      bucket: checkBucket,
+      ...(duration && duration !== "0" ? { duration } : {}),
+      ...(link ? { link } : {}),
+      ...(description ? { description } : {}),
+    } satisfies GitHubCheck;
+    const identity = link || name;
+    if (byIdentity.has(identity)) byIdentity.delete(identity);
+    byIdentity.set(identity, check);
+  }
+  return [...byIdentity.values()].slice(-MAX_CHECKS);
+}
+
+export function parseGitHubActionsSnapshot(input: {
+  readonly command: unknown;
+  readonly output?: unknown;
+}): GitHubActionsSnapshot | null {
+  const command = commandText(input.command);
+  if (!command || !isGitHubPrChecksCommand(command)) return null;
+
+  const watching = /(?:^|\s)--watch(?:\s|$)|(?:^|\s)-[^\s]*w[^\s]*(?:\s|$)/i.test(command);
+  const rawOutput = typeof input.output === "string" ? input.output : "";
+  const output = rawOutput
+    .slice(-MAX_OUTPUT_LENGTH)
+    .replace(ANSI_CSI_SEQUENCE, "")
+    .replace(/\r/g, "\n");
+  const checks = parseJsonChecks(output) ?? parseTableChecks(output);
+  return { kind: "pr-checks", watching, checks };
+}


### PR DESCRIPTION
GitHub Actions watch commands currently appear as generic command output, which makes it difficult to see what is being watched and how individual PR checks are progressing from inside a thread.

This adds a first-party GitHub Actions check card for `gh pr checks` activity on web and mobile. The server projects a bounded snapshot from the command lifecycle, while clients render the overall state, per-check outcomes, durations, workflow context, and links back to GitHub. Longer check lists stay compact until expanded.

## Proof of work

- 144 focused tests passed across the shared parser, server ingestion/projection, web timeline, and mobile activity derivation.
- Shared, server, web, and mobile package typechecks passed.
- Manually verified an in-progress eight-check watch in the T3 web client, including passed, skipped, running, and queued states plus the expand/collapse control.
- `git diff --check` passed after rebasing onto current `upstream/main`.

Built with GPT-5.6 in T3 Code via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration ingestion, payload projection, and timeline folding on web and mobile; parsing is bounded but new surface area on the activity/work-log path.
> 
> **Overview**
> Adds structured **GitHub Actions** UI for `gh pr checks` / `--watch` instead of burying results in generic command output.
> 
> A new shared **`githubActions`** module detects PR-check commands, parses tabular and JSON `gh` output into bounded snapshots (checks, buckets, links, durations), and summarizes pass/fail/pending counts. The server attaches snapshots on **`tool.started`** (from command) and in **activity payload projection** (from command output), replacing raw stdout for clients.
> 
> **Web** and **mobile** work-log pipelines carry `githubActions` through lifecycle collapse, keep those rows visible when turns fold, and render **`GitHubActionsWorkEntry`** / **`GitHubActionsCard`** with per-check status, optional expand past six checks, and links to GitHub. User docs note thread follow-along and that monitoring stays tied to the agent’s `gh` command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f9cb13f012e89855cb1402ea2da3e1974d8dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render GitHub Actions pull request checks as cards in thread work logs
> - Adds a new shared [`githubActions.ts`](https://github.com/pingdotgg/t3code/pull/5325/files#diff-75ccd868153c704dbb3a6ccae5e8ad4c705b2da18e0fa08e31c04a9e533506df) module with types (`GitHubActionsSnapshot`, `GitHubCheck`, etc.) and parsers that extract structured check data from `gh pr checks` output (JSON and tab-delimited), including ANSI stripping and deduplication.
> - Propagates GitHub Actions snapshots from server ingestion through activity payloads ([`ActivityPayloadProjection.ts`](https://github.com/pingdotgg/t3code/pull/5325/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130), [`ProviderRuntimeIngestion.ts`](https://github.com/pingdotgg/t3code/pull/5325/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7)) to client-side work log derivation on both web and mobile.
> - Renders a dedicated `GitHubActionsWorkEntry` card (web) and `GitHubActionsCard` component (mobile) showing aggregated check status, per-check icons, durations, and tappable external links; a "Show more" control handles runs with more than 6 checks.
> - Updates turn-fold and work-log-collapse logic on both platforms to keep GitHub Actions entries visible even when their tool status is neutral or the surrounding turn is folded.
> - `tool.started` activities that carry a GitHub Actions snapshot are now retained and collapsed with subsequent `tool.updated`/`tool.completed` events sharing the same `github-actions:<command>` collapse key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7f9cb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->