### PR TITLE
Prevent terminal loading flash

### DIFF
--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -642,6 +642,11 @@ export class GhosttyTerminalSurface {
 
     const context = canvas.getContext("2d", { alpha: false });
     if (!context) throw new Error("Canvas 2D is unavailable");
+    // An opaque canvas backing store initializes to solid black, and the font
+    // and WASM loads below leave it on screen for the whole setup window; paint
+    // the theme background first so the mount never flashes a black box.
+    context.fillStyle = `rgb(${options.theme.background.r}, ${options.theme.background.g}, ${options.theme.background.b})`;
+    context.fillRect(0, 0, canvas.width, canvas.height);
     const fontSize = terminalFontSize(options.font?.size);
     try {
       // Cell metrics must come from the faces that will render; measuring before


### PR DESCRIPTION
## What Changed

Paint the terminal canvas with the configured theme background immediately after creating its 2D context, before font and WASM initialization completes.

## Why

Opaque canvas backing stores start black, causing a visible black box during terminal setup. Initializing the canvas with the theme background prevents the loading flash while the terminal finishes mounting.

## UI Changes

The terminal no longer flashes black during initialization. Before/after screenshots are not included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single early paint in terminal mount path; no auth, data, or behavioral logic changes.
> 
> **Overview**
> Fixes a **black flash** while the Ghostty terminal canvas is still setting up (fonts, WASM, first render).
> 
> Right after creating the opaque 2D context in `GhosttyTerminalSurface.create`, the canvas is **filled once** with `options.theme.background` so the mount shows the theme color instead of the default black backing store until initialization finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc2b90daad654108e8dfc25fc60ddd6c7762567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent black canvas flash during terminal initialization
> Fills the canvas with the theme background color immediately after the 2D context is created in `GhosttyTerminalSurface`, before async font loading begins. This eliminates a transient black frame visible during terminal startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dc2b90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->