### PR TITLE
fix(mobile): make bare URLs with underscores tappable in chat markdown

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/package.json
+++ b/apps/mobile/modules/t3-markdown-text/package.json
@@ -18,6 +18,7 @@
   "react-native": "./index.ts",
   "exports": {
     ".": "./index.ts",
+    "./autolink": "./src/markdownAutolink.ts",
     "./file-icons": "./src/markdownFileIcons.ts",
     "./links": "./src/markdownLinks.ts",
     "./markdown": "./src/nativeMarkdownText.ts",

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { View } from "react-native";
 import { parseMarkdownWithOptions } from "react-native-nitro-markdown/headless";
 
+import { autolinkMarkdownUrls } from "./markdownAutolink";
 import {
   nativeMarkdownChunkSpacing,
   nativeMarkdownDocumentChunks,
@@ -40,11 +41,13 @@ export function SelectableMarkdownText({
   marginBottom = 0,
 }: SelectableMarkdownTextProps) {
   const chunks = useMemo(() => {
-    const parsedDocument = parseMarkdownWithOptions(markdown, {
-      gfm: true,
-      html: true,
-      math: false,
-    });
+    const parsedDocument = autolinkMarkdownUrls(
+      parseMarkdownWithOptions(markdown, {
+        gfm: true,
+        html: true,
+        math: false,
+      }),
+    );
     const document = preserveSoftBreaks
       ? nativeMarkdownWithPreservedSoftBreaks(parsedDocument)
       : parsedDocument;

--- a/apps/mobile/modules/t3-markdown-text/src/markdownAutolink.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/markdownAutolink.ts
@@ -1,0 +1,212 @@
+import type { MarkdownNode } from "react-native-nitro-markdown/headless";
+
+// md4c's MD_FLAG_PERMISSIVEAUTOLINKS refuses to linkify a bare URL that contains a
+// "_" which is not flanked on both sides by ASCII alphanumerics, so paths such as
+// "https://example.com/v/abc_/" survive parsing as plain text with no href. This
+// transform re-scans leftover text nodes and applies GFM autolink-literal rules.
+
+const AUTOLINK_HINT_PATTERN = /https?:\/\/|www\./i;
+const AUTOLINK_START_PATTERN = /https?:\/\/|www\./gi;
+const WHITESPACE_PATTERN = /\s/;
+const HOST_BOUNDARY_PATTERN = /[/?#]/;
+
+/** Node types md4c already resolved, or whose contents must never be linkified. */
+const OPAQUE_NODE_TYPES: ReadonlySet<string> = new Set([
+  "link",
+  "image",
+  "code_inline",
+  "code_block",
+  "html_block",
+  "html_inline",
+  "math_inline",
+  "math_block",
+]);
+
+/** GFM: trailing punctuation is never part of an autolink literal. */
+const TRAILING_PUNCTUATION: ReadonlySet<string> = new Set([
+  "?",
+  "!",
+  ".",
+  ",",
+  ":",
+  "*",
+  "_",
+  "~",
+  "'",
+  '"',
+  ";",
+]);
+
+/** GFM: an autolink may only start after whitespace or one of these delimiters. */
+const OPENING_DELIMITERS: ReadonlySet<string> = new Set(["*", "_", "~", "("]);
+
+interface AutolinkMatch {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+  readonly href: string;
+}
+
+export function autolinkMarkdownUrls(node: MarkdownNode): MarkdownNode {
+  if (OPAQUE_NODE_TYPES.has(node.type)) {
+    return node;
+  }
+  const children = node.children;
+  if (!children || children.length === 0) {
+    return node;
+  }
+  const nextChildren = autolinkChildren(children);
+  return nextChildren === children ? node : { ...node, children: nextChildren };
+}
+
+function autolinkChildren(children: MarkdownNode[]): MarkdownNode[] {
+  let result: MarkdownNode[] | undefined;
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index] as MarkdownNode;
+    const split = child.type === "text" ? splitTextNode(child) : undefined;
+    if (split) {
+      result ??= children.slice(0, index);
+      result.push(...split);
+      continue;
+    }
+    const next = child.type === "text" ? child : autolinkMarkdownUrls(child);
+    if (next !== child) {
+      result ??= children.slice(0, index);
+    }
+    result?.push(next);
+  }
+  return result ?? children;
+}
+
+function splitTextNode(node: MarkdownNode): MarkdownNode[] | undefined {
+  const content = node.content;
+  if (!content || !AUTOLINK_HINT_PATTERN.test(content)) {
+    return undefined;
+  }
+  const matches = findAutolinkMatches(content);
+  if (matches.length === 0) {
+    return undefined;
+  }
+  const pieces: MarkdownNode[] = [];
+  let cursor = 0;
+  for (const match of matches) {
+    if (match.start > cursor) {
+      pieces.push({ type: "text", content: content.slice(cursor, match.start) });
+    }
+    pieces.push({
+      type: "link",
+      href: match.href,
+      children: [{ type: "text", content: match.text }],
+    });
+    cursor = match.end;
+  }
+  if (cursor < content.length) {
+    pieces.push({ type: "text", content: content.slice(cursor) });
+  }
+  return pieces;
+}
+
+function findAutolinkMatches(content: string): AutolinkMatch[] {
+  const matches: AutolinkMatch[] = [];
+  AUTOLINK_START_PATTERN.lastIndex = 0;
+  let started = AUTOLINK_START_PATTERN.exec(content);
+  while (started) {
+    const start = started.index;
+    const prefix = started[0];
+    const match = hasValidOpening(content, start)
+      ? resolveAutolinkMatch(content, start, prefix)
+      : undefined;
+    if (match) {
+      matches.push(match);
+      AUTOLINK_START_PATTERN.lastIndex = match.end;
+    } else {
+      AUTOLINK_START_PATTERN.lastIndex = start + prefix.length;
+    }
+    started = AUTOLINK_START_PATTERN.exec(content);
+  }
+  return matches;
+}
+
+function hasValidOpening(content: string, index: number): boolean {
+  if (index === 0) {
+    return true;
+  }
+  const preceding = content.charAt(index - 1);
+  return WHITESPACE_PATTERN.test(preceding) || OPENING_DELIMITERS.has(preceding);
+}
+
+function resolveAutolinkMatch(
+  content: string,
+  start: number,
+  prefix: string,
+): AutolinkMatch | undefined {
+  let stop = start;
+  while (stop < content.length) {
+    const character = content.charAt(stop);
+    if (WHITESPACE_PATTERN.test(character) || character === "<") {
+      break;
+    }
+    stop += 1;
+  }
+  const text = trimTrailingPunctuation(content.slice(start, stop));
+  const hasScheme = prefix.toLowerCase() !== "www.";
+  if (!hasPlausibleHost(text, hasScheme)) {
+    return undefined;
+  }
+  return {
+    start,
+    end: start + text.length,
+    text,
+    href: hasScheme ? text : `http://${text}`,
+  };
+}
+
+function trimTrailingPunctuation(value: string): string {
+  let openParens = 0;
+  let closeParens = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value.charAt(index);
+    if (character === "(") {
+      openParens += 1;
+    } else if (character === ")") {
+      closeParens += 1;
+    }
+  }
+  let end = value.length;
+  while (end > 0) {
+    const character = value.charAt(end - 1);
+    if (TRAILING_PUNCTUATION.has(character)) {
+      end -= 1;
+      continue;
+    }
+    // GFM balanced-paren rule: a trailing ")" closes the autolink only when the
+    // candidate has more ")" than "(", so "(https://example.com/a)" drops it but
+    // "https://en.wikipedia.org/wiki/Foo_(bar)" keeps it.
+    if (character === ")" && closeParens > openParens) {
+      closeParens -= 1;
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+  return value.slice(0, end);
+}
+
+function hasPlausibleHost(text: string, hasScheme: boolean): boolean {
+  const schemeEnd = hasScheme ? text.indexOf("://") : -1;
+  if (hasScheme && schemeEnd === -1) {
+    return false;
+  }
+  const authority = hasScheme ? text.slice(schemeEnd + 3) : text;
+  const boundary = authority.search(HOST_BOUNDARY_PATTERN);
+  const host = boundary === -1 ? authority : authority.slice(0, boundary);
+  if (host.length === 0) {
+    return false;
+  }
+  if (hasScheme) {
+    // Developer tooling links at dotless hosts such as http://localhost:3000 are common.
+    return true;
+  }
+  const lastDot = host.lastIndexOf(".");
+  return lastDot > 0 && lastDot < host.length - 1;
+}

--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -7,6 +7,8 @@ import {
 } from "react-native-nitro-markdown";
 import { RefreshControl, ScrollView, Text as NativeText, View } from "react-native";
 
+import { autolinkMarkdownUrls } from "@t3tools/mobile-markdown-text/autolink";
+
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useFontFamily } from "../../lib/useFontFamily";
 import {
@@ -213,6 +215,7 @@ export function FileMarkdownPreview(props: {
           />
         ) : (
           <Markdown
+            astTransform={autolinkMarkdownUrls}
             options={{ gfm: true }}
             renderers={styles.renderers}
             styles={styles.styles}

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -87,6 +87,7 @@ import {
 import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import { useAppearanceCodeSurface } from "../settings/appearance/useAppearanceCodeSurface";
+import { autolinkMarkdownUrls } from "@t3tools/mobile-markdown-text/autolink";
 import { markdownFileIconSource } from "@t3tools/mobile-markdown-text/file-icons";
 import { resolveMarkdownLinkPresentation } from "@t3tools/mobile-markdown-text/links";
 import {
@@ -972,6 +973,7 @@ function renderFeedEntry(
             />
           ) : (
             <Markdown
+              astTransform={autolinkMarkdownUrls}
               options={{ gfm: true }}
               renderers={styles.renderers}
               styles={styles.styles}
@@ -1071,6 +1073,7 @@ function UserMessageContent(props: {
     }
     return (
       <Markdown
+        astTransform={autolinkMarkdownUrls}
         options={{ gfm: true }}
         renderers={props.markdownStyles.renderers}
         styles={props.markdownStyles.styles}
@@ -1111,6 +1114,7 @@ function UserMessageContent(props: {
         ) : (
           <Markdown
             key={segment.id}
+            astTransform={autolinkMarkdownUrls}
             options={{ gfm: true }}
             renderers={props.markdownStyles.renderers}
             styles={props.markdownStyles.styles}

--- a/apps/mobile/src/lib/markdownAutolink.test.ts
+++ b/apps/mobile/src/lib/markdownAutolink.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { MarkdownNode } from "react-native-nitro-markdown/headless";
+
+import { autolinkMarkdownUrls } from "@t3tools/mobile-markdown-text/autolink";
+import { nativeMarkdownDocumentRuns } from "@t3tools/mobile-markdown-text/markdown";
+
+const REPORTED_URL = "https://passpage.space/v/EU7PayhOU9PDVIXUPjT8x_/";
+
+function paragraph(...children: MarkdownNode[]): MarkdownNode {
+  return { type: "paragraph", children };
+}
+
+function linkedHrefs(node: MarkdownNode): string[] {
+  const hrefs: string[] = [];
+  const visit = (current: MarkdownNode) => {
+    if (current.type === "link" && current.href) {
+      hrefs.push(current.href);
+    }
+    for (const child of current.children ?? []) {
+      visit(child);
+    }
+  };
+  visit(node);
+  return hrefs;
+}
+
+describe("autolinkMarkdownUrls", () => {
+  it("linkifies the reported underscore URL md4c leaves as text", () => {
+    const node = paragraph({
+      type: "text",
+      content: `Here it is ${REPORTED_URL} enjoy`,
+    });
+
+    expect(autolinkMarkdownUrls(node)).toEqual(
+      paragraph(
+        { type: "text", content: "Here it is " },
+        {
+          type: "link",
+          href: REPORTED_URL,
+          children: [{ type: "text", content: REPORTED_URL }],
+        },
+        { type: "text", content: " enjoy" },
+      ),
+    );
+  });
+
+  it("linkifies the reported URL inside bold emphasis", () => {
+    const node = paragraph({
+      type: "bold",
+      children: [{ type: "text", content: REPORTED_URL }],
+    });
+
+    expect(autolinkMarkdownUrls(node)).toEqual(
+      paragraph({
+        type: "bold",
+        children: [
+          {
+            type: "link",
+            href: REPORTED_URL,
+            children: [{ type: "text", content: REPORTED_URL }],
+          },
+        ],
+      }),
+    );
+  });
+
+  it("linkifies underscore variants md4c rejects", () => {
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      // A trailing "_" is GFM trailing punctuation, so it stays outside the link.
+      ["https://example.com/x_", "https://example.com/x"],
+      ["https://example.com/_x", "https://example.com/_x"],
+      ["https://example.com/a__b", "https://example.com/a__b"],
+      ["https://example.com/café_test", "https://example.com/café_test"],
+    ];
+
+    for (const [content, href] of cases) {
+      expect(linkedHrefs(autolinkMarkdownUrls(paragraph({ type: "text", content })))).toEqual([
+        href,
+      ]);
+    }
+  });
+
+  it("trims trailing punctuation but keeps balanced parentheses", () => {
+    expect(
+      autolinkMarkdownUrls(paragraph({ type: "text", content: "see https://example.com/x_y." })),
+    ).toEqual(
+      paragraph(
+        { type: "text", content: "see " },
+        {
+          type: "link",
+          href: "https://example.com/x_y",
+          children: [{ type: "text", content: "https://example.com/x_y" }],
+        },
+        { type: "text", content: "." },
+      ),
+    );
+
+    expect(
+      autolinkMarkdownUrls(paragraph({ type: "text", content: "(https://example.com/x_)" })),
+    ).toEqual(
+      paragraph(
+        { type: "text", content: "(" },
+        {
+          type: "link",
+          href: "https://example.com/x",
+          children: [{ type: "text", content: "https://example.com/x" }],
+        },
+        { type: "text", content: "_)" },
+      ),
+    );
+
+    expect(
+      linkedHrefs(
+        autolinkMarkdownUrls(
+          paragraph({ type: "text", content: "https://en.wikipedia.org/wiki/Foo_(bar)" }),
+        ),
+      ),
+    ).toEqual(["https://en.wikipedia.org/wiki/Foo_(bar)"]);
+  });
+
+  it("prefixes bare www hosts with http", () => {
+    expect(
+      autolinkMarkdownUrls(paragraph({ type: "text", content: "www.example.com/a_b" })),
+    ).toEqual(
+      paragraph({
+        type: "link",
+        href: "http://www.example.com/a_b",
+        children: [{ type: "text", content: "www.example.com/a_b" }],
+      }),
+    );
+  });
+
+  it("linkifies dotless hosts such as localhost", () => {
+    expect(
+      linkedHrefs(
+        autolinkMarkdownUrls(paragraph({ type: "text", content: "http://localhost:3000/path_" })),
+      ),
+    ).toEqual(["http://localhost:3000/path"]);
+  });
+
+  it("linkifies every URL in a single text node", () => {
+    expect(
+      linkedHrefs(
+        autolinkMarkdownUrls(
+          paragraph({
+            type: "text",
+            content: `${REPORTED_URL} and https://example.com/b_ and www.other.dev/c_`,
+          }),
+        ),
+      ),
+    ).toEqual([REPORTED_URL, "https://example.com/b", "http://www.other.dev/c"]);
+  });
+
+  it("never descends into links, code, html, or math", () => {
+    const link: MarkdownNode = {
+      type: "link",
+      href: REPORTED_URL,
+      children: [{ type: "text", content: REPORTED_URL }],
+    };
+    const codeInline: MarkdownNode = { type: "code_inline", content: REPORTED_URL };
+    const codeBlock: MarkdownNode = {
+      type: "code_block",
+      language: "sh",
+      content: `curl ${REPORTED_URL}`,
+    };
+    const htmlInline: MarkdownNode = { type: "html_inline", content: `<i>${REPORTED_URL}</i>` };
+    const mathInline: MarkdownNode = { type: "math_inline", content: REPORTED_URL };
+    const node = paragraph(link, codeInline, codeBlock, htmlInline, mathInline);
+
+    const result = autolinkMarkdownUrls(node);
+
+    expect(result).toBe(node);
+    expect(linkedHrefs(result)).toEqual([REPORTED_URL]);
+  });
+
+  it("returns the same reference when nothing changes", () => {
+    const plain = paragraph({ type: "text", content: "no urls here, just prose." });
+    expect(autolinkMarkdownUrls(plain)).toBe(plain);
+
+    const document: MarkdownNode = {
+      type: "document",
+      children: [paragraph({ type: "text", content: "still nothing to linkify" })],
+    };
+    expect(autolinkMarkdownUrls(document)).toBe(document);
+  });
+
+  it("feeds the iOS run builder an href-carrying run inside bold", () => {
+    const document: MarkdownNode = {
+      type: "document",
+      children: [
+        paragraph(
+          { type: "text", content: "Open " },
+          { type: "bold", children: [{ type: "text", content: REPORTED_URL }] },
+          { type: "text", content: " now" },
+        ),
+      ],
+    };
+
+    const runs = nativeMarkdownDocumentRuns(autolinkMarkdownUrls(document));
+    const linkRun = runs.find((run) => run.href !== undefined);
+
+    expect(linkRun).toMatchObject({
+      text: REPORTED_URL,
+      href: REPORTED_URL,
+      externalHost: "passpage.space",
+      bold: true,
+    });
+  });
+});


### PR DESCRIPTION
## Problem

In the mobile app (reported on iOS), some links in chat messages can't be tapped — e.g. a published share link like `**https://passpage.space/v/EU7PayhOU9PDVIXUPjT8x_/**` renders as plain text with no tap target, forcing users to copy the URL manually.

## Root cause

The mobile markdown pipeline parses with md4c (`react-native-nitro-markdown`, `MD_FLAG_PERMISSIVEAUTOLINKS`). md4c's permissive autolink **rejects any bare URL containing a `_` that is not flanked on both sides by ASCII alphanumerics** — verified against the vendored md4c with a C harness:

| input | linkified? |
|---|---|
| `https://example.com/x_y/z` | ✅ |
| `https://passpage.space/v/EU7PayhOU9PDVIXUPjT8x_/` (trailing `_/`) | ❌ |
| `https://example.com/_x`, `a__b`, `café_test` | ❌ |

Bold wrapping is unrelated — bold bare URLs without underscores linkify fine. Since the URL never becomes a `link` AST node, no `href`/tap handler is ever attached (this affected both the iOS native renderer and the Android `<Markdown>` fallback).

## Fix

- New `autolinkMarkdownUrls` AST transform (`modules/t3-markdown-text/src/markdownAutolink.ts`): rescans leftover text nodes using GFM autolink-literal rules (opening delimiter check, iterative trailing-punctuation trim, balanced-paren rule, `www.` → `http://` href). Subtrees md4c already resolved (`link`, `image`, code, html, math) are never descended into, so no double-linkification; unchanged subtrees keep reference identity so streaming re-renders stay cheap.
- Wired into the iOS native renderer (`SelectableMarkdownText.ios.tsx`, before chunking so rich blocks are covered too) and all four `<Markdown>` fallback sites (`ThreadFeed.tsx` ×3, `FileMarkdownPreview.tsx`) via the library's `astTransform` prop.

## Verification

- 10 new unit tests (`src/lib/markdownAutolink.test.ts`), including an end-to-end assertion that the transformed AST produces an iOS text run with `href` + `bold` set via `nativeMarkdownDocumentRuns`.
- Full `apps/mobile` suite: 625 tests pass; `tsc --noEmit` and lint clean.
- Adversarial review pass (fuzzed 20k inputs: no text loss, idempotent, no infinite loop; verified no double-linkify against md4c's node-type enum). One finding fixed: trailing-paren trim was O(n²) on pathological `)` runs, now single-pass.
- Verified live on the Android emulator against a seeded thread: the underscore URL renders as a tappable link and tapping opens the system browser with the exact URL. iOS couldn't be exercised on this Linux host, but the iOS path shares the same transform and its run-builder output is covered by the unit tests.

Note for anyone pulling this branch: run `pnpm install` once so pnpm re-materializes the `@t3tools/mobile-markdown-text` workspace copy (new file + `exports` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized markdown rendering change with tests; no auth, data, or API surface changes. Slight risk of over-linkifying edge-case text, mitigated by GFM rules and opaque-node skipping.
> 
> **Overview**
> Fixes **untappable bare URLs** in chat and file markdown when md4c leaves them as plain text (notably paths with underscores md4c’s permissive autolinks reject, e.g. share links ending in `_/`).
> 
> Adds **`autolinkMarkdownUrls`**, a post-parse AST pass that rescans leftover text nodes with GFM autolink-literal rules (opening delimiters, trailing punctuation trim, balanced parens, `www.` → `http://`), skips opaque subtrees (existing links, code, HTML, math), and preserves reference identity when nothing changes. Exported as `@t3tools/mobile-markdown-text/autolink`.
> 
> Wires the transform into **iOS `SelectableMarkdownText`** (after `parseMarkdownWithOptions`) and all **`<Markdown>` fallbacks** in thread feed and file preview via `astTransform`. **10 unit tests** cover the reported URL, emphasis, edge cases, and iOS run `href` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379c6ec883e3a793e0067470fb88a4f4874ebbda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bare URLs with underscores to be tappable in chat markdown on mobile
> - Adds a new AST transform [`autolinkMarkdownUrls`](https://github.com/pingdotgg/t3code/pull/5485/files#diff-f84b22e207a5f823341efb58948f35cf88117a207b7005fb561d14ef1e320f27) that scans markdown text nodes for bare URLs (e.g. `http://`, `https://`, `www.`) and replaces them with link nodes, following GFM autolink-literal behavior.
> - The transform skips opaque node types (link, image, code, html, math) to avoid double-processing and trims trailing punctuation while preserving balanced parentheses.
> - Applied to all markdown rendering paths in chat: the native iOS selectable renderer, assistant messages, user messages, and file markdown previews.
> - Behavioral Change: bare URLs that were previously unclickable (especially those containing underscores, which md4c rejects) are now rendered as tappable links.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 379c6ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->