### PR TITLE
feat(web): add create PR and archive thread keybindings

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -3,6 +3,7 @@ import { assert, describe, it } from "vite-plus/test";
 import {
   buildGitActionProgressStages,
   buildMenuItems,
+  canCreatePrFromPushedWork,
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
   resolveDefaultBranchActionDialogCopy,
@@ -871,6 +872,80 @@ describe("when: ref has no upstream configured", () => {
         dialogAction: "create_pr",
       },
     ]);
+  });
+});
+
+describe("canCreatePrFromPushedWork", () => {
+  it("arms once the ref is clean, in sync, and has no open PR", () => {
+    assert.isTrue(canCreatePrFromPushedWork(status({ aheadOfDefaultCount: 2 }), false));
+  });
+
+  it("stays inert while an action is running or status is unknown", () => {
+    assert.isFalse(canCreatePrFromPushedWork(status({ aheadOfDefaultCount: 2 }), true));
+    assert.isFalse(canCreatePrFromPushedWork(null, false));
+  });
+
+  it("stays inert outside a repo with a primary remote", () => {
+    assert.isFalse(
+      canCreatePrFromPushedWork(status({ isRepo: false, aheadOfDefaultCount: 2 }), false),
+    );
+    assert.isFalse(
+      canCreatePrFromPushedWork(status({ hasPrimaryRemote: false, aheadOfDefaultCount: 2 }), false),
+    );
+  });
+
+  it("stays inert on a detached HEAD", () => {
+    assert.isFalse(
+      canCreatePrFromPushedWork(status({ refName: null, aheadOfDefaultCount: 2 }), false),
+    );
+  });
+
+  it("stays inert while any work is unpushed", () => {
+    assert.isFalse(
+      canCreatePrFromPushedWork(
+        status({ hasWorkingTreeChanges: true, aheadOfDefaultCount: 2 }),
+        false,
+      ),
+    );
+    assert.isFalse(
+      canCreatePrFromPushedWork(status({ hasUpstream: false, aheadOfDefaultCount: 2 }), false),
+    );
+    assert.isFalse(
+      canCreatePrFromPushedWork(status({ aheadCount: 1, aheadOfDefaultCount: 2 }), false),
+    );
+    assert.isFalse(
+      canCreatePrFromPushedWork(status({ behindCount: 1, aheadOfDefaultCount: 2 }), false),
+    );
+  });
+
+  it("stays inert when a PR is already open", () => {
+    assert.isFalse(
+      canCreatePrFromPushedWork(
+        status({
+          aheadOfDefaultCount: 2,
+          pr: {
+            number: 12,
+            title: "Open PR",
+            url: "https://example.com/pr/12",
+            baseRef: "main",
+            headRef: "feature/test",
+            state: "open",
+          },
+        }),
+        false,
+      ),
+    );
+  });
+
+  it("stays inert when the ref has nothing to propose against the default ref", () => {
+    assert.isFalse(canCreatePrFromPushedWork(status({ aheadOfDefaultCount: 0 }), false));
+  });
+
+  it("falls back to the default-ref check when the count is missing", () => {
+    assert.isTrue(canCreatePrFromPushedWork(status(), false));
+    assert.isFalse(
+      canCreatePrFromPushedWork(status({ isDefaultRef: true, refName: "main" }), false),
+    );
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -164,6 +164,33 @@ export function buildMenuItems(
   ];
 }
 
+/**
+ * Gates the `git.createPullRequest` keybinding via the `gitCanCreatePr` when-clause
+ * variable. Deliberately narrower than the "Create PR" menu item: that item also
+ * accepts unpushed work and pushes first, whereas the shortcut only arms once the
+ * ref has nothing left to send, so a stray keypress can never publish commits the
+ * user has not pushed yet.
+ *
+ * `aheadOfDefaultCount` is optional on the wire. Servers old enough to omit it fall
+ * back to "not on the default ref", which keeps the shortcut alive there and lets the
+ * server reject the action if the ref turns out to have nothing to propose.
+ */
+export function canCreatePrFromPushedWork(
+  gitStatus: VcsStatusResult | null,
+  isBusy: boolean,
+): boolean {
+  if (isBusy || !gitStatus) return false;
+  if (!gitStatus.isRepo || !gitStatus.hasPrimaryRemote) return false;
+  if (gitStatus.refName === null) return false;
+  if (gitStatus.hasWorkingTreeChanges) return false;
+  if (!gitStatus.hasUpstream) return false;
+  if (gitStatus.aheadCount > 0 || gitStatus.behindCount > 0) return false;
+  if (gitStatus.pr?.state === "open") return false;
+  return gitStatus.aheadOfDefaultCount === undefined
+    ? !gitStatus.isDefaultRef
+    : gitStatus.aheadOfDefaultCount > 0;
+}
+
 export function resolveQuickAction(
   gitStatus: VcsStatusResult | null,
   isBusy: boolean,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -38,6 +38,7 @@ import { cn } from "~/lib/utils";
 import {
   buildGitActionProgressStages,
   buildMenuItems,
+  canCreatePrFromPushedWork,
   type GitActionIconName,
   type GitActionMenuItem,
   type GitQuickAction,
@@ -79,7 +80,7 @@ import {
 } from "~/lib/sourceControlActions";
 import { useThread } from "~/state/entities";
 import { useEnvironmentQuery } from "~/state/query";
-import { serverEnvironment } from "~/state/server";
+import { primaryServerKeybindingsAtom, serverEnvironment } from "~/state/server";
 import { sourceControlEnvironment } from "~/state/sourceControl";
 import { threadEnvironment } from "~/state/threads";
 import { useAtomCommand } from "~/state/use-atom-command";
@@ -90,6 +91,9 @@ import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { readLocalApi } from "~/localApi";
 import { getSourceControlPresentation } from "~/sourceControlPresentation";
 import { openPullRequestLink } from "~/lib/openPullRequestLink";
+import { isCommandPaletteOpen } from "~/commandPaletteBus";
+import { resolveShortcutCommand } from "~/keybindings";
+import { isTerminalFocused } from "~/lib/terminalFocus";
 
 interface GitActionsControlProps {
   gitCwd: string | null;
@@ -977,6 +981,7 @@ export default function GitActionsControl({
     "thread branch metadata update",
   );
   const activeEnvironmentId = activeThreadRef?.environmentId ?? null;
+  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const serverConfig = useAtomValue(serverEnvironment.configValueAtom(activeEnvironmentId));
   const openInPreferredEditor = useOpenInPreferredEditor(
     activeEnvironmentId,
@@ -1153,6 +1158,10 @@ export default function GitActionsControl({
     () =>
       resolveQuickAction(gitStatusForActions, isGitActionRunning, isDefaultRef, hasPrimaryRemote),
     [gitStatusForActions, hasPrimaryRemote, isDefaultRef, isGitActionRunning],
+  );
+  const canCreatePrFromShortcut = useMemo(
+    () => canCreatePrFromPushedWork(gitStatusForActions, isGitActionRunning),
+    [gitStatusForActions, isGitActionRunning],
   );
   const quickActionDisabledReason = quickAction.disabled
     ? (quickAction.hint ?? "This action is currently unavailable.")
@@ -1605,6 +1614,30 @@ export default function GitActionsControl({
     setIsEditingFiles(false);
     setIsCommitDialogOpen(true);
   };
+
+  // This control owns the git status for the active thread, so it also owns the
+  // `git.createPullRequest` shortcut rather than routing it through the global
+  // handler in `routes/_chat.tsx`, which would need a second status subscription
+  // to evaluate `gitCanCreatePr`.
+  const handleCreatePrShortcut = useEffectEvent((event: KeyboardEvent) => {
+    if (event.defaultPrevented || isCommandPaletteOpen()) return;
+    const command = resolveShortcutCommand(event, keybindings, {
+      context: {
+        terminalFocus: isTerminalFocused(),
+        gitCanCreatePr: canCreatePrFromShortcut,
+      },
+    });
+    if (command !== "git.createPullRequest") return;
+    event.preventDefault();
+    event.stopPropagation();
+    void runGitActionWithToast({ action: "create_pr" });
+  });
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => handleCreatePrShortcut(event);
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   const runDialogAction = () => {
     if (!isCommitDialogOpen) return;

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -136,8 +136,18 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("o", { shiftKey: true }), command: "chat.new" },
   { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
+  {
+    shortcut: modShortcut("p", { shiftKey: true }),
+    command: "git.createPullRequest",
+    whenAst: whenAnd(whenNot(whenIdentifier("terminalFocus")), whenIdentifier("gitCanCreatePr")),
+  },
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
+  {
+    shortcut: modShortcut("a", { shiftKey: true }),
+    command: "thread.archive",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
   { shortcut: modShortcut("1"), command: "thread.jump.1" },
   { shortcut: modShortcut("2"), command: "thread.jump.2" },
   { shortcut: modShortcut("3"), command: "thread.jump.3" },
@@ -511,6 +521,53 @@ describe("chat/editor shortcuts", () => {
     assert.isTrue(
       isOpenFavoriteEditorShortcut(event({ key: "o", ctrlKey: true }), DEFAULT_BINDINGS, {
         platform: "Linux",
+      }),
+    );
+  });
+
+  it("matches git.createPullRequest only when the ref has nothing left to send", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "p", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { gitCanCreatePr: true },
+      }),
+      "git.createPullRequest",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "p", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { gitCanCreatePr: false },
+      }),
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "p", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { gitCanCreatePr: true, terminalFocus: true },
+      }),
+    );
+  });
+
+  it("keeps filePicker.toggle on the unshifted mod+p", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "p", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { gitCanCreatePr: true },
+      }),
+      "filePicker.toggle",
+    );
+  });
+
+  it("matches thread.archive outside terminal focus", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "a", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+      "thread.archive",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "a", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
       }),
     );
   });

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,6 +1,11 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
-import { useEffect, useMemo } from "react";
+import type { ScopedThreadRef } from "@t3tools/contracts";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useSidebarV2Enabled } from "../hooks/useSettings";
@@ -18,6 +23,7 @@ import { resolveShortcutCommand } from "../keybindings";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
+import { useThreadActions } from "../hooks/useThreadActions";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { stackedThreadToast, toastManager } from "~/components/ui/toast";
 import { primaryServerKeybindingsAtom } from "~/state/server";
