### PR TITLE
fix(ci): isolate releases from shared API rate limits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -747,15 +747,9 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.build.result == 'success' && needs.publish_cli.result == 'success' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
-      - id: app_token
-        name: Mint release app token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -823,7 +817,7 @@ jobs:
 
       - name: Publish release
         if: needs.preflight.outputs.previous_tag != ''
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.preflight.outputs.tag }}
           target_commitish: ${{ needs.preflight.outputs.ref }}
@@ -840,11 +834,11 @@ jobs:
             release-assets/*.blockmap
             release-assets/*.yml
           fail_on_unmatched_files: true
-          token: ${{ steps.app_token.outputs.token }}
+          token: ${{ github.token }}
 
       - name: Publish first release
         if: needs.preflight.outputs.previous_tag == ''
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.preflight.outputs.tag }}
           target_commitish: ${{ needs.preflight.outputs.ref }}
@@ -860,7 +854,7 @@ jobs:
             release-assets/*.blockmap
             release-assets/*.yml
           fail_on_unmatched_files: true
-          token: ${{ steps.app_token.outputs.token }}
+          token: ${{ github.token }}
 
   deploy_web:
     name: Deploy hosted web app

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -34,14 +34,15 @@ This document covers the unified release workflow for stable and nightly desktop
 
 ## Required release credentials
 
-The release workflow requires these GitHub Actions secrets in addition to the platform and deployment
+Stable releases require these GitHub Actions secrets in addition to the platform and deployment
 credentials documented below:
 
 - `RELEASE_APP_ID`
 - `RELEASE_APP_PRIVATE_KEY`
 
-The GitHub Release job uses them to mint the token that publishes release assets. Stable releases use
-them again in the finalize job, which can commit and push aligned package versions to `main`.
+The finalize job uses them to commit and push aligned package versions to `main` as the Release App.
+GitHub Release publication uses the repository-scoped workflow token so it has a rate-limit quota
+independent from the shared Release App installation.
 
 ## T3 Connect relay deployment
 


### PR DESCRIPTION
Recent nightly releases failed while generating GitHub release notes because publication shared the Release App installation API quota, which was exhausted repeatedly.

Publish releases with the job-scoped GITHUB_TOKEN and least-privilege contents access so release API calls use this repository quota. Keep the Release App for the stable finalize push, upgrade action-gh-release to its Node 24 release, and document the credential boundary.

## Testing

- vp fmt --check .github/workflows/release.yml docs/operations/release.md
- git diff --check

Generated by GPT-5.6-sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only credential and action version changes; release publishing still needs contents write on the workflow token, with no application runtime impact.
> 
> **Overview**
> **GitHub Release publication** no longer mints or uses the Release App token. The `release` job now grants **`contents: write`** and passes **`github.token`** into **`softprops/action-gh-release@v3`** (upgraded from v2) for both normal and first-release publish steps, so release-note generation and asset uploads draw on this repo’s workflow token quota instead of the shared installation limit that was exhausting on nightlies.
> 
> **Release App credentials** are documented and still used only in **`finalize`** for committing aligned package versions to `main`. Ops docs now state that **`RELEASE_APP_*`** secrets are required for stable finalize, not for publishing the GitHub Release itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2aef90ab0bc68311e2a18030ad67459eb72147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch release workflow to use default `github.token` instead of GitHub App token
> - Removes the `actions/create-github-app-token` minting step from [release.yml](.github/workflows/release.yml) and replaces all references with the default `github.token`.
> - Adds `contents: write` permission to the release job to authorize the default token for publishing releases.
> - Upgrades `softprops/action-gh-release` from v2 to v3 for both release publication steps.
> - Updates [release.md](docs/operations/release.md) to clarify that only the finalize job uses GitHub App credentials; release publication uses the repository-scoped workflow token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f2aef9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->