### PR TITLE
refactor(server): make title prompts plaintext

### DIFF
--- a/apps/server/src/textGeneration/TextGenerationPrompts.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.ts
@@ -150,26 +150,10 @@ export interface BranchNamePromptInput {
 interface PromptFromMessageInput {
   instruction: string;
   responseShape: string;
-  guidance?: ReadonlyArray<string> | undefined;
-  rulesLabel?: string | undefined;
   rules: ReadonlyArray<string>;
-  afterRules?: ReadonlyArray<string> | undefined;
   message: string;
-  messageLabel?: string | undefined;
-  preserveMessageEnd?: boolean | undefined;
   attachments?: ReadonlyArray<ChatAttachment> | undefined;
   additionalInstructions?: string | undefined;
-}
-
-function preserveMessageEnd(message: string): string {
-  const alreadyTruncated = message.startsWith(EARLIER_CONTENT_TRUNCATION_MARKER);
-  const contents = alreadyTruncated
-    ? message.slice(EARLIER_CONTENT_TRUNCATION_MARKER.length)
-    : message;
-  if (!alreadyTruncated && contents.length <= 8_000) {
-    return contents;
-  }
-  return `${EARLIER_CONTENT_TRUNCATION_MARKER}${contents.slice(-8_000)}`;
 }
 
 function buildPromptFromMessage(input: PromptFromMessageInput): string {
@@ -180,15 +164,11 @@ function buildPromptFromMessage(input: PromptFromMessageInput): string {
   const promptSections = [
     input.instruction,
     input.responseShape,
-    ...(input.guidance ?? []),
-    input.rulesLabel ?? "Rules:",
+    "Rules:",
     ...input.rules.map((rule) => `- ${rule}`),
-    ...(input.afterRules ?? []),
     "",
-    `${input.messageLabel ?? "User message"}:`,
-    input.preserveMessageEnd
-      ? preserveMessageEnd(input.message)
-      : limitSection(input.message, 8_000),
+    "User message:",
+    limitSection(input.message, 8_000),
     ...policyInstruction(input.additionalInstructions),
   ];
   if (attachmentLines.length > 0) {
@@ -234,88 +214,102 @@ export interface ThreadTitlePromptInput {
   policy?: TextGenerationPolicy | undefined;
 }
 
+// Keep shared editorial rules in these two prompts in sync. Regeneration
+// intentionally adds guidance for thread history and the previous title.
+const INITIAL_THREAD_TITLE_PROMPT = `Generate a title that will help the user recognize this T3 Code thread weeks later.
+Return JSON with exactly one key: title.
+
+Before answering, silently reduce the request to:
+- Subject: What system, feature, or problem is this really about?
+- Outcome: What does the user ultimately want to understand or change?
+- Incidental instructions: What only describes how the agent should do the work?
+
+Title the subject and outcome. Discard incidental instructions.
+
+Editorial rules:
+- 3-8 words, fewer than 40 characters.
+- Use a compact noun phrase or clear action phrase.
+- Capture the umbrella goal when the request lists several symptoms or steps.
+- Name the product change, not the mock, plan, report, branch, or PR used to produce it.
+- Models, subagents, tools, output formats, and monitoring instructions do not belong in the title unless they are themselves the topic.
+- For reviews, name what is being reviewed and the relevant concern. Avoid generic titles such as "Review PR 123" when linked or attached context reveals the subject.
+- For research, name the question domain rather than the requested research process.
+- Do not claim the work is complete.
+- Do not copy and truncate the user's message.
+- Avoid project names already visible in the UI, quotes, labels, filler, and trailing punctuation.
+- Use attached images as primary context for UI issues.
+- When a URL or attachment is the only source of the subject, use available tools to inspect it. If it cannot be resolved, remain accurate rather than guessing.`;
+
+function regenerateThreadTitlePrompt(previousTitle: string): string {
+  return `Regenerate the title for an existing T3 Code thread so the user can recognize it weeks later.
+The previous title was ${JSON.stringify(previousTitle)}.
+Return JSON with exactly one key: title.
+
+Determine the title in this order:
+1. Read the USER messages first. Identify the latest explicit durable goal. The original subject remains the subject until the user clearly changes what the thread is about.
+2. Use ASSISTANT messages to resolve vague links, unnamed code, and discovered product nouns. Do not promote one assistant finding into the thread subject unless the user adopts it as a new goal.
+3. Compare that subject with the previous title. Preserve accurate scope words, especially when earlier content is truncated. Replace the previous title when it is generic, artifact-based, a completion update, or contradicted by the thread.
+4. Title the durable subject and desired outcome, not the current workflow state.
+
+Editorial rules:
+- 3-8 words, fewer than 40 characters.
+- Use a compact noun phrase or clear action phrase.
+- Preserve the umbrella subject when later messages focus on one finding, provider, platform, or implementation detail.
+- A thread progressing through research, planning, implementation, review, CI, merge, and monitoring has usually not changed subjects.
+- Ignore deliverables and operations such as mocks, plans, HTML, branches, PRs, tests, CI, commits, merging, and monitoring unless they are the actual topic.
+- Models, subagents, tools, output formats, and monitoring instructions do not belong in the title unless they are themselves the topic.
+- Treat final operational follow-ups and assistant completion summaries as weak evidence of subject.
+- For reviews, name the reviewed feature or system and its durable concern, not one finding from the review.
+- For research, name the question domain rather than the research process.
+- Do not claim the work is complete.
+- Do not copy and truncate a thread message.
+- Avoid project names already visible in the UI, PR numbers, quotes, labels, filler, and trailing punctuation.
+- Use attached images as primary context for UI issues.
+- When a URL or attachment is the only source of the subject, use available tools to inspect it. If it cannot be resolved, remain accurate rather than guessing.
+- Return a meaningfully improved title, not a cosmetic paraphrase of the previous title.
+
+Examples of the distinction:
+- A subagent-monitoring review that finds a Codex roster bug remains "Review Subagent Monitoring Risks," not "Codex Roster Bug Review."
+- A vague failing-test request later identified as a lazy thread-feed mismatch becomes "Fix Lazy Thread Feed Test," not "Prevent Mobile Feed Regressions."
+- A QR-sharing overhaul that ends with CI and merge work remains about QR sharing, not the PR lifecycle.`;
+}
+
+function preserveMessageEnd(message: string): string {
+  const alreadyTruncated = message.startsWith(EARLIER_CONTENT_TRUNCATION_MARKER);
+  const contents = alreadyTruncated
+    ? message.slice(EARLIER_CONTENT_TRUNCATION_MARKER.length)
+    : message;
+  if (!alreadyTruncated && contents.length <= 8_000) {
+    return contents;
+  }
+  return `${EARLIER_CONTENT_TRUNCATION_MARKER}${contents.slice(-8_000)}`;
+}
+
+function threadTitlePromptSuffix(input: ThreadTitlePromptInput): string {
+  const additionalInstructions = policyInstruction(input.policy?.threadTitleInstructions);
+  const attachmentLines = (input.attachments ?? []).map(
+    (attachment) => `- ${attachment.name} (${attachment.mimeType}, ${attachment.sizeBytes} bytes)`,
+  );
+
+  let suffix = "";
+  if (additionalInstructions.length > 0) {
+    suffix = `\n${additionalInstructions.join("\n")}`;
+  }
+  if (attachmentLines.length > 0) {
+    suffix += `\n\nAttachment metadata:\n${limitSection(attachmentLines.join("\n"), 4_000)}`;
+  }
+  return suffix;
+}
+
 export function buildThreadTitlePrompt(input: ThreadTitlePromptInput) {
-  const isRegeneration = input.previousTitle !== undefined;
-  const prompt = buildPromptFromMessage({
-    instruction: isRegeneration
-      ? [
-          "Regenerate the title for an existing T3 Code thread so the user can recognize it weeks later.",
-          `The previous title was ${JSON.stringify(input.previousTitle)}.`,
-        ].join("\n")
-      : "Generate a title that will help the user recognize this T3 Code thread weeks later.",
-    responseShape: "Return JSON with exactly one key: title.",
-    guidance: isRegeneration
-      ? [
-          "",
-          "Determine the title in this order:",
-          "1. Read the USER messages first. Identify the latest explicit durable goal. The original subject remains the subject until the user clearly changes what the thread is about.",
-          "2. Use ASSISTANT messages to resolve vague links, unnamed code, and discovered product nouns. Do not promote one assistant finding into the thread subject unless the user adopts it as a new goal.",
-          "3. Compare that subject with the previous title. Preserve accurate scope words, especially when earlier content is truncated. Replace the previous title when it is generic, artifact-based, a completion update, or contradicted by the thread.",
-          "4. Title the durable subject and desired outcome, not the current workflow state.",
-          "",
-        ]
-      : [
-          "",
-          "Before answering, silently reduce the request to:",
-          "- Subject: What system, feature, or problem is this really about?",
-          "- Outcome: What does the user ultimately want to understand or change?",
-          "- Incidental instructions: What only describes how the agent should do the work?",
-          "",
-          "Title the subject and outcome. Discard incidental instructions.",
-          "",
-        ],
-    rulesLabel: "Editorial rules:",
-    rules: isRegeneration
-      ? [
-          "3-8 words, fewer than 40 characters.",
-          "Use a compact noun phrase or clear action phrase.",
-          "Preserve the umbrella subject when later messages focus on one finding, provider, platform, or implementation detail.",
-          "A thread progressing through research, planning, implementation, review, CI, merge, and monitoring has usually not changed subjects.",
-          "Ignore deliverables and operations such as mocks, plans, HTML, branches, PRs, tests, CI, commits, merging, and monitoring unless they are the actual topic.",
-          "Models, subagents, tools, output formats, and monitoring instructions do not belong in the title unless they are themselves the topic.",
-          "Treat final operational follow-ups and assistant completion summaries as weak evidence of subject.",
-          "For reviews, name the reviewed feature or system and its durable concern, not one finding from the review.",
-          "For research, name the question domain rather than the research process.",
-          "Do not claim the work is complete.",
-          "Do not copy and truncate a thread message.",
-          "Avoid project names already visible in the UI, PR numbers, quotes, labels, filler, and trailing punctuation.",
-          "Use attached images as primary context for UI issues.",
-          "When a URL or attachment is the only source of the subject, use available tools to inspect it. If it cannot be resolved, remain accurate rather than guessing.",
-          "Return a meaningfully improved title, not a cosmetic paraphrase of the previous title.",
-        ]
-      : [
-          "3-8 words, fewer than 40 characters.",
-          "Use a compact noun phrase or clear action phrase.",
-          "Capture the umbrella goal when the request lists several symptoms or steps.",
-          "Name the product change, not the mock, plan, report, branch, or PR used to produce it.",
-          "Models, subagents, tools, output formats, and monitoring instructions do not belong in the title unless they are themselves the topic.",
-          'For reviews, name what is being reviewed and the relevant concern. Avoid generic titles such as "Review PR 123" when linked or attached context reveals the subject.',
-          "For research, name the question domain rather than the requested research process.",
-          "Do not claim the work is complete.",
-          "Do not copy and truncate the user's message.",
-          "Avoid project names already visible in the UI, quotes, labels, filler, and trailing punctuation.",
-          "Use attached images as primary context for UI issues.",
-          "When a URL or attachment is the only source of the subject, use available tools to inspect it. If it cannot be resolved, remain accurate rather than guessing.",
-        ],
-    afterRules: isRegeneration
-      ? [
-          "",
-          "Examples of the distinction:",
-          '- A subagent-monitoring review that finds a Codex roster bug remains "Review Subagent Monitoring Risks," not "Codex Roster Bug Review."',
-          '- A vague failing-test request later identified as a lazy thread-feed mismatch becomes "Fix Lazy Thread Feed Test," not "Prevent Mobile Feed Regressions."',
-          "- A QR-sharing overhaul that ends with CI and merge work remains about QR sharing, not the PR lifecycle.",
-        ]
-      : undefined,
-    message: input.message,
-    ...(isRegeneration
-      ? {
-          messageLabel: "Thread contents",
-          preserveMessageEnd: true,
-        }
-      : {}),
-    attachments: input.attachments,
-    additionalInstructions: input.policy?.threadTitleInstructions,
-  });
+  let prompt: string;
+  if (input.previousTitle === undefined) {
+    const message = limitSection(input.message, 8_000);
+    prompt = `${INITIAL_THREAD_TITLE_PROMPT}\n\nUser message:\n${message}${threadTitlePromptSuffix(input)}`;
+  } else {
+    const message = preserveMessageEnd(input.message);
+    prompt = `${regenerateThreadTitlePrompt(input.previousTitle)}\n\nThread contents:\n${message}${threadTitlePromptSuffix(input)}`;
+  }
   const outputSchema = Schema.Struct({
     title: Schema.String,
   });


### PR DESCRIPTION
The initial and regeneration title prompts became difficult to read and tune after being assembled from conditional arrays.

This makes both prompts explicit plaintext templates, leaves a reminder to keep their shared editorial rules aligned, and reduces the shared message builder to the branch-name behavior it actually supports. Generated prompt content and runtime behavior are unchanged.

## Testing

- `vp test run apps/server/src/textGeneration/TextGenerationPrompts.test.ts` (19 tests passed)
- `vp fmt apps/server/src/textGeneration/TextGenerationPrompts.ts --write`
- `git diff --check`

The server-wide local typecheck remains blocked by existing Effect and dependency diagnostics in unrelated files; the changed file reports no diagnostic.

Made with GPT-5.6 Sol (low reasoning) through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only refactor with existing tests passing; no API or provider wiring changes beyond how strings are assembled.
> 
> **Overview**
> **Thread title generation** no longer builds prompts from nested conditional arrays via `buildPromptFromMessage`. Initial and regeneration flows now use dedicated plaintext templates (`INITIAL_THREAD_TITLE_PROMPT`, `regenerateThreadTitlePrompt`), with a comment to keep shared editorial rules aligned between them.
> 
> The shared **`buildPromptFromMessage`** helper is trimmed to what branch-name generation still needs: fixed `"Rules:"` / `"User message:"` labels and no optional guidance, custom rule labels, or tail sections. **`preserveMessageEnd`** and attachment/policy suffix assembly move to thread-title-only helpers (`threadTitlePromptSuffix`, direct string composition in `buildThreadTitlePrompt`).
> 
> Intended **prompt text and runtime behavior** stay the same; this is structure and readability for tuning titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ef544f3522e7f75dd891d114d9abf2dba11db77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite thread title prompts as plaintext in `buildThreadTitlePrompt`
> - Replaces the generic `buildPromptFromMessage`-based title prompts with dedicated plaintext prompt strings for initial and regeneration modes.
> - Adds `INITIAL_THREAD_TITLE_PROMPT` (fixed editorial instructions) and `regenerateThreadTitlePrompt` (references the previous title with structured guidance) in [TextGenerationPrompts.ts](https://github.com/pingdotgg/t3code/pull/5368/files#diff-90cc284c5147149b6716e9117535710ac55311db230c4f9302015d0f3bb0cd8e).
> - Regeneration mode now uses tail-preserving truncation via `preserveMessageEnd` so the most recent content is retained; initial mode uses start-based truncation via `limitSection`.
> - Strips `guidance`, `rulesLabel`, `afterRules`, `messageLabel`, and `preserveMessageEnd` from `PromptFromMessageInput`, making `buildPromptFromMessage` always emit fixed `Rules:` and `User message:` labels.
> - Behavioral Change: title prompts now differ substantially from other prompts — regeneration includes a truncation marker for long threads, and callers can no longer customize labels or guidance sections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ef544f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->