### PR TITLE
fix(web): allow removing a relay environment whose server is gone

### DIFF
--- a/apps/web/src/components/cloud/CloudEnvironmentConnectList.tsx
+++ b/apps/web/src/components/cloud/CloudEnvironmentConnectList.tsx
@@ -30,6 +30,25 @@ export interface SavedCloudEnvironmentConnection {
   readonly connection: EnvironmentConnectionPresentation;
 }
 
+function reportEnvironmentActionFailure(title: string, fallbackMessage: string, cause: unknown) {
+  const message = cause instanceof Error ? cause.message : fallbackMessage;
+  const traceId = findErrorTraceId(cause);
+  console.error(`[t3-connect] ${title}`, { message, traceId, cause });
+  toastManager.add({
+    type: "error",
+    title,
+    description: message,
+    data: traceId
+      ? {
+          secondaryActionProps: {
+            children: "Copy trace ID",
+            onClick: () => void navigator.clipboard?.writeText(traceId),
+          },
+        }
+      : undefined,
+  });
+}
+
 export function RemoteEnvironmentRowsSkeleton() {
   return (
     <div className={ITEM_ROW_CLASSNAME}>
@@ -81,9 +100,13 @@ export function CloudEnvironmentConnectRows({
       ),
     [registerEnvironment],
   );
+  const removeRelayEnvironment = useAtomCommand(relayEnvironmentDiscovery.remove, {
+    reportFailure: false,
+  });
   const [connectingEnvironmentId, setConnectingEnvironmentId] = useState<EnvironmentId | null>(
     null,
   );
+  const [removingEnvironmentId, setRemovingEnvironmentId] = useState<EnvironmentId | null>(null);
   const savedById = new Map(
     savedEnvironments.map((environment) => [environment.environmentId, environment]),
   );
@@ -107,24 +130,36 @@ export function CloudEnvironmentConnectRows({
     if (isAtomCommandInterrupted(result)) {
       return;
     }
-    const cause = squashAtomCommandFailure(result);
-    const message =
-      cause instanceof Error ? cause.message : "Could not connect the T3 Connect environment.";
-    const traceId = findErrorTraceId(cause);
-    console.error("[t3-connect] Could not connect environment", { message, traceId, cause });
-    toastManager.add({
-      type: "error",
-      title: "Could not connect environment",
-      description: message,
-      data: traceId
-        ? {
-            secondaryActionProps: {
-              children: "Copy trace ID",
-              onClick: () => void navigator.clipboard?.writeText(traceId),
-            },
-          }
-        : undefined,
-    });
+    reportEnvironmentActionFailure(
+      "Could not connect environment",
+      "Could not connect the T3 Connect environment.",
+      squashAtomCommandFailure(result),
+    );
+  };
+
+  // Removing revokes the environment's link for the whole account rather than
+  // just this client, which is the only teardown an environment whose server is
+  // gone can still get: `t3 connect unlink` has to run on that machine.
+  const removeEnvironment = async (environment: RelayClientEnvironmentRecord) => {
+    setRemovingEnvironmentId(environment.environmentId);
+    const result = await removeRelayEnvironment(environment.environmentId);
+    setRemovingEnvironmentId(null);
+    if (result._tag === "Success") {
+      toastManager.add({
+        type: "success",
+        title: "Environment removed",
+        description: `${environment.label} is no longer linked to T3 Connect.`,
+      });
+      return;
+    }
+    if (isAtomCommandInterrupted(result)) {
+      return;
+    }
+    reportEnvironmentActionFailure(
+      "Could not remove environment",
+      "Could not remove the T3 Connect environment.",
+      squashAtomCommandFailure(result),
+    );
   };
 
   const visibleEnvironments = [...environmentsState.environments.values()].filter(
@@ -245,13 +280,23 @@ export function CloudEnvironmentConnectRows({
               {savedConnection.buttonLabel}
             </Button>
           ) : (
-            <Button
-              size="sm"
-              disabled={connectingEnvironmentId !== null}
-              onClick={() => void connectEnvironment(environment)}
-            >
-              {connectingEnvironmentId === environment.environmentId ? "Connecting…" : "Connect"}
-            </Button>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                size="sm"
+                variant="destructive-outline"
+                disabled={connectingEnvironmentId !== null || removingEnvironmentId !== null}
+                onClick={() => void removeEnvironment(environment)}
+              >
+                {removingEnvironmentId === environment.environmentId ? "Removing…" : "Remove"}
+              </Button>
+              <Button
+                size="sm"
+                disabled={connectingEnvironmentId !== null || removingEnvironmentId !== null}
+                onClick={() => void connectEnvironment(environment)}
+              >
+                {connectingEnvironmentId === environment.environmentId ? "Connecting…" : "Connect"}
+              </Button>
+            </div>
           )}
         </div>
       </div>

--- a/packages/client-runtime/src/relay/discovery.test.ts
+++ b/packages/client-runtime/src/relay/discovery.test.ts
@@ -61,6 +61,7 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
   const listFailure = yield* Ref.make<ManagedRelay.ManagedRelayClientError | null>(null);
   const secondListCall = yield* Deferred.make<void>();
   const clerkToken = yield* Ref.make<string | null>("clerk-token");
+  const unlinkedEnvironmentIds = yield* Ref.make<ReadonlyArray<string>>([]);
   const wakeups = yield* SubscriptionRef.make<{
     readonly sequence: number;
     readonly reason: "application-active" | "credentials-changed";
@@ -107,7 +108,10 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
     listDevices: () => Effect.die("unused"),
     createEnvironmentLinkChallenge: () => Effect.die("unused"),
     linkEnvironment: () => Effect.die("unused"),
-    unlinkEnvironment: () => Effect.die("unused"),
+    unlinkEnvironment: ({ environmentId }) =>
+      Ref.update(unlinkedEnvironmentIds, (current) => [...current, environmentId]).pipe(
+        Effect.as({ ok: true }),
+      ),
     connectEnvironment: () => Effect.die("unused"),
     registerDevice: () => Effect.die("unused"),
     unregisterDevice: () => Effect.die("unused"),
@@ -162,6 +166,7 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
     networkStatus,
     secondListCall,
     statusRequests,
+    unlinkedEnvironmentIds,
     wake: (reason: "application-active" | "credentials-changed") =>
       SubscriptionRef.update(wakeups, (event) => ({
         sequence: event.sequence + 1,
@@ -216,6 +221,58 @@ describe("RelayEnvironmentDiscovery", () => {
           "offline",
         );
         expect(complete.refreshing).toBe(false);
+      }).pipe(Effect.provide(harness.layer));
+    }),
+  );
+
+  it.effect("revokes an environment link and drops its row without a refresh", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      yield* Effect.gen(function* () {
+        const discovery = yield* RelayEnvironmentDiscovery.RelayEnvironmentDiscovery;
+        const requests = yield* Ref.get(harness.statusRequests);
+        for (const environment of environments) {
+          yield* Deferred.succeed(
+            requests.get(environment.environmentId)!,
+            status(environment, "online"),
+          );
+        }
+        yield* discovery.refresh;
+        expect((yield* SubscriptionRef.get(discovery.state)).environments.size).toBe(2);
+
+        yield* discovery.remove(environments[0]!.environmentId);
+
+        expect(yield* Ref.get(harness.unlinkedEnvironmentIds)).toEqual([
+          environments[0]!.environmentId,
+        ]);
+        const remaining = yield* SubscriptionRef.get(discovery.state);
+        expect(remaining.environments.has(environments[0]!.environmentId)).toBe(false);
+        expect(remaining.environments.has(environments[1]!.environmentId)).toBe(true);
+        expect(yield* Ref.get(harness.listCalls)).toBe(1);
+      }).pipe(Effect.provide(harness.layer));
+    }),
+  );
+
+  it.effect("reports a signed-out removal instead of dropping the row", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      yield* Effect.gen(function* () {
+        const discovery = yield* RelayEnvironmentDiscovery.RelayEnvironmentDiscovery;
+        const requests = yield* Ref.get(harness.statusRequests);
+        for (const environment of environments) {
+          yield* Deferred.succeed(
+            requests.get(environment.environmentId)!,
+            status(environment, "online"),
+          );
+        }
+        yield* discovery.refresh;
+        yield* Ref.set(harness.clerkToken, null);
+
+        const error = yield* discovery.remove(environments[0]!.environmentId).pipe(Effect.flip);
+
+        expect(error._tag).toBe("ConnectionBlockedError");
+        expect(yield* Ref.get(harness.unlinkedEnvironmentIds)).toEqual([]);
+        expect((yield* SubscriptionRef.get(discovery.state)).environments.size).toBe(2);
       }).pipe(Effect.provide(harness.layer));
     }),
   );

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -44,6 +44,9 @@ export class RelayEnvironmentDiscovery extends Context.Service<
   {
     readonly state: SubscriptionRef.SubscriptionRef<RelayEnvironmentDiscoveryState>;
     readonly refresh: Effect.Effect<void>;
+    readonly remove: (
+      environmentId: RelayClientEnvironmentRecord["environmentId"],
+    ) => Effect.Effect<void, ConnectionAttemptError>;
   }
 >()("@t3tools/client-runtime/relay/discovery/RelayEnvironmentDiscovery") {}
 
