### PR TITLE
fix: smooth remote server updates

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -31,7 +31,7 @@ it("keeps systemd pinned to the stable launcher rather than a versioned server",
   });
 
   expect(unit).toContain("ExecStart=/usr/bin/node /home/theo/.t3/runtime/service-launcher.mjs");
-  expect(unit).toContain("KillMode=control-group");
+  expect(unit).toContain("KillMode=mixed");
   expect(unit).not.toContain("versions/1.2.3");
 });
 

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -64,7 +64,9 @@ export function renderBootServiceUnit(plan: BootServicePlan): string {
     `Environment=T3CODE_HOME=${quoteSystemdValue(plan.baseDir)}`,
     `Environment=${BOOT_SERVICE_UNIT_ENV}=${BOOT_SERVICE_UNIT_FILE}`,
     `ExecStart=${quoteSystemdValue(plan.nodePath)} ${quoteSystemdValue(plan.launcherPath)}`,
-    "KillMode=control-group",
+    // Let the launcher mark an explicit stop before it signals the server.
+    // systemd still SIGKILLs the whole cgroup if graceful shutdown times out.
+    "KillMode=mixed",
     "Restart=always",
     "RestartSec=5",
     `StandardOutput=append:${escapeSystemdSpecifiers(plan.logPath)}`,

--- a/apps/server/src/cloud/http.test.ts
+++ b/apps/server/src/cloud/http.test.ts
@@ -1,6 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
@@ -22,6 +23,7 @@ import { writeServiceState } from "../serviceLauncher.ts";
 import {
   SERVICE_LAUNCHER_PROTOCOL,
   SERVICE_STATE_FILE,
+  SERVICE_STOP_MARKER_FILE,
   type ServiceUpdateRecord,
 } from "./serviceProtocol.ts";
 import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
@@ -448,6 +450,35 @@ describe("releaseManagedTunnelOnShutdown", () => {
       expect(applyConfigCalls).toEqual([]);
       expect(requests).toEqual([]);
       expect(values.has(CLOUD_ENDPOINT_RUNTIME_CONFIG)).toBe(true);
+    }).pipe(provideReleaseHarness({ store, applyConfigCalls, requests }));
+  });
+
+  it.effect("still releases a pending update when the launcher is stopping", () => {
+    // `t3 service uninstall` or `systemctl stop` during the pending window:
+    // the launcher writes its stop marker before signalling the child, so no
+    // replacement server is coming and the tunnel must not be kept.
+    const { store, values } = makeMemorySecretStore(managedLinkSecrets);
+    const applyConfigCalls: Array<unknown> = [];
+    const requests: Array<HttpClientRequest.HttpClientRequest> = [];
+
+    return Effect.gen(function* () {
+      yield* writeLauncherState({
+        id: "update-1",
+        fromVersion: "0.0.30",
+        targetVersion: "0.0.31",
+        dbPath: "/tmp/state.sqlite",
+        status: "pending",
+      });
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const config = yield* ServerConfigModule.ServerConfig;
+      yield* fs.writeFileString(path.join(config.baseDir, "runtime", SERVICE_STOP_MARKER_FILE), "");
+
+      const released = yield* releaseManagedTunnelOnShutdown();
+
+      expect(released).toBe(true);
+      expect(requests).toHaveLength(1);
+      expect(values.has(CLOUD_ENDPOINT_RUNTIME_CONFIG)).toBe(false);
     }).pipe(provideReleaseHarness({ store, applyConfigCalls, requests }));
   });
 

--- a/apps/server/src/cloud/http.test.ts
+++ b/apps/server/src/cloud/http.test.ts
@@ -1,7 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
@@ -18,6 +18,12 @@ import { RelayClientTracer } from "@t3tools/shared/relayTracing";
 import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import * as ServerConfigModule from "../config.ts";
+import { writeServiceState } from "../serviceLauncher.ts";
+import {
+  SERVICE_LAUNCHER_PROTOCOL,
+  SERVICE_STATE_FILE,
+  type ServiceUpdateRecord,
+} from "./serviceProtocol.ts";
 import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
 import { CLOUD_CLI_DESIRED_LINK_SECRET } from "./CliState.ts";
 import * as CliTokenManager from "./CliTokenManager.ts";
@@ -259,18 +265,20 @@ describe("releaseManagedTunnelOnShutdown", () => {
     readonly respond?: () => Response;
   }
 
-  // Writes the launcher's durable state file into this test's baseDir; the
-  // release reads it to detect an in-flight update handoff.
-  const writeServiceState = (update: Record<string, unknown>) =>
+  // Writes the launcher's durable state file into this test's baseDir with
+  // the launcher's own writer; the release reads it to detect an in-flight
+  // update handoff.
+  const writeLauncherState = (update: ServiceUpdateRecord) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const config = yield* ServerConfigModule.ServerConfig;
-      const statePath = path.join(config.baseDir, "runtime", "service-state.json");
-      yield* fs.makeDirectory(path.dirname(statePath), { recursive: true });
-      yield* fs.writeFileString(
-        statePath,
-        JSON.stringify({ version: 1, activeVersion: "0.0.30", update }),
+      const statePath = path.join(config.baseDir, "runtime", SERVICE_STATE_FILE);
+      yield* Effect.promise(() =>
+        writeServiceState(statePath, {
+          protocol: SERVICE_LAUNCHER_PROTOCOL,
+          activeVersion: "0.0.30",
+          update,
+        }),
       );
     });
 
