### PR TITLE
fix(web): clean up archived thread worktrees

### DIFF
--- a/apps/web/src/hooks/useThreadActions.test.ts
+++ b/apps/web/src/hooks/useThreadActions.test.ts
@@ -1,19 +1,238 @@
-import { EnvironmentId, ThreadId } from "@t3tools/contracts";
-import { describe, expect, it } from "vite-plus/test";
+import type { ScopedThreadRef } from "@t3tools/contracts";
+import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { ThreadArchiveBlockedError } from "./useThreadActions";
+import type { ThreadShell } from "../types";
+
+const testState = vi.hoisted(() => ({
+  archiveThread: vi.fn(),
+  archivedThreadDeletionContext: vi.fn(),
+  clearComposerDraftForThread: vi.fn(),
+  clearProjectDraftThreadById: vi.fn(),
+  clearTerminalUiState: vi.fn(),
+  closeTerminal: vi.fn(),
+  confirm: vi.fn(),
+  deleteThread: vi.fn(),
+  navigate: vi.fn(),
+  noopCommand: vi.fn(),
+  refreshArchivedThreads: vi.fn(),
+  refreshVcsStatus: vi.fn(),
+  removeWorktree: vi.fn(),
+  stopThreadSession: vi.fn(),
+  toast: vi.fn(),
+  unarchiveThread: vi.fn(),
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useCallback: <T>(callback: T): T => callback,
+    useMemo: <T>(factory: () => T): T => factory(),
+    useRef: <T>(value: T): { current: T } => ({ current: value }),
+  };
+});
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouter: () => ({ state: { matches: [] }, navigate: testState.navigate }),
+}));
+
+vi.mock("../components/Sidebar.logic", () => ({
+  getFallbackThreadIdAfterDelete: () => null,
+}));
+
+vi.mock("../components/ui/toast", () => ({
+  stackedThreadToast: (toast: unknown) => toast,
+  toastManager: { add: testState.toast },
+}));
+
+vi.mock("../composerDraftStore", () => ({
+  useComposerDraftStore: (select: (state: unknown) => unknown) =>
+    select({
+      clearDraftThread: testState.clearComposerDraftForThread,
+      clearProjectDraftThreadById: testState.clearProjectDraftThreadById,
+    }),
+}));
+
+vi.mock("../lib/archivedThreadsState", () => ({
+  readArchivedThreadDeletionContext: testState.archivedThreadDeletionContext,
+  refreshArchivedThreadsForEnvironment: testState.refreshArchivedThreads,
+}));
+
+vi.mock("../localApi", () => ({
+  readLocalApi: () => ({ dialogs: { confirm: testState.confirm } }),
+}));
+
+vi.mock("../state/entities", () => ({
+  readEnvironmentSupportsPinning: () => true,
+  readEnvironmentSupportsSettlement: () => true,
+  readEnvironmentSupportsSnooze: () => true,
+  readEnvironmentThreadRefs: () => [],
+  readProject: () => null,
+  readThreadShell: () => null,
+}));
+
+vi.mock("../state/terminal", () => ({
+  terminalEnvironment: { close: "closeTerminal" },
+}));
+
+vi.mock("../state/threads", () => ({
+  threadEnvironment: {
+    archive: "archiveThread",
+    delete: "deleteThread",
+    pin: "pinThread",
+    settle: "settleThread",
+    snooze: "snoozeThread",
+    unarchive: "unarchiveThread",
+    unpin: "unpinThread",
+    unsettle: "unsettleThread",
+    unsnooze: "unsnoozeThread",
+  },
+}));
+
+vi.mock("../state/use-atom-command", () => ({
+  useAtomCommand: (command: string) => {
+    switch (command) {
+      case "archiveThread":
+        return testState.archiveThread;
+      case "closeTerminal":
+        return testState.closeTerminal;
+      case "deleteThread":
+        return testState.deleteThread;
+      case "removeWorktree":
+        return testState.removeWorktree;
+      case "refreshVcsStatus":
+        return testState.refreshVcsStatus;
+      case "stopThreadSession":
+        return testState.stopThreadSession;
+      case "unarchiveThread":
+        return testState.unarchiveThread;
+      default:
+        return testState.noopCommand;
+    }
+  },
+}));
+
+vi.mock("../state/vcs", () => ({
+  vcsEnvironment: {
+    refreshStatus: "refreshVcsStatus",
+    removeWorktree: "removeWorktree",
+  },
+}));
+
+vi.mock("../terminalUiStateStore", () => ({
+  useTerminalUiStateStore: (select: (state: unknown) => unknown) =>
+    select({ clearTerminalUiState: testState.clearTerminalUiState }),
+}));
+
+vi.mock("./useHandleNewThread", () => ({
+  useNewThreadHandler: () => vi.fn(),
+}));
+
+vi.mock("./useSettings", () => ({
+  useClientSettings: (
+    select: (settings: {
+      confirmThreadDelete: boolean;
+      sidebarThreadSortOrder: "updated_at";
+    }) => unknown,
+  ) => select({ confirmThreadDelete: false, sidebarThreadSortOrder: "updated_at" }),
+}));
+
+import { ThreadArchiveBlockedError, useThreadActions } from "./useThreadActions";
+
+const environmentId = EnvironmentId.make("environment-1");
+const projectId = ProjectId.make("project-1");
+const threadId = ThreadId.make("thread-1");
+const threadRef: ScopedThreadRef = { environmentId, threadId };
+
+function makeArchivedThread(): ThreadShell {
+  return {
+    id: threadId,
+    environmentId,
+    projectId,
+    title: "Archived worktree thread",
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5.3-codex",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: "t3/archived-worktree",
+    worktreePath: "/repo/.t3/worktrees/archived-worktree",
+    latestTurn: null,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-02T00:00:00.000Z",
+    archivedAt: "2026-08-03T00:00:00.000Z",
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+  };
+}
 
 describe("ThreadArchiveBlockedError", () => {
   it("keeps the blocked thread context with the fixed message", () => {
-    const error = new ThreadArchiveBlockedError({
-      environmentId: EnvironmentId.make("environment-1"),
-      threadId: ThreadId.make("thread-1"),
-    });
+    const error = new ThreadArchiveBlockedError({ environmentId, threadId });
 
-    expect(error).toMatchObject({
-      environmentId: "environment-1",
-      threadId: "thread-1",
-    });
+    expect(error).toMatchObject({ environmentId, threadId });
     expect(error.message).toBe("Cannot archive a running thread.");
+  });
+});
+
+describe("useThreadActions", () => {
+  beforeEach(() => {
+    for (const mock of Object.values(testState)) {
+      mock.mockReset();
+    }
+    testState.confirm.mockResolvedValue(true);
+    testState.deleteThread.mockResolvedValue(AsyncResult.success(undefined));
+    testState.refreshVcsStatus.mockResolvedValue(AsyncResult.success(undefined));
+    testState.removeWorktree.mockResolvedValue(AsyncResult.success(undefined));
+  });
+
+  it("removes an orphaned worktree when deleting an archived thread", async () => {
+    const thread = makeArchivedThread();
+    testState.archivedThreadDeletionContext.mockReturnValue({
+      thread,
+      threads: [thread],
+      projectCwd: "/repo",
+    });
+    const actions = useThreadActions();
+
+    await actions.confirmAndDeleteThread(threadRef);
+
+    expect(testState.deleteThread).toHaveBeenCalledWith({
+      environmentId,
+      input: { threadId },
+    });
+    expect(testState.removeWorktree).toHaveBeenCalledWith({
+      environmentId,
+      input: {
+        cwd: "/repo",
+        path: "/repo/.t3/worktrees/archived-worktree",
+        force: true,
+      },
+    });
+  });
+
+  it("keeps an archived worktree that is still shared by another thread", async () => {
+    const thread = makeArchivedThread();
+    const sibling = { ...makeArchivedThread(), id: ThreadId.make("thread-2") };
+    testState.archivedThreadDeletionContext.mockReturnValue({
+      thread,
+      threads: [thread, sibling],
+      projectCwd: "/repo",
+    });
+    const actions = useThreadActions();
+
+    await actions.confirmAndDeleteThread(threadRef);
+
+    expect(testState.deleteThread).toHaveBeenCalledOnce();
+    expect(testState.confirm).not.toHaveBeenCalled();
+    expect(testState.removeWorktree).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -18,7 +18,10 @@ import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
 import { useNewThreadHandler } from "./useHandleNewThread";
-import { refreshArchivedThreadsForEnvironment } from "../lib/archivedThreadsState";
+import {
+  readArchivedThreadDeletionContext,
+  refreshArchivedThreadsForEnvironment,
+} from "../lib/archivedThreadsState";
 import { readLocalApi } from "../localApi";
 import {
   readEnvironmentSupportsPinning,
@@ -236,8 +239,9 @@ export function useThreadActions() {
   const deleteThread = useCallback(
     async (target: ScopedThreadRef, opts: { deletedThreadKeys?: ReadonlySet<string> } = {}) => {
       const resolved = resolveThreadTarget(target);
-      if (!resolved) {
-        // Thread not in main store (e.g. archived thread) — dispatch delete directly.
+      const archivedContext = resolved ? null : readArchivedThreadDeletionContext(target);
+      const thread = resolved?.thread ?? archivedContext?.thread;
+      if (!thread) {
         const result = await deleteThreadMutation({
           environmentId: target.environmentId,
           input: { threadId: target.threadId },
@@ -247,15 +251,19 @@ export function useThreadActions() {
         }
         return result;
       }
-      const { thread, threadRef } = resolved;
+      const threadRef = target;
       const threads = readEnvironmentThreadRefs(threadRef.environmentId).flatMap((ref) => {
         const shell = readThreadShell(ref);
         return shell === null ? [] : [shell];
       });
-      const threadProject = readProject({
-        environmentId: threadRef.environmentId,
-        projectId: thread.projectId,
-      });
+      const worktreeThreads = archivedContext ? [...threads, ...archivedContext.threads] : threads;
+      const projectCwd =
+        resolved !== null
+          ? (readProject({
+              environmentId: threadRef.environmentId,
+              projectId: thread.projectId,
+            })?.workspaceRoot ?? null)
+          : (archivedContext?.projectCwd ?? null);
       const deletedIds =
         opts.deletedThreadKeys && opts.deletedThreadKeys.size > 0
           ? new Set<ThreadId>(
@@ -265,18 +273,20 @@ export function useThreadActions() {
               }),
             )
           : undefined;
-      const survivingThreads =
+      const survivingWorktreeThreads =
         deletedIds && deletedIds.size > 0
-          ? threads.filter((entry) => entry.id === threadRef.threadId || !deletedIds.has(entry.id))
-          : threads;
+          ? worktreeThreads.filter(
+              (entry) => entry.id === threadRef.threadId || !deletedIds.has(entry.id),
+            )
+          : worktreeThreads;
       const orphanedWorktreePath = getOrphanedWorktreePathForThread(
-        survivingThreads,
+        survivingWorktreeThreads,
         threadRef.threadId,
       );
       const displayWorktreePath = orphanedWorktreePath
         ? formatWorktreePathForDisplay(orphanedWorktreePath)
         : null;
-      const canDeleteWorktree = orphanedWorktreePath !== null && threadProject !== null;
+      const canDeleteWorktree = orphanedWorktreePath !== null && projectCwd !== null;
       const localApi = readLocalApi();
       let shouldDeleteWorktree = false;
       if (canDeleteWorktree && localApi) {
@@ -370,14 +380,14 @@ export function useThreadActions() {
         }
       }
 
-      if (!shouldDeleteWorktree || !orphanedWorktreePath || !threadProject) {
+      if (!shouldDeleteWorktree || !orphanedWorktreePath || !projectCwd) {
         return deleteResult;
       }
 
       const removeResult = await removeWorktree({
         environmentId: threadRef.environmentId,
         input: {
-          cwd: threadProject.workspaceRoot,
+          cwd: projectCwd,
           path: orphanedWorktreePath,
           force: true,
         },
@@ -386,7 +396,7 @@ export function useThreadActions() {
         removeResult._tag === "Success"
           ? await refreshVcsStatus({
               environmentId: threadRef.environmentId,
-              input: { cwd: threadProject.workspaceRoot },
+              input: { cwd: projectCwd },
             })
           : null;
       const cleanupFailure =
@@ -400,7 +410,7 @@ export function useThreadActions() {
         const message = error instanceof Error ? error.message : "Unknown error removing worktree.";
         console.error("Failed to remove orphaned worktree after thread deletion", {
           threadId: threadRef.threadId,
-          projectCwd: threadProject.workspaceRoot,
+          projectCwd,
           worktreePath: orphanedWorktreePath,
           error,
         });
@@ -591,9 +601,10 @@ export function useThreadActions() {
     async (target: ScopedThreadRef) => {
       const localApi = readLocalApi();
       const resolved = resolveThreadTarget(target);
+      const archivedContext = resolved ? null : readArchivedThreadDeletionContext(target);
 
       if (confirmThreadDelete && localApi) {
-        const title = resolved?.thread.title ?? "this thread";
+        const title = resolved?.thread.title ?? archivedContext?.thread.title ?? "this thread";
         const confirmationResult = await settlePromise(() =>
           localApi.dialogs.confirm(
             [

--- a/apps/web/src/lib/archivedThreadsState.test.ts
+++ b/apps/web/src/lib/archivedThreadsState.test.ts
@@ -1,0 +1,84 @@
+import {
+  EnvironmentId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationShellSnapshot,
+  type OrchestrationThreadShell,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveArchivedThreadDeletionContext } from "./archivedThreadsState";
+
+const environmentId = EnvironmentId.make("environment-1");
+const projectId = ProjectId.make("project-1");
+
+function makeThread(id: string, worktreePath: string): OrchestrationThreadShell {
+  return {
+    id: ThreadId.make(id),
+    projectId,
+    title: id,
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5.3-codex",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: `t3/${id}`,
+    worktreePath,
+    latestTurn: null,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-02T00:00:00.000Z",
+    archivedAt: "2026-08-03T00:00:00.000Z",
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+  };
+}
+
+const target = makeThread("target", "/repo/.t3/worktrees/shared");
+const sibling = makeThread("sibling", "/repo/.t3/worktrees/shared");
+const snapshot = {
+  snapshotSequence: 1,
+  projects: [
+    {
+      id: projectId,
+      title: "Project",
+      workspaceRoot: "/repo",
+      defaultModelSelection: null,
+      scripts: [],
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-02T00:00:00.000Z",
+    },
+  ],
+  threads: [target, sibling],
+  updatedAt: "2026-08-03T00:00:00.000Z",
+} satisfies OrchestrationShellSnapshot;
+
+describe("resolveArchivedThreadDeletionContext", () => {
+  it("restores the archived thread, project cwd, and worktree-sharing siblings", () => {
+    const context = resolveArchivedThreadDeletionContext(snapshot, {
+      environmentId,
+      threadId: target.id,
+    });
+
+    expect(context).toMatchObject({
+      thread: { id: target.id, environmentId },
+      projectCwd: "/repo",
+    });
+    expect(context?.threads.map((thread) => thread.id)).toEqual([target.id, sibling.id]);
+  });
+
+  it("returns null when the archived snapshot does not contain the thread", () => {
+    expect(
+      resolveArchivedThreadDeletionContext(snapshot, {
+        environmentId,
+        threadId: ThreadId.make("missing"),
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/archivedThreadsState.ts
+++ b/apps/web/src/lib/archivedThreadsState.ts
@@ -4,7 +4,17 @@ import {
   createArchivedThreadSnapshotsAtomFamily,
   makeArchivedThreadsEnvironmentKey,
 } from "@t3tools/client-runtime/state/threads";
-import type { EnvironmentId } from "@t3tools/contracts";
+import {
+  scopeThreadShell,
+  type EnvironmentThreadShell,
+} from "@t3tools/client-runtime/state/models";
+import type {
+  EnvironmentId,
+  OrchestrationShellSnapshot,
+  ScopedThreadRef,
+} from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useMemo } from "react";
 
 import { orchestrationEnvironment } from "../state/orchestration";
@@ -24,6 +34,38 @@ const archivedSnapshotsAtom = createArchivedThreadSnapshotsAtomFamily({
 
 export function refreshArchivedThreadsForEnvironment(environmentId: EnvironmentId): void {
   appAtomRegistry.refresh(archivedSnapshotAtom(environmentId));
+}
+
+export interface ArchivedThreadDeletionContext {
+  readonly thread: EnvironmentThreadShell;
+  readonly threads: ReadonlyArray<EnvironmentThreadShell>;
+  readonly projectCwd: string | null;
+}
+
+export function resolveArchivedThreadDeletionContext(
+  snapshot: OrchestrationShellSnapshot,
+  ref: ScopedThreadRef,
+): ArchivedThreadDeletionContext | null {
+  const thread = snapshot.threads.find((candidate) => candidate.id === ref.threadId);
+  if (!thread) {
+    return null;
+  }
+
+  return {
+    thread: scopeThreadShell(ref.environmentId, thread),
+    threads: snapshot.threads.map((candidate) => scopeThreadShell(ref.environmentId, candidate)),
+    projectCwd:
+      snapshot.projects.find((candidate) => candidate.id === thread.projectId)?.workspaceRoot ??
+      null,
+  };
+}
+
+export function readArchivedThreadDeletionContext(
+  ref: ScopedThreadRef,
+): ArchivedThreadDeletionContext | null {
+  const result = appAtomRegistry.get(archivedSnapshotAtom(ref.environmentId));
+  const snapshot = Option.getOrNull(AsyncResult.value(result));
+  return snapshot ? resolveArchivedThreadDeletionContext(snapshot, ref) : null;
 }
 
 export function useArchivedThreadSnapshots(environmentIds: ReadonlyArray<EnvironmentId>): {


### PR DESCRIPTION
## Problem

Deleting an archived thread bypassed the archived snapshot context and dispatched the delete directly. As a result, orphaned worktree cleanup never ran, so registered worktrees could continue reserving Kiwi worktree slots and ports.

## Fix

- reconstruct deletion context from the cached archived-thread snapshot
- apply the same orphaned/shared worktree cleanup path used for active threads
- keep worktrees that are still referenced by another thread
- use the archived thread title in the confirmation prompt

## Impact

Deleting an archived worktree thread can now remove its orphaned Git worktree when confirmed. Once that worktree disappears, Kiwi can reclaim the corresponding slot and ports.

## Validation

- `vp test run apps/web/src/hooks/useThreadActions.test.ts apps/web/src/lib/archivedThreadsState.test.ts apps/web/src/worktreeCleanup.test.ts` — 14 tests passed
- `vp run --filter @t3tools/web typecheck`
- commit formatting hook and `git diff --check`
- browser E2E: created a worktree thread, archived it, deleted it with worktree cleanup confirmed, then verified both the directory and Git worktree registration were gone

Model: GPT-5.6
Harness: Codex in T3 Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clean up orphaned worktrees when deleting archived threads
> - When deleting a thread that exists only in the archived snapshot (not the live store), `deleteThread` now checks for an orphaned worktree and removes it, then refreshes VCS status using the archived project's `cwd` and sibling thread list.
> - Introduces `resolveArchivedThreadDeletionContext` and `readArchivedThreadDeletionContext` in [`archivedThreadsState.ts`](https://github.com/pingdotgg/t3code/pull/5464/files#diff-5d17e8a5507587ce4a9a6a4e6420d8c091134a8615a8fcb23acee13b593f13b1) to derive deletion context (thread, siblings, project cwd) from an archived snapshot without requiring a live thread.
> - The delete confirmation dialog for archived-only threads now shows the thread's title instead of a generic label.
> - Adds tests in [`useThreadActions.test.ts`](https://github.com/pingdotgg/t3code/pull/5464/files#diff-159674f7ca6cca2949e2d5abe0370a29c490aef26370bd99fc3599e7f4efe421) covering orphan removal and the shared-worktree no-op case.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7334267. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->