### PR TITLE
fix(web): keep release notes tooltip open on hover

### DIFF
--- a/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { NIGHTLY_RELEASE_NOTES_TOOLTIP_CLASS_NAME } from "./SidebarUpdatePill";
+
+describe("nightly release notes tooltip", () => {
+  it("keeps the whole popup hoverable while moving from the update pill", () => {
+    expect(NIGHTLY_RELEASE_NOTES_TOOLTIP_CLASS_NAME).toContain("pointer-events-auto");
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -19,6 +19,9 @@ import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { Separator } from "../ui/separator";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
+export const NIGHTLY_RELEASE_NOTES_TOOLTIP_CLASS_NAME =
+  "pointer-events-auto max-w-none text-balance";
+
 function SidebarUpdateReleaseNotesTooltip({
   state,
   tooltip,
@@ -35,7 +38,7 @@ function SidebarUpdateReleaseNotesTooltip({
       <div className="px-1">
         <div className="text-sm leading-5 font-medium">{tooltip}</div>
       </div>
-      <div className="pointer-events-auto max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
+      <div className="max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
         {state.releaseNotes.map((releaseNote, index) => (
           <div key={releaseNote.version}>
             {index > 0 && <Separator className="my-3 bg-border/60" />}
@@ -194,7 +197,7 @@ export function SidebarUpdatePill() {
               align="start"
               className={
                 state?.channel === "nightly" && state.releaseNotes.length > 0
-                  ? "max-w-none text-balance"
+                  ? NIGHTLY_RELEASE_NOTES_TOOLTIP_CLASS_NAME
                   : undefined
               }
               side="top"


### PR DESCRIPTION
## What Changed

- Make the nightly release-notes tooltip popup pointer-interactive across its full bounds, including its padding and heading.
- Keep the existing scroll container behavior and add a focused regression test for the hoverable popup class.

## Why

The shared tooltip positioner disables pointer events. The release-notes tooltip previously re-enabled them only on the inner scrolling region, leaving a non-interactive boundary around the popup. Moving the cursor from the update pill across that boundary closed the tooltip before the cursor could reach and scroll the notes.

Enabling pointer events on the popup itself lets Base UI preserve its hoverable-popup behavior for the entire release-notes surface.

## UI Changes

The appearance is unchanged; this only changes pointer interaction.

![Release notes tooltip after the fix](https://raw.githubusercontent.com/KyleKincer/t3code/pr-assets-release-notes-hover-scroll/release-notes-after.png)

### Interaction video

The cursor moves from the update pill into the tooltip, then scrolls the release notes without dismissing it.

![Release notes hover and scroll interaction](https://raw.githubusercontent.com/KyleKincer/t3code/pr-assets-release-notes-hover-scroll/release-notes-hover-scroll.gif)

[MP4 recording](https://raw.githubusercontent.com/KyleKincer/t3code/pr-assets-release-notes-hover-scroll/release-notes-hover-scroll.mp4)

## Verification

- `vp test run src/components/sidebar/SidebarUpdatePill.test.tsx --project unit`
- `vp run typecheck` (apps/web)
- Automated browser interaction: entered the tooltip, waited, scrolled 500px, and asserted it remained visible

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after evidence for the UI interaction (appearance is unchanged)
- [x] I included a video for the interaction change

Generated with GPT-5.6 Sol in Cursor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized tooltip pointer-event styling for the nightly release-notes UI; no auth, data, or core logic changes.
> 
> **Overview**
> Fixes the nightly desktop update **release notes tooltip** dismissing when the cursor moves from the update pill into the tooltip padding or heading.
> 
> **`pointer-events-auto`** is applied on **`TooltipPopup`** via exported **`NIGHTLY_RELEASE_NOTES_TOOLTIP_CLASS_NAME`** (with **`max-w-none`** and **`text-balance`**), instead of only on the inner scroll region. The shared tooltip positioner uses **`pointer-events-none`**, so re-enabling events on the full popup surface lets Base UI keep the tooltip open while hovering the entire release-notes area.
> 
> A unit test asserts the shared class string still includes **`pointer-events-auto`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec744d87616e975a09d701ddae1a1779eaf1f844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release notes tooltip in sidebar to stay open on hover
> Moves `pointer-events-auto` from the inner scrollable div to the `TooltipPopup` element itself, so the tooltip stays open as the cursor moves from the update pill into the tooltip. Extracts the nightly tooltip classes into an exported `NIGHTLY_RELEASE_NOTES_TOOLTIP_CLASS_NAME` constant in [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/5337/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf) and adds a test asserting the constant includes `pointer-events-auto`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec744d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->