### PR TITLE
fix(server): refresh provider session lastSeenAt on turn and task activity

### DIFF
--- a/apps/server/src/persistence/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/ProviderSessionRuntime.ts
@@ -58,6 +58,12 @@ export type GetProviderSessionRuntimeInput = typeof GetProviderSessionRuntimeInp
 export const DeleteProviderSessionRuntimeInput = Schema.Struct({ threadId: ThreadId });
 export type DeleteProviderSessionRuntimeInput = typeof DeleteProviderSessionRuntimeInput.Type;
 
+export const TouchProviderSessionRuntimeInput = Schema.Struct({
+  threadId: ThreadId,
+  lastSeenAt: IsoDateTime,
+});
+export type TouchProviderSessionRuntimeInput = typeof TouchProviderSessionRuntimeInput.Type;
+
 /**
  * ProviderSessionRuntimeRepository - Service tag for provider runtime persistence.
  */
@@ -71,6 +77,15 @@ export class ProviderSessionRuntimeRepository extends Context.Service<
      */
     readonly upsert: (
       runtime: ProviderSessionRuntime,
+    ) => Effect.Effect<void, ProviderSessionRuntimeRepositoryError>;
+
+    /**
+     * Update only `last_seen_at` for an existing runtime row.
+     *
+     * No-op when no row exists for the thread; never creates a row.
+     */
+    readonly touchByThreadId: (
+      input: TouchProviderSessionRuntimeInput,
     ) => Effect.Effect<void, ProviderSessionRuntimeRepositoryError>;
 
     /**
@@ -186,6 +201,16 @@ export const make = Effect.gen(function* () {
       `,
   });
 
+  const touchRuntimeRow = SqlSchema.void({
+    Request: TouchProviderSessionRuntimeInput,
+    execute: ({ threadId, lastSeenAt }) =>
+      sql`
+        UPDATE provider_session_runtime
+        SET last_seen_at = ${lastSeenAt}
+        WHERE thread_id = ${threadId}
+      `,
+  });
+
   const getRuntimeRowByThreadId = SqlSchema.findOneOption({
     Request: GetRuntimeRequestSchema,
     Result: ProviderSessionRuntimeRawDbRowSchema,
@@ -242,6 +267,17 @@ export const make = Effect.gen(function* () {
           "ProviderSessionRuntimeRepository.upsert:query",
           "ProviderSessionRuntimeRepository.upsert:encodeRequest",
           { threadId: runtime.threadId },
+        ),
+      ),
+    );
+
+  const touchByThreadId: ProviderSessionRuntimeRepository["Service"]["touchByThreadId"] = (input) =>
+    touchRuntimeRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProviderSessionRuntimeRepository.touchByThreadId:query",
+          "ProviderSessionRuntimeRepository.touchByThreadId:encodeRequest",
+          { threadId: input.threadId },
         ),
       ),
     );
@@ -324,6 +360,7 @@ export const make = Effect.gen(function* () {
 
   return {
     upsert,
+    touchByThreadId,
     getByThreadId,
     list,
     deleteByThreadId,

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -213,6 +213,7 @@ function makeScopedRuntimeFactory(options?: { readonly failConstruction?: boolea
 
 const providerSessionDirectoryTestLayer = Layer.succeed(ProviderSessionDirectory, {
   upsert: () => Effect.void,
+  touch: () => Effect.void,
   getProvider: () =>
     Effect.die(new Error("ProviderSessionDirectory.getProvider is not used in test")),
   getBinding: () => Effect.succeed(Option.none()),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -233,6 +233,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
 
 const providerSessionDirectoryTestLayer = Layer.succeed(ProviderSessionDirectory, {
   upsert: () => Effect.void,
+  touch: () => Effect.void,
   getProvider: () =>
     Effect.die(new Error("ProviderSessionDirectory.getProvider is not used in test")),
   getBinding: () => Effect.succeed(Option.none()),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -46,7 +46,7 @@ import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import * as ProviderAdapterRegistry from "../Services/ProviderAdapterRegistry.ts";
 import * as ProviderService from "../Services/ProviderService.ts";
 import * as ProviderSessionDirectory from "../Services/ProviderSessionDirectory.ts";
-import { makeProviderServiceLive } from "./ProviderService.ts";
+import { makeProviderServiceLive, SESSION_ACTIVITY_EVENT_TYPES } from "./ProviderService.ts";
 import * as ProviderEventLoggers from "./ProviderEventLoggers.ts";
 import { ProviderSessionDirectoryLive } from "./ProviderSessionDirectory.ts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -1533,6 +1533,68 @@ fanout.layer("ProviderServiceLive fanout", (it) => {
         ),
         true,
       );
+    }),
+  );
+
+  it.effect("refreshes binding lastSeenAt on turn and task lifecycle events", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      const threadId = asThreadId("thread-last-seen");
+      yield* provider.startSession(threadId, {
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const lastSeenAt = directory
+        .listBindings()
+        .pipe(
+          Effect.map(
+            (bindings) => bindings.find((entry) => entry.threadId === threadId)?.lastSeenAt,
+          ),
+        );
+
+      const emitEvent = (type: string, eventId: string) => {
+        fanout.codex.emit({
+          type,
+          eventId: asEventId(eventId),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+          threadId,
+          turnId: asTurnId("turn-last-seen"),
+        });
+      };
+
+      const initial = yield* lastSeenAt;
+      assert.notEqual(initial, undefined);
+      yield* advanceTestClock(50);
+
+      // A content delta is not a session-activity boundary and must not
+      // write to the binding on every streamed token.
+      emitEvent("content.delta", "evt-seen-delta");
+      yield* advanceTestClock(50);
+      const afterDelta = yield* lastSeenAt;
+      assert.equal(afterDelta, initial);
+
+      let previous = initial as string;
+      for (const [index, type] of [...SESSION_ACTIVITY_EVENT_TYPES].entries()) {
+        yield* advanceTestClock(61_000);
+        emitEvent(type, `evt-seen-${index}`);
+        yield* advanceTestClock(50);
+        const current = yield* lastSeenAt;
+        assert.notEqual(current, undefined);
+        assert.equal(Date.parse(current as string) > Date.parse(previous), true);
+        previous = current as string;
+      }
+
+      // Touches are throttled per thread: a boundary arriving right after
+      // another one must not hit the database again.
+      emitEvent("turn.completed", "evt-seen-throttled");
+      yield* advanceTestClock(50);
+      const afterThrottled = yield* lastSeenAt;
+      assert.equal(afterThrottled, previous);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -186,6 +186,7 @@ export const SESSION_ACTIVITY_EVENT_TYPES: ReadonlySet<ProviderRuntimeEvent["typ
   "turn.aborted",
   "task.started",
   "task.progress",
+  "task.updated",
   "task.completed",
 ]);
 
@@ -324,7 +325,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
                 Effect.logWarning("provider.session.activity-touch-failed", {
                   threadId: event.threadId,
                   eventType: event.type,
-                  cause,
+                  errorTag: causeErrorTag(cause),
                 }),
               ),
             );

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -25,6 +25,7 @@ import {
   type ProviderSession,
 } from "@t3tools/contracts";
 import { causeErrorTag } from "@t3tools/shared/observability";
+import * as Clock from "effect/Clock";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -179,6 +180,17 @@ const dieOnMissingBindingInstanceId = (
   );
 };
 
+export const SESSION_ACTIVITY_EVENT_TYPES: ReadonlySet<ProviderRuntimeEvent["type"]> = new Set([
+  "turn.started",
+  "turn.completed",
+  "turn.aborted",
+  "task.started",
+  "task.progress",
+  "task.completed",
+]);
+
+const SESSION_ACTIVITY_TOUCH_MIN_INTERVAL_MS = 60_000;
+
 const correlateRuntimeEventWithInstance = (
   source: {
     readonly instanceId: ProviderInstanceId;
@@ -281,6 +293,45 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       });
     });
 
+  // Turn and background-task lifecycle events prove the provider session is
+  // still doing user-visible work even when no `sendTurn` call delivered it
+  // (queued follow-ups, plan-sourced turns, background tasks that outlive
+  // their foreground turn). Without this, `lastSeenAt` stays at the last
+  // explicit send and the inactivity reaper measures idleness from the last
+  // user message instead of the last completed work.
+  //
+  // Touches are throttled per thread because this runs on the event drain
+  // fiber and task.progress can fire many times per second in multi-agent
+  // sessions; the reaper thresholds are minutes, so minute-level lastSeenAt
+  // granularity is enough. The gate timestamp is set before the write so a
+  // failing database is not retried on every event.
+  const lastTouchAtByThread = new Map<ThreadId, number>();
+
+  const touchSessionActivity = (event: ProviderRuntimeEvent): Effect.Effect<void> =>
+    SESSION_ACTIVITY_EVENT_TYPES.has(event.type)
+      ? Clock.currentTimeMillis.pipe(
+          Effect.flatMap((now) => {
+            const lastTouchAt = lastTouchAtByThread.get(event.threadId);
+            if (
+              lastTouchAt !== undefined &&
+              now - lastTouchAt < SESSION_ACTIVITY_TOUCH_MIN_INTERVAL_MS
+            ) {
+              return Effect.void;
+            }
+            lastTouchAtByThread.set(event.threadId, now);
+            return directory.touch(event.threadId).pipe(
+              Effect.catchCause((cause) =>
+                Effect.logWarning("provider.session.activity-touch-failed", {
+                  threadId: event.threadId,
+                  eventType: event.type,
+                  cause,
+                }),
+              ),
+            );
+          }),
+        )
+      : Effect.void;
+
   const processRuntimeEvent = (
     source: {
       readonly instanceId: ProviderInstanceId;
@@ -293,7 +344,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         increment(providerRuntimeEventsTotal, {
           provider: canonicalEvent.provider,
           eventType: canonicalEvent.type,
-        }).pipe(Effect.andThen(publishRuntimeEvent(canonicalEvent))),
+        }).pipe(
+          Effect.andThen(publishRuntimeEvent(canonicalEvent)),
+          Effect.andThen(touchSessionActivity(canonicalEvent)),
+        ),
       ),
     );
 
@@ -856,6 +910,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           yield* routed.adapter.stopSession(routed.threadId);
         }
         yield* clearMcpSession(input.threadId);
+        lastTouchAtByThread.delete(input.threadId);
         yield* directory.upsert({
           threadId: input.threadId,
           provider: routed.adapter.provider,

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
@@ -227,6 +227,61 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
       }
     }));
 
+  it.effect("touch refreshes lastSeenAt and leaves every other field unchanged", () =>
+    Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory;
+      const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+      const threadId = ThreadId.make("thread-touch");
+
+      yield* runtimeRepository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: "2026-01-01T00:00:00.000Z",
+        resumeCursor: {
+          opaque: "resume-touch",
+        },
+        runtimePayload: {
+          cwd: "/tmp/touch",
+        },
+      });
+
+      yield* directory.touch(threadId);
+
+      const runtime = yield* runtimeRepository.getByThreadId({ threadId });
+      assert.equal(Option.isSome(runtime), true);
+      if (Option.isSome(runtime)) {
+        assert.notEqual(runtime.value.lastSeenAt, "2026-01-01T00:00:00.000Z");
+        assert.equal(Number.isNaN(Date.parse(runtime.value.lastSeenAt)), false);
+        assert.equal(runtime.value.providerName, "claudeAgent");
+        assert.equal(runtime.value.adapterKey, "claudeAgent");
+        assert.equal(runtime.value.runtimeMode, "full-access");
+        assert.equal(runtime.value.status, "running");
+        assert.deepEqual(runtime.value.resumeCursor, {
+          opaque: "resume-touch",
+        });
+        assert.deepEqual(runtime.value.runtimePayload, {
+          cwd: "/tmp/touch",
+        });
+      }
+    }),
+  );
+
+  it.effect("touch never creates a row for an unknown thread", () =>
+    Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = ThreadId.make("thread-touch-missing");
+
+      yield* directory.touch(threadId);
+
+      const binding = yield* directory.getBinding(threadId);
+      assert.equal(Option.isNone(binding), true);
+    }),
+  );
+
   it("rehydrates persisted mappings across layer restart", () =>
     Effect.gen(function* () {
       const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-directory-"));

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -148,6 +148,13 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
       .pipe(Effect.mapError(toPersistenceError("ProviderSessionDirectory.upsert:upsert")));
   });
 
+  const touch: ProviderSessionDirectoryShape["touch"] = Effect.fn(function* (threadId) {
+    const now = DateTime.formatIso(yield* DateTime.now);
+    yield* repository
+      .touchByThreadId({ threadId, lastSeenAt: now })
+      .pipe(Effect.mapError(toPersistenceError("ProviderSessionDirectory.touch:touchByThreadId")));
+  });
+
   const getProvider: ProviderSessionDirectoryShape["getProvider"] = (threadId) =>
     getBinding(threadId).pipe(
       Effect.flatMap((binding) =>
@@ -184,6 +191,7 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
 
   return {
     upsert,
+    touch,
     getProvider,
     getBinding,
     listThreadIds,

--- a/apps/server/src/provider/Services/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Services/ProviderSessionDirectory.ts
@@ -45,6 +45,12 @@ export interface ProviderSessionDirectoryShape {
     binding: ProviderRuntimeBinding,
   ) => Effect.Effect<void, ProviderSessionDirectoryWriteError>;
 
+  /**
+   * Refresh only `lastSeenAt` for an existing binding, marking the session
+   * as recently active. No-op when no binding exists for the thread.
+   */
+  readonly touch: (threadId: ThreadId) => Effect.Effect<void, ProviderSessionDirectoryWriteError>;
+
   readonly getProvider: (
     threadId: ThreadId,
   ) => Effect.Effect<ProviderDriverKind, ProviderSessionDirectoryReadError>;


