### PR TITLE
feat(desktop): open chat links matching site patterns in the integrated browser

### DIFF
--- a/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
@@ -27,6 +27,10 @@ describe("parseIntegratedBrowserUrlPattern", () => {
       host: "example.com",
       pathPrefix: null,
     });
+    expect(parseIntegratedBrowserUrlPattern("example.com/docs/v1:api")).toEqual({
+      host: "example.com",
+      pathPrefix: "/docs/v1:api",
+    });
   });
 
   it("rejects schemes, ports, whitespace, malformed hosts, and non-leading wildcards", () => {
@@ -38,6 +42,8 @@ describe("parseIntegratedBrowserUrlPattern", () => {
       "git hub.com",
       "/just/a/path",
       "héllo.com",
+      "example.com/docs?view=full",
+      "example.com/docs#anchor",
       "gist*.github.com",
       "*.gist*.github.com",
       "*",

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  normalizeIntegratedBrowserUrlPattern,
+  parseIntegratedBrowserUrlPattern,
+  urlMatchesIntegratedBrowserPatterns,
+} from "./integratedBrowserLinkPatterns";
+
+describe("parseIntegratedBrowserUrlPattern", () => {
+  it("parses host-only patterns, lowercasing and stripping www", () => {
+    expect(parseIntegratedBrowserUrlPattern("  GitHub.com ")).toEqual({
+      host: "github.com",
+      pathPrefix: null,
+    });
+    expect(parseIntegratedBrowserUrlPattern("www.github.com")).toEqual({
+      host: "github.com",
+      pathPrefix: null,
+    });
+  });
+
+  it("parses path prefixes, dropping trailing slashes", () => {
+    expect(parseIntegratedBrowserUrlPattern("docs.example.com/api/")).toEqual({
+      host: "docs.example.com",
+      pathPrefix: "/api",
+    });
+    expect(parseIntegratedBrowserUrlPattern("example.com/")).toEqual({
+      host: "example.com",
+      pathPrefix: null,
+    });
+  });
+
+  it("rejects schemes, ports, whitespace, malformed hosts, and non-leading wildcards", () => {
+    for (const raw of [
+      "",
+      "   ",
+      "https://github.com",
+      "github.com:8080",
+      "git hub.com",
+      "/just/a/path",
+      "héllo.com",
+      "gist*.github.com",
+      "*.gist*.github.com",
+      "*",
+    ]) {
+      expect(parseIntegratedBrowserUrlPattern(raw)).toBeNull();
+    }
+  });
+});
+
+describe("normalizeIntegratedBrowserUrlPattern", () => {
+  it("wildcards bare domains and keeps more specific patterns as entered", () => {
+    expect(normalizeIntegratedBrowserUrlPattern("github.com")).toBe("*.github.com");
+    expect(normalizeIntegratedBrowserUrlPattern("GitHub.com/T3")).toBe("*.github.com/T3");
+    expect(normalizeIntegratedBrowserUrlPattern("docs.example.com/api/")).toBe(
+      "docs.example.com/api",
+    );
+    expect(normalizeIntegratedBrowserUrlPattern("*.vercel.app")).toBe("*.vercel.app");
+    expect(normalizeIntegratedBrowserUrlPattern("localhost")).toBe("localhost");
+    expect(normalizeIntegratedBrowserUrlPattern("https://github.com")).toBeNull();
+  });
+});
+
+describe("urlMatchesIntegratedBrowserPatterns", () => {
+  it("matches exact hosts case-insensitively, ignoring ports and www", () => {
+    expect(urlMatchesIntegratedBrowserPatterns("https://GitHub.com/t3", ["github.com"])).toBe(true);
+    expect(urlMatchesIntegratedBrowserPatterns("https://www.github.com", ["github.com"])).toBe(
+      true,
+    );
+    expect(urlMatchesIntegratedBrowserPatterns("https://github.com", ["www.github.com"])).toBe(
+      true,
+    );
+    expect(urlMatchesIntegratedBrowserPatterns("http://localhost:5173/x", ["localhost"])).toBe(
+      true,
+    );
+  });
+
+  it("matches the apex and any subdomain depth for leading wildcards", () => {
+    const patterns = ["*.github.com"];
+    expect(urlMatchesIntegratedBrowserPatterns("https://github.com", patterns)).toBe(true);
+    expect(urlMatchesIntegratedBrowserPatterns("https://gist.github.com", patterns)).toBe(true);
+    expect(urlMatchesIntegratedBrowserPatterns("https://a.b.github.com", patterns)).toBe(true);
+    expect(urlMatchesIntegratedBrowserPatterns("https://notgithub.com", patterns)).toBe(false);
+  });
+
+  it("matches plain hosts exactly, without subdomains", () => {
+    expect(
+      urlMatchesIntegratedBrowserPatterns("https://docs.example.com", ["docs.example.com"]),
+    ).toBe(true);
+    expect(
+      urlMatchesIntegratedBrowserPatterns("https://v2.docs.example.com", ["docs.example.com"]),
+    ).toBe(false);
+  });
+
+  it("matches path prefixes on segment boundaries only", () => {
+    const patterns = ["docs.example.com/api"];
+    expect(urlMatchesIntegratedBrowserPatterns("https://docs.example.com/api", patterns)).toBe(
+      true,
+    );
+    expect(urlMatchesIntegratedBrowserPatterns("https://docs.example.com/api/v2", patterns)).toBe(
+      true,
+    );
+    expect(urlMatchesIntegratedBrowserPatterns("https://docs.example.com/api-keys", patterns)).toBe(
+      false,
+    );
+  });
+
+  it("never matches non-http schemes, unparseable hrefs, or invalid patterns", () => {
+    expect(urlMatchesIntegratedBrowserPatterns("mailto:hi@github.com", ["github.com"])).toBe(false);
+    expect(urlMatchesIntegratedBrowserPatterns("not a url", ["github.com"])).toBe(false);
+    expect(
+      urlMatchesIntegratedBrowserPatterns("https://github.com", ["https://github.com", "   "]),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
@@ -33,6 +33,13 @@ describe("parseIntegratedBrowserUrlPattern", () => {
     });
   });
 
+  it("canonicalizes path prefixes to the URL.pathname representation", () => {
+    expect(parseIntegratedBrowserUrlPattern("example.com/über")).toEqual({
+      host: "example.com",
+      pathPrefix: "/%C3%BCber",
+    });
+  });
+
   it("rejects schemes, ports, whitespace, malformed hosts, and non-leading wildcards", () => {
     for (const raw of [
       "",
@@ -108,6 +115,16 @@ describe("urlMatchesIntegratedBrowserPatterns", () => {
     );
     expect(urlMatchesIntegratedBrowserPatterns("https://docs.example.com/api-keys", patterns)).toBe(
       false,
+    );
+  });
+
+  it("matches non-ASCII path prefixes against percent-encoded pathnames", () => {
+    const patterns = ["example.com/über"];
+    expect(urlMatchesIntegratedBrowserPatterns("https://example.com/über/docs", patterns)).toBe(
+      true,
+    );
+    expect(urlMatchesIntegratedBrowserPatterns("https://example.com/%C3%BCber", patterns)).toBe(
+      true,
     );
   });
 

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
@@ -102,6 +102,13 @@ describe("urlMatchesIntegratedBrowserPatterns", () => {
     expect(urlMatchesIntegratedBrowserPatterns("https://notgithub.com", patterns)).toBe(false);
   });
 
+  it("matches wildcard apexes that name www against the unstripped hostname", () => {
+    const patterns = ["*.www.example.com"];
+    expect(urlMatchesIntegratedBrowserPatterns("https://www.example.com", patterns)).toBe(true);
+    expect(urlMatchesIntegratedBrowserPatterns("https://a.www.example.com", patterns)).toBe(true);
+    expect(urlMatchesIntegratedBrowserPatterns("https://example.com", patterns)).toBe(false);
+  });
+
   it("matches plain hosts exactly, without subdomains", () => {
     expect(
       urlMatchesIntegratedBrowserPatterns("https://docs.example.com", ["docs.example.com"]),

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
@@ -54,6 +54,11 @@ describe("parseIntegratedBrowserUrlPattern", () => {
       "gist*.github.com",
       "*.gist*.github.com",
       "www.*.example.com",
+      "example..com",
+      ".example.com",
+      "example.com.",
+      "-example.com",
+      "example-.com",
       "*",
       "*.",
     ]) {

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
@@ -47,6 +47,7 @@ describe("parseIntegratedBrowserUrlPattern", () => {
       "gist*.github.com",
       "*.gist*.github.com",
       "*",
+      "*.",
     ]) {
       expect(parseIntegratedBrowserUrlPattern(raw)).toBeNull();
     }

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.test.ts
@@ -53,6 +53,7 @@ describe("parseIntegratedBrowserUrlPattern", () => {
       "example.com/docs#anchor",
       "gist*.github.com",
       "*.gist*.github.com",
+      "www.*.example.com",
       "*",
       "*.",
     ]) {
@@ -126,6 +127,12 @@ describe("urlMatchesIntegratedBrowserPatterns", () => {
     expect(urlMatchesIntegratedBrowserPatterns("https://example.com/%C3%BCber", patterns)).toBe(
       true,
     );
+    expect(urlMatchesIntegratedBrowserPatterns("https://example.com/%c3%bcber", patterns)).toBe(
+      true,
+    );
+    expect(
+      urlMatchesIntegratedBrowserPatterns("https://example.com/über", ["example.com/%c3%bcber"]),
+    ).toBe(true);
   });
 
   it("never matches non-http schemes, unparseable hrefs, or invalid patterns", () => {

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.ts
@@ -39,10 +39,14 @@ export function parseIntegratedBrowserUrlPattern(raw: string): IntegratedBrowser
   if (host.length === 0 || !HOST_PATTERN_CHARS.test(host)) {
     return null;
   }
-  // `*` is only meaningful as a leading `*.` wildcard; reject it anywhere else
-  // so a pattern that would silently never match is flagged at entry.
-  if (host.includes("*") && (!host.startsWith("*.") || host.slice(2).includes("*"))) {
-    return null;
+  // `*` is only meaningful as a leading `*.` wildcard with a non-empty apex;
+  // reject it anywhere else so a pattern that would silently never match is
+  // flagged at entry.
+  if (host.includes("*")) {
+    const apex = host.startsWith("*.") ? host.slice(2) : "";
+    if (apex.length === 0 || apex.includes("*")) {
+      return null;
+    }
   }
 
   if (rawPath === null || rawPath === "/") {

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.ts
@@ -1,0 +1,124 @@
+// Matching for the "always open in integrated browser" URL patterns stored in
+// `ClientSettings.integratedBrowserUrlPatterns`. Patterns are host names with
+// an optional path prefix — `*.github.com`, `docs.example.com/api`. A leading
+// `*.` matches the apex domain and any subdomain; a plain host matches only
+// itself. Bare domains normalize to `*.domain.com` on entry. No schemes, no
+// ports.
+
+export interface IntegratedBrowserUrlPattern {
+  /** Lowercased host pattern with any leading `www.` stripped. */
+  readonly host: string;
+  /** Normalized path prefix (leading `/`, no trailing `/`), or null for host-only patterns. */
+  readonly pathPrefix: string | null;
+}
+
+const HOST_PATTERN_CHARS = /^[a-z0-9*.-]+$/u;
+
+function stripWww(host: string): string {
+  return host.startsWith("www.") ? host.slice(4) : host;
+}
+
+/**
+ * Parses a raw user-entered pattern. Returns null when the pattern is invalid
+ * (schemes, ports, whitespace, empty host, or illegal host characters).
+ */
+export function parseIntegratedBrowserUrlPattern(raw: string): IntegratedBrowserUrlPattern | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.includes(":") || /\s/u.test(trimmed)) {
+    return null;
+  }
+
+  const slashIndex = trimmed.indexOf("/");
+  const rawHost = slashIndex === -1 ? trimmed : trimmed.slice(0, slashIndex);
+  const rawPath = slashIndex === -1 ? null : trimmed.slice(slashIndex);
+
+  const host = stripWww(rawHost.toLowerCase());
+  if (host.length === 0 || !HOST_PATTERN_CHARS.test(host)) {
+    return null;
+  }
+  // `*` is only meaningful as a leading `*.` wildcard; reject it anywhere else
+  // so a pattern that would silently never match is flagged at entry.
+  if (host.includes("*") && (!host.startsWith("*.") || host.slice(2).includes("*"))) {
+    return null;
+  }
+
+  if (rawPath === null || rawPath === "/") {
+    return { host, pathPrefix: null };
+  }
+  return {
+    host,
+    pathPrefix: rawPath.endsWith("/") ? rawPath.slice(0, -1) : rawPath,
+  };
+}
+
+/**
+ * Canonical string form for storage and display. A bare domain with no
+ * subdomain specified becomes `*.domain.com`; anything more specific (a
+ * subdomain, a wildcard, a single-label host) is kept as entered. Returns
+ * null for invalid patterns.
+ */
+export function normalizeIntegratedBrowserUrlPattern(raw: string): string | null {
+  const pattern = parseIntegratedBrowserUrlPattern(raw);
+  if (pattern === null) {
+    return null;
+  }
+  const host =
+    !pattern.host.includes("*") && pattern.host.split(".").length === 2
+      ? `*.${pattern.host}`
+      : pattern.host;
+  return `${host}${pattern.pathPrefix ?? ""}`;
+}
+
+/**
+ * A leading `*.` matches the apex domain and any subdomain at any depth:
+ * `*.github.com` matches `github.com`, `gist.github.com`, `a.b.github.com`.
+ * A plain host matches only itself.
+ */
+function hostMatchesPattern(host: string, hostPattern: string): boolean {
+  if (hostPattern.startsWith("*.")) {
+    const apex = hostPattern.slice(2);
+    return host === apex || host.endsWith(`.${apex}`);
+  }
+  return host === hostPattern;
+}
+
+function pathMatchesPrefix(pathname: string, prefix: string): boolean {
+  if (!pathname.startsWith(prefix)) {
+    return false;
+  }
+  const rest = pathname.slice(prefix.length);
+  return rest.length === 0 || rest.startsWith("/");
+}
+
+/**
+ * Returns true when `href` is an http(s) URL whose host (and path, if the
+ * pattern has one) matches any of the raw patterns. Invalid patterns and
+ * unparseable hrefs never match.
+ */
+export function urlMatchesIntegratedBrowserPatterns(
+  href: string,
+  patterns: readonly string[],
+): boolean {
+  if (patterns.length === 0) {
+    return false;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return false;
+  }
+
+  const host = stripWww(url.hostname.toLowerCase());
+  return patterns.some((raw) => {
+    const pattern = parseIntegratedBrowserUrlPattern(raw);
+    if (pattern === null || !hostMatchesPattern(host, pattern.host)) {
+      return false;
+    }
+    return pattern.pathPrefix === null || pathMatchesPrefix(url.pathname, pattern.pathPrefix);
+  });
+}

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.ts
@@ -19,6 +19,15 @@ function stripWww(host: string): string {
 }
 
 /**
+ * Uppercases percent-escape hex digits so equivalent escapes compare equal
+ * (`URL.pathname` preserves the casing it was given, so `/%c3%bcber` and
+ * `/%C3%BCber` would otherwise never prefix-match).
+ */
+function normalizePercentEscapes(pathname: string): string {
+  return pathname.replace(/%[0-9a-f]{2}/giu, (escape) => escape.toUpperCase());
+}
+
+/**
  * Parses a raw user-entered pattern. Returns null when the pattern is invalid
  * (schemes, ports, whitespace, queries, fragments, empty host, or illegal
  * host characters). Matching compares `URL.pathname`, so `?`/`#` in a
@@ -35,18 +44,23 @@ export function parseIntegratedBrowserUrlPattern(raw: string): IntegratedBrowser
   const rawHost = slashIndex === -1 ? trimmed : trimmed.slice(0, slashIndex);
   const rawPath = slashIndex === -1 ? null : trimmed.slice(slashIndex);
 
-  const host = stripWww(rawHost.toLowerCase());
-  if (host.length === 0 || !HOST_PATTERN_CHARS.test(host)) {
+  const lowerHost = rawHost.toLowerCase();
+  if (!HOST_PATTERN_CHARS.test(lowerHost)) {
     return null;
   }
   // `*` is only meaningful as a leading `*.` wildcard with a non-empty apex;
   // reject it anywhere else so a pattern that would silently never match is
-  // flagged at entry.
-  if (host.includes("*")) {
-    const apex = host.startsWith("*.") ? host.slice(2) : "";
+  // flagged at entry. Validated before `www.` stripping — stripping first
+  // would silently widen `www.*.example.com` into a valid `*.example.com`.
+  if (lowerHost.includes("*")) {
+    const apex = lowerHost.startsWith("*.") ? lowerHost.slice(2) : "";
     if (apex.length === 0 || apex.includes("*")) {
       return null;
     }
+  }
+  const host = stripWww(lowerHost);
+  if (host.length === 0) {
+    return null;
   }
 
   if (rawPath === null || rawPath === "/") {
@@ -56,7 +70,7 @@ export function parseIntegratedBrowserUrlPattern(raw: string): IntegratedBrowser
   // the `URL.pathname` it is compared against (e.g. `/über` → `/%C3%BCber`).
   let pathname: string;
   try {
-    pathname = new URL(`https://h${rawPath}`).pathname;
+    pathname = normalizePercentEscapes(new URL(`https://h${rawPath}`).pathname);
   } catch {
     return null;
   }
@@ -137,6 +151,9 @@ export function urlMatchesIntegratedBrowserPatterns(
     if (pattern === null || !hostMatchesPattern(host, pattern.host)) {
       return false;
     }
-    return pattern.pathPrefix === null || pathMatchesPrefix(url.pathname, pattern.pathPrefix);
+    return (
+      pattern.pathPrefix === null ||
+      pathMatchesPrefix(normalizePercentEscapes(url.pathname), pattern.pathPrefix)
+    );
   });
 }

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.ts
@@ -52,9 +52,20 @@ export function parseIntegratedBrowserUrlPattern(raw: string): IntegratedBrowser
   if (rawPath === null || rawPath === "/") {
     return { host, pathPrefix: null };
   }
+  // Canonicalize through URL so the prefix uses the same representation as
+  // the `URL.pathname` it is compared against (e.g. `/über` → `/%C3%BCber`).
+  let pathname: string;
+  try {
+    pathname = new URL(`https://h${rawPath}`).pathname;
+  } catch {
+    return null;
+  }
+  if (pathname === "/") {
+    return { host, pathPrefix: null };
+  }
   return {
     host,
-    pathPrefix: rawPath.endsWith("/") ? rawPath.slice(0, -1) : rawPath,
+    pathPrefix: pathname.endsWith("/") ? pathname.slice(0, -1) : pathname,
   };
 }
 

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.ts
@@ -62,6 +62,13 @@ export function parseIntegratedBrowserUrlPattern(raw: string): IntegratedBrowser
   if (host.length === 0) {
     return null;
   }
+  // Reject structurally invalid hosts (`example..com`, `.example.com`,
+  // `-example.com`, `example.com.`) — they pass the character check but can
+  // never match a real link hostname, so the pattern would be silently dead.
+  const labels = (host.startsWith("*.") ? host.slice(2) : host).split(".");
+  if (labels.some((label) => label.length === 0 || label.startsWith("-") || label.endsWith("-"))) {
+    return null;
+  }
 
   if (rawPath === null || rawPath === "/") {
     return { host, pathPrefix: null };

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.ts
@@ -152,10 +152,18 @@ export function urlMatchesIntegratedBrowserPatterns(
     return false;
   }
 
-  const host = stripWww(url.hostname.toLowerCase());
+  // Match both the raw and www-stripped hostname: stripping lets `example.com`
+  // patterns match `www.example.com` links, while the raw form keeps patterns
+  // that name `www` explicitly (e.g. a `*.www.example.com` apex) working.
+  const rawHostname = url.hostname.toLowerCase();
+  const strippedHost = stripWww(rawHostname);
   return patterns.some((raw) => {
     const pattern = parseIntegratedBrowserUrlPattern(raw);
-    if (pattern === null || !hostMatchesPattern(host, pattern.host)) {
+    if (
+      pattern === null ||
+      (!hostMatchesPattern(strippedHost, pattern.host) &&
+        !hostMatchesPattern(rawHostname, pattern.host))
+    ) {
       return false;
     }
     return (

--- a/apps/web/src/browser/integratedBrowserLinkPatterns.ts
+++ b/apps/web/src/browser/integratedBrowserLinkPatterns.ts
@@ -2,8 +2,8 @@
 // `ClientSettings.integratedBrowserUrlPatterns`. Patterns are host names with
 // an optional path prefix — `*.github.com`, `docs.example.com/api`. A leading
 // `*.` matches the apex domain and any subdomain; a plain host matches only
-// itself. Bare domains normalize to `*.domain.com` on entry. No schemes, no
-// ports.
+// itself. Bare domains normalize to `*.domain.com` on entry. No schemes,
+// ports, queries, or fragments.
 
 export interface IntegratedBrowserUrlPattern {
   /** Lowercased host pattern with any leading `www.` stripped. */
@@ -20,11 +20,14 @@ function stripWww(host: string): string {
 
 /**
  * Parses a raw user-entered pattern. Returns null when the pattern is invalid
- * (schemes, ports, whitespace, empty host, or illegal host characters).
+ * (schemes, ports, whitespace, queries, fragments, empty host, or illegal
+ * host characters). Matching compares `URL.pathname`, so `?`/`#` in a
+ * pattern could never match and are rejected up front. Schemes and ports are
+ * caught by the host character check — both leave a `:` in the host segment.
  */
 export function parseIntegratedBrowserUrlPattern(raw: string): IntegratedBrowserUrlPattern | null {
   const trimmed = raw.trim();
-  if (trimmed.length === 0 || trimmed.includes(":") || /\s/u.test(trimmed)) {
+  if (trimmed.length === 0 || /[\s?#]/u.test(trimmed)) {
     return null;
   }
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -84,6 +84,7 @@ import { previewEnvironment } from "../state/preview";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
+import { urlMatchesIntegratedBrowserPatterns } from "../browser/integratedBrowserLinkPatterns";
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import {
   isBrowserPreviewFile,
@@ -1459,6 +1460,15 @@ function ChatMarkdown({
           const isSameDocumentLink = href?.startsWith("#") ?? false;
           const onClick = props.onClick;
           const canOpenInPreview = Boolean(threadRef) && isPreviewSupportedInRuntime();
+          const openInPreviewReportingFailure = async (target: string) => {
+            const result = await openExternalLinkInPreview(target);
+            if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+              reportMarkdownActionFailure(
+                { operation: "open-link-in-preview", target },
+                result.cause,
+              );
+            }
+          };
           const link = (
             <a
               {...props}
@@ -1469,7 +1479,28 @@ function ChatMarkdown({
                 onClick?.(event);
                 if (isSameDocumentLink && href) {
                   handleMarkdownFragmentClick(event, href);
+                  return;
                 }
+                // Modifier- and middle-clicks keep opening externally.
+                if (
+                  event.defaultPrevented ||
+                  event.button !== 0 ||
+                  event.metaKey ||
+                  event.ctrlKey ||
+                  event.shiftKey ||
+                  event.altKey ||
+                  !canOpenInPreview ||
+                  !href ||
+                  !faviconHost
+                ) {
+                  return;
+                }
+                const patterns = getClientSettings().integratedBrowserUrlPatterns;
+                if (!urlMatchesIntegratedBrowserPatterns(href, patterns)) {
+                  return;
+                }
+                event.preventDefault();
+                void openInPreviewReportingFailure(href);
               }}
               onContextMenu={(event) => {
                 if (!canOpenInPreview || !href || !faviconHost) return;
@@ -1481,15 +1512,7 @@ function ChatMarkdown({
                   href,
                   position: { x: event.clientX, y: event.clientY },
                   showContextMenu: (items, position) => api.contextMenu.show(items, position),
-                  openInPreview: async (target) => {
-                    const result = await openExternalLinkInPreview(target);
-                    if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-                      reportMarkdownActionFailure(
-                        { operation: "open-link-in-preview", target },
-                        result.cause,
-                      );
-                    }
-                  },
+                  openInPreview: openInPreviewReportingFailure,
                   openExternal: (target) => api.shell.openExternal(target),
                   copyLink: (target) => writeTextToClipboard(target, "link"),
                   reportFailure: (operation, cause) => {

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1460,14 +1460,16 @@ function ChatMarkdown({
           const isSameDocumentLink = href?.startsWith("#") ?? false;
           const onClick = props.onClick;
           const canOpenInPreview = Boolean(threadRef) && isPreviewSupportedInRuntime();
-          const openInPreviewReportingFailure = async (target: string) => {
+          const openInPreviewReportingFailure = async (target: string): Promise<boolean> => {
             const result = await openExternalLinkInPreview(target);
-            if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-              reportMarkdownActionFailure(
-                { operation: "open-link-in-preview", target },
-                result.cause,
-              );
+            if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) {
+              return true;
             }
+            reportMarkdownActionFailure(
+              { operation: "open-link-in-preview", target },
+              result.cause,
+            );
+            return false;
           };
           const link = (
             <a
@@ -1500,7 +1502,22 @@ function ChatMarkdown({
                   return;
                 }
                 event.preventDefault();
-                void openInPreviewReportingFailure(href);
+                void openInPreviewReportingFailure(href).then((opened) => {
+                  // Default navigation was prevented, so a failed preview
+                  // open must fall back to the system browser.
+                  if (opened) return;
+                  const api = readLocalApi();
+                  if (api) {
+                    void api.shell.openExternal(href).catch((cause: unknown) => {
+                      reportMarkdownActionFailure(
+                        { operation: "open-link-external", target: href },
+                        cause,
+                      );
+                    });
+                  } else {
+                    window.open(href, "_blank", "noopener,noreferrer");
+                  }
+                });
               }}
               onContextMenu={(event) => {
                 if (!canOpenInPreview || !href || !faviconHost) return;
@@ -1512,7 +1529,9 @@ function ChatMarkdown({
                   href,
                   position: { x: event.clientX, y: event.clientY },
                   showContextMenu: (items, position) => api.contextMenu.show(items, position),
-                  openInPreview: openInPreviewReportingFailure,
+                  openInPreview: async (target) => {
+                    await openInPreviewReportingFailure(target);
+                  },
                   openExternal: (target) => api.shell.openExternal(target),
                   copyLink: (target) => writeTextToClipboard(target, "link"),
                   reportFailure: (operation, cause) => {

--- a/apps/web/src/components/settings/IntegratedBrowserLinksSetting.tsx
+++ b/apps/web/src/components/settings/IntegratedBrowserLinksSetting.tsx
@@ -1,0 +1,102 @@
+import { PlusIcon, XIcon } from "lucide-react";
+import { useState } from "react";
+
+import { normalizeIntegratedBrowserUrlPattern } from "../../browser/integratedBrowserLinkPatterns";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+interface IntegratedBrowserLinksSettingProps {
+  readonly patterns: readonly string[];
+  readonly onChange: (next: readonly string[]) => void;
+}
+
+/**
+ * Add/remove editor for the URL patterns that make chat links open in the
+ * integrated browser panel. Entries are stored and shown in canonical form
+ * via `normalizeIntegratedBrowserUrlPattern` (bare domains → `*.domain.com`).
+ */
+export function IntegratedBrowserLinksSetting({
+  patterns,
+  onChange,
+}: IntegratedBrowserLinksSettingProps) {
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAdd = () => {
+    const trimmed = input.trim();
+    if (trimmed.length === 0) {
+      setError("Enter a URL pattern.");
+      return;
+    }
+    const normalized = normalizeIntegratedBrowserUrlPattern(trimmed);
+    if (normalized === null) {
+      setError(
+        "Use a host with an optional path, like github.com or docs.example.com/api — no scheme or port.",
+      );
+      return;
+    }
+    if (patterns.includes(normalized)) {
+      setError("That pattern is already in the list.");
+      return;
+    }
+    onChange([...patterns, normalized]);
+    setInput("");
+    setError(null);
+  };
+
+  const handleRemove = (pattern: string) => {
+    onChange(patterns.filter((entry) => entry !== pattern));
+    setError(null);
+  };
+
+  return (
+    <div className="pb-2">
+      {patterns.length > 0 ? (
+        <div className="max-h-40 overflow-y-auto pb-1">
+          {patterns.map((pattern) => (
+            <div
+              key={pattern}
+              className="grid min-h-7 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 py-1"
+            >
+              <code className="min-w-0 truncate text-xs text-foreground/90">{pattern}</code>
+              <Button
+                size="icon-xs"
+                variant="ghost"
+                className="size-5 shrink-0 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                aria-label={`Remove ${pattern}`}
+                onClick={() => handleRemove(pattern)}
+              >
+                <XIcon className="size-3" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+        <Input
+          id="integrated-browser-link-pattern"
+          value={input}
+          onChange={(event) => {
+            setInput(event.target.value);
+            if (error) setError(null);
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter") return;
+            event.preventDefault();
+            handleAdd();
+          }}
+          placeholder="github.com or *.vercel.app"
+          spellCheck={false}
+          aria-label="Integrated browser URL pattern"
+        />
+        <Button className="shrink-0" variant="outline" onClick={handleAdd}>
+          <PlusIcon className="size-3.5" />
+          Add
+        </Button>
+      </div>
+
+      {error ? <p className="mt-2 text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/IntegratedBrowserLinksSetting.tsx
+++ b/apps/web/src/components/settings/IntegratedBrowserLinksSetting.tsx
@@ -12,8 +12,9 @@ interface IntegratedBrowserLinksSettingProps {
 
 /**
  * Add/remove editor for the URL patterns that make chat links open in the
- * integrated browser panel. Entries are stored and shown in canonical form
- * via `normalizeIntegratedBrowserUrlPattern` (bare domains → `*.domain.com`).
+ * integrated browser panel. New entries are canonicalized on add via
+ * `normalizeIntegratedBrowserUrlPattern` (bare domains → `*.domain.com`);
+ * persisted entries are shown as stored.
  */
 export function IntegratedBrowserLinksSetting({
   patterns,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -140,6 +140,7 @@ import {
   type ProviderUpdateCandidate,
 } from "../ProviderUpdateLaunchNotification.logic";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
+import { IntegratedBrowserLinksSetting } from "./IntegratedBrowserLinksSetting";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import {
   backgroundActivitySharedPolicySettings,
@@ -650,12 +651,14 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
+      ...(settings.integratedBrowserUrlPatterns.length > 0 ? ["Integrated browser links"] : []),
       ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
     ],
     [
       isTextGenerationModelDirty,
       isBackgroundActivityDirty,
       settings.autoOpenPlanSidebar,
+      settings.integratedBrowserUrlPatterns,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
@@ -713,6 +716,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+      integratedBrowserUrlPatterns: DEFAULT_UNIFIED_SETTINGS.integratedBrowserUrlPatterns,
       textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
       fontFamilySans: DEFAULT_UNIFIED_SETTINGS.fontFamilySans,
       fontFamilyComposer: DEFAULT_UNIFIED_SETTINGS.fontFamilyComposer,
@@ -2026,6 +2030,26 @@ export function GeneralSettingsPanel() {
             />
           }
         />
+
+        {isElectron ? (
+          <SettingsRow
+            {...searchableSetting("integrated-browser-links")}
+            description="Chat links matching these patterns open in the integrated browser panel instead of your system browser."
+            resetAction={
+              settings.integratedBrowserUrlPatterns.length > 0 ? (
+                <SettingResetButton
+                  label="integrated browser links"
+                  onClick={() => updateSettings({ integratedBrowserUrlPatterns: [] })}
+                />
+              ) : null
+            }
+          >
+            <IntegratedBrowserLinksSetting
+              patterns={settings.integratedBrowserUrlPatterns}
+              onChange={(next) => updateSettings({ integratedBrowserUrlPatterns: next })}
+            />
+          </SettingsRow>
+        ) : null}
 
         <SettingsRow
           {...searchableSetting("archive-confirmation")}

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -1,3 +1,5 @@
+import { isElectron } from "../../env";
+
 export type SettingsPath =
   | "/settings/general"
   | "/settings/appearance"
@@ -13,6 +15,8 @@ export interface SettingsSearchItem {
   readonly title: string;
   readonly to: SettingsPath;
   readonly targetId?: string;
+  /** Rendered only in the desktop app; hidden from search elsewhere. */
+  readonly electronOnly?: boolean;
 }
 
 /**
@@ -135,6 +139,7 @@ export const SETTINGS_SEARCH_ITEMS = [
     id: "integrated-browser-links",
     title: "Integrated browser links",
     to: "/settings/general",
+    electronOnly: true,
   },
   {
     id: "archive-confirmation",
@@ -222,9 +227,14 @@ function normalizeSearchText(value: string): string {
     .trim();
 }
 
+const AVAILABLE_SETTINGS_SEARCH_ITEMS: ReadonlyArray<SettingsSearchItem> =
+  SETTINGS_SEARCH_ITEMS.filter(
+    (item: SettingsSearchItem) => isElectron || item.electronOnly !== true,
+  );
+
 export function searchSettings(
   query: string,
-  items: ReadonlyArray<SettingsSearchItem> = SETTINGS_SEARCH_ITEMS,
+  items: ReadonlyArray<SettingsSearchItem> = AVAILABLE_SETTINGS_SEARCH_ITEMS,
 ): ReadonlyArray<SettingsSearchItem> {
   const normalizedQuery = normalizeSearchText(query);
   if (normalizedQuery.length === 0) return [];

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -132,6 +132,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "integrated-browser-links",
+    title: "Integrated browser links",
+    to: "/settings/general",
+  },
+  {
     id: "archive-confirmation",
     title: "Archive confirmation",
     to: "/settings/general",

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -49,6 +49,24 @@ describe("ClientSettings glass opacity", () => {
   });
 });
 
+describe("ClientSettings integrated browser url patterns", () => {
+  it("defaults to an empty list for legacy configs", () => {
+    expect(decodeClientSettings({}).integratedBrowserUrlPatterns).toEqual([]);
+  });
+
+  it("accepts and trims pattern updates", () => {
+    expect(
+      decodeClientSettingsPatch({
+        integratedBrowserUrlPatterns: ["github.com", "  *.vercel.app  "],
+      }).integratedBrowserUrlPatterns,
+    ).toEqual(["github.com", "*.vercel.app"]);
+  });
+
+  it("rejects blank patterns", () => {
+    expect(() => decodeClientSettings({ integratedBrowserUrlPatterns: ["   "] })).toThrow();
+  });
+});
+
 describe("ClientSettings environment identification", () => {
   it("defaults to artwork and accepts each presentation mode", () => {
     expect(decodeClientSettings({}).environmentIdentificationMode).toBe("artwork");

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -143,6 +143,13 @@ export const ClientSettingsSchema = Schema.Struct({
   // Grayscale `-webkit-font-smoothing: antialiased` (thinner strokes);
   // disabling restores the platform's heavier default. No effect off macOS.
   fontSmoothing: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  // Host(+path-prefix) patterns for chat links that should open in the
+  // integrated browser panel instead of the system browser. Stored raw;
+  // parsing/validation lives in the web app so an invalid persisted entry
+  // can never break settings decoding.
+  integratedBrowserUrlPatterns: Schema.Array(TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
   // Model favorites. Historically keyed by provider kind, now
   // widened to `ProviderInstanceId` so users can favorite a specific model
   // on a custom provider instance (e.g. "Codex Personal · gpt-5") without
@@ -762,6 +769,7 @@ export const ClientSettingsPatch = Schema.Struct({
   fontFamilySans: Schema.optionalKey(FontFamilyPreference),
   fontFamilyTerminal: Schema.optionalKey(FontFamilyPreference),
   fontSmoothing: Schema.optionalKey(Schema.Boolean),
+  integratedBrowserUrlPatterns: Schema.optionalKey(Schema.Array(TrimmedNonEmptyString)),
   favorites: Schema.optionalKey(
     Schema.Array(
       Schema.Struct({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -144,9 +144,9 @@ export const ClientSettingsSchema = Schema.Struct({
   // disabling restores the platform's heavier default. No effect off macOS.
   fontSmoothing: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   // Host(+path-prefix) patterns for chat links that should open in the
-  // integrated browser panel instead of the system browser. Stored raw;
-  // parsing/validation lives in the web app so an invalid persisted entry
-  // can never break settings decoding.
+  // integrated browser panel instead of the system browser. The schema only
+  // requires non-empty trimmed strings; pattern syntax is parsed in the web
+  // app, and an entry it can't parse simply never matches.
   integratedBrowserUrlPatterns: Schema.Array(TrimmedNonEmptyString).pipe(
     Schema.withDecodingDefault(Effect.succeed([])),
   ),


### PR DESCRIPTION
I wanted links to my postplans (and other sites I always view in-app) to open in the integrated browser panel instead of bouncing out to my system browser every time I click them in chat.

Now there's an "Integrated browser links" setting (Electron only, under General) where you list host patterns like `*.github.com` or `docs.example.com/api`. Left-clicking a chat link that matches opens it in the integrated browser; modifier- and middle-clicks still open externally, and everything else behaves as before.

- Patterns are host + optional path prefix — no schemes or ports. Bare domains normalize to `*.domain.com`; a leading `*.` matches the apex and any subdomain, anything else matches exactly.
- Stored raw in `ClientSettings` with parsing/validation in the web app, so a bad persisted entry can never break settings decoding.
- Matching + normalization are unit tested; setting participates in search and settings restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Electron chat link clicks and optional client settings; invalid patterns are ignored at match time and schema stays permissive.
> 
> **Overview**
> Adds user-configurable **integrated browser link patterns** so matching chat URLs open in the in-app browser panel (Electron) instead of the system browser on a normal left-click.
> 
> **Settings & persistence:** New `integratedBrowserUrlPatterns` on `ClientSettings` (default `[]`, trimmed non-empty strings only). General settings get an Electron-only **Integrated browser links** editor to add/remove patterns; search hides that item on web, and restore/reset includes the list.
> 
> **Pattern engine:** New `integratedBrowserLinkPatterns` helpers parse/normalize host + optional path patterns (`*.` subdomains, segment-boundary paths, bare domains → `*.domain.com`), with unit tests.
> 
> **Chat behavior:** `ChatMarkdown` intercepts external link clicks when preview is available: modifier/middle-clicks unchanged; if the href matches configured patterns, opens integrated preview and falls back to external open on failure. Context-menu preview path shares the same failure reporting helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80af8e43cf3558be7ea670acbd90c06012e1d40e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open chat links matching configured site patterns in the integrated browser
> - Adds `integratedBrowserUrlPatterns` to `ClientSettingsSchema` as a list of URL patterns (host + optional path prefix) that controls which links open in the integrated browser panel instead of the system browser.
> - Implements pattern parsing, normalization, and matching in [`integratedBrowserLinkPatterns.ts`](https://github.com/pingdotgg/t3code/pull/5352/files#diff-bece76eb7cf91d06382c968e06be61d2eb17de7870cb8e6dd8306429775b74cd), supporting `*.` wildcards, `www` stripping, segment-boundary path prefixes, and case-insensitive percent-escape handling.
> - Updates the `ChatMarkdown` anchor renderer to check clicked links against the configured patterns and open matches in the integrated preview, falling back to external open on failure.
> - Adds a settings UI in [`IntegratedBrowserLinksSetting.tsx`](https://github.com/pingdotgg/t3code/pull/5352/files#diff-bf1049c1c01524115b46ae7b791c3f5367c10b5868d1d942f48efbb719d9959b) (desktop only) to add/remove patterns, with canonicalization and duplicate prevention on add.
> - Behavioral Change: left-clicking a matching link no longer opens the system browser; modifier keys, non-http(s) links, and unmatched links are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80af8e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->