### PR TITLE
Insert file mentions when non-image files are dropped on the composer

### DIFF
--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,7 +5,7 @@ import type {
   DesktopPreviewTabState,
 } from "@t3tools/contracts";
 import { exposeClerkBridge } from "@clerk/electron/preload";
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 
 import * as IpcChannels from "./ipc/channels.ts";
 
@@ -105,6 +105,9 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ...(position === undefined ? {} : { position }),
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
+  // Synchronous and in-process: webUtils reads the path off the drag payload,
+  // no IPC hop. Returns "" for files without a backing path.
+  getPathForFile: (file) => webUtils.getPathForFile(file as File),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
       if (typeof action !== "string") return;

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2474,11 +2474,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         unresolvedFiles.push(file);
       }
     }
+    let insertedMentions = false;
     if (mentionPaths.length > 0) {
-      const inserted = insertComposerTextAtEnd(buildDroppedFileMentions(mentionPaths, gitCwd), {
-        ensureLeadingBoundary: true,
-      });
-      if (!inserted) {
+      // Trailing space: the mention token grammar requires trailing
+      // whitespace, same as every other mention insert site.
+      insertedMentions = insertComposerTextAtEnd(
+        `${buildDroppedFileMentions(mentionPaths, gitCwd)} `,
+        { ensureLeadingBoundary: true },
+      );
+      if (!insertedMentions) {
         toastManager.add({
           type: "error",
           title: "Unable to add to chat",
@@ -2491,7 +2495,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (imagesToAttach.length > 0) {
       void addComposerImages(imagesToAttach);
     }
-    focusComposer();
+    // Focusing synchronously after a prompt insert would push the editor's
+    // stale snapshot back over the inserted mention (see the note on
+    // ComposerMentionDropHost); the insert path already focuses next frame.
+    if (!insertedMentions) {
+      focusComposer();
+    }
   };
 
   // File-tree drags land as mentions. Handled in the capture phase so the

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -47,6 +47,7 @@ import {
   dataTransferHasComposerMention,
   makeComposerMentionDragHandlers,
 } from "./composerMentionDrag";
+import { buildDroppedFileMentions, partitionDroppedComposerFiles } from "./composerFileDrop";
 import {
   type ComposerImageAttachment,
   type DraftId,
@@ -2419,16 +2420,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }
   };
 
-  const onComposerDrop = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
-    event.preventDefault();
-    dragDepthRef.current = 0;
-    setIsDragOverComposer(false);
-    const files = Array.from(event.dataTransfer.files);
-    void addComposerImages(files);
-    focusComposer();
-  };
-
   const insertComposerTextAtEnd = (
     text: string,
     options?: { ensureLeadingBoundary?: boolean },
@@ -2450,6 +2441,57 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       prompt.length,
       needsLeadingSpace ? ` ${text}` : text,
     );
+  };
+
+  // OS file drops: images attach inline (as before), while other files become
+  // file mentions when the desktop shell can resolve the dropped File's on-disk
+  // path (Electron webUtils). Files whose path can't be resolved — browser
+  // builds, or in-memory Files — fall back to the image path so the existing
+  // "unsupported file type" error still surfaces instead of silently vanishing.
+  const onComposerDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    dragDepthRef.current = 0;
+    setIsDragOverComposer(false);
+    const { imageFiles, pathFiles } = partitionDroppedComposerFiles(
+      Array.from(event.dataTransfer.files),
+    );
+    const resolvePath = window.desktopBridge?.getPathForFile;
+    const mentionPaths: string[] = [];
+    const unresolvedFiles: File[] = [];
+    for (const file of pathFiles) {
+      let absolutePath = "";
+      if (resolvePath) {
+        try {
+          absolutePath = resolvePath(file);
+        } catch {
+          absolutePath = "";
+        }
+      }
+      if (absolutePath.length > 0) {
+        mentionPaths.push(absolutePath);
+      } else {
+        unresolvedFiles.push(file);
+      }
+    }
+    if (mentionPaths.length > 0) {
+      const inserted = insertComposerTextAtEnd(buildDroppedFileMentions(mentionPaths, gitCwd), {
+        ensureLeadingBoundary: true,
+      });
+      if (!inserted) {
+        toastManager.add({
+          type: "error",
+          title: "Unable to add to chat",
+          description: "The composer is busy; try again once it is ready.",
+        });
+      }
+    }
+    const imagesToAttach =
+      unresolvedFiles.length > 0 ? [...imageFiles, ...unresolvedFiles] : imageFiles;
+    if (imagesToAttach.length > 0) {
+      void addComposerImages(imagesToAttach);
+    }
+    focusComposer();
   };
 
   // File-tree drags land as mentions. Handled in the capture phase so the