@@ -326,8 +334,11 @@ describe("releaseManagedTunnelOnShutdown", () => {
         ),
         // The release consults the launcher state file under the configured
         // baseDir, so every harness run gets a scoped temp baseDir.
-        Effect.provide(ServerConfigModule.layerTest("/", { prefix: "t3-http-release-test-" })),
-        Effect.provide(NodeServices.layer),
+        Effect.provide(
+          ServerConfigModule.layerTest("/", { prefix: "t3-http-release-test-" }).pipe(
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
         Effect.scoped,
       );
 
@@ -419,7 +430,7 @@ describe("releaseManagedTunnelOnShutdown", () => {
     const requests: Array<HttpClientRequest.HttpClientRequest> = [];
 
     return Effect.gen(function* () {
-      yield* writeServiceState({
+      yield* writeLauncherState({
         id: "update-1",
         fromVersion: "0.0.30",
         targetVersion: "0.0.31",
@@ -446,7 +457,7 @@ describe("releaseManagedTunnelOnShutdown", () => {
     const requests: Array<HttpClientRequest.HttpClientRequest> = [];
 
     return Effect.gen(function* () {
-      yield* writeServiceState({
+      yield* writeLauncherState({
         id: "update-1",
         fromVersion: "0.0.30",
         targetVersion: "0.0.31",

--- a/apps/server/src/cloud/http.test.ts
+++ b/apps/server/src/cloud/http.test.ts
@@ -35,6 +35,7 @@ import {
   consumeCloudReplayGuards,
   isSupportedLinkProviderKind,
   linkProofScopes,
+  pendingServiceUpdateExists,
   reconcileDesiredCloudLink,
   releaseManagedTunnelOnShutdown,
 } from "./http.ts";
@@ -474,6 +475,7 @@ describe("releaseManagedTunnelOnShutdown", () => {
       const config = yield* ServerConfigModule.ServerConfig;
       yield* fs.writeFileString(path.join(config.baseDir, "runtime", SERVICE_STOP_MARKER_FILE), "");
 
+      expect(yield* pendingServiceUpdateExists).toBe(true);
       const released = yield* releaseManagedTunnelOnShutdown();
 
       expect(released).toBe(true);

--- a/apps/server/src/cloud/http.test.ts
+++ b/apps/server/src/cloud/http.test.ts
@@ -1,7 +1,9 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
 import * as Tracer from "effect/Tracer";
 import {
@@ -15,6 +17,7 @@ import { EnvironmentId } from "@t3tools/contracts";
 import { RelayClientTracer } from "@t3tools/shared/relayTracing";
 import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import * as ServerConfigModule from "../config.ts";
 import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
 import { CLOUD_CLI_DESIRED_LINK_SECRET } from "./CliState.ts";
 import * as CliTokenManager from "./CliTokenManager.ts";
@@ -256,6 +259,21 @@ describe("releaseManagedTunnelOnShutdown", () => {
     readonly respond?: () => Response;
   }
 
+  // Writes the launcher's durable state file into this test's baseDir; the
+  // release reads it to detect an in-flight update handoff.
+  const writeServiceState = (update: Record<string, unknown>) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const config = yield* ServerConfigModule.ServerConfig;
+      const statePath = path.join(config.baseDir, "runtime", "service-state.json");
+      yield* fs.makeDirectory(path.dirname(statePath), { recursive: true });
+      yield* fs.writeFileString(
+        statePath,
+        JSON.stringify({ version: 1, activeVersion: "0.0.30", update }),
+      );
+    });
+
   const provideReleaseHarness =
     (harness: ReleaseHarness) =>
     <A, E, R>(effect: Effect.Effect<A, E, R>) =>
@@ -306,6 +324,11 @@ describe("releaseManagedTunnelOnShutdown", () => {
             }),
           ),
         ),
+        // The release consults the launcher state file under the configured
+        // baseDir, so every harness run gets a scoped temp baseDir.
+        Effect.provide(ServerConfigModule.layerTest("/", { prefix: "t3-http-release-test-" })),
+        Effect.provide(NodeServices.layer),
+        Effect.scoped,
       );
 
   // The persisted state of a CLI-managed link whose tunnel is releasable.
@@ -387,6 +410,54 @@ describe("releaseManagedTunnelOnShutdown", () => {
       expect(applyConfigCalls).toEqual([]);
       expect(requests).toEqual([]);
       expect(values.has(CLOUD_ENDPOINT_RUNTIME_CONFIG)).toBe(true);
+    }).pipe(provideReleaseHarness({ store, applyConfigCalls, requests }));
+  });
+
+  it.effect("keeps the tunnel when shutdown hands off to a pending update", () => {
+    const { store, values } = makeMemorySecretStore(managedLinkSecrets);
+    const applyConfigCalls: Array<unknown> = [];
+    const requests: Array<HttpClientRequest.HttpClientRequest> = [];
+
+    return Effect.gen(function* () {
+      yield* writeServiceState({
+        id: "update-1",
+        fromVersion: "0.0.30",
+        targetVersion: "0.0.31",
+        dbPath: "/tmp/state.sqlite",
+        status: "pending",
+      });
+
+      const released = yield* releaseManagedTunnelOnShutdown();
+
+      // The launcher restarts a server immediately, so the tunnel is not
+      // orphaned; keeping it avoids the hostname route re-propagation that
+      // dominates update downtime. The stored config must survive so the
+      // next boot respawns the connector against the same tunnel.
+      expect(released).toBe(false);
+      expect(applyConfigCalls).toEqual([]);
+      expect(requests).toEqual([]);
+      expect(values.has(CLOUD_ENDPOINT_RUNTIME_CONFIG)).toBe(true);
+    }).pipe(provideReleaseHarness({ store, applyConfigCalls, requests }));
+  });
+
+  it.effect("still releases when the recorded update already settled", () => {
+    const { store, values } = makeMemorySecretStore(managedLinkSecrets);
+    const applyConfigCalls: Array<unknown> = [];
+    const requests: Array<HttpClientRequest.HttpClientRequest> = [];
+
+    return Effect.gen(function* () {
+      yield* writeServiceState({
+        id: "update-1",
+        fromVersion: "0.0.30",
+        targetVersion: "0.0.31",
+        status: "committed",
+      });
+
+      const released = yield* releaseManagedTunnelOnShutdown();
+
+      expect(released).toBe(true);
+      expect(requests).toHaveLength(1);
+      expect(values.has(CLOUD_ENDPOINT_RUNTIME_CONFIG)).toBe(false);
     }).pipe(provideReleaseHarness({ store, applyConfigCalls, requests }));
   });
 

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -61,7 +61,11 @@ import { requireEnvironmentScope } from "../auth/http.ts";
 import * as ServerConfig from "../config.ts";
 import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
 import * as ManagedEndpointRuntime from "./ManagedEndpointRuntime.ts";
-import { SERVICE_STATE_FILE, serviceStateHasPendingUpdate } from "./serviceProtocol.ts";
+import {
+  SERVICE_STATE_FILE,
+  SERVICE_STOP_MARKER_FILE,
+  serviceStateHasPendingUpdate,
+} from "./serviceProtocol.ts";
 import {
   CLOUD_ENDPOINT_RUNTIME_CONFIG,
   CLOUD_LINKED_USER_ID,
@@ -635,14 +639,27 @@ export const reconcileDesiredCloudLink = Effect.fn("environment.cloud.reconcileD
 // straight from disk: the launcher owns that file, and this runs while the
 // server is tearing down. Unreadable or unparseable state means no pending
 // update — the release then proceeds as before.
-const pendingServiceUpdateExists = Effect.gen(function* () {
+//
+// A pending update alone is not proof a replacement server is coming: an
+// explicit launcher stop (`t3 service uninstall`, `systemctl stop`) during
+// the pending window also tears this server down, with nothing starting
+// afterwards. The launcher marks that case with a stop-marker file just
+// before it signals the child, so pending + no marker is the update handoff.
+const pendingUpdateHandoffExists = Effect.gen(function* () {
   const config = yield* ServerConfig.ServerConfig;
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const runtimeDir = path.join(config.baseDir, "runtime");
   const stateText = yield* fs
-    .readFileString(path.join(config.baseDir, "runtime", SERVICE_STATE_FILE))
+    .readFileString(path.join(runtimeDir, SERVICE_STATE_FILE))
     .pipe(Effect.option);
-  return Option.isSome(stateText) && serviceStateHasPendingUpdate(stateText.value);
+  if (Option.isNone(stateText) || !serviceStateHasPendingUpdate(stateText.value)) {
+    return false;
+  }
+  const stopping = yield* fs
+    .exists(path.join(runtimeDir, SERVICE_STOP_MARKER_FILE))
+    .pipe(Effect.orElseSucceed(() => false));
+  return !stopping;
 });
 
 // Cloudflare bills per provisioned tunnel, so an environment that goes offline
@@ -676,7 +693,7 @@ export const releaseManagedTunnelOnShutdown = Effect.fn(
   // boot respawns the connector from the stored config and is reachable as
   // soon as it connects, and the reconcile confirms the still-live tunnel
   // without replacing it.
-  if (yield* pendingServiceUpdateExists) {
+  if (yield* pendingUpdateHandoffExists) {
     yield* Effect.logInfo("Keeping the managed tunnel across the update restart");
     return false;
   }

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -635,17 +635,9 @@ export const reconcileDesiredCloudLink = Effect.fn("environment.cloud.reconcileD
   },
 );
 
-// The launcher records an in-flight update in its durable state file. Read
-// straight from disk: the launcher owns that file, and this runs while the
-// server is tearing down. Unreadable or unparseable state means no pending
-// update — the release then proceeds as before.
-//
-// A pending update alone is not proof a replacement server is coming: an
-// explicit launcher stop (`t3 service uninstall`, `systemctl stop`) during
-// the pending window also tears this server down, with nothing starting
-// afterwards. The launcher marks that case with a stop-marker file just
-// before it signals the child, so pending + no marker is the update handoff.
-export const pendingUpdateHandoffExists = Effect.gen(function* () {
+// The launcher owns this durable state, so read it directly both when a trial
+// decides whether it owns pre-activation cleanup and while a server tears down.
+export const pendingServiceUpdateExists = Effect.gen(function* () {
   const config = yield* ServerConfig.ServerConfig;
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -653,9 +645,21 @@ export const pendingUpdateHandoffExists = Effect.gen(function* () {
   const stateText = yield* fs
     .readFileString(path.join(runtimeDir, SERVICE_STATE_FILE))
     .pipe(Effect.option);
-  if (Option.isNone(stateText) || !serviceStateHasPendingUpdate(stateText.value)) {
+  return Option.isSome(stateText) && serviceStateHasPendingUpdate(stateText.value);
+});
+
+// A pending update alone is not proof a replacement server is coming: an
+// explicit launcher stop (`t3 service uninstall`, `systemctl stop`) during
+// the pending window also tears this server down. The launcher marks that case
+// just before it signals the child, so pending + no marker is the handoff.
+const pendingUpdateHandoffExists = Effect.gen(function* () {
+  if (!(yield* pendingServiceUpdateExists)) {
     return false;
   }
+  const config = yield* ServerConfig.ServerConfig;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const runtimeDir = path.join(config.baseDir, "runtime");
   const stopping = yield* fs
     .exists(path.join(runtimeDir, SERVICE_STOP_MARKER_FILE))
     .pipe(Effect.orElseSucceed(() => false));

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -46,7 +46,9 @@ import * as DateTime from "effect/DateTime";
 import * as Crypto from "effect/Crypto";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as HttpEffect from "effect/unstable/http/HttpEffect";
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
@@ -56,8 +58,10 @@ import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import { requireEnvironmentScope } from "../auth/http.ts";
+import * as ServerConfig from "../config.ts";
 import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
 import * as ManagedEndpointRuntime from "./ManagedEndpointRuntime.ts";
+import { SERVICE_STATE_FILE, serviceStateHasPendingUpdate } from "./serviceProtocol.ts";
 import {
   CLOUD_ENDPOINT_RUNTIME_CONFIG,
   CLOUD_LINKED_USER_ID,
@@ -627,6 +631,20 @@ export const reconcileDesiredCloudLink = Effect.fn("environment.cloud.reconcileD
   },
 );
 
+// The launcher records an in-flight update in its durable state file. Read
+// straight from disk: the launcher owns that file, and this runs while the
+// server is tearing down. Unreadable or unparseable state means no pending
+// update — the release then proceeds as before.
+const pendingServiceUpdateExists = Effect.gen(function* () {
+  const config = yield* ServerConfig.ServerConfig;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const stateText = yield* fs
+    .readFileString(path.join(config.baseDir, "runtime", SERVICE_STATE_FILE))
+    .pipe(Effect.option);
+  return Option.isSome(stateText) && serviceStateHasPendingUpdate(stateText.value);
+});
+
 // Cloudflare bills per provisioned tunnel, so an environment that goes offline
 // must not leave its tunnel behind. Releasing deletes only the tunnel — the
 // relay keeps the link and its hostname reservation, and the next startup's
@@ -647,6 +665,19 @@ export const releaseManagedTunnelOnShutdown = Effect.fn(
   // reapplying the stored connector token — it has no boot-time re-provision
   // path — so its tunnel must survive the restart. (Unlink still deletes it.)
   if (!(yield* readCliDesiredCloudLink) || (yield* readCliDesiredLinkMode) !== "managed") {
+    return false;
+  }
+  // A shutdown that hands off to a pending remote update is not the
+  // environment going offline: the launcher immediately brings a server back
+  // (the new version, or the old one after a rollback). Deleting the tunnel
+  // here forces that server to provision a replacement UUID, and the public
+  // hostname's route to the new tunnel takes 1-2 minutes to propagate — the
+  // dominant cost of an update restart. Keep the tunnel instead: the next
+  // boot respawns the connector from the stored config and is reachable as
+  // soon as it connects, and the reconcile confirms the still-live tunnel
+  // without replacing it.
+  if (yield* pendingServiceUpdateExists) {
+    yield* Effect.logInfo("Keeping the managed tunnel across the update restart");
     return false;
   }
   const token = yield* dependencies.cliTokenManager.getExisting;

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -645,7 +645,7 @@ export const reconcileDesiredCloudLink = Effect.fn("environment.cloud.reconcileD
 // the pending window also tears this server down, with nothing starting
 // afterwards. The launcher marks that case with a stop-marker file just
 // before it signals the child, so pending + no marker is the update handoff.
-const pendingUpdateHandoffExists = Effect.gen(function* () {
+export const pendingUpdateHandoffExists = Effect.gen(function* () {
   const config = yield* ServerConfig.ServerConfig;
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;

--- a/apps/server/src/cloud/serviceProtocol.ts
+++ b/apps/server/src/cloud/serviceProtocol.ts
@@ -5,6 +5,10 @@ export const SERVICE_LAUNCHER_PROTOCOL = 2 as const;
 export const SERVICE_LAUNCHER_CONTEXT_ENV = "T3_SERVICE_LAUNCHER_CONTEXT";
 export const SERVICE_LAUNCHER_FILE = "service-launcher.mjs";
 export const SERVICE_STATE_FILE = "service-state.json";
+/** Written by the launcher just before an explicit stop kills its child, so
+    the child can tell "the service is going away" from "the launcher is about
+    to start my replacement" while a pending update is recorded. */
+export const SERVICE_STOP_MARKER_FILE = ".service-stopping";
 
 export interface PendingServiceUpdate {
   readonly id: string;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -83,6 +83,7 @@ import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import {
   connectHttpApiLayer,
+  pendingUpdateHandoffExists,
   reconcileDesiredCloudLink,
   releaseManagedTunnelOnShutdown,
 } from "./cloud/http.ts";
@@ -559,26 +560,34 @@ export const makeServerLayer = Layer.unwrap(
           yield* Deferred.succeed(cloudLinkParked, undefined).pipe(Effect.orDie);
           return;
         }
+        const releaseManagedTunnel = releaseManagedTunnelOnShutdown().pipe(
+          Effect.timeout("10 seconds"),
+          Effect.tap((released) =>
+            released ? Effect.logInfo("Released the managed tunnel on shutdown") : Effect.void,
+          ),
+          Effect.catchCause((cause) =>
+            Effect.logWarning(
+              "Failed to release the managed tunnel on shutdown; the next link reuses it",
+              { cause },
+            ),
+          ),
+          Effect.asVoid,
+        );
+        // A launcher trial can be stopped before activation. The previous
+        // server is already gone, so the trial owns cleanup immediately; the
+        // pending-state check keeps the tunnel for normal commit or rollback,
+        // while the launcher's explicit-stop marker allows it to be released.
+        // Other runtimes wait for activation so a failed standby cannot tear
+        // down the active runtime's tunnel.
+        const cleanupBeforeActivation = yield* pendingUpdateHandoffExists;
+        if (cleanupBeforeActivation) {
+          yield* Effect.addFinalizer(() => releaseManagedTunnel);
+        }
         yield* forkParked(
           Effect.gen(function* () {
-            // Only an activated runtime owns the tunnel cleanup finalizer.
-            yield* Effect.addFinalizer(() =>
-              releaseManagedTunnelOnShutdown().pipe(
-                Effect.timeout("10 seconds"),
-                Effect.tap((released) =>
-                  released
-                    ? Effect.logInfo("Released the managed tunnel on shutdown")
-                    : Effect.void,
-                ),
-                Effect.catchCause((cause) =>
-                  Effect.logWarning(
-                    "Failed to release the managed tunnel on shutdown; the next link reuses it",
-                    { cause },
-                  ),
-                ),
-                Effect.asVoid,
-              ),
-            );
+            if (!cleanupBeforeActivation) {
+              yield* Effect.addFinalizer(() => releaseManagedTunnel);
+            }
             if (!(yield* CloudCliState.readCliDesiredCloudLink)) return;
             const server = yield* HttpServer.HttpServer;
             const address = server.address;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -83,7 +83,7 @@ import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import {
   connectHttpApiLayer,
-  pendingUpdateHandoffExists,
+  pendingServiceUpdateExists,
   reconcileDesiredCloudLink,
   releaseManagedTunnelOnShutdown,
 } from "./cloud/http.ts";
@@ -579,7 +579,7 @@ export const makeServerLayer = Layer.unwrap(
         // while the launcher's explicit-stop marker allows it to be released.
         // Other runtimes wait for activation so a failed standby cannot tear
         // down the active runtime's tunnel.
-        const cleanupBeforeActivation = yield* pendingUpdateHandoffExists;
+        const cleanupBeforeActivation = yield* pendingServiceUpdateExists;
         if (cleanupBeforeActivation) {
           yield* Effect.addFinalizer(() => releaseManagedTunnel);
         }

--- a/apps/server/src/serviceLauncher.test.ts
+++ b/apps/server/src/serviceLauncher.test.ts
@@ -1,6 +1,3 @@
-// @effect-diagnostics-next-line nodeBuiltinImport:off - sync marker poll outside the test clock.
-import * as NodeFS from "node:fs";
-
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -120,25 +117,6 @@ it.layer(NodeServices.layer)("service state persistence", (it) => {
       // An explicit stop leaves the marker that tells a child shutting down
       // mid-update that no replacement server is coming.
       assert.isTrue(yield* fs.exists(path.join(root, "runtime", SERVICE_STOP_MARKER_FILE)));
-
-      // The next launcher start clears the stale marker so a later update
-      // handoff keeps its tunnel again. Recovery runs before any stop
-      // transition, so polling until the marker disappears observes it; the
-      // poll uses real timers because it.effect runs under the test clock.
-      const restarted = new Launcher(
-        root,
-        yield* Effect.promise(() => readServiceState(statePath)),
-      );
-      const runningAgain = restarted.run();
-      const markerPath = path.join(root, "runtime", SERVICE_STOP_MARKER_FILE);
-      yield* Effect.promise(async () => {
-        while (NodeFS.existsSync(markerPath)) {
-          // @effect-diagnostics-next-line globalTimers:off - real delay under the test clock.
-          await new Promise((resolve) => setTimeout(resolve, 25));
-        }
-      });
-      yield* Effect.promise(() => restarted.stop("SIGTERM"));
-      yield* Effect.promise(() => runningAgain);
     }),
   );
 

--- a/apps/server/src/serviceLauncher.test.ts
+++ b/apps/server/src/serviceLauncher.test.ts
@@ -1,3 +1,6 @@
+// @effect-diagnostics-next-line nodeBuiltinImport:off - sync marker poll outside the test clock.
+import * as NodeFS from "node:fs";
+
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -10,6 +13,7 @@ import {
   decodeServiceState,
   isExactServiceVersion,
   SERVICE_LAUNCHER_PROTOCOL,
+  SERVICE_STOP_MARKER_FILE,
 } from "./cloud/serviceProtocol.ts";
 
 it("accepts only exact semantic versions", () => {
@@ -113,6 +117,28 @@ it.layer(NodeServices.layer)("service state persistence", (it) => {
       const running = launcher.run();
       yield* Effect.promise(() => launcher.stop("SIGTERM"));
       yield* Effect.promise(() => running);
+      // An explicit stop leaves the marker that tells a child shutting down
+      // mid-update that no replacement server is coming.
+      assert.isTrue(yield* fs.exists(path.join(root, "runtime", SERVICE_STOP_MARKER_FILE)));
+
+      // The next launcher start clears the stale marker so a later update
+      // handoff keeps its tunnel again. Recovery runs before any stop
+      // transition, so polling until the marker disappears observes it; the
+      // poll uses real timers because it.effect runs under the test clock.
+      const restarted = new Launcher(
+        root,
+        yield* Effect.promise(() => readServiceState(statePath)),
+      );
+      const runningAgain = restarted.run();
+      const markerPath = path.join(root, "runtime", SERVICE_STOP_MARKER_FILE);
+      yield* Effect.promise(async () => {
+        while (NodeFS.existsSync(markerPath)) {
+          // @effect-diagnostics-next-line globalTimers:off - real delay under the test clock.
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+      });
+      yield* Effect.promise(() => restarted.stop("SIGTERM"));
+      yield* Effect.promise(() => runningAgain);
     }),
   );
 

--- a/apps/server/src/serviceLauncher.test.ts
+++ b/apps/server/src/serviceLauncher.test.ts
@@ -112,11 +112,13 @@ it.layer(NodeServices.layer)("service state persistence", (it) => {
 
       const launcher = new Launcher(root, yield* Effect.promise(() => readServiceState(statePath)));
       const running = launcher.run();
-      yield* Effect.promise(() => launcher.stop("SIGTERM"));
-      yield* Effect.promise(() => running);
+      const stopping = launcher.stop("SIGTERM");
       // An explicit stop leaves the marker that tells a child shutting down
-      // mid-update that no replacement server is coming.
+      // mid-update that no replacement server is coming. It is present as
+      // soon as stop() returns its promise, before queued transitions run.
       assert.isTrue(yield* fs.exists(path.join(root, "runtime", SERVICE_STOP_MARKER_FILE)));
+      yield* Effect.promise(() => stopping);
+      yield* Effect.promise(() => running);
     }),
   );
 

--- a/apps/server/src/serviceLauncher.ts
+++ b/apps/server/src/serviceLauncher.ts
@@ -24,6 +24,7 @@ import {
   SERVICE_LAUNCHER_CONTEXT_ENV,
   SERVICE_LAUNCHER_PROTOCOL,
   SERVICE_STATE_FILE,
+  SERVICE_STOP_MARKER_FILE,
 } from "./cloud/serviceProtocol.ts";
 
 const HANDOFF_DELAY_MS = 2_000;
@@ -257,6 +258,9 @@ async function terminateChild(
   }
 }
 
+const stopMarkerPath = (baseDir: string) =>
+  NodePath.join(baseDir, "runtime", SERVICE_STOP_MARKER_FILE);
+
 export class Launcher {
   readonly #baseDir: string;
   readonly #statePath: string;
@@ -315,6 +319,15 @@ export class Launcher {
     this.#stopping = true;
     this.#clearTimer();
     this.#enqueue(async () => {
+      // An explicit stop is the service going away, not an update handoff.
+      // The marker lets the child's shutdown release the managed tunnel even
+      // while an update is recorded as pending; the next launcher start
+      // clears it. Written before the child is signalled so the child sees
+      // it during teardown. Best-effort: if the write fails the child errs
+      // toward keeping the tunnel, and the next link or unlink reconciles it.
+      await NodeFSP.writeFile(stopMarkerPath(this.#baseDir), "", { mode: 0o600 }).catch(
+        () => undefined,
+      );
       const child = this.#child?.process;
       this.#child = null;
       if (child !== undefined) await terminateChild(child, signal);
@@ -330,6 +343,10 @@ export class Launcher {
   }
 
   async #recover(): Promise<void> {
+    // A fresh launcher means servers are running again: any stop marker from
+    // a previous explicit stop is stale and must not make a future update
+    // handoff release its tunnel.
+    await NodeFSP.rm(stopMarkerPath(this.#baseDir), { force: true }).catch(() => undefined);
     const update = this.#state.update;
     if (update?.status !== "pending") {
       if (update !== undefined) {

--- a/apps/server/src/serviceLauncher.ts
+++ b/apps/server/src/serviceLauncher.ts
@@ -5,6 +5,7 @@
 // `t3 service update`. Keep runtime imports limited to Node built-ins.
 import * as NodeChildProcess from "node:child_process";
 import * as NodeCrypto from "node:crypto";
+import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
 
@@ -268,6 +269,7 @@ export class Launcher {
   #child: ManagedChild | null = null;
   #timer: NodeJS.Timeout | undefined;
   #transitions: Promise<void> = Promise.resolve();
+  #stopRequested = false;
   #stopping = false;
   #done = false;
   readonly #completion = Promise.withResolvers<void>();
@@ -312,22 +314,26 @@ export class Launcher {
   }
 
   async stop(signal: NodeJS.Signals): Promise<void> {
-    if (this.#stopping) {
+    // This must happen synchronously at signal receipt. A queued update
+    // transition may already be terminating the active child, and that child
+    // needs to see the marker in its shutdown finalizer. KillMode=mixed also
+    // ensures systemd signals the launcher before the rest of the cgroup.
+    try {
+      NodeFS.writeFileSync(stopMarkerPath(this.#baseDir), "", { mode: 0o600 });
+    } catch {
+      // Err toward keeping the tunnel; the next link or unlink reconciles it.
+    }
+    if (this.#stopRequested || this.#stopping) {
       await this.#completion.promise.catch(() => undefined);
       return;
     }
-    this.#stopping = true;
+    this.#stopRequested = true;
     this.#clearTimer();
     this.#enqueue(async () => {
-      // An explicit stop is the service going away, not an update handoff.
-      // The marker lets the child's shutdown release the managed tunnel even
-      // while an update is recorded as pending; the next launcher start
-      // clears it. Written before the child is signalled so the child sees
-      // it during teardown. Best-effort: if the write fails the child errs
-      // toward keeping the tunnel, and the next link or unlink reconciles it.
-      await NodeFSP.writeFile(stopMarkerPath(this.#baseDir), "", { mode: 0o600 }).catch(
-        () => undefined,
-      );
+      // Let an update transition already in progress start its replacement
+      // before this queued stop tears it down. That replacement owns the
+      // pre-activation tunnel cleanup path and observes the marker above.
+      this.#stopping = true;
       const child = this.#child?.process;
       this.#child = null;
       if (child !== undefined) await terminateChild(child, signal);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -160,7 +160,6 @@ import {
   CheckCircle2Icon,
   ChevronDownIcon,
   GitBranchIcon,
-  TriangleAlertIcon,
   WifiOffIcon,
 } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
@@ -1986,31 +1985,35 @@ function ChatViewContent(props: ChatViewProps) {
       const updateFailed = serverUpdateState.status === "failed";
       items.push({
         id: `server-version:${serverUpdateEnvironmentId}`,
-        variant: updateFailed ? "error" : updateInProgress ? "default" : "warning",
-        icon: updateInProgress ? (
-          <span
-            className="size-1.5 animate-status-pulse rounded-full bg-foreground"
-            aria-hidden="true"
-          />
-        ) : (
-          <TriangleAlertIcon />
-        ),
+        variant: updateFailed ? "error" : "default",
+        // In-flight and failed states carry their own status dot inside
+        // ServerUpdateProgress; only the idle offer needs an icon.
+        icon:
+          updateInProgress || updateFailed ? null : (
+            <span
+              className="size-1.5 rounded-full border border-muted-foreground/40"
+              aria-hidden="true"
+            />
+          ),
         title:
-          updateInProgress || updateFailed
-            ? `${updateFailed ? "Could not update" : "Updating"} ${versionMismatchServerLabel}`
-            : "Client and server versions differ",
+          updateInProgress || updateFailed ? (
+            `${updateFailed ? "Could not update" : "Updating"} ${versionMismatchServerLabel}`
+          ) : versionMismatch ? (
+            <Tooltip>
+              <TooltipTrigger render={<span>Server update available</span>} />
+              <TooltipPopup side="top">
+                {versionMismatchServerLabel} {versionMismatch.serverVersion}{" "}
+                <span aria-hidden="true">→</span> {versionMismatch.clientVersion}
+              </TooltipPopup>
+            </Tooltip>
+          ) : (
+            "Server update available"
+          ),
         description:
           updateInProgress || updateFailed ? (
-            <ServerUpdateProgress
-              fromVersion={serverUpdateState.fromVersion}
-              state={serverUpdateState}
-            />
-          ) : versionMismatch ? (
-            <>
-              Client {versionMismatch.clientVersion} is connected to {versionMismatchServerLabel}{" "}
-              {versionMismatch.serverVersion}.{" "}
-              {serverUpdateGuidance(versionMismatchSelfUpdate, versionMismatchServerLabel)}
-            </>
+            <ServerUpdateProgress state={serverUpdateState} />
+          ) : versionMismatchSelfUpdate === "desktop-managed" ? (
+            serverUpdateGuidance(versionMismatchSelfUpdate, versionMismatchServerLabel)
           ) : null,
         // The desktop-managed guidance is already the description; the action
         // slot would only repeat it.
@@ -2023,13 +2026,13 @@ function ChatViewContent(props: ChatViewProps) {
               serverLabel={versionMismatchServerLabel}
               selfUpdate={versionMismatchSelfUpdate}
               targetVersion={versionMismatch.clientVersion}
-              {...(updateFailed ? { label: "Retry update" } : {})}
+              label={updateFailed ? "Retry" : "Update"}
             />
           ),
         ...(updateInProgress || updateFailed || !versionMismatchDismissKey
           ? {}
           : {
-              dismissLabel: "Dismiss version mismatch warning",
+              dismissLabel: "Dismiss update notice",
               onDismiss: () => {
                 dismissVersionMismatch(versionMismatchDismissKey);
                 setDismissedVersionMismatchKey(versionMismatchDismissKey);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2000,7 +2000,13 @@ function ChatViewContent(props: ChatViewProps) {
             `${updateFailed ? "Could not update" : "Updating"} ${versionMismatchServerLabel}`
           ) : versionMismatch ? (
             <Tooltip>
-              <TooltipTrigger render={<span>Server update available</span>} />
+              <TooltipTrigger
+                render={
+                  <button type="button" className="cursor-help rounded-sm text-left">
+                    Server update available
+                  </button>
+                }
+              />
               <TooltipPopup side="top">
                 {versionMismatchServerLabel} {versionMismatch.serverVersion}{" "}
                 <span aria-hidden="true">→</span> {versionMismatch.clientVersion}

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -101,10 +101,9 @@ describe("ServerUpdateAction", () => {
 });
 
 describe("ServerUpdateProgress", () => {
-  it("renders the monochrome step rail with only the active step highlighted", () => {
+  it("shows one calm status row for the restart wait", () => {
     const markup = renderToStaticMarkup(
       <ServerUpdateProgress
-        fromVersion="0.0.30"
         state={{
           status: "running",
           stage: "resuming",
@@ -114,23 +113,36 @@ describe("ServerUpdateProgress", () => {
       />,
     );
 
-    expect(markup).toContain("0.0.30");
-    expect(markup).toContain("0.0.31");
-    expect(markup).toContain("Download");
-    expect(markup).toContain("Install");
-    expect(markup).toContain("Resuming");
-    // The wait state is monochrome and calm: no success/warning colors, no
-    // status sentence, one duty-cycled pulse on the active step.
+    expect(markup).toContain("Restarting…");
+    // The wait state is monochrome and calm: no versions, no step rail, no
+    // success/warning colors, one duty-cycled pulse on the dot.
+    expect(markup).not.toContain("0.0.30");
+    expect(markup).not.toContain("Resum");
     expect(markup).not.toContain("text-success");
     expect(markup).not.toContain("text-primary");
     expect(markup).toContain("animate-status-pulse");
     expect(markup).not.toContain("animate-spin");
   });
 
-  it("keeps the failed stage visible with its retryable error", () => {
+  it("folds the sub-second installing handoff into the download phase", () => {
     const markup = renderToStaticMarkup(
       <ServerUpdateProgress
-        fromVersion="0.0.30"
+        state={{
+          status: "running",
+          stage: "installing",
+          fromVersion: "0.0.30",
+          targetVersion: "0.0.31",
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Downloading…");
+    expect(markup).not.toContain("Install");
+  });
+
+  it("keeps the failure visible with its retryable error", () => {
+    const markup = renderToStaticMarkup(
+      <ServerUpdateProgress
         state={{
           status: "failed",
           stage: "installing",

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -1,110 +1,63 @@
 import type { EnvironmentId, ServerSelfUpdateCapability } from "@t3tools/contracts";
-import type { ServerUpdateState } from "@t3tools/client-runtime/state/server";
+import type { ServerUpdateStage, ServerUpdateState } from "@t3tools/client-runtime/state/server";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { CheckIcon } from "lucide-react";
 
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
-import { cn } from "~/lib/utils";
 import { serverEnvironment } from "~/state/server";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { manualServerUpdateCommand } from "~/versionSkew";
 import { Button } from "./ui/button";
 import { toastManager } from "./ui/toast";
 
-const UPDATE_STEPS = [
-  { stage: "downloading", label: "Download", activeLabel: "Downloading" },
-  { stage: "installing", label: "Install", activeLabel: "Installing" },
-  { stage: "resuming", label: "Resume", activeLabel: "Resuming" },
-] as const;
+// The wire "installing" stage is a sub-second launcher handoff, so the UI
+// folds it into the download phase; everything after the handoff is the
+// restart the user is actually waiting through.
+const UPDATE_STAGE_LABELS: Record<ServerUpdateStage, string> = {
+  downloading: "Downloading…",
+  installing: "Downloading…",
+  resuming: "Restarting…",
+};
 const pendingUpdateEnvironmentIds = new Set<EnvironmentId>();
+
+export function serverUpdateStageLabel(stage: ServerUpdateStage): string {
+  return UPDATE_STAGE_LABELS[stage];
+}
 
 function updateFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Server update failed.";
 }
 
 /**
- * Monochrome step rail for an in-flight server update. The update is a
- * wait, not a warning: done steps recede to gray, the active step is the
- * only bright element and pulses. Failure keeps the rail but surfaces the
- * error below it.
+ * One-row status for an in-flight server update: "Downloading…" then
+ * "Restarting…". The update is a wait, not a warning: a single pulsing dot
+ * and label, no step rail, no versions. Failure turns the row red with the
+ * rollback reason.
  */
 export function ServerUpdateProgress({
-  fromVersion,
   state,
 }: {
-  readonly fromVersion: string;
   readonly state: Exclude<ServerUpdateState, { status: "idle" }>;
 }) {
-  const currentIndex = UPDATE_STEPS.findIndex(({ stage }) => stage === state.stage);
-
-  return (
-    <div className="mt-1 min-w-0 space-y-2.5">
-      <p className="text-xs text-muted-foreground/70">
-        {fromVersion} <span aria-hidden="true">→</span> {state.targetVersion}
-      </p>
-      <ol className="flex min-w-0 items-center" aria-label="Server update progress">
-        {UPDATE_STEPS.map((step, index) => {
-          const complete = index < currentIndex;
-          const current = index === currentIndex;
-          const failed = current && state.status === "failed";
-          const running = current && state.status === "running";
-          return (
-            <li
-              key={step.stage}
-              className={cn(
-                "flex min-w-0 items-center text-xs font-medium",
-                index < UPDATE_STEPS.length - 1 ? "flex-1" : null,
-                complete
-                  ? "text-muted-foreground"
-                  : failed
-                    ? "text-destructive"
-                    : running
-                      ? "animate-status-pulse text-foreground"
-                      : "text-muted-foreground/50",
-              )}
-              aria-current={running ? "step" : undefined}
-            >
-              {complete ? (
-                <CheckIcon
-                  className="size-3.5 shrink-0 opacity-70"
-                  strokeWidth={2.5}
-                  aria-hidden="true"
-                />
-              ) : (
-                <span
-                  className={cn(
-                    "size-1.5 shrink-0 rounded-full",
-                    failed
-                      ? "bg-destructive"
-                      : running
-                        ? "bg-foreground"
-                        : "border border-muted-foreground/40",
-                  )}
-                  aria-hidden="true"
-                />
-              )}
-              <span className="ml-1.5 truncate">{running ? step.activeLabel : step.label}</span>
-              {index < UPDATE_STEPS.length - 1 ? (
-                <span
-                  className={cn(
-                    "mx-2 h-px min-w-3 flex-1",
-                    complete ? "bg-muted-foreground/40" : "bg-border",
-                  )}
-                  aria-hidden="true"
-                />
-              ) : null}
-            </li>
-          );
-        })}
-      </ol>
-      {state.status === "failed" ? (
-        <p className="text-xs text-destructive" role="alert">
+  if (state.status === "failed") {
+    return (
+      <div className="mt-1 flex min-w-0 items-center gap-2 text-xs text-destructive" role="alert">
+        <span className="size-1.5 shrink-0 rounded-full bg-destructive" aria-hidden="true" />
+        <span className="min-w-0 truncate" title={state.message}>
           {state.message}
-        </p>
-      ) : null}
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="mt-1 flex items-center gap-2 text-xs font-medium text-foreground">
+      <span
+        className="size-1.5 shrink-0 animate-status-pulse rounded-full bg-foreground"
+        aria-hidden="true"
+      />
+      <span>{serverUpdateStageLabel(state.stage)}</span>
     </div>
   );
 }
@@ -119,7 +72,7 @@ export function ServerUpdateAction({
   serverLabel,
   selfUpdate,
   targetVersion,
-  label = "Update server",
+  label = "Update",
 }: {
   readonly environmentId: EnvironmentId;
   readonly serverLabel: string;

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1431,7 +1431,12 @@ function SavedBackendListRow({
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <p className="w-fit text-muted-foreground text-xs">Server update available</p>
+                  <button
+                    type="button"
+                    className="w-fit cursor-help rounded-sm text-left text-muted-foreground text-xs"
+                  >
+                    Server update available
+                  </button>
                 }
               />
               <TooltipPopup side="top">
@@ -3008,7 +3013,11 @@ export function ConnectionsSettings() {
                   ) : primaryVersionMismatch ? (
                     <Tooltip>
                       <TooltipTrigger
-                        render={<span className="w-fit">Update to match this client.</span>}
+                        render={
+                          <button type="button" className="w-fit cursor-help rounded-sm text-left">
+                            Update to match this client.
+                          </button>
+                        }
                       />
                       <TooltipPopup side="top">
                         {primaryVersionMismatch.serverVersion} <span aria-hidden="true">→</span>{" "}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -4,7 +4,6 @@ import {
   QrCodeIcon,
   RefreshCwIcon,
   TerminalIcon,
-  TriangleAlertIcon,
 } from "lucide-react";
 import { useAtomValue } from "@effect/atom-react";
 import { type ReactNode, memo, useCallback, useId, useMemo, useState } from "react";
@@ -1426,17 +1425,20 @@ function SavedBackendListRow({
           ) : null}
           {serverUpdateState.status !== "idle" ? (
             <div className="max-w-md">
-              <ServerUpdateProgress
-                fromVersion={serverUpdateState.fromVersion}
-                state={serverUpdateState}
-              />
+              <ServerUpdateProgress state={serverUpdateState} />
             </div>
           ) : versionMismatch ? (
-            <p className="flex items-center gap-1 text-warning text-xs">
-              <TriangleAlertIcon className="size-3.5 shrink-0" />
-              Version drift: client {versionMismatch.clientVersion}, server{" "}
-              {versionMismatch.serverVersion}.
-            </p>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <p className="w-fit text-muted-foreground text-xs">Server update available</p>
+                }
+              />
+              <TooltipPopup side="top">
+                {versionMismatch.serverVersion} <span aria-hidden="true">→</span>{" "}
+                {versionMismatch.clientVersion}
+              </TooltipPopup>
+            </Tooltip>
           ) : null}
           {environment.connection.error && !resumingServerUpdate ? (
             <p className="flex min-w-0 items-center gap-2 text-destructive text-xs">
@@ -1461,7 +1463,7 @@ function SavedBackendListRow({
               serverLabel={`${environment.label} server`}
               selfUpdate={resolveServerSelfUpdateCapability(environment.serverConfig)}
               targetVersion={versionMismatch.clientVersion}
-              label={serverUpdateState.status === "failed" ? "Retry update" : "Update server"}
+              label={serverUpdateState.status === "failed" ? "Retry" : "Update"}
             />
           ) : null}
           {isWslEnvironment ? (
@@ -2998,21 +3000,21 @@ export function ConnectionsSettings() {
                     ? "Update failed"
                     : primaryServerUpdateState.status === "running"
                       ? "Updating server"
-                      : "Version drift"
+                      : "Server update available"
                 }
                 description={
                   primaryServerUpdateState.status !== "idle" ? (
-                    <ServerUpdateProgress
-                      fromVersion={primaryServerUpdateState.fromVersion}
-                      state={primaryServerUpdateState}
-                    />
+                    <ServerUpdateProgress state={primaryServerUpdateState} />
                   ) : primaryVersionMismatch ? (
-                    <span className="flex items-center gap-1 text-warning">
-                      <TriangleAlertIcon className="size-3.5 shrink-0" />
-                      Client {primaryVersionMismatch.clientVersion}, server{" "}
-                      {primaryVersionMismatch.serverVersion}. Sync them if RPC calls or reconnects
-                      fail.
-                    </span>
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={<span className="w-fit">Update to match this client.</span>}
+                      />
+                      <TooltipPopup side="top">
+                        {primaryVersionMismatch.serverVersion} <span aria-hidden="true">→</span>{" "}
+                        {primaryVersionMismatch.clientVersion}
+                      </TooltipPopup>
+                    </Tooltip>
                   ) : null
                 }
                 control={
@@ -3024,9 +3026,7 @@ export function ConnectionsSettings() {
                       serverLabel={primaryEnvironment?.label ?? "this server"}
                       selfUpdate={resolveServerSelfUpdateCapability(primaryServerConfig)}
                       targetVersion={primaryVersionMismatch.clientVersion}
-                      {...(primaryServerUpdateState.status === "failed"
-                        ? { label: "Retry update" }
-                        : {})}
+                      label={primaryServerUpdateState.status === "failed" ? "Retry" : "Update"}
                     />
                   ) : undefined
                 }

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -35,10 +35,10 @@ An older background-service launcher may ask you to run the exact
 `npx t3@<version> service update` command on the server machine. That one local update installs the
 rollback support needed for later remote updates, including versions that change the database.
 
-After selecting **Update server**, the warning becomes a three-step progress rail:
-**Download**, **Install**, and **Resume**. The same progress appears in the conversation and in
-Connections, so navigating between them does not lose the update. A failed step remains visible
-with its error and an option to retry.
+After selecting **Update**, the notice becomes a live status line: **Downloading…** while the new
+version is fetched and verified, then **Restarting…** while the server restarts into it. The same
+status appears in the conversation and in Connections, so navigating between them does not lose the
+update. A failure remains visible with its error and an option to retry.
 
 **Copy update command** gives you `npx t3@<client-version>`, which relaunches the server directly
 at the matching version. Add whatever startup options you normally use.


### PR DESCRIPTION
A remote server update restarts the server in ~9 seconds, but the client stayed disconnected for 90+ seconds, and the progress UI was a three-step rail (Download / Install / Resume) where "Install" is a sub-second launcher handoff and "Resuming" meant nothing to most people.

Two changes:

**Keep the managed tunnel across update restarts.** Shutdown released the Cloudflare tunnel, so every update forced the replacement tunnel's hostname route through 1-2 minutes of edge propagation — measured on a live update: server listening at T+9s, first inbound request at T+96s. An update handoff always brings a server right back (new version, or the old one after rollback), so the tunnel is never orphaned. The release now checks the launcher's durable state file and skips deletion when an update is pending; the next boot respawns the connector from the stored config against the same tunnel and is reachable as soon as it connects (~T+12s). Explicit unlink and non-update shutdowns still release, so the per-tunnel billing hygiene is unchanged.

**Calmer, honest update UI.** The version-skew banner is no longer an amber warning: it reads "Server update available" with the raw versions (unreadable for nightlies) in a tooltip. The in-flight rail becomes a single status row, "Downloading…" then "Restarting…", matching what actually happens; failures keep the row with the rollback reason and a Retry action.

Together with #5404 (merged), an update should now be: ~6s "Downloading…", ~10s "Restarting…", reconnected.

---
Written by Claude Fable 5 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes managed-tunnel lifecycle on shutdown and systemd kill behavior during updates; mistakes could leak tunnels or drop connectivity on uninstall, though new tests cover handoff vs explicit stop.
> 
> **Overview**
> Remote server updates were slow to reconnect because shutdown **released the managed Cloudflare tunnel**, forcing a new tunnel and long hostname route propagation. Shutdown now reads the launcher’s `service-state.json` and **skips tunnel release** when a pending update is a handoff (pending update **without** `.service-stopping`). Explicit stops (`systemctl stop`, uninstall) still release the tunnel.
> 
> The service launcher **writes `.service-stopping` synchronously** on `stop()` so the child can tell “service going away” from “replacement starting”; recovery clears stale markers. The systemd unit uses **`KillMode=mixed`** so the launcher gets signals before the cgroup is torn down. Trial servers register tunnel cleanup **before activation** when a pending update exists; normal runtimes still wait until after activation.
> 
> **UI/docs:** version skew is no longer an amber warning—**“Server update available”** with versions in a tooltip. In-flight progress is a single row (**Downloading…** / **Restarting…**), folding the sub-second install handoff into download; docs match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 063ddb7c1484f6aca3db7de73dd344e1d5cbc5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve managed tunnel during server update handoff on shutdown
> - During shutdown, `releaseManagedTunnelOnShutdown` now checks for a pending update handoff (pending update recorded + no explicit stop marker). If detected, the managed tunnel is kept alive so the replacement server can inherit it.
> - The launcher writes a `SERVICE_STOP_MARKER_FILE` synchronously at the start of `stop()` so the child can distinguish an explicit stop from an update handoff. The marker is cleared on recovery to avoid stale state.
> - The systemd unit's `KillMode` changes from `control-group` to `mixed` in `renderBootServiceUnit` to support smoother process handoff.
> - The server update progress UI is simplified to a single status row (pulsing dot + stage label) replacing the multi-step rail, with action labels shortened to 'Update'/'Retry'.
> - Behavioral Change: tunnels are no longer released on shutdown when an update handoff is in progress; they continue to release on explicit stops and other shutdown paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 063ddb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->