### PR TITLE
fix(web): obscure scrolled messages under the docked composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5924,6 +5924,9 @@ function ChatViewContent(props: ChatViewProps) {
                   : "pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 sm:pt-2"
               }
             >
+              {!isDraftHeroState && (
+                <div aria-hidden className="chat-composer-glass absolute inset-0 -z-10" />
+              )}
               <div
                 ref={attachDraftHeroTransitionGroupRef}
                 className="chat-composer-horizontal-inset w-full"


### PR DESCRIPTION
## Summary
- Long threads were still readable under the docked chat composer because only the input shell itself used glass.
- Add a docked-only `chat-composer-glass` underlay behind the composer so scrolled messages are obscured while glass opacity still applies.
- Keep the underlay as a sibling (`-z-10`) so nested composer backdrop-filter is not broken.

## Test plan
- [ ] Open a long thread and scroll so messages sit under the composer — text should not remain readable through the dock area
- [ ] Confirm draft/hero composer state is unchanged (no underlay)
- [ ] Toggle Settings → Appearance → Glass opacity and confirm the underlay tracks it
- [ ] Confirm composer controls remain clickable


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Obscure scrolled messages under the docked chat composer
> Adds a `chat-composer-glass` background div behind the composer overlay in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/5383/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) when not in draft hero state. This prevents scrolled message content from showing through the docked composer area.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 985eba0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->