@@ -27,6 +33,7 @@ function ChatRouteGlobalShortcuts() {
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
     useHandleNewThread();
+  const { archiveThread } = useThreadActions();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const sidebarV2Enabled = useSidebarV2Enabled();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
@@ -55,6 +62,22 @@ function ChatRouteGlobalShortcuts() {
       ? selectActiveRightPanel(state.byThreadKey, routeThreadRef) === "preview"
       : false,
   );
+  const archiveActiveThread = useCallback(
+    async (threadRef: ScopedThreadRef) => {
+      const result = await archiveThread(threadRef);
+      if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) return;
+      const error = squashAtomCommandFailure(result);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Failed to archive thread",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    },
+    [archiveThread],
+  );
+
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
@@ -74,6 +97,14 @@ function ChatRouteGlobalShortcuts() {
       if (event.key === "Escape" && selectedThreadKeysSize > 0) {
         event.preventDefault();
         clearSelection();
+        return;
+      }
+
+      if (command === "thread.archive") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!routeThreadRef) return;
+        void archiveActiveThread(routeThreadRef);
         return;
       }
 
@@ -159,6 +190,7 @@ function ChatRouteGlobalShortcuts() {
   }, [
     activeDraftThread,
     activeThread,
+    archiveActiveThread,
     clearSelection,
     handleNewThread,
     keybindings,

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -46,6 +46,16 @@ agent responses across connected environments. Message matches show one labeled 
 keeping the thread's project, branch, and machine context visible. Message search begins after two
 characters and uses SQLite's ASCII case-insensitive matching.
 
+`git.createPullRequest` opens a pull request for the thread's ref and defaults to `mod+shift+p`.
+It is deliberately narrow: the shortcut only works when the ref has nothing left to send, which
+means no uncommitted changes, no local commits waiting on the upstream, nothing to pull, and no
+pull request open already. While work is still uncommitted or unpushed, the shortcut does nothing;
+use the source control button in the thread header, which offers to commit and push first.
+
+`thread.archive` archives the thread you are looking at and defaults to `mod+shift+a`. Archiving
+the open thread moves you to a new draft in the same project. A thread with a turn in flight is not
+archived, and you get an error toast instead. Restore threads from **Settings** → **Archived**.
+
 The full command list and the current defaults are shown in **Settings** → **Keybindings**, which
 always matches the build you are running. Use that rather than a copied list.
 
@@ -59,9 +69,13 @@ project, `chat.new` opens a project chooser first.
 ## `when` Conditions
 
 A `when` expression is evaluated against context keys describing the current UI state. The keys
-the app supplies today are `terminalFocus`, `terminalOpen`, `previewFocus`, `previewOpen`, and
-`modelPickerOpen`. The set is open and grows over time, so treat that as the current list rather
-than a fixed one. Any key the running app does not supply evaluates to `false`.
+the app supplies today are `terminalFocus`, `terminalOpen`, `previewFocus`, `previewOpen`,
+`modelPickerOpen`, and `gitCanCreatePr`. The set is open and grows over time, so treat that as the
+current list rather than a fixed one. Any key the running app does not supply evaluates to `false`.
+
+`gitCanCreatePr` is true only while the thread's ref has nothing left to send and no pull request
+open. It is supplied to the source control shortcuts, so a rule that uses it elsewhere reads as
+`false`.
 
 Operators: `!` (not), `&&` (and), `||` (or), and parentheses.
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -37,6 +37,7 @@ export type ModelPickerJumpKeybindingCommand =
 export const THREAD_KEYBINDING_COMMANDS = [
   "thread.previous",
   "thread.next",
+  "thread.archive",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,
 ] as const;
 export type ThreadKeybindingCommand = (typeof THREAD_KEYBINDING_COMMANDS)[number];
@@ -69,6 +70,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "chat.new",
   "chat.newLocal",
   "editor.openFavorite",
+  "git.createPullRequest",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,
 ] as const;

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -43,8 +43,16 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
+  // `gitCanCreatePr` is only true once the ref has nothing left to send, so the
+  // shortcut stays inert while there is uncommitted or unpushed work.
+  {
+    key: "mod+shift+p",
+    command: "git.createPullRequest",
+    when: "!terminalFocus && gitCanCreatePr",
+  },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "mod+shift+a", command: "thread.archive", when: "!terminalFocus" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,


