### PR TITLE
fix(web): keep pasted link text when the clipboard also carries an image

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -868,6 +868,7 @@ export interface ComposerPromptEditorHandle {
   focus: () => void;
   focusAt: (cursor: number) => void;
   focusAtEnd: () => void;
+  insertText: (text: string) => void;
   readSnapshot: () => {
     value: string;
     cursor: number;
@@ -1691,9 +1692,19 @@ function ComposerPromptEditorInner({
           ),
         );
       },
+      insertText: (text: string) => {
+        editor.update(() => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            selection.insertRawText(text);
+            return;
+          }
+          $getRoot().selectEnd().insertRawText(text);
+        });
+      },
       readSnapshot,
     }),
-    [focusAt, readSnapshot],
+    [editor, focusAt, readSnapshot],
   );
 
   const handleEditorChange = useCallback((editorState: EditorState) => {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -296,6 +296,17 @@ function isInsideComposerFloatingLayer(element: Element): boolean {
   return element.closest(COMPOSER_FLOATING_LAYER_SELECTOR) !== null;
 }
 
+/** A pasted link the user meant to keep, as opposed to accessory clipboard text. */
+function isHttpUrlText(text: string): boolean {
+  if (!/^https?:\/\//i.test(text)) return false;
+  try {
+    const url = new URL(text);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 const ComposerFooterModeControls = memo(function ComposerFooterModeControls(props: {
   showInteractionModeToggle: boolean;
   interactionMode: ProviderInteractionMode;
@@ -2418,9 +2429,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     // Copying a link from a browser or chat app often puts the URL text and a
     // preview image on the clipboard together. preventDefault above suppresses
     // the native text insertion, so re-insert the text half instead of
-    // silently dropping it with the attachment.
-    const text = event.clipboardData.getData("text/plain");
-    if (text.length > 0) {
+    // silently dropping it with the attachment. Only URL-shaped text
+    // qualifies: OS file copies and image copies can carry accessory
+    // text/plain (file names, local paths) the user never meant to insert.
+    const text = event.clipboardData.getData("text/plain").trim();
+    if (isHttpUrlText(text)) {
       composerEditorRef.current?.insertText(text);
     }
   };

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2415,6 +2415,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (imageFiles.length === 0) return;
     event.preventDefault();
     void addComposerImages(imageFiles);
+    // Copying a link from a browser or chat app often puts the URL text and a
+    // preview image on the clipboard together. preventDefault above suppresses
+    // the native text insertion, so re-insert the text half instead of
+    // silently dropping it with the attachment.
+    const text = event.clipboardData.getData("text/plain");
+    if (text.length > 0) {
+      composerEditorRef.current?.insertText(text);
+    }
   };
 
   const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {


### PR DESCRIPTION
Pasting a link copied from a browser tab or a chat app frequently puts both the URL text and a preview image on the clipboard. `onComposerPaste` sees the image file, calls `preventDefault()` to route it into the attachment flow, and the text half of the clipboard is silently discarded — the pasted link never enters the composer, so the message goes out without it.

Repro: copy a link from X/Discord/Slack (or any source that adds an image flavor to the clipboard), paste into the composer — the image attaches, the URL text is gone. Copying the same URL from the address bar (text-only clipboard) pastes fine, which is why this is easy to miss.

Fix: add an `insertText` method to `ComposerPromptEditorHandle` (Lexical `insertRawText` at the current selection, falling back to end of document) and have `onComposerPaste` re-insert the clipboard's `text/plain` after attaching the images. Behavior-only change — no visual/layout difference; `tsgo --noEmit` clean on `apps/web`.

Fable 5 via T3 Code (claudeAgent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to composer paste and editor imperative API; no auth, data, or backend impact.
> 
> **Overview**
> Fixes a composer paste bug where copying a link from apps like Slack or a browser tab puts both a preview image and the URL on the clipboard. The paste handler already intercepts images with `preventDefault()`, which stopped the URL from being inserted.
> 
> **`ComposerPromptEditor`** now exposes **`insertText`** on the editor handle (Lexical `insertRawText` at the selection, or at the end if there is no range).
> 
> **`ChatComposer`** paste flow still attaches clipboard images, then reads `text/plain` and calls **`insertText`** only when the text passes a new **`isHttpUrlText`** check, so incidental plain text from file or screenshot copies (paths, filenames) is not injected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b12b7a9b6640abdb07f9e455e6272c4a306232c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep pasted link text in chat composer when clipboard contains both an image and a URL
> When pasting clipboard content that includes an image and a URL, the chat composer was dropping the URL text after attaching the image. The fix reads the `text/plain` clipboard payload after handling the image, and if it is a valid http(s) URL, calls the new `insertText` method on the composer editor ref to re-insert it.
>
> - Adds `insertText(text)` to `ComposerPromptEditorHandle` in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/5442/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4), inserting at the current selection or appending at the end.
> - Adds `isHttpUrlText` helper and updates `onComposerPaste` in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/5442/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) to call `insertText` after image attachment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b12b7a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->