### PR TITLE
fix(server): preserve latest turn after session completion

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1429,6 +1429,13 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       assert.deepEqual(settledRows, [
         { state: "completed", completedAt: "2026-01-01T00:01:00.000Z" },
       ]);
+
+      const threadRows = yield* sql<{ readonly latestTurnId: string | null }>`
+        SELECT latest_turn_id AS "latestTurnId"
+        FROM projection_threads
+        WHERE thread_id = ${threadId}
+      `;
+      assert.deepEqual(threadRows, [{ latestTurnId: turnId }]);
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -850,7 +850,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           }
           yield* projectionThreadRepository.upsert({
             ...existingRow.value,
-            latestTurnId: event.payload.session.activeTurnId,
+            latestTurnId: event.payload.session.activeTurnId ?? existingRow.value.latestTurnId,
             updatedAt: event.occurredAt,
           });
           yield* refreshThreadShellSummary(event.payload.threadId);


### PR DESCRIPTION
### Before: 
Completed threads briefly lost their latest turn reference, causing Settle to incorrectly report that work was still pending.
<img width="1512" height="982" alt="SCR-20260805-nyyy" src="https://github.com/user-attachments/assets/2488b5e7-775e-48d5-a1f9-9716823e8687" />

### After: 
Completed threads preserve their latest turn reference when the session becomes ready, allowing them to settle immediately.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field fallback in one projection handler with a targeted regression test; no auth or broad API changes.
> 
> **Overview**
> Fixes **`projection_threads.latest_turn_id`** being cleared when a thread’s session moves to a non-running state (e.g. `ready`) with no **`activeTurnId`**.
> 
> On **`thread.session-set`**, the threads projector no longer overwrites **`latestTurnId`** with a nullish **`activeTurnId`**; it keeps the existing value instead. That stops completed threads from briefly losing their last turn reference, which had caused **Settle** to treat work as still pending.
> 
> A projection test now asserts **`latest_turn_id`** stays set after the session leaves **`running`** and the turn is marked completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da525fb5cc192b066eb20476b89701b82f2e582e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `projection_threads.latest_turn_id` to preserve value on session completion
> In the `thread.session-set` event handler in [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/5445/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4), `latestTurnId` was unconditionally set to `event.payload.session.activeTurnId`, which could overwrite the stored value with `null` or `undefined` when the session ended. It now falls back to `existingRow.value.latestTurnId` when `activeTurnId` is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da525fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->