### PR TITLE
feat(server): make provider session reaper timing configurable

### DIFF
--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@t3tools/contracts";
 import * as Clock from "effect/Clock";
 import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
@@ -23,8 +24,12 @@ import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntim
 import { ProviderValidationError } from "../Errors.ts";
 import { ProviderSessionReaper } from "../Services/ProviderSessionReaper.ts";
 import { ProviderService, type ProviderServiceShape } from "../Services/ProviderService.ts";
+import { layerTest as serverSettingsLayerTest } from "../../serverSettings.ts";
 import { ProviderSessionDirectoryLive } from "./ProviderSessionDirectory.ts";
-import { makeProviderSessionReaperLive } from "./ProviderSessionReaper.ts";
+import {
+  makeProviderSessionReaperLive,
+  type ProviderSessionReaperLiveOptions,
+} from "./ProviderSessionReaper.ts";
 
 const defaultModelSelection = {
   instanceId: ProviderInstanceId.make("codex"),
@@ -140,6 +145,8 @@ describe("ProviderSessionReaper", () => {
     readonly stopSessionImplementation?: (input: {
       readonly threadId: ThreadId;
     }) => ReturnType<ProviderServiceShape["stopSession"]>;
+    readonly reaperOptions?: ProviderSessionReaperLiveOptions;
+    readonly settingsOverrides?: Parameters<typeof serverSettingsLayerTest>[0];
   }) {
     const stoppedThreadIds = new Set<ThreadId>();
     const stopSession = vi.fn<ProviderServiceShape["stopSession"]>(
@@ -183,10 +190,13 @@ describe("ProviderSessionReaper", () => {
     const providerSessionDirectoryLayer = ProviderSessionDirectoryLive.pipe(
       Layer.provide(runtimeRepositoryLayer),
     );
-    const layer = makeProviderSessionReaperLive({
-      inactivityThresholdMs: 1_000,
-      sweepIntervalMs: 60_000,
-    }).pipe(
+    const layer = makeProviderSessionReaperLive(
+      input.reaperOptions ?? {
+        inactivityThresholdMs: 1_000,
+        sweepIntervalMs: 60_000,
+      },
+    ).pipe(
+      Layer.provideMerge(serverSettingsLayerTest(input.settingsOverrides ?? {})),
       Layer.provideMerge(providerSessionDirectoryLayer),
       Layer.provideMerge(runtimeRepositoryLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, providerService)),
@@ -256,6 +266,178 @@ describe("ProviderSessionReaper", () => {
         lastSeenAt: "2026-04-14T00:00:00.000Z",
         resumeCursor: {
           opaque: "resume-stale",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await Effect.runPromise(Scope.make("sequential"));
+    await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
+
+    await waitFor(() => harness.stopSession.mock.calls.length === 1);
+
+    expect(harness.stopSession.mock.calls[0]?.[0]).toEqual({ threadId });
+    expect(harness.stoppedThreadIds.has(threadId)).toBe(true);
+  });
+
+  // These cases seed a session idle for ~5 seconds — between the small and
+  // large candidate thresholds — so they fail if the settings plumbing is
+  // broken (hardcoded 30-minute default would not reap) or the precedence
+  // is inverted.
+  it("reads reaper timing from server settings when no options are provided", async () => {
+    const threadId = ThreadId.make("thread-reaper-settings");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "claudeAgent",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+      reaperOptions: {},
+      settingsOverrides: {
+        providerSessionInactivityThreshold: Duration.millis(1_000),
+        providerSessionSweepInterval: Duration.minutes(1),
+      },
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+
+    const nowMs = await Effect.runPromise(Clock.currentTimeMillis);
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: new Date(nowMs - 5_000).toISOString(),
+        resumeCursor: {
+          opaque: "resume-settings",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await Effect.runPromise(Scope.make("sequential"));
+    await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
+
+    await waitFor(() => harness.stopSession.mock.calls.length === 1);
+
+    expect(harness.stopSession.mock.calls[0]?.[0]).toEqual({ threadId });
+    expect(harness.stoppedThreadIds.has(threadId)).toBe(true);
+  });
+
+  it("does not reap when the configured threshold exceeds the idle time", async () => {
+    const threadId = ThreadId.make("thread-reaper-settings-fresh");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "claudeAgent",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+      reaperOptions: {},
+      settingsOverrides: {
+        providerSessionInactivityThreshold: Duration.days(30),
+        providerSessionSweepInterval: Duration.minutes(1),
+      },
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+
+    const nowMs = await Effect.runPromise(Clock.currentTimeMillis);
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: new Date(nowMs - 5_000).toISOString(),
+        resumeCursor: {
+          opaque: "resume-settings-fresh",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await Effect.runPromise(Scope.make("sequential"));
+    await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
+    await Effect.runPromise(drainFibers);
+
+    expect(harness.stopSession).not.toHaveBeenCalled();
+    const remaining = await runtime!.runPromise(repository.getByThreadId({ threadId }));
+    expect(Option.isSome(remaining)).toBe(true);
+  });
+
+  it("prefers explicit options over server settings", async () => {
+    const threadId = ThreadId.make("thread-reaper-option-override");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "claudeAgent",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+      reaperOptions: {
+        inactivityThresholdMs: 1_000,
+        sweepIntervalMs: 60_000,
+      },
+      settingsOverrides: {
+        providerSessionInactivityThreshold: Duration.days(30),
+        providerSessionSweepInterval: Duration.hours(1),
+      },
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+
+    const nowMs = await Effect.runPromise(Clock.currentTimeMillis);
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: new Date(nowMs - 5_000).toISOString(),
+        resumeCursor: {
+          opaque: "resume-option-override",
         },
         runtimePayload: null,
       }),

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -24,7 +24,7 @@ import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntim
 import { ProviderValidationError } from "../Errors.ts";
 import { ProviderSessionReaper } from "../Services/ProviderSessionReaper.ts";
 import { ProviderService, type ProviderServiceShape } from "../Services/ProviderService.ts";
-import { layerTest as serverSettingsLayerTest } from "../../serverSettings.ts";
+import * as ServerSettings from "../../serverSettings.ts";
 import { ProviderSessionDirectoryLive } from "./ProviderSessionDirectory.ts";
 import {
   makeProviderSessionReaperLive,
@@ -146,7 +146,7 @@ describe("ProviderSessionReaper", () => {
       readonly threadId: ThreadId;
     }) => ReturnType<ProviderServiceShape["stopSession"]>;
     readonly reaperOptions?: ProviderSessionReaperLiveOptions;
-    readonly settingsOverrides?: Parameters<typeof serverSettingsLayerTest>[0];
+    readonly settingsOverrides?: Parameters<typeof ServerSettings.layerTest>[0];
   }) {
     const stoppedThreadIds = new Set<ThreadId>();
     const stopSession = vi.fn<ProviderServiceShape["stopSession"]>(
@@ -196,7 +196,7 @@ describe("ProviderSessionReaper", () => {
         sweepIntervalMs: 60_000,
       },
     ).pipe(
-      Layer.provideMerge(serverSettingsLayerTest(input.settingsOverrides ?? {})),
+      Layer.provideMerge(ServerSettings.layerTest(input.settingsOverrides ?? {})),
       Layer.provideMerge(providerSessionDirectoryLayer),
       Layer.provideMerge(runtimeRepositoryLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, providerService)),
@@ -322,7 +322,7 @@ describe("ProviderSessionReaper", () => {
         adapterKey: "claudeAgent",
         runtimeMode: "full-access",
         status: "running",
-        lastSeenAt: new Date(nowMs - 5_000).toISOString(),
+        lastSeenAt: DateTime.formatIso(DateTime.makeUnsafe(nowMs - 5_000)),
         resumeCursor: {
           opaque: "resume-settings",
         },
@@ -377,7 +377,7 @@ describe("ProviderSessionReaper", () => {
         adapterKey: "claudeAgent",
         runtimeMode: "full-access",
         status: "running",
-        lastSeenAt: new Date(nowMs - 5_000).toISOString(),
+        lastSeenAt: DateTime.formatIso(DateTime.makeUnsafe(nowMs - 5_000)),
         resumeCursor: {
           opaque: "resume-settings-fresh",
         },
@@ -435,7 +435,7 @@ describe("ProviderSessionReaper", () => {
         adapterKey: "claudeAgent",
         runtimeMode: "full-access",
         status: "running",
-        lastSeenAt: new Date(nowMs - 5_000).toISOString(),
+        lastSeenAt: DateTime.formatIso(DateTime.makeUnsafe(nowMs - 5_000)),
         resumeCursor: {
           opaque: "resume-option-override",
         },

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -130,7 +130,11 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
 
     const start: ProviderSessionReaperShape["start"] = () =>
       Effect.gen(function* () {
-        const inactivityThresholdMs = yield* resolveInactivityThresholdMs;
+        // Informational only — the sweep re-reads the threshold, so a failed
+        // settings read here must not abort the startup phase.
+        const inactivityThresholdMs = yield* resolveInactivityThresholdMs.pipe(
+          Effect.orElseSucceed(() => undefined),
+        );
         const sweepIntervalMs = yield* resolveSweepIntervalMs;
         yield* forkParked(
           sweep.pipe(

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PROVIDER_SESSION_SWEEP_INTERVAL } from "@t3tools/contracts";
 import * as Clock from "effect/Clock";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -6,6 +7,7 @@ import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import {
   ProviderSessionReaper,
@@ -14,11 +16,10 @@ import {
 import { forkParked } from "../../serverActivation.ts";
 import { ProviderService } from "../Services/ProviderService.ts";
 
-const DEFAULT_INACTIVITY_THRESHOLD_MS = 30 * 60 * 1000;
-const DEFAULT_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
-
 export interface ProviderSessionReaperLiveOptions {
+  /** Overrides the `providerSessionInactivityThreshold` server setting. */
   readonly inactivityThresholdMs?: number;
+  /** Overrides the `providerSessionSweepInterval` server setting. */
   readonly sweepIntervalMs?: number;
 }
 
@@ -27,14 +28,37 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
     const providerService = yield* ProviderService;
     const directory = yield* ProviderSessionDirectory;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+    const serverSettings = yield* ServerSettingsService;
 
-    const inactivityThresholdMs = Math.max(
-      1,
-      options?.inactivityThresholdMs ?? DEFAULT_INACTIVITY_THRESHOLD_MS,
-    );
-    const sweepIntervalMs = Math.max(1, options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS);
+    // Threshold is re-read every sweep so settings edits apply live; the
+    // sweep interval is fixed into the schedule when `start()` runs. A
+    // failed settings read fails the sweep (logged and retried on the next
+    // one) rather than silently reaping with a default the user overrode.
+    const resolveInactivityThresholdMs =
+      options?.inactivityThresholdMs !== undefined
+        ? Effect.succeed(Math.max(1, options.inactivityThresholdMs))
+        : serverSettings.getSettings.pipe(
+            Effect.map((settings) =>
+              Math.max(1, Duration.toMillis(settings.providerSessionInactivityThreshold)),
+            ),
+          );
+
+    const resolveSweepIntervalMs =
+      options?.sweepIntervalMs !== undefined
+        ? Effect.succeed(Math.max(1, options.sweepIntervalMs))
+        : serverSettings.getSettings.pipe(
+            Effect.map((settings) =>
+              Math.max(1, Duration.toMillis(settings.providerSessionSweepInterval)),
+            ),
+            Effect.catch((error) =>
+              Effect.logWarning("provider.session.reaper.settings-fallback", {
+                error,
+              }).pipe(Effect.as(Duration.toMillis(DEFAULT_PROVIDER_SESSION_SWEEP_INTERVAL))),
+            ),
+          );
 
     const sweep = Effect.gen(function* () {
+      const inactivityThresholdMs = yield* resolveInactivityThresholdMs;
       const bindings = yield* directory.listBindings();
       const now = yield* Clock.currentTimeMillis;
       let reapedCount = 0;
@@ -106,6 +130,8 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
 
     const start: ProviderSessionReaperShape["start"] = () =>
       Effect.gen(function* () {
+        const inactivityThresholdMs = yield* resolveInactivityThresholdMs;
+        const sweepIntervalMs = yield* resolveSweepIntervalMs;
         yield* forkParked(
           sweep.pipe(
             Effect.catch((error: unknown) =>

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -146,8 +146,13 @@ export class ServerSettingsService extends Context.Service<
 
 const makeTest = (overrides: DeepPartial<ServerSettings> = {}) =>
   Effect.gen(function* () {
-    const { automaticGitFetchInterval, providerHealthRefreshInterval, ...overridesForMerge } =
-      overrides;
+    const {
+      automaticGitFetchInterval,
+      providerHealthRefreshInterval,
+      providerSessionInactivityThreshold,
+      providerSessionSweepInterval,
+      ...overridesForMerge
+    } = overrides;
     const merged = deepMerge(DEFAULT_SERVER_SETTINGS, overridesForMerge);
     const initialSettings = yield* normalizeServerSettings({
       ...merged,
@@ -156,6 +161,15 @@ const makeTest = (overrides: DeepPartial<ServerSettings> = {}) =>
         : {}),
       ...(providerHealthRefreshInterval !== undefined
         ? { providerHealthRefreshInterval: providerHealthRefreshInterval as Duration.Duration }
+        : {}),
+      ...(providerSessionInactivityThreshold !== undefined
+        ? {
+            providerSessionInactivityThreshold:
+              providerSessionInactivityThreshold as Duration.Duration,
+          }
+        : {}),
+      ...(providerSessionSweepInterval !== undefined
+        ? { providerSessionSweepInterval: providerSessionSweepInterval as Duration.Duration }
         : {}),
     });
     const currentSettingsRef = yield* Ref.make<ServerSettings>(initialSettings);
@@ -212,6 +226,8 @@ const ATOMIC_SETTINGS_KEYS: ReadonlySet<string> = new Set([
   "backgroundActivity",
   "automaticGitFetchInterval",
   "providerHealthRefreshInterval",
+  "providerSessionInactivityThreshold",
+  "providerSessionSweepInterval",
   "sourceControlWriterModelSelection",
   "textGenerationModelSelection",
 ]);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -494,6 +494,8 @@ export type SourceControlWritingStyleSettings = typeof SourceControlWritingStyle
 
 export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 export const DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL = Duration.minutes(5);
+export const DEFAULT_PROVIDER_SESSION_INACTIVITY_THRESHOLD = Duration.minutes(30);
+export const DEFAULT_PROVIDER_SESSION_SWEEP_INTERVAL = Duration.minutes(5);
 
 export const BackgroundActivityProfile = Schema.Literals([
   "balanced",
@@ -538,6 +540,20 @@ export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   backgroundActivity: BackgroundActivitySettings,
+  // How long a provider session may sit idle before the inactivity reaper
+  // stops it (applies from the next sweep), and how often the reaper sweeps
+  // (applies after a server restart). Idle sessions resume from their
+  // persisted cursor on the next message.
+  providerSessionInactivityThreshold: Schema.DurationFromMillis.pipe(
+    Schema.withDecodingDefault(
+      Effect.succeed(Duration.toMillis(DEFAULT_PROVIDER_SESSION_INACTIVITY_THRESHOLD)),
+    ),
+  ),
+  providerSessionSweepInterval: Schema.DurationFromMillis.pipe(
+    Schema.withDecodingDefault(
+      Effect.succeed(Duration.toMillis(DEFAULT_PROVIDER_SESSION_SWEEP_INTERVAL)),
+    ),
+  ),
   // Legacy flat fields retained for old settings files and old clients. New
   // consumers should resolve `backgroundActivity` instead.
   automaticGitFetchInterval: Schema.DurationFromMillis.pipe(
@@ -710,6 +726,8 @@ export const ServerSettingsPatch = Schema.Struct({
   ),
   automaticGitFetchInterval: Schema.optionalKey(Schema.DurationFromMillis),
   providerHealthRefreshInterval: Schema.optionalKey(Schema.DurationFromMillis),
+  providerSessionInactivityThreshold: Schema.optionalKey(Schema.DurationFromMillis),
+  providerSessionSweepInterval: Schema.optionalKey(Schema.DurationFromMillis),
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -129,6 +129,8 @@ export function applyServerSettingsPatch(
   const {
     automaticGitFetchInterval,
     providerHealthRefreshInterval,
+    providerSessionInactivityThreshold,
+    providerSessionSweepInterval,
     backgroundActivityProfile,
     backgroundActivity,
     ...patchForMerge
@@ -192,6 +194,10 @@ export function applyServerSettingsPatch(
       : {}),
     ...(automaticGitFetchInterval !== undefined ? { automaticGitFetchInterval } : {}),
     ...(providerHealthRefreshInterval !== undefined ? { providerHealthRefreshInterval } : {}),
+    ...(providerSessionInactivityThreshold !== undefined
+      ? { providerSessionInactivityThreshold }
+      : {}),
+    ...(providerSessionSweepInterval !== undefined ? { providerSessionSweepInterval } : {}),
   };
   const normalizedBackgroundActivity = normalizeBackgroundActivitySettings(
     nextWithReplacementsBase.backgroundActivity,


### PR DESCRIPTION
### What

Adds `providerSessionInactivityThreshold` and `providerSessionSweepInterval` server settings (persisted as millis, defaults unchanged: 30 min / 5 min) consumed by `ProviderSessionReaper`.

Implements #5523. Related: #4198.

### Why

Both reaper values are hardcoded; `ProviderSessionReaperLiveOptions` exists but the shipped layer is built with no arguments, and nothing user-facing feeds it. Users with long-running threads currently have no supported way to keep sessions warm longer than 30 minutes.

### How

- Schema in `packages/contracts/src/settings.ts` (flat fields with `Schema.DurationFromMillis` + decoding defaults, patch keys in `ServerSettingsPatch`), placed outside the legacy-marked block. Whether these should instead live in the `backgroundActivity` profile system is raised in #5523 — happy to rework.
- Duration fields get the same `deepMerge`/strip special-casing as `automaticGitFetchInterval` (`ATOMIC_SETTINGS_KEYS`, `makeTest`, `applyServerSettingsPatch`).
- The reaper resolves the threshold from settings on every sweep (settings edits apply live); the sweep interval is resolved once at `start()` and documented as restart-required. A failed settings read fails the sweep — logged by the existing `sweep-failed` handler and retried next sweep — instead of silently reaping with a default the user overrode; the interval read falls back to the default with a `settings-fallback` warning so startup never blocks.
- Explicit `ProviderSessionReaperLiveOptions` keep precedence over settings, so existing test seams are unchanged. `ServerSettingsLayerLive` already sits above `ProviderRuntimeLayerLive` in `server.ts`, so no composition changes.

### Tests

- Reaper reads timing from settings when constructed without options: a session idle ~5 s is reaped under a 1 s settings threshold (would time out under the hardcoded 30 min default) and survives under a 30-day threshold.
- Explicit options beat settings with the idle time placed between the two candidate thresholds, so an inverted precedence fails the test.
- `vp test run` on the touched test files (26 tests) and `tsgo --noEmit` for contracts/shared/server pass.

### Positioning notes

- Until a busy-guard for quiet background work lands (see #4198), a larger `providerSessionInactivityThreshold` is the practical mitigation for long-running agent sessions; that is the immediate user demand behind #5523.
- Lowering `providerSessionSweepInterval` bounds the worst-case reap lag (a session becomes reap-eligible at most one interval before the next sweep observes it), which covers the configurability motivation of #2351 while deliberately keeping the simple polling model — the deadline-driven alternative was previously closed with real defects.
- The asymmetry is intentional: the threshold is re-read every sweep so settings edits apply live; the interval is fixed into the schedule at `start()` and applies after a restart (documented in the schema comment).

Written by Claude Fable 5 via [Claude Code](https://claude.com/claude-code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when idle provider sessions are stopped (user-visible session lifetime) and adds asymmetric failure handling for settings reads during sweeps vs startup.
> 
> **Overview**
> **Provider session reaper timing** is no longer hardcoded in `ProviderSessionReaper`. New persisted server settings `providerSessionInactivityThreshold` and `providerSessionSweepInterval` (defaults **30 min** / **5 min**, unchanged behavior) are defined in contracts, patchable via `applyServerSettingsPatch`, and treated as atomic duration fields like other git/health intervals.
> 
> The reaper resolves **inactivity threshold on every sweep** so edits apply without restart; **sweep interval** is read once at `start()` (restart to change). Explicit `ProviderSessionReaperLiveOptions` still override settings for tests. Failed threshold reads fail that sweep (logged, retried next time) instead of silently using a default; sweep interval read falls back to the contract default with a warning so startup does not block.
> 
> Tests cover settings-driven reaping, a high threshold that skips reaping, and option-over-settings precedence, with harness wiring for `ServerSettings.layerTest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47869a8e81a5ff332e40e2985ec155072e2994e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make provider session reaper timing configurable via server settings
> - Adds `providerSessionInactivityThreshold` and `providerSessionSweepInterval` fields to `ServerSettings` schema in [settings.ts](https://github.com/pingdotgg/t3code/pull/5525/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), defaulting to 30 minutes and 5 minutes respectively.
> - `ProviderSessionReaper` now reads these values from `ServerSettingsService` instead of using hardcoded constants; explicit `ProviderSessionReaperLiveOptions` still override server settings.
> - The sweep interval is resolved once at startup (with a warning + fallback on failure); the inactivity threshold is re-read from settings on every sweep.
> - `applyServerSettingsPatch` in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/5525/files#diff-043ca428f05b5295b6161cdcb2c48bd97c3985f21faa3a8214057decca51518f) propagates the new fields when patching.
> - Risk: a settings read failure for the inactivity threshold causes that sweep run to fail and be logged, rather than silently using a fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47869a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->