@@ -309,6 +312,32 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
     ),
   );
 
+  /**
+   * Revokes an environment's link for this account and drops its row. Nothing
+   * is asked of the environment itself, so an environment whose server no
+   * longer exists — wiped host, reinstalled machine — can still be retired;
+   * `t3 connect unlink` only runs where that server still lives. A relay reply
+   * of `ok: false` means the link was already gone, which is the same outcome
+   * the caller wanted, so the row is dropped either way.
+   */
+  const remove = Effect.fn("RelayEnvironmentDiscovery.remove")(function* (
+    environmentId: RelayClientEnvironmentRecord["environmentId"],
+  ) {
+    const clerkToken = yield* session.clerkToken;
+    yield* relay
+      .unlinkEnvironment({ clerkToken, environmentId })
+      .pipe(Effect.mapError(mapManagedRelayError));
+    yield* clearOfflineReport(environmentId);
+    yield* SubscriptionRef.update(state, (current) => {
+      if (!current.environments.has(environmentId)) {
+        return current;
+      }
+      const environments = new Map(current.environments);
+      environments.delete(environmentId);
+      return { ...current, environments };
+    });
+  });
+
   yield* connectivity.changes.pipe(
     Stream.changes,
     Stream.runForEach((networkStatus) =>
@@ -343,7 +372,7 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
     Effect.forkScoped,
   );
 
-  return RelayEnvironmentDiscovery.of({ state, refresh });
+  return RelayEnvironmentDiscovery.of({ state, refresh, remove });
 });
 
 export const layer = Layer.effect(RelayEnvironmentDiscovery, make());

