### PR TITLE
perf(server): stop shipping full MCP tool results in thread payloads

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
@@ -44,6 +44,60 @@ describe("projectActivityPayload agent-field survival", () => {
     expect(data.somethingClientNeverReads).toBeUndefined();
   });
 
+  it("slims Codex-shaped mcp_tool_call items to rendered fields plus a result summary", () => {
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "mcp_tool_call",
+        data: {
+          item: {
+            type: "mcpToolCall",
+            id: "item-1",
+            tool: "fetch_pr",
+            server: "github",
+            status: "completed",
+            arguments: { pr: 42 },
+            durationMs: 1200,
+            result: {
+              content: [{ type: "text", text: `PR body line one\n${"x".repeat(5000)}` }],
+              structuredContent: { huge: "y".repeat(5000) },
+            },
+            _meta: { internal: true },
+          },
+        },
+      }),
+    );
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    const item = data.item as Record<string, unknown>;
+    expect(item.tool).toBe("fetch_pr");
+    expect(item.server).toBe("github");
+    expect(item.arguments).toEqual({ pr: 42 });
+    expect(item._meta).toBeUndefined();
+    expect(item.result).toEqual({ content: "PR body line one" });
+    expect(JSON.stringify(projected.payload).length).toBeLessThan(500);
+  });
+
+  it("slims Claude-shaped mcp_tool_call data (toolName/input/result block)", () => {
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "mcp_tool_call",
+        data: {
+          toolName: "mcp__github__fetch_pr",
+          input: { pr: 42 },
+          result: {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: [{ type: "text", text: `first line of output\n${"z".repeat(5000)}` }],
+          },
+        },
+      }),
+    );
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    expect(data.toolName).toBe("mcp__github__fetch_pr");
+    expect(data.input).toEqual({ pr: 42 });
+    expect(data.result).toEqual({ content: "first line of output" });
+    expect(JSON.stringify(projected.payload).length).toBeLessThan(500);
+  });
+
   it("passes task lifecycle payloads (no data field) through untouched", () => {
     const source = activity({
       taskId: "task-9",

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -123,6 +123,114 @@ function summarizeToolTextOutput(value: string): string | null {
   return null;
 }
 
+/**
+ * Fields of an MCP tool-call item both clients render in the expanded
+ * work-log row. Everything else — notably `result`, which carries the full
+ * tool output and dominates wire size on MCP-heavy threads — is summarized
+ * or dropped. Full payloads remain in persistence.
+ */
+const MCP_ITEM_KEPT_FIELDS = [
+  "type",
+  "id",
+  "tool",
+  "server",
+  "status",
+  "arguments",
+  "appContext",
+  "error",
+  "durationMs",
+] as const;
+
+/**
+ * Pulls renderable text out of an MCP tool result: either a Codex-style
+ * `{content: [{type: "text", text}, ...]}` record or a raw Claude
+ * `tool_result` block whose `content` is a string or block array.
+ */
+function extractMcpResultText(result: unknown): string | null {
+  const record = asRecord(result);
+  if (!record) {
+    return typeof result === "string" ? result : null;
+  }
+  if (typeof record.content === "string") {
+    return record.content;
+  }
+  if (Array.isArray(record.content)) {
+    const texts: string[] = [];
+    for (const entry of record.content) {
+      const text = asRecord(entry)?.text;
+      if (typeof text === "string" && text.trim().length > 0) {
+        texts.push(text);
+      }
+    }
+    if (texts.length > 0) {
+      return texts.join("\n");
+    }
+  }
+  return null;
+}
+
+function summarizeMcpResult(result: unknown): Record<string, unknown> | undefined {
+  if (result === undefined || result === null) {
+    return undefined;
+  }
+  const text = extractMcpResultText(result);
+  const summary = text ? summarizeToolTextOutput(text) : null;
+  return summary ? { content: summary } : undefined;
+}
+
+/**
+ * MCP tool calls carry full tool results (`data.item.result` on Codex,
+ * `data.result` on Claude/OpenCode) that used to bypass slimming entirely to
+ * keep the expanded-row UI working. Keep the fields the UI actually renders
+ * and summarize the result like regular tool output.
+ */
+function projectMcpToolCallData(data: Record<string, unknown>): Record<string, unknown> {
+  const projectedData: Record<string, unknown> = {};
+
+  const item = asRecord(data.item);
+  if (item) {
+    const projectedItem: Record<string, unknown> = {};
+    for (const key of MCP_ITEM_KEPT_FIELDS) {
+      if (key in item) {
+        projectedItem[key] = item[key];
+      }
+    }
+    const result = summarizeMcpResult(item.result);
+    if (result) {
+      projectedItem.result = result;
+    }
+    projectedData.item = projectedItem;
+  }
+
+  if ("toolName" in data) {
+    projectedData.toolName = data.toolName;
+  }
+  if ("input" in data) {
+    projectedData.input = data.input;
+  }
+  if (!item) {
+    const result = summarizeMcpResult(data.result);
+    if (result) {
+      projectedData.result = result;
+    }
+  }
+
+  if ("toolCallId" in data) {
+    projectedData.toolCallId = data.toolCallId;
+  }
+  if ("kind" in data) {
+    projectedData.kind = data.kind;
+  }
+
+  const changedFiles: string[] = [];
+  collectChangedFiles(data, changedFiles, new Set<string>(), 0);
+  if (changedFiles.length > 0) {
+    projectedData.files = changedFiles.map((path) => ({ path }));
+  }
+
+  return projectedData;
+}
+
 function projectRawOutput(value: unknown): Record<string, unknown> | undefined {
   const rawOutput = asRecord(value);
   if (!rawOutput) {
@@ -160,8 +268,18 @@ export function projectActivityPayload(
 ): OrchestrationThreadActivity {
   const payload = asRecord(activity.payload);
   const data = asRecord(payload?.data);
-  if (!payload || !data || payload.itemType === "mcp_tool_call") {
+  if (!payload || !data) {
     return activity;
+  }
+
+  if (payload.itemType === "mcp_tool_call") {
+    return {
+      ...activity,
+      payload: {
+        ...payload,
+        data: projectMcpToolCallData(data),
+      },
+    };
   }
 
   const projectedData: Record<string, unknown> = {};

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -117,9 +117,9 @@ const fixtures = [
       server: "repository",
       tool: "search",
       arguments: { query: "activity projection" },
-      aggregatedOutput: "mcp payload remains available",
+      aggregatedOutput: "mcp bulk is dropped",
     },
-    ignored: "MCP data is rendered verbatim",
+    ignored: "top-level bulk",
   }),
   makeActivity("search", "web_search", {
     rawOutput: {
@@ -184,13 +184,37 @@ describe("projectActivityPayload", () => {
     });
   });
 
-  it("passes MCP tool data through unchanged", () => {
-    expect(projectActivityPayload(fixtures[4]!)).toBe(fixtures[4]);
+  it("slims MCP tool data to the fields the expanded row renders", () => {
+    expect(projectActivityPayload(fixtures[4]!).payload).toEqual({
+      itemType: "mcp_tool_call",
+      title: "mcp_tool_call",
+      detail: "mcp_tool_call detail",
+      status: "completed",
+      requestKind: "command",
+      data: {
+        item: {
+          server: "repository",
+          tool: "search",
+          arguments: { query: "activity projection" },
+        },
+      },
+    });
   });
 
   it("keeps current web and mobile derived output identical for every tool item type", () => {
     for (const activity of fixtures) {
       const projected = projectActivityPayload(activity);
+      if (activity === fixtures[4]) {
+        // MCP is the one deliberate difference: the expanded row's toolData
+        // loses result bulk but keeps the rendered identity fields.
+        const [entry] = deriveWorkLogEntries([projected]);
+        expect(entry?.toolData).toEqual({
+          server: "repository",
+          tool: "search",
+          arguments: { query: "activity projection" },
+        });
+        continue;
+      }
       expect(deriveWorkLogEntries([projected])).toEqual(deriveWorkLogEntries([activity]));
       expect(comparableThreadFeed([projected])).toEqual(comparableThreadFeed([activity]));
     }
@@ -328,12 +352,12 @@ describe("context-window snapshot dedup", () => {
     );
   });
 
-  it("leaves snapshots without context-window activities untouched", () => {
+  it("applies only payload slimming when there are no context-window activities", () => {
     const projected = projectThreadDetailSnapshot({
       snapshotSequence: 7,
       thread: makeThread([fixtures[4]!]),
     });
-    expect(projected.thread.activities).toEqual([fixtures[4]]);
+    expect(projected.thread.activities).toEqual([projectActivityPayload(fixtures[4]!)]);
   });
 
   it("does not filter live activity-appended events", () => {


### PR DESCRIPTION
MCP tool calls were exempt from activity payload slimming: `projectActivityPayload` early-returns on `itemType === "mcp_tool_call"`, so the full tool result rides along in every snapshot and live event. On MCP-heavy threads this dominates the wire — one imported thread ships 3.2 MB gzipped, with two-thirds of its post-slimming bytes being unslimmed MCP payloads (worst single call: a GitHub `fetch_pr` result at 1 MB).

The exemption existed because both clients render `payload.data.item` in the expanded work-log row. The fix keeps exactly the fields that row renders (`tool`, `server`, `status`, `arguments`, `appContext`, `error`, `durationMs`, plus `toolName`/`input` for the Claude-adapter shape) and summarizes the result to one 84-char line, same as regular tool output. Full payloads stay in SQLite, so an on-demand detail endpoint can be added later without data loss.

Measured against a real db seeded with six representative threads (2,991 MCP activities): **12.2 MB of MCP payload JSON drops to 546 KB (95.6% reduction)**. Both provider payload shapes (Codex `data.item`, Claude/OpenCode `data.result`) verified against real rows.

Note: this trades away in-app access to full historical MCP results (they were previously visible in the expanded row). Per the pagination investigation, that's an accepted temporary loss; the data remains in persistence.

---
Change made by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape and fidelity of MCP activity data on thread snapshots and live events (lossy summaries), but scope is limited to projection with strong test coverage and no persistence changes.
> 
> **Overview**
> **MCP tool calls are no longer exempt from activity payload slimming** in `projectActivityPayload`. Instead of passing `mcp_tool_call` through unchanged, the server now runs **`projectMcpToolCallData`**, which keeps only fields the expanded work-log row uses (`tool`, `server`, `status`, `arguments`, `appContext`, `error`, `durationMs`, plus Claude-style `toolName`/`input`) and **replaces full tool results** with a one-line summary via the same `summarizeToolTextOutput` helper used for other tools.
> 
> Codex-shaped payloads (`data.item.result`) and Claude/OpenCode-shaped payloads (`data.result` blocks) are both handled; internal metadata like `_meta` and large `structuredContent` are dropped. **Changed file paths** can still be collected into a `files` array. Full MCP results remain in persistence—only snapshot/live thread transports shrink.
> 
> Tests now assert large MCP fixtures compress dramatically and that web/mobile derived views stay aligned except for the **intentional loss of full historical MCP result text** in the expanded row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22f7a583f1ef616f0273ede3cf85f6335c472725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop shipping full MCP tool results in thread payloads
> - Adds `projectMcpToolCallData` in [ActivityPayloadProjection.ts](https://github.com/pingdotgg/t3code/pull/5482/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130) to slim MCP tool-call payloads: only whitelisted fields (`tool`, `server`, `arguments`, etc.) are kept, and `result` content is replaced with a short text summary.
> - Handles both Codex-shaped (item array) and Claude-shaped (`toolName`/`input`/`result`) MCP data formats.
> - Changed files detected in results are surfaced as a `files` array on the slimmed payload.
> - Behavioral Change: activities with `itemType === "mcp_tool_call"` previously passed through unchanged; they now return a slimmed data object, which reduces payload size significantly (tests assert < 500 bytes).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22f7a58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->