### PR TITLE
fix(web): closed plan sidebar stays closed when returning to a thread

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -117,6 +117,11 @@ import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import { useMediaQuery } from "../hooks/useMediaQuery";
+import {
+  clearPlanSidebarDismissal,
+  dismissPlanSidebarForTurn,
+  isPlanSidebarDismissedForTurn,
+} from "../planSidebarDismissal";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import {
   selectActiveRightPanel,
@@ -1310,8 +1315,6 @@ function ChatViewContent(props: ChatViewProps) {
   const [pendingUserInputQuestionIndexByRequestId, setPendingUserInputQuestionIndexByRequestId] =
     useState<Record<string, number>>({});
   const shouldUsePlanSidebarSheet = useMediaQuery(RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY);
-  // Tracks whether the user explicitly dismissed the sidebar for the active turn.
-  const planSidebarDismissedForTurnRef = useRef<string | null>(null);
   // When set, the thread-change reset effect will open the sidebar instead of closing it.
   // Used by "Implement in a new thread" to carry the sidebar-open intent across navigation.
   const planSidebarOpenOnNextThreadRef = useRef(false);
@@ -3110,18 +3113,21 @@ function ChatViewContent(props: ChatViewProps) {
     handleInteractionModeChange(interactionMode === "plan" ? "default" : "plan");
   }, [handleInteractionModeChange, interactionMode]);
   const dismissPlanSidebarForCurrentTurn = useCallback(() => {
-    planSidebarDismissedForTurnRef.current =
-      activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
-  }, [activePlan?.turnId, sidebarProposedPlan?.turnId]);
+    if (!activeThreadKey) return;
+    dismissPlanSidebarForTurn(
+      activeThreadKey,
+      activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__",
+    );
+  }, [activeThreadKey, activePlan?.turnId, sidebarProposedPlan?.turnId]);
   const togglePlanSidebar = useCallback(() => {
     if (!activeThreadRef) return;
     if (planSidebarOpen) {
       dismissPlanSidebarForCurrentTurn();
-    } else {
-      planSidebarDismissedForTurnRef.current = null;
+    } else if (activeThreadKey) {
+      clearPlanSidebarDismissal(activeThreadKey);
     }
     useRightPanelStore.getState().toggle(activeThreadRef, "plan");
-  }, [activeThreadRef, dismissPlanSidebarForCurrentTurn, planSidebarOpen]);
+  }, [activeThreadKey, activeThreadRef, dismissPlanSidebarForCurrentTurn, planSidebarOpen]);
   const closePlanSidebar = useCallback(() => {
     if (!activeThreadRef) return;
     setMaximizedRightPanelThreadKey(null);
@@ -3283,7 +3289,7 @@ function ChatViewContent(props: ChatViewProps) {
     (surface: RightPanelSurface) => {
       if (!activeThreadRef) return;
       if (surface.kind === "plan") {
-        planSidebarDismissedForTurnRef.current = null;
+        clearPlanSidebarDismissal(scopedThreadKey(activeThreadRef));
       } else if (planSidebarOpen) {
         dismissPlanSidebarForCurrentTurn();
       }
@@ -3852,10 +3858,10 @@ function ChatViewContent(props: ChatViewProps) {
     if (planSidebarOpenOnNextThreadRef.current) {
       planSidebarOpenOnNextThreadRef.current = false;
       if (activeThreadRef) {
+        clearPlanSidebarDismissal(scopedThreadKey(activeThreadRef));
         useRightPanelStore.getState().open(activeThreadRef, "plan");
       }
     }
-    planSidebarDismissedForTurnRef.current = null;
     // activeThreadRef resets transitively with the active thread.
   }, [activeThread?.id]);
 
@@ -3868,10 +3874,9 @@ function ChatViewContent(props: ChatViewProps) {
     const latestTurnId = activeLatestTurn?.turnId ?? null;
     if (latestTurnId && activePlan.turnId !== latestTurnId) return;
     const turnKey = activePlan.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
-    if (planSidebarDismissedForTurnRef.current === turnKey) return;
-    if (activeThreadRef) {
-      useRightPanelStore.getState().open(activeThreadRef, "plan");
-    }
+    if (!activeThreadRef) return;
+    if (isPlanSidebarDismissedForTurn(scopedThreadKey(activeThreadRef), turnKey)) return;
+    useRightPanelStore.getState().open(activeThreadRef, "plan");
   }, [
     activePlan,
     activeLatestTurn?.turnId,
@@ -5412,8 +5417,8 @@ function ChatViewContent(props: ChatViewProps) {
         // "default" mode here means the agent is executing the plan, which produces
         // step-tracking activities that the sidebar will display.
         if (nextInteractionMode === "default" && autoOpenPlanSidebar) {
-          planSidebarDismissedForTurnRef.current = null;
           if (activeThreadRef) {
+            clearPlanSidebarDismissal(scopedThreadKey(activeThreadRef));
             useRightPanelStore.getState().open(activeThreadRef, "plan");
           }
         }

--- a/apps/web/src/planSidebarDismissal.ts
+++ b/apps/web/src/planSidebarDismissal.ts
@@ -1,0 +1,21 @@
+/**
+ * Tracks which turn's plan sidebar the user explicitly dismissed, per thread.
+ *
+ * Kept outside React state so a dismissal survives leaving and re-entering a
+ * thread (ChatView resets its per-thread refs on navigation). Dismissals are
+ * keyed by turn, so when a new turn produces fresh plan steps the sidebar
+ * still auto-opens.
+ */
+const dismissedTurnByThreadKey = new Map<string, string>();
+
+export function dismissPlanSidebarForTurn(threadKey: string, turnKey: string): void {
+  dismissedTurnByThreadKey.set(threadKey, turnKey);
+}
+
+export function clearPlanSidebarDismissal(threadKey: string): void {
+  dismissedTurnByThreadKey.delete(threadKey);
+}
+
+export function isPlanSidebarDismissedForTurn(threadKey: string, turnKey: string): boolean {
+  return dismissedTurnByThreadKey.get(threadKey) === turnKey;
+}


### PR DESCRIPTION
Closing the plan sidebar, leaving the thread, and coming back reopened the plan sidebar. It shouldn't.

The "user dismissed the plan for this turn" marker lived in a ChatView ref that gets wiped on every thread change, so re-entering a thread forgot the dismissal and the auto-open effect kicked in again. The dismissal now lives in a small module-level per-thread map (`planSidebarDismissal.ts`) that survives navigation. It stays keyed by turn, so a new turn producing fresh plan steps still auto-opens the sidebar, and explicitly reopening or starting a plan implementation still clears the dismissal.

---
Change authored by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized right-panel UX state with no auth, data, or API changes; behavior is limited to when the plan sidebar auto-opens.
> 
> **Overview**
> Fixes the plan sidebar **reopening after you leave and return to a thread** even though you had closed it.
> 
> Dismissal state moves out of a `ChatView` ref (which was cleared on every thread change) into **`planSidebarDismissal.ts`**, a small module-level map keyed by **thread** and **turn**. `ChatView` now calls `dismissPlanSidebarForTurn`, `clearPlanSidebarDismissal`, and `isPlanSidebarDismissedForTurn` with `activeThreadKey` / `scopedThreadKey` everywhere dismissal mattered—toggle/close, activating the plan surface, thread reset with “open on next thread”, auto-open when plan steps arrive, and optimistic open when implementing a plan.
> 
> **Turn-scoped behavior is unchanged:** a new turn can still auto-open the sidebar, and explicitly reopening the plan or starting implementation still clears the dismissal for that thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9589e1092a0f6e78ab2ba6957de96977fbde5d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix plan sidebar to stay closed when returning to a thread
> - Replaces a component-level `useRef` with a new module [`planSidebarDismissal.ts`](https://github.com/pingdotgg/t3code/pull/5484/files#diff-0d5c664b443680de30af5549e4cadf85534f2969524b3e343068c135cb1afb71) that tracks dismissed turn keys per thread in a `Map`, persisting across component lifecycles and thread navigation.
> - The auto-open effect in [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/5484/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) now checks this shared store before opening, so a dismissed sidebar stays closed when re-entering the same thread on the same turn.
> - Dismissal is cleared when the plan surface is explicitly activated, when the user manually opens the sidebar, or when a new implementation begins, ensuring auto-open works correctly for future turns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9589e10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->