### PR TITLE
fix(desktop): prevent automatic passkey prompt during sign-in

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { ClerkProvider } from "@clerk/react";
-import { passkeys } from "@clerk/electron/passkeys";
+import { createPasskeys } from "@clerk/electron/passkeys";
 import { ClerkProvider as ElectronClerkProvider } from "@clerk/electron/react";
 import { createHashHistory, createBrowserHistory } from "@tanstack/react-router";
 
@@ -23,11 +23,18 @@ const history = isElectron ? createHashHistory() : createBrowserHistory();
 const router = getRouter(history);
 
 if (isElectron) {
+  if (globalThis.PublicKeyCredential) {
+    Object.defineProperty(PublicKeyCredential, "isConditionalMediationAvailable", {
+      configurable: true,
+      value: () => Promise.resolve(false),
+    });
+  }
   syncDocumentElectronPlatformClasses(navigator.platform);
   syncDocumentWindowControlsOverlayClass();
 }
 
 const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
+const desktopPasskeys = createPasskeys({ mode: "native" });
 
 const app = <AppRoot router={router} />;
 
@@ -35,7 +42,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     {clerkPublishableKey && hasCloudPublicConfig() ? (
       isElectron ? (
-        <ElectronClerkProvider publishableKey={clerkPublishableKey} passkeys={passkeys}>
+        <ElectronClerkProvider publishableKey={clerkPublishableKey} passkeys={desktopPasskeys}>
           <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
         </ElectronClerkProvider>
       ) : (


### PR DESCRIPTION
## Problem

Opening “Sign in to T3 Connect” in the macOS desktop app immediately triggered the native passkey prompt before the user selected a sign-in method.

Clerk’s sign-in UI checks conditional WebAuthn mediation directly and begins an autofill passkey request when macOS reports it as available.

## Fix

Configure the Electron passkey adapter to use native mode, which reports automatic passkey autofill as unavailable.

Also disable conditional mediation before Clerk mounts because Clerk’s sign-in UI checks `PublicKeyCredential.isConditionalMediationAvailable()` directly instead of relying exclusively on the configured Electron adapter.

Explicit user-initiated passkey authentication remains supported.

## Verification

- Passed `vp run --filter @t3tools/web typecheck`.
- Completed a production desktop build.
- Manually verified on macOS that opening T3 Connect sign-in no longer automatically displays the passkey prompt.

## Before

Opening “Sign in to T3 Connect” immediately displays the native passkey prompt.

https://github.com/user-attachments/assets/1607f271-1238-4d05-bf52-b9666d77b374

## After

The sign-in dialog opens normally and waits for the user to choose a sign-in method.

https://github.com/user-attachments/assets/e7f8a853-0983-4c40-87dd-4399e3702f5f

Implemented with GPT-5.6-sol through T3 Code using the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent automatic passkey prompt during sign-in on desktop
> - Overrides `PublicKeyCredential.isConditionalMediationAvailable` in Electron to always return `false`, preventing the browser-style conditional UI passkey prompt from appearing automatically during sign-in.
> - Switches passkey initialization in [main.tsx](https://github.com/pingdotgg/t3code/pull/5472/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b) to use `createPasskeys({ mode: "native" })` so the desktop app uses native passkey handling instead of the directly imported `passkeys` symbol.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8957144.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Electron-only bootstrap change to sign-in UX; does not alter server auth or remove explicit passkey flows.
> 
> **Overview**
> Stops the macOS desktop **T3 Connect** sign-in flow from immediately showing the native passkey sheet when the dialog opens.
> 
> On Electron startup, **`PublicKeyCredential.isConditionalMediationAvailable`** is stubbed to resolve **`false`** before Clerk mounts, because the sign-in UI probes that API directly and would otherwise start conditional WebAuthn autofill when macOS reports it as available. Desktop Clerk is wired to **`createPasskeys({ mode: "native" })`** instead of the default **`passkeys`** export so the Electron adapter treats automatic passkey autofill as unavailable; user-initiated passkey sign-in is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895714413ef42473244d8fbceec83487211c849e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->