### PR TITLE
fix(web): increase tooltip z-index to overlay popovers and menus

### DIFF
--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -33,7 +33,7 @@ function TooltipPopup({
       <TooltipPrimitive.Positioner
         align={align}
         anchor={anchor}
-        className="pointer-events-none z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none"
+        className="pointer-events-none z-70 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none"
         data-slot="tooltip-positioner"
         side={side}
         sideOffset={sideOffset}


### PR DESCRIPTION
## What Changed

Increased the `TooltipPositioner` `z-index` from `z-50` to `z-70` in `apps/web/src/components/ui/tooltip.tsx`.

## Why

Tooltips rendered inside popovers or dropdown menus (such as the "Add to favorites" star button inside model list items) were being clipped and rendered behind the popover container.

This occurred because `PopoverPositioner` (`apps/web/src/components/ui/popover.tsx`) and `MenuPositioner` (`apps/web/src/components/ui/menu.tsx`) use `z-[60]`, whereas `TooltipPositioner` was set to `z-50`. Since both elements render via React Portals as siblings at the document root, the lower `z-index` caused tooltips to render underneath popover surfaces.

Updating `TooltipPositioner` to `z-70` ensures tooltips always correctly overlay popovers and menus.

## UI Changes
 Before:
<img width="293" height="219" alt="before" src="https://github.com/user-attachments/assets/c697ef5e-3b43-45aa-868e-7171d05fdd96" />
After:
<img width="239" height="98" alt="after" src="https://github.com/user-attachments/assets/8fea0d15-3895-441d-b081-8d762e9788e4" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS stacking-order tweak in the shared tooltip component; no auth, data, or behavioral logic changes.
> 
> **Overview**
> Raises **`TooltipPositioner`** stacking from **`z-50`** to **`z-70`** so portal-rendered tooltips sit above popovers and menus (which use **`z-[60]`**), fixing clipping when tooltips appear inside those surfaces (e.g. favorite actions in model lists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c33257317e7f81bf0766250080518006e93c721a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase tooltip z-index to overlay popovers and menus
> Updates the `TooltipPopup` positioner in [tooltip.tsx](https://github.com/pingdotgg/t3code/pull/5326/files#diff-97acc7c97f91957af019082b41210bb280e2dd2af1a011328a1549f5647431d9) from `z-50` to `z-70` so tooltips render above popovers and menus.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c332573.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->