### PR TITLE
feat(web): rich tool-call transcript — tool rows, inline diffs, thinking bursts, live status

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -151,6 +151,54 @@ function projectRawOutput(value: unknown): Record<string, unknown> | undefined {
   return undefined;
 }
 
+// Tool-detail fields the transcript's rich tool rows read when re-hydrating a
+// thread from a snapshot: tool identity + input for the `Tool(arg)` header,
+// result/output for the `⎿ result` line, and diff payloads (Claude
+// structuredPatch summaries, Codex native items, ACP content/rawInput) for
+// inline edit diffs. Clamped rather than summarized so the historical
+// transcript renders the same as the live stream did.
+const RETAINED_TOOL_DETAIL_KEYS = [
+  "toolName",
+  "input",
+  "result",
+  "toolUseResult",
+  "item",
+  "content",
+  "rawInput",
+] as const;
+
+const TOOL_DETAIL_MAX_STRING = 4_000;
+const TOOL_DETAIL_MAX_ARRAY = 100;
+const TOOL_DETAIL_MAX_DEPTH = 6;
+
+/**
+ * Bounds a retained tool-detail value: long strings truncate, arrays cap, and
+ * deeply nested structures cut off. Keeps snapshot rows a predictable size
+ * without flattening them into one-line summaries.
+ */
+function clampToolDetail(value: unknown, depth = 0): unknown {
+  if (typeof value === "string") {
+    return value.length > TOOL_DETAIL_MAX_STRING
+      ? `${value.slice(0, TOOL_DETAIL_MAX_STRING)}…`
+      : value;
+  }
+  if (value === null || typeof value !== "object" || depth >= TOOL_DETAIL_MAX_DEPTH) {
+    return typeof value === "object" && value !== null ? undefined : value;
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, TOOL_DETAIL_MAX_ARRAY).map((entry) => clampToolDetail(entry, depth + 1));
+  }
+  const record = value as Record<string, unknown>;
+  const clamped: Record<string, unknown> = {};
+  for (const key of Object.keys(record)) {
+    const entry = clampToolDetail(record[key], depth + 1);
+    if (entry !== undefined) {
+      clamped[key] = entry;
+    }
+  }
+  return clamped;
+}
+
 /**
  * Removes activity payload fields that no current client reads while retaining
  * the full payload in persistence and the event store.
@@ -172,6 +220,15 @@ export function projectActivityPayload(
   if ("command" in data) {
     projectedData.command = data.command;
   }
+  for (const key of RETAINED_TOOL_DETAIL_KEYS) {
+    if (!(key in data)) {
+      continue;
+    }
+    const clamped = clampToolDetail(data[key]);
+    if (clamped !== undefined) {
+      projectedData[key] = clamped;
+    }
+  }
 
   const changedFiles: string[] = [];
   collectChangedFiles(data, changedFiles, new Set<string>(), 0);
@@ -187,8 +244,11 @@ export function projectActivityPayload(
     projectedData.kind = data.kind;
   }
 
-  const rawOutput = projectRawOutput(data.rawOutput);
-  if (rawOutput) {
+  // Prefer the clamped full output (ACP tool rows read result text from it);
+  // fall back to the one-line summary for shapes the clamp drops entirely.
+  const clampedRawOutput = "rawOutput" in data ? clampToolDetail(data.rawOutput) : undefined;
+  const rawOutput = clampedRawOutput ?? projectRawOutput(data.rawOutput);
+  if (rawOutput !== undefined && rawOutput !== null) {
     projectedData.rawOutput = rawOutput;
   }
 

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -153,10 +153,11 @@ function projectRawOutput(value: unknown): Record<string, unknown> | undefined {
 
 // Tool-detail fields the transcript's rich tool rows read when re-hydrating a
 // thread from a snapshot: tool identity + input for the `Tool(arg)` header,
-// result/output for the `⎿ result` line, and diff payloads (Claude
+// result/output for the `⎿ result` line, diff payloads (Claude
 // structuredPatch summaries, Codex native items, ACP content/rawInput) for
-// inline edit diffs. Clamped rather than summarized so the historical
-// transcript renders the same as the live stream did.
+// inline edit diffs, and ACP `locations` for the primary file-path argument.
+// Clamped rather than summarized so the historical transcript renders the
+// same as the live stream did.
 const RETAINED_TOOL_DETAIL_KEYS = [
   "toolName",
   "input",
@@ -165,16 +166,18 @@ const RETAINED_TOOL_DETAIL_KEYS = [
   "item",
   "content",
   "rawInput",
+  "locations",
 ] as const;
 
 const TOOL_DETAIL_MAX_STRING = 4_000;
 const TOOL_DETAIL_MAX_ARRAY = 100;
 const TOOL_DETAIL_MAX_DEPTH = 6;
+const TOOL_DETAIL_MAX_KEYS = 100;
 
 /**
- * Bounds a retained tool-detail value: long strings truncate, arrays cap, and
- * deeply nested structures cut off. Keeps snapshot rows a predictable size
- * without flattening them into one-line summaries.
+ * Bounds a retained tool-detail value: long strings truncate, arrays and
+ * object key counts cap, and deeply nested structures cut off. Keeps snapshot
+ * rows a predictable size without flattening them into one-line summaries.
  */
 function clampToolDetail(value: unknown, depth = 0): unknown {
   if (typeof value === "string") {
@@ -190,10 +193,15 @@ function clampToolDetail(value: unknown, depth = 0): unknown {
   }
   const record = value as Record<string, unknown>;
   const clamped: Record<string, unknown> = {};
+  let keys = 0;
   for (const key of Object.keys(record)) {
+    if (keys >= TOOL_DETAIL_MAX_KEYS) {
+      break;
+    }
     const entry = clampToolDetail(record[key], depth + 1);
     if (entry !== undefined) {
       clamped[key] = entry;
+      keys += 1;
     }
   }
   return clamped;

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3569,4 +3569,68 @@ describe("ProviderRuntimeIngestion", () => {
     // not the closing event's.
     expect(completed?.createdAt).toBe("2026-01-01T00:00:03.000Z");
   });
+
+  it("does not close a thinking burst on a stale turn.completed for another turn", async () => {
+    const harness = await createHarness();
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-live-reasoning-1"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-live"),
+      payload: {
+        streamKind: "reasoning_text",
+        delta: "First half of the thought.",
+      },
+    });
+    // Stale completion replayed for an earlier turn must not split the burst.
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-stale-turn-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:01.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-stale"),
+      status: "completed",
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-live-reasoning-2"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:02.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-live"),
+      payload: {
+        streamKind: "reasoning_text",
+        delta: " Second half of the thought.",
+      },
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-live-assistant"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:03.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-live"),
+      itemId: asItemId("item-live-assistant"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "Done.",
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some((activity) => activity.kind === "thinking.completed"),
+    );
+
+    const completedActivities = thread.activities.filter(
+      (activity) => activity.kind === "thinking.completed",
+    );
+    expect(completedActivities).toHaveLength(1);
+    expect((completedActivities[0]?.payload as { text?: string }).text).toBe(
+      "First half of the thought. Second half of the thought.",
+    );
+  });
 });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3484,4 +3484,89 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.status).toBe("error");
     expect(thread.session?.lastError).toBe("runtime still processed");
   });
