### PR TITLE
fix(web): prevent legacy model picker layout shift

### DIFF
--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -777,7 +777,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                   onLayout={updateModelListScrollFades}
                   onScroll={updateModelListScrollFades}
                   className={cn(
-                    "model-picker-list h-full overflow-x-hidden overscroll-y-contain py-1.5 [--fade-size:1.5rem]",
+                    "model-picker-list scrollbar-gutter-stable h-full overflow-x-hidden overscroll-y-contain py-1.5 [--fade-size:1.5rem]",
                     showTopScrollFade && "model-picker-list-scroll-fade-top",
                     showBottomScrollFade && "model-picker-list-scroll-fade-bottom",
                   )}


### PR DESCRIPTION
## What Changed

Reserved a stable scrollbar gutter in the virtualized model list.

This keeps model names, shortcuts, and favorite controls in the same horizontal position when the **Legacy models** section is expanded or collapsed. The change applies to both web and desktop.

## Why

Expanding the legacy-model section can make the model list taller than its viewport, causing a scrollbar to appear.

The virtualized model picker allowed that scrollbar to consume layout width only after the list began overflowing. This changed the available row width and produced a visible horizontal layout shift.

The non-virtualized combobox already reserves a stable scrollbar gutter. Applying the same behavior to the virtualized `LegendList` keeps its width consistent in both states.

## Verification

- `vp lint apps/web/src/components/chat/ModelPickerContent.tsx --report-unused-disable-directives`
- `vp fmt --check apps/web/src/components/chat/ModelPickerContent.tsx`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`

## UI Changes

### Before

<img width="790" height="740" alt="T3 Code (Nightly) 2026-08-04 at 20 01 50" src="https://github.com/user-attachments/assets/428342b6-80e5-4213-bf22-53f0dafe629b" />


### After

<img width="768" height="732" alt="T3 Code (Dev) 2026-08-04 at 20 02 59" src="https://github.com/user-attachments/assets/cdc13458-0a2a-4667-aaf5-789c390d1512" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Model and harness: GPT-5.6 Sol via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS utility on the model picker list; no logic, data, or security impact.
> 
> **Overview**
> Adds **`scrollbar-gutter-stable`** to the virtualized model list in `ModelPickerContent` so scrollbar space is reserved even before the list overflows.
> 
> When the **Legacy models** section expands and the list becomes scrollable, the gutter stays fixed and model rows no longer shift horizontally—matching behavior already used on non-virtualized combobox lists and elsewhere (e.g. branch selector).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecbc0fed454097624ea5c48aae120bb2ec4e77f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix layout shift in legacy model picker by stabilizing scrollbar gutter
> Adds the `scrollbar-gutter-stable` CSS class to the virtualized model list in [ModelPickerContent.tsx](https://github.com/pingdotgg/t3code/pull/5349/files#diff-af6ec8809b715e3718ef62e155f706b7bfc2b5331a509865043ed81e0f10f50c), preventing layout shift when the scrollbar appears or disappears.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecbc0fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->