### PR TITLE
fix(server): stop idle private-memory growth from immortal parent spans

### DIFF
--- a/apps/server/src/auth/ServerSecretStore.ts
+++ b/apps/server/src/auth/ServerSecretStore.ts
@@ -168,6 +168,9 @@ export const make = Effect.gen(function* () {
 
   const resolveSecretPath = (name: string) => path.join(serverConfig.secretsDir, `${name}.bin`);
 
+  // Hot path: called every few seconds from parked runtime fibers. Spans here
+  // previously nested under immortal startup ParentSpans and dominated idle
+  // trace volume; keep reads cheap and untraced.
   const get: ServerSecretStore["Service"]["get"] = (name) =>
     fileSystem.readFile(resolveSecretPath(name)).pipe(
       Effect.map((bytes) => Option.some(Uint8Array.from(bytes))),
@@ -181,7 +184,7 @@ export const make = Effect.gen(function* () {
               }),
             ),
       ),
-      Effect.withSpan("ServerSecretStore.get"),
+      Effect.withTracerEnabled(false),
     );
 
   const set: ServerSecretStore["Service"]["set"] = (name, value) => {

--- a/apps/server/src/auth/ServerSecretStore.ts
+++ b/apps/server/src/auth/ServerSecretStore.ts
@@ -168,9 +168,6 @@ export const make = Effect.gen(function* () {
 
   const resolveSecretPath = (name: string) => path.join(serverConfig.secretsDir, `${name}.bin`);
 
-  // Hot path: called every few seconds from parked runtime fibers. Spans here
-  // previously nested under immortal startup ParentSpans and dominated idle
-  // trace volume; keep reads cheap and untraced.
   const get: ServerSecretStore["Service"]["get"] = (name) =>
     fileSystem.readFile(resolveSecretPath(name)).pipe(
       Effect.map((bytes) => Option.some(Uint8Array.from(bytes))),

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -39,6 +39,7 @@ import * as Semaphore from "effect/Semaphore";
 import { FetchHttpClient, HttpClient } from "effect/unstable/http";
 
 import * as ProcessRunner from "../processRunner.ts";
+import { withoutAmbientParentSpan } from "../serverActivation.ts";
 
 export class PortDiscovery extends Context.Service<
   PortDiscovery,
@@ -579,9 +580,17 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
   );
 
   // Single layer-scoped polling fiber. Ticks are no-ops when no client is
-  // currently retained, so the cost is one Ref.get every POLL_INTERVAL.
-  yield* Effect.forkScoped(pollTick().pipe(Effect.repeat(Schedule.spaced(POLL_INTERVAL))));
-
+  // currently retained. Run detached from any ambient ParentSpan (e.g.
+  // PortDiscovery.make) and without tracing idle no-ops — otherwise every
+  // 3s tick parents under an immortal span and grows server private memory.
+  yield* Effect.forkScoped(
+    withoutAmbientParentSpan(
+      pollTick().pipe(
+        Effect.repeat(Schedule.spaced(POLL_INTERVAL)),
+        Effect.withTracerEnabled(false),
+      ),
+    ),
+  );
   const acquireRetention = Effect.fn("PortDiscovery.retain")(function* () {
     const wasIdle = yield* Ref.modify(stateRef, (state) => [
       state.retainCount === 0,
@@ -659,6 +668,6 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     registerTerminalProcesses,
     unregisterTerminal,
   });
-}).pipe(Effect.withSpan("PortDiscovery.make"));
+});
 
 export const layer = Layer.effect(PortDiscovery, make);

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -548,9 +548,8 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     );
   };
 
