### PR TITLE
fix(server): type the account rate-limit runtime payload

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1995,6 +1995,64 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("normalizes Claude rate limit events onto canonical usage windows", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "allowed_warning",
+          rateLimitType: "five_hour",
+          utilization: 82,
+          resetsAt: 1_800_000_000,
+        },
+        session_id: "session",
+        uuid: "rate-limit-1",
+      } as unknown as SDKMessage);
+      // A bare status carries no usage figures and must not invent a window.
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "allowed" },
+        session_id: "session",
+        uuid: "rate-limit-2",
+      } as unknown as SDKMessage);
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      const rateLimitEvents = runtimeEvents.filter(
+        (event) => event.type === "account.rate-limits.updated",
+      );
+      assert.deepEqual(
+        rateLimitEvents.map((event) =>
+          event.type === "account.rate-limits.updated" ? event.payload : undefined,
+        ),
+        [
+          {
+            status: "warning",
+            windows: [{ kind: "five_hour", usedPercent: 82, resetsAt: 1_800_000_000 }],
+          },
+          { status: "allowed", windows: [] },
+        ],
+      );
+      runtimeEventsFiber.interruptUnsafe();
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("consumes undeclared and UX-internal system subtypes without warning rows", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -15,6 +15,7 @@ import {
   type PermissionUpdate,
   type SDKMessage,
   type SDKControlGetContextUsageResponse,
+  type SDKRateLimitInfo,
   type SDKResultMessage,
   type SettingSource,
   type SDKUserMessage,
@@ -22,6 +23,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
 import {
+  type AccountRateLimitsUpdatedPayload,
   ApprovalRequestId,
   type CanonicalItemType,
   type CanonicalRequestType,
@@ -1498,6 +1500,35 @@ function sdkMessageSubtype(value: unknown): string | undefined {
   }
   const record = value as { subtype?: unknown };
   return typeof record.subtype === "string" ? record.subtype : undefined;
+}
+
+const CLAUDE_RATE_LIMIT_STATUS = {
+  allowed: "allowed",
+  allowed_warning: "warning",
+  rejected: "rejected",
+} as const satisfies Record<SDKRateLimitInfo["status"], AccountRateLimitsUpdatedPayload["status"]>;
+
+/**
+ * Normalizes the SDK rate-limit snapshot onto the canonical payload. Claude
+ * reports the one window currently governing the account rather than a full
+ * set, so `windows` holds at most one entry, and none at all when the SDK
+ * sends a bare status. `utilization` is a 0-100 percentage, matching the
+ * `rate_limits` windows the SDK documents on its usage response.
+ */
+function rateLimitsPayloadFromSdk(info: SDKRateLimitInfo): AccountRateLimitsUpdatedPayload {
+  const window =
+    info.rateLimitType !== undefined && info.utilization !== undefined
+      ? {
+          kind: info.rateLimitType,
+          usedPercent: info.utilization,
+          ...(info.resetsAt !== undefined ? { resetsAt: info.resetsAt } : {}),
+        }
+      : undefined;
+
+  return {
+    status: CLAUDE_RATE_LIMIT_STATUS[info.status],
+    windows: window ? [window] : [],
+  };
 }
 
 function sdkNativeMethod(message: SDKMessage): string {
@@ -3446,9 +3477,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       yield* offerRuntimeEvent({
         ...base,
         type: "account.rate-limits.updated",
-        payload: {
-          rateLimits: message,
-        },
+        payload: rateLimitsPayloadFromSdk(message.rate_limit_info),
       });
       return;
     }

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -753,13 +753,45 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
       if (firstEvent.value.type !== "account.rate-limits.updated") {
         return;
       }
+      // No exhaustion signal in the snapshot: status stays absent rather than
+      // asserting an `allowed` Codex never reported.
       NodeAssert.deepEqual(firstEvent.value.payload, {
-        status: "allowed",
         windows: [
           { kind: "primary", usedPercent: 40, resetsAt: 1_800_000_000, windowDurationMins: 300 },
           { kind: "secondary", usedPercent: 12 },
         ],
       });
+    }),
+  );
+
+  it.effect("treats Codex spend-control exhaustion as a rejected account", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      yield* runtime.emit({
+        id: asEventId("evt-spend-control"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "account/rateLimits/updated",
+        payload: {
+          rateLimits: { spendControlReached: true },
+        },
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.type, "account.rate-limits.updated");
+      if (firstEvent.value.type !== "account.rate-limits.updated") {
+        return;
+      }
+      NodeAssert.deepEqual(firstEvent.value.payload, { status: "rejected", windows: [] });
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -723,6 +723,46 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("normalizes Codex rate limit notifications onto canonical usage windows", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      yield* runtime.emit({
+        id: asEventId("evt-rate-limits"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "account/rateLimits/updated",
+        payload: {
+          rateLimits: {
+            primary: { usedPercent: 40, resetsAt: 1_800_000_000, windowDurationMins: 300 },
+            secondary: { usedPercent: 12 },
+          },
+        },
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.type, "account.rate-limits.updated");
+      if (firstEvent.value.type !== "account.rate-limits.updated") {
+        return;
+      }
+      NodeAssert.deepEqual(firstEvent.value.payload, {
+        status: "allowed",
+        windows: [
+          { kind: "primary", usedPercent: 40, resetsAt: 1_800_000_000, windowDurationMins: 300 },
+          { kind: "secondary", usedPercent: 12 },
+        ],
+      });
+    }),
+  );
+
   it.effect("maps retryable Codex error notifications to runtime.warning", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -8,6 +8,7 @@
  * @module CodexAdapterLive
  */
 import {
+  type AccountRateLimitsUpdatedPayload,
   type CanonicalItemType,
   type CanonicalRequestType,
   type CodexSettings,
@@ -434,6 +435,40 @@ function providerRefsFromEvent(
   if (event.requestId) refs.providerRequestId = event.requestId;
 
   return Object.keys(refs).length > 0 ? (refs as ProviderRuntimeEvent["providerRefs"]) : undefined;
+}
+
+function rateLimitWindow(
+  kind: string,
+  window: EffectCodexSchema.V2AccountRateLimitsUpdatedNotification__RateLimitWindow | null,
+): AccountRateLimitsUpdatedPayload["windows"][number] | undefined {
+  if (!window) {
+    return undefined;
+  }
+  return {
+    kind,
+    usedPercent: window.usedPercent,
+    ...(window.resetsAt != null ? { resetsAt: window.resetsAt } : {}),
+    ...(window.windowDurationMins != null ? { windowDurationMins: window.windowDurationMins } : {}),
+  };
+}
+
+/**
+ * Normalizes a Codex rate-limit snapshot onto the canonical payload. Codex
+ * reports two windows at once and signals exhaustion out of band, via
+ * `rateLimitReachedType`, rather than as a status on the windows themselves.
+ */
+function rateLimitsPayloadFromNotification(
+  snapshot: EffectCodexSchema.V2AccountRateLimitsUpdatedNotification__RateLimitSnapshot,
+): AccountRateLimitsUpdatedPayload {
+  const windows = [
+    rateLimitWindow("primary", snapshot.primary ?? null),
+    rateLimitWindow("secondary", snapshot.secondary ?? null),
+  ].filter((window) => window !== undefined);
+
+  return {
+    status: snapshot.rateLimitReachedType != null ? "rejected" : "allowed",
+    windows,
+  };
 }
 
 function runtimeEventBase(
@@ -1393,16 +1428,18 @@ function mapToRuntimeEvents(
   }
 
   if (event.method === "account/rateLimits/updated") {
-    if (!readPayload(EffectCodexSchema.V2AccountRateLimitsUpdatedNotification, event.payload)) {
+    const payload = readPayload(
+      EffectCodexSchema.V2AccountRateLimitsUpdatedNotification,
+      event.payload,
+    );
+    if (!payload) {
       return [];
     }
     return [
       {
         type: "account.rate-limits.updated",
         ...runtimeEventBase(event, canonicalThreadId),
-        payload: {
-          rateLimits: event.payload ?? {},
-        },
+        payload: rateLimitsPayloadFromNotification(payload.rateLimits),
       },
     ];
   }

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -454,8 +454,14 @@ function rateLimitWindow(
 
 /**
  * Normalizes a Codex rate-limit snapshot onto the canonical payload. Codex
- * reports two windows at once and signals exhaustion out of band, via
- * `rateLimitReachedType`, rather than as a status on the windows themselves.
+ * reports two windows at once and signals exhaustion out of band, through
+ * `rateLimitReachedType` and `spendControlReached`, rather than as a status on
+ * the windows themselves.
+ *
+ * These notifications are sparse: an omitted field means "unknown", not
+ * "recovered" — the generated schema says as much on `spendControlReached`.
+ * So a status is claimed only on positive evidence of exhaustion, and left
+ * absent otherwise rather than asserting `allowed` the snapshot never stated.
  */
 function rateLimitsPayloadFromNotification(
   snapshot: EffectCodexSchema.V2AccountRateLimitsUpdatedNotification__RateLimitSnapshot,
@@ -464,9 +470,10 @@ function rateLimitsPayloadFromNotification(
     rateLimitWindow("primary", snapshot.primary ?? null),
     rateLimitWindow("secondary", snapshot.secondary ?? null),
   ].filter((window) => window !== undefined);
+  const exhausted = snapshot.rateLimitReachedType != null || snapshot.spendControlReached === true;
 
   return {
-    status: snapshot.rateLimitReachedType != null ? "rejected" : "allowed",
+    ...(exhausted ? { status: "rejected" as const } : {}),
     windows,
   };
 }

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -701,7 +701,9 @@ export type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
 
 /**
  * Whether the account may currently send work. `warning` means the provider
- * accepted this turn but flagged the window as close to exhausted.
+ * accepted this turn but flagged the window as close to exhausted. Absent
+ * means the update did not report one — providers send sparse snapshots, and
+ * silence is not recovery.
  */
 const RateLimitStatus = Schema.Literals(["allowed", "warning", "rejected"]);
 export type RateLimitStatus = typeof RateLimitStatus.Type;
@@ -725,7 +727,11 @@ export type RateLimitWindow = typeof RateLimitWindow.Type;
 
 const AccountRateLimitsUpdatedPayload = Schema.Struct({
   status: Schema.optional(RateLimitStatus),
-  /** Empty when the provider reported a status but no usage figures. */
+  /**
+   * The windows this update reported, empty when it carried none. Updates are
+   * sparse, so a window missing here is unchanged rather than cleared — merge
+   * by `kind` instead of replacing wholesale.
+   */
   windows: Schema.Array(RateLimitWindow),
 });
 export type AccountRateLimitsUpdatedPayload = typeof AccountRateLimitsUpdatedPayload.Type;

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -699,8 +699,34 @@ const AccountUpdatedPayload = Schema.Struct({
 });
 export type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
 
+/**
+ * Whether the account may currently send work. `warning` means the provider
+ * accepted this turn but flagged the window as close to exhausted.
+ */
+const RateLimitStatus = Schema.Literals(["allowed", "warning", "rejected"]);
+export type RateLimitStatus = typeof RateLimitStatus.Type;
+
+/**
+ * One rolling usage window on a provider account. Providers disagree on how
+ * many they report — Claude sends the single governing window, Codex sends a
+ * primary/secondary pair — so consumers read the array, not fixed fields.
+ */
+const RateLimitWindow = Schema.Struct({
+  /** Provider-native window name, e.g. `five_hour`, `seven_day`, `primary`. */
+  kind: TrimmedNonEmptyStringSchema,
+  /** Share of the window consumed, 0-100. */
+  usedPercent: Schema.Number,
+  /** Unix epoch seconds at which the window resets. */
+  resetsAt: Schema.optional(Schema.Number),
+  /** Window length in minutes, when the provider reports one. */
+  windowDurationMins: Schema.optional(Schema.Number),
+});
+export type RateLimitWindow = typeof RateLimitWindow.Type;
+
 const AccountRateLimitsUpdatedPayload = Schema.Struct({
-  rateLimits: Schema.Unknown,
+  status: Schema.optional(RateLimitStatus),
+  /** Empty when the provider reported a status but no usage figures. */
+  windows: Schema.Array(RateLimitWindow),
 });
 export type AccountRateLimitsUpdatedPayload = typeof AccountRateLimitsUpdatedPayload.Type;
 


### PR DESCRIPTION
## Problem

`account.rate-limits.updated` is declared with `rateLimits: Schema.Unknown` in `packages/contracts/src/providerRuntime.ts`. Both adapters that emit it forward their provider's native message verbatim:

- `ClaudeAdapter.ts` passes the whole `SDKRateLimitEvent`
- `CodexAdapter.ts` passes the whole `V2AccountRateLimitsUpdatedNotification`

So the event carries two different shapes under one type, and neither is typed. Nothing in the repo consumes it today — I grepped for `account.rate-limits.updated` and `AccountRateLimitsUpdated` across the tree, and every hit is the two emitters, the contract, and the generated Codex schema. There is no projector, reactor, or client reader. Nothing *can* consume it until the two shapes agree.

Worth noting the structure is already there and being discarded: the Codex app-server schema types `primary`/`secondary` windows with `usedPercent`, `resetsAt`, and `windowDurationMins`, and the Claude SDK types `rate_limit_info` with a status, window type, utilization, and reset time.

## Change

Normalize at the adapter boundary, per "complexity belongs at the adapter boundary" in AGENTS.md:

```ts
const AccountRateLimitsUpdatedPayload = Schema.Struct({
  status: Schema.optional(RateLimitStatus),        // "allowed" | "warning" | "rejected"
  windows: Schema.Array(RateLimitWindow),          // { kind, usedPercent, resetsAt?, windowDurationMins? }
});
```

`windows` is an array rather than fixed fields because the providers genuinely disagree on how many they report: Claude sends the one window currently governing the account, Codex sends a primary/secondary pair.

- **Claude** maps `rate_limit_info` — `allowed_warning` becomes `warning`, and a bare status with no figures yields an empty `windows` rather than a fabricated one. `utilization` is treated as a 0–100 percentage, matching how the same SDK documents the `rate_limits` windows on its usage response.
- **Codex** maps the primary/secondary pair and derives `rejected` from `rateLimitReachedType`, which is how Codex signals exhaustion — out of band from the windows themselves.

The passthrough field is dropped rather than kept alongside: the native message already reaches consumers unchanged via `raw.payload`, so nothing is lost.

## Scope

No behavior change — the event has no consumers, so this only makes it possible to add one. No UI, so no before/after images. No docs, since nothing user-visible changed.

Both adapters ship focused tests for the mapping, including the empty-windows case.

## Verification

- `tsgo --noEmit` in `apps/server` and `packages/contracts` — 0 errors; the 9 remaining diagnostics are pre-existing `suggestion`-level hits in `orchestration/decider.ts` and `orchestration/workflowScriptQuery.ts`, none in the touched files
- `vp test run src/provider/Layers/CodexAdapter.test.ts src/provider/Layers/ClaudeAdapter.test.ts` — 92 passed
- `vp lint` and `vp format --check` clean on the five touched files
- Rebased on `main` at the time of opening

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract and adapter-boundary normalization only; the event had no in-repo consumers, so runtime behavior for existing flows is unchanged aside from the emitted payload shape.
> 
> **Overview**
> **Replaces the untyped `rateLimits` blob** on `account.rate-limits.updated` with a shared contract: optional `status` (`allowed` | `warning` | `rejected`) and a `windows` array (`kind`, `usedPercent`, optional `resetsAt` / `windowDurationMins`). Sparse updates are documented so consumers merge by `kind` instead of replacing state wholesale.
> 
> **Claude** now maps SDK `rate_limit_event.rate_limit_info` through `rateLimitsPayloadFromSdk` (e.g. `allowed_warning` → `warning`; status-only events yield empty `windows`).
> 
> **Codex** maps `account/rateLimits/updated` through `rateLimitsPayloadFromNotification` (primary/secondary windows; `rejected` only when exhaustion signals are present, otherwise status is omitted).
> 
> Adapter tests cover warning windows, bare status, multi-window snapshots, and spend-control rejection. Native payloads remain on `raw` for debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de6f0e5ac6492fbab3d9bce7583f0348e58bb2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Type the `account.rate-limits.updated` runtime payload with canonical status and windows
> - Replaces the opaque `rateLimits: Unknown` field in `AccountRateLimitsUpdatedPayload` ([providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/5473/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7)) with a structured schema: optional `status` (`'allowed' | 'warning' | 'rejected'`) and a `windows` array of `RateLimitWindow` objects.
> - Updates [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/5473/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) to normalize SDK `rate_limit_event` messages into the canonical payload via a new `rateLimitsPayloadFromSdk` helper, mapping SDK statuses (e.g. `'allowed_warning'` → `'warning'`).
> - Updates [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/5473/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) to map `account/rateLimits/updated` notifications into canonical windows, setting `status: 'rejected'` when `spendControlReached` or `rateLimitReachedType` is set.
> - Behavioral Change: both adapters now emit a structured `{ status, windows }` payload instead of a provider-specific blob; consumers reading the old `rateLimits` field will receive `undefined`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9de6f0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->