### PR TITLE
fix: reconnect faster after remote server updates

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -583,8 +583,13 @@ export const makeServerLayer = Layer.unwrap(
             const server = yield* HttpServer.HttpServer;
             const address = server.address;
             if (typeof address === "string" || !("port" in address)) return;
-            yield* Effect.sleep("250 millis").pipe(
-              Effect.andThen(reconcileDesiredCloudLink(`http://127.0.0.1:${address.port}`)),
+            // No settling delay before the first attempt: routes are already
+            // serving by the time activation opens this gate (the startup
+            // sequence awaits routesReady), and the retry schedule below
+            // covers anything this sleep used to hedge against. Every
+            // millisecond here is dead time on the path to remote
+            // reachability after a restart.
+            yield* reconcileDesiredCloudLink(`http://127.0.0.1:${address.port}`).pipe(
               Effect.retry({
                 while: (error) =>
                   error._tag !== "EnvironmentHttpBadRequestError" &&

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -7,12 +7,16 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
+import * as TestClock from "effect/testing/TestClock";
 import { RpcClientError } from "effect/unstable/rpc";
 import * as Socket from "effect/unstable/socket/Socket";
 
@@ -30,6 +34,7 @@ import {
   makeEnvironmentServerConfigState,
   isLegacyUpdateHandoffLoss,
   matchesServerUpdateReadyEvent,
+  nudgeReconnectDuringUpdateRestart,
   projectServerWelcome,
   resolveServerConfigValue,
   resolveServerUpdateProgressResult,
@@ -70,6 +75,56 @@ function session(client: WsRpcProtocolClient): RpcSession {
     closed: Effect.never,
   };
 }
+
+describe("update restart reconnect nudges", () => {
+  it.effect("retries once per backoff entry instead of only the first", () =>
+    Effect.gen(function* () {
+      const retries = yield* Ref.make(0);
+      const states = [
+        { phase: "backoff" },
+        { phase: "connecting" },
+        { phase: "backoff" },
+        { phase: "backoff" },
+      ];
+
+      yield* nudgeReconnectDuringUpdateRestart({
+        stateChanges: Stream.fromIterable(states),
+        retryNow: Ref.update(retries, (count) => count + 1),
+        interval: Duration.zero,
+      });
+
+      // Three backoff entries, three nudges. The old one-shot behavior fired
+      // once and then let the supervisor's ladder stretch to 16-second gaps.
+      expect(yield* Ref.get(retries)).toBe(3);
+    }),
+  );
+
+  it.effect("paces nudges so a fast-failing connection cannot spin", () =>
+    Effect.gen(function* () {
+      const retries = yield* Ref.make(0);
+
+      const fiber = yield* Effect.forkChild(
+        nudgeReconnectDuringUpdateRestart({
+          stateChanges: Stream.fromIterable([{ phase: "backoff" }, { phase: "backoff" }]),
+          retryNow: Ref.update(retries, (count) => count + 1),
+        }),
+        { startImmediately: true },
+      );
+
+      // Each nudge waits out the interval first, so nothing fires immediately.
+      yield* TestClock.adjust(Duration.millis(999));
+      expect(yield* Ref.get(retries)).toBe(0);
+
+      yield* TestClock.adjust(Duration.millis(1));
+      expect(yield* Ref.get(retries)).toBe(1);
+
+      yield* TestClock.adjust(Duration.seconds(1));
+      expect(yield* Ref.get(retries)).toBe(2);
+
+      yield* Fiber.join(fiber);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
 
 describe("server state projection", () => {
   it("only treats a legacy transport interruption as an unacknowledged handoff", () => {

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -149,6 +149,35 @@ export function validateServerUpdateReadyEvent(
   );
 }
 
+/**
+ * Keeps reconnect attempts ~1s apart for the whole update restart.
+ *
+ * A restart takes the server down for ~15 seconds, but the supervisor's normal
+ * backoff ladder (1/2/4/8/16s) assumes an unexpected failure and lands attempts
+ * at ~3, 5, 9, 17 and 33 seconds — so a 15-second restart is observed as a
+ * 33-second "Resuming". Nudging on every backoff entry (not just the first)
+ * holds the retry cadence flat until the server answers again. The sleep before
+ * each nudge is the pacer: a connection that fails instantly re-enters backoff
+ * immediately and would otherwise spin a tight retry loop.
+ *
+ * Callers fork this as a child of the update command so it is interrupted as
+ * soon as the update settles, whether it succeeds, fails, or times out.
+ */
+export function nudgeReconnectDuringUpdateRestart(input: {
+  readonly stateChanges: Stream.Stream<{ readonly phase: string }, unknown>;
+  readonly retryNow: Effect.Effect<void>;
+  readonly interval?: Duration.Duration;
+}): Effect.Effect<void> {
+  return input.stateChanges.pipe(
+    Stream.filter((state) => state.phase === "backoff"),
+    Stream.runForEach(() =>
+      Effect.sleep(input.interval ?? Duration.seconds(1)).pipe(Effect.andThen(input.retryNow)),
+    ),
+    Effect.timeoutOption(SERVER_UPDATE_RESUME_TIMEOUT),
+    Effect.ignore,
+  );
+}
+
 export function serverUpdateStateForProgressEvent(
   fromVersion: string,
   targetVersion: string,
@@ -589,18 +618,13 @@ export function createServerEnvironmentAtoms<R, E>(
           }),
         );
 
-        // The update restart is intentional. As soon as the supervisor sees
-        // that first failed connection, discard any prior backoff debt and
-        // retry immediately instead of carrying an old 16-second delay.
-        yield* environmentRegistry.stateChanges(target.environmentId).pipe(
-          Stream.filter((state) => state.phase === "backoff"),
-          Stream.take(1),
-          Stream.runDrain,
-          Effect.andThen(environmentRegistry.retryNow(target.environmentId)),
-          Effect.timeoutOption(Duration.seconds(30)),
-          Effect.ignore,
-          Effect.forkChild,
-        );
+        // The update restart is intentional and the server stays unreachable
+        // for the whole restart, so hold the retry cadence flat instead of
+        // letting the supervisor climb its backoff ladder.
+        yield* nudgeReconnectDuringUpdateRestart({
+          stateChanges: environmentRegistry.stateChanges(target.environmentId),
+          retryNow: environmentRegistry.retryNow(target.environmentId),
+        }).pipe(Effect.forkChild);
 
         const resumed = yield* environmentRegistry
           .followStream(target.environmentId, subscribe(WS_METHODS.subscribeServerLifecycle, {}))


### PR DESCRIPTION
A remote server update restarts the server for about 15 seconds, but the client shows "Resuming" for up to ~33s. Separately, the relay tunnel becomes reachable ~5s after the new server starts listening.

Measured from `boot-service.log` across recent updates: old server dies at T+2s, new server listens at T+7-9s, relay tunnel reachable at T+13-15s.

## Client: nudge reconnect for the whole restart, not just once

The update flow forked a fiber that waited for the **first** `backoff` state and called `retryNow` once. That nudge lands at ~T+2s while the server is still down for another ~11s, so it is wasted. The supervisor then climbs its normal `1/2/4/8/16s` ladder and attempts land at ~3, 5, 9, 17 and 33s, which is how a ~15s restart becomes a ~33s wait.

Now it nudges on **every** backoff entry, with a one-second sleep before each one, so attempts stay ~1s apart for the whole restart window. The sleep is the pacer: a connection that fails instantly (ECONNREFUSED, or a 502 through the relay) re-enters backoff immediately and would otherwise spin a tight retry loop.

The fiber stays `Effect.forkChild`, so it is interrupted as soon as the update command settles. With that in place the 30s cap is unnecessary and now matches `SERVER_UPDATE_RESUME_TIMEOUT`, covering the realistic restart window instead of cutting off at 30s.

The loop is extracted as `nudgeReconnectDuringUpdateRestart` so it is testable without standing up an `AtomRegistry`; two tests cover the repeated-nudge count and the pacing.

## Server: what the ~5s actually is

Worth stating plainly, since it changes what is fixable here: the ~5s between `Listening on http://127.0.0.1:3773` and `Relay client process started` is **not** local serialization behind activation. Activation opens ~50ms after the listen log, and nothing is logged in the remaining window. The time is spent inside the two relay calls in `reconcileDesiredCloudLinkWith`, dominated by server-side Cloudflare control-plane work on `POST /v1/client/environment-links` — a serial chain of tunnel create, configure, and DNS mutations. Measured locally: secret store I/O is under 1ms total, the ed25519 keypair is genuinely first-run-only, and network transport for both POSTs is ~0.6s.

That chain runs on every boot because `releaseManagedTunnelOnShutdown` deletes the tunnel at shutdown (a deliberate Cloudflare per-tunnel billing tradeoff), so the next startup always pays full tunnel-creation latency instead of reusing an existing tunnel.

So moving the reconcile earlier would not have bought the 5 seconds — the work is remote and already starts promptly. Keeping the reconcile gated on activation is also the safe choice: it preserves the finalizer ownership rule at `server.ts:564` and keeps a rolling-back trial from fighting the previous version for the tunnel. I left that gate alone and removed the one piece of local dead time on the path, the 250ms sleep in front of the first attempt. Routes are already serving when activation opens the gate, and the retry schedule covers what the sleep hedged against.

The real leverage is relay-side (keep the tunnel alive across restarts, or parallelize the independent legs of `provision`), which is out of scope here.

## Validation

- `packages/client-runtime` tests: 524 passed
- `apps/server` tests: 1846 passed, 7 skipped
- typecheck and lint clean

Note: running the server suite on a machine with a live T3 server leaks `T3_SERVICE_LAUNCHER_CONTEXT` into the test process and fails 125 tests on `main` as well. Unsetting it makes the suite pass on both `main` and this branch.

---

Made by Claude Fable 5 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches update/reconnect timing and server cloud-link startup reconcile—user-visible recovery paths but localized changes with new tests on the client nudge logic.
> 
> **Overview**
> Shortens **"Resuming"** after a remote server self-update by keeping client reconnect attempts on a ~1s cadence for the whole restart, and trims a small server startup delay before cloud link reconcile.
> 
> **Client:** Replaces the one-shot "first `backoff` → `retryNow`" fiber with **`nudgeReconnectDuringUpdateRestart`**, which reacts to **every** supervisor `backoff` during the update (1s sleep before each nudge so instant failures do not spin). The nudge fiber still forks as a child of the update command and now times out with **`SERVER_UPDATE_RESUME_TIMEOUT`** instead of 30s. Unit tests cover repeated nudges and pacing.
> 
> **Server:** Drops the **250ms** delay before the first **`reconcileDesiredCloudLink`** attempt after activation; exponential retry on reconcile is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dedb6a3e5e0f221b605c4d928f11ca3b0370e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconnect faster during remote server updates by retrying once per second across the restart window
> - Previously, on a server update restart, the client issued a single immediate retry and then fell back to the supervisor's escalating backoff schedule.
> - Adds `nudgeReconnectDuringUpdateRestart` in [server.ts](https://github.com/pingdotgg/t3code/pull/5404/files#diff-e89d2e49b487037c2e7108610cb27c1e8ad8800a8f2e66427f7e783a4fc1d428), which watches connection state changes and triggers a retry for every `backoff` phase at ~1s intervals until `SERVER_UPDATE_RESUME_TIMEOUT` is reached.
> - Also removes a 250ms settling delay before the first `reconcileDesiredCloudLink` call in [server.ts](https://github.com/pingdotgg/t3code/pull/5404/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd), so the initial reconciliation starts immediately.
> - Behavioral Change: connections during a server update now retry roughly once per second for the full restart window instead of once immediately then at escalating intervals.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4dedb6a. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->