### PR TITLE
fix(cli): repair bundled resource monitor permissions

### DIFF
--- a/apps/server/src/resourceTelemetry/ResourceMonitorBinary.test.ts
+++ b/apps/server/src/resourceTelemetry/ResourceMonitorBinary.test.ts
@@ -7,11 +7,38 @@ import {
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 
 import { ServerConfig } from "../config.ts";
 import * as ResourceMonitorBinary from "./ResourceMonitorBinary.ts";
 
 describe("ResourceMonitorBinary", () => {
+  it.effect("repairs a non-executable bundled monitor", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-resource-monitor-binary-",
+      });
+      const binaryPath = `${baseDir}/t3-resource-monitor`;
+      yield* fileSystem.writeFileString(binaryPath, "binary");
+      yield* fileSystem.chmod(binaryPath, 0o644);
+
+      const service = yield* ResourceMonitorBinary.make().pipe(
+        Effect.provide(ServerConfig.layerTest(process.cwd(), baseDir)),
+        Effect.provideService(HostProcessPlatform, "linux"),
+        Effect.provideService(HostProcessArchitecture, "x64"),
+        Effect.provideService(ResourceMonitorBinary.ResourceMonitorHostLinuxLibc, "gnu"),
+        Effect.provideService(HostProcessEnvironment, {}),
+        Effect.provideService(Path.Path, { ...path, resolve: () => binaryPath }),
+      );
+
+      assert.equal(yield* service.resolve, binaryPath);
+      const stat = yield* fileSystem.stat(binaryPath);
+      assert.notEqual(stat.mode & 0o111, 0);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("resolves an executable override", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/resourceTelemetry/ResourceMonitorBinary.ts
+++ b/apps/server/src/resourceTelemetry/ResourceMonitorBinary.ts
@@ -193,30 +193,41 @@ export const make = Effect.fn("resourceTelemetry.resourceMonitorBinary.make")(fu
     });
   }
 
-  const candidates = [...overrideCandidates, ...bundledCandidates];
+  const candidates = [
+    ...overrideCandidates.map((path) => ({ path, bundled: false })),
+    ...bundledCandidates.map((path) => ({ path, bundled: true })),
+  ];
 
   const resolve: ResourceMonitorBinary["Service"]["resolve"] = Effect.gen(function* () {
     for (const candidate of candidates) {
-      const exists = yield* fileSystem.exists(candidate).pipe(Effect.orElseSucceed(() => false));
+      const exists = yield* fileSystem
+        .exists(candidate.path)
+        .pipe(Effect.orElseSucceed(() => false));
       if (!exists) continue;
 
       if (platform !== "win32") {
-        const stat = yield* fileSystem.stat(candidate).pipe(Effect.option);
+        let stat = yield* fileSystem.stat(candidate.path).pipe(Effect.option);
+        if (candidate.bundled && Option.isSome(stat) && (stat.value.mode & 0o111) === 0) {
+          yield* fileSystem
+            .chmod(candidate.path, (stat.value.mode & 0o777) | 0o111)
+            .pipe(Effect.orElseSucceed(() => undefined));
+          stat = yield* fileSystem.stat(candidate.path).pipe(Effect.option);
+        }
         if (Option.isSome(stat) && (stat.value.mode & 0o111) === 0) {
           return yield* new ResourceMonitorBinaryNotExecutable({
-            path: candidate,
+            path: candidate.path,
             mode: stat.value.mode,
           });
         }
       }
 
-      return candidate;
+      return candidate.path;
     }
 
     return yield* new ResourceMonitorBinaryNotFound({
       platform,
       architecture,
-      candidates,
+      candidates: candidates.map((candidate) => candidate.path),
     });
   });
 


### PR DESCRIPTION
## Problem

On Linux, the Resource monitor diagnostics do not load. The Settings page reports **Native unavailable** and shows zeroed CPU, memory, process, and throughput values.

The native monitor binary is present at `dist/resource-monitor/linux-x64/t3-resource-monitor`, but the npm package publishes it with mode `0644` instead of an executable mode. T3 detects the bundled binary, rejects it as non-executable, and therefore never starts the native telemetry process.

This is not a CPU architecture, shared-library, or `noexec` mount problem: the affected binary is a valid Linux x64 ELF and its required libraries are available.

## Fix

- distinguish bundled monitor candidates from explicitly configured override paths
- when a bundled POSIX monitor lacks execute bits, add them before resolving it
- retain the existing error for a monitor that still cannot be made executable
- do not mutate explicit user-supplied monitor override paths

This lets the diagnostics sidecar start even when npm packaging removes executable permissions from native files.

## Regression coverage

One focused test creates a bundled monitor fixture with mode `0644`, verifies resolution repairs it, and verifies it becomes executable. Existing coverage continues to ensure a non-executable explicit override is rejected.

## Verification

- `vp test run apps/server/src/resourceTelemetry/ResourceMonitorBinary.test.ts` — 6 passed

## Reproduction

`t3@0.0.31` and the current nightly package both publish the Linux monitor without execute bits. After this change, retrying the monitor or restarting the server should populate the Resource monitor instead of showing Native unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to monitor binary resolution on POSIX; only mutates bundled paths when missing execute bits, with existing override behavior preserved.
> 
> **Overview**
> Fixes Linux **Native unavailable** diagnostics when the bundled `t3-resource-monitor` ships from npm with mode `0644` (no execute bit).
> 
> `ResourceMonitorBinary` now tags each resolve candidate as **bundled** vs **override**. On POSIX, if a **bundled** path exists but lacks execute permission, resolution **chmods** it (`mode | 0o111`) and re-stat before returning the path. **Explicit** paths (`T3CODE_RESOURCE_MONITOR_PATH` / config) are unchanged—non-executable overrides still raise `ResourceMonitorBinaryNotExecutable`.
> 
> Adds a test that simulates a `0644` bundled binary and asserts resolve succeeds and the file becomes executable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bc32807fa98206b06d6c80913a62de0fb1e19fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->