--- a/apps/web/src/components/chat/composerFileDrop.test.ts
+++ b/apps/web/src/components/chat/composerFileDrop.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  buildDroppedFileMentions,
+  partitionDroppedComposerFiles,
+  toComposerMentionPath,
+} from "./composerFileDrop.ts";
+
+const fakeFile = (type: string, name: string): File => ({ type, name }) as unknown as File;
+
+describe("partitionDroppedComposerFiles", () => {
+  it("splits image files from everything else, preserving order", () => {
+    const png = fakeFile("image/png", "shot.png");
+    const doc = fakeFile("text/markdown", "notes.md");
+    const jpeg = fakeFile("image/jpeg", "photo.jpg");
+    const bin = fakeFile("", "Makefile");
+
+    const { imageFiles, pathFiles } = partitionDroppedComposerFiles([png, doc, jpeg, bin]);
+
+    expect(imageFiles).toEqual([png, jpeg]);
+    expect(pathFiles).toEqual([doc, bin]);
+  });
+
+  it("returns empty partitions for no files", () => {
+    expect(partitionDroppedComposerFiles([])).toEqual({ imageFiles: [], pathFiles: [] });
+  });
+});
+
+describe("toComposerMentionPath", () => {
+  it("relativises a path inside the workspace cwd", () => {
+    expect(toComposerMentionPath("/home/me/proj/src/app.ts", "/home/me/proj")).toBe("src/app.ts");
+  });
+
+  it("tolerates a trailing slash on the cwd", () => {
+    expect(toComposerMentionPath("/home/me/proj/src/app.ts", "/home/me/proj/")).toBe("src/app.ts");
+  });
+
+  it("keeps the absolute path when it is outside the cwd", () => {
+    expect(toComposerMentionPath("/etc/hosts", "/home/me/proj")).toBe("/etc/hosts");
+  });
+
+  it("keeps the absolute path when there is no cwd", () => {
+    expect(toComposerMentionPath("/home/me/proj/src/app.ts", null)).toBe("/home/me/proj/src/app.ts");
+  });
+
+  it("does not relativise the cwd itself to an empty string", () => {
+    expect(toComposerMentionPath("/home/me/proj", "/home/me/proj")).toBe("/home/me/proj");
+  });
+
+  it("normalises Windows separators and relativises", () => {
+    expect(toComposerMentionPath("C:\\Users\\me\\proj\\src\\app.ts", "C:\\Users\\me\\proj")).toBe(
+      "src/app.ts",
+    );
+  });
+});
+
+describe("buildDroppedFileMentions", () => {
+  it("serializes each path as a space-separated file link", () => {
+    expect(
+      buildDroppedFileMentions(["/home/me/proj/src/app.ts", "/etc/hosts"], "/home/me/proj"),
+    ).toBe("[app.ts](src/app.ts) [hosts](/etc/hosts)");
+  });
+
+  it("returns an empty string for no paths", () => {
+    expect(buildDroppedFileMentions([], "/home/me/proj")).toBe("");
+  });
+});

