### PR TITLE
fix(web): align composer inline chips with prompt text

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -72,8 +72,8 @@ import { cn, isMacPlatform } from "~/lib/utils";
 import { basenameOfPath } from "~/pierre-icons";
 import {
   COMPOSER_INLINE_CHIP_ICON_CLASS_NAME,
-  COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME,
   COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME,
+  COMPOSER_INLINE_SKILL_CHIP_LABEL_CLASS_NAME,
   SKILL_CHIP_ICON_SVG,
 } from "./composerInlineChip";
 import { FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
@@ -256,7 +256,7 @@ function ComposerSkillDecorator(props: { skillLabel: string; skillDescription: s
         className={COMPOSER_INLINE_CHIP_ICON_CLASS_NAME}
         dangerouslySetInnerHTML={{ __html: SKILL_CHIP_ICON_SVG }}
       />
-      <span className={COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME}>{props.skillLabel}</span>
+      <span className={COMPOSER_INLINE_SKILL_CHIP_LABEL_CLASS_NAME}>{props.skillLabel}</span>
     </span>
   );
 

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -188,7 +188,7 @@ class ComposerMentionNode extends DecoratorNode<React.ReactElement> {
 
   override createDOM(): HTMLElement {
     const dom = document.createElement("span");
-    dom.className = "composer-inline-chip relative inline-flex align-middle leading-none";
+    dom.className = "composer-inline-chip relative inline-flex align-[-0.125em] leading-none";
     return dom;
   }
 
@@ -326,7 +326,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
 
   override createDOM(): HTMLElement {
     const dom = document.createElement("span");
-    dom.className = "composer-inline-chip relative inline-flex align-middle leading-none";
+    dom.className = "composer-inline-chip relative inline-flex align-[-0.125em] leading-none";
     return dom;
   }
 
@@ -397,7 +397,7 @@ class ComposerTerminalContextNode extends DecoratorNode<React.ReactElement> {
 
   override createDOM(): HTMLElement {
     const dom = document.createElement("span");
-    dom.className = "composer-inline-chip relative inline-flex align-middle leading-none";
+    dom.className = "composer-inline-chip relative inline-flex align-[-0.125em] leading-none";
     return dom;
   }
 

--- a/apps/web/src/components/composerInlineChip.ts
+++ b/apps/web/src/components/composerInlineChip.ts
@@ -12,9 +12,11 @@ export const COMPOSER_INLINE_CHIP_ICON_CLASS_NAME = "size-[1.17em] shrink-0 opac
 
 export const CHAT_INLINE_CHIP_LABEL_CLASS_NAME = "truncate leading-tight";
 
-// The composer label is smaller than the surrounding prompt text; offset its
+export const COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME = `${CHAT_INLINE_CHIP_LABEL_CLASS_NAME} select-none`;
+
+// The skill label is smaller than the surrounding prompt text; offset its
 // glyphs without moving the pill box or changing the editor's line height.
-export const COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME = `${CHAT_INLINE_CHIP_LABEL_CLASS_NAME} relative top-[0.15em] select-none`;
+export const COMPOSER_INLINE_SKILL_CHIP_LABEL_CLASS_NAME = `${COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME} relative top-[0.15em]`;
 
 export const COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME =
   "inline-flex max-w-full select-none items-center gap-[0.33em] rounded-[0.5em] border border-fuchsia-500/25 bg-fuchsia-500/12 px-[0.5em] py-[0.08em] font-medium text-[0.86em] leading-[1.1] text-fuchsia-700 align-middle dark:text-fuchsia-300";

--- a/apps/web/src/components/composerInlineChip.ts
+++ b/apps/web/src/components/composerInlineChip.ts
@@ -12,7 +12,9 @@ export const COMPOSER_INLINE_CHIP_ICON_CLASS_NAME = "size-[1.17em] shrink-0 opac
 
 export const CHAT_INLINE_CHIP_LABEL_CLASS_NAME = "truncate leading-tight";
 
-export const COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME = `${CHAT_INLINE_CHIP_LABEL_CLASS_NAME} select-none`;
+// The composer label is smaller than the surrounding prompt text; offset its
+// glyphs without moving the pill box or changing the editor's line height.
+export const COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME = `${CHAT_INLINE_CHIP_LABEL_CLASS_NAME} relative top-[0.15em] select-none`;
 
 export const COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME =
   "inline-flex max-w-full select-none items-center gap-[0.33em] rounded-[0.5em] border border-fuchsia-500/25 bg-fuchsia-500/12 px-[0.5em] py-[0.08em] font-medium text-[0.86em] leading-[1.1] text-fuchsia-700 align-middle dark:text-fuchsia-300";


### PR DESCRIPTION
## Summary

The Prompt font preview's inline skill pill sat low relative to surrounding text when custom prompt fonts were used. The first pass corrected the outer pill placement; this follow-up corrects the smaller label glyph position inside that pill.

The shared composer inline-token wrapper uses a small em-based negative vertical alignment. The smaller skill label gets a scoped em-based relative offset so its glyph bottom aligns with surrounding prompt text without moving the pill box or changing the editor's line height; shared file and terminal-context labels retain their existing positioning.

## Validation

- `vp fmt --check apps/web/src/components/ComposerPromptEditor.tsx`
- `vp lint apps/web/src/components/ComposerPromptEditor.tsx --report-unused-disable-directives`
- `vp fmt --check apps/web/src/components/composerInlineChip.ts`
- `vp lint apps/web/src/components/composerInlineChip.ts --report-unused-disable-directives`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/web build`
- Browser verification at desktop and 390px widths: the label bottom moved from `619.25px` to `621.05px`, matching surrounding text at `621.06px`; the pill box stayed unchanged and the narrow layout had no clipping.
- The label offset is scoped to composer skill chips; shared chat and terminal label styles remain unchanged.
- Visual evidence:

  | Before | After |
  | --- | --- |
  | ![Before label alignment](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/769288ef-16ef-4d6c-9536-9925191694a5/skill-label-before-followup.png) | ![After label alignment](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/b8080645-7282-4c22-bcf5-700f0f973027/skill-label-after-scoped-final.png) |
- The focused Vitest command was attempted after `vp i`, but the runner failed before test execution with `TypeError: Cannot read properties of undefined (reading 'config')`; the same runner-stage failure reproduced on an unrelated web test.

Model/harness: Codex (GPT-5.6-Luna) via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation tweaks in the composer prompt editor; no behavior, auth, or data changes.
> 
> **Overview**
> Fixes composer inline chips (file mentions, skills, terminal context) sitting low relative to surrounding prompt text, especially with custom prompt fonts.
> 
> Lexical decorator wrappers for those chips now use **`align-[-0.125em]`** instead of **`align-middle`** so the pill aligns with the prompt line without changing line height. Skill chips additionally get **`COMPOSER_INLINE_SKILL_CHIP_LABEL_CLASS_NAME`** with **`relative top-[0.15em]`** so the smaller label glyphs line up with adjacent text while the pill box stays put.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b727ac13b77e0c0d7938488de30bb095384beeac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix vertical alignment of inline chips in the composer prompt editor
> Changes the vertical alignment of mention, skill, and terminal context chips from `align-middle` to `align-[-0.125em]` so chips sit flush with surrounding prompt text. Also adds a new `COMPOSER_INLINE_SKILL_CHIP_LABEL_CLASS_NAME` constant in [composerInlineChip.ts](https://github.com/pingdotgg/t3code/pull/5495/files#diff-f147d6e9773ccf583558123809ae27ff81353b779a9c10add9bca4fdda2d9ff5) that applies an additional `relative top-[0.15em]` offset to correct glyph positioning within skill chip labels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b727ac1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->