### PR TITLE
fix(web): stop the chat timeline reading through the provider status banner

### DIFF
--- a/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
@@ -44,6 +44,15 @@ describe("ProviderStatusBanner", () => {
     expect(markup).toContain("absolute top-2 right-2");
   });
 
+  it("renders on a glass surface so the timeline never reads through the banner", () => {
+    const markup = renderToStaticMarkup(
+      <ProviderStatusBanner status={warningProvider()} onDismiss={() => {}} />,
+    );
+
+    expect(markup).toContain("alert-glass");
+    expect(markup).toContain('data-variant="warning"');
+  });
+
   it("labels error dismiss controls with the correct severity", () => {
     const markup = renderToStaticMarkup(
       <ProviderStatusBanner

--- a/apps/web/src/components/chat/ProviderStatusBanner.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.tsx
@@ -46,11 +46,12 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
     <div className="pointer-events-auto mx-auto w-fit max-w-[calc(100%-2rem)] pt-3">
       <div
         className={cn(
-          "relative inline-flex items-center gap-3 rounded-xl border py-3 ps-3.5 pe-10 text-card-foreground text-sm",
+          "alert-glass relative inline-flex items-center gap-3 rounded-xl border py-3 ps-3.5 pe-10 text-card-foreground text-sm",
           status.status === "warning"
-            ? "border-warning/32 bg-warning/4 [&_svg]:text-warning"
-            : "border-destructive/32 bg-destructive/4 text-destructive-foreground [&_svg]:text-destructive",
+            ? "border-warning/32 [&_svg]:text-warning"
+            : "border-destructive/32 text-destructive-foreground [&_svg]:text-destructive",
         )}
+        data-variant={status.status === "warning" ? "warning" : "error"}
         role="alert"
       >
         <InfoIcon className="size-4 shrink-0" aria-hidden />


### PR DESCRIPTION
## Problem

The provider status banner floats above the message timeline — `ChatView` renders it in an
`absolute inset-x-0 top-0` layer so it can appear without shifting the timeline's content height.

Its only backing, though, was a 4% variant tint (`bg-warning/4` / `bg-destructive/4`). That is
effectively transparent, so the messages underneath stayed fully sharp and legible straight through
the card: code spans, inline chips and body copy all collided with the banner's own title and
message, and neither layer was readable.

Every other floating surface in the app already sits on an opaque, blurred backing — dialogs on
`dialog-glass`, menus/popovers/tooltips on `dropdown-glass`, and the composer banner stack on
`alert-glass`. The provider banner was the one overlay that opted out.

## Fix

The banner now floats on `alert-glass`, the same surface `ComposerBannerStack` uses. That utility
already layers a 4% variant tint (selected via `data-variant`) over
`color-mix(--background, var(--glass-opacity))` plus a saturating backdrop blur, so the banner keeps
its exact severity tinting while the timeline behind it is properly occluded. The per-variant
`bg-*/4` classes are dropped because `alert-glass` supplies that tint itself.

The utility also carries the existing `@supports not (backdrop-filter)` fallback to a fully opaque
`--background`, so browsers without backdrop filters get a solid surface rather than a see-through one.

## Scope

I swept the other floating overlays before settling on this one-surface change — the scroll-to-end
pill, terminal drawer controls, preview badges, mini player chrome, sidebar pills and every
`ui/` popup surface all already back themselves with glass or a solid `bg-background`/`bg-popover`.
The provider status banner was the only overlay left reading through to the content below it.

`Alert` itself is left alone on purpose: its translucent variants are correct for the inline,
in-flow usages in settings and the sidebar, where there is nothing behind them to bleed through.

## Before / after

### Before

<img width="1102" height="334" alt="CleanShot 2026-08-04 at 10  11 36@2x" src="https://github.com/user-attachments/assets/3dc0a7cf-cf39-4546-b77f-1d323cf3eb10" />

### After

<img width="1122" height="242" alt="CleanShot 2026-08-04 at 10  10 51@2x" src="https://github.com/user-attachments/assets/a87ada66-d72e-4219-bdd1-d662e1d27db3" />

## Verification

- `vp lint --report-unused-disable-directives` — exit 0, no new warnings
- `vp run --filter @t3tools/web typecheck` — clean
- `vp run --filter @t3tools/web test` — 1776 passed; the single failure
  (`src/lib/imageCompression.test.ts` timing out on canvas encoding) reproduces identically on an
  unmodified tree and is unrelated to this change
- Added a regression test asserting the banner renders on the glass surface with its severity
  `data-variant`, so a future refactor cannot silently drop the backing again


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chat timeline from reading through the provider status banner
> Replaces the background color classes (`bg-warning/4`, `bg-destructive/4`) on `ProviderStatusBanner` with the `alert-glass` class, which provides a solid visual barrier so the chat timeline no longer shows through. A `data-variant` attribute (`warning` or `error`) is added to the alert element to preserve semantic styling hooks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47f06a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
