### PR TITLE
feat(web): open a project's terminal from the chat header

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -252,6 +252,12 @@ it.effect("opens a CLI-less macOS terminal through its app bundle", () =>
     yield* fileSystem.writeFileString(path.join(binDir, "open"), "#!/bin/sh\n");
     yield* fileSystem.chmod(path.join(binDir, "open"), 0o755);
     const workspace = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-workspace-" });
+    // The bundle lives under a temp HOME so the test does not depend on the
+    // machine it runs on having Terminal.app.
+    const home = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-home-" });
+    yield* fileSystem.makeDirectory(path.join(home, "Applications", "Terminal.app"), {
+      recursive: true,
+    });
 
     let spawned: ChildProcess.StandardCommand | undefined;
     yield* Effect.gen(function* () {
@@ -261,7 +267,7 @@ it.effect("opens a CLI-less macOS terminal through its app bundle", () =>
       Effect.provide(
         testLayer({
           platform: "darwin",
-          env: { PATH: binDir },
+          env: { PATH: binDir, HOME: home },
           onSpawn: (command) => {
             spawned = command;
           },

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -155,6 +155,71 @@ it.effect("discovers editors through the service API", () =>
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 
+it.effect("opens a terminal at the directory holding the launch target", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-terminals-" });
+    yield* fileSystem.writeFileString(path.join(binDir, "ghostty"), "#!/bin/sh\n");
+    yield* fileSystem.chmod(path.join(binDir, "ghostty"), 0o755);
+    const workspace = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-workspace-" });
+    const file = path.join(workspace, "index.ts");
+    yield* fileSystem.writeFileString(file, "");
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      // A file with a position, as the "open this config file" flows send.
+      yield* launcher.launchEditor({ editor: "ghostty", cwd: `${file}:12:4` });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "linux",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.equal(spawned.command, "ghostty");
+    assert.deepEqual(spawned.args, [`--working-directory=${workspace}`]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("opens a CLI-less macOS terminal through its app bundle", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-terminals-" });
+    yield* fileSystem.writeFileString(path.join(binDir, "open"), "#!/bin/sh\n");
+    yield* fileSystem.chmod(path.join(binDir, "open"), 0o755);
+    const workspace = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-workspace-" });
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.launchEditor({ editor: "apple-terminal", cwd: workspace });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "darwin",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.equal(spawned.command, "open");
+    assert.deepEqual(spawned.args, ["-a", "Terminal", workspace]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
 it.effect("rejects unknown editors through the service API", () =>
   Effect.gen(function* () {
     const launcher = yield* ExternalLauncher.ExternalLauncher;

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -189,6 +189,61 @@ it.effect("opens a terminal at the directory holding the launch target", () =>
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 
+// A colon is legal in a POSIX directory name, so the position suffix must not
+// be stripped off a path that is already a directory.
+it.effect("keeps a directory whose name ends in a colon-number intact", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-terminals-" });
+    yield* fileSystem.writeFileString(path.join(binDir, "ghostty"), "#!/bin/sh\n");
+    yield* fileSystem.chmod(path.join(binDir, "ghostty"), 0o755);
+    const parent = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-workspace-" });
+    const workspace = path.join(parent, "project:12");
+    yield* fileSystem.makeDirectory(workspace);
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.launchEditor({ editor: "ghostty", cwd: workspace });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "linux",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.deepEqual(spawned.args, [`--working-directory=${workspace}`]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+// `open` is macOS-only, so a stray .app path on another platform must not
+// hijack the launch away from a plain command-not-found.
+it.effect("does not fall back to a macOS app bundle off darwin", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const home = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-home-" });
+    yield* fileSystem.makeDirectory(path.join(home, "Applications", "Ghostty.app"), {
+      recursive: true,
+    });
+
+    const error = yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      return yield* launcher.launchEditor({ editor: "ghostty", cwd: "/tmp" }).pipe(Effect.flip);
+    }).pipe(Effect.provide(testLayer({ platform: "linux", env: { PATH: "", HOME: home } })));
+
+    assert.instanceOf(error, ExternalLauncher.ExternalLauncherCommandNotFoundError);
+    assert.equal(error.command, "ghostty");
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
 it.effect("opens a CLI-less macOS terminal through its app bundle", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -435,8 +435,14 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
   }
 
   // No CLI at all: a GUI-only bundle handed the path to open, which is how the
-  // macOS terminals (Terminal, iTerm, Warp) take a working directory.
+  // macOS terminals (Terminal, iTerm, Warp) take a working directory. The
+  // bundle is checked first because `open` detaches with stdio ignored, so a
+  // missing app would otherwise look like success and simply do nothing.
   if (macAppName && platform === "darwin") {
+    if (!(yield* isMacAppAvailable(macAppName, env))) {
+      return yield* new ExternalLauncherUnsupportedEditorError({ editor: input.editor });
+    }
+
     return {
       editor: editorDef.id,
       target,

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -7,6 +7,7 @@
  * @module ExternalLauncher
  */
 import {
+  EDITOR_CWD_PLACEHOLDER,
   EDITORS,
   ExternalLauncherError,
   ExternalLauncherBrowserSpawnError,
@@ -104,6 +105,7 @@ const CommandLookupEnvConfig = Config.all({
   Path: Config.string("Path").pipe(Config.option),
   path: Config.string("path").pipe(Config.option),
   PATHEXT: Config.string("PATHEXT").pipe(Config.option),
+  HOME: Config.string("HOME").pipe(Config.option),
 }).pipe(Config.map(compactEnv));
 
 const readBrowserLaunchEnv = BrowserLaunchEnvConfig.pipe(Effect.orElseSucceed(() => ({})));
@@ -146,6 +148,11 @@ function resolveCommandEditorArgs(
           path,
         ],
       });
+    // `target` is already the resolved directory here — see resolveWorkingDirectory.
+    case "working-directory":
+      return "cwdArgs" in editor && editor.cwdArgs
+        ? editor.cwdArgs.map((arg) => arg.replaceAll(EDITOR_CWD_PLACEHOLDER, target))
+        : [target];
   }
 }
 
@@ -167,6 +174,49 @@ const resolveAvailableCommand = Effect.fn("externalLauncher.resolveAvailableComm
     }
   }
   return Option.none();
+});
+
+const isMacAppAvailable = Effect.fn("externalLauncher.isMacAppAvailable")(function* (
+  appName: string,
+  env: NodeJS.ProcessEnv,
+): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const candidates = [
+    `/Applications/${appName}.app`,
+    // Apple's own bundles (Terminal) live under /System, not /Applications.
+    `/System/Applications/${appName}.app`,
+    `/System/Applications/Utilities/${appName}.app`,
+    ...(env.HOME ? [`${env.HOME}/Applications/${appName}.app`] : []),
+  ];
+  for (const candidate of candidates) {
+    if (yield* fileSystem.exists(candidate).pipe(Effect.orElseSucceed(() => false))) {
+      return true;
+    }
+  }
+  return false;
+});
+
+/**
+ * Directory a `working-directory` launch should start in.
+ *
+ * The launch target is whatever the caller wanted opened, which may carry a
+ * `:line:column` suffix and may be a file rather than a directory — a terminal
+ * takes neither, so strip the position and step up to the containing folder.
+ */
+const resolveWorkingDirectory = Effect.fn("externalLauncher.resolveWorkingDirectory")(function* (
+  target: string,
+): Effect.fn.Return<string, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const candidate = Option.match(parseTargetPathAndPosition(target), {
+    onNone: () => target,
+    onSome: (parsed) => parsed.path,
+  });
+  const isDirectory = yield* fileSystem.stat(candidate).pipe(
+    Effect.map((info) => info.type === "Directory"),
+    Effect.orElseSucceed(() => false),
+  );
+  return isDirectory ? candidate : path.dirname(candidate);
 });
 
 function encodeUtf16LeBase64(input: string): string {
@@ -267,7 +317,7 @@ const buildAvailableEditors = Effect.fn("externalLauncher.buildAvailableEditors"
   const available: EditorId[] = [];
 
   for (const editor of EDITORS) {
-    if (editor.commands === null) {
+    if ("kind" in editor && editor.kind === "file-manager") {
       const command = fileManagerCommandForPlatform(platform);
       if (yield* isCommandAvailable(command, { env })) {
         available.push(editor.id);
@@ -275,9 +325,18 @@ const buildAvailableEditors = Effect.fn("externalLauncher.buildAvailableEditors"
       continue;
     }
 
-    const command = yield* resolveAvailableCommand(editor.commands, env);
-    if (Option.isSome(command)) {
-      available.push(editor.id);
+    if (editor.commands !== null) {
+      const command = yield* resolveAvailableCommand(editor.commands, env);
+      if (Option.isSome(command)) {
+        available.push(editor.id);
+        continue;
+      }
+    }
+
+    if ("macAppName" in editor && editor.macAppName && platform === "darwin") {
+      if (yield* isMacAppAvailable(editor.macAppName, env)) {
+        available.push(editor.id);
+      }
     }
   }
 
@@ -335,28 +394,51 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
     return yield* new ExternalLauncherUnknownEditorError({ editor: input.editor });
   }
 
+  const target =
+    editorDef.launchStyle === "working-directory"
+      ? yield* resolveWorkingDirectory(input.cwd)
+      : input.cwd;
+  const macAppName = "macAppName" in editorDef ? editorDef.macAppName : undefined;
+
   if (editorDef.commands) {
-    const command = Option.getOrElse(
-      yield* resolveAvailableCommand(editorDef.commands, env),
-      () => editorDef.commands[0],
-    );
+    const resolved = yield* resolveAvailableCommand(editorDef.commands, env);
+    if (Option.isNone(resolved) && macAppName && (yield* isMacAppAvailable(macAppName, env))) {
+      return {
+        editor: editorDef.id,
+        target,
+        command: "open",
+        args: ["-a", macAppName, target],
+      };
+    }
+
     return {
       editor: editorDef.id,
-      target: input.cwd,
-      command,
-      args: resolveEditorArgs(editorDef, input.cwd),
+      target,
+      command: Option.getOrElse(resolved, () => editorDef.commands[0]),
+      args: resolveEditorArgs(editorDef, target),
     };
   }
 
-  if (editorDef.id !== "file-manager") {
+  // No CLI at all: a GUI-only bundle handed the path to open, which is how the
+  // macOS terminals (Terminal, iTerm, Warp) take a working directory.
+  if (macAppName && platform === "darwin") {
+    return {
+      editor: editorDef.id,
+      target,
+      command: "open",
+      args: ["-a", macAppName, target],
+    };
+  }
+
+  if (!("kind" in editorDef) || editorDef.kind !== "file-manager") {
     return yield* new ExternalLauncherUnsupportedEditorError({ editor: input.editor });
   }
 
   return {
     editor: editorDef.id,
-    target: input.cwd,
+    target,
     command: fileManagerCommandForPlatform(platform),
-    args: [input.cwd],
+    args: [target],
   };
 });
 

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -202,21 +202,31 @@ const isMacAppAvailable = Effect.fn("externalLauncher.isMacAppAvailable")(functi
  * The launch target is whatever the caller wanted opened, which may carry a
  * `:line:column` suffix and may be a file rather than a directory — a terminal
  * takes neither, so strip the position and step up to the containing folder.
+ *
+ * The target is tested as-is first: a colon is legal in a POSIX directory
+ * name, so stripping a position before looking would send a real directory
+ * named `project:12` to its parent instead.
  */
 const resolveWorkingDirectory = Effect.fn("externalLauncher.resolveWorkingDirectory")(function* (
   target: string,
 ): Effect.fn.Return<string, never, FileSystem.FileSystem | Path.Path> {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const candidate = Option.match(parseTargetPathAndPosition(target), {
+  const isDirectory = (candidate: string) =>
+    fileSystem.stat(candidate).pipe(
+      Effect.map((info) => info.type === "Directory"),
+      Effect.orElseSucceed(() => false),
+    );
+
+  if (yield* isDirectory(target)) {
+    return target;
+  }
+
+  const withoutPosition = Option.match(parseTargetPathAndPosition(target), {
     onNone: () => target,
     onSome: (parsed) => parsed.path,
   });
-  const isDirectory = yield* fileSystem.stat(candidate).pipe(
-    Effect.map((info) => info.type === "Directory"),
-    Effect.orElseSucceed(() => false),
-  );
-  return isDirectory ? candidate : path.dirname(candidate);
+  return (yield* isDirectory(withoutPosition)) ? withoutPosition : path.dirname(withoutPosition);
 });
 
 function encodeUtf16LeBase64(input: string): string {
@@ -402,7 +412,12 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
 
   if (editorDef.commands) {
     const resolved = yield* resolveAvailableCommand(editorDef.commands, env);
-    if (Option.isNone(resolved) && macAppName && (yield* isMacAppAvailable(macAppName, env))) {
+    if (
+      Option.isNone(resolved) &&
+      macAppName &&
+      platform === "darwin" &&
+      (yield* isMacAppAvailable(macAppName, env))
+    ) {
       return {
         editor: editorDef.id,
         target,

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -15,6 +15,7 @@ import ProjectScriptsControl, {
   type ProjectScriptActionResult,
 } from "../ProjectScriptsControl";
 import { OpenInPicker } from "./OpenInPicker";
+import { OpenTerminalPicker } from "./OpenTerminalPicker";
 import { usePrimaryEnvironmentId } from "../../state/environments";
 import { useT3ProjectFileScripts } from "~/hooks/useT3ProjectFileScripts";
 import { ProjectFavicon } from "../ProjectFavicon";
@@ -150,6 +151,13 @@ export const ChatHeader = memo(function ChatHeader({
             onAddScript={onAddProjectScript}
             onUpdateScript={onUpdateProjectScript}
             onDeleteScript={onDeleteProjectScript}
+          />
+        )}
+        {showOpenInPicker && (
+          <OpenTerminalPicker
+            environmentId={activeThreadEnvironmentId}
+            availableEditors={availableEditors}
+            openInCwd={openInCwd}
           />
         )}
         {showOpenInPicker && (

--- a/apps/web/src/components/chat/OpenTerminalPicker.tsx
+++ b/apps/web/src/components/chat/OpenTerminalPicker.tsx
@@ -1,0 +1,116 @@
+import {
+  isTerminalId,
+  TERMINAL_IDS,
+  terminalLabel,
+  type EditorId,
+  type EnvironmentId,
+  type TerminalId,
+} from "@t3tools/contracts";
+import { ChevronDownIcon, TerminalIcon } from "lucide-react";
+import { memo, useCallback, useMemo } from "react";
+
+import { usePreferredTerminal } from "../../editorPreferences";
+import { Button } from "../ui/button";
+import { Group, GroupSeparator } from "../ui/group";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../ui/menu";
+import { shellEnvironment } from "~/state/shell";
+import { useAtomCommand } from "~/state/use-atom-command";
+
+/** Installed terminals, in the order the menu lists them. */
+export const resolveTerminalOptions = (
+  availableEditors: ReadonlyArray<EditorId>,
+): ReadonlyArray<TerminalId> => {
+  const available = new Set(availableEditors.filter(isTerminalId));
+  return TERMINAL_IDS.filter((id) => available.has(id));
+};
+
+/**
+ * Opens a shell in the project. Deliberately its own control rather than a row
+ * in the Open-in picker: a terminal is not an app you open the project *in*,
+ * and picking one should not move the editor the Open button uses.
+ */
+export const OpenTerminalPicker = memo(function OpenTerminalPicker({
+  environmentId,
+  availableEditors,
+  openInCwd,
+  compact = false,
+}: {
+  environmentId: EnvironmentId;
+  availableEditors: ReadonlyArray<EditorId>;
+  openInCwd: string | null;
+  compact?: boolean;
+}) {
+  const openTerminalMutation = useAtomCommand(shellEnvironment.openInEditor, "open terminal");
+  const terminals = useMemo(() => resolveTerminalOptions(availableEditors), [availableEditors]);
+  const [preferredTerminal, setPreferredTerminal] = usePreferredTerminal(terminals);
+
+  const openTerminal = useCallback(
+    (terminalId: TerminalId | null) => {
+      if (!openInCwd) return;
+      const terminal = terminalId ?? preferredTerminal;
+      if (!terminal) return;
+      const result = openTerminalMutation({
+        environmentId,
+        input: {
+          cwd: openInCwd,
+          editor: terminal,
+        },
+      });
+      setPreferredTerminal(terminal);
+      return result;
+    },
+    [environmentId, openInCwd, openTerminalMutation, preferredTerminal, setPreferredTerminal],
+  );
+
+  if (terminals.length === 0) return null;
+
+  return (
+    <Group aria-label="Open terminal">
+      <Button
+        aria-label={
+          preferredTerminal
+            ? `Open project in ${terminalLabel(preferredTerminal)}`
+            : "Open project terminal"
+        }
+        className="ps-[8.5px]"
+        size="xs"
+        variant="outline"
+        disabled={!preferredTerminal || !openInCwd}
+        onClick={() => openTerminal(preferredTerminal)}
+      >
+        <TerminalIcon aria-hidden="true" className="size-3.5 text-muted-foreground" />
+        <span
+          className={
+            compact
+              ? "sr-only"
+              : "sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5"
+          }
+        >
+          Terminal
+        </span>
+      </Button>
+      {terminals.length > 1 && (
+        <>
+          <GroupSeparator
+            {...(!compact ? { className: "hidden @3xl/header-actions:block" } : {})}
+          />
+          <Menu>
+            <MenuTrigger
+              render={<Button aria-label="Choose terminal" size="icon-xs" variant="outline" />}
+            >
+              <ChevronDownIcon aria-hidden="true" className="size-4" />
+            </MenuTrigger>
+            <MenuPopup align="end">
+              {terminals.map((terminal) => (
+                <MenuItem key={terminal} onClick={() => openTerminal(terminal)}>
+                  <TerminalIcon aria-hidden="true" className="text-muted-foreground" />
+                  {terminalLabel(terminal)}
+                </MenuItem>
+              ))}
+            </MenuPopup>
+          </Menu>
+        </>
+      )}
+    </Group>
+  );
+});

--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -1,4 +1,4 @@
-import { EDITORS, EditorId, EnvironmentId } from "@t3tools/contracts";
+import { EDITORS, EditorId, EnvironmentId, isTerminalId, TerminalId } from "@t3tools/contracts";
 import {
   mapAtomCommandResult,
   type AtomCommandFailure,
@@ -13,6 +13,7 @@ import { shellEnvironment } from "./state/shell";
 import { useAtomCommand } from "./state/use-atom-command";
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
+const LAST_TERMINAL_KEY = "t3code:last-terminal";
 
 export class PreferredEditorEnvironmentRequiredError extends Schema.TaggedErrorClass<PreferredEditorEnvironmentRequiredError>()(
   "PreferredEditorEnvironmentRequiredError",
@@ -43,10 +44,32 @@ export function usePreferredEditor(availableEditors: ReadonlyArray<EditorId>) {
 
   const effectiveEditor = useMemo(() => {
     if (lastEditor && availableEditors.includes(lastEditor)) return lastEditor;
-    return EDITORS.find((editor) => availableEditors.includes(editor.id))?.id ?? null;
+    // Terminals are launch targets too, but they belong to the Terminal action,
+    // not the Open-in picker — never fall back into one.
+    return (
+      EDITORS.find((editor) => availableEditors.includes(editor.id) && !isTerminalId(editor.id))
+        ?.id ?? null
+    );
   }, [lastEditor, availableEditors]);
 
   return [effectiveEditor, setLastEditor] as const;
+}
+
+/**
+ * Terminal the Terminal action opens, plus the setter its menu uses. Mirrors
+ * {@link usePreferredEditor}: the last pick wins, and a pick the environment no
+ * longer offers falls through to the first installed terminal rather than
+ * leaving a dead button.
+ */
+export function usePreferredTerminal(availableTerminals: ReadonlyArray<TerminalId>) {
+  const [lastTerminal, setLastTerminal] = useLocalStorage(LAST_TERMINAL_KEY, null, TerminalId);
+
+  const effectiveTerminal = useMemo(() => {
+    if (lastTerminal && availableTerminals.includes(lastTerminal)) return lastTerminal;
+    return availableTerminals[0] ?? null;
+  }, [lastTerminal, availableTerminals]);
+
+  return [effectiveTerminal, setLastTerminal] as const;
 }
 
 export function resolveAndPersistPreferredEditor(
@@ -55,7 +78,9 @@ export function resolveAndPersistPreferredEditor(
   const availableEditorIds = new Set(availableEditors);
   const stored = getLocalStorageItem(LAST_EDITOR_KEY, EditorId);
   if (stored && availableEditorIds.has(stored)) return stored;
-  const editor = EDITORS.find((editor) => availableEditorIds.has(editor.id))?.id ?? null;
+  const editor =
+    EDITORS.find((editor) => availableEditorIds.has(editor.id) && !isTerminalId(editor.id))?.id ??
+    null;
   if (editor) setLocalStorageItem(LAST_EDITOR_KEY, editor, EditorId);
   return editor ?? null;
 }

--- a/packages/contracts/src/editor.test.ts
+++ b/packages/contracts/src/editor.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { EDITORS, isTerminalId, TERMINAL_IDS, terminalLabel } from "./editor.ts";
+
+describe("terminal ids", () => {
+  // Terminals ride the editor launch path but are their own UI action, so the
+  // ids have to stay tellable apart from the apps the Open-in picker lists.
+  it("classifies exactly the terminal definitions as terminals", () => {
+    expect(TERMINAL_IDS.length).toBeGreaterThan(0);
+    expect(EDITORS.filter((editor) => isTerminalId(editor.id)).map((editor) => editor.id)).toEqual([
+      ...TERMINAL_IDS,
+    ]);
+
+    expect(isTerminalId("vscode")).toBe(false);
+    expect(isTerminalId("file-manager")).toBe(false);
+  });
+
+  it("labels every terminal and nothing else", () => {
+    for (const terminal of TERMINAL_IDS) {
+      expect(terminalLabel(terminal)).toBeTruthy();
+    }
+
+    expect(terminalLabel("vscode")).toBeNull();
+  });
+
+  // A terminal takes a directory, so it must not inherit a file-oriented
+  // launch style by accident.
+  it("gives every terminal a working-directory launch", () => {
+    for (const editor of EDITORS) {
+      if (!isTerminalId(editor.id)) continue;
+      expect(editor.launchStyle).toBe("working-directory");
+    }
+  });
+
+  // Editors are listed first so a fresh install with no stored preference
+  // still falls back to an editor rather than a terminal.
+  it("orders terminals after every editor", () => {
+    const ids = EDITORS.map((editor) => editor.id);
+    const firstTerminal = ids.findIndex((id) => isTerminalId(id));
+    const lastEditor = ids.reduce(
+      (last, id, index) => (isTerminalId(id) || id === "file-manager" ? last : index),
+      -1,
+    );
+
+    expect(firstTerminal).toBeGreaterThan(lastEditor);
+  });
+});

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -1,8 +1,16 @@
 import * as Schema from "effect/Schema";
 import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 
-export const EditorLaunchStyle = Schema.Literals(["direct-path", "goto", "line-column"]);
+export const EditorLaunchStyle = Schema.Literals([
+  "direct-path",
+  "goto",
+  "line-column",
+  "working-directory",
+]);
 export type EditorLaunchStyle = typeof EditorLaunchStyle.Type;
+
+/** Stands in for the resolved directory inside {@link EditorDefinition.cwdArgs}. */
+export const EDITOR_CWD_PLACEHOLDER = "{cwd}";
 
 type EditorDefinition = {
   readonly id: string;
@@ -10,6 +18,18 @@ type EditorDefinition = {
   readonly commands: readonly [string, ...string[]] | null;
   readonly baseArgs?: readonly string[];
   readonly launchStyle: EditorLaunchStyle;
+  readonly macAppName?: string;
+  /**
+   * Integrations that open a directory rather than a file, and so need their
+   * own launch path on the server.
+   */
+  readonly kind?: "file-manager" | "terminal";
+  /**
+   * Arguments a `working-directory` launch passes to the CLI, with
+   * {@link EDITOR_CWD_PLACEHOLDER} standing in for the resolved directory.
+   * Omitted means "pass the directory as the only argument".
+   */
+  readonly cwdArgs?: readonly [string, ...string[]];
 };
 
 export const EDITORS = [
@@ -38,11 +58,112 @@ export const EDITORS = [
   { id: "rubymine", label: "RubyMine", commands: ["rubymine"], launchStyle: "line-column" },
   { id: "rustrover", label: "RustRover", commands: ["rustrover"], launchStyle: "line-column" },
   { id: "webstorm", label: "WebStorm", commands: ["webstorm"], launchStyle: "line-column" },
-  { id: "file-manager", label: "File Manager", commands: null, launchStyle: "direct-path" },
+  // Terminals open the project directory rather than a file. `macAppName` is
+  // set only for the ones whose macOS bundle opens a folder argument in that
+  // directory; the rest would silently start in the user's home, so they show
+  // up only when their CLI is on PATH. They sit after the editors so a fresh
+  // install with no stored preference still falls back to an editor.
+  {
+    id: "apple-terminal",
+    label: "Terminal",
+    commands: null,
+    launchStyle: "working-directory",
+    macAppName: "Terminal",
+    kind: "terminal",
+  },
+  {
+    id: "iterm2",
+    label: "iTerm",
+    commands: null,
+    launchStyle: "working-directory",
+    macAppName: "iTerm",
+    kind: "terminal",
+  },
+  {
+    id: "ghostty",
+    label: "Ghostty",
+    commands: ["ghostty"],
+    cwdArgs: ["--working-directory={cwd}"],
+    launchStyle: "working-directory",
+    macAppName: "Ghostty",
+    kind: "terminal",
+  },
+  {
+    id: "warp",
+    label: "Warp",
+    commands: null,
+    launchStyle: "working-directory",
+    macAppName: "Warp",
+    kind: "terminal",
+  },
+  {
+    id: "wezterm",
+    label: "WezTerm",
+    commands: ["wezterm"],
+    cwdArgs: ["start", "--cwd", "{cwd}"],
+    launchStyle: "working-directory",
+    kind: "terminal",
+  },
+  {
+    id: "kitty",
+    label: "kitty",
+    commands: ["kitty"],
+    cwdArgs: ["--directory", "{cwd}"],
+    launchStyle: "working-directory",
+    kind: "terminal",
+  },
+  {
+    id: "alacritty",
+    label: "Alacritty",
+    commands: ["alacritty"],
+    cwdArgs: ["--working-directory", "{cwd}"],
+    launchStyle: "working-directory",
+    kind: "terminal",
+  },
+  {
+    id: "windows-terminal",
+    label: "Windows Terminal",
+    commands: ["wt"],
+    cwdArgs: ["-d", "{cwd}"],
+    launchStyle: "working-directory",
+    kind: "terminal",
+  },
+  {
+    id: "file-manager",
+    label: "File Manager",
+    commands: null,
+    launchStyle: "direct-path",
+    kind: "file-manager",
+  },
 ] as const satisfies ReadonlyArray<EditorDefinition>;
 
 export const EditorId = Schema.Literals(EDITORS.map((e) => e.id));
 export type EditorId = typeof EditorId.Type;
+
+/**
+ * Terminals are launch targets like the editors, but they are not an "open
+ * this in an app" choice: they open a shell in the project, so the UI surfaces
+ * them as their own action rather than as a row in the Open-in picker.
+ */
+export type TerminalId = Extract<(typeof EDITORS)[number], { kind: "terminal" }>["id"];
+
+export const TERMINAL_IDS = EDITORS.filter(
+  (editor): editor is Extract<(typeof EDITORS)[number], { kind: "terminal" }> =>
+    "kind" in editor && editor.kind === "terminal",
+).map((editor) => editor.id);
+
+export const TerminalId = Schema.Literals(TERMINAL_IDS);
+
+const TERMINAL_ID_SET: ReadonlySet<string> = new Set(TERMINAL_IDS);
+
+export function isTerminalId(id: EditorId): id is TerminalId {
+  return TERMINAL_ID_SET.has(id);
+}
+
+/** Label a terminal shows in the UI, or null when the id is not a terminal. */
+export function terminalLabel(id: EditorId): string | null {
+  return EDITORS.find((editor) => editor.id === id && isTerminalId(editor.id))?.label ?? null;
+}
 
 export const LaunchEditorInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,


### PR DESCRIPTION
## What Changed

Adds a **Terminal** control to the chat header, next to Open-in, that launches the project directory in an installed terminal.

- Supported: Terminal, iTerm, Warp and Ghostty on macOS via their app bundles, plus Ghostty, WezTerm, kitty, Alacritty and Windows Terminal via their CLIs. Only installed ones appear.
- The preferred terminal is remembered exactly like the preferred editor (`t3code:last-terminal` in localStorage, mirroring `usePreferredEditor`). The chevron menu only renders when more than one terminal is installed, so the common case is a single button.
- `EDITORS` gains a `working-directory` launch style. Its target is resolved to a directory first: a `:line:column` suffix is stripped, and a file steps up to its containing folder, so the existing "open this file" call sites work unchanged.
- The `commands === null` file-manager special case becomes a `kind` discriminator (`file-manager` | `terminal`), so terminals reuse the same detection and launch path instead of adding a parallel one.
- Terminals are excluded from the Open-in picker's fallback, so a terminal can never become the editor the Open button uses.

`macAppName` is set only for bundles that actually open a folder argument in that directory. The rest would silently start in the user's home, so they appear only when their CLI is on PATH.

## Why

Opening a project in an editor is one click, but opening a shell in that same directory means leaving the app and `cd`-ing by hand.

It is a separate control rather than a row in the Open-in picker because a terminal opens a shell *in* the project rather than a file in an app, and choosing one should not move the editor the Open button uses.

## UI Changes

Before — header with no terminal affordance:

![before](https://raw.githubusercontent.com/Brechard/t3code/terminal-open-action-assets/.pr-assets/before.png)

After — Terminal control between Add action and Open:

![after](https://raw.githubusercontent.com/Brechard/t3code/terminal-open-action-assets/.pr-assets/after.png)

The screenshots are from a machine with only Terminal.app installed, which is why no chevron is shown; with several terminals installed the control gains a chevron menu listing them.

## Verification

- `vp run --filter @t3tools/contracts --filter t3 --filter @t3tools/web typecheck` clean.
- New tests in `externalLauncher.test.ts` (working-directory launch with `:line:column` stripping, and the CLI-less macOS app-bundle path) and `packages/contracts/src/editor.test.ts` (terminal classification, launch style, ordering after editors).
- Checked end to end in a dev build: clicking Terminal spawned a shell whose `cwd` was the project directory, confirmed with `lsof`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes — n/a, no motion

Generated with Claude Sonnet 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process spawning and path resolution on the server; mistakes could open the wrong directory or mis-detect macOS apps, but scope is limited to external launch helpers with new tests.
> 
> **Overview**
> Adds a **Terminal** control in the chat header (alongside Open-in) that opens the project directory in an installed terminal, with a separate preferred-terminal preference (`t3code:last-terminal`) so it does not change the Open-in editor default.
> 
> **Contracts & launcher:** `EDITORS` gains terminal entries and a **`working-directory`** launch style with optional `cwdArgs` / `macAppName`. `ExternalLauncher` resolves the cwd from file paths (strip `:line:column`, use parent dir), detects macOS `.app` bundles only on darwin, and launches GUI-only terminals via `open -a`. File manager is distinguished with `kind: "file-manager"` instead of `commands === null` alone.
> 
> **Web:** `OpenTerminalPicker` filters installed terminals from `availableEditors`; `usePreferredEditor` / `resolveAndPersistPreferredEditor` skip terminal IDs so Open-in never defaults to a terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0826276aa0bf8a792aef33b9e683ca759d118c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add terminal launcher to the chat header for opening a project directory
> - Adds an `OpenTerminalPicker` component to [`ChatHeader.tsx`](https://github.com/pingdotgg/t3code/pull/5339/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c) that lets users open a terminal in the current project's working directory, with preference persistence and multi-terminal selection.
> - Defines terminal editor entries (Apple Terminal, iTerm, Ghostty, Warp, WezTerm, kitty, Alacritty, Windows Terminal) in [`editor.ts`](https://github.com/pingdotgg/t3code/pull/5339/files#diff-952d09e8dcc92b201e44f8f0b5edc71af952e9af9479b5853c41ce6e93d636f7) using a new `working-directory` launch style and optional `cwdArgs` templates.
> - Extends [`externalLauncher.ts`](https://github.com/pingdotgg/t3code/pull/5339/files#diff-157ca66b5181820e0a628ef443d244577cda2329dd1d88fe5f2aff441da05e56) to resolve the working directory from a file path (stripping `:line:col` suffixes), support GUI-only macOS app bundles via `open -a`, and skip macOS bundle fallback on non-darwin platforms.
> - Separates terminal preference storage from editor preference in [`editorPreferences.ts`](https://github.com/pingdotgg/t3code/pull/5339/files#diff-b95642bd2ec02008455dc34d764b6b380dc3cb63bf4eb8fc249e0a105220efdd) using a new `usePreferredTerminal` hook so terminals are never auto-selected as the default editor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf08262.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->