### PR DESCRIPTION
### What

Refreshes `provider_session_runtime.last_seen_at` when the adapter emits turn or background-task lifecycle events, so the inactivity reaper measures idleness from the last completed work instead of the last explicit `sendTurn`.

Addresses the staleness half of #4198.

### Why

`last_seen_at` is only written by `startSession` / `recoverSessionForThread` / `sendTurn` / `stopSession`. Turns delivered without a `sendTurn` call (queued follow-ups, plan-sourced turns) and background tasks never refresh it. Observed on `0.0.32-nightly.20260805.1006`: one thread was reaped 6 times in ~12 hours, three of those 105 s - 4 m 53 s after a turn had actually completed — the reaper was measuring idleness from a `last_seen_at` several turns stale, exactly what the reporters in #4198 back-computed from their logs.

### How

- `ProviderSessionDirectory.touch(threadId)` updates only `last_seen_at` for an existing binding via a new repository `touchByThreadId` (`UPDATE ... WHERE thread_id`). It never creates rows, and preserves every other column.
- `ProviderService.processRuntimeEvent` touches the binding on `turn.started/completed/aborted` and `task.started/progress/completed`, after event fan-out.
- Touches are throttled to one per thread per 60 s (in-memory map, cleared on `stopSession`) because this runs on the event drain fiber and `task.progress` can fire many times per second in multi-agent sessions; reaper thresholds are minutes, so minute-level granularity is sufficient. The gate timestamp is set before the write so a failing database is not retried per event.
- Touch failures log `provider.session.activity-touch-failed` and never disturb fan-out.

