### PR TITLE
fix(web): clear main branch lint warnings

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1363,6 +1363,9 @@ function ChatMarkdown({
     },
     [createAssetUrl, openPreview, preparedConnection, threadRef],
   );
+  /* eslint-disable react/no-unstable-nested-components -- ReactMarkdown requires component
+   * renderers that close over this message's metadata. useMemo keeps them stable until that
+   * metadata changes. */
   const markdownComponents = useMemo<Components>(() => {
     const fileLinkChip = (
       fileLinkMeta: MarkdownFileLinkMeta,
@@ -1593,6 +1596,7 @@ function ChatMarkdown({
     text,
     threadRef,
   ]);
+  /* eslint-enable react/no-unstable-nested-components */
 
   return (
     <div

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -138,8 +138,19 @@ import {
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
 } from "../sidebarProjectGrouping";
+import type { Project } from "../types";
 
 const EMPTY_BROWSE_ENTRIES: FilesystemBrowseResult["entries"] = [];
+
+function projectFavicon(project: Project) {
+  return (
+    <ProjectFavicon
+      environmentId={project.environmentId}
+      cwd={project.workspaceRoot}
+      className={ITEM_ICON_CLASS}
+    />
+  );
+}
 
 function getLocalFileManagerName(platform: string): string {
   if (isMacPlatform(platform)) {
@@ -924,13 +935,7 @@ function OpenCommandPaletteDialog(props: {
             group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
           );
         },
-        icon: (project) => (
-          <ProjectFavicon
-            environmentId={project.environmentId}
-            cwd={project.workspaceRoot}
-            className={ITEM_ICON_CLASS}
-          />
-        ),
+        icon: projectFavicon,
         runProject: openProjectFromSearch,
       }),
     [openProjectFromSearch, pickerProjects, projectGroupByTargetKey],
@@ -948,13 +953,7 @@ function OpenCommandPaletteDialog(props: {
               group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
             );
           },
-          icon: (project) => (
-            <ProjectFavicon
-              environmentId={project.environmentId}
-              cwd={project.workspaceRoot}
-              className={ITEM_ICON_CLASS}
-            />
-          ),
+          icon: projectFavicon,
           runProject: async (project) => {
             const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
             const contextualRefBelongsToGroup =

--- a/apps/web/src/components/settings/FontFamilyPicker.tsx
+++ b/apps/web/src/components/settings/FontFamilyPicker.tsx
@@ -129,7 +129,6 @@ export function FontFamilyPicker({
     if (initialOpen) setOpen(true);
     // The prop is only meaningful at mount - the control just swapped in
     // under an active focus - so later changes are deliberately ignored.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const listRef = useRef<LegendListRef | null>(null);
   const enumeration = useFontEnumeration();

--- a/apps/web/src/components/settings/SettingsFontPreviews.tsx
+++ b/apps/web/src/components/settings/SettingsFontPreviews.tsx
@@ -113,8 +113,8 @@ export function CodeFontPreview() {
   if (htmlByFile === null) return null;
   return (
     <div className="mt-1 mb-2 space-y-2">
-      {htmlByFile.map((html, index) => (
-        <StaticDiffHtml key={index} html={html} />
+      {htmlByFile.map((html) => (
+        <StaticDiffHtml key={html} html={html} />
       ))}
     </div>
   );

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -116,7 +116,6 @@ import {
   isMonospaceFamily,
   resolveDefaultFamilyLabel,
 } from "../../appearanceFonts";
-import { DEFAULT_TERMINAL_FONT_FAMILY } from "~/terminal/ghostty/surface";
 import { CodeFontPreview, PromptFontPreview, TerminalFontPreview } from "./SettingsFontPreviews";
 import { discoverInstalledFonts, FontFamilyPicker, useFontEnumeration } from "./FontFamilyPicker";
 import {

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -44,8 +44,8 @@ function SidebarUpdateReleaseNotesTooltip({
                 {index === 0 ? "What's changed" : `Changes in ${releaseNote.version}`}
               </h3>
               <ul className="mt-2 space-y-1.5 pl-4 text-xs leading-5 text-popover-foreground/90">
-                {releaseNote.items.map((item, itemIndex) => (
-                  <li className="list-disc break-words" key={`${releaseNote.version}-${itemIndex}`}>
+                {releaseNote.items.map((item) => (
+                  <li className="list-disc break-words" key={`${releaseNote.version}-${item}`}>
                     {item}
                   </li>
                 ))}

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -19,6 +19,15 @@ import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { Separator } from "../ui/separator";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
+function keyReleaseNoteItems(items: ReadonlyArray<string>) {
+  const occurrences = new Map<string, number>();
+  return items.map((item) => {
+    const occurrence = occurrences.get(item) ?? 0;
+    occurrences.set(item, occurrence + 1);
+    return { item, key: JSON.stringify([item, occurrence]) };
+  });
+}
+
 function SidebarUpdateReleaseNotesTooltip({
   state,
   tooltip,
@@ -44,8 +53,8 @@ function SidebarUpdateReleaseNotesTooltip({
                 {index === 0 ? "What's changed" : `Changes in ${releaseNote.version}`}
               </h3>
               <ul className="mt-2 space-y-1.5 pl-4 text-xs leading-5 text-popover-foreground/90">
-                {releaseNote.items.map((item) => (
-                  <li className="list-disc break-words" key={`${releaseNote.version}-${item}`}>
+                {keyReleaseNoteItems(releaseNote.items).map(({ item, key }) => (
+                  <li className="list-disc break-words" key={key}>
                     {item}
                   </li>
                 ))}


### PR DESCRIPTION
Main had accumulated lint warnings in recently changed web components, making clean lint runs noisy.

This removes stale code, uses data-derived list keys, and keeps render callbacks stable. The ReactMarkdown adapter retains its existing memoization with a narrowly documented lint exception because its renderers intentionally capture per-message metadata.

Made by gpt-5.6-sol through the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and key hygiene only; no auth, data, or core business-logic changes.
> 
> **Overview**
> Cleans up accumulated ESLint warnings in web components so `main` lint runs stay quiet, without changing product behavior.
> 
> **Command palette** — Inline `ProjectFavicon` lambdas for project search items are replaced with a shared `projectFavicon` helper so `react/no-unstable-nested-components` stops firing on those `useMemo` blocks.
> 
> **Chat markdown** — Documents the existing `useMemo`-wrapped ReactMarkdown component map with a scoped `eslint-disable` for `react/no-unstable-nested-components`, since those renderers intentionally close over per-message metadata.
> 
> **List keys** — Diff font previews use each preview HTML string as the React key instead of the array index. Nightly update release notes get stable keys via a small `keyReleaseNoteItems` helper that disambiguates duplicate bullet text.
> 
> **Settings** — Drops an unused `DEFAULT_TERMINAL_FONT_FAMILY` import from `SettingsPanels` and removes a no-longer-needed `react-hooks/exhaustive-deps` disable in `FontFamilyPicker` after the mount-only `useEffect` deps were tightened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b10ac9dd4b24c6f8ab32ef5761da3e10ff002a87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix lint warnings in web main branch
> - Adds `projectFavicon` helper in [CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/5384/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a) to replace inline lambdas, resolving `react/no-unstable-nested-components` warnings
> - Adds `keyReleaseNoteItems` helper in [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/5384/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf) to generate occurrence-aware, content-based keys for release note list items instead of version-and-index keys
> - Changes `StaticDiffHtml` list keys in [SettingsFontPreviews.tsx](https://github.com/pingdotgg/t3code/pull/5384/files#diff-41c2627f285aa954989f64cc12c833d239ab22024e21d3690434eb1d2fb8dacc) from array index to html string content
> - Removes unused `DEFAULT_TERMINAL_FONT_FAMILY` import and inline ESLint suppressions in settings components
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b10ac9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->