### PR TITLE
ci: label-gated hosted-web preview deploys

### DIFF
--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -1,0 +1,132 @@
+name: Web Preview
+
+# Label a PR `preview:web` to get a hosted-web preview deployment on Vercel for
+# that push and every subsequent push. The deployment is a plain (non-prod,
+# non-aliased) deploy into the existing hosted-web Vercel project, so the
+# latest/nightly channel aliases are never touched.
+#
+# The build intentionally omits the T3 Connect cloud config (Clerk keys, relay
+# URL): previews boot as the hosted-static app with manual pairing only. Pair a
+# server into a preview with `t3 pair --tailscale` (or any reachable HTTPS
+# backend) and open the pairing URL against the preview origin.
+#
+# The preview must be opened at the exact deployment URL from the PR comment.
+# Vite bakes that URL in as the hosted origin (via VERCEL_URL), and
+# `isHostedStaticApp` matches on origin, so branch-alias URLs will not
+# self-identify as the hosted app.
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: web-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy web preview
+    # Same-repo PRs only: fork PRs do not receive the Vercel secrets, and this
+    # workflow should skip rather than fail for them. On `labeled` events, only
+    # the preview label itself triggers a deploy.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'preview:web') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview:web')
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 10
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TEAM_SLUG: ${{ vars.VERCEL_TEAM_SLUG }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          sparse-checkout: |
+            /*
+            !/.repos/
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: |
+            args:
+              - --filter=@t3tools/scripts...
+              - --filter=@t3tools/web...
+
+      - id: deploy
+        name: Deploy preview
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${VERCEL_TOKEN:-}" || -z "${VERCEL_ORG_ID:-}" || -z "${VERCEL_PROJECT_ID:-}" ]]; then
+            echo "Missing one or more required Vercel secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID." >&2
+            exit 1
+          fi
+
+          vercel_scope="${VERCEL_TEAM_SLUG:-$VERCEL_ORG_ID}"
+
+          deployment_url="$(
+            vp dlx vercel@53.1.1 deploy \
+              --archive=tgz \
+              --yes \
+              --token "$VERCEL_TOKEN" \
+              --scope "$vercel_scope"
+          )"
+
+          echo "Deployed $deployment_url"
+          echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment deployment URL
+        uses: actions/github-script@v8
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const marker = "<!-- web-preview-deploy -->";
+            const body = [
+              marker,
+              "### Web preview",
+              "",
+              `${process.env.DEPLOYMENT_URL} (for ${process.env.HEAD_SHA.slice(0, 7)})`,
+              "",
+              "Open this exact URL — the hosted-app origin is baked in at build time.",
+              "Pair a server into it with `t3 pair --tailscale`, or paste a host + pairing",
+              "code under Settings → Connections.",
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }


### PR DESCRIPTION
Testing client-only web changes today means running the whole stack locally or waiting for a release. Anything visible on app.t3.codes had no per-PR preview.

This adds a \`preview:web\` label that, when applied to a same-repo PR, deploys the web app to Vercel on that push and every subsequent push. The deploy is a plain non-prod, non-aliased deployment into the existing hosted-web project, so the \`latest\`/\`nightly\` channel aliases are never touched. A sticky PR comment carries the deployment URL.

How it fits the existing architecture:

- The hosted app is already a pure static SPA with no backend proxy. \`apps/web/vite.config.ts\` already derives \`VITE_HOSTED_APP_URL\` from \`VERCEL_URL\` on non-production deploys, so a preview self-identifies as the hosted-static app at its own unique URL with zero build-config changes.
- Previews omit the T3 Connect cloud config (Clerk/relay), so they boot into manual pairing. The intended flow: spin up a server, run \`t3 pair --tailscale\`, open the pairing URL against the preview origin (or paste host + code in Settings → Connections). Packaged servers already send wildcard CORS, and HTTPS/WSS over Tailscale Serve satisfies mixed-content rules.
- Label-gating keeps Vercel build volume sane and restricts secret-bearing deploys to deliberate opt-ins; fork PRs are skipped entirely.

Caveats:

- The preview must be opened at the exact deployment URL from the comment (the hosted origin is baked in at build time).
- If the Vercel project has Deployment Protection enabled for previews, the URLs will be gated behind Vercel SSO — that's a project-settings toggle, not something this workflow can change.

The \`preview:web\` label has been created on the repo.

---

Written by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only, opt-in via label; deploys are non-prod and unaliased, reusing existing Vercel secrets with no application code changes.
> 
> **Overview**
> Adds a **`preview:web`** GitHub Actions workflow so same-repo PRs can get a per-push hosted-web deployment on Vercel without touching **`latest`**/**`nightly`** aliases.
> 
> The job runs only when the label is present (including on later pushes), skips fork PRs, checks out the PR head, installs **`@t3tools/web`**, and runs a plain **`vercel deploy`** (no **`--prod`**, no channel **`build-env`** for Clerk/relay). It upserts a sticky PR comment with the exact deployment URL and pairing instructions. Concurrency is per-PR with cancel-in-progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 672e454d447fe51cda7ddb0231a2e4cd4ddef252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add label-gated Vercel preview deploys for web PRs
> Adds a new [web-preview.yml](https://github.com/pingdotgg/t3code/pull/5465/files#diff-2ea47d95fc0bb75f1e5fc32c792c3684d618ab56b6948c32800d0ea80984bd46) GitHub Actions workflow that deploys a Vercel preview when a same-repo PR has the `preview:web` label. After deployment, it posts or updates a PR comment with the deployment URL for the current head SHA. Concurrency is scoped per-PR to cancel stale runs, and permissions are limited to contents read and pull-requests write.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 672e454.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->