### PR TITLE
fix(server): skip Linux libc detection on Windows/macOS

### DIFF
--- a/apps/server/src/resourceTelemetry/ResourceMonitorBinary.test.ts
+++ b/apps/server/src/resourceTelemetry/ResourceMonitorBinary.test.ts
@@ -4,7 +4,7 @@ import {
   HostProcessEnvironment,
   HostProcessPlatform,
 } from "@t3tools/shared/hostProcess";
-import { assert, describe, it } from "@effect/vitest";
+import { afterEach, assert, describe, expect, it, vi } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 
@@ -12,6 +12,36 @@ import { ServerConfig } from "../config.ts";
 import * as ResourceMonitorBinary from "./ResourceMonitorBinary.ts";
 
 describe("ResourceMonitorBinary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.effect("skips Linux libc detection on Windows", () =>
+    Effect.gen(function* () {
+      const getReport = vi.spyOn(process.report, "getReport").mockImplementation(() => {
+        throw new Error("Linux libc detection must not run on Windows");
+      });
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-resource-monitor-binary-",
+      });
+      const binaryPath = `${baseDir}/t3-resource-monitor.exe`;
+      yield* fileSystem.writeFileString(binaryPath, "binary");
+
+      const service = yield* ResourceMonitorBinary.make().pipe(
+        Effect.provide(ServerConfig.layerTest(process.cwd(), baseDir)),
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(HostProcessArchitecture, "arm64"),
+        Effect.provideService(HostProcessEnvironment, {
+          T3CODE_RESOURCE_MONITOR_PATH: binaryPath,
+        }),
+      );
+
+      assert.equal(yield* service.resolve, binaryPath);
+      expect(getReport).not.toHaveBeenCalled();
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("resolves an executable override", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/resourceTelemetry/ResourceMonitorBinary.ts
+++ b/apps/server/src/resourceTelemetry/ResourceMonitorBinary.ts
@@ -106,7 +106,7 @@ export function resourceMonitorPlatformKey(
 export function resourceMonitorRustTarget(
   platform: NodeJS.Platform,
   architecture: NodeJS.Architecture,
-  linuxLibc: ResourceMonitorLinuxLibc,
+  linuxLibc?: ResourceMonitorLinuxLibc,
 ): string | undefined {
   if (platform === "darwin") {
     return architecture === "arm64"
@@ -142,7 +142,7 @@ export const make = Effect.fn("resourceTelemetry.resourceMonitorBinary.make")(fu
   const platform = yield* HostProcessPlatform;
   const architecture = yield* HostProcessArchitecture;
   const environment = yield* HostProcessEnvironment;
-  const linuxLibc = yield* ResourceMonitorHostLinuxLibc;
+  const linuxLibc = platform === "linux" ? yield* ResourceMonitorHostLinuxLibc : undefined;
   const executableName = binaryName(platform);
   const platformKey = resourceMonitorPlatformKey(platform, architecture);
   const rustTarget = resourceMonitorRustTarget(platform, architecture, linuxLibc);


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Only detect the host Linux libc when the server is actually running on Linux.

Tried to keep the actual change as minimal as possible. Apologies if the unit test is slop, I am not a ts developer.

## Why

The resource-monitor binary resolver unconditionally evaluated `ResourceMonitorHostLinuxLibc`. Its default implementation calls `process.report.getReport()`, even though the result is ignored when selecting a non-Linux resource-monitor binary.

On my Windows ARM64 machine (I built ARM64 from source), this unused call took approximately 154.4 seconds, which exceeded the 60 second backend readiness check timeout and resulted in the gui never showing. After the fix the app started quickly.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, platform-gated change in binary resolution; Linux libc behavior is unchanged when `platform === "linux"`.
> 
> **Overview**
> **Fixes slow or failed server startup on Windows (and macOS)** by not running Linux libc detection when resolving the resource-monitor binary on non-Linux hosts.
> 
> `ResourceMonitorBinary.make()` now only evaluates `ResourceMonitorHostLinuxLibc` when `platform === "linux"`. Previously it always ran the default detector, which calls `process.report.getReport()`—unnecessary for Windows/macOS binary selection and reportedly very slow on Windows ARM64 (e.g. exceeding readiness timeouts). `resourceMonitorRustTarget` now accepts an optional `linuxLibc` for that path.
> 
> A new test stubs `process.report.getReport` to throw on a mocked `win32` host and asserts it is never called while override resolution still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8475e3c683fee1e793c6437203d8fc30d1b1e33e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip Linux libc detection on Windows and macOS in `ResourceMonitorBinary`
> On non-Linux platforms, `resourceTelemetry.resourceMonitorBinary.make` no longer attempts to obtain `ResourceMonitorHostLinuxLibc`. The `linuxLibc` parameter in `resourceMonitorRustTarget` is now optional, and is only populated when `platform === "linux"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8475e3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->