### PR TITLE
feat(web): tag files and directories from anywhere on the filesystem

### DIFF
--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -31,6 +31,7 @@ import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSna
 import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
 import { orchestrationHttpApiLayer } from "./orchestration/http.ts";
+import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
 import * as RepositoryIdentityResolver from "./project/RepositoryIdentityResolver.ts";
 import {
@@ -116,6 +117,9 @@ const readPersistedSnapshot = (baseDir: string) =>
 const withLiveProjectCliServer = <A, E, R>(baseDir: string, run: () => Effect.Effect<A, E, R>) =>
   Effect.gen(function* () {
     const config = yield* makeCliTestServerConfig(baseDir);
+    yield* Effect.promise(() =>
+      NodeFS.promises.mkdir(NodePath.dirname(config.environmentIdPath), { recursive: true }),
+    );
     const routesLayer = HttpApiBuilder.layer(ProjectCliHttpApi).pipe(
       Layer.provide(orchestrationHttpApiLayer),
       Layer.provide(environmentAuthenticatedAuthLayer),
@@ -138,6 +142,12 @@ const withLiveProjectCliServer = <A, E, R>(baseDir: string, run: () => Effect.Ef
         }),
       ),
       Layer.provideMerge(NodeServices.layer),
+      Layer.provideMerge(
+        ServerEnvironment.layer.pipe(
+          Layer.provide(NodeServices.layer),
+          Layer.provide(ServerConfig.layer(config)),
+        ),
+      ),
       Layer.provide(ServerConfig.layer(config)),
     );
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -972,6 +972,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
                   attachments: event.payload.attachments,
                 })
               : previousMessage?.attachments;