This deliberately does not add a busy-guard for in-flight background tasks (discussed in #4198) — that is a separate lifecycle change; this PR only fixes the idle clock.

### Tests

- `ProviderService.test.ts`: every activity event type refreshes the binding's `lastSeenAt`; `content.delta` does not; a second boundary inside the throttle window does not write again.
- `ProviderSessionDirectory.test.ts`: `touch` refreshes `lastSeenAt` and leaves all other fields unchanged; `touch` on an unknown thread creates no row.
- `vp test run` on the five touched test files (97 tests) and `tsgo --noEmit` pass.

### Prior art and non-goals

This addresses the liveness-staleness half of #4198. Back-computing the reaper's logged `idleDurationMs` against turn timestamps shows every incident reported there is an event-emitting case this PR covers: ordinary provider-started turns that never refreshed `last_seen_at` (NoorChasib's table — turns at 06:08 and 06:17 with `last_seen_at` stuck at 05:49), and background tasks killed seconds after their foreground turn settled (Mooned8, Zeus-Deus — `task.started`/`turn.completed` both now touch the binding).

Earlier attempts in this area (#4199, #3856, #4994) were closed for orchestration-V2 roadmap reasons rather than on the mechanism, and #2829 is still open — this PR is deliberately the smallest reviewable slice of that idea: one new directory method, one call site on the existing event drain, throttled, with no lifecycle behavior changes.

Non-goals, intentionally out of scope here:
- a busy-guard exempting sessions with outstanding-but-quiet background tasks (the remaining half of #4198) — planned as a small follow-up building on the existing `backgroundLiveness` thread-shell state;
- post-reap result re-delivery / respawn-on-completion (#4265);
- reaper convergence for wedged threads (#4723, #4584) — only sensible after this PR makes `lastSeenAt` trustworthy.

Written by Claude Fable 5 via [Claude Code](https://claude.com/claude-code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when sessions are considered idle for reaping (core provider lifecycle), but scope is narrow—targeted DB updates with throttling and non-blocking failure handling.
> 
> **Overview**
> Provider session **`lastSeenAt`** now advances when adapters emit turn or background-task lifecycle events, not only on `startSession`, `sendTurn`, or `stopSession`. That aligns the inactivity reaper with **last completed work** (queued turns, plan-driven work, long-running tasks) instead of the last explicit user send.
> 
> A **`touch`** path updates only `last_seen_at` via repository **`touchByThreadId`** (`UPDATE … WHERE thread_id`); it never inserts rows and leaves other binding fields unchanged. **`ProviderService.processRuntimeEvent`** calls it after fan-out for `SESSION_ACTIVITY_EVENT_TYPES` (`turn.*`, `task.*`), with a **60s per-thread throttle** and throttle state cleared on **`stopSession`**. Streaming events like **`content.delta`** do not touch; touch failures are logged and do not affect event delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fadabd37e6508ab6685a04cf4a0d103e5dad39b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh provider session `lastSeenAt` on turn and task activity events
> - Adds a `touch` method to `ProviderSessionDirectory` and `ProviderSessionDirectoryShape` that updates only `last_seen_at` for an existing binding, with no-op behavior for unknown threads.
> - Extends `ProviderSessionRuntimeRepository` with `touchByThreadId`, which performs a targeted `UPDATE` on `last_seen_at` without affecting other fields.
> - In `makeProviderService`, emitting events from the new `SESSION_ACTIVITY_EVENT_TYPES` set (`turn.started`, `turn.completed`, `turn.aborted`, `task.*`) triggers `directory.touch`, throttled to at most once per 60 seconds per thread. The throttle map entry is cleared on `stopSession`.
> - Behavioral Change: provider session `lastSeenAt` now updates during active turns and tasks, where previously it only updated on session creation or explicit upsert.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fadabd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->