### PR TITLE
fix(mobile): avoid iOS terminal reset on clear

### DIFF
--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -535,6 +535,12 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
       return
     }
 
+    if buffer.isEmpty {
+      feedData(Data("\u{1B}[3J\u{1B}[H\u{1B}[2J".utf8))
+      lastAppliedBuffer = ""
+      return
+    }
+
     if buffer.hasPrefix(lastAppliedBuffer) {
       let suffix = String(buffer.dropFirst(lastAppliedBuffer.count))
       feedData(Data(suffix.utf8))


### PR DESCRIPTION


https://github.com/user-attachments/assets/8ec3c980-af20-4ddf-915e-07f494b34e12


## What Changed

<!-- Describe the change clearly and keep scope tight. -->
Setting an empty buffer now clears the existing Ghostty surface with ANSI commands instead of destroying and recreating it, so `Ctrl+C` output can safely arrive immediately afterward.


## Why

<!-- Explain the problem being solved and why this approach is the right one. -->
On IOS application t3code terminal, it crashes after pressing "CLEAR" followed by "CRTL+C". (see video attached)
New terminal output arrived while the Ghostty surface was being destroyed and recreated. 

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [v ] This PR is small and focused
- [v] I explained what changed and why
- [v] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to empty-buffer handling in the iOS terminal view; no auth, data, or shared backend impact.
> 
> **Overview**
> **Fixes iOS terminal crashes when clearing then sending input (e.g. CLEAR + Ctrl+C).**
> 
> When `applyRemoteBuffer` receives an **empty** remote buffer (terminal clear), it now **feeds ANSI clear-screen sequences** (`ESC[3J`, `ESC[H`, `ESC[2J`) into the existing Ghostty surface and resets `lastAppliedBuffer`, instead of falling through to **`resetSurface()`** / surface recreation.
> 
> That keeps the Ghostty surface alive so new PTY output can be applied immediately after a clear without racing teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9ad3a957bc255159a5359ac725a216f0c22b8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iOS terminal clear by sending escape sequences instead of no-op in `T3TerminalView`
> When `applyRemoteBuffer` receives an empty buffer, it now feeds a clear-screen escape sequence (`ESC[3J ESC[H ESC[2J`) to the terminal instead of treating the empty buffer as a prefix match and doing nothing. This fixes a bug where clearing the terminal on iOS had no visible effect.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9ad3a9.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->