### PR TITLE
fix(server): favicon resolution no longer pins the event loop

### DIFF
--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -133,6 +133,109 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
       }),
     );
 
+    it.effect("resolves icon hrefs from object-literal route metadata", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "src/routes/__root.tsx",
+          `export const Route = createRootRoute({
+  head: () => ({
+    links: [
+      { rel: "stylesheet", href: "/app.css" },
+      { rel: "icon", href: "/brand/logo.svg" },
+    ],
+  }),
+});`,
+        );
+        yield* writeTextFile(cwd, "public/brand/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("public/brand/logo.svg");
+      }),
+    );
+
+    it.effect("resolves object-literal icon metadata when href precedes rel", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "src/root.tsx",
+          `const links = [{ href: "/brand/logo.svg", rel: "shortcut icon" }];`,
+        );
+        yield* writeTextFile(cwd, "public/brand/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("public/brand/logo.svg");
+      }),
+    );
+
+    it.effect("resolves object-literal icon metadata alongside nested objects", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "src/root.tsx",
+          `const links = [{ attributes: {}, rel: "icon", href: "/brand/logo.svg" }];`,
+        );
+        yield* writeTextFile(cwd, "public/brand/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("public/brand/logo.svg");
+      }),
+    );
+
+    it.effect("skips icon metadata without an href and keeps scanning", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "src/root.tsx",
+          `const links = [{ rel: "icon" }, { rel: "icon", href: "/brand/logo.svg" }];`,
+        );
+        yield* writeTextFile(cwd, "public/brand/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("public/brand/logo.svg");
+      }),
+    );
+
+    // A large icon source with no icon metadata used to pin the server's event loop for
+    // minutes: the object pattern was unanchored, so it restarted at every offset and
+    // rescanned forward from each one. Anchoring keeps this proportional to file size.
+    it.effect("scans large icon sources without an icon in reasonable time", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        // Mirrors a generated single-file build: large, brace-sparse, and no icon metadata.
+        const filler = `<p>${"pokopia companion guide ".repeat(24)}</p>\n`;
+        yield* writeTextFile(
+          cwd,
+          "index.html",
+          `<!doctype html><html><head><title>guide</title></head><body>\n${filler.repeat(1200)}</body></html>`,
+        );
+
+        const startedAt = performance.now();
+        const resolved = yield* resolver.resolvePath(cwd);
+        const elapsedMs = performance.now() - startedAt;
+
+        expect(resolved).toBeNull();
+        expect(elapsedMs).toBeLessThan(5_000);
+      }),
+    );
+
     it.effect("returns null when no icon is present", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -55,10 +55,13 @@ const ICON_SOURCE_FILES = [
 ] as const;
 
 // Matches <link ...> tags or object-like icon metadata where rel/href can appear in any order.
+// The tag pattern is anchored on `<link`, so it only starts at real candidates. Object metadata
+// is matched by scanning brace-free runs instead of by one combined pattern: an unanchored
+// pattern restarts at every offset and rescans forward, which is quadratic on large sources.
 const LINK_ICON_HTML_RE =
   /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i;
-const LINK_ICON_OBJ_RE =
-  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i;
+const ICON_REL_RE = /\brel\s*:\s*["'](?:icon|shortcut icon)["']/i;
+const ICON_HREF_RE = /\bhref\s*:\s*["']([^"'?]+)/i;
 
 export class ProjectFaviconResolutionError extends Schema.TaggedErrorClass<ProjectFaviconResolutionError>()(
   "ProjectFaviconResolutionError",
@@ -98,8 +101,13 @@ export class ProjectFaviconResolver extends Context.Service<
 function extractIconHref(source: string): string | null {
   const htmlMatch = source.match(LINK_ICON_HTML_RE);
   if (htmlMatch?.[1]) return htmlMatch[1];
-  const objMatch = source.match(LINK_ICON_OBJ_RE);
-  if (objMatch?.[1]) return objMatch[1];
+  // Icon metadata counts when `rel` and `href` share a brace-free run, so a run holding `rel`
+  // but no href falls through to the next one rather than ending the search.
+  for (const run of source.split("}")) {
+    if (!ICON_REL_RE.test(run)) continue;
+    const hrefMatch = run.match(ICON_HREF_RE);
+    if (hrefMatch?.[1]) return hrefMatch[1];
+  }
   return null;
 }
 


### PR DESCRIPTION
## What Changed

`LINK_ICON_OBJ_RE` is gone. Object icon metadata is now found by scanning brace-free runs instead of by one combined pattern:

```diff
-const LINK_ICON_OBJ_RE =
-  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i;
+const ICON_REL_RE = /\brel\s*:\s*["'](?:icon|shortcut icon)["']/i;
+const ICON_HREF_RE = /\bhref\s*:\s*["']([^"'?]+)/i;

 function extractIconHref(source: string): string | null {
   const htmlMatch = source.match(LINK_ICON_HTML_RE);
   if (htmlMatch?.[1]) return htmlMatch[1];
-  const objMatch = source.match(LINK_ICON_OBJ_RE);
-  if (objMatch?.[1]) return objMatch[1];
+  for (const run of source.split("}")) {
+    if (!ICON_REL_RE.test(run)) continue;
+    const hrefMatch = run.match(ICON_HREF_RE);
+    if (hrefMatch?.[1]) return hrefMatch[1];
+  }
   return null;
 }
```

Five tests come with it. The object branch had no coverage at all — every existing case exercises the `<link>` branch — so this adds both key orders, a nested-object case, a no-href-then-valid case, and a large brace-sparse source that hangs the suite without the fix.

`LINK_ICON_HTML_RE` is untouched. It is already anchored on `<link\b`, so it was never part of the problem.

## Why

Fixes #5537.

The old pattern began with a lookahead and no literal anchor, so the engine retried at every offset and rescanned forward with `[^}]*` from each one. On a brace-sparse file that is quadratic.

That turns one file into a full environment outage. A project with no icon and a large `index.html` lacking `<link rel="icon">` — the shape of a generated single-file build — made `resolvePath` spin for minutes on the server's only thread. Every endpoint stopped answering, including `/.well-known/t3/environment`; the desktop client timed out at 10s, respawned the server, and it re-scanned and re-wedged. The environment never recovered on its own.

| | before | after |
|---|---|---|
| 1.6 MB icon source, no icon metadata | killed at 30s, never completed | 2 ms |
| 200 KB | ~4s | <1 ms |

### Why runs rather than an anchored pattern

Anchoring the existing pattern on `{` is the obvious fix and it is **not** equivalent. It breaks two cases the current code handles:

| source | current | anchored `\{…\}` | this PR |
|---|---|---|---|
| `{ attributes: {}, rel: "icon", href: "/x.svg" }` | `/x.svg` | `null` | `/x.svg` |
| `[{ rel: "icon" }, { rel: "icon", href: "/x.svg" }]` | `/x.svg` | `null` | `/x.svg` |

The old pattern accepted any position from which both `rel` and `href` were visible before the next `}` — which is exactly "both live in the same brace-free run". Walking those runs reproduces that rule directly: a run holding `rel` but no `href` falls through to the next candidate, and metadata beside a nested object still resolves because the run boundary sits at `}`, not at the enclosing object.

I checked this against the old pattern across both key orders, `shortcut icon`, query stripping, `rel: "stylesheet"`, a TanStack `head()` block, and the two rows above: same result on every one.

## UI Changes

None.

## Verification

- `vp test run src/project/ProjectFaviconResolver.test.ts` — 17 passed (12 existing + 5 new), 445 ms.
- Reverting only the source change and keeping the new tests: the run was still going at 100s and had to be killed, confirming the regression test actually catches this.
- `vp lint` on both changed files: clean.
- `tsgo --noEmit` for `apps/server`: exit 0, no diagnostics in the changed files.

Branched off `main` @ `e4abc31f`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A, no UI change)
- [x] I included a video for animation/interaction changes (N/A)

Model: Claude Opus 5 · Harness: Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches server-side favicon discovery on every workspace scan; behavior is intended to be equivalent for object metadata but the parsing path changed, so edge-case regressions are possible despite new tests.
> 
> **Overview**
> Fixes **event-loop wedging** when `ProjectFaviconResolver` scans large project sources that have no icon metadata (e.g. generated single-file `index.html`).
> 
> Object-literal icon detection no longer uses the unanchored `LINK_ICON_OBJ_RE` regex (which retried at every offset and could run for minutes). **`extractIconHref`** now splits the source on `}` and, within each brace-free run, looks for `rel: "icon"` / `shortcut icon` and a matching `href`—same semantics as before for TanStack-style `head()` blocks, arbitrary key order, nested objects, and “icon without href then valid entry” cases. HTML `<link rel="icon">` matching is unchanged.
> 
> Adds five tests covering object metadata cases plus a large-file timing guard (&lt; 5s, expects `null`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba92f5fe17982724a19a05407363897a7da454d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `extractIconHref` to resolve object-literal favicons without pinning the event loop
> - Replaces the single unanchored `LINK_ICON_OBJ_RE` regex with a segment-based scan in [`ProjectFaviconResolver.ts`](https://github.com/pingdotgg/t3code/pull/5538/files#diff-326ea26189bf71bd26429a43747f009862cf90147e00f0f77fcfde9540fd74cc): the source is split on `}` into brace-free runs, each checked for `rel: "icon"` then `href`.
> - Fixes correctness issues where `href` before `rel`, extra nested properties, or rel-only segments caused resolution to fail.
> - Behavioral Change: scanning large sources without icon metadata now runs in linear time instead of quadratic time, preventing the event loop from stalling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ba92f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->