### PR TITLE
fix(server): stop tying codex text-generation temp files to the caller's scope

### DIFF
--- a/apps/server/src/textGeneration/CodexTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.test.ts
@@ -1,11 +1,13 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
 import { createModelSelection } from "@t3tools/shared/model";
 import { expect } from "vite-plus/test";
 
@@ -396,6 +398,34 @@ it.layer(CodexTextGenerationTestLayer)("CodexTextGeneration", (it) => {
           });
 
           expect(generated.branch).toBe("feat/session");
+        }),
+    ),
+  );
+
+  it.effect("generates branch names even when the ambient scope is already closed", () =>
+    withFakeCodexEnv(
+      {
+        output: JSON.stringify({
+          branch: "feat/background-generation",
+        }),
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          // Background fibers (e.g. the worktree branch rename fork) can run
+          // after their launching request's scope has closed; temp files must
+          // not be tied to that ambient scope or they are reaped on creation.
+          const closedScope = yield* Scope.make();
+          yield* Scope.close(closedScope, Exit.void);
+
+          const generated = yield* textGeneration
+            .generateBranchName({
+              cwd: process.cwd(),
+              message: "Please update session handling.",
+              modelSelection: DEFAULT_TEST_MODEL_SELECTION,
+            })
+            .pipe(Effect.provideService(Scope.Scope, closedScope));
+
+          expect(generated.branch).toBe("feat/background-generation");
         }),
     ),
   );

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -68,9 +68,18 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       ),
     );
 
+  const safeUnlink = (filePath: string): Effect.Effect<void, never> =>
+    fileSystem.remove(filePath).pipe(Effect.catch(() => Effect.void));
+
+  const removeTempFileDir = (filePath: string): Effect.Effect<void, never> =>
+    fileSystem
+      .remove(path.dirname(filePath), { recursive: true })
+      .pipe(Effect.catch(() => Effect.void));
+
   // Deliberately unscoped: text generation runs from background fibers whose
   // ambient scope may already be closed (a closed scope reaps the temp
-  // directory the moment it is created). Cleanup is explicit in runCodexJson.
+  // directory the moment it is created). Each allocation removes its own
+  // directory on failure; success-path cleanup is explicit in runCodexJson.
   const writeTempFile = (
     operation: string,
     prefix: string,
@@ -81,7 +90,11 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
         prefix: `t3code-${prefix}-${process.pid}-`,
       })
       .pipe(
-        Effect.tap((filePath) => fileSystem.writeFileString(filePath, content)),
+        Effect.tap((filePath) =>
+          fileSystem
+            .writeFileString(filePath, content)
+            .pipe(Effect.onError(() => removeTempFileDir(filePath))),
+        ),
         Effect.mapError(
           (cause) =>
             new TextGenerationError({
@@ -91,14 +104,6 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
             }),
         ),
       );
-
-  const safeUnlink = (filePath: string): Effect.Effect<void, never> =>
-    fileSystem.remove(filePath).pipe(Effect.catch(() => Effect.void));
-
-  const removeTempFileDir = (filePath: string): Effect.Effect<void, never> =>
-    fileSystem
-      .remove(path.dirname(filePath), { recursive: true })
-      .pipe(Effect.catch(() => Effect.void));
 
   const encodeJsonForOperation = (
     operation:
@@ -179,7 +184,9 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       toJsonSchemaObject(outputSchemaJson),
     );
     const schemaPath = yield* writeTempFile(operation, "codex-schema", schemaJson);
-    const outputPath = yield* writeTempFile(operation, "codex-output", "");
+    const outputPath = yield* writeTempFile(operation, "codex-output", "").pipe(
+      Effect.onError(() => removeTempFileDir(schemaPath)),
+    );
 
     const runCodexCommand = Effect.fn("runCodexJson.runCodexCommand")(function* () {
       const launchArgs = resolveCodexLaunchArgs(codexConfig.launchArgs, resolvedEnvironment);

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -3,7 +3,6 @@ import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
-import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
@@ -69,13 +68,16 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       ),
     );
 
+  // Deliberately unscoped: text generation runs from background fibers whose
+  // ambient scope may already be closed (a closed scope reaps the temp
+  // directory the moment it is created). Cleanup is explicit in runCodexJson.
   const writeTempFile = (
     operation: string,
     prefix: string,
     content: string,
-  ): Effect.Effect<string, TextGenerationError, Scope.Scope> =>
+  ): Effect.Effect<string, TextGenerationError> =>
     fileSystem
