### PR TITLE
fix(contracts): decode ServerProviders forward-compatibly

### DIFF
--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -1,11 +1,29 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { ServerConfig, ServerProvider, ServerUpsertKeybindingResult } from "./server.ts";
+import {
+  ServerConfig,
+  ServerProvider,
+  ServerProviders,
+  ServerUpsertKeybindingResult,
+} from "./server.ts";
 
 const decodeServerProvider = Schema.decodeUnknownSync(ServerProvider);
+const decodeServerProviders = Schema.decodeUnknownSync(ServerProviders);
 const decodeUpsertKeybindingResult = Schema.decodeUnknownSync(ServerUpsertKeybindingResult);
 const decodeAvailableEditors = Schema.decodeUnknownSync(ServerConfig.fields.availableEditors);
+
+const baseProviderSnapshot = {
+  instanceId: "codex",
+  driver: "codex",
+  enabled: true,
+  installed: true,
+  version: "1.0.0",
+  status: "ready",
+  auth: { status: "authenticated" },
+  checkedAt: "2026-04-10T00:00:00.000Z",
+  models: [],
+};
 
 describe("ServerProvider", () => {
   it("defaults capability arrays when decoding provider snapshots", () => {
@@ -118,5 +136,22 @@ describe("server config forward compatibility", () => {
     const parsed = decodeAvailableEditors(["zed", "some-future-editor", "vscode"]);
 
     expect(parsed).toEqual(["zed", "vscode"]);
+  });
+
+  // A provider status this build has never seen (a new ServerProviderState,
+  // ServerProviderAuthStatus, etc. member) previously failed the whole
+  // `providers` array, taking every other provider down with it and, since
+  // `providers` sits inside `ServerConfig`, failing the whole config decode —
+  // an older client would drop its connection over one provider it can't
+  // render. Dropping just that element keeps every other provider working.
+  it("drops providers this build cannot decode instead of failing the whole array", () => {
+    const decodedBase = decodeServerProvider(baseProviderSnapshot);
+
+    const parsed = decodeServerProviders([
+      baseProviderSnapshot,
+      { ...baseProviderSnapshot, instanceId: "future", status: "some-future-status" },
+    ]);
+
+    expect(parsed).toEqual([decodedBase]);
   });
 });

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -197,7 +197,11 @@ export const ServerProvider = Schema.Struct({
 });
 export type ServerProvider = typeof ServerProvider.Type;
 
-export const ServerProviders = Schema.Array(ServerProvider);
+// Provider status kinds grow over time (ServerProviderState,
+// ServerProviderAuthStatus, ServerProviderVersionAdvisoryStatus,
+// ServerProviderUpdateStatus); an older client must not fail the whole config
+// decode over one provider it cannot render.
+export const ServerProviders = ForwardCompatibleArray(ServerProvider);
 export type ServerProviders = typeof ServerProviders.Type;
 
 /**


### PR DESCRIPTION
## What Changed

`ServerProviders` (`packages/contracts/src/server.ts`) was `Schema.Array(ServerProvider)`. This wraps it in `ForwardCompatibleArray` — the same helper #5055 introduced for `ServerConfigIssues` and `availableEditors` — so a provider element this build can't decode is dropped instead of failing the whole array.

Adds one test alongside the existing forward-compat tests in `server.test.ts`: an array with one decodable provider and one with an unknown `status` decodes to just the first.

## Why

`ServerProvider` has several nested literal-union status fields: `ServerProviderState`, `ServerProviderAuthStatus`, `ServerProviderVersionAdvisoryStatus`, `ServerProviderUpdateStatus`. Adding a new member to any of them — which happens whenever provider status/update features grow — makes an older client's entire `providers` array fail to decode. Since `providers` lives inside `ServerConfig`, that failure isn't scoped to the provider list: `ServerConfig` decodes as one atomic unit, and `server.getConfig` is the client's initial-sync gate on every WebSocket connection (`packages/client-runtime/src/rpc/session.ts`). One unrecognized provider status takes down the whole config decode, which the client can't distinguish from a transport error, and it retries forever.

I hit this from a different angle (a downstream fork added editor ids that don't exist upstream, which failed `availableEditors` decode the same way `#5055` already covers) and noticed `ServerProviders` was the one array left on the un-wrapped `Schema.Array` from that same PR. Since provider status enums are the field most likely to grow next, it seemed worth closing before it bites a real client version-skew case — an older mobile/desktop build against a server that shipped a new provider status.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Tests pass locally (`vp test run` in `packages/contracts`, plus full workspace `vp run -r typecheck`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract decoding behavior change in contracts only; aligns with existing forward-compat patterns and reduces version-skew connection failures.
> 
> **Overview**
> **`ServerProviders`** now uses **`ForwardCompatibleArray(ServerProvider)`** instead of a plain **`Schema.Array`**, matching **`availableEditors`** and **`ServerConfigIssues`**.
> 
> When the server sends a provider snapshot this build cannot decode (e.g. a new **`status`** literal), that element is **dropped** instead of failing the entire **`providers`** array and **`ServerConfig`** decode on initial WebSocket sync.
> 
> A test in **`server.test.ts`** asserts a mix of valid and unknown-status providers decodes to only the recognizable entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc16ad876d57b6e14d715f3a68b4b741adcb93a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Decode `ServerProviders` forward-compatibly by dropping unknown entries
> Changes `ServerProviders` in [server.ts](https://github.com/pingdotgg/t3code/pull/5327/files#diff-e575e7eac4053ca860f2d99f4f5bf09331b4e959961ac7bfed0562e916fc5dbb) from `Schema.Array(ServerProvider)` to `ForwardCompatibleArray(ServerProvider)`. This makes decoding tolerant of unknown provider status kinds — entries that cannot be decoded are silently dropped instead of failing the entire array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc16ad8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->