--- a/apps/web/src/components/chat/composerFileDrop.ts
+++ b/apps/web/src/components/chat/composerFileDrop.ts
@@ -1,0 +1,59 @@
+import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
+
+/**
+ * Split files from an OS drag-and-drop into the two ways the composer can use
+ * them: images become inline attachments, everything else becomes a file
+ * mention that points the agent at the dropped path.
+ */
+export interface DroppedComposerFilePartition {
+  readonly imageFiles: File[];
+  readonly pathFiles: File[];
+}
+
+export function partitionDroppedComposerFiles(
+  files: readonly File[],
+): DroppedComposerFilePartition {
+  const imageFiles: File[] = [];
+  const pathFiles: File[] = [];
+  for (const file of files) {
+    if (file.type.startsWith("image/")) {
+      imageFiles.push(file);
+    } else {
+      pathFiles.push(file);
+    }
+  }
+  return { imageFiles, pathFiles };
+}
+
+/**
+ * Convert an absolute filesystem path into the value inserted as a composer
+ * mention. When the path lives inside the workspace cwd it is made
+ * workspace-relative so it matches typed and file-tree mentions; otherwise the
+ * absolute path is kept so the reference is still unambiguous.
+ *
+ * Path separators are normalised to `/` so Windows drops relativise too. The
+ * prefix comparison is case-sensitive, so a drop that differs only in casing
+ * from the cwd (possible on case-insensitive volumes) keeps its absolute path
+ * rather than guessing a relative one.
+ */
+export function toComposerMentionPath(absolutePath: string, cwd: string | null): string {
+  const normalizedPath = absolutePath.replace(/\\/g, "/");
+  if (cwd !== null) {
+    const normalizedCwd = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+    if (normalizedCwd.length > 0) {
+      const prefix = `${normalizedCwd}/`;
+      if (normalizedPath.startsWith(prefix) && normalizedPath.length > prefix.length) {
+        return normalizedPath.slice(prefix.length);
+      }
+    }
+  }
+  return normalizedPath;
+}
+
+/**
+ * Build the composer text for a set of dropped file paths: one serialized file
+ * link per path, space-separated so each stays a valid mention token.
+ */
+export function buildDroppedFileMentions(paths: readonly string[], cwd: string | null): string {
+  return paths.map((path) => serializeComposerFileLink(toComposerMentionPath(path, cwd))).join(" ");
+}

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1026,6 +1026,15 @@ export interface DesktopBridge {
     position?: { x: number; y: number },
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
+  /**
+   * Resolve the absolute filesystem path backing a dragged or picked file
+   * (Electron `webUtils.getPathForFile`). Returns an empty string when the file
+   * has no on-disk path (e.g. synthesized in-memory). The argument is a DOM
+   * `File`; it is typed as `unknown` because the contracts package is built
+   * without the DOM lib. Optional so browser builds, which cannot resolve OS
+   * paths, may omit it.
+   */
+  getPathForFile?: (file: unknown) => string;
   onMenuAction: (listener: (action: string) => void) => () => void;
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;


### PR DESCRIPTION
## Problem

Dropping a file onto the composer routes **every** dropped file through the image-attachment path (`onComposerDrop` → `addComposerImages`). Anything that isn't an image is rejected with:

> Unsupported file type for '<name>'. Please attach image files only.

So there's no way to drag a file from Finder/Explorer to reference it by path — you can only do it by typing `@` or dragging from the in-app file tree.

## Change

`onComposerDrop` now partitions the dropped files:

- **Images** → attach inline, exactly as before.
- **Other files** → become composer file mentions, using the dropped `File`'s on-disk path resolved via Electron `webUtils.getPathForFile`, exposed as a new optional `DesktopBridge.getPathForFile`.
  - Paths inside the workspace cwd are made **workspace-relative** so they match typed / file-tree mentions; paths outside stay absolute.
- Files whose path **can't** be resolved (browser builds, in-memory `File`s) fall back to the existing image path, so the "unsupported file type" error still surfaces and **non-desktop behavior is unchanged**.

## Files

- `packages/contracts/src/ipc.ts` — add optional `DesktopBridge.getPathForFile` (typed `unknown` since contracts is built without the DOM lib).
- `apps/desktop/src/preload.ts` — implement it via `webUtils.getPathForFile` (synchronous, in-process, no IPC hop).
- `apps/web/src/components/chat/composerFileDrop.ts` — `partitionDroppedComposerFiles`, `toComposerMentionPath`, `buildDroppedFileMentions` (pure helpers) + `composerFileDrop.test.ts`.
- `apps/web/src/components/chat/ChatComposer.tsx` — wire helpers into `onComposerDrop`; `insertComposerTextAtEnd` moved above the drop handler so it's defined before use.

## Notes / open questions

- Absolute-vs-relative: in-workspace drops become relative to match existing mentions; out-of-workspace drops keep the absolute path so the reference stays unambiguous. Happy to change this if you'd rather always keep absolute (or reject out-of-workspace drops).
- cwd prefix match is case-sensitive, so a drop differing only in case from the cwd (possible on case-insensitive volumes) keeps its absolute path rather than guessing.
- **Remote environments (reviewer finding, needs a maintainer call):** `getPathForFile` resolves paths on the *local desktop host*, while mentions are resolved against the *environment* workspace. On a local environment (the common case) these agree. On SSH/WSL environments the inserted mention would be a local path the backend can't read (before this PR such drops errored loudly). Options: gate mention insertion on the environment being local, or accept the dangling reference. Happy to implement whichever you prefer.
- Dropping a **folder** now inserts a folder mention instead of erroring (folders have empty MIME type, so they take the mention path).
- Draft: opened for testing/review before it's ready to merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Insert file-mention tokens when non-image files are dropped on the composer
> - Adds a `getPathForFile(file)` method to `window.desktopBridge` (via [preload.ts](https://github.com/pingdotgg/t3code/pull/5390/files#diff-eae0078d2bf4ac4beed2884f918b2816a97752917390f09980ba2cfad8c42cac) and the `DesktopBridge` interface) that synchronously returns the absolute backing path for a DOM `File`.
> - Introduces [composerFileDrop.ts](https://github.com/pingdotgg/t3code/pull/5390/files#diff-2cab160942e8a7d0823e6492111ae960dbe4f6207f615c31b589e27dd7a11cd6) with helpers to partition dropped files into images vs. non-images, normalize paths relative to cwd, and serialize them as composer file-mention tokens.
> - Updates the `onComposerDrop` handler in `ChatComposer` to resolve paths via `desktopBridge`, insert mention tokens for resolved non-image files, and fall back to image attachment for unresolved files. An error toast is shown if the composer is busy when mentions need to be inserted.
> - Behavioral Change: focus is deferred when mentions are inserted to avoid overwriting the insertion snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 254a259.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Composer drop behavior changes on desktop (mentions vs image errors), and resolved paths are host-local which may not match SSH/WSL workspace paths.
> 
> **Overview**
> **OS file drops on the chat composer** no longer send every file through the image-attachment path. Dropped files are split into images (still attached inline) and everything else, which on desktop can become **file mention tokens** in the prompt.
> 
> A new optional **`DesktopBridge.getPathForFile`** (contracts + Electron preload via `webUtils.getPathForFile`) resolves the on-disk path for each non-image `File`. **`composerFileDrop`** helpers relativize in-workspace paths to match typed/file-tree mentions, serialize links with `serializeComposerFileLink`, and are covered by unit tests. **`ChatComposer.onComposerDrop`** inserts those mentions (with error toast if the composer is busy), avoids eager focus after a successful mention insert, and routes path-unresolved files back through **`addComposerImages`** so browser builds and in-memory files keep the prior “unsupported file type” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254a259580c82ec365f7faa48e0717de7f113b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->