### PR TITLE
feat(grok): add /compact slash command and compaction feedback

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -68,6 +68,25 @@ function promptIdFromRequestMeta(
   return typeof promptId === "string" && promptId.length > 0 ? promptId : undefined;
 }
 
+function promptTextFromRequest(request: AcpSchema.PromptRequest): string {
+  const blocks = request.prompt;
+  if (!Array.isArray(blocks)) {
+    return "";
+  }
+  return blocks
+    .flatMap((block) =>
+      typeof block === "object" &&
+      block !== null &&
+      "type" in block &&
+      block.type === "text" &&
+      "text" in block &&
+      typeof block.text === "string"
+        ? [block.text]
+        : [],
+    )
+    .join("");
+}
+
 function logExit(reason: string): void {
   if (!exitLogPath) {
     return;
@@ -520,6 +539,21 @@ const program = Effect.gen(function* () {
 
       if (hangPromptForever || (hangFirstPromptForever && promptCount === 1)) {
         return yield* Effect.never;
+      }
+
+      // Mirror real Grok: `/compact` is handled as a prompt and emits auto_compact_completed.
+      const promptText = promptTextFromRequest(request).trim();
+      if (/^\/compact(?:\s|$)/i.test(promptText)) {
+        writeJsonRpcNotification("_x.ai/session_notification", {
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "auto_compact_completed",
+            tokens_before: 12_000,
+            tokens_after: 4_000,
+            summary_preview: null,
+          },
+        });
+        return { stopReason: "end_turn" };
       }
 
       if (emitXAiPromptCompleteThenHang) {

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -188,6 +188,63 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("maps /compact session notifications to thread.state.changed compacted", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-compact-thread");
+      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const compacted = yield* Deferred.make<void>();
+      const turnCompleted = yield* Deferred.make<void>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.type === "thread.state.changed" && event.payload.state === "compacted"
+              ? Deferred.succeed(compacted, undefined)
+              : event.type === "turn.completed"
+                ? Deferred.succeed(turnCompleted, undefined)
+                : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "/compact keep the auth details",
+        attachments: [],
+      });
+
+      yield* Deferred.await(compacted).pipe(Effect.timeout("3 seconds"));
+      yield* Deferred.await(turnCompleted).pipe(Effect.timeout("3 seconds"));
+      yield* Fiber.interrupt(runtimeEventsFiber);
+
+      const compactEvent = runtimeEvents.find(
+        (event): event is Extract<ProviderRuntimeEvent, { type: "thread.state.changed" }> =>
+          event.type === "thread.state.changed" && event.payload.state === "compacted",
+      );
+      assert.isDefined(compactEvent);
+      if (compactEvent?.type === "thread.state.changed") {
+        assert.deepEqual(compactEvent.payload.detail, {
+          tokensBefore: 12_000,
+          tokensAfter: 4_000,
+        });
+        assert.equal(compactEvent.raw?.method, "_x.ai/session_notification");
+      }
+
+      yield* adapter.stopSession(threadId);
+    }).pipe(TestClock.withLive),
+  );
+
   it.effect("closes the ACP child process when a session stops", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-stop-session-close");

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -61,10 +61,12 @@ import {
 } from "../acp/GrokAcpSupport.ts";
 import {
   extractXAiAskUserQuestions,
+  extractXAiAutoCompactCompleted,
   makeXAiAskUserQuestionCancelledResponse,
   makeXAiAskUserQuestionResponse,
   promptResponseHasMissingXAiStopReason,
   XAiAskUserQuestionRequest,
+  XAiSessionNotification,
 } from "../acp/XAiAcpExtension.ts";
 import { type GrokAdapterShape } from "../Services/GrokAdapter.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
@@ -658,6 +660,54 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         case "cancelled":
                           return makeXAiAskUserQuestionCancelledResponse();
                       }