+
+  it("tracks reasoning deltas as thinking burst activities", async () => {
+    const harness = await createHarness();
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-reasoning-delta-1"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-think"),
+      payload: {
+        streamKind: "reasoning_text",
+        delta: "Let me look at the failing test.",
+      },
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-reasoning-delta-2"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:03.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-think"),
+      payload: {
+        streamKind: "reasoning_text",
+        delta: " The assertion is inverted.",
+      },
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-post-thinking-assistant-delta"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:04.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-think"),
+      itemId: asItemId("item-post-thinking"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "Found it.",
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some((activity) => activity.kind === "thinking.completed"),
+    );
+
+    const started = thread.activities.find((activity) => activity.kind === "thinking.started");
+    expect(started?.summary).toBe("Thinking");
+    expect(started?.turnId).toBe("turn-think");
+
+    // Progress uses a stable activity id, so the projected list keeps a single
+    // progress row with the full accumulated reasoning text.
+    const progressActivities = thread.activities.filter(
+      (activity) => activity.kind === "thinking.progress",
+    );
+    expect(progressActivities).toHaveLength(1);
+    expect(progressActivities[0]?.id).toBe("evt-reasoning-delta-1:thinking-progress");
+    const progressPayload = progressActivities[0]?.payload as {
+      chars?: number;
+      text?: string;
+    };
+    expect(progressPayload?.chars).toBe(
+      "Let me look at the failing test. The assertion is inverted.".length,
+    );
+    expect(progressPayload?.text).toBe(
+      "Let me look at the failing test. The assertion is inverted.",
+    );
+
+    const completed = thread.activities.find((activity) => activity.kind === "thinking.completed");
+    expect(completed?.summary).toBe("Thought for 3s");
+    const completedPayload = completed?.payload as {
+      chars?: number;
+      durationMs?: number;
+      text?: string;
+      textTruncated?: boolean;
+    };
+    expect(completedPayload.durationMs).toBe(3000);
+    expect(completedPayload.text).toBe(
+      "Let me look at the failing test. The assertion is inverted.",
+    );
+    expect(completedPayload.textTruncated).toBeUndefined();
+    // The completed row is stamped with the last reasoning delta's timestamp,
+    // not the closing event's.
+    expect(completed?.createdAt).toBe("2026-01-01T00:00:03.000Z");
+  });
 });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -219,13 +219,17 @@ function truncateDetail(value: string, limit = 180): string {
 // ---------------------------------------------------------------------------
 
 const THINKING_PROGRESS_MIN_INTERVAL_MS = 250;
+// Bounds both the in-memory burst state and the size of each persisted
+// progress/completed payload; `chars` keeps counting past the cap so the
+// summary still reflects the real reasoning volume.
+const MAX_THINKING_BURST_TEXT_CHARS = 32_000;
 
 interface ThinkingBurstState {
   burstId: string;
   turnId: TurnId | null;
   startedAt: string;
   chars: number;
-  /** Full accumulated reasoning text for this burst (no cap). */
+  /** Accumulated reasoning text, capped at MAX_THINKING_BURST_TEXT_CHARS. */
   text: string;
   lastEventAt: string;
   lastProgressAtMs: number;
@@ -272,6 +276,7 @@ function eventEndsThinkingBurst(event: ProviderRuntimeEvent): boolean {
     case "user-input.requested":
     case "turn.completed":
     case "turn.aborted":
+    case "runtime.error":
     case "session.exited":
       return true;
     default:
@@ -988,7 +993,6 @@ const make = Effect.gen(function* () {
     if (!burst) {
       return;
     }
-    thinkingBurstByThreadId.delete(threadId);
     const durationMs = Math.max(0, Date.parse(burst.lastEventAt) - Date.parse(burst.startedAt));
     // Flush full text one last time so the live stream is complete before the
     // durable "Thought for Xs" row replaces it.
@@ -1012,6 +1016,10 @@ const make = Effect.gen(function* () {
       },
       turnId: burst.turnId,
     });
+    // Deleted only after both dispatches land so a failed close can be retried
+    // by the next burst-ending event (the stable activity ids make retries
+    // idempotent).
+    thinkingBurstByThreadId.delete(threadId);
   });
 
   const trackThinkingBurst = Effect.fn("trackThinkingBurst")(function* (
@@ -1032,7 +1040,7 @@ const make = Effect.gen(function* () {
           turnId: eventTurnId,
           startedAt: event.createdAt,
           chars: event.payload.delta.length,
-          text: event.payload.delta,
+          text: event.payload.delta.slice(0, MAX_THINKING_BURST_TEXT_CHARS),
           lastEventAt: event.createdAt,
           lastProgressAtMs: Number.isFinite(eventAtMs) ? eventAtMs : 0,
         };
@@ -1052,7 +1060,9 @@ const make = Effect.gen(function* () {
         return;
       }
       burst.chars += event.payload.delta.length;
-      burst.text += event.payload.delta;
+      if (burst.text.length < MAX_THINKING_BURST_TEXT_CHARS) {
+        burst.text = `${burst.text}${event.payload.delta}`.slice(0, MAX_THINKING_BURST_TEXT_CHARS);
+      }
       burst.lastEventAt = event.createdAt;
       if (
         Number.isFinite(eventAtMs) &&
@@ -1065,6 +1075,21 @@ const make = Effect.gen(function* () {
     }
 
     if (eventEndsThinkingBurst(event)) {
+      // Turn lifecycle events only close a burst belonging to that turn — a
+      // stale completion replayed for an earlier turn must not fold the
+      // active turn's reasoning into a premature "Thought for Xs" row.
+      if (event.type === "turn.completed" || event.type === "turn.aborted") {
+        const burst = thinkingBurstByThreadId.get(threadId);
+        const eventTurnId = toTurnId(event.turnId) ?? null;
+        if (
+          burst &&
+          burst.turnId !== null &&
+          eventTurnId !== null &&
+          burst.turnId !== eventTurnId
+        ) {
+          return;
+        }
+      }
       yield* closeThinkingBurst(event, threadId);
     }
   });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -208,6 +208,77 @@ function truncateDetail(value: string, limit = 180): string {
   return value.length > limit ? `${value.slice(0, limit - 3)}...` : value;
 }
 
+// ---------------------------------------------------------------------------
+// Thinking bursts — reasoning content deltas are far too frequent to persist
+// individually, so ingestion tracks a per-thread "burst" and emits at most a
+// started/throttled-progress/completed activity triple per burst. Progress
+// uses a stable activity id so each update replaces the previous progress
+// payload (full accumulated text) instead of appending O(n) rows. Clients use
+// the open burst for a live streamed "Thinking…" panel and the completed
+// activity for a durable "Thought for Xs" work-log row.
+// ---------------------------------------------------------------------------
+
+const THINKING_PROGRESS_MIN_INTERVAL_MS = 250;
+
+interface ThinkingBurstState {
+  burstId: string;
+  turnId: TurnId | null;
+  startedAt: string;
+  chars: number;
+  /** Full accumulated reasoning text for this burst (no cap). */
+  text: string;
+  lastEventAt: string;
+  lastProgressAtMs: number;
+}
+
+function formatThinkingDurationLabel(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs < 1_000) {
+    return "a moment";
+  }
+  const totalSeconds = Math.round(durationMs / 1_000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+}
+
+function isReasoningContentDelta(event: ProviderRuntimeEvent): boolean {
+  return (
+    event.type === "content.delta" &&
+    (event.payload.streamKind === "reasoning_text" ||
+      event.payload.streamKind === "reasoning_summary_text") &&
+    event.payload.delta.length > 0
+  );
+}
+
+/**
+ * Any signal that the model moved on from reasoning ends the open burst:
+ * visible assistant text, a tool call, a request back to the user, or the
+ * turn/session lifecycle closing underneath it.
+ */
+function eventEndsThinkingBurst(event: ProviderRuntimeEvent): boolean {
+  switch (event.type) {
+    case "content.delta":
+      return event.payload.streamKind === "assistant_text" && event.payload.delta.length > 0;
+    case "item.started":
+      return isToolLifecycleItemType(event.payload.itemType);
+    case "item.completed":
+      return (
+        event.payload.itemType === "reasoning" || event.payload.itemType === "assistant_message"
+      );
+    case "request.opened":
+    case "user-input.requested":
+    case "turn.completed":
+    case "turn.aborted":
+    case "session.exited":
+      return true;
+    default:
+      return false;
+  }
+}
+
 function normalizeProposedPlanMarkdown(planMarkdown: string | undefined): string | undefined {
   const trimmed = planMarkdown?.trim();
   if (!trimmed) {
@@ -759,6 +830,7 @@ export function runtimeEventToActivities(
             ...(event.payload.parentToolUseId
               ? { parentToolUseId: event.payload.parentToolUseId }
               : {}),
+            ...(event.itemId ? { toolCallId: event.itemId } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
@@ -785,6 +857,7 @@ export function runtimeEventToActivities(
             ...(event.payload.parentToolUseId
               ? { parentToolUseId: event.payload.parentToolUseId }
               : {}),
+            ...(event.itemId ? { toolCallId: event.itemId } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
@@ -806,10 +879,36 @@ export function runtimeEventToActivities(
           payload: {
             itemType: event.payload.itemType,
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId
               ? { parentToolUseId: event.payload.parentToolUseId }
               : {}),
+            ...(event.itemId ? { toolCallId: event.itemId } : {}),
+          },
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
+    case "session.state.changed": {
+      // Providers report compaction as an opaque waiting state; surface the
+      // start so clients can show a live "compacting" indicator until the
+      // thread.state.changed "compacted" boundary lands.
+      if (event.payload.reason !== "status:compacting") {
+        return [];
+      }
+
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "context-compaction.started",
+          summary: "Compacting context",
+          payload: {
+            ...(event.payload.detail !== undefined ? { detail: event.payload.detail } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
@@ -836,6 +935,139 @@ const make = Effect.gen(function* () {
     crypto.randomUUIDv4.pipe(
       Effect.map((uuid) => CommandId.make(`provider:${event.eventId}:${tag}:${uuid}`)),
     );
+
+  const thinkingBurstByThreadId = new Map<ThreadId, ThinkingBurstState>();
+
+  const appendThinkingBurstActivity = (
+    event: ProviderRuntimeEvent,
+    threadId: ThreadId,
+    tag: string,
+    activity: OrchestrationThreadActivity,
+  ) =>
+    providerCommandId(event, tag).pipe(
+      Effect.flatMap((commandId) =>
+        orchestrationEngine.dispatch({
+          type: "thread.activity.append",
+          commandId,
+          threadId,
+          activity,
+          createdAt: activity.createdAt,
+        }),
+      ),
+    );
+
+  const emitThinkingProgress = (
+    event: ProviderRuntimeEvent,
+    threadId: ThreadId,
+    burst: ThinkingBurstState,
+    createdAt: string = event.createdAt,
+  ) =>
+    appendThinkingBurstActivity(event, threadId, "thinking-progress", {
+      // Stable id so the projector replaces the previous progress row instead of
+      // accumulating one activity per throttle tick (and so full text does not
+      // multiply across the activity list).
+      id: EventId.make(`${burst.burstId}:thinking-progress`),
+      createdAt,
+      tone: "info",
+      kind: "thinking.progress",
+      summary: "Thinking",
+      payload: {
+        burstId: burst.burstId,
+        startedAt: burst.startedAt,
+        chars: burst.chars,
+        ...(burst.text.length > 0 ? { text: burst.text } : {}),
+      },
+      turnId: burst.turnId,
+    });
+
+  const closeThinkingBurst = Effect.fn("closeThinkingBurst")(function* (
+    event: ProviderRuntimeEvent,
+    threadId: ThreadId,
+  ) {
+    const burst = thinkingBurstByThreadId.get(threadId);
+    if (!burst) {
+      return;
+    }
+    thinkingBurstByThreadId.delete(threadId);
+    const durationMs = Math.max(0, Date.parse(burst.lastEventAt) - Date.parse(burst.startedAt));
+    // Flush full text one last time so the live stream is complete before the
+    // durable "Thought for Xs" row replaces it.
+    if (burst.text.length > 0) {
+      yield* emitThinkingProgress(event, threadId, burst, burst.lastEventAt);
+    }
+    // Stamped with the last reasoning delta's timestamp so the row sorts
+    // before activities produced by the event that ended the burst.
+    yield* appendThinkingBurstActivity(event, threadId, "thinking-completed", {
+      id: EventId.make(`${burst.burstId}:thinking-completed`),
+      createdAt: burst.lastEventAt,
+      tone: "info",
+      kind: "thinking.completed",
+      summary: `Thought for ${formatThinkingDurationLabel(durationMs)}`,
+      payload: {
+        burstId: burst.burstId,
+        startedAt: burst.startedAt,
+        durationMs,
+        chars: burst.chars,
+        ...(burst.text.trim().length > 0 ? { text: burst.text } : {}),
+      },
+      turnId: burst.turnId,
+    });
+  });
+
+  const trackThinkingBurst = Effect.fn("trackThinkingBurst")(function* (
+    event: ProviderRuntimeEvent,
+    threadId: ThreadId,
+  ) {
+    if (event.type === "content.delta" && isReasoningContentDelta(event)) {
+      const eventTurnId = toTurnId(event.turnId) ?? null;
+      const existing = thinkingBurstByThreadId.get(threadId);
+      if (existing && existing.turnId !== eventTurnId) {
+        yield* closeThinkingBurst(event, threadId);
+      }
+      const burst = thinkingBurstByThreadId.get(threadId);
+      const eventAtMs = Date.parse(event.createdAt);
+      if (!burst) {
+        const next: ThinkingBurstState = {
+          burstId: event.eventId,
+          turnId: eventTurnId,
+          startedAt: event.createdAt,
+          chars: event.payload.delta.length,
+          text: event.payload.delta,
+          lastEventAt: event.createdAt,
+          lastProgressAtMs: Number.isFinite(eventAtMs) ? eventAtMs : 0,
+        };
+        thinkingBurstByThreadId.set(threadId, next);
+        yield* appendThinkingBurstActivity(event, threadId, "thinking-started", {
+          id: EventId.make(`${event.eventId}:thinking-started`),
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "thinking.started",
+          summary: "Thinking",
+          payload: { burstId: next.burstId, startedAt: next.startedAt },
+          turnId: eventTurnId,
+        });
+        // Stream the first chunk immediately so the client can show full
+        // reasoning from the first delta, not only after the throttle window.
+        yield* emitThinkingProgress(event, threadId, next);
+        return;
+      }
+      burst.chars += event.payload.delta.length;
+      burst.text += event.payload.delta;
+      burst.lastEventAt = event.createdAt;
+      if (
+        Number.isFinite(eventAtMs) &&
+        eventAtMs - burst.lastProgressAtMs >= THINKING_PROGRESS_MIN_INTERVAL_MS
+      ) {
+        burst.lastProgressAtMs = eventAtMs;
+        yield* emitThinkingProgress(event, threadId, burst);
+      }
+      return;
+    }
+
+    if (eventEndsThinkingBurst(event)) {
+      yield* closeThinkingBurst(event, threadId);
+    }
+  });
 
   const turnMessageIdsByTurnKey = yield* Cache.make<string, Set<MessageId>>({
     capacity: TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY,
@@ -1452,6 +1684,8 @@ const make = Effect.gen(function* () {
       });
       const hasPendingTurnStart =
         Option.isSome(pendingTurnStart) && thread.session?.status === "starting";
+
+      yield* trackThinkingBurst(event, thread.id);
 
       const conflictsWithActiveTurn =
         activeTurnId !== null && eventTurnId !== undefined && !sameId(activeTurnId, eventTurnId);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -765,6 +765,51 @@ function readClaudeToolUseResult(message: SDKMessage): Record<string, unknown> |
     : undefined;
 }
 
+const FILE_EDIT_TOOL_PATTERN = /^(edit|multiedit|write|notebookedit)$/i;
+const MAX_STRUCTURED_PATCH_LINES = 400;
+
+/**
+ * File-edit tool results carry a `structuredPatch` (real line numbers) that
+ * the web transcript renders as an inline diff. Forward just that slice —
+ * the full tool_use_result also embeds the original file contents, which
+ * would bloat persisted activities.
+ */
+function summarizeToolUseResultForData(
+  toolName: string,
+  result: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!result || !FILE_EDIT_TOOL_PATTERN.test(toolName)) {
+    return undefined;
+  }
+  const structuredPatch = Array.isArray(result.structuredPatch)
+    ? result.structuredPatch
+    : undefined;
+  const filePath = readString(result.filePath);
+  if (!structuredPatch && !filePath) {
+    return undefined;
+  }
+  let remaining = MAX_STRUCTURED_PATCH_LINES;
+  const cappedPatch = structuredPatch?.flatMap((rawHunk) => {
+    if (remaining <= 0 || rawHunk === null || typeof rawHunk !== "object") {
+      return [];
+    }
+    const hunk = rawHunk as Record<string, unknown>;
+    const lines = Array.isArray(hunk.lines)
+      ? hunk.lines.filter((line): line is string => typeof line === "string")
+      : [];
+    if (lines.length === 0) {
+      return [];
+    }
+    const kept = lines.slice(0, remaining);
+    remaining -= kept.length;
+    return [{ oldStart: hunk.oldStart, newStart: hunk.newStart, lines: kept }];
+  });
+  return {
+    ...(filePath ? { filePath } : {}),
+    ...(cappedPatch && cappedPatch.length > 0 ? { structuredPatch: cappedPatch } : {}),
+  };
+}
+
 function readClaudeTaskFromResult(
   result: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
@@ -2662,10 +2707,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const [index, tool] = toolEntry;
       const itemStatus = toolResult.isError ? "failed" : "completed";
       const toolUseResult = readClaudeToolUseResult(message);
+      const toolUseResultSummary = summarizeToolUseResultForData(tool.toolName, toolUseResult);
       const toolData = {
         toolName: tool.toolName,
         input: tool.input,
         result: toolResult.block,
+        ...(toolUseResultSummary ? { toolUseResult: toolUseResultSummary } : {}),
       };
 
       const updatedStamp = yield* makeEventStamp();

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -767,6 +767,9 @@ function readClaudeToolUseResult(message: SDKMessage): Record<string, unknown> |
 
 const FILE_EDIT_TOOL_PATTERN = /^(edit|multiedit|write|notebookedit)$/i;
 const MAX_STRUCTURED_PATCH_LINES = 400;
+// A single hunk line from a generated/minified file can be megabytes long;
+// cap each line so the forwarded patch stays bounded in both dimensions.
+const MAX_STRUCTURED_PATCH_LINE_CHARS = 500;
 
 /**
  * File-edit tool results carry a `structuredPatch` (real line numbers) that
@@ -800,7 +803,13 @@ function summarizeToolUseResultForData(
     if (lines.length === 0) {
       return [];
     }
-    const kept = lines.slice(0, remaining);
+    const kept = lines
+      .slice(0, remaining)
+      .map((line) =>
+        line.length > MAX_STRUCTURED_PATCH_LINE_CHARS
+          ? `${line.slice(0, MAX_STRUCTURED_PATCH_LINE_CHARS)}…`
+          : line,
+      );
     remaining -= kept.length;
     return [{ oldStart: hunk.oldStart, newStart: hunk.newStart, lines: kept }];
   });

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -156,7 +156,7 @@ describe("projectActivityPayload", () => {
     );
   }
 
-  it("drops unread bulk while retaining command, file, tool, and summary inputs", () => {
+  it("retains clamped tool detail while dropping unread top-level bulk", () => {
     const projected = projectActivityPayload(fixtures[0]!);
     expect(projected.payload).toEqual({
       itemType: "command_execution",
@@ -167,13 +167,18 @@ describe("projectActivityPayload", () => {
       data: {
         item: {
           command: ["bash", "-lc", "pnpm test"],
-          input: { command: "fallback input" },
-          result: { command: "fallback result" },
+          input: { command: "fallback input", ignored: "input bulk" },
+          result: { command: "fallback result", aggregatedOutput: `${"x".repeat(4_000)}…` },
+          commandActions: [{ type: "unknown", output: `${"y".repeat(4_000)}…` }],
         },
         command: "fallback data",
         toolCallId: "tool-command",
         kind: "execute",
-        rawOutput: { content: "first useful line" },
+        rawOutput: {
+          content: "\n```\nfirst useful line\nsecond line",
+          stdout: "unused stdout",
+          ignored: "raw bulk",
+        },
       },
     });
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -83,6 +83,7 @@ import {
   deriveActivePlanState,
   findSidebarProposedPlan,
   findLatestProposedPlan,
+  deriveLiveWorkStatus,
   deriveWorkLogEntries,
   hasActionableProposedPlan,
   isLatestTurnSettled,
@@ -2415,6 +2416,25 @@ function ChatViewContent(props: ChatViewProps) {
     attachDraftHeroComposerAnchorRef,
     captureDraftHeroComposerRect,
   ] = useDraftHeroLayoutTransition(isDraftHeroState);
+  const runningTurnId =
+    activeThread?.session?.status === "running" ? activeThread.session.activeTurnId : null;
+  const sessionProviderName = activeThread?.session?.providerName ?? null;
+  const liveWorkStatus = useMemo(() => {
+    const streamingMessage = timelineMessages.findLast(
+      (message) => message.role === "assistant" && message.streaming,
+    );
+    return deriveLiveWorkStatus({
+      activities: threadActivities,
+      runningTurnId,
+      streamingMessage: streamingMessage
+        ? { createdAt: streamingMessage.createdAt, updatedAt: streamingMessage.updatedAt }
+        : null,
+      // Claude never streams thinking text (blocks arrive encrypted with only
+      // a signature), so a silent stretch of a running turn is the model
+      // thinking rather than idle time.
+      assumeThinkingWhenSilent: sessionProviderName === "claudeAgent",
+    });
+  }, [runningTurnId, sessionProviderName, threadActivities, timelineMessages]);
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
   const turnDiffSummaryByAssistantMessageId = useMemo(() => {
@@ -5975,14 +5995,11 @@ function ChatViewContent(props: ChatViewProps) {
                 isWorking={isWorking}
                 activeTurnInProgress={isWorking || !latestTurnSettled}
                 activeTurnStartedAt={activeWorkStartedAt}
+                liveWorkStatus={liveWorkStatus}
                 listRef={legendListRef}
                 timelineEntries={timelineEntries}
                 latestTurn={activeLatestTurn}
-                runningTurnId={
-                  activeThread.session?.status === "running"
-                    ? activeThread.session.activeTurnId
-                    : null
-                }
+                runningTurnId={runningTurnId}
                 turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
                 activeThreadEnvironmentId={activeThread.environmentId}
                 routeThreadKey={routeThreadKey}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -988,10 +988,10 @@ describe("deriveMessagesTimelineRows", () => {
       turnDiffSummaryByAssistantMessageId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     };
-    const collapsedRows = deriveMessagesTimelineRows(baseInput);
-    const expandedRows = deriveMessagesTimelineRows({
+    const expandedRows = deriveMessagesTimelineRows(baseInput);
+    const collapsedRows = deriveMessagesTimelineRows({
       ...baseInput,
-      expandedWorkGroupIds: new Set(["work-group:work-entry-1"]),
+      collapsedWorkGroupIds: new Set(["work-group:work-entry-1"]),
     });
 
     expect(collapsedRows.map((row) => row.id)).toEqual(["work-3", "work-toggle:work-entry-1"]);
@@ -1169,5 +1169,44 @@ describe("computeStableMessagesTimelineRows", () => {
 
     expect(reordered).not.toBe(initial);
     expect(reordered.result).toEqual([initial.result[1], initial.result[0]]);
+  });
+});
+
+describe("working row live status", () => {
+  it("threads the live work status into the working row", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [],
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      liveWorkStatus: {
+        kind: "thinking",
+        label: "Thinking",
+        since: "2026-01-01T00:00:10Z",
+        thinkingChars: 800,
+      },
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    const workingRow = rows.find((row) => row.kind === "working");
+    expect(workingRow?.kind === "working" ? workingRow.status : null).toEqual({
+      kind: "thinking",
+      label: "Thinking",
+      since: "2026-01-01T00:00:10Z",
+      thinkingChars: 800,
+    });
+  });
+
+  it("defaults the working row status to null", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [],
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    const workingRow = rows.find((row) => row.kind === "working");
+    expect(workingRow?.kind === "working" ? workingRow.status : undefined).toBeNull();
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -3,6 +3,7 @@ import {
   formatDuration,
   workEntryIndicatesToolNeutralStatus,
   workLogEntryIsToolLike,
+  type LiveWorkStatus,
   type TimelineEntry,
   type WorkLogEntry,
 } from "../../session-logic";
@@ -175,7 +176,7 @@ export type MessagesTimelineRow =
       createdAt: string;
       proposedPlan: ProposedPlan;
     }
-  | { kind: "working"; id: string; createdAt: string | null };
+  | { kind: "working"; id: string; createdAt: string | null; status: LiveWorkStatus | null };
 
 export interface StableMessagesTimelineRowsState {
   byId: Map<string, MessagesTimelineRow>;
@@ -414,9 +415,10 @@ export function deriveMessagesTimelineRows(input: {
   latestTurn?: TimelineLatestTurn | null;
   runningTurnId?: TurnId | null;
   expandedTurnIds?: ReadonlySet<TurnId>;
-  expandedWorkGroupIds?: ReadonlySet<string>;
+  collapsedWorkGroupIds?: ReadonlySet<string>;
   isWorking: boolean;
   activeTurnStartedAt: string | null;
+  liveWorkStatus?: LiveWorkStatus | null;
   turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
   revertTurnCountByUserMessageId: ReadonlyMap<MessageId, number>;
 }): MessagesTimelineRow[] {
@@ -495,7 +497,9 @@ export function deriveMessagesTimelineRows(input: {
           });
         } else {
           const groupId = `work-group:${timelineEntry.id}`;
-          const expanded = input.expandedWorkGroupIds?.has(groupId) ?? false;
+          // Groups render fully by default; the set tracks groups the user
+          // explicitly collapsed via "Show fewer".
+          const expanded = !(input.collapsedWorkGroupIds?.has(groupId) ?? false);
           // Agent-spawn CTA rows are always visible: a running fleet must
           // never hide behind a "+N tool calls" toggle. Selection is by
           // membership (spawn OR recent-tail), preserving the group's
@@ -591,6 +595,7 @@ export function deriveMessagesTimelineRows(input: {
       kind: "working",
       id: "working-indicator-row",
       createdAt: input.activeTurnStartedAt,
+      status: input.liveWorkStatus ?? null,
     });
   }
 
@@ -622,8 +627,17 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
   if (a.kind !== b.kind || a.id !== b.id) return false;
 
   switch (a.kind) {
-    case "working":
-      return a.createdAt === (b as typeof a).createdAt;
+    case "working": {
+      const bw = b as typeof a;
+      return (
+        a.createdAt === bw.createdAt &&
+        a.status?.kind === bw.status?.kind &&
+        a.status?.label === bw.status?.label &&
+        a.status?.since === bw.status?.since &&
+        a.status?.thinkingChars === bw.status?.thinkingChars &&
+        a.status?.thinkingText === bw.status?.thinkingText
+      );
+    }
 
     case "turn-fold": {
       const bf = b as typeof a;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -34,13 +34,16 @@ import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { FileDiff } from "@pierre/diffs/react";
 import {
   deriveTimelineEntries,
+  summarizeToolTextOutput,
   workEntryIndicatesToolFailure,
   workEntryIndicatesToolNeutralStatus,
   workEntryIndicatesToolSuccess,
   workLogEntryIsToolLike,
+  type LiveWorkStatus,
 } from "../../session-logic";
 import { type TurnDiffSummary } from "../../types";
 import {
+  buildFileDiffRenderKey,
   getRenderablePatch,
   resolveDiffThemeName,
   resolveFileDiffPath,
@@ -59,6 +62,7 @@ import {
   MousePointerClickIcon,
   PaintbrushIcon,
   MinusIcon,
+  SparklesIcon,
   SquarePenIcon,
   TerminalIcon,
   Undo2Icon,
@@ -171,6 +175,7 @@ interface MessagesTimelineProps {
   isWorking: boolean;
   activeTurnInProgress: boolean;
   activeTurnStartedAt: string | null;
+  liveWorkStatus?: LiveWorkStatus | null;
   listRef: React.RefObject<LegendListRef | null>;
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
   latestTurn: TimelineLatestTurn | null;
@@ -206,6 +211,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   isWorking,
   activeTurnInProgress,
   activeTurnStartedAt,
+  liveWorkStatus = null,
   agentPanelModel = EMPTY_AGENT_PANEL_MODEL,
   onOpenAgents = NOOP_OPEN_AGENTS,
   listRef,
@@ -235,7 +241,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   topFadeEnabled = false,
 }: MessagesTimelineProps) {
   const [expandedTurnIds, setExpandedTurnIds] = useState<ReadonlySet<TurnId>>(new Set());
-  const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
+  const [collapsedWorkGroupIds, setCollapsedWorkGroupIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
   const [minimapStripMap] = useState(() => new Map<string, HTMLSpanElement>());
 
   const onToggleTurnFold = useCallback((turnId: TurnId) => {
@@ -254,7 +262,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       const anchorBottomBeforeToggle = anchorElement?.getBoundingClientRect().bottom ?? null;
 
       flushSync(() => {
-        setExpandedWorkGroupIds((existing) => {
+        setCollapsedWorkGroupIds((existing) => {
           const next = new Set(existing);
           if (next.has(groupId)) {
             next.delete(groupId);
@@ -319,9 +327,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         latestTurn,
         runningTurnId,
         expandedTurnIds,
-        expandedWorkGroupIds,
+        collapsedWorkGroupIds,
         isWorking,
         activeTurnStartedAt,
+        liveWorkStatus,
         turnDiffSummaryByAssistantMessageId,
         revertTurnCountByUserMessageId,
       }),
@@ -330,9 +339,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       latestTurn,
       runningTurnId,
       expandedTurnIds,
-      expandedWorkGroupIds,
+      collapsedWorkGroupIds,
       isWorking,
       activeTurnStartedAt,
+      liveWorkStatus,
       turnDiffSummaryByAssistantMessageId,
       revertTurnCountByUserMessageId,
     ],
@@ -1109,25 +1119,134 @@ function ProposedPlanTimelineRow({
   );
 }
 
+function formatApproxThinkingTokens(chars: number): string | null {
+  const tokens = Math.round(chars / 4);
+  if (tokens < 50) {
+    return null;
+  }
+  if (tokens < 1000) {
+    return `~${tokens} tokens`;
+  }
+  return `~${(tokens / 1000).toFixed(1)}k tokens`;
+}
+
 function WorkingTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "working" }> }) {
+  const status = row.status;
+  const label = status?.label ?? "Working";
+  const since = status?.since ?? row.createdAt;
+  const thinkingText =
+    status?.kind === "thinking" && status.thinkingText ? status.thinkingText.trim() : "";
+  const canExpandThinking = thinkingText.length > 0;
+  // Live reasoning streams in expanded by default; user can collapse.
+  const [thinkingExpanded, setThinkingExpanded] = useState(true);
+  const approxTokens =
+    status?.kind === "thinking" && status.thinkingChars !== undefined
+      ? formatApproxThinkingTokens(status.thinkingChars)
+      : null;
+  // The phase timer replaces the turn timer when a phase is active; keep the
+  // total visible so long turns still read as one continuous run.
+  const showTotalTimer =
+    status?.since !== undefined &&
+    status?.since !== null &&
+    row.createdAt !== null &&
+    status.since !== row.createdAt;
+
   return (
     <div className="py-0.5 pl-1.5">
-      <div className="flex items-center gap-2 pt-1 text-[11px] text-muted-foreground/70 tabular-nums">
+      <div
+        className={cn(
+          "flex items-center gap-2 pt-1 text-[11px] text-muted-foreground/70 tabular-nums",
+          canExpandThinking &&
+            "cursor-pointer rounded-md hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70",
+        )}
+        {...(canExpandThinking
+          ? {
+              role: "button" as const,
+              tabIndex: 0 as const,
+              "aria-expanded": thinkingExpanded,
+              "aria-label": `${label} reasoning`,
+              onClick: () => setThinkingExpanded((value) => !value),
+              onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setThinkingExpanded((value) => !value);
+                }
+              },
+            }
+          : {})}
+      >
         <span className="inline-flex items-center gap-[3px]">
           <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse" />
           <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse [animation-delay:200ms]" />
           <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse [animation-delay:400ms]" />
         </span>
-        <span>
-          {row.createdAt ? (
+        <span className="min-w-0 flex-1 truncate">
+          {since ? (
             <>
-              Working for <WorkingTimer createdAt={row.createdAt} />
+              {label} for <WorkingTimer createdAt={since} />
             </>
           ) : (
-            "Working..."
+            `${label}...`
           )}
+          {approxTokens ? <span> · {approxTokens}</span> : null}
+          {showTotalTimer && row.createdAt ? (
+            <span className="text-muted-foreground/50">
+              {" · "}
+              <WorkingTimer createdAt={row.createdAt} /> total
+            </span>
+          ) : null}
         </span>
+        {canExpandThinking ? (
+          <span
+            className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/55"
+            aria-hidden
+          >
+            <ChevronDownIcon
+              className={cn(
+                "size-3 shrink-0 opacity-70 transition-transform duration-200",
+                thinkingExpanded && "rotate-180",
+              )}
+              aria-hidden
+            />
+          </span>
+        ) : null}
       </div>
+      {thinkingExpanded && canExpandThinking ? <LiveThinkingStream text={thinkingText} /> : null}
+    </div>
+  );
+}
+
+/**
+ * Full streamed reasoning text under the live "Thinking" indicator.
+ * Auto-scrolls to the bottom as new text arrives while the user is at the end.
+ */
+function LiveThinkingStream({ text }: { text: string }) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const stickToBottomRef = useRef(true);
+
+  useEffect(() => {
+    const el = preRef.current;
+    if (!el || !stickToBottomRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [text]);
+
+  return (
+    <div
+      className="mt-1 ms-[19px] max-w-[720px] border-s border-border/45 ps-3 pt-0.5"
+      onClick={stopRowToggle}
+      onPointerDown={stopRowToggle}
+    >
+      <pre
+        ref={preRef}
+        className="max-h-[min(60vh,28rem)] cursor-text overflow-auto whitespace-pre-wrap break-words text-[11px] italic leading-relaxed text-muted-foreground/70 select-text"
+        onScroll={(event) => {
+          const el = event.currentTarget;
+          const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+          stickToBottomRef.current = distanceFromBottom < 48;
+        }}
+      >
+        {text}
+      </pre>
     </div>
   );
 }
@@ -1880,6 +1999,9 @@ function buildToolCallExpandedBody(
   if (workEntry.detail?.trim()) {
     blocks.push(workEntry.detail.trim());
   }
+  if (workEntry.toolResultText && workEntry.toolResultText !== workEntry.detail?.trim()) {
+    blocks.push(workEntry.toolResultText);
+  }
   const changedFiles = workEntry.changedFiles ?? [];
   if (changedFiles.length > 0) {
     blocks.push(
@@ -1941,6 +2063,536 @@ function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
     return capitalizePhrase(normalizeCompactToolLabel(workEntry.label));
   }
   return capitalizePhrase(normalizeCompactToolLabel(workEntry.toolTitle));
+}
+
+const TOOL_ARG_MAX_LENGTH = 96;
+
+function compactToolArg(value: string): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= TOOL_ARG_MAX_LENGTH) {
+    return normalized;
+  }
+  return `${normalized.slice(0, TOOL_ARG_MAX_LENGTH - 1).trimEnd()}…`;
+}
+
+/**
+ * Claude Code-style display names for tool headers. Raw names are kept for
+ * anything unmapped so MCP/dynamic tools stay recognizable.
+ */
+const TOOL_DISPLAY_NAMES: Record<string, string> = {
+  edit: "Update",
+  multiedit: "Update",
+  notebookedit: "Update",
+  edit_file: "Update",
+  update_file: "Update",
+  apply_patch: "Update",
+  applypatch: "Update",
+  write: "Write",
+  write_file: "Write",
+  create_file: "Write",
+  websearch: "Web Search",
+  web_search: "Web Search",
+  webfetch: "Fetch",
+  todowrite: "Todos",
+  update_plan: "Todos",
+  glob: "Glob",
+  grep: "Search",
+  spawnagent: "Spawn Agent",
+  sendinput: "Message Agent",
+  resumeagent: "Resume Agent",
+  closeagent: "Close Agent",
+  wait: "Wait for Agents",
+};
+
+/**
+ * Prettify raw snake_case tool names from non-Claude harnesses
+ * (`read_file` → "Read File"). MCP names keep their raw form — the
+ * `mcp__server__tool` shape is more recognizable than a mangled title.
+ */
+function prettifySnakeCaseToolName(toolName: string): string {
+  if (!/^[a-z0-9_]+$/.test(toolName) || toolName.startsWith("mcp")) {
+    return toolName;
+  }
+  return toolName
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word[0]!.toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function toolDisplayName(toolName: string): string {
+  return TOOL_DISPLAY_NAMES[toolName.toLowerCase()] ?? prettifySnakeCaseToolName(toolName);
+}
+
+/** The single most descriptive argument, mirroring Claude Code's `Tool(arg)` header. */
+function toolPrimaryArg(
+  workEntry: TimelineWorkEntry,
+  workspaceRoot: string | undefined,
+): string | null {
+  const input = workEntry.toolInput;
+  if (input) {
+    if (typeof input.command === "string" && input.command.trim()) {
+      return compactToolArg(input.command);
+    }
+    const pathValue = [
+      input.file_path,
+      input.notebook_path,
+      input.path,
+      input.target_file,
+      input.target_directory,
+    ].find(
+      (candidate): candidate is string =>
+        typeof candidate === "string" && candidate.trim().length > 0,
+    );
+    if (pathValue) {
+      return compactToolArg(formatWorkspaceRelativePath(pathValue, workspaceRoot));
+    }
+    for (const key of ["pattern", "query", "url", "skill", "description", "server"] as const) {
+      const value = input[key];
+      if (typeof value === "string" && value.trim()) {
+        return key === "query" ? compactToolArg(`"${value.trim()}"`) : compactToolArg(value);
+      }
+    }
+    const prompt = input.prompt;
+    if (typeof prompt === "string" && prompt.trim()) {
+      return compactToolArg(prompt);
+    }
+  }
+  if (workEntry.command) {
+    return compactToolArg(workEntry.command);
+  }
+  const [firstChanged] = workEntry.changedFiles ?? [];
+  if (firstChanged) {
+    return compactToolArg(formatWorkspaceRelativePath(firstChanged, workspaceRoot));
+  }
+  return null;
+}
+
+interface ToolCallHeader {
+  name: string;
+  arg: string | null;
+}
+
+function toolCallHeader(
+  workEntry: TimelineWorkEntry,
+  workspaceRoot: string | undefined,
+): ToolCallHeader | null {
+  if (!workEntry.toolName) {
+    return null;
+  }
+  return {
+    name: toolDisplayName(workEntry.toolName),
+    arg: toolPrimaryArg(workEntry, workspaceRoot),
+  };
+}
+
+/** The compact `⎿ …` line under a tool header. */
+function toolResultLine(
+  workEntry: TimelineWorkEntry,
+  header: ToolCallHeader | null,
+  workspaceRoot: string | undefined,
+): string | null {
+  if (workEntry.toolDiff) {
+    const added = countDiffLines(workEntry.toolDiff, "+");
+    const removed = countDiffLines(workEntry.toolDiff, "-");
+    if (added > 0 || removed > 0) {
+      const parts: string[] = [];
+      if (added > 0) parts.push(`Added ${added} line${added === 1 ? "" : "s"}`);
+      if (removed > 0) parts.push(`removed ${removed} line${removed === 1 ? "" : "s"}`);
+      return parts.join(", ");
+    }
+  }
+  if (workEntry.toolResultText) {
+    const summary = summarizeToolTextOutput(workEntry.toolResultText);
+    if (summary) {
+      return summary;
+    }
+  }
+  const preview = workEntryPreview(workEntry, workspaceRoot);
+  if (!preview) {
+    return null;
+  }
+  // Drop previews that just repeat the header (e.g. detail "Bash: git status"
+  // under a `Bash(git status)` header).
+  const normalizedPreview = preview.replace(/\s+/g, " ").trim().toLowerCase();
+  const headerArg = header?.arg?.toLowerCase() ?? "";
+  if (headerArg && normalizedPreview === headerArg) {
+    return null;
+  }
+  if (
+    workEntry.toolName &&
+    normalizedPreview === `${workEntry.toolName.toLowerCase()}: ${headerArg}`
+  ) {
+    return null;
+  }
+  return preview;
+}
+
+function countDiffLines(diff: NonNullable<TimelineWorkEntry["toolDiff"]>, sign: "+" | "-") {
+  let count = 0;
+  for (const hunk of diff.hunks) {
+    for (const line of hunk.lines) {
+      if (line.startsWith(sign)) count += 1;
+    }
+  }
+  return count;
+}
+
+const INLINE_DIFF_COLLAPSED_LINES = 16;
+
+interface InlineDiffRow {
+  key: string;
+  sign: "+" | "-" | " ";
+  lineNumber: number | null;
+  text: string;
+}
+
+function buildInlineDiffRows(diff: NonNullable<TimelineWorkEntry["toolDiff"]>): InlineDiffRow[] {
+  const rows: InlineDiffRow[] = [];
+  diff.hunks.forEach((hunk, hunkIndex) => {
+    let oldLine = hunk.oldStart;
+    let newLine = hunk.newStart;
+    hunk.lines.forEach((line, lineIndex) => {
+      const sign = line.startsWith("+") ? "+" : line.startsWith("-") ? "-" : " ";
+      const text = sign === " " ? line.replace(/^ /, "") : line.slice(1);
+      let lineNumber: number | null = null;
+      if (sign === "-") {
+        lineNumber = oldLine;
+        if (oldLine !== null) oldLine += 1;
+      } else if (sign === "+") {
+        lineNumber = newLine;
+        if (newLine !== null) newLine += 1;
+      } else {
+        lineNumber = newLine ?? oldLine;
+        if (oldLine !== null) oldLine += 1;
+        if (newLine !== null) newLine += 1;
+      }
+      rows.push({ key: `${hunkIndex}:${lineIndex}`, sign, lineNumber, text });
+    });
+  });
+  return rows;
+}
+
+/**
+ * Serializes the tool diff into a unified patch so it can flow through the
+ * same parse + syntax-highlight pipeline as the diff panel. Hunks without
+ * known positions (reconstructed while the edit streams) anchor at line 1;
+ * the completed tool result replaces them with real numbers.
+ */
+function buildToolDiffPatch(
+  diff: NonNullable<TimelineWorkEntry["toolDiff"]>,
+  maxLines: number,
+): { patch: string; hiddenLines: number } {
+  const path = diff.filePath ?? "file";
+  const parts = [`--- a/${path}`, `+++ b/${path}`];
+  let remaining = maxLines;
+  let hiddenLines = 0;
+  for (const hunk of diff.hunks) {
+    if (remaining <= 0) {
+      hiddenLines += hunk.lines.length;
+      continue;
+    }
+    const lines = hunk.lines.slice(0, remaining);
+    hiddenLines += hunk.lines.length - lines.length;
+    remaining -= lines.length;
+    const oldCount = lines.filter((line) => !line.startsWith("+")).length;
+    const newCount = lines.filter((line) => !line.startsWith("-")).length;
+    parts.push(
+      `@@ -${hunk.oldStart ?? 1},${oldCount} +${hunk.newStart ?? 1},${newCount} @@`,
+      ...lines,
+    );
+  }
+  return { patch: `${parts.join("\n")}\n`, hiddenLines };
+}
+
+/**
+ * The diff shadow root defaults `--diffs-bg` to pure white/black, so without
+ * this bridge dark mode renders an opaque black slab behind every inline
+ * diff. Custom properties inherit across the shadow boundary, so pointing the
+ * background variables at the app tokens makes the diff sit flush on the chat
+ * surface. The `[data-separator]` rule restyles the hunk gap: the default
+ * "line-info" separator is a 32px "N unmodified lines" band with expand
+ * buttons that cannot work here (there is no source file to expand into), so
+ * hunks use `hunkSeparators: "simple"` plus a hairline divider instead.
+ */
+const INLINE_TOOL_DIFF_UNSAFE_CSS = `
+[data-diffs-header],
+[data-diff],
+[data-file],
+[data-error-wrapper],
+[data-virtualizer-buffer] {
+  --diffs-font-family: var(--font-mono) !important;
+  --diffs-bg: var(--background) !important;
+  --diffs-light-bg: var(--background) !important;
+  --diffs-dark-bg: var(--background) !important;
+  --diffs-token-light-bg: transparent;
+  --diffs-token-dark-bg: transparent;
+
+  --diffs-bg-context-override: color-mix(in srgb, var(--background) 97%, var(--foreground));
+  --diffs-bg-hover-override: color-mix(in srgb, var(--background) 94%, var(--foreground));
+  --diffs-bg-separator-override: color-mix(in srgb, var(--background) 95%, var(--foreground));
+  --diffs-bg-buffer-override: color-mix(in srgb, var(--background) 90%, var(--foreground));
+
+  --diffs-bg-addition-override: color-mix(in srgb, var(--background) 92%, var(--success));
+  --diffs-bg-addition-number-override: color-mix(in srgb, var(--background) 88%, var(--success));
+  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--background) 85%, var(--success));
+  --diffs-bg-addition-emphasis-override: color-mix(in srgb, var(--background) 80%, var(--success));
+
+  --diffs-bg-deletion-override: color-mix(in srgb, var(--background) 92%, var(--destructive));
+  --diffs-bg-deletion-number-override: color-mix(in srgb, var(--background) 88%, var(--destructive));
+  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--background) 85%, var(--destructive));
+  --diffs-bg-deletion-emphasis-override: color-mix(in srgb, var(--background) 80%, var(--destructive));
+}
+
+[data-separator="simple"] {
+  min-height: 5px;
+  background:
+    linear-gradient(
+        color-mix(in srgb, var(--border) 60%, transparent),
+        color-mix(in srgb, var(--border) 60%, transparent)
+      )
+      center / 100% 1px no-repeat !important;
+}
+`;
+
+function InlineToolDiff({ diff }: { diff: NonNullable<TimelineWorkEntry["toolDiff"]> }) {
+  const ctx = use(TimelineRowCtx);
+  const [showAll, setShowAll] = useState(false);
+  const totalLines = diff.hunks.reduce((sum, hunk) => sum + hunk.lines.length, 0);
+  const maxLines = showAll ? Number.POSITIVE_INFINITY : INLINE_DIFF_COLLAPSED_LINES;
+  const renderable = useMemo(() => {
+    const { patch, hiddenLines } = buildToolDiffPatch(diff, maxLines);
+    return {
+      hiddenLines,
+      parsed: getRenderablePatch(patch, `tool-diff:${diff.filePath ?? "file"}:${totalLines}`),
+    };
+  }, [diff, maxLines, totalLines]);
+
+  if (renderable.parsed?.kind === "files") {
+    return (
+      <div
+        className="mt-1 ms-[18px] cursor-text select-text overflow-hidden rounded-md border border-border/40 text-[11px]"
+        onClick={stopRowToggle}
+        onPointerDown={stopRowToggle}
+      >
+        {renderable.parsed.files.map((fileDiff) => (
+          <FileDiff
+            key={buildFileDiffRenderKey(fileDiff)}
+            fileDiff={fileDiff}
+            options={{
+              collapsed: false,
+              diffStyle: "unified",
+              theme: resolveDiffThemeName(ctx.resolvedTheme),
+              // The tool row header already names the file.
+              disableFileHeader: true,
+              disableBackground: true,
+              hunkSeparators: "simple",
+              unsafeCSS: INLINE_TOOL_DIFF_UNSAFE_CSS,
+            }}
+          />
+        ))}
+        {renderable.hiddenLines > 0 || diff.truncated ? (
+          <button
+            type="button"
+            className="w-full cursor-pointer px-2 py-0.5 text-start font-mono text-muted-foreground/70 transition-colors hover:bg-accent/20 hover:text-foreground"
+            onClick={(event) => {
+              event.stopPropagation();
+              setShowAll((value) => !value);
+            }}
+          >
+            {renderable.hiddenLines > 0
+              ? `… +${renderable.hiddenLines} more line${renderable.hiddenLines === 1 ? "" : "s"}`
+              : showAll && diff.truncated
+                ? "Diff truncated"
+                : "Collapse"}
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return <InlineToolDiffPlain diff={diff} />;
+}
+
+function InlineToolDiffPlain({ diff }: { diff: NonNullable<TimelineWorkEntry["toolDiff"]> }) {
+  const [showAll, setShowAll] = useState(false);
+  const rows = useMemo(() => buildInlineDiffRows(diff), [diff]);
+  const hasLineNumbers = rows.some((row) => row.lineNumber !== null);
+  const visibleRows = showAll ? rows : rows.slice(0, INLINE_DIFF_COLLAPSED_LINES);
+  const hiddenCount = rows.length - visibleRows.length;
+  const gutterWidth = hasLineNumbers
+    ? `${Math.max(2, String(rows.reduce((max, row) => Math.max(max, row.lineNumber ?? 0), 0)).length)}ch`
+    : "0ch";
+
+  return (
+    <div
+      className="mt-1 ms-[18px] cursor-text select-text overflow-hidden rounded-md border border-border/40 font-mono text-[11px] leading-[1.6]"
+      onClick={stopRowToggle}
+      onPointerDown={stopRowToggle}
+    >
+      {visibleRows.map((row) => (
+        <div
+          key={row.key}
+          className={cn(
+            "flex min-w-0",
+            row.sign === "+" && "bg-success/12",
+            row.sign === "-" && "bg-destructive/12",
+          )}
+        >
+          {hasLineNumbers ? (
+            <span
+              className="shrink-0 select-none px-1.5 text-end text-muted-foreground/45"
+              style={{ minWidth: `calc(${gutterWidth} + 0.75rem)` }}
+            >
+              {row.lineNumber ?? ""}
+            </span>
+          ) : null}
+          <span
+            className={cn(
+              "w-4 shrink-0 select-none text-center",
+              row.sign === "+" && "text-success-foreground",
+              row.sign === "-" && "text-destructive",
+              row.sign === " " && "text-transparent",
+            )}
+          >
+            {row.sign}
+          </span>
+          <span className="min-w-0 flex-1 whitespace-pre-wrap break-words pe-2">
+            {row.text || " "}
+          </span>
+        </div>
+      ))}
+      {hiddenCount > 0 || diff.truncated ? (
+        <button
+          type="button"
+          className="w-full cursor-pointer px-2 py-0.5 text-start text-muted-foreground/70 transition-colors hover:bg-accent/20 hover:text-foreground"
+          onClick={(event) => {
+            event.stopPropagation();
+            setShowAll((value) => !value);
+          }}
+        >
+          {hiddenCount > 0
+            ? `… +${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`
+            : showAll && diff.truncated
+              ? "Diff truncated"
+              : "Collapse"}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+type ToolDotState = "running" | "success" | "failed" | "neutral";
+
+function ToolStatusDot({ state }: { state: ToolDotState }) {
+  return (
+    <span className="flex size-5 shrink-0 items-center justify-center">
+      <span
+        className={cn(
+          "size-[7px] rounded-full",
+          state === "running" && "animate-pulse bg-primary",
+          state === "success" && "bg-success",
+          state === "failed" && "bg-destructive",
+          state === "neutral" && "bg-muted-foreground/40",
+        )}
+        aria-hidden
+      />
+    </span>
+  );
+}
+
+/** Divider-style transcript row for context compaction boundaries. */
+function ContextCompactionRow({ inProgress }: { inProgress: boolean }) {
+  return (
+    <div className="flex select-none items-center gap-2.5 px-0.5 py-2" role="status">
+      <span className="h-px flex-1 bg-gradient-to-r from-transparent to-primary/30" aria-hidden />
+      <span className="flex shrink-0 items-center gap-1.5 text-[11px] font-medium">
+        <SparklesIcon
+          className={cn("size-3.5 text-primary/70", inProgress && "animate-status-pulse")}
+          aria-hidden
+        />
+        <span className="animate-compaction-shimmer bg-[linear-gradient(90deg,var(--color-muted-foreground),var(--color-foreground),var(--color-muted-foreground))] bg-[length:200%_100%] bg-clip-text text-transparent">
+          {inProgress ? "Compacting context…" : "Context compacted"}
+        </span>
+      </span>
+      <span className="h-px flex-1 bg-gradient-to-l from-transparent to-primary/30" aria-hidden />
+    </div>
+  );
+}
+
+/** Completed reasoning burst — "Thought for Xs", expandable to the full thinking text (default open). */
+function ThinkingWorkEntryRow({
+  workEntry,
+  expanded,
+  onToggle,
+}: {
+  workEntry: TimelineWorkEntry;
+  expanded: boolean;
+  onToggle: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
+  const thinkingText = workEntry.detail?.trim() ?? "";
+  const canExpand = thinkingText.length > 0;
+  return (
+    <div
+      className={cn(
+        "flex flex-col rounded-md px-0.5 py-0.5 transition-colors",
+        canExpand &&
+          "cursor-pointer hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70",
+      )}
+      {...(canExpand
+        ? {
+            role: "button" as const,
+            tabIndex: 0 as const,
+            "aria-expanded": expanded,
+            "aria-label": workEntry.label,
+            onClick: () => onToggle((value) => !value),
+            onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onToggle((value) => !value);
+              }
+            },
+          }
+        : {})}
+    >
+      <div className="flex select-none items-center gap-0.5">
+        <span
+          className="flex size-5 shrink-0 items-center justify-center text-muted-foreground/65"
+          aria-hidden
+        >
+          ✻
+        </span>
+        <p className="min-w-0 flex-1 truncate text-[12px] italic leading-5 text-muted-foreground/80">
+          {workEntry.label}
+        </p>
+        <span
+          className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/55"
+          aria-hidden={!canExpand}
+        >
+          {canExpand ? (
+            <ChevronDownIcon
+              className={cn(
+                "size-3 shrink-0 opacity-70 transition-transform duration-200",
+                expanded && "rotate-180",
+              )}
+              aria-hidden
+            />
+          ) : null}
+        </span>
+      </div>
+      {expanded && canExpand ? (
+        <div
+          className="mt-1 ms-[18px] cursor-default border-s border-border/45 ps-3 pt-0.5"
+          onClick={stopRowToggle}
+          onPointerDown={stopRowToggle}
+        >
+          <pre className="max-h-[min(60vh,28rem)] cursor-text overflow-auto whitespace-pre-wrap break-words text-[11px] italic leading-relaxed text-muted-foreground select-text">
+            {thinkingText}
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 const stopRowToggle = (e: { stopPropagation: () => void }) => e.stopPropagation();
@@ -2057,11 +2709,30 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
 }) {
   const { workEntry, workspaceRoot } = props;
   const activity = use(TimelineRowActivityCtx);
-  const [expanded, setExpanded] = useState(false);
+  // Reasoning rows default expanded so the full thought is visible; other work rows stay collapsed.
+  const [expanded, setExpanded] = useState(
+    () => workEntry.sourceActivityKind === "thinking.completed",
+  );
   const iconConfig = workToneIcon(workEntry.tone);
+  if (
+    workEntry.sourceActivityKind === "context-compaction" ||
+    workEntry.sourceActivityKind === "context-compaction.started"
+  ) {
+    return (
+      <ContextCompactionRow
+        inProgress={workEntry.sourceActivityKind === "context-compaction.started"}
+      />
+    );
+  }
+  if (workEntry.sourceActivityKind === "thinking.completed") {
+    return (
+      <ThinkingWorkEntryRow workEntry={workEntry} expanded={expanded} onToggle={setExpanded} />
+    );
+  }
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
   const entryIconName = showWarningIndicator ? "x" : workEntryIconName(workEntry);
   const heading = toolWorkEntryHeading(workEntry);
+  const header = showWarningIndicator ? null : toolCallHeader(workEntry, workspaceRoot);
   const rawPreview = workEntryPreview(workEntry, workspaceRoot);
   const preview =
     rawPreview &&
@@ -2110,6 +2781,81 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         },
       }
     : {};
+
+  if (header) {
+    const dotState: ToolDotState = showFailedIndicator
+      ? "failed"
+      : !turnSettled && workEntry.toolLifecycleStatus === "inProgress"
+        ? "running"
+        : showSuccessIndicator
+          ? "success"
+          : "neutral";
+    const resultLine = toolResultLine(workEntry, header, workspaceRoot);
+
+    return (
+      <div
+        className={cn(
+          "flex flex-col rounded-md px-0.5 py-0.5 transition-colors",
+          canExpand &&
+            "cursor-pointer hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70",
+        )}
+        {...rowToggleProps}
+      >
+        <div className="flex select-none items-center gap-0.5">
+          <ToolStatusDot state={dotState} />
+          <p className="min-w-0 flex-1 truncate font-mono text-[12px] leading-5">
+            <span
+              className={cn(
+                "font-semibold",
+                showFailedIndicator ? "text-destructive" : "text-foreground/90",
+              )}
+            >
+              {header.name}
+            </span>
+            {header.arg ? (
+              <span className="text-muted-foreground/80">
+                (<span className="text-foreground/65">{header.arg}</span>)
+              </span>
+            ) : null}
+          </p>
+          <span
+            className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/55"
+            aria-hidden={!canExpand}
+          >
+            {canExpand ? (
+              <ChevronDownIcon
+                className={cn(
+                  "size-3 shrink-0 opacity-70 transition-transform duration-200",
+                  expanded && "rotate-180",
+                )}
+                aria-hidden
+              />
+            ) : null}
+          </span>
+        </div>
+        {resultLine ? (
+          <div className="flex select-none items-start gap-1 ps-[7px] font-mono text-[11px] leading-5 text-muted-foreground/75">
+            <span className="shrink-0 text-muted-foreground/45" aria-hidden>
+              ⎿
+            </span>
+            <span className="min-w-0 flex-1 truncate">{resultLine}</span>
+          </div>
+        ) : null}
+        {workEntry.toolDiff ? <InlineToolDiff diff={workEntry.toolDiff} /> : null}
+        {expanded && canExpand && expandedBody ? (
+          <div
+            className="mt-1 ms-[18px] cursor-default border-s border-border/45 ps-3 pt-0.5"
+            onClick={stopRowToggle}
+            onPointerDown={stopRowToggle}
+          >
+            <pre className="max-h-64 cursor-text overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground select-text">
+              {expandedBody}
+            </pre>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -146,6 +146,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
      compositor updates discrete frames instead of every vsync. */
   --animate-status-pulse: status-pulse 2s infinite;
   --animate-status-ping: status-ping 2s infinite;
+  --animate-compaction-shimmer: compaction-shimmer 2.4s linear infinite;
   --animate-sidebar-working-text: sidebar-working-text 3.4s infinite;
   --color-warning-foreground: var(--warning-foreground);
   --color-warning: var(--warning);
@@ -189,6 +190,13 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
   @keyframes skeleton {
+    to {
+      background-position: -200% 0;
+    }
+  }
+  /* Left-to-right highlight sweep over gradient-clipped text (used by the
+     context-compaction rows in the transcript). */
+  @keyframes compaction-shimmer {
     to {
       background-position: -200% 0;
     }

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
+  deriveLiveWorkStatus,
   derivePendingApprovals,
   derivePendingUserInputs,
   deriveTimelineEntries,
@@ -1909,5 +1910,847 @@ describe("rerun workflows", () => {
     const spawnRows = entries.filter((entry) => entry.agentSpawn !== undefined);
     expect(spawnRows.map((row) => row.agentSpawn!.workflowId)).toEqual(["wf-run1", "wf-run2"]);
     expect(spawnRows.map((row) => row.turnId)).toEqual(["turn-1", "turn-2"]);
+  });
+});
+
+describe("work log tool metadata", () => {
+  it("extracts toolName, toolInput and result text from payload.data", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Command run",
+        payload: {
+          itemType: "command_execution",
+          title: "Command run",
+          data: {
+            toolName: "Bash",
+            input: { command: "git status" },
+            result: { content: [{ type: "text", text: "On branch main\nnothing to commit" }] },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.toolName).toBe("Bash");
+    expect(entries[0]?.toolInput).toEqual({ command: "git status" });
+    expect(entries[0]?.toolResultText).toBe("On branch main\nnothing to commit");
+  });
+
+  it("builds a diff with real line numbers from the tool result structuredPatch", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "File updated",
+        payload: {
+          itemType: "file_change",
+          title: "File updated",
+          data: {
+            toolName: "Edit",
+            input: {
+              file_path: "/repo/src/a.ts",
+              old_string: "let x = 1",
+              new_string: "let x = 2",
+            },
+            toolUseResult: {
+              filePath: "/repo/src/a.ts",
+              structuredPatch: [
+                { oldStart: 4, newStart: 4, lines: [" context", "-let x = 1", "+let x = 2"] },
+              ],
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "/repo/src/a.ts",
+      hunks: [{ oldStart: 4, newStart: 4, lines: [" context", "-let x = 1", "+let x = 2"] }],
+      truncated: false,
+    });
+  });
+
+  it("reconstructs a numberless diff from streaming Edit input", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.updated",
+        summary: "File update",
+        payload: {
+          itemType: "file_change",
+          status: "inProgress",
+          data: {
+            toolName: "Edit",
+            input: {
+              file_path: "/repo/src/a.ts",
+              old_string: "old line",
+              new_string: "new line one\nnew line two",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "/repo/src/a.ts",
+      hunks: [
+        { oldStart: null, newStart: null, lines: ["-old line", "+new line one", "+new line two"] },
+      ],
+      truncated: false,
+    });
+  });
+
+  it("keeps the numbered diff when a streaming update collapses into the completed entry", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.updated",
+        summary: "File update",
+        payload: {
+          itemType: "file_change",
+          status: "inProgress",
+          toolCallId: "tool-1",
+          data: {
+            toolCallId: "tool-1",
+            toolName: "Edit",
+            input: { file_path: "/repo/src/a.ts", old_string: "a", new_string: "b" },
+          },
+        },
+      }),
+      makeActivity({
+        kind: "tool.completed",
+        summary: "File updated",
+        payload: {
+          itemType: "file_change",
+          toolCallId: "tool-1",
+          data: {
+            toolCallId: "tool-1",
+            toolName: "Edit",
+            input: { file_path: "/repo/src/a.ts", old_string: "a", new_string: "b" },
+            toolUseResult: {
+              filePath: "/repo/src/a.ts",
+              structuredPatch: [{ oldStart: 9, newStart: 9, lines: ["-a", "+b"] }],
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.toolDiff?.hunks[0]?.oldStart).toBe(9);
+  });
+
+  it("builds an all-additions diff for Write input", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "File created",
+        payload: {
+          itemType: "file_change",
+          data: {
+            toolName: "Write",
+            input: { file_path: "/repo/new.ts", content: "line one\nline two\n" },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "/repo/new.ts",
+      hunks: [{ oldStart: null, newStart: 1, lines: ["+line one", "+line two"] }],
+      truncated: false,
+    });
+  });
+});
+
+describe("thinking burst work log entries", () => {
+  it("omits started/progress and maps completed to a thinking row with detail", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "thinking-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "thinking.started",
+        summary: "Thinking",
+        tone: "info",
+        payload: { burstId: "burst-1", startedAt: "2026-02-23T00:00:01.000Z" },
+      }),
+      makeActivity({
+        id: "thinking-progress",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "thinking.progress",
+        summary: "Thinking",
+        tone: "info",
+        payload: { burstId: "burst-1", chars: 420 },
+      }),
+      makeActivity({
+        id: "thinking-complete",
+        createdAt: "2026-02-23T00:00:05.000Z",
+        kind: "thinking.completed",
+        summary: "Thought for 4s",
+        tone: "info",
+        payload: {
+          burstId: "burst-1",
+          chars: 500,
+          durationMs: 4000,
+          text: "The test asserts the inverse.",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries.map((entry) => entry.id)).toEqual(["thinking-complete"]);
+    const entry = entries[0]!;
+    expect(entry.tone).toBe("thinking");
+    expect(entry.label).toBe("Thought for 4s");
+    expect(entry.detail).toBe("The test asserts the inverse.");
+    expect(workEntryIndicatesToolNeutralStatus(entry)).toBe(false);
+  });
+});
+
+describe("deriveLiveWorkStatus", () => {
+  it("returns null when no turn is running", () => {
+    expect(
+      deriveLiveWorkStatus({
+        activities: [
+          makeActivity({
+            id: "thinking-start",
+            kind: "thinking.started",
+            summary: "Thinking",
+            tone: "info",
+            turnId: "turn-1",
+          }),
+        ],
+        runningTurnId: null,
+        streamingMessage: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("reports an open thinking burst with streamed size", () => {
+    const status = deriveLiveWorkStatus({
+      activities: [
+        makeActivity({
+          id: "thinking-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "thinking.started",
+          summary: "Thinking",
+          tone: "info",
+          turnId: "turn-1",
+          payload: { burstId: "burst-1", startedAt: "2026-02-23T00:00:01.000Z" },
+        }),
+        makeActivity({
+          id: "thinking-progress",
+          createdAt: "2026-02-23T00:00:04.000Z",
+          kind: "thinking.progress",
+          summary: "Thinking",
+          tone: "info",
+          turnId: "turn-1",
+          payload: { burstId: "burst-1", chars: 1234 },
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+    });
+    expect(status).toEqual({
+      kind: "thinking",
+      label: "Thinking",
+      since: "2026-02-23T00:00:01.000Z",
+      thinkingChars: 1234,
+    });
+  });
+
+  it("re-opens a thinking burst from a progress event after an interleaved tool call", () => {
+    const status = deriveLiveWorkStatus({
+      activities: [
+        makeActivity({
+          id: "thinking-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "thinking.started",
+          summary: "Thinking",
+          tone: "info",
+          turnId: "turn-1",
+          payload: { burstId: "burst-1", startedAt: "2026-02-23T00:00:01.000Z" },
+        }),
+        makeActivity({
+          id: "tool-complete",
+          createdAt: "2026-02-23T00:00:02.000Z",
+          kind: "tool.completed",
+          summary: "Command run completed",
+          tone: "tool",
+          turnId: "turn-1",
+          payload: { itemType: "command_execution", toolCallId: "tool-1" },
+        }),
+        makeActivity({
+          id: "thinking-progress",
+          createdAt: "2026-02-23T00:00:04.000Z",
+          kind: "thinking.progress",
+          summary: "Thinking",
+          tone: "info",
+          turnId: "turn-1",
+          payload: {
+            burstId: "burst-1",
+            startedAt: "2026-02-23T00:00:01.000Z",
+            chars: 640,
+            text: "still reasoning about the fix — full accumulated stream",
+          },
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+    });
+    expect(status).toEqual({
+      kind: "thinking",
+      label: "Thinking",
+      since: "2026-02-23T00:00:01.000Z",
+      thinkingChars: 640,
+      thinkingText: "still reasoning about the fix — full accumulated stream",
+    });
+  });
+
+  it("falls back to legacy textTail on thinking.progress when text is absent", () => {
+    const status = deriveLiveWorkStatus({
+      activities: [
+        makeActivity({
+          id: "thinking-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "thinking.started",
+          summary: "Thinking",
+          tone: "info",
+          turnId: "turn-1",
+          payload: { burstId: "burst-1", startedAt: "2026-02-23T00:00:01.000Z" },
+        }),
+        makeActivity({
+          id: "thinking-progress",
+          createdAt: "2026-02-23T00:00:04.000Z",
+          kind: "thinking.progress",
+          summary: "Thinking",
+          tone: "info",
+          turnId: "turn-1",
+          payload: {
+            burstId: "burst-1",
+            startedAt: "2026-02-23T00:00:01.000Z",
+            chars: 120,
+            textTail: "legacy tail only",
+          },
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+    });
+    expect(status).toEqual({
+      kind: "thinking",
+      label: "Thinking",
+      since: "2026-02-23T00:00:01.000Z",
+      thinkingChars: 120,
+      thinkingText: "legacy tail only",
+    });
+  });
+
+  it("clears the thinking status once the burst completes", () => {
+    const status = deriveLiveWorkStatus({
+      activities: [
+        makeActivity({
+          id: "thinking-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "thinking.started",
+          summary: "Thinking",
+          tone: "info",
+          turnId: "turn-1",
+        }),
+        makeActivity({
+          id: "thinking-complete",
+          createdAt: "2026-02-23T00:00:05.000Z",
+          kind: "thinking.completed",
+          summary: "Thought for 4s",
+          tone: "info",
+          turnId: "turn-1",
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+    });
+    expect(status).toBeNull();
+  });
+
+  it("reports an in-flight command tool and clears it on completion", () => {
+    const inFlight = [
+      makeActivity({
+        id: "tool-update",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.updated",
+        summary: "Terminal",
+        tone: "tool",
+        turnId: "turn-1",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          data: { toolCallId: "call-1", item: { command: "pnpm test" } },
+        },
+      }),
+    ];
+    const running = deriveLiveWorkStatus({
+      activities: inFlight,
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+    });
+    expect(running?.kind).toBe("tool");
+    expect(running?.label).toBe("Running pnpm test");
+    expect(running?.since).toBe("2026-02-23T00:00:02.000Z");
+
+    const completed = deriveLiveWorkStatus({
+      activities: [
+        ...inFlight,
+        makeActivity({
+          id: "tool-complete",
+          createdAt: "2026-02-23T00:00:06.000Z",
+          kind: "tool.completed",
+          summary: "Terminal",
+          tone: "tool",
+          turnId: "turn-1",
+          payload: {
+            itemType: "command_execution",
+            data: { toolCallId: "call-1", item: { command: "pnpm test" } },
+          },
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+    });
+    expect(completed).toBeNull();
+  });
+
+  it("prefers the newest signal and reports streaming responses", () => {
+    const status = deriveLiveWorkStatus({
+      activities: [
+        makeActivity({
+          id: "thinking-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "thinking.started",
+          summary: "Thinking",
+          tone: "info",
+          turnId: "turn-1",
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: {
+        createdAt: "2026-02-23T00:00:03.000Z",
+        updatedAt: "2026-02-23T00:00:04.000Z",
+      },
+    });
+    expect(status).toEqual({
+      kind: "responding",
+      label: "Writing",
+      since: "2026-02-23T00:00:03.000Z",
+    });
+  });
+
+  it("ignores signals from other turns", () => {
+    const status = deriveLiveWorkStatus({
+      activities: [
+        makeActivity({
+          id: "thinking-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "thinking.started",
+          summary: "Thinking",
+          tone: "info",
+          turnId: "turn-0",
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+    });
+    expect(status).toBeNull();
+  });
+
+  it("labels silent stretches as thinking when the provider hides thinking", () => {
+    const status = deriveLiveWorkStatus({
+      activities: [
+        makeActivity({
+          id: "tool-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.started",
+          summary: "Command run started",
+          tone: "tool",
+          turnId: "turn-1",
+          // Claude ingestion stamps toolCallId on the payload root.
+          payload: { itemType: "command_execution", toolCallId: "call-1" },
+        }),
+        makeActivity({
+          id: "tool-complete",
+          createdAt: "2026-02-23T00:00:05.000Z",
+          kind: "tool.completed",
+          summary: "Command run",
+          tone: "tool",
+          turnId: "turn-1",
+          payload: { itemType: "command_execution", toolCallId: "call-1" },
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+      assumeThinkingWhenSilent: true,
+    });
+    expect(status).toEqual({
+      kind: "thinking",
+      label: "Thinking",
+      since: "2026-02-23T00:00:05.000Z",
+    });
+  });
+
+  it("keeps the silent fallback quiet without the provider opt-in", () => {
+    const status = deriveLiveWorkStatus({
+      activities: [
+        makeActivity({
+          id: "tool-complete",
+          createdAt: "2026-02-23T00:00:05.000Z",
+          kind: "tool.completed",
+          summary: "Command run",
+          tone: "tool",
+          turnId: "turn-1",
+          payload: { itemType: "command_execution", data: { toolCallId: "call-1" } },
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+    });
+    expect(status).toBeNull();
+  });
+
+  it("prefers concrete signals over the silent-thinking fallback", () => {
+    const status = deriveLiveWorkStatus({
+      activities: [
+        makeActivity({
+          id: "tool-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.started",
+          summary: "Command run started",
+          tone: "tool",
+          turnId: "turn-1",
+          payload: {
+            itemType: "command_execution",
+            data: { toolCallId: "call-1", toolName: "Bash", input: { command: "pnpm test" } },
+          },
+        }),
+      ],
+      runningTurnId: TurnId.make("turn-1"),
+      streamingMessage: null,
+      assumeThinkingWhenSilent: true,
+    });
+    expect(status?.kind).toBe("tool");
+  });
+});
+
+describe("codex tool item normalization", () => {
+  it("maps commandExecution items to a Shell tool row with output", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            item: {
+              id: "item-1",
+              type: "commandExecution",
+              command: "pnpm test",
+              cwd: "/repo",
+              aggregatedOutput: "1 passed\n",
+              exitCode: 0,
+              status: "completed",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.toolName).toBe("Shell");
+    expect(entries[0]?.toolInput).toEqual({ command: "pnpm test" });
+    expect(entries[0]?.toolResultText).toBe("1 passed");
+  });
+
+  it("maps fileChange items to an Edit row with parsed unified diff hunks", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          title: "File change",
+          data: {
+            item: {
+              id: "item-2",
+              type: "fileChange",
+              status: "completed",
+              changes: [
+                {
+                  path: "src/app.ts",
+                  kind: "update",
+                  diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -3,2 +3,2 @@\n-const a = 1;\n+const a = 2;\n context\n",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.toolName).toBe("Edit");
+    expect(entries[0]?.toolInput).toEqual({ file_path: "src/app.ts" });
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "src/app.ts",
+      truncated: false,
+      hunks: [
+        {
+          oldStart: 3,
+          newStart: 3,
+          lines: ["-const a = 1;", "+const a = 2;", " context"],
+        },
+      ],
+    });
+  });
+
+  it("maps all-add fileChange items to a Write row", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          data: {
+            item: {
+              id: "item-3",
+              type: "fileChange",
+              status: "completed",
+              changes: [{ path: "src/new.ts", kind: "add", diff: "@@ -0,0 +1,1 @@\n+hello\n" }],
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolName).toBe("Write");
+    expect(entries[0]?.toolDiff?.hunks[0]?.lines).toEqual(["+hello"]);
+  });
+
+  it("maps mcpToolCall items to the tool name with block result text", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "MCP tool call",
+        payload: {
+          itemType: "mcp_tool_call",
+          data: {
+            item: {
+              id: "item-4",
+              type: "mcpToolCall",
+              server: "linear",
+              tool: "create_issue",
+              arguments: { title: "Bug" },
+              result: { content: [{ type: "text", text: "created" }] },
+              status: "completed",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolName).toBe("create_issue");
+    expect(entries[0]?.toolInput).toEqual({ title: "Bug" });
+    expect(entries[0]?.toolResultText).toBe("created");
+  });
+
+  it("prefers the Claude-style envelope over item normalization", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Command run",
+        payload: {
+          itemType: "command_execution",
+          data: {
+            toolName: "Bash",
+            input: { command: "ls" },
+            item: { id: "item-5", type: "commandExecution", command: "ls", status: "completed" },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolName).toBe("Bash");
+    expect(entries[0]?.toolInput).toEqual({ command: "ls" });
+  });
+});
+
+describe("acp tool call normalization", () => {
+  it("maps ACP command tool calls without a variant to a Shell row with output", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "dynamic_tool_call",
+          data: {
+            toolCallId: "tool_1",
+            kind: "other",
+            command: "ls -la",
+            rawInput: { command: "ls -la" },
+            rawOutput: { content: [{ type: "text", text: "total 4\n" }] },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.toolName).toBe("Shell");
+    expect(entries[0]?.toolInput).toEqual({ command: "ls -la" });
+    expect(entries[0]?.toolResultText).toBe("total 4");
+  });
+
+  it("maps ACP read tool calls to a Read row with the file path", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "dynamic_tool_call",
+          data: {
+            toolCallId: "tool_2",
+            kind: "read",
+            rawInput: { path: "src/app.ts" },
+            locations: [{ path: "src/app.ts" }],
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolName).toBe("Read");
+    expect(entries[0]?.toolInput).toEqual({ path: "src/app.ts" });
+  });
+
+  it("maps ACP edit tool calls to an Edit row with a reconstructed diff", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "file_change",
+          data: {
+            toolCallId: "tool_3",
+            kind: "edit",
+            rawInput: {
+              file_path: "src/app.ts",
+              old_string: "const a = 1;",
+              new_string: "const a = 2;",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolName).toBe("Edit");
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "src/app.ts",
+      truncated: false,
+      hunks: [{ oldStart: null, newStart: null, lines: ["-const a = 1;", "+const a = 2;"] }],
+    });
+  });
+
+  it("builds a diff from ACP diff content entries", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "file_change",
+          data: {
+            toolCallId: "tool_4",
+            kind: "edit",
+            content: [
+              { type: "diff", path: "src/app.ts", oldText: "old line", newText: "new line" },
+            ],
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolName).toBe("Edit");
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "src/app.ts",
+      truncated: false,
+      hunks: [{ oldStart: 1, newStart: 1, lines: ["-old line", "+new line"] }],
+    });
+  });
+
+  it("reduces full-file ACP diff content to a contextual hunk", () => {
+    const oldText = ["line 1", "line 2", "line 3", "line 4", "line 5", "line 6", "line 7"].join(
+      "\n",
+    );
+    const newText = ["line 1", "line 2", "line 3", "line 4", "changed 5", "line 6", "line 7"].join(
+      "\n",
+    );
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "file_change",
+          data: {
+            toolCallId: "tool_4b",
+            kind: "edit",
+            content: [{ type: "diff", path: "src/app.ts", oldText, newText }],
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "src/app.ts",
+      truncated: false,
+      hunks: [
+        {
+          oldStart: 2,
+          newStart: 2,
+          lines: [" line 2", " line 3", " line 4", "-line 5", "+changed 5", " line 6", " line 7"],
+        },
+      ],
+    });
+  });
+
+  it("maps ACP search tool calls with a pattern to a Grep row", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "web_search",
+          data: {
+            toolCallId: "tool_5",
+            kind: "search",
+            rawInput: { pattern: "toolName", path: "src" },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolName).toBe("Grep");
+  });
+
+  it("still prefers rawInput.variant as the tool name", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "command_execution",
+          data: {
+            toolCallId: "tool_6",
+            kind: "execute",
+            command: "ls",
+            rawInput: { variant: "shell", command: "ls" },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolName).toBe("shell");
   });
 });

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -2754,3 +2754,141 @@ describe("acp tool call normalization", () => {
     expect(entries[0]?.toolName).toBe("shell");
   });
 });
+
+describe("review regressions", () => {
+  it("ignores a stale unstamped open tool from before the running turn", () => {
+    expect(
+      deriveLiveWorkStatus({
+        activities: [
+          makeActivity({
+            id: "stale-tool",
+            createdAt: "2026-02-23T00:00:00.000Z",
+            kind: "tool.started",
+            summary: "Tool",
+            tone: "tool",
+            payload: { itemType: "dynamic_tool_call", data: { toolName: "Read" } },
+          }),
+          makeActivity({
+            id: "turn-signal",
+            createdAt: "2026-02-23T00:00:05.000Z",
+            kind: "thinking.completed",
+            summary: "Thought for 2s",
+            tone: "info",
+            turnId: "turn-1",
+            payload: { burstId: "burst-1", durationMs: 2000 },
+          }),
+        ],
+        runningTurnId: TurnId.make("turn-1"),
+        streamingMessage: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("splits distant ACP edits into separate contextual hunks", () => {
+    const lines = Array.from({ length: 20 }, (_, index) => `line ${index + 1}`);
+    const newLines = lines.map((line) =>
+      line === "line 3" ? "changed 3" : line === "line 15" ? "changed 15" : line,
+    );
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "file_change",
+          data: {
+            toolCallId: "tool_split",
+            kind: "edit",
+            content: [
+              {
+                type: "diff",
+                path: "src/app.ts",
+                oldText: lines.join("\n"),
+                newText: newLines.join("\n"),
+              },
+            ],
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "src/app.ts",
+      truncated: false,
+      hunks: [
+        {
+          oldStart: 1,
+          newStart: 1,
+          lines: [" line 1", " line 2", "-line 3", "+changed 3", " line 4", " line 5", " line 6"],
+        },
+        {
+          oldStart: 12,
+          newStart: 12,
+          lines: [
+            " line 12",
+            " line 13",
+            " line 14",
+            "-line 15",
+            "+changed 15",
+            " line 16",
+            " line 17",
+            " line 18",
+          ],
+        },
+      ],
+    });
+  });
+
+  it("attributes multi-file ACP diff content to the first file only", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "file_change",
+          data: {
+            toolCallId: "tool_multi",
+            kind: "edit",
+            content: [
+              { type: "diff", path: "src/first.ts", oldText: "a1", newText: "a2" },
+              { type: "diff", path: "src/second.ts", oldText: "b1", newText: "b2" },
+            ],
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "src/first.ts",
+      truncated: false,
+      hunks: [{ oldStart: 1, newStart: 1, lines: ["-a1", "+a2"] }],
+    });
+  });
+
+  it("attributes multi-file Codex fileChange diffs to the first file only", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Tool",
+        payload: {
+          itemType: "file_change",
+          data: {
+            item: {
+              type: "fileChange",
+              changes: [
+                { path: "src/first.ts", kind: "edit", diff: "@@ -1 +1 @@\n-a\n+b\n" },
+                { path: "src/second.ts", kind: "edit", diff: "@@ -1 +1 @@\n-c\n+d\n" },
+              ],
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.toolInput).toEqual({ file_path: "src/first.ts (+1 more)" });
+    expect(entries[0]?.toolDiff).toEqual({
+      filePath: "src/first.ts",
+      truncated: false,
+      hunks: [{ oldStart: 1, newStart: 1, lines: ["-a", "+b"] }],
+    });
+  });
+});

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -848,6 +848,13 @@ export function deriveLiveWorkStatus(input: {
     return null;
   }
   const ordered = [...input.activities].toSorted(compareActivitiesByOrder);
+  // Activities without a turn stamp only count as live signals once the
+  // running turn has started — an open thinking/tool row left behind by an
+  // earlier interrupted turn must not resurface as current status. When no
+  // activity carries the running turn's id (providers that never stamp turn
+  // ids), fall back to accepting unstamped activities.
+  const runningTurnStartAt =
+    ordered.find((activity) => activity.turnId === input.runningTurnId)?.createdAt ?? null;
   let lastTurnSignalAt: string | null = null;
 
   interface OpenThinkingBurst {
@@ -865,6 +872,13 @@ export function deriveLiveWorkStatus(input: {
 
   for (const activity of ordered) {
     if (activity.turnId !== null && activity.turnId !== input.runningTurnId) {
+      continue;
+    }
+    if (
+      activity.turnId === null &&
+      runningTurnStartAt !== null &&
+      activity.createdAt.localeCompare(runningTurnStartAt) < 0
+    ) {
       continue;
     }
     if (
@@ -1869,8 +1883,14 @@ function normalizeCodexToolItem(
       });
       const kinds = changes.map((change) => asTrimmedString(change.kind));
       const firstPath = changes.length > 0 ? asTrimmedString(changes[0]?.path) : null;
+      // The diff is keyed by one file path, so only include hunks from
+      // changes to that file — hunks from the other files would render under
+      // the wrong filename and line numbers. The header still advertises the
+      // remaining files via `(+N more)`.
       const hunks = changes.flatMap((change) =>
-        typeof change.diff === "string" ? parseUnifiedDiffHunks(change.diff) : [],
+        typeof change.diff === "string" && (asTrimmedString(change.path) ?? firstPath) === firstPath
+          ? parseUnifiedDiffHunks(change.diff)
+          : [],
       );
       return {
         toolName: kinds.length > 0 && kinds.every((kind) => kind === "add") ? "Write" : "Edit",
@@ -1969,55 +1989,139 @@ function acpToolResultText(data: Record<string, unknown>): string | null {
 }
 
 const ACP_DIFF_CONTEXT_LINES = 3;
+const MAX_CONTEXTUAL_DIFF_LINES = 5_000;
+const MAX_CONTEXTUAL_DIFF_SPLIT_DEPTH = 100;
+
+interface ContextualDiffBlock {
+  oldIndex: number;
+  newIndex: number;
+  removed: string[];
+  added: string[];
+}
+
+/**
+ * Recursively splits an old/new line range into changed blocks. Trims the
+ * common prefix/suffix, then anchors on a line unique to both sides so two
+ * edits at distant locations become separate blocks instead of one giant
+ * replacement that double-counts every unchanged line between them.
+ */
+function collectContextualDiffBlocks(
+  oldLines: string[],
+  newLines: string[],
+  range: { oldFrom: number; oldTo: number; newFrom: number; newTo: number },
+  out: ContextualDiffBlock[],
+  depth: number,
+): void {
+  let { oldFrom, oldTo, newFrom, newTo } = range;
+  while (oldFrom < oldTo && newFrom < newTo && oldLines[oldFrom] === newLines[newFrom]) {
+    oldFrom += 1;
+    newFrom += 1;
+  }
+  while (oldTo > oldFrom && newTo > newFrom && oldLines[oldTo - 1] === newLines[newTo - 1]) {
+    oldTo -= 1;
+    newTo -= 1;
+  }
+  if (oldFrom === oldTo && newFrom === newTo) {
+    return;
+  }
+  if (oldFrom < oldTo && newFrom < newTo && depth < MAX_CONTEXTUAL_DIFF_SPLIT_DEPTH) {
+    const oldUnique = new Map<string, number>();
+    for (let index = oldFrom; index < oldTo; index += 1) {
+      oldUnique.set(oldLines[index]!, oldUnique.has(oldLines[index]!) ? -1 : index);
+    }
+    const newUnique = new Map<string, number>();
+    for (let index = newFrom; index < newTo; index += 1) {
+      newUnique.set(newLines[index]!, newUnique.has(newLines[index]!) ? -1 : index);
+    }
+    // Prefer the anchor whose relative position matches on both sides — it is
+    // least likely to be a moved line splitting the ranges out of order.
+    let anchorOld = -1;
+    let anchorNew = -1;
+    let anchorSkew = Number.POSITIVE_INFINITY;
+    for (const [line, newIndex] of newUnique) {
+      if (newIndex === -1) {
+        continue;
+      }
+      const oldIndex = oldUnique.get(line);
+      if (oldIndex === undefined || oldIndex === -1) {
+        continue;
+      }
+      const skew = Math.abs(oldIndex - oldFrom - (newIndex - newFrom));
+      if (skew < anchorSkew) {
+        anchorSkew = skew;
+        anchorOld = oldIndex;
+        anchorNew = newIndex;
+      }
+    }
+    if (anchorOld !== -1) {
+      collectContextualDiffBlocks(
+        oldLines,
+        newLines,
+        { oldFrom, oldTo: anchorOld, newFrom, newTo: anchorNew },
+        out,
+        depth + 1,
+      );
+      collectContextualDiffBlocks(
+        oldLines,
+        newLines,
+        { oldFrom: anchorOld + 1, oldTo, newFrom: anchorNew + 1, newTo },
+        out,
+        depth + 1,
+      );
+      return;
+    }
+  }
+  out.push({
+    oldIndex: oldFrom,
+    newIndex: newFrom,
+    removed: oldLines.slice(oldFrom, oldTo),
+    added: newLines.slice(newFrom, newTo),
+  });
+}
 
 /**
  * ACP diff content carries whole old/new text blobs (often the full file).
- * Reduce them to a contextual hunk by trimming the common line prefix/suffix
- * so edits render like Claude's structured patches instead of a full-file
- * remove/add wall.
+ * Reduce them to contextual hunks so edits render like Claude's structured
+ * patches instead of a full-file remove/add wall.
  */
-function contextualDiffHunk(oldText: string, newText: string): WorkLogToolDiffHunk | null {
+function contextualDiffHunks(oldText: string, newText: string): WorkLogToolDiffHunk[] {
   const oldLines = splitDiffContent(oldText);
   const newLines = splitDiffContent(newText);
   if (oldLines.length === 0) {
-    return reconstructedEditHunk(oldText, newText);
+    const hunk = reconstructedEditHunk(oldText, newText);
+    return hunk ? [hunk] : [];
   }
-  let prefix = 0;
-  while (
-    prefix < oldLines.length &&
-    prefix < newLines.length &&
-    oldLines[prefix] === newLines[prefix]
-  ) {
-    prefix += 1;
+  if (oldLines.length + newLines.length > MAX_CONTEXTUAL_DIFF_LINES) {
+    // Too large to split safely; capToolDiff truncates the single block.
+    const hunk = reconstructedEditHunk(oldText, newText);
+    return hunk ? [hunk] : [];
   }
-  let suffix = 0;
-  while (
-    suffix < oldLines.length - prefix &&
-    suffix < newLines.length - prefix &&
-    oldLines[oldLines.length - 1 - suffix] === newLines[newLines.length - 1 - suffix]
-  ) {
-    suffix += 1;
-  }
-  const removed = oldLines.slice(prefix, oldLines.length - suffix);
-  const added = newLines.slice(prefix, newLines.length - suffix);
-  if (removed.length === 0 && added.length === 0) {
-    return null;
-  }
-  const contextStart = Math.max(0, prefix - ACP_DIFF_CONTEXT_LINES);
-  const leadingContext = oldLines.slice(contextStart, prefix).map((line) => ` ${line}`);
-  const trailingContext = oldLines
-    .slice(oldLines.length - suffix, oldLines.length - suffix + ACP_DIFF_CONTEXT_LINES)
-    .map((line) => ` ${line}`);
-  return {
-    oldStart: contextStart + 1,
-    newStart: contextStart + 1,
-    lines: [
-      ...leadingContext,
-      ...removed.map((line) => `-${line}`),
-      ...added.map((line) => `+${line}`),
-      ...trailingContext,
-    ],
-  };
+  const blocks: ContextualDiffBlock[] = [];
+  collectContextualDiffBlocks(
+    oldLines,
+    newLines,
+    { oldFrom: 0, oldTo: oldLines.length, newFrom: 0, newTo: newLines.length },
+    blocks,
+    0,
+  );
+  return blocks.map((block, index) => {
+    const previousEnd =
+      index > 0 ? blocks[index - 1]!.oldIndex + blocks[index - 1]!.removed.length : 0;
+    const nextStart = index + 1 < blocks.length ? blocks[index + 1]!.oldIndex : oldLines.length;
+    const contextStart = Math.max(previousEnd, block.oldIndex - ACP_DIFF_CONTEXT_LINES);
+    const blockOldEnd = block.oldIndex + block.removed.length;
+    const contextEnd = Math.min(nextStart, blockOldEnd + ACP_DIFF_CONTEXT_LINES);
+    return {
+      oldStart: contextStart + 1,
+      newStart: block.newIndex - (block.oldIndex - contextStart) + 1,
+      lines: [
+        ...oldLines.slice(contextStart, block.oldIndex).map((line) => ` ${line}`),
+        ...block.removed.map((line) => `-${line}`),
+        ...block.added.map((line) => `+${line}`),
+        ...oldLines.slice(blockOldEnd, contextEnd).map((line) => ` ${line}`),
+      ],
+    };
+  });
 }
 
 function acpContentDiff(data: Record<string, unknown>): WorkLogToolDiff | null {
@@ -2031,14 +2135,19 @@ function acpContentDiff(data: Record<string, unknown>): WorkLogToolDiff | null {
     if (record?.type !== "diff") {
       continue;
     }
-    filePath ??= asTrimmedString(record.path);
-    const hunk = contextualDiffHunk(
-      typeof record.oldText === "string" ? record.oldText : "",
-      typeof record.newText === "string" ? record.newText : "",
-    );
-    if (hunk) {
-      hunks.push(hunk);
+    const path = asTrimmedString(record.path);
+    filePath ??= path;
+    // A WorkLogToolDiff carries one file path; entries for other files would
+    // render their hunks under the wrong filename, so skip them.
+    if (path !== null && filePath !== null && path !== filePath) {
+      continue;
     }
+    hunks.push(
+      ...contextualDiffHunks(
+        typeof record.oldText === "string" ? record.oldText : "",
+        typeof record.newText === "string" ? record.newText : "",
+      ),
+    );
   }
   return hunks.length > 0 ? capToolDiff(filePath, hunks) : null;
 }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -73,6 +73,14 @@ export interface WorkLogEntry {
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
   toolData?: unknown;
+  /** Raw provider tool name (e.g. `Bash`, `Read`) when the adapter carries it in `payload.data`. */
+  toolName?: string;
+  /** Raw provider tool input when the adapter carries it in `payload.data`. */
+  toolInput?: Record<string, unknown>;
+  /** Line-level diff for file-edit tools, from the provider result or reconstructed from input. */
+  toolDiff?: WorkLogToolDiff;
+  /** Text content of the tool result block when the adapter carries it in `payload.data`. */
+  toolResultText?: string;
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];
   /** From runtime item / task payload `status` when present (e.g. tool.updated). */
@@ -94,6 +102,20 @@ export interface WorkLogEntry {
     workflowId: string | null;
     agentTaskIds: ReadonlyArray<string>;
   };
+}
+
+export interface WorkLogToolDiffHunk {
+  /** 1-based line numbers in the old/new file; null when reconstructed from streaming input. */
+  oldStart: number | null;
+  newStart: number | null;
+  /** Unified-diff lines including their leading `+` / `-` / ` ` marker. */
+  lines: ReadonlyArray<string>;
+}
+
+export interface WorkLogToolDiff {
+  filePath: string | null;
+  hunks: ReadonlyArray<WorkLogToolDiffHunk>;
+  truncated: boolean;
 }
 
 interface DerivedWorkLogEntry extends WorkLogEntry {
@@ -273,6 +295,11 @@ export function workEntryIndicatesToolNeutralStatus(entry: WorkLogEntry): boolea
   // task.progress (tone "thinking") and the neutral filter was swallowing
   // them exactly while the fleet ran — the one moment they matter most.
   if (entry.agentSpawn !== undefined) {
+    return false;
+  }
+  // Completed thinking bursts are informational rows, not stuck tools — they
+  // must survive the neutral-status filter that hides incomplete tool rows.
+  if (entry.sourceActivityKind === "thinking.completed") {
     return false;
   }
   if (!workLogEntryIsToolLike(entry)) {
@@ -725,15 +752,261 @@ export function deriveWorkLogEntries(
     if (activity.kind === "task.updated") continue;
     if (activity.kind === "tool.progress") continue;
     if (activity.kind === "context-window.updated") continue;
+    // In-flight thinking feeds the live working indicator; only the completed
+    // burst earns a durable "Thought for Xs" row.
+    if (activity.kind === "thinking.started") continue;
+    if (activity.kind === "thinking.progress") continue;
     if (activity.summary === "Checkpoint captured") continue;
     if (isPlanBoundaryToolActivity(activity)) continue;
     if (isAgentInternalActivity(activity)) continue;
     entries.push(toDerivedWorkLogEntry(activity));
   }
-  return collapseDerivedWorkLogEntries(entries).map((entry) => {
-    const { activityKind, collapseKey: _collapseKey, ...rest } = entry;
-    return Object.assign(rest, { sourceActivityKind: activityKind });
-  });
+  const collapsed = collapseDerivedWorkLogEntries(entries);
+  // A "compacting" marker is only meaningful until its compaction boundary
+  // arrives; after that the completed row alone marks the spot.
+  const lastCompactionBoundary = collapsed.findLastIndex(
+    (entry) => entry.activityKind === "context-compaction",
+  );
+  return collapsed
+    .filter(
+      (entry, index) =>
+        !(entry.activityKind === "context-compaction.started" && index < lastCompactionBoundary),
+    )
+    .map((entry) => {
+      const { activityKind, collapseKey: _collapseKey, ...rest } = entry;
+      return Object.assign(rest, { sourceActivityKind: activityKind });
+    });
+}
+
+export interface LiveWorkStatus {
+  kind: "thinking" | "tool" | "responding";
+  /** e.g. "Thinking", "Running pnpm test", "Writing" */
+  label: string;
+  /** Start of the current phase, for a live elapsed timer. */
+  since: string | null;
+  /** Streamed reasoning size so far (characters), when the provider reports it. */
+  thinkingChars?: number;
+  /** Full accumulated streamed reasoning text for the open thinking burst. */
+  thinkingText?: string;
+}
+
+function truncateLiveStatusLabel(value: string, maxLength = 56): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function liveToolStatusLabel(entry: DerivedWorkLogEntry): string {
+  if (entry.command) {
+    // A tool.started can land before its input streamed in ("Bash: {}").
+    const command = entry.command.replace(/:?\s*\{\}\s*$/, "");
+    if (command.length > 0) {
+      return `Running ${truncateLiveStatusLabel(command)}`;
+    }
+  }
+  if (entry.itemType === "web_search") {
+    return "Searching the web";
+  }
+  const changedFile = entry.toolDiff?.filePath ?? entry.changedFiles?.[0];
+  if (entry.itemType === "file_change" || changedFile) {
+    if (changedFile) {
+      const basename = changedFile.replace(/\\/g, "/").split("/").at(-1);
+      if (basename) {
+        return `Editing ${truncateLiveStatusLabel(basename)}`;
+      }
+    }
+    return "Editing files";
+  }
+  const heading = normalizeCompactToolLabel(entry.toolTitle ?? entry.label)
+    .replace(/\s+started\s*$/i, "")
+    .trim();
+  return heading.length > 0 ? truncateLiveStatusLabel(heading) : "Running a tool";
+}
+
+/**
+ * What the provider is doing right now, derived from the newest live signal:
+ * an open thinking burst, an in-flight tool call, or a streaming assistant
+ * message. Returns null when there is no signal (callers fall back to a
+ * generic "Working" indicator).
+ */
+export function deriveLiveWorkStatus(input: {
+  activities: ReadonlyArray<OrchestrationThreadActivity>;
+  runningTurnId: TurnId | null;
+  streamingMessage: { createdAt: string; updatedAt: string } | null;
+  /**
+   * Current Claude models never stream thinking text (blocks arrive encrypted
+   * with only a signature), so no thinking-burst activities exist to report.
+   * For those providers a silent stretch of a running turn — no tool open, no
+   * text streaming — is the model thinking, so label it that way instead of
+   * falling back to the generic "Working".
+   */
+  assumeThinkingWhenSilent?: boolean;
+}): LiveWorkStatus | null {
+  if (input.runningTurnId === null) {
+    return null;
+  }
+  const ordered = [...input.activities].toSorted(compareActivitiesByOrder);
+  let lastTurnSignalAt: string | null = null;
+
+  interface OpenThinkingBurst {
+    burstId: string;
+    startedAt: string;
+    chars: number;
+    text: string | null;
+    lastAt: string;
+  }
+  let openThinking: OpenThinkingBurst | null = null;
+  const openToolsByKey = new Map<
+    string,
+    { entry: DerivedWorkLogEntry; since: string; lastAt: string }
+  >();
+
+  for (const activity of ordered) {
+    if (activity.turnId !== null && activity.turnId !== input.runningTurnId) {
+      continue;
+    }
+    if (
+      activity.turnId === input.runningTurnId &&
+      (lastTurnSignalAt === null || activity.createdAt.localeCompare(lastTurnSignalAt) > 0)
+    ) {
+      lastTurnSignalAt = activity.createdAt;
+    }
+    const payload =
+      activity.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : null;
+
+    if (activity.kind === "thinking.started") {
+      openThinking = {
+        burstId: typeof payload?.burstId === "string" ? payload.burstId : activity.id,
+        startedAt: typeof payload?.startedAt === "string" ? payload.startedAt : activity.createdAt,
+        chars: 0,
+        text: null,
+        lastAt: activity.createdAt,
+      };
+      continue;
+    }
+    if (activity.kind === "thinking.progress") {
+      // Some providers keep one thinking burst open across interleaved tool
+      // calls, so a progress event may arrive after a tool activity cleared
+      // the open burst — re-open it from the progress payload.
+      // Prefer full `text` (current servers); fall back to legacy `textTail`.
+      const payloadText = typeof payload?.text === "string" ? payload.text : null;
+      const payloadTextTail = typeof payload?.textTail === "string" ? payload.textTail : null;
+      const nextText: string | null = payloadText ?? payloadTextTail ?? openThinking?.text ?? null;
+      openThinking = {
+        burstId:
+          typeof payload?.burstId === "string"
+            ? payload.burstId
+            : (openThinking?.burstId ?? activity.id),
+        startedAt:
+          typeof payload?.startedAt === "string"
+            ? payload.startedAt
+            : (openThinking?.startedAt ?? activity.createdAt),
+        chars: typeof payload?.chars === "number" ? payload.chars : (openThinking?.chars ?? 0),
+        text: nextText,
+        lastAt: activity.createdAt,
+      };
+      continue;
+    }
+    if (activity.kind === "thinking.completed") {
+      openThinking = null;
+      continue;
+    }
+
+    if (
+      activity.kind === "tool.started" ||
+      activity.kind === "tool.updated" ||
+      activity.kind === "tool.completed"
+    ) {
+      // A tool call means the model moved past any open thinking burst even if
+      // the burst-completion activity was lost.
+      openThinking = null;
+      const entry = toDerivedWorkLogEntry(activity);
+      const key = entry.toolCallId ?? entry.collapseKey ?? entry.id;
+      if (
+        activity.kind === "tool.completed" ||
+        (entry.toolLifecycleStatus !== undefined && entry.toolLifecycleStatus !== "inProgress")
+      ) {
+        openToolsByKey.delete(key);
+        continue;
+      }
+      const existing = openToolsByKey.get(key);
+      openToolsByKey.set(key, {
+        entry: existing ? { ...existing.entry, ...entry } : entry,
+        since: existing?.since ?? activity.createdAt,
+        lastAt: activity.createdAt,
+      });
+    }
+  }
+
+  const latestOpenTool = [...openToolsByKey.values()].reduce<{
+    entry: DerivedWorkLogEntry;
+    since: string;
+    lastAt: string;
+  } | null>((latest, candidate) => {
+    if (!latest || candidate.lastAt.localeCompare(latest.lastAt) > 0) {
+      return candidate;
+    }
+    return latest;
+  }, null);
+
+  const candidates: Array<{ status: LiveWorkStatus; lastAt: string }> = [];
+  if (openThinking) {
+    candidates.push({
+      status: {
+        kind: "thinking",
+        label: "Thinking",
+        since: openThinking.startedAt,
+        ...(openThinking.chars > 0 ? { thinkingChars: openThinking.chars } : {}),
+        ...(openThinking.text !== null && openThinking.text.trim().length > 0
+          ? { thinkingText: openThinking.text }
+          : {}),
+      },
+      lastAt: openThinking.lastAt,
+    });
+  }
+  if (latestOpenTool) {
+    candidates.push({
+      status: {
+        kind: "tool",
+        label: liveToolStatusLabel(latestOpenTool.entry),
+        since: latestOpenTool.since,
+      },
+      lastAt: latestOpenTool.lastAt,
+    });
+  }
+  if (input.streamingMessage) {
+    candidates.push({
+      status: {
+        kind: "responding",
+        label: "Writing",
+        since: input.streamingMessage.createdAt,
+      },
+      lastAt: input.streamingMessage.updatedAt,
+    });
+  }
+
+  const winner = candidates.reduce<{ status: LiveWorkStatus; lastAt: string } | null>(
+    (latest, candidate) => {
+      if (!latest || candidate.lastAt.localeCompare(latest.lastAt) > 0) {
+        return candidate;
+      }
+      return latest;
+    },
+    null,
+  );
+  if (winner) {
+    return winner.status;
+  }
+  if (input.assumeThinkingWhenSilent) {
+    // Silence started at the newest signal the turn produced; with none yet
+    // the row falls back to its own turn-start timestamp.
+    return { kind: "thinking", label: "Thinking", since: lastTurnSignalAt };
+  }
+  return null;
 }
 
 function isPlanBoundaryToolActivity(activity: OrchestrationThreadActivity): boolean {
@@ -772,6 +1045,20 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     activity.payload && typeof activity.payload === "object"
       ? (activity.payload as Record<string, unknown>)
       : null;
+  if (activity.kind === "thinking.completed") {
+    const thinkingText = typeof payload?.text === "string" ? payload.text.trim() : "";
+    return {
+      id: activity.id,
+      createdAt: activity.createdAt,
+      turnId: activity.turnId,
+      label: activity.summary,
+      tone: "thinking",
+      activityKind: activity.kind,
+      ...(thinkingText.length > 0
+        ? { detail: payload?.textTruncated === true ? `${thinkingText}…` : thinkingText }
+        : {}),
+    };
+  }
   const commandPreview = extractToolCommand(payload);
   const changedFiles = extractChangedFiles(payload);
   const title = extractToolTitle(payload);
@@ -838,6 +1125,26 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   }
   if (itemType) {
     entry.itemType = itemType;
+  }
+  if (!isTaskActivity) {
+    const normalizedItem = normalizeCodexToolItem(payload) ?? normalizeAcpToolCall(payload);
+    const toolName = extractToolName(payload) ?? normalizedItem?.toolName ?? null;
+    const toolInput = extractToolInput(payload) ?? normalizedItem?.toolInput ?? null;
+    if (toolName) {
+      entry.toolName = toolName;
+    }
+    if (toolInput) {
+      entry.toolInput = toolInput;
+    }
+    const toolDiff =
+      extractToolDiff(payload, toolName, toolInput) ?? normalizedItem?.toolDiff ?? null;
+    if (toolDiff) {
+      entry.toolDiff = toolDiff;
+    }
+    const toolResultText = extractToolResultText(payload) ?? normalizedItem?.toolResultText ?? null;
+    if (toolResultText) {
+      entry.toolResultText = toolResultText;
+    }
   }
   if (requestKind) {
     entry.requestKind = requestKind;
@@ -1011,6 +1318,16 @@ function mergeDerivedWorkLogEntries(
   const toolCallId = next.toolCallId ?? previous.toolCallId;
   const toolLifecycleStatus = next.toolLifecycleStatus ?? previous.toolLifecycleStatus;
   const toolData = next.toolData ?? previous.toolData;
+  const toolName = next.toolName ?? previous.toolName;
+  const toolInput = next.toolInput ?? previous.toolInput;
+  // Prefer a diff with real line numbers (from the tool result) over a
+  // reconstructed streaming diff, regardless of arrival order.
+  const toolDiff =
+    next.toolDiff && next.toolDiff.hunks.some((hunk) => hunk.oldStart !== null)
+      ? next.toolDiff
+      : previous.toolDiff && previous.toolDiff.hunks.some((hunk) => hunk.oldStart !== null)
+        ? previous.toolDiff
+        : (next.toolDiff ?? previous.toolDiff);
   return {
     ...previous,
     ...next,
@@ -1025,6 +1342,12 @@ function mergeDerivedWorkLogEntries(
     ...(toolCallId ? { toolCallId } : {}),
     ...(toolLifecycleStatus !== undefined ? { toolLifecycleStatus } : {}),
     ...(toolData !== undefined ? { toolData } : {}),
+    ...(toolName ? { toolName } : {}),
+    ...(toolInput ? { toolInput } : {}),
+    ...(toolDiff ? { toolDiff } : {}),
+    ...((next.toolResultText ?? previous.toolResultText)
+      ? { toolResultText: next.toolResultText ?? previous.toolResultText }
+      : {}),
   };
 }
 
@@ -1282,9 +1605,544 @@ function extractToolTitle(payload: Record<string, unknown> | null): string | nul
   return asTrimmedString(payload?.title);
 }
 
+function extractToolName(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const direct = asTrimmedString(data?.toolName);
+  if (direct) {
+    return direct;
+  }
+  // ACP harnesses surface dynamic tools with the tool name as `rawInput.variant`.
+  return asTrimmedString(asRecord(data?.rawInput)?.variant);
+}
+
+function extractToolInput(payload: Record<string, unknown> | null): Record<string, unknown> | null {
+  const data = asRecord(payload?.data);
+  return asRecord(data?.input) ?? asRecord(data?.rawInput) ?? asRecord(asRecord(data?.item)?.input);
+}
+
+const MAX_TOOL_DIFF_LINES = 400;
+const MAX_TOOL_RESULT_TEXT = 4000;
+
+function truncateToolResultText(text: string | null | undefined): string | null {
+  const trimmed = text?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.length > MAX_TOOL_RESULT_TEXT
+    ? `${trimmed.slice(0, MAX_TOOL_RESULT_TEXT)}…`
+    : trimmed;
+}
+
+function textFromContentBlocks(content: unknown): string | null {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  const parts = content.flatMap((block) => {
+    const record = asRecord(block);
+    return typeof record?.text === "string" ? [record.text] : [];
+  });
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
+function extractToolResultText(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const result = asRecord(data?.result);
+  if (!result) {
+    return null;
+  }
+  return truncateToolResultText(textFromContentBlocks(result.content));
+}
+
+function splitDiffContent(value: string): string[] {
+  const lines = value.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function parseStructuredPatch(value: unknown): WorkLogToolDiffHunk[] | null {
+  if (!Array.isArray(value) || value.length === 0) {
+    return null;
+  }
+  const hunks: WorkLogToolDiffHunk[] = [];
+  for (const rawHunk of value) {
+    const hunk = asRecord(rawHunk);
+    if (!hunk || !Array.isArray(hunk.lines)) {
+      return null;
+    }
+    const lines = hunk.lines.filter((line): line is string => typeof line === "string");
+    if (lines.length === 0) {
+      continue;
+    }
+    hunks.push({
+      oldStart: asNumber(hunk.oldStart),
+      newStart: asNumber(hunk.newStart),
+      lines,
+    });
+  }
+  return hunks.length > 0 ? hunks : null;
+}
+
+function capToolDiff(filePath: string | null, hunks: WorkLogToolDiffHunk[]): WorkLogToolDiff {
+  let remaining = MAX_TOOL_DIFF_LINES;
+  let truncated = false;
+  const capped: WorkLogToolDiffHunk[] = [];
+  for (const hunk of hunks) {
+    if (remaining <= 0) {
+      truncated = true;
+      break;
+    }
+    if (hunk.lines.length <= remaining) {
+      capped.push(hunk);
+      remaining -= hunk.lines.length;
+      continue;
+    }
+    capped.push({ ...hunk, lines: hunk.lines.slice(0, remaining) });
+    remaining = 0;
+    truncated = true;
+  }
+  return { filePath, hunks: capped, truncated };
+}
+
+function reconstructedEditHunk(oldText: string, newText: string): WorkLogToolDiffHunk | null {
+  const lines = [
+    ...splitDiffContent(oldText).map((line) => `-${line}`),
+    ...splitDiffContent(newText).map((line) => `+${line}`),
+  ];
+  if (lines.length === 0) {
+    return null;
+  }
+  return { oldStart: null, newStart: null, lines };
+}
+
+const FILE_EDIT_TOOL_NAME =
+  /^(edit|multiedit|write|notebookedit|str_replace.*|create_file|apply_?patch|edit_file|write_file|update_file)$/i;
+
+/**
+ * Parse a unified-diff string (as emitted by Codex `fileChange` items and
+ * patch-style edit tools) into displayable hunks with real line numbers.
+ */
+function parseUnifiedDiffHunks(diff: string): WorkLogToolDiffHunk[] {
+  interface MutableHunk {
+    oldStart: number | null;
+    newStart: number | null;
+    lines: string[];
+  }
+  const hunks: MutableHunk[] = [];
+  let current: MutableHunk | null = null;
+  const rawLines = diff.split("\n");
+  if (rawLines.at(-1) === "") {
+    rawLines.pop();
+  }
+  for (const line of rawLines) {
+    const header = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (header) {
+      current = { oldStart: Number(header[1]), newStart: Number(header[2]), lines: [] };
+      hunks.push(current);
+      continue;
+    }
+    if (!current || line.startsWith("\\")) {
+      continue;
+    }
+    if (line.startsWith("+") || line.startsWith("-") || line.startsWith(" ") || line === "") {
+      current.lines.push(line);
+    }
+  }
+  return hunks.filter((hunk) => hunk.lines.length > 0);
+}
+
+/**
+ * Diff for file-edit tools: prefer the provider's structured patch (real line
+ * numbers, present once the tool result lands); otherwise reconstruct a
+ * numberless old/new block from the streaming tool input so edits are visible
+ * live while the tool call is still in flight.
+ */
+function extractToolDiff(
+  payload: Record<string, unknown> | null,
+  toolName: string | null,
+  toolInput: Record<string, unknown> | null,
+): WorkLogToolDiff | null {
+  const data = asRecord(payload?.data);
+  const toolUseResult = asRecord(data?.toolUseResult);
+  const filePath =
+    asTrimmedString(toolUseResult?.filePath) ?? asTrimmedString(toolInput?.file_path);
+
+  const structured = parseStructuredPatch(toolUseResult?.structuredPatch);
+  if (structured) {
+    return capToolDiff(filePath, structured);
+  }
+
+  if (!toolName || !FILE_EDIT_TOOL_NAME.test(toolName) || !toolInput) {
+    return null;
+  }
+
+  const edits = Array.isArray(toolInput.edits) ? toolInput.edits : null;
+  if (edits) {
+    const hunks: WorkLogToolDiffHunk[] = [];
+    for (const rawEdit of edits) {
+      const edit = asRecord(rawEdit);
+      const oldText = typeof edit?.old_string === "string" ? edit.old_string : null;
+      const newText = typeof edit?.new_string === "string" ? edit.new_string : null;
+      if (oldText === null || newText === null) {
+        continue;
+      }
+      const hunk = reconstructedEditHunk(oldText, newText);
+      if (hunk) {
+        hunks.push(hunk);
+      }
+    }
+    return hunks.length > 0 ? capToolDiff(filePath, hunks) : null;
+  }
+
+  const oldText = typeof toolInput.old_string === "string" ? toolInput.old_string : null;
+  const newText = typeof toolInput.new_string === "string" ? toolInput.new_string : null;
+  if (oldText !== null && newText !== null) {
+    const hunk = reconstructedEditHunk(oldText, newText);
+    return hunk ? capToolDiff(filePath, [hunk]) : null;
+  }
+
+  const content = typeof toolInput.content === "string" ? toolInput.content : null;
+  if (content !== null) {
+    const lines = splitDiffContent(content).map((line) => `+${line}`);
+    if (lines.length === 0) {
+      return null;
+    }
+    return capToolDiff(filePath, [{ oldStart: null, newStart: 1, lines }]);
+  }
+
+  // Patch-style edit tools (apply_patch and friends) pass a unified diff.
+  const patchText = [toolInput.diff, toolInput.patch].find(
+    (candidate): candidate is string =>
+      typeof candidate === "string" && candidate.trim().length > 0,
+  );
+  if (patchText !== undefined) {
+    const hunks = parseUnifiedDiffHunks(patchText);
+    if (hunks.length > 0) {
+      return capToolDiff(filePath, hunks);
+    }
+  }
+
+  return null;
+}
+
+interface NormalizedProviderToolCall {
+  toolName: string;
+  toolInput: Record<string, unknown> | null;
+  toolResultText: string | null;
+  toolDiff: WorkLogToolDiff | null;
+}
+
+/**
+ * Codex forwards its native thread item verbatim in `data.item` without the
+ * `toolName`/`input` envelope Claude uses. Synthesize the same normalized
+ * fields from the item so Codex tool calls render with the styled
+ * `Tool(arg)` headers, inline diffs, and result lines.
+ */
+function normalizeCodexToolItem(
+  payload: Record<string, unknown> | null,
+): NormalizedProviderToolCall | null {
+  const item = asRecord(asRecord(payload?.data)?.item);
+  const type = asTrimmedString(item?.type);
+  if (!item || !type) {
+    return null;
+  }
+  switch (type) {
+    case "commandExecution": {
+      const command = asTrimmedString(item.command);
+      return {
+        toolName: "Shell",
+        toolInput: command ? { command } : null,
+        toolResultText: truncateToolResultText(
+          typeof item.aggregatedOutput === "string" ? item.aggregatedOutput : null,
+        ),
+        toolDiff: null,
+      };
+    }
+    case "fileChange": {
+      const changes = (Array.isArray(item.changes) ? item.changes : []).flatMap((change) => {
+        const record = asRecord(change);
+        return record ? [record] : [];
+      });
+      const kinds = changes.map((change) => asTrimmedString(change.kind));
+      const firstPath = changes.length > 0 ? asTrimmedString(changes[0]?.path) : null;
+      const hunks = changes.flatMap((change) =>
+        typeof change.diff === "string" ? parseUnifiedDiffHunks(change.diff) : [],
+      );
+      return {
+        toolName: kinds.length > 0 && kinds.every((kind) => kind === "add") ? "Write" : "Edit",
+        toolInput: firstPath
+          ? {
+              file_path:
+                changes.length > 1 ? `${firstPath} (+${changes.length - 1} more)` : firstPath,
+            }
+          : null,
+        toolResultText: null,
+        toolDiff: hunks.length > 0 ? capToolDiff(firstPath, hunks) : null,
+      };
+    }
+    case "mcpToolCall": {
+      const tool = asTrimmedString(item.tool);
+      const server = asTrimmedString(item.server);
+      const result = asRecord(item.result);
+      return {
+        toolName: tool ?? "MCP tool",
+        toolInput: asRecord(item.arguments) ?? (server ? { server } : null),
+        toolResultText: truncateToolResultText(textFromContentBlocks(result?.content)),
+        toolDiff: null,
+      };
+    }
+    case "dynamicToolCall": {
+      const tool = asTrimmedString(item.tool);
+      return {
+        toolName: tool ?? "Tool",
+        toolInput: asRecord(item.arguments),
+        toolResultText: truncateToolResultText(textFromContentBlocks(item.contentItems)),
+        toolDiff: null,
+      };
+    }
+    case "webSearch": {
+      const query = asTrimmedString(item.query);
+      return {
+        toolName: "WebSearch",
+        toolInput: query ? { query } : null,
+        toolResultText: null,
+        toolDiff: null,
+      };
+    }
+    case "imageView": {
+      const path = asTrimmedString(item.path);
+      return {
+        toolName: "Read",
+        toolInput: path ? { file_path: path } : null,
+        toolResultText: null,
+        toolDiff: null,
+      };
+    }
+    case "collabAgentToolCall": {
+      const tool = asTrimmedString(item.tool);
+      const prompt = asTrimmedString(item.prompt);
+      return {
+        toolName: tool ?? "Agent",
+        toolInput: prompt ? { prompt } : null,
+        toolResultText: null,
+        toolDiff: null,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function acpToolResultText(data: Record<string, unknown>): string | null {
+  const chunks: string[] = [];
+  if (Array.isArray(data.content)) {
+    for (const entry of data.content) {
+      const record = asRecord(entry);
+      if (record?.type !== "content") {
+        continue;
+      }
+      const nested = asRecord(record.content);
+      if (typeof nested?.text === "string" && nested.text.trim().length > 0) {
+        chunks.push(nested.text);
+      }
+    }
+  }
+  if (chunks.length === 0) {
+    if (typeof data.rawOutput === "string") {
+      chunks.push(data.rawOutput);
+    } else {
+      const rawOutput = asRecord(data.rawOutput);
+      const text =
+        textFromContentBlocks(rawOutput?.content) ??
+        asTrimmedString(rawOutput?.output) ??
+        asTrimmedString(rawOutput?.stdout);
+      if (text) {
+        chunks.push(text);
+      }
+    }
+  }
+  return truncateToolResultText(chunks.join("\n"));
+}
+
+const ACP_DIFF_CONTEXT_LINES = 3;
+
+/**
+ * ACP diff content carries whole old/new text blobs (often the full file).
+ * Reduce them to a contextual hunk by trimming the common line prefix/suffix
+ * so edits render like Claude's structured patches instead of a full-file
+ * remove/add wall.
+ */
+function contextualDiffHunk(oldText: string, newText: string): WorkLogToolDiffHunk | null {
+  const oldLines = splitDiffContent(oldText);
+  const newLines = splitDiffContent(newText);
+  if (oldLines.length === 0) {
+    return reconstructedEditHunk(oldText, newText);
+  }
+  let prefix = 0;
+  while (
+    prefix < oldLines.length &&
+    prefix < newLines.length &&
+    oldLines[prefix] === newLines[prefix]
+  ) {
+    prefix += 1;
+  }
+  let suffix = 0;
+  while (
+    suffix < oldLines.length - prefix &&
+    suffix < newLines.length - prefix &&
+    oldLines[oldLines.length - 1 - suffix] === newLines[newLines.length - 1 - suffix]
+  ) {
+    suffix += 1;
+  }
+  const removed = oldLines.slice(prefix, oldLines.length - suffix);
+  const added = newLines.slice(prefix, newLines.length - suffix);
+  if (removed.length === 0 && added.length === 0) {
+    return null;
+  }
+  const contextStart = Math.max(0, prefix - ACP_DIFF_CONTEXT_LINES);
+  const leadingContext = oldLines.slice(contextStart, prefix).map((line) => ` ${line}`);
+  const trailingContext = oldLines
+    .slice(oldLines.length - suffix, oldLines.length - suffix + ACP_DIFF_CONTEXT_LINES)
+    .map((line) => ` ${line}`);
+  return {
+    oldStart: contextStart + 1,
+    newStart: contextStart + 1,
+    lines: [
+      ...leadingContext,
+      ...removed.map((line) => `-${line}`),
+      ...added.map((line) => `+${line}`),
+      ...trailingContext,
+    ],
+  };
+}
+
+function acpContentDiff(data: Record<string, unknown>): WorkLogToolDiff | null {
+  if (!Array.isArray(data.content)) {
+    return null;
+  }
+  const hunks: WorkLogToolDiffHunk[] = [];
+  let filePath: string | null = null;
+  for (const entry of data.content) {
+    const record = asRecord(entry);
+    if (record?.type !== "diff") {
+      continue;
+    }
+    filePath ??= asTrimmedString(record.path);
+    const hunk = contextualDiffHunk(
+      typeof record.oldText === "string" ? record.oldText : "",
+      typeof record.newText === "string" ? record.newText : "",
+    );
+    if (hunk) {
+      hunks.push(hunk);
+    }
+  }
+  return hunks.length > 0 ? capToolDiff(filePath, hunks) : null;
+}
+
+function acpFirstLocationPath(data: Record<string, unknown>): string | null {
+  if (!Array.isArray(data.locations)) {
+    return null;
+  }
+  for (const entry of data.locations) {
+    const path = asTrimmedString(asRecord(entry)?.path);
+    if (path) {
+      return path;
+    }
+  }
+  return null;
+}
+
+/**
+ * ACP providers (cursor/grok/opencode/slave) surface tool calls as
+ * `{toolCallId, kind, command, rawInput, rawOutput, content, locations}`
+ * without a tool-name envelope. Some stamp the tool name in
+ * `rawInput.variant` (handled by extractToolName); the rest are classified
+ * here from the ACP tool kind and raw-input shape so they still render as
+ * styled `Tool(arg)` rows with result lines and diffs.
+ */
+function normalizeAcpToolCall(
+  payload: Record<string, unknown> | null,
+): NormalizedProviderToolCall | null {
+  const data = asRecord(payload?.data);
+  if (
+    !data ||
+    !asTrimmedString(data.toolCallId) ||
+    data.toolName !== undefined ||
+    data.item !== undefined
+  ) {
+    return null;
+  }
+  const rawInput = asRecord(data.rawInput);
+  const kind = asTrimmedString(data.kind);
+  const itemType = asTrimmedString(payload?.itemType);
+  const toolResultText = acpToolResultText(data);
+  const toolDiff = acpContentDiff(data);
+
+  const command = asTrimmedString(data.command) ?? asTrimmedString(rawInput?.command);
+  if (command && kind !== "edit" && itemType !== "file_change") {
+    return { toolName: "Shell", toolInput: { command }, toolResultText, toolDiff: null };
+  }
+
+  const filePath =
+    asTrimmedString(rawInput?.file_path) ??
+    asTrimmedString(rawInput?.path) ??
+    asTrimmedString(rawInput?.target_file) ??
+    asTrimmedString(toolDiff?.filePath) ??
+    acpFirstLocationPath(data);
+  const fileInput = filePath ? { file_path: filePath } : null;
+
+  if (kind === "edit" || kind === "move" || kind === "delete" || itemType === "file_change") {
+    const isCreate =
+      toolDiff === null &&
+      typeof rawInput?.content === "string" &&
+      rawInput.old_string === undefined;
+    return {
+      toolName: isCreate ? "Write" : "Edit",
+      toolInput: fileInput,
+      toolResultText,
+      toolDiff,
+    };
+  }
+  if (toolDiff) {
+    return { toolName: "Edit", toolInput: fileInput, toolResultText, toolDiff };
+  }
+  if (kind === "read") {
+    return { toolName: "Read", toolInput: fileInput, toolResultText, toolDiff: null };
+  }
+  if (kind === "search" || itemType === "web_search") {
+    const pattern = asTrimmedString(rawInput?.pattern);
+    if (pattern) {
+      return { toolName: "Grep", toolInput: { pattern }, toolResultText, toolDiff: null };
+    }
+    const query = asTrimmedString(rawInput?.query) ?? asTrimmedString(rawInput?.url);
+    return {
+      toolName: "WebSearch",
+      toolInput: query ? { query } : null,
+      toolResultText,
+      toolDiff: null,
+    };
+  }
+  if (kind === "fetch") {
+    const url = asTrimmedString(rawInput?.url) ?? asTrimmedString(rawInput?.query);
+    return {
+      toolName: "WebFetch",
+      toolInput: url ? { url } : null,
+      toolResultText,
+      toolDiff: null,
+    };
+  }
+  return null;
+}
+
 function extractToolCallId(payload: Record<string, unknown> | null): string | null {
   const data = asRecord(payload?.data);
-  return asTrimmedString(data?.toolCallId);
+  // Claude ingestion stamps toolCallId on the payload root; other providers
+  // nest it in the passthrough data record.
+  return asTrimmedString(data?.toolCallId) ?? asTrimmedString(payload?.toolCallId);
 }
 
 function normalizeInlinePreview(value: string): string {
@@ -1306,7 +2164,7 @@ function normalizePreviewForComparison(value: string | null | undefined): string
   return normalizeCompactToolLabel(normalizeInlinePreview(normalized)).toLowerCase();
 }
 
-function summarizeToolTextOutput(value: string): string | null {
+export function summarizeToolTextOutput(value: string): string | null {
   const lines: Array<string> = [];
   for (const rawLine of value.split(/\r?\n/u)) {
     const line = normalizeInlinePreview(rawLine);


### PR DESCRIPTION
## What

Upgrades the chat transcript's tool-call rendering to compact, information-dense rows (in the style of Claude Code's transcript):

- **Tool rows** — each tool call renders as `Tool(primary arg)` with a status dot (running / done / error) and a `⎿ result` one-liner, expandable for full input/output.
- **Inline diffs** — file edits (Claude `Edit`/`Write`/`MultiEdit`, Codex native patches, ACP content diffs) render as inline unified diffs directly in the transcript, with add/remove line counts and theme-aware colors.
- **Thinking bursts** — streamed reasoning deltas are grouped into a live "Thinking…" row that folds into a `Thought for Xs` entry when the burst ends, expandable to the reasoning text.
- **Live work status** — the working indicator shows what the agent is doing right now (current tool + arg, or "Thinking…"), derived from recent activities and the streaming message.
- **Context-compaction rows** — compaction starts render as a distinct shimmer row instead of disappearing.

## How

**Server**
- `ClaudeAdapter` forwards a bounded `toolUseResult` summary in `toolData` (structuredPatch capped at 400 lines, filePath kept) so the client can render edit diffs without replaying the file.
- `ProviderRuntimeIngestion` tracks reasoning deltas into thinking-burst activities (throttled to 250ms, stable progress id per burst), forwards `toolCallId`/`data` on item events, and emits a `context-compaction.started` activity from `session.state.changed`.
- `ActivityPayloadProjection` now retains tool-detail fields (`toolName`, `input`, `result`, `toolUseResult`, `item`, `content`, `rawInput`) in snapshots under a recursive clamp (4k-char strings, 100-item arrays, depth 6) instead of pruning them to one-line summaries — re-hydrated threads render the same rows the live stream did, with bounded row size. Live events were already unpruned; this only affects snapshot rows.

**Web**
- `session-logic` normalizes Codex native tool items and ACP tool calls into one shape (tool name, input, diff hunks, result text), merges it into work-log entries, and adds `deriveLiveWorkStatus`.
- `MessagesTimeline` renders the new rows; work groups keep their existing fold behavior (state tracked as collapsed-set with expanded default). Existing agent/subagent rendering (spawn CTA rows, agents panel, task linkage) is untouched.

## Scope notes

- No contract changes — new activity kinds ride the open `kind` string, and payload additions are additive.
- Deliberately excluded from this PR to keep it reviewable: composer agent-status strip, scroll-behavior tweaks, plan-progress derivation.

## Testing

- New/updated unit tests: thinking-burst ingestion, snapshot clamp retention, tool metadata extraction (Claude/Codex/ACP), `deriveLiveWorkStatus`, timeline fold semantics, live-status row diffing.
- Full web suite passes (207 files / 1845 tests); server suite passes apart from 3 pre-existing failures that require a non-root user (chmod-based permission tests).
- Running in production on our fork for several weeks across Claude Code, Codex, and ACP providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider ingestion, activity projection, and large timeline UI paths; behavior is well-tested but regressions could affect transcript accuracy, snapshot size, or live status for all providers.
> 
> **Overview**
> Delivers a **richer chat transcript**: compact `Tool(arg)` rows with status dots, `⎿` result lines, **inline file diffs**, expandable **“Thought for Xs”** reasoning, **context-compaction** shimmer rows, and a **phase-aware working indicator** (thinking / running tool / writing).
> 
> **Server:** `ProviderRuntimeIngestion` collapses reasoning `content.delta` streams into throttled `thinking.started` / `thinking.progress` / `thinking.completed` activities (stable progress id, turn-aware close, stale `turn.completed` guard). Tool lifecycle events now carry **`toolCallId`**, more **`data` on `tool.started`**, and **`context-compaction.started`** from compacting session state. `ClaudeAdapter` attaches a bounded **`toolUseResult`** (`structuredPatch` + `filePath`) on edit tools. `ActivityPayloadProjection` **retains and clamps** tool-detail fields in snapshots instead of one-line summaries so re-hydrated threads match live rendering.
> 
> **Web:** `session-logic` normalizes **Claude / Codex / ACP** tool payloads into `toolName`, `toolInput`, `toolDiff`, `toolResultText`, maps completed thinking to work-log rows, and adds **`deriveLiveWorkStatus`** (with optional Claude silent-thinking fallback). `MessagesTimeline` renders the new row types and passes live status into the working row; work groups default **expanded** (track **`collapsedWorkGroupIds`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc67dd44f1bc83818294064d5467de9aa823f987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add rich tool-call transcript with inline diffs, thinking bursts, and live status to chat timeline
> - Server-side ingestion in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/5471/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) now coalesces reasoning deltas into `thinking.started`, throttled `thinking.progress`, and `thinking.completed` activities, and emits a `context-compaction.started` activity when the provider reports compaction.
> - [ActivityPayloadProjection.ts](https://github.com/pingdotgg/t3code/pull/5471/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130) and [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/5471/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) now retain and clamp structured tool detail fields (input, result, `structuredPatch`) in projected activity payloads.
> - [session-logic.ts](https://github.com/pingdotgg/t3code/pull/5471/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) adds `deriveLiveWorkStatus` to compute a live phase indicator (Thinking / Running / Editing) from activities and streaming state, and enriches `WorkLogEntry` with `toolName`, `toolInput`, `toolDiff`, and `toolResultText`.
> - [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/5471/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) renders tool rows with a standardized header, inline unified diffs with expand/collapse, a `ThinkingWorkEntryRow` for completed reasoning bursts, a `ContextCompactionRow` divider, and a `LiveThinkingStream` with auto-scroll in the live working indicator.
> - Work groups in the timeline now default to expanded and only collapse when toggled (inverted from previous opt-in expand behavior).
> - Behavioral Change: `collapsedWorkGroupIds` replaces `expandedWorkGroupIds` in `deriveMessagesTimelineRows`; callers that previously passed expanded IDs must invert their state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc67dd4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->