### PR TITLE
fix(server): bound mcp tool payloads on the wire

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -104,6 +104,89 @@ function projectCommandData(data: Record<string, unknown>): Record<string, unkno
   return Object.keys(projectedItem).length > 0 ? projectedItem : undefined;
 }
 
+/**
+ * Fields of an MCP tool call item worth shipping: everything that describes
+ * the call itself. `result` is handled separately because it carries the
+ * unbounded tool output.
+ */
+const MCP_ITEM_DESCRIPTOR_FIELDS = [
+  "type",
+  "id",
+  "tool",
+  "server",
+  "status",
+  "arguments",
+  "appContext",
+  "error",
+  "durationMs",
+] as const;
+
+/** Cap on the text handed to the summarizer — results reach megabytes. */
+const MCP_RESULT_TEXT_LIMIT = 4_096;
+
+/**
+ * MCP results carry their payload in `result.content`, either as a plain
+ * string or as the MCP content-block array (`[{ type: "text", text }, …]`).
+ * Flattens the leading text so the shared tool-output summarizer can bound it.
+ */
+function extractMcpResultText(content: unknown): string | null {
+  if (typeof content === "string") {
+    return asTrimmedString(content.slice(0, MCP_RESULT_TEXT_LIMIT));
+  }
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  let joined = "";
+  for (const block of content) {
+    const text = asTrimmedString(asRecord(block)?.text);
+    if (!text) {
+      continue;
+    }
+    joined = joined.length > 0 ? `${joined}\n${text}` : text;
+    if (joined.length >= MCP_RESULT_TEXT_LIMIT) {
+      break;
+    }
+  }
+  return asTrimmedString(joined.slice(0, MCP_RESULT_TEXT_LIMIT));
+}
+
+/**
+ * Bounds an MCP tool call item for the wire. Both clients render `data.item`
+ * as JSON in the expanded work-log row, so the call descriptor stays intact
+ * while `result` — which carries the whole tool result, routinely a megabyte
+ * for connector fetches — collapses to the same one-line preview regular tool
+ * output gets. An item record always projects to a record so the clients'
+ * `data.item !== undefined` check keeps holding.
+ */
+function projectMcpToolCallData(
+  data: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const item = asRecord(data.item);
+  if (!item) {
+    return undefined;
+  }
+
+  const projectedItem: Record<string, unknown> = {};
+  for (const field of MCP_ITEM_DESCRIPTOR_FIELDS) {
+    if (field in item) {
+      projectedItem[field] = item[field];
+    }
+  }
+
+  const result = asRecord(item.result);
+  if (result) {
+    const text = extractMcpResultText(result.content);
+    const summary = text ? summarizeToolTextOutput(text) : null;
+    projectedItem.result = {
+      ...(summary ? { content: summary } : {}),
+      // MCP signals tool-level failure on the result, not on `item.error`.
+      ...(result.isError === true ? { isError: true } : {}),
+    };
+  }
+
+  return projectedItem;
+}
+
 function summarizeToolTextOutput(value: string): string | null {
   const lines: string[] = [];
   for (const rawLine of value.split(/\r?\n/u)) {
@@ -160,12 +243,13 @@ export function projectActivityPayload(
 ): OrchestrationThreadActivity {
   const payload = asRecord(activity.payload);
   const data = asRecord(payload?.data);
-  if (!payload || !data || payload.itemType === "mcp_tool_call") {
+  if (!payload || !data) {
     return activity;
   }
 
   const projectedData: Record<string, unknown> = {};
-  const item = projectCommandData(data);
+  const item =
+    payload.itemType === "mcp_tool_call" ? projectMcpToolCallData(data) : projectCommandData(data);
   if (item) {
     projectedData.item = item;
   }

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -114,12 +114,19 @@ const fixtures = [
   }),
   makeActivity("mcp", "mcp_tool_call", {
     item: {
+      type: "mcpToolCall",
+      id: "mcp_1",
       server: "repository",
       tool: "search",
       arguments: { query: "activity projection" },
-      aggregatedOutput: "mcp payload remains available",
+      status: "completed",
+      durationMs: 12,
+      error: null,
+      result: { content: [{ type: "text", text: "first result line\nsecond result line" }] },
+      aggregatedOutput: "bulk that no client reads",
     },
-    ignored: "MCP data is rendered verbatim",
+    toolCallId: "tool-mcp",
+    ignored: "top-level bulk",
   }),
   makeActivity("search", "web_search", {
     rawOutput: {
@@ -184,12 +191,111 @@ describe("projectActivityPayload", () => {
     });
   });
 
-  it("passes MCP tool data through unchanged", () => {
-    expect(projectActivityPayload(fixtures[4]!)).toBe(fixtures[4]);
+  it("keeps the MCP call descriptor and bounds its result", () => {
+    const projected = projectActivityPayload(fixtures[4]!);
+
+    expect(projected.payload).toEqual({
+      itemType: "mcp_tool_call",
+      title: "mcp_tool_call",
+      detail: "mcp_tool_call detail",
+      status: "completed",
+      requestKind: "command",
+      data: {
+        item: {
+          type: "mcpToolCall",
+          id: "mcp_1",
+          tool: "search",
+          server: "repository",
+          status: "completed",
+          arguments: { query: "activity projection" },
+          error: null,
+          durationMs: 12,
+          result: { content: "first result line" },
+        },
+        toolCallId: "tool-mcp",
+      },
+    });
   });
 
-  it("keeps current web and mobile derived output identical for every tool item type", () => {
-    for (const activity of fixtures) {
+  it("bounds a megabyte-scale MCP result", () => {
+    const huge = makeActivity("mcp-huge", "mcp_tool_call", {
+      item: {
+        server: "github",
+        tool: "fetch_pr",
+        arguments: { number: 5219 },
+        status: "completed",
+        result: {
+          content: [
+            { type: "text", text: `pull request body\n${"diff line\n".repeat(120_000)}` },
+            { type: "text", text: "x".repeat(200_000) },
+          ],
+        },
+      },
+    });
+
+    const projected = projectActivityPayload(huge);
+    const projectedSize = JSON.stringify(projected.payload).length;
+
+    expect(JSON.stringify(huge.payload).length).toBeGreaterThan(1_000_000);
+    expect(projectedSize).toBeLessThan(500);
+    expect(projected.payload).toMatchObject({
+      data: {
+        item: {
+          server: "github",
+          tool: "fetch_pr",
+          arguments: { number: 5219 },
+          status: "completed",
+          result: { content: "pull request body" },
+        },
+      },
+    });
+  });
+
+  it("keeps a failing MCP call's error and isError flag", () => {
+    const failed = makeActivity("mcp-error", "mcp_tool_call", {
+      item: {
+        server: "github",
+        tool: "fetch_pr",
+        status: "failed",
+        error: { message: "not found", code: 404 },
+        result: { isError: true, content: [{ type: "text", text: "HTTP 404" }] },
+      },
+    });
+
+    expect(projectActivityPayload(failed).payload).toMatchObject({
+      data: {
+        item: {
+          error: { message: "not found", code: 404 },
+          result: { content: "HTTP 404", isError: true },
+        },
+      },
+    });
+  });
+
+  it("keeps in-flight MCP calls renderable without a result", () => {
+    const started: OrchestrationThreadActivity = {
+      ...makeActivity("mcp-started", "mcp_tool_call", {
+        item: { server: "github", tool: "fetch_pr", arguments: {}, status: "inProgress" },
+      }),
+      kind: "tool.started",
+    };
+
+    const projected = projectActivityPayload(started);
+    const data = (projected.payload as { data: Record<string, unknown> }).data;
+
+    // The clients gate the expanded body on `data.item !== undefined`.
+    expect(data.item).toEqual({
+      server: "github",
+      tool: "fetch_pr",
+      arguments: {},
+      status: "inProgress",
+    });
+  });
+
+  it("keeps current web and mobile derived output identical for every non-MCP tool item type", () => {
+    for (const activity of fixtures.filter(
+      (fixture) => (fixture.payload as { itemType: string }).itemType !== "mcp_tool_call",
+    )) {
       const projected = projectActivityPayload(activity);
       expect(deriveWorkLogEntries([projected])).toEqual(deriveWorkLogEntries([activity]));
       expect(comparableThreadFeed([projected])).toEqual(comparableThreadFeed([activity]));
@@ -333,7 +439,7 @@ describe("context-window snapshot dedup", () => {
       snapshotSequence: 7,
       thread: makeThread([fixtures[4]!]),
     });
-    expect(projected.thread.activities).toEqual([fixtures[4]]);
+    expect(projected.thread.activities).toEqual([projectActivityPayload(fixtures[4]!)]);
   });
 
   it("does not filter live activity-appended events", () => {


### PR DESCRIPTION
## Problem

MCP tool call payloads were the one activity type that skipped the wire projection — `projectActivityPayload` early-returned on `itemType === "mcp_tool_call"`, so `payload.data.item.result.content` shipped the entire tool result. A single connector call (e.g. fetching a whole GitHub PR) reaches 1MB+, and one real MCP-heavy thread ships 11.7MB of mcp_tool_call payloads out of 17.8MB total wire size.

## Fix

Run MCP payloads through the projection like every other tool payload. `data.item` is retained with a bounded shape: the call descriptor (`tool`, `server`, `status`, `arguments`, `appContext`, `error`, `durationMs`, `type`, `id`) survives intact, and `item.result` collapses to the same one-line preview that regular tool output already gets via `summarizeToolTextOutput`. `data.toolCallId` / `data.kind` are retained as before.

Both clients render `data.item` as JSON in the expanded work-log row and gate that row on `data.item !== undefined`, so an item record always projects to a record — the descriptor plus a result preview still renders. `tool.started` MCP rows go through the same path for consistency. Full payloads are untouched in SQLite and the event store; this only affects the wire.

## Tests

Added to `apps/server/test/ActivityPayloadProjection.test.ts`: a 1MB+ result projects under 500 bytes while keeping tool/server/arguments/status, a small call keeps its fields, a failing call keeps `error` and `isError`, and an in-flight call with no result still renders. Full server suite green (1873 passed).

---

Changes made by Claude Fable 5 via Claude Code, running as a subagent of a planning session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration wire payloads for a high-volume activity type; clients still get descriptors but lose full MCP result text in expanded work-log JSON unless they read persistence elsewhere.
> 
> **Overview**
> **MCP tool call activities are no longer exempt from wire projection.** `projectActivityPayload` used to return them unchanged, so megabyte-scale `result.content` shipped on thread snapshots and activity events.
> 
> MCP rows now go through **`projectMcpToolCallData`**: call metadata (`tool`, `server`, `status`, `arguments`, `error`, `durationMs`, etc.) stays on `data.item`, while `result` is flattened from string or MCP text blocks (capped at 4KB) and collapsed to the same one-line preview other tools use via `summarizeToolTextOutput`. **`isError`** on failed tool results is preserved. In-flight calls without a result still expose a descriptor-only `item` so clients’ `data.item !== undefined` checks keep working.
> 
> Tests cover bounded megabyte payloads, failures, and in-progress calls; the web/mobile parity loop now excludes MCP because expanded work-log JSON will show the summarized result instead of the full blob. Persistence and the event store are unchanged—only API projection is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ede7111c08d210d6cf8ddf877de1e3ac34d4cb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound MCP tool call payloads on the wire by projecting and summarizing large results
> - MCP tool call activities were previously passed through verbatim; they are now projected in [`ActivityPayloadProjection.ts`](https://github.com/pingdotgg/t3code/pull/5481/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130) to strip large result payloads down to a bounded summary.
> - Result content (string or MCP content blocks) is trimmed to 4096 characters via `extractMcpResultText`, then passed through `summarizeToolTextOutput`.
> - Only descriptor fields (`type`, `id`, `tool`, `server`, `status`, `arguments`, `appContext`, `error`, `durationMs`) are retained on the projected item; `result` is replaced with `{ content: summary }` plus `isError` if the call failed.
> - Behavioral Change: MCP tool call activities no longer reach consumers with their raw result payloads; only the summarized content and descriptor fields are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ede711.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->