--- a/packages/client-runtime/src/state/relayDiscovery.ts
+++ b/packages/client-runtime/src/state/relayDiscovery.ts
@@ -1,3 +1,4 @@
+import type { RelayClientEnvironmentRecord } from "@t3tools/contracts/relay";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
@@ -33,9 +34,22 @@ export function createRelayEnvironmentDiscoveryAtoms<R, E>(
       ),
   });
 
+  const remove = createRuntimeCommand(runtime, {
+    label: "relay-environment-discovery:remove",
+    concurrency: {
+      mode: "serial",
+      key: (environmentId: RelayClientEnvironmentRecord["environmentId"]) => environmentId,
+    },
+    execute: (environmentId: RelayClientEnvironmentRecord["environmentId"]) =>
+      RelayEnvironmentDiscovery.RelayEnvironmentDiscovery.pipe(
+        Effect.flatMap((discovery) => discovery.remove(environmentId)),
+      ),
+  });
+
   return {
     stateAtom,
     stateValueAtom,
     refresh,
+    remove,
   };
 }


### PR DESCRIPTION
Fixes #5135

## What happens
A relay environment whose server no longer exists can never be removed: desktop/web relay rows have no Remove control, mobile's remove is device-local (the row returns via discovery), `t3 connect unlink` only works on the environment's own machine, and relay links have no expiry.

## The gap (and the non-gap)
As corrected in #5135: the owner-scoped delete **already exists end-to-end** (`DELETE /v1/client/environment-links/:environmentId` behind `RelayClientAuth` → `EnvironmentLinks.revokeForUser`, a soft revoke that never contacts the environment, so it works for dead servers; `ManagedRelayClient.unlinkEnvironment` is a ready client method). Nothing user-reachable calls it for a foreign/dead environment.

