### PR TITLE
fix(clients): refresh project folders when reopened

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -29,7 +29,15 @@ import {
 import { CommandId, type EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { StackActions, useNavigation } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { ActivityIndicator, Alert, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as Arr from "effect/Array";
@@ -247,6 +255,7 @@ function useBrowsePathInput(environment: EnvironmentOption | null) {
   const loadBrowsePath = useAtomQueryRunner(filesystemEnvironment.browse, {
     reportFailure: false,
     reportDefect: false,
+    refresh: true,
   });
   const [browseNavigation] = useState(createBrowseNavigationCoordinator);
   const [isBrowseNavigating, setIsBrowseNavigating] = useState(false);
@@ -705,6 +714,17 @@ function FolderBrowser(props: {
           input: browseInput,
         }),
   );
+  const shouldRefreshCachedBrowseOnMountRef = useRef(
+    browseState.data !== null && !browseState.isPending,
+  );
+  const refreshCachedBrowseOnMount = useEffectEvent(() => {
+    browseState.refresh();
+  });
+  useEffect(() => {
+    if (shouldRefreshCachedBrowseOnMountRef.current) {
+      refreshCachedBrowseOnMount();
+    }
+  }, []);
   const { visibleEntries: visibleBrowseEntries } = useMemo(
     () => filterFilesystemBrowseEntries(browseState.data?.entries ?? [], browsePath.filterQuery),
     [browsePath.filterQuery, browseState.data?.entries],

--- a/apps/mobile/src/state/use-atom-query-runner.ts
+++ b/apps/mobile/src/state/use-atom-query-runner.ts
@@ -1,20 +1,21 @@
 import { RegistryContext } from "@effect/atom-react";
 import {
   executeAtomQuery,
-  type AtomCommandOptions,
   type AtomCommandResult,
+  type AtomQueryOptions,
 } from "@t3tools/client-runtime/state/runtime";
 import { AsyncResult, type Atom } from "effect/unstable/reactivity";
 import { useCallback, useContext } from "react";
 
 export function useAtomQueryRunner<T, A, E>(
   family: (target: T) => Atom.Atom<AsyncResult.AsyncResult<A, E>>,
-  options?: string | AtomCommandOptions,
+  options?: string | AtomQueryOptions,
 ): (target: T) => Promise<AtomCommandResult<A, E>> {
   const registry = useContext(RegistryContext);
   const explicitLabel = typeof options === "string" ? options : options?.label;
   const reportFailure = typeof options === "string" ? true : (options?.reportFailure ?? true);
   const reportDefect = typeof options === "string" ? true : (options?.reportDefect ?? true);
+  const refresh = typeof options === "string" ? false : (options?.refresh ?? false);
 
   return useCallback(
     (target: T) => {
@@ -23,8 +24,9 @@ export function useAtomQueryRunner<T, A, E>(
         label: explicitLabel ?? atom.label?.[0] ?? "atom query",
         reportFailure,
         reportDefect,
+        refresh,
       });
     },
-    [explicitLabel, family, registry, reportDefect, reportFailure],
+    [explicitLabel, family, refresh, registry, reportDefect, reportFailure],
   );
 }

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -543,6 +543,7 @@ function OpenCommandPaletteDialog(props: {
   const loadBrowsePath = useAtomQueryRunner(filesystemEnvironment.browse, {
     reportFailure: false,
     reportDefect: false,
+    refresh: true,
   });
   const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
     reportFailure: false,

--- a/apps/web/src/state/use-atom-query-runner.ts
+++ b/apps/web/src/state/use-atom-query-runner.ts
@@ -1,20 +1,21 @@
 import { RegistryContext } from "@effect/atom-react";
 import {
   executeAtomQuery,
-  type AtomCommandOptions,
   type AtomCommandResult,
+  type AtomQueryOptions,
 } from "@t3tools/client-runtime/state/runtime";
 import { AsyncResult, type Atom } from "effect/unstable/reactivity";
 import { useCallback, useContext } from "react";
 
 export function useAtomQueryRunner<T, A, E>(
   family: (target: T) => Atom.Atom<AsyncResult.AsyncResult<A, E>>,
-  options?: string | AtomCommandOptions,
+  options?: string | AtomQueryOptions,
 ): (target: T) => Promise<AtomCommandResult<A, E>> {
   const registry = useContext(RegistryContext);
   const explicitLabel = typeof options === "string" ? options : options?.label;
   const reportFailure = typeof options === "string" ? true : (options?.reportFailure ?? true);
   const reportDefect = typeof options === "string" ? true : (options?.reportDefect ?? true);
+  const refresh = typeof options === "string" ? false : (options?.refresh ?? false);
 
   return useCallback(
     (target: T) => {
@@ -23,8 +24,9 @@ export function useAtomQueryRunner<T, A, E>(
         label: explicitLabel ?? atom.label?.[0] ?? "atom query",
         reportFailure,
         reportDefect,
+        refresh,
       });
     },
-    [explicitLabel, family, registry, reportDefect, reportFailure],
+    [explicitLabel, family, refresh, registry, reportDefect, reportFailure],
   );
 }

--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -296,6 +296,36 @@ describe("executeAtomQuery", () => {
 
     registry.dispose();
   });
+
+  it("can refresh a retained query while its cached value is still fresh", async () => {
+    let value = "before";
+    const atom = Atom.make(Effect.sync(() => value)).pipe(
+      Atom.swr({ staleTime: 60_000, revalidateOnMount: true }),
+      Atom.setIdleTTL(60_000),
+    );
+    const registry = AtomRegistry.make();
+
+    const initial = await executeAtomQuery(registry, atom);
+    expect(initial._tag).toBe("Success");
+    if (initial._tag === "Success") {
+      expect(initial.value).toBe("before");
+    }
+
+    value = "after";
+    const cached = await executeAtomQuery(registry, atom);
+    expect(cached._tag).toBe("Success");
+    if (cached._tag === "Success") {
+      expect(cached.value).toBe("before");
+    }
+
+    const refreshed = await executeAtomQuery(registry, atom, { refresh: true });
+    expect(refreshed._tag).toBe("Success");
+    if (refreshed._tag === "Success") {
+      expect(refreshed.value).toBe("after");
+    }
+
+    registry.dispose();
+  });
 });
 
 describe("runtime command runner", () => {

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -74,6 +74,11 @@ export interface AtomCommandOptions {
   readonly reportDefect?: boolean;
 }
 
+export interface AtomQueryOptions extends AtomCommandOptions {
+  /** Re-run a retained query before reading it, even while its cached value is still fresh. */
+  readonly refresh?: boolean;
+}
+
 export interface AtomCommandReporter {
   readonly warn: (message: string, cause: Cause.Cause<unknown>) => void;
   readonly error: (message: string, cause: Cause.Cause<unknown>) => void;
@@ -329,9 +334,12 @@ export async function executeAtomCommand<A, E>(
 export async function executeAtomQuery<A, E>(
   registry: AtomRegistry.AtomRegistry,
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
-  options: AtomCommandOptions = {},
+  options: AtomQueryOptions = {},
   reporter: AtomCommandReporter = console,
 ): Promise<AtomCommandResult<A, E>> {
+  if (options.refresh) {
+    registry.refresh(atom);
+  }
   const query = Effect.scoped(
     Effect.gen(function* () {
       yield* AtomRegistry.mount(registry, atom);


### PR DESCRIPTION
## Problem

The Add Project folder browser retained directory results for 30 seconds. If a user closed the picker, cloned a repository in a terminal, and reopened the picker during that window, the new folder was missing until the cache expired or T3 Code restarted.

## Fix

- Add an opt-in forced refresh to retained atom queries.
- Force filesystem browse preloads to reread the directory when web/desktop opens or navigates the Add Project picker.
- Refresh completed cached listings when the mobile folder browser remounts, while leaving initial and already-revalidating requests alone.
- Preserve the existing short cache for rendering and back-navigation performance.

## Before / after

Both captures reopen the picker within the old 30-second freshness window after a real external `git clone`.

| Before: cloned folder is missing | After: cloned folder appears immediately |
| --- | --- |
| ![Before: reopened picker omits the externally cloned folder](https://raw.githubusercontent.com/Zeus-Deus/t3code/4024c0ed8907df72f392f7b81c040c3c3524b546/project-refresh-after-clone/before.png) | ![After: reopened picker includes the externally cloned folder](https://raw.githubusercontent.com/Zeus-Deus/t3code/4024c0ed8907df72f392f7b81c040c3c3524b546/project-refresh-after-clone/after.png) |

## Testing

- `vp test run packages/client-runtime/src/state/runtime.test.ts packages/client-runtime/src/state/filesystem.test.ts` — 24 tests passed
- client-runtime, web, and mobile typechecks passed
- targeted lint and formatting checks passed; only pre-existing CommandPalette nested-component warnings remain
- isolated browser E2E reproduced the stale listing on `main` 2.3 seconds after `git clone`
- the same E2E passed on this branch: the cloned folder appeared after reopening in 400 ms without restarting T3 Code

Model: GPT-5.6; harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted query-cache refresh for filesystem browse only; existing SWR caching remains the default elsewhere.
> 
> **Overview**
> Fixes stale Add Project folder listings when the picker is reopened while cached directory results are still fresh (e.g. after an external `git clone`).
> 
> **Runtime:** Adds opt-in `refresh` on `AtomQueryOptions` / `executeAtomQuery`, which calls `registry.refresh(atom)` before reading so retained queries can re-fetch even inside the SWR stale window. A unit test covers refresh vs cached reads.
> 
> **Web & mobile:** Filesystem browse preloads via `useAtomQueryRunner` now pass `refresh: true`, so opening or navigating the Add Project picker forces a directory re-read. On mobile, `FolderBrowser` also calls `browseState.refresh()` on mount when a completed cached listing is already present, without disturbing in-flight loads.
> 
> Short-lived cache behavior for rendering and back navigation is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4646f2c759113a6c0661f5dc6b490c5646c07c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh project folder contents when reopening the browse dialog
> - Adds a `refresh` option to `executeAtomQuery` in [runtime.ts](https://github.com/pingdotgg/t3code/pull/5367/files#diff-bc61b3883f7adacdcd4ab084328117c3be3fc0c91d1e23f09cdf0b73d1e593ee) that calls `registry.refresh(atom)` before reading, returning up-to-date data even when the cache is fresh.
> - Updates `useAtomQueryRunner` (web and mobile) to accept and forward the `refresh` flag, and passes `refresh: true` when loading browse paths in the Command Palette and Add Project screen.
> - On mount, `FolderBrowser` in [AddProjectScreen.tsx](https://github.com/pingdotgg/t3code/pull/5367/files#diff-8d2af7e60f72647a590cd07374db01b9c44b29ebe1f0b9f3ba264e1c38d08bb2) triggers a refresh if a non-pending cached value exists, ensuring stale directory listings are re-fetched.
> - Behavioral Change: browse queries now always trigger a network revalidation when the dialog opens, even if the cached value is considered fresh.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4646f2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->