### PR DESCRIPTION
## What changed

Two new keybinding commands:

| Command | Default | `when` |
|---|---|---|
| `git.createPullRequest` | `mod+shift+p` | `!terminalFocus && gitCanCreatePr` |
| `thread.archive` | `mod+shift+a` | `!terminalFocus` |

`thread.archive` archives the thread you are currently on and lands you in a new draft in the same project, reusing the existing `archiveThread` action so the running-turn refusal and the archived-thread refresh behave exactly as they do from the sidebar.

`git.createPullRequest` opens a PR for the thread's ref.

## Why the PR shortcut is gated

The shortcut is deliberately narrower than the existing "Create PR" menu item. That item accepts unpushed work and offers to commit and push first. A keyboard shortcut that did the same could publish commits the user had not decided to push, from a single mistyped chord.

So the shortcut only arms once the ref has nothing left to send: no working tree changes, an upstream configured, `aheadCount` and `behindCount` both zero, no PR already open, and something to propose against the default ref. While work is still uncommitted or unpushed the shortcut does nothing and the user goes through the menu, which explains what it is about to do.

This is expressed as a new `gitCanCreatePr` when-clause variable. It is supplied by `GitActionsControl`, which already owns the git status for the active thread. Routing the shortcut through the global handler in `routes/_chat.tsx` instead would have needed a second status subscription just to evaluate the gate.

