### PR TITLE
fix(web): truncate long project switcher names

### DIFF
--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -101,7 +101,8 @@ export function DraftHeroHeadline({
     <Menu>
       <MenuTrigger
         aria-label={hasResolvedProject ? "Change project" : "Choose a project"}
-        className="pointer-events-auto inline cursor-pointer border-foreground/60 border-b border-dotted text-foreground transition-colors hover:border-foreground/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+        className="pointer-events-auto inline-block max-w-64 truncate border-foreground/60 border-b border-dotted align-bottom text-foreground transition-colors hover:border-foreground/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+        title={activeProjectDisplayName ?? undefined}
       >
         {activeProjectDisplayName ?? "Choose a project"}
       </MenuTrigger>
@@ -122,7 +123,9 @@ export function DraftHeroHeadline({
           {projectPickerEntries.map(({ group }) => {
             return (
               <MenuRadioItem key={group.projectKey} value={group.projectKey} closeOnClick>
-                <span className="min-w-0 truncate">{group.displayName}</span>
+                <span className="block min-w-0 truncate" title={group.displayName}>
+                  {group.displayName}
+                </span>
               </MenuRadioItem>
             );
           })}


### PR DESCRIPTION
## What Changed

- Constrained the active project name in the new-thread headline and truncated long names with an ellipsis.
- Made project names inside the switcher menu use a constrained block so truncation works correctly.
- Added title text so the full project name remains available on hover.

This applies to both web and desktop. Mobile uses a separate native project picker and is unchanged.

## Why

Long project names overflowed the project switcher and introduced a horizontal scrollbar, breaking the menu layout.

The menu already applied truncation styles, but they were attached to an inline element. Since inline elements do not provide the constrained box required by `text-overflow: ellipsis`, the project name continued to overflow. The selected project name in the headline was also unconstrained.

## Verification

- `vp lint apps/web/src/components/chat/DraftHeroHeadline.tsx --report-unused-disable-directives`
- `vp fmt --check apps/web/src/components/chat/DraftHeroHeadline.tsx`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`

## UI Changes

### Before

<img width="642" height="452" alt="T3 Code (Nightly) 2026-08-04 at 19 16 22@2x" src="https://github.com/user-attachments/assets/688970ab-87b7-4633-a847-7c824e450047" />
<img width="1094" height="996" alt="T3 Code (Nightly) 2026-08-04 at 19 16 27@2x" src="https://github.com/user-attachments/assets/c9f91532-de0e-4098-bb37-69596ee9c788" />

### After

<img width="770" height="240" alt="T3 Code (Dev) 2026-08-04 at 19 54 10@2x" src="https://github.com/user-attachments/assets/fe0a557a-f4ae-449a-ba81-8bff46118088" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Model and harness: GPT-5.6 Sol via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e8b399b29bcaeddcaedce41b3fe7dd61eb6f3196. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Truncate long project names in the project switcher with tooltip fallback
> Long project names in `DraftHeroHeadline` now truncate at a max width of `max-w-64`, and the full name is shown via the browser's native tooltip (`title` attribute) on both the trigger and menu items. Also removes the `cursor-pointer` class from the menu trigger.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8b399b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->