### PR TITLE
fix(oxlint-plugin): catch platform and arch reads through node:process namespace imports

### DIFF
--- a/oxlint-plugin-t3code/rules/no-global-process-runtime.test.ts
+++ b/oxlint-plugin-t3code/rules/no-global-process-runtime.test.ts
@@ -93,6 +93,42 @@ describe("t3code/no-global-process-runtime", () => {
   );
 
   rule.valid(
+    "allows a shadowed node os namespace parameter",
+    `
+      import * as NodeOS from "node:os";
+
+      export const read = (NodeOS: { platform: () => string }) => NodeOS.platform();
+    `,
+  );
+
+  rule.valid(
+    "allows a shadowed node os namespace local const",
+    `
+      import * as NodeOS from "node:os";
+
+      export const read = () => {
+        const NodeOS = { platform: () => "win32" };
+        return NodeOS.platform();
+      };
+    `,
+  );
+
+  rule.valid(
+    "allows a shadowed node os namespace catch param",
+    `
+      import * as NodeOS from "node:os";
+
+      export const read = () => {
+        try {
+          return "ok";
+        } catch (NodeOS) {
+          return (NodeOS as { platform: () => string }).platform();
+        }
+      };
+    `,
+  );
+
+  rule.valid(
     "allows unrelated node process imports",
     `
       import * as NodeProcess from "node:process";

--- a/oxlint-plugin-t3code/rules/no-global-process-runtime.test.ts
+++ b/oxlint-plugin-t3code/rules/no-global-process-runtime.test.ts
@@ -129,11 +129,29 @@ describe("t3code/no-global-process-runtime", () => {
   );
 
   rule.valid(
+    "allows a shadowed node os namespace destructured parameter",
+    `
+      import * as NodeOS from "node:os";
+
+      export const read = ({ NodeOS }: { NodeOS: { platform: () => string } }) => NodeOS.platform();
+    `,
+  );
+
+  rule.valid(
     "allows a shadowed node process namespace parameter",
     `
       import * as NodeProcess from "node:process";
 
       export const read = (NodeProcess: { platform: string }) => NodeProcess.platform;
+    `,
+  );
+
+  rule.valid(
+    "allows a shadowed node process namespace destructured parameter",
+    `
+      import * as NodeProcess from "node:process";
+
+      export const read = ({ NodeProcess }: { NodeProcess: { arch: string } }) => NodeProcess.arch;
     `,
   );
 

--- a/oxlint-plugin-t3code/rules/no-global-process-runtime.test.ts
+++ b/oxlint-plugin-t3code/rules/no-global-process-runtime.test.ts
@@ -129,6 +129,27 @@ describe("t3code/no-global-process-runtime", () => {
   );
 
   rule.valid(
+    "allows a shadowed node process namespace parameter",
+    `
+      import * as NodeProcess from "node:process";
+
+      export const read = (NodeProcess: { platform: string }) => NodeProcess.platform;
+    `,
+  );
+
+  rule.valid(
+    "allows a shadowed node process namespace local const",
+    `
+      import * as NodeProcess from "node:process";
+
+      export const read = () => {
+        const NodeProcess = { arch: "arm64" };
+        return NodeProcess.arch;
+      };
+    `,
+  );
+
+  rule.valid(
     "allows unrelated node process imports",
     `
       import * as NodeProcess from "node:process";

--- a/oxlint-plugin-t3code/rules/no-global-process-runtime.test.ts
+++ b/oxlint-plugin-t3code/rules/no-global-process-runtime.test.ts
@@ -91,4 +91,47 @@ describe("t3code/no-global-process-runtime", () => {
       export const isWindows = os.platform() === "win32";
     `,
   );
+
+  rule.valid(
+    "allows unrelated node process imports",
+    `
+      import * as NodeProcess from "node:process";
+
+      export const nodeEnv = NodeProcess.env.NODE_ENV;
+      export const args = NodeProcess.argv.slice(2);
+    `,
+  );
+
+  rule.invalid(
+    "reports node process namespace platform reads",
+    `
+      import * as NodeProcess from "node:process";
+
+      export const isWindows = NodeProcess.platform === "win32";
+    `,
+    (output) => {
+      assert.match(output, /Use HostProcessPlatform/);
+    },
+  );
+
+  rule.invalid(
+    "reports node process namespace architecture reads",
+    `
+      import * as NodeProcess from "node:process";
+
+      export const isArm = NodeProcess.arch === "arm64";
+    `,
+    (output) => {
+      assert.match(output, /Use HostProcessArchitecture/);
+    },
+  );
+
+  rule.invalid(
+    "reports default node process platform reads",
+    `
+      import nodeProcess from "node:process";
+
+      export const isWindows = nodeProcess.platform === "win32";
+    `,
+  );
 });

--- a/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
+++ b/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
@@ -6,6 +6,7 @@ import { getPropertyName, isIdentifier, unwrapExpression } from "../utils.ts";
 const RUNTIME_PROPERTIES = new Set(["platform", "arch"]);
 const HOST_PROCESS_REFERENCE_FILE = "packages/shared/src/hostProcess.ts";
 const NODE_OS_MODULES = new Set(["node:os", "os"]);
+const NODE_PROCESS_MODULES = new Set(["node:process", "process"]);
 
 const normalizePath = (path: string) => path.replaceAll("\\", "/");
 
@@ -54,10 +55,12 @@ export default defineRule({
   createOnce(context) {
     const nodeOsNamespaces = new Set<string>();
     const nodeOsRuntimeImports = new Map<string, string>();
+    const nodeProcessNamespaces = new Set<string>();
 
     const resetBindings = () => {
       nodeOsNamespaces.clear();
       nodeOsRuntimeImports.clear();
+      nodeProcessNamespaces.clear();
     };
 
     const trackImportDeclaration = (node: unknown) => {
@@ -65,7 +68,10 @@ export default defineRule({
       if (!("source" in node)) return;
 
       const source = getLiteralStringValue(node.source);
-      if (Option.isNone(source) || !NODE_OS_MODULES.has(source.value)) return;
+      if (Option.isNone(source)) return;
+      const isNodeOsModule = NODE_OS_MODULES.has(source.value);
+      const isNodeProcessModule = NODE_PROCESS_MODULES.has(source.value);
+      if (!isNodeOsModule && !isNodeProcessModule) return;
       if (!("specifiers" in node) || !Array.isArray(node.specifiers)) return;
 
       for (const specifier of node.specifiers) {
@@ -80,10 +86,15 @@ export default defineRule({
           specifier.type === "ImportNamespaceSpecifier" ||
           specifier.type === "ImportDefaultSpecifier"
         ) {
-          nodeOsNamespaces.add(localName);
+          if (isNodeProcessModule) {
+            nodeProcessNamespaces.add(localName);
+          } else {
+            nodeOsNamespaces.add(localName);
+          }
           continue;
         }
 
+        if (!isNodeOsModule) continue;
         if (specifier.type !== "ImportSpecifier" || !("imported" in specifier)) continue;
 
         const imported = getPropertyName(specifier.imported);
@@ -113,6 +124,17 @@ export default defineRule({
       );
     };
 
+    const isProcessRuntimeObject = (node: unknown): boolean => {
+      if (isGlobalProcessObject(node)) return true;
+
+      const expression = unwrapExpression(node);
+      return (
+        Option.isSome(expression) &&
+        expression.value.type === "Identifier" &&
+        nodeProcessNamespaces.has(expression.value.name)
+      );
+    };
+
     return {
       before: resetBindings,
       ImportDeclaration: trackImportDeclaration,
@@ -121,7 +143,7 @@ export default defineRule({
 
         const property = getPropertyName(node.property);
         if (Option.isNone(property) || !RUNTIME_PROPERTIES.has(property.value)) return;
-        if (!isGlobalProcessObject(node.object)) return;
+        if (!isProcessRuntimeObject(node.object)) return;
 
         context.report({
           node,

--- a/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
+++ b/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
@@ -73,6 +73,10 @@ const collectBindingNames = (pattern: unknown, names: Set<string>): void => {
         for (const property of properties) collectBindingNames(property, names);
       return;
     }
+    // Oxlint's `BindingProperty` interface carries the runtime tag "Property",
+    // so "BindingProperty" never appears in the AST. Match both, as the
+    // Identifier and RestElement cases above already do.
+    case "Property":
     case "BindingProperty":
       collectBindingNames((node as { value?: unknown }).value, names);
       return;

--- a/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
+++ b/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
@@ -241,7 +241,8 @@ export default defineRule({
       return (
         Option.isSome(expression) &&
         expression.value.type === "Identifier" &&
-        nodeProcessNamespaces.has(expression.value.name)
+        nodeProcessNamespaces.has(expression.value.name) &&
+        !isShadowedByLocalBinding(expression.value, expression.value.name)
       );
     };
 

--- a/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
+++ b/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
@@ -44,6 +44,113 @@ const getLiteralStringValue = (node: unknown): Option.Option<string> => {
   return Option.some(node.value);
 };
 
+// A binding (function param, local var/let/const, catch param) with the same
+// name as a tracked namespace import shadows it lexically, so a reference to
+// that name no longer resolves to the import. @oxlint/plugins declares a
+// scope API in its types but doesn't actually export it at runtime (only
+// definePlugin/defineRule/eslintCompatPlugin are exported), so we walk
+// `.parent` — present on every node — instead of resolving bindings via scope.
+const FUNCTION_NODE_TYPES = new Set([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+]);
+const BLOCK_NODE_TYPES = new Set(["BlockStatement", "FunctionBody", "Program"]);
+
+const collectBindingNames = (pattern: unknown, names: Set<string>): void => {
+  if (typeof pattern !== "object" || pattern === null || !("type" in pattern)) return;
+  const node = pattern as { type: unknown };
+  switch (node.type) {
+    case "Identifier":
+    case "BindingIdentifier": {
+      const name = (node as { name?: unknown }).name;
+      if (typeof name === "string") names.add(name);
+      return;
+    }
+    case "ObjectPattern": {
+      const properties = (node as { properties?: unknown }).properties;
+      if (Array.isArray(properties))
+        for (const property of properties) collectBindingNames(property, names);
+      return;
+    }
+    case "BindingProperty":
+      collectBindingNames((node as { value?: unknown }).value, names);
+      return;
+    case "ArrayPattern": {
+      const elements = (node as { elements?: unknown }).elements;
+      if (Array.isArray(elements))
+        for (const element of elements) collectBindingNames(element, names);
+      return;
+    }
+    case "AssignmentPattern":
+      collectBindingNames((node as { left?: unknown }).left, names);
+      return;
+    case "BindingRestElement":
+    case "RestElement":
+      collectBindingNames((node as { argument?: unknown }).argument, names);
+      return;
+    default:
+      return;
+  }
+};
+
+const statementsDeclare = (statements: unknown, name: string): boolean => {
+  if (!Array.isArray(statements)) return false;
+  for (const statement of statements) {
+    if (typeof statement !== "object" || statement === null || !("type" in statement)) continue;
+    const node = statement as { type: unknown };
+    const names = new Set<string>();
+    if (node.type === "VariableDeclaration") {
+      const declarations = (node as { declarations?: unknown }).declarations;
+      if (Array.isArray(declarations)) {
+        for (const declarator of declarations)
+          collectBindingNames((declarator as { id?: unknown }).id, names);
+      }
+    } else if (node.type === "FunctionDeclaration" || node.type === "ClassDeclaration") {
+      collectBindingNames((node as { id?: unknown }).id, names);
+    }
+    if (names.has(name)) return true;
+  }
+  return false;
+};
+
+// Walks up from `node` looking for a closer binding named `name` (function
+// param, local var/let/const, or catch param) that would shadow an
+// module-scope import of that name.
+const isShadowedByLocalBinding = (node: unknown, name: string): boolean => {
+  let current =
+    typeof node === "object" && node !== null ? (node as { parent?: unknown }).parent : undefined;
+
+  while (typeof current === "object" && current !== null && "type" in current) {
+    const ancestor = current as { type: unknown; parent?: unknown };
+
+    if (typeof ancestor.type === "string" && FUNCTION_NODE_TYPES.has(ancestor.type)) {
+      const params = (ancestor as { params?: unknown }).params;
+      if (Array.isArray(params)) {
+        for (const param of params) {
+          const names = new Set<string>();
+          collectBindingNames(param, names);
+          if (names.has(name)) return true;
+        }
+      }
+    } else if (ancestor.type === "CatchClause") {
+      const param = (ancestor as { param?: unknown }).param;
+      if (param !== null && param !== undefined) {
+        const names = new Set<string>();
+        collectBindingNames(param, names);
+        if (names.has(name)) return true;
+      }
+    } else if (typeof ancestor.type === "string" && BLOCK_NODE_TYPES.has(ancestor.type)) {
+      if (statementsDeclare((ancestor as { body?: unknown }).body, name)) return true;
+    }
+
+    if (ancestor.type === "Program") break;
+    current = ancestor.parent;
+  }
+
+  return false;
+};
+
 export default defineRule({
   meta: {
     type: "problem",
@@ -110,7 +217,9 @@ export default defineRule({
 
       if (expression.value.type === "Identifier") {
         const property = nodeOsRuntimeImports.get(expression.value.name);
-        return property === undefined ? Option.none() : Option.some(property);
+        if (property === undefined) return Option.none();
+        if (isShadowedByLocalBinding(expression.value, expression.value.name)) return Option.none();
+        return Option.some(property);
       }
 
       if (expression.value.type !== "MemberExpression") return Option.none();
@@ -118,6 +227,7 @@ export default defineRule({
       const object = unwrapExpression(expression.value.object);
       if (Option.isNone(object) || object.value.type !== "Identifier") return Option.none();
       if (!nodeOsNamespaces.has(object.value.name)) return Option.none();
+      if (isShadowedByLocalBinding(object.value, object.value.name)) return Option.none();
 
       return Option.filter(getPropertyName(expression.value.property), (property) =>
         RUNTIME_PROPERTIES.has(property),

--- a/scripts/mobile-showcase.ts
+++ b/scripts/mobile-showcase.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 // @effect-diagnostics nodeBuiltinImport:off globalTimers:off globalDate:off - Host-side simulator and emulator automation uses Node subprocess and timing APIs directly.
+/* oxlint-disable t3code/no-global-process-runtime -- Standalone host-side automation script; there is no Effect runtime to inject HostProcess references into. */
 
 import * as NodeChildProcess from "node:child_process";
 import * as NodeFSP from "node:fs/promises";


### PR DESCRIPTION
## What Changed

`t3code/no-global-process-runtime` now reports `platform` and `arch` reads on `node:process` / `process` namespace and default imports, not only bare `process` and `globalThis.process`.

- `trackImportDeclaration` records `node:process` namespace and default import bindings in a `nodeProcessNamespaces` set, cleared by `resetBindings`. `NODE_PROCESS_MODULES` includes the bare `"process"` specifier, matching `NODE_OS_MODULES`.
- `isProcessRuntimeObject` wraps the untouched `isGlobalProcessObject` and also accepts identifiers bound to those imports. The `MemberExpression` visitor calls it.
- `isShadowedByLocalBinding` and `collectBindingNames` skip the report when the tracked `node:os` or `node:process` name is redeclared by a parameter, destructured parameter, catch clause, or block declaration. The `collectBindingNames` object-pattern case matches the runtime `"Property"` tag, not the `BindingProperty` interface name, which never appears in the AST.
- `scripts/mobile-showcase.ts` is exempted at file level rather than converted. It is a `#!/usr/bin/env node` script with no Effect runtime for `HostProcessPlatform` / `HostProcessArchitecture`, and already opts out of `@effect-diagnostics` on the line above for the same reason. `packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts:39` and `packages/shared/src/qrCode.ts:1` use the same pattern. Happy to switch to per-line directives.

`node:os` named-import handling (`import { arch } from "node:os"`) is unchanged: those are calls on the `nodeOsRuntimeImports` / `CallExpression` path.

## Why

The rule is configured as `error`, but a `node:process` namespace import walked past it, so `NodeProcess.platform` and `NodeProcess.arch` were never reported. `scripts/mobile-showcase.ts` on `main` reads `.arch` and `.platform` that way in three places, and `scripts` is a workspace member lint covers.

The rule already solved this shape for `node:os` via `nodeOsNamespaces`. `node:process` was never wired in.

Verification:

- `oxlint-plugin-t3code` suite: 39/39 pass (4 files).
- The three new `invalid` cases fail without the change, pass with it. The `valid` cases cover `NodeProcess.env` / `NodeProcess.argv` and the shadowing shapes above.
- The two destructured-parameter fixtures fail on fa0ce744 and pass on 11b9530:

```
FAIL  allows a shadowed node os namespace destructured parameter
FAIL  allows a shadowed node process namespace destructured parameter
Tests  2 failed | 33 passed (35)
```

```
Tests  35 passed (35)
```

- `vp lint --report-unused-disable-directives` passes clean and does not report the new directive as unused, so the rule fires there.
- `typecheck` clean for `oxlint-plugin-t3code` and `scripts`.

Known gap, out of scope: `import { platform } from "node:process"` as a bare identifier is still not caught. That needs a new `Identifier` visitor, so it belongs in its own PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to a custom oxlint rule and its tests plus one intentional lint exemption in a host script; no production runtime or auth/data paths are affected.
> 
> **Overview**
> **Extends `t3code/no-global-process-runtime`** so `platform` and `arch` reads on `node:process` / `process` namespace or default imports are reported the same way as bare `process` / `globalThis.process`, via tracked `nodeProcessNamespaces` and `isProcessRuntimeObject` on the `MemberExpression` visitor.
> 
> **Adds lexical shadowing** for tracked `node:os` and `node:process` bindings: parent-walk helpers (`isShadowedByLocalBinding`, `collectBindingNames`) skip reports when the import name is redeclared in params, catch clauses, or block scope, avoiding false positives on patterns like shadowed `NodeOS` / `NodeProcess`.
> 
> **Tests** cover shadowing (valid) and namespace/default `node:process` violations (invalid), plus unrelated `env` / `argv` still allowed.
> 
> **`scripts/mobile-showcase.ts`** gets a file-level `oxlint-disable` for this rule because it is a standalone Node script with no Effect runtime for `HostProcess*` references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11b953019894832e97119280ab7dc210b400d700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `no-global-process-runtime` rule to detect `platform`/`arch` reads via `node:process` namespace imports
> - Extends the rule to track `node:process`/`process` namespace and default imports, reporting `platform`/`arch` member reads on those imports in addition to the global `process` object.
> - Adds `isShadowedByLocalBinding` to walk parent scopes (functions, catch clauses, blocks) and skip reporting when the tracked identifier is shadowed by a local binding.
> - Adds `collectBindingNames` and `statementsDeclare` helpers to accurately resolve declared names across destructuring patterns and block-level declarations.
> - Adds an oxlint disable comment to [mobile-showcase.ts](https://github.com/pingdotgg/t3code/pull/5375/files#diff-4c6db0a1db2f6a714f8822c0a8a8fab41c97ba88c4a49fb52c21332ac758133c) to suppress the rule for that script.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11b9530.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
