### PR TITLE
fix(mobile): prevent Android thread search crash

### DIFF
--- a/packages/client-runtime/src/state/threadSearch.test.ts
+++ b/packages/client-runtime/src/state/threadSearch.test.ts
@@ -23,6 +23,19 @@ it("creates stable keys regardless of environment order", () => {
   );
 });
 
+it("creates keys without array methods unavailable in Hermes", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(Array.prototype, "toSorted");
+  Reflect.deleteProperty(Array.prototype, "toSorted");
+
+  try {
+    expect(makeThreadSearchKey([envB, envA], "needle")).toBe('[["env-a","env-b"],"needle"]');
+  } finally {
+    if (descriptor !== undefined) {
+      Reflect.defineProperty(Array.prototype, "toSorted", descriptor);
+    }
+  }
+});
+
 it("encodes scoped thread keys without delimiter collisions", () => {
   const first = threadSearchMatchKey({
     environmentId: EnvironmentId.make("env\u0000thread"),

--- a/packages/client-runtime/src/state/threadSearch.ts
+++ b/packages/client-runtime/src/state/threadSearch.ts
@@ -28,7 +28,7 @@ export function makeThreadSearchKey(
   query: string,
 ): string {
   return JSON.stringify([
-    [...environmentIds].toSorted((left, right) => left.localeCompare(right)),
+    [...environmentIds].sort((left, right) => left.localeCompare(right)),
     query,
   ]);
 }


### PR DESCRIPTION
Fixes #5250.

Android thread search crashes as soon as a query reaches two characters because content search builds its cache key with `Array.prototype.toSorted()`, which Hermes does not provide. The resulting render-time exception blanks the home screen.

Use a copied mutable sort instead, preserving the stable key and leaving the input array untouched. Add a regression test that removes `toSorted` from the runtime so this compatibility path stays covered.

### Android verification

| Before — two-character search blanks the screen | After — two-character search stays rendered |
| --- | --- |
| <img src="https://files.catbox.moe/jv07uo.png" width="320" alt="Before fix: Android app blank after a two-character thread search" /> | <img src="https://files.catbox.moe/amcxit.png" width="320" alt="After fix: Android app shows matching threads after a two-character thread search" /> |

Verification:
- `vp test run packages/client-runtime/src/state/threadSearch.test.ts`
- `vp fmt --check packages/client-runtime/src/state/threadSearch.ts packages/client-runtime/src/state/threadSearch.test.ts`
- `vp lint packages/client-runtime/src/state/threadSearch.ts packages/client-runtime/src/state/threadSearch.test.ts`
- `vp run typecheck` in `packages/client-runtime`
- Physical Android 16 device: one- and two-character searches remain rendered; no React Native exception in logcat

Generated with GPT-5.6-Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to cache-key construction with an added test; behavior is intended to match the previous stable key format.
> 
> **Overview**
> Fixes Android thread search crashing once queries reach two characters, when Hermes throws because **`Array.prototype.toSorted`** is missing.
> 
> **`makeThreadSearchKey`** now copies environment IDs and uses **`.sort()`** on that copy so cache keys stay order-stable without mutating the caller’s array. A regression test strips **`toSorted`** from the prototype to lock in Hermes-compatible behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed9d0fd716da2a1c7d3e3bbcfdbbc9386dd5d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `makeThreadSearchKey` crash on Android by replacing `toSorted` with `sort`
> The Hermes JavaScript engine used on Android does not support `Array.prototype.toSorted`, causing a crash in thread search. [threadSearch.ts](https://github.com/pingdotgg/t3code/pull/5386/files#diff-4057f08c1bb8dbe59eef65c3a080d3b9440ae057fb668391059aac96aeb65657) is updated to spread-copy the environment IDs array and call `.sort()` instead, achieving the same deterministic key output without relying on the unavailable method. A Jest test is added that removes `toSorted` from `Array.prototype` to verify the fallback behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ed9d0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->