## The fix
- `packages/client-runtime/src/relay/discovery.ts`: `remove(environmentId)` on the discovery service — reads the CloudSession token, calls `relay.unlinkEnvironment`, maps errors via the module's existing `mapManagedRelayError`, clears the offline-report fingerprint, drops the row from state immediately (`ok:false` = already gone, still dropped).
- `packages/client-runtime/src/state/relayDiscovery.ts`: `remove` runtime command (serial, keyed by environmentId) alongside `refresh`.
- `apps/web/.../CloudEnvironmentConnectList.tsx`: destructive-outline **Remove** button on unsaved relay rows, using the file's existing toast/`useAtomCommand` idiom (the duplicated error-toast block is lifted into one shared helper used by connect and remove).

Deliberately NOT included (possible follow-ups): wiring the same command into `SavedBackendListRow` for saved relay rows, the mobile equivalent, and relay-side stale eviction (infra-touching, not needed to make removal possible).

## Validation
- `packages/client-runtime`: `pnpm test` 568/568 (incl. 2 new discovery tests: revoke-drops-row-without-refresh asserting the relay call and untouched siblings; signed-out removal reports `ConnectionBlockedError` without a relay call), `pnpm typecheck` clean.
- `apps/web`: full unit suite (207 files) + typecheck clean, on current `main`.
- Caveats: not exercised against the live relay; UI media per the contribution guide: the "before" state is the screenshot flow in #5135 — happy to add a video if the approach is acceptable. No confirmation dialog (matches the file's existing Revoke buttons); flag if you'd prefer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SnL8Kiba6YBbxNnunPiHg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removal revokes environment links for the whole account via relay API; incorrect UX could unlink the wrong environment, but scope is limited to discovery UI and existing unlink endpoint with new tests.
> 
> **Overview**
> Users can **remove** T3 Connect relay environments from the web UI even when the remote server is dead—previously there was no way to revoke account-level links without running `t3 connect unlink` on the original machine.
> 
> **Client runtime:** `RelayEnvironmentDiscovery` gains `remove(environmentId)`, which calls the existing relay `unlinkEnvironment` API (account-scoped revoke, no contact with the environment), clears offline-report state, and drops the row from discovery state immediately without a full refresh. A serial `remove` runtime command is wired through `relayDiscovery` atoms.
> 
> **Web:** Unsaved relay rows in `CloudEnvironmentConnectList` show a destructive **Remove** button alongside **Connect**, with loading state and success/error toasts. Connect and remove failures share a new `reportEnvironmentActionFailure` helper (trace ID copy preserved).
> 
> **Tests:** Two discovery tests cover successful revoke (relay called, sibling rows untouched, no extra list refresh) and signed-out removal (`ConnectionBlockedError`, no relay call).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9726b395e5a3e6ffb50ae781392fd1b01093c631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add remove button to relay environment list for environments whose server is gone
> - Adds a `Remove` button to each row in [CloudEnvironmentConnectList.tsx](https://github.com/pingdotgg/t3code/pull/5494/files#diff-18f369a6fd1384b0ae3c2fafe9e8415f7fbe2977bb50cd533d98c0a81772299b), allowing users to unlink a relay environment directly from the UI without needing the server to be reachable.
> - Introduces `RelayEnvironmentDiscovery.remove` in [discovery.ts](https://github.com/pingdotgg/t3code/pull/5494/files#diff-369c203ffefe19f8f7f69500106593a7d8f82927adb2eb1ce564d30dcab3a6a8), which calls `relay.unlinkEnvironment`, clears any offline report, and immediately drops the environment from discovery state without a refresh.
> - Exposes a `relay-environment-discovery:remove` atom command in [relayDiscovery.ts](https://github.com/pingdotgg/t3code/pull/5494/files#diff-76a7184f8151c4a936412593e5dc6e89dd4803fcf8f44bbdc964807746e869ce) that serializes concurrent removals per environment ID.
> - Action buttons in the row are disabled while a connect or remove operation is in flight, with dynamic labels ('Connecting…' / 'Removing…') per row.
> - Success and failure are surfaced via toasts; failures include an optional action to copy the trace ID to the clipboard.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9726b39. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->