-  const pollTick = Effect.fn("PortDiscovery.pollTick")(
+  const pollTickActive = Effect.fn("PortDiscovery.pollTick")(
     function* () {
-      if ((yield* Ref.get(stateRef)).retainCount <= 0) return;
       const configuredUrls = [
         ...new Set(
           [...(yield* Ref.get(stateRef)).listeners.values()].flatMap(
@@ -579,14 +578,14 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     ),
   );
 
-  // Idle ticks are no-ops; keep them untraced and detached from ambient ParentSpan (#5410).
+  // Idle early-return stays outside Effect.fn so no-op ticks create no span; detach ParentSpan (#5410).
+  const pollTick = Effect.gen(function* () {
+    if ((yield* Ref.get(stateRef)).retainCount <= 0) return;
+    yield* pollTickActive();
+  });
+
   yield* Effect.forkScoped(
-    withoutAmbientParentSpan(
-      pollTick().pipe(
-        Effect.repeat(Schedule.spaced(POLL_INTERVAL)),
-        Effect.withTracerEnabled(false),
-      ),
-    ),
+    withoutAmbientParentSpan(pollTick.pipe(Effect.repeat(Schedule.spaced(POLL_INTERVAL)))),
   );
   const acquireRetention = Effect.fn("PortDiscovery.retain")(function* () {
     const wasIdle = yield* Ref.modify(stateRef, (state) => [
@@ -596,7 +595,7 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     if (wasIdle) {
       // Run an immediate scan + broadcast so the new retainer doesn't have
       // to wait up to POLL_INTERVAL for the first emission.
-      yield* pollTick();
+      yield* pollTick;
     }
   });
 

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -579,10 +579,7 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     ),
   );
 
-  // Single layer-scoped polling fiber. Ticks are no-ops when no client is
-  // currently retained. Run detached from any ambient ParentSpan (e.g.
-  // PortDiscovery.make) and without tracing idle no-ops — otherwise every
-  // 3s tick parents under an immortal span and grows server private memory.
+  // Idle ticks are no-ops; keep them untraced and detached from ambient ParentSpan (#5410).
   yield* Effect.forkScoped(
     withoutAmbientParentSpan(
       pollTick().pipe(

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -309,10 +309,7 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     ),
   );
 
-  // Single layer-scoped polling fiber. Ticks are no-ops when no client is
-  // currently retained. Run detached from any ambient ParentSpan (e.g.
-  // PortDiscovery.make) and without tracing idle no-ops — otherwise every
-  // 3s tick parents under an immortal span and grows server private memory.
+  // Idle ticks are no-ops; keep them untraced and detached from ambient ParentSpan (#5410).
   yield* Effect.forkScoped(
     withoutAmbientParentSpan(
       pollTick().pipe(

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -293,9 +293,8 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     yield* Effect.forEach(listeners, (listener) => listener(servers), { discard: true });
   });
 
-  const pollTick = Effect.fn("PortDiscovery.pollTick")(
+  const pollTickActive = Effect.fn("PortDiscovery.pollTick")(
     function* () {
-      if ((yield* Ref.get(stateRef)).retainCount <= 0) return;
       const next = yield* scanOnce();
       const changed = yield* Ref.modify(stateRef, (state) =>
         serversEqual(state.lastSnapshot, next)
@@ -309,14 +308,14 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     ),
   );
 
-  // Idle ticks are no-ops; keep them untraced and detached from ambient ParentSpan (#5410).
+  // Idle early-return stays outside Effect.fn so no-op ticks create no span; detach ParentSpan (#5410).
+  const pollTick = Effect.gen(function* () {
+    if ((yield* Ref.get(stateRef)).retainCount <= 0) return;
+    yield* pollTickActive();
+  });
+
   yield* Effect.forkScoped(
-    withoutAmbientParentSpan(
-      pollTick().pipe(
-        Effect.repeat(Schedule.spaced(POLL_INTERVAL)),
-        Effect.withTracerEnabled(false),
-      ),
-    ),
+    withoutAmbientParentSpan(pollTick.pipe(Effect.repeat(Schedule.spaced(POLL_INTERVAL)))),
   );
   const acquireRetention = Effect.fn("PortDiscovery.retain")(function* () {
     const wasIdle = yield* Ref.modify(stateRef, (state) => [
@@ -326,7 +325,7 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     if (wasIdle) {
       // Run an immediate scan + broadcast so the new retainer doesn't have
       // to wait up to POLL_INTERVAL for the first emission.
-      yield* pollTick();
+      yield* pollTick;
     }
   });
 

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -25,6 +25,7 @@ import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
 
 import * as ProcessRunner from "../processRunner.ts";
+import { withoutAmbientParentSpan } from "../serverActivation.ts";
 
 export class PortDiscovery extends Context.Service<
   PortDiscovery,
@@ -309,9 +310,17 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
   );
 
   // Single layer-scoped polling fiber. Ticks are no-ops when no client is
-  // currently retained, so the cost is one Ref.get every POLL_INTERVAL.
-  yield* Effect.forkScoped(pollTick().pipe(Effect.repeat(Schedule.spaced(POLL_INTERVAL))));
-
+  // currently retained. Run detached from any ambient ParentSpan (e.g.
+  // PortDiscovery.make) and without tracing idle no-ops — otherwise every
+  // 3s tick parents under an immortal span and grows server private memory.
+  yield* Effect.forkScoped(
+    withoutAmbientParentSpan(
+      pollTick().pipe(
+        Effect.repeat(Schedule.spaced(POLL_INTERVAL)),
+        Effect.withTracerEnabled(false),
+      ),
+    ),
+  );
   const acquireRetention = Effect.fn("PortDiscovery.retain")(function* () {
     const wasIdle = yield* Ref.modify(stateRef, (state) => [
       state.retainCount === 0,
@@ -385,6 +394,6 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     registerTerminalProcesses,
     unregisterTerminal,
   });
-}).pipe(Effect.withSpan("PortDiscovery.make"));
+});
 
 export const layer = Layer.effect(PortDiscovery, make);

--- a/apps/server/src/serverActivation.test.ts
+++ b/apps/server/src/serverActivation.test.ts
@@ -48,6 +48,6 @@ it.effect("withoutAmbientParentSpan drops inherited ParentSpan for long-lived ro
     expect(stillHasParent).toBe(true);
 
     const stripped = Context.omit(Tracer.ParentSpan)(Context.make(Tracer.ParentSpan, ambient));
-    expect(Context.getOption(stripped, Tracer.ParentSpan)._tag).toBe("None");
+    expect(Option.isNone(Context.getOption(stripped, Tracer.ParentSpan))).toBe(true);
   }),
 );

--- a/apps/server/src/serverActivation.test.ts
+++ b/apps/server/src/serverActivation.test.ts
@@ -1,8 +1,11 @@
 import { expect, it } from "@effect/vitest";
+import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Tracer from "effect/Tracer";
 
-import { forkParked, ServerActivation } from "./serverActivation.ts";
+import { forkParked, ServerActivation, withoutAmbientParentSpan } from "./serverActivation.ts";
 
 it.effect("proves a root is parked before returning and releases it with one gate", () =>
   Effect.scoped(
@@ -20,4 +23,31 @@ it.effect("proves a root is parked before returning and releases it with one gat
       expect(yield* Deferred.isDone(ran)).toBe(true);
     }),
   ),
+);
+
+it.effect("withoutAmbientParentSpan drops inherited ParentSpan for long-lived roots", () =>
+  Effect.gen(function* () {
+    const ambient = Tracer.externalSpan({
+      traceId: "00000000000000000000000000000001",
+      spanId: "0000000000000001",
+      sampled: true,
+    });
+
+    const sawParent = yield* Effect.serviceOption(Tracer.ParentSpan).pipe(
+      Effect.map(Option.isSome),
+      withoutAmbientParentSpan,
+      Effect.provideService(Tracer.ParentSpan, ambient),
+    );
+
+    expect(sawParent).toBe(false);
+
+    const stillHasParent = yield* Effect.serviceOption(Tracer.ParentSpan).pipe(
+      Effect.map(Option.isSome),
+      Effect.provideService(Tracer.ParentSpan, ambient),
+    );
+    expect(stillHasParent).toBe(true);
+
+    const stripped = Context.omit(Tracer.ParentSpan)(Context.make(Tracer.ParentSpan, ambient));
+    expect(Context.getOption(stripped, Tracer.ParentSpan)._tag).toBe("None");
+  }),
 );

--- a/apps/server/src/serverActivation.ts
+++ b/apps/server/src/serverActivation.ts
@@ -9,16 +9,7 @@ export class ServerActivation extends Context.Reference<Effect.Effect<void> | un
   { defaultValue: () => undefined },
 ) {}
 
-/**
- * Drop any ambient `Tracer.ParentSpan` before running long-lived roots.
- *
- * Startup phases (and other short-lived `Effect.withSpan` scopes) often call
- * `forkParked` while a parent span is still current. Forked fibers inherit
- * that `ParentSpan` for their entire lifetime, so every nested span
- * (`ServerSecretStore.get`, RPC handlers, …) keeps parenting under an
- * immortal startup span and pins the `LocalFileSpan` object graph — steady
- * private-memory growth while "idle".
- */
+// Clear inherited ParentSpan so long-lived forks don't pin short-lived startup spans (#5410).
 export const withoutAmbientParentSpan = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> =>

--- a/apps/server/src/serverActivation.ts
+++ b/apps/server/src/serverActivation.ts
@@ -12,10 +12,13 @@ export class ServerActivation extends Context.Reference<Effect.Effect<void> | un
 // Clear inherited ParentSpan so long-lived forks don't pin short-lived startup spans (#5410).
 export const withoutAmbientParentSpan = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
-): Effect.Effect<A, E, R> =>
+): Effect.Effect<A, E, Exclude<R, Tracer.ParentSpan>> =>
   Effect.updateContext(
     effect,
-    (context) => Context.omit(Tracer.ParentSpan)(context) as Context.Context<NoInfer<R>>,
+    (context) =>
+      Context.omit(Tracer.ParentSpan)(context) as Context.Context<
+        Exclude<NoInfer<R>, Tracer.ParentSpan>
+      >,
   );
 
 /** Forks a long-running root before commit and proves it is parked at the activation boundary. */

--- a/apps/server/src/serverActivation.ts
+++ b/apps/server/src/serverActivation.ts
@@ -2,11 +2,30 @@ import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import type * as Scope from "effect/Scope";
+import * as Tracer from "effect/Tracer";
 
 export class ServerActivation extends Context.Reference<Effect.Effect<void> | undefined>(
   "t3/serverActivation",
   { defaultValue: () => undefined },
 ) {}
+
+/**
+ * Drop any ambient `Tracer.ParentSpan` before running long-lived roots.
+ *
+ * Startup phases (and other short-lived `Effect.withSpan` scopes) often call
+ * `forkParked` while a parent span is still current. Forked fibers inherit
+ * that `ParentSpan` for their entire lifetime, so every nested span
+ * (`ServerSecretStore.get`, RPC handlers, …) keeps parenting under an
+ * immortal startup span and pins the `LocalFileSpan` object graph — steady
+ * private-memory growth while "idle".
+ */
+export const withoutAmbientParentSpan = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.updateContext(
+    effect,
+    (context) => Context.omit(Tracer.ParentSpan)(context) as Context.Context<NoInfer<R>>,
+  );
 
 /** Forks a long-running root before commit and proves it is parked at the activation boundary. */
 export const forkParked = <A, E, R>(
@@ -14,13 +33,17 @@ export const forkParked = <A, E, R>(
 ): Effect.Effect<void, never, Scope.Scope | R> =>
   Effect.gen(function* () {
     const activation = yield* ServerActivation;
+    const detached = withoutAmbientParentSpan(effect);
     if (activation === undefined) {
-      yield* Effect.forkScoped(effect);
+      yield* Effect.forkScoped(detached);
       return;
     }
     const parked = yield* Deferred.make<void>();
     yield* Effect.forkScoped(
-      Deferred.succeed(parked, undefined).pipe(Effect.andThen(activation), Effect.andThen(effect)),
+      Deferred.succeed(parked, undefined).pipe(
+        Effect.andThen(activation),
+        Effect.andThen(detached),
+      ),
     );
     yield* Deferred.await(parked);
   });

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -346,9 +346,6 @@ export const make = (options?: StartupOptions) =>
       );
 
       yield* Effect.logDebug("startup phase: parking orchestration roots at activation");
-      // `forkParked` inside these starts detaches ambient ParentSpan so the
-      // short-lived `server.startup.reactors.start` span can end instead of
-      // staying pinned on long-lived reactor fibers for the process lifetime.
       yield* runStartupPhase(
         "reactors.start",
         Effect.gen(function* () {

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -346,6 +346,9 @@ export const make = (options?: StartupOptions) =>
       );
 
       yield* Effect.logDebug("startup phase: parking orchestration roots at activation");
+      // `forkParked` inside these starts detaches ambient ParentSpan so the
+      // short-lived `server.startup.reactors.start` span can end instead of
+      // staying pinned on long-lived reactor fibers for the process lifetime.
       yield* runStartupPhase(
         "reactors.start",
         Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- Fixes steady ~25–30 MB/h **Private** growth in the desktop server while idle (tracked in #5410).
- Long-lived `forkParked` roots and the PortDiscovery poll loop were inheriting Effect `ParentSpan` from short-lived startup/`make` spans, so hot-path nested spans kept parenting under immortal spans.
- Detach ambient `ParentSpan` in `forkParked`, untrace idle port polls + secret gets, and drop `PortDiscovery.make`'s wrapping span.

## Test plan
- [x] `vp test run src/serverActivation.test.ts src/preview/PortScanner.test.ts` (apps/server)
- [ ] Restart desktop build with this change; leave idle/unfocused for 2–3 hours
- [ ] Confirm server **Private** bytes stay roughly flat (ignore Working Set trims)
- [ ] Confirm `server.trace.ndjson` no longer floods with `PortDiscovery.pollTick` / `ServerSecretStore.get` under `startup.phase=reactors.start`
- [ ] Spot-check provider health / preview port discovery still work when used

Fixes #5410

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only Effect tracing context and span emission on background fibers and secret reads; no auth, data, or business-logic paths. Main risk is reduced trace detail during idle periods, not functional regression.
> 
> **Overview**
> Fixes steady idle **Private** memory growth (#5410) by breaking the link between short-lived startup spans and long-lived background work.
> 
> Adds **`withoutAmbientParentSpan`** in `serverActivation.ts` to remove `Tracer.ParentSpan` from an effect’s context. **`forkParked`** now forks through that helper so reactor and other long-running roots no longer pin immortal parent spans.
> 
> **PortDiscovery** polling: the retain-count idle check lives outside `Effect.fn` so no-op ticks don’t create spans; the repeating poll fiber runs inside **`withoutAmbientParentSpan`**. The **`PortDiscovery.make`** wrapper span is removed.
> 
> **`ServerSecretStore.get`** switches from a per-call named span to **`Effect.withTracerEnabled(false)`**, cutting trace noise on a hot path.
> 
> **Observability:** fewer or no spans for idle poll ticks, secret reads, and some layer roots; preview port discovery behavior is unchanged when retained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 655748bf3a0c3eabec1ceef50b731c51e97ee506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop idle private-memory growth from immortal parent spans in background fibers
> - Adds `withoutAmbientParentSpan` helper in [serverActivation.ts](https://github.com/pingdotgg/t3code/pull/5411/files#diff-f1b3973a0df9d977d0fb183a925ff0d4721298d00620d950bc2e7c7f3e892c0a) that strips `Tracer.ParentSpan` from an effect's context, preventing long-lived forked fibers from holding a reference to a parent span.
> - Applies `withoutAmbientParentSpan` in `forkParked` so all long-running roots it forks no longer inherit an ambient parent span.
> - Refactors `PortDiscovery` polling in [PortScanner.ts](https://github.com/pingdotgg/t3code/pull/5411/files#diff-0f6b3292e660acf982893ba130c26e1ffa8f91ff09032cce9b07d55074e296f4) so idle no-op ticks skip span creation entirely, and the background polling fiber runs without an inherited parent span.
> - Disables tracing on `ServerSecretStore.get` in [ServerSecretStore.ts](https://github.com/pingdotgg/t3code/pull/5411/files#diff-ba1dc01960ef9039f0c35daa5ed29eb4c63ae7c4202faf83b04259d422c1c557) instead of creating a named span per call.
> - Behavioral Change: named tracing spans are no longer emitted for idle poll ticks, `ServerSecretStore.get`, or the `PortDiscovery.make` and `forkParked` roots.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 655748b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->