+                    }),
+                  ),
+                ),
+              { discard: true },
+            );
+            // Manual `/compact` and auto-compact complete as x.ai session notifications.
+            // Map them to thread.state.changed → UI work log "Context compacted".
+            yield* Effect.forEach(
+              ["x.ai/session_notification", "_x.ai/session_notification"] as const,
+              (method) =>
+                acp.handleExtNotification(method, XAiSessionNotification, (notification) =>
+                  mapAcpCallbackFailure(
+                    Effect.gen(function* () {
+                      yield* logNative(input.threadId, method, notification);
+                      const compact = extractXAiAutoCompactCompleted(notification);
+                      if (!compact) {
+                        return;
+                      }
+                      const live = sessions.get(input.threadId);
+                      if (!live || live.stopped) {
+                        return;
+                      }
+                      const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
+                      if (turnId !== undefined && live.interruptedTurnIds.has(turnId)) {
+                        return;
+                      }
+                      yield* offerRuntimeEvent({
+                        type: "thread.state.changed",
+                        ...(yield* makeEventStamp()),
+                        provider: PROVIDER,
+                        threadId: input.threadId,
+                        turnId,
+                        payload: {
+                          state: "compacted",
+                          detail: {
+                            tokensBefore: compact.tokensBefore,
+                            tokensAfter: compact.tokensAfter,
+                            ...(compact.summaryPreview
+                              ? { summaryPreview: compact.summaryPreview }
+                              : {}),
+                          },
+                        },
+                        raw: {
+                          source: "acp.grok.extension",
+                          method,
+                          payload: notification,
+                        },
+                      });
                     }),
                   ),
                 ),

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -32,6 +32,13 @@ describe("buildInitialGrokProviderSnapshot", () => {
       expect(snapshot.version).toBeNull();
       expect(snapshot.message).toContain("Checking Grok");
       expect(snapshot.requiresNewThreadForModelChange).toBe(true);
+      expect(snapshot.slashCommands).toEqual([
+        {
+          name: "compact",
+          description: "Compress conversation history to reclaim context window",
+          input: { hint: "optional context about what to preserve" },
+        },
+      ]);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -3,6 +3,7 @@ import {
   type ModelCapabilities,
   type ServerProvider,
   type ServerProviderModel,
+  type ServerProviderSlashCommand,
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
@@ -44,6 +45,15 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 
+/** Grok ACP handles `/compact` as prompt text; surface it in the composer slash menu. */
+const GROK_SLASH_COMMANDS: ReadonlyArray<ServerProviderSlashCommand> = [
+  {
+    name: "compact",
+    description: "Compress conversation history to reclaim context window",
+    input: { hint: "optional context about what to preserve" },
+  },
+];
+
 const GROK_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   {
     slug: "grok-build",
@@ -66,6 +76,7 @@ export function buildInitialGrokProviderSnapshot(
         enabled: false,
         checkedAt,
         models,
+        slashCommands: GROK_SLASH_COMMANDS,
         probe: {
           installed: false,
           version: null,
@@ -81,6 +92,7 @@ export function buildInitialGrokProviderSnapshot(
       enabled: true,
       checkedAt,
       models,
+      slashCommands: GROK_SLASH_COMMANDS,
       probe: {
         installed: true,
         version: null,
@@ -175,6 +187,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       enabled: false,
       checkedAt,
       models: fallbackModels,
+      slashCommands: GROK_SLASH_COMMANDS,
       probe: {
         installed: false,
         version: null,
@@ -200,6 +213,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      slashCommands: GROK_SLASH_COMMANDS,
       probe: {
         installed: !isCommandMissingCause(error),
         version: null,
@@ -218,6 +232,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      slashCommands: GROK_SLASH_COMMANDS,
       probe: {
         installed: true,
         version: null,
@@ -241,6 +256,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      slashCommands: GROK_SLASH_COMMANDS,
       probe: {
         installed: true,
         version,
@@ -264,6 +280,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      slashCommands: GROK_SLASH_COMMANDS,
       probe: {
         installed: true,
         version,
@@ -282,6 +299,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      slashCommands: GROK_SLASH_COMMANDS,
       probe: {
         installed: true,
         version,
@@ -302,6 +320,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     enabled: grokSettings.enabled,
     checkedAt,
     models,
+    slashCommands: GROK_SLASH_COMMANDS,
     probe: {
       installed: true,
       version,

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -10,10 +10,12 @@ import { describe, expect } from "vite-plus/test";
 
 import {
   extractXAiAskUserQuestions,
+  extractXAiAutoCompactCompleted,
   makeXAiAskUserQuestionCancelledResponse,
   makeXAiAskUserQuestionResponse,
   makeXAiPromptCompletionRuntime,
   XAiAskUserQuestionRequest,
+  XAiSessionNotification,
 } from "./XAiAcpExtension.ts";
 import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
@@ -100,6 +102,34 @@ describe("XAiAcpExtension", () => {
         ],
       },
     ]);
+  });
+
+  it("extracts auto_compact_completed session notifications", () => {
+    const notification = Schema.decodeUnknownSync(XAiSessionNotification)({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "auto_compact_completed",
+        tokens_before: 12_000,
+        tokens_after: 4_000,
+        summary_preview: null,
+      },
+    });
+    const compact = extractXAiAutoCompactCompleted(notification);
+    expect(compact).toEqual({
+      sessionId: "session-1",
+      tokensBefore: 12_000,
+      tokensAfter: 4_000,
+      summaryPreview: undefined,
+      raw: notification,
+    });
+  });
+
+  it("ignores non-compact session notifications", () => {
+    const notification = Schema.decodeUnknownSync(XAiSessionNotification)({
+      sessionId: "session-1",
+      update: { sessionUpdate: "turn_completed", tokens_before: 1, tokens_after: 1 },
+    });
+    expect(extractXAiAutoCompactCompleted(notification)).toBeNull();
   });
 
   it("treats nullable multiSelect from Grok as single-select", () => {

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -197,6 +197,54 @@ export function makeXAiAskUserQuestionCancelledResponse(): XAiAskUserQuestionCan
 }
 
 /**
+ * Grok session lifecycle notifications (`_x.ai/session_notification`).
+ * Manual `/compact` and auto-compact complete as `auto_compact_completed`.
+ */
+const XAiSessionNotificationUpdate = Schema.Struct({
+  sessionUpdate: Schema.String,
+  tokens_before: Schema.optional(Schema.Number),
+  tokens_after: Schema.optional(Schema.Number),
+  summary_preview: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+export const XAiSessionNotification = Schema.Struct({
+  sessionId: Schema.String,
+  update: XAiSessionNotificationUpdate,
+  _meta: Schema.optional(Schema.Unknown),
+});
+
+export type XAiSessionNotification = typeof XAiSessionNotification.Type;
+
+export interface XAiAutoCompactCompleted {
+  readonly sessionId: string;
+  readonly tokensBefore: number | undefined;
+  readonly tokensAfter: number | undefined;
+  readonly summaryPreview: string | undefined;
+  readonly raw: XAiSessionNotification;
+}
+
+function finiteNonNegative(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** Returns compact details when the notification is a completed compaction; otherwise null. */
+export function extractXAiAutoCompactCompleted(
+  notification: XAiSessionNotification,
+): XAiAutoCompactCompleted | null {
+  if (notification.update.sessionUpdate !== "auto_compact_completed") {
+    return null;
+  }
+  const summaryPreview = trimmed(notification.update.summary_preview ?? undefined);
+  return {
+    sessionId: notification.sessionId,
+    tokensBefore: finiteNonNegative(notification.update.tokens_before),
+    tokensAfter: finiteNonNegative(notification.update.tokens_after),
+    summaryPreview,
+    raw: notification,
+  };
+}
+
+/**
  * Adds Grok's private prompt-completion fallback around a standards-only ACP runtime.
  * The underlying runtime remains unaware of xAI methods and metadata.
  */


### PR DESCRIPTION
## What Changed

Grok Build already has a first-class **`/compact [context]`** command to manually compress conversation history. T3 could technically send that text as a prompt (Grok ACP treats `/compact` as the compact command), but:

1. The command never appeared in the composer `/` menu for Grok (unlike Claude provider slash commands)
2. When compaction finished, Grok emitted `_x.ai/session_notification` with `auto_compact_completed` and T3 ignored it — so the turn looked empty with no success feedback

This PR:

- Advertises **`/compact`** on the Grok provider snapshot as a provider slash command (Grok-only; optional note for what to preserve)
- Handles `x.ai/session_notification` / `_x.ai/session_notification` for `auto_compact_completed`
- Emits `thread.state.changed` `{ state: "compacted" }`, which the existing ingestion path turns into the **Context compacted** work-log row (same UI as Claude/Codex compaction)

## Why

Grok 4.5’s context window is large (**500k** tokens), but model quality typically degrades well before that — often around the **~200k** range in long agent threads. Auto-compact only kicks in near the window limit, so long productive Grok threads in T3 can get “soft-bad” (worse tool use, more drift) without an obvious way to reclaim context mid-session.

Grok Build already ships manual `/compact` for this reason. T3 should expose the same control so users can compact proactively instead of only when auto-compact finally runs (or when quality has already slipped). Showing **Context compacted** makes the action trustworthy — without it, sending `/compact` looks like a no-op.

Wire format (Grok 0.2.118 ACP): there is no working dedicated compact RPC in this version; manual compact is **`session/prompt` with text `/compact…`**, then **`auto_compact_completed`** on the session notification channel.

## UI Changes

- Before: Grok `/` menu has no compact entry; sending `/compact` may run but leaves no visible feedback.
- After: `/compact` appears under Grok provider commands; successful compact shows the existing **Context compacted** work-log entry (with token before/after in event detail).

No new UI components — reuses provider slash commands + context-compaction activity.

## Validation

- `vp test apps/server/src/provider/acp/XAiAcpExtension.test.ts apps/server/src/provider/Layers/GrokProvider.test.ts apps/server/src/provider/Layers/GrokAdapter.test.ts` — **38 passed**
- Live ACP probe: `session/prompt` `/compact` emits `_x.ai/session_notification` `auto_compact_completed`
- Manual T3 web (feat/grok-compact-slash): Grok menu shows compact; after send, **Context compacted** appears in the work log

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (happy to add)
- [x] A video is not applicable (no animation/timing change)

Made by Grok Build via the Grok Build harness while working on T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Grok ACP session-notification handling and runtime event emission, which can affect turn/work-log feedback if mapping is wrong. Risk is moderated by focused tests and reuse of the existing compacted ingestion path.
> 
> **Overview**
> Grok users can now discover and run **`/compact`** from the composer slash menu, and successful compaction shows the same **Context compacted** work-log feedback already used by other providers.
> 
> Advertises a `compact` slash command on every Grok provider snapshot (with an optional preserve-context hint). Handles `x.ai/session_notification` / `_x.ai/session_notification` `auto_compact_completed` events in `GrokAdapter`, emitting `thread.state.changed` with `state: "compacted"` plus token before/after detail.
> 
> Adds `XAiSessionNotification` parsing/`extractXAiAutoCompactCompleted` in `XAiAcpExtension`, and updates the ACP mock agent so `/compact` prompts emit the matching notification for end-to-end tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b83aa60787db919701775933d70d055971723135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/compact` slash command and compaction feedback to Grok provider
> - Adds a `compact` slash command to the Grok provider's snapshot metadata so clients can surface it in the UI.
> - Extends [`GrokAdapter`](https://github.com/pingdotgg/t3code/pull/5412/files#diff-1a00c5b795ace1b6633f05c6d3b900dc8d4778afd1879ebdbdf3fb41d04ed521) to handle `x.ai/session_notification` and `_x.ai/session_notification` ACP events, translating `auto_compact_completed` notifications into `thread.state.changed` events with a `compacted` payload including `tokensBefore`, `tokensAfter`, and optional `summaryPreview`.
> - Adds [`XAiAcpExtension`](https://github.com/pingdotgg/t3code/pull/5412/files#diff-facfffc25c57123d8d9a118e55dc2c9856d28b4ed93f1c10cc9dbf6f6f5c360a) with schema validation and an `extractXAiAutoCompactCompleted` utility to parse and normalize compaction notification payloads.
> - Updates the ACP mock agent to emit a session notification when a prompt starts with `/compact`, enabling end-to-end integration testing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b83aa60.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->