+          const nextFileMentions = event.payload.fileMentions ?? previousMessage?.fileMentions;
           yield* projectionThreadMessageRepository.upsert({
             messageId: event.payload.messageId,
             threadId: event.payload.threadId,
@@ -979,6 +980,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             role: event.payload.role,
             text: nextText,
             ...(nextAttachments !== undefined ? { attachments: [...nextAttachments] } : {}),
+            ...(nextFileMentions !== undefined ? { fileMentions: [...nextFileMentions] } : {}),
             isStreaming: event.payload.streaming,
             createdAt: previousMessage?.createdAt ?? event.payload.createdAt,
             updatedAt: event.payload.updatedAt,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -1,5 +1,6 @@
 import {
   CheckpointRef,
+  EnvironmentId,
   EventId,
   MessageId,
   ProjectId,
@@ -2022,10 +2023,15 @@ projectionSnapshotLayer("ProjectionSnapshotQuery windowed thread detail", (it) =
     // turn's pending_message_id.
     yield* sql`
       INSERT INTO projection_thread_messages (
-        message_id, thread_id, turn_id, role, text, is_streaming, created_at, updated_at
+        message_id, thread_id, turn_id, role, text, file_mentions_json, is_streaming,
+        created_at, updated_at
       )
-      VALUES ('user-msg-straggler', 'thread-w', NULL, 'user', 'while you are at it',
-        0, '2026-03-01T00:03:30.000Z', '2026-03-01T00:03:30.000Z')
+      VALUES (
+        'user-msg-straggler', 'thread-w', NULL, 'user',
+        '[AGENTS.md](/repo/AGENTS.md)',
+        '[{"version":1,"environmentId":"environment-1","path":"/repo/AGENTS.md","kind":"file","start":0,"end":28}]',
+        0, '2026-03-01T00:03:30.000Z', '2026-03-01T00:03:30.000Z'
+      )
     `;
     // Turnless activity in the same time range.
     yield* sql`
@@ -2062,6 +2068,20 @@ projectionSnapshotLayer("ProjectionSnapshotQuery windowed thread detail", (it) =
         assert.equal(snapshot.value.thread.messages.length, 9);
         assert.equal(snapshot.value.thread.activities.length, 6);
         assert.equal(snapshot.value.snapshotSequence, 42);
+        assert.deepEqual(
+          snapshot.value.thread.messages.find((message) => message.id === "user-msg-straggler")
+            ?.fileMentions,
+          [
+            {
+              version: 1,
+              environmentId: EnvironmentId.make("environment-1"),
+              path: "/repo/AGENTS.md",
+              kind: "file",
+              start: 0,
+              end: 28,
+            },
+          ],
+        );
       }
     }),
   );

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1,5 +1,6 @@
 import {
   ChatAttachment,
+  ExplicitFileMentions,
   CheckpointRef,
   IsoDateTime,
   MessageId,
@@ -79,6 +80,7 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
+    fileMentions: Schema.NullOr(Schema.fromJsonString(ExplicitFileMentions)),
   }),
 );
 const ProjectionThreadProposedPlanDbRowSchema = ProjectionThreadProposedPlan;
@@ -528,6 +530,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          file_mentions_json AS "fileMentions",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -971,6 +974,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          file_mentions_json AS "fileMentions",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -1197,6 +1201,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          file_mentions_json AS "fileMentions",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -1433,6 +1438,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   role: row.role,
                   text: row.text,
                   ...(row.attachments !== null ? { attachments: row.attachments } : {}),
+                  ...(row.fileMentions !== null ? { fileMentions: row.fileMentions } : {}),
                   turnId: row.turnId,
                   streaming: row.isStreaming === 1,
                   createdAt: row.createdAt,
@@ -2478,7 +2484,10 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             updatedAt: row.updatedAt,
           };
           if (row.attachments !== null) {
-            return Object.assign(message, { attachments: row.attachments });
+            Object.assign(message, { attachments: row.attachments });
+          }
+          if (row.fileMentions !== null) {
+            Object.assign(message, { fileMentions: row.fileMentions });
           }
           return message;
         }),

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -4,11 +4,13 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import {
   type ClientOrchestrationCommand,
+  type EnvironmentId,
   type IsoDateTime,
   type OrchestrationCommand,
   OrchestrationDispatchCommandError,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
+import { validateExplicitFileMentions } from "@t3tools/shared/fileMentions";
 
 import { createAttachmentId, resolveAttachmentPath } from "../attachmentStore.ts";
 import { ServerConfig } from "../config.ts";
@@ -43,7 +45,10 @@ export const canonicalizeClientCommandTimestamps = (
   };
 };
 
-export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
+export const normalizeDispatchCommand = (
+  command: ClientOrchestrationCommand,
+  options: { readonly environmentId?: EnvironmentId } = {},
+) =>
   Effect.gen(function* () {
     const receivedAt = DateTime.formatIso(yield* DateTime.now);
     const canonicalCommand = canonicalizeClientCommandTimestamps(command, receivedAt);
@@ -102,6 +107,20 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
 
     if (canonicalCommand.type !== "thread.turn.start") {
       return canonicalCommand as OrchestrationCommand;
+    }
+
+    const fileMentions = canonicalCommand.message.fileMentions ?? [];
+    if (fileMentions.length > 0) {
+      const failure = validateExplicitFileMentions(
+        canonicalCommand.message.text,
+        fileMentions,
+        options.environmentId,
+      );
+      if (failure !== null) {
+        return yield* new OrchestrationDispatchCommandError({
+          message: `Invalid explicit file mention ${failure}.`,
+        });
+      }
     }
 
     const normalizedAttachments = yield* Effect.forEach(

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -1,6 +1,7 @@
 import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
+  EnvironmentId,
   EventId,
   MessageId,
   ProjectId,
@@ -309,6 +310,16 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
             role: "user",
             text: "hello",
             attachments: [],
+            fileMentions: [
+              {
+                version: 1,
+                environmentId: EnvironmentId.make("environment-1"),
+                path: "/tmp/hello",
+                kind: "file",
+                start: 0,
+                end: 5,
+              },
+            ],
           },
           modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex", [
             { id: "reasoningEffort", value: "high" },
@@ -325,6 +336,9 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
       const events = Array.isArray(result) ? result : [result];
       expect(events).toHaveLength(2);
       expect(events[0]?.type).toBe("thread.message-sent");
+      expect(events[0]?.payload).toMatchObject({
+        fileMentions: [expect.objectContaining({ path: "/tmp/hello", kind: "file" })],
+      });
       const turnStartEvent = events[1];
       expect(turnStartEvent?.type).toBe("thread.turn-start-requested");
       expect(turnStartEvent?.causationEventId).toBe(events[0]?.eventId ?? null);

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -955,6 +955,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           role: "user",
           text: command.message.text,
           attachments: command.message.attachments,
+          ...(command.message.fileMentions !== undefined
+            ? { fileMentions: command.message.fileMentions }
+            : {}),
           turnId: null,
           streaming: false,
           createdAt: command.createdAt,

--- a/apps/server/src/orchestration/http.ts
+++ b/apps/server/src/orchestration/http.ts
@@ -18,6 +18,7 @@ import {
 } from "../auth/http.ts";
 import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
+import { ServerEnvironment } from "../environment/ServerEnvironment.ts";
 
 export const orchestrationHttpApiLayer = HttpApiBuilder.group(
   EnvironmentHttpApi,
@@ -25,6 +26,7 @@ export const orchestrationHttpApiLayer = HttpApiBuilder.group(
   Effect.fnUntraced(function* (handlers) {
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
     const orchestrationEngine = yield* OrchestrationEngineService;
+    const serverEnvironment = yield* ServerEnvironment;
 
     return handlers
       .handle(
@@ -93,9 +95,9 @@ export const orchestrationHttpApiLayer = HttpApiBuilder.group(
         Effect.fn("environment.orchestration.dispatch")(function* (args) {
           yield* annotateEnvironmentRequest(args.endpoint.name);
           yield* requireEnvironmentScope(AuthOrchestrationOperateScope);
-          const normalizedCommand = yield* normalizeDispatchCommand(args.payload).pipe(
-            Effect.catch(() => failEnvironmentInvalidRequest("invalid_command")),
-          );
+          const normalizedCommand = yield* normalizeDispatchCommand(args.payload, {
+            environmentId: yield* serverEnvironment.getEnvironmentId,
+          }).pipe(Effect.catch(() => failEnvironmentInvalidRequest("invalid_command")));
           return yield* orchestrationEngine
             .dispatch(normalizedCommand)
             .pipe(

--- a/apps/server/src/orchestration/http.ts
+++ b/apps/server/src/orchestration/http.ts
@@ -16,9 +16,9 @@ import {
   failEnvironmentNotFound,
   requireEnvironmentScope,
 } from "../auth/http.ts";
+import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
 import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
-import { ServerEnvironment } from "../environment/ServerEnvironment.ts";
 
 export const orchestrationHttpApiLayer = HttpApiBuilder.group(
   EnvironmentHttpApi,
@@ -26,7 +26,7 @@ export const orchestrationHttpApiLayer = HttpApiBuilder.group(
   Effect.fnUntraced(function* (handlers) {
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
     const orchestrationEngine = yield* OrchestrationEngineService;
-    const serverEnvironment = yield* ServerEnvironment;
+    const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
 
     return handlers
       .handle(

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -508,6 +508,7 @@ export function projectEvent(
             role: payload.role,
             text: payload.text,
             ...(payload.attachments !== undefined ? { attachments: payload.attachments } : {}),
+            ...(payload.fileMentions !== undefined ? { fileMentions: payload.fileMentions } : {}),
             turnId: payload.turnId,
             streaming: payload.streaming,
             createdAt: payload.createdAt,
@@ -533,6 +534,9 @@ export function projectEvent(
                     turnId: message.turnId,
                     ...(message.attachments !== undefined
                       ? { attachments: message.attachments }
+                      : {}),
+                    ...(message.fileMentions !== undefined
+                      ? { fileMentions: message.fileMentions }
                       : {}),
                   }
                 : entry,

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
@@ -1,4 +1,4 @@
-import { MessageId, ThreadId } from "@t3tools/contracts";
+import { EnvironmentId, MessageId, ThreadId } from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -28,6 +28,16 @@ layer("ProjectionThreadMessageRepository", (it) => {
           sizeBytes: 5,
         },
       ];
+      const persistedFileMentions = [
+        {
+          version: 1 as const,
+          environmentId: EnvironmentId.make("environment-1"),
+          path: "/tmp/example.png",
+          kind: "file" as const,
+          start: 0,
+          end: 27,
+        },
+      ];
 
       yield* repository.upsert({
         messageId,
@@ -36,6 +46,7 @@ layer("ProjectionThreadMessageRepository", (it) => {
         role: "user",
         text: "initial",
         attachments: persistedAttachments,
+        fileMentions: persistedFileMentions,
         isStreaming: false,
         createdAt,
         updatedAt,
@@ -56,12 +67,14 @@ layer("ProjectionThreadMessageRepository", (it) => {
       assert.equal(rows.length, 1);
       assert.equal(rows[0]?.text, "updated");
       assert.deepEqual(rows[0]?.attachments, persistedAttachments);
+      assert.deepEqual(rows[0]?.fileMentions, persistedFileMentions);
 
       const rowById = yield* repository.getByMessageId({ messageId });
       assert.equal(rowById._tag, "Some");
       if (rowById._tag === "Some") {
         assert.equal(rowById.value.text, "updated");
         assert.deepEqual(rowById.value.attachments, persistedAttachments);
+        assert.deepEqual(rowById.value.fileMentions, persistedFileMentions);
       }
     }),
   );

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Struct from "effect/Struct";
-import { ChatAttachment } from "@t3tools/contracts";
+import { ChatAttachment, ExplicitFileMentions } from "@t3tools/contracts";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
@@ -21,6 +21,7 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
+    fileMentions: Schema.NullOr(Schema.fromJsonString(ExplicitFileMentions)),
   }),
 );
 
@@ -37,6 +38,7 @@ function toProjectionThreadMessage(
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     ...(row.attachments !== null ? { attachments: row.attachments } : {}),
+    ...(row.fileMentions !== null ? { fileMentions: row.fileMentions } : {}),
   };
 }
 
@@ -48,6 +50,8 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
     execute: (row) => {
       const nextAttachmentsJson =
         row.attachments !== undefined ? JSON.stringify(row.attachments) : null;
+      const nextFileMentionsJson =
+        row.fileMentions !== undefined ? JSON.stringify(row.fileMentions) : null;
       return sql`
         INSERT INTO projection_thread_messages (
           message_id,
@@ -56,6 +60,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json,
+          file_mentions_json,
           is_streaming,
           created_at,
           updated_at
@@ -74,6 +79,14 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
               WHERE message_id = ${row.messageId}
             )
           ),
+          COALESCE(
+            ${nextFileMentionsJson},
+            (
+              SELECT file_mentions_json
+              FROM projection_thread_messages
+              WHERE message_id = ${row.messageId}
+            )
+          ),
           ${row.isStreaming ? 1 : 0},
           ${row.createdAt},
           ${row.updatedAt}
@@ -87,6 +100,10 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           attachments_json = COALESCE(
             excluded.attachments_json,
             projection_thread_messages.attachments_json
+          ),
+          file_mentions_json = COALESCE(
+            excluded.file_mentions_json,
+            projection_thread_messages.file_mentions_json
           ),
           is_streaming = excluded.is_streaming,
           created_at = excluded.created_at,
@@ -107,6 +124,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          file_mentions_json AS "fileMentions",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -128,6 +146,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          file_mentions_json AS "fileMentions",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -53,6 +53,7 @@ import Migration0037 from "./Migrations/037_ProjectionTurnsKeysetIndex.ts";
 import Migration0038 from "./Migrations/038_ProjectionThreadsPinOrderKey.ts";
 import Migration0039 from "./Migrations/039_ProjectionProjectsDefaultThreadEnvMode.ts";
 import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
+import Migration0041 from "./Migrations/041_ProjectionThreadMessageFileMentions.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -105,6 +106,7 @@ export const migrationEntries = [
   [38, "ProjectionThreadsPinOrderKey", Migration0038],
   [39, "ProjectionProjectsDefaultThreadEnvMode", Migration0039],
   [40, "ProjectionProjectFaviconPath", Migration0040],
+  [41, "ProjectionThreadMessageFileMentions", Migration0041],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/041_ProjectionThreadMessageFileMentions.test.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionThreadMessageFileMentions.test.ts
@@ -1,0 +1,26 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("041_ProjectionThreadMessageFileMentions", (it) => {
+  it.effect("adds nullable explicit provenance to message projections", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 40 });
+      yield* runMigrations({ toMigrationInclusive: 41 });
+
+      const columns = yield* sql<{ readonly name: string; readonly notnull: number }>`
+        PRAGMA table_info(projection_thread_messages)
+      `;
+      const fileMentions = columns.find((column) => column.name === "file_mentions_json");
+      assert.equal(fileMentions?.name, "file_mentions_json");
+      assert.equal(fileMentions?.notnull, 0);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/041_ProjectionThreadMessageFileMentions.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionThreadMessageFileMentions.ts
@@ -1,0 +1,16 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_thread_messages)
+  `;
+
+  if (!columns.some((column) => column.name === "file_mentions_json")) {
+    yield* sql`
+      ALTER TABLE projection_thread_messages
+      ADD COLUMN file_mentions_json TEXT
+    `;
+  }
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
@@ -8,6 +8,7 @@
  */
 import {
   ChatAttachment,
+  ExplicitFileMentions,
   MessageId,
   OrchestrationMessageRole,
   ThreadId,
@@ -28,6 +29,7 @@ export const ProjectionThreadMessage = Schema.Struct({
   role: OrchestrationMessageRole,
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
+  fileMentions: Schema.optional(ExplicitFileMentions),
   isStreaming: Schema.Boolean,
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -677,6 +677,7 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
           kinds: ["file", "directory"],
           limit: 3,
         });
+        yield* writeTextFile(cwd, "beta/index.ts", "export {};\n");
         const filteredResult = yield* workspaceEntries.browse({
           partialPath: path.join(cwd, "bet"),
           kinds: ["file", "directory"],
@@ -694,6 +695,31 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         expect(filteredResult.entries).toEqual([
           { name: "beta.txt", fullPath: path.join(cwd, "beta.txt"), kind: "file" },
         ]);
+      }),
+    );
+
+    it.effect("includes symlinks to files and directories with their target kinds", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-symlinks-" });
+        yield* writeTextFile(cwd, "target.txt", "target");
+        yield* writeTextFile(cwd, "target-dir/index.ts", "export {};\n");
+        yield* fileSystem.symlink(path.join(cwd, "target.txt"), path.join(cwd, "linked.txt"));
+        yield* fileSystem.symlink(path.join(cwd, "target-dir"), path.join(cwd, "linked-dir"));
+
+        const result = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+          kinds: ["file", "directory"],
+        });
+
+        expect(result.entries).toEqual(
+          expect.arrayContaining([
+            { name: "linked-dir", fullPath: path.join(cwd, "linked-dir"), kind: "directory" },
+            { name: "linked.txt", fullPath: path.join(cwd, "linked.txt"), kind: "file" },
+          ]),
+        );
       }),
     );
 

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -651,10 +651,64 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         expect(result).toEqual({
           parentPath: cwd,
           entries: [
-            { name: "alpha", fullPath: path.join(cwd, "alpha") },
-            { name: "alpine", fullPath: path.join(cwd, "alpine") },
+            { name: "alpha", fullPath: path.join(cwd, "alpha"), kind: "directory" },
+            { name: "alpine", fullPath: path.join(cwd, "alpine"), kind: "directory" },
           ],
         });
+      }),
+    );
+
+    it.effect("returns requested kinds in directory-first order and applies the limit", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-kinds-" });
+        yield* writeTextFile(cwd, ".alpha/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, ".bravo/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "alpha/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "bravo/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "charlie/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "zeta/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "alphabet.txt", "a");
+        yield* writeTextFile(cwd, "beta.txt", "b");
+
+        const result = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+          kinds: ["file", "directory"],
+          limit: 3,
+        });
+        const filteredResult = yield* workspaceEntries.browse({
+          partialPath: path.join(cwd, "bet"),
+          kinds: ["file", "directory"],
+          limit: 1,
+        });
+
+        expect(result).toEqual({
+          parentPath: cwd,
+          entries: [
+            { name: "alpha", fullPath: path.join(cwd, "alpha"), kind: "directory" },
+            { name: "bravo", fullPath: path.join(cwd, "bravo"), kind: "directory" },
+            { name: "alphabet.txt", fullPath: path.join(cwd, "alphabet.txt"), kind: "file" },
+          ],
+        });
+        expect(filteredResult.entries).toEqual([
+          { name: "beta.txt", fullPath: path.join(cwd, "beta.txt"), kind: "file" },
+        ]);
+      }),
+    );
+
+    it.effect("returns no entries when no kinds are requested", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-empty-kinds-" });
+        yield* writeTextFile(cwd, "src/index.ts", "export {};\n");
+
+        const result = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+          kinds: [],
+        });
+
+        expect(result).toEqual({ parentPath: cwd, entries: [] });
       }),
     );
 
@@ -673,12 +727,16 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         const hiddenPrefixResult = yield* workspaceEntries.browse({
           partialPath: `${cwdWithSeparator}.c`,
         });
+        const dotPrefixResult = yield* workspaceEntries.browse({
+          partialPath: `${cwdWithSeparator}.`,
+        });
 
         expect(directoryResult.entries.map((entry) => entry.name)).toEqual([".config", "config"]);
         expect(hiddenPrefixResult).toEqual({
           parentPath: cwd,
-          entries: [{ name: ".config", fullPath: path.join(cwd, ".config") }],
+          entries: [{ name: ".config", fullPath: path.join(cwd, ".config"), kind: "directory" }],
         });
+        expect(dotPrefixResult).toEqual(hiddenPrefixResult);
       }),
     );
 
@@ -696,7 +754,7 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
 
         expect(result).toEqual({
           parentPath: cwd,
-          entries: [{ name: "packages", fullPath: path.join(cwd, "packages") }],
+          entries: [{ name: "packages", fullPath: path.join(cwd, "packages"), kind: "directory" }],
         });
       }),
     );

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -651,10 +651,60 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         expect(result).toEqual({
           parentPath: cwd,
           entries: [
-            { name: "alpha", fullPath: path.join(cwd, "alpha") },
-            { name: "alpine", fullPath: path.join(cwd, "alpine") },
+            { name: "alpha", fullPath: path.join(cwd, "alpha"), kind: "directory" },
+            { name: "alpine", fullPath: path.join(cwd, "alpine"), kind: "directory" },
           ],
         });
+      }),
+    );
+
+    it.effect("returns requested kinds in directory-first order and applies the limit", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-kinds-" });
+        yield* writeTextFile(cwd, "alpha/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "zeta/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "alphabet.txt", "a");
+        yield* writeTextFile(cwd, "beta.txt", "b");
+
+        const result = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+          kinds: ["file", "directory"],
+          limit: 3,
+        });
+        const filteredResult = yield* workspaceEntries.browse({
+          partialPath: path.join(cwd, "b"),
+          kinds: ["file", "directory"],
+          limit: 1,
+        });
+
+        expect(result).toEqual({
+          parentPath: cwd,
+          entries: [
+            { name: "alpha", fullPath: path.join(cwd, "alpha"), kind: "directory" },
+            { name: "zeta", fullPath: path.join(cwd, "zeta"), kind: "directory" },
+            { name: "alphabet.txt", fullPath: path.join(cwd, "alphabet.txt"), kind: "file" },
+          ],
+        });
+        expect(filteredResult.entries).toEqual([
+          { name: "beta.txt", fullPath: path.join(cwd, "beta.txt"), kind: "file" },
+        ]);
+      }),
+    );
+
+    it.effect("returns no entries when no kinds are requested", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-empty-kinds-" });
+        yield* writeTextFile(cwd, "src/index.ts", "export {};\n");
+
+        const result = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+          kinds: [],
+        });
+
+        expect(result).toEqual({ parentPath: cwd, entries: [] });
       }),
     );
 
@@ -677,7 +727,7 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         expect(directoryResult.entries.map((entry) => entry.name)).toEqual([".config", "config"]);
         expect(hiddenPrefixResult).toEqual({
           parentPath: cwd,
-          entries: [{ name: ".config", fullPath: path.join(cwd, ".config") }],
+          entries: [{ name: ".config", fullPath: path.join(cwd, ".config"), kind: "directory" }],
         });
       }),
     );
@@ -696,7 +746,7 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
 
         expect(result).toEqual({
           parentPath: cwd,
-          entries: [{ name: "packages", fullPath: path.join(cwd, "packages") }],
+          entries: [{ name: "packages", fullPath: path.join(cwd, "packages"), kind: "directory" }],
         });
       }),
     );

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -220,15 +220,35 @@ export const make = Effect.gen(function* () {
       const showHidden = endsWithSeparator || prefix.startsWith(".");
       const lowerPrefix = prefix.toLowerCase();
       const requestedKinds = new Set(input.kinds ?? ["directory"]);
-      const entries: FilesystemBrowseEntry[] = [];
-      for (const dirent of dirents) {
-        const kind = dirent.isDirectory() ? "directory" : dirent.isFile() ? "file" : null;
-        if (
-          kind !== null &&
-          requestedKinds.has(kind) &&
+      const candidateDirents = dirents.filter(
+        (dirent) =>
           dirent.name.toLowerCase().startsWith(lowerPrefix) &&
-          (showHidden || !dirent.name.startsWith("."))
-        ) {
+          (showHidden || !dirent.name.startsWith(".")),
+      );
+      const symlinkKinds = yield* Effect.promise(async () => {
+        const resolved = await Promise.all(
+          candidateDirents
+            .filter((dirent) => dirent.isSymbolicLink())
+            .map(async (dirent) => {
+              try {
+                const stats = await NodeFSP.stat(path.join(parentPath, dirent.name));
+                const kind = stats.isDirectory() ? "directory" : stats.isFile() ? "file" : null;
+                return [dirent.name, kind] as const;
+              } catch {
+                return [dirent.name, null] as const;
+              }
+            }),
+        );
+        return new Map(resolved);
+      });
+      const entries: FilesystemBrowseEntry[] = [];
+      for (const dirent of candidateDirents) {
+        const kind = dirent.isDirectory()
+          ? "directory"
+          : dirent.isFile()
+            ? "file"
+            : (symlinkKinds.get(dirent.name) ?? null);
+        if (kind !== null && requestedKinds.has(kind)) {
           entries.push({
             name: dirent.name,
             fullPath: path.join(parentPath, dirent.name),
@@ -256,7 +276,9 @@ export const make = Effect.gen(function* () {
       // large enough set of directories, so each kind keeps a share of the limit.
       const limit = input.limit ?? directories.length + files.length;
       const fileCount = Math.min(files.length, Math.max(0, limit - directories.length));
-      const keptFiles = files.slice(0, Math.max(fileCount, Math.min(files.length, limit >> 1)));
+      const reservedFileCount =
+        files.length > 0 && limit > 0 ? Math.min(files.length, Math.max(1, limit >> 1)) : 0;
+      const keptFiles = files.slice(0, Math.max(fileCount, reservedFileCount));
       const keptDirectories = directories.slice(0, limit - keptFiles.length);
 
       return {

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -10,6 +10,7 @@ import * as RcMap from "effect/RcMap";
 import * as Schema from "effect/Schema";
 
 import type {
+  FilesystemBrowseEntry,
   FilesystemBrowseInput,
   FilesystemBrowseResult,
   ProjectListEntriesInput,
@@ -192,8 +193,10 @@ export const make = Effect.gen(function* () {
     function* (input) {
       const resolvedInputPath = yield* resolveBrowseTarget(input, path);
       const endsWithSeparator = /[\\/]$/.test(input.partialPath) || input.partialPath === "~";
-      const parentPath = endsWithSeparator ? resolvedInputPath : path.dirname(resolvedInputPath);
-      const prefix = endsWithSeparator ? "" : path.basename(resolvedInputPath);
+      const isDotPrefix = /(^|[\\/])\.$/.test(input.partialPath);
+      const parentPath =
+        endsWithSeparator || isDotPrefix ? resolvedInputPath : path.dirname(resolvedInputPath);
+      const prefix = isDotPrefix ? "." : endsWithSeparator ? "" : path.basename(resolvedInputPath);
 
       const dirents = yield* Effect.tryPromise({
         try: () => NodeFSP.readdir(parentPath, { withFileTypes: true }),
@@ -216,23 +219,49 @@ export const make = Effect.gen(function* () {
 
       const showHidden = endsWithSeparator || prefix.startsWith(".");
       const lowerPrefix = prefix.toLowerCase();
-      const entries: Array<{ readonly name: string; readonly fullPath: string }> = [];
+      const requestedKinds = new Set(input.kinds ?? ["directory"]);
+      const entries: FilesystemBrowseEntry[] = [];
       for (const dirent of dirents) {
+        const kind = dirent.isDirectory() ? "directory" : dirent.isFile() ? "file" : null;
         if (
-          dirent.isDirectory() &&
+          kind !== null &&
+          requestedKinds.has(kind) &&
           dirent.name.toLowerCase().startsWith(lowerPrefix) &&
           (showHidden || !dirent.name.startsWith("."))
         ) {
           entries.push({
             name: dirent.name,
             fullPath: path.join(parentPath, dirent.name),
+            kind,
           });
         }
       }
 
+      const byName = (left: FilesystemBrowseEntry, right: FilesystemBrowseEntry) =>
+        left.name.localeCompare(right.name);
+      const byBrowseOrder = (left: FilesystemBrowseEntry, right: FilesystemBrowseEntry) => {
+        if (input.limit !== undefined && prefix.length === 0) {
+          const hiddenOrder =
+            Number(left.name.startsWith(".")) - Number(right.name.startsWith("."));
+          if (hiddenOrder !== 0) return hiddenOrder;
+        }
+        return byName(left, right);
+      };
+      const directories = entries
+        .filter((entry) => entry.kind === "directory")
+        .toSorted(byBrowseOrder);
+      const files = entries.filter((entry) => entry.kind !== "directory").toSorted(byBrowseOrder);
+
+      // Truncating the directories-first order would hide every file behind a
+      // large enough set of directories, so each kind keeps a share of the limit.
+      const limit = input.limit ?? directories.length + files.length;
+      const fileCount = Math.min(files.length, Math.max(0, limit - directories.length));
+      const keptFiles = files.slice(0, Math.max(fileCount, Math.min(files.length, limit >> 1)));
+      const keptDirectories = directories.slice(0, limit - keptFiles.length);
+
       return {
         parentPath,
-        entries: entries.toSorted((left, right) => left.name.localeCompare(right.name)),
+        entries: [...keptDirectories, ...keptFiles],
       };
     },
   );

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -10,6 +10,7 @@ import * as RcMap from "effect/RcMap";
 import * as Schema from "effect/Schema";
 
 import type {
+  FilesystemBrowseEntry,
   FilesystemBrowseInput,
   FilesystemBrowseResult,
   ProjectListEntriesInput,
@@ -216,23 +217,39 @@ export const make = Effect.gen(function* () {
 
       const showHidden = endsWithSeparator || prefix.startsWith(".");
       const lowerPrefix = prefix.toLowerCase();
-      const entries: Array<{ readonly name: string; readonly fullPath: string }> = [];
+      const requestedKinds = new Set(input.kinds ?? ["directory"]);
+      const entries: FilesystemBrowseEntry[] = [];
       for (const dirent of dirents) {
+        const kind = dirent.isDirectory() ? "directory" : dirent.isFile() ? "file" : null;
         if (
-          dirent.isDirectory() &&
+          kind !== null &&
+          requestedKinds.has(kind) &&
           dirent.name.toLowerCase().startsWith(lowerPrefix) &&
           (showHidden || !dirent.name.startsWith("."))
         ) {
           entries.push({
             name: dirent.name,
             fullPath: path.join(parentPath, dirent.name),
+            kind,
           });
         }
       }
 
+      const byName = (left: FilesystemBrowseEntry, right: FilesystemBrowseEntry) =>
+        left.name.localeCompare(right.name);
+      const directories = entries.filter((entry) => entry.kind === "directory").toSorted(byName);
+      const files = entries.filter((entry) => entry.kind !== "directory").toSorted(byName);
+
+      // Truncating the directories-first order would hide every file behind a
+      // large enough set of directories, so each kind keeps a share of the limit.
+      const limit = input.limit ?? directories.length + files.length;
+      const fileCount = Math.min(files.length, Math.max(0, limit - directories.length));
+      const keptFiles = files.slice(0, Math.max(fileCount, Math.min(files.length, limit >> 1)));
+      const keptDirectories = directories.slice(0, limit - keptFiles.length);
+
       return {
         parentPath,
-        entries: entries.toSorted((left, right) => left.name.localeCompare(right.name)),
+        entries: [...keptDirectories, ...keptFiles],
       };
     },
   );

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1037,7 +1037,9 @@ const makeWsRpcLayer = (
           observeRpcEffect(
             ORCHESTRATION_WS_METHODS.dispatchCommand,
             Effect.gen(function* () {
-              const normalizedCommand = yield* normalizeDispatchCommand(command);
+              const normalizedCommand = yield* normalizeDispatchCommand(command, {
+                environmentId: yield* serverEnvironment.getEnvironmentId,
+              });
               // Archive and settle both mean "done with this thread", so a
               // live provider session must not keep running background work
               // (PR monitors, dev servers, subagent fleets) after either

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "jszip": "3.10.1",
     "lexical": "^0.41.0",
     "lucide-react": "^0.564.0",
+    "micromark-util-decode-string": "^2.0.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "^10.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,6 @@
     "jszip": "3.10.1",
     "lexical": "^0.41.0",
     "lucide-react": "^0.564.0",
-    "micromark-util-decode-string": "^2.0.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "^10.1.0",

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -13,13 +13,13 @@ import {
   TriangleAlertIcon,
   WrapTextIcon,
 } from "lucide-react";
-import { decodeString } from "micromark-util-decode-string";
-import type { ScopedThreadRef, ServerProviderSkill } from "@t3tools/contracts";
+import type { ExplicitFileMention, ScopedThreadRef, ServerProviderSkill } from "@t3tools/contracts";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
+import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 import React, {
@@ -77,7 +77,7 @@ import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation
 import {
   normalizeMarkdownLinkDestination,
   preserveWindowsMarkdownFileHref,
-  resolveCanonicalMarkdownFileLinkMeta,
+  resolveExplicitFileMentionMeta,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
@@ -106,7 +106,7 @@ import {
 interface ChatMarkdownProps {
   text: string;
   cwd: string | undefined;
-  canonicalFileLinks?: boolean;
+  fileMentions?: ReadonlyArray<ExplicitFileMention>;
   threadRef?: ScopedThreadRef | undefined;
   onTaskListChange?: ((input: { markerOffset: number; checked: boolean }) => void) | undefined;
   isStreaming?: boolean;
@@ -894,46 +894,14 @@ function extractInlineCodeSpans(text: string): string[] {
   return spans;
 }
 
-const WRAPPED_LABEL_DELIMITERS = ["***", "___", "**", "__", "*", "_", "`"];
-
-/** Unwraps a fully wrapped label (`*name*`) to the text the parser will render. */
-function markdownLabelInnerText(label: string): string {
-  let start = 0;
-  let end = label.length;
-  let matched = true;
-  while (matched) {
-    matched = false;
-    for (const delimiter of WRAPPED_LABEL_DELIMITERS) {
-      if (
-        end - start > delimiter.length * 2 &&
-        label.startsWith(delimiter, start) &&
-        label.endsWith(delimiter, end)
-      ) {
-        start += delimiter.length;
-        end -= delimiter.length;
-        matched = true;
-        break;
-      }
-    }
-  }
-  return label.slice(start, end);
-}
-
-function extractMarkdownLinks(text: string): Array<{ label: string; href: string }> {
-  const links: Array<{ label: string; href: string }> = [];
+function extractMarkdownLinkHrefs(text: string): string[] {
+  const hrefs: string[] = [];
   for (const match of text.matchAll(MARKDOWN_LINK_PATTERN)) {
     const href = match[2]?.trim();
     if (!href) continue;
-    links.push({
-      label: decodeString(match[1] ?? ""),
-      href,
-    });
+    hrefs.push(href);
   }
-  return links;
-}
-
-function canonicalMarkdownLinkKey(label: string, href: string): string {
-  return `${label}\0${href}`;
+  return hrefs;
 }
 
 function normalizeMarkdownLinkHrefKey(href: string): string {
@@ -982,30 +950,6 @@ function breakableExternalLinkText(text: string): ReactNode[] {
       <wbr />
     </React.Fragment>
   ));
-}
-
-/**
- * Link labels reach the renderer as parsed nodes, so `[*name*](path)` arrives as
- * an `em` wrapping the text. Reading through inline formatting keeps the lookup
- * key aligned with the label text indexed from the source.
- */
-function inlineHastText(node: unknown): string | null {
-  const pending = [node];
-  const parts: string[] = [];
-  while (pending.length > 0) {
-    const current = pending.pop();
-    if (!current || typeof current !== "object") return null;
-    if ("type" in current && current.type === "text") {
-      if (!("value" in current) || typeof current.value !== "string") return null;
-      parts.push(current.value);
-      continue;
-    }
-    if (!("children" in current) || !Array.isArray(current.children)) return null;
-    for (let index = current.children.length - 1; index >= 0; index -= 1) {
-      pending.push(current.children[index]);
-    }
-  }
-  return parts.join("");
 }
 
 function plainHastText(node: unknown): string | null {
@@ -1421,7 +1365,7 @@ function areMarkdownFileLinkPropsEqual(
 function ChatMarkdown({
   text,
   cwd,
-  canonicalFileLinks = false,
+  fileMentions,
   threadRef,
   onTaskListChange,
   isStreaming = false,
@@ -1449,7 +1393,8 @@ function ChatMarkdown({
       string,
       NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>
     >();
-    for (const { href } of extractMarkdownLinks(text)) {
+    if (fileMentions !== undefined) return metaByHref;
+    for (const href of extractMarkdownLinkHrefs(text)) {
       const normalizedHref = normalizeMarkdownLinkHrefKey(href);
       if (metaByHref.has(normalizedHref)) continue;
       const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
@@ -1458,25 +1403,18 @@ function ChatMarkdown({
       }
     }
     return metaByHref;
-  }, [cwd, text]);
-  const canonicalFileLinkMetaByKey = useMemo(() => {
-    const metaByKey = new Map<string, MarkdownFileLinkMeta>();
-    if (!canonicalFileLinks) return metaByKey;
-    for (const { label, href } of extractMarkdownLinks(text)) {
-      const normalizedHref = normalizeMarkdownLinkHrefKey(href);
-      // A formatted label such as `*name*` renders as its inner text, so index
-      // both forms and let whichever the renderer reports find the entry.
-      for (const candidate of new Set([label, markdownLabelInnerText(label)])) {
-        const key = canonicalMarkdownLinkKey(candidate, normalizedHref);
-        if (metaByKey.has(key)) continue;
-        const meta = resolveCanonicalMarkdownFileLinkMeta(candidate, normalizedHref, cwd);
-        if (meta) {
-          metaByKey.set(key, meta);
-        }
+  }, [cwd, fileMentions, text]);
+  const explicitFileLinkMetaByRange = useMemo(() => {
+    const metaByRange = new Map<string, MarkdownFileLinkMeta>();
+    for (const mention of fileMentions ?? []) {
+      if (text.slice(mention.start, mention.end) !== serializeComposerFileLink(mention.path)) {
+        continue;
       }
+      const meta = resolveExplicitFileMentionMeta(mention.path, cwd);
+      if (meta) metaByRange.set(`${mention.start}:${mention.end}`, meta);
     }
-    return metaByKey;
-  }, [canonicalFileLinks, cwd, text]);
+    return metaByRange;
+  }, [cwd, fileMentions, text]);
   const inlineCodeFileLinkMetaByText = useMemo(() => {
     const metaByText = new Map<string, MarkdownFileLinkMeta>();
     for (const span of extractInlineCodeSpans(text)) {
@@ -1491,11 +1429,11 @@ function ChatMarkdown({
   const fileLinkParentSuffixByPath = useMemo(() => {
     const filePaths = [
       ...[...markdownFileLinkMetaByHref.values()].map((meta) => meta.filePath),
-      ...[...canonicalFileLinkMetaByKey.values()].map((meta) => meta.filePath),
+      ...[...explicitFileLinkMetaByRange.values()].map((meta) => meta.filePath),
       ...[...inlineCodeFileLinkMetaByText.values()].map((meta) => meta.filePath),
     ];
     return buildFileLinkParentSuffixByPath(filePaths);
-  }, [canonicalFileLinkMetaByKey, inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
+  }, [explicitFileLinkMetaByRange, inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
   const markdownUrlTransform = useCallback((href: string) => {
     return (
       rewriteMarkdownFileUriHref(href) ??
@@ -1671,13 +1609,13 @@ function ChatMarkdown({
       },
       a({ node, href, children, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
-        const linkLabel = inlineHastText(node);
+        const start = node?.position?.start.offset;
+        const end = node?.position?.end.offset;
         const fileLinkMeta = normalizedHref
-          ? ((linkLabel === null
-              ? null
-              : canonicalFileLinkMetaByKey.get(
-                  canonicalMarkdownLinkKey(linkLabel, normalizedHref),
-                )) ?? markdownFileLinkMetaByHref.get(normalizedHref))
+          ? ((typeof start === "number" && typeof end === "number"
+              ? explicitFileLinkMetaByRange.get(`${start}:${end}`)
+              : null) ??
+            (fileMentions === undefined ? markdownFileLinkMetaByHref.get(normalizedHref) : null))
           : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
@@ -1814,7 +1752,8 @@ function ChatMarkdown({
       },
     };
   }, [
-    canonicalFileLinkMetaByKey,
+    explicitFileLinkMetaByRange,
+    fileMentions,
     cwd,
     diffThemeName,
     fileLinkParentSuffixByPath,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -106,7 +106,7 @@ import {
 interface ChatMarkdownProps {
   text: string;
   cwd: string | undefined;
-  fileMentions?: ReadonlyArray<ExplicitFileMention>;
+  fileMentions?: ReadonlyArray<ExplicitFileMention> | undefined;
   threadRef?: ScopedThreadRef | undefined;
   onTaskListChange?: ((input: { markerOffset: number; checked: boolean }) => void) | undefined;
   isStreaming?: boolean;
@@ -180,11 +180,6 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
   remarkPreserveCodeMeta,
   remarkTagInlineCode,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
-
-const CHAT_MARKDOWN_REHYPE_PLUGINS = [
-  rehypeRaw,
-  [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
-] satisfies NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 
 /** GitHub's own five alert kinds, in its colors: the glyph names the urgency, the title says it. */
 const GITHUB_ALERT_PRESENTATIONS: Record<
@@ -800,8 +795,6 @@ interface MarkdownFileLinkProps {
   className?: string | undefined;
 }
 
-const MARKDOWN_LINK_PATTERN = /\[((?:\\.|[^\]\\])*)]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
-const WHOLE_MARKDOWN_LINK_PATTERN = new RegExp(`^${MARKDOWN_LINK_PATTERN.source}$`);
 const MARKDOWN_FILE_LINK_CLASS_NAME = "chat-markdown-file-link transition-colors";
 
 /**
@@ -816,7 +809,7 @@ function authoredMarkdownLinkSource(
 ): string | null {
   if (typeof start !== "number" || typeof end !== "number" || end > text.length) return null;
   const slice = text.slice(start, end);
-  return WHOLE_MARKDOWN_LINK_PATTERN.test(slice) ? slice : null;
+  return slice.startsWith("[") && slice.endsWith(")") ? slice : null;
 }
 
 function pathParentSegments(path: string): string[] {
@@ -892,16 +885,6 @@ function extractInlineCodeSpans(text: string): string[] {
     }
   }
   return spans;
-}
-
-function extractMarkdownLinkHrefs(text: string): string[] {
-  const hrefs: string[] = [];
-  for (const match of text.matchAll(MARKDOWN_LINK_PATTERN)) {
-    const href = match[2]?.trim();
-    if (!href) continue;
-    hrefs.push(href);
-  }
-  return hrefs;
 }
 
 function normalizeMarkdownLinkHrefKey(href: string): string {
@@ -1388,22 +1371,6 @@ function ChatMarkdown({
     serverConfig?.availableEditors ?? [],
   );
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
-  const markdownFileLinkMetaByHref = useMemo(() => {
-    const metaByHref = new Map<
-      string,
-      NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>
-    >();
-    if (fileMentions !== undefined) return metaByHref;
-    for (const href of extractMarkdownLinkHrefs(text)) {
-      const normalizedHref = normalizeMarkdownLinkHrefKey(href);
-      if (metaByHref.has(normalizedHref)) continue;
-      const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
-      if (meta) {
-        metaByHref.set(normalizedHref, meta);
-      }
-    }
-    return metaByHref;
-  }, [cwd, fileMentions, text]);
   const explicitFileLinkMetaByRange = useMemo(() => {
     const metaByRange = new Map<string, MarkdownFileLinkMeta>();
     for (const mention of fileMentions ?? []) {
@@ -1426,14 +1393,64 @@ function ChatMarkdown({
     }
     return metaByText;
   }, [cwd, text]);
-  const fileLinkParentSuffixByPath = useMemo(() => {
-    const filePaths = [
-      ...[...markdownFileLinkMetaByHref.values()].map((meta) => meta.filePath),
-      ...[...explicitFileLinkMetaByRange.values()].map((meta) => meta.filePath),
-      ...[...inlineCodeFileLinkMetaByText.values()].map((meta) => meta.filePath),
-    ];
-    return buildFileLinkParentSuffixByPath(filePaths);
-  }, [explicitFileLinkMetaByRange, inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
+  const markdownFileLinkAnalysis = useMemo(() => {
+    const metaByRange = new Map<string, MarkdownFileLinkMeta>();
+    const parentSuffixByPath = new Map<string, string>();
+    const rehypePlugin = () => (tree: unknown) => {
+      metaByRange.clear();
+      parentSuffixByPath.clear();
+      const filePaths = [...inlineCodeFileLinkMetaByText.values()].map((meta) => meta.filePath);
+      const pending: unknown[] = [tree];
+      while (pending.length > 0) {
+        const node = pending.pop();
+        if (!node || typeof node !== "object") continue;
+        const candidate = node as {
+          readonly tagName?: unknown;
+          readonly properties?: Readonly<Record<string, unknown>>;
+          readonly children?: ReadonlyArray<unknown>;
+          readonly position?: {
+            readonly start?: { readonly offset?: number };
+            readonly end?: { readonly offset?: number };
+          };
+        };
+        if (candidate.tagName === "a") {
+          const start = candidate.position?.start?.offset;
+          const end = candidate.position?.end?.offset;
+          if (typeof start === "number" && typeof end === "number") {
+            const rangeKey = `${start}:${end}`;
+            let meta = explicitFileLinkMetaByRange.get(rangeKey) ?? null;
+            if (
+              meta === null &&
+              fileMentions === undefined &&
+              authoredMarkdownLinkSource(text, start, end) !== null
+            ) {
+              const href = candidate.properties?.href;
+              if (typeof href === "string") {
+                meta = resolveMarkdownFileLinkMeta(normalizeMarkdownLinkHrefKey(href), cwd);
+              }
+            }
+            if (meta) {
+              metaByRange.set(rangeKey, meta);
+              filePaths.push(meta.filePath);
+            }
+          }
+        }
+        if (candidate.children) pending.push(...candidate.children);
+      }
+      for (const [path, suffix] of buildFileLinkParentSuffixByPath(filePaths)) {
+        parentSuffixByPath.set(path, suffix);
+      }
+    };
+    return { metaByRange, parentSuffixByPath, rehypePlugin };
+  }, [cwd, explicitFileLinkMetaByRange, fileMentions, inlineCodeFileLinkMetaByText, text]);
+  const markdownRehypePlugins = useMemo<NonNullable<ReactMarkdownOptions["rehypePlugins"]>>(
+    () => [
+      rehypeRaw,
+      markdownFileLinkAnalysis.rehypePlugin,
+      [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
+    ],
+    [markdownFileLinkAnalysis.rehypePlugin],
+  );
   const markdownUrlTransform = useCallback((href: string) => {
     return (
       rewriteMarkdownFileUriHref(href) ??
@@ -1505,7 +1522,7 @@ function ChatMarkdown({
       copyMarkdown: string,
       className?: string,
     ) => {
-      const parentSuffix = fileLinkParentSuffixByPath.get(fileLinkMeta.filePath);
+      const parentSuffix = markdownFileLinkAnalysis.parentSuffixByPath.get(fileLinkMeta.filePath);
       const labelParts = [fileLinkMeta.basename];
       if (typeof parentSuffix === "string" && parentSuffix.length > 0) {
         labelParts.push(parentSuffix);
@@ -1608,15 +1625,12 @@ function ChatMarkdown({
         );
       },
       a({ node, href, children, ...props }) {
-        const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
         const start = node?.position?.start.offset;
         const end = node?.position?.end.offset;
-        const fileLinkMeta = normalizedHref
-          ? ((typeof start === "number" && typeof end === "number"
-              ? explicitFileLinkMetaByRange.get(`${start}:${end}`)
-              : null) ??
-            (fileMentions === undefined ? markdownFileLinkMetaByHref.get(normalizedHref) : null))
-          : null;
+        const fileLinkMeta =
+          typeof start === "number" && typeof end === "number"
+            ? markdownFileLinkAnalysis.metaByRange.get(`${start}:${end}`)
+            : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
           const isSameDocumentLink = href?.startsWith("#") ?? false;
@@ -1693,11 +1707,8 @@ function ChatMarkdown({
         }
 
         const copyMarkdown =
-          authoredMarkdownLinkSource(
-            text,
-            node?.position?.start.offset,
-            node?.position?.end.offset,
-          ) ?? `[${fileLinkMeta.basename}](${normalizedHref})`;
+          authoredMarkdownLinkSource(text, start, end) ??
+          `[${fileLinkMeta.basename}](${fileLinkMeta.targetPath})`;
         return fileLinkChip(fileLinkMeta, copyMarkdown, props.className);
       },
       code({ node, children, className, ...props }) {
@@ -1752,14 +1763,11 @@ function ChatMarkdown({
       },
     };
   }, [
-    explicitFileLinkMetaByRange,
-    fileMentions,
     cwd,
     diffThemeName,
-    fileLinkParentSuffixByPath,
     inlineCodeFileLinkMetaByText,
     isStreaming,
-    markdownFileLinkMetaByHref,
+    markdownFileLinkAnalysis,
     onTaskListChange,
     openInPreferredEditor,
     openExternalLinkInPreview,
@@ -1783,7 +1791,7 @@ function ChatMarkdown({
         remarkPlugins={
           lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS
         }
-        rehypePlugins={CHAT_MARKDOWN_REHYPE_PLUGINS}
+        rehypePlugins={markdownRehypePlugins}
         components={markdownComponents}
         urlTransform={markdownUrlTransform}
       >

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -13,6 +13,7 @@ import {
   TriangleAlertIcon,
   WrapTextIcon,
 } from "lucide-react";
+import { decodeString } from "micromark-util-decode-string";
 import type { ScopedThreadRef, ServerProviderSkill } from "@t3tools/contracts";
 import {
   isAtomCommandInterrupted,
@@ -75,6 +76,8 @@ import {
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
   normalizeMarkdownLinkDestination,
+  preserveWindowsMarkdownFileHref,
+  resolveCanonicalMarkdownFileLinkMeta,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
@@ -103,6 +106,7 @@ import {
 interface ChatMarkdownProps {
   text: string;
   cwd: string | undefined;
+  canonicalFileLinks?: boolean;
   threadRef?: ScopedThreadRef | undefined;
   onTaskListChange?: ((input: { markerOffset: number; checked: boolean }) => void) | undefined;
   isStreaming?: boolean;
@@ -782,6 +786,7 @@ function UncachedShikiCodeBlock({
 interface MarkdownFileLinkProps {
   href: string;
   targetPath: string;
+  openTargetPath: string | null;
   iconPath: string;
   displayPath: string;
   workspaceRelativePath: string | null;
@@ -795,9 +800,24 @@ interface MarkdownFileLinkProps {
   className?: string | undefined;
 }
 
-const MARKDOWN_LINK_HREF_PATTERN = /\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
-const MARKDOWN_FILE_LINK_CLASS_NAME =
-  "chat-markdown-file-link cursor-pointer transition-colors hover:bg-accent/70";
+const MARKDOWN_LINK_PATTERN = /\[((?:\\.|[^\]\\])*)]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+const WHOLE_MARKDOWN_LINK_PATTERN = new RegExp(`^${MARKDOWN_LINK_PATTERN.source}$`);
+const MARKDOWN_FILE_LINK_CLASS_NAME = "chat-markdown-file-link transition-colors";
+
+/**
+ * Nodes recovered by `remarkNormalizeListItemIndentation` carry offsets into a
+ * synthetic reparsed source, so slicing the original text by them yields the
+ * wrong span. Fall back to a reconstruction unless the slice really is a link.
+ */
+function authoredMarkdownLinkSource(
+  text: string,
+  start: number | undefined,
+  end: number | undefined,
+): string | null {
+  if (typeof start !== "number" || typeof end !== "number" || end > text.length) return null;
+  const slice = text.slice(start, end);
+  return WHOLE_MARKDOWN_LINK_PATTERN.test(slice) ? slice : null;
+}
 
 function pathParentSegments(path: string): string[] {
   const normalized = path.replaceAll("\\", "/");
@@ -874,14 +894,46 @@ function extractInlineCodeSpans(text: string): string[] {
   return spans;
 }
 
-function extractMarkdownLinkHrefs(text: string): string[] {
-  const hrefs: string[] = [];
-  for (const match of text.matchAll(MARKDOWN_LINK_HREF_PATTERN)) {
-    const href = match[1]?.trim();
-    if (!href) continue;
-    hrefs.push(href);
+const WRAPPED_LABEL_DELIMITERS = ["***", "___", "**", "__", "*", "_", "`"];
+
+/** Unwraps a fully wrapped label (`*name*`) to the text the parser will render. */
+function markdownLabelInnerText(label: string): string {
+  let start = 0;
+  let end = label.length;
+  let matched = true;
+  while (matched) {
+    matched = false;
+    for (const delimiter of WRAPPED_LABEL_DELIMITERS) {
+      if (
+        end - start > delimiter.length * 2 &&
+        label.startsWith(delimiter, start) &&
+        label.endsWith(delimiter, end)
+      ) {
+        start += delimiter.length;
+        end -= delimiter.length;
+        matched = true;
+        break;
+      }
+    }
   }
-  return hrefs;
+  return label.slice(start, end);
+}
+
+function extractMarkdownLinks(text: string): Array<{ label: string; href: string }> {
+  const links: Array<{ label: string; href: string }> = [];
+  for (const match of text.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const href = match[2]?.trim();
+    if (!href) continue;
+    links.push({
+      label: decodeString(match[1] ?? ""),
+      href,
+    });
+  }
+  return links;
+}
+
+function canonicalMarkdownLinkKey(label: string, href: string): string {
+  return `${label}\0${href}`;
 }
 
 function normalizeMarkdownLinkHrefKey(href: string): string {
@@ -930,6 +982,30 @@ function breakableExternalLinkText(text: string): ReactNode[] {
       <wbr />
     </React.Fragment>
   ));
+}
+
+/**
+ * Link labels reach the renderer as parsed nodes, so `[*name*](path)` arrives as
+ * an `em` wrapping the text. Reading through inline formatting keeps the lookup
+ * key aligned with the label text indexed from the source.
+ */
+function inlineHastText(node: unknown): string | null {
+  const pending = [node];
+  const parts: string[] = [];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || typeof current !== "object") return null;
+    if ("type" in current && current.type === "text") {
+      if (!("value" in current) || typeof current.value !== "string") return null;
+      parts.push(current.value);
+      continue;
+    }
+    if (!("children" in current) || !Array.isArray(current.children)) return null;
+    for (let index = current.children.length - 1; index >= 0; index -= 1) {
+      pending.push(current.children[index]);
+    }
+  }
+  return parts.join("");
 }
 
 function plainHastText(node: unknown): string | null {
@@ -1084,6 +1160,7 @@ function MarkdownExternalLinkContent({
 const MarkdownFileLink = memo(function MarkdownFileLink({
   href,
   targetPath,
+  openTargetPath,
   iconPath,
   displayPath,
   workspaceRelativePath,
@@ -1097,14 +1174,15 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   className,
 }: MarkdownFileLinkProps) {
   const handleOpenInEditor = useCallback(() => {
+    if (openTargetPath === null) return;
     void (async () => {
       try {
-        const result = await onOpen(targetPath);
+        const result = await onOpen(openTargetPath);
         if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
           return;
         }
         reportMarkdownActionFailure(
-          { operation: "open-file-in-editor", target: targetPath },
+          { operation: "open-file-in-editor", target: openTargetPath },
           result.cause,
         );
         const error = squashAtomCommandFailure(result);
@@ -1117,7 +1195,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         );
       } catch (cause) {
         reportMarkdownActionFailure(
-          { operation: "open-file-in-editor", target: targetPath },
+          { operation: "open-file-in-editor", target: openTargetPath },
           cause,
         );
         toastManager.add(
@@ -1129,7 +1207,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         );
       }
     })();
-  }, [onOpen, targetPath]);
+  }, [onOpen, openTargetPath]);
 
   const handleOpenInFilePreview = useCallback(() => {
     if (!threadRef || !workspaceRelativePath) {
@@ -1217,7 +1295,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   );
 
   const handleContextMenu = useCallback(
-    async (event: ReactMouseEvent<HTMLAnchorElement>) => {
+    async (event: ReactMouseEvent<HTMLElement>) => {
       event.preventDefault();
       event.stopPropagation();
 
@@ -1227,7 +1305,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
       try {
         const clicked = await api.contextMenu.show(
           [
-            { id: "open", label: "Open in editor" },
+            ...(openTargetPath ? ([{ id: "open", label: "Open in editor" }] as const) : []),
             ...(onOpenInBrowser
               ? ([{ id: "open-in-browser", label: "Open in integrated browser" }] as const)
               : []),
@@ -1259,32 +1337,53 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         );
       }
     },
-    [displayPath, handleCopy, handleOpenInBrowser, handleOpenInEditor, onOpenInBrowser, targetPath],
+    [
+      displayPath,
+      handleCopy,
+      handleOpenInBrowser,
+      handleOpenInEditor,
+      onOpenInBrowser,
+      openTargetPath,
+      targetPath,
+    ],
+  );
+
+  const chip = openTargetPath ? (
+    <a
+      href={href}
+      className={cn(
+        CHAT_FILE_TAG_CHIP_CLASS_NAME,
+        MARKDOWN_FILE_LINK_CLASS_NAME,
+        "cursor-pointer hover:bg-accent/70",
+        className,
+      )}
+      data-markdown-copy={copyMarkdown}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (onOpenInBrowser) {
+          handleOpenInBrowser();
+          return;
+        }
+        handleOpenInFilePreview();
+      }}
+      onContextMenu={handleContextMenu}
+    >
+      <FileTagChipContent path={iconPath} label={label} theme={theme} selectable />
+    </a>
+  ) : (
+    <span
+      className={cn(CHAT_FILE_TAG_CHIP_CLASS_NAME, MARKDOWN_FILE_LINK_CLASS_NAME, className)}
+      data-markdown-copy={copyMarkdown}
+      onContextMenu={handleContextMenu}
+    >
+      <FileTagChipContent path={iconPath} label={label} theme={theme} selectable />
+    </span>
   );
 
   return (
     <Tooltip>
-      <TooltipTrigger
-        render={
-          <a
-            href={href}
-            className={cn(CHAT_FILE_TAG_CHIP_CLASS_NAME, MARKDOWN_FILE_LINK_CLASS_NAME, className)}
-            data-markdown-copy={copyMarkdown}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              if (onOpenInBrowser) {
-                handleOpenInBrowser();
-                return;
-              }
-              handleOpenInFilePreview();
-            }}
-            onContextMenu={handleContextMenu}
-          >
-            <FileTagChipContent path={iconPath} label={label} theme={theme} selectable />
-          </a>
-        }
-      />
+      <TooltipTrigger render={chip} />
       <TooltipPopup
         side="top"
         className="max-w-[min(40rem,calc(100vw-2rem))] font-mono text-[11px] leading-tight"
@@ -1304,6 +1403,7 @@ function areMarkdownFileLinkPropsEqual(
   return (
     previous.href === next.href &&
     previous.targetPath === next.targetPath &&
+    previous.openTargetPath === next.openTargetPath &&
     previous.iconPath === next.iconPath &&
     previous.displayPath === next.displayPath &&
     previous.workspaceRelativePath === next.workspaceRelativePath &&
@@ -1321,6 +1421,7 @@ function areMarkdownFileLinkPropsEqual(
 function ChatMarkdown({
   text,
   cwd,
+  canonicalFileLinks = false,
   threadRef,
   onTaskListChange,
   isStreaming = false,
@@ -1348,7 +1449,7 @@ function ChatMarkdown({
       string,
       NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>
     >();
-    for (const href of extractMarkdownLinkHrefs(text)) {
+    for (const { href } of extractMarkdownLinks(text)) {
       const normalizedHref = normalizeMarkdownLinkHrefKey(href);
       if (metaByHref.has(normalizedHref)) continue;
       const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
@@ -1358,6 +1459,24 @@ function ChatMarkdown({
     }
     return metaByHref;
   }, [cwd, text]);
+  const canonicalFileLinkMetaByKey = useMemo(() => {
+    const metaByKey = new Map<string, MarkdownFileLinkMeta>();
+    if (!canonicalFileLinks) return metaByKey;
+    for (const { label, href } of extractMarkdownLinks(text)) {
+      const normalizedHref = normalizeMarkdownLinkHrefKey(href);
+      // A formatted label such as `*name*` renders as its inner text, so index
+      // both forms and let whichever the renderer reports find the entry.
+      for (const candidate of new Set([label, markdownLabelInnerText(label)])) {
+        const key = canonicalMarkdownLinkKey(candidate, normalizedHref);
+        if (metaByKey.has(key)) continue;
+        const meta = resolveCanonicalMarkdownFileLinkMeta(candidate, normalizedHref, cwd);
+        if (meta) {
+          metaByKey.set(key, meta);
+        }
+      }
+    }
+    return metaByKey;
+  }, [canonicalFileLinks, cwd, text]);
   const inlineCodeFileLinkMetaByText = useMemo(() => {
     const metaByText = new Map<string, MarkdownFileLinkMeta>();
     for (const span of extractInlineCodeSpans(text)) {
@@ -1372,12 +1491,17 @@ function ChatMarkdown({
   const fileLinkParentSuffixByPath = useMemo(() => {
     const filePaths = [
       ...[...markdownFileLinkMetaByHref.values()].map((meta) => meta.filePath),
+      ...[...canonicalFileLinkMetaByKey.values()].map((meta) => meta.filePath),
       ...[...inlineCodeFileLinkMetaByText.values()].map((meta) => meta.filePath),
     ];
     return buildFileLinkParentSuffixByPath(filePaths);
-  }, [inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
+  }, [canonicalFileLinkMetaByKey, inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
   const markdownUrlTransform = useCallback((href: string) => {
-    return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
+    return (
+      rewriteMarkdownFileUriHref(href) ??
+      preserveWindowsMarkdownFileHref(href) ??
+      defaultUrlTransform(href)
+    );
   }, []);
   // Re-emit highlighted content as markdown so copying out of the rendered
   // view keeps links, emphasis, lists, and code fences intact.
@@ -1458,6 +1582,7 @@ function ChatMarkdown({
         <MarkdownFileLink
           href={fileLinkMeta.targetPath}
           targetPath={fileLinkMeta.targetPath}
+          openTargetPath={fileLinkMeta.openTargetPath}
           iconPath={fileLinkMeta.filePath}
           displayPath={fileLinkMeta.displayPath}
           workspaceRelativePath={fileLinkMeta.workspaceRelativePath}
@@ -1468,6 +1593,8 @@ function ChatMarkdown({
           threadRef={threadRef}
           onOpen={openInPreferredEditor}
           onOpenInBrowser={
+            fileLinkMeta.openTargetPath &&
+            fileLinkMeta.workspaceRelativePath &&
             threadRef &&
             isPreviewSupportedInRuntime() &&
             isBrowserPreviewFile(fileLinkMeta.filePath)
@@ -1544,7 +1671,14 @@ function ChatMarkdown({
       },
       a({ node, href, children, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
-        const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
+        const linkLabel = inlineHastText(node);
+        const fileLinkMeta = normalizedHref
+          ? ((linkLabel === null
+              ? null
+              : canonicalFileLinkMetaByKey.get(
+                  canonicalMarkdownLinkKey(linkLabel, normalizedHref),
+                )) ?? markdownFileLinkMetaByHref.get(normalizedHref))
+          : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
           const isSameDocumentLink = href?.startsWith("#") ?? false;
@@ -1620,11 +1754,13 @@ function ChatMarkdown({
           );
         }
 
-        return fileLinkChip(
-          fileLinkMeta,
-          `[${fileLinkMeta.basename}](${normalizedHref})`,
-          props.className,
-        );
+        const copyMarkdown =
+          authoredMarkdownLinkSource(
+            text,
+            node?.position?.start.offset,
+            node?.position?.end.offset,
+          ) ?? `[${fileLinkMeta.basename}](${normalizedHref})`;
+        return fileLinkChip(fileLinkMeta, copyMarkdown, props.className);
       },
       code({ node, children, className, ...props }) {
         if (node?.properties?.dataInlineCode != null) {
@@ -1678,6 +1814,7 @@ function ChatMarkdown({
       },
     };
   }, [
+    canonicalFileLinkMetaByKey,
     cwd,
     diffThemeName,
     fileLinkParentSuffixByPath,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -68,6 +68,8 @@ import {
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
   normalizeMarkdownLinkDestination,
+  preserveWindowsMarkdownFileHref,
+  resolveCanonicalMarkdownFileLinkMeta,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
@@ -734,6 +736,7 @@ function UncachedShikiCodeBlock({
 interface MarkdownFileLinkProps {
   href: string;
   targetPath: string;
+  openTargetPath: string | null;
   iconPath: string;
   displayPath: string;
   workspaceRelativePath: string | null;
@@ -747,9 +750,24 @@ interface MarkdownFileLinkProps {
   className?: string | undefined;
 }
 
-const MARKDOWN_LINK_HREF_PATTERN = /\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
-const MARKDOWN_FILE_LINK_CLASS_NAME =
-  "chat-markdown-file-link cursor-pointer transition-colors hover:bg-accent/70";
+const MARKDOWN_LINK_PATTERN = /\[((?:\\.|[^\]\\])*)]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+const WHOLE_MARKDOWN_LINK_PATTERN = new RegExp(`^${MARKDOWN_LINK_PATTERN.source}$`);
+const MARKDOWN_FILE_LINK_CLASS_NAME = "chat-markdown-file-link transition-colors";
+
+/**
+ * Nodes recovered by `remarkNormalizeListItemIndentation` carry offsets into a
+ * synthetic reparsed source, so slicing the original text by them yields the
+ * wrong span. Fall back to a reconstruction unless the slice really is a link.
+ */
+function authoredMarkdownLinkSource(
+  text: string,
+  start: number | undefined,
+  end: number | undefined,
+): string | null {
+  if (typeof start !== "number" || typeof end !== "number" || end > text.length) return null;
+  const slice = text.slice(start, end);
+  return WHOLE_MARKDOWN_LINK_PATTERN.test(slice) ? slice : null;
+}
 
 function pathParentSegments(path: string): string[] {
   const normalized = path.replaceAll("\\", "/");
@@ -826,14 +844,44 @@ function extractInlineCodeSpans(text: string): string[] {
   return spans;
 }
 
-function extractMarkdownLinkHrefs(text: string): string[] {
-  const hrefs: string[] = [];
-  for (const match of text.matchAll(MARKDOWN_LINK_HREF_PATTERN)) {
-    const href = match[1]?.trim();
-    if (!href) continue;
-    hrefs.push(href);
+const WRAPPED_LABEL_DELIMITERS = ["***", "___", "**", "__", "*", "_", "`"];
+
+/** Unwraps a fully wrapped label (`*name*`) to the text the parser will render. */
+function markdownLabelInnerText(label: string): string {
+  let inner = label;
+  let unwrapping = true;
+  while (unwrapping) {
+    unwrapping = false;
+    for (const delimiter of WRAPPED_LABEL_DELIMITERS) {
+      if (
+        inner.length > delimiter.length * 2 &&
+        inner.startsWith(delimiter) &&
+        inner.endsWith(delimiter)
+      ) {
+        inner = inner.slice(delimiter.length, -delimiter.length);
+        unwrapping = true;
+        break;
+      }
+    }
   }
-  return hrefs;
+  return inner;
+}
+
+function extractMarkdownLinks(text: string): Array<{ label: string; href: string }> {
+  const links: Array<{ label: string; href: string }> = [];
+  for (const match of text.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const href = match[2]?.trim();
+    if (!href) continue;
+    links.push({
+      label: (match[1] ?? "").replace(/\\(.)/g, "$1"),
+      href,
+    });
+  }
+  return links;
+}
+
+function canonicalMarkdownLinkKey(label: string, href: string): string {
+  return `${label}\0${href}`;
 }
 
 function normalizeMarkdownLinkHrefKey(href: string): string {
@@ -882,6 +930,21 @@ function breakableExternalLinkText(text: string): ReactNode[] {
       <wbr />
     </React.Fragment>
   ));
+}
+
+/**
+ * Link labels reach the renderer as parsed nodes, so `[*name*](path)` arrives as
+ * an `em` wrapping the text. Reading through inline formatting keeps the lookup
+ * key aligned with the label text indexed from the source.
+ */
+function inlineHastText(node: unknown): string | null {
+  if (!node || typeof node !== "object") return null;
+  if ("type" in node && node.type === "text") {
+    return "value" in node && typeof node.value === "string" ? node.value : null;
+  }
+  if (!("children" in node) || !Array.isArray(node.children)) return null;
+  const parts = node.children.map((child) => inlineHastText(child));
+  return parts.every((part) => part !== null) ? parts.join("") : null;
 }
 
 function plainHastText(node: unknown): string | null {
@@ -1017,6 +1080,7 @@ function MarkdownExternalLinkContent({
 const MarkdownFileLink = memo(function MarkdownFileLink({
   href,
   targetPath,
+  openTargetPath,
   iconPath,
   displayPath,
   workspaceRelativePath,
@@ -1030,14 +1094,15 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   className,
 }: MarkdownFileLinkProps) {
   const handleOpenInEditor = useCallback(() => {
+    if (openTargetPath === null) return;
     void (async () => {
       try {
-        const result = await onOpen(targetPath);
+        const result = await onOpen(openTargetPath);
         if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
           return;
         }
         reportMarkdownActionFailure(
-          { operation: "open-file-in-editor", target: targetPath },
+          { operation: "open-file-in-editor", target: openTargetPath },
           result.cause,
         );
         const error = squashAtomCommandFailure(result);
@@ -1050,7 +1115,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         );
       } catch (cause) {
         reportMarkdownActionFailure(
-          { operation: "open-file-in-editor", target: targetPath },
+          { operation: "open-file-in-editor", target: openTargetPath },
           cause,
         );
         toastManager.add(
@@ -1062,7 +1127,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         );
       }
     })();
-  }, [onOpen, targetPath]);
+  }, [onOpen, openTargetPath]);
 
   const handleOpenInFilePreview = useCallback(() => {
     if (!threadRef || !workspaceRelativePath) {
@@ -1150,7 +1215,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   );
 
   const handleContextMenu = useCallback(
-    async (event: ReactMouseEvent<HTMLAnchorElement>) => {
+    async (event: ReactMouseEvent<HTMLElement>) => {
       event.preventDefault();
       event.stopPropagation();
 
@@ -1160,7 +1225,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
       try {
         const clicked = await api.contextMenu.show(
           [
-            { id: "open", label: "Open in editor" },
+            ...(openTargetPath ? ([{ id: "open", label: "Open in editor" }] as const) : []),
             ...(onOpenInBrowser
               ? ([{ id: "open-in-browser", label: "Open in integrated browser" }] as const)
               : []),
@@ -1192,32 +1257,53 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         );
       }
     },
-    [displayPath, handleCopy, handleOpenInBrowser, handleOpenInEditor, onOpenInBrowser, targetPath],
+    [
+      displayPath,
+      handleCopy,
+      handleOpenInBrowser,
+      handleOpenInEditor,
+      onOpenInBrowser,
+      openTargetPath,
+      targetPath,
+    ],
+  );
+
+  const chip = openTargetPath ? (
+    <a
+      href={href}
+      className={cn(
+        CHAT_FILE_TAG_CHIP_CLASS_NAME,
+        MARKDOWN_FILE_LINK_CLASS_NAME,
+        "cursor-pointer hover:bg-accent/70",
+        className,
+      )}
+      data-markdown-copy={copyMarkdown}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (onOpenInBrowser) {
+          handleOpenInBrowser();
+          return;
+        }
+        handleOpenInFilePreview();
+      }}
+      onContextMenu={handleContextMenu}
+    >
+      <FileTagChipContent path={iconPath} label={label} theme={theme} selectable />
+    </a>
+  ) : (
+    <span
+      className={cn(CHAT_FILE_TAG_CHIP_CLASS_NAME, MARKDOWN_FILE_LINK_CLASS_NAME, className)}
+      data-markdown-copy={copyMarkdown}
+      onContextMenu={handleContextMenu}
+    >
+      <FileTagChipContent path={iconPath} label={label} theme={theme} selectable />
+    </span>
   );
 
   return (
     <Tooltip>
-      <TooltipTrigger
-        render={
-          <a
-            href={href}
-            className={cn(CHAT_FILE_TAG_CHIP_CLASS_NAME, MARKDOWN_FILE_LINK_CLASS_NAME, className)}
-            data-markdown-copy={copyMarkdown}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              if (onOpenInBrowser) {
-                handleOpenInBrowser();
-                return;
-              }
-              handleOpenInFilePreview();
-            }}
-            onContextMenu={handleContextMenu}
-          >
-            <FileTagChipContent path={iconPath} label={label} theme={theme} selectable />
-          </a>
-        }
-      />
+      <TooltipTrigger render={chip} />
       <TooltipPopup
         side="top"
         className="max-w-[min(40rem,calc(100vw-2rem))] font-mono text-[11px] leading-tight"
@@ -1237,6 +1323,7 @@ function areMarkdownFileLinkPropsEqual(
   return (
     previous.href === next.href &&
     previous.targetPath === next.targetPath &&
+    previous.openTargetPath === next.openTargetPath &&
     previous.iconPath === next.iconPath &&
     previous.displayPath === next.displayPath &&
     previous.workspaceRelativePath === next.workspaceRelativePath &&
@@ -1281,7 +1368,7 @@ function ChatMarkdown({
       string,
       NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>
     >();
-    for (const href of extractMarkdownLinkHrefs(text)) {
+    for (const { href } of extractMarkdownLinks(text)) {
       const normalizedHref = normalizeMarkdownLinkHrefKey(href);
       if (metaByHref.has(normalizedHref)) continue;
       const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
@@ -1290,6 +1377,23 @@ function ChatMarkdown({
       }
     }
     return metaByHref;
+  }, [cwd, text]);
+  const canonicalFileLinkMetaByKey = useMemo(() => {
+    const metaByKey = new Map<string, MarkdownFileLinkMeta>();
+    for (const { label, href } of extractMarkdownLinks(text)) {
+      const normalizedHref = normalizeMarkdownLinkHrefKey(href);
+      // A formatted label such as `*name*` renders as its inner text, so index
+      // both forms and let whichever the renderer reports find the entry.
+      for (const candidate of new Set([label, markdownLabelInnerText(label)])) {
+        const key = canonicalMarkdownLinkKey(candidate, normalizedHref);
+        if (metaByKey.has(key)) continue;
+        const meta = resolveCanonicalMarkdownFileLinkMeta(candidate, normalizedHref, cwd);
+        if (meta) {
+          metaByKey.set(key, meta);
+        }
+      }
+    }
+    return metaByKey;
   }, [cwd, text]);
   const inlineCodeFileLinkMetaByText = useMemo(() => {
     const metaByText = new Map<string, MarkdownFileLinkMeta>();
@@ -1305,12 +1409,17 @@ function ChatMarkdown({
   const fileLinkParentSuffixByPath = useMemo(() => {
     const filePaths = [
       ...[...markdownFileLinkMetaByHref.values()].map((meta) => meta.filePath),
+      ...[...canonicalFileLinkMetaByKey.values()].map((meta) => meta.filePath),
       ...[...inlineCodeFileLinkMetaByText.values()].map((meta) => meta.filePath),
     ];
     return buildFileLinkParentSuffixByPath(filePaths);
-  }, [inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
+  }, [canonicalFileLinkMetaByKey, inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
   const markdownUrlTransform = useCallback((href: string) => {
-    return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
+    return (
+      rewriteMarkdownFileUriHref(href) ??
+      preserveWindowsMarkdownFileHref(href) ??
+      defaultUrlTransform(href)
+    );
   }, []);
   // Re-emit highlighted content as markdown so copying out of the rendered
   // view keeps links, emphasis, lists, and code fences intact.
@@ -1387,6 +1496,7 @@ function ChatMarkdown({
         <MarkdownFileLink
           href={fileLinkMeta.targetPath}
           targetPath={fileLinkMeta.targetPath}
+          openTargetPath={fileLinkMeta.openTargetPath}
           iconPath={fileLinkMeta.filePath}
           displayPath={fileLinkMeta.displayPath}
           workspaceRelativePath={fileLinkMeta.workspaceRelativePath}
@@ -1397,6 +1507,8 @@ function ChatMarkdown({
           threadRef={threadRef}
           onOpen={openInPreferredEditor}
           onOpenInBrowser={
+            fileLinkMeta.openTargetPath &&
+            fileLinkMeta.workspaceRelativePath &&
             threadRef &&
             isPreviewSupportedInRuntime() &&
             isBrowserPreviewFile(fileLinkMeta.filePath)
@@ -1453,7 +1565,14 @@ function ChatMarkdown({
       },
       a({ node, href, children, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
-        const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
+        const linkLabel = inlineHastText(node);
+        const fileLinkMeta = normalizedHref
+          ? ((linkLabel === null
+              ? null
+              : canonicalFileLinkMetaByKey.get(
+                  canonicalMarkdownLinkKey(linkLabel, normalizedHref),
+                )) ?? markdownFileLinkMetaByHref.get(normalizedHref))
+          : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
           const isSameDocumentLink = href?.startsWith("#") ?? false;
@@ -1523,11 +1642,13 @@ function ChatMarkdown({
           );
         }
 
-        return fileLinkChip(
-          fileLinkMeta,
-          `[${fileLinkMeta.basename}](${normalizedHref})`,
-          props.className,
-        );
+        const copyMarkdown =
+          authoredMarkdownLinkSource(
+            text,
+            node?.position?.start.offset,
+            node?.position?.end.offset,
+          ) ?? `[${fileLinkMeta.basename}](${normalizedHref})`;
+        return fileLinkChip(fileLinkMeta, copyMarkdown, props.className);
       },
       code({ node, children, className, ...props }) {
         if (node?.properties?.dataInlineCode != null) {
@@ -1581,6 +1702,7 @@ function ChatMarkdown({
       },
     };
   }, [
+    canonicalFileLinkMetaByKey,
     cwd,
     diffThemeName,
     fileLinkParentSuffixByPath,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3,6 +3,7 @@ import {
   DEFAULT_MODEL,
   defaultInstanceIdForDriver,
   type EnvironmentId,
+  type ExplicitFileMention,
   type MessageId,
   type ModelSelection,
   type ProjectScript,
@@ -45,6 +46,7 @@ import {
 import { CHAT_LIST_ANCHOR_OFFSET } from "@t3tools/shared/chatList";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
+import { shiftFileMentions, trimTextWithFileMentions } from "@t3tools/shared/fileMentions";
 import { nextTerminalId, resolveTerminalSessionLabel } from "@t3tools/shared/terminalLabels";
 import { Debouncer } from "@tanstack/react-pacer";
 import { useAtomValue } from "@effect/atom-react";
@@ -204,7 +206,7 @@ import {
   type DraftId,
 } from "../composerDraftStore";
 import {
-  appendTerminalContextsToPrompt,
+  appendTerminalContextsToPromptWithFileMentions,
   formatTerminalContextLabel,
   type TerminalContextDraft,
   type TerminalContextSelection,
@@ -4918,6 +4920,7 @@ function ChatViewContent(props: ChatViewProps) {
       elementContexts: composerElementContexts,
       previewAnnotations: sendContextPreviewAnnotations,
       reviewComments: composerReviewComments,
+      fileMentions: composerFileMentions,
       selectedProvider: ctxSelectedProvider,
       selectedModel: ctxSelectedModel,
       selectedProviderModels: ctxSelectedProviderModels,
@@ -4964,12 +4967,17 @@ function ChatViewContent(props: ChatViewProps) {
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
       });
+      const followUpFileMentions = trimTextWithFileMentions(
+        promptForSend,
+        composerFileMentions,
+      ).fileMentions;
       promptRef.current = "";
       clearComposerDraftContent(composerDraftTarget);
       composerRef.current?.resetCursorState();
       await onSubmitPlanFollowUp({
         text: followUp.text,
         interactionMode: followUp.interactionMode,
+        fileMentions: followUp.interactionMode === "plan" ? followUpFileMentions : [],
       });
       return;
     }
@@ -5056,8 +5064,14 @@ function ChatViewContent(props: ChatViewProps) {
     const composerElementContextsSnapshot = [...composerElementContexts];
     const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
     const composerReviewCommentsSnapshot: ReviewCommentContext[] = [...composerReviewComments];
+    const composerFileMentionsSnapshot = [...composerFileMentions];
+    const promptWithTerminalContexts = appendTerminalContextsToPromptWithFileMentions(
+      promptForSend,
+      composerTerminalContextsSnapshot,
+      composerFileMentionsSnapshot,
+    );
     const messageTextWithContexts = appendElementContextsToPrompt(
-      appendTerminalContextsToPrompt(promptForSend, composerTerminalContextsSnapshot),
+      promptWithTerminalContexts.text,
       composerElementContextsSnapshot,
     );
     const messageTextWithPreviewAnnotations = composerPreviewAnnotationsSnapshot.reduce(
@@ -5077,6 +5091,11 @@ function ChatViewContent(props: ChatViewProps) {
       effort: ctxSelectedPromptEffort,
       text: messageTextForSend || IMAGE_ONLY_BOOTSTRAP_PROMPT,
     });
+    const outgoingPromptOffset = outgoingMessageText.lastIndexOf(messageTextForSend);
+    const outgoingFileMentions =
+      messageTextForSend.length > 0 && outgoingPromptOffset >= 0
+        ? shiftFileMentions(promptWithTerminalContexts.fileMentions, outgoingPromptOffset)
+        : [];
     const turnAttachmentsPromise = Promise.all(
       composerImagesSnapshot.map(async (image) => ({
         type: "image" as const,
@@ -5116,6 +5135,7 @@ function ChatViewContent(props: ChatViewProps) {
         role: "user",
         text: outgoingMessageText,
         ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
+        ...(outgoingFileMentions.length > 0 ? { fileMentions: outgoingFileMentions } : {}),
         turnId: null,
         createdAt: messageCreatedAt,
         updatedAt: messageCreatedAt,
@@ -5244,6 +5264,7 @@ function ChatViewContent(props: ChatViewProps) {
             role: "user",
             text: outgoingMessageText,
             attachments: turnAttachmentsResult.value,
+            ...(outgoingFileMentions.length > 0 ? { fileMentions: outgoingFileMentions } : {}),
           },
           modelSelection: ctxSelectedModelSelection,
           titleSeed: title,
@@ -5285,7 +5306,7 @@ function ChatViewContent(props: ChatViewProps) {
         composerImagesRef.current = retryComposerImages;
         composerTerminalContextsRef.current = composerTerminalContextsSnapshot;
         composerElementContextsRef.current = composerElementContextsSnapshot;
-        setComposerDraftPrompt(composerDraftTarget, promptForSend);
+        setComposerDraftPrompt(composerDraftTarget, promptForSend, composerFileMentionsSnapshot);
         addComposerDraftImages(composerDraftTarget, retryComposerImages);
         setComposerDraftTerminalContexts(composerDraftTarget, composerTerminalContextsSnapshot);
         setComposerDraftElementContexts(composerDraftTarget, composerElementContextsSnapshot);
@@ -5495,9 +5516,11 @@ function ChatViewContent(props: ChatViewProps) {
     async ({
       text,
       interactionMode: nextInteractionMode,
+      fileMentions,
     }: {
       text: string;
       interactionMode: "default" | "plan";
+      fileMentions: ReadonlyArray<ExplicitFileMention>;
     }) => {
       if (
         !activeThread ||
@@ -5536,6 +5559,10 @@ function ChatViewContent(props: ChatViewProps) {
         effort: ctxSelectedPromptEffort,
         text: trimmed,
       });
+      const outgoingFileMentions = shiftFileMentions(
+        fileMentions,
+        Math.max(0, outgoingMessageText.lastIndexOf(trimmed)),
+      );
 
       sendInFlightRef.current = true;
       beginLocalDispatch({ preparingWorktree: false });
@@ -5561,6 +5588,7 @@ function ChatViewContent(props: ChatViewProps) {
           id: messageIdForSend,
           role: "user",
           text: outgoingMessageText,
+          ...(outgoingFileMentions.length > 0 ? { fileMentions: outgoingFileMentions } : {}),
           turnId: null,
           createdAt: messageCreatedAt,
           updatedAt: messageCreatedAt,
@@ -5598,6 +5626,7 @@ function ChatViewContent(props: ChatViewProps) {
               role: "user",
               text: outgoingMessageText,
               attachments: [],
+              ...(outgoingFileMentions.length > 0 ? { fileMentions: outgoingFileMentions } : {}),
             },
             modelSelection: ctxSelectedModelSelection,
             titleSeed: activeThread.title,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -46,7 +46,7 @@ import {
 import { CHAT_LIST_ANCHOR_OFFSET } from "@t3tools/shared/chatList";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
-import { shiftFileMentions, trimTextWithFileMentions } from "@t3tools/shared/fileMentions";
+import { shiftFileMentions } from "@t3tools/shared/fileMentions";
 import { nextTerminalId, resolveTerminalSessionLabel } from "@t3tools/shared/terminalLabels";
 import { Debouncer } from "@tanstack/react-pacer";
 import { useAtomValue } from "@effect/atom-react";
@@ -4963,21 +4963,22 @@ function ChatViewContent(props: ChatViewProps) {
         composerReviewComments.length,
     });
     if (!directAnnotation && showPlanFollowUpPrompt && activeProposedPlan) {
+      const followUpPrompt = appendTerminalContextsToPromptWithFileMentions(
+        promptForSend,
+        [],
+        composerFileMentions,
+      );
       const followUp = resolvePlanFollowUpSubmission({
-        draftText: trimmed,
+        draftText: followUpPrompt.text,
         planMarkdown: activeProposedPlan.planMarkdown,
       });
-      const followUpFileMentions = trimTextWithFileMentions(
-        promptForSend,
-        composerFileMentions,
-      ).fileMentions;
       promptRef.current = "";
       clearComposerDraftContent(composerDraftTarget);
       composerRef.current?.resetCursorState();
       await onSubmitPlanFollowUp({
         text: followUp.text,
         interactionMode: followUp.interactionMode,
-        fileMentions: followUp.interactionMode === "plan" ? followUpFileMentions : [],
+        fileMentions: followUp.interactionMode === "plan" ? followUpPrompt.fileMentions : [],
       });
       return;
     }
@@ -5135,7 +5136,7 @@ function ChatViewContent(props: ChatViewProps) {
         role: "user",
         text: outgoingMessageText,
         ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
-        ...(outgoingFileMentions.length > 0 ? { fileMentions: outgoingFileMentions } : {}),
+        fileMentions: outgoingFileMentions,
         turnId: null,
         createdAt: messageCreatedAt,
         updatedAt: messageCreatedAt,
@@ -5264,7 +5265,7 @@ function ChatViewContent(props: ChatViewProps) {
             role: "user",
             text: outgoingMessageText,
             attachments: turnAttachmentsResult.value,
-            ...(outgoingFileMentions.length > 0 ? { fileMentions: outgoingFileMentions } : {}),
+            fileMentions: outgoingFileMentions,
           },
           modelSelection: ctxSelectedModelSelection,
           titleSeed: title,
@@ -5559,10 +5560,9 @@ function ChatViewContent(props: ChatViewProps) {
         effort: ctxSelectedPromptEffort,
         text: trimmed,
       });
-      const outgoingFileMentions = shiftFileMentions(
-        fileMentions,
-        Math.max(0, outgoingMessageText.lastIndexOf(trimmed)),
-      );
+      const outgoingPromptOffset = outgoingMessageText.lastIndexOf(trimmed);
+      const outgoingFileMentions =
+        outgoingPromptOffset >= 0 ? shiftFileMentions(fileMentions, outgoingPromptOffset) : [];
 
       sendInFlightRef.current = true;
       beginLocalDispatch({ preparingWorktree: false });
@@ -5588,7 +5588,7 @@ function ChatViewContent(props: ChatViewProps) {
           id: messageIdForSend,
           role: "user",
           text: outgoingMessageText,
-          ...(outgoingFileMentions.length > 0 ? { fileMentions: outgoingFileMentions } : {}),
+          fileMentions: outgoingFileMentions,
           turnId: null,
           createdAt: messageCreatedAt,
           updatedAt: messageCreatedAt,
@@ -5626,7 +5626,7 @@ function ChatViewContent(props: ChatViewProps) {
               role: "user",
               text: outgoingMessageText,
               attachments: [],
-              ...(outgoingFileMentions.length > 0 ? { fileMentions: outgoingFileMentions } : {}),
+              fileMentions: outgoingFileMentions,
             },
             modelSelection: ctxSelectedModelSelection,
             titleSeed: activeThread.title,
@@ -5759,6 +5759,7 @@ function ChatViewContent(props: ChatViewProps) {
             role: "user",
             text: outgoingImplementationPrompt,
             attachments: [],
+            fileMentions: [],
           },
           modelSelection: ctxSelectedModelSelection,
           titleSeed: nextThreadTitle,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -75,6 +75,12 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import { useComposerPathSearch } from "../../lib/composerPathSearchState";
+import {
+  canBrowseComposerFilesystemPath,
+  composerFilesystemSuggestionParentPath,
+  composerFilesystemSuggestionPath,
+  isComposerFilesystemPathQuery,
+} from "../../lib/composerFilesystemBrowse";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
@@ -104,6 +110,8 @@ import {
 import { ContextWindowMeter } from "./ContextWindowMeter";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../pierre-icons";
+import { useEnvironment } from "../../state/environments";
+import { useComposerFilesystemBrowse } from "../../state/queries";
 import { cn, randomUUID } from "~/lib/utils";
 import { Separator } from "../ui/separator";
 
@@ -1018,15 +1026,37 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const composerTriggerKind = composerTrigger?.kind ?? null;
   const pathTriggerQuery = composerTrigger?.kind === "path" ? composerTrigger.query : "";
   const isPathTrigger = composerTriggerKind === "path";
+  const environment = useEnvironment(environmentId);
+  const environmentPlatform = environment?.serverConfig?.environment.platform.os ?? "";
+  const isFilesystemPathTrigger =
+    isPathTrigger && isComposerFilesystemPathQuery(pathTriggerQuery, environmentPlatform);
+  const canBrowseFilesystemPath =
+    isFilesystemPathTrigger &&
+    canBrowseComposerFilesystemPath(pathTriggerQuery, gitCwd, environmentPlatform);
   const workspaceEntries = useComposerPathSearch({
     environmentId,
-    cwd: isPathTrigger ? gitCwd : null,
-    query: isPathTrigger ? pathTriggerQuery : null,
+    cwd: isPathTrigger && !isFilesystemPathTrigger ? gitCwd : null,
+    query: isPathTrigger && !isFilesystemPathTrigger ? pathTriggerQuery : null,
+  });
+  const filesystemEntries = useComposerFilesystemBrowse({
+    environmentId,
+    cwd: canBrowseFilesystemPath ? gitCwd : null,
+    query: canBrowseFilesystemPath ? pathTriggerQuery : null,
   });
 
   const composerMenuItems = useMemo<ComposerCommandItem[]>(() => {
     if (!composerTrigger) return [];
     if (composerTrigger.kind === "path") {
+      if (isFilesystemPathTrigger) {
+        return filesystemEntries.entries.map((entry) => ({
+          id: `filesystem-path:${entry.kind ?? "directory"}:${entry.fullPath}`,
+          type: "path" as const,
+          path: composerFilesystemSuggestionPath(pathTriggerQuery, entry.name),
+          pathKind: entry.kind ?? "directory",
+          label: entry.name,
+          description: composerFilesystemSuggestionParentPath(pathTriggerQuery),
+        }));
+      }
       return workspaceEntries.entries.map((entry) => ({
         id: `path:${entry.kind}:${entry.path}`,
         type: "path",
@@ -1099,7 +1129,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     return [];
   }, [
     composerTrigger,
+    filesystemEntries.entries,
+    isFilesystemPathTrigger,
     planModeUiEnabled,
+    pathTriggerQuery,
     selectedProvider,
     selectedProviderStatus,
     workspaceEntries.entries,
@@ -1167,7 +1200,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   ]);
 
   const isComposerMenuLoading =
-    composerTriggerKind === "path" && pathTriggerQuery.length > 0 && workspaceEntries.isPending;
+    composerTriggerKind === "path" &&
+    pathTriggerQuery.length > 0 &&
+    (isFilesystemPathTrigger ? filesystemEntries.isPending : workspaceEntries.isPending);
   const composerMenuEmptyState = useMemo(() => {
     if (composerTriggerKind === "skill") {
       return "No skills found. Try / to browse provider commands.";

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1,6 +1,7 @@
 import type {
   ApprovalRequestId,
   EnvironmentId,
+  ExplicitFileMention,
   ModelSelection,
   PreviewAnnotationPayload,
   ProviderApprovalDecision,
@@ -19,6 +20,10 @@ import {
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
+import {
+  reconcileFileMentionsAfterEdit,
+  replaceTextRangeInFileMentions,
+} from "@t3tools/shared/fileMentions";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import {
   memo,
@@ -43,6 +48,7 @@ import {
 } from "../../composer-logic";
 import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
 import {
+  type ComposerDraggedMention,
   dataTransferHasComposerMention,
   makeComposerMentionDragHandlers,
 } from "./composerMentionDrag";
@@ -479,6 +485,7 @@ export interface ChatComposerHandle {
   /** Get the current prompt/effort/model state for use in send. */
   getSendContext: () => {
     prompt: string;
+    fileMentions: ExplicitFileMention[];
     images: ComposerImageAttachment[];
     terminalContexts: TerminalContextDraft[];
     elementContexts: ElementContextDraft[];
@@ -681,6 +688,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   const composerDraft = useComposerThreadDraft(composerDraftTarget);
   const prompt = composerDraft.prompt;
+  const composerFileMentions = composerDraft.fileMentions;
   const composerImages = composerDraft.images;
   const composerTerminalContexts = composerDraft.terminalContexts;
   const composerElementContexts = composerDraft.elementContexts;
@@ -689,6 +697,19 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
 
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
+  const fileMentionsRef = useRef<ExplicitFileMention[]>(composerFileMentions);
+
+  const setPrompt = useCallback(
+    (nextPrompt: string, nextFileMentions?: ReadonlyArray<ExplicitFileMention>) => {
+      const mentions = nextFileMentions
+        ? [...nextFileMentions]
+        : reconcileFileMentionsAfterEdit(promptRef.current, nextPrompt, fileMentionsRef.current);
+      promptRef.current = nextPrompt;
+      fileMentionsRef.current = mentions;
+      setComposerDraftPrompt(composerDraftTarget, nextPrompt, mentions);
+    },
+    [composerDraftTarget, promptRef, setComposerDraftPrompt],
+  );
   const addComposerDraftImage = useComposerDraftStore((store) => store.addImage);
   const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
   const removeComposerDraftImage = useComposerDraftStore((store) => store.removeImage);
@@ -1221,14 +1242,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         scheduleComposerFocus();
         return;
       }
-      promptRef.current = nextPrompt;
-      setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+      setPrompt(nextPrompt);
       const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
       setComposerCursor(nextCursor);
       setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
       scheduleComposerFocus();
     },
-    [composerDraftTarget, promptRef, scheduleComposerFocus, setComposerDraftPrompt],
+    [promptRef, scheduleComposerFocus, setPrompt],
   );
 
   const providerTraitsMenuContent = renderProviderTraitsMenuContent({
@@ -1282,13 +1302,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Prompt helpers
   // ------------------------------------------------------------------
-  const setPrompt = useCallback(
-    (nextPrompt: string) => {
-      setComposerDraftPrompt(composerDraftTarget, nextPrompt);
-    },
-    [composerDraftTarget, setComposerDraftPrompt],
-  );
-
   const addComposerImage = useCallback(
     (image: ComposerImageAttachment) => {
       addComposerDraftImage(composerDraftTarget, image);
@@ -1317,7 +1330,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       );
       if (contextIndex < 0) return;
       const removal = removeInlineTerminalContextPlaceholder(promptRef.current, contextIndex);
-      promptRef.current = removal.prompt;
       setPrompt(removal.prompt);
       removeComposerDraftTerminalContext(composerDraftTarget, contextId);
       const nextCursor = collapseExpandedComposerCursor(removal.prompt, removal.cursor);
@@ -1338,8 +1350,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   useEffect(() => {
     promptRef.current = prompt;
+    fileMentionsRef.current = composerFileMentions;
     setComposerCursor((existing) => clampCollapsedComposerCursor(prompt, existing));
-  }, [prompt, promptRef]);
+  }, [composerFileMentions, prompt, promptRef]);
 
   useEffect(() => {
     composerImagesRef.current = composerImages;
@@ -1577,7 +1590,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         );
         return;
       }
-      promptRef.current = nextPrompt;
       setPrompt(nextPrompt);
       if (!terminalContextIdListsEqual(composerTerminalContexts, terminalContextIds)) {
         setComposerDraftTerminalContexts(
@@ -1610,7 +1622,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       rangeStart: number,
       rangeEnd: number,
       replacement: string,
-      options?: { expectedText?: string; focusEditorAfterReplace?: boolean },
+      options?: {
+        expectedText?: string;
+        focusEditorAfterReplace?: boolean;
+        fileMention?: Pick<ExplicitFileMention, "environmentId" | "path" | "kind">;
+        fileMentions?: ReadonlyArray<ComposerDraggedMention>;
+      },
     ): boolean => {
       const currentText = promptRef.current;
       const safeStart = Math.max(0, Math.min(currentText.length, rangeStart));
@@ -1622,9 +1639,39 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         return false;
       }
       const next = replaceTextRange(promptRef.current, rangeStart, rangeEnd, replacement);
+      const nextFileMentions = replaceTextRangeInFileMentions(
+        fileMentionsRef.current,
+        safeStart,
+        safeEnd,
+        replacement.length,
+      );
+      if (options?.fileMention) {
+        const mentionSource = serializeComposerFileLink(options.fileMention.path);
+        nextFileMentions.push({
+          version: 1,
+          ...options.fileMention,
+          start: safeStart,
+          end: safeStart + mentionSource.length,
+        });
+      }
+      for (const mention of options?.fileMentions ?? []) {
+        if (
+          replacement.slice(mention.start, mention.end) !== serializeComposerFileLink(mention.path)
+        ) {
+          continue;
+        }
+        nextFileMentions.push({
+          version: 1,
+          environmentId,
+          path: mention.path,
+          kind: mention.kind,
+          start: safeStart + mention.start,
+          end: safeStart + mention.end,
+        });
+      }
+      nextFileMentions.sort((left, right) => left.start - right.start);
       const nextCursor = collapseExpandedComposerCursor(next.text, next.cursor);
       const nextExpandedCursor = expandCollapsedComposerCursor(next.text, nextCursor);
-      promptRef.current = next.text;
       const activePendingQuestion = activePendingProgress?.activeQuestion;
       if (activePendingQuestion && activePendingUserInput) {
         onChangeActivePendingUserInputCustomAnswer(
@@ -1635,7 +1682,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           false,
         );
       } else {
-        setPrompt(next.text);
+        setPrompt(next.text, nextFileMentions);
       }
       setComposerCursor(nextCursor);
       setComposerTrigger(detectComposerTrigger(next.text, nextExpandedCursor));
@@ -1704,7 +1751,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           trigger.rangeStart,
           replacementRangeEnd,
           replacement,
-          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+          {
+            expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd),
+            fileMention: {
+              environmentId,
+              path: item.path,
+              kind: item.pathKind,
+            },
+          },
         );
         if (applied) {
           setComposerHighlightedItemId(null);
@@ -1995,8 +2049,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             : entry.prompt;
       const promptChanged = nextPrompt !== currentPrompt;
       if (promptChanged) {
-        promptRef.current = nextPrompt;
-        setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+        setPrompt(nextPrompt);
         setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
         setComposerTrigger(null);
       }
@@ -2452,7 +2505,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
   const insertComposerTextAtEnd = (
     text: string,
-    options?: { ensureLeadingBoundary?: boolean },
+    options?: {
+      ensureLeadingBoundary?: boolean;
+      fileMentions?: ReadonlyArray<ComposerDraggedMention>;
+    },
   ): boolean => {
     if (
       text.length === 0 ||
@@ -2466,10 +2522,21 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     const prompt = promptRef.current;
     const needsLeadingSpace =
       (options?.ensureLeadingBoundary ?? false) && prompt.length > 0 && !/\s$/.test(prompt);
+    const leadingText = needsLeadingSpace ? " " : "";
+    const replacementOptions = options?.fileMentions
+      ? {
+          fileMentions: options.fileMentions.map((mention) => ({
+            ...mention,
+            start: mention.start + leadingText.length,
+            end: mention.end + leadingText.length,
+          })),
+        }
+      : undefined;
     return applyPromptReplacement(
       prompt.length,
       prompt.length,
-      needsLeadingSpace ? ` ${text}` : text,
+      `${leadingText}${text}`,
+      replacementOptions,
     );
   };
 
@@ -2477,7 +2544,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // editor never sees the drop; the load-bearing rules (native stop, "move"
   // effect, no eager focus) live in makeComposerMentionDragHandlers.
   const composerMentionDragHandlers = makeComposerMentionDragHandlers({
-    insertMentionAtEnd: (text) => insertComposerTextAtEnd(text, { ensureLeadingBoundary: true }),
+    insertMentionAtEnd: (text, fileMentions) =>
+      insertComposerTextAtEnd(text, { ensureLeadingBoundary: true, fileMentions }),
     setDragActive: setIsDragOverComposer,
     onInsertRejected: () => {
       toastManager.add({
@@ -2629,7 +2697,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           insertion.contextIndex,
         );
         if (!inserted) return;
-        promptRef.current = insertion.prompt;
+        setPrompt(insertion.prompt);
         setComposerCursor(nextCollapsedCursor);
         setComposerTrigger(detectComposerTrigger(insertion.prompt, insertion.cursor));
         window.requestAnimationFrame(() => {
@@ -2638,6 +2706,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       },
       getSendContext: () => ({
         prompt: promptRef.current,
+        fileMentions: [...fileMentionsRef.current],
         images: composerImagesRef.current,
         terminalContexts: composerTerminalContextsRef.current,
         elementContexts: composerElementContextsRef.current,
@@ -2658,6 +2727,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       composerCursor,
       composerTerminalContexts,
       insertComposerDraftTerminalContext,
+      setPrompt,
       promptRef,
       composerImagesRef,
       composerTerminalContextsRef,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -16,6 +16,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  PROVIDER_SEND_TURN_MAX_FILE_MENTIONS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
@@ -1403,7 +1404,18 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   useEffect(() => {
     const nextCustomAnswer = activePendingProgress?.customAnswer;
     if (typeof nextCustomAnswer !== "string") {
+      const wasPending = lastSyncedPendingInputRef.current !== null;
       lastSyncedPendingInputRef.current = null;
+      if (wasPending) {
+        promptRef.current = prompt;
+        fileMentionsRef.current = composerFileMentions;
+        const nextCursor = collapseExpandedComposerCursor(prompt, prompt.length);
+        setComposerCursor(nextCursor);
+        setComposerTrigger(
+          detectComposerTrigger(prompt, expandCollapsedComposerCursor(prompt, nextCursor)),
+        );
+        setComposerHighlightedItemId(null);
+      }
       return;
     }
 
@@ -1437,6 +1449,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activePendingProgress?.customAnswer,
     activePendingProgress?.activeQuestion?.id,
     activePendingUserInput?.requestId,
+    composerFileMentions,
+    prompt,
     promptRef,
   ]);
 
@@ -1696,6 +1710,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     [
       activePendingProgress?.activeQuestion,
       activePendingUserInput,
+      environmentId,
       onChangeActivePendingUserInputCustomAnswer,
       promptRef,
       setPrompt,
@@ -1741,6 +1756,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       const { snapshot, trigger } = resolveActiveComposerTrigger();
       if (!trigger) return;
       if (item.type === "path") {
+        if (fileMentionsRef.current.length >= PROVIDER_SEND_TURN_MAX_FILE_MENTIONS) {
+          toastManager.add({
+            type: "error",
+            title: "Unable to add file tag",
+            description: `Messages can include up to ${PROVIDER_SEND_TURN_MAX_FILE_MENTIONS} file tags.`,
+          });
+          return;
+        }
         const replacement = `${serializeComposerFileLink(item.path)} `;
         const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
           snapshot.value,
@@ -2544,8 +2567,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // editor never sees the drop; the load-bearing rules (native stop, "move"
   // effect, no eager focus) live in makeComposerMentionDragHandlers.
   const composerMentionDragHandlers = makeComposerMentionDragHandlers({
-    insertMentionAtEnd: (text, fileMentions) =>
-      insertComposerTextAtEnd(text, { ensureLeadingBoundary: true, fileMentions }),
+    insertMentionAtEnd: (text, fileMentions) => {
+      if (
+        fileMentionsRef.current.length + fileMentions.length >
+        PROVIDER_SEND_TURN_MAX_FILE_MENTIONS
+      ) {
+        toastManager.add({
+          type: "error",
+          title: "Unable to add file tags",
+          description: `Messages can include up to ${PROVIDER_SEND_TURN_MAX_FILE_MENTIONS} file tags.`,
+        });
+        return true;
+      }
+      return insertComposerTextAtEnd(text, { ensureLeadingBoundary: true, fileMentions });
+    },
     setDragActive: setIsDragOverComposer,
     onInsertRejected: () => {
       toastManager.add({

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -76,6 +76,12 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import { useComposerPathSearch } from "../../lib/composerPathSearchState";
+import {
+  canBrowseComposerFilesystemPath,
+  composerFilesystemSuggestionParentPath,
+  composerFilesystemSuggestionPath,
+  isComposerFilesystemPathQuery,
+} from "../../lib/composerFilesystemBrowse";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
@@ -105,6 +111,8 @@ import {
 import { ContextWindowMeter } from "./ContextWindowMeter";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../pierre-icons";
+import { useEnvironment } from "../../state/environments";
+import { useComposerFilesystemBrowse } from "../../state/queries";
 import { cn, randomUUID } from "~/lib/utils";
 import { Separator } from "../ui/separator";
 
@@ -1065,15 +1073,37 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const composerTriggerKind = composerTrigger?.kind ?? null;
   const pathTriggerQuery = composerTrigger?.kind === "path" ? composerTrigger.query : "";
   const isPathTrigger = composerTriggerKind === "path";
+  const environment = useEnvironment(environmentId);
+  const environmentPlatform = environment?.serverConfig?.environment.platform.os ?? "";
+  const isFilesystemPathTrigger =
+    isPathTrigger && isComposerFilesystemPathQuery(pathTriggerQuery, environmentPlatform);
+  const canBrowseFilesystemPath =
+    isFilesystemPathTrigger &&
+    canBrowseComposerFilesystemPath(pathTriggerQuery, gitCwd, environmentPlatform);
   const workspaceEntries = useComposerPathSearch({
     environmentId,
-    cwd: isPathTrigger ? gitCwd : null,
-    query: isPathTrigger ? pathTriggerQuery : null,
+    cwd: isPathTrigger && !isFilesystemPathTrigger ? gitCwd : null,
+    query: isPathTrigger && !isFilesystemPathTrigger ? pathTriggerQuery : null,
+  });
+  const filesystemEntries = useComposerFilesystemBrowse({
+    environmentId,
+    cwd: canBrowseFilesystemPath ? gitCwd : null,
+    query: canBrowseFilesystemPath ? pathTriggerQuery : null,
   });
 
   const composerMenuItems = useMemo<ComposerCommandItem[]>(() => {
     if (!composerTrigger) return [];
     if (composerTrigger.kind === "path") {
+      if (isFilesystemPathTrigger) {
+        return filesystemEntries.entries.map((entry) => ({
+          id: `filesystem-path:${entry.kind ?? "directory"}:${entry.fullPath}`,
+          type: "path" as const,
+          path: composerFilesystemSuggestionPath(pathTriggerQuery, entry.name),
+          pathKind: entry.kind ?? "directory",
+          label: entry.name,
+          description: composerFilesystemSuggestionParentPath(pathTriggerQuery),
+        }));
+      }
       return workspaceEntries.entries.map((entry) => ({
         id: `path:${entry.kind}:${entry.path}`,
         type: "path",
@@ -1140,7 +1170,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       );
     }
     return [];
-  }, [composerTrigger, selectedProvider, selectedProviderStatus, workspaceEntries.entries]);
+  }, [
+    composerTrigger,
+    filesystemEntries.entries,
+    isFilesystemPathTrigger,
+    pathTriggerQuery,
+    selectedProvider,
+    selectedProviderStatus,
+    workspaceEntries.entries,
+  ]);
 
   const composerMenuOpen = Boolean(composerTrigger);
   const composerMenuSearchKey = composerTrigger
@@ -1205,7 +1243,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   ]);
 
   const isComposerMenuLoading =
-    composerTriggerKind === "path" && pathTriggerQuery.length > 0 && workspaceEntries.isPending;
+    composerTriggerKind === "path" &&
+    pathTriggerQuery.length > 0 &&
+    (isFilesystemPathTrigger ? filesystemEntries.isPending : workspaceEntries.isPending);
   const composerMenuEmptyState = useMemo(() => {
     if (composerTriggerKind === "skill") {
       return "No skills found. Try / to browse provider commands.";

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1,4 +1,5 @@
 import { CheckpointRef, EnvironmentId, MessageId, TurnId } from "@t3tools/contracts";
+import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { createRef, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
@@ -226,6 +227,35 @@ function buildUserTimelineEntry(text: string) {
 }
 
 describe("MessagesTimeline", () => {
+  it("uses legacy file-link discovery only when provenance is absent", () => {
+    const text = serializeComposerFileLink("src/index.ts");
+    const legacyMessage = buildUserTimelineEntry(text);
+    const explicitBase = buildUserTimelineEntry(text);
+    const explicitMessage = {
+      ...explicitBase,
+      id: "entry-2",
+      message: {
+        ...explicitBase.message,
+        id: MessageId.make("message-2"),
+        fileMentions: [],
+      },
+    };
+
+    const legacyMarkup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} markdownCwd="/repo" timelineEntries={[legacyMessage]} />,
+    );
+    const explicitMarkup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        markdownCwd="/repo"
+        timelineEntries={[explicitMessage]}
+      />,
+    );
+
+    expect(legacyMarkup).toContain("chat-markdown-file-link");
+    expect(explicitMarkup).not.toContain("chat-markdown-file-link");
+  });
+
   it("uses the larger leading inset only when the top fade is enabled", () => {
     const timelineEntries = [buildUserTimelineEntry("Hello")];
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1692,6 +1692,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
           <ChatMarkdown
             text={content}
             cwd={props.markdownCwd}
+            canonicalFileLinks
             threadRef={ctx.threadRef ?? undefined}
             skills={props.skills}
             className="text-message-foreground"
@@ -1714,6 +1715,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
                 <ChatMarkdown
                   text={segment.text.trim()}
                   cwd={props.markdownCwd}
+                  canonicalFileLinks
                   threadRef={ctx.threadRef ?? undefined}
                   skills={props.skills}
                   className="text-message-foreground"
@@ -1802,6 +1804,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
           key="user-message-terminal-context-inline-text"
           text={props.text}
           cwd={props.markdownCwd}
+          canonicalFileLinks
           threadRef={ctx.threadRef ?? undefined}
           skills={props.skills}
           className="text-message-foreground"
@@ -1827,6 +1830,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
     <ChatMarkdown
       text={props.text}
       cwd={props.markdownCwd}
+      canonicalFileLinks
       threadRef={ctx.threadRef ?? undefined}
       skills={props.skills}
       className="text-message-foreground"

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1036,7 +1036,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
         ) : null}
         <CollapsibleUserMessageBody
           text={elementContextState.promptText}
-          fileMentions={(row.message.fileMentions ?? []).filter(
+          fileMentions={row.message.fileMentions?.filter(
             (mention) => mention.end <= elementContextState.promptText.length,
           )}
           terminalContexts={terminalContexts}
@@ -1607,7 +1607,7 @@ function shouldCollapseUserMessage(text: string): boolean {
 
 const CollapsibleUserMessageBody = memo(function CollapsibleUserMessageBody(props: {
   text: string;
-  fileMentions: ReadonlyArray<ExplicitFileMention>;
+  fileMentions: ReadonlyArray<ExplicitFileMention> | undefined;
   terminalContexts: ParsedTerminalContextEntry[];
   skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   markdownCwd: string | undefined;
@@ -1677,14 +1677,14 @@ const CollapsibleUserMessageBody = memo(function CollapsibleUserMessageBody(prop
 
 const UserMessageBody = memo(function UserMessageBody(props: {
   text: string;
-  fileMentions: ReadonlyArray<ExplicitFileMention>;
+  fileMentions: ReadonlyArray<ExplicitFileMention> | undefined;
   terminalContexts: ParsedTerminalContextEntry[];
   skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   markdownCwd: string | undefined;
 }) {
   const ctx = use(TimelineRowCtx);
   const fileMentionsForRange = (start: number, end: number) =>
-    props.fileMentions.flatMap((mention) =>
+    props.fileMentions?.flatMap((mention) =>
       mention.start >= start && mention.end <= end
         ? [{ ...mention, start: mention.start - start, end: mention.end - start }]
         : [],

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1,5 +1,6 @@
 import {
   type EnvironmentId,
+  type ExplicitFileMention,
   type MessageId,
   type ScopedThreadRef,
   type ServerProviderSkill,
@@ -1035,6 +1036,9 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
         ) : null}
         <CollapsibleUserMessageBody
           text={elementContextState.promptText}
+          fileMentions={(row.message.fileMentions ?? []).filter(
+            (mention) => mention.end <= elementContextState.promptText.length,
+          )}
           terminalContexts={terminalContexts}
           skills={ctx.skills}
           markdownCwd={ctx.markdownCwd}
@@ -1603,6 +1607,7 @@ function shouldCollapseUserMessage(text: string): boolean {
 
 const CollapsibleUserMessageBody = memo(function CollapsibleUserMessageBody(props: {
   text: string;
+  fileMentions: ReadonlyArray<ExplicitFileMention>;
   terminalContexts: ParsedTerminalContextEntry[];
   skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   markdownCwd: string | undefined;
@@ -1633,6 +1638,7 @@ const CollapsibleUserMessageBody = memo(function CollapsibleUserMessageBody(prop
         >
           <UserMessageBody
             text={props.text}
+            fileMentions={props.fileMentions}
             terminalContexts={props.terminalContexts}
             skills={props.skills}
             markdownCwd={props.markdownCwd}
@@ -1671,12 +1677,19 @@ const CollapsibleUserMessageBody = memo(function CollapsibleUserMessageBody(prop
 
 const UserMessageBody = memo(function UserMessageBody(props: {
   text: string;
+  fileMentions: ReadonlyArray<ExplicitFileMention>;
   terminalContexts: ParsedTerminalContextEntry[];
   skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   markdownCwd: string | undefined;
 }) {
   const ctx = use(TimelineRowCtx);
-  const renderInlineMarkdownSegment = (text: string, key: string) => {
+  const fileMentionsForRange = (start: number, end: number) =>
+    props.fileMentions.flatMap((mention) =>
+      mention.start >= start && mention.end <= end
+        ? [{ ...mention, start: mention.start - start, end: mention.end - start }]
+        : [],
+    );
+  const renderInlineMarkdownSegment = (text: string, key: string, sourceStart: number) => {
     const leadingWhitespace = /^\s+/.exec(text)?.[0] ?? "";
     const textWithoutLeadingWhitespace = text.slice(leadingWhitespace.length);
     const trailingWhitespace = /\s+$/.exec(textWithoutLeadingWhitespace)?.[0] ?? "";
@@ -1692,7 +1705,10 @@ const UserMessageBody = memo(function UserMessageBody(props: {
           <ChatMarkdown
             text={content}
             cwd={props.markdownCwd}
-            canonicalFileLinks
+            fileMentions={fileMentionsForRange(
+              sourceStart + leadingWhitespace.length,
+              sourceStart + leadingWhitespace.length + content.length,
+            )}
             threadRef={ctx.threadRef ?? undefined}
             skills={props.skills}
             className="text-message-foreground"
@@ -1708,25 +1724,36 @@ const UserMessageBody = memo(function UserMessageBody(props: {
   if (reviewCommentSegments.some((segment) => segment.kind === "review-comment")) {
     return (
       <div className="space-y-3 text-message-foreground text-sm leading-relaxed">
-        {reviewCommentSegments.map((segment) =>
-          segment.kind === "text" ? (
-            segment.text.trim().length > 0 ? (
-              <div key={segment.id} className="wrap-break-word">
-                <ChatMarkdown
-                  text={segment.text.trim()}
-                  cwd={props.markdownCwd}
-                  canonicalFileLinks
-                  threadRef={ctx.threadRef ?? undefined}
-                  skills={props.skills}
-                  className="text-message-foreground"
-                  lineBreaks
-                />
-              </div>
-            ) : null
-          ) : (
-            <UserMessageReviewCommentCard key={segment.comment.id} comment={segment.comment} />
-          ),
-        )}
+        {reviewCommentSegments.map((segment) => {
+          if (segment.kind !== "text") {
+            return (
+              <UserMessageReviewCommentCard key={segment.comment.id} comment={segment.comment} />
+            );
+          }
+          const sourceStart = Number(segment.id.slice(segment.id.lastIndexOf(":") + 1));
+          const leadingTrim = segment.text.length - segment.text.trimStart().length;
+          const content = segment.text.trim();
+          return content.length > 0 ? (
+            <div key={segment.id} className="wrap-break-word">
+              <ChatMarkdown
+                text={content}
+                cwd={props.markdownCwd}
+                fileMentions={
+                  !Number.isFinite(sourceStart)
+                    ? []
+                    : fileMentionsForRange(
+                        sourceStart + leadingTrim,
+                        sourceStart + leadingTrim + content.length,
+                      )
+                }
+                threadRef={ctx.threadRef ?? undefined}
+                skills={props.skills}
+                className="text-message-foreground"
+                lineBreaks
+              />
+            </div>
+          ) : null;
+        })}
       </div>
     );
   }
@@ -1754,6 +1781,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
             renderInlineMarkdownSegment(
               props.text.slice(cursor, matchIndex),
               `user-terminal-context-inline-before:${context.header}:${cursor}`,
+              cursor,
             ),
           );
         }
@@ -1772,6 +1800,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
             renderInlineMarkdownSegment(
               props.text.slice(cursor),
               `user-message-terminal-context-inline-rest:${cursor}`,
+              cursor,
             ),
           );
         }
@@ -1804,7 +1833,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
           key="user-message-terminal-context-inline-text"
           text={props.text}
           cwd={props.markdownCwd}
-          canonicalFileLinks
+          fileMentions={props.fileMentions}
           threadRef={ctx.threadRef ?? undefined}
           skills={props.skills}
           className="text-message-foreground"
@@ -1830,7 +1859,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
     <ChatMarkdown
       text={props.text}
       cwd={props.markdownCwd}
-      canonicalFileLinks
+      fileMentions={props.fileMentions}
       threadRef={ctx.threadRef ?? undefined}
       skills={props.skills}
       className="text-message-foreground"

--- a/apps/web/src/components/chat/composerMentionDrag.ts
+++ b/apps/web/src/components/chat/composerMentionDrag.ts
@@ -6,6 +6,15 @@ import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
  * OS file drags and plain text selections.
  */
 export const COMPOSER_MENTION_DRAG_TYPE = "application/x-t3code-composer-mention";
+export const COMPOSER_MENTION_PROVENANCE_DRAG_TYPE =
+  "application/x-t3code-composer-mention-provenance";
+
+export interface ComposerDraggedMention {
+  readonly path: string;
+  readonly kind: "file" | "directory";
+  readonly start: number;
+  readonly end: number;
+}
 
 export function composerMentionFromTreePath(treePath: string): string | null {
   const relativePath = treePath.replace(/\/+$/, "");
@@ -13,6 +22,27 @@ export function composerMentionFromTreePath(treePath: string): string | null {
     return null;
   }
   return serializeComposerFileLink(relativePath);
+}
+
+export function composerMentionProvenanceFromTreePaths(
+  treePaths: ReadonlyArray<string>,
+): { readonly text: string; readonly mentions: ReadonlyArray<ComposerDraggedMention> } | null {
+  const mentions: ComposerDraggedMention[] = [];
+  let text = "";
+  for (const treePath of treePaths) {
+    const source = composerMentionFromTreePath(treePath);
+    if (source === null) continue;
+    if (text.length > 0) text += " ";
+    const start = text.length;
+    text += source;
+    mentions.push({
+      path: treePath.replace(/\/+$/, ""),
+      kind: treePath.endsWith("/") ? "directory" : "file",
+      start,
+      end: text.length,
+    });
+  }
+  return mentions.length > 0 ? { text, mentions } : null;
 }
 
 export function dataTransferHasComposerMention(types: ReadonlyArray<string>): boolean {
@@ -40,7 +70,7 @@ export interface ComposerMentionDragEvent {
  * the next frame, after the editor has caught up.
  */
 export interface ComposerMentionDropHost {
-  insertMentionAtEnd(text: string): boolean;
+  insertMentionAtEnd(text: string, mentions: ReadonlyArray<ComposerDraggedMention>): boolean;
   setDragActive(active: boolean): void;
   onInsertRejected(): void;
 }
@@ -90,7 +120,30 @@ export function makeComposerMentionDragHandlers(
       if (mention.length === 0) {
         return;
       }
-      if (!host.insertMentionAtEnd(`${mention} `)) {
+      let mentions: ReadonlyArray<ComposerDraggedMention> = [];
+      try {
+        const parsed = JSON.parse(
+          event.dataTransfer.getData(COMPOSER_MENTION_PROVENANCE_DRAG_TYPE),
+        ) as { readonly text?: unknown; readonly mentions?: unknown };
+        if (parsed.text === mention && Array.isArray(parsed.mentions)) {
+          mentions = parsed.mentions.filter(
+            (item): item is ComposerDraggedMention =>
+              typeof item === "object" &&
+              item !== null &&
+              "path" in item &&
+              typeof item.path === "string" &&
+              "kind" in item &&
+              (item.kind === "file" || item.kind === "directory") &&
+              "start" in item &&
+              Number.isInteger(item.start) &&
+              "end" in item &&
+              Number.isInteger(item.end),
+          );
+        }
+      } catch {
+        // Older clients carry only the display text; it remains a normal link.
+      }
+      if (!host.insertMentionAtEnd(`${mention} `, mentions)) {
         host.onInsertRejected();
       }
     },

--- a/apps/web/src/components/files/fileTreeDragMention.test.ts
+++ b/apps/web/src/components/files/fileTreeDragMention.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import { COMPOSER_MENTION_DRAG_TYPE } from "~/components/chat/composerMentionDrag";
+import {
+  COMPOSER_MENTION_DRAG_TYPE,
+  COMPOSER_MENTION_PROVENANCE_DRAG_TYPE,
+} from "~/components/chat/composerMentionDrag";
 import { createFileTreeDragMentionController } from "./fileTreeDragMention.ts";
 
 const makeTransfer = (plainText = "") => {
@@ -36,6 +39,9 @@ describe("createFileTreeDragMentionController", () => {
       composedPath: () => [rowNode("docs/architecture/")],
     });
     expect(transfer.getData(COMPOSER_MENTION_DRAG_TYPE)).toBe("[architecture](docs/architecture)");
+    expect(JSON.parse(transfer.getData(COMPOSER_MENTION_PROVENANCE_DRAG_TYPE))).toMatchObject({
+      mentions: [{ path: "docs/architecture", kind: "directory" }],
+    });
   });
 
   it("does not tag drags of selected text from the panel chrome", () => {

--- a/apps/web/src/components/files/fileTreeDragMention.ts
+++ b/apps/web/src/components/files/fileTreeDragMention.ts
@@ -1,6 +1,7 @@
 import {
   COMPOSER_MENTION_DRAG_TYPE,
-  composerMentionFromTreePath,
+  COMPOSER_MENTION_PROVENANCE_DRAG_TYPE,
+  composerMentionProvenanceFromTreePaths,
 } from "~/components/chat/composerMentionDrag";
 
 interface FileTreeDragTransfer {
@@ -73,14 +74,13 @@ export function createFileTreeDragMentionController(
       // Same rule the tree applies to the drag itself: dragging a row that is
       // part of the current selection drags the whole selection.
       const dragged = selection.includes(itemPath) ? selection : [itemPath];
-      const mentions = dragged
-        .map((path) => composerMentionFromTreePath(path))
-        .filter((mention): mention is string => mention !== null);
-      if (mentions.length === 0) {
+      const payload = composerMentionProvenanceFromTreePaths(dragged);
+      if (payload === null) {
         return;
       }
       draggedPaths = dragged;
-      event.dataTransfer.setData(COMPOSER_MENTION_DRAG_TYPE, mentions.join(" "));
+      event.dataTransfer.setData(COMPOSER_MENTION_DRAG_TYPE, payload.text);
+      event.dataTransfer.setData(COMPOSER_MENTION_PROVENANCE_DRAG_TYPE, JSON.stringify(payload));
     },
     handleDragEnd() {
       if (draggedPaths.length === 0) {

--- a/apps/web/src/composer-file-link-markdown.test.tsx
+++ b/apps/web/src/composer-file-link-markdown.test.tsx
@@ -33,6 +33,61 @@ describe("composer file link markdown", () => {
     expect(markup).toContain("chat-markdown-file-link");
   });
 
+  it("renders an explicit chip inside an over-indented list item", () => {
+    const path = "/custom/mount/data";
+    const source = serializeComposerFileLink(path);
+    const text = `-       ${source}`;
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown text={text} cwd="/repo" fileMentions={[mention(path, text)]} />,
+    );
+
+    expect(markup).toContain("chat-markdown-file-link");
+  });
+
+  it("does not promote an identical unmentioned link beside a normalized list item", () => {
+    const path = "/custom/mount/data";
+    const source = serializeComposerFileLink(path);
+    const text = `${source}\n\n-       ${source}`;
+    const secondStart = text.lastIndexOf(source);
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown
+        text={text}
+        cwd="/repo"
+        fileMentions={[
+          {
+            ...mention(path, text),
+            start: secondStart,
+            end: secondStart + source.length,
+          },
+        ]}
+      />,
+    );
+
+    expect(markup.match(/chat-markdown-file-link/g)).toHaveLength(1);
+  });
+
+  it("preserves explicit ranges in multiline recovered list content", () => {
+    const path = "/custom/mount/data";
+    const source = serializeComposerFileLink(path);
+    const text = `-       first block\n\n        ${source}`;
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown text={text} cwd="/repo" fileMentions={[mention(path, text)]} />,
+    );
+
+    expect(markup).toContain("chat-markdown-file-link");
+  });
+
+  it("preserves explicit ranges through nested list recovery", () => {
+    const path = "/custom/mount/data";
+    const source = serializeComposerFileLink(path);
+    const text = `-       first block\n\n        -       ${source}`;
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown text={text} cwd="/repo" fileMentions={[mention(path, text)]} />,
+    );
+
+    expect(markup).toContain("chat-markdown-file-link");
+  });
+
   it("does not promote an identical hand-authored link outside the mentioned range", () => {
     const source = serializeComposerFileLink("/custom/mount/data");
     const text = `${source} and ${source}`;
@@ -64,6 +119,24 @@ describe("composer file link markdown", () => {
     expect(markup).toContain("chat-markdown-file-link");
   });
 
+  it("renders explicit Windows drive paths after link sanitization", () => {
+    const path = "C:\\Users\\me\\file.ts";
+    const text = serializeComposerFileLink(path);
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown text={text} cwd="C:\\repo" fileMentions={[mention(path, text)]} />,
+    );
+
+    expect(markup).toContain("chat-markdown-file-link");
+    expect(markup).toContain("file.ts");
+  });
+
+  it("discovers Windows drive paths before link sanitization", () => {
+    const text = serializeComposerFileLink("C:\\Users\\me\\file.ts");
+    const markup = renderToStaticMarkup(<ChatMarkdown text={text} cwd="C:\\repo" />);
+
+    expect(markup).toContain("chat-markdown-file-link");
+  });
+
   it("ignores provenance whose range does not exactly match its canonical source", () => {
     const text = "before [data](/custom/mount/data)";
     const markup = renderToStaticMarkup(
@@ -84,6 +157,13 @@ describe("composer file link markdown", () => {
 
     expect(markup).not.toContain("chat-markdown-file-link");
     expect(markup).toContain('href="/chat/settings"');
+  });
+
+  it("handles large malformed link input without quadratic scanning", () => {
+    const startedAt = performance.now();
+    renderToStaticMarkup(<ChatMarkdown text={"[".repeat(64_000)} cwd="/repo" />);
+
+    expect(performance.now() - startedAt).toBeLessThan(1_500);
   });
 
   it("keeps pipes in filenames inside GFM table cells", () => {

--- a/apps/web/src/composer-file-link-markdown.test.tsx
+++ b/apps/web/src/composer-file-link-markdown.test.tsx
@@ -1,0 +1,60 @@
+import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { describe, expect, it } from "vite-plus/test";
+import ChatMarkdown from "./components/ChatMarkdown";
+
+describe("composer file link markdown", () => {
+  it("keeps markdown syntax in a filename as plain link text", () => {
+    const markdown = serializeComposerFileLink("/custom/*draft* &amp;");
+    const markup = renderToStaticMarkup(<ReactMarkdown>{markdown}</ReactMarkdown>);
+
+    expect(markup).toContain('href="/custom/*draft*%20%26amp;"');
+    expect(markup).toContain(">*draft* &amp;amp;</a>");
+    expect(markup).not.toContain("<em>");
+  });
+
+  it("renders a chip when the label carries inline formatting", () => {
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown text="[*data*](/custom/mount/data)" cwd="/repo" canonicalFileLinks />,
+    );
+
+    expect(markup).toContain("chat-markdown-file-link");
+  });
+
+  it("matches canonical labels using rendered character references", () => {
+    const entityMarkup = renderToStaticMarkup(
+      <ChatMarkdown text="[a&amp;b](/tmp/a%26b)" cwd="/repo" canonicalFileLinks />,
+    );
+    const escapedEntityMarkup = renderToStaticMarkup(
+      <ChatMarkdown
+        text={serializeComposerFileLink("/tmp/a&amp;b")}
+        cwd="/repo"
+        canonicalFileLinks
+      />,
+    );
+
+    expect(entityMarkup).toContain("chat-markdown-file-link");
+    expect(escapedEntityMarkup).toContain("chat-markdown-file-link");
+  });
+
+  it("does not promote route-shaped links in composer messages", () => {
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown text="[settings](/chat/settings)" cwd="/repo" canonicalFileLinks />,
+    );
+
+    expect(markup).not.toContain("chat-markdown-file-link");
+    expect(markup).toContain('href="/chat/settings"');
+  });
+
+  it("keeps pipes in filenames inside GFM table cells", () => {
+    const markdown = `| File |\n| --- |\n| ${serializeComposerFileLink("/tmp/a|b")} |`;
+    const markup = renderToStaticMarkup(
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>,
+    );
+
+    expect(markup).toContain('href="/tmp/a%7Cb"');
+    expect(markup).toContain(">a|b</a>");
+  });
+});

--- a/apps/web/src/composer-file-link-markdown.test.tsx
+++ b/apps/web/src/composer-file-link-markdown.test.tsx
@@ -5,6 +5,15 @@ import remarkGfm from "remark-gfm";
 import { describe, expect, it } from "vite-plus/test";
 import ChatMarkdown from "./components/ChatMarkdown";
 
+const mention = (path: string, text: string) => ({
+  version: 1 as const,
+  environmentId: "test" as never,
+  path,
+  kind: "file" as const,
+  start: text.indexOf(serializeComposerFileLink(path)),
+  end: text.indexOf(serializeComposerFileLink(path)) + serializeComposerFileLink(path).length,
+});
+
 describe("composer file link markdown", () => {
   it("keeps markdown syntax in a filename as plain link text", () => {
     const markdown = serializeComposerFileLink("/custom/*draft* &amp;");
@@ -15,33 +24,62 @@ describe("composer file link markdown", () => {
     expect(markup).not.toContain("<em>");
   });
 
-  it("renders a chip when the label carries inline formatting", () => {
+  it("renders a chip only for an explicitly mentioned range", () => {
+    const text = serializeComposerFileLink("/custom/mount/data");
     const markup = renderToStaticMarkup(
-      <ChatMarkdown text="[*data*](/custom/mount/data)" cwd="/repo" canonicalFileLinks />,
+      <ChatMarkdown text={text} cwd="/repo" fileMentions={[mention("/custom/mount/data", text)]} />,
     );
 
     expect(markup).toContain("chat-markdown-file-link");
   });
 
-  it("matches canonical labels using rendered character references", () => {
-    const entityMarkup = renderToStaticMarkup(
-      <ChatMarkdown text="[a&amp;b](/tmp/a%26b)" cwd="/repo" canonicalFileLinks />,
-    );
-    const escapedEntityMarkup = renderToStaticMarkup(
+  it("does not promote an identical hand-authored link outside the mentioned range", () => {
+    const source = serializeComposerFileLink("/custom/mount/data");
+    const text = `${source} and ${source}`;
+    const secondStart = text.lastIndexOf(source);
+    const markup = renderToStaticMarkup(
       <ChatMarkdown
-        text={serializeComposerFileLink("/tmp/a&amp;b")}
+        text={text}
         cwd="/repo"
-        canonicalFileLinks
+        fileMentions={[
+          {
+            ...mention("/custom/mount/data", text),
+            start: secondStart,
+            end: secondStart + source.length,
+          },
+        ]}
       />,
     );
 
-    expect(entityMarkup).toContain("chat-markdown-file-link");
-    expect(escapedEntityMarkup).toContain("chat-markdown-file-link");
+    expect(markup.match(/chat-markdown-file-link/g)).toHaveLength(1);
   });
 
-  it("does not promote route-shaped links in composer messages", () => {
+  it("matches AST offsets in UTF-16 code units", () => {
+    const source = serializeComposerFileLink("/tmp/💾.txt");
+    const text = `😀 ${source}`;
     const markup = renderToStaticMarkup(
-      <ChatMarkdown text="[settings](/chat/settings)" cwd="/repo" canonicalFileLinks />,
+      <ChatMarkdown text={text} cwd="/repo" fileMentions={[mention("/tmp/💾.txt", text)]} />,
+    );
+
+    expect(markup).toContain("chat-markdown-file-link");
+  });
+
+  it("ignores provenance whose range does not exactly match its canonical source", () => {
+    const text = "before [data](/custom/mount/data)";
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown
+        text={text}
+        cwd="/repo"
+        fileMentions={[{ ...mention("/custom/mount/data", text), start: 0, end: text.length }]}
+      />,
+    );
+
+    expect(markup).not.toContain("chat-markdown-file-link");
+  });
+
+  it("does not promote hand-authored route-shaped links", () => {
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown text="[settings](/chat/settings)" cwd="/repo" fileMentions={[]} />,
     );
 
     expect(markup).not.toContain("chat-markdown-file-link");

--- a/apps/web/src/composer-file-link-markdown.test.tsx
+++ b/apps/web/src/composer-file-link-markdown.test.tsx
@@ -1,0 +1,35 @@
+import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { describe, expect, it } from "vite-plus/test";
+import ChatMarkdown from "./components/ChatMarkdown";
+
+describe("composer file link markdown", () => {
+  it("keeps markdown syntax in a filename as plain link text", () => {
+    const markdown = serializeComposerFileLink("/custom/*draft* &amp;");
+    const markup = renderToStaticMarkup(<ReactMarkdown>{markdown}</ReactMarkdown>);
+
+    expect(markup).toContain('href="/custom/*draft*%20%26amp;"');
+    expect(markup).toContain(">*draft* &amp;amp;</a>");
+    expect(markup).not.toContain("<em>");
+  });
+
+  it("renders a chip when the label carries inline formatting", () => {
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown text="[*data*](/custom/mount/data)" cwd="/repo" />,
+    );
+
+    expect(markup).toContain("chat-markdown-file-link");
+  });
+
+  it("keeps pipes in filenames inside GFM table cells", () => {
+    const markdown = `| File |\n| --- |\n| ${serializeComposerFileLink("/tmp/a|b")} |`;
+    const markup = renderToStaticMarkup(
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>,
+    );
+
+    expect(markup).toContain('href="/tmp/a%7Cb"');
+    expect(markup).toContain(">a|b</a>");
+  });
+});

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -145,6 +145,23 @@ describe("detectComposerTrigger", () => {
     });
   });
 
+  it("keeps escaped quotes in an active quoted path query", () => {
+    const text = String.raw`Please check @"docs/My \"File`;
+
+    expect(detectComposerTrigger(text, text.length)).toEqual({
+      kind: "path",
+      query: 'docs/My "File',
+      rangeStart: "Please check ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("ends a quoted path query at a quote preceded by an even backslash run", () => {
+    const text = String.raw`Please check @"docs/My \\"`;
+
+    expect(detectComposerTrigger(text, text.length)).toBeNull();
+  });
+
   it("detects trigger with true cursor even when regex-based mention detection would false-match", () => {
     // MENTION_TOKEN_REGEX can false-match plain text like "@in" as a mention.
     // The fix bypasses it by computing the expanded cursor from the Lexical node tree.

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -134,6 +134,17 @@ describe("detectComposerTrigger", () => {
     });
   });
 
+  it("keeps a quoted path trigger active across spaces", () => {
+    const text = 'Please check @"/Users/chris/My Project/src';
+
+    expect(detectComposerTrigger(text, text.length)).toEqual({
+      kind: "path",
+      query: "/Users/chris/My Project/src",
+      rangeStart: "Please check ".length,
+      rangeEnd: text.length,
+    });
+  });
+
   it("detects trigger with true cursor even when regex-based mention detection would false-match", () => {
     // MENTION_TOKEN_REGEX can false-match plain text like "@in" as a mention.
     // The fix bypasses it by computing the expanded cursor from the Lexical node tree.

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -240,6 +240,22 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
     }
   }
 
+  const quotedPathStart = linePrefix.lastIndexOf('@"');
+  if (
+    quotedPathStart >= 0 &&
+    (quotedPathStart === 0 || isWhitespace(linePrefix[quotedPathStart - 1] ?? ""))
+  ) {
+    const query = linePrefix.slice(quotedPathStart + 2);
+    if (!query.includes('"')) {
+      return {
+        kind: "path",
+        query,
+        rangeStart: lineStart + quotedPathStart,
+        rangeEnd: cursor,
+      };
+    }
+  }
+
   const tokenStart = tokenStartForCursor(text, cursor);
   const token = text.slice(tokenStart, cursor);
   if (token.startsWith("$")) {

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -222,6 +222,27 @@ export function isCollapsedCursorAdjacentToInlineToken(
 
 export const isCollapsedCursorAdjacentToMention = isCollapsedCursorAdjacentToInlineToken;
 
+function decodeActiveQuotedPathQuery(source: string): string | null {
+  const decoded: string[] = [];
+  let backslashRun = 0;
+  for (const char of source) {
+    if (char === "\\") {
+      decoded.push(char);
+      backslashRun += 1;
+      continue;
+    }
+    if (char === '"') {
+      if (backslashRun % 2 === 0) return null;
+      decoded.pop();
+      decoded.push(char);
+    } else {
+      decoded.push(char);
+    }
+    backslashRun = 0;
+  }
+  return decoded.join("");
+}
+
 export function detectComposerTrigger(text: string, cursorInput: number): ComposerTrigger | null {
   const cursor = clampCursor(text, cursorInput);
   const lineStart = text.lastIndexOf("\n", Math.max(0, cursor - 1)) + 1;
@@ -245,8 +266,8 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
     quotedPathStart >= 0 &&
     (quotedPathStart === 0 || isWhitespace(linePrefix[quotedPathStart - 1] ?? ""))
   ) {
-    const query = linePrefix.slice(quotedPathStart + 2);
-    if (!query.includes('"')) {
+    const query = decodeActiveQuotedPathQuery(linePrefix.slice(quotedPathStart + 2));
+    if (query !== null) {
       return {
         kind: "path",
         query,

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -16,6 +16,7 @@ import {
   type ProviderOptionSelection,
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
+import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 
 // The composer draft's `modelSelectionByProvider` and
 // `stickyModelSelectionByProvider` maps are keyed by `ProviderInstanceId`
@@ -781,6 +782,26 @@ describe("composerDraftStore project draft thread mapping", () => {
     expect(useComposerDraftStore.getState().getDraftThreadByProjectRef(projectRef)).toBeNull();
     expect(useComposerDraftStore.getState().getDraftThread(draftId)).toBeNull();
     expect(draftByKey(draftId)).toBeUndefined();
+  });
+
+  it("persists explicit file mention provenance with its prompt", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+    const prompt = serializeComposerFileLink("/tmp/example.ts");
+    store.setPrompt(draftId, prompt, [
+      {
+        version: 1,
+        environmentId: TEST_ENVIRONMENT_ID,
+        path: "/tmp/example.ts",
+        kind: "file",
+        start: 0,
+        end: prompt.length,
+      },
+    ]);
+
+    expect(draftByKey(draftId)?.fileMentions).toEqual([
+      expect.objectContaining({ path: "/tmp/example.ts", end: prompt.length }),
+    ]);
   });
 
   it("clears project draft mapping by project id", () => {

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -522,6 +522,305 @@ describe("composerDraftStore terminal contexts", () => {
     expect(mergedState.draftThreadsByThreadKey).toEqual({});
     expect(mergedState.logicalProjectDraftThreadKeyByLogicalProjectKey).toEqual({});
   });
+
+  it("drops persisted file mentions whose source range is stale", () => {
+    const prompt = serializeComposerFileLink("/tmp/example.ts");
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const mergedState = persistApi.getOptions().merge(
+      {
+        draftsByThreadId: {
+          [threadId]: {
+            prompt,
+            fileMentions: [
+              {
+                version: 1,
+                environmentId: TEST_ENVIRONMENT_ID,
+                path: "/tmp/other.ts",
+                kind: "file",
+                start: 0,
+                end: prompt.length,
+              },
+            ],
+          },
+        },
+      },
+      useComposerDraftStore.getInitialState(),
+    );
+
+    expect(mergedState.draftsByThreadKey[threadKeyFor(threadId)]?.fileMentions).toEqual([]);
+  });
+
+  it("drops persisted file mentions from a different environment", () => {
+    const prompt = serializeComposerFileLink("/tmp/example.ts");
+    const threadKey = threadKeyFor(threadId, TEST_ENVIRONMENT_ID);
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const mergedState = persistApi.getOptions().merge(
+      {
+        draftsByThreadKey: {
+          [threadKey]: {
+            prompt,
+            fileMentions: [
+              {
+                version: 1,
+                environmentId: OTHER_TEST_ENVIRONMENT_ID,
+                path: "/tmp/example.ts",
+                kind: "file",
+                start: 0,
+                end: prompt.length,
+              },
+            ],
+          },
+        },
+      },
+      useComposerDraftStore.getInitialState(),
+    );
+
+    expect(mergedState.draftsByThreadKey[threadKey]?.fileMentions).toEqual([]);
+  });
+
+  it("does not infer an environment for ambiguous legacy thread ids", () => {
+    const prompt = serializeComposerFileLink("/tmp/example.ts");
+    const localThreadKey = threadKeyFor(threadId, TEST_ENVIRONMENT_ID);
+    const remoteThreadKey = threadKeyFor(threadId, OTHER_TEST_ENVIRONMENT_ID);
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+        migrate: (
+          persistedState: unknown,
+          version: number,
+        ) => {
+          draftsByThreadKey: Record<
+            string,
+            { prompt?: string; fileMentions?: ReadonlyArray<unknown> }
+          >;
+          draftThreadsByThreadKey: Record<string, unknown>;
+          logicalProjectDraftThreadKeyByLogicalProjectKey: Record<string, string>;
+        };
+      };
+    };
+    const hydrate = (threadKeys: ReadonlyArray<string>) =>
+      persistApi.getOptions().merge(
+        {
+          draftsByThreadId: {
+            [threadId]: {
+              prompt,
+              fileMentions: [
+                {
+                  version: 1,
+                  environmentId: OTHER_TEST_ENVIRONMENT_ID,
+                  path: "/tmp/example.ts",
+                  kind: "file",
+                  start: 0,
+                  end: prompt.length,
+                },
+              ],
+            },
+          },
+          draftThreadsByThreadKey: Object.fromEntries(
+            threadKeys.map((threadKey) => {
+              const environmentId =
+                threadKey === localThreadKey ? TEST_ENVIRONMENT_ID : OTHER_TEST_ENVIRONMENT_ID;
+              return [
+                threadKey,
+                {
+                  threadId,
+                  environmentId,
+                  projectId: `project-${environmentId}`,
+                  createdAt: "2026-08-13T12:00:00.000Z",
+                },
+              ];
+            }),
+          ),
+        },
+        useComposerDraftStore.getInitialState(),
+      );
+
+    const localFirst = hydrate([localThreadKey, remoteThreadKey]);
+    const remoteFirst = hydrate([remoteThreadKey, localThreadKey]);
+
+    expect(localFirst.draftsByThreadKey).toEqual(remoteFirst.draftsByThreadKey);
+    expect(localFirst.draftsByThreadKey[threadId]).toMatchObject({
+      prompt,
+      fileMentions: [],
+    });
+    expect(localFirst.draftsByThreadKey[localThreadKey]).toBeUndefined();
+    expect(localFirst.draftsByThreadKey[remoteThreadKey]).toBeUndefined();
+
+    const localProjectKey = scopedProjectKey(
+      scopeProjectRef(TEST_ENVIRONMENT_ID, ProjectId.make("project-local")),
+    );
+    const remoteProjectKey = scopedProjectKey(
+      scopeProjectRef(OTHER_TEST_ENVIRONMENT_ID, ProjectId.make("project-remote")),
+    );
+    const rawDraft = {
+      prompt,
+      fileMentions: [
+        {
+          version: 1,
+          environmentId: TEST_ENVIRONMENT_ID,
+          path: "/tmp/example.ts",
+          kind: "file",
+          start: 0,
+          end: prompt.length,
+        },
+      ],
+    };
+    const mappingCases = [
+      {
+        mappings: [
+          [localProjectKey, threadId],
+          [remoteProjectKey, threadId],
+        ],
+        expectedScopedThreadKeys: [],
+        expectedProjectKeys: [],
+      },
+      {
+        mappings: [
+          [localProjectKey, localThreadKey],
+          [remoteProjectKey, remoteThreadKey],
+        ],
+        expectedScopedThreadKeys: [localThreadKey, remoteThreadKey],
+        expectedProjectKeys: [localProjectKey, remoteProjectKey],
+      },
+      {
+        mappings: [
+          [localProjectKey, localThreadKey],
+          [remoteProjectKey, threadId],
+        ],
+        expectedScopedThreadKeys: [localThreadKey],
+        expectedProjectKeys: [localProjectKey],
+      },
+      {
+        mappings: [
+          [localProjectKey, threadId],
+          [remoteProjectKey, remoteThreadKey],
+        ],
+        expectedScopedThreadKeys: [remoteThreadKey],
+        expectedProjectKeys: [remoteProjectKey],
+      },
+    ];
+
+    for (const { mappings, expectedScopedThreadKeys, expectedProjectKeys } of mappingCases) {
+      const states = [mappings, mappings.toReversed()].map((orderedMappings) => ({
+        draftsByThreadId: { [threadId]: rawDraft },
+        projectDraftThreadIdByProjectKey: Object.fromEntries(orderedMappings),
+      }));
+      const hydrated = states.map((state) =>
+        persistApi.getOptions().merge(state, useComposerDraftStore.getInitialState()),
+      );
+      const migrated = states.map((state) => persistApi.getOptions().migrate(state, 7));
+      const hydratedMigrations = migrated.map((state) =>
+        persistApi.getOptions().merge(state, useComposerDraftStore.getInitialState()),
+      );
+
+      expect(hydrated[0]!.draftsByThreadKey).toEqual(hydrated[1]!.draftsByThreadKey);
+      expect(migrated[0]!.draftsByThreadKey).toEqual(migrated[1]!.draftsByThreadKey);
+      expect(hydratedMigrations[0]!.draftsByThreadKey).toEqual(
+        hydratedMigrations[1]!.draftsByThreadKey,
+      );
+      for (const state of [...hydrated, ...migrated, ...hydratedMigrations]) {
+        expect(state.draftsByThreadKey[threadId]?.prompt).toBe(prompt);
+        expect(state.draftsByThreadKey[threadId]?.fileMentions ?? []).toEqual([]);
+        expect(state.draftsByThreadKey[localThreadKey]).toBeUndefined();
+        expect(state.draftsByThreadKey[remoteThreadKey]).toBeUndefined();
+        expect(Object.keys(state.draftThreadsByThreadKey).sort()).toEqual(
+          [...expectedScopedThreadKeys].sort(),
+        );
+        expect(Object.keys(state.logicalProjectDraftThreadKeyByLogicalProjectKey).sort()).toEqual(
+          [...expectedProjectKeys].sort(),
+        );
+      }
+    }
+
+    const conflictingScopedMappingCases: ReadonlyArray<ReadonlyArray<readonly [string, string]>> = [
+      [[localProjectKey, remoteThreadKey]],
+      [
+        [localProjectKey, remoteThreadKey],
+        [remoteProjectKey, localThreadKey],
+      ],
+    ];
+    for (const conflictingScopedMappings of conflictingScopedMappingCases) {
+      const conflictingStates = [
+        conflictingScopedMappings,
+        conflictingScopedMappings.toReversed(),
+      ].map((orderedMappings) => ({
+        draftsByThreadId: { [threadId]: rawDraft },
+        projectDraftThreadIdByProjectKey: Object.fromEntries(orderedMappings),
+      }));
+      const conflictingHydrated = conflictingStates.map((state) =>
+        persistApi.getOptions().merge(state, useComposerDraftStore.getInitialState()),
+      );
+      const conflictingMigrated = conflictingStates.map((state) =>
+        persistApi.getOptions().migrate(state, 7),
+      );
+      const conflictingHydratedMigrations = conflictingMigrated.map((state) =>
+        persistApi.getOptions().merge(state, useComposerDraftStore.getInitialState()),
+      );
+
+      for (const state of [
+        ...conflictingHydrated,
+        ...conflictingMigrated,
+        ...conflictingHydratedMigrations,
+      ]) {
+        expect(Object.keys(state.draftsByThreadKey)).toEqual([threadId]);
+        expect(state.draftsByThreadKey[threadId]?.prompt).toBe(prompt);
+        expect(state.draftsByThreadKey[threadId]?.fileMentions ?? []).toEqual([]);
+        expect(state.draftThreadsByThreadKey).toEqual({});
+        expect(state.logicalProjectDraftThreadKeyByLogicalProjectKey).toEqual({});
+      }
+    }
+
+    const uniquelyMapped = persistApi.getOptions().merge(
+      {
+        draftsByThreadId: { [threadId]: rawDraft },
+        projectDraftThreadIdByProjectKey: {
+          [localProjectKey]: threadId,
+        },
+      },
+      useComposerDraftStore.getInitialState(),
+    );
+    expect(uniquelyMapped.draftsByThreadKey[threadId]?.fileMentions).toHaveLength(1);
+
+    const consistentlyMapped = persistApi.getOptions().merge(
+      {
+        draftsByThreadId: { [threadId]: rawDraft },
+        projectDraftThreadIdByProjectKey: {
+          [localProjectKey]: threadId,
+          [scopedProjectKey(
+            scopeProjectRef(TEST_ENVIRONMENT_ID, ProjectId.make("project-local-two")),
+          )]: localThreadKey,
+        },
+      },
+      useComposerDraftStore.getInitialState(),
+    );
+    expect(consistentlyMapped.draftsByThreadKey[threadId]?.fileMentions).toHaveLength(1);
+
+    const explicitlyScoped = persistApi.getOptions().merge(
+      {
+        draftsByThreadKey: { [localThreadKey]: rawDraft },
+        projectDraftThreadIdByProjectKey: Object.fromEntries(mappingCases[0]!.mappings),
+      },
+      useComposerDraftStore.getInitialState(),
+    );
+    expect(explicitlyScoped.draftsByThreadKey[localThreadKey]?.fileMentions).toHaveLength(1);
+  });
 });
 
 describe("composerDraftStore element contexts", () => {
@@ -801,6 +1100,48 @@ describe("composerDraftStore project draft thread mapping", () => {
 
     expect(draftByKey(draftId)?.fileMentions).toEqual([
       expect.objectContaining({ path: "/tmp/example.ts", end: prompt.length }),
+    ]);
+
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const persistedState = persistApi.getOptions().partialize(useComposerDraftStore.getState());
+    const mergedState = persistApi
+      .getOptions()
+      .merge(persistedState, useComposerDraftStore.getInitialState());
+
+    expect(mergedState.draftsByThreadKey[draftId]?.fileMentions).toEqual([
+      expect.objectContaining({ path: "/tmp/example.ts", end: prompt.length }),
+    ]);
+  });
+
+  it("reconciles existing file mentions when setPrompt omits provenance", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+    const source = serializeComposerFileLink("/tmp/example.ts");
+    const prompt = `Review ${source}`;
+    const start = prompt.indexOf(source);
+    store.setPrompt(draftId, prompt, [
+      {
+        version: 1,
+        environmentId: TEST_ENVIRONMENT_ID,
+        path: "/tmp/example.ts",
+        kind: "file",
+        start,
+        end: start + source.length,
+      },
+    ]);
+
+    store.setPrompt(draftId, `Please ${prompt}`);
+
+    expect(draftByKey(draftId)?.fileMentions).toEqual([
+      expect.objectContaining({ start: start + "Please ".length }),
     ]);
   });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -3,6 +3,8 @@ import {
   DEFAULT_MODEL_BY_PROVIDER,
   defaultInstanceIdForDriver,
   type EnvironmentId,
+  ExplicitFileMentions,
+  type ExplicitFileMention,
   ModelSelection,
   ProjectId,
   ProviderInstanceId,
@@ -127,6 +129,7 @@ type PersistedElementContextDraft = typeof PersistedElementContextDraft.Type;
 
 const PersistedComposerThreadDraftState = Schema.Struct({
   prompt: Schema.String,
+  fileMentions: Schema.optionalKey(ExplicitFileMentions),
   attachments: Schema.Array(PersistedComposerImageAttachment),
   terminalContexts: Schema.optionalKey(Schema.Array(PersistedTerminalContextDraft)),
   elementContexts: Schema.optionalKey(Schema.Array(PersistedElementContextDraft)),
@@ -249,6 +252,7 @@ const PersistedComposerDraftStoreStorage = Schema.Struct({
  */
 export interface ComposerThreadDraftState {
   prompt: string;
+  fileMentions: ExplicitFileMention[];
   images: ComposerImageAttachment[];
   nonPersistedImageIds: string[];
   persistedAttachments: PersistedComposerImageAttachment[];
@@ -426,7 +430,11 @@ interface ComposerDraftStoreState {
   finalizePromotedDraftThread: (threadRef: ComposerThreadTarget) => void;
   clearDraftThread: (threadRef: ComposerThreadTarget) => void;
   setStickyModelSelection: (modelSelection: ModelSelection | null | undefined) => void;
-  setPrompt: (threadRef: ComposerThreadTarget, prompt: string) => void;
+  setPrompt: (
+    threadRef: ComposerThreadTarget,
+    prompt: string,
+    fileMentions?: ReadonlyArray<ExplicitFileMention>,
+  ) => void;
   setTerminalContexts: (threadRef: ComposerThreadTarget, contexts: TerminalContextDraft[]) => void;
   setModelSelection: (
     threadRef: ComposerThreadTarget,
@@ -599,12 +607,14 @@ const EMPTY_TERMINAL_CONTEXTS: TerminalContextDraft[] = [];
 const EMPTY_ELEMENT_CONTEXTS: ElementContextDraft[] = [];
 const EMPTY_PREVIEW_ANNOTATIONS: PreviewAnnotationPayload[] = [];
 const EMPTY_REVIEW_COMMENTS: ReviewCommentContext[] = [];
+const EMPTY_FILE_MENTIONS: ExplicitFileMention[] = [];
 Object.freeze(EMPTY_IMAGES);
 Object.freeze(EMPTY_IDS);
 Object.freeze(EMPTY_PERSISTED_ATTACHMENTS);
 Object.freeze(EMPTY_ELEMENT_CONTEXTS);
 Object.freeze(EMPTY_PREVIEW_ANNOTATIONS);
 Object.freeze(EMPTY_REVIEW_COMMENTS);
+Object.freeze(EMPTY_FILE_MENTIONS);
 const EMPTY_MODEL_SELECTION_BY_PROVIDER: Partial<Record<ProviderDriverKind, ModelSelection>> =
   Object.freeze({});
 const EMPTY_COMPOSER_DRAFT_MODEL_STATE = Object.freeze<ComposerDraftModelState>({
@@ -614,6 +624,7 @@ const EMPTY_COMPOSER_DRAFT_MODEL_STATE = Object.freeze<ComposerDraftModelState>(
 
 const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   prompt: "",
+  fileMentions: EMPTY_FILE_MENTIONS,
   images: EMPTY_IMAGES,
   nonPersistedImageIds: EMPTY_IDS,
   persistedAttachments: EMPTY_PERSISTED_ATTACHMENTS,
@@ -636,6 +647,7 @@ const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
 export function createEmptyThreadDraft(): ComposerThreadDraftState {
   return {
     prompt: "",
+    fileMentions: [],
     images: [],
     nonPersistedImageIds: [],
     persistedAttachments: [],
@@ -1903,6 +1915,7 @@ function partializeComposerDraftStoreState(
     }
     const persistedDraft: DeepMutable<PersistedComposerThreadDraftState> = {
       prompt: draft.prompt,
+      ...(draft.fileMentions.length > 0 ? { fileMentions: draft.fileMentions } : {}),
       attachments: draft.persistedAttachments,
       ...(draft.terminalContexts.length > 0
         ? {
@@ -2183,6 +2196,7 @@ function toHydratedThreadDraft(
 
   return {
     prompt: persistedDraft.prompt,
+    fileMentions: persistedDraft.fileMentions ? [...persistedDraft.fileMentions] : [],
     images: hydrateImagesFromPersisted(persistedDraft.attachments),
     nonPersistedImageIds: [],
     persistedAttachments: [...persistedDraft.attachments],
@@ -2655,7 +2669,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return { draftsByThreadKey: nextDraftsByThreadKey };
           });
         },
-        setPrompt: (threadRef, prompt) => {
+        setPrompt: (threadRef, prompt, fileMentions) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
           if (threadKey.length === 0) {
             return;
@@ -2665,6 +2679,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const nextDraft: ComposerThreadDraftState = {
               ...existing,
               prompt,
+              fileMentions: fileMentions === undefined ? [] : [...fileMentions],
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {
@@ -3428,6 +3443,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const nextDraft: ComposerThreadDraftState = {
               ...current,
               prompt: "",
+              fileMentions: [],
               images: [],
               nonPersistedImageIds: [],
               persistedAttachments: [],
@@ -3461,6 +3477,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const nextDraft: ComposerThreadDraftState = {
               ...current,
               prompt: ensureInlineTerminalContextPlaceholders("", current.terminalContexts.length),
+              fileMentions: [],
               images: [],
               nonPersistedImageIds: [],
               persistedAttachments: [],

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -32,6 +32,10 @@ import * as Equal from "effect/Equal";
 import * as Effect from "effect/Effect";
 import { DeepMutable } from "effect/Types";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
+import {
+  reconcileFileMentionsAfterEdit,
+  validateExplicitFileMentions,
+} from "@t3tools/shared/fileMentions";
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection, resolveAppModelSelectionForInstance } from "./modelSelection";
@@ -57,6 +61,7 @@ import { ReviewCommentContextSchema, type ReviewCommentContext } from "./reviewC
 const isRuntimeMode = Schema.is(RuntimeMode);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
 const isReviewCommentContext = Schema.is(ReviewCommentContextSchema);
+const isExplicitFileMentions = Schema.is(ExplicitFileMentions);
 
 export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
 const COMPOSER_DRAFT_STORAGE_VERSION = 8;
@@ -1275,10 +1280,6 @@ function normalizeLegacyComposerStorageKey(
   return threadKeyOrId;
 }
 
-function composerThreadRefFromKey(threadKey: string): ScopedThreadRef | null {
-  return parseScopedThreadKey(threadKey);
-}
-
 type ComposerThreadLookupState = Pick<
   ComposerDraftStoreState,
   "draftsByThreadKey" | "draftThreadsByThreadKey"
@@ -1481,15 +1482,32 @@ function removeDraftThreadReferences(
   };
 }
 
+function recordThreadEnvironment(
+  environmentIdByThreadId: Map<ThreadId, EnvironmentId | null>,
+  threadId: ThreadId,
+  environmentId: EnvironmentId,
+): void {
+  const existingEnvironmentId = environmentIdByThreadId.get(threadId);
+  if (existingEnvironmentId === undefined) {
+    environmentIdByThreadId.set(threadId, environmentId);
+  } else if (existingEnvironmentId !== environmentId) {
+    environmentIdByThreadId.set(threadId, null);
+  }
+}
+
 function normalizePersistedDraftThreads(
   rawDraftThreadsByThreadId: unknown,
   rawProjectDraftThreadIdByProjectKey: unknown,
 ): Pick<
   PersistedComposerDraftStoreState,
   "draftThreadsByThreadKey" | "logicalProjectDraftThreadKeyByLogicalProjectKey"
-> {
+> & {
+  environmentIdByLegacyThreadId: ReadonlyMap<ThreadId, EnvironmentId | null>;
+  legacyThreadIdsWithRawEvidence: ReadonlySet<ThreadId>;
+} {
   const draftThreadsByThreadKey: Record<string, PersistedDraftThreadState> = {};
-  const environmentIdByThreadId = new Map<ThreadId, EnvironmentId>();
+  const environmentIdByThreadId = new Map<ThreadId, EnvironmentId | null>();
+  const legacyThreadIdsWithRawEvidence = new Set<ThreadId>();
   if (
     rawProjectDraftThreadIdByProjectKey &&
     typeof rawProjectDraftThreadIdByProjectKey === "object"
@@ -1506,10 +1524,60 @@ function normalizePersistedDraftThreads(
       }
       const parsedThreadRef = parseScopedThreadKey(threadId);
       if (parsedThreadRef) {
-        environmentIdByThreadId.set(parsedThreadRef.threadId, parsedThreadRef.environmentId);
+        recordThreadEnvironment(
+          environmentIdByThreadId,
+          parsedThreadRef.threadId,
+          parsedThreadRef.environmentId,
+        );
+        recordThreadEnvironment(
+          environmentIdByThreadId,
+          parsedThreadRef.threadId,
+          projectRef.environmentId,
+        );
         continue;
       }
-      environmentIdByThreadId.set(threadId as ThreadId, projectRef.environmentId);
+      legacyThreadIdsWithRawEvidence.add(threadId as ThreadId);
+      recordThreadEnvironment(
+        environmentIdByThreadId,
+        threadId as ThreadId,
+        projectRef.environmentId,
+      );
+    }
+  }
+  if (rawDraftThreadsByThreadId && typeof rawDraftThreadsByThreadId === "object") {
+    for (const [threadKeyOrId, rawDraftThread] of Object.entries(
+      rawDraftThreadsByThreadId as Record<string, unknown>,
+    )) {
+      if (threadKeyOrId.length === 0) {
+        continue;
+      }
+      if (!rawDraftThread || typeof rawDraftThread !== "object") {
+        continue;
+      }
+      const candidateDraftThread = rawDraftThread as Record<string, unknown>;
+      const parsedThreadRef = parseScopedThreadKey(threadKeyOrId);
+      const threadId =
+        parsedThreadRef?.threadId ??
+        (typeof candidateDraftThread.threadId === "string" &&
+        candidateDraftThread.threadId.length > 0
+          ? (candidateDraftThread.threadId as ThreadId)
+          : (threadKeyOrId as ThreadId));
+      if (!parsedThreadRef && threadKeyOrId === threadId) {
+        legacyThreadIdsWithRawEvidence.add(threadId);
+      }
+      if (parsedThreadRef) {
+        recordThreadEnvironment(environmentIdByThreadId, threadId, parsedThreadRef.environmentId);
+      }
+      if (
+        typeof candidateDraftThread.environmentId === "string" &&
+        candidateDraftThread.environmentId.length > 0
+      ) {
+        recordThreadEnvironment(
+          environmentIdByThreadId,
+          threadId,
+          candidateDraftThread.environmentId as EnvironmentId,
+        );
+      }
     }
   }
   if (rawDraftThreadsByThreadId && typeof rawDraftThreadsByThreadId === "object") {
@@ -1536,7 +1604,7 @@ function normalizePersistedDraftThreads(
         (typeof candidateDraftThread.environmentId === "string" &&
         candidateDraftThread.environmentId.length > 0
           ? (candidateDraftThread.environmentId as EnvironmentId)
-          : environmentIdByThreadId.get(threadKeyOrId as ThreadId));
+          : environmentIdByThreadId.get(threadId));
       const projectId = candidateDraftThread.projectId;
       const createdAt = candidateDraftThread.createdAt;
       const branch = candidateDraftThread.branch;
@@ -1559,7 +1627,7 @@ function normalizePersistedDraftThreads(
               promotedToRecord.threadId as ThreadId,
             )
           : null;
-      if (typeof projectId !== "string" || projectId.length === 0 || environmentId === undefined) {
+      if (typeof projectId !== "string" || projectId.length === 0 || environmentId == null) {
         continue;
       }
       const normalizedEnvironmentId = environmentId as EnvironmentId;
@@ -1609,10 +1677,17 @@ function normalizePersistedDraftThreads(
       const projectRef = parseScopedProjectKey(logicalProjectKey);
       const parsedThreadRef = parseScopedThreadKey(threadKeyOrId);
       const threadKey = normalizeLegacyComposerStorageKey(threadKeyOrId);
-      logicalProjectDraftThreadKeyByLogicalProjectKey[logicalProjectKey] = threadKey;
-      if (parsedThreadRef) {
-        environmentIdByThreadId.set(parsedThreadRef.threadId, parsedThreadRef.environmentId);
+      if (
+        projectRef &&
+        parsedThreadRef &&
+        projectRef.environmentId !== parsedThreadRef.environmentId
+      ) {
+        continue;
       }
+      if (!parsedThreadRef && environmentIdByThreadId.get(threadKeyOrId as ThreadId) === null) {
+        continue;
+      }
+      logicalProjectDraftThreadKeyByLogicalProjectKey[logicalProjectKey] = threadKey;
       if (!projectRef) {
         const existingDraftThread = draftThreadsByThreadKey[threadKey];
         if (existingDraftThread && !existingDraftThread.logicalProjectKey) {
@@ -1653,27 +1728,22 @@ function normalizePersistedDraftThreads(
     }
   }
 
-  return { draftThreadsByThreadKey, logicalProjectDraftThreadKeyByLogicalProjectKey };
+  return {
+    draftThreadsByThreadKey,
+    logicalProjectDraftThreadKeyByLogicalProjectKey,
+    environmentIdByLegacyThreadId: environmentIdByThreadId,
+    legacyThreadIdsWithRawEvidence,
+  };
 }
 
 function normalizePersistedDraftsByThreadId(
   rawDraftMap: unknown,
   draftThreadsByThreadKey: PersistedComposerDraftStoreState["draftThreadsByThreadKey"],
+  environmentIdByLegacyThreadId: ReadonlyMap<ThreadId, EnvironmentId | null>,
+  legacyThreadIdsWithRawEvidence: ReadonlySet<ThreadId>,
 ): PersistedComposerDraftStoreState["draftsByThreadKey"] {
   if (!rawDraftMap || typeof rawDraftMap !== "object") {
     return {};
-  }
-
-  const environmentIdByThreadId = new Map<ThreadId, EnvironmentId>();
-  for (const [threadKey, draftThread] of Object.entries(draftThreadsByThreadKey)) {
-    const parsedThreadRef = composerThreadRefFromKey(threadKey);
-    if (!parsedThreadRef) {
-      continue;
-    }
-    environmentIdByThreadId.set(
-      parsedThreadRef.threadId,
-      draftThread.environmentId as EnvironmentId,
-    );
   }
 
   const nextDraftsByThreadKey: DeepMutable<PersistedComposerDraftStoreState["draftsByThreadKey"]> =
@@ -1687,6 +1757,28 @@ function normalizePersistedDraftsByThreadId(
     if (!draftValue || typeof draftValue !== "object") {
       continue;
     }
+    const parsedThreadRef = parseScopedThreadKey(threadKeyOrId);
+    const mappedEnvironmentId = draftThreadsByThreadKey[threadKeyOrId]?.environmentId as
+      | EnvironmentId
+      | undefined;
+    const hasLegacyEnvironmentResolution =
+      legacyThreadIdsWithRawEvidence.has(threadKeyOrId as ThreadId) &&
+      environmentIdByLegacyThreadId.has(threadKeyOrId as ThreadId);
+    const expectedEnvironmentId =
+      parsedThreadRef?.environmentId ??
+      (hasLegacyEnvironmentResolution
+        ? (environmentIdByLegacyThreadId.get(threadKeyOrId as ThreadId) ?? undefined)
+        : mappedEnvironmentId);
+    const normalizedThreadKey =
+      parsedThreadRef !== null
+        ? normalizeLegacyComposerStorageKey(threadKeyOrId)
+        : draftThreadsByThreadKey[threadKeyOrId] !== undefined
+          ? threadKeyOrId
+          : expectedEnvironmentId
+            ? normalizeLegacyComposerStorageKey(threadKeyOrId, {
+                environmentId: expectedEnvironmentId,
+              })
+            : threadKeyOrId;
     const draftCandidate = draftValue as PersistedComposerThreadDraftState;
     const promptCandidate = typeof draftCandidate.prompt === "string" ? draftCandidate.prompt : "";
     const attachments = Array.isArray(draftCandidate.attachments)
@@ -1721,6 +1813,14 @@ function normalizePersistedDraftsByThreadId(
       promptCandidate,
       terminalContexts.length,
     );
+    const reconciledFileMentions = isExplicitFileMentions(draftCandidate.fileMentions)
+      ? reconcileFileMentionsAfterEdit(promptCandidate, prompt, draftCandidate.fileMentions)
+      : [];
+    const fileMentions =
+      expectedEnvironmentId !== undefined &&
+      validateExplicitFileMentions(prompt, reconciledFileMentions, expectedEnvironmentId) === null
+        ? reconciledFileMentions
+        : [];
     // If the draft already has the v3 shape, use it directly
     const legacyDraftCandidate = draftValue as LegacyPersistedComposerThreadDraftState;
     let modelSelectionByProvider: Partial<Record<ProviderInstanceId, ModelSelection>> = {};
@@ -1781,20 +1881,9 @@ function normalizePersistedDraftsByThreadId(
     ) {
       continue;
     }
-    const parsedThreadRef = parseScopedThreadKey(threadKeyOrId);
-    const normalizedThreadKey =
-      parsedThreadRef !== null
-        ? normalizeLegacyComposerStorageKey(threadKeyOrId)
-        : draftThreadsByThreadKey[threadKeyOrId] !== undefined
-          ? threadKeyOrId
-          : (() => {
-              const environmentId = environmentIdByThreadId.get(threadKeyOrId as ThreadId);
-              return environmentId
-                ? normalizeLegacyComposerStorageKey(threadKeyOrId, { environmentId })
-                : threadKeyOrId;
-            })();
     nextDraftsByThreadKey[normalizedThreadKey] = {
       prompt,
+      ...(fileMentions.length > 0 ? { fileMentions } : {}),
       attachments,
       ...(terminalContexts.length > 0 ? { terminalContexts } : {}),
       ...(elementContexts.length > 0 ? { elementContexts } : {}),
@@ -1850,11 +1939,20 @@ function migratePersistedComposerDraftStoreState(
   );
   const stickyActiveProvider = normalizeProviderInstanceId(candidate.stickyProvider) ?? null;
 
-  const { draftThreadsByThreadKey, logicalProjectDraftThreadKeyByLogicalProjectKey } =
-    normalizePersistedDraftThreads(rawDraftThreadsByThreadId, rawProjectDraftThreadIdByProjectKey);
+  const {
+    draftThreadsByThreadKey,
+    logicalProjectDraftThreadKeyByLogicalProjectKey,
+    environmentIdByLegacyThreadId,
+    legacyThreadIdsWithRawEvidence,
+  } = normalizePersistedDraftThreads(
+    rawDraftThreadsByThreadId,
+    rawProjectDraftThreadIdByProjectKey,
+  );
   const draftsByThreadKey = normalizePersistedDraftsByThreadId(
     rawDraftMap,
     draftThreadsByThreadKey,
+    environmentIdByLegacyThreadId,
+    legacyThreadIdsWithRawEvidence,
   );
   return {
     draftsByThreadKey,
@@ -2000,15 +2098,19 @@ function normalizeCurrentPersistedComposerDraftStoreState(
     return EMPTY_PERSISTED_DRAFT_STORE_STATE;
   }
   const normalizedPersistedState = persistedState as LegacyPersistedComposerDraftStoreState;
-  const { draftThreadsByThreadKey, logicalProjectDraftThreadKeyByLogicalProjectKey } =
-    normalizePersistedDraftThreads(
-      normalizedPersistedState.draftThreadsByThreadKey ??
-        normalizedPersistedState.draftThreadsByThreadId,
-      normalizedPersistedState.logicalProjectDraftThreadKeyByLogicalProjectKey ??
-        normalizedPersistedState.projectDraftThreadKeyByProjectKey ??
-        normalizedPersistedState.projectDraftThreadIdByProjectKey ??
-        normalizedPersistedState.projectDraftThreadIdByProjectId,
-    );
+  const {
+    draftThreadsByThreadKey,
+    logicalProjectDraftThreadKeyByLogicalProjectKey,
+    environmentIdByLegacyThreadId,
+    legacyThreadIdsWithRawEvidence,
+  } = normalizePersistedDraftThreads(
+    normalizedPersistedState.draftThreadsByThreadKey ??
+      normalizedPersistedState.draftThreadsByThreadId,
+    normalizedPersistedState.logicalProjectDraftThreadKeyByLogicalProjectKey ??
+      normalizedPersistedState.projectDraftThreadKeyByProjectKey ??
+      normalizedPersistedState.projectDraftThreadIdByProjectKey ??
+      normalizedPersistedState.projectDraftThreadIdByProjectId,
+  );
 
   // Handle both v3 (modelSelectionByProvider) and v2/legacy formats
   let stickyModelSelectionByProvider: Partial<Record<ProviderInstanceId, ModelSelection>> = {};
@@ -2055,6 +2157,8 @@ function normalizeCurrentPersistedComposerDraftStoreState(
     draftsByThreadKey: normalizePersistedDraftsByThreadId(
       normalizedPersistedState.draftsByThreadKey ?? normalizedPersistedState.draftsByThreadId,
       draftThreadsByThreadKey,
+      environmentIdByLegacyThreadId,
+      legacyThreadIdsWithRawEvidence,
     ),
     draftThreadsByThreadKey,
     logicalProjectDraftThreadKeyByLogicalProjectKey,
@@ -2679,7 +2783,10 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const nextDraft: ComposerThreadDraftState = {
               ...existing,
               prompt,
-              fileMentions: fileMentions === undefined ? [] : [...fileMentions],
+              fileMentions:
+                fileMentions === undefined
+                  ? reconcileFileMentionsAfterEdit(existing.prompt, prompt, existing.fileMentions)
+                  : [...fileMentions],
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {

--- a/apps/web/src/lib/composerFilesystemBrowse.test.ts
+++ b/apps/web/src/lib/composerFilesystemBrowse.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  canBrowseComposerFilesystemPath,
+  composerFilesystemSuggestionPath,
+  isComposerFilesystemPathQuery,
+} from "./composerFilesystemBrowse";
+
+describe("composer filesystem browsing", () => {
+  it.each([
+    ["~/Sites/t3", "t3code", "~/Sites/t3code"],
+    ["../sha", "shared", "../shared"],
+    ["/tmp/rep", "report.md", "/tmp/report.md"],
+    ["/Users/me/My Project/fi", "file.ts", "/Users/me/My Project/file.ts"],
+    ["C:\\Users\\ch", "chris", "C:\\Users\\chris"],
+  ])("preserves the typed parent for %s", (query, name, expected) => {
+    expect(composerFilesystemSuggestionPath(query, name)).toBe(expected);
+  });
+
+  it("routes explicit paths according to platform and cwd", () => {
+    expect(isComposerFilesystemPathQuery("./src", "linux")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("~/src", null, "linux")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("/tmp", null, "linux")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("./src", null, "linux")).toBe(false);
+    expect(canBrowseComposerFilesystemPath("../src", "/repo", "linux")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("C:\\Users\\ch", null, "linux")).toBe(false);
+    expect(canBrowseComposerFilesystemPath("C:\\Users\\ch", null, "win32")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("component", "/repo", "linux")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/composerFilesystemBrowse.test.ts
+++ b/apps/web/src/lib/composerFilesystemBrowse.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  canBrowseComposerFilesystemPath,
+  composerFilesystemSuggestionPath,
+  isComposerFilesystemPathQuery,
+} from "./composerFilesystemBrowse";
+
+describe("composer filesystem browsing", () => {
+  it.each([
+    ["~/Sites/t3", "t3code", "~/Sites/t3code"],
+    ["../sha", "shared", "../shared"],
+    ["/tmp/rep", "report.md", "/tmp/report.md"],
+    ["C:\\Users\\ch", "chris", "C:\\Users\\chris"],
+  ])("preserves the typed parent for %s", (query, name, expected) => {
+    expect(composerFilesystemSuggestionPath(query, name)).toBe(expected);
+  });
+
+  it("routes explicit paths according to platform and cwd", () => {
+    expect(isComposerFilesystemPathQuery("./src", "linux")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("~/src", null, "linux")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("/tmp", null, "linux")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("./src", null, "linux")).toBe(false);
+    expect(canBrowseComposerFilesystemPath("../src", "/repo", "linux")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("C:\\Users\\ch", null, "linux")).toBe(false);
+    expect(canBrowseComposerFilesystemPath("C:\\Users\\ch", null, "win32")).toBe(true);
+    expect(canBrowseComposerFilesystemPath("component", "/repo", "linux")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/composerFilesystemBrowse.ts
+++ b/apps/web/src/lib/composerFilesystemBrowse.ts
@@ -1,0 +1,28 @@
+import {
+  getBrowseDirectoryPath,
+  isExplicitRelativeProjectPath,
+  isFilesystemBrowseQuery,
+} from "./projectPaths";
+
+export function canBrowseComposerFilesystemPath(
+  query: string,
+  cwd: string | null,
+  platform: string,
+): boolean {
+  return (
+    isFilesystemBrowseQuery(query, platform) &&
+    (!isExplicitRelativeProjectPath(query) || cwd !== null)
+  );
+}
+
+export function isComposerFilesystemPathQuery(query: string, platform: string): boolean {
+  return isFilesystemBrowseQuery(query, platform);
+}
+
+export function composerFilesystemSuggestionParentPath(query: string): string {
+  return getBrowseDirectoryPath(query);
+}
+
+export function composerFilesystemSuggestionPath(query: string, entryName: string): string {
+  return `${getBrowseDirectoryPath(query)}${entryName}`;
+}

--- a/apps/web/src/lib/terminalContext.test.ts
+++ b/apps/web/src/lib/terminalContext.test.ts
@@ -124,6 +124,31 @@ describe("terminalContext", () => {
     ]);
   });
 
+  it("maps file mention offsets when expired terminal placeholders are removed", () => {
+    const source = serializeComposerFileLink("/tmp/example.ts");
+    const prompt = `  ${INLINE_TERMINAL_CONTEXT_PLACEHOLDER} ${source}  `;
+    const start = prompt.indexOf(source);
+    const result = appendTerminalContextsToPromptWithFileMentions(
+      prompt,
+      [],
+      [
+        {
+          version: 1,
+          environmentId: EnvironmentId.make("environment-1"),
+          path: "/tmp/example.ts",
+          kind: "file",
+          start,
+          end: start + source.length,
+        },
+      ],
+    );
+
+    expect(result).toEqual({
+      text: source,
+      fileMentions: [expect.objectContaining({ start: 0, end: source.length })],
+    });
+  });
+
   it("extracts terminal context blocks from message text", () => {
     const prompt = appendTerminalContextsToPrompt("Investigate this", [makeContext()]);
     expect(extractTrailingTerminalContexts(prompt)).toEqual({

--- a/apps/web/src/lib/terminalContext.test.ts
+++ b/apps/web/src/lib/terminalContext.test.ts
@@ -1,8 +1,10 @@
-import { ThreadId } from "@t3tools/contracts";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
   appendTerminalContextsToPrompt,
+  appendTerminalContextsToPromptWithFileMentions,
   buildTerminalContextPreviewTitle,
   buildTerminalContextBlock,
   countInlineTerminalContextPlaceholders,
@@ -92,6 +94,34 @@ describe("terminalContext", () => {
         "</terminal_context>",
       ].join("\n"),
     );
+  });
+
+  it("maps UTF-16 file mention offsets through inline terminal labels and trimming", () => {
+    const source = serializeComposerFileLink("/tmp/💾.txt");
+    const prompt = `  ${INLINE_TERMINAL_CONTEXT_PLACEHOLDER} 😀 ${source}  `;
+    const start = prompt.indexOf(source);
+    const result = appendTerminalContextsToPromptWithFileMentions(
+      prompt,
+      [makeContext()],
+      [
+        {
+          version: 1,
+          environmentId: EnvironmentId.make("environment-1"),
+          path: "/tmp/💾.txt",
+          kind: "file",
+          start,
+          end: start + source.length,
+        },
+      ],
+    );
+
+    expect(result.text.startsWith(`@terminal-1:12-13 😀 ${source}`)).toBe(true);
+    expect(result.fileMentions).toEqual([
+      expect.objectContaining({
+        start: `@terminal-1:12-13 😀 `.length,
+        end: `@terminal-1:12-13 😀 ${source}`.length,
+      }),
+    ]);
   });
 
   it("extracts terminal context blocks from message text", () => {

--- a/apps/web/src/lib/terminalContext.ts
+++ b/apps/web/src/lib/terminalContext.ts
@@ -1,4 +1,4 @@
-import { type ThreadId } from "@t3tools/contracts";
+import { type ExplicitFileMention, type ThreadId } from "@t3tools/contracts";
 
 import { extractTrailingElementContexts, type ParsedElementContextEntry } from "./elementContext";
 
@@ -218,6 +218,46 @@ export function appendTerminalContextsToPrompt(
     return trimmedPrompt;
   }
   return trimmedPrompt.length > 0 ? `${trimmedPrompt}\n\n${contextBlock}` : contextBlock;
+}
+
+export function appendTerminalContextsToPromptWithFileMentions(
+  prompt: string,
+  contexts: ReadonlyArray<TerminalContextSelection>,
+  fileMentions: ReadonlyArray<ExplicitFileMention>,
+): { readonly text: string; readonly fileMentions: ExplicitFileMention[] } {
+  const offsets = Array.from<number>({ length: prompt.length + 1 });
+  let nextContextIndex = 0;
+  let materialized = "";
+  for (let index = 0; index < prompt.length; index += 1) {
+    offsets[index] = materialized.length;
+    const char = prompt[index];
+    if (char !== INLINE_TERMINAL_CONTEXT_PLACEHOLDER) {
+      materialized += char;
+      continue;
+    }
+    const context = contexts[nextContextIndex] ?? null;
+    nextContextIndex += 1;
+    if (context) materialized += formatInlineTerminalContextLabel(context);
+  }
+  offsets[prompt.length] = materialized.length;
+
+  const trimmed = materialized.trim();
+  const leadingTrim = materialized.length - materialized.trimStart().length;
+  const mappedMentions = fileMentions.flatMap((mention) => {
+    const start = (offsets[mention.start] ?? 0) - leadingTrim;
+    const end = (offsets[mention.end] ?? 0) - leadingTrim;
+    return start >= 0 && end <= trimmed.length ? [{ ...mention, start, end }] : [];
+  });
+  const contextBlock = buildTerminalContextBlock(contexts);
+  return {
+    text:
+      contextBlock.length === 0
+        ? trimmed
+        : trimmed.length > 0
+          ? `${trimmed}\n\n${contextBlock}`
+          : contextBlock,
+    fileMentions: mappedMentions,
+  };
 }
 
 export function extractTrailingTerminalContexts(prompt: string): ExtractedTerminalContexts {

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -35,11 +35,28 @@ describe("resolveExplicitFileMentionMeta", () => {
     });
   });
 
+  it("resolves home paths for projects under the root user's home", () => {
+    expect(resolveExplicitFileMentionMeta("~/project", "/root/workspace")).toMatchObject({
+      targetPath: "/root/project",
+      openTargetPath: "/root/project",
+    });
+  });
+
   it("does not interpret numeric filename suffixes as source positions", () => {
     const meta = resolveExplicitFileMentionMeta("/tmp/report:12");
     expect(meta).toMatchObject({
       filePath: "/tmp/report:12",
       openTargetPath: "/tmp/report:12",
+      basename: "report:12",
+    });
+    expect(meta?.line).toBeUndefined();
+  });
+
+  it("preserves numeric suffixes on relative filenames", () => {
+    const meta = resolveExplicitFileMentionMeta("report:12", "/repo");
+    expect(meta).toMatchObject({
+      filePath: "/repo/report:12",
+      openTargetPath: "/repo/report:12",
       basename: "report:12",
     });
     expect(meta?.line).toBeUndefined();

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -1,11 +1,113 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  preserveWindowsMarkdownFileHref,
+  resolveCanonicalMarkdownFileLinkMeta,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
 } from "./markdown-links";
+
+describe("resolveCanonicalMarkdownFileLinkMeta", () => {
+  it("recognizes absolute extensionless paths outside conventional roots", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("data", "/custom/mount/data")).toMatchObject({
+      filePath: "/custom/mount/data",
+      openTargetPath: "/custom/mount/data",
+      basename: "data",
+    });
+  });
+
+  it("resolves relative canonical paths against the cwd", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("shared", "../shared", "/repo/app")).toMatchObject({
+      targetPath: "/repo/shared",
+      openTargetPath: "/repo/shared",
+      workspaceRelativePath: null,
+    });
+  });
+
+  it("keeps unresolved home paths displayable but inert", () => {
+    expect(
+      resolveCanonicalMarkdownFileLinkMeta("project", "~/project", "/workspace/repo"),
+    ).toMatchObject({
+      targetPath: "~/project",
+      openTargetPath: null,
+      displayPath: "~/project",
+      basename: "project",
+    });
+  });
+
+  it("rejects label mismatches and external links", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("other", "/custom/mount/data")).toBeNull();
+    expect(resolveCanonicalMarkdownFileLinkMeta("docs", "https://example.com/docs")).toBeNull();
+  });
+
+  it("does not promote app routes without file evidence", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("settings", "/chat/settings", "/repo")).toBeNull();
+    expect(
+      resolveCanonicalMarkdownFileLinkMeta("general", "/settings/general", "/repo"),
+    ).toBeNull();
+    expect(resolveCanonicalMarkdownFileLinkMeta("connections", "/connections", "/repo")).toBeNull();
+    expect(
+      resolveCanonicalMarkdownFileLinkMeta("settings.ts", "/chat/settings.ts", "/repo"),
+    ).toMatchObject({ targetPath: "/chat/settings.ts" });
+  });
+
+  it("does not interpret numeric filename suffixes as source positions", () => {
+    const meta = resolveCanonicalMarkdownFileLinkMeta("report:12", "/tmp/report:12");
+    expect(meta).toMatchObject({
+      filePath: "/tmp/report:12",
+      openTargetPath: "/tmp/report:12",
+      basename: "report:12",
+    });
+    expect(meta?.line).toBeUndefined();
+  });
+
+  it("resolves a canonical path under a scoped directory against the cwd", () => {
+    expect(
+      resolveCanonicalMarkdownFileLinkMeta("package.json", "@scope/package.json", "/repo"),
+    ).toMatchObject({
+      targetPath: "/repo/@scope/package.json",
+      openTargetPath: "/repo/@scope/package.json",
+      basename: "package.json",
+    });
+  });
+
+  it("still resolves an ordinary relative path against the cwd", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("index.ts", "src/index.ts", "/repo")).toMatchObject(
+      {
+        targetPath: "/repo/src/index.ts",
+        openTargetPath: "/repo/src/index.ts",
+      },
+    );
+  });
+
+  it("normalizes absolute paths before workspace containment", () => {
+    expect(
+      resolveCanonicalMarkdownFileLinkMeta("page.html", "/repo/../outside/page.html", "/repo"),
+    ).toMatchObject({ workspaceRelativePath: null });
+  });
+
+  it("uses platform-appropriate casing for workspace containment", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("Page.ts", "/Repo/Page.ts", "/repo")).toMatchObject(
+      { workspaceRelativePath: null },
+    );
+    expect(
+      resolveCanonicalMarkdownFileLinkMeta("Page.ts", "C:/Repo/Page.ts", "c:/repo"),
+    ).toMatchObject({ workspaceRelativePath: "Page.ts" });
+  });
+});
+
+describe("preserveWindowsMarkdownFileHref", () => {
+  it("preserves only Windows drive path destinations", () => {
+    expect(preserveWindowsMarkdownFileHref("C:%5CUsers%5Cme%5Cfile.ts")).toBe(
+      "C:%5CUsers%5Cme%5Cfile.ts",
+    );
+    expect(preserveWindowsMarkdownFileHref("C:/Users/me/file.ts")).toBe("C:/Users/me/file.ts");
+    expect(preserveWindowsMarkdownFileHref("custom:thing")).toBeNull();
+    expect(preserveWindowsMarkdownFileHref("https://example.com")).toBeNull();
+  });
+});
 
 describe("rewriteMarkdownFileUriHref", () => {
   it("rewrites file uri hrefs into direct path hrefs", () => {

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   preserveWindowsMarkdownFileHref,
-  resolveCanonicalMarkdownFileLinkMeta,
+  resolveExplicitFileMentionMeta,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
 } from "./markdown-links";
 
-describe("resolveCanonicalMarkdownFileLinkMeta", () => {
+describe("resolveExplicitFileMentionMeta", () => {
   it("recognizes absolute extensionless paths outside conventional roots", () => {
-    expect(resolveCanonicalMarkdownFileLinkMeta("data", "/custom/mount/data")).toMatchObject({
+    expect(resolveExplicitFileMentionMeta("/custom/mount/data")).toMatchObject({
       filePath: "/custom/mount/data",
       openTargetPath: "/custom/mount/data",
       basename: "data",
@@ -19,7 +19,7 @@ describe("resolveCanonicalMarkdownFileLinkMeta", () => {
   });
 
   it("resolves relative canonical paths against the cwd", () => {
-    expect(resolveCanonicalMarkdownFileLinkMeta("shared", "../shared", "/repo/app")).toMatchObject({
+    expect(resolveExplicitFileMentionMeta("../shared", "/repo/app")).toMatchObject({
       targetPath: "/repo/shared",
       openTargetPath: "/repo/shared",
       workspaceRelativePath: null,
@@ -27,9 +27,7 @@ describe("resolveCanonicalMarkdownFileLinkMeta", () => {
   });
 
   it("keeps unresolved home paths displayable but inert", () => {
-    expect(
-      resolveCanonicalMarkdownFileLinkMeta("project", "~/project", "/workspace/repo"),
-    ).toMatchObject({
+    expect(resolveExplicitFileMentionMeta("~/project", "/workspace/repo")).toMatchObject({
       targetPath: "~/project",
       openTargetPath: null,
       displayPath: "~/project",
@@ -37,24 +35,8 @@ describe("resolveCanonicalMarkdownFileLinkMeta", () => {
     });
   });
 
-  it("rejects label mismatches and external links", () => {
-    expect(resolveCanonicalMarkdownFileLinkMeta("other", "/custom/mount/data")).toBeNull();
-    expect(resolveCanonicalMarkdownFileLinkMeta("docs", "https://example.com/docs")).toBeNull();
-  });
-
-  it("does not promote app routes without file evidence", () => {
-    expect(resolveCanonicalMarkdownFileLinkMeta("settings", "/chat/settings", "/repo")).toBeNull();
-    expect(
-      resolveCanonicalMarkdownFileLinkMeta("general", "/settings/general", "/repo"),
-    ).toBeNull();
-    expect(resolveCanonicalMarkdownFileLinkMeta("connections", "/connections", "/repo")).toBeNull();
-    expect(
-      resolveCanonicalMarkdownFileLinkMeta("settings.ts", "/chat/settings.ts", "/repo"),
-    ).toMatchObject({ targetPath: "/chat/settings.ts" });
-  });
-
   it("does not interpret numeric filename suffixes as source positions", () => {
-    const meta = resolveCanonicalMarkdownFileLinkMeta("report:12", "/tmp/report:12");
+    const meta = resolveExplicitFileMentionMeta("/tmp/report:12");
     expect(meta).toMatchObject({
       filePath: "/tmp/report:12",
       openTargetPath: "/tmp/report:12",
@@ -64,9 +46,7 @@ describe("resolveCanonicalMarkdownFileLinkMeta", () => {
   });
 
   it("resolves a canonical path under a scoped directory against the cwd", () => {
-    expect(
-      resolveCanonicalMarkdownFileLinkMeta("package.json", "@scope/package.json", "/repo"),
-    ).toMatchObject({
+    expect(resolveExplicitFileMentionMeta("@scope/package.json", "/repo")).toMatchObject({
       targetPath: "/repo/@scope/package.json",
       openTargetPath: "/repo/@scope/package.json",
       basename: "package.json",
@@ -74,27 +54,25 @@ describe("resolveCanonicalMarkdownFileLinkMeta", () => {
   });
 
   it("still resolves an ordinary relative path against the cwd", () => {
-    expect(resolveCanonicalMarkdownFileLinkMeta("index.ts", "src/index.ts", "/repo")).toMatchObject(
-      {
-        targetPath: "/repo/src/index.ts",
-        openTargetPath: "/repo/src/index.ts",
-      },
-    );
+    expect(resolveExplicitFileMentionMeta("src/index.ts", "/repo")).toMatchObject({
+      targetPath: "/repo/src/index.ts",
+      openTargetPath: "/repo/src/index.ts",
+    });
   });
 
   it("normalizes absolute paths before workspace containment", () => {
-    expect(
-      resolveCanonicalMarkdownFileLinkMeta("page.html", "/repo/../outside/page.html", "/repo"),
-    ).toMatchObject({ workspaceRelativePath: null });
+    expect(resolveExplicitFileMentionMeta("/repo/../outside/page.html", "/repo")).toMatchObject({
+      workspaceRelativePath: null,
+    });
   });
 
   it("uses platform-appropriate casing for workspace containment", () => {
-    expect(resolveCanonicalMarkdownFileLinkMeta("Page.ts", "/Repo/Page.ts", "/repo")).toMatchObject(
-      { workspaceRelativePath: null },
-    );
-    expect(
-      resolveCanonicalMarkdownFileLinkMeta("Page.ts", "C:/Repo/Page.ts", "c:/repo"),
-    ).toMatchObject({ workspaceRelativePath: "Page.ts" });
+    expect(resolveExplicitFileMentionMeta("/Repo/Page.ts", "/repo")).toMatchObject({
+      workspaceRelativePath: null,
+    });
+    expect(resolveExplicitFileMentionMeta("C:/Repo/Page.ts", "c:/repo")).toMatchObject({
+      workspaceRelativePath: "Page.ts",
+    });
   });
 });
 

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -1,11 +1,99 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  preserveWindowsMarkdownFileHref,
+  resolveCanonicalMarkdownFileLinkMeta,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
 } from "./markdown-links";
+
+describe("resolveCanonicalMarkdownFileLinkMeta", () => {
+  it("recognizes absolute extensionless paths outside conventional roots", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("data", "/custom/mount/data")).toMatchObject({
+      filePath: "/custom/mount/data",
+      openTargetPath: "/custom/mount/data",
+      basename: "data",
+    });
+  });
+
+  it("resolves relative canonical paths against the cwd", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("shared", "../shared", "/repo/app")).toMatchObject({
+      targetPath: "/repo/shared",
+      openTargetPath: "/repo/shared",
+      workspaceRelativePath: null,
+    });
+  });
+
+  it("keeps unresolved home paths displayable but inert", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("project", "~/project")).toMatchObject({
+      targetPath: "~/project",
+      openTargetPath: null,
+      basename: "project",
+    });
+  });
+
+  it("rejects label mismatches and external links", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("other", "/custom/mount/data")).toBeNull();
+    expect(resolveCanonicalMarkdownFileLinkMeta("docs", "https://example.com/docs")).toBeNull();
+  });
+
+  it("does not interpret numeric filename suffixes as source positions", () => {
+    const meta = resolveCanonicalMarkdownFileLinkMeta("report:12", "/tmp/report:12");
+    expect(meta).toMatchObject({
+      filePath: "/tmp/report:12",
+      openTargetPath: "/tmp/report:12",
+      basename: "report:12",
+    });
+    expect(meta?.line).toBeUndefined();
+  });
+
+  it("keeps a scoped package reference displayable but inert instead of resolving under cwd", () => {
+    expect(
+      resolveCanonicalMarkdownFileLinkMeta("package.json", "@scope/package.json", "/repo"),
+    ).toMatchObject({
+      targetPath: "@scope/package.json",
+      openTargetPath: null,
+      basename: "package.json",
+    });
+  });
+
+  it("still resolves an ordinary relative path against the cwd", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("index.ts", "src/index.ts", "/repo")).toMatchObject(
+      {
+        targetPath: "/repo/src/index.ts",
+        openTargetPath: "/repo/src/index.ts",
+      },
+    );
+  });
+
+  it("normalizes absolute paths before workspace containment", () => {
+    expect(
+      resolveCanonicalMarkdownFileLinkMeta("page.html", "/repo/../outside/page.html", "/repo"),
+    ).toMatchObject({ workspaceRelativePath: null });
+  });
+
+  it("uses platform-appropriate casing for workspace containment", () => {
+    expect(resolveCanonicalMarkdownFileLinkMeta("Page.ts", "/Repo/Page.ts", "/repo")).toMatchObject(
+      { workspaceRelativePath: null },
+    );
+    expect(
+      resolveCanonicalMarkdownFileLinkMeta("Page.ts", "C:/Repo/Page.ts", "c:/repo"),
+    ).toMatchObject({ workspaceRelativePath: "Page.ts" });
+  });
+});
+
+describe("preserveWindowsMarkdownFileHref", () => {
+  it("preserves only Windows drive path destinations", () => {
+    expect(preserveWindowsMarkdownFileHref("C:%5CUsers%5Cme%5Cfile.ts")).toBe(
+      "C:%5CUsers%5Cme%5Cfile.ts",
+    );
+    expect(preserveWindowsMarkdownFileHref("C:/Users/me/file.ts")).toBe("C:/Users/me/file.ts");
+    expect(preserveWindowsMarkdownFileHref("custom:thing")).toBeNull();
+    expect(preserveWindowsMarkdownFileHref("https://example.com")).toBeNull();
+  });
+});
 
 describe("rewriteMarkdownFileUriHref", () => {
   it("rewrites file uri hrefs into direct path hrefs", () => {

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -437,7 +437,7 @@ export function resolveExplicitFileMentionMeta(
 
   const resolvedPath = isExplicitRelativeProjectPath(authoredPath)
     ? resolveProjectPathForDispatch(authoredPath, cwd)
-    : resolvePathLinkTarget(authoredPath, cwd);
+    : resolvePathLinkTarget(authoredPath, cwd, { parsePosition: false });
   if (resolvedPath.startsWith("~/")) {
     return buildFileLinkMetaFromTarget(authoredPath, cwd, {
       displayPath: authoredPath,

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -1,4 +1,7 @@
+import { decodeCanonicalComposerFileLinkPath } from "@t3tools/shared/composerInlineTokens";
+
 import { formatWorkspaceRelativePath } from "./filePathDisplay";
+import { isExplicitRelativeProjectPath, resolveProjectPathForDispatch } from "./lib/projectPaths";
 import { resolvePathLinkTarget, splitPathAndPosition } from "./terminal-links";
 
 const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
@@ -37,10 +40,23 @@ const POSIX_FILE_ROOT_PREFIXES = [
   "/workspace/",
   "/workspaces/",
 ] as const;
+const APP_ROUTE_ROOT_SEGMENTS = new Set([
+  "app",
+  "chat",
+  "connect",
+  "connections",
+  "draft",
+  "pair",
+  "projects",
+  "pull-requests",
+  "settings",
+  "usage",
+]);
 
 export interface MarkdownFileLinkMeta {
   filePath: string;
   targetPath: string;
+  openTargetPath: string | null;
   displayPath: string;
   workspaceRelativePath: string | null;
   basename: string;
@@ -108,12 +124,23 @@ export function rewriteMarkdownFileUriHref(href: string | undefined): string | n
   return `${target.path}${target.hash}`;
 }
 
+export function preserveWindowsMarkdownFileHref(href: string): string | null {
+  const normalizedHref = normalizeMarkdownLinkDestination(href);
+  return /^[A-Za-z]:(?:[\\/]|%5c)/i.test(normalizedHref) ? normalizedHref : null;
+}
+
 function looksLikePosixFilesystemPath(path: string): boolean {
   if (!path.startsWith("/")) return false;
   if (POSIX_FILE_ROOT_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;
   if (POSITION_SUFFIX_PATTERN.test(path)) return true;
   const basename = path.slice(path.lastIndexOf("/") + 1);
   return /\.[A-Za-z0-9_-]+$/.test(basename);
+}
+
+function looksLikeAppRoute(path: string): boolean {
+  if (!path.startsWith("/") || looksLikePosixFilesystemPath(path)) return false;
+  const rootSegment = path.slice(1).split("/", 1)[0];
+  return rootSegment !== undefined && APP_ROUTE_ROOT_SEGMENTS.has(rootSegment);
 }
 
 function appendLineColumnFromHash(path: string, hash: string): string {
@@ -365,15 +392,44 @@ function basenameOfPath(path: string): string {
 
 function workspaceRelativePath(path: string, workspaceRoot: string | undefined): string | null {
   if (!workspaceRoot) return null;
-  const normalizedPath = normalizeWindowsDrivePath(path.replaceAll("\\", "/"));
-  const normalizedRoot = normalizeWindowsDrivePath(workspaceRoot.replaceAll("\\", "/")).replace(
-    /\/+$/,
-    "",
-  );
-  const pathForCompare = normalizedPath.toLowerCase();
-  const rootForCompare = normalizedRoot.toLowerCase();
-  if (!pathForCompare.startsWith(`${rootForCompare}/`)) return null;
-  return normalizedPath.slice(normalizedRoot.length + 1);
+  const normalizedPath = normalizeAbsolutePathForContainment(path);
+  const normalizedRoot = normalizeAbsolutePathForContainment(workspaceRoot);
+  if (!normalizedPath || !normalizedRoot) return null;
+  const caseInsensitive = normalizedPath.windowsStyle && normalizedRoot.windowsStyle;
+  const pathForCompare = caseInsensitive
+    ? normalizedPath.value.toLowerCase()
+    : normalizedPath.value;
+  const rootForCompare = caseInsensitive
+    ? normalizedRoot.value.toLowerCase()
+    : normalizedRoot.value;
+  const rootPrefix = rootForCompare.endsWith("/") ? rootForCompare : `${rootForCompare}/`;
+  if (!pathForCompare.startsWith(rootPrefix)) return null;
+  return normalizedPath.value.slice(rootPrefix.length);
+}
+
+function normalizeAbsolutePathForContainment(
+  path: string,
+): { readonly value: string; readonly windowsStyle: boolean } | null {
+  const normalized = normalizeWindowsDrivePath(path.replaceAll("\\", "/"));
+  const windowsDrive = /^[A-Za-z]:\//.exec(normalized)?.[0];
+  const windowsStyle = windowsDrive !== undefined || normalized.startsWith("//");
+  const root =
+    windowsDrive ?? (normalized.startsWith("//") ? "//" : normalized.startsWith("/") ? "/" : null);
+  if (root === null) return null;
+
+  const segments: string[] = [];
+  for (const segment of normalized.slice(root.length).split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+    } else {
+      segments.push(segment);
+    }
+  }
+  return {
+    value: segments.length === 0 ? root : `${root}${segments.join("/")}`,
+    windowsStyle,
+  };
 }
 
 export function resolveMarkdownFileLinkMeta(
@@ -385,8 +441,54 @@ export function resolveMarkdownFileLinkMeta(
   return buildFileLinkMetaFromTarget(targetPath, cwd);
 }
 
-function buildFileLinkMetaFromTarget(targetPath: string, cwd?: string): MarkdownFileLinkMeta {
-  const { path, line, column } = splitPathAndPosition(targetPath);
+export function resolveCanonicalMarkdownFileLinkMeta(
+  label: string,
+  href: string,
+  cwd?: string,
+): MarkdownFileLinkMeta | null {
+  const authoredPath = decodeCanonicalComposerFileLinkPath(
+    label,
+    normalizeMarkdownLinkDestination(href),
+  );
+  if (authoredPath === null) return null;
+  if (looksLikeAppRoute(authoredPath)) return null;
+
+  if (!isRelativePath(authoredPath)) {
+    return buildFileLinkMetaFromTarget(authoredPath, cwd, { parsePosition: false });
+  }
+  if (!cwd) {
+    return buildFileLinkMetaFromTarget(authoredPath, cwd, {
+      openTargetPath: null,
+      parsePosition: false,
+    });
+  }
+
+  const resolvedPath = isExplicitRelativeProjectPath(authoredPath)
+    ? resolveProjectPathForDispatch(authoredPath, cwd)
+    : resolvePathLinkTarget(authoredPath, cwd);
+  if (resolvedPath.startsWith("~/")) {
+    return buildFileLinkMetaFromTarget(authoredPath, cwd, {
+      displayPath: authoredPath,
+      openTargetPath: null,
+      parsePosition: false,
+    });
+  }
+  return buildFileLinkMetaFromTarget(resolvedPath, cwd, { parsePosition: false });
+}
+
+function buildFileLinkMetaFromTarget(
+  targetPath: string,
+  cwd?: string,
+  options: {
+    readonly displayPath?: string;
+    readonly openTargetPath?: string | null;
+    readonly parsePosition?: boolean;
+  } = {},
+): MarkdownFileLinkMeta {
+  const { path, line, column } =
+    options.parsePosition === false
+      ? { path: targetPath, line: undefined, column: undefined }
+      : splitPathAndPosition(targetPath);
   const parsedLine = line ? Number.parseInt(line, 10) : Number.NaN;
   const parsedColumn = column ? Number.parseInt(column, 10) : Number.NaN;
   const lineNumber = Number.isFinite(parsedLine) ? parsedLine : undefined;
@@ -395,7 +497,8 @@ function buildFileLinkMetaFromTarget(targetPath: string, cwd?: string): Markdown
   return {
     filePath: path,
     targetPath,
-    displayPath: formatWorkspaceRelativePath(targetPath, cwd),
+    openTargetPath: options.openTargetPath === undefined ? targetPath : options.openTargetPath,
+    displayPath: options.displayPath ?? formatWorkspaceRelativePath(targetPath, cwd),
     workspaceRelativePath: workspaceRelativePath(path, cwd),
     basename: basenameOfPath(path),
     ...(lineNumber !== undefined ? { line: lineNumber } : {}),

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -1,5 +1,3 @@
-import { decodeCanonicalComposerFileLinkPath } from "@t3tools/shared/composerInlineTokens";
-
 import { formatWorkspaceRelativePath } from "./filePathDisplay";
 import { isExplicitRelativeProjectPath, resolveProjectPathForDispatch } from "./lib/projectPaths";
 import { resolvePathLinkTarget, splitPathAndPosition } from "./terminal-links";
@@ -40,18 +38,6 @@ const POSIX_FILE_ROOT_PREFIXES = [
   "/workspace/",
   "/workspaces/",
 ] as const;
-const APP_ROUTE_ROOT_SEGMENTS = new Set([
-  "app",
-  "chat",
-  "connect",
-  "connections",
-  "draft",
-  "pair",
-  "projects",
-  "pull-requests",
-  "settings",
-  "usage",
-]);
 
 export interface MarkdownFileLinkMeta {
   filePath: string;
@@ -135,12 +121,6 @@ function looksLikePosixFilesystemPath(path: string): boolean {
   if (POSITION_SUFFIX_PATTERN.test(path)) return true;
   const basename = path.slice(path.lastIndexOf("/") + 1);
   return /\.[A-Za-z0-9_-]+$/.test(basename);
-}
-
-function looksLikeAppRoute(path: string): boolean {
-  if (!path.startsWith("/") || looksLikePosixFilesystemPath(path)) return false;
-  const rootSegment = path.slice(1).split("/", 1)[0];
-  return rootSegment !== undefined && APP_ROUTE_ROOT_SEGMENTS.has(rootSegment);
 }
 
 function appendLineColumnFromHash(path: string, hash: string): string {
@@ -441,18 +421,10 @@ export function resolveMarkdownFileLinkMeta(
   return buildFileLinkMetaFromTarget(targetPath, cwd);
 }
 
-export function resolveCanonicalMarkdownFileLinkMeta(
-  label: string,
-  href: string,
+export function resolveExplicitFileMentionMeta(
+  authoredPath: string,
   cwd?: string,
 ): MarkdownFileLinkMeta | null {
-  const authoredPath = decodeCanonicalComposerFileLinkPath(
-    label,
-    normalizeMarkdownLinkDestination(href),
-  );
-  if (authoredPath === null) return null;
-  if (looksLikeAppRoute(authoredPath)) return null;
-
   if (!isRelativePath(authoredPath)) {
     return buildFileLinkMetaFromTarget(authoredPath, cwd, { parsePosition: false });
   }

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -1,4 +1,10 @@
+import {
+  decodeCanonicalComposerFileLinkPath,
+  isScopedPackageReferencePath,
+} from "@t3tools/shared/composerInlineTokens";
+
 import { formatWorkspaceRelativePath } from "./filePathDisplay";
+import { isExplicitRelativeProjectPath, resolveProjectPathForDispatch } from "./lib/projectPaths";
 import { resolvePathLinkTarget, splitPathAndPosition } from "./terminal-links";
 
 const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
@@ -41,6 +47,7 @@ const POSIX_FILE_ROOT_PREFIXES = [
 export interface MarkdownFileLinkMeta {
   filePath: string;
   targetPath: string;
+  openTargetPath: string | null;
   displayPath: string;
   workspaceRelativePath: string | null;
   basename: string;
@@ -106,6 +113,11 @@ export function rewriteMarkdownFileUriHref(href: string | undefined): string | n
   const target = parseFileUrlHref(normalizedHref, { decodePath: false });
   if (!target) return null;
   return `${target.path}${target.hash}`;
+}
+
+export function preserveWindowsMarkdownFileHref(href: string): string | null {
+  const normalizedHref = normalizeMarkdownLinkDestination(href);
+  return /^[A-Za-z]:(?:[\\/]|%5c)/i.test(normalizedHref) ? normalizedHref : null;
 }
 
 function looksLikePosixFilesystemPath(path: string): boolean {
@@ -365,15 +377,44 @@ function basenameOfPath(path: string): string {
 
 function workspaceRelativePath(path: string, workspaceRoot: string | undefined): string | null {
   if (!workspaceRoot) return null;
-  const normalizedPath = normalizeWindowsDrivePath(path.replaceAll("\\", "/"));
-  const normalizedRoot = normalizeWindowsDrivePath(workspaceRoot.replaceAll("\\", "/")).replace(
-    /\/+$/,
-    "",
-  );
-  const pathForCompare = normalizedPath.toLowerCase();
-  const rootForCompare = normalizedRoot.toLowerCase();
-  if (!pathForCompare.startsWith(`${rootForCompare}/`)) return null;
-  return normalizedPath.slice(normalizedRoot.length + 1);
+  const normalizedPath = normalizeAbsolutePathForContainment(path);
+  const normalizedRoot = normalizeAbsolutePathForContainment(workspaceRoot);
+  if (!normalizedPath || !normalizedRoot) return null;
+  const caseInsensitive = normalizedPath.windowsStyle && normalizedRoot.windowsStyle;
+  const pathForCompare = caseInsensitive
+    ? normalizedPath.value.toLowerCase()
+    : normalizedPath.value;
+  const rootForCompare = caseInsensitive
+    ? normalizedRoot.value.toLowerCase()
+    : normalizedRoot.value;
+  const rootPrefix = rootForCompare.endsWith("/") ? rootForCompare : `${rootForCompare}/`;
+  if (!pathForCompare.startsWith(rootPrefix)) return null;
+  return normalizedPath.value.slice(rootPrefix.length);
+}
+
+function normalizeAbsolutePathForContainment(
+  path: string,
+): { readonly value: string; readonly windowsStyle: boolean } | null {
+  const normalized = normalizeWindowsDrivePath(path.replaceAll("\\", "/"));
+  const windowsDrive = /^[A-Za-z]:\//.exec(normalized)?.[0];
+  const windowsStyle = windowsDrive !== undefined || normalized.startsWith("//");
+  const root =
+    windowsDrive ?? (normalized.startsWith("//") ? "//" : normalized.startsWith("/") ? "/" : null);
+  if (root === null) return null;
+
+  const segments: string[] = [];
+  for (const segment of normalized.slice(root.length).split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+    } else {
+      segments.push(segment);
+    }
+  }
+  return {
+    value: segments.length === 0 ? root : `${root}${segments.join("/")}`,
+    windowsStyle,
+  };
 }
 
 export function resolveMarkdownFileLinkMeta(
@@ -385,8 +426,51 @@ export function resolveMarkdownFileLinkMeta(
   return buildFileLinkMetaFromTarget(targetPath, cwd);
 }
 
-function buildFileLinkMetaFromTarget(targetPath: string, cwd?: string): MarkdownFileLinkMeta {
-  const { path, line, column } = splitPathAndPosition(targetPath);
+export function resolveCanonicalMarkdownFileLinkMeta(
+  label: string,
+  href: string,
+  cwd?: string,
+): MarkdownFileLinkMeta | null {
+  const authoredPath = decodeCanonicalComposerFileLinkPath(
+    label,
+    normalizeMarkdownLinkDestination(href),
+  );
+  if (authoredPath === null) return null;
+
+  if (!isRelativePath(authoredPath)) {
+    return buildFileLinkMetaFromTarget(authoredPath, cwd, { parsePosition: false });
+  }
+  if (!cwd || isScopedPackageReferencePath(authoredPath)) {
+    return buildFileLinkMetaFromTarget(authoredPath, cwd, {
+      openTargetPath: null,
+      parsePosition: false,
+    });
+  }
+
+  const resolvedPath = isExplicitRelativeProjectPath(authoredPath)
+    ? resolveProjectPathForDispatch(authoredPath, cwd)
+    : resolvePathLinkTarget(authoredPath, cwd);
+  if (resolvedPath.startsWith("~/")) {
+    return buildFileLinkMetaFromTarget(authoredPath, cwd, {
+      openTargetPath: null,
+      parsePosition: false,
+    });
+  }
+  return buildFileLinkMetaFromTarget(resolvedPath, cwd, { parsePosition: false });
+}
+
+function buildFileLinkMetaFromTarget(
+  targetPath: string,
+  cwd?: string,
+  options: {
+    readonly openTargetPath?: string | null;
+    readonly parsePosition?: boolean;
+  } = {},
+): MarkdownFileLinkMeta {
+  const { path, line, column } =
+    options.parsePosition === false
+      ? { path: targetPath, line: undefined, column: undefined }
+      : splitPathAndPosition(targetPath);
   const parsedLine = line ? Number.parseInt(line, 10) : Number.NaN;
   const parsedColumn = column ? Number.parseInt(column, 10) : Number.NaN;
   const lineNumber = Number.isFinite(parsedLine) ? parsedLine : undefined;
@@ -395,6 +479,7 @@ function buildFileLinkMetaFromTarget(targetPath: string, cwd?: string): Markdown
   return {
     filePath: path,
     targetPath,
+    openTargetPath: options.openTargetPath === undefined ? targetPath : options.openTargetPath,
     displayPath: formatWorkspaceRelativePath(targetPath, cwd),
     workspaceRelativePath: workspaceRelativePath(path, cwd),
     basename: basenameOfPath(path),

--- a/apps/web/src/markdown-list-indentation.ts
+++ b/apps/web/src/markdown-list-indentation.ts
@@ -1,6 +1,12 @@
 interface MarkdownPosition {
   readonly start?: {
     readonly line?: number;
+    readonly column?: number;
+    readonly offset?: number;
+  };
+  readonly end?: {
+    readonly line?: number;
+    readonly column?: number;
     readonly offset?: number;
   };
 }
@@ -23,6 +29,10 @@ interface MarkdownParser {
 interface RecoveredMarkdown {
   readonly blocks: MarkdownAstNode[];
   readonly source: string;
+}
+
+interface RecoveredIndentedMarkdown extends RecoveredMarkdown {
+  readonly rebase: () => MarkdownAstNode[];
 }
 
 const INLINE_PARSE_PREFIX = "t3-markdown-inline-prefix:";
@@ -91,16 +101,142 @@ function parseRecoveredMarkdown(value: string, parser: MarkdownParser): Recovere
   };
 }
 
-function blocksFromIndentedCode(node: MarkdownAstNode, parser: MarkdownParser): RecoveredMarkdown {
+function lineSlices(value: string): Array<{ readonly start: number; readonly text: string }> {
+  const lines: Array<{ readonly start: number; readonly text: string }> = [];
+  let start = 0;
+  for (let index = 0; index <= value.length; index += 1) {
+    if (index === value.length || value[index] === "\n") {
+      lines.push({ start, text: value.slice(start, index) });
+      start = index + 1;
+    }
+  }
+  return lines;
+}
+
+function recoveredOffsetMapper(
+  value: string,
+  node: MarkdownAstNode,
+  markdown: string,
+):
+  | ((
+      offset: number,
+    ) => { readonly offset: number; readonly line: number; readonly column: number } | undefined)
+  | null {
+  const nodeStartPoint = node.position?.start;
+  const nodeStart = nodeStartPoint?.offset;
+  const nodeEnd = node.position?.end?.offset;
+  if (!nodeStartPoint || nodeStart === undefined || nodeEnd === undefined) return null;
+
+  const recoveredLines = lineSlices(value);
+  const sourceLines = lineSlices(markdown.slice(nodeStart, nodeEnd));
+  const mappings: Array<{
+    readonly recoveredStart: number;
+    readonly recoveredEnd: number;
+    readonly sourceStart: number;
+    readonly sourceLine: number;
+    readonly sourceColumn: number;
+  }> = [];
+  let sourceLineIndex = 0;
+  for (const recoveredLine of recoveredLines) {
+    let matched = false;
+    while (sourceLineIndex < sourceLines.length) {
+      const sourceLine = sourceLines[sourceLineIndex];
+      sourceLineIndex += 1;
+      if (!sourceLine) continue;
+      const column =
+        recoveredLine.text.length === 0
+          ? sourceLine.text.trim().length === 0
+            ? sourceLine.text.length
+            : -1
+          : sourceLine.text.lastIndexOf(recoveredLine.text);
+      if (column < 0) continue;
+      mappings.push({
+        recoveredStart: recoveredLine.start,
+        recoveredEnd: recoveredLine.start + recoveredLine.text.length,
+        sourceStart: nodeStart + sourceLine.start + column,
+        sourceLine: (nodeStartPoint.line ?? 1) + sourceLineIndex - 1,
+        sourceColumn: sourceLineIndex === 1 ? (nodeStartPoint.column ?? 1) + column : column + 1,
+      });
+      matched = true;
+      break;
+    }
+    if (!matched) return null;
+  }
+
+  return (offset) => {
+    const relativeOffset = offset - INLINE_PARSE_PREFIX.length;
+    let low = 0;
+    let high = mappings.length - 1;
+    while (low <= high) {
+      const middle = (low + high) >> 1;
+      const mapping = mappings[middle];
+      if (!mapping) return undefined;
+      if (relativeOffset < mapping.recoveredStart) {
+        high = middle - 1;
+      } else if (relativeOffset > mapping.recoveredEnd) {
+        low = middle + 1;
+      } else {
+        const columnOffset = relativeOffset - mapping.recoveredStart;
+        return {
+          offset: mapping.sourceStart + columnOffset,
+          line: mapping.sourceLine,
+          column: mapping.sourceColumn + columnOffset,
+        };
+      }
+    }
+    return undefined;
+  };
+}
+
+function rebaseRecoveredOffsets(
+  node: MarkdownAstNode,
+  mapOffset: (
+    offset: number,
+  ) => { readonly offset: number; readonly line: number; readonly column: number } | undefined,
+): MarkdownAstNode {
+  const rebasePoint = (point: {
+    readonly line?: number;
+    readonly column?: number;
+    readonly offset?: number;
+  }) => {
+    if (point.offset === undefined) return point;
+    const mapped = mapOffset(point.offset);
+    return mapped === undefined ? undefined : { ...point, ...mapped };
+  };
+  const start = node.position?.start ? rebasePoint(node.position.start) : undefined;
+  const end = node.position?.end ? rebasePoint(node.position.end) : undefined;
+  const { position: _position, ...nodeWithoutPosition } = node;
+  return {
+    ...nodeWithoutPosition,
+    ...(start || end ? { position: { ...(start ? { start } : {}), ...(end ? { end } : {}) } } : {}),
+    ...(node.children
+      ? { children: node.children.map((child) => rebaseRecoveredOffsets(child, mapOffset)) }
+      : {}),
+  };
+}
+
+function blocksFromIndentedCode(
+  node: MarkdownAstNode,
+  parser: MarkdownParser,
+  markdown: string,
+): RecoveredIndentedMarkdown {
   const value = typeof node.value === "string" ? node.value.trim() : "";
   const recovered = parseRecoveredMarkdown(value, parser);
-  const first = recovered.blocks[0];
+  const mapOffset = recoveredOffsetMapper(value, node, markdown);
   return {
     ...recovered,
-    blocks:
-      first && node.position
-        ? [{ ...first, position: node.position }, ...recovered.blocks.slice(1)]
-        : recovered.blocks,
+    rebase: () => {
+      const rebasedBlocks = mapOffset
+        ? recovered.blocks.map((block) => rebaseRecoveredOffsets(block, mapOffset))
+        : recovered.blocks;
+      const first = rebasedBlocks[0];
+      return first && node.position
+        ? ([
+            { ...first, position: node.position },
+            ...rebasedBlocks.slice(1),
+          ] satisfies MarkdownAstNode[])
+        : rebasedBlocks;
+    },
   };
 }
 
@@ -125,11 +261,11 @@ function attachListItemIndentationNormalizer(this: MarkdownParser) {
       }
       node.children = node.children.flatMap((child) => {
         if (isSameLineOverIndentedCode(child, node, source)) {
-          const recovered = blocksFromIndentedCode(child, this);
+          const recovered = blocksFromIndentedCode(child, this, source);
           for (const block of recovered.blocks) {
             visit(block, recovered.source);
           }
-          return recovered.blocks;
+          return recovered.rebase();
         }
         visit(child, source);
         return [child];

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -1,4 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
+import { filterFilesystemBrowseEntries } from "@t3tools/client-runtime/state/filesystem";
+import { getBrowseLeafPathSegment } from "@t3tools/client-runtime/state/projects";
 import {
   type CheckpointDiffTarget,
   type ComposerPathSearchTarget,
@@ -11,6 +13,7 @@ import {
 import { type VcsRefTarget } from "@t3tools/client-runtime/state/vcs";
 import type {
   EnvironmentId,
+  FilesystemBrowseEntry,
   OrchestrationThread,
   ProjectContentMatch,
   ProjectEntryKind,
@@ -24,6 +27,7 @@ import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { appAtomRegistry } from "../rpc/atomRegistry";
+import { filesystemEnvironment } from "./filesystem";
 import { orchestrationEnvironment } from "./orchestration";
 import { isPaginatedBranchesNextPagePending } from "./paginatedBranches";
 import { projectContentSearch, projectEnvironment } from "./projects";
@@ -33,6 +37,7 @@ import { vcsEnvironment } from "./vcs";
 
 const PROJECT_PATH_SEARCH_DEBOUNCE_MS = 120;
 const COMPOSER_PATH_SEARCH_LIMIT = 80;
+const COMPOSER_FILESYSTEM_BROWSE_LIMIT = 80;
 const PROJECT_CONTENT_SEARCH_DEBOUNCE_MS = 120;
 const PROJECT_CONTENT_SEARCH_LIMIT = 500;
 const THREAD_SEARCH_DEBOUNCE_MS = 200;
@@ -300,6 +305,64 @@ export function useProjectPathSearch(
 
 export function useComposerPathSearch(target: ComposerPathSearchTarget) {
   return useProjectPathSearch(target, COMPOSER_PATH_SEARCH_LIMIT);
+}
+
+interface ComposerFilesystemBrowseTarget {
+  readonly environmentId: EnvironmentId | null;
+  readonly cwd: string | null;
+  readonly query: string | null;
+}
+
+const EMPTY_FILESYSTEM_ENTRIES: ReadonlyArray<FilesystemBrowseEntry> = [];
+
+function areComposerFilesystemBrowseTargetsEqual(
+  left: ComposerFilesystemBrowseTarget,
+  right: ComposerFilesystemBrowseTarget,
+): boolean {
+  return (
+    left.environmentId === right.environmentId &&
+    left.cwd === right.cwd &&
+    left.query === right.query
+  );
+}
+
+export function useComposerFilesystemBrowse(target: ComposerFilesystemBrowseTarget) {
+  const normalizedTarget = useMemo(
+    () => ({
+      environmentId: target.environmentId,
+      cwd: target.cwd,
+      query: target.query?.trim() || null,
+    }),
+    [target.cwd, target.environmentId, target.query],
+  );
+  const debouncedTarget = useDebouncedValue(normalizedTarget, PROJECT_PATH_SEARCH_DEBOUNCE_MS);
+  const isSettled = areComposerFilesystemBrowseTargetsEqual(normalizedTarget, debouncedTarget);
+  const result = useEnvironmentQuery(
+    debouncedTarget.environmentId !== null && debouncedTarget.query !== null
+      ? filesystemEnvironment.browse({
+          environmentId: debouncedTarget.environmentId,
+          input: {
+            partialPath: debouncedTarget.query,
+            ...(debouncedTarget.cwd === null ? {} : { cwd: debouncedTarget.cwd }),
+            kinds: ["file", "directory"],
+            limit: COMPOSER_FILESYSTEM_BROWSE_LIMIT,
+          },
+        })
+      : null,
+  );
+  const entries = useMemo(() => {
+    if (!result.data || debouncedTarget.query === null) return EMPTY_FILESYSTEM_ENTRIES;
+    return filterFilesystemBrowseEntries(
+      result.data.entries,
+      getBrowseLeafPathSegment(debouncedTarget.query),
+    ).visibleEntries;
+  }, [debouncedTarget.query, result.data]);
+
+  return {
+    entries: isSettled ? entries : EMPTY_FILESYSTEM_ENTRIES,
+    error: result.error,
+    isPending: !isSettled || result.isPending,
+  };
 }
 
 interface ProjectContentSearchTarget {

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -11,6 +11,7 @@ import {
 import { type VcsRefTarget } from "@t3tools/client-runtime/state/vcs";
 import type {
   EnvironmentId,
+  FilesystemBrowseEntry,
   OrchestrationThread,
   ProjectContentMatch,
   ProjectEntryKind,
@@ -24,6 +25,7 @@ import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { appAtomRegistry } from "../rpc/atomRegistry";
+import { filesystemEnvironment } from "./filesystem";
 import { orchestrationEnvironment } from "./orchestration";
 import { isPaginatedBranchesNextPagePending } from "./paginatedBranches";
 import { projectContentSearch, projectEnvironment } from "./projects";
@@ -33,6 +35,7 @@ import { vcsEnvironment } from "./vcs";
 
 const PROJECT_PATH_SEARCH_DEBOUNCE_MS = 120;
 const COMPOSER_PATH_SEARCH_LIMIT = 80;
+const COMPOSER_FILESYSTEM_BROWSE_LIMIT = 80;
 const PROJECT_CONTENT_SEARCH_DEBOUNCE_MS = 120;
 const PROJECT_CONTENT_SEARCH_LIMIT = 500;
 const THREAD_SEARCH_DEBOUNCE_MS = 200;
@@ -295,6 +298,59 @@ export function useProjectPathSearch(
 
 export function useComposerPathSearch(target: ComposerPathSearchTarget) {
   return useProjectPathSearch(target, COMPOSER_PATH_SEARCH_LIMIT);
+}
+
+interface ComposerFilesystemBrowseTarget {
+  readonly environmentId: EnvironmentId | null;
+  readonly cwd: string | null;
+  readonly query: string | null;
+}
+
+const EMPTY_FILESYSTEM_ENTRIES: ReadonlyArray<FilesystemBrowseEntry> = [];
+
+function areComposerFilesystemBrowseTargetsEqual(
+  left: ComposerFilesystemBrowseTarget,
+  right: ComposerFilesystemBrowseTarget,
+): boolean {
+  return (
+    left.environmentId === right.environmentId &&
+    left.cwd === right.cwd &&
+    left.query === right.query
+  );
+}
+
+export function useComposerFilesystemBrowse(target: ComposerFilesystemBrowseTarget) {
+  const normalizedTarget = useMemo(
+    () => ({
+      environmentId: target.environmentId,
+      cwd: target.cwd,
+      query: target.query?.trim() || null,
+    }),
+    [target.cwd, target.environmentId, target.query],
+  );
+  const debouncedTarget = useDebouncedValue(normalizedTarget, PROJECT_PATH_SEARCH_DEBOUNCE_MS);
+  const isSettled = areComposerFilesystemBrowseTargetsEqual(normalizedTarget, debouncedTarget);
+  const result = useEnvironmentQuery(
+    debouncedTarget.environmentId !== null && debouncedTarget.query !== null
+      ? filesystemEnvironment.browse({
+          environmentId: debouncedTarget.environmentId,
+          input: {
+            partialPath: debouncedTarget.query,
+            ...(debouncedTarget.cwd === null ? {} : { cwd: debouncedTarget.cwd }),
+            kinds: ["file", "directory"],
+            limit: COMPOSER_FILESYSTEM_BROWSE_LIMIT,
+          },
+        })
+      : null,
+  );
+
+  return {
+    entries: isSettled
+      ? (result.data?.entries ?? EMPTY_FILESYSTEM_ENTRIES)
+      : EMPTY_FILESYSTEM_ENTRIES,
+    error: result.error,
+    isPending: !isSettled || result.isPending,
+  };
 }
 
 interface ProjectContentSearchTarget {

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -119,6 +119,10 @@ function joinPath(base: string, next: string, separator: "/" | "\\"): string {
 }
 
 function inferHomeFromCwd(cwd: string): string | undefined {
+  if (cwd === "/root" || cwd.startsWith("/root/")) {
+    return "/root";
+  }
+
   const posixUser = cwd.match(/^\/Users\/([^/]+)/);
   if (posixUser?.[1]) {
     return `/Users/${posixUser[1]}`;
@@ -266,8 +270,15 @@ export function isTerminalLinkActivation(
     : event.ctrlKey && !event.metaKey;
 }
 
-export function resolvePathLinkTarget(rawPath: string, cwd: string): string {
-  const { path, line, column } = splitPathAndPosition(rawPath);
+export function resolvePathLinkTarget(
+  rawPath: string,
+  cwd: string,
+  options: { readonly parsePosition?: boolean } = {},
+): string {
+  const { path, line, column } =
+    options.parsePosition === false
+      ? { path: rawPath, line: undefined, column: undefined }
+      : splitPathAndPosition(rawPath);
 
   let resolvedPath = path;
   if (path.startsWith("~/")) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Install and first run](./user/install.md)
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
+- [Tagging files and directories](./user/file-tags.md)
 - [Organizing threads](./user/thread-sidebar.md)
 - [Review usage](./user/usage.md)
 - [Customize a project icon](./user/project-settings.md)

--- a/docs/user/file-tags.md
+++ b/docs/user/file-tags.md
@@ -11,7 +11,7 @@ To browse outside the current project, start the query with an explicit filesyst
 - On Windows, drive and UNC paths are also supported.
 
 Use the existing quoted mention form when a directory name contains spaces, for example
-`@"~/My Projects/`.
+`@"~/My Projects/"`.
 
 Browsing happens on the thread's environment, so a remote thread sees the remote filesystem rather
 than files on the device running the client. Only the current directory is listed; T3 Code does not

--- a/docs/user/file-tags.md
+++ b/docs/user/file-tags.md
@@ -1,0 +1,22 @@
+# Tagging files and directories
+
+Type `@` in the web or desktop composer to search for files and directories in the current
+project. Selecting a result adds a tag to the message without changing the path sent to the agent.
+
+To browse outside the current project, start the query with an explicit filesystem path:
+
+- `@~/Sites/` browses from your home directory.
+- `@../` browses relative to the current project.
+- `@/tmp/` browses an absolute path.
+- On Windows, drive and UNC paths are also supported.
+
+Use the existing quoted mention form when a directory name contains spaces, for example
+`@"~/My Projects/`.
+
+Browsing happens on the thread's environment, so a remote thread sees the remote filesystem rather
+than files on the device running the client. Only the current directory is listed; T3 Code does not
+recursively search outside the project.
+
+The picker includes regular files and directories. A tag can always be copied, but opening it from a
+sent message is available only when T3 Code can resolve the authored path in that message's
+environment.

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   CheckpointRef,
   CommandId,
+  EnvironmentId,
   EventId,
   MessageId,
   ProjectId,
@@ -309,6 +310,14 @@ describe("applyThreadDetailEvent", () => {
 
   describe("thread.message-sent", () => {
     it("appends a new message", () => {
+      const fileMention = {
+        version: 1 as const,
+        environmentId: EnvironmentId.make("environment-1"),
+        path: "/repo/AGENTS.md",
+        kind: "file" as const,
+        start: 0,
+        end: 28,
+      };
       const result = applyThreadDetailEvent(baseThread, {
         ...baseEventFields,
         sequence: 6,
@@ -320,7 +329,8 @@ describe("applyThreadDetailEvent", () => {
           threadId: ThreadId.make("thread-1"),
           messageId: MessageId.make("msg-1"),
           role: "user",
-          text: "Hello, world!",
+          text: "[AGENTS.md](/repo/AGENTS.md)",
+          fileMentions: [fileMention],
           turnId: null,
           streaming: false,
           createdAt: "2026-04-01T06:00:00.000Z",
@@ -331,7 +341,8 @@ describe("applyThreadDetailEvent", () => {
       expect(result.kind).toBe("updated");
       if (result.kind === "updated") {
         expect(result.thread.messages).toHaveLength(1);
-        expect(result.thread.messages[0]?.text).toBe("Hello, world!");
+        expect(result.thread.messages[0]?.text).toBe("[AGENTS.md](/repo/AGENTS.md)");
+        expect(result.thread.messages[0]?.fileMentions).toEqual([fileMention]);
       }
     });
 

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -289,6 +289,9 @@ export function applyThreadDetailEvent(
         ...(event.payload.attachments !== undefined
           ? { attachments: event.payload.attachments }
           : {}),
+        ...(event.payload.fileMentions !== undefined
+          ? { fileMentions: event.payload.fileMentions }
+          : {}),
         turnId: event.payload.turnId,
         streaming: event.payload.streaming,
         createdAt: event.payload.createdAt,
@@ -312,6 +315,9 @@ export function applyThreadDetailEvent(
                   ...(message.streaming ? {} : { updatedAt: message.updatedAt }),
                   ...(message.attachments !== undefined
                     ? { attachments: message.attachments }
+                    : {}),
+                  ...(message.fileMentions !== undefined
+                    ? { fileMentions: message.fileMentions }
                     : {}),
                 },
           )

--- a/packages/contracts/src/filesystem.test.ts
+++ b/packages/contracts/src/filesystem.test.ts
@@ -1,7 +1,43 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { FilesystemBrowseError } from "./filesystem.ts";
+import {
+  FILESYSTEM_BROWSE_MAX_LIMIT,
+  FilesystemBrowseEntry,
+  FilesystemBrowseError,
+  FilesystemBrowseInput,
+} from "./filesystem.ts";
+
+describe("filesystem browse schemas", () => {
+  it("decodes legacy and extended browse inputs", () => {
+    const decode = Schema.decodeUnknownSync(FilesystemBrowseInput);
+    expect(decode({ partialPath: "~/" })).toEqual({ partialPath: "~/" });
+    expect(decode({ partialPath: "~/src", kinds: ["file", "directory"], limit: 50 })).toEqual({
+      partialPath: "~/src",
+      kinds: ["file", "directory"],
+      limit: 50,
+    });
+    expect(() => decode({ partialPath: "~/", limit: FILESYSTEM_BROWSE_MAX_LIMIT + 1 })).toThrow();
+  });
+
+  it("accepts legacy entries without kind and new typed entries", () => {
+    const decode = Schema.decodeUnknownSync(FilesystemBrowseEntry);
+    expect(decode({ name: "src", fullPath: "/repo/src" })).toEqual({
+      name: "src",
+      fullPath: "/repo/src",
+    });
+    expect(decode({ name: "main.ts", fullPath: "/repo/main.ts", kind: "file" })).toEqual({
+      name: "main.ts",
+      fullPath: "/repo/main.ts",
+      kind: "file",
+    });
+    expect(decode({ name: "src", fullPath: "/repo/src", kind: "directory" })).toEqual({
+      name: "src",
+      fullPath: "/repo/src",
+      kind: "directory",
+    });
+  });
+});
 
 describe("FilesystemBrowseError", () => {
   it("derives a stable message from browse context while retaining the cause", () => {

--- a/packages/contracts/src/filesystem.ts
+++ b/packages/contracts/src/filesystem.ts
@@ -1,17 +1,26 @@
 import * as Schema from "effect/Schema";
-import { TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 const FILESYSTEM_PATH_MAX_LENGTH = 512;
+export const FILESYSTEM_BROWSE_MAX_LIMIT = 200;
+
+export const FilesystemBrowseKind = Schema.Literals(["file", "directory"]);
+export type FilesystemBrowseKind = typeof FilesystemBrowseKind.Type;
 
 export const FilesystemBrowseInput = Schema.Struct({
   partialPath: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
   cwd: Schema.optional(TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH))),
+  kinds: Schema.optionalKey(Schema.Array(FilesystemBrowseKind)),
+  limit: Schema.optionalKey(
+    PositiveInt.check(Schema.isLessThanOrEqualTo(FILESYSTEM_BROWSE_MAX_LIMIT)),
+  ),
 });
 export type FilesystemBrowseInput = typeof FilesystemBrowseInput.Type;
 
 export const FilesystemBrowseEntry = Schema.Struct({
   name: TrimmedNonEmptyString,
   fullPath: TrimmedNonEmptyString,
+  kind: Schema.optionalKey(FilesystemBrowseKind),
 });
 export type FilesystemBrowseEntry = typeof FilesystemBrowseEntry.Type;
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -145,6 +145,7 @@ export type ProviderUserInputAnswers = typeof ProviderUserInputAnswers.Type;
 export const PROVIDER_SEND_TURN_MAX_INPUT_CHARS = 120_000;
 export const PROVIDER_SEND_TURN_MAX_ATTACHMENTS = 8;
 export const PROVIDER_SEND_TURN_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const PROVIDER_SEND_TURN_MAX_FILE_MENTIONS = 100;
 const PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS = 14_000_000;
 const CHAT_ATTACHMENT_ID_MAX_CHARS = 128;
 // Correlation id is command id by design in this model.
@@ -198,7 +199,7 @@ export const ExplicitFileMention = Schema.Struct({
 export type ExplicitFileMention = typeof ExplicitFileMention.Type;
 
 export const ExplicitFileMentions = Schema.Array(ExplicitFileMention).check(
-  Schema.isMaxLength(100),
+  Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_FILE_MENTIONS),
 );
 export type ExplicitFileMentions = typeof ExplicitFileMentions.Type;
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -10,6 +10,7 @@ import {
   CheckpointRef,
   CommandId,
   EventId,
+  EnvironmentId,
   IsoDateTime,
   MessageId,
   NonNegativeInt,
@@ -181,6 +182,26 @@ export type ChatAttachment = typeof ChatAttachment.Type;
 const UploadChatAttachment = Schema.Union([UploadChatImageAttachment]);
 export type UploadChatAttachment = typeof UploadChatAttachment.Type;
 
+/**
+ * Explicit provenance for a file tag inserted by a T3 composer.
+ * `start` and `end` are a half-open range of UTF-16 code units in the
+ * containing message text, matching JavaScript string offsets.
+ */
+export const ExplicitFileMention = Schema.Struct({
+  version: Schema.Literal(1),
+  environmentId: EnvironmentId,
+  path: Schema.String.check(Schema.isNonEmpty(), Schema.isMaxLength(4096)),
+  kind: Schema.Literals(["file", "directory"]),
+  start: NonNegativeInt,
+  end: PositiveInt,
+});
+export type ExplicitFileMention = typeof ExplicitFileMention.Type;
+
+export const ExplicitFileMentions = Schema.Array(ExplicitFileMention).check(
+  Schema.isMaxLength(100),
+);
+export type ExplicitFileMentions = typeof ExplicitFileMentions.Type;
+
 export const ProjectScriptIcon = Schema.Literals([
   "play",
   "test",
@@ -243,6 +264,7 @@ export const OrchestrationMessage = Schema.Struct({
   role: OrchestrationMessageRole,
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
+  fileMentions: Schema.optional(ExplicitFileMentions),
   turnId: Schema.NullOr(TurnId),
   streaming: Schema.Boolean,
   createdAt: IsoDateTime,
@@ -817,6 +839,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
     role: Schema.Literal("user"),
     text: Schema.String,
     attachments: Schema.Array(ChatAttachment),
+    fileMentions: Schema.optional(ExplicitFileMentions),
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
@@ -838,6 +861,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
     role: Schema.Literal("user"),
     text: Schema.String,
     attachments: Schema.Array(UploadChatAttachment),
+    fileMentions: Schema.optional(ExplicitFileMentions),
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
@@ -1224,6 +1248,7 @@ export const ThreadMessageSentPayload = Schema.Struct({
   role: OrchestrationMessageRole,
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
+  fileMentions: Schema.optional(ExplicitFileMentions),
   turnId: Schema.NullOr(TurnId),
   streaming: Schema.Boolean,
   createdAt: IsoDateTime,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -167,6 +167,10 @@
       "types": "./src/composerInlineTokens.ts",
       "import": "./src/composerInlineTokens.ts"
     },
+    "./fileMentions": {
+      "types": "./src/fileMentions.ts",
+      "import": "./src/fileMentions.ts"
+    },
     "./terminalLabels": {
       "types": "./src/terminalLabels.ts",
       "import": "./src/terminalLabels.ts"

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -1,6 +1,36 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { collectComposerInlineTokens } from "./composerInlineTokens.ts";
+import {
+  collectComposerInlineTokens,
+  decodeCanonicalComposerFileLinkPath,
+  isCanonicalComposerFileLink,
+} from "./composerInlineTokens.ts";
+
+describe("isCanonicalComposerFileLink", () => {
+  it.each([
+    ["data", "/custom/mount/data"],
+    ["project", "~/Sites/project"],
+    ["shared", "../shared"],
+    ["file.ts", "C:%5CUsers%5Cme%5Cfile.ts"],
+    ["my file.txt", "/tmp/my%20file.txt"],
+  ])("accepts %s for %s", (label, path) => {
+    expect(isCanonicalComposerFileLink(label, path)).toBe(true);
+  });
+
+  it.each([
+    ["other", "/custom/mount/data"],
+    ["docs", "https://example.com/docs"],
+    ["", ""],
+  ])("rejects %s for %s", (label, path) => {
+    expect(isCanonicalComposerFileLink(label, path)).toBe(false);
+  });
+
+  it("returns the decoded path", () => {
+    expect(decodeCanonicalComposerFileLinkPath("my file.txt", "/tmp/my%20file.txt")).toBe(
+      "/tmp/my file.txt",
+    );
+  });
+});
 
 describe("collectComposerInlineTokens", () => {
   it("collects file links, mentions, and skills with source ranges", () => {

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -1,6 +1,37 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { collectComposerInlineTokens } from "./composerInlineTokens.ts";
+import {
+  collectComposerInlineTokens,
+  decodeCanonicalComposerFileLinkPath,
+  isCanonicalComposerFileLink,
+  isScopedPackageReferencePath,
+} from "./composerInlineTokens.ts";
+
+describe("isCanonicalComposerFileLink", () => {
+  it.each([
+    ["data", "/custom/mount/data"],
+    ["project", "~/Sites/project"],
+    ["shared", "../shared"],
+    ["file.ts", "C:%5CUsers%5Cme%5Cfile.ts"],
+    ["my file.txt", "/tmp/my%20file.txt"],
+  ])("accepts %s for %s", (label, path) => {
+    expect(isCanonicalComposerFileLink(label, path)).toBe(true);
+  });
+
+  it.each([
+    ["other", "/custom/mount/data"],
+    ["docs", "https://example.com/docs"],
+    ["", ""],
+  ])("rejects %s for %s", (label, path) => {
+    expect(isCanonicalComposerFileLink(label, path)).toBe(false);
+  });
+
+  it("returns the decoded path", () => {
+    expect(decodeCanonicalComposerFileLinkPath("my file.txt", "/tmp/my%20file.txt")).toBe(
+      "/tmp/my file.txt",
+    );
+  });
+});
 
 describe("collectComposerInlineTokens", () => {
   it("collects file links, mentions, and skills with source ranges", () => {
@@ -117,6 +148,20 @@ describe("collectComposerInlineTokens", () => {
       },
     ]);
   });
+
+  it.each(["@scope/package.json", "@expo/ui", "@jane/foo.js/deep"])(
+    "isScopedPackageReferencePath accepts %s",
+    (reference) => {
+      expect(isScopedPackageReferencePath(reference)).toBe(true);
+    },
+  );
+
+  it.each(["src/index.ts", "./src/index.ts", "scope/package.json", "package.json"])(
+    "isScopedPackageReferencePath rejects %s",
+    (reference) => {
+      expect(isScopedPackageReferencePath(reference)).toBe(false);
+    },
+  );
 
   it("allows ambiguous scoped paths through explicit quoted mentions", () => {
     expect(collectComposerInlineTokens('Inspect @"expo/ui" next')).toEqual([

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -41,6 +41,26 @@ const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
 const SCOPED_PACKAGE_REFERENCE_REGEX =
   /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*(?:\/[^\s@"]+)*$/;
 
+export function decodeCanonicalComposerFileLinkPath(
+  label: string,
+  encodedPath: string,
+): string | null {
+  let path = encodedPath;
+  try {
+    path = decodeURIComponent(encodedPath);
+  } catch {
+    // Preserve malformed source so manually authored paths remain usable.
+  }
+  const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  const basename = separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
+  const hasExternalScheme = URI_SCHEME_REGEX.test(path) && !WINDOWS_DRIVE_PATH_REGEX.test(path);
+  return path && !hasExternalScheme && label === basename ? path : null;
+}
+
+export function isCanonicalComposerFileLink(label: string, encodedPath: string): boolean {
+  return decodeCanonicalComposerFileLinkPath(label, encodedPath) !== null;
+}
+
 function collectMentionTokens(text: string): ComposerInlineToken[] {
   const matches: ComposerInlineToken[] = [];
 
@@ -49,16 +69,8 @@ function collectMentionTokens(text: string): ComposerInlineToken[] {
     const prefix = match[1] ?? "";
     const label = (match[2] ?? "").replace(/\\(.)/g, "$1");
     const encodedPath = match[3] ?? "";
-    let path = encodedPath;
-    try {
-      path = decodeURIComponent(encodedPath);
-    } catch {
-      // Preserve malformed source rather than dropping a user-authored token.
-    }
-    const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
-    const basename = separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
-    const hasExternalScheme = URI_SCHEME_REGEX.test(path) && !WINDOWS_DRIVE_PATH_REGEX.test(path);
-    if (!path || hasExternalScheme || label !== basename) {
+    const path = decodeCanonicalComposerFileLinkPath(label, encodedPath);
+    if (path === null) {
       continue;
     }
     const start = (match.index ?? 0) + prefix.length;

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -27,6 +27,36 @@ const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
 const SCOPED_PACKAGE_REFERENCE_REGEX =
   /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*(?:\/[^\s@"]+)*$/;
 
+/**
+ * Matches an authored `@scope/name[/...]` reference (npm-style scoped
+ * package), as distinct from a relative filesystem path. Callers resolving
+ * paths against a cwd use this to avoid treating a package reference as a
+ * directory under the project root.
+ */
+export function isScopedPackageReferencePath(path: string): boolean {
+  return path.startsWith("@") && SCOPED_PACKAGE_REFERENCE_REGEX.test(path.slice(1));
+}
+
+export function decodeCanonicalComposerFileLinkPath(
+  label: string,
+  encodedPath: string,
+): string | null {
+  let path = encodedPath;
+  try {
+    path = decodeURIComponent(encodedPath);
+  } catch {
+    // Preserve malformed source so manually authored paths remain usable.
+  }
+  const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  const basename = separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
+  const hasExternalScheme = URI_SCHEME_REGEX.test(path) && !WINDOWS_DRIVE_PATH_REGEX.test(path);
+  return path && !hasExternalScheme && label === basename ? path : null;
+}
+
+export function isCanonicalComposerFileLink(label: string, encodedPath: string): boolean {
+  return decodeCanonicalComposerFileLinkPath(label, encodedPath) !== null;
+}
+
 function collectMentionTokens(text: string): ComposerInlineToken[] {
   const matches: ComposerInlineToken[] = [];
 
@@ -35,16 +65,8 @@ function collectMentionTokens(text: string): ComposerInlineToken[] {
     const prefix = match[1] ?? "";
     const label = (match[2] ?? "").replace(/\\(.)/g, "$1");
     const encodedPath = match[3] ?? "";
-    let path = encodedPath;
-    try {
-      path = decodeURIComponent(encodedPath);
-    } catch {
-      // Preserve malformed source rather than dropping a user-authored token.
-    }
-    const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
-    const basename = separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
-    const hasExternalScheme = URI_SCHEME_REGEX.test(path) && !WINDOWS_DRIVE_PATH_REGEX.test(path);
-    if (!path || hasExternalScheme || label !== basename) {
+    const path = decodeCanonicalComposerFileLinkPath(label, encodedPath);
+    if (path === null) {
       continue;
     }
     const start = (match.index ?? 0) + prefix.length;

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -40,4 +40,11 @@ describe("serializeComposerFileLink", () => {
       "[package.json](@scope/package.json)",
     );
   });
+
+  it("escapes markdown syntax in filenames", () => {
+    expect(serializeComposerFileLink("/custom/*draft* &amp;")).toBe(
+      "[\\*draft\\* \\&amp;](/custom/*draft*%20%26amp;)",
+    );
+    expect(serializeComposerFileLink("/tmp/a|b")).toBe("[a\\|b](/tmp/a%7Cb)");
+  });
 });

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -23,7 +23,7 @@ function composerFileLinkBasename(path: string): string {
 }
 
 function escapeMarkdownLinkLabel(label: string): string {
-  return label.replaceAll("\\", "\\\\").replaceAll("[", "\\[").replaceAll("]", "\\]");
+  return label.replace(/[\\[\]*_~`<>&|]/g, "\\$&");
 }
 
 function encodeMarkdownLinkDestination(path: string): string {
@@ -32,6 +32,7 @@ function encodeMarkdownLinkDestination(path: string): string {
     .replaceAll(")", "%29")
     .replaceAll("#", "%23")
     .replaceAll("?", "%3F")
+    .replaceAll("&", "%26")
     .replaceAll("\\", "%5C");
 }
 

--- a/packages/shared/src/fileMentions.test.ts
+++ b/packages/shared/src/fileMentions.test.ts
@@ -1,0 +1,69 @@
+import { EnvironmentId, type ExplicitFileMention } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { serializeComposerFileLink } from "./composerTrigger.ts";
+import {
+  reconcileFileMentionsAfterEdit,
+  trimTextWithFileMentions,
+  validateExplicitFileMentions,
+} from "./fileMentions.ts";
+
+const environmentId = EnvironmentId.make("environment-1");
+
+function mention(path: string, start = 0): ExplicitFileMention {
+  return {
+    version: 1,
+    environmentId,
+    path,
+    kind: "file",
+    start,
+    end: start + serializeComposerFileLink(path).length,
+  };
+}
+
+describe("explicit file mentions", () => {
+  it("validates UTF-16 ranges, source text, ordering, and environment", () => {
+    const source = serializeComposerFileLink("/tmp/💾.txt");
+    const valid = mention("/tmp/💾.txt", 2);
+    const text = `😀${source}`;
+
+    expect(validateExplicitFileMentions(text, [valid], environmentId)).toBeNull();
+    expect(validateExplicitFileMentions(text, [{ ...valid, start: 1 }], environmentId)).toBe(
+      "source",
+    );
+    expect(
+      validateExplicitFileMentions(
+        text,
+        [valid, { ...valid, start: valid.end - 1 }],
+        environmentId,
+      ),
+    ).toBe("overlap");
+    expect(validateExplicitFileMentions(text, [valid], EnvironmentId.make("environment-2"))).toBe(
+      "environment",
+    );
+  });
+
+  it("shifts intact mentions and drops mentions touched by an edit", () => {
+    const source = serializeComposerFileLink("/tmp/a.txt");
+    const original = `one ${source} two`;
+    const originalMention = mention("/tmp/a.txt", 4);
+
+    expect(reconcileFileMentionsAfterEdit(original, `😀 ${original}`, [originalMention])).toEqual([
+      { ...originalMention, start: 7, end: originalMention.end + 3 },
+    ]);
+    expect(
+      reconcileFileMentionsAfterEdit(original, original.replace("a.txt", "b.txt"), [
+        originalMention,
+      ]),
+    ).toEqual([]);
+  });
+
+  it("maps mentions through trimming without losing interior ranges", () => {
+    const source = serializeComposerFileLink("/tmp/a.txt");
+    const originalMention = mention("/tmp/a.txt", 2);
+    expect(trimTextWithFileMentions(`  ${source}  `, [originalMention])).toEqual({
+      text: source,
+      fileMentions: [{ ...originalMention, start: 0, end: source.length }],
+    });
+  });
+});

--- a/packages/shared/src/fileMentions.test.ts
+++ b/packages/shared/src/fileMentions.test.ts
@@ -58,6 +58,15 @@ describe("explicit file mentions", () => {
     ).toEqual([]);
   });
 
+  it("drops provenance when repeated text makes the retained occurrence ambiguous", () => {
+    const source = serializeComposerFileLink("/tmp/a.txt");
+    const original = `${source} ${source}`;
+
+    expect(reconcileFileMentionsAfterEdit(original, source, [mention("/tmp/a.txt", 0)])).toEqual(
+      [],
+    );
+  });
+
   it("maps mentions through trimming without losing interior ranges", () => {
     const source = serializeComposerFileLink("/tmp/a.txt");
     const originalMention = mention("/tmp/a.txt", 2);

--- a/packages/shared/src/fileMentions.ts
+++ b/packages/shared/src/fileMentions.ts
@@ -1,0 +1,98 @@
+import type { EnvironmentId, ExplicitFileMention } from "@t3tools/contracts";
+
+import { serializeComposerFileLink } from "./composerTrigger.ts";
+
+export type FileMentionValidationFailure = "environment" | "range" | "overlap" | "source";
+
+/** Validates explicit provenance without treating it as a security boundary. */
+export function validateExplicitFileMentions(
+  text: string,
+  mentions: ReadonlyArray<ExplicitFileMention>,
+  environmentId?: EnvironmentId,
+): FileMentionValidationFailure | null {
+  let previousEnd = 0;
+  for (const mention of mentions) {
+    if (environmentId !== undefined && mention.environmentId !== environmentId) {
+      return "environment";
+    }
+    if (mention.start < 0 || mention.end <= mention.start || mention.end > text.length) {
+      return "range";
+    }
+    if (mention.start < previousEnd) return "overlap";
+    if (text.slice(mention.start, mention.end) !== serializeComposerFileLink(mention.path)) {
+      return "source";
+    }
+    previousEnd = mention.end;
+  }
+  return null;
+}
+
+export function replaceTextRangeInFileMentions(
+  mentions: ReadonlyArray<ExplicitFileMention>,
+  start: number,
+  end: number,
+  replacementLength: number,
+): ExplicitFileMention[] {
+  const delta = replacementLength - (end - start);
+  const next: ExplicitFileMention[] = [];
+  for (const mention of mentions) {
+    if (mention.end <= start) {
+      next.push(mention);
+    } else if (mention.start >= end) {
+      next.push({ ...mention, start: mention.start + delta, end: mention.end + delta });
+    }
+  }
+  return next;
+}
+
+/** Conservatively maps provenance through a single contiguous text edit. */
+export function reconcileFileMentionsAfterEdit(
+  previousText: string,
+  nextText: string,
+  mentions: ReadonlyArray<ExplicitFileMention>,
+): ExplicitFileMention[] {
+  if (previousText === nextText) return [...mentions];
+  let start = 0;
+  const prefixLimit = Math.min(previousText.length, nextText.length);
+  while (start < prefixLimit && previousText[start] === nextText[start]) start += 1;
+
+  let previousEnd = previousText.length;
+  let nextEnd = nextText.length;
+  while (
+    previousEnd > start &&
+    nextEnd > start &&
+    previousText[previousEnd - 1] === nextText[nextEnd - 1]
+  ) {
+    previousEnd -= 1;
+    nextEnd -= 1;
+  }
+  return replaceTextRangeInFileMentions(mentions, start, previousEnd, nextEnd - start);
+}
+
+export function shiftFileMentions(
+  mentions: ReadonlyArray<ExplicitFileMention>,
+  offset: number,
+): ExplicitFileMention[] {
+  if (offset === 0) return [...mentions];
+  return mentions.map((mention) => ({
+    ...mention,
+    start: mention.start + offset,
+    end: mention.end + offset,
+  }));
+}
+
+export function trimTextWithFileMentions(
+  text: string,
+  mentions: ReadonlyArray<ExplicitFileMention>,
+): { readonly text: string; readonly fileMentions: ExplicitFileMention[] } {
+  const trimmed = text.trim();
+  const leadingTrim = text.length - text.trimStart().length;
+  return {
+    text: trimmed,
+    fileMentions: mentions.flatMap((mention) => {
+      const start = mention.start - leadingTrim;
+      const end = mention.end - leadingTrim;
+      return start >= 0 && end <= trimmed.length ? [{ ...mention, start, end }] : [];
+    }),
+  };
+}

--- a/packages/shared/src/fileMentions.ts
+++ b/packages/shared/src/fileMentions.ts
@@ -56,6 +56,15 @@ export function reconcileFileMentionsAfterEdit(
   const prefixLimit = Math.min(previousText.length, nextText.length);
   while (start < prefixLimit && previousText[start] === nextText[start]) start += 1;
 
+  let commonSuffixLength = 0;
+  while (
+    commonSuffixLength < prefixLimit &&
+    previousText[previousText.length - commonSuffixLength - 1] ===
+      nextText[nextText.length - commonSuffixLength - 1]
+  ) {
+    commonSuffixLength += 1;
+  }
+
   let previousEnd = previousText.length;
   let nextEnd = nextText.length;
   while (
@@ -66,7 +75,15 @@ export function reconcileFileMentionsAfterEdit(
     previousEnd -= 1;
     nextEnd -= 1;
   }
-  return replaceTextRangeInFileMentions(mentions, start, previousEnd, nextEnd - start);
+  const reconciled = replaceTextRangeInFileMentions(mentions, start, previousEnd, nextEnd - start);
+  const ambiguousStart = nextText.length - commonSuffixLength;
+  const ambiguousEnd = start;
+  if (ambiguousStart >= ambiguousEnd) {
+    return reconciled;
+  }
+  return reconciled.filter(
+    (mention) => mention.end <= ambiguousStart || mention.start >= ambiguousEnd,
+  );
 }
 
 export function shiftFileMentions(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,9 +594,6 @@ importers:
       lucide-react:
         specifier: ^0.564.0
         version: 0.564.0(react@19.2.6)
-      micromark-util-decode-string:
-        specifier: ^2.0.1
-        version: 2.0.1
       react:
         specifier: 19.2.6
         version: 19.2.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,6 +594,9 @@ importers:
       lucide-react:
         specifier: ^0.564.0
         version: 0.564.0(react@19.2.6)
+      micromark-util-decode-string:
+        specifier: ^2.0.1
+        version: 2.0.1
       react:
         specifier: 19.2.6
         version: 19.2.6


### PR DESCRIPTION
## What Changed

The composer's `@` picker can now complete filesystem paths. Type `/`, `~/`, `./` or `../` and it browses the thread's environment a segment at a time, so you can tag any file or directory. Plain `@foo` queries still search the workspace exactly as before.

Tags pointing outside the workspace now render as chips instead of plain links.

`filesystem.browse` gains optional `kinds` and `limit` inputs and returns a `kind` per entry. Leave `kinds` off and it returns directories only, so the project picker is untouched.

## Why

The picker only knew about workspace files, so there was no way to tag anything outside the project.

Completing one explicit segment keeps it small: no new index, no fuzzy search outside the workspace, no change to plain `@` queries. Browsing runs over the environment RPC, so on a remote thread `~` means the remote home, matching where the agent runs.

Bare paths keep the existing heuristics, so routes like `/chat/settings` still never become chips.

Unchanged: the text sent to the agent, and `projects.readFile` containment. One fix along the way — workspace containment now normalises `..`, so `/repo/../outside/page.html` no longer counts as inside `/repo`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] ~~I included before/after screenshots for any UI changes~~
- [x] ~~I included a video for animation/interaction changes~~


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches message dispatch validation, a DB migration, and draft hydration logic; client/server must stay aligned on mention caps and offset semantics.
> 
> **Overview**
> **Explicit file mentions** flow from the composer through orchestration into SQLite (`file_mentions_json`, migration 041) and back out on thread snapshots. Each mention records path, file/directory kind, `environmentId`, and UTF-16 start/end offsets aligned with the serialized `[label](path)` text in the message.
> 
> The **`@` picker** can complete absolute, `~/`, `./`, and `../` paths via extended **`filesystem.browse`** (optional `kinds`/`limit`, per-entry `kind`, symlink resolution, directories-first ordering with a shared limit). Plain `@foo` still uses workspace search. **`@"..."`** supports paths with spaces. Picks and file-tree drags attach provenance (including a JSON drag payload); edits reconcile or shift offsets through terminal-context materialization and provider effort prefixes on send.
> 
> **Dispatch** validates mentions against message text and the active environment (`invalid_command` on failure). **Chat markdown** turns links into file chips only when an explicit range matches (or legacy href discovery when `fileMentions` is absent), with non-openable paths shown as inert chips. Composer drafts persist and migrate mentions with stricter legacy thread/environment resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e5241828d68944feb935d02146743aadfa805b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file tag support for any path in the composer with explicit mention tracking
> - Introduces `ExplicitFileMention` schema (path, kind, UTF-16 start/end offsets, environmentId) carried through the full stack: composer → send → `thread.message-sent` event → DB column `file_mentions_json` (migration 041) → read model → message rendering.
> - Adds `@"..."` quoted path trigger in the composer to allow tagging files with spaces or special characters, with backslash-escape handling for embedded quotes.
> - File-tree drag-and-drop now attaches structured provenance (`COMPOSER_MENTION_PROVENANCE_DRAG_TYPE`) so dropped paths register as typed file mentions with accurate offsets.
> - `ChatMarkdown` resolves file link chips using AST node positions and explicit mention ranges; chips without a resolvable `openTargetPath` render as non-clickable `<span>` elements instead of anchors.
> - `useComposerFilesystemBrowse` hook debounces filesystem browse queries (limit 80) as an alternative to workspace search when a path trigger is detected.
> - `FilesystemBrowseInput` gains optional `kinds` and `limit` fields; `browse` returns entries annotated with `kind`, sorted directories-first with per-kind limit distribution.
> - Mention offsets are reconciled through text edits, terminal context placeholder expansion, and trimming via utilities in [`fileMentions.ts`](https://github.com/pingdotgg/t3code/pull/5446/files#diff-c7120e73d175d3fe42784a3b7eb82bd4d573055cac1abdd05fcf26091a14b15c).
> - Risk: file mention validation runs synchronously on every `thread.turn.start` dispatch; invalid or environment-mismatched mentions are rejected with an `OrchestrationDispatchCommandError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39e5241.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->