`aheadOfDefaultCount` is optional on the wire, so a server old enough to omit it falls back to "not on the default ref". That keeps the shortcut alive there and lets the server reject the action if the ref turns out to have nothing to propose.

## Collision check

`mod+shift+p` does not collide with `mod+p` (file picker), which matches unshifted only. There is a regression test for this.

## Tests

- `GitActionsControl.logic.test.ts`: the full gate matrix, including each negative branch and the missing-`aheadOfDefaultCount` fallback.
- `keybindings.test.ts`: resolution of both commands, the `gitCanCreatePr` and `terminalFocus` gating, and the `mod+p` collision check.

## On screenshots

CONTRIBUTING asks for before/after images on UI changes. There is nothing visual to show here: no new UI, no changed layout. The only rendered surface is Settings > Keybindings, which picks both rows up automatically from the existing label derivation, so they read as "Git: Create Pull Request" and "Thread: Archive" with no per-command wiring. Happy to add a short video of the shortcuts firing if that would help.

I read the "not actively accepting contributions" note and did not open an issue first. Close this if it is not wanted, no hard feelings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard-only UX on top of existing git and archive flows; PR shortcut is intentionally conservative to avoid accidental publishes.
> 
> **Overview**
> Adds two keyboard shortcuts: **`mod+shift+p`** runs **`git.createPullRequest`**, and **`mod+shift+a`** runs **`thread.archive`** on the open thread (via existing **`archiveThread`**, with error toasts on failure).
> 
> The PR shortcut is **stricter** than the source-control “Create PR” menu: it only arms when **`gitCanCreatePr`** is true—clean worktree, upstream in sync (no ahead/behind), no open PR, and commits ahead of the default ref (with a fallback when **`aheadOfDefaultCount`** is missing). Uncommitted or unpushed work leaves the chord inert so a mistype cannot push or open a PR. **`GitActionsControl`** owns the listener and supplies **`gitCanCreatePr`** from git status already loaded there; **`_chat.tsx`** is not used for this command.
> 
> Defaults, contract command IDs, user docs, and tests cover the gate matrix, **`when`** gating (including terminal focus), and that unshifted **`mod+p`** still opens the file picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfd830201db1d77132529a5672eefd922123dc6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `git.createPullRequest` and `thread.archive` keybindings
> - Adds `mod+shift+p` to trigger the create PR action from the active thread, gated by a new `gitCanCreatePr` context key that requires a clean, synced branch with upstream and no open PR.
> - Adds `mod+shift+a` to archive the active thread; shows an error toast on failure. Both shortcuts are suppressed when terminal focus is active.
> - Implements `canCreatePrFromPushedWork` in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/5443/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) to compute `gitCanCreatePr` and wires the keydown handler into [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/5443/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f).
> - Documents both shortcuts and the `gitCanCreatePr` context key in [keybindings.md](https://github.com/pingdotgg/t3code/pull/5443/files#diff-2858dfbce3443e10e5180f361437183badc111f8cac64cfe3094bae56b568e43).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfd8302.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->