### PR TITLE
fix(web): restore horizontal scrolling in right panel tabs

### DIFF
--- a/apps/web/src/components/RightPanelTabs.test.tsx
+++ b/apps/web/src/components/RightPanelTabs.test.tsx
@@ -1,6 +1,6 @@
 import type { DesktopPreviewFavicon, PreviewSessionSnapshot } from "@t3tools/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   RightPanelTabs,
@@ -8,6 +8,10 @@ import {
   surfaceShortcutTargetsTypingContext,
   tabMuteMenuItem,
 } from "./RightPanelTabs";
+
+// Inline mode on desktop owns the window title bar, which is where the tab
+// strip has to stay scrollable while the unused space stays draggable.
+vi.mock("~/env", () => ({ isElectron: true }));
 
 function shortcutEvent(
   key: string,
@@ -265,5 +269,16 @@ describe("tabMuteMenuItem", () => {
       label: "Unmute tab",
       disabled: false,
     });
+  });
+});
+
+describe("RightPanelTabs desktop title bar", () => {
+  it("keeps the tab strip out of the drag region and restores drag on the trailing space", () => {
+    const html = renderTabs(null);
+    const tabList = html.match(/<div[^>]*data-right-panel-tab-list[^>]*>/)?.[0];
+
+    expect(tabList).toContain("[-webkit-app-region:no-drag]");
+    expect(tabList).not.toContain("drag-region");
+    expect(html).toMatch(/<div aria-hidden="true" class="drag-region[^"]*"><\/div>/);
   });
 });

--- a/apps/web/src/components/RightPanelTabs.test.tsx
+++ b/apps/web/src/components/RightPanelTabs.test.tsx
@@ -1,0 +1,52 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { RightPanelTabs } from "./RightPanelTabs";
+
+vi.mock("~/env", () => ({ isElectron: true }));
+
+/** The opening tag carrying `attribute`, so class assertions pin the element, not attribute order. */
+function tagWith(markup: string, attribute: string): string {
+  const index = markup.indexOf(attribute);
+  if (index === -1) throw new Error(`no element carries ${attribute}`);
+  return markup.slice(markup.lastIndexOf("<", index), markup.indexOf(">", index) + 1);
+}
+
+describe("RightPanelTabs", () => {
+  it("keeps the Electron titlebar draggable without swallowing tab strip scrolling", () => {
+    const markup = renderToStaticMarkup(
+      <RightPanelTabs
+        mode="inline"
+        surfaces={[]}
+        activeSurfaceId={null}
+        pendingSurfaceIds={new Set()}
+        previewSessions={{}}
+        terminalLabelsById={new Map()}
+        onActivate={vi.fn()}
+        onCloseSurface={vi.fn()}
+        onCloseOtherSurfaces={vi.fn()}
+        onCloseSurfacesToRight={vi.fn()}
+        onCloseAllSurfaces={vi.fn()}
+        onCopyFilePath={vi.fn()}
+        onAddBrowser={vi.fn()}
+        onAddTerminal={vi.fn()}
+        onAddDiff={vi.fn()}
+        onAddFiles={vi.fn()}
+        onAddAgents={vi.fn()}
+        browserAvailable
+        diffAvailable
+        filesAvailable
+      >
+        <div />
+      </RightPanelTabs>,
+    );
+
+    expect(tagWith(markup, "data-right-panel-tabbar")).toContain("drag-region");
+
+    // -webkit-app-region: drag swallows pointer and wheel events, so the scroll
+    // container itself must opt out or the tab strip cannot be scrolled.
+    const tabList = tagWith(markup, "data-right-panel-tab-list");
+    expect(tabList).toContain("[-webkit-app-region:no-drag]");
+    expect(tabList).not.toContain("drag-region");
+  });
+});

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -792,7 +792,10 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
           ref={tabListRef}
           hideScrollbars
           scrollFade
-          className={cn("min-w-0 flex-1 rounded-none", ownsDesktopTitleBar && "drag-region")}
+          className={cn(
+            "min-w-0 flex-1 rounded-none",
+            ownsDesktopTitleBar && "[-webkit-app-region:no-drag]",
+          )}
           data-right-panel-tab-list
         >
           <div className="flex h-full w-max min-w-full items-center gap-1">
