### PR TITLE
fix(claude): discover repo-local .agents/skills in skill discovery

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -66,6 +66,105 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
     }),
   );
 
+  it.effect("discovers project skills from the workspace .agents directory", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "review",
+        ["---", "name: review", "description: Review the changes.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
+
+      assert.deepEqual(skills, [
+        {
+          name: "review",
+          path: path.join(workspace, ".agents", "skills", "review", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Review the changes.",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("prefers workspace .claude skills on three-way name collisions", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: User deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Agents deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".claude", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Claude deploy.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
+
+      assert.deepEqual(skills, [
+        {
+          name: "deploy",
+          path: path.join(workspace, ".claude", "skills", "deploy", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Claude deploy.",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("prefers workspace .agents skills over user skills on name collisions", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: User deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Agents deploy.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
+
+      assert.deepEqual(skills, [
+        {
+          name: "deploy",
+          path: path.join(workspace, ".agents", "skills", "deploy", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Agents deploy.",
+        },
+      ]);
+    }),
+  );
+
   it.effect("prefers project skills over user skills on name collisions", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -1,12 +1,13 @@
 /**
  * ClaudeSkills — filesystem discovery of Claude Code skills for the `$` picker.
  *
- * Claude Code loads skills from `<config dir>/skills` (user scope) and
- * `<cwd>/.claude/skills` (project scope), one directory per skill with a
- * `SKILL.md` carrying YAML frontmatter. The Agent SDK init handshake surfaces
- * skills only as slash commands without their filesystem paths, so the
- * provider snapshot scans the same locations directly, mirroring how the
- * Codex app-server reports its skills.
+ * Claude Code loads skills from `<config dir>/skills` (user scope), then
+ * `<cwd>/.agents/skills` and `<cwd>/.claude/skills` (project scope), one
+ * directory per skill with a `SKILL.md` carrying YAML frontmatter. Later roots
+ * win on name collisions, so precedence is user, `.agents`, then `.claude`.
+ * The Agent SDK init handshake surfaces skills only as slash commands without
+ * their filesystem paths, so the provider snapshot scans the same locations
+ * directly, mirroring how the Codex app-server reports its skills.
  *
  * @module provider/Drivers/ClaudeSkills
  */
@@ -84,11 +85,12 @@ const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(funct
 });
 
 /**
- * Enumerate Claude Code skills from the user config dir and the workspace.
- * Discovery is best-effort: unreadable roots and malformed skill entries are
- * skipped so a broken skill never degrades the provider snapshot. On name
- * collisions the project-scoped skill wins, matching Claude Code's
- * most-specific-wins resolution.
+ * Enumerate Claude Code skills from the user config dir, workspace
+ * `.agents/skills`, and workspace `.claude/skills`, in that order. Discovery
+ * is best-effort: unreadable roots and malformed skill entries are skipped so
+ * a broken skill never degrades the provider snapshot. On name collisions,
+ * later roots win: `.agents` beats user and `.claude` beats `.agents`, matching
+ * Claude Code's resolution.
  */
 export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* (
   config: Pick<ClaudeSettings, "homePath">,
@@ -101,7 +103,12 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
 
   const roots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = [
     { directory: path.join(configDirPath, "skills"), scope: "user" },
-    ...(cwd ? [{ directory: path.join(cwd, ".claude", "skills"), scope: "project" as const }] : []),
+    ...(cwd
+      ? [
+          { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
+        ]
+      : []),
   ];
 
   const skillsByName = new Map<string, ServerProviderSkill>();

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -34,6 +34,13 @@ When you set this field, T3 Code points Claude Code at that directory with the
 `CLAUDE_CONFIG_DIR` environment variable. It does not change `HOME`, so your system keychain and
 the rest of your environment stay as they are.
 
+## Where Claude Skills Are Loaded
+
+T3 Code looks for Claude skills in the Claude config directory's `skills` folder, then
+`<workspace>/.agents/skills`, then `<workspace>/.claude/skills`.
+
+If the same skill name exists in more than one folder, the later folder wins.
+
 ## I Want Work And Personal Claude Accounts
 
 Use a different Claude config directory for each account.


### PR DESCRIPTION
Fixes #5487.

## What changed

`discoverClaudeSkills` (`apps/server/src/provider/Drivers/ClaudeSkills.ts`) now scans `<cwd>/.agents/skills` in addition to `<Claude config dir>/skills` and `<cwd>/.claude/skills`. The new root is project-scoped and sits between the existing two, keeping the existing last-write-wins map so collision precedence is `user < .agents < .claude` — project beats user, and `.claude/skills` beats `.agents/skills` on a same-name collision. 5 lines of driver code; the rest is tests and a short doc note in `docs/user/providers-claude.md`.

## Why it should exist

Claude Code loads repo-local skills from `.agents/skills` (the [Agent Skills](https://agentskills.io) cross-tool standard directory) as well as `.claude/skills`, and the Codex app-server already reports `.agents/skills` entries to T3. But T3's own Claude filesystem discovery only scanned `.claude/skills`, so `.agents/skills` skills could never reach the provider snapshot or the `$` picker — even with a correct project cwd.

## Scope: deliberately Claude-only

The same user-visible symptom exists on Codex, but with a different root cause that is already tracked with a fix in flight: Codex discovery is delegated to `codex app-server` (which does scan `.agents/skills`), and the failure there is the probe cwd — #3040, fix in #5335. This PR intentionally does not touch that. It is complementary to the cwd work (#5335, #4546): once those land, Claude's `.agents/skills` would still be missing without this scan root, and with both, repo-local `.agents/skills` work across providers.

## Testing

```
$ vp test run src/provider/Drivers/ClaudeSkills.test.ts   # apps/server
Test Files  1 passed (1)
     Tests  9 passed (9)
```

Three new cases: `.agents/skills`-only discovery, three-way name collision (`.claude` wins), and `.agents`-vs-user collision (`.agents` wins). `tsgo --noEmit` on apps/server passes; `vp lint` and `vp fmt --check` on the touched files are clean. No UI change (the picker consumes the snapshot as before), so no screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to skill path scanning and merge order; behavior is covered by new tests and does not touch auth or data handling.
> 
> **Overview**
> **Claude skill discovery** now includes the workspace **`.agents/skills`** tree (Agent Skills layout) so repo-local skills show up in the provider snapshot and **`$` picker**, not only **`.claude/skills`**.
> 
> Scan order is **user config `skills` → `.agents/skills` → `.claude/skills`**, with **later roots winning** on same name (**user < `.agents` < `.claude`**). Comments and user docs describe that precedence.
> 
> Three tests cover **`.agents`-only** discovery and **two- and three-way** name collisions; no UI changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40778e6b862151fbe5b1647190071dfbdb22e9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `<workspace>/.agents/skills` to Claude skill discovery with precedence ordering
> - [`discoverClaudeSkills`](https://github.com/pingdotgg/t3code/pull/5488/files#diff-df655ed95ed759ff78376524f2ceda1b436b639952ddab7e7e19f618a43e77c3) now scans three roots in order: user config skills, `<cwd>/.agents/skills`, then `<cwd>/.claude/skills`, with later roots winning on name collisions.
> - Skills are accumulated into a `Map` by name, so `.claude` project skills override `.agents` project skills, which override user skills.
> - New tests cover discovery from `<workspace>/.agents/skills` and verify all three precedence tiers.
> - [providers-claude.md](https://github.com/pingdotgg/t3code/pull/5488/files#diff-f3b54bb573c78b526a8c1181ccd8146c7df38119b974038b08aff6f4e5a3819d) documents the updated lookup order.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40778e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->