### PR TITLE
fix(server): keep regenerated titles on topic

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -785,6 +785,77 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.titleRegeneration).toBeNull();
   });
 
+  it("pins the first user message when regeneration context is truncated", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const firstUserMessage = "Review the subagent monitoring design for release risks.";
+    const recentAssistantMessage = `LATEST FINDING: ${"implementation detail ".repeat(500)}`;
+    harness.generateThreadTitle.mockReturnValue(
+      Effect.succeed({ title: "Review subagent monitoring risks" }),
+    );
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-title-existing-long"),
+        threadId: ThreadId.make("thread-1"),
+        title: "Generic PR review",
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-before-long-title-regeneration"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-before-long-title-regeneration"),
+          role: "user",
+          text: firstUserMessage,
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.message.assistant.delta",
+        commandId: CommandId.make("cmd-assistant-before-long-title-regeneration"),
+        threadId: ThreadId.make("thread-1"),
+        messageId: asMessageId("assistant-message-before-long-title-regeneration"),
+        delta: recentAssistantMessage,
+        createdAt: "2026-01-01T00:00:01.000Z",
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.message.assistant.complete",
+        commandId: CommandId.make("cmd-assistant-complete-before-long-title-regeneration"),
+        threadId: ThreadId.make("thread-1"),
+        messageId: asMessageId("assistant-message-before-long-title-regeneration"),
+        createdAt: "2026-01-01T00:00:02.000Z",
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-title-regenerate-long"),
+        threadId: ThreadId.make("thread-1"),
+        regenerateTitle: true,
+      }),
+    );
+
+    await harness.drain();
+
+    expect(harness.generateThreadTitle).toHaveBeenCalledTimes(1);
+    const message = harness.generateThreadTitle.mock.calls[0]?.[0].message;
+    expect(message?.startsWith(`USER:\n${firstUserMessage}`)).toBe(true);
+    expect(message).toContain("[Earlier content truncated]");
+    expect(message).toContain("implementation detail");
+    expect(message).toHaveLength(8_000);
+  });
+
   it("clears title regeneration state left pending across reactor startup", async () => {
     const harness = await createHarness({
       titleRegenerationBeforeStart: "one",
@@ -972,10 +1043,14 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.titleRegeneration).toBeNull();
   });
 
-  it("keeps the full retained context and excludes attachments outside it", async () => {
+  it("pins the first user context and attachment before the retained tail", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
-    const retainedContext = "x".repeat(8_000);
+    const firstUserContext = "USER:\nOld visual issue\n[Attachments: old-issue.png]";
+    const truncationMarker = "[Earlier content truncated]\n\n";
+    const retainedContext = "x".repeat(
+      8_000 - firstUserContext.length - "\n\n".length - truncationMarker.length,
+    );
 
     await harness.runEffect(
       harness.engine.dispatch({
@@ -1040,9 +1115,14 @@ describe("ProviderCommandReactor", () => {
     await harness.drain();
 
     expect(harness.generateThreadTitle.mock.calls[0]?.[0].message).toBe(
-      `[Earlier content truncated]\n\n${retainedContext}`,
+      `${firstUserContext}\n\n${truncationMarker}${retainedContext}`,
     );
-    expect(harness.generateThreadTitle.mock.calls[0]?.[0].attachments).toBeUndefined();
+    expect(harness.generateThreadTitle.mock.calls[0]?.[0].attachments).toEqual([
+      expect.objectContaining({
+        id: "old-title-context-image",
+        name: "old-issue.png",
+      }),
+    ]);
   });
 
   it("does not overwrite a manual rename while title regeneration is running", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -815,7 +815,7 @@ describe("ProviderCommandReactor", () => {
             {
               type: "image",
               id: "opening-context-image",
-              name: "opening.png",
+              name: "image.png",
               mimeType: "image/png",
               sizeBytes: 5,
             },
@@ -839,7 +839,7 @@ describe("ProviderCommandReactor", () => {
             {
               type: "image",
               id: "middle-context-image",
-              name: "middle.png",
+              name: "image.png",
               mimeType: "image/png",
               sizeBytes: 5,
             },
@@ -863,7 +863,7 @@ describe("ProviderCommandReactor", () => {
             {
               type: "image",
               id: "recent-context-image",
-              name: "recent.png",
+              name: "image.png",
               mimeType: "image/png",
               sizeBytes: 5,
             },
@@ -894,8 +894,7 @@ describe("ProviderCommandReactor", () => {
     expect(message.startsWith("USER:\nReview subagent monitoring risks.")).toBe(true);
     expect(message).toContain("[First user message truncated]");
     expect(message).toContain("[Earlier content truncated]");
-    expect(message).toContain("recent.png");
-    expect(message).not.toContain("middle.png");
+    expect(message).toContain("image.png");
     expect(message).toHaveLength(8_000);
     expect(input.attachments?.map((attachment) => attachment.id)).toEqual([
       "opening-context-image",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -788,8 +788,8 @@ describe("ProviderCommandReactor", () => {
   it("pins the first user message when regeneration context is truncated", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
-    const firstUserMessage = "Review the subagent monitoring design for release risks.";
-    const recentAssistantMessage = `LATEST FINDING: ${"implementation detail ".repeat(500)}`;
+    const firstUserMessage = `Review subagent monitoring risks. ${"Opening context. ".repeat(200)}`;
+    const recentUserMessage = `LATEST FINDING: ${"implementation detail ".repeat(320)}`;
     harness.generateThreadTitle.mockReturnValue(
       Effect.succeed({ title: "Review subagent monitoring risks" }),
     );
@@ -811,7 +811,15 @@ describe("ProviderCommandReactor", () => {
           messageId: asMessageId("user-message-before-long-title-regeneration"),
           role: "user",
           text: firstUserMessage,
-          attachments: [],
+          attachments: [
+            {
+              type: "image",
+              id: "opening-context-image",
+              name: "opening.png",
+              mimeType: "image/png",
+              sizeBytes: 5,
+            },
+          ],
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
@@ -820,20 +828,49 @@ describe("ProviderCommandReactor", () => {
     );
     await harness.runEffect(
       harness.engine.dispatch({
-        type: "thread.message.assistant.delta",
-        commandId: CommandId.make("cmd-assistant-before-long-title-regeneration"),
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-middle-turn-before-long-title-regeneration"),
         threadId: ThreadId.make("thread-1"),
-        messageId: asMessageId("assistant-message-before-long-title-regeneration"),
-        delta: recentAssistantMessage,
+        message: {
+          messageId: asMessageId("middle-message-before-long-title-regeneration"),
+          role: "user",
+          text: "Temporary handoff details.",
+          attachments: [
+            {
+              type: "image",
+              id: "middle-context-image",
+              name: "middle.png",
+              mimeType: "image/png",
+              sizeBytes: 5,
+            },
+          ],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
         createdAt: "2026-01-01T00:00:01.000Z",
       }),
     );
     await harness.runEffect(
       harness.engine.dispatch({
-        type: "thread.message.assistant.complete",
-        commandId: CommandId.make("cmd-assistant-complete-before-long-title-regeneration"),
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-recent-turn-before-long-title-regeneration"),
         threadId: ThreadId.make("thread-1"),
-        messageId: asMessageId("assistant-message-before-long-title-regeneration"),
+        message: {
+          messageId: asMessageId("recent-message-before-long-title-regeneration"),
+          role: "user",
+          text: recentUserMessage,
+          attachments: [
+            {
+              type: "image",
+              id: "recent-context-image",
+              name: "recent.png",
+              mimeType: "image/png",
+              sizeBytes: 5,
+            },
+          ],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
         createdAt: "2026-01-01T00:00:02.000Z",
       }),
     );
@@ -849,11 +886,18 @@ describe("ProviderCommandReactor", () => {
     await harness.drain();
 
     expect(harness.generateThreadTitle).toHaveBeenCalledTimes(1);
-    const message = harness.generateThreadTitle.mock.calls[0]?.[0].message;
-    expect(message?.startsWith(`USER:\n${firstUserMessage}`)).toBe(true);
+    const input = harness.generateThreadTitle.mock.calls[0]?.[0];
+    const message = input.message;
+    expect(message.startsWith("USER:\nReview subagent monitoring risks.")).toBe(true);
+    expect(message).toContain("[First user message truncated]");
     expect(message).toContain("[Earlier content truncated]");
-    expect(message).toContain("implementation detail");
+    expect(message).toContain("recent.png");
+    expect(message).not.toContain("middle.png");
     expect(message).toHaveLength(8_000);
+    expect(input.attachments?.map((attachment) => attachment.id)).toEqual([
+      "opening-context-image",
+      "recent-context-image",
+    ]);
   });
 
   it("clears title regeneration state left pending across reactor startup", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -887,6 +887,9 @@ describe("ProviderCommandReactor", () => {
 
     expect(harness.generateThreadTitle).toHaveBeenCalledTimes(1);
     const input = harness.generateThreadTitle.mock.calls[0]?.[0];
+    if (!input) {
+      throw new Error("Expected a title generation input");
+    }
     const message = input.message;
     expect(message.startsWith("USER:\nReview subagent monitoring risks.")).toBe(true);
     expect(message).toContain("[First user message truncated]");

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -129,9 +129,13 @@ function limitFirstUserSection(section: string): string {
   )}${FIRST_USER_CONTEXT_TRUNCATION_MARKER}`;
 }
 
-function formatThreadTitleContext(messages: ReadonlyArray<ThreadTitleMessage>): {
-  readonly message: string;
+function collectRecentThreadTitleContext(
+  messages: ReadonlyArray<ThreadTitleMessage>,
+  maxChars: number,
+): {
+  readonly context: string;
   readonly attachments: ReadonlyArray<ChatAttachment>;
+  readonly truncated: boolean;
 } {
   let context = "";
   let truncated = false;
@@ -144,7 +148,7 @@ function formatThreadTitleContext(messages: ReadonlyArray<ThreadTitleMessage>): 
     }
 
     const separator = context.length > 0 ? "\n\n" : "";
-    const available = MAX_THREAD_TITLE_CONTEXT_CHARS - context.length - separator.length;
+    const available = maxChars - context.length - separator.length;
     if (section.length > available) {
       if (available > 0) {
         context = `${section.slice(-available)}${separator}${context}`;
@@ -157,34 +161,48 @@ function formatThreadTitleContext(messages: ReadonlyArray<ThreadTitleMessage>): 
     retainedAttachments.unshift(...(message.attachments ?? []));
   }
 
-  let recentContext = context;
-  const firstUserMessage = truncated
-    ? messages.find((message) => message.role === "user" && formatThreadTitleSection(message))
-    : undefined;
-  if (firstUserMessage) {
-    const firstUserSection = formatThreadTitleSection(firstUserMessage);
-    if (firstUserSection) {
-      const pinnedSection = limitFirstUserSection(firstUserSection);
-      const recentContextBudget =
-        MAX_THREAD_TITLE_CONTEXT_CHARS -
-        pinnedSection.length -
-        "\n\n".length -
-        THREAD_TITLE_CONTEXT_TRUNCATION_MARKER.length;
-      recentContext = context.slice(-recentContextBudget);
-      context = `${pinnedSection}\n\n${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${recentContext}`;
-    }
-  } else if (truncated) {
-    context = `${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${context}`;
+  return { context, attachments: retainedAttachments, truncated };
+}
+
+function formatThreadTitleContext(messages: ReadonlyArray<ThreadTitleMessage>): {
+  readonly message: string;
+  readonly attachments: ReadonlyArray<ChatAttachment>;
+} {
+  const recent = collectRecentThreadTitleContext(messages, MAX_THREAD_TITLE_CONTEXT_CHARS);
+  if (!recent.truncated) {
+    return {
+      message: recent.context,
+      attachments: recent.attachments.slice(-MAX_REGENERATION_ATTACHMENTS),
+    };
   }
 
-  const pinnedAttachment = firstUserMessage?.attachments?.[0];
-  const recentAttachments = retainedAttachments.filter(
-    (attachment) =>
-      attachment.id !== pinnedAttachment?.id && recentContext.includes(attachment.name),
+  const firstUserMessage = messages.find(
+    (message) => message.role === "user" && formatThreadTitleSection(message),
+  );
+  const firstUserSection = firstUserMessage
+    ? formatThreadTitleSection(firstUserMessage)
+    : undefined;
+  if (!firstUserMessage || !firstUserSection) {
+    return {
+      message: `${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${recent.context}`,
+      attachments: recent.attachments.slice(-MAX_REGENERATION_ATTACHMENTS),
+    };
+  }
+
+  const pinnedSection = limitFirstUserSection(firstUserSection);
+  const recentContextBudget =
+    MAX_THREAD_TITLE_CONTEXT_CHARS -
+    pinnedSection.length -
+    "\n\n".length -
+    THREAD_TITLE_CONTEXT_TRUNCATION_MARKER.length;
+  const retainedRecent = collectRecentThreadTitleContext(messages, recentContextBudget);
+  const pinnedAttachment = firstUserMessage.attachments?.[0];
+  const recentAttachments = retainedRecent.attachments.filter(
+    (attachment) => attachment.id !== pinnedAttachment?.id,
   );
 
   return {
-    message: context,
+    message: `${pinnedSection}\n\n${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${retainedRecent.context}`,
     attachments: [
       ...(pinnedAttachment ? [pinnedAttachment] : []),
       ...recentAttachments.slice(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -157,6 +157,7 @@ function formatThreadTitleContext(messages: ReadonlyArray<ThreadTitleMessage>): 
     retainedAttachments.unshift(...(message.attachments ?? []));
   }
 
+  let recentContext = context;
   const firstUserMessage = truncated
     ? messages.find((message) => message.role === "user" && formatThreadTitleSection(message))
     : undefined;
@@ -169,8 +170,8 @@ function formatThreadTitleContext(messages: ReadonlyArray<ThreadTitleMessage>): 
         pinnedSection.length -
         "\n\n".length -
         THREAD_TITLE_CONTEXT_TRUNCATION_MARKER.length;
-      context = context.slice(-recentContextBudget);
-      context = `${pinnedSection}\n\n${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${context}`;
+      recentContext = context.slice(-recentContextBudget);
+      context = `${pinnedSection}\n\n${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${recentContext}`;
     }
   } else if (truncated) {
     context = `${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${context}`;
@@ -178,7 +179,8 @@ function formatThreadTitleContext(messages: ReadonlyArray<ThreadTitleMessage>): 
 
   const pinnedAttachment = firstUserMessage?.attachments?.[0];
   const recentAttachments = retainedAttachments.filter(
-    (attachment) => attachment.id !== pinnedAttachment?.id,
+    (attachment) =>
+      attachment.id !== pinnedAttachment?.id && recentContext.includes(attachment.name),
   );
 
   return {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -94,15 +94,42 @@ const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
 const DEFAULT_THREAD_TITLE = "New thread";
 const MAX_REGENERATION_ATTACHMENTS = 4;
 const MAX_THREAD_TITLE_CONTEXT_CHARS = 8_000;
+const MAX_FIRST_USER_TITLE_CONTEXT_CHARS = 2_000;
 const THREAD_TITLE_CONTEXT_TRUNCATION_MARKER = "[Earlier content truncated]\n\n";
+const FIRST_USER_CONTEXT_TRUNCATION_MARKER = "\n[First user message truncated]";
 
-function formatThreadTitleContext(
-  messages: ReadonlyArray<{
-    readonly role: "user" | "assistant" | "system";
-    readonly text: string;
-    readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;
-  }>,
-): {
+type ThreadTitleMessage = {
+  readonly role: "user" | "assistant" | "system";
+  readonly text: string;
+  readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;
+};
+
+function formatThreadTitleSection(message: ThreadTitleMessage): string | undefined {
+  if (message.role === "system") {
+    return undefined;
+  }
+  const text = message.text.trim();
+  const attachmentSummary = (message.attachments ?? [])
+    .map((attachment) => attachment.name)
+    .join(", ");
+  const contents = [
+    ...(text.length > 0 ? [text] : []),
+    ...(attachmentSummary.length > 0 ? [`[Attachments: ${attachmentSummary}]`] : []),
+  ].join("\n");
+  return contents.length > 0 ? `${message.role.toUpperCase()}:\n${contents}` : undefined;
+}
+
+function limitFirstUserSection(section: string): string {
+  if (section.length <= MAX_FIRST_USER_TITLE_CONTEXT_CHARS) {
+    return section;
+  }
+  return `${section.slice(
+    0,
+    MAX_FIRST_USER_TITLE_CONTEXT_CHARS - FIRST_USER_CONTEXT_TRUNCATION_MARKER.length,
+  )}${FIRST_USER_CONTEXT_TRUNCATION_MARKER}`;
+}
+
+function formatThreadTitleContext(messages: ReadonlyArray<ThreadTitleMessage>): {
   readonly message: string;
   readonly attachments: ReadonlyArray<ChatAttachment>;
 } {
@@ -111,22 +138,11 @@ function formatThreadTitleContext(
   const retainedAttachments: Array<ChatAttachment> = [];
 
   for (const message of messages.toReversed()) {
-    if (message.role === "system") {
-      continue;
-    }
-    const text = message.text.trim();
-    const attachmentSummary = (message.attachments ?? [])
-      .map((attachment) => attachment.name)
-      .join(", ");
-    const contents = [
-      ...(text.length > 0 ? [text] : []),
-      ...(attachmentSummary.length > 0 ? [`[Attachments: ${attachmentSummary}]`] : []),
-    ].join("\n");
-    if (contents.length === 0) {
+    const section = formatThreadTitleSection(message);
+    if (section === undefined) {
       continue;
     }
 
-    const section = `${message.role.toUpperCase()}:\n${contents}`;
     const separator = context.length > 0 ? "\n\n" : "";
     const available = MAX_THREAD_TITLE_CONTEXT_CHARS - context.length - separator.length;
     if (section.length > available) {
@@ -141,9 +157,38 @@ function formatThreadTitleContext(
     retainedAttachments.unshift(...(message.attachments ?? []));
   }
 
+  const firstUserMessage = truncated
+    ? messages.find((message) => message.role === "user" && formatThreadTitleSection(message))
+    : undefined;
+  if (firstUserMessage) {
+    const firstUserSection = formatThreadTitleSection(firstUserMessage);
+    if (firstUserSection) {
+      const pinnedSection = limitFirstUserSection(firstUserSection);
+      const recentContextBudget =
+        MAX_THREAD_TITLE_CONTEXT_CHARS -
+        pinnedSection.length -
+        "\n\n".length -
+        THREAD_TITLE_CONTEXT_TRUNCATION_MARKER.length;
+      context = context.slice(-recentContextBudget);
+      context = `${pinnedSection}\n\n${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${context}`;
+    }
+  } else if (truncated) {
+    context = `${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${context}`;
+  }
+
+  const pinnedAttachment = firstUserMessage?.attachments?.[0];
+  const recentAttachments = retainedAttachments.filter(
+    (attachment) => attachment.id !== pinnedAttachment?.id,
+  );
+
   return {
-    message: truncated ? `${THREAD_TITLE_CONTEXT_TRUNCATION_MARKER}${context}` : context,
-    attachments: retainedAttachments.slice(-MAX_REGENERATION_ATTACHMENTS),
+    message: context,
+    attachments: [
+      ...(pinnedAttachment ? [pinnedAttachment] : []),
+      ...recentAttachments.slice(
+        -(MAX_REGENERATION_ATTACHMENTS - (pinnedAttachment === undefined ? 0 : 1)),
+      ),
+    ],
   };
 }
 

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -195,11 +195,17 @@ describe("buildThreadTitlePrompt", () => {
     });
 
     expect(result.prompt).toContain(
-      "Generate a new title that will help the user recognize this T3 Code thread weeks later.",
+      "Regenerate the title for an existing T3 Code thread so the user can recognize it weeks later.",
     );
     expect(result.prompt).toContain('The previous title was "Investigate reconnect regressions".');
     expect(result.prompt).toContain(
-      "Capture the current durable subject and outcome across the whole thread, not merely its initial request or latest step.",
+      "Read the USER messages first. Identify the latest explicit durable goal.",
+    );
+    expect(result.prompt).toContain(
+      "Do not promote one assistant finding into the thread subject unless the user adopts it as a new goal.",
+    );
+    expect(result.prompt).toContain(
+      'A subagent-monitoring review that finds a Codex roster bug remains "Review Subagent Monitoring Risks,"',
     );
     expect(result.prompt).toContain("Thread contents:");
     expect(result.prompt).toContain("The remaining issue is stale session state");

--- a/apps/server/src/textGeneration/TextGenerationPrompts.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.ts
@@ -153,6 +153,7 @@ interface PromptFromMessageInput {
   guidance?: ReadonlyArray<string> | undefined;
   rulesLabel?: string | undefined;
   rules: ReadonlyArray<string>;
+  afterRules?: ReadonlyArray<string> | undefined;
   message: string;
   messageLabel?: string | undefined;
   preserveMessageEnd?: boolean | undefined;
@@ -182,6 +183,7 @@ function buildPromptFromMessage(input: PromptFromMessageInput): string {
     ...(input.guidance ?? []),
     input.rulesLabel ?? "Rules:",
     ...input.rules.map((rule) => `- ${rule}`),
+    ...(input.afterRules ?? []),
     "",
     `${input.messageLabel ?? "User message"}:`,
     input.preserveMessageEnd
@@ -237,42 +239,73 @@ export function buildThreadTitlePrompt(input: ThreadTitlePromptInput) {
   const prompt = buildPromptFromMessage({
     instruction: isRegeneration
       ? [
-          "Generate a new title that will help the user recognize this T3 Code thread weeks later.",
+          "Regenerate the title for an existing T3 Code thread so the user can recognize it weeks later.",
           `The previous title was ${JSON.stringify(input.previousTitle)}.`,
         ].join("\n")
       : "Generate a title that will help the user recognize this T3 Code thread weeks later.",
     responseShape: "Return JSON with exactly one key: title.",
-    guidance: [
-      "",
-      "Before answering, silently reduce the request to:",
-      "- Subject: What system, feature, or problem is this really about?",
-      "- Outcome: What does the user ultimately want to understand or change?",
-      "- Incidental instructions: What only describes how the agent should do the work?",
-      "",
-      "Title the subject and outcome. Discard incidental instructions.",
-      "",
-    ],
+    guidance: isRegeneration
+      ? [
+          "",
+          "Determine the title in this order:",
+          "1. Read the USER messages first. Identify the latest explicit durable goal. The original subject remains the subject until the user clearly changes what the thread is about.",
+          "2. Use ASSISTANT messages to resolve vague links, unnamed code, and discovered product nouns. Do not promote one assistant finding into the thread subject unless the user adopts it as a new goal.",
+          "3. Compare that subject with the previous title. Preserve accurate scope words, especially when earlier content is truncated. Replace the previous title when it is generic, artifact-based, a completion update, or contradicted by the thread.",
+          "4. Title the durable subject and desired outcome, not the current workflow state.",
+          "",
+        ]
+      : [
+          "",
+          "Before answering, silently reduce the request to:",
+          "- Subject: What system, feature, or problem is this really about?",
+          "- Outcome: What does the user ultimately want to understand or change?",
+          "- Incidental instructions: What only describes how the agent should do the work?",
+          "",
+          "Title the subject and outcome. Discard incidental instructions.",
+          "",
+        ],
     rulesLabel: "Editorial rules:",
-    rules: [
-      "3-8 words, fewer than 40 characters.",
-      "Use a compact noun phrase or clear action phrase.",
-      "Capture the umbrella goal when the request lists several symptoms or steps.",
-      "Name the product change, not the mock, plan, report, branch, or PR used to produce it.",
-      "Models, subagents, tools, output formats, and monitoring instructions do not belong in the title unless they are themselves the topic.",
-      'For reviews, name what is being reviewed and the relevant concern. Avoid generic titles such as "Review PR 123" when linked or attached context reveals the subject.',
-      "For research, name the question domain rather than the requested research process.",
-      "Do not claim the work is complete.",
-      "Do not copy and truncate the user's message.",
-      "Avoid project names already visible in the UI, quotes, labels, filler, and trailing punctuation.",
-      "Use attached images as primary context for UI issues.",
-      "When a URL or attachment is the only source of the subject, use available tools to inspect it. If it cannot be resolved, remain accurate rather than guessing.",
-      ...(isRegeneration
-        ? [
-            "Capture the current durable subject and outcome across the whole thread, not merely its initial request or latest step.",
-            "Return a different title from the previous title.",
-          ]
-        : []),
-    ],
+    rules: isRegeneration
+      ? [
+          "3-8 words, fewer than 40 characters.",
+          "Use a compact noun phrase or clear action phrase.",
+          "Preserve the umbrella subject when later messages focus on one finding, provider, platform, or implementation detail.",
+          "A thread progressing through research, planning, implementation, review, CI, merge, and monitoring has usually not changed subjects.",
+          "Ignore deliverables and operations such as mocks, plans, HTML, branches, PRs, tests, CI, commits, merging, and monitoring unless they are the actual topic.",
+          "Models, subagents, tools, output formats, and monitoring instructions do not belong in the title unless they are themselves the topic.",
+          "Treat final operational follow-ups and assistant completion summaries as weak evidence of subject.",
+          "For reviews, name the reviewed feature or system and its durable concern, not one finding from the review.",
+          "For research, name the question domain rather than the research process.",
+          "Do not claim the work is complete.",
+          "Do not copy and truncate a thread message.",
+          "Avoid project names already visible in the UI, PR numbers, quotes, labels, filler, and trailing punctuation.",
+          "Use attached images as primary context for UI issues.",
+          "When a URL or attachment is the only source of the subject, use available tools to inspect it. If it cannot be resolved, remain accurate rather than guessing.",
+          "Return a meaningfully improved title, not a cosmetic paraphrase of the previous title.",
+        ]
+      : [
+          "3-8 words, fewer than 40 characters.",
+          "Use a compact noun phrase or clear action phrase.",
+          "Capture the umbrella goal when the request lists several symptoms or steps.",
+          "Name the product change, not the mock, plan, report, branch, or PR used to produce it.",
+          "Models, subagents, tools, output formats, and monitoring instructions do not belong in the title unless they are themselves the topic.",
+          'For reviews, name what is being reviewed and the relevant concern. Avoid generic titles such as "Review PR 123" when linked or attached context reveals the subject.',
+          "For research, name the question domain rather than the requested research process.",
+          "Do not claim the work is complete.",
+          "Do not copy and truncate the user's message.",
+          "Avoid project names already visible in the UI, quotes, labels, filler, and trailing punctuation.",
+          "Use attached images as primary context for UI issues.",
+          "When a URL or attachment is the only source of the subject, use available tools to inspect it. If it cannot be resolved, remain accurate rather than guessing.",
+        ],
+    afterRules: isRegeneration
+      ? [
+          "",
+          "Examples of the distinction:",
+          '- A subagent-monitoring review that finds a Codex roster bug remains "Review Subagent Monitoring Risks," not "Codex Roster Bug Review."',
+          '- A vague failing-test request later identified as a lazy thread-feed mismatch becomes "Fix Lazy Thread Feed Test," not "Prevent Mobile Feed Regressions."',
+          "- A QR-sharing overhaul that ends with CI and merge work remains about QR sharing, not the PR lifecycle.",
+        ]
+      : undefined,
     message: input.message,
     ...(isRegeneration
       ? {


### PR DESCRIPTION
Regenerated titles can drift toward the latest assistant finding or operational follow-up, especially after the original request falls out of the recent context window.

This gives regeneration its own subject-selection guidance and keeps the opening user message inside the existing 8,000-character budget alongside the recent tail. Opening image context is retained too.

## Testing

- `vp test run apps/server/src/textGeneration/TextGenerationPrompts.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts`
- `git diff --check`
- Server typecheck attempted; currently fails on existing unrelated Effect and Bun typing errors across the package

Generated by GPT-5.6 Sol (high reasoning) through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized server-side title regeneration and prompt text; behavior is covered by tests and does not touch auth, persistence, or provider session logic.
> 
> **Overview**
> **Regenerated thread titles** were drifting toward the latest assistant finding or operational detail when long threads exceeded the title model’s context window.
> 
> **Context assembly** (`formatThreadTitleContext` in `ProviderCommandReactor`) now, when the 8,000-character budget is exceeded, **pins the first USER section** (up to 2,000 chars, with `[First user message truncated]` if needed), then `[Earlier content truncated]` and the **recent message tail**. Title-generation attachments prefer the **first user message’s first image** plus recent retained images (up to four, deduped).
> 
> **Regeneration prompts** (`buildThreadTitlePrompt`) use separate guidance and editorial rules: prioritize the user’s durable goal, don’t elevate a single assistant finding unless the user adopts it, and add **`afterRules` examples** (e.g. subagent-monitoring review vs. one Codex bug). First-turn title prompts are unchanged.
> 
> Tests cover long-thread pinning, attachment selection, and updated prompt expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224145f48e31a054671632ae55a428a59d7f01ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread title regeneration to stay on topic by pinning the first user message
> - Updates `buildThreadTitlePrompt` in [TextGenerationPrompts.ts](https://github.com/pingdotgg/t3code/pull/5365/files#diff-90cc284c5147149b6716e9117535710ac55311db230c4f9302015d0f3bb0cd8e) with regeneration-specific instruction wording, guidance, and rules that direct the model to identify the durable thread subject from USER messages rather than promoting transient assistant findings.
> - Updates `formatThreadTitleContext` in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/5365/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) so that when the context exceeds 8,000 chars, the first USER message section is pinned at the start (capped at 2,000 chars), followed by `[Earlier content truncated]` and the recent tail.
> - Attachments for title generation now include the first user message's first attachment plus recent retained attachments, up to four total, excluding duplicates.
> - Adds an `afterRules` field to `PromptFromMessageInput` so regeneration prompts can append worked examples (e.g. distinguishing a durable bug topic from a transient subagent-monitoring state) directly after the rules block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 224145f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->