### PR TITLE
fix(web): keep the composer command menu anchored to the composer

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -108,13 +108,24 @@ import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
 import { Separator } from "../ui/separator";
 
+type ComposerCommandMenuPosition = {
+  bottom: number;
+  left: number;
+  maxHeight: number;
+  width: number;
+};
+
+function composerCommandMenuPositionsEqual(
+  a: ComposerCommandMenuPosition,
+  b: ComposerCommandMenuPosition,
+): boolean {
+  return (
+    a.bottom === b.bottom && a.left === b.left && a.maxHeight === b.maxHeight && a.width === b.width
+  );
+}
+
 function ComposerCommandMenuLayer(props: { anchor: HTMLElement | null; children: ReactNode }) {
-  const [position, setPosition] = useState<{
-    bottom: number;
-    left: number;
-    maxHeight: number;
-    width: number;
-  } | null>(null);
+  const [position, setPosition] = useState<ComposerCommandMenuPosition | null>(null);
 
   useLayoutEffect(() => {
     const anchor = props.anchor;
@@ -125,12 +136,15 @@ function ComposerCommandMenuLayer(props: { anchor: HTMLElement | null; children:
 
     const updatePosition = () => {
       const rect = anchor.getBoundingClientRect();
-      setPosition({
+      const next = {
         bottom: window.innerHeight - rect.top + 8,
         left: rect.left,
         maxHeight: Math.max(96, rect.top - 24),
         width: rect.width,
-      });
+      };
+      setPosition((current) =>
+        current && composerCommandMenuPositionsEqual(current, next) ? current : next,
+      );
     };
 
     updatePosition();
@@ -139,7 +153,16 @@ function ComposerCommandMenuLayer(props: { anchor: HTMLElement | null; children:
 
     const observer =
       typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updatePosition);
-    observer?.observe(anchor);
+    if (observer) {
+      // The composer is centered and capped at a max width, so opening a side
+      // panel slides it sideways without ever resizing it. Watching the anchor
+      // alone would leave the menu behind; the ancestors are what shrink, and
+      // they resize on every frame of the panel animation.
+      observer.observe(anchor);
+      for (let element = anchor.parentElement; element; element = element.parentElement) {
+        observer.observe(element);
+      }
+    }
 
     return () => {
       observer?.disconnect();


### PR DESCRIPTION
## Problem

Type `/`, `@`, or `$` in the composer, then open the right panel (or the terminal drawer) while the menu is up: the menu stays exactly where it was and detaches from the composer it belongs to.

The menu is portaled to the body and positioned from the anchor's rect, refreshed on window `resize`, `scroll`, and a `ResizeObserver` on the anchor itself. But the composer is centered and capped at `max-w-3xl`, so on a wide window opening a side panel *slides* it without ever resizing it. The observer never fires and the menu is left behind.

Measured at a 2200px viewport, menu vs. composer left edge:

| | before | after |
| --- | --- | --- |
| right panel opened | menu `846`, composer `574` | menu `576`, composer `574` |
| terminal drawer opened | menu bottom `536`, composer top `404` (overlapping) | menu bottom `396`, composer top `404` |

## Fix

Observe the anchor's ancestors as well. They are what actually shrink, and they resize on every frame of the panel animation, so the menu tracks the composer through the transition instead of snapping late. Positions are compared before committing to state so the extra observations don't re-render the menu on no-op resizes.

Same layer backs the slash/mention/skill menus and the stash menu, so all of them are fixed.

![Composer command menu staying anchored when the right panel opens](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/ae8f3f8a-fe1d-4360-84ef-d734898b3914/composer-command-menu-anchor-fix.gif)

## Testing

- Drove the web client in a local dev environment (Playwright, 2200x1200): opened the `$` skills menu, then toggled the right panel and the terminal drawer, with and without the patch — numbers above.
- `vp lint` and `typecheck` on the touched scope.

## Surfaces

- **Clients:** web only. Mobile has its own `ComposerCommandPopover` with React Native layout and is unaffected; desktop wraps web and inherits the fix.
- **Entry points:** all four composer triggers (`/`, `@`, `$`, stash) share this layer.
- No contract, provider, or docs impact — the behavior was always intended to be anchored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI positioning fix in ChatComposer with no auth, data, or API changes.
> 
> **Overview**
> Fixes **composer command menus** (`/`, `@`, `$`, stash) drifting away from the composer when the right panel or terminal drawer opens.
> 
> The portaled `ComposerCommandMenuLayer` only watched the anchor for resize; on wide layouts the composer **slides** when a side panel opens without changing size, so the menu never repositioned. The layer now attaches **ResizeObserver** to the anchor’s **ancestor chain** so layout shrinks during panel animation trigger updates.
> 
> Position updates are **deduplicated** via a `ComposerCommandMenuPosition` type and equality check before `setState`, so extra observer callbacks don’t re-render on no-op geometry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f68017e7fe0d95b3c6aeaad737b4d42fa6b021f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer command menu position to track ancestor element resizes
> The `ComposerCommandMenuLayer` in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/5336/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) was only observing the anchor element for resize events, causing the menu to drift when parent containers resized.
>
> - Extends `ResizeObserver` to observe the anchor and all its DOM ancestors, so position updates trigger on any ancestor resize.
> - Adds `composerCommandMenuPositionsEqual` to skip redundant state updates when the computed position is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f68017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->