### PR TITLE
fix(web): keep model picker shortcuts in sync

### DIFF
--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -541,6 +541,10 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     }
     return mapping.size > 0 ? mapping : EMPTY_MODEL_JUMP_LABELS;
   }, [keybindings, modelJumpCommandByKey, modelJumpShortcutContext]);
+  const modelListExtraData = useMemo(
+    () => ({ favoritesSet, modelJumpLabelByKey }),
+    [favoritesSet, modelJumpLabelByKey],
+  );
 
   useEffect(() => {
     const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
@@ -710,7 +714,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                 <LegendList<string>
                   ref={modelListRef}
                   data={filteredItemKeys}
-                  extraData={favoritesSet}
+                  extraData={modelListExtraData}
                   keyExtractor={(modelKey) => modelKey}
                   renderItem={({ item: modelKey, index }) => {
                     if (legacySection?.key === modelKey) {


### PR DESCRIPTION
The model picker could keep a model’s positional shortcut from Favorites after switching to a provider-specific menu. The displayed hint then disagreed with the current menu and could duplicate another shortcut.

The virtualized list now redraws rows when either favorite state or the current menu’s shortcut labels change, keeping the visible hints aligned with keyboard selection.

Tests: web typecheck; targeted format and lint; 45 focused model-ordering and keybinding tests.

Made by GPT-5.6 Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to virtualized list invalidation in the model picker; no auth, data, or API impact.
> 
> **Overview**
> Fixes **stale positional shortcut hints** in the model picker when switching between Favorites and a provider-specific sidebar view.
> 
> The virtualized `LegendList` only passed `favoritesSet` as `extraData`, so recycled rows did not redraw when **menu-specific jump labels** (`modelJumpLabelByKey`) changed. **`extraData`** is now a memoized `{ favoritesSet, modelJumpLabelByKey }` object so list rows refresh when either favorites or the current menu’s shortcut mapping updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29be19519413512e690b22d0a597a416516e5f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model picker shortcuts staying in sync with `LegendList` renders
> The `LegendList` in [ModelPickerContent.tsx](https://github.com/pingdotgg/t3code/pull/5400/files#diff-af6ec8809b715e3718ef62e155f706b7bfc2b5331a509865043ed81e0f10f50c) previously only received `favoritesSet` as `extraData`, so shortcut labels (`modelJumpLabelByKey`) were not triggering re-renders when updated. Both values are now bundled into a memoized `modelListExtraData` object passed as `extraData`, keeping shortcut labels in sync with list item rendering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29be195.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->