### PR TITLE
fix(mobile): stop thread messages reading through pending cards

### DIFF
--- a/apps/mobile/src/features/threads/PendingApprovalCard.tsx
+++ b/apps/mobile/src/features/threads/PendingApprovalCard.tsx
@@ -14,8 +14,10 @@ export interface PendingApprovalCardProps {
 }
 
 export function PendingApprovalCard(props: PendingApprovalCardProps) {
+  // Opaque for the same reason as PendingUserInputCard: nothing blurs the feed
+  // behind this card, so a translucent surface bleeds messages through it.
   return (
-    <View className="gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100/80 p-4 dark:border-white/6 dark:bg-neutral-900/80">
+    <View className="gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100 p-4 dark:border-white/6 dark:bg-neutral-900">
       <Text className="font-t3-bold text-2xs uppercase tracking-[1.1px] text-sky-700 dark:text-sky-300">
         Approval needed
       </Text>

--- a/apps/mobile/src/features/threads/PendingUserInputCard.tsx
+++ b/apps/mobile/src/features/threads/PendingUserInputCard.tsx
@@ -24,8 +24,11 @@ export interface PendingUserInputCardProps {
 }
 
 export function PendingUserInputCard(props: PendingUserInputCardProps) {
+  // The surface is opaque on purpose: the card floats over the thread feed
+  // with no blur behind it, so a translucent background renders the questions
+  // on top of whatever message happens to sit underneath.
   return (
-    <View className="gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100/80 p-4 dark:border-white/6 dark:bg-neutral-900/80">
+    <View className="gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100 p-4 dark:border-white/6 dark:bg-neutral-900">
       <Text className="font-t3-bold text-2xs uppercase tracking-[1.1px] text-sky-700 dark:text-sky-300">
         User input needed
       </Text>


### PR DESCRIPTION
## The problem

`PendingApprovalCard` and `PendingUserInputCard` render at `bg-neutral-100/80 dark:bg-neutral-900/80`, but they float over `ThreadFeed` inside the composer overlay with nothing blurring the feed behind them — the app's actual glass surfaces go through `GlassSurface`/`expo-glass-effect`, and these are plain `View`s. So the 0.8 alpha has no material to sample and simply lets 20% of the message underneath through the card: the thread's text reads over the questions.

It is worst on an `AskUserQuestion` carrying several questions, where the card covers most of the screen and most of the conversation shows through it. Reported from an iPhone, dark mode, opening the thread from a user-input notification.

## The fix

Drop the alpha on the two card surfaces. The colors are unchanged — `neutral-100` and `neutral-900` are what the translucent values already resolved toward — so opacity is the only property that moves. Two lines, one per card.

Not converted to `GlassSurface`: it brings its own 32px radius, border and shadow (a bigger visual change than the defect), and off iOS it falls back to a flat `--color-glass-surface` at 0.78, which is the same bleed-through. The option pills and the custom-answer input keep their alpha, since those now composite against the card rather than the feed.

## Verification

`pnpm --filter @t3tools/mobile typecheck`, `vp lint`, and `vp fmt --check` on both files are green.

**No before/after images, and I want to be straight about why:** the machine I'm on has neither Xcode nor the Android SDK, so I could not boot a simulator, and I would rather say that than pass a mockup off as a capture. The change is legible without one — the diff is `bg-neutral-100/80` → `bg-neutral-100` and `dark:bg-neutral-900/80` → `dark:bg-neutral-900` — and any thread where an agent asks a question reproduces the before state. Happy to add captures if someone with a simulator wants to run it, or to close this if you would rather keep the translucency deliberate and add a blur behind the card instead.

## Related

Independent of pingdotgg/t3code#5288, which bounds and scrolls the same card stack but does not touch its surface. No file overlap, so the two can land in either order. (I sent a patch for that PR's open bot findings to its branch as KyleKincer/t3code#1.)

Model: Claude Opus 5. Harness: T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure mobile UI styling on two thread overlay cards; no logic, API, or data-path changes.
> 
> **Overview**
> Fixes thread message text showing through **pending approval** and **user input** cards in the mobile thread composer overlay.
> 
> Those cards used **80% opacity** backgrounds (`bg-neutral-100/80`, `dark:bg-neutral-900/80`) while sitting on plain `View`s over `ThreadFeed` with no blur—so underlying messages bled through the surface. The change makes both card containers **fully opaque** with the same neutral colors and adds short comments explaining why translucency was removed.
> 
> No behavior, layout, or child control styling changes beyond the card shell background classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b5c3e85a250f037fb3c7fd6a6ba94256e49a82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread message text reading through pending cards by making backgrounds opaque
> Sets the background of [PendingApprovalCard](https://github.com/pingdotgg/t3code/pull/5450/files#diff-5649c9793e898352b2429ea37586c8f6b39fb626c3fcfc2ee11708ab6142f538) and [PendingUserInputCard](https://github.com/pingdotgg/t3code/pull/5450/files#diff-7e638162740719ba1f11003bf9376f0b089c32c5b55bedd73929281fc98ff7bf) to fully opaque in both light and dark themes. Previously, the `bg-neutral-100/80` and `dark:bg-neutral-900/80` semi-transparent backgrounds allowed thread messages behind the cards to show through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b5c3e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->