### PR TITLE
fix(server): find project icons inside monorepo workspace packages

### DIFF
--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -133,6 +133,66 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
       }),
     );
 
+    it.effect("resolves an icon from a monorepo workspace package", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "apps/frontend/app/favicon.ico", "icon");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("apps/frontend/app/favicon.ico");
+      }),
+    );
+
+    it.effect("resolves icon hrefs from a workspace package source file", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "apps/web/index.html",
+          '<link rel="icon" href="/brand/logo.svg">',
+        );
+        yield* writeTextFile(cwd, "apps/web/public/brand/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("apps/web/public/brand/logo.svg");
+      }),
+    );
+
+    it.effect("prefers a root icon over a workspace package icon", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "apps/web/public/favicon.svg", "<svg>web</svg>");
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>root</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("favicon.svg");
+        expect(resolved).not.toContain("apps");
+      }),
+    );
+
+    it.effect("prefers apps over packages", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "packages/ui/public/favicon.svg", "<svg>ui</svg>");
+        yield* writeTextFile(cwd, "apps/web/public/favicon.svg", "<svg>web</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("apps/web/public/favicon.svg");
+      }),
+    );
+
     it.effect("returns null when no icon is present", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
@@ -189,6 +249,42 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
           workspaceRoot: cwd,
           relativePath: "favicon.svg",
           absolutePath: faviconPath,
+        });
+        expect(error.cause).toBe(cause);
+      }),
+    );
+
+    it.effect("preserves non-missing workspace package listing failures", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const appsPath = path.join(cwd, "apps");
+        yield* writeTextFile(cwd, "apps/web/public/favicon.svg", "<svg>web</svg>");
+        const cause = PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method: "readDirectory",
+          pathOrDescriptor: appsPath,
+        });
+        const resolver = yield* makeResolverWithFileSystem(
+          FileSystem.FileSystem.of({
+            ...fileSystem,
+            readDirectory: (directoryPath, options) =>
+              directoryPath === appsPath
+                ? Effect.fail(cause)
+                : fileSystem.readDirectory(directoryPath, options),
+          }),
+        );
+
+        const error = yield* resolver.resolvePath(cwd).pipe(Effect.flip);
+
+        expect(error).toMatchObject({
+          _tag: "ProjectFaviconResolutionError",
+          operation: "list-packages",
+          workspaceRoot: cwd,
+          relativePath: "apps",
+          absolutePath: appsPath,
         });
         expect(error.cause).toBe(cause);
       }),

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -2,7 +2,9 @@
  * ProjectFaviconResolver - Effect service contract for project icon discovery.
  *
  * Resolves a representative favicon or app icon file for a workspace by
- * checking common file locations and project source metadata.
+ * checking common file locations and project source metadata. Monorepo roots
+ * (Turborepo and friends) keep their icons inside a workspace package, so the
+ * same locations are checked again in each `apps/*` and `packages/*` directory.
  *
  * @module ProjectFaviconResolver
  */
@@ -54,6 +56,9 @@ const ICON_SOURCE_FILES = [
   "src/index.html",
 ] as const;
 
+// Directories holding workspace packages in a conventional monorepo layout.
+const MONOREPO_PACKAGE_DIRECTORIES = ["apps", "packages"] as const;
+
 // Matches <link ...> tags or object-like icon metadata where rel/href can appear in any order.
 const LINK_ICON_HTML_RE =
   /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i;
@@ -68,6 +73,7 @@ export class ProjectFaviconResolutionError extends Schema.TaggedErrorClass<Proje
       "resolve-path",
       "stat-candidate",
       "read-source",
+      "list-packages",
     ]),
     workspaceRoot: Schema.String,
     relativePath: Schema.optional(Schema.String),
