### PR TITLE
fix(web): show pointer on add project button

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3892,7 +3892,7 @@ export default function Sidebar() {
                   <button
                     type="button"
                     onClick={openAddProjectCommandPalette}
-                    className="inline-flex items-center gap-1.5 rounded-md border border-sidebar-border px-2.5 py-1 text-[11px] font-medium text-sidebar-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+                    className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-sidebar-border px-2.5 py-1 text-[11px] font-medium text-sidebar-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
                   >
                     <PlusIcon className="-mx-0.5 size-3" />
                     Add project


### PR DESCRIPTION
## Problem

The Sidebar V2 empty state’s “Add project” button keeps the default mouse cursor, so it does not visually communicate that it is clickable.

## Fix

Add the `cursor-pointer` utility to the button’s existing styles.

## Verification

- `vp fmt apps/web/src/components/SidebarV2.tsx --check`
- `git diff --check upstream/main...HEAD`

Static before/after images are omitted because the change only affects the mouse cursor on hover.

Built with GPT-5.6-sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on a sidebar empty-state button; no logic, auth, or data changes.
> 
> **Overview**
> When the sidebar has **no projects**, the empty-state **Add project** control now uses the `cursor-pointer` class so the hover cursor matches other clickable sidebar actions.
> 
> No behavior or routing changes—only the pointer affordance on that button in `Sidebar.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e227eab6af508d9ee770b353d1a3df7b5d5c92b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show pointer cursor on 'Add project' button in empty sidebar state
> Adds the `cursor-pointer` CSS class to the 'Add project' button in [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/5545/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) so it visually indicates clickability when no projects exist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d09dc7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->