-      .makeTempFileScoped({
+      .makeTempFile({
         prefix: `t3code-${prefix}-${process.pid}-`,
       })
       .pipe(
@@ -92,6 +94,11 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
 
   const safeUnlink = (filePath: string): Effect.Effect<void, never> =>
     fileSystem.remove(filePath).pipe(Effect.catch(() => Effect.void));
+
+  const removeTempFileDir = (filePath: string): Effect.Effect<void, never> =>
+    fileSystem
+      .remove(path.dirname(filePath), { recursive: true })
+      .pipe(Effect.catch(() => Effect.void));
 
   const encodeJsonForOperation = (
     operation:
@@ -251,7 +258,11 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
     });
 
     const cleanup = Effect.all(
-      [schemaPath, outputPath, ...cleanupPaths].map((filePath) => safeUnlink(filePath)),
+      [
+        removeTempFileDir(schemaPath),
+        removeTempFileDir(outputPath),
+        ...cleanupPaths.map((filePath) => safeUnlink(filePath)),
+      ],
       {
         concurrency: "unbounded",
       },


### PR DESCRIPTION
Stacked on #2829. Follow-up to #5309 — explains and fixes why branch renaming still didn't work in real builds even though #5309's rename path executed.

## Diagnosis (from a live Alpha build containing #5176 + #5309)

Titles generated fine, branches stayed `t3code/<hash>`. Traces showed the rename fork running and failing in 22ms:

```
TextGenerationError: Text generation failed in generateBranchName: Failed to write temp file
  [cause]: ENOENT: no such file or directory, open '/var/folders/.../T/t3code-codex-schema-10580-Ahg5y9/a30ebec4bc02'
```

`runCodexJson` writes its `--output-schema` / `--output-last-message` temp files with `makeTempFileScoped`, whose `Scope` requirement leaks to the ambient fiber context (swallowed by the generic `S["DecodingServices"]` in the return annotation, so it never typechecked as missing). The branch rename fork inherits its context from the `launchThread` RPC request, whose scope has long since closed by the time the fork runs — and registering a finalizer on a closed scope runs it **immediately**, deleting the temp directory between creation and write. Hence ENOENT on every branch generation, with #5309's deliberate fallback keeping the temp name.

Title generation kept working because #5176 runs it on the durable effect worker, whose ambient scope stays live — which is exactly why the symptom split (titles ✓ / branches ✗).

## Fix

Use unscoped `makeTempFile` and remove the per-file temp directories in `runCodexJson`'s existing explicit `Effect.ensuring(cleanup)` instead. Generation is now self-contained regardless of which fiber calls it, and the temp *directories* (previously left behind by the file-only unlink whenever the scope path wasn't exercised) are cleaned up too.

## Testing

- New regression test: `generateBranchName` succeeds with an explicitly **closed** ambient `Scope` provided — fails with the ENOENT error before the fix, passes after.
- Full `CodexTextGeneration` suite: 18 passed.
- Typecheck clean for `t3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes temp-file lifecycle for all Codex JSON generation paths; behavior is intentional but touches shared CLI orchestration used by commits, PRs, branches, and titles.
> 
> **Overview**
> Fixes **background `generateBranchName` failures** (ENOENT on temp files) when Codex CLI schema/output temps were created via **`makeTempFileScoped`**, so a **closed ambient `Scope`** from the launching RPC could reap the directory before the write finished.
> 
> **`writeTempFile`** now uses unscoped **`makeTempFile`** with explicit cleanup: **`removeTempFileDir`** on write failure, and **`runCodexJson`**’s existing **`Effect.ensuring`** removes the full temp directories (not single-file unlinks) on success or failure.
> 
> Adds a regression test that **`generateBranchName`** succeeds when **`Scope.Scope`** is already closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a5b8c18c595577bbe4acf15cd26a5a2cfef51d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix codex text-generation temp files to be independent of the caller's scope
> - `writeTempFile` in [`CodexTextGeneration.ts`](https://github.com/pingdotgg/t3code/pull/5406/files#diff-203268bf51406720251f9faaf2c0c10f1764c3d78b0a3b539da7ef2a0a4c87ed) switches from `makeTempFileScoped` to `makeTempFile`, removing the dependency on an ambient `Scope` being open.
> - A new `removeTempFileDir` helper cleans up the entire temp directory (recursively) on both success and error paths, replacing per-file unlinks that could leave directories behind.
> - If output temp file creation fails, the schema temp directory is now explicitly removed to prevent leakage.
> - A regression test verifies that `generateBranchName` works correctly even when the ambient scope is already closed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a5b8c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->