@@ -120,9 +126,15 @@ export const make = Effect.gen(function* () {
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
   const projectFileLoader = yield* T3ProjectFileLoader.T3ProjectFileLoader;
 
-  const resolveIconHref = (href: string): ReadonlyArray<string> => {
+  const withinPackage = (packageDir: string, relativePath: string) =>
+    packageDir ? `${packageDir}/${relativePath}` : relativePath;
+
+  const resolveIconHref = (packageDir: string, href: string): ReadonlyArray<string> => {
     const clean = href.replace(/^\//, "");
-    return [path.join("public", clean), clean];
+    return [
+      withinPackage(packageDir, path.join("public", clean)),
+      withinPackage(packageDir, clean),
+    ];
   };
 
   const findExistingFile = Effect.fn("ProjectFaviconResolver.findExistingFile")(function* (
@@ -166,6 +178,120 @@ export const make = Effect.gen(function* () {
     return null;
   });
 
+  /**
+   * Check the well-known icon locations inside one directory of the project.
+   * `packageDir` is `""` for the project root, or a workspace-relative package
+   * directory such as `apps/web`.
+   */
+  const findIconWithin = Effect.fn("ProjectFaviconResolver.findIconWithin")(function* (
+    projectCwd: string,
+    packageDir: string,
+  ): Effect.fn.Return<string | null, ProjectFaviconResolutionError> {
+    for (const candidate of FAVICON_CANDIDATES) {
+      const existing = yield* findExistingFile(projectCwd, [withinPackage(packageDir, candidate)]);
+      if (existing) {
+        return existing;
+      }
+    }
+
+    for (const sourceFile of ICON_SOURCE_FILES) {
+      const relativePath = withinPackage(packageDir, sourceFile);
+      const sourcePath = yield* workspacePaths
+        .resolveRelativePathWithinRoot({
+          workspaceRoot: projectCwd,
+          relativePath,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ProjectFaviconResolutionError({
+                operation: "resolve-path",
+                workspaceRoot: projectCwd,
+                relativePath,
+                cause,
+              }),
+          ),
+        );
+      const source = yield* optionOnNotFound(
+        fileSystem.readFileString(sourcePath.absolutePath),
+      ).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProjectFaviconResolutionError({
+              operation: "read-source",
+              workspaceRoot: projectCwd,
+              relativePath,
+              absolutePath: sourcePath.absolutePath,
+              cause,
+            }),
+        ),
+      );
+      if (Option.isNone(source)) {
+        continue;
+      }
+      const href = extractIconHref(source.value);
+      if (!href) {
+        continue;
+      }
+      const existing = yield* findExistingFile(projectCwd, resolveIconHref(packageDir, href));
+      if (existing) {
+        return existing;
+      }
+    }
+
+    return null;
+  });
+
+  /**
+   * List the workspace package directories of a conventional monorepo, sorted
+   * within each parent. Parents that do not exist are skipped; other failures
+   * surface, matching how the well-known candidates are checked.
+   */
+  const findPackageDirectories = Effect.fn("ProjectFaviconResolver.findPackageDirectories")(
+    function* (
+      projectCwd: string,
+    ): Effect.fn.Return<ReadonlyArray<string>, ProjectFaviconResolutionError> {
+      const directories: Array<string> = [];
+      for (const parent of MONOREPO_PACKAGE_DIRECTORIES) {
+        const parentPath = path.join(projectCwd, parent);
+        const entries = yield* optionOnNotFound(fileSystem.readDirectory(parentPath)).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ProjectFaviconResolutionError({
+                operation: "list-packages",
+                workspaceRoot: projectCwd,
+                relativePath: parent,
+                absolutePath: parentPath,
+                cause,
+              }),
+          ),
+        );
+        if (Option.isNone(entries)) {
+          continue;
+        }
+        for (const entry of [...entries.value].sort()) {
+          const absolutePath = path.join(parentPath, entry);
+          const stats = yield* optionOnNotFound(fileSystem.stat(absolutePath)).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProjectFaviconResolutionError({
+                  operation: "list-packages",
+                  workspaceRoot: projectCwd,
+                  relativePath: `${parent}/${entry}`,
+                  absolutePath,
+                  cause,
+                }),
+            ),
+          );
+          if (Option.isSome(stats) && stats.value.type === "Directory") {
+            directories.push(`${parent}/${entry}`);
+          }
+        }
+      }
+      return directories;
+    },
+  );
+
   const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = Effect.fn(
     "ProjectFaviconResolver.resolvePath",
   )(function* (cwd) {
@@ -188,54 +314,17 @@ export const make = Effect.gen(function* () {
       }
     }
 
-    for (const candidate of FAVICON_CANDIDATES) {
-      const existing = yield* findExistingFile(projectCwd, [candidate]);
-      if (existing) {
-        return existing;
-      }
+    const rootIcon = yield* findIconWithin(projectCwd, "");
+    if (rootIcon) {
+      return rootIcon;
     }
 
-    for (const sourceFile of ICON_SOURCE_FILES) {
-      const sourcePath = yield* workspacePaths
-        .resolveRelativePathWithinRoot({
-          workspaceRoot: projectCwd,
-          relativePath: sourceFile,
-        })
-        .pipe(
-          Effect.mapError(
-            (cause) =>
-              new ProjectFaviconResolutionError({
-                operation: "resolve-path",
-                workspaceRoot: projectCwd,
-                relativePath: sourceFile,
-                cause,
-              }),
-          ),
-        );
-      const source = yield* optionOnNotFound(
-        fileSystem.readFileString(sourcePath.absolutePath),
-      ).pipe(
-        Effect.mapError(
-          (cause) =>
-            new ProjectFaviconResolutionError({
-              operation: "read-source",
-              workspaceRoot: projectCwd,
-              relativePath: sourceFile,
-              absolutePath: sourcePath.absolutePath,
-              cause,
-            }),
-        ),
-      );
-      if (Option.isNone(source)) {
-        continue;
-      }
-      const href = extractIconHref(source.value);
-      if (!href) {
-        continue;
-      }
-      const existing = yield* findExistingFile(projectCwd, resolveIconHref(href));
-      if (existing) {
-        return existing;
+    // Monorepo roots rarely carry an icon of their own; fall back to the
+    // workspace packages, apps before packages.
+    for (const packageDir of yield* findPackageDirectories(projectCwd)) {
+      const packageIcon = yield* findIconWithin(projectCwd, packageDir);
+      if (packageIcon) {
+        return packageIcon;
       }
     }
 


### PR DESCRIPTION
## Problem

Project favicons are resolved by checking a fixed list of paths relative to the project root (`favicon.ico`, `public/favicon.*`, `app/favicon.ico`, `src/app/icon.*`, …). A monorepo root almost never has any of those — the icon lives inside a workspace package. A Turborepo whose web app sits at `apps/frontend` shows the generic fallback icon even though `apps/frontend/app/favicon.ico` exists.

Setting `iconPath` in `t3.json` works around it, but it shouldn't be needed for the standard layout.

## Fix

When the root scan comes up empty, `ProjectFaviconResolver` re-checks the same well-known icon locations and `<link rel="icon">` source files inside each `apps/*` and `packages/*` directory.

Most of the diff is moving the existing root scan into a `findIconWithin(projectCwd, packageDir)` helper that takes a package directory prefix; the new logic is one directory listing and the loop that calls it.

- The root is checked first and `t3.json` `iconPath` still wins over everything, so single-package projects are unchanged.
- `apps/*` is scanned before `packages/*`, children sorted, so the result is deterministic.
- A missing `apps/` or `packages/` directory is skipped. Other filesystem failures surface as `ProjectFaviconResolutionError` (`list-packages`), matching how candidate stats are already handled rather than silently reporting "no icon".

This deliberately keys off the `apps/`/`packages/` convention rather than parsing `pnpm-workspace.yaml` or `package.json` workspace globs. That covers the layout Turborepo scaffolds and nearly everyone uses, without a glob engine in the resolver. A project with a custom layout still has `t3.json` `iconPath`.

No UI change beyond the icon itself now resolving, so there's nothing meaningful to screenshot.

## Testing

`vp test run src/project/ProjectFaviconResolver.test.ts src/assets/AssetAccess.test.ts` — 25 passed. Five new cases cover a package favicon file, package-level `<link rel="icon">` resolution, root precedence, apps-before-packages ordering, and a propagated listing failure.

Also ran the resolver against a real Turborepo: it now returns `apps/frontend/app/favicon.ico` instead of `null`, and this repo still resolves via its own `t3.json` `iconPath`.

Model: Claude Opus 5. Harness: T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project icon resolution to search inside monorepo workspace packages
> - `ProjectFaviconResolver.resolvePath` now searches `apps/*` and `packages/*` workspace directories for icons when no icon is found at the repo root.
> - Adds `findIconWithin` to scope icon discovery (favicon candidates and `<link rel="icon">` hrefs in source files) to a single directory, and `findPackageDirectories` to enumerate workspace package dirs.
> - Root-level icons take precedence over workspace package icons; among packages, `apps/` is checked before `packages/`, with subdirectories sorted alphabetically.
> - Non-`NotFound` filesystem errors during package directory listing are surfaced as `ProjectFaviconResolutionError` with the new `list-packages` operation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6229a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->