### PR TITLE
feat(server): name generated worktree branches feature/* instead of t3code/*

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1464,19 +1464,8 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    harness.generateBranchName.mockImplementation((input: unknown) =>
-      Effect.succeed({
-        branch:
-          typeof input === "object" &&
-          input !== null &&
-          "modelSelection" in input &&
-          typeof input.modelSelection === "object" &&
-          input.modelSelection !== null &&
-          "model" in input.modelSelection &&
-          typeof input.modelSelection.model === "string"
-            ? `feature/${input.modelSelection.model}`
-            : "feature/generated",
-      }),
+    harness.generateBranchName.mockImplementation(() =>
+      Effect.succeed({ branch: "t3code/Safer Reconnect Backoff" }),
     );
 
     await Effect.runPromise(
@@ -1500,6 +1489,10 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
     expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
       message: "Add a safer reconnect backoff.",
+    });
+    expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+      oldBranch: "t3code/1234abcd",
+      newBranch: "feature/safer-reconnect-backoff",
     });
     expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
   });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,7 +12,11 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
-import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import {
+  isTemporaryWorktreeBranch,
+  sanitizeFeatureBranchName,
+  WORKTREE_BRANCH_PREFIX,
+} from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -291,23 +295,15 @@ function buildGeneratedWorktreeBranchName(raw: string): string {
   const normalized = raw
     .trim()
     .toLowerCase()
-    .replace(/^refs\/heads\//, "")
-    .replace(/['"`]/g, "");
+    .replace(/^refs\/heads\//, "");
 
+  // The model may echo the temporary `t3code/<hex>` branch it was asked to
+  // replace; strip that prefix so the generated name stands on its own.
   const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
     ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
     : normalized;
 
-  const branchFragment = withoutPrefix
-    .replace(/[^a-z0-9/_-]+/g, "-")
-    .replace(/\/+/g, "/")
-    .replace(/-+/g, "-")
-    .replace(/^[./_-]+|[./_-]+$/g, "")
-    .slice(0, 64)
-    .replace(/[./_-]+$/g, "");
-
-  const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
+  return sanitizeFeatureBranchName(withoutPrefix);
 }
 
 const make = Effect.gen(function* () {


### PR DESCRIPTION
## Problem

**New worktree branches will have names like "feature/add-dark-mode" rather than "t3code/add-dark-mode"**

| Before | After |
|---|---|
| ![before chip](https://agentfiles.xyz/yauuv8ayak/pr-before-chip.png) | ![after chip](https://agentfiles.xyz/2k5cgs2m93/pr-after-chip.png) |

New-worktree branches were renamed to a hardcoded `t3code/<fragment>` after the
first turn. The fragment was already generated by the settings-selected text
generation model (default `gpt-5.6-luna`), so the prefix just branded every
branch with the app name instead of a conventional namespace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized git branch naming in the provider reactor with updated test coverage; no auth or data-path changes.
> 
> **Overview**
> After the first turn on a temporary worktree branch (`t3code/<hex>`), the server renames it using the text model’s suggested name. **That rename now targets `feature/…` refs** instead of keeping everything under `t3code/…`.
> 
> `buildGeneratedWorktreeBranchName` in `ProviderCommandReactor` delegates to shared `sanitizeFeatureBranchName` after normalizing input (lowercase, strip `refs/heads/`, and drop a echoed `t3code/` prefix). The old inline slugging and `t3code/` prefix are removed. The worktree branch test asserts `renameBranch` goes from `t3code/1234abcd` to `feature/safer-reconnect-backoff` for a human-readable generated title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f9c75e112711ba18e13096193a5f7132229541d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename generated worktree branches from `t3code/*` to `feature/*`
> Updates `buildGeneratedWorktreeBranchName` in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/5387/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) to delegate sanitization to `sanitizeFeatureBranchName` from `@t3tools/shared/git`, stripping any leading `WORKTREE_BRANCH_PREFIX` before applying it. The result is a `feature/`-prefixed branch name instead of the previous `t3code/`-prefixed one.
> - Behavioral Change: any worktree branch previously named `t3code/<slug>` will now be named `feature/<slug>` going forward; existing branches are renamed via `renameBranch` as shown in updated tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f9c75e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->