### PR TITLE
perf(mobile): speed up large Android threads

### DIFF
--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -415,7 +415,13 @@ export const RootStack = createNativeStackNavigator({
     Thread: createNativeStackScreen({
       screen: ThreadRouteScreen,
       linking: THREAD_LINKING_PREFIX,
-      options: GLASS_HEADER_OPTIONS,
+      options: {
+        ...GLASS_HEADER_OPTIONS,
+        // Android owns an in-flow thread header. Hide the native header before
+        // the route's loading state mounts so hydration cannot move the whole
+        // screen by one toolbar height when runtime options arrive.
+        ...(Platform.OS === "android" ? { headerShown: false } : null),
+      },
     }),
     ThreadTerminal: createNativeStackScreen({
       screen: ThreadTerminalRouteScreen,

--- a/apps/mobile/src/components/AndroidScreenHeader.tsx
+++ b/apps/mobile/src/components/AndroidScreenHeader.tsx
@@ -48,6 +48,7 @@ export function AndroidHeaderIconButton(props: {
 export function AndroidScreenHeader(props: {
   readonly title: string;
   readonly subtitle?: string | null;
+  readonly reserveSubtitleSpace?: boolean;
   readonly actions?: ReadonlyArray<AndroidHeaderAction>;
   readonly trailing?: ReactNode;
   readonly onBack?: () => void;
@@ -85,12 +86,15 @@ export function AndroidScreenHeader(props: {
           <Text numberOfLines={1} className="text-lg font-t3-bold text-foreground">
             {props.title}
           </Text>
-          {props.subtitle ? (
+          {props.subtitle || props.reserveSubtitleSpace ? (
             <Text
               numberOfLines={1}
-              className="mt-px text-[13px] font-t3-medium text-foreground-muted"
+              className={cn(
+                "mt-px text-[13px] font-t3-medium text-foreground-muted",
+                !props.subtitle && "opacity-0",
+              )}
             >
-              {props.subtitle}
+              {props.subtitle || " "}
             </Text>
           ) : null}
         </View>

--- a/apps/mobile/src/components/CopyTextButton.tsx
+++ b/apps/mobile/src/components/CopyTextButton.tsx
@@ -16,7 +16,8 @@ export const CopyTextButton = memo(function CopyTextButton(props: {
   readonly iconSize?: number;
   readonly buttonSize?: number;
 }) {
-  const [copied, setCopied] = useState(false);
+  const [copiedText, setCopiedText] = useState<string | null>(null);
+  const copied = copiedText === props.text;
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(
@@ -36,12 +37,12 @@ export const CopyTextButton = memo(function CopyTextButton(props: {
       hitSlop={8}
       onPress={() => {
         copyTextWithHaptic(props.text);
-        setCopied(true);
+        setCopiedText(props.text);
         if (resetTimeoutRef.current) {
           clearTimeout(resetTimeoutRef.current);
         }
         resetTimeoutRef.current = setTimeout(() => {
-          setCopied(false);
+          setCopiedText(null);
           resetTimeoutRef.current = null;
         }, COPY_FEEDBACK_DURATION_MS);
       }}

--- a/apps/mobile/src/features/review/reviewHighlighterEngine.test.ts
+++ b/apps/mobile/src/features/review/reviewHighlighterEngine.test.ts
@@ -6,9 +6,9 @@ import {
 } from "./reviewHighlighterEngine";
 
 describe("resolveReviewHighlighterEnginePreference", () => {
-  it("defaults invalid values to native", () => {
-    expect(resolveReviewHighlighterEnginePreference(undefined)).toBe("native");
-    expect(resolveReviewHighlighterEnginePreference("bogus")).toBe("native");
+  it("defaults invalid values to javascript", () => {
+    expect(resolveReviewHighlighterEnginePreference(undefined)).toBe("javascript");
+    expect(resolveReviewHighlighterEnginePreference("bogus")).toBe("javascript");
   });
 
   it("accepts supported values", () => {

--- a/apps/mobile/src/features/review/reviewHighlighterEngine.ts
+++ b/apps/mobile/src/features/review/reviewHighlighterEngine.ts
@@ -11,7 +11,7 @@ export function resolveReviewHighlighterEnginePreference(
     case "native":
       return "native";
     default:
-      return "native";
+      return "javascript";
   }
 }
 

--- a/apps/mobile/src/features/review/shikiReviewHighlighter.ts
+++ b/apps/mobile/src/features/review/shikiReviewHighlighter.ts
@@ -59,8 +59,7 @@ const SHIKI_THEME_NAME_BY_SCHEME = {
   dark: "github-dark-default",
 } as const;
 const REVIEW_HIGHLIGHTER_ENGINE_ENV_VALUE =
-  process.env.EXPO_PUBLIC_REVIEW_HIGHLIGHTER_ENGINE ??
-  (process.env.NODE_ENV === "test" ? "javascript" : "native");
+  process.env.EXPO_PUBLIC_REVIEW_HIGHLIGHTER_ENGINE ?? "javascript";
 const REVIEW_HIGHLIGHTER_ENGINE_PREFERENCE = resolveReviewHighlighterEnginePreference(
   REVIEW_HIGHLIGHTER_ENGINE_ENV_VALUE,
 );

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -65,8 +65,12 @@ export interface ThreadDetailScreenProps {
   readonly connectionStateLabel: EnvironmentConnectionPhase;
   /** Message sync status for the selected thread (drives the composer status pill). */
   readonly threadSyncStatus?: EnvironmentThreadStatus;
-  /** Non-null when older turns exist beyond the loaded window. */
-  readonly loadEarlier?: { readonly loading: boolean; readonly onLoadEarlier: () => void } | null;
+  /** Non-null for a windowed thread, including once its oldest page is loaded. */
+  readonly loadEarlier?: {
+    readonly hasMore: boolean;
+    readonly loading: boolean;
+    readonly onLoadEarlier: () => void;
+  } | null;
   readonly activeThreadBusy: boolean;
   readonly environmentId: EnvironmentId;
   readonly projectWorkspaceRoot: string | null;

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -120,6 +120,11 @@ const TURN_FOLD_HEIGHT = 56; // min-h-11 (44) + mb-3 (12)
 // The working row has no min-height clamp — its height follows the scaled
 // text-xs line height (see workingRowHeight in ThreadFeed).
 const WORKING_ROW_VERTICAL_EXTRAS = 24; // py-1 (8) + mb-4 (16)
+const THREAD_HISTORY_CONTROL_HEIGHT = 36;
+const THREAD_FEED_CONTENT_TOP_PADDING = 12;
+const ANDROID_THREAD_DRAW_DISTANCE = 250;
+const DEFAULT_THREAD_DRAW_DISTANCE = 500;
+const ANDROID_THREAD_ALWAYS_RENDER = { top: 1, bottom: 1 } as const;
 
 // Entering animations must only play for rows born just now — LegendList
 // remounts rows when they scroll back into view, and replaying an entrance for
@@ -150,8 +155,9 @@ export interface ThreadFeedProps {
   readonly usesAutomaticContentInsets?: boolean;
   readonly onHeaderMaterialVisibilityChange?: (visible: boolean) => void;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
-  /** Non-null when older turns exist beyond the loaded window. */
+  /** Non-null for a windowed thread, including once its oldest page is loaded. */
   readonly loadEarlier?: {
+    readonly hasMore: boolean;
     readonly loading: boolean;
     readonly onLoadEarlier: () => void;
   } | null;
@@ -1565,6 +1571,28 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     }
   }, [listMountKey, props.contentInsetEndAdjustment, props.listRef]);
 
+  const handleThreadListLoad = useCallback(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+
+    const list = props.listRef.current;
+    const state = list?.getState();
+    if (!list || !state || state.data.length === 0 || state.scroll <= 1) {
+      return;
+    }
+
+    // Under memory pressure, LegendList can finish its initial end-scroll
+    // without Android attaching the visible recycled rows. A one-pixel scroll
+    // wakes the native path; immediately restoring the intended end position
+    // keeps this invisible and isolated from later prepends/user scrolling.
+    void list.scrollToOffset({ offset: state.scroll - 1, animated: false }).then(() => {
+      if (props.listRef.current === list) {
+        void list.scrollToEnd({ animated: false });
+      }
+    });
+  }, [props.listRef]);
+
   const anchoredEndSpace = useMemo(
     () =>
       resolveChatListAnchoredEndSpace(
@@ -1886,6 +1914,12 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             }
             maintainVisibleContentPosition={maintainVisibleContentPosition}
             data={presentedFeed}
+            dataKey={props.threadId}
+            // LegendList can settle Android at either edge before its recycled
+            // containers are attached. Keeping one row at each edge mounted
+            // gives native scrolling a real target, so opening a history or
+            // flinging to its start cannot stay blank until another gesture.
+            alwaysRender={Platform.OS === "android" ? ANDROID_THREAD_ALWAYS_RENDER : undefined}
             recycleItems={Platform.OS === "android"}
             extraData={listAppearanceData}
             renderItem={renderItem}
@@ -1896,7 +1930,11 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             getFixedItemSize={getFixedItemSize}
             // Measure rows well before they scroll into view so estimate→actual
             // corrections land offscreen instead of under the user's finger.
-            drawDistance={500}
+            drawDistance={
+              Platform.OS === "android"
+                ? ANDROID_THREAD_DRAW_DISTANCE
+                : DEFAULT_THREAD_DRAW_DISTANCE
+            }
             keyboardShouldPersistTaps="always"
             keyboardDismissMode="none"
             keyboardLiftBehavior="whenAtEnd"
@@ -1916,12 +1954,17 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             // user overscroll back to the adjusted rest position.
             scrollToOverflowEnabled
             estimatedItemSize={180}
+            estimatedHeaderSize={
+              (usesNativeAutomaticInsets ? 0 : topContentInset) +
+              (props.loadEarlier == null ? 0 : THREAD_HISTORY_CONTROL_HEIGHT)
+            }
             // Chat-style bottom alignment: when a thread is shorter than the
             // viewport, pad above the content so messages rest just above the
             // composer instead of under the header. No effect on threads that
             // overflow the viewport (the padding clamps to zero).
             alignItemsAtEnd
             initialScrollAtEnd
+            onLoad={handleThreadListLoad}
             onScroll={handleScroll}
             onScrollBeginDrag={handleScrollBeginDrag}
             onScrollEndDrag={handleScrollEndDrag}
@@ -1933,18 +1976,28 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
                 {props.loadEarlier != null ? (
                   <Pressable
                     onPress={props.loadEarlier.onLoadEarlier}
-                    disabled={props.loadEarlier.loading}
-                    className="items-center py-2"
+                    disabled={props.loadEarlier.loading || !props.loadEarlier.hasMore}
+                    accessibilityRole="button"
+                    accessibilityState={{
+                      busy: props.loadEarlier.loading,
+                      disabled: props.loadEarlier.loading || !props.loadEarlier.hasMore,
+                    }}
+                    className="items-center justify-center"
+                    style={{ height: THREAD_HISTORY_CONTROL_HEIGHT }}
                   >
                     <Text className="text-xs text-foreground-secondary">
-                      {props.loadEarlier.loading ? "Loading earlier turns…" : "Load earlier turns"}
+                      {props.loadEarlier.loading
+                        ? "Loading earlier turns…"
+                        : props.loadEarlier.hasMore
+                          ? "Load earlier turns"
+                          : "Beginning of thread"}
                     </Text>
                   </Pressable>
                 ) : null}
               </>
             }
             contentContainerStyle={{
-              paddingTop: 12,
+              paddingTop: THREAD_FEED_CONTENT_TOP_PADDING,
               paddingHorizontal: contentHorizontalPadding,
             }}
           />

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -266,7 +266,10 @@ const MarkdownExternalLink = memo(function MarkdownExternalLink(props: {
   readonly host: string;
   readonly href: string;
 }) {
-  const [failed, setFailed] = useState(() => failedMarkdownFaviconHosts.has(props.host));
+  const [failedHost, setFailedHost] = useState<string | null>(() =>
+    failedMarkdownFaviconHosts.has(props.host) ? props.host : null,
+  );
+  const failed = failedHost === props.host || failedMarkdownFaviconHosts.has(props.host);
 
   return (
     <NativeText
@@ -287,7 +290,7 @@ const MarkdownExternalLink = memo(function MarkdownExternalLink(props: {
           style={[markdownLinkStyles.inlineIcon, markdownLinkStyles.favicon]}
           onError={() => {
             failedMarkdownFaviconHosts.add(props.host);
-            setFailed(true);
+            setFailedHost(props.host);
           }}
         />
       ) : (
@@ -1883,6 +1886,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             }
             maintainVisibleContentPosition={maintainVisibleContentPosition}
             data={presentedFeed}
+            recycleItems={Platform.OS === "android"}
             extraData={listAppearanceData}
             renderItem={renderItem}
             keyExtractor={(entry) => entry.id}

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -1582,12 +1582,20 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       return;
     }
 
+    const dataLength = state.data.length;
+    const wakeOffset = state.scroll - 1;
     // Under memory pressure, LegendList can finish its initial end-scroll
     // without Android attaching the visible recycled rows. A one-pixel scroll
     // wakes the native path; immediately restoring the intended end position
     // keeps this invisible and isolated from later prepends/user scrolling.
-    void list.scrollToOffset({ offset: state.scroll - 1, animated: false }).then(() => {
-      if (props.listRef.current === list) {
+    void list.scrollToOffset({ offset: wakeOffset, animated: false }).then(() => {
+      const settledState = list.getState();
+      const canRestoreEnd =
+        props.listRef.current === list &&
+        !userScrollSessionRef.current &&
+        settledState.data.length === dataLength &&
+        Math.abs(settledState.scroll - wakeOffset) <= 1;
+      if (canRestoreEnd) {
         void list.scrollToEnd({ animated: false });
       }
     });

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -130,17 +130,46 @@ interface ThreadRouteScreenProps extends ThreadRouteScreenRouteProps {
 
 function ThreadRouteStateScreen(props: {
   readonly children: ReactNode;
+  readonly fileInspectorSupported: boolean;
   readonly onNavigateUp: () => void;
+  readonly onReturnToThread?: () => void;
   readonly title: string;
+  readonly usesSplitView: boolean;
 }) {
+  const actions = useMemo<ReadonlyArray<AndroidHeaderAction>>(
+    () => [
+      ...(props.usesSplitView && props.onReturnToThread
+        ? [
+            {
+              accessibilityLabel: "Return to chat",
+              icon: "chevron.left" as const,
+              onPress: props.onReturnToThread,
+            },
+          ]
+        : []),
+      ...ANDROID_THREAD_LOADING_ACTIONS,
+      ...(props.fileInspectorSupported
+        ? [
+            {
+              accessibilityLabel: "Toggle inspector",
+              icon: "sidebar.right" as const,
+              disabled: true,
+              onPress: () => undefined,
+            },
+          ]
+        : []),
+    ],
+    [props.fileInspectorSupported, props.onReturnToThread, props.usesSplitView],
+  );
+
   return (
     <>
       {Platform.OS === "android" ? (
         <AndroidScreenHeader
           title={props.title}
           reserveSubtitleSpace
-          onBack={props.onNavigateUp}
-          actions={ANDROID_THREAD_LOADING_ACTIONS}
+          onBack={props.usesSplitView ? undefined : props.onNavigateUp}
+          actions={actions}
         />
       ) : null}
       {props.children}
@@ -148,9 +177,14 @@ function ThreadRouteStateScreen(props: {
   );
 }
 
-function ThreadUnavailableScreen(props: { readonly onNavigateUp: () => void }) {
+function ThreadUnavailableScreen(props: {
+  readonly fileInspectorSupported: boolean;
+  readonly onNavigateUp: () => void;
+  readonly onReturnToThread?: () => void;
+  readonly usesSplitView: boolean;
+}) {
   return (
-    <ThreadRouteStateScreen title="Thread unavailable" onNavigateUp={props.onNavigateUp}>
+    <ThreadRouteStateScreen title="Thread unavailable" {...props}>
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{
@@ -170,9 +204,14 @@ function ThreadUnavailableScreen(props: { readonly onNavigateUp: () => void }) {
   );
 }
 
-function OpeningThreadRouteScreen(props: { readonly onNavigateUp: () => void }) {
+function OpeningThreadRouteScreen(props: {
+  readonly fileInspectorSupported: boolean;
+  readonly onNavigateUp: () => void;
+  readonly onReturnToThread?: () => void;
+  readonly usesSplitView: boolean;
+}) {
   return (
-    <ThreadRouteStateScreen title="Opening thread…" onNavigateUp={props.onNavigateUp}>
+    <ThreadRouteStateScreen title="Opening thread…" {...props}>
       <OpeningThreadLoadingScreen />
     </ThreadRouteStateScreen>
   );
@@ -180,6 +219,7 @@ function OpeningThreadRouteScreen(props: { readonly onNavigateUp: () => void }) 
 
 export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
   const navigation = useNavigation();
+  const { fileInspector, layout } = useAdaptiveWorkspaceLayout();
   const handleNavigateUp = useCallback(() => {
     if (navigation.canGoBack()) {
       navigation.goBack();
@@ -207,9 +247,15 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
       ? null
       : scopedThreadKey(selectedThread.environmentId, selectedThread.id);
   const selectedThreadDetailState = useSelectedThreadDetailState();
+  const routeStateScreenProps = {
+    fileInspectorSupported: fileInspector.supported,
+    onNavigateUp: handleRouteNavigateUp,
+    onReturnToThread: props.onReturnToThread,
+    usesSplitView: layout.usesSplitView,
+  };
 
   if (environmentId === null || threadIdRaw === null) {
-    return <OpeningThreadRouteScreen onNavigateUp={handleRouteNavigateUp} />;
+    return <OpeningThreadRouteScreen {...routeStateScreenProps} />;
   }
 
   // Render the full thread chrome (header, feed, composer) as soon as the
@@ -226,10 +272,10 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
     routeConnectionState === "reconnecting";
 
   if (stillHydrating) {
-    return <OpeningThreadRouteScreen onNavigateUp={handleRouteNavigateUp} />;
+    return <OpeningThreadRouteScreen {...routeStateScreenProps} />;
   }
 
-  return <ThreadUnavailableScreen onNavigateUp={handleRouteNavigateUp} />;
+  return <ThreadUnavailableScreen {...routeStateScreenProps} />;
 }
 
 function ThreadRouteContent(

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -689,30 +689,29 @@ function ThreadRouteContent(
         onPress: props.onReturnToThread,
       });
     }
-    if (selectedThreadCwd !== null) {
-      actions.push({
-        accessibilityLabel: "Open files",
-        icon: "folder",
-        onPress: handleOpenFilesInspector,
-      });
-    }
-    if (selectedThreadProject?.workspaceRoot) {
-      actions.push({
-        accessibilityLabel: "Open terminal",
-        icon: "terminal",
-        onPress: () => handleOpenTerminal(null),
-      });
-    }
+    actions.push({
+      accessibilityLabel: "Open files",
+      icon: "folder",
+      onPress: handleOpenFilesInspector,
+      disabled: selectedThreadCwd === null,
+    });
+    actions.push({
+      accessibilityLabel: "Open terminal",
+      icon: "terminal",
+      onPress: () => handleOpenTerminal(null),
+      disabled: !selectedThreadProject?.workspaceRoot,
+    });
     actions.push({
       accessibilityLabel: "Open git controls",
       icon: "point.topleft.down.curvedto.point.bottomright.up",
       onPress: handleOpenGitInspector,
     });
-    if (fileInspector.supported && selectedThreadCwd !== null) {
+    if (fileInspector.supported) {
       actions.push({
         accessibilityLabel: "Toggle inspector",
         icon: "sidebar.right",
         onPress: handleToggleInspector,
+        disabled: selectedThreadCwd === null,
       });
     }
     return actions;
@@ -856,6 +855,7 @@ function ThreadRouteContent(
         <AndroidScreenHeader
           title={selectedThread.title}
           subtitle={headerSubtitle}
+          reserveSubtitleSpace
           onBack={layout.usesSplitView ? undefined : () => navigation.goBack()}
           actions={androidHeaderActions}
         />

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -100,6 +100,27 @@ function OpeningThreadLoadingScreen() {
   return <LoadingScreen message="Opening thread…" messagePlacement="above-spinner" />;
 }
 
+const ANDROID_THREAD_LOADING_ACTIONS: ReadonlyArray<AndroidHeaderAction> = [
+  {
+    accessibilityLabel: "Open files",
+    icon: "folder",
+    disabled: true,
+    onPress: () => undefined,
+  },
+  {
+    accessibilityLabel: "Open terminal",
+    icon: "terminal",
+    disabled: true,
+    onPress: () => undefined,
+  },
+  {
+    accessibilityLabel: "Open git controls",
+    icon: "point.topleft.down.curvedto.point.bottomright.up",
+    disabled: true,
+    onPress: () => undefined,
+  },
+];
+
 type ThreadRouteScreenRouteProps = StaticScreenProps<{
   readonly environmentId: string;
   readonly threadId: string;
@@ -110,27 +131,65 @@ interface ThreadRouteScreenProps extends ThreadRouteScreenRouteProps {
   readonly renderInspector?: (headerInset: number) => ReactNode;
 }
 
-function ThreadUnavailableScreen() {
+function ThreadRouteStateScreen(props: {
+  readonly children: ReactNode;
+  readonly onNavigateUp: () => void;
+  readonly title: string;
+}) {
   return (
-    <ScrollView
-      contentInsetAdjustmentBehavior="automatic"
-      contentContainerStyle={{
-        flexGrow: 1,
-        justifyContent: "center",
-        paddingHorizontal: 24,
-        paddingVertical: 32,
-      }}
-      className="bg-screen flex-1"
-    >
-      <EmptyState
-        title="Thread unavailable"
-        detail="This thread is not available in the current mobile snapshot."
-      />
-    </ScrollView>
+    <>
+      {Platform.OS === "android" ? (
+        <AndroidScreenHeader
+          title={props.title}
+          reserveSubtitleSpace
+          onBack={props.onNavigateUp}
+          actions={ANDROID_THREAD_LOADING_ACTIONS}
+        />
+      ) : null}
+      {props.children}
+    </>
+  );
+}
+
+function ThreadUnavailableScreen(props: { readonly onNavigateUp: () => void }) {
+  return (
+    <ThreadRouteStateScreen title="Thread unavailable" onNavigateUp={props.onNavigateUp}>
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={{
+          flexGrow: 1,
+          justifyContent: "center",
+          paddingHorizontal: 24,
+          paddingVertical: 32,
+        }}
+        className="bg-screen flex-1"
+      >
+        <EmptyState
+          title="Thread unavailable"
+          detail="This thread is not available in the current mobile snapshot."
+        />
+      </ScrollView>
+    </ThreadRouteStateScreen>
+  );
+}
+
+function OpeningThreadRouteScreen(props: { readonly onNavigateUp: () => void }) {
+  return (
+    <ThreadRouteStateScreen title="Opening thread…" onNavigateUp={props.onNavigateUp}>
+      <OpeningThreadLoadingScreen />
+    </ThreadRouteStateScreen>
   );
 }
 
 export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
+  const navigation = useNavigation();
+  const handleNavigateUp = useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+    navigation.dispatch(StackActions.replace("Home"));
+  }, [navigation]);
   const { state: workspaceState } = useWorkspaceState();
   const { connectionState } = useRemoteConnectionStatus();
   const { selectedThread } = useThreadSelection();
@@ -152,7 +211,7 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
   const selectedThreadDetailState = useSelectedThreadDetailState();
 
   if (environmentId === null || threadIdRaw === null) {
-    return <OpeningThreadLoadingScreen />;
+    return <OpeningThreadRouteScreen onNavigateUp={handleNavigateUp} />;
   }
 
   // Render the full thread chrome (header, feed, composer) as soon as the
@@ -169,10 +228,10 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
     routeConnectionState === "reconnecting";
 
   if (stillHydrating) {
-    return <OpeningThreadLoadingScreen />;
+    return <OpeningThreadRouteScreen onNavigateUp={handleNavigateUp} />;
   }
 
-  return <ThreadUnavailableScreen />;
+  return <ThreadUnavailableScreen onNavigateUp={handleNavigateUp} />;
 }
 
 function ThreadRouteContent(
@@ -730,6 +789,13 @@ function ThreadRouteContent(
   // native back button does not render. Provide an explicit Home escape for
   // that case; when history exists the native back button is used instead.
   const canGoBack = navigation.canGoBack();
+  const handleNavigateUp = useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+    navigation.dispatch(StackActions.replace("Home"));
+  }, [navigation]);
   const compactHomeHeaderItems = useMemo<NativeHeaderItems>(
     () => [
       withNativeGlassHeaderItem({
@@ -856,7 +922,7 @@ function ThreadRouteContent(
           title={selectedThread.title}
           subtitle={headerSubtitle}
           reserveSubtitleSpace
-          onBack={layout.usesSplitView ? undefined : () => navigation.goBack()}
+          onBack={layout.usesSplitView ? undefined : handleNavigateUp}
           actions={androidHeaderActions}
         />
       ) : null}

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -187,6 +187,7 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
     }
     navigation.dispatch(StackActions.replace("Home"));
   }, [navigation]);
+  const handleRouteNavigateUp = props.onReturnToThread ?? handleNavigateUp;
   const { state: workspaceState } = useWorkspaceState();
   const { connectionState } = useRemoteConnectionStatus();
   const { selectedThread } = useThreadSelection();
@@ -208,7 +209,7 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
   const selectedThreadDetailState = useSelectedThreadDetailState();
 
   if (environmentId === null || threadIdRaw === null) {
-    return <OpeningThreadRouteScreen onNavigateUp={handleNavigateUp} />;
+    return <OpeningThreadRouteScreen onNavigateUp={handleRouteNavigateUp} />;
   }
 
   // Render the full thread chrome (header, feed, composer) as soon as the
@@ -225,10 +226,10 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
     routeConnectionState === "reconnecting";
 
   if (stillHydrating) {
-    return <OpeningThreadRouteScreen onNavigateUp={handleNavigateUp} />;
+    return <OpeningThreadRouteScreen onNavigateUp={handleRouteNavigateUp} />;
   }
 
-  return <ThreadUnavailableScreen onNavigateUp={handleNavigateUp} />;
+  return <ThreadUnavailableScreen onNavigateUp={handleRouteNavigateUp} />;
 }
 
 function ThreadRouteContent(

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -8,10 +8,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import * as Option from "effect/Option";
 import { EnvironmentId, ThreadId, type ProjectScript } from "@t3tools/contracts";
-import {
-  requestOlderThreadTurns,
-  threadHasOlderTurns,
-} from "@t3tools/client-runtime/state/threads";
+import { requestOlderThreadTurns } from "@t3tools/client-runtime/state/threads";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { Platform, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -253,20 +250,35 @@ function ThreadRouteContent(
     useThreadSelection();
   const selectedThreadDetailState = props.selectedThreadDetailState;
   const selectedThreadDetail = Option.getOrNull(selectedThreadDetailState.data);
-  // "Load earlier turns" header state for windowed (paginated) thread loads.
+  const selectedThreadPage = Option.getOrNull(selectedThreadDetailState.page);
+  const isWindowedThread = selectedThreadPage !== null;
+  const selectedThreadEnvironmentId = selectedThread?.environmentId ?? null;
+  const selectedThreadId = selectedThread?.id ?? null;
+  const canLoadEarlierTurns =
+    selectedThreadPage?.hasMore === true && selectedThreadPage.beforeCursor !== null;
+  const loadingEarlierTurns = selectedThreadPage?.loadingOlder === true;
+  // Keep the history control mounted after the final page. Removing it in the
+  // same commit as a prepend changes the list header height while Android's
+  // native MVCP is restoring the old first row, which can leave every recycled
+  // container outside the viewport until the next gesture.
   const loadEarlierTurns = useMemo(() => {
-    if (selectedThread === null || !threadHasOlderTurns(selectedThreadDetailState)) {
+    if (!isWindowedThread || selectedThreadEnvironmentId === null || selectedThreadId === null) {
       return null;
     }
     return {
-      loading:
-        selectedThreadDetailState.page._tag === "Some" &&
-        selectedThreadDetailState.page.value.loadingOlder,
+      hasMore: canLoadEarlierTurns,
+      loading: loadingEarlierTurns,
       onLoadEarlier: () => {
-        requestOlderThreadTurns(selectedThread.environmentId, selectedThread.id);
+        requestOlderThreadTurns(selectedThreadEnvironmentId, selectedThreadId);
       },
     };
-  }, [selectedThread, selectedThreadDetailState]);
+  }, [
+    canLoadEarlierTurns,
+    isWindowedThread,
+    loadingEarlierTurns,
+    selectedThreadEnvironmentId,
+    selectedThreadId,
+  ]);
   const { selectedThreadCwd } = useSelectedThreadWorktree();
   const composer = useThreadComposerState();
   const gitState = useSelectedThreadGitState();

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   buildThreadFeed,
+  derivePendingApprovals,
   deriveThreadFeedPresentation,
   type ThreadFeedActivity,
   type ThreadFeedEntry,
@@ -530,6 +531,86 @@ describe("buildThreadFeed", () => {
       type: "work-toggle",
       expanded: true,
     });
+  });
+
+  it("orders feed entries chronologically without relying on timestamp string order", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-ordering"),
+      projectId: ProjectId.make("project-1"),
+      title: "Ordering",
+      messages: [
+        {
+          id: MessageId.make("message-late"),
+          role: "assistant",
+          text: "Last",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:00.000Z",
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        },
+        {
+          id: MessageId.make("message-early"),
+          role: "user",
+          text: "First",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-04-01T01:00:00.000+02:00",
+          updatedAt: "2026-04-01T01:00:00.000+02:00",
+        },
+      ],
+      activities: [
+        makeActivity({
+          id: EventId.make("warning-between"),
+          kind: "runtime.warning",
+          summary: "Runtime warning",
+          createdAt: "2026-03-31T23:30:00.000Z",
+          payload: { message: "Between the messages" },
+        }),
+      ],
+    });
+
+    expect(buildThreadFeed(thread).map((entry) => entry.id)).toEqual([
+      "message-early",
+      "warning-between",
+      "message-late",
+    ]);
+  });
+});
+
+describe("derivePendingApprovals", () => {
+  it("returns open approvals oldest-first regardless of event order", () => {
+    const approvals = derivePendingApprovals([
+      makeActivity({
+        id: EventId.make("approval-late"),
+        kind: "approval.requested",
+        summary: "Approve command",
+        createdAt: "2026-04-01T00:00:09.000Z",
+        payload: { requestId: "request-late", requestKind: "command" },
+      }),
+      makeActivity({
+        id: EventId.make("approval-early"),
+        kind: "approval.requested",
+        summary: "Approve file change",
+        createdAt: "2026-04-01T00:00:03.000Z",
+        payload: { requestId: "request-early", requestKind: "file-change" },
+      }),
+      makeActivity({
+        id: EventId.make("approval-resolved"),
+        kind: "approval.requested",
+        summary: "Approve command",
+        createdAt: "2026-04-01T00:00:01.000Z",
+        payload: { requestId: "request-resolved", requestKind: "command" },
+      }),
+      makeActivity({
+        id: EventId.make("approval-resolution"),
+        kind: "approval.resolved",
+        summary: "Approved",
+        createdAt: "2026-04-01T00:00:02.000Z",
+        payload: { requestId: "request-resolved" },
+      }),
+    ]);
+
+    expect(approvals.map(({ requestId }) => requestId)).toEqual(["request-early", "request-late"]);
   });
 });
 

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1040,6 +1040,16 @@ const activityOrder = Order.combineAll<OrchestrationThreadActivity>([
   Order.mapInput(Order.String, (activity) => activity.id),
 ]);
 
+function sortByCreatedAt<T extends { readonly createdAt: string }>(items: Iterable<T>): T[] {
+  const decorated = Array.from(items, (item) => ({ item, timestamp: Date.parse(item.createdAt) }));
+  decorated.sort((left, right) => {
+    if (left.timestamp < right.timestamp) return -1;
+    if (left.timestamp > right.timestamp) return 1;
+    return 0;
+  });
+  return decorated.map(({ item }) => item);
+}
+
 function isEmptyMessage(entry: RawThreadFeedEntry): boolean {
   if (entry.type !== "message") {
     return false;
@@ -1378,7 +1388,7 @@ export function derivePendingApprovals(
     }
   }
 
-  return Arr.sortWith([...openByRequestId.values()], (s) => new Date(s.createdAt), Order.Date);
+  return sortByCreatedAt(openByRequestId.values());
 }
 
 export function derivePendingUserInputs(
@@ -1421,7 +1431,7 @@ export function derivePendingUserInputs(
     }
   }
 
-  return Arr.sortWith(openByRequestId.values(), (s) => new Date(s.createdAt), Order.Date);
+  return sortByCreatedAt(openByRequestId.values());
 }
 
 export function setPendingUserInputCustomAnswer(
@@ -1463,58 +1473,54 @@ export function buildThreadFeed(
   const oldestLoadedMessageCreatedAt =
     options?.loadedMessages !== undefined ? (loadedMessages[0]?.createdAt ?? null) : null;
   const workLogEntries = deriveWorkLogEntries(thread.activities);
-  const entries = Arr.sortWith(
-    [
-      ...loadedMessages.map<RawThreadFeedEntry>((message) => ({
-        type: "message",
-        id: message.id,
-        createdAt: message.createdAt,
-        message,
-      })),
-      ...workLogEntries
-        .filter((entry) => {
-          if (options?.loadedMessages === undefined) {
-            return true;
-          }
-          return (
-            oldestLoadedMessageCreatedAt === null || entry.createdAt >= oldestLoadedMessageCreatedAt
-          );
-        })
-        .map<RawThreadFeedEntry>((entry) => {
-          const summary = workEntryHeading(entry);
-          const detail = workEntryPreview(entry);
-          const getFullDetail = memoizeValue(() => buildWorkEntryExpandedBody(entry));
-          const getCopyText = memoizeValue(() =>
-            [summary, detail, getFullDetail()]
-              .filter((value, index, values): value is string => {
-                return Boolean(value) && values.indexOf(value) === index;
-              })
-              .join("\n"),
-          );
-          return {
-            type: "activity",
+  const entries = sortByCreatedAt<RawThreadFeedEntry>([
+    ...loadedMessages.map<RawThreadFeedEntry>((message) => ({
+      type: "message",
+      id: message.id,
+      createdAt: message.createdAt,
+      message,
+    })),
+    ...workLogEntries
+      .filter((entry) => {
+        if (options?.loadedMessages === undefined) {
+          return true;
+        }
+        return (
+          oldestLoadedMessageCreatedAt === null || entry.createdAt >= oldestLoadedMessageCreatedAt
+        );
+      })
+      .map<RawThreadFeedEntry>((entry) => {
+        const summary = workEntryHeading(entry);
+        const detail = workEntryPreview(entry);
+        const getFullDetail = memoizeValue(() => buildWorkEntryExpandedBody(entry));
+        const getCopyText = memoizeValue(() =>
+          [summary, detail, getFullDetail()]
+            .filter((value, index, values): value is string => {
+              return Boolean(value) && values.indexOf(value) === index;
+            })
+            .join("\n"),
+        );
+        return {
+          type: "activity",
+          id: entry.id,
+          createdAt: entry.createdAt,
+          turnId: entry.turnId,
+          activity: {
             id: entry.id,
             createdAt: entry.createdAt,
             turnId: entry.turnId,
-            activity: {
-              id: entry.id,
-              createdAt: entry.createdAt,
-              turnId: entry.turnId,
-              summary,
-              detail,
-              canExpand: workEntryHasExpandedBody(entry),
-              getFullDetail,
-              getCopyText,
-              icon: workEntryIcon(entry),
-              toolLike: workLogEntryIsToolLike(entry),
-              status: workEntryStatus(entry),
-            },
-          };
-        }),
-    ],
-    (s) => new Date(s.createdAt),
-    Order.Date,
-  );
+            summary,
+            detail,
+            canExpand: workEntryHasExpandedBody(entry),
+            getFullDetail,
+            getCopyText,
+            icon: workEntryIcon(entry),
+            toolLike: workLogEntryIsToolLike(entry),
+            status: workEntryStatus(entry),
+          },
+        };
+      }),
+  ]);
 
   return groupAdjacentActivities(entries);
 }


### PR DESCRIPTION
Large Android threads can finish syncing while LegendList has no attached visible rows, leaving a blank feed until the user scrolls. Paginated prepends also changed the list-header height on the final page, which moved the title/feed anchor while Android restored visible content.

This draft stays mobile-only:

- keep Android loading, unavailable, and hydrated thread headers on the same geometry;
- recycle Android feed rows, reduce the Android draw window, and keep one row mounted at each list edge;
- wake the Android native row-attachment path once after LegendList's initial end positioning;
- keep a fixed-height history control through loading, additional pages, and “Beginning of thread” so final-page prepends do not change header height;
- retain the existing feed-derivation and review-highlighter reductions already in this branch.

This does not replace server pagination from #5493. It also does not duplicate #5585: that PR seeds the composer inset before the initial scroll; this one handles positioned recycled rows that still fail to attach/paint. The final #5585 diff applies cleanly on top of this branch.

Verification on `eeb9a52b2`, rebased onto upstream `main` at `89c320df0`:

- signed-in preview development client on the API 36 Android emulator, using its existing T3 Connect account and three saved environments; no fixture or environment re-pairing;
- `fafo about t3code`: cold current-head feed became visible without a gesture after roughly 40–45s; 24 alternating full-height swipes left 19 visible text nodes and six copy targets, with no blank recycled viewport;
- dashboard thread: initial content became visible without a gesture after roughly 13s; its two older-page loads rendered in roughly 8–12s each; the final fixed control read “Beginning of thread”;
- title bounds stayed exactly `[129,136]–[696,197]` across initial loading, both prepends, the final-page transition, and every stress pass;
- the full-history dashboard stress pass rendered 201 frames with 45.27% modern jank, p50 32ms, p90 77ms, p95 93ms, p99 150ms, and 40 missed vsyncs;
- preview-dev-client PSS rose from about 1.98 GB before opening the dashboard thread to about 2.39 GB after full history and stress scrolling; these absolute dev-client values are diagnostic, not release acceptance numbers;
- 16 focused tests passed and mobile typecheck passed again after the rebase. Targeted lint, targeted formatting, and `git diff --check` passed on the implementation head before the rebase.

The native blank-until-gesture and title/header-shift failures are fixed in these runs, but the current emulator measurements are not merge-ready. Keep this draft until the final rebased head gets a physical-device release-profile A/B and the remaining thread-load latency and scroll-frame costs are profiled. An earlier same-device physical A/B on the broader mobile rendering scope improved p99 from about 150ms to 73ms and PSS growth from about 161 MB to 97 MB, but that is not a substitute for a final-head rerun.

Implemented with GPT-5.6 Sol in the T3 Code Codex harness.