@@ -924,6 +927,9 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
                   })}
                 </MenuPopup>
               </Menu>
+            ) : null}
+            {ownsDesktopTitleBar ? (
+              <div aria-hidden className="drag-region -ml-1 h-full flex-1" />
             ) : null}
           </div>
         </ScrollArea>

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -374,7 +374,8 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
           "workspace-topbar gap-1 pl-2",
           props.mode !== "inline" && "[--workspace-topbar-height:--spacing(11)]",
           props.mode === "inline" ? "pr-28" : "pr-3",
-          ownsDesktopTitleBar && "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
+          ownsDesktopTitleBar &&
+            "drag-region wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
           props.mode === "inline" && props.maximized && COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
         )}
         data-right-panel-tabbar
@@ -383,7 +384,10 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
           ref={tabListRef}
           hideScrollbars
           scrollFade
-          className={cn("min-w-0 flex-1 rounded-none", ownsDesktopTitleBar && "drag-region")}
+          className={cn(
+            "min-w-0 flex-1 rounded-none",
+            ownsDesktopTitleBar && "[-webkit-app-region:no-drag]",
+          )}
           data-right-panel-tab-list
         >
           <div className="flex h-full w-max min-w-full items-center gap-1">


### PR DESCRIPTION
## What Changed

On desktop, the right panel tab strip's `ScrollArea` opts out of the window drag region with `-webkit-app-region: no-drag`, so wheel and trackpad events reach the scroller. A trailing `drag-region` spacer inside the tab row keeps the unused titlebar space draggable: it fills the leftover width when the tabs fit and collapses to zero when they overflow, so it never adds scroll range or a phantom fade.

## Why

Electron drag regions swallow pointer and wheel events. The tab strip was itself the drag region, so once tabs overflowed, the ones past the right edge could not be reached without widening the panel or closing tabs.

## UI Changes

No styling changes, interaction only.

Before

https://github.com/user-attachments/assets/243057fe-7905-4754-bf35-47ed5be0cabf

After

https://github.com/user-attachments/assets/f38dfb0b-1c77-46e5-9be1-08b967c0c102

## Verification

- `vp test run apps/web/src/components/RightPanelTabs.test.tsx` (18 passed; includes a regression test that the tab strip is no-drag and the trailing spacer is the drag surface in desktop inline mode)
- web typecheck, targeted lint and fmt

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual styling changes, so no screenshots
- [x] I included before and after videos for the interaction change

Built with Claude Fable 5.1 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop title-bar interaction only; no auth, data, or API changes. Drag handle shrinks when tabs fill the bar width.
> 
> **Overview**
> **Fixes horizontal tab scrolling on Electron** when inline mode owns the desktop title bar. The tab strip `ScrollArea` no longer acts as the window drag surface; it uses `[-webkit-app-region:no-drag]` so trackpad and wheel input reach the scroller when tabs overflow.
> 
> **Window dragging** is moved to a trailing `flex-1` spacer inside the tab row (still `drag-region`), so empty title-bar space stays draggable without blocking scroll on the tabs themselves.
> 
> Tests mock Electron and assert the tab list is no-drag and the trailing drag spacer is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7501b4435d1c1fc0172c8c384f4728c167e27698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore horizontal scrolling in right panel tabs in Electron inline mode
> - In [RightPanelTabs.tsx](https://github.com/pingdotgg/t3code/pull/5541/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91), when `ownsDesktopTitleBar` is true, replaces the `drag-region` class on the `ScrollArea` container with an inline `[-webkit-app-region:no-drag]` style so the tab strip is scrollable instead of draggable.
> - Adds a trailing `aria-hidden` div with `drag-region` classes inside the tab list container to preserve window-dragging on the empty space after the tabs.
> - Behavioral Change: in Electron inline mode, the tab strip itself is no longer a window drag region; dragging the title bar now works only on the trailing empty space.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7501b44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->




