### PR TITLE
fix(server): favicon resolution no longer pins the event loop

### DIFF
--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -133,6 +133,73 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
       }),
     );
 
+    it.effect("resolves icon hrefs from object-literal route metadata", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "src/routes/__root.tsx",
+          `export const Route = createRootRoute({
+  head: () => ({
+    links: [
+      { rel: "stylesheet", href: "/app.css" },
+      { rel: "icon", href: "/brand/logo.svg" },
+    ],
+  }),
+});`,
+        );
+        yield* writeTextFile(cwd, "public/brand/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("public/brand/logo.svg");
+      }),
+    );
+
+    it.effect("resolves object-literal icon metadata when href precedes rel", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "src/root.tsx",
+          `const links = [{ href: "/brand/logo.svg", rel: "shortcut icon" }];`,
+        );
+        yield* writeTextFile(cwd, "public/brand/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("public/brand/logo.svg");
+      }),
+    );
+
+    // A large icon source with no icon metadata used to pin the server's event loop for
+    // minutes: the object pattern was unanchored, so it restarted at every offset and
+    // rescanned forward from each one. Anchoring keeps this proportional to file size.
+    it.effect("scans large icon sources without an icon in reasonable time", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        // Mirrors a generated single-file build: large, brace-sparse, and no icon metadata.
+        const filler = `<p>${"pokopia companion guide ".repeat(24)}</p>\n`;
+        yield* writeTextFile(
+          cwd,
+          "index.html",
+          `<!doctype html><html><head><title>guide</title></head><body>\n${filler.repeat(1200)}</body></html>`,
+        );
+
+        const startedAt = performance.now();
+        const resolved = yield* resolver.resolvePath(cwd);
+        const elapsedMs = performance.now() - startedAt;
+
+        expect(resolved).toBeNull();
+        expect(elapsedMs).toBeLessThan(5_000);
+      }),
+    );
+
     it.effect("returns null when no icon is present", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -55,10 +55,12 @@ const ICON_SOURCE_FILES = [
 ] as const;
 
 // Matches <link ...> tags or object-like icon metadata where rel/href can appear in any order.
+// Both patterns stay anchored on a literal opening delimiter (`<link` / `{`) so the scan starts
+// only at real candidates and each attempt is bounded by the enclosing tag or object.
 const LINK_ICON_HTML_RE =
   /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i;
-const LINK_ICON_OBJ_RE =
-  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i;
+const LINK_ICON_OBJ_RE = /\{[^{}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'][^{}]*\}/i;
+const ICON_HREF_RE = /\bhref\s*:\s*["']([^"'?]+)/i;
 
 export class ProjectFaviconResolutionError extends Schema.TaggedErrorClass<ProjectFaviconResolutionError>()(
   "ProjectFaviconResolutionError",
@@ -99,7 +101,8 @@ function extractIconHref(source: string): string | null {
   const htmlMatch = source.match(LINK_ICON_HTML_RE);
   if (htmlMatch?.[1]) return htmlMatch[1];
   const objMatch = source.match(LINK_ICON_OBJ_RE);
-  if (objMatch?.[1]) return objMatch[1];
+  const objHref = objMatch?.[0].match(ICON_HREF_RE);
+  if (objHref?.[1]) return objHref[1];
   return null;
 }
 


### PR DESCRIPTION
## What Changed

`LINK_ICON_OBJ_RE` in `ProjectFaviconResolver` is now anchored on the literal `{` and bounded to the enclosing object, with `href` pulled out of the matched object by a second small pattern.

```diff
-const LINK_ICON_OBJ_RE =
-  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i;
+const LINK_ICON_OBJ_RE = /\{[^{}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'][^{}]*\}/i;
+const ICON_HREF_RE = /\bhref\s*:\s*["']([^"'?]+)/i;
```

Three tests come with it. The object branch had no coverage at all — every existing case exercises the `<link>` branch — so this adds both key orders (`rel` first, `href` first with `shortcut icon`) plus a large brace-sparse source that hangs the suite without the fix.

`LINK_ICON_HTML_RE` is untouched. It is already anchored on `<link\b`, so it was never part of the problem.

## Why

Fixes #5530.

The old pattern started with a lookahead and no literal anchor, so the engine retried at every offset in the file and rescanned forward with `[^}]*` from each one. On a brace-sparse file that is quadratic.

That turns one file into a full environment outage. A project with no icon and a large `index.html` lacking `<link rel="icon">` — the shape of a generated single-file build — made `resolvePath` spin for minutes on the server's only thread. Every endpoint stopped answering, including `/.well-known/t3/environment`; the desktop client timed out at 10s, respawned the server, and it re-scanned and re-wedged. The environment never recovered on its own.

Anchoring on `{` restricts start positions to real object literals and bounds each attempt to a single brace group, so the work stays proportional to file size.

Measured on the 1.6 MB generated `index.html` that triggered this:

| | before | after |
|---|---|---|
| 1.6 MB icon source, no icon metadata | killed at 30s, never completed | 2 ms |
| 200 KB | ~4s | <1 ms |

Semantics are preserved — `rel` before `href`, `href` before `rel`, `shortcut icon`, and query-string stripping all still resolve.

## UI Changes

None.

## Verification

- `vp test run src/project/ProjectFaviconResolver.test.ts` — 15 passed (12 existing + 3 new), 415 ms.
- Reverting only the source change and keeping the new tests: the run was still going at 100s and had to be killed, confirming the regression test actually catches this.
- `vp lint` on both changed files: clean.
- `tsgo --noEmit` for `apps/server`: exit 0, no diagnostics in the changed files.

Branched off `main` @ `e4abc31f`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A, no UI change)
- [x] I included a video for animation/interaction changes (N/A)

Model: Claude Opus 5 · Harness: Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core server favicon discovery on every workspace resolve; regex change is localized but incorrect matching could miss icons in nested objects with inner braces.
> 
> **Overview**
> **Fixes catastrophic slowdown in `ProjectFaviconResolver` when scanning large sources that lack icon metadata** (e.g. generated single-file `index.html`), which could block the server event loop for minutes.
> 
> Object-literal icon detection no longer uses an unanchored lookahead over `[^}]*`. It now matches only brace-bounded objects that declare `rel: "icon"` / `"shortcut icon"`, then reads `href` via a separate `ICON_HREF_RE` pass so `rel`/`href` order stays flexible without rescanning the whole file at every offset.
> 
> **Tests** add first coverage for the object-metadata path (route `head` links and `href`-before-`rel`), plus a large-file timing guard that expects `resolvePath` to finish in under 5s when no icon is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b77158b6e2d6e6a32d43ec0eca1fbf3fd8c3d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix favicon resolution in `ProjectFaviconResolver` to avoid pinning the event loop
> - Replaces the previous unanchored lookahead-based regex (`LINK_ICON_OBJ_RE`) with an anchored brace-delimited pattern, bounding object-metadata scans to a single `{...}` block.
> - Introduces `ICON_HREF_RE` to extract `href` from the matched object block, supporting any property order.
> - Adds a performance test in [ProjectFaviconResolver.test.ts](https://github.com/pingdotgg/t3code/pull/5531/files#diff-e4b7f213c41e9f2c8d783794583a8ead691c42453cf2806016261957c36daf6e) asserting large icon-free sources are scanned in under 5 seconds.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4b77158. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->