### PR TITLE
fix(mobile): pad scroll views above Android nav bar

### DIFF
--- a/apps/mobile/src/features/connection/ConnectionsRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsRouteScreen.tsx
@@ -58,8 +58,8 @@ export function ConnectionsRouteScreen() {
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
         className="flex-1"
-        contentInset={{ bottom: Math.max(insets.bottom, 18) + 18 }}
         contentContainerStyle={{
+          paddingBottom: Math.max(insets.bottom, 18) + 18,
           paddingHorizontal: 20,
           paddingTop: 16,
         }}

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -235,10 +235,9 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
         className="flex-1"
-        contentInset={{ bottom: Math.max(insets.bottom, 18) + 18 }}
         contentContainerStyle={{
           gap: 12,
-          paddingBottom: 8,
+          paddingBottom: Math.max(insets.bottom, 18) + 18,
           paddingHorizontal: 20,
           paddingTop: 8,
         }}


### PR DESCRIPTION
## What Changed

Moved the bottom spacing of the **Choose project** screen (`NewTaskRouteScreen`) and the **Connections** screen (`ConnectionsRouteScreen`) from the ScrollView `contentInset` prop into `contentContainerStyle.paddingBottom`, using the same `Math.max(insets.bottom, 18) + 18` expression the screens already computed.

## Why

Fixes #5414.

`contentInset` is an iOS-only ScrollView prop — a no-op on Android. Since Android edge-to-edge is always on (Expo SDK 54+), these lists draw under the system navigation bar, and with 3-button navigation the last row cannot be scrolled into view. Moving the inset-aware padding into `contentContainerStyle` fixes both platforms and matches the pattern already used by the sibling screens (`AddProjectScreen`, `SettingsProjectGroupingRouteScreen`, `SettingsEnvironmentsRouteScreen`).

The Connections screen had the identical bug, so it gets the identical one-line fix.

## UI Changes

Android 16 emulator (Pixel 7, API 36), 3-button navigation enabled, list scrolled to the bottom in both shots:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/StoneCotton/t3code/pr-5415-assets/before.png" width="320" /> | <img src="https://raw.githubusercontent.com/StoneCotton/t3code/pr-5415-assets/after.png" width="320" /> |

Before: the last project stays clipped behind the 3-button navigation bar at max scroll. After: it scrolls fully into view above the bar.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bottom padding in mobile scroll views to respect Android nav bar insets
> Replaces `contentInset` with `contentContainerStyle` `paddingBottom` in two scroll views, using `Math.max(insets.bottom, 18) + 18` to account for the Android navigation bar height. Affected screens: [ConnectionsRouteScreen](https://github.com/pingdotgg/t3code/pull/5415/files#diff-30606d32080dd98f17a466edfd593e75a378d612488f1dc1f85ae44c8714242d) and [NewTaskRouteScreen](https://github.com/pingdotgg/t3code/pull/5415/files#diff-ff6990d7f3ffc05e93955c8a5c7bf5a3b77e8139e45c8b63e3a296596cd2d29e). Behavioral Change: `NewTaskRouteScreen` bottom padding increases from 8px to at least 36px.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c94c61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->