### PR TITLE
fix(mobile): restore Android tablet thread controls, clean up header

### DIFF
--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -94,7 +94,7 @@ export function CompactBrandTitle(
 }
 
 export function renderCompactBrandTitle() {
-  return <CompactBrandTitle />;
+  return <CompactBrandTitle allowFontScaling={Platform.OS === "ios"} />;
 }
 
 export function renderCompactBrandHeaderItems(): NativeStackHeaderItem[] {

--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -33,6 +33,7 @@ export function brandTitleOffset(nativeLeadingItem: boolean): number {
  */
 export function CompactBrandTitle(
   props: {
+    readonly allowFontScaling?: boolean;
     readonly nativeLeadingItem?: boolean;
   } = {},
 ) {
@@ -57,7 +58,7 @@ export function CompactBrandTitle(
     >
       <T3Wordmark color={iconColor} height={15} />
       <Text
-        allowFontScaling={false}
+        allowFontScaling={props.allowFontScaling}
         style={{
           color: mutedColor,
           fontFamily: "DMSans-Medium",
@@ -76,7 +77,7 @@ export function CompactBrandTitle(
         }}
       >
         <Text
-          allowFontScaling={false}
+          allowFontScaling={props.allowFontScaling}
           style={{
             color: mutedColor,
             fontFamily: "DMSans-Bold",

--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -57,6 +57,7 @@ export function CompactBrandTitle(
     >
       <T3Wordmark color={iconColor} height={15} />
       <Text
+        allowFontScaling={false}
         style={{
           color: mutedColor,
           fontFamily: "DMSans-Medium",
@@ -75,6 +76,7 @@ export function CompactBrandTitle(
         }}
       >
         <Text
+          allowFontScaling={false}
           style={{
             color: mutedColor,
             fontFamily: "DMSans-Bold",

--- a/apps/mobile/src/features/home/AndroidHomeFab.tsx
+++ b/apps/mobile/src/features/home/AndroidHomeFab.tsx
@@ -6,8 +6,8 @@ import { SymbolView } from "../../components/AppSymbol";
 import { useThemeColor } from "../../lib/useThemeColor";
 
 /**
- * Android-only wrapper that overlays a bottom-right new-task FAB on the home
- * screen. Other platforms render children unchanged.
+ * Android-only wrapper that overlays a bottom-right new-task FAB on a thread
+ * list. Other platforms render children unchanged.
  */
 export function AndroidHomeFabLayout(props: {
   readonly onStartNewTask: () => void;

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -2,6 +2,7 @@ import * as Arr from "effect/Array";
 import * as Order from "effect/Order";
 import { useNavigation } from "@react-navigation/native";
 import { useEffect, useMemo, useState } from "react";
+import { Platform } from "react-native";
 
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { useProjects, useThreadShells } from "../../state/entities";
@@ -106,7 +107,11 @@ export function HomeRouteScreen() {
     return (
       <>
         <NativeStackScreenOptions
-          options={{ title: "", headerTitle: "", unstable_headerLeftItems: () => [] }}
+          options={
+            Platform.OS === "android"
+              ? { headerShown: false }
+              : { title: "", headerTitle: "", unstable_headerLeftItems: () => [] }
+          }
         />
         <WorkspaceSidebarToolbar
           afterSidebarButton={
@@ -129,18 +134,20 @@ export function HomeRouteScreen() {
       onStartNewTask={() => navigation.navigate("NewTaskSheet", { screen: "NewTask" })}
     >
       <>
-        {/* Restore the compact title after the split branch blanks the detail
-            header. The brand slot doubles as the connection status surface:
-            while an environment reconnects, the lockup fades to a status label
-            in place (no layout shift in the list below). */}
+        {/* Restore the header after leaving split view; screen options are
+            shallow-merged. The brand slot also doubles as the connection
+            status surface while an environment reconnects. */}
         <NativeStackScreenOptions
-          options={getConnectionAwareBrandHeaderOptions({
-            onOpenEnvironments: () =>
-              navigation.navigate("SettingsSheet", {
-                screen: "SettingsContent",
-                params: { screen: "SettingsEnvironments" },
-              }),
-          })}
+          options={{
+            ...getConnectionAwareBrandHeaderOptions({
+              onOpenEnvironments: () =>
+                navigation.navigate("SettingsSheet", {
+                  screen: "SettingsContent",
+                  params: { screen: "SettingsEnvironments" },
+                }),
+            }),
+            headerShown: true,
+          }}
         />
         <HomeHeader
           environments={environments}

--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -45,6 +45,7 @@ import {
   parseActiveThreadPath,
   useHardwareKeyboardCommand,
 } from "../keyboard/hardwareKeyboardCommands";
+import { AndroidHomeFabLayout } from "../home/AndroidHomeFab";
 import { HomeListOptionsProvider } from "../home/home-list-options";
 import { ThreadNavigationSidebar } from "../threads/ThreadNavigationSidebar";
 import { WORKSPACE_PANE_TIMING } from "./workspace-pane-animation";
@@ -435,6 +436,10 @@ function AdaptiveWorkspaceLayoutContent(
     });
   }, [navigation]);
 
+  const handleStartNewTask = useCallback(() => {
+    navigation.navigate("NewTaskSheet", { screen: "NewTask" });
+  }, [navigation]);
+
   // Minted here (root stack navigation) so the sidebar pane stays free of
   // navigation hooks — on iOS it renders inside an independent nav tree.
   const handleOpenEnvironmentSettings = useCallback(() => {
@@ -528,18 +533,22 @@ function AdaptiveWorkspaceLayoutContent(
               pointerEvents={panes.primarySidebarVisible ? "auto" : "none"}
               style={sidebarAnimatedStyle}
             >
-              <ThreadNavigationSidebar
-                width={layout.listPaneWidth}
-                visible={panes.primarySidebarVisible}
-                onRequestVisibility={revealPrimarySidebar}
-                selectedThreadKey={selectedThreadKey}
-                onOpenSettings={handleOpenSettings}
-                onOpenEnvironmentSettings={handleOpenEnvironmentSettings}
-                onNewThreadInProject={handleNewThreadInProject}
-                onSelectThread={handleSelectThread}
-                onSearchQueryChange={setPrimarySidebarSearchQuery}
-                searchQuery={primarySidebarSearchQuery}
-              />
+              <View className="flex-1" style={{ width: layout.listPaneWidth }}>
+                <AndroidHomeFabLayout onStartNewTask={handleStartNewTask}>
+                  <ThreadNavigationSidebar
+                    width={layout.listPaneWidth}
+                    visible={panes.primarySidebarVisible}
+                    onRequestVisibility={revealPrimarySidebar}
+                    selectedThreadKey={selectedThreadKey}
+                    onOpenSettings={handleOpenSettings}
+                    onOpenEnvironmentSettings={handleOpenEnvironmentSettings}
+                    onNewThreadInProject={handleNewThreadInProject}
+                    onSelectThread={handleSelectThread}
+                    onSearchQueryChange={setPrimarySidebarSearchQuery}
+                    searchQuery={primarySidebarSearchQuery}
+                  />
+                </AndroidHomeFabLayout>
+              </View>
             </Animated.View>
           ) : null}
           <View className="flex-1 overflow-hidden bg-screen" collapsable={false}>

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -1298,7 +1298,7 @@ function ThreadNavigationSidebarPane(
                 {
                   paddingBottom:
                     Platform.OS === "android"
-                      ? Math.max(insets.bottom, 16) + 88
+                      ? Math.max(insets.bottom, 16) + 88 - insets.bottom
                       : 16 + insets.bottom,
                   paddingTop: topListInset,
                 },

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -1,4 +1,3 @@
-import { isLiquidGlassSupported, LiquidGlassView } from "@callstack/liquid-glass";
 import type {
   EnvironmentProject,
   EnvironmentThreadShell,
@@ -14,7 +13,7 @@ import { AsyncResult } from "effect/unstable/reactivity";
 import type { EnvironmentId } from "@t3tools/contracts";
 import { sortPinnedThreadsByOrderKey } from "@t3tools/client-runtime/state/thread-sort";
 import type { ChangeRequestSettleSource } from "@t3tools/client-runtime/state/thread-settled";
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { LayoutChangeEvent } from "react-native";
 import { Platform, Pressable, StyleSheet, TextInput, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
@@ -39,7 +38,6 @@ import { usePendingNewTasks } from "../../state/use-pending-new-tasks";
 import { useWorkspaceState } from "../../state/workspace";
 import { useSavedRemoteConnections } from "../../state/use-remote-environment-registry";
 import { useHardwareKeyboardCommand } from "../keyboard/hardwareKeyboardCommands";
-import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import {
   hasCustomHomeListOptions,
   PROJECT_SORT_OPTIONS,
@@ -95,42 +93,6 @@ type SidebarListItem =
   | HomeListItem
   | ThreadListV2ListItem
   | { readonly type: "v2-show-more"; readonly key: string; readonly hiddenCount: number };
-
-/**
- * Shared capsule behind the sidebar header buttons — a native liquid-glass
- * surface on iOS 26+, a tinted pill everywhere else.
- */
-function SidebarHeaderButtonGroup(props: {
-  readonly children: ReactNode;
-  readonly colorScheme: "light" | "dark";
-}) {
-  const fallbackBackground = useThemeColor("--color-glass-surface");
-  const fallbackBorder = useThemeColor("--color-header-border");
-  if (isLiquidGlassSupported) {
-    return (
-      <LiquidGlassView
-        colorScheme={props.colorScheme}
-        effect="regular"
-        interactive
-        style={styles.headerButtonGroup}
-      >
-        {props.children}
-      </LiquidGlassView>
-    );
-  }
-
-  return (
-    <View
-      style={[
-        styles.headerButtonGroup,
-        { backgroundColor: fallbackBackground, borderColor: fallbackBorder },
-        { borderWidth: StyleSheet.hairlineWidth },
-      ]}
-    >
-      {props.children}
-    </View>
-  );
-}
 
 const SIDEBAR_STICKY_HEADER_HEIGHT = 106;
 
@@ -189,7 +151,6 @@ function ThreadNavigationSidebarPane(
   props: ThreadNavigationSidebarProps & { readonly nativeChrome: boolean },
 ) {
   const insets = useSafeAreaInsets();
-  const { themeAppearance: colorScheme } = useAppearancePreferences();
   const projects = useProjects();
   const threads = useThreadShells();
   const { environments: workspaceEnvironments, state: catalogState } = useWorkspaceState();
@@ -1340,16 +1301,12 @@ function ThreadNavigationSidebarPane(
               </View>
             }
           />
-          <SidebarHeaderButtonGroup colorScheme={colorScheme}>
+          <View className="flex-row items-center gap-2.5">
             <ControlPillMenu actions={listMenuActions} onPressAction={handleListMenuAction}>
-              <SidebarFilterButton
-                grouped
-                accessibilityLabel="Filter and sort threads"
-                icon={filterIcon}
-              />
+              <SidebarFilterButton accessibilityLabel="Filter and sort threads" icon={filterIcon} />
             </ControlPillMenu>
-            <SidebarHeaderActions grouped onOpenSettings={props.onOpenSettings} />
-          </SidebarHeaderButtonGroup>
+            <SidebarHeaderActions onOpenSettings={props.onOpenSettings} />
+          </View>
         </View>
 
         <View className="mx-4 mt-[9px] h-[38px] flex-row items-center gap-1.5 rounded-xl bg-sidebar-search pr-2.5 pl-[11px]">
@@ -1374,12 +1331,6 @@ function ThreadNavigationSidebarPane(
 }
 
 const styles = StyleSheet.create({
-  headerButtonGroup: {
-    alignItems: "center",
-    borderRadius: 22,
-    flexDirection: "row",
-    overflow: "hidden",
-  },
   threadList: {
     flex: 1,
   },

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -766,7 +766,6 @@ function ThreadNavigationSidebarPane(
   );
 
   const backgroundColor = useThemeColor("--color-drawer");
-  const headerBackgroundColor = useThemeColor("--color-screen");
   const borderColor = useThemeColor("--color-border");
   const mutedColor = useThemeColor("--color-foreground-muted");
   const placeholderColor = useThemeColor("--color-placeholder");
@@ -1321,12 +1320,10 @@ function ThreadNavigationSidebarPane(
         className="absolute inset-x-0 top-0 z-[4]"
         collapsable={false}
         onLayout={handleStickyHeaderLayout}
-        pointerEvents="box-none"
+        pointerEvents="auto"
         style={{
           paddingTop: insets.top,
-          backgroundColor: headerBackgroundColor,
-          elevation: 100,
-          shadowColor: "transparent",
+          backgroundColor,
         }}
       >
         <View className="h-[50px] flex-row items-end gap-0.5 pr-2 pl-5">
@@ -1339,7 +1336,7 @@ function ThreadNavigationSidebarPane(
             size="pageTitle"
             brand={
               <View className="h-11 flex-1 justify-center">
-                <CompactBrandTitle />
+                <CompactBrandTitle allowFontScaling={false} />
               </View>
             }
           />

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -1322,7 +1322,12 @@ function ThreadNavigationSidebarPane(
         collapsable={false}
         onLayout={handleStickyHeaderLayout}
         pointerEvents="box-none"
-        style={{ paddingTop: insets.top, backgroundColor: headerBackgroundColor, elevation: 100 }}
+        style={{
+          paddingTop: insets.top,
+          backgroundColor: headerBackgroundColor,
+          elevation: 100,
+          shadowColor: "transparent",
+        }}
       >
         <View className="h-[50px] flex-row items-end gap-0.5 pr-2 pl-5">
           {/* Title slot doubles as the connection status surface: while an

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -24,6 +24,7 @@ import type { SearchBarCommands } from "react-native-screens";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 
 import { AppText as Text } from "../../components/AppText";
+import { CompactBrandTitle } from "../../components/CompactBrandTitle";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { SymbolView } from "../../components/AppSymbol";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
@@ -1314,7 +1315,10 @@ function ThreadNavigationSidebarPane(
               contentContainerStyle={[
                 styles.threadListContent,
                 {
-                  paddingBottom: 16 + insets.bottom,
+                  paddingBottom:
+                    Platform.OS === "android"
+                      ? Math.max(insets.bottom, 16) + 88
+                      : 16 + insets.bottom,
                   paddingTop: topListInset,
                 },
               ]}
@@ -1370,16 +1374,16 @@ function ThreadNavigationSidebarPane(
         </View>
         <View className="h-[50px] flex-row items-end gap-0.5 pr-2 pl-5">
           {/* Title slot doubles as the connection status surface: while an
-              environment reconnects, "Threads" fades to a status label in
+              environment reconnects, the brand fades to a status label in
               place (no layout shift in the list below). */}
           <WorkspaceConnectionTitle
             grow
             onPress={props.onOpenEnvironmentSettings}
             size="pageTitle"
             brand={
-              <Text className="flex-1 text-[34px] font-t3-bold text-foreground" numberOfLines={1}>
-                Threads
-              </Text>
+              <View className="h-11 flex-1 justify-center overflow-hidden">
+                <CompactBrandTitle />
+              </View>
             }
           />
           <SidebarHeaderButtonGroup colorScheme={colorScheme}>

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -15,13 +15,12 @@ import type { EnvironmentId } from "@t3tools/contracts";
 import { sortPinnedThreadsByOrderKey } from "@t3tools/client-runtime/state/thread-sort";
 import type { ChangeRequestSettleSource } from "@t3tools/client-runtime/state/thread-settled";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import type { LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+import type { LayoutChangeEvent } from "react-native";
 import { Platform, Pressable, StyleSheet, TextInput, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { SearchBarCommands } from "react-native-screens";
-import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 
 import { AppText as Text } from "../../components/AppText";
 import { CompactBrandTitle } from "../../components/CompactBrandTitle";
@@ -134,11 +133,6 @@ function SidebarHeaderButtonGroup(props: {
 }
 
 const SIDEBAR_STICKY_HEADER_HEIGHT = 106;
-const SIDEBAR_STICKY_HEADER_FADE_HEIGHT = 44;
-const SIDEBAR_HEADER_WASH_OPACITY = {
-  dark: [0.22, 0.14, 0.04],
-  light: [0.46, 0.3, 0.08],
-} as const;
 
 interface ThreadNavigationSidebarProps {
   readonly width: number;
@@ -200,11 +194,9 @@ function ThreadNavigationSidebarPane(
   const threads = useThreadShells();
   const { environments: workspaceEnvironments, state: catalogState } = useWorkspaceState();
   const { savedConnectionsById } = useSavedRemoteConnections();
-  const [headerIsOverContent, setHeaderIsOverContent] = useState(false);
   const searchInputRef = useRef<TextInput>(null);
   const searchBarRef = useRef<SearchBarCommands>(null);
   const openSwipeableRef = useRef<SwipeableMethods | null>(null);
-  const headerIsOverContentRef = useRef(false);
   const sidebarScrollGesture = useMemo(() => Gesture.Native(), []);
   const {
     archiveThread,
@@ -774,11 +766,10 @@ function ThreadNavigationSidebarPane(
   );
 
   const backgroundColor = useThemeColor("--color-drawer");
+  const headerBackgroundColor = useThemeColor("--color-screen");
   const borderColor = useThemeColor("--color-border");
   const mutedColor = useThemeColor("--color-foreground-muted");
   const placeholderColor = useThemeColor("--color-placeholder");
-  const headerFadeColor = String(backgroundColor);
-  const headerWashOpacity = SIDEBAR_HEADER_WASH_OPACITY[colorScheme];
   const [measuredHeaderHeight, setMeasuredHeaderHeight] = useState<number | null>(null);
   // The sticky header (title row, search field, optional connection status)
   // is measured so the list inset always matches its real height — no
@@ -807,19 +798,10 @@ function ThreadNavigationSidebarPane(
     },
     [props.onSelectThread],
   );
-  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    const next = event.nativeEvent.contentOffset.y > 6;
-    if (headerIsOverContentRef.current === next) {
-      return;
-    }
-    headerIsOverContentRef.current = next;
-    setHeaderIsOverContent(next);
-  }, []);
   const handleScrollBeginDrag = useCallback(() => {
     openSwipeableRef.current?.close();
   }, []);
   const { swipeEnabled, scrollGateHandlers } = useSwipeableScrollGate({
-    onScroll: handleScroll,
     onScrollBeginDrag: handleScrollBeginDrag,
   });
   // Project shells load after the first rows draw, so the maps they feed have
@@ -1337,41 +1319,11 @@ function ThreadNavigationSidebarPane(
 
       <View
         className="absolute inset-x-0 top-0 z-[4]"
+        collapsable={false}
         onLayout={handleStickyHeaderLayout}
         pointerEvents="box-none"
-        style={{ paddingTop: insets.top }}
+        style={{ paddingTop: insets.top, backgroundColor: headerBackgroundColor, elevation: 100 }}
       >
-        <View
-          className="absolute inset-x-0 top-0"
-          pointerEvents="none"
-          accessibilityElementsHidden
-          importantForAccessibility="no-hide-descendants"
-          style={{ height: stickyHeaderHeight + SIDEBAR_STICKY_HEADER_FADE_HEIGHT }}
-        >
-          <Svg width="100%" height="100%">
-            <Defs>
-              <LinearGradient id="sidebar-header-wash" x1="0%" x2="0%" y1="0%" y2="100%">
-                <Stop
-                  offset="0%"
-                  stopColor={headerFadeColor}
-                  stopOpacity={headerIsOverContent ? headerWashOpacity[0] : 0}
-                />
-                <Stop
-                  offset="58%"
-                  stopColor={headerFadeColor}
-                  stopOpacity={headerIsOverContent ? headerWashOpacity[1] : 0}
-                />
-                <Stop
-                  offset="88%"
-                  stopColor={headerFadeColor}
-                  stopOpacity={headerIsOverContent ? headerWashOpacity[2] : 0}
-                />
-                <Stop offset="100%" stopColor={headerFadeColor} stopOpacity={0} />
-              </LinearGradient>
-            </Defs>
-            <Rect width="100%" height="100%" fill="url(#sidebar-header-wash)" />
-          </Svg>
-        </View>
         <View className="h-[50px] flex-row items-end gap-0.5 pr-2 pl-5">
           {/* Title slot doubles as the connection status surface: while an
               environment reconnects, the brand fades to a status label in
@@ -1381,7 +1333,7 @@ function ThreadNavigationSidebarPane(
             onPress={props.onOpenEnvironmentSettings}
             size="pageTitle"
             brand={
-              <View className="h-11 flex-1 justify-center overflow-hidden">
+              <View className="h-11 flex-1 justify-center">
                 <CompactBrandTitle />
               </View>
             }

--- a/apps/mobile/src/features/threads/sidebar-filter-button.tsx
+++ b/apps/mobile/src/features/threads/sidebar-filter-button.tsx
@@ -1,5 +1,5 @@
 import { SymbolView } from "../../components/AppSymbol";
-import { Pressable, StyleSheet } from "react-native";
+import { Pressable } from "react-native";
 
 import { useThemeColor } from "../../lib/useThemeColor";
 
@@ -10,31 +10,17 @@ export type SidebarFilterButtonIcon =
 export function SidebarFilterButton(props: {
   readonly accessibilityLabel: string;
   readonly icon: SidebarFilterButtonIcon;
-  /** Rendered inside a shared capsule group — no own background/border. */
-  readonly grouped?: boolean;
 }) {
   const iconColor = useThemeColor("--color-foreground");
-  const pressedBackgroundColor = useThemeColor("--color-subtle");
-  const idleBackgroundColor = useThemeColor("--color-glass-surface");
-  const borderColor = useThemeColor("--color-header-border");
 
   return (
     <Pressable
-      className="h-11 w-[50px] cursor-pointer items-center justify-center rounded-[22px]"
+      className="size-11 cursor-pointer items-center justify-center rounded-full bg-subtle active:opacity-70"
       accessibilityLabel={props.accessibilityLabel}
       accessibilityRole="button"
       hitSlop={4}
-      style={({ pressed }) => [
-        props.grouped
-          ? { backgroundColor: pressed ? pressedBackgroundColor : "transparent", borderWidth: 0 }
-          : {
-              backgroundColor: pressed ? pressedBackgroundColor : idleBackgroundColor,
-              borderColor,
-              borderWidth: StyleSheet.hairlineWidth,
-            },
-      ]}
     >
-      <SymbolView name={props.icon} size={20} tintColor={iconColor} type="monochrome" />
+      <SymbolView name={props.icon} size={16} tintColor={iconColor} type="monochrome" />
     </Pressable>
   );
 }

--- a/apps/mobile/src/features/threads/sidebar-header-actions.tsx
+++ b/apps/mobile/src/features/threads/sidebar-header-actions.tsx
@@ -1,43 +1,28 @@
 import { SymbolView } from "../../components/AppSymbol";
-import { Pressable, StyleSheet, View } from "react-native";
+import { Pressable, View } from "react-native";
 
 import { useThemeColor } from "../../lib/useThemeColor";
 
 export interface SidebarHeaderActionsProps {
   readonly onOpenSettings: () => void;
-  /** Rendered inside a shared capsule group — buttons drop their own chrome. */
-  readonly grouped?: boolean;
 }
 
 function FallbackHeaderButton(props: {
   readonly accessibilityLabel: string;
   readonly icon: "gearshape" | "square.and.pencil";
-  readonly grouped?: boolean;
   readonly onPress: () => void;
 }) {
   const iconColor = useThemeColor("--color-foreground");
-  const pressedBackgroundColor = useThemeColor("--color-subtle");
-  const idleBackgroundColor = useThemeColor("--color-glass-surface");
-  const borderColor = useThemeColor("--color-header-border");
 
   return (
     <Pressable
-      className="h-11 w-[50px] items-center justify-center rounded-[22px]"
+      className="size-11 items-center justify-center rounded-full bg-subtle active:opacity-70"
       accessibilityLabel={props.accessibilityLabel}
       accessibilityRole="button"
       hitSlop={4}
       onPress={props.onPress}
-      style={({ pressed }) => [
-        props.grouped
-          ? { backgroundColor: pressed ? pressedBackgroundColor : "transparent", borderWidth: 0 }
-          : {
-              backgroundColor: pressed ? pressedBackgroundColor : idleBackgroundColor,
-              borderColor,
-              borderWidth: StyleSheet.hairlineWidth,
-            },
-      ]}
     >
-      <SymbolView name={props.icon} size={20} tintColor={iconColor} type="monochrome" />
+      <SymbolView name={props.icon} size={18} tintColor={iconColor} type="monochrome" />
     </Pressable>
   );
 }
@@ -47,7 +32,6 @@ export function SidebarHeaderActions(props: SidebarHeaderActionsProps) {
     <View className="flex-row items-center gap-0.5">
       <FallbackHeaderButton
         accessibilityLabel="Open settings"
-        grouped={props.grouped}
         icon="gearshape"
         onPress={props.onOpenSettings}
       />


### PR DESCRIPTION
## What Changed

- restore the compact T3 Code brand lockup in the Android split-view thread sidebar
- align the lockup with the primary thread-title column
- expose the existing Android new-task FAB inside the persistent sidebar and keep list rows clear of it
- remove the empty Android detail pane's blank native-header wash
- keep the focused new-thread composer and toolbar attached to the Android keyboard, matching existing threads

## Why

Android tablets and unfolded foldables use a separate split-view sidebar once the window reaches 720dp × 600dp. That sidebar had drifted from the phone surface: it showed a hardcoded “Threads” title and had no persistent way to start a task.

The new-thread screen also used padding-based keyboard avoidance while existing threads used a frame-synced sticky composer. On a foldable, the IME could cover the new-thread toolbar even though the existing-thread toolbar remained visible.

The empty split-view detail route still mounted a blank Android native header, leaving a lighter strip and divider above the otherwise uniform detail background.

This addresses the header, settings, and new-task portions of #5338. Sidebar collapse is intentionally outside this focused PR.

## UI Changes

| Before | After |
| --- | --- |
| <img width="420" alt="Android unfolded Fold sidebar before, showing the Threads title, fixed filter and settings controls, and no compose control" src="https://raw.githubusercontent.com/PixPMusic/t3code/bbe2cbb322f983e32a2cbeb39344c47ce1097d12/.pr-assets/android-tablet-header-before.png"> | <img width="420" alt="Android unfolded Fold sidebar after, showing the T3 Code Alpha lockup, shared settings gear, and compose FAB" src="https://raw.githubusercontent.com/PixPMusic/t3code/pr-assets-android-tablet-header/.pr-assets/android-tablet-header-after.png"> |

Both captures use the same deterministic dark-mode Threads fixture on an unfolded Pixel 9 Pro Fold AVD at its native 2076×2152 display size. The “Before” capture was regenerated from current `main` (`7107a98a2`), including the settings-cog fix from #6520. The “After” captures use the production/Alpha variant with this PR’s layout changes.

### Final baseline and empty-detail proof

<img width="840" alt="Android unfolded Fold final layout, with the T3 Code lockup aligned to thread titles and a uniform empty-detail background" src="https://raw.githubusercontent.com/PixPMusic/t3code/pr-assets-android-tablet-header/.pr-assets/android-tablet-baselines-after.png">

### New thread with keyboard open

<img width="840" alt="Android unfolded Fold new-thread composer after the fix, with its editor and controls visible above the open keyboard" src="https://raw.githubusercontent.com/PixPMusic/t3code/pr-assets-android-tablet-header/.pr-assets/android-tablet-new-thread-keyboard-after.png">

## Verification

- `pnpm --filter @t3tools/mobile typecheck`
- targeted formatting and lint for the changed mobile files
- `git diff --check`
- matched before/after pass on the real `pixel_9_pro_fold` Android hardware profile
- focused new-thread pass with the IME open; editor and toolbar accessibility bounds remain above the keyboard
- one fresh Codex review and one Claude Opus counter-review; the actionable animation and large-font clipping findings were addressed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI changes
- [x] No new animation behavior was introduced

Model: GPT-5.6 Sol | Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only mobile layout and header chrome; no auth, data, or navigation contract changes beyond screen options.
> 
> **Overview**
> Restores Android tablet/fold split-view thread chrome so the persistent sidebar matches the phone home list.
> 
> The sidebar title is the compact T3 Code lockup (`CompactBrandTitle`, font scaling off) instead of a hardcoded “Threads” label. The sticky header is a solid drawer background; the scroll-driven SVG wash is gone. `AndroidHomeFabLayout` now wraps the split sidebar list, with extra bottom padding so rows clear the FAB.
> 
> On Android split layouts, the empty Home detail pane hides the native header (`headerShown: false`) to drop the leftover wash. Leaving split view explicitly re-enables the header because screen options are shallow-merged. `CompactBrandTitle` gains `allowFontScaling`; native header rendering keeps scaling on iOS only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b040b6b8d90cd2a49cdb82c5ff7000388a1d9bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore Android tablet thread controls and clean up `ThreadNavigationSidebar` header
> - On Android split layouts, `HomeRouteScreen` hides the native header and `AdaptiveWorkspaceLayout` overlays `AndroidHomeFab` on the thread list via `AndroidHomeFabLayout`; the list reserves bottom padding so the FAB does not cover items.
> - `ThreadNavigationSidebar` replaces the static 'Threads' title with `CompactBrandTitle`, removes the liquid-glass header chrome and gradient wash, and replaces `SidebarHeaderButtonGroup` with plain container views.
> - `SidebarFilterButton` and `FallbackHeaderButton` drop the `grouped` prop and render fixed subtle pill backgrounds (16px and 18px icons).
> - `CompactBrandTitle` adds an `allowFontScaling` prop, which `renderCompactBrandTitle` disables on non-iOS platforms.
> - Risk: `SidebarFilterButton`, `FallbackHeaderButton`, and `SidebarHeaderActions` no longer accept the `grouped` prop; in